### PR TITLE
fix(skills): update himalaya flag add/remove syntax for v1.2.0

### DIFF
--- a/skills/email/himalaya/SKILL.md
+++ b/skills/email/himalaya/SKILL.md
@@ -233,16 +233,27 @@ himalaya message delete 42
 
 ### Manage Flags
 
+In himalaya v1.2.0+, the ``flag`` subcommand takes positional arguments:
+every integer is a message ID, every other token is the flag name. The
+old ``--flag <name>`` syntax was removed and prints
+``error: unexpected argument --flag found``.
+
 Add flag:
 
 ```bash
-himalaya flag add 42 --flag seen
+himalaya flag add 42 seen
 ```
 
 Remove flag:
 
 ```bash
-himalaya flag remove 42 --flag seen
+himalaya flag remove 42 seen
+```
+
+Batch — mark several messages at once (any number of IDs, then the flag):
+
+```bash
+himalaya flag add 42 43 44 seen
 ```
 
 ## Multiple Accounts


### PR DESCRIPTION
## Summary

The himalaya v1.2.0 `flag` subcommand no longer accepts `--flag <name>`. It now takes positional arguments: every integer is a message ID, every other token is the flag name. Refresh the bundled skill's examples and add a batch-form note.

## Changes

- `skills/email/himalaya/SKILL.md` — replace the two outdated `himalaya flag add 42 --flag seen` / `himalaya flag remove 42 --flag seen` examples with positional-arg form; add an explanatory paragraph citing the v1.2.0 change and showing a batch example (`himalaya flag add 42 43 44 seen`).

No test required — the bundled skill loads its instructions verbatim into the agent context; the change is content-only.

## How to Test

Manual:
```
himalaya flag add 42 seen        # works on himalaya >= 1.2.0
himalaya flag remove 42 seen
himalaya flag add 42 43 44 seen   # batch
```

Or load the skill via Hermes and ask the agent to "flag message 42 as seen" — the skill's example block now matches the real CLI.

## Checklist

- [x] One-file content fix
- [x] Follows Conventional Commits
- [x] Cross-platform impact — none (markdown only; himalaya is the macOS/Linux/WSL CLI behind the skill)
- [x] profile-safe paths used — no path code touched
- [x] .env not used for non-credential settings — no config surface

## Risk & Impact

Minimal. Documentation-only change in a bundled skill. The old `--flag <name>` syntax is shown nowhere else in the repo (checked via grep of the skill directory) so this is a complete replacement rather than a parallel addition.

Type: Bug fix
Closes: #58239