### PR TITLE
feat(image-gen): use OpenRouter Image API

### DIFF
--- a/plugins/image_gen/openrouter/__init__.py
+++ b/plugins/image_gen/openrouter/__init__.py
@@ -1,17 +1,13 @@
 """OpenRouter-compatible image generation backend (OpenRouter + Nous Portal).
 
-Both OpenRouter and the Nous Portal inference endpoint speak the same
-OpenAI-style ``/chat/completions`` image-generation protocol: send
-``modalities: ["image", "text"]`` with an image-output model (e.g.
-``google/gemini-3-pro-image``), pass reference images as ``image_url``
-content parts for grounding, and read the generated images back from
-``choices[0].message.images[].image_url.url`` (a ``data:image/...;base64`` URI).
-
-Nous Portal proxies OpenRouter, so one implementation services both — we only
-swap the resolved ``(base_url, api_key)``. Credentials are resolved through the
-agent's existing :func:`~hermes_cli.runtime_provider.resolve_runtime_provider`,
-which already understands OpenRouter's key pool and the Nous OAuth device-code
-token, so this plugin never reinvents auth.
+OpenRouter exposes a dedicated Image API at ``/images`` and
+``/images/models``.  Nous Portal still uses the OpenAI-style
+``/chat/completions`` image-generation protocol, so this provider keeps both
+wire shapes behind one implementation while swapping only the resolved
+``(base_url, api_key)``. Credentials are resolved through the agent's existing
+:func:`~hermes_cli.runtime_provider.resolve_runtime_provider`, which already
+understands OpenRouter's key pool and the Nous OAuth device-code token, so this
+plugin never reinvents auth.
 
 Reference grounding is the reason pet sprite generation cares about this
 backend: each animation row must stay the same character as the chosen base
@@ -136,6 +132,30 @@ def _extract_images(payload: Dict[str, Any]) -> List[str]:
     return out
 
 
+def _extract_image_api_images(payload: Dict[str, Any]) -> List[str]:
+    """Pull generated image URLs/data from OpenRouter's Image API response."""
+    out: List[str] = []
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(data, list):
+        return out
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        b64_json = item.get("b64_json")
+        if isinstance(b64_json, str) and b64_json.strip():
+            media_type = item.get("media_type")
+            if not isinstance(media_type, str) or not media_type.strip():
+                media_type = "image/png"
+            else:
+                media_type = media_type.strip()
+            out.append(f"data:{media_type};base64,{b64_json.strip()}")
+            continue
+        url = item.get("url")
+        if isinstance(url, str) and url.strip():
+            out.append(url.strip())
+    return out
+
+
 def _access_error_hint(
     display: str, model_id: str, env_var: str, status: int, err_msg: str
 ) -> Optional[str]:
@@ -171,6 +191,22 @@ def _dedupe_models(models: list[str]) -> list[str]:
         seen.add(m)
         out.append(m)
     return out
+
+
+_MEDIA_TYPE_EXTENSIONS = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/jpg": "jpg",
+    "image/webp": "webp",
+    "image/svg+xml": "svg",
+}
+
+
+def _data_uri_extension(uri: str) -> str:
+    """Choose a safe saved-file extension from an image data URI."""
+    header = uri.partition(",")[0]
+    media_type = header.removeprefix("data:").split(";", 1)[0].lower()
+    return _MEDIA_TYPE_EXTENSIONS.get(media_type, "png")
 
 
 class OpenRouterCompatImageProvider(ImageGenProvider):
@@ -229,6 +265,45 @@ class OpenRouterCompatImageProvider(ImageGenProvider):
         }
 
     def list_models(self) -> List[Dict[str, Any]]:
+        if self._runtime_name == "openrouter":
+            try:
+                import requests
+
+                runtime = self._resolve_runtime()
+                api_key = str(runtime.get("api_key") or "").strip()
+                base_url = str(runtime.get("base_url") or "").strip().rstrip("/")
+                if api_key and base_url:
+                    response = requests.get(
+                        f"{base_url}/images/models",
+                        headers={
+                            "Authorization": f"Bearer {api_key}",
+                            "HTTP-Referer": "https://github.com/NousResearch/hermes-agent",
+                            "X-Title": "Hermes Agent",
+                        },
+                        timeout=30.0,
+                    )
+                    response.raise_for_status()
+                    payload = response.json()
+                    rows = payload.get("data") if isinstance(payload, dict) else None
+                    models: List[Dict[str, Any]] = []
+                    if isinstance(rows, list):
+                        for row in rows:
+                            if not isinstance(row, dict):
+                                continue
+                            model_id = row.get("id")
+                            if not isinstance(model_id, str) or not model_id.strip():
+                                continue
+                            models.append(
+                                {
+                                    "id": model_id.strip(),
+                                    "display": str(row.get("name") or model_id).strip(),
+                                    "strengths": str(row.get("description") or "").strip(),
+                                }
+                            )
+                    if models:
+                        return models
+            except Exception as exc:  # noqa: BLE001 - discovery is best-effort
+                logger.debug("%s image model discovery failed: %s", self._name, exc)
         return [
             {
                 "id": DEFAULT_MODEL,
@@ -342,16 +417,36 @@ class OpenRouterCompatImageProvider(ImageGenProvider):
         }
         last_error: Optional[Dict[str, Any]] = None
         for i, model_id in enumerate(model_chain):
-            payload: Dict[str, Any] = {
-                "model": model_id,
-                "modalities": ["image", "text"],
-                "messages": [{"role": "user", "content": content}],
-                "image_config": {"aspect_ratio": or_aspect},
-            }
+            if self._runtime_name == "openrouter":
+                input_references = [
+                    part
+                    for part in content[1:]
+                    if isinstance(part, dict)
+                    and part.get("type") == "image_url"
+                    and isinstance(part.get("image_url"), dict)
+                    and isinstance(part["image_url"].get("url"), str)
+                ]
+                payload: Dict[str, Any] = {
+                    "model": model_id,
+                    "prompt": prompt,
+                    "n": 1,
+                    "aspect_ratio": or_aspect,
+                }
+                if input_references:
+                    payload["input_references"] = input_references
+                endpoint = f"{base_url}/images"
+            else:
+                payload = {
+                    "model": model_id,
+                    "modalities": ["image", "text"],
+                    "messages": [{"role": "user", "content": content}],
+                    "image_config": {"aspect_ratio": or_aspect},
+                }
+                endpoint = f"{base_url}/chat/completions"
             is_last = i == len(model_chain) - 1
             try:
                 response = requests.post(
-                    f"{base_url}/chat/completions",
+                    endpoint,
                     headers=headers,
                     json=payload,
                     timeout=_REQUEST_TIMEOUT,
@@ -423,7 +518,7 @@ class OpenRouterCompatImageProvider(ImageGenProvider):
                     aspect_ratio=aspect,
                 )
 
-            images = _extract_images(result)
+            images = _extract_image_api_images(result) if self._runtime_name == "openrouter" else _extract_images(result)
             if not images:
                 if not is_last:
                     logger.info(
@@ -451,7 +546,11 @@ class OpenRouterCompatImageProvider(ImageGenProvider):
             try:
                 if first.startswith("data:"):
                     b64 = first.split(",", 1)[1] if "," in first else ""
-                    saved_path = save_b64_image(b64, prefix=f"{self._name}_gen")
+                    saved_path = save_b64_image(
+                        b64,
+                        prefix=f"{self._name}_gen",
+                        extension=_data_uri_extension(first),
+                    )
                 else:
                     saved_path = save_url_image(first, prefix=f"{self._name}_gen")
             except Exception as exc:  # noqa: BLE001

--- a/plugins/image_gen/openrouter/plugin.yaml
+++ b/plugins/image_gen/openrouter/plugin.yaml
@@ -1,6 +1,6 @@
 name: openrouter
 version: 1.0.0
-description: "OpenRouter + Nous Portal image generation (chat-completions image output; reference-grounded). Text-to-image and image-to-image."
+description: "OpenRouter dedicated Image API + Nous Portal chat-completions image generation. Text-to-image and reference-grounded image-to-image."
 author: Hermes Agent
 kind: backend
 requires_env:

--- a/tests/plugins/image_gen/test_openrouter_compat_provider.py
+++ b/tests/plugins/image_gen/test_openrouter_compat_provider.py
@@ -45,6 +45,35 @@ def _mock_chat_response(images):
     return resp
 
 
+def _mock_image_api_response(images):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = {
+        "data": [
+            {"b64_json": u.split(",", 1)[1]} if u.startswith("data:") else {"url": u}
+            for u in images
+        ]
+    }
+    return resp
+
+
+def _mock_models_response():
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = {
+        "data": [
+            {
+                "id": "bytedance-seed/seedream-4.5",
+                "name": "Seedream 4.5",
+                "description": "Text-to-image and image-editing model",
+            }
+        ]
+    }
+    return resp
+
+
 def _openrouter():
     from plugins.image_gen.openrouter import OpenRouterCompatImageProvider
 
@@ -245,6 +274,21 @@ class TestHelpers:
         # A 200-class transient with an openai model but no access signal → no hint.
         assert _access_error_hint("OpenRouter", "openai/gpt-5.4-image-2", "X", 500, "server error") is None
 
+    def test_extract_image_api_images(self):
+        from plugins.image_gen.openrouter import _extract_image_api_images
+
+        payload = {"data": [{"b64_json": "AA"}, {"url": "https://cdn/x.png"}]}
+        assert _extract_image_api_images(payload) == [
+            "data:image/png;base64,AA",
+            "https://cdn/x.png",
+        ]
+
+    def test_extract_image_api_images_preserves_media_type(self):
+        from plugins.image_gen.openrouter import _extract_image_api_images
+
+        payload = {"data": [{"b64_json": "AA", "media_type": "image/webp"}]}
+        assert _extract_image_api_images(payload) == ["data:image/webp;base64,AA"]
+
 
 # ---------------------------------------------------------------------------
 # generate()
@@ -260,7 +304,7 @@ class TestGenerate:
 
     def test_success_data_uri(self):
         with patch(_RUNTIME, return_value=_runtime_ok()), \
-             patch("requests.post", return_value=_mock_chat_response([_PNG_DATA_URI])), \
+             patch("requests.post", return_value=_mock_image_api_response([_PNG_DATA_URI])), \
              patch(
                  "plugins.image_gen.openrouter.save_b64_image",
                  return_value=Path("/tmp/openrouter_gen.png"),
@@ -274,7 +318,7 @@ class TestGenerate:
 
     def test_success_http_url(self):
         with patch(_RUNTIME, return_value=_runtime_ok()), \
-             patch("requests.post", return_value=_mock_chat_response(["https://cdn/x.png"])), \
+             patch("requests.post", return_value=_mock_image_api_response(["https://cdn/x.png"])), \
              patch(
                  "plugins.image_gen.openrouter.save_url_image",
                  return_value=Path("/tmp/openrouter_gen_url.png"),
@@ -285,39 +329,54 @@ class TestGenerate:
         assert result["image"] == "/tmp/openrouter_gen_url.png"
         mock_save_url.assert_called_once()
 
+    def test_success_uses_media_type_for_saved_extension(self):
+        response = _mock_image_api_response([])
+        response.json.return_value = {
+            "data": [{"b64_json": "AA", "media_type": "image/jpeg"}]
+        }
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("requests.post", return_value=response), \
+             patch(
+                 "plugins.image_gen.openrouter.save_b64_image",
+                 return_value=Path("/tmp/openrouter_gen.jpg"),
+             ) as mock_save:
+            result = _openrouter().generate(prompt="a pet")
+
+        assert result["success"] is True
+        assert result["image"].endswith(".jpg")
+        assert mock_save.call_args.kwargs["extension"] == "jpg"
+
     def test_empty_response(self):
         with patch(_RUNTIME, return_value=_runtime_ok()), \
-             patch("requests.post", return_value=_mock_chat_response([])):
+             patch("requests.post", return_value=_mock_image_api_response([])):
             result = _openrouter().generate(prompt="a pet")
         assert result["success"] is False
         assert result["error_type"] == "empty_response"
 
-    def test_payload_shape_and_references(self, tmp_path):
-        """Wire payload must carry image modalities, aspect_ratio, and the
-        reference image inlined as a data URI (this is what makes pet rows
-        stay on-model)."""
+    def test_openrouter_image_api_payload_shape_and_references(self, tmp_path):
+        """OpenRouter uses the dedicated Image API and passes references."""
         ref = tmp_path / "base.png"
         ref.write_bytes(b"\x89PNG\r\n")
 
         with patch(_RUNTIME, return_value=_runtime_ok()), \
-             patch("requests.post", return_value=_mock_chat_response([_PNG_DATA_URI])) as mock_post, \
+             patch("requests.post", return_value=_mock_image_api_response([_PNG_DATA_URI])) as mock_post, \
              patch("plugins.image_gen.openrouter.save_b64_image", return_value=Path("/tmp/x.png")):
             _openrouter().generate(
                 prompt="a pet", aspect_ratio="square", reference_images=[str(ref)]
             )
 
+        assert mock_post.call_args[0][0] == "https://openrouter.ai/api/v1/images"
         payload = mock_post.call_args.kwargs["json"]
-        assert payload["modalities"] == ["image", "text"]
-        assert payload["image_config"]["aspect_ratio"] == "1:1"
-        content = payload["messages"][0]["content"]
-        assert content[0] == {"type": "text", "text": "a pet"}
-        image_parts = [c for c in content if c["type"] == "image_url"]
-        assert len(image_parts) == 1
-        assert image_parts[0]["image_url"]["url"].startswith("data:image/png;base64,")
+        assert payload["prompt"] == "a pet"
+        assert payload["aspect_ratio"] == "1:1"
+        assert payload["n"] == 1
+        reference = payload["input_references"][0]
+        assert reference["type"] == "image_url"
+        assert reference["image_url"]["url"].startswith("data:image/png;base64,")
 
     def test_auth_header(self):
         with patch(_RUNTIME, return_value=_runtime_ok()), \
-             patch("requests.post", return_value=_mock_chat_response([_PNG_DATA_URI])) as mock_post, \
+             patch("requests.post", return_value=_mock_image_api_response([_PNG_DATA_URI])) as mock_post, \
              patch("plugins.image_gen.openrouter.save_b64_image", return_value=Path("/tmp/x.png")):
             _openrouter().generate(prompt="a pet")
 
@@ -327,7 +386,7 @@ class TestGenerate:
     def test_generate_uses_model_kwarg_from_dispatch(self):
         """image_generate passes image_gen.model as a model kwarg — honor it."""
         with patch(_RUNTIME, return_value=_runtime_ok()), \
-             patch("requests.post", return_value=_mock_chat_response([_PNG_DATA_URI])) as mock_post, \
+             patch("requests.post", return_value=_mock_image_api_response([_PNG_DATA_URI])) as mock_post, \
              patch("plugins.image_gen.openrouter.save_b64_image", return_value=Path("/tmp/x.png")):
             result = _openrouter().generate(prompt="a pet", model="openai/gpt-image-2")
 
@@ -352,6 +411,36 @@ class TestGenerate:
         assert result["provider"] == "nous"
         url = mock_post.call_args[0][0]
         assert url == "https://inference.nousresearch.com/v1/chat/completions"
+
+    def test_nous_payload_still_uses_chat_completions(self):
+        nous_runtime = _runtime_ok(
+            provider="nous", base_url="https://inference.nousresearch.com/v1", api_key="nous-tok"
+        )
+        with patch(_RUNTIME, return_value=nous_runtime), \
+             patch("requests.post", return_value=_mock_chat_response([_PNG_DATA_URI])) as mock_post, \
+             patch("plugins.image_gen.openrouter.save_b64_image", return_value=Path("/tmp/x.png")):
+            from plugins.image_gen.openrouter import _build_providers
+
+            nous = {p.name: p for p in _build_providers()}["nous"]
+            nous.generate(prompt="a pet", aspect_ratio="landscape")
+
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["modalities"] == ["image", "text"]
+        assert payload["image_config"]["aspect_ratio"] == "16:9"
+
+    def test_openrouter_lists_image_models_from_image_api(self):
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("requests.get", return_value=_mock_models_response()) as mock_get:
+            models = _openrouter().list_models()
+
+        assert mock_get.call_args[0][0] == "https://openrouter.ai/api/v1/images/models"
+        assert models == [
+            {
+                "id": "bytedance-seed/seedream-4.5",
+                "display": "Seedream 4.5",
+                "strengths": "Text-to-image and image-editing model",
+            }
+        ]
 
     def test_api_error(self):
         import requests as req_lib
@@ -411,7 +500,7 @@ class TestGenerate:
         gated.raise_for_status.side_effect = req_lib.HTTPError(response=gated)
 
         with patch(_RUNTIME, return_value=_runtime_ok()), \
-             patch("requests.post", side_effect=[gated, _mock_chat_response([_PNG_DATA_URI])]) as mock_post, \
+             patch("requests.post", side_effect=[gated, _mock_image_api_response([_PNG_DATA_URI])]) as mock_post, \
              patch(
                  "plugins.image_gen.openrouter.save_b64_image",
                  return_value=Path("/tmp/openrouter_gen_fallback.png"),


### PR DESCRIPTION
## Summary
- route only the OpenRouter backend through the documented dedicated `POST /api/v1/images` API while keeping Nous Portal on chat completions
- discover OpenRouter image models from `/images/models`, with the existing static model fallback
- preserve OpenAI-style `image_url` content-part objects in `input_references` for image-to-image requests
- preserve response `media_type` (PNG fallback) and save base64 outputs with matching PNG/JPEG/WebP/SVG extensions
- keep the request surface limited to options currently reachable from Hermes (`prompt`, aspect ratio, and references); remove unreachable passthrough claims
- update plugin metadata to describe the split OpenRouter/Nous wire protocols

OpenRouter Image API reference: https://openrouter.ai/docs/guides/overview/multimodal/image-generation

## Verification
- `pytest -q tests/plugins/image_gen/test_openrouter_compat_provider.py tests/plugins/image_gen/test_openai_codex_provider.py tests/plugins/image_gen/test_xai_provider.py tests/tools/test_image_generation_plugin_dispatch.py tests/tools/test_image_generation_image_to_image.py` (129 passed)
- Ruff and compileall pass for the modified provider and tests
