### PR TITLE
fix(wecom): accept reconnect flag in callback adapter

### DIFF
--- a/plugins/platforms/wecom/callback_adapter.py
+++ b/plugins/platforms/wecom/callback_adapter.py
@@ -115,7 +115,7 @@ class WecomCallbackAdapter(BasePlatformAdapter):
     # Lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         if not self._apps:
             logger.warning("[WecomCallback] No callback apps configured")
             return False

--- a/tests/gateway/test_wecom_callback.py
+++ b/tests/gateway/test_wecom_callback.py
@@ -153,6 +153,24 @@ class TestWecomCallbackRouting:
         assert calls["json"]["agentid"] == 1001
 
 
+class TestWecomCallbackLifecycle:
+    @pytest.mark.asyncio
+    async def test_connect_accepts_reconnect_kwarg_without_apps(self):
+        adapter = WecomCallbackAdapter(
+            PlatformConfig(
+                enabled=True,
+                extra={
+                    "mode": "callback",
+                    "host": "127.0.0.1",
+                    "port": 0,
+                    "apps": [],
+                },
+            )
+        )
+
+        assert await adapter.connect(is_reconnect=True) is False
+
+
 class TestWecomCallbackSendTokenRefresh:
     @pytest.mark.asyncio
     async def test_send_retries_with_fresh_token_on_errcode_40001(self):
@@ -345,5 +363,4 @@ class TestWecomCallbackBodySizeLimit:
         small = b"<xml><Encrypt>not-real</Encrypt></xml>"
         response = await adapter._handle_callback(self._request(small))
         assert response.status != 413
-
 


### PR DESCRIPTION
## Summary
- Update the WeCom callback adapter connect signature to accept the gateway reconnect contract is_reconnect kwarg.
- Add a regression test that calls connect(is_reconnect=True) on the no-apps fast-fail path, which previously raised TypeError before adapter logic could run.

## Why
GatewayRunner._connect_adapter() forwards is_reconnect=True when the platform reconnect watcher restarts an adapter. Most platform adapters already accept that keyword, but WecomCallbackAdapter.connect() did not, so a reconnect attempt could fail at the method boundary instead of reaching the adapter normal connection logic.

## Verification
- .venv/bin/python -m pytest tests/gateway/test_wecom_callback.py -q
- .venv/bin/python -m pytest tests/gateway/test_platform_reconnect.py::TestPlatformReconnectWatcher::test_reconnect_passes_is_reconnect_true -q
- .venv/bin/python -m ruff check plugins/platforms/wecom/callback_adapter.py tests/gateway/test_wecom_callback.py
- git diff --check