### PR TITLE
fix: avoid fallback sends during Weixin cooldown

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4099,6 +4099,8 @@ class BasePlatformAdapter(ABC):
             return result
 
         error_str = result.error or ""
+        error_kind = result.error_kind or classify_send_error(None, error_str)
+        is_rate_limited = error_kind == "rate_limited"
         is_network = result.retryable or self._is_retryable_error(error_str)
 
         # Timeout errors are not safe to retry (message may have been
@@ -4106,7 +4108,7 @@ class BasePlatformAdapter(ABC):
         if not is_network and self._is_timeout_error(error_str):
             return result
 
-        if is_network:
+        if is_network or is_rate_limited:
             # Retry with exponential backoff for transient errors.
             # Honor server-requested retry_after (e.g. Telegram FloodWait)
             # when present — it is authoritative over our backoff schedule.
@@ -4132,12 +4134,25 @@ class BasePlatformAdapter(ABC):
                     logger.info("[%s] Send succeeded on retry %d", self.name, attempt)
                     return result
                 error_str = result.error or ""
+                error_kind = result.error_kind or classify_send_error(None, error_str)
+                is_rate_limited = error_kind == "rate_limited"
                 if result.retry_after is not None:
                     server_retry_after = result.retry_after
-                if not (result.retryable or self._is_retryable_error(error_str)):
+                if not (result.retryable or self._is_retryable_error(error_str) or is_rate_limited):
                     break  # error switched to non-transient — fall through to plain-text fallback
             else:
-                # All retries exhausted (loop completed without break) — notify user
+                # All retries exhausted (loop completed without break).  Do
+                # not immediately send a second fallback/notice when the
+                # platform is rate-limiting: that extra send hits the same
+                # cooldown and can extend the failure window (#21126/#31131).
+                if is_rate_limited:
+                    logger.error(
+                        "[%s] Failed to deliver response after %d rate-limit retries: %s",
+                        self.name,
+                        max_retries,
+                        error_str,
+                    )
+                    return result
                 logger.error("[%s] Failed to deliver response after %d retries: %s", self.name, max_retries, error_str)
                 notice = (
                     "\u26a0\ufe0f Message delivery failed after multiple attempts. "
@@ -4148,6 +4163,14 @@ class BasePlatformAdapter(ABC):
                 except Exception as notify_err:
                     logger.debug("[%s] Could not send delivery-failure notice: %s", self.name, notify_err)
                 return result
+
+        # Only formatting-style failures benefit from a plain-text fallback.
+        # Permission, not-found, and rate-limit failures are transport/state
+        # failures: re-sending the same payload with plainer markup cannot fix
+        # them and may worsen platform flood control.
+        error_kind = result.error_kind or classify_send_error(None, error_str)
+        if error_kind not in {"bad_format", "unknown"}:
+            return result
 
         # Non-network / post-retry formatting failure: try plain text as fallback
         logger.warning("[%s] Send failed: %s — trying plain-text fallback", self.name, error_str)

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -65,6 +65,7 @@ from gateway.platforms.base import (
     cache_audio_from_bytes,
     cache_document_from_bytes,
     cache_image_from_bytes,
+    classify_send_error,
 )
 from hermes_constants import get_hermes_home
 from utils import atomic_json_write
@@ -1694,6 +1695,17 @@ class WeixinAdapter(BasePlatformAdapter):
             f"iLink sendmessage rate limited; cooldown active for {self._rate_limit_cooldown_remaining():.1f}s"
         )
 
+    @staticmethod
+    def _retry_after_from_error(error: str) -> Optional[float]:
+        """Extract a useful retry_after from iLink/circuit-breaker text."""
+        match = re.search(r"cooldown active for\s+([0-9]+(?:\.[0-9]+)?)s", error, re.I)
+        if match:
+            try:
+                return max(0.0, float(match.group(1)))
+            except ValueError:
+                return None
+        return None
+
     def _open_rate_limit_circuit(self) -> None:
         if self._rate_limit_circuit_open_seconds <= 0:
             return
@@ -1901,7 +1913,14 @@ class WeixinAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=last_message_id)
         except Exception as exc:
             logger.error("[%s] send failed to=%s: %s", self.name, _safe_id(chat_id), exc)
-            return SendResult(success=False, error=str(exc))
+            error = str(exc)
+            kind = classify_send_error(exc, error)
+            return SendResult(
+                success=False,
+                error=error,
+                error_kind=kind,
+                retry_after=self._retry_after_from_error(error) if kind == "rate_limited" else None,
+            )
 
     async def _ensure_typing_ticket(self, chat_id: str) -> Optional[str]:
         """Return a valid typing ticket, refreshing from getConfig if expired.

--- a/tests/gateway/test_send_retry.py
+++ b/tests/gateway/test_send_retry.py
@@ -272,16 +272,35 @@ class TestSendWithRetryFallback:
         assert "plain text" in adapter._send_calls[1][1].lower()
 
     @pytest.mark.asyncio
-    async def test_fallback_failure_logged_but_not_raised(self):
+    async def test_forbidden_does_not_plain_text_fallback(self):
         adapter = _StubAdapter()
         adapter._send_results = [
             SendResult(success=False, error="Forbidden: bot blocked"),
-            SendResult(success=False, error="Forbidden: bot blocked"),
         ]
-        with patch("asyncio.sleep", new_callable=AsyncMock):
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
             result = await adapter._send_with_retry("chat1", "hello", max_retries=2)
         assert not result.success
-        assert len(adapter._send_calls) == 2  # original + fallback only
+        mock_sleep.assert_not_called()
+        assert len(adapter._send_calls) == 1  # original only; fallback cannot fix permissions
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_retries_without_plain_text_fallback_or_notice(self):
+        adapter = _StubAdapter()
+        limited = SendResult(
+            success=False,
+            error="iLink sendmessage rate limited; cooldown active for 30.0s",
+            error_kind="rate_limited",
+            retry_after=30.0,
+        )
+        adapter._send_results = [limited, limited]
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await adapter._send_with_retry("chat1", "hello", max_retries=1, base_delay=0)
+        assert not result.success
+        assert result.error_kind == "rate_limited"
+        assert len(adapter._send_calls) == 2  # original + delayed retry only
+        assert "plain text" not in adapter._send_calls[-1][1].lower()
+        first_sleep = mock_sleep.call_args_list[0][0][0]
+        assert first_sleep >= 30.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -772,6 +772,31 @@ class TestWeixinMediaBuilder:
         assert media_type == weixin.MEDIA_VOICE
 
 
+class TestWeixinSendFailureClassification:
+    def test_retry_after_from_cooldown_error(self):
+        assert WeixinAdapter._retry_after_from_error(
+            "iLink sendmessage rate limited; cooldown active for 30.0s"
+        ) == 30.0
+
+    def test_retry_after_absent_for_unstructured_error(self):
+        assert WeixinAdapter._retry_after_from_error("iLink sendmessage rate limited") is None
+
+    @patch.object(WeixinAdapter, "_send_text_chunk", new_callable=AsyncMock)
+    def test_send_classifies_rate_limited_failure(self, send_text_mock):
+        adapter = _make_adapter()
+        adapter._send_session = object()
+        adapter._token = "test-token"
+        send_text_mock.side_effect = RuntimeError(
+            "iLink sendmessage rate limited; cooldown active for 30.0s"
+        )
+
+        result = asyncio.run(adapter.send("wxid_test123", "hello"))
+
+        assert result.success is False
+        assert result.error_kind == "rate_limited"
+        assert result.retry_after == 30.0
+
+
 class TestWeixinSendImageFileParameterName:
     """Regression test for send_image_file parameter name mismatch.
 


### PR DESCRIPTION
## Summary

Fixes a Weixin/iLink delivery failure mode where a rate-limit/cooldown error immediately triggers the base adapter's plain-text fallback path. The fallback send hits the same iLink cooldown again, creating extra failed sends and potentially extending the platform flood-control window.

This PR:

- classifies Weixin send failures with `error_kind`
- extracts `retry_after` from `cooldown active for ...s`
- lets the base retry path honor rate-limit cooldowns
- skips delivery-failure notices/plain-text fallback when the transport is rate-limited
- keeps plain-text fallback for formatting/unknown failures only

## Motivation

Related to the Weixin delivery reliability reports around iLink rate limiting and message loss, especially:

- #21011
- #21126
- #31131

When iLink opens a cooldown circuit, immediately retrying with a plain-text fallback cannot repair the send. It is another platform send attempt during the same cooldown.

## Tests

```bash
scripts/run_tests.sh tests/gateway/test_send_retry.py tests/gateway/test_weixin.py -q
```

Result:

```text
111 tests passed, 0 failed
```
