### PR TITLE
fix(kanban): recover from broken board DBs without silent retry loop

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -972,6 +972,108 @@ class GatewayKanbanWatchersMixin:
                 or "database disk image is malformed" in msg
             )
 
+        # Tables created by SCHEMA_SQL (kanban_db.py). A "no such table"
+        # error naming one of these means the DB file opened cleanly (it's
+        # not corrupt — see `_is_corrupt_board_db_error` above) but never
+        # got its schema, or lost it after this process already cached the
+        # resolved path in `_kb._INITIALIZED_PATHS`. That cache is
+        # process-local and keyed by path only: `connect()` skips schema
+        # creation on every call after the first successful one for a given
+        # path, so if the file underneath gets replaced/truncated/wiped
+        # out-of-band (external cleanup, board reset), every subsequent
+        # tick keeps opening the same gutted file and failing forever —
+        # what happened to board `test-05-regression-02` on 2026-06-28
+        # (~85 consecutive "no such table: tasks" ticks over 84 minutes,
+        # only resolved once something outside the gateway process ran
+        # `hermes kanban init` and rewrote the file).
+        _SCHEMA_TABLES = frozenset({
+            "tasks", "task_links", "task_comments", "task_events",
+            "task_runs", "task_attachments", "kanban_notify_subs",
+        })
+
+        def _is_missing_schema_error(exc: Exception) -> bool:
+            # Deliberately narrow: only `OperationalError: no such table:
+            # <schema table>`. Does NOT match "database is locked" or other
+            # OperationalError shapes from ordinary WAL/lock contention —
+            # those already retry fine on the next tick and must not be
+            # treated as broken-board state.
+            if not isinstance(exc, sqlite3.OperationalError):
+                return False
+            msg = str(exc).lower().strip()
+            if not msg.startswith("no such table:"):
+                return False
+            table = msg.split(":", 1)[1].strip()
+            return table in _SCHEMA_TABLES
+
+        def _board_structure_diagnostics(slug: str) -> str:
+            """Describe what's missing on disk, for the alert log line
+            only — never used as a detection trigger by itself. Actual
+            healthy boards vary a lot in which of these exist (e.g. a
+            board with no tasks yet has no logs/; several boards in this
+            install have no workspaces/), so gating on directory contents
+            directly would over-trigger on ordinary idle boards."""
+            d = _kb.board_dir(slug)
+            missing = [
+                name for name in ("board.json", "logs", "workspaces")
+                if not (d / name).exists()
+            ]
+            return (
+                f"missing on disk: {', '.join(missing)}" if missing
+                else "directory structure looks intact"
+            )
+
+        # One clean cache-invalidation is attempted per (board, fingerprint)
+        # the first time a missing-schema error is seen for it. If the
+        # NEXT tick against that same fingerprint still fails the same way,
+        # invalidating the cache didn't help — quarantine via
+        # `disabled_corrupt_boards` instead of retrying forever.
+        schema_reinit_attempted: dict[
+            str, tuple[tuple[str, int | None, int | None], float]
+        ] = {}
+
+        def _handle_missing_schema(
+            slug: str,
+            fingerprint: tuple[str, int | None, int | None],
+            exc: Exception,
+        ) -> bool:
+            """Returns True if this tick's error was handled here (caller
+            should return None without falling through to the generic
+            `logger.exception` path)."""
+            if not _is_missing_schema_error(exc):
+                return False
+            attempted = schema_reinit_attempted.get(slug)
+            if attempted is not None and attempted[0] == fingerprint:
+                # Already invalidated the cache for this exact file state
+                # on a prior tick and the NEXT tick's connect() still
+                # couldn't find the schema — it's not a stale-cache issue,
+                # something is actually wrong with the file. Stop
+                # hammering it every tick.
+                schema_reinit_attempted.pop(slug, None)
+                disabled_corrupt_boards[slug] = (fingerprint, time.monotonic())
+                logger.error(
+                    "kanban dispatcher: board %s database %s is still "
+                    "missing core tables after a cache-invalidated retry "
+                    "(%s); pausing dispatch for this board until the file "
+                    "changes, the gateway restarts, or the quarantine "
+                    "timer expires. %s. Investigate manually, then run "
+                    "`hermes kanban init` for this board if it's safe to "
+                    "recreate.",
+                    slug, fingerprint[0], exc,
+                    _board_structure_diagnostics(slug),
+                )
+                return True
+            logger.error(
+                "kanban dispatcher: board %s database %s is missing core "
+                "tables (%s); %s. Invalidating this process's schema cache "
+                "for the board so the next scheduled tick's connect() "
+                "re-creates the schema; will quarantine if that doesn't "
+                "fix it.",
+                slug, fingerprint[0], exc, _board_structure_diagnostics(slug),
+            )
+            schema_reinit_attempted[slug] = (fingerprint, time.monotonic())
+            _kb.invalidate_cached_schema(board=slug)
+            return True
+
         def _tick_once_for_board(slug: str) -> "Optional[object]":
             """Run one dispatch_once for a specific board.
 
@@ -1036,6 +1138,8 @@ class GatewayKanbanWatchersMixin:
                         fingerprint[0],
                     )
                     return None
+                if _handle_missing_schema(slug, fingerprint, exc):
+                    return None
                 logger.exception("kanban dispatcher: tick failed on board %s", slug)
                 return None
             except Exception as exc:
@@ -1050,6 +1154,8 @@ class GatewayKanbanWatchersMixin:
                         slug,
                         fingerprint[0],
                     )
+                    return None
+                if _handle_missing_schema(slug, fingerprint, exc):
                     return None
                 logger.exception("kanban dispatcher: tick failed on board %s", slug)
                 return None

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1849,6 +1849,43 @@ def init_db(
     return path
 
 
+def invalidate_cached_schema(
+    db_path: Optional[Path] = None,
+    *,
+    board: Optional[str] = None,
+) -> Path:
+    """Drop the process-local "already initialized" cache entry for a
+    board's DB path, without opening a second connection.
+
+    Unlike :func:`init_db` — which busts the cache AND immediately opens
+    its own `connect()` to re-run the migration right then — this only
+    clears the cache bit. Whichever caller naturally calls `connect()`
+    for this path next (on its own schedule, its own connection) will
+    see the path is no longer cached and safely redo the schema/migration
+    pass under the normal init lock, as a single connection.
+
+    Exists for callers that detected a broken/gutted DB file (e.g. the
+    kanban dispatcher's tick loop, see `kanban_watchers.py`) and need it
+    to self-heal on the next natural connection — not `init_db()`,
+    which those callers must never invoke directly: a second connection
+    doing schema work in the same pass as the first can race it (see
+    `init_db`'s callers in `gateway/kanban_watchers.py` and issue #21378
+    for the incident this caused when the dispatcher and notifier watchers
+    each called `init_db()` unconditionally).
+    """
+    if db_path is not None:
+        path = db_path
+    else:
+        path = kanban_db_path(board=board)
+    try:
+        resolved = str(path.resolve())
+    except Exception:
+        resolved = str(path)
+    with _INIT_LOCK:
+        _INITIALIZED_PATHS.discard(resolved)
+    return path
+
+
 def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     """Add columns that were introduced after v1 release to legacy DBs.
 

--- a/tests/hermes_cli/test_kanban_broken_board_recovery.py
+++ b/tests/hermes_cli/test_kanban_broken_board_recovery.py
@@ -1,0 +1,277 @@
+"""Regression tests for PR #58244 — broken-board DB recovery without silent retry loop.
+
+Covers two behaviours added in kanban_watchers.py + kanban_db.py:
+
+1. Recovery path: when a cached board's DB is replaced or truncated out-of-band,
+   the next natural dispatcher tick detects the missing-schema error, invalidates
+   the cache entry, and the *following* tick's connect() rebuilds the schema —
+   without ever calling init_db() directly from the watcher.
+
+2. Quarantine path: if the schema is still missing after the cache-invalidation
+   recovery attempt (i.e. the DB is genuinely corrupt/unrecoverable), the board
+   is quarantined via disabled_corrupt_boards and no further ticks are attempted.
+
+Fixture pattern mirrors test_kanban_boards.py:fresh_home (local fixture, not in
+conftest) and dispatcher harness mirrors test_kanban_core_functionality.py:3672.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_WORKTREE = Path(__file__).resolve().parents[2]
+if str(_WORKTREE) not in sys.path:
+    sys.path.insert(0, str(_WORKTREE))
+
+import hermes_cli.kanban_db as _kb
+
+
+# ---------------------------------------------------------------------------
+# Fixture — mirrors test_kanban_boards.py:fresh_home exactly.
+# Cannot import it directly as it is local to that module.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def fresh_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with clean kanban state and reset module-level cache."""
+    home = tmp_path / "hermes_home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for var in (
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_WORKSPACES_ROOT",
+        "HERMES_KANBAN_HOME",
+        "HERMES_KANBAN_BOARD",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    try:
+        import hermes_constants
+        hermes_constants._cached_default_hermes_root = None  # type: ignore[attr-defined]
+    except Exception:
+        pass
+    _kb._INITIALIZED_PATHS.clear()
+    return home
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _warm_cache(slug: str) -> Path:
+    """Create a board, connect to it (populating _INITIALIZED_PATHS), return db path."""
+    _kb.create_board(slug)
+    db_path = _kb.kanban_db_path(board=slug)
+    with _kb.connect(board=slug) as conn:
+        _kb.create_task(conn, title="seed-task", assignee="dev")
+    assert str(db_path.resolve()) in _kb._INITIALIZED_PATHS, (
+        "Cache warm-up failed — _INITIALIZED_PATHS does not contain board path"
+    )
+    return db_path
+
+
+def _make_dispatcher_runner(monkeypatch, slug: str, dispatch_interval: int = 1):
+    """Return a GatewayRunner wired to dispatch only the given board slug."""
+    from gateway.run import GatewayRunner
+    import hermes_cli.config as _cfg_mod
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+
+    monkeypatch.setattr(
+        _cfg_mod,
+        "load_config",
+        lambda: {
+            "kanban": {
+                "dispatch_in_gateway": True,
+                "dispatch_interval_seconds": dispatch_interval,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        _kb,
+        "list_boards",
+        lambda include_archived=False: [{"slug": slug}],
+    )
+    monkeypatch.setattr(
+        _kb,
+        "read_board_metadata",
+        lambda s: {"slug": s},
+    )
+    return runner
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — Recovery path
+# ---------------------------------------------------------------------------
+
+def test_broken_board_db_recovery_via_cache_invalidation(
+    fresh_home, monkeypatch, caplog
+):
+    """Cache invalidation on missing-schema error allows schema rebuild on next tick.
+
+    Sequence:
+      1. Warm _INITIALIZED_PATHS by connecting to a real board.
+      2. Replace the DB file with an empty/truncated file out-of-band.
+      3. Drive the real dispatcher watcher for enough ticks to cover:
+           - Tick N  : detects OperationalError(no such table), calls
+                       invalidate_cached_schema(), returns without retrying.
+           - Tick N+1: _INITIALIZED_PATHS cache entry is gone; connect()
+                       runs the schema-init pass and rebuilds the schema.
+      4. Assert init_db() was never called directly from within the watcher.
+      5. Assert the DB is readable with a valid schema after recovery.
+    """
+    SLUG = "recovery-test"
+    db_path = _warm_cache(SLUG)
+
+    # Replace the DB with an empty file — triggers "no such table" on next connect.
+    db_path.write_bytes(b"")
+
+    runner = _make_dispatcher_runner(monkeypatch, SLUG, dispatch_interval=1)
+
+    init_db_calls: list[str] = []
+    _real_init_db = _kb.init_db
+
+    def _spy_init_db(*args, **kwargs):
+        init_db_calls.append("called")
+        return _real_init_db(*args, **kwargs)
+
+    with caplog.at_level(logging.WARNING, logger="hermes"):
+        with patch.object(_kb, "init_db", side_effect=_spy_init_db):
+            # 4 seconds gives the 1-second dispatcher at least 3 full ticks:
+            # tick 1 = detects error + invalidates cache
+            # tick 2 = schema rebuild via normal connect()
+            # tick 3 = confirms board is stable
+            try:
+                asyncio.run(
+                    asyncio.wait_for(
+                        runner._kanban_dispatcher_watcher(),
+                        timeout=12.0,
+                    )
+                )
+            except asyncio.TimeoutError:
+                pass  # Expected — watcher runs until cancelled.
+
+    # Core assertion: init_db() must never be called directly from the watcher.
+    assert init_db_calls == [], (
+        "init_db() was called directly from the dispatcher watcher — "
+        "this reintroduces the race condition from issue #21378. "
+        "Recovery must go through cache invalidation + natural connect() only."
+    )
+
+    # The DB must be readable with a valid schema after recovery.
+    with _kb.connect(board=SLUG) as conn:
+        rows = conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    table_names = {r[0] for r in rows}
+    assert "tasks" in table_names, (
+        f"Schema was not rebuilt after cache invalidation. Tables found: {table_names}"
+    )
+
+    # Cache entry must be repopulated (connect() re-warmed it on tick N+1).
+    assert str(db_path.resolve()) in _kb._INITIALIZED_PATHS, (
+        "Cache entry was not repopulated after recovery — "
+        "subsequent connects will re-run schema init on every tick."
+    )
+
+    # The first-attempt log must have fired (confirms recovery path was taken,
+    # not the generic corrupt-board path).
+    # Exact message fragment from kanban_watchers.py:1069.
+    first_attempt_logs = [
+        r for r in caplog.records
+        if SLUG in r.message and "will quarantine if that doesn't fix it" in r.message
+    ]
+    assert len(first_attempt_logs) == 1, (
+        f"Expected exactly one cache-invalidation log for '{SLUG}', "
+        f"got {len(first_attempt_logs)}. Records: {[r.message for r in caplog.records]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — Quarantine path
+# ---------------------------------------------------------------------------
+
+def test_broken_board_db_quarantined_on_repeated_schema_failure(
+    fresh_home, monkeypatch, caplog
+):
+    """Board is quarantined after repeated missing-schema errors, not retried each tick.
+
+    disabled_corrupt_boards is a local variable inside _kanban_dispatcher_watcher,
+    not an attribute on GatewayRunner. Quarantine is observed via the ERROR log
+    message emitted when the board is paused (kanban_watchers.py:1057).
+
+    Sequence:
+      1. Warm cache.
+      2. Replace DB with a valid-but-schema-less SQLite file and patch init_db
+         to be a no-op so the schema can never be rebuilt — simulates a DB that
+         is permanently unrecoverable within this process.
+      3. Drive the real dispatcher watcher for enough ticks to trigger:
+           - Tick N  : first missing-schema error → cache invalidated, logged.
+           - Tick N+1: same fingerprint still fails → board quarantined, logged.
+           - Tick N+2: board is in disabled_corrupt_boards → skipped entirely.
+      4. Assert the quarantine log fired exactly once.
+      5. Assert no further dispatch attempts occur after quarantine.
+    """
+    SLUG = "quarantine-test"
+    db_path = _warm_cache(SLUG)
+
+    # Patch connect() to always raise the exact OperationalError that
+    # _is_missing_schema_error() matches (kanban_watchers.py:994).
+    # This guarantees both tick N (cache invalidation) and tick N+1
+    # (quarantine) see the error on every call, simulating a DB that
+    # is permanently unrecoverable within this process.
+    # We do NOT patch init_db — the error fires before init_db is
+    # reached, so patching connect() is sufficient and cleaner.
+    _missing_schema_exc = sqlite3.OperationalError("no such table: tasks")
+
+    runner = _make_dispatcher_runner(monkeypatch, SLUG, dispatch_interval=1)
+
+    # Track connect() calls so we can assert dispatch stops after quarantine.
+    connect_calls: list[float] = []
+
+    def _always_raise_missing_schema(*args, **kwargs):
+        import time
+        connect_calls.append(time.monotonic())
+        raise _missing_schema_exc
+
+    with caplog.at_level(logging.ERROR, logger="hermes"):
+        with patch.object(_kb, "connect", side_effect=_always_raise_missing_schema):
+                try:
+                    asyncio.run(
+                        asyncio.wait_for(
+                            runner._kanban_dispatcher_watcher(),
+                            timeout=14.0,
+                        )
+                    )
+                except asyncio.TimeoutError:
+                    pass
+
+    # Quarantine log must have fired exactly once.
+    # Exact message fragment from kanban_watchers.py:1057.
+    quarantine_logs = [
+        r for r in caplog.records
+        if SLUG in r.message and "pausing dispatch for this board" in r.message
+    ]
+    assert len(quarantine_logs) == 1, (
+        f"Expected exactly one quarantine log for '{SLUG}', "
+        f"got {len(quarantine_logs)}. "
+        f"Records: {[r.message for r in caplog.records if SLUG in r.message]}"
+    )
+
+    # After quarantine, connect() must not be called again.
+    # Quarantine fires on tick N+1 (~2s in). Remaining ~3s are tick N+2 onward.
+    # If connect() is called after the quarantine log timestamp, board is still
+    # being retried.
+    quarantine_time = quarantine_logs[0].created  # log record timestamp (epoch float)
+    post_quarantine_connects = [t for t in connect_calls if t > quarantine_time]
+    assert post_quarantine_connects == [], (
+        f"connect() was called {len(post_quarantine_connects)} time(s) after "
+        f"quarantine was logged — board is still being dispatched. "
+        f"connect() call times: {connect_calls}, quarantine at: {quarantine_time}"
+    )


### PR DESCRIPTION
Problem
When a board's DB file is replaced or truncated out-of-band (external cleanup, manual reset), the dispatcher's process-local schema-init cache (_INITIALIZED_PATHS) still marks the path as initialized. Every subsequent tick opens the gutted file, hits sqlite3.OperationalError: no such table: tasks, and retries — forever, silently, until the gateway restarts or someone manually runs hermes kanban init.
Confirmed production incident: board test-05-regression-02, 2026-06-28, ~85 consecutive failing ticks over 84 minutes.
Fix

kanban_db.py: adds invalidate_cached_schema() — a cache-bust-only counterpart to init_db(). Clears the _INITIALIZED_PATHS entry under _INIT_LOCK without opening a second connection.
kanban_watchers.py: adds _is_missing_schema_error() to detect no such table: <schema table> errors distinctly from DB corruption or ordinary lock contention. On first detection for a board, calls invalidate_cached_schema() and returns — the next scheduled tick's normal connect() redoes the schema pass as a single connection. If the same fingerprint fails again after that, the board is quarantined via disabled_corrupt_boards with a clear log alert instead of retrying indefinitely.

Why invalidate_cached_schema() instead of init_db()
Calling init_db() directly from the dispatcher tick would reintroduce the race condition from issue #21378 (dispatcher and notifier each calling init_db() unconditionally, causing duplicate-column tracebacks and intermittent lock errors). This is enforced by existing regression tests in test_kanban_notify.py that explicitly assert init_db() must never be called from watcher source. The cache-invalidation approach avoids this entirely — recovery takes one extra dispatch interval (~60s) in exchange for never opening a second connection inside the detection tick.