### PR TITLE
fix(dashboard-auth): skip password-only providers in auto-SSO redirect (#58237)

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -177,7 +177,11 @@ def _auto_sso_response(request: Request) -> Response | None:
 
     # list_session_providers() already filters on supports_session=True, so
     # token-only credentials (drain/service providers) are never candidates.
-    providers = list_session_providers()
+    # Also drop password-only providers: their start_login() is a stub that
+    # raises NotImplementedError (there's no OAuth redirect to auto-initiate),
+    # so /auth/login would 500. They render the /login credential form instead,
+    # which is exactly the fall-through when this returns None.
+    providers = [p for p in list_session_providers() if not p.supports_password]
     if len(providers) != 1:
         # Zero → nothing to redirect to. Two+ → user must choose at /login.
         return None

--- a/tests/hermes_cli/test_dashboard_auth_password_login.py
+++ b/tests/hermes_cli/test_dashboard_auth_password_login.py
@@ -441,3 +441,29 @@ class TestLoginPageRender:
             assert "<script>" in html
         finally:
             clear_providers()
+
+
+# ---------------------------------------------------------------------------
+# Auto-SSO fall-through — password-only provider has no OAuth redirect
+# ---------------------------------------------------------------------------
+
+
+class TestAutoSsoSkipsPasswordOnlyProvider:
+    """Regression: with only a password-only provider registered, an unauth
+    HTML load must fall back to the /login credential form, NOT auto-initiate
+    the OAuth redirect. Password-only providers implement complete_password_login
+    and leave start_login a NotImplementedError stub, so /auth/login would 500.
+    """
+
+    def test_unauth_html_load_falls_back_to_login_not_auto_sso(self, gated_app):
+        r = gated_app.get("/", follow_redirects=False)
+        assert r.status_code == 302
+        # Interstitial credential form, not the OAuth-initiation route.
+        assert r.headers["location"].startswith("/login")
+        assert "/auth/login" not in r.headers["location"]
+
+    def test_unauth_html_load_does_not_500(self, gated_app):
+        # End-to-end: following the redirect must land on the login page,
+        # never the NotImplementedError 500 from start_login().
+        r = gated_app.get("/", follow_redirects=True)
+        assert r.status_code == 200


### PR DESCRIPTION
## What does this PR do?

Fixes a 500 Internal Server Error when the dashboard is secured with **only** a password-only auth provider (e.g. basic auth) and visited unauthenticated.

`_auto_sso_response()` in `hermes_cli/dashboard_auth/middleware.py` auto-initiates the portal OAuth redirect when exactly one interactive (session) provider is registered. It filtered candidates via `list_session_providers()` (which only checks `supports_session=True`), so a password-only provider like basic auth was treated as a redirect provider. The middleware then 302'd to `/auth/login?provider=basic`, whose `start_login()` is a `NotImplementedError` stub for password-only providers — yielding a 500 instead of the login form.

The fix drops password-only providers (`supports_password=True`) from the auto-SSO candidate list. When none remain the function returns `None`, and the middleware falls through to its ordinary `_unauth_response`, which already redirects HTML navigation to `/login` (the credential form) and returns 401 JSON for `/api/*`. Only the auto-SSO fast-path had the bug.

## Related Issue

Fixes #58237

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/dashboard_auth/middleware.py` — in `_auto_sso_response`, filter out `supports_password` providers before the single-provider auto-redirect check (they have no OAuth `start_login` to initiate).
- `tests/hermes_cli/test_dashboard_auth_password_login.py` — add `TestAutoSsoSkipsPasswordOnlyProvider`: with only a password-only provider registered, an unauth HTML load falls back to `/login` (not `/auth/login`) and does not 500.

## How to Test

```
scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_password_login.py tests/hermes_cli/test_dashboard_auth_401_reauth.py tests/hermes_cli/test_dashboard_auth_middleware.py
```

Result: **98 passed**. The two new tests fail against `upstream/main` (reproducing the `NotImplementedError` 500 from `start_login()`) and pass with this change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
