### PR TITLE
fix(desktop): persist removed composer attachments

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
@@ -2,7 +2,13 @@ import { useAui, useAuiState, useComposerRuntime } from '@assistant-ui/react'
 import { type RefObject, useCallback, useEffect, useRef, useState } from 'react'
 
 import { SLASH_COMMAND_RE } from '@/lib/chat-runtime'
-import { $composerAttachments, type ComposerAttachment, stashSessionDraft, takeSessionDraft } from '@/store/composer'
+import {
+  $composerAttachments,
+  bindActiveComposerDraft,
+  type ComposerAttachment,
+  stashSessionDraft,
+  takeSessionDraft
+} from '@/store/composer'
 import { isBrowsingHistory } from '@/store/composer-input-history'
 
 import { cloneAttachments, DRAFT_PERSIST_DEBOUNCE_MS, type QueueEditState } from '../composer-utils'
@@ -163,6 +169,8 @@ export function useComposerDraft({
 
   const stashAt = (scope: string | null, text = draftRef.current, attachments = $composerAttachments.get()) =>
     stashSessionDraft(scope, text, attachments)
+
+  useEffect(() => bindActiveComposerDraft(activeQueueSessionKey, () => draftRef.current), [activeQueueSessionKey])
 
   const loadIntoComposer = (text: string, attachments: ComposerAttachment[]) => {
     $composerAttachments.set(cloneAttachments(attachments))

--- a/apps/desktop/src/store/composer.test.ts
+++ b/apps/desktop/src/store/composer.test.ts
@@ -1,8 +1,10 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import {
   $composerAttachments,
   addComposerAttachment,
+  bindActiveComposerDraft,
+  clearComposerAttachments,
   clearSessionDraft,
   type ComposerAttachment,
   removeComposerAttachment,
@@ -15,6 +17,24 @@ import {
 function attachment(overrides: Partial<ComposerAttachment> & Pick<ComposerAttachment, 'id'>): ComposerAttachment {
   return { kind: 'file', label: 'doc.pdf', ...overrides }
 }
+
+function createLocalStorage() {
+  const values = new Map<string, string>()
+
+  return {
+    clear: () => values.clear(),
+    getItem: (key: string) => values.get(key) ?? null,
+    removeItem: (key: string) => values.delete(key),
+    setItem: (key: string, value: string) => values.set(key, value)
+  }
+}
+
+beforeEach(() => {
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: createLocalStorage()
+  })
+})
 
 describe('updateComposerAttachment', () => {
   afterEach(() => {
@@ -105,5 +125,34 @@ describe('session drafts', () => {
     taken.attachments[0]!.label = 'mutated'
 
     expect(takeSessionDraft('session-a').attachments[0]?.label).toBe('doc.pdf')
+  })
+
+  it('persists removed attachments into the active session draft immediately', () => {
+    stashSessionDraft('session-a', 'draft text', [attachment({ id: 'file:a' }), attachment({ id: 'file:b' })])
+    $composerAttachments.set(takeSessionDraft('session-a').attachments)
+    const unbind = bindActiveComposerDraft('session-a', () => 'draft text')
+
+    try {
+      removeComposerAttachment('file:a')
+    } finally {
+      unbind()
+    }
+
+    expect(takeSessionDraft('session-a').attachments.map(item => item.id)).toEqual(['file:b'])
+    expect(takeSessionDraft('session-a').text).toBe('draft text')
+  })
+
+  it('persists cleared attachments into the active session draft immediately', () => {
+    stashSessionDraft('session-a', 'keep text', [attachment({ id: 'file:a' })])
+    $composerAttachments.set(takeSessionDraft('session-a').attachments)
+    const unbind = bindActiveComposerDraft('session-a', () => 'keep text')
+
+    try {
+      clearComposerAttachments()
+    } finally {
+      unbind()
+    }
+
+    expect(takeSessionDraft('session-a')).toEqual({ attachments: [], text: 'keep text' })
   })
 })

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -60,6 +60,8 @@ function loadPersistedDraftTexts(): [string, SessionDraft][] {
 }
 
 const draftsBySession = new Map<string, SessionDraft>(loadPersistedDraftTexts())
+let activeDraftScope: string | null | undefined
+let readActiveDraftText: (() => string) | null = null
 
 function persistDraftTexts() {
   try {
@@ -98,6 +100,26 @@ export function takeSessionDraft(scope: string | null | undefined): SessionDraft
 }
 
 export const clearSessionDraft = (scope: string | null | undefined) => stashSessionDraft(scope, '', [])
+
+export function bindActiveComposerDraft(scope: string | null | undefined, readText: () => string) {
+  activeDraftScope = scope
+  readActiveDraftText = readText
+
+  return () => {
+    if (readActiveDraftText === readText) {
+      activeDraftScope = undefined
+      readActiveDraftText = null
+    }
+  }
+}
+
+function stashActiveComposerAttachments(attachments: ComposerAttachment[]) {
+  if (!readActiveDraftText) {
+    return
+  }
+
+  stashSessionDraft(activeDraftScope, readActiveDraftText(), attachments)
+}
 
 export function setComposerDraft(value: string) {
   $composerDraft.set(value)
@@ -146,7 +168,12 @@ export function addComposerAttachment(attachment: ComposerAttachment) {
 export function removeComposerAttachment(id: string): ComposerAttachment | null {
   const current = $composerAttachments.get()
   const removed = current.find(attachment => attachment.id === id) || null
-  $composerAttachments.set(current.filter(attachment => attachment.id !== id))
+  const next = current.filter(attachment => attachment.id !== id)
+  $composerAttachments.set(next)
+
+  if (removed) {
+    stashActiveComposerAttachments(next)
+  }
 
   return removed
 }
@@ -172,6 +199,7 @@ export function updateComposerAttachment(attachment: ComposerAttachment): boolea
 
 export function clearComposerAttachments() {
   $composerAttachments.set([])
+  stashActiveComposerAttachments([])
 }
 
 /** Update only the upload state of an existing attachment (no-op if it's gone,


### PR DESCRIPTION
Fixes #58251.

## Summary
- bind the active composer draft scope to the composer store
- immediately update the active session draft when attachments are removed or cleared
- add regression coverage so removed/cleared attachments do not reappear after a session draft restore

## Tests
- npm run test:ui -- src/store/composer.test.ts
- npm run typecheck
- npx prettier --check src/store/composer.ts src/store/composer.test.ts src/app/chat/composer/hooks/use-composer-draft.ts
- git diff --check