### PR TITLE
Preserve local approval and streaming guards after v0.18.0 update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1354,3 +1354,15 @@ not the specific names.
 
 Reviewers should reject new change-detector tests; authors should convert
 them into invariants before re-requesting review.
+
+## DOX Framework Contract
+
+- This `AGENTS.md` participates in a DOX-style documentation hierarchy inspired by `agent0ai/dox`: root and child `AGENTS.md` files form the local operating contract for their subtrees.
+- Before editing, read the nearest applicable `AGENTS.md` chain from the workspace/profile root down to the target path. Do not rely on memory when the current files can be read.
+- After meaningful changes, update the closest owning `AGENTS.md` and any affected parent/child index when purpose, scope, workflow, ownership, inputs, outputs, side effects, permissions, verification, or durable structure changes.
+- Child docs may add local detail, but no child doc may weaken system, developer, user, profile, project, safety, approval, credential, legal/tax/accounting/financial, public-posting, trading, production, or destructive-action gates.
+- Keep DOX docs concise and operational: stable contracts only, no diary entries, no raw secrets, no copied credentials, and no unverified success claims.
+
+## Child DOX Index
+
+- No child `AGENTS.md` files are currently indexed for this root. Add entries when durable child documentation boundaries are created.

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2717,6 +2717,21 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             "stream" in _err_lower
                             and "not supported" in _err_lower
                         )
+                        # Some local OpenAI-compatible proxies ignore stream=True
+                        # and return a regular JSON chat completion. The OpenAI
+                        # SDK's streaming iterator then yields no chunks, which
+                        # trips the zero-chunk guard above. Treat that local-only
+                        # malformed-SSE shape as permanent streaming unsupported
+                        # for this agent session so the main loop retries through
+                        # the working non-streaming path instead of failing the
+                        # turn.
+                        _agent_base_url = getattr(agent, "base_url", "") or ""
+                        _is_local_empty_stream = (
+                            is_local_endpoint(str(_agent_base_url))
+                            and "empty stream with no finish_reason" in _err_lower
+                        )
+                        if _is_local_empty_stream:
+                            agent._disable_streaming = True
                         # AWS Bedrock (AnthropicBedrock SDK path): IAM policies
                         # with bedrock:InvokeModel but not
                         # InvokeModelWithResponseStream reject messages.stream()
@@ -2738,13 +2753,16 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             _is_bedrock_stream_denied = (
                                 is_streaming_access_denied_error(e)
                             )
-                        if _is_stream_unsupported or _is_bedrock_stream_denied:
+                        if _is_stream_unsupported or _is_bedrock_stream_denied or _is_local_empty_stream:
                             agent._disable_streaming = True
                             agent._safe_print(
                                 "\n⚠  AWS IAM denied bedrock:InvokeModelWithResponseStream. "
                                 "Switching to non-streaming.\n"
                                 "   Grant that action to restore streaming output.\n"
                                 if _is_bedrock_stream_denied else
+                                "\n⚠  Local provider returned an empty streaming response. "
+                                "Switching to non-streaming.\n"
+                                if _is_local_empty_stream else
                                 "\n⚠  Streaming is not supported for this "
                                 "model/provider. Switching to non-streaming.\n"
                                 "   To avoid this delay, set display.streaming: false "

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2414,6 +2414,10 @@ DEFAULT_CONFIG = {
         "mode": "manual",
         "timeout": 60,
         "cron_mode": "deny",
+        # URL prefixes for profile-scoped read-only Python urllib preflights
+        # that should bypass script-execution prompts. Only literal GETs to
+        # these prefixes are allowed; POST/data and unsafe imports still block.
+        "trusted_readonly_http_prefixes": [],
         # When true, /reload-mcp asks the user to confirm before rebuilding
         # the MCP tool set for the active session.  Reloading invalidates
         # the provider prompt cache (tool schemas are baked into the system

--- a/tests/tools/test_trusted_readonly_http_approval.py
+++ b/tests/tools/test_trusted_readonly_http_approval.py
@@ -1,0 +1,102 @@
+"""Tests for profile-scoped trusted read-only HTTP approval."""
+
+from unittest.mock import patch as mock_patch
+
+from tools.approval import check_all_command_guards
+
+
+def _config(prefixes):
+    return {
+        "approvals": {
+            "mode": "manual",
+            "trusted_readonly_http_prefixes": prefixes,
+        }
+    }
+
+
+def test_trusted_readonly_urllib_heredoc_is_approved(monkeypatch):
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    command = """python3 - <<'PY'
+import urllib.request
+urls = [
+    'http://10.0.0.10:8189/system_stats',
+    'http://10.0.0.10:8189/queue',
+    'http://10.0.0.10:8192/health',
+]
+for url in urls:
+    with urllib.request.urlopen(url, timeout=15) as r:
+        body = r.read(2000).decode('utf-8', 'replace')
+        print('STATUS', r.status, body[:300].replace('\\n', ' '))
+PY"""
+    with mock_patch(
+        "hermes_cli.config.load_config",
+        return_value=_config([
+            "http://10.0.0.10:8189",
+            "http://10.0.0.10:8192",
+        ]),
+    ):
+        result = check_all_command_guards(command, "local")
+
+    assert result["approved"] is True
+    assert result["trusted_readonly_http"] is True
+
+
+def test_trusted_readonly_urllib_heredoc_rejects_untrusted_url(monkeypatch):
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    command = """python3 <<'PY'
+import urllib.request
+urllib.request.urlopen('http://example.com/system_stats', timeout=15)
+PY"""
+    with mock_patch(
+        "hermes_cli.config.load_config",
+        return_value=_config(["http://10.0.0.10:8189"]),
+    ):
+        result = check_all_command_guards(
+            command,
+            "local",
+            approval_callback=lambda *_a, **_kw: "deny",
+        )
+
+    assert result["approved"] is False
+    assert result["outcome"] == "denied"
+
+
+def test_trusted_readonly_urllib_heredoc_rejects_post_data(monkeypatch):
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    command = """python3 <<'PY'
+import urllib.request
+urllib.request.urlopen('http://10.0.0.10:8189/prompt', data=b'{}')
+PY"""
+    with mock_patch(
+        "hermes_cli.config.load_config",
+        return_value=_config(["http://10.0.0.10:8189"]),
+    ):
+        result = check_all_command_guards(
+            command,
+            "local",
+            approval_callback=lambda *_a, **_kw: "deny",
+        )
+
+    assert result["approved"] is False
+    assert result["outcome"] == "denied"
+
+
+def test_trusted_readonly_urllib_heredoc_rejects_unsafe_import(monkeypatch):
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    command = """python3 <<'PY'
+import os
+import urllib.request
+urllib.request.urlopen('http://10.0.0.10:8189/system_stats', timeout=15)
+PY"""
+    with mock_patch(
+        "hermes_cli.config.load_config",
+        return_value=_config(["http://10.0.0.10:8189"]),
+    ):
+        result = check_all_command_guards(
+            command,
+            "local",
+            approval_callback=lambda *_a, **_kw: "deny",
+        )
+
+    assert result["approved"] is False
+    assert result["outcome"] == "denied"

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -9,6 +9,7 @@ This module is the single source of truth for the dangerous command system:
 """
 
 import contextvars
+import ast
 import fnmatch
 import functools
 import logging
@@ -20,6 +21,7 @@ import threading
 import time
 import unicodedata
 from typing import Optional
+from urllib.parse import urlencode, urlsplit
 from hermes_cli.config import cfg_get
 
 from tools.interrupt import is_interrupted
@@ -1812,6 +1814,211 @@ def _get_cron_approval_mode() -> str:
         return "deny"
 
 
+def _get_trusted_readonly_http_prefixes() -> list[str]:
+    """Return profile-configured URL prefixes for trusted read-only probes."""
+    try:
+        from hermes_cli.config import load_config
+        config = load_config()
+        raw = cfg_get(
+            config,
+            "approvals",
+            "trusted_readonly_http_prefixes",
+            default=[],
+        )
+    except Exception:
+        return []
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, (list, tuple)):
+        return []
+    prefixes: list[str] = []
+    for item in raw:
+        prefix = str(item or "").strip()
+        if not prefix:
+            continue
+        parsed = urlsplit(prefix)
+        if parsed.scheme in {"http", "https"} and parsed.netloc:
+            prefixes.append(prefix.rstrip("/"))
+    return prefixes
+
+
+_PYTHON_HEREDOC_RE = re.compile(
+    r"""^\s*
+        (?:(?:cd)\s+(?:"[^"]+"|'[^']+'|[^\s;&|]+)\s*(?:&&|;)\s*)?
+        python[23]?(?:\s+-)?\s+<<\s*['"]?(?P<tag>[A-Za-z_][A-Za-z0-9_]*)['"]?\s*
+        \n(?P<body>.*)\n(?P=tag)\s*$
+    """,
+    re.DOTALL | re.VERBOSE,
+)
+
+_READONLY_HTTP_SAFE_IMPORTS = {
+    "json",
+    "urllib",
+    "urllib.parse",
+    "urllib.request",
+}
+_READONLY_HTTP_BLOCKED_NAMES = {
+    "__import__",
+    "compile",
+    "eval",
+    "exec",
+    "input",
+    "open",
+}
+_READONLY_HTTP_BLOCKED_ATTRS = {
+    "chmod",
+    "chown",
+    "delete",
+    "exec",
+    "mkdir",
+    "open",
+    "popen",
+    "post",
+    "put",
+    "remove",
+    "rename",
+    "request",
+    "rmdir",
+    "run",
+    "send",
+    "system",
+    "unlink",
+    "write",
+    "writelines",
+}
+
+
+def _ast_qualname(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = _ast_qualname(node.value)
+        return f"{parent}.{node.attr}" if parent else node.attr
+    return ""
+
+
+def _readonly_literal_value(node: ast.AST, env: dict[str, object]) -> object:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Name):
+        return env.get(node.id)
+    if isinstance(node, (ast.List, ast.Tuple)):
+        values = [_readonly_literal_value(elt, env) for elt in node.elts]
+        if all(isinstance(value, str) for value in values):
+            return values
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = _readonly_literal_value(node.left, env)
+        right = _readonly_literal_value(node.right, env)
+        if isinstance(left, str) and isinstance(right, str):
+            return left + right
+    if (
+        isinstance(node, ast.Call)
+        and _ast_qualname(node.func).endswith("urllib.parse.urlencode")
+        and len(node.args) == 1
+        and not node.keywords
+    ):
+        try:
+            value = ast.literal_eval(node.args[0])
+        except Exception:
+            return None
+        if isinstance(value, dict):
+            return urlencode(value)
+    return None
+
+
+def _url_matches_trusted_prefix(url: str, prefixes: list[str]) -> bool:
+    parsed = urlsplit(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return False
+    for prefix in prefixes:
+        base = prefix.rstrip("/")
+        if url == base or url.startswith(base + "/") or url.startswith(base + "?"):
+            return True
+    return False
+
+
+def _trusted_readonly_http_probe(command: str) -> tuple[bool, str | None]:
+    """Approve tightly-scoped Python urllib GET probes to configured URLs.
+
+    This exists for local maintenance preflights that are read-only but trip
+    the generic "script execution via heredoc" rule. It is intentionally
+    profile-scoped and URL-prefix-scoped.
+    """
+    prefixes = _get_trusted_readonly_http_prefixes()
+    if not prefixes:
+        return False, None
+    match = _PYTHON_HEREDOC_RE.match(command)
+    if not match:
+        return False, None
+    body = match.group("body")
+    try:
+        tree = ast.parse(body)
+    except SyntaxError:
+        return False, None
+
+    env: dict[str, object] = {}
+    urls: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name not in _READONLY_HTTP_SAFE_IMPORTS:
+                    return False, None
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module not in _READONLY_HTTP_SAFE_IMPORTS:
+                return False, None
+        elif isinstance(node, ast.Assign):
+            value = _readonly_literal_value(node.value, env)
+            if value is not None:
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        env[target.id] = value
+        elif isinstance(node, ast.For):
+            value = _readonly_literal_value(node.iter, env)
+            if (
+                isinstance(node.target, ast.Name)
+                and isinstance(value, list)
+                and all(isinstance(item, str) for item in value)
+            ):
+                env[node.target.id] = value
+        elif isinstance(node, ast.Call):
+            qualname = _ast_qualname(node.func)
+            attr = qualname.rsplit(".", 1)[-1]
+            if attr.startswith("__"):
+                return False, None
+            if (
+                qualname in _READONLY_HTTP_BLOCKED_NAMES
+                or attr in _READONLY_HTTP_BLOCKED_ATTRS
+            ):
+                return False, None
+            if attr == "urlopen":
+                if not node.args:
+                    return False, None
+                # urllib.request.urlopen(url, data=...) switches to POST.
+                if len(node.args) > 1:
+                    return False, None
+                for kw in node.keywords:
+                    if kw.arg in {"data", "method"}:
+                        return False, None
+                value = _readonly_literal_value(node.args[0], env)
+                if isinstance(value, str):
+                    urls.append(value)
+                elif (
+                    isinstance(value, list)
+                    and all(isinstance(item, str) for item in value)
+                ):
+                    urls.extend(value)
+                else:
+                    return False, None
+
+    if not urls:
+        return False, None
+    if not all(_url_matches_trusted_prefix(url, prefixes) for url in urls):
+        return False, None
+    return True, "trusted read-only HTTP preflight"
+
+
+
 def _strip_shell_comments(command: str) -> str:
     """Strip shell-style comments from a command before LLM assessment.
 
@@ -2247,6 +2454,15 @@ def check_all_command_guards(command: str, env_type: str,
         logger.warning("Sudo stdin guard block: %s (command: %s)",
                        sudo_guess_desc, command[:200])
         return _sudo_stdin_block_result(sudo_guess_desc)
+
+    is_trusted_probe, trusted_probe_desc = _trusted_readonly_http_probe(command)
+    if is_trusted_probe:
+        return {
+            "approved": True,
+            "message": None,
+            "trusted_readonly_http": True,
+            "description": trusted_probe_desc,
+        }
 
     # --yolo or approvals.mode=off: bypass all approval prompts.
     # Gateway /yolo is session-scoped; CLI --yolo remains process-scoped.


### PR DESCRIPTION
## Summary
- add config-gated trusted read-only HTTP approval bypass for literal urllib GET probes
- add focused regression coverage for trusted read-only HTTP approval behavior
- add local-provider empty-stream retry fallback that disables streaming for the session
- document AGENTS.md child-index / durable-doc update expectations

## Safety
- trusted HTTP bypass is inert by default because trusted_readonly_http_prefixes defaults to []
- bypass only allows literal HTTP/HTTPS GET URLs matching configured prefixes
- rejects POST/data/method keywords, unsafe imports, dynamic execution, shell/process operations, and untrusted URLs
- local empty-stream fallback is scoped to local OpenAI-compatible endpoints

## Tests
- git diff --check origin/main..HEAD
- python3.14 -m py_compile tools/approval.py hermes_cli/config.py agent/chat_completion_helpers.py
- pytest approval subset: 351 passed
- broader local-only subset: 560 passed, 2 skipped
- real Hermes CLI oneshot smoke: HERMES_REBASED_LOCAL_COMMIT_SMOKE_OK
