### PR TITLE
fix: forward max_tokens to gemini-native so MoA reference_max_tokens applies

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5789,9 +5789,25 @@ def _build_call_kwargs(
             _provider_norm in {"nvidia", "nvidia-nim", "nim", "build-nvidia", "nemotron"}
             or base_url_host_matches(_effective_base, "integrate.api.nvidia.com")
         )
+        # Gemini's native generateContent maps max_tokens → maxOutputTokens and,
+        # when it is omitted, applies a fixed 65,535-token ceiling rather than
+        # "the model's full budget" (see gemini_native_adapter.build_gemini_request).
+        # So an explicit cap is both safe and the ONLY way to honor it here —
+        # dropping max_tokens silently makes MoA's reference_max_tokens a no-op
+        # for gemini advisors (they run effectively uncapped).
+        _is_gemini_native = _provider_norm in {
+            "gemini", "google", "google-gemini", "google-ai-studio",
+        }
+        if not _is_gemini_native and _effective_base:
+            try:
+                from agent.gemini_native_adapter import is_native_gemini_base_url
+                _is_gemini_native = is_native_gemini_base_url(_effective_base)
+            except Exception:
+                pass
         if (
             _is_anthropic_compat_endpoint(provider, _effective_base)
             or _is_nvidia_nim
+            or _is_gemini_native
         ):
             kwargs["max_tokens"] = max_tokens
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -236,6 +236,55 @@ class TestBuildCallKwargsMaxTokens:
         )
         assert kwargs["max_tokens"] == 4096
 
+    @pytest.mark.parametrize(
+        "provider,model,base_url",
+        [
+            ("gemini", "gemini-2.5-pro", None),
+            ("google", "gemini-2.5-flash", None),
+            (
+                "custom",
+                "gemini-2.5-pro",
+                "https://generativelanguage.googleapis.com/v1beta",
+            ),
+        ],
+    )
+    def test_keeps_max_tokens_for_gemini_native(self, provider, model, base_url):
+        # Native generateContent maps max_tokens → maxOutputTokens; when it is
+        # omitted Gemini applies a fixed 65,535-token ceiling, which silently
+        # turned MoA's reference_max_tokens into a no-op for gemini advisors.
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider=provider,
+            model=model,
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=600,
+            base_url=base_url,
+        )
+        assert kwargs["max_tokens"] == 600
+        assert "max_completion_tokens" not in kwargs
+
+    def test_omits_max_tokens_for_gemini_model_on_openai_compatible_endpoint(self):
+        # Control: the gemini branch keys on provider/base_url, never the model
+        # name. A gemini model served through an OpenAI-compatible endpoint
+        # keeps the default omission behavior (#34530), including Gemini's own
+        # /openai compatibility endpoint.
+        from agent.auxiliary_client import _build_call_kwargs
+
+        for provider, base_url in [
+            ("openrouter", "https://openrouter.ai/api/v1"),
+            ("custom", "https://generativelanguage.googleapis.com/v1beta/openai"),
+        ]:
+            kwargs = _build_call_kwargs(
+                provider=provider,
+                model="google/gemini-2.5-pro",
+                messages=[{"role": "user", "content": "hi"}],
+                max_tokens=600,
+                base_url=base_url,
+            )
+            assert "max_tokens" not in kwargs
+            assert "max_completion_tokens" not in kwargs
+
 
 class TestNousTagsScoping:
     def test_tags_injected_when_provider_is_nous(self, monkeypatch):


### PR DESCRIPTION
## Problem

`_build_call_kwargs` in `agent/auxiliary_client.py` omits `max_tokens` for every provider **except** anthropic-compat endpoints and NVIDIA NIM. That default is deliberate for most aux tasks (avoids truncating summaries and 400s on providers that reject the param), but it silently breaks MoA's documented `reference_max_tokens` cap for gemini advisors.

Gemini's **native** `generateContent` maps `max_tokens → generationConfig.maxOutputTokens`, and when the value is omitted it applies a fixed 65,535-token ceiling rather than "the model's full budget" (see `gemini_native_adapter.build_gemini_request`, the `else` branch that sets `GEMINI_DEFAULT_MAX_OUTPUT_TOKENS`). So dropping `max_tokens` on the way in means a gemini reference model runs effectively **uncapped**.

### Observed

With a MoA preset `reference_max_tokens: 600` and a `gemini:gemini-3.5-flash` reference, the advisor emitted **~2,900 output tokens** per turn (verified via a MoA turn trace). Since advisor generation is the dominant MoA per-turn latency, the cap being a no-op inflates wall-clock time on every MoA turn that uses a gemini reference.

## Fix

Forward `max_tokens` for the gemini-native path (matched by provider name — `gemini` / `google` / `google-gemini` / `google-ai-studio` — or by native gemini base_url). Gemini supports `maxOutputTokens`, so the explicit cap is safe here.

Providers that reject `max_tokens` (GitHub Copilot, newer OpenAI GPT-5 requiring `max_completion_tokens`, ZAI vision) are unaffected — they still omit it exactly as before. Anthropic-compat and NVIDIA NIM keep their existing mandatory-`max_tokens` behavior.

## Verification

Unit-level check of `_build_call_kwargs`:

| provider | `max_tokens` in kwargs | expected |
|---|---|---|
| `gemini` | ✅ 600 | forwarded |
| `google` | ✅ 600 | forwarded |
| `openai` | ⛔ omitted | unchanged |
| `openai-codex` | ⛔ omitted | unchanged |

After the fix, a repeat MoA turn caps the gemini advisor at the configured `reference_max_tokens` and the per-turn latency drops accordingly, while the aggregator (the acting, user-visible model) remains uncapped as designed.