### PR TITLE
fix(desktop): preserve project cwd for new sessions

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { getSessionMessages, type SessionInfo } from '@/hermes'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { $activeGatewayProfile, $newChatProfile } from '@/store/profile'
+import { $projectScope, $projectTree, ALL_PROJECTS } from '@/store/projects'
 import {
   $activeSessionId,
   $currentCwd,
@@ -113,6 +114,8 @@ describe('createBackendSessionForSend profile routing', () => {
     cleanup()
     $newChatProfile.set(null)
     $activeGatewayProfile.set('default')
+    $projectScope.set(ALL_PROJECTS)
+    $projectTree.set([])
     $currentCwd.set('')
     vi.restoreAllMocks()
   })
@@ -154,6 +157,24 @@ describe('createBackendSessionForSend profile routing', () => {
     })
 
     expect(params).toMatchObject({ cwd: '/remote/worktree' })
+  })
+
+  it('falls back to the entered project cwd when the current cwd is blank', async () => {
+    const params = await createWith(() => {
+      $projectTree.set([
+        {
+          id: 'p_app',
+          label: 'App',
+          path: '/repo/app',
+          repos: [{ groups: [], id: '/repo/app', label: 'app', path: '/repo/app', sessionCount: 0 }],
+          sessionCount: 0
+        }
+      ])
+      $projectScope.set('p_app')
+      $currentCwd.set('')
+    })
+
+    expect(params).toMatchObject({ cwd: '/repo/app' })
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -38,8 +38,7 @@ import {
   setSessionStartedAt,
   setSessionsTotal,
   setTurnStartedAt,
-  setYoloActive,
-  workspaceCwdForNewSession
+  setYoloActive
 } from '@/store/session'
 import { broadcastSessionsChanged } from '@/store/session-sync'
 import { isWatchWindow } from '@/store/windows'
@@ -163,7 +162,7 @@ export function useSessionActions({
         // a backend resolves its own launch profile to None (_profile_home).
         const newChatProfile = $newChatProfile.get() ?? normalizeProfileKey($activeGatewayProfile.get())
         await ensureGatewayProfile(newChatProfile)
-        const cwd = $currentCwd.get().trim() || workspaceCwdForNewSession()
+        const cwd = $currentCwd.get().trim() || resolveNewSessionCwd()
         // The composer's model/effort/fast is sticky UI state ($currentModel,
         // $currentProvider, $currentReasoningEffort, $currentFastMode). Ship it
         // with every session.create so the new chat opens on whatever the picker


### PR DESCRIPTION
## Summary
- keep Desktop `session.create` project-aware when the current cwd is blank
- reuse `resolveNewSessionCwd()` at the backend session creation boundary so entered projects still provide their root cwd
- add a regression test for creating a new session inside a project after `$currentCwd` has been cleared

Addresses #54898.

## Tests
- `NODE_OPTIONS="--localstorage-file=/tmp/hermes-vitest-localstorage.json" npm --workspace apps/desktop run test:ui -- src/app/session/hooks/use-session-actions.test.tsx`
- `NODE_OPTIONS="--localstorage-file=/tmp/hermes-vitest-localstorage.json" npm --workspace apps/desktop run test:ui -- src/app/session/hooks/use-session-actions.test.tsx src/store/projects.test.ts`
- `npm --workspace apps/desktop exec eslint src/app/session/hooks/use-session-actions/index.ts src/app/session/hooks/use-session-actions.test.tsx`
- `npm --workspace apps/desktop run typecheck`
- `git diff --check`