### PR TITLE
feat(cli): pin active provider first in model picker

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3021,6 +3021,10 @@ def select_provider_and_model(args=None):
         else:
             ordered.append((key, label, []))
 
+    if default_idx:
+        ordered.insert(0, ordered.pop(default_idx))
+        default_idx = 0
+
     ordered.append(("custom", "Custom endpoint (enter URL manually)", []))
     _has_saved_custom_list = isinstance(config.get("custom_providers"), list) and bool(
         config.get("custom_providers")
@@ -3045,11 +3049,14 @@ def select_provider_and_model(args=None):
     # if the active provider lives in this group. The descriptive text lives on
     # the group row itself, so member rows show only their short label here.
     if selected_members:
+        member_entries = list(selected_members)
         member_default = 0
-        if active in selected_members:
-            member_default = selected_members.index(active)
+        if active in member_entries:
+            active_member_idx = member_entries.index(active)
+            if active_member_idx:
+                member_entries.insert(0, member_entries.pop(active_member_idx))
         member_labels = [
-            provider_labels.get(m, m) for m in selected_members
+            provider_labels.get(m, m) for m in member_entries
         ]
         group_label = ordered[provider_idx][1].split(" ▸", 1)[0]
         member_idx = _prompt_provider_choice(
@@ -3060,7 +3067,7 @@ def select_provider_and_model(args=None):
         if member_idx is None:
             print("No change.")
             return
-        selected_provider = selected_members[member_idx]
+        selected_provider = member_entries[member_idx]
     else:
         selected_provider = selected_key
 

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -385,6 +385,90 @@ def test_select_provider_and_model_accepts_named_provider_from_providers_section
     assert "Active provider:  volcengine-plan" in out
 
 
+def test_select_provider_and_model_pins_active_named_provider_first(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_env(monkeypatch)
+
+    cfg = load_config()
+    cfg["model"] = {
+        "provider": "volcengine-plan",
+        "default": "doubao-seed-2.0-code",
+    }
+    cfg["providers"] = {
+        "volcengine-plan": {
+            "name": "volcengine-plan",
+            "base_url": "https://ark.cn-beijing.volces.com/api/coding/v3",
+            "default_model": "doubao-seed-2.0-code",
+            "models": {"doubao-seed-2.0-code": {}},
+        }
+    }
+    save_config(cfg)
+
+    captured = {}
+
+    def fake_prompt_provider_choice(choices, default=0, title="Select provider:"):
+        captured["choices"] = choices
+        captured["default"] = default
+        return None
+
+    monkeypatch.setattr(
+        "hermes_cli.main._prompt_provider_choice",
+        fake_prompt_provider_choice,
+    )
+
+    from hermes_cli.main import select_provider_and_model
+
+    select_provider_and_model()
+
+    assert captured["default"] == 0
+    assert "volcengine-plan" in captured["choices"][0]
+    assert "currently active" in captured["choices"][0]
+
+
+def test_select_provider_and_model_pins_active_group_member_first(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_env(monkeypatch)
+
+    cfg = load_config()
+    cfg["model"] = {
+        "provider": "minimax-cn",
+        "default": "minimax-m3",
+    }
+    save_config(cfg)
+
+    captured = {}
+    prompt_calls = []
+
+    def fake_prompt_provider_choice(choices, default=0, title="Select provider:"):
+        prompt_calls.append((choices, default, title))
+        if len(prompt_calls) == 1:
+            captured["provider_choices"] = choices
+            captured["provider_default"] = default
+            return 0
+        captured["member_choices"] = choices
+        captured["member_default"] = default
+        return None
+
+    monkeypatch.setattr(
+        "hermes_cli.main._prompt_provider_choice",
+        fake_prompt_provider_choice,
+    )
+
+    from hermes_cli.main import select_provider_and_model
+
+    select_provider_and_model()
+
+    assert captured["provider_default"] == 0
+    assert "MiniMax" in captured["provider_choices"][0]
+    assert "currently active" in captured["provider_choices"][0]
+    assert captured["member_default"] == 0
+    assert captured["member_choices"][0] == "MiniMax (China)"
+
+
 def test_codex_setup_uses_runtime_access_token_for_live_model_list(tmp_path, monkeypatch):
     """Codex model list fetching uses the runtime access token."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
## What does this PR do?

Fixes #58198.

Moves the currently active provider to the top of the classic `hermes model` provider picker. The model list already puts the current model first, so this makes the provider picker match that behavior.

This only changes picker order. It does not change provider resolution, credential handling, or model saving.

## Related Issue

Fixes #58198

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Keep the existing `currently active` marker.
- Move the active provider row to the first provider picker row.
- Move the active grouped provider member to the first row in the member picker.
- Keep the action rows like `Custom endpoint` and `Leave unchanged` after the provider rows.

## How to Test

1. `/Users/blackishgreen03/workspace/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_setup.py -q`
2. `/Users/blackishgreen03/workspace/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_setup.py tests/hermes_cli/test_custom_provider_model_switch.py -q`
3. `git diff --check`

## Checklist

### Code

- [x] I've searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Documentation update is N/A
- [x] `cli-config.yaml.example` update is N/A
- [x] Architecture/workflow doc update is N/A
- [x] Tool schema update is N/A
