### PR TITLE
fix(skills): expand HOME defaults against tool home

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -12,7 +12,12 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from hermes_constants import get_config_path, get_skills_dir, is_termux
+from hermes_constants import (
+    get_config_path,
+    get_skills_dir,
+    get_subprocess_home,
+    is_termux,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -674,6 +679,21 @@ def _resolve_dotpath(config: Dict[str, Any], dotted_key: str):
     return current
 
 
+_HOME_VAR_RE = re.compile(r"\$(?:\{HOME\}|HOME)(?=$|[/\\])")
+
+
+def _expand_skill_config_path(value: str) -> str:
+    """Expand user-facing skill paths against the HOME used by tools."""
+    subprocess_home = get_subprocess_home()
+    if subprocess_home:
+        if value == "~":
+            return subprocess_home
+        if value.startswith(("~/", "~\\")):
+            return os.path.join(subprocess_home, value[2:])
+        value = _HOME_VAR_RE.sub(subprocess_home, value)
+    return os.path.expanduser(os.path.expandvars(value))
+
+
 def resolve_skill_config_values(
     config_vars: List[Dict[str, Any]],
 ) -> Dict[str, Any]:
@@ -682,7 +702,7 @@ def resolve_skill_config_values(
     Skill config is stored under ``skills.config.<key>`` in config.yaml.
     Returns a dict mapping **logical** keys (as declared by skills) to their
     current values (or the declared default if the key isn't set).
-    Path values are expanded via ``os.path.expanduser``.
+    Path values are expanded against the HOME that Hermes injects into tools.
     """
     config = _load_raw_config()
 
@@ -695,9 +715,13 @@ def resolve_skill_config_values(
         if value is None or (isinstance(value, str) and not value.strip()):
             value = var.get("default", "")
 
-        # Expand ~ in path-like values
-        if isinstance(value, str) and ("~" in value or "${" in value):
-            value = os.path.expanduser(os.path.expandvars(value))
+        # Expand path-like values with subprocess HOME semantics.  Skill
+        # defaults describe paths the agent will hand to tools, not paths the
+        # Python control process itself will open.
+        if isinstance(value, str) and (
+            "~" in value or "${" in value or "$HOME" in value
+        ):
+            value = _expand_skill_config_path(value)
 
         resolved[logical_key] = value
 

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -171,6 +171,35 @@ def test_skill_config_raw_cache_invalidates_on_config_edit(tmp_path, monkeypatch
     assert get_disabled_skill_names() == {"new-skill"}
 
 
+def test_skill_config_home_vars_use_subprocess_home(tmp_path, monkeypatch):
+    """$HOME defaults should match the HOME that tools receive."""
+    from agent import skill_utils
+
+    hermes_home = tmp_path / "data"
+    subprocess_home = hermes_home / "home"
+    subprocess_home.mkdir(parents=True)
+    (hermes_home / "config.yaml").write_text("", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HOME", str(hermes_home))
+    monkeypatch.setenv("TERMINAL_HOME_MODE", "profile")
+    skill_utils._external_dirs_cache_clear()
+
+    resolved = resolve_skill_config_values(
+        [
+            {"key": "wiki.home_var", "default": "$HOME/wiki"},
+            {"key": "wiki.braced_home", "default": "${HOME}/notes"},
+            {"key": "wiki.tilde", "default": "~/scratch"},
+            {"key": "wiki.other_var", "default": "${PROJECT_ROOT}/cache"},
+        ]
+    )
+
+    assert resolved["wiki.home_var"] == str(subprocess_home / "wiki")
+    assert resolved["wiki.braced_home"] == str(subprocess_home / "notes")
+    assert resolved["wiki.tilde"] == str(subprocess_home / "scratch")
+    assert resolved["wiki.other_var"].endswith("/cache")
+
+
 def test_is_external_skill_path_matches_configured_external_dir(tmp_path, monkeypatch):
     from agent import skill_utils
 


### PR DESCRIPTION
## Summary
- Expand skill config path defaults with the same HOME that Hermes injects into tool subprocesses
- Handle `~`, `/Users/tianma`, and `/Users/tianma` consistently when `TERMINAL_HOME_MODE=profile`
- Keep other environment-variable expansion behavior unchanged

## Why
This addresses the remaining HOME-var variant of #12260: prior fixes covered tilde-style defaults, but `/Users/tianma/wiki` and `/Users/tianma/wiki` could still resolve against the Python process HOME instead of the subprocess HOME that tools actually receive.

## Tests
- `.venv/bin/python -m pytest tests/agent/test_skill_utils.py -q -k 'skill_config'`
- `.venv/bin/python -m pytest tests/agent/test_skill_utils.py -q`
- `.venv/bin/python -m py_compile agent/skill_utils.py tests/agent/test_skill_utils.py`
- `.venv/bin/python -m ruff check agent/skill_utils.py tests/agent/test_skill_utils.py`
- `git diff --check`