### PR TITLE
fix(langfuse): configure OpenTelemetry service identity

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -38,6 +38,16 @@ runtime:
   nofile_soft_limit: 4096
 
 # =============================================================================
+# Observability Configuration
+# =============================================================================
+# Stable OpenTelemetry service identity used by observability plugins.
+# Existing Langfuse installations warn and default to "hermes-agent" when this
+# key is absent. Use a distinct value when multiple agents share one project.
+# An explicit empty value or "unknown_service" prevents Langfuse from loading.
+observability:
+  service_name: "hermes-agent"
+
+# =============================================================================
 # Model Configuration
 # =============================================================================
 model:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -19,6 +19,16 @@ database:
   # journal_size_limit: 67108864 # cap the WAL/journal file size in bytes
 
 # =============================================================================
+# Observability Configuration
+# =============================================================================
+# Stable OpenTelemetry service identity used by observability plugins.
+# Existing Langfuse installations warn and default to "hermes-agent" when this
+# key is absent. Use a distinct value when multiple agents share one project.
+# An explicit empty value or "unknown_service" prevents Langfuse from loading.
+observability:
+  service_name: "hermes-agent"
+
+# =============================================================================
 # Model Configuration
 # =============================================================================
 model:

--- a/contributors/emails/axegggl@gmail.com
+++ b/contributors/emails/axegggl@gmail.com
@@ -1,0 +1,2 @@
+AXEG0
+# PR #58264 (Langfuse OpenTelemetry service identity)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -407,6 +407,13 @@ DEFAULT_CONFIG = {
         },
     },
 
+    # A stable OpenTelemetry identity for bundled observability plugins. The
+    # default keeps existing credential-only Langfuse installations working;
+    # `hermes tools` writes an explicit value when a user sets Langfuse up.
+    "observability": {
+        "service_name": "hermes-agent",
+    },
+
     "terminal": {
         "backend": "local",
         "modal_mode": "auto",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -248,6 +248,13 @@ DEFAULT_CONFIG = {
         "reasoning_overrides": {},
     },
 
+    # A stable OpenTelemetry identity for bundled observability plugins. The
+    # default keeps existing credential-only Langfuse installations working;
+    # `hermes tools` writes an explicit value when a user sets Langfuse up.
+    "observability": {
+        "service_name": "hermes-agent",
+    },
+
     "terminal": {
         "backend": "local",
         "modal_mode": "auto",

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2326,6 +2326,23 @@ def _run_post_setup(post_setup_key: str):
                 _print_success("    langfuse SDK installed")
             else:
                 _print_warning("    langfuse SDK install failed — run manually: uv pip install langfuse")
+        # Service identity is configuration, rather than a credential.  Save
+        # it alongside the rest of the setup so Langfuse never relies on an
+        # unattributable OpenTelemetry default.
+        config = load_config()
+        observability = config.setdefault("observability", {})
+        if not isinstance(observability, dict):
+            observability = {}
+            config["observability"] = observability
+        service_name = _prompt(
+            "Langfuse service name",
+            default=str(observability.get("service_name") or "hermes-agent"),
+        ).strip()
+        observability["service_name"] = service_name or "hermes-agent"
+        save_config(config)
+        _print_success(
+            f"    Langfuse service identity set to {observability['service_name']!r}"
+        )
         # Opt the bundled observability/langfuse plugin into plugins.enabled.
         # The plugin ships in the repo but doesn't load until the user enables
         # it (standalone plugins are opt-in).

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1920,6 +1920,23 @@ def _run_post_setup(post_setup_key: str):
                 _print_success("    langfuse SDK installed")
             else:
                 _print_warning("    langfuse SDK install failed — run manually: uv pip install langfuse")
+        # Service identity is configuration, rather than a credential.  Save
+        # it alongside the rest of the setup so Langfuse never relies on an
+        # unattributable OpenTelemetry default.
+        config = load_config()
+        observability = config.setdefault("observability", {})
+        if not isinstance(observability, dict):
+            observability = {}
+            config["observability"] = observability
+        service_name = _prompt(
+            "Langfuse service name",
+            default=str(observability.get("service_name") or "hermes-agent"),
+        ).strip()
+        observability["service_name"] = service_name or "hermes-agent"
+        save_config(config)
+        _print_success(
+            f"    Langfuse service identity set to {observability['service_name']!r}"
+        )
         # Opt the bundled observability/langfuse plugin into plugins.enabled.
         # The plugin ships in the repo but doesn't load until the user enables
         # it (standalone plugins are opt-in).

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1487,6 +1487,10 @@ _CATEGORY_MERGE: Dict[str, str] = {
     # (`enabled`/`disabled` are list allow-lists omitted from DEFAULT_CONFIG) —
     # fold it into the agent tab rather than spawning a one-field orphan category.
     "plugins": "agent",
+    # `observability.service_name` is the only schema-surfaced observability
+    # field — keep it alongside the plugin settings it configures instead of
+    # creating a one-field dashboard tab.
+    "observability": "agent",
     # `doctor.live_probe_timeout` is the only schema-surfaced doctor field —
     # fold it into general rather than spawning a one-field orphan category.
     "doctor": "general",

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -35,7 +35,14 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
+from hermes_constants import get_config_path
+
 logger = logging.getLogger(__name__)
+
+try:
+    import yaml
+except Exception:  # pragma: no cover - PyYAML is a core dependency
+    yaml = None
 
 try:
     from langfuse import Langfuse, propagate_attributes
@@ -95,6 +102,13 @@ _LANGFUSE_KEY_PREFIXES: Dict[str, str] = {
     "HERMES_LANGFUSE_PUBLIC_KEY": "pk-lf-",
     "HERMES_LANGFUSE_SECRET_KEY": "sk-lf-",
 }
+_INVALID_SERVICE_NAMES = {"unknown_service"}
+_DEFAULT_SERVICE_NAME = "hermes-agent"
+_DEFAULT_SERVICE_NAME_WARNED = False
+
+
+class LangfuseServiceNameError(RuntimeError):
+    """Langfuse configuration cannot provide a usable service identity."""
 
 
 def _env(name: str, default: str = "") -> str:
@@ -249,6 +263,81 @@ def _validate_langfuse_key(env_name: str, value: str) -> Optional[str]:
     )
 
 
+def _compatibility_service_name() -> str:
+    """Return the legacy identity while making the ambiguity visible once."""
+    global _DEFAULT_SERVICE_NAME_WARNED
+    if not _DEFAULT_SERVICE_NAME_WARNED:
+        logger.warning(
+            "Langfuse plugin: observability.service_name is not configured; "
+            "using compatibility identity %r. Set a distinct service name in "
+            "config.yaml when multiple Hermes agents share a Langfuse project.",
+            _DEFAULT_SERVICE_NAME,
+        )
+        _DEFAULT_SERVICE_NAME_WARNED = True
+    return _DEFAULT_SERVICE_NAME
+
+
+def _configured_service_name() -> str:
+    config_path = get_config_path()
+    if yaml is None:
+        raise LangfuseServiceNameError(
+            "Langfuse plugin requires observability.service_name in Hermes "
+            "config, but PyYAML is unavailable so config.yaml cannot be read"
+        )
+    if not config_path.is_file():
+        raise LangfuseServiceNameError(
+            "Langfuse plugin requires observability.service_name in Hermes "
+            f"config, but {config_path} does not exist"
+        )
+    try:
+        with config_path.open("r", encoding="utf-8") as handle:
+            config = yaml.safe_load(handle) or {}
+    except Exception as exc:
+        raise LangfuseServiceNameError(
+            "Langfuse plugin requires observability.service_name in Hermes "
+            f"config, but {config_path} could not be read: {exc}"
+        ) from exc
+    if not isinstance(config, dict):
+        return _compatibility_service_name()
+    observability = config.get("observability")
+    if not isinstance(observability, dict):
+        return _compatibility_service_name()
+    if "service_name" not in observability:
+        return _compatibility_service_name()
+    return str(observability["service_name"] or "").strip()
+
+
+def _langfuse_credentials_configured() -> bool:
+    public_key = _env("HERMES_LANGFUSE_PUBLIC_KEY") or _env("LANGFUSE_PUBLIC_KEY")
+    secret_key = _env("HERMES_LANGFUSE_SECRET_KEY") or _env("LANGFUSE_SECRET_KEY")
+    return bool(public_key and secret_key)
+
+
+def _require_service_name() -> str:
+    service_name = _configured_service_name()
+    if not service_name or service_name in _INVALID_SERVICE_NAMES:
+        raise LangfuseServiceNameError(
+            "Langfuse plugin requires observability.service_name to be a "
+            "non-empty value other than unknown_service; refusing to initialize "
+            "because OpenTelemetry would emit an unattributable service.name"
+        )
+    return service_name
+
+
+def _ensure_otel_service_name(service_name: str) -> None:
+    os.environ["OTEL_SERVICE_NAME"] = service_name
+
+    resource_attributes = _env("OTEL_RESOURCE_ATTRIBUTES")
+    parts = [part.strip() for part in resource_attributes.split(",") if part.strip()]
+    parts = [
+        part
+        for part in parts
+        if part.split("=", 1)[0].strip() != "service.name"
+    ]
+    parts.insert(0, f"service.name={service_name}")
+    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = ",".join(parts)
+
+
 def _get_langfuse() -> Optional[Langfuse]:
     """Return a cached Langfuse client, or ``None`` if unavailable.
 
@@ -340,6 +429,8 @@ def _get_langfuse() -> Optional[Langfuse]:
                 kwargs["sample_rate"] = float(sample_rate)
             except ValueError:
                 logger.warning("Invalid HERMES_LANGFUSE_SAMPLE_RATE=%r", sample_rate)
+
+        _ensure_otel_service_name(_require_service_name())
 
         try:
             _LANGFUSE_CLIENT = Langfuse(**kwargs)
@@ -1785,6 +1876,9 @@ def on_subagent_stop(*, parent_session_id: Any = None, parent_turn_id: str = "",
 
 
 def register(ctx) -> None:
+    if _langfuse_credentials_configured():
+        _ensure_otel_service_name(_require_service_name())
+
     # Register for both hook name variants so the plugin works across
     # Hermes versions.  pre_api_request / post_api_request fire per API
     # call (preferred); pre_llm_call / post_llm_call fire once per turn.

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -31,7 +31,14 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
+from hermes_constants import get_config_path
+
 logger = logging.getLogger(__name__)
+
+try:
+    import yaml
+except Exception:  # pragma: no cover - PyYAML is a core dependency
+    yaml = None
 
 try:
     from langfuse import Langfuse, propagate_attributes
@@ -78,6 +85,13 @@ _LANGFUSE_KEY_PREFIXES: Dict[str, str] = {
     "HERMES_LANGFUSE_PUBLIC_KEY": "pk-lf-",
     "HERMES_LANGFUSE_SECRET_KEY": "sk-lf-",
 }
+_INVALID_SERVICE_NAMES = {"unknown_service"}
+_DEFAULT_SERVICE_NAME = "hermes-agent"
+_DEFAULT_SERVICE_NAME_WARNED = False
+
+
+class LangfuseServiceNameError(RuntimeError):
+    """Langfuse configuration cannot provide a usable service identity."""
 
 
 def _env(name: str, default: str = "") -> str:
@@ -144,6 +158,81 @@ def _validate_langfuse_key(env_name: str, value: str) -> Optional[str]:
         f"{env_name}={_redact_key_preview(value)} "
         f"(expected {expected!r} prefix)"
     )
+
+
+def _compatibility_service_name() -> str:
+    """Return the legacy identity while making the ambiguity visible once."""
+    global _DEFAULT_SERVICE_NAME_WARNED
+    if not _DEFAULT_SERVICE_NAME_WARNED:
+        logger.warning(
+            "Langfuse plugin: observability.service_name is not configured; "
+            "using compatibility identity %r. Set a distinct service name in "
+            "config.yaml when multiple Hermes agents share a Langfuse project.",
+            _DEFAULT_SERVICE_NAME,
+        )
+        _DEFAULT_SERVICE_NAME_WARNED = True
+    return _DEFAULT_SERVICE_NAME
+
+
+def _configured_service_name() -> str:
+    config_path = get_config_path()
+    if yaml is None:
+        raise LangfuseServiceNameError(
+            "Langfuse plugin requires observability.service_name in Hermes "
+            "config, but PyYAML is unavailable so config.yaml cannot be read"
+        )
+    if not config_path.is_file():
+        raise LangfuseServiceNameError(
+            "Langfuse plugin requires observability.service_name in Hermes "
+            f"config, but {config_path} does not exist"
+        )
+    try:
+        with config_path.open("r", encoding="utf-8") as handle:
+            config = yaml.safe_load(handle) or {}
+    except Exception as exc:
+        raise LangfuseServiceNameError(
+            "Langfuse plugin requires observability.service_name in Hermes "
+            f"config, but {config_path} could not be read: {exc}"
+        ) from exc
+    if not isinstance(config, dict):
+        return _compatibility_service_name()
+    observability = config.get("observability")
+    if not isinstance(observability, dict):
+        return _compatibility_service_name()
+    if "service_name" not in observability:
+        return _compatibility_service_name()
+    return str(observability["service_name"] or "").strip()
+
+
+def _langfuse_credentials_configured() -> bool:
+    public_key = _env("HERMES_LANGFUSE_PUBLIC_KEY") or _env("LANGFUSE_PUBLIC_KEY")
+    secret_key = _env("HERMES_LANGFUSE_SECRET_KEY") or _env("LANGFUSE_SECRET_KEY")
+    return bool(public_key and secret_key)
+
+
+def _require_service_name() -> str:
+    service_name = _configured_service_name()
+    if not service_name or service_name in _INVALID_SERVICE_NAMES:
+        raise LangfuseServiceNameError(
+            "Langfuse plugin requires observability.service_name to be a "
+            "non-empty value other than unknown_service; refusing to initialize "
+            "because OpenTelemetry would emit an unattributable service.name"
+        )
+    return service_name
+
+
+def _ensure_otel_service_name(service_name: str) -> None:
+    os.environ["OTEL_SERVICE_NAME"] = service_name
+
+    resource_attributes = _env("OTEL_RESOURCE_ATTRIBUTES")
+    parts = [part.strip() for part in resource_attributes.split(",") if part.strip()]
+    parts = [
+        part
+        for part in parts
+        if part.split("=", 1)[0].strip() != "service.name"
+    ]
+    parts.insert(0, f"service.name={service_name}")
+    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = ",".join(parts)
 
 
 def _get_langfuse() -> Optional[Langfuse]:
@@ -217,6 +306,8 @@ def _get_langfuse() -> Optional[Langfuse]:
             kwargs["sample_rate"] = float(sample_rate)
         except ValueError:
             logger.warning("Invalid HERMES_LANGFUSE_SAMPLE_RATE=%r", sample_rate)
+
+    _ensure_otel_service_name(_require_service_name())
 
     try:
         _LANGFUSE_CLIENT = Langfuse(**kwargs)
@@ -1126,6 +1217,9 @@ def on_post_tool_call(*, tool_name: str = "", args: Any = None, result: Any = No
 
 
 def register(ctx) -> None:
+    if _langfuse_credentials_configured():
+        _ensure_otel_service_name(_require_service_name())
+
     # Register for both hook name variants so the plugin works across
     # Hermes versions.  pre_api_request / post_api_request fire per API
     # call (preferred); pre_llm_call / post_llm_call fire once per turn.

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -2,6 +2,7 @@
 
 import logging
 import subprocess
+import sys
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -703,6 +704,22 @@ class TestBrowserUseCliInstalledForAllNonCamofoxBackends:
             _ensure_browser_use_cli()  # must not raise
 
         assert any("failed" in c.args[0] for c in warn.call_args_list)
+
+def test_langfuse_post_setup_persists_service_identity(monkeypatch):
+    """The supported Langfuse wizard writes its non-secret OTel identity."""
+    config = {}
+    saved = []
+    monkeypatch.setitem(sys.modules, "langfuse", object())
+    monkeypatch.setattr("hermes_cli.tools_config.load_config", lambda: config)
+    monkeypatch.setattr("hermes_cli.tools_config.save_config", lambda value: saved.append(value))
+    monkeypatch.setattr("hermes_cli.tools_config._prompt", lambda *args, **kwargs: "production-agent")
+    monkeypatch.setattr("hermes_cli.plugins_cmd._get_enabled_set", lambda: set())
+    monkeypatch.setattr("hermes_cli.plugins_cmd._save_enabled_set", lambda enabled: None)
+
+    _run_post_setup("langfuse")
+
+    assert config["observability"]["service_name"] == "production-agent"
+    assert saved == [config]
 
 
 class TestImagegenBackendRegistry:

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -1,6 +1,7 @@
 """Tests for hermes_cli.tools_config platform tool persistence."""
 
 import logging
+import sys
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -342,6 +343,23 @@ def test_numeric_mcp_server_name_does_not_crash_sorted():
 
 
 
+
+
+def test_langfuse_post_setup_persists_service_identity(monkeypatch):
+    """The supported Langfuse wizard writes its non-secret OTel identity."""
+    config = {}
+    saved = []
+    monkeypatch.setitem(sys.modules, "langfuse", object())
+    monkeypatch.setattr("hermes_cli.tools_config.load_config", lambda: config)
+    monkeypatch.setattr("hermes_cli.tools_config.save_config", lambda value: saved.append(value))
+    monkeypatch.setattr("hermes_cli.tools_config._prompt", lambda *args, **kwargs: "production-agent")
+    monkeypatch.setattr("hermes_cli.plugins_cmd._get_enabled_set", lambda: set())
+    monkeypatch.setattr("hermes_cli.plugins_cmd._save_enabled_set", lambda enabled: None)
+
+    _run_post_setup("langfuse")
+
+    assert config["observability"]["service_name"] == "production-agent"
+    assert saved == [config]
 
 
 class TestImagegenBackendRegistry:

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import importlib
 import logging
+import os
 import sys
 from pathlib import Path
 
@@ -22,7 +23,9 @@ PLUGIN_DIR = REPO_ROOT / "plugins" / "observability" / "langfuse"
 class TestManifest:
 
     def test_manifest_fields(self):
-        data = yaml.safe_load((PLUGIN_DIR / "plugin.yaml").read_text())
+        data = yaml.safe_load(
+            (PLUGIN_DIR / "plugin.yaml").read_text(encoding="utf-8")
+        )
         assert data["name"] == "langfuse"
         assert data["version"]
         # All six hooks the plugin implements.
@@ -43,6 +46,11 @@ class TestManifest:
 # ---------------------------------------------------------------------------
 
 class TestDiscovery:
+    @staticmethod
+    def _write_config(home: Path, text: str) -> None:
+        home.mkdir()
+        (home / "config.yaml").write_text(text, encoding="utf-8")
+
     def test_plugin_is_discovered_as_standalone_opt_in(self, tmp_path, monkeypatch):
         """Scanner should find the plugin but NOT load it by default."""
         from hermes_cli import plugins as plugins_mod
@@ -62,6 +70,90 @@ class TestDiscovery:
         # … but is not loaded (opt-in default → no config.yaml means nothing enabled)
         assert loaded.enabled is False
         assert "not enabled" in (loaded.error or "").lower()
+
+    @pytest.mark.parametrize("service_name", ["", "unknown_service"])
+    def test_invalid_service_name_prevents_plugin_loading_without_breaking_agent(
+        self, tmp_path, monkeypatch, service_name
+    ):
+        from hermes_cli import plugins as plugins_mod
+
+        home = tmp_path / ".hermes"
+        rendered_service = f"  service_name: {service_name!r}\n"
+        self._write_config(
+            home,
+            "plugins:\n"
+            "  enabled:\n"
+            "    - observability/langfuse\n"
+            "observability:\n"
+            f"{rendered_service}",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-real-public-xyz")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-real-secret-xyz")
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        manager = plugins_mod.PluginManager()
+        manager.discover_and_load()
+
+        loaded = manager._plugins["observability/langfuse"]
+        assert loaded.enabled is False
+        assert "observability.service_name" in (loaded.error or "")
+
+    def test_credential_only_legacy_config_uses_service_name_default(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli import plugins as plugins_mod
+
+        home = tmp_path / ".hermes"
+        self._write_config(
+            home,
+            "plugins:\n"
+            "  enabled:\n"
+            "    - observability/langfuse\n",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-real-public-xyz")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-real-secret-xyz")
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        manager = plugins_mod.PluginManager()
+        manager.discover_and_load()
+
+        loaded = manager._plugins["observability/langfuse"]
+        assert loaded.enabled is True
+
+    def test_service_name_config_read_failures_are_fail_closed(self, tmp_path, monkeypatch):
+        langfuse_plugin = importlib.import_module("plugins.observability.langfuse")
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-real-public-xyz")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-real-secret-xyz")
+
+        with pytest.raises(langfuse_plugin.LangfuseServiceNameError, match="does not exist"):
+            langfuse_plugin._require_service_name()
+
+        (home / "config.yaml").write_text("observability: [", encoding="utf-8")
+
+        with pytest.raises(langfuse_plugin.LangfuseServiceNameError, match="could not be read"):
+            langfuse_plugin._require_service_name()
+
+    def test_plugin_hook_errors_remain_isolated(self, caplog):
+        from hermes_cli import plugins as plugins_mod
+        from plugins.observability.langfuse import LangfuseServiceNameError
+
+        manager = plugins_mod.PluginManager()
+        manager._hooks["pre_api_request"] = [
+            lambda **_: (_ for _ in ()).throw(
+                LangfuseServiceNameError("unknown_service")
+            )
+        ]
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            manager.invoke_hook("pre_api_request")
+
+        assert "unknown_service" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -414,8 +506,17 @@ class TestPlaceholderKeyDetection:
         for k in (
             "HERMES_LANGFUSE_PUBLIC_KEY", "HERMES_LANGFUSE_SECRET_KEY",
             "LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY",
+            "HERMES_HOME",
+            "OTEL_SERVICE_NAME",
+            "OTEL_RESOURCE_ATTRIBUTES",
         ):
             monkeypatch.delenv(k, raising=False)
+
+    @staticmethod
+    def _write_config(tmp_path, text: str) -> None:
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(text, encoding="utf-8")
 
     # -- helper unit tests (no SDK stub needed: these don't go through
     #    _get_langfuse, they exercise the pure-Python helpers directly) ------
@@ -505,6 +606,180 @@ class TestPlaceholderKeyDetection:
             f"Warning fired {len(warnings)} times across 15 calls; "
             "expected 1 (cached via _INIT_FAILED)"
         )
+
+    @pytest.mark.parametrize("placeholder", [
+        "placeholder",
+        "test-key",
+        "your-langfuse-key",
+        "change-me",
+        "xxx",
+        "dummy-key-here",
+        "<your-key>",
+        "REPLACE_ME",
+    ])
+    def test_common_placeholders_detected(self, monkeypatch, caplog, placeholder):
+        """A grab-bag of values that real-world ``.env.example`` templates
+        use as stand-ins.  Any of them in either key must trip the guard."""
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", placeholder)
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-real-secret-xyz")
+        plugin = self._fresh_plugin(monkeypatch)
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            assert plugin._get_langfuse() is None
+        assert "HERMES_LANGFUSE_PUBLIC_KEY" in caplog.text
+
+    def test_legacy_LANGFUSE_PUBLIC_KEY_also_validated(self, monkeypatch, caplog):
+        """The plugin reads both the canonical HERMES_-prefixed env var and
+        the legacy bare ``LANGFUSE_PUBLIC_KEY``.  The validator must run on
+        whichever value ``_get_langfuse()`` actually consumed."""
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "placeholder")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-lf-real-secret-xyz")
+        plugin = self._fresh_plugin(monkeypatch)
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            assert plugin._get_langfuse() is None
+        # Warning names the canonical user-facing env var (the bare
+        # LANGFUSE_PUBLIC_KEY is a backwards-compat alias for the
+        # HERMES_-prefixed one — operators set the HERMES_-prefixed one).
+        assert "HERMES_LANGFUSE_PUBLIC_KEY" in caplog.text
+        assert "'placeholder'" in caplog.text
+
+    def test_missing_credentials_still_skip_silently(self, monkeypatch, caplog):
+        """Missing-creds is the documented opt-out path (operator hasn't
+        configured the plugin yet) — it must remain SILENT.  Regression
+        guard against the placeholder validator accidentally running on
+        empty values and re-introducing log noise for unconfigured
+        installs."""
+        self._clear_env(monkeypatch)
+        plugin = self._fresh_plugin(monkeypatch)
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            assert plugin._get_langfuse() is None
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"
+                    and r.name == self.LOGGER_NAME]
+        assert warnings == []
+
+    def test_sdk_not_installed_still_skips_silently(self, monkeypatch, caplog):
+        """If the langfuse SDK isn't installed at all, the placeholder
+        check should never run — there's nothing the operator can do
+        about a credential mismatch when the package is missing, and
+        re-warning here would dilute the actually-actionable SDK-missing
+        signal upstream.  The ``Langfuse is None`` guard at the top of
+        ``_get_langfuse`` already handles this; this test pins that
+        behaviour."""
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "placeholder")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "placeholder")
+        # NO monkeypatch on Langfuse here — falls back to whatever the
+        # plugin imported at module load (None if SDK absent).
+        plugin = self._fresh_plugin()
+        monkeypatch.setattr(plugin, "Langfuse", None, raising=False)
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            assert plugin._get_langfuse() is None
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"
+                    and r.name == self.LOGGER_NAME]
+        assert warnings == []
+
+    def test_valid_prefixes_do_not_trigger_placeholder_warning(self, monkeypatch, caplog, tmp_path):
+        """Real Langfuse keys (``pk-lf-…`` / ``sk-lf-…``) must pass the
+        guard and proceed to SDK init.  We stub the SDK constructor with
+        a recording fake so the assertion can confirm BOTH that the
+        placeholder warning didn't fire AND that the client was actually
+        constructed — the latter is the success signal the bug report
+        wanted."""
+        self._clear_env(monkeypatch)
+        self._write_config(tmp_path, "observability:\n  service_name: riemann\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-real-public-xyz")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-real-secret-xyz")
+        plugin = self._fresh_plugin(monkeypatch)
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            client = plugin._get_langfuse()
+        assert isinstance(client, _FakeLangfuse)
+        assert client.kwargs["public_key"] == "pk-lf-real-public-xyz"
+        assert client.kwargs["secret_key"] == "sk-lf-real-secret-xyz"
+        assert "placeholders" not in caplog.text.lower(), (
+            f"Valid Langfuse keys tripped the placeholder guard: {caplog.text!r}"
+        )
+
+    def test_missing_service_name_warns_and_uses_compatibility_default(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        self._clear_env(monkeypatch)
+        self._write_config(tmp_path, "observability: {}\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-real-public-xyz")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-real-secret-xyz")
+        plugin = self._fresh_plugin(monkeypatch)
+
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            client = plugin._get_langfuse()
+
+        assert isinstance(client, _FakeLangfuse)
+        assert os.environ["OTEL_SERVICE_NAME"] == "hermes-agent"
+        assert "observability.service_name is not configured" in caplog.text
+        assert "using compatibility identity 'hermes-agent'" in caplog.text
+
+    def test_unknown_service_name_fails_closed(self, monkeypatch, tmp_path):
+        self._clear_env(monkeypatch)
+        self._write_config(
+            tmp_path,
+            "observability:\n  service_name: unknown_service\n",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-real-public-xyz")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-real-secret-xyz")
+        plugin = self._fresh_plugin(monkeypatch)
+
+        with pytest.raises(RuntimeError, match="unknown_service"):
+            plugin._get_langfuse()
+
+        assert _FakeLangfuse.instances == []
+
+    def test_service_name_sets_otel_resource_before_client_init(self, monkeypatch, tmp_path):
+        self._clear_env(monkeypatch)
+        self._write_config(
+            tmp_path,
+            "observability:\n  service_name: riemann\n",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-real-public-xyz")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-real-secret-xyz")
+        monkeypatch.setenv("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=staging")
+        plugin = self._fresh_plugin(monkeypatch)
+
+        client = plugin._get_langfuse()
+
+        assert isinstance(client, _FakeLangfuse)
+        assert os.environ["OTEL_SERVICE_NAME"] == "riemann"
+        assert os.environ["OTEL_RESOURCE_ATTRIBUTES"].split(",") == [
+            "service.name=riemann",
+            "deployment.environment=staging",
+        ]
+
+    def test_service_name_overwrites_stale_otel_identity(self, monkeypatch, tmp_path):
+        self._clear_env(monkeypatch)
+        self._write_config(
+            tmp_path,
+            "observability:\n  service_name: riemann\n",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-real-public-xyz")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-real-secret-xyz")
+        monkeypatch.setenv("OTEL_SERVICE_NAME", "unknown_service")
+        monkeypatch.setenv(
+            "OTEL_RESOURCE_ATTRIBUTES",
+            "deployment.environment=staging,service.name=unknown_service",
+        )
+        plugin = self._fresh_plugin(monkeypatch)
+
+        client = plugin._get_langfuse()
+
+        assert isinstance(client, _FakeLangfuse)
+        assert os.environ["OTEL_SERVICE_NAME"] == "riemann"
+        assert os.environ["OTEL_RESOURCE_ATTRIBUTES"].split(",") == [
+            "service.name=riemann",
+            "deployment.environment=staging",
+        ]
 
 
 class TestRequestMessageCoercion:

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import importlib
 import logging
+import os
 import sys
 from decimal import Decimal
 from pathlib import Path
@@ -24,7 +25,9 @@ PLUGIN_DIR = REPO_ROOT / "plugins" / "observability" / "langfuse"
 class TestManifest:
 
     def test_manifest_fields(self):
-        data = yaml.safe_load((PLUGIN_DIR / "plugin.yaml").read_text())
+        data = yaml.safe_load(
+            (PLUGIN_DIR / "plugin.yaml").read_text(encoding="utf-8")
+        )
         assert data["name"] == "langfuse"
         assert data["version"]
         # All eleven hooks the plugin implements.
@@ -47,6 +50,11 @@ class TestManifest:
 # ---------------------------------------------------------------------------
 
 class TestDiscovery:
+    @staticmethod
+    def _write_config(home: Path, text: str) -> None:
+        home.mkdir()
+        (home / "config.yaml").write_text(text, encoding="utf-8")
+
     def test_plugin_is_discovered_as_standalone_opt_in(self, tmp_path, monkeypatch):
         """Scanner should find the plugin but NOT load it by default."""
         from hermes_cli import plugins as plugins_mod
@@ -66,6 +74,90 @@ class TestDiscovery:
         # … but is not loaded (opt-in default → no config.yaml means nothing enabled)
         assert loaded.enabled is False
         assert "not enabled" in (loaded.error or "").lower()
+
+    @pytest.mark.parametrize("service_name", ["", "unknown_service"])
+    def test_invalid_service_name_prevents_plugin_loading_without_breaking_agent(
+        self, tmp_path, monkeypatch, service_name
+    ):
+        from hermes_cli import plugins as plugins_mod
+
+        home = tmp_path / ".hermes"
+        rendered_service = f"  service_name: {service_name!r}\n"
+        self._write_config(
+            home,
+            "plugins:\n"
+            "  enabled:\n"
+            "    - observability/langfuse\n"
+            "observability:\n"
+            f"{rendered_service}",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-real-public-xyz")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-real-secret-xyz")
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        manager = plugins_mod.PluginManager()
+        manager.discover_and_load()
+
+        loaded = manager._plugins["observability/langfuse"]
+        assert loaded.enabled is False
+        assert "observability.service_name" in (loaded.error or "")
+
+    def test_credential_only_legacy_config_uses_service_name_default(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli import plugins as plugins_mod
+
+        home = tmp_path / ".hermes"
+        self._write_config(
+            home,
+            "plugins:\n"
+            "  enabled:\n"
+            "    - observability/langfuse\n",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-real-public-xyz")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-real-secret-xyz")
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        manager = plugins_mod.PluginManager()
+        manager.discover_and_load()
+
+        loaded = manager._plugins["observability/langfuse"]
+        assert loaded.enabled is True
+
+    def test_service_name_config_read_failures_are_fail_closed(self, tmp_path, monkeypatch):
+        langfuse_plugin = importlib.import_module("plugins.observability.langfuse")
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-real-public-xyz")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-real-secret-xyz")
+
+        with pytest.raises(langfuse_plugin.LangfuseServiceNameError, match="does not exist"):
+            langfuse_plugin._require_service_name()
+
+        (home / "config.yaml").write_text("observability: [", encoding="utf-8")
+
+        with pytest.raises(langfuse_plugin.LangfuseServiceNameError, match="could not be read"):
+            langfuse_plugin._require_service_name()
+
+    def test_plugin_hook_errors_remain_isolated(self, caplog):
+        from hermes_cli import plugins as plugins_mod
+        from plugins.observability.langfuse import LangfuseServiceNameError
+
+        manager = plugins_mod.PluginManager()
+        manager._hooks["pre_api_request"] = [
+            lambda **_: (_ for _ in ()).throw(
+                LangfuseServiceNameError("unknown_service")
+            )
+        ]
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            manager.invoke_hook("pre_api_request")
+
+        assert "unknown_service" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -486,8 +578,17 @@ class TestPlaceholderKeyDetection:
         for k in (
             "HERMES_LANGFUSE_PUBLIC_KEY", "HERMES_LANGFUSE_SECRET_KEY",
             "LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY",
+            "HERMES_HOME",
+            "OTEL_SERVICE_NAME",
+            "OTEL_RESOURCE_ATTRIBUTES",
         ):
             monkeypatch.delenv(k, raising=False)
+
+    @staticmethod
+    def _write_config(tmp_path, text: str) -> None:
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(text, encoding="utf-8")
 
     # -- helper unit tests (no SDK stub needed: these don't go through
     #    _get_langfuse, they exercise the pure-Python helpers directly) ------
@@ -577,6 +678,180 @@ class TestPlaceholderKeyDetection:
             f"Warning fired {len(warnings)} times across 15 calls; "
             "expected 1 (cached via _INIT_FAILED)"
         )
+
+    @pytest.mark.parametrize("placeholder", [
+        "placeholder",
+        "test-key",
+        "your-langfuse-key",
+        "change-me",
+        "xxx",
+        "dummy-key-here",
+        "<your-key>",
+        "REPLACE_ME",
+    ])
+    def test_common_placeholders_detected(self, monkeypatch, caplog, placeholder):
+        """A grab-bag of values that real-world ``.env.example`` templates
+        use as stand-ins.  Any of them in either key must trip the guard."""
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", placeholder)
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-real-secret-xyz")
+        plugin = self._fresh_plugin(monkeypatch)
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            assert plugin._get_langfuse() is None
+        assert "HERMES_LANGFUSE_PUBLIC_KEY" in caplog.text
+
+    def test_legacy_LANGFUSE_PUBLIC_KEY_also_validated(self, monkeypatch, caplog):
+        """The plugin reads both the canonical HERMES_-prefixed env var and
+        the legacy bare ``LANGFUSE_PUBLIC_KEY``.  The validator must run on
+        whichever value ``_get_langfuse()`` actually consumed."""
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "placeholder")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-lf-real-secret-xyz")
+        plugin = self._fresh_plugin(monkeypatch)
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            assert plugin._get_langfuse() is None
+        # Warning names the canonical user-facing env var (the bare
+        # LANGFUSE_PUBLIC_KEY is a backwards-compat alias for the
+        # HERMES_-prefixed one — operators set the HERMES_-prefixed one).
+        assert "HERMES_LANGFUSE_PUBLIC_KEY" in caplog.text
+        assert "'placeholder'" in caplog.text
+
+    def test_missing_credentials_still_skip_silently(self, monkeypatch, caplog):
+        """Missing-creds is the documented opt-out path (operator hasn't
+        configured the plugin yet) — it must remain SILENT.  Regression
+        guard against the placeholder validator accidentally running on
+        empty values and re-introducing log noise for unconfigured
+        installs."""
+        self._clear_env(monkeypatch)
+        plugin = self._fresh_plugin(monkeypatch)
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            assert plugin._get_langfuse() is None
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"
+                    and r.name == self.LOGGER_NAME]
+        assert warnings == []
+
+    def test_sdk_not_installed_still_skips_silently(self, monkeypatch, caplog):
+        """If the langfuse SDK isn't installed at all, the placeholder
+        check should never run — there's nothing the operator can do
+        about a credential mismatch when the package is missing, and
+        re-warning here would dilute the actually-actionable SDK-missing
+        signal upstream.  The ``Langfuse is None`` guard at the top of
+        ``_get_langfuse`` already handles this; this test pins that
+        behaviour."""
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "placeholder")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "placeholder")
+        # NO monkeypatch on Langfuse here — falls back to whatever the
+        # plugin imported at module load (None if SDK absent).
+        plugin = self._fresh_plugin()
+        monkeypatch.setattr(plugin, "Langfuse", None, raising=False)
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            assert plugin._get_langfuse() is None
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"
+                    and r.name == self.LOGGER_NAME]
+        assert warnings == []
+
+    def test_valid_prefixes_do_not_trigger_placeholder_warning(self, monkeypatch, caplog, tmp_path):
+        """Real Langfuse keys (``pk-lf-…`` / ``sk-lf-…``) must pass the
+        guard and proceed to SDK init.  We stub the SDK constructor with
+        a recording fake so the assertion can confirm BOTH that the
+        placeholder warning didn't fire AND that the client was actually
+        constructed — the latter is the success signal the bug report
+        wanted."""
+        self._clear_env(monkeypatch)
+        self._write_config(tmp_path, "observability:\n  service_name: riemann\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-real-public-xyz")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-real-secret-xyz")
+        plugin = self._fresh_plugin(monkeypatch)
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            client = plugin._get_langfuse()
+        assert isinstance(client, _FakeLangfuse)
+        assert client.kwargs["public_key"] == "pk-lf-real-public-xyz"
+        assert client.kwargs["secret_key"] == "sk-lf-real-secret-xyz"
+        assert "placeholders" not in caplog.text.lower(), (
+            f"Valid Langfuse keys tripped the placeholder guard: {caplog.text!r}"
+        )
+
+    def test_missing_service_name_warns_and_uses_compatibility_default(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        self._clear_env(monkeypatch)
+        self._write_config(tmp_path, "observability: {}\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-real-public-xyz")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-real-secret-xyz")
+        plugin = self._fresh_plugin(monkeypatch)
+
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            client = plugin._get_langfuse()
+
+        assert isinstance(client, _FakeLangfuse)
+        assert os.environ["OTEL_SERVICE_NAME"] == "hermes-agent"
+        assert "observability.service_name is not configured" in caplog.text
+        assert "using compatibility identity 'hermes-agent'" in caplog.text
+
+    def test_unknown_service_name_fails_closed(self, monkeypatch, tmp_path):
+        self._clear_env(monkeypatch)
+        self._write_config(
+            tmp_path,
+            "observability:\n  service_name: unknown_service\n",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-real-public-xyz")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-real-secret-xyz")
+        plugin = self._fresh_plugin(monkeypatch)
+
+        with pytest.raises(RuntimeError, match="unknown_service"):
+            plugin._get_langfuse()
+
+        assert _FakeLangfuse.instances == []
+
+    def test_service_name_sets_otel_resource_before_client_init(self, monkeypatch, tmp_path):
+        self._clear_env(monkeypatch)
+        self._write_config(
+            tmp_path,
+            "observability:\n  service_name: riemann\n",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-real-public-xyz")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-real-secret-xyz")
+        monkeypatch.setenv("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=staging")
+        plugin = self._fresh_plugin(monkeypatch)
+
+        client = plugin._get_langfuse()
+
+        assert isinstance(client, _FakeLangfuse)
+        assert os.environ["OTEL_SERVICE_NAME"] == "riemann"
+        assert os.environ["OTEL_RESOURCE_ATTRIBUTES"].split(",") == [
+            "service.name=riemann",
+            "deployment.environment=staging",
+        ]
+
+    def test_service_name_overwrites_stale_otel_identity(self, monkeypatch, tmp_path):
+        self._clear_env(monkeypatch)
+        self._write_config(
+            tmp_path,
+            "observability:\n  service_name: riemann\n",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-real-public-xyz")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-real-secret-xyz")
+        monkeypatch.setenv("OTEL_SERVICE_NAME", "unknown_service")
+        monkeypatch.setenv(
+            "OTEL_RESOURCE_ATTRIBUTES",
+            "deployment.environment=staging,service.name=unknown_service",
+        )
+        plugin = self._fresh_plugin(monkeypatch)
+
+        client = plugin._get_langfuse()
+
+        assert isinstance(client, _FakeLangfuse)
+        assert os.environ["OTEL_SERVICE_NAME"] == "riemann"
+        assert os.environ["OTEL_RESOURCE_ATTRIBUTES"].split(",") == [
+            "service.name=riemann",
+            "deployment.environment=staging",
+        ]
 
 
 class TestRequestMessageCoercion:

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -730,14 +730,10 @@ class TestPlaceholderKeyDetection:
                     and r.name == self.LOGGER_NAME]
         assert warnings == []
 
-    def test_sdk_not_installed_still_skips_silently(self, monkeypatch, caplog):
-        """If the langfuse SDK isn't installed at all, the placeholder
-        check should never run — there's nothing the operator can do
-        about a credential mismatch when the package is missing, and
-        re-warning here would dilute the actually-actionable SDK-missing
-        signal upstream.  The ``Langfuse is None`` guard at the top of
-        ``_get_langfuse`` already handles this; this test pins that
-        behaviour."""
+    def test_sdk_not_installed_warns_without_placeholder_message(
+        self, monkeypatch, caplog
+    ):
+        """The SDK-missing path stays actionable without blaming credentials."""
         self._clear_env(monkeypatch)
         monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "placeholder")
         monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "placeholder")
@@ -749,7 +745,9 @@ class TestPlaceholderKeyDetection:
             assert plugin._get_langfuse() is None
         warnings = [r for r in caplog.records if r.levelname == "WARNING"
                     and r.name == self.LOGGER_NAME]
-        assert warnings == []
+        assert len(warnings) == 1
+        assert "SDK is unavailable" in warnings[0].getMessage()
+        assert "placeholder" not in warnings[0].getMessage()
 
     def test_valid_prefixes_do_not_trigger_placeholder_warning(self, monkeypatch, caplog, tmp_path):
         """Real Langfuse keys (``pk-lf-…`` / ``sk-lf-…``) must pass the
@@ -2011,6 +2009,7 @@ class TestAtexitFinalization(TestTurnTraceIsolation):
         )
         monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-0123456789abcdef")
         monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-0123456789abcdef")
+        monkeypatch.setattr(mod, "_require_service_name", lambda: "hermes-agent")
         mod._LANGFUSE_CLIENT = None
 
         assert mod._get_langfuse() is not None

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -143,7 +143,7 @@ The file is still written. The model reads the warning in the next turn's tool m
 
 Traces Hermes turns, LLM calls, and tool invocations to [Langfuse](https://langfuse.com) — an open-source LLM observability platform. One span per turn, one generation per API call, one tool observation per tool call. Usage totals, per-type token counts, and cost estimates come out of Hermes' canonical `agent.usage_pricing` numbers, so the Langfuse dashboard sees the same breakdown (input / output / `cache_read_input_tokens` / `cache_creation_input_tokens` / `reasoning_tokens`) that appears in `hermes logs`.
 
-The plugin is fail-open: no SDK installed, no credentials, or a transient Langfuse error — all turn into a silent no-op in the hook. The agent loop is never impacted.
+The plugin is fail-open: no SDK installed, no credentials, or a transient Langfuse error — all turn into a silent no-op in the hook. The agent loop is never impacted. If Langfuse is configured with an invalid service identity, the plugin does not load; other plugins and the agent loop remain isolated.
 
 **Setup (interactive — recommended):**
 
@@ -151,7 +151,7 @@ The plugin is fail-open: no SDK installed, no credentials, or a transient Langfu
 hermes tools          # → Langfuse Observability → Cloud or Self-Hosted
 ```
 
-The wizard collects your keys, `pip install`s the `langfuse` SDK, and adds `observability/langfuse` to `plugins.enabled` for you. Restart Hermes and the next turn ships a trace.
+The wizard collects your keys, asks for the OpenTelemetry service identity (default: `hermes-agent`), `pip install`s the `langfuse` SDK, and adds `observability/langfuse` to `plugins.enabled` for you. Restart Hermes and the next turn ships a trace.
 
 **Setup (manual):**
 
@@ -167,6 +167,15 @@ HERMES_LANGFUSE_PUBLIC_KEY=pk-lf-...
 HERMES_LANGFUSE_SECRET_KEY=sk-lf-...
 HERMES_LANGFUSE_BASE_URL=https://cloud.langfuse.com   # or your self-hosted URL
 ```
+
+Set the non-secret service identity in `~/.hermes/config.yaml`:
+
+```yaml
+observability:
+  service_name: hermes-agent
+```
+
+`hermes-agent` is the compatibility default for existing credential-only installations. A missing value emits a startup warning because that fallback is shared; choose a distinct value when multiple Hermes deployments share a Langfuse project. An empty value or `unknown_service` prevents the Langfuse plugin from loading.
 
 **How it works:**
 

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -144,7 +144,7 @@ The file is still written. The model reads the warning in the next turn's tool m
 
 Traces Hermes turns, LLM calls, and tool invocations to [Langfuse](https://langfuse.com) — an open-source LLM observability platform. One span per turn, one generation per API call, one tool observation per tool call. Usage totals, per-type token counts, and cost estimates come out of Hermes' canonical `agent.usage_pricing` numbers, so the Langfuse dashboard sees the same breakdown (input / output / `cache_read_input_tokens` / `cache_creation_input_tokens` / `reasoning_tokens`) that appears in `hermes logs`.
 
-The plugin is fail-open: no SDK installed, no credentials, or a transient Langfuse error — all turn into a silent no-op in the hook. The agent loop is never impacted.
+The plugin is fail-open: no SDK installed, no credentials, or a transient Langfuse error — all turn into a silent no-op in the hook. The agent loop is never impacted. If Langfuse is configured with an invalid service identity, the plugin does not load; other plugins and the agent loop remain isolated.
 
 **Setup (interactive — recommended):**
 
@@ -152,7 +152,7 @@ The plugin is fail-open: no SDK installed, no credentials, or a transient Langfu
 hermes tools          # → Langfuse Observability → Cloud or Self-Hosted
 ```
 
-The wizard collects your keys, `pip install`s the `langfuse` SDK, and adds `observability/langfuse` to `plugins.enabled` for you. Restart Hermes and the next turn ships a trace.
+The wizard collects your keys, asks for the OpenTelemetry service identity (default: `hermes-agent`), `pip install`s the `langfuse` SDK, and adds `observability/langfuse` to `plugins.enabled` for you. Restart Hermes and the next turn ships a trace.
 
 **Setup (manual):**
 
@@ -168,6 +168,15 @@ HERMES_LANGFUSE_PUBLIC_KEY=pk-lf-...
 HERMES_LANGFUSE_SECRET_KEY=sk-lf-...
 HERMES_LANGFUSE_BASE_URL=https://cloud.langfuse.com   # or your self-hosted URL
 ```
+
+Set the non-secret service identity in `~/.hermes/config.yaml`:
+
+```yaml
+observability:
+  service_name: hermes-agent
+```
+
+`hermes-agent` is the compatibility default for existing credential-only installations. A missing value emits a startup warning because that fallback is shared; choose a distinct value when multiple Hermes deployments share a Langfuse project. An empty value or `unknown_service` prevents the Langfuse plugin from loading.
 
 **How it works:**
 


### PR DESCRIPTION
## What does this PR do?

Langfuse now establishes a stable OpenTelemetry service identity before constructing its SDK client, preventing traces from being exported as `unknown_service`.

Existing credential-only installations remain compatible: an absent `observability.service_name` emits a one-time startup warning and uses `hermes-agent`. The supported setup wizard writes an explicit value, and an explicitly empty value or `unknown_service` prevents only the Langfuse plugin from loading while the agent loop and other plugins remain isolated.

## Related Issue

Partially addresses #58322

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/observability/langfuse/__init__.py`: read the active profile config through `get_config_path()`, validate the service identity, warn once when the shared compatibility fallback is used, and set `OTEL_SERVICE_NAME` plus `service.name` in `OTEL_RESOURCE_ATTRIBUTES` before Langfuse initialization.
- `hermes_cli/config_defaults.py`: add the `hermes-agent` compatibility default.
- `hermes_cli/tools_config.py`: prompt for and persist the non-secret service identity during supported Langfuse setup.
- `hermes_cli/web_server.py`: place the single schema-surfaced observability field in the existing Agent settings category, satisfying the dashboard rule against one-field tabs.
- `cli-config.yaml.example` and `website/docs/user-guide/features/built-in-plugins.md`: document configuration, compatibility, and failure behavior.
- `tests/plugins/test_langfuse_plugin.py`, `tests/hermes_cli/test_tools_config.py`, and the existing Web settings schema regression: cover SDK initialization ordering, legacy defaults, explicit invalid values, wizard persistence, plugin isolation, and dashboard category validity.
- `contributors/emails/axegggl@gmail.com`: provide the repository-required contributor attribution mapping.

## How to Test

1. Enable Langfuse with valid credentials and no `observability.service_name`; verify startup warns and the plugin loads with `service.name=hermes-agent`.
2. Set `observability.service_name: my-agent`; verify both OpenTelemetry environment surfaces contain `my-agent` before the Langfuse client is constructed.
3. Set an explicit empty value or `unknown_service`; verify the Langfuse plugin is rejected while the agent loop and other plugins remain available.
4. Run:

   ```bash
   scripts/run_tests.sh tests/plugins/test_langfuse_plugin.py tests/hermes_cli/test_tools_config.py tests/hermes_cli/test_plugins.py tests/scripts/test_contributor_map.py tests/hermes_cli/test_web_server.py -q
   ```

## Verification

Exact current head: `50351291901432bef000d4a2bd75869b38084bd2`, based on current `main` at `18a76be124d7c16ed98b629a358b23fef76a7f46`.

- Required repository runner, focused and neighboring suites: **426 passed, 0 failed, 6 skipped**.
- The Web settings suite passes **184/184**, including `test_no_single_field_categories`, which caught and now verifies the final dashboard-category fix.
- Required repository runner, complete exact-head suite: **42,270 passed, 149 failed, 414 skipped** across 3,519 files.
- The complete run's failures are unrelated current-repository/host failures dominated by the restricted macOS process environment (live-system signal guard, process/port permissions, unavailable platform binaries). The affected Langfuse, setup, plugin-loading, config-schema, and Web settings paths are green.
- Ruff on the touched Python surface: passed.
- `scripts/check-windows-footguns.py --all`: passed (1,054 files).
- `cli-config.yaml.example` YAML parse: passed.
- Contributor-map tests and `git diff --check`: passed.
- Hosted fork workflows require maintainer approval before they can run.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched existing PRs for this issue; this is the only matching PR
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — the required complete runner finished, but unrelated current-repository/host failures remain as documented above
- [x] I've added tests for the bug fix
- [x] I've tested on macOS (Darwin)

### Documentation & Housekeeping

- [x] Relevant user documentation is updated
- [x] `cli-config.yaml.example` is updated for the new config key
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are not applicable
- [x] Cross-platform impact was considered; active-profile config resolution uses the existing `get_config_path()` abstraction and the Windows footgun scan passes
- [x] Tool descriptions/schemas are not affected

## Telemetry and Compatibility

- Langfuse remains opt-in through `plugins.enabled` and configured credentials.
- No telemetry client is created when the SDK or credentials are absent.
- Existing credential-only installations keep working through the `hermes-agent` default and now receive a one-time startup warning to choose a distinct identity.
- Invalid explicit identities disable only the Langfuse plugin; generic hook isolation is unchanged.

## Current Repository Policy Compatibility

- This PR does **not** add a third-party integration, plugin directory, hook, or core escape hatch. It repairs the Langfuse plugin already bundled on current `main`.
- The setup change extends the pre-existing Langfuse branch in `hermes tools`; it does not introduce a new product-specific setup surface.
- Telemetry remains explicitly opt-in through the existing plugin enablement and credential configuration. The service name is non-secret and user-configurable.
- Generic plugin loading and failure isolation remain unchanged; an invalid identity disables only this existing plugin.
- Current `CONTRIBUTING.md` directs new observability backends to standalone plugin repositories. If maintainers intend that placement rule to require extraction of already-bundled Langfuse code, that would supersede the earlier review direction and needs a maintainer placement decision; this maintenance PR does not broaden the existing integration.

## Remaining Issue AC

This PR prevents `unknown_service`, configures both OpenTelemetry identity surfaces before SDK initialization, adds the supported setup/config/docs path, and makes the legacy ambiguity visible. The compatibility fallback is intentionally shared rather than automatically unique, per maintainer feedback for existing credential-only installations. Strict absence failure or automatic per-agent identity generation remains tracked by #58322, so this PR does not claim to close the issue.

## Screenshots / Logs

Not applicable: this change has no UI surface.

## AI Assistance

OpenAI — GPT-5 (Codex). Earlier implementation used Codex CLI; the final review, current-main rebase, compatibility amendments, exact-head test execution, dashboard-schema correction, PR-description rewrite, and GitHub update used Codex desktop with connected GitHub access.