### PR TITLE
fix(unbroker): verify fanout ledger writes

### DIFF
--- a/optional-skills/security/unbroker/SKILL.md
+++ b/optional-skills/security/unbroker/SKILL.md
@@ -139,11 +139,16 @@ For anything past a couple of brokers, run this as **map → reduce → act**, n
 - **Phase 1 - DISCOVER (read-only, parallel, idempotent).** Crawl *every* broker first and record a
   verdict for each (`found` / `not_found` / `indirect_exposure` / `blocked`). Scanning has no side
   effects, so it is safe to parallelize and retry. Getting the full exposure map *before* acting is
-  what unlocks cluster dedup and prioritization below. **Default: the parent drives `web_extract`
-  probes directly** - most people-search sites render name/phone/address results as static HTML that
-  `web_extract` reads in seconds. Escalate to `browser_*` only for the few JS-only sites, and to
-  `delegate_task` subagents only for genuinely *reasoning*-heavy work (large-scale namesake/relative
-  disambiguation). **Do NOT hand a browser-toolset subagent a big list of brokers to crawl** - in the
+  what unlocks cluster dedup and prioritization below. **Default: the parent drives the cheap scan
+  ladder directly** - use `web_extract` only when Hermes is configured with a real page-extraction
+  backend for arbitrary URLs. Hermes leaves the provider settings blank by default; DDGS is a
+  search-only provider, while extraction falls back to Firecrawl when that service is available.
+  When no extractor is configured/available, start with `web_search site:` probes and then escalate
+  to browser/operator checks. Most accessible
+  people-search pages are static HTML and are cheap when a content extractor is available, but a
+  search-only backend will not fetch the page body for you. Escalate to `browser_*` only for the few
+  JS-only sites, and to `delegate_task` subagents only for genuinely *reasoning*-heavy work
+  (large-scale namesake/relative disambiguation). **Do NOT hand a browser-toolset subagent a big list of brokers to crawl** - in the
   field this timed out repeatedly (600s, ~5-6 brokers each, no summary) because browser navigation is
   heavy; the ledger writes that survived came at 10x the cost of parent `web_extract`. A `blocked`
   (DataDome/Cloudflare/`antibot`) site is *not* a subagent job either: record `blocked` and requeue it
@@ -222,12 +227,18 @@ recording `found` and before any deletion.
 4. **Scanning (when `next` says so).** For `fanout_scan`: run `$PDD fanout <subject>` and **spawn one
    `delegate_task` subagent per `batch`, in parallel, passing that batch's ready-made `brief`** - do
    not scan all brokers yourself sequentially. For `scan_inline`: scan the few brokers yourself.
-   Either way, each broker gets **every** `search_vectors` entry via the `references/methods.md`
-   ladder (`web_extract` → `site:` probe → `browser_navigate` → `scrapling`), a 404 is INCONCLUSIVE
+   Either way, each broker gets **every** `search_vectors` entry via the capability-conditioned
+   `references/methods.md` ladder: use `web_extract` only with a real extraction backend, otherwise
+   start with a `site:` probe; escalate to `browser_navigate` and then `scrapling` only when those
+   capabilities are available and needed. A 404 is INCONCLUSIVE
    (not `not_found`), `blocked` is recorded when `antibot` is set and no stealth browser is available,
    and subject vs namesake/relative is confirmed before recording:
    `$PDD record <subject> <broker> <found|not_found|indirect_exposure|blocked> --found <bool> --evidence '{"listing_urls":[...]}'`.
-   The parent re-verifies key `found` claims from subagents before trusting them.
+   Every worker returns its intended state/evidence. **From the parent process**, run
+   `$PDD show <subject> <broker>` for every returned verdict and compare `state`, `found`, and
+   `evidence`; a worker's own readback may point at a different `PDD_DATA_DIR`/`HERMES_HOME` and is
+   not proof. Missing or mismatched parent records are failed writes and must not advance to opt-out.
+   The parent also re-verifies key `found` claims before trusting them.
 5. **Opt-outs (when `next` says so).** Actions come pre-ordered parents-first with `steps` from each
    broker record's own `optout.playbook` (field-verified; cluster parents like PeopleConnect,
    Whitepages, BeenVerified, Spokeo have exact, live-checked recipes). **Deletion usually beats

--- a/optional-skills/security/unbroker/references/methods.md
+++ b/optional-skills/security/unbroker/references/methods.md
@@ -59,8 +59,13 @@ blind-opt-out even if the scan is inconclusive - see the posture section above).
 `search.by` supports) - different vectors surface different listings for the same person; dedupe found
 URLs.
 
-1. `web_extract` on the broker `search.url` (fast HTML -> markdown). Look for `search.match_signal`.
-   Build per-vector URLs from `search.url_patterns` and heed `search.url_format_quirks` (see below).
+1. If Hermes has a real page-extraction backend for arbitrary URLs, `web_extract` on the broker
+   `search.url` or constructed per-vector URL (fast HTML -> markdown). Look for `search.match_signal`.
+   Provider settings are blank by default. DDGS supplies search only; extraction uses a separate
+   backend and falls back to Firecrawl when that service is available. If no real extractor is
+   configured/available, go straight to the `site:` probe below, then browser/operator checks as
+   needed. Build per-vector URLs from `search.url_patterns` and heed
+   `search.url_format_quirks` (see below).
 1b. **`site:` search-engine probe (cheap, do it early and in parallel).** `web_search` with
    `site:<broker-domain> "First Last"` (add a city/ZIP or a unique phone/address to cut namesake
    noise) often returns the **exact profile-slug URL** in one shot - which both confirms the listing
@@ -358,4 +363,3 @@ A parent without a hand-verified `optout.playbook` gets synthesised steps from i
 back into `references/brokers/<id>.json`** (`optout.playbook`, `optout.deletion`, `quirks`,
 `last_verified`) so the next run is exact - that file, not this one, is where per-broker knowledge
 accrues.
-

--- a/optional-skills/security/unbroker/scripts/pdd.py
+++ b/optional-skills/security/unbroker/scripts/pdd.py
@@ -473,6 +473,8 @@ def cmd_fanout(args) -> None:
             f"result card; a public property/address record with no displayed personal NAME is "
             f"not_found, not found). Record each outcome via `pdd.py record {args.subject} <broker> "
             f"<found|not_found|indirect_exposure|blocked> --found <bool> --evidence '{{\"listing_urls\":[...]}}'`. "
+            f"Return the exact intended state/evidence and the `record` command result for every broker; "
+            f"the parent will independently read its own ledger with `pdd.py show`. "
             f"Mode: {mode}. Broker JSON files are READ-ONLY for you -- do NOT edit them; if you discover "
             f"a URL/quirk, put it in your report for the parent to fold in. Return a concise structured "
             f"per-broker report."
@@ -488,7 +490,11 @@ def cmd_fanout(args) -> None:
         "instruction": (
             "If should_fanout is true you MUST spawn ONE delegate_task subagent per batch IN PARALLEL, "
             "passing each batch's `brief`; do not scan all brokers yourself sequentially. Wait for every "
-            "report, consolidate, then proceed to opt-outs. If false, just scan the brokers inline."
+            f"report, then FROM THE PARENT PROCESS run `pdd.py show {args.subject} <broker>` for every "
+            "returned verdict and compare state, found, and evidence. A worker's own readback does not "
+            "prove it wrote the parent's PDD_DATA_DIR/HERMES_HOME. Treat a missing or mismatched parent "
+            "record as a failed write and do not proceed to opt-outs for that broker. If false, just "
+            "scan the brokers inline."
         ),
     })
 

--- a/tests/skills/test_unbroker_skill.py
+++ b/tests/skills/test_unbroker_skill.py
@@ -493,6 +493,41 @@ def test_fanout_default_batch_size_is_five():
     assert len(g["batches"]) == 3  # 5 + 5 + 2
 
 
+def test_fanout_requires_parent_ledger_readback_after_worker_reports():
+    with temp_env():
+        sid = _run(["intake", "--full-name", "Jane Q. Public",
+                    "--email", "jane@example.com", "--consent"])["subject_id"]
+        out = _run(["fanout", sid, "--priority", "crucial", "--size", "2"])
+        brief = out["batches"][0]["brief"]
+        assert "exact intended state/evidence" in brief
+        assert f"pdd.py show {sid} <broker>" in out["instruction"]
+        assert "FROM THE PARENT PROCESS" in out["instruction"]
+
+
+def test_parent_readback_rejects_worker_write_to_different_data_dir():
+    with temp_env():
+        sid = _run(["intake", "--full-name", "Jane Q. Public",
+                    "--email", "jane@example.com", "--consent"])["subject_id"]
+
+        # Simulate a worker inheriting a different PDD_DATA_DIR. Its own
+        # transition/readback succeeds, but it has not updated the parent.
+        with temp_env():
+            worker_case = ledger.transition(
+                sid,
+                "spokeo",
+                "found",
+                found=True,
+                evidence={"listing_urls": ["https://example.test/profile"]},
+            )
+            assert worker_case["state"] == "found"
+            assert ledger.get_case(sid, "spokeo")["found"] is True
+
+        parent_case = _run(["show", sid, "spokeo"])
+        assert parent_case["state"] == "new"
+        assert parent_case["found"] is None
+        assert parent_case["evidence"] == {}
+
+
 # --- cdp (operator browser over the DevTools protocol) --------------------------------------
 
 def test_cdp_launch_command_has_debug_flags():


### PR DESCRIPTION
## Summary
- make the fanout parent independently reconcile every returned worker verdict with `pdd.py show` from the parent's own data directory
- treat missing or mismatched parent state/evidence as a failed worker write and prevent that broker from advancing to opt-out
- have workers return exact intended state/evidence and record output instead of treating self-readback as proof of shared storage
- correct backend guidance: provider defaults are blank, DDGS is search-only, and extraction uses the separate Firecrawl fallback when available
- make both scan-ladder descriptions capability-conditioned

## Verification
- `pytest -q tests/skills/test_unbroker_skill.py` (99 passed)
- includes a regression where a worker successfully writes and reads a different `PDD_DATA_DIR`, while the parent readback correctly remains `new`
- `ruff check optional-skills/security/unbroker/scripts/pdd.py tests/skills/test_unbroker_skill.py`
