### PR TITLE
fix(uninstall): preserve non-ASCII bytes when editing shell configs

### DIFF
--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -57,7 +57,14 @@ def remove_path_from_shell_configs():
     
     for config_path in configs:
         try:
-            content = config_path.read_text()
+            # Read/write with surrogateescape so a non-UTF-8 byte (legacy
+            # ISO-8859 .bashrc, a mojibake prompt) survives the round-trip
+            # byte-for-byte. A bare read_text()/write_text() uses the locale
+            # default (cp1252 on Windows): a non-ASCII byte either raises
+            # UnicodeDecodeError — silently skipping PATH cleanup — or, worse,
+            # decodes to wrong chars and write_text() re-encodes the damage
+            # back, permanently corrupting the user's shell config.
+            content = config_path.read_text(encoding="utf-8", errors="surrogateescape")
             original_content = content
             
             # Remove lines containing hermes-agent or hermes PATH entries
@@ -87,7 +94,7 @@ def remove_path_from_shell_configs():
                 new_content = new_content.replace('\n\n\n', '\n\n')
             
             if new_content != original_content:
-                config_path.write_text(new_content)
+                config_path.write_text(new_content, encoding="utf-8", errors="surrogateescape")
                 removed_from.append(config_path)
                 
         except Exception as e:

--- a/tests/hermes_cli/test_uninstall_bashrc_encoding.py
+++ b/tests/hermes_cli/test_uninstall_bashrc_encoding.py
@@ -1,0 +1,188 @@
+"""Regression tests for shell-config editing encoding on Windows.
+
+``remove_path_from_shell_configs`` reads/writes ``~/.bashrc`` and friends.
+A bare ``read_text()``/``write_text()`` uses ``locale.getpreferredencoding()``
+(cp1252 on Windows). On a Git Bash install — which the Windows installer
+explicitly supports (``install.ps1`` sets ``HERMES_GIT_BASH_PATH``) — users
+commonly have non-ASCII bytes in their ``.bashrc`` (CJK comments, accented
+paths, Powerline glyphs, emoji prompts). The pre-fix behavior on Windows:
+
+  * if the byte can't decode as cp1252 → ``UnicodeDecodeError``, swallowed by
+    the broad ``except``, PATH cleanup silently skipped;
+  * if it *can* decode (many UTF-8 multibyte sequences are legal-but-wrong in
+    cp1252) → ``write_text()`` re-encoded the mojibake, **permanently
+    corrupting** the user's shell config.
+
+The fix reads/writes with ``encoding="utf-8", errors="surrogateescape"`` so
+the round-trip is byte-for-byte lossless regardless of the file's encoding.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+import hermes_cli.uninstall as uninstall
+
+
+# --- helpers ---------------------------------------------------------------
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    """Point HOME at a tmp dir so find_shell_configs() reads our fixtures."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # Path.home() caches nothing per-call on POSIX, but be explicit on Windows.
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    return tmp_path
+
+
+def _write_bytes(path: Path, data: bytes) -> None:
+    path.write_bytes(data)
+
+
+@pytest.fixture
+def windows_default_encoding(monkeypatch):
+    """Simulate the Windows locale default for read_text/write_text.
+
+    POSIX runners default to UTF-8, so the cp1252 corruption is invisible
+    there. This forces a no-encoding read_text/write_text to use cp1252 (the
+    Windows default), so the regression tests catch the bug on any platform.
+    Calls that pass an explicit encoding are left untouched.
+    """
+    real_read = Path.read_text
+    real_write = Path.write_text
+
+    def _read(self, *args, **kwargs):
+        if "encoding" not in kwargs and not args:
+            kwargs["encoding"] = "cp1252"
+        return real_read(self, *args, **kwargs)
+
+    def _write(self, data, *args, **kwargs):
+        if "encoding" not in kwargs and not args:
+            kwargs["encoding"] = "cp1252"
+        return real_write(self, data, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _read)
+    monkeypatch.setattr(Path, "write_text", _write)
+
+
+# --- the bug: a non-ASCII .bashrc must round-trip losslessly ---------------
+
+class TestShellConfigEncodingRoundTrip:
+    def test_cjk_bashrc_round_trips_losslessly(self, home, windows_default_encoding):
+        """A CJK .bashrc with a hermes PATH line is edited, not corrupted.
+
+        Pre-fix on Windows, the CJK bytes (0xE5..) either raised
+        UnicodeDecodeError (skipping cleanup) or mojibake'd the file on write.
+        With surrogateescape the non-ASCII bytes survive byte-for-byte. The
+        windows_default_encoding fixture makes a no-encoding read/write behave
+        like cp1252, so this catches the bug on POSIX runners too.
+        """
+        bashrc = home / ".bashrc"
+        original = (
+            "# 我的配置\n"
+            'export PATH="$HOME/.local/bin:$PATH"\n'
+            'export PATH="/Users/x/.hermes/bin:$PATH"  # Hermes Agent\n'
+            "alias ll='ls -la'\n"
+            "export PS1='🦊 > '\n"
+        ).encode("utf-8")
+        _write_bytes(bashrc, original)
+
+        removed_from = uninstall.remove_path_from_shell_configs()
+
+        # The hermes PATH line was removed (so the file changed)…
+        assert bashrc in removed_from
+        new = bashrc.read_bytes()
+        assert b".hermes/bin" not in new
+        # …and every non-ASCII byte that wasn't part of the removed line is
+        # preserved exactly — no mojibake, no loss.
+        assert "我的配置".encode("utf-8") in new
+        assert "🦊 > ".encode("utf-8") in new
+        assert b"alias ll='ls -la'" in new
+
+    def test_non_utf8_bytes_survive_round_trip(self, home):
+        """A legacy ISO-8859 byte must survive even though it isn't valid UTF-8.
+
+        surrogateescape round-trips undecodable bytes through the surrogate
+        half, so a file Hermes doesn't fully understand is still written back
+        byte-identically (minus the removed line).
+        """
+        bashrc = home / ".bashrc"
+        # 0xE9 is 'é' in ISO-8859-1 but invalid as a standalone UTF-8 byte.
+        original = b"# caf\xe9 notes\nexport PATH=/x  # Hermes Agent\n"
+        _write_bytes(bashrc, original)
+
+        uninstall.remove_path_from_shell_configs()
+
+        new = bashrc.read_bytes()
+        assert b"caf\xe9 notes" in new  # the exotic byte survived
+        assert b"# Hermes Agent" not in new
+
+    def test_pure_ascii_bashrc_unchanged_behavior(self, home):
+        """The common case (pure ASCII) still removes the hermes line."""
+        bashrc = home / ".bashrc"
+        original = (
+            "# my config\n"
+            'export PATH="/Users/x/.hermes/bin:$PATH"  # Hermes Agent\n'
+        ).encode("ascii")
+        _write_bytes(bashrc, original)
+
+        removed_from = uninstall.remove_path_from_shell_configs()
+
+        assert bashrc in removed_from
+        assert b".hermes/bin" not in bashrc.read_bytes()
+
+    def test_file_without_hermes_entries_is_not_rewritten(self, home):
+        """A .bashrc with no hermes PATH line is left byte-identical (no write)."""
+        bashrc = home / ".bashrc"
+        original = "# 我的配置\nalias ll='ls -la'\n".encode("utf-8")
+        _write_bytes(bashrc, original)
+
+        removed_from = uninstall.remove_path_from_shell_configs()
+
+        assert removed_from == []
+        assert bashrc.read_bytes() == original
+
+
+# --- the fix: read/write pass an explicit encoding -------------------------
+
+class TestExplicitEncodingPassed:
+    """Guard against a future refactor dropping the encoding kwargs."""
+
+    def test_read_and_write_pass_utf8_encoding(self, home, monkeypatch):
+        bashrc = home / ".bashrc"
+        _write_bytes(
+            bashrc,
+            b"# config\nexport PATH=/x  # Hermes Agent\n",
+        )
+
+        read_calls = []
+        write_calls = []
+
+        real_read = Path.read_text
+        real_write = Path.write_text
+
+        def spy_read(self, *args, **kwargs):
+            read_calls.append(kwargs)
+            return real_read(self, *args, **kwargs)
+
+        def spy_write(self, data, *args, **kwargs):
+            write_calls.append(kwargs)
+            return real_write(self, data, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", spy_read)
+        monkeypatch.setattr(Path, "write_text", spy_write)
+
+        uninstall.remove_path_from_shell_configs()
+
+        # At least one read happened (and it passed encoding).
+        assert read_calls, "expected a read of the .bashrc"
+        assert all("encoding" in c for c in read_calls), \
+            "read_text() must pass an explicit encoding"
+        assert all("utf-8" in str(c["encoding"]).lower() for c in read_calls)
+        # The hermes line was present, so a write happened too — with encoding.
+        assert write_calls, "expected a rewrite of the .bashrc"
+        assert all("encoding" in c for c in write_calls), \
+            "write_text() must pass an explicit encoding"


### PR DESCRIPTION
## What

Fixes a **shell-config corruption** bug in `remove_path_from_shell_configs()`: it read/wrote `~/.bashrc`, `~/.zshrc`, etc. with bare `read_text()` / `write_text()`, which use the locale default encoding (`cp1252` on Windows).

## Why it's a real bug (config corruption)

The Windows installer **explicitly supports Git Bash** (`scripts/install.ps1` sets `HERMES_GIT_BASH_PATH`), and `find_shell_configs()` has **no platform guard** — so on Windows, `hermes uninstall` goes looking for `~/.bashrc`. Git Bash users commonly have non-ASCII bytes there: CJK comments, accented paths, Powerline glyphs, emoji prompts.

With the bare `read_text()` / `write_text()` (cp1252 on Windows), one of two things happens:
- The byte can't decode as cp1252 → `UnicodeDecodeError` → swallowed by the broad `except` → **Hermes PATH entries silently NOT removed** (uninstall leaves junk in the file).
- The byte *can* decode (many UTF-8 multibyte sequences are legal-but-wrong in cp1252) → `write_text()` re-encodes the mojibake → **the user's `.bashrc` is permanently corrupted**. Their next shell session shows a garbled prompt.

## The fix

Read and write with `encoding="utf-8", errors="surrogateescape"`. This makes the round-trip **byte-for-byte lossless regardless of the file's actual encoding**: the hermes PATH line is removed, every other byte is preserved exactly. `surrogateescape` round-trips undecodable bytes through the surrogate half, so even a legacy ISO-8859 file is edited safely.

## Why CI didn't catch it

`scripts/check-windows-footguns.py` only matches `open(` calls — it doesn't flag `Path.read_text()` / `Path.write_text()`. Same blindspot as the auth-store encoding fix in #58158 (that one is a separate PR/bug: different file, different data).

## How to test

```bash
pytest tests/hermes_cli/test_uninstall_bashrc_encoding.py -v   # 5 passed
```

Tests cover:
- a CJK `.bashrc` round-trips losslessly (hermes line removed, CJK preserved byte-for-byte)
- a legacy ISO-8859 byte survives the round-trip
- the pure-ASCII case still removes the line
- a file with no hermes entries is not rewritten
- regression guard: read/write pass an explicit `encoding=`

A `windows_default_encoding` fixture forces a no-encoding `read_text`/`write_text` to use cp1252 (the Windows default), so the tests **catch the bug on POSIX runners too**. Verified all three encoding-sensitive tests fail when the fix is reverted.

## Platforms tested

macOS (Darwin 24.3.0, Python 3.11.15). The bug is Windows-specific (cp1252 locale default); the fix is a pure encoding-kwarg addition with `surrogateescape`, which is no-op on POSIX for valid UTF-8 and lossless for everything else. `check-windows-footguns.py` passes clean.

## Scope

One logical change: two lines in `hermes_cli/uninstall.py` + regression tests. No new dependencies, no core-file changes outside `uninstall.py`.

## Related

Closes no issue — found via cross-platform code audit. Related encoding fix in #58158 (auth.json) — same bug class, different file/data, kept as separate PRs per "one logical change per PR".