### PR TITLE
fix(usage): treat Anthropic OAuth utilization as percent, not fraction

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -518,7 +518,7 @@ def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
         util = window.get("utilization")
         if util is None:
             continue
-        used = float(util) * 100 if float(util) <= 1 else float(util)
+        used = float(util)
         windows.append(
             AccountUsageWindow(
                 label=label,

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -95,6 +95,41 @@ def test_fetch_account_usage_codex(monkeypatch):
     assert "Credits balance: $12.50" in snapshot.details
 
 
+def test_fetch_account_usage_anthropic_treats_utilization_as_percent(monkeypatch):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_anthropic_token",
+        lambda: "oauth-access-token",
+    )
+    monkeypatch.setattr(
+        "agent.account_usage._is_oauth_token",
+        lambda token: True,
+    )
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client(
+            {
+                "five_hour": {"utilization": 1.0, "resets_at": 1_900_000_000},
+                "seven_day": {"utilization": 55.0, "resets_at": 1_900_500_000},
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("anthropic")
+
+    assert snapshot is not None
+    assert snapshot.provider == "anthropic"
+    assert len(snapshot.windows) == 2
+    # The OAuth usage API already reports utilization as a percentage:
+    # 1.0 == 1% used (NOT a 0-1 fraction to be scaled to 100%).
+    assert snapshot.windows[0].label == "Current session"
+    assert snapshot.windows[0].used_percent == 1.0
+    assert snapshot.windows[0].reset_at == datetime.fromtimestamp(1_900_000_000, tz=timezone.utc)
+    assert snapshot.windows[1].label == "Current week"
+    assert snapshot.windows[1].used_percent == 55.0
+    lines = render_account_usage_lines(snapshot)
+    assert any("Current session: 99% remaining (1% used)" in line for line in lines)
+
+
 def test_render_account_usage_lines_includes_reset_and_provider():
     snapshot = AccountUsageSnapshot(
         provider="openai-codex",


### PR DESCRIPTION
## What does this PR do?

`_fetch_anthropic_account_usage()` in `agent/account_usage.py` rescales the OAuth `utilization` value with a `<= 1 → ×100` heuristic. But the Anthropic OAuth usage API (`GET /api/oauth/usage`) already reports `utilization` as a **percentage** (`1.0` == 1% used, `55.0` == 55% used), so low-usage windows get wrongly inflated — a barely-used account renders as **100% used / 0% remaining**. The sibling Codex path (`_fetch_codex_account_usage`) already consumes its percentage verbatim, so the two providers were inconsistent. This treats the value as a percent verbatim.

## Related Issue

Fixes #58226

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/account_usage.py`: replace `used = float(util) * 100 if float(util) <= 1 else float(util)` with `used = float(util)` in `_fetch_anthropic_account_usage()`.
- `tests/test_account_usage.py`: add `test_fetch_account_usage_anthropic_treats_utilization_as_percent` — regression test asserting `utilization 1.0 → 1% used` (not 100%), following the existing `_Client` monkeypatch pattern.

## Before / after

| `utilization` (raw) | before | after |
|---|---|---|
| `1.0`  | 0% remaining (**100% used**) ❌ | 99% remaining (**1% used**) ✅ |
| `0.5`  | 50% remaining (**50% used**) ❌ | 100% remaining (**0% used**) ✅ |
| `4.0`  | 96% remaining (4% used) ✅ | 96% remaining (4% used) ✅ |
| `55.0` | 45% remaining (55% used) ✅ | 45% remaining (55% used) ✅ |

Values already ≥ 1 are unchanged; only the wrongly-rescaled 0–1% range is corrected.

## How to Test

1. `pytest tests/test_account_usage.py -q` → `5 passed`.
2. The new test drives `fetch_account_usage("anthropic")` with a mocked `utilization=1.0` window and asserts `used_percent == 1.0` and the rendered line `Current session: 99% remaining (1% used)`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `test(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/test_account_usage.py -q` and all tests pass (`5 passed`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Docs update — N/A (internal render logic, no user-facing doc)
- [x] `cli-config.yaml.example` — N/A (no config keys changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact — N/A (pure numeric logic, platform-independent)
- [x] Tool descriptions/schemas — N/A (no tool behavior changed)