### PR TITLE
fix(desktop): keep current OpenRouter model in picker

### DIFF
--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -100,3 +100,28 @@ describe('ModelMenuPanel MoA presets', () => {
     expect(onSelectModel).toHaveBeenCalledWith({ model: 'BeastMode', provider: 'moa' })
   })
 })
+
+describe('ModelMenuPanel current model fallback', () => {
+  it('keeps the current OpenRouter model visible when the catalog omits it', async () => {
+    $currentProvider.set('openrouter')
+    $currentModel.set('qwen/qwen-2.5-72b-instruct')
+    getGlobalModelOptions.mockResolvedValueOnce({
+      model: 'qwen/qwen-2.5-72b-instruct',
+      provider: 'openrouter',
+      providers: [
+        {
+          models: ['openai/gpt-4o-mini'],
+          name: 'OpenRouter',
+          slug: 'openrouter'
+        }
+      ]
+    })
+
+    renderPanel()
+
+    const row = await findByText(document.body, 'Qwen 2.5 72b Instruct')
+    const item = row.closest('[role="menuitem"]') ?? row.parentElement
+
+    expect(item?.querySelector('.codicon-check')).not.toBeNull()
+  })
+})

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -387,7 +387,13 @@ function groupModels(
   const groups: ProviderGroup[] = []
 
   for (const provider of providers) {
-    const allFamilies = collapseModelFamilies(provider.models ?? [])
+    const currentModel = current.model.trim()
+    const currentProvider = provider.slug === current.provider && currentModel
+    let allFamilies = collapseModelFamilies(provider.models ?? [])
+
+    if (currentProvider && !allFamilies.some(family => family.id === currentModel || family.fastId === currentModel)) {
+      allFamilies = [{ fastId: null, id: currentModel }, ...allFamilies]
+    }
 
     if (allFamilies.length === 0) {
       continue
@@ -417,10 +423,9 @@ function groupModels(
     // Always include the active model — but keep every row in the provider's
     // stable curated order (filter `allFamilies`, never reorder), so selecting
     // a model can't shuffle the list.
-    const activeId =
-      provider.slug === current.provider && current.model
-        ? allFamilies.find(family => family.id === current.model || family.fastId === current.model)?.id
-        : undefined
+    const activeId = currentProvider
+      ? allFamilies.find(family => family.id === currentModel || family.fastId === currentModel)?.id
+      : undefined
 
     const families = allFamilies.filter(family => shown.has(family.id) || family.id === activeId)
 


### PR DESCRIPTION
Fixes #57534.

## Summary
- keep the active model visible in the desktop model menu even when the provider catalog omits it
- preserve the existing curated order and visibility filtering for all catalog models
- add a regression test for an OpenRouter current model missing from the returned catalog

## Tests
- npm run test:ui -- src/app/shell/model-menu-panel.test.tsx
- npm run typecheck
- npx prettier --check src/app/shell/model-menu-panel.tsx src/app/shell/model-menu-panel.test.tsx
- git diff --check