### PR TITLE
fix(agent): avoid fallback on tool-call output 400s

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -299,6 +299,22 @@ _REQUEST_VALIDATION_PATTERNS = [
     "unsupported_parameter",
 ]
 
+# Tool-call output validation errors. These are produced by some
+# OpenAI-compatible gateways after the model has already chosen a tool call
+# but emitted malformed arguments. Switching to the next fallback provider
+# sends the same prompt/tool schema through another model and usually just
+# burns the fallback chain; the normal in-turn tool-call repair path is the
+# right recovery surface when we can reach it.
+_MODEL_OUTPUT_TOOL_CALL_PATTERNS = [
+    "invalid tool call",
+    "invalid_tool_call",
+    "tool call arguments",
+    "tool_call arguments",
+    "tool_calls arguments",
+    "function call arguments",
+    "function_call arguments",
+]
+
 # OpenRouter aggregator policy-block patterns.
 #
 # When a user's OpenRouter account privacy setting (or a per-request
@@ -1117,6 +1133,13 @@ def _classify_400(
             FailoverReason.format_error,
             retryable=False,
             should_fallback=True,
+        )
+
+    if any(p in error_msg for p in _MODEL_OUTPUT_TOOL_CALL_PATTERNS):
+        return result_fn(
+            FailoverReason.format_error,
+            retryable=False,
+            should_fallback=False,
         )
 
     # Context overflow from 400

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1137,6 +1137,37 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.format_error
         assert result.should_compress is False
 
+    def test_400_invalid_tool_call_arguments_does_not_fallback(self):
+        """Malformed model-emitted tool arguments are not provider failures.
+
+        Ollama's OpenAI-compatible proxy rejects malformed tool-call JSON as a
+        400 before Hermes can run the in-turn repair path. Cascading through
+        fallback providers just repeats the same prompt/tool schema and burns
+        latency, so classify it as a terminal format error for this attempt.
+        """
+        msg = "invalid tool call arguments: failed to parse JSON"
+        e = MockAPIError(
+            msg,
+            status_code=400,
+            body={"error": {"message": msg, "type": "invalid_request_error"}},
+        )
+        result = classify_api_error(e, approx_tokens=1000)
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+        assert result.should_compress is False
+        assert result.should_fallback is False
+
+    def test_400_function_call_arguments_does_not_fallback(self):
+        msg = "function_call arguments must be valid JSON"
+        e = MockAPIError(
+            msg,
+            status_code=400,
+            body={"error": {"message": msg}},
+        )
+        result = classify_api_error(e, approx_tokens=1000)
+        assert result.reason == FailoverReason.format_error
+        assert result.should_fallback is False
+
     def test_400_real_overflow_with_invalid_request_error_code_still_compresses(self):
         """Guard the guard: OpenAI stamps genuine context-overflow 400s with
         the generic 'invalid_request_error' code. The request-validation guard


### PR DESCRIPTION
## Summary
- classify 400 responses about malformed tool-call/function-call arguments as terminal format errors for the current attempt
- keep the existing `format_error` reason instead of adding a new public failover reason
- add regression coverage for Ollama/OpenAI-compatible proxy messages that previously cascaded through every fallback provider

Fixes #12770.

## Why
Some OpenAI-compatible gateways reject malformed model-emitted tool-call arguments with HTTP 400 before Hermes can enter its normal in-turn repair path. That is a model-output/schema problem, not evidence that another configured provider is healthier. Falling through the generic 400 path caused `should_fallback=True`, wasting 20-60s across fallback chains.

## Tests
- `.venv/bin/python -m pytest tests/agent/test_error_classifier.py -q -k 'invalid_tool_call_arguments or function_call_arguments or unsupported_max_tokens or real_overflow'`\n- `.venv/bin/python -m pytest tests/agent/test_error_classifier.py -q`\n- `.venv/bin/python -m py_compile agent/error_classifier.py tests/agent/test_error_classifier.py`\n- `.venv/bin/python -m ruff check agent/error_classifier.py tests/agent/test_error_classifier.py`\n- `git diff --check`