### PR TITLE
fix(cron): mark live deliveries as final notifications

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1529,10 +1529,14 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 route_metadata = {
                     "direct_messages_topic_id": str(thread_id),
                     "job_id": job["id"],
+                    "notify": True,
                 }
                 # Media metadata mirrors the text routing so attachments land in
                 # the same DM topic instead of the General lane (#22773).
-                media_metadata = {"direct_messages_topic_id": str(thread_id)}
+                media_metadata = {
+                    "direct_messages_topic_id": str(thread_id),
+                    "notify": True,
+                }
             else:
                 # Forum-style topic (private chat / supergroup) or non-topic
                 # target: route via message_thread_id (#52060).  Put thread_id in
@@ -1543,10 +1547,12 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # anchor, so the metadata key bypasses that check and lets the
                 # adapter route via a plain message_thread_id.
                 route_thread_id = str(thread_id) if thread_id is not None else None
-                route_metadata = {"job_id": job["id"]}
+                route_metadata = {"job_id": job["id"], "notify": True}
                 if route_thread_id:
                     route_metadata["thread_id"] = route_thread_id
-                media_metadata = {"thread_id": thread_id} if thread_id else None
+                media_metadata = {"notify": True}
+                if thread_id:
+                    media_metadata["thread_id"] = thread_id
 
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content.

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -877,6 +877,56 @@ class TestDeliverResultWrapping:
         assert "MEDIA:" not in text_sent
         assert "Report" in text_sent
 
+    def test_live_adapter_marks_cron_text_delivery_notify(self):
+        """Cron result delivery is final user-visible output, not progress.
+
+        Telegram uses notify=True to avoid re-triggering sendChatAction after
+        the final send; without it, a cron delivery re-arms the typing bubble
+        even though no gateway typing refresh loop owns it anymore.
+        """
+        from gateway.config import Platform
+        from concurrent.futures import Future
+
+        adapter = AsyncMock()
+        adapter.send.return_value = MagicMock(success=True)
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        def fake_run_coro(coro, _loop):
+            import asyncio as _asyncio
+            future = Future()
+            try:
+                future.set_result(_asyncio.run(coro))
+            except BaseException as _e:  # noqa: BLE001
+                future.set_exception(_e)
+            return future
+
+        job = {
+            "id": "typing-job",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "555"},
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+            _deliver_result(
+                job,
+                "Cron output is ready.",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            )
+
+        metadata = adapter.send.call_args.kwargs["metadata"]
+        assert metadata["job_id"] == "typing-job"
+        assert metadata["notify"] is True
+
     def test_no_mirror_to_session_call(self):
         """Cron deliveries should NOT mirror into the gateway session."""
         from gateway.config import Platform


### PR DESCRIPTION
## Summary
- mark cron live-adapter delivery metadata with `notify=True` because cron output is final user-visible delivery, not an intermediate progress send
- preserve Telegram topic/direct-message routing metadata while carrying the final-delivery marker through text and media sends
- add a regression test for the live cron delivery path so Telegram does not re-trigger typing after the cron result is sent

Fixes #58258.

## Tests
- `.venv/bin/python -m pytest tests/cron/test_scheduler.py -q`
- `.venv/bin/python -m pytest tests/gateway/test_telegram_format.py -q`
- `.venv/bin/python -m pytest tests/cron/test_scheduler.py::TestDeliverResultWrapping::test_live_adapter_marks_cron_text_delivery_notify -q -W error`
- `.venv/bin/python -m ruff check cron/scheduler.py tests/cron/test_scheduler.py`
- `git diff --check`

Note: the full cron scheduler test file passes, but pytest emits an existing unraisable coroutine warning from another test during GC (`_send_to_platform` was never awaited); the new targeted regression passes under `-W error`.