### PR TITLE
fix(skills): include user taps in default search

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1302,6 +1302,23 @@ class TestCreateSourceRouter:
         gh_idx = next(i for i, src in enumerate(sources) if isinstance(src, GitHubSource))
         assert url_idx < gh_idx
 
+    def test_user_taps_are_split_from_default_github_source(self, monkeypatch):
+        monkeypatch.setattr(
+            "tools.skills_hub.TapsManager",
+            lambda: type("Mgr", (), {
+                "list_taps": lambda self: [{"repo": "owner/repo", "path": "skills/"}],
+            })(),
+        )
+
+        sources = create_source_router(auth=MagicMock(spec=GitHubAuth))
+        github_sources = [src for src in sources if isinstance(src, GitHubSource)]
+
+        assert len(github_sources) == 2
+        assert github_sources[0].user_tap_source is False
+        assert github_sources[0].taps == GitHubSource.DEFAULT_TAPS
+        assert github_sources[1].user_tap_source is True
+        assert github_sources[1].taps == [{"repo": "owner/repo", "path": "skills/"}]
+
 
 # ---------------------------------------------------------------------------
 # HubLockFile
@@ -2471,3 +2488,35 @@ class TestParallelSearchSourcesTimeout:
         assert source_counts.get("a") == 1
         assert source_counts.get("b") == 1
         assert len(all_results) == 2
+
+    def test_index_available_keeps_user_github_taps(self):
+        """Default search skips indexed API sources, but not user taps.
+
+        Custom taps live in the user's local taps.json, so the centralized
+        index cannot cover them. Regression for #14466.
+        """
+        index = _FakeSource("hermes-index", results=[])
+        index.is_available = True
+
+        default_github = _FakeSource("github", results=[self._meta("default")])
+        default_called = {"value": False}
+
+        def _default_search(_query: str, limit: int = 10) -> List[SkillMeta]:
+            default_called["value"] = True
+            return [self._meta("default")]
+
+        default_github.search = _default_search  # type: ignore[method-assign]
+
+        user_tap = _FakeSource("github", results=[self._meta("user-tap")])
+        user_tap.user_tap_source = True
+
+        all_results, source_counts, timed_out_ids = parallel_search_sources(
+            [index, default_github, user_tap],
+            query="my-fancy-skill",
+            overall_timeout=1,
+        )
+
+        assert default_called["value"] is False
+        assert timed_out_ids == []
+        assert source_counts == {"hermes-index": 0, "github": 1}
+        assert [r.identifier for r in all_results] == ["user-tap/x"]

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -527,11 +527,18 @@ class GitHubSource(SkillSource):
         {"repo": "garrytan/gstack", "path": ""},
     ]
 
-    def __init__(self, auth: GitHubAuth, extra_taps: Optional[List[Dict]] = None):
+    def __init__(
+        self,
+        auth: GitHubAuth,
+        extra_taps: Optional[List[Dict]] = None,
+        include_default_taps: bool = True,
+        user_tap_source: bool = False,
+    ):
         self.auth = auth
-        self.taps = list(self.DEFAULT_TAPS)
+        self.taps = list(self.DEFAULT_TAPS) if include_default_taps else []
         if extra_taps:
             self.taps.extend(extra_taps)
+        self.user_tap_source = user_tap_source
         # Per-instance cache: repo -> (default_branch, tree_entries)
         # Survives within a single search/install flow, avoiding redundant API calls.
         self._tree_cache: Dict[str, Tuple[str, List[dict]]] = {}
@@ -3920,12 +3927,28 @@ def create_source_router(auth: Optional[GitHubAuth] = None) -> List[SkillSource]
         SkillsShSource(auth=auth),
         WellKnownSkillSource(),
         UrlSource(),                  # Direct HTTP(S) URL to a SKILL.md file
-        GitHubSource(auth=auth, extra_taps=extra_taps),
+        GitHubSource(auth=auth),
         ClawHubSource(),
         ClaudeMarketplaceSource(auth=auth),
         LobeHubSource(),
         BrowseShSource(),   # browse.sh: 169+ site-specific browser automation skills
     ]
+
+    if extra_taps:
+        # User-configured taps are not part of the centralized Hermes index.
+        # Keep them as a separate GitHub source so the "index is available"
+        # optimization can still skip the built-in GitHub taps while searching
+        # the user's own repos. (#14466)
+        github_idx = next(i for i, src in enumerate(sources) if isinstance(src, GitHubSource))
+        sources.insert(
+            github_idx + 1,
+            GitHubSource(
+                auth=auth,
+                extra_taps=extra_taps,
+                include_default_taps=False,
+                user_tap_source=True,
+            ),
+        )
 
     return sources
 
@@ -3988,8 +4011,14 @@ def parallel_search_sources(
         sid = src.source_id()
         if _effective_filter != "all" and sid != _effective_filter and sid != "official":
             continue
-        # Skip external API sources when the index covers them
-        if _index_available and sid in _api_source_ids:
+        # Skip external API sources when the index covers them. User-configured
+        # GitHub taps are local configuration, not index content, so they must
+        # still run under source_filter="all".
+        if (
+            _index_available
+            and sid in _api_source_ids
+            and not getattr(src, "user_tap_source", False)
+        ):
             continue
         active.append(src)
 


### PR DESCRIPTION
## Summary
- keep user-configured GitHub taps as a separate source from built-in GitHub taps
- continue skipping indexed API sources when the Hermes index is available
- still search the user tap source for `hermes skills search` / default `source=all` results

Fixes #14466.

## Why
When the centralized Hermes index is available, default search skips external API sources because the index covers built-in registries and taps. User-configured taps come from local `taps.json`, so they are not part of the central index. That made `hermes skills search my-skill` miss custom tap skills while `--source github` worked.

This keeps the existing performance optimization for built-in GitHub taps, but lets user taps participate in default search.

## Tests
- `.venv/bin/python -m pytest tests/tools/test_skills_hub.py -q -k 'user_taps_are_split or index_available_keeps_user_github_taps or source_filter or provider_filter'`\n- `.venv/bin/python -m pytest tests/tools/test_skills_hub.py -q`\n- `.venv/bin/python -m py_compile tools/skills_hub.py tests/tools/test_skills_hub.py`\n- `.venv/bin/python -m ruff check tools/skills_hub.py tests/tools/test_skills_hub.py`\n- `git diff --check`