### PR TITLE
fix(terminal): preserve remote-shell tilde cwd for container backends

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1477,15 +1477,16 @@ if _config_path.exists():
                     # Only bridge explicit absolute paths from config.yaml.
                     if _cfg_key == "cwd" and str(_val) in {".", "auto", "cwd"}:
                         continue
-                    # Expand shell tilde in local/container cwd so subprocess.Popen
-                    # never receives a literal "~/" which the kernel rejects.
-                    # SSH cwd is interpreted by the remote shell, so preserve
-                    # "~" / "~/..." for the SSH backend instead of expanding it
+                    # Expand shell tilde in local cwd so subprocess.Popen never
+                    # receives a literal "~/" which the kernel rejects. SSH and
+                    # container/sandbox backends (docker/singularity/modal/
+                    # daytona) resolve cwd in their OWN shell, so preserve
+                    # "~" / "~/..." for those backends instead of expanding it
                     # to the Hermes host/container HOME (often /opt/data). Shared
                     # predicate with terminal_tool so the two sites can't drift.
                     if _cfg_key == "cwd" and isinstance(_val, str):
-                        from tools.terminal_tool import _is_ssh_remote_tilde_cwd
-                        if not _is_ssh_remote_tilde_cwd(_terminal_backend, _val.strip()):
+                        from tools.terminal_tool import _is_remote_shell_tilde_cwd
+                        if not _is_remote_shell_tilde_cwd(_terminal_backend, _val.strip()):
                             _val = os.path.expanduser(_val)
                     if isinstance(_val, (list, dict)):
                         os.environ[_env_var] = json.dumps(_val)

--- a/tests/gateway/test_config_cwd_bridge.py
+++ b/tests/gateway/test_config_cwd_bridge.py
@@ -12,7 +12,7 @@ asserting the expected env var outcomes.
 import os
 import json
 
-from tools.terminal_tool import _is_ssh_remote_tilde_cwd
+from tools.terminal_tool import _is_remote_shell_tilde_cwd
 
 
 def _simulate_config_bridge(cfg: dict, initial_env: dict | None = None):
@@ -50,12 +50,13 @@ def _simulate_config_bridge(cfg: dict, initial_env: dict | None = None):
                 # TERMINAL_CWD.  Mirrors the fix in gateway/run.py.
                 if cfg_key == "cwd" and str(val) in {".", "auto", "cwd"}:
                     continue
-                # Expand shell tilde for local/container backends so subprocess.Popen
-                # never receives a literal "~/" which the kernel rejects. SSH cwd is
-                # interpreted by the remote shell, so preserve "~" / "~/..." there.
-                # Uses the same production predicate as gateway/run.py.
+                # Expand shell tilde for the local backend so subprocess.Popen
+                # never receives a literal "~/" which the kernel rejects. SSH and
+                # container/sandbox backends resolve cwd in their OWN shell, so
+                # preserve "~" / "~/..." there. Uses the same production
+                # predicate as gateway/run.py.
                 if cfg_key == "cwd" and isinstance(val, str):
-                    if not _is_ssh_remote_tilde_cwd(terminal_backend, val.strip()):
+                    if not _is_remote_shell_tilde_cwd(terminal_backend, val.strip()):
                         val = os.path.expanduser(val)
                 if isinstance(val, list):
                     env[env_var] = json.dumps(val)
@@ -283,3 +284,39 @@ class TestTildeExpansion:
         result = _simulate_config_bridge(cfg, {"MESSAGING_CWD": "/host/project"})
         assert result["TERMINAL_ENV"] == "ssh"
         assert "TERMINAL_CWD" not in result
+
+    def test_docker_terminal_cwd_tilde_preserved_for_container_shell(self, monkeypatch):
+        """Docker cwd '~/x' must survive until the container's own shell
+        resolves it — it must not become the Hermes host/container HOME
+        (often /opt/data under Docker)."""
+        monkeypatch.setenv("HOME", "/opt/data")
+        cfg = {"terminal": {"backend": "docker", "cwd": "~/work"}}
+        result = _simulate_config_bridge(cfg)
+        assert result["TERMINAL_ENV"] == "docker"
+        assert result["TERMINAL_CWD"] == "~/work"
+
+    def test_singularity_terminal_cwd_tilde_preserved_for_container_shell(self, monkeypatch):
+        monkeypatch.setenv("HOME", "/opt/data")
+        cfg = {"terminal": {"backend": "singularity", "cwd": "~/work"}}
+        result = _simulate_config_bridge(cfg)
+        assert result["TERMINAL_CWD"] == "~/work"
+
+    def test_modal_terminal_cwd_tilde_preserved_for_container_shell(self, monkeypatch):
+        monkeypatch.setenv("HOME", "/opt/data")
+        cfg = {"terminal": {"backend": "modal", "cwd": "~/work"}}
+        result = _simulate_config_bridge(cfg)
+        assert result["TERMINAL_CWD"] == "~/work"
+
+    def test_daytona_terminal_cwd_tilde_preserved_for_container_shell(self, monkeypatch):
+        monkeypatch.setenv("HOME", "/opt/data")
+        cfg = {"terminal": {"backend": "daytona", "cwd": "~/work"}}
+        result = _simulate_config_bridge(cfg)
+        assert result["TERMINAL_CWD"] == "~/work"
+
+    def test_local_terminal_cwd_tilde_still_expanded(self, monkeypatch):
+        """The local backend executes on the Hermes host itself, so local
+        expansion against the host's own HOME remains correct there."""
+        monkeypatch.setenv("HOME", "/opt/data")
+        cfg = {"terminal": {"backend": "local", "cwd": "~/work"}}
+        result = _simulate_config_bridge(cfg)
+        assert result["TERMINAL_CWD"] == "/opt/data/work"

--- a/tests/tools/test_container_cwd_sanitize.py
+++ b/tests/tools/test_container_cwd_sanitize.py
@@ -65,6 +65,14 @@ class TestIsUnusableContainerCwd:
             {"docker", "singularity", "modal", "daytona"}
         )
 
+    def test_bare_tilde_is_not_unusable(self):
+        # "~" is resolved by the sandbox's own shell at `cd` time
+        # (BaseEnvironment._quote_cwd_for_cd), not rejected as a relative path.
+        assert tt._is_unusable_container_cwd("~") is False
+
+    def test_tilde_child_path_is_not_unusable(self):
+        assert tt._is_unusable_container_cwd("~/projects") is False
+
 
 class TestOverrideCwdSanitizedAtCallSite:
     """E2E pin: a per-task cwd OVERRIDE that is a host path must NOT reach the
@@ -144,6 +152,13 @@ class TestOverrideCwdSanitizedAtCallSite:
         # RL/benchmark envs set an in-container path; it must pass through.
         cwd = self._run_and_capture_cwd(monkeypatch, "/workspace/task42")
         assert cwd == "/workspace/task42"
+
+    def test_tilde_override_is_preserved_not_replaced(self, monkeypatch):
+        # A literal "~/..." override must reach _create_environment unchanged
+        # (the sandbox's own shell resolves it) instead of being discarded as
+        # an unusable relative path and replaced by config["cwd"].
+        cwd = self._run_and_capture_cwd(monkeypatch, "~/project")
+        assert cwd == "~/project"
 
 
 class TestFileOpsCwdSanitizedAtCallSite:

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -141,6 +141,37 @@ def test_auto_mount_host_cwd_adds_volume(monkeypatch, tmp_path):
     assert f"{project_dir}:/workspace" in run_args_str
 
 
+def test_bare_tilde_cwd_resolves_to_root_before_container_creation(monkeypatch):
+    """``docker run -w`` receives *cwd* as a literal daemon argument — dockerd
+    never expands "~" — so it must be resolved to an absolute path before the
+    container is created, unlike Singularity/Modal/Daytona which resolve "~"
+    via their own sandbox shell in ``BaseEnvironment.init_session()``.
+    """
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    env = _make_dummy_env(cwd="~")
+
+    assert env.cwd == "/root"
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args = run_calls[0][0]
+    assert run_args[run_args.index("-w") + 1] == "/root"
+
+
+def test_tilde_child_cwd_resolves_relative_to_root(monkeypatch):
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    env = _make_dummy_env(cwd="~/project")
+
+    assert env.cwd == "/root/project"
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args = run_calls[0][0]
+    assert run_args[run_args.index("-w") + 1] == "/root/project"
+
+
 def test_auto_mount_disabled_by_default(monkeypatch, tmp_path):
     """Host cwd should not be mounted unless the caller explicitly opts in."""
     project_dir = tmp_path / "my-project"

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -256,6 +256,72 @@ def test_get_env_config_preserves_ssh_tilde_child_cwd(monkeypatch):
     assert config["cwd"] == "~/project"
 
 
+def test_get_env_config_preserves_docker_tilde_cwd(monkeypatch):
+    """Docker cwd '~' is resolved by the container's own shell, not the host."""
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setenv("TERMINAL_CWD", "~")
+    monkeypatch.setenv("HOME", "/opt/data")
+
+    config = terminal_tool._get_env_config()
+
+    assert config["env_type"] == "docker"
+    assert config["cwd"] == "~"
+
+
+def test_get_env_config_preserves_docker_tilde_child_cwd(monkeypatch):
+    """Docker cwd '~/x' must not become the Hermes host's HOME path."""
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setenv("TERMINAL_CWD", "~/project")
+    monkeypatch.setenv("HOME", "/opt/data")
+
+    config = terminal_tool._get_env_config()
+
+    assert config["env_type"] == "docker"
+    assert config["cwd"] == "~/project"
+
+
+def test_get_env_config_preserves_singularity_tilde_child_cwd(monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "singularity")
+    monkeypatch.setenv("TERMINAL_CWD", "~/project")
+    monkeypatch.setenv("HOME", "/opt/data")
+
+    config = terminal_tool._get_env_config()
+
+    assert config["cwd"] == "~/project"
+
+
+def test_get_env_config_preserves_modal_tilde_child_cwd(monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "modal")
+    monkeypatch.setenv("TERMINAL_CWD", "~/project")
+    monkeypatch.setenv("HOME", "/opt/data")
+
+    config = terminal_tool._get_env_config()
+
+    assert config["cwd"] == "~/project"
+
+
+def test_get_env_config_preserves_daytona_tilde_child_cwd(monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "daytona")
+    monkeypatch.setenv("TERMINAL_CWD", "~/project")
+    monkeypatch.setenv("HOME", "/opt/data")
+
+    config = terminal_tool._get_env_config()
+
+    assert config["cwd"] == "~/project"
+
+
+def test_get_env_config_local_backend_still_expands_tilde(monkeypatch):
+    """The local backend executes on the Hermes host itself, so local
+    expansion against the host's own HOME is correct there."""
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setenv("TERMINAL_CWD", "~/project")
+    monkeypatch.setenv("HOME", "/opt/data")
+
+    config = terminal_tool._get_env_config()
+
+    assert config["cwd"] == "/opt/data/project"
+
+
 def test_get_env_config_still_rejects_bad_docker_json_for_docker_backend(monkeypatch):
     """Selecting Docker should keep the existing actionable config error."""
     monkeypatch.setenv("TERMINAL_ENV", "docker")

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -597,8 +597,19 @@ class DockerEnvironment(BaseEnvironment):
         extra_args: list = None,
         persist_across_processes: bool = True,
     ):
+        # ``docker run -w`` receives *cwd* as a literal daemon argument, not a
+        # shell command — dockerd never expands "~", so a bare "~" or a
+        # "~/..." path must be resolved to an absolute path here, before the
+        # container is created (unlike Singularity/Modal/Daytona, which have
+        # no creation-time working-dir flag and resolve "~" via the sandbox's
+        # own shell in ``BaseEnvironment.init_session()``). This mirrors the
+        # container's default HOME for the common (root) case; it does not
+        # account for ``run_as_host_user``, matching the bare "~" handling
+        # this already had before "~/..." support was added.
         if cwd == "~":
             cwd = "/root"
+        elif cwd.startswith("~/"):
+            cwd = "/root/" + cwd[2:]
         super().__init__(cwd=cwd, timeout=timeout)
         self._persistent = persistent_filesystem
         self._persist_across_processes = persist_across_processes

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1215,19 +1215,32 @@ _HOST_CWD_PREFIXES = ("/Users/", "/home/", "C:\\", "C:/")
 
 _CONTAINER_BACKENDS = frozenset({"docker", "singularity", "modal", "daytona"})
 
+# Backends whose working directory is resolved by a shell other than the
+# Hermes host's own — SSH's remote shell, or a container/sandbox's bash
+# session started by ``BaseEnvironment.init_session()``. ``local`` is the
+# only backend that executes directly on the Hermes host, so it's the only
+# one where local ``expanduser`` is correct.
+_REMOTE_SHELL_BACKENDS = frozenset({"ssh"}) | _CONTAINER_BACKENDS
 
-def _is_ssh_remote_tilde_cwd(backend: str, cwd: str) -> bool:
-    """Return True when *cwd* is a tilde path that the remote SSH shell must
-    expand itself, so the Hermes host/container must NOT ``expanduser`` it.
+
+def _is_remote_shell_tilde_cwd(backend: str, cwd: str) -> bool:
+    """Return True when *cwd* is a tilde path that a non-local backend's own
+    shell must expand, so the Hermes host must NOT ``expanduser`` it.
 
     SSH ``cwd`` is interpreted by the *remote* shell (``cd ~`` / ``cd ~/x``
-    over ``ssh ... bash -c``). Expanding ``~`` locally would rewrite it to the
-    Hermes host HOME (often ``/opt/data`` under Docker) and inject a
-    nonexistent path into the remote session. Only ``~`` / ``~/...`` on the
-    ``ssh`` backend qualify; absolute remote paths still pass through
-    unchanged, and every other backend keeps expanding locally.
+    over ``ssh ... bash -c``). Container/sandbox backends (Docker,
+    Singularity, Modal, Daytona) are the same shape: the working directory is
+    set inside the sandbox's own bash session by
+    ``BaseEnvironment.init_session()`` / ``_quote_cwd_for_cd()``, which already
+    routes ``~`` / ``~/...`` through *that* session's own ``$HOME`` — not the
+    Hermes host's. Expanding ``~`` locally for any of these backends would
+    rewrite it to the Hermes host/container HOME (often ``/opt/data`` under
+    Docker, or ``/root`` when Hermes runs as root) and inject a nonexistent
+    path into the remote/sandboxed session. Only ``~`` / ``~/...`` on a
+    remote-shell backend qualify; absolute remote paths still pass through
+    unchanged, and the ``local`` backend keeps expanding locally.
     """
-    if (backend or "").strip().lower() != "ssh":
+    if (backend or "").strip().lower() not in _REMOTE_SHELL_BACKENDS:
         return False
     return cwd == "~" or cwd.startswith("~/")
 
@@ -1240,8 +1253,15 @@ def _is_unusable_container_cwd(cwd: str) -> bool:
     sandbox (e.g. ``/workspace`` or ``/root``). A host path (``/home/user``,
     ``C:\\Users\\me``) or a relative path (``.``, ``src/``) is meaningless to
     ``docker run -w`` and makes the container fail to start (exit 125).
+
+    A literal ``~`` / ``~/...`` is NOT unusable here: it is resolved by the
+    sandbox's own shell at ``cd`` time (see ``_is_remote_shell_tilde_cwd`` and
+    ``BaseEnvironment._quote_cwd_for_cd``), so it must pass through unchanged
+    rather than being rejected as a host/relative path.
     """
     if not cwd:
+        return False
+    if cwd == "~" or cwd.startswith("~/"):
         return False
     if any(cwd.startswith(p) for p in _HOST_CWD_PREFIXES):
         return True
@@ -1302,7 +1322,7 @@ def _get_env_config() -> Dict[str, Any]:
     # /workspace and track the original host path separately. Otherwise keep the
     # normal sandbox behavior and discard host paths.
     cwd = os.getenv("TERMINAL_CWD", default_cwd)
-    if cwd and not _is_ssh_remote_tilde_cwd(env_type, cwd):
+    if cwd and not _is_remote_shell_tilde_cwd(env_type, cwd):
         cwd = os.path.expanduser(cwd)
     host_cwd = None
     if env_type == "docker" and mount_docker_cwd:


### PR DESCRIPTION
## Summary

`83fb8ec27` preserved a literal `"~"` / `"~/..."` `terminal.cwd` for the SSH backend only, so the remote shell resolves it against its own `$HOME` instead of the Hermes host's. Docker, Singularity, Modal, and Daytona are the same shape in `terminal_tool.py`: the working directory is set inside a sandbox bash session by `BaseEnvironment.init_session()` / `_quote_cwd_for_cd()`, not by the Hermes host. They still went through `os.path.expanduser()` against the host's own `HOME` (e.g. `/opt/data` under the Docker image, or `/root` when Hermes runs as root), so an explicit `terminal.cwd: "~/project"` silently landed the sandbox in a nonexistent directory and the bootstrap `cd` swallowed the failure.

## Changes

- `tools/terminal_tool.py`: generalize `_is_ssh_remote_tilde_cwd` into `_is_remote_shell_tilde_cwd`, covering `ssh` plus all `_CONTAINER_BACKENDS` (docker/singularity/modal/daytona). `_is_unusable_container_cwd()` no longer rejects a literal tilde cwd as an unusable relative path — it's a valid pass-through the sandbox's own shell resolves at `cd` time.
- `gateway/run.py`: the config bridge's cwd guard uses the same generalized predicate so the two sites can't drift.
- `tools/environments/docker.py`: `docker run -w` receives `cwd` as a literal daemon argument — dockerd never expands `~` — unlike Singularity/Modal/Daytona, which have no creation-time working-dir flag and resolve `~` entirely via the sandbox's own shell. Extended the existing bare `"~"` → `"/root"` resolution to also cover `"~/subpath"` → `"/root/subpath"`, so `docker run -w` never receives an unresolved tilde.

Explicit absolute/relative paths and the placeholder (`"."`/`"auto"`/`"cwd"`) fallback behavior are unaffected by this change — that separate placeholder-resolution path is being reworked in #58176, which this PR does not overlap with (different code path: placeholder-empty-cwd fallback vs. an explicitly-configured tilde value).

## Test plan

- [x] Added `_get_env_config()` regression tests for docker/singularity/modal/daytona preserving `~`/`~/project`, and confirming `local` still expands against the host's own HOME (`tests/tools/test_terminal_tool.py`)
- [x] Added `_is_unusable_container_cwd()` tests confirming a literal tilde is no longer flagged as unusable, plus an override-path test confirming a tilde override reaches `_create_environment` unchanged (`tests/tools/test_container_cwd_sanitize.py`)
- [x] Added `DockerEnvironment` tests confirming a bare `"~"` and `"~/project"` cwd resolve to `/root` and `/root/project` respectively in the constructor and in the real `docker run -w` argument (`tests/tools/test_docker_environment.py`)
- [x] Added config-bridge tests mirroring the SSH tilde-preservation tests for docker/singularity/modal/daytona, plus a `local`-still-expands control (`tests/gateway/test_config_cwd_bridge.py`)
- [x] `scripts/run_tests.sh tests/tools/test_terminal_tool.py tests/tools/test_container_cwd_sanitize.py tests/tools/test_docker_environment.py tests/gateway/test_config_cwd_bridge.py tests/tools/test_daytona_environment.py tests/tools/test_modal_sandbox_fixes.py tests/tools/test_singularity_preflight.py` — 219 passed
- [x] `ruff check` clean on all changed files
- [x] `ty check` before/after diff on changed files shows only line-number shifts, no new diagnostics