### PR TITLE
fix(telegram): bound updater.stop() with timeout to prevent CLOSE-WAIT reconnect hang

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1871,7 +1871,25 @@ class TelegramAdapter(BasePlatformAdapter):
 
         try:
             if app and app.updater and app.updater.running:
-                await app.updater.stop()
+                try:
+                    # Guard stop() with a timeout: when the underlying TCP
+                    # connection is in CLOSE-WAIT the PTB polling task is
+                    # blocked on epoll on the dead socket and never wakes up,
+                    # so an unguarded stop() hangs indefinitely.  The result
+                    # is that _polling_error_task stays alive-but-blocked
+                    # forever, every subsequent heartbeat probe sees it as
+                    # "in-flight" and skips triggering a new reconnect, and
+                    # the gateway silently drops messages for hours.
+                    # Bounding stop() lets the reconnect ladder always advance.
+                    # Refs: NousResearch/hermes-agent#58270
+                    await asyncio.wait_for(app.updater.stop(), timeout=15.0)
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "[%s] updater.stop() timed out during network-error "
+                        "reconnect (likely CLOSE-WAIT socket); forcing drain "
+                        "and restart without clean stop",
+                        self.name,
+                    )
         except Exception:
             pass
 

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -812,3 +812,62 @@ async def test_schedule_polling_recovery_tracks_background_task():
     await adapter._polling_error_task
     adapter._handle_polling_network_error.assert_awaited_once()
 
+
+@pytest.mark.asyncio
+async def test_handle_polling_network_error_updater_stop_timeout():
+    """updater.stop() hanging (CLOSE-WAIT) must not block the reconnect ladder.
+
+    When the underlying TCP connection is in CLOSE-WAIT, PTB's polling task is
+    blocked on epoll on the dead socket.  updater.stop() awaits that task and
+    therefore hangs indefinitely.  The fix wraps stop() in asyncio.wait_for()
+    with a 15-second timeout so the reconnect always advances.
+
+    This test simulates the hang by making stop() sleep forever and verifies
+    that _drain_polling_connections() and start_polling() are still called
+    after the timeout fires.
+    Refs: NousResearch/hermes-agent#58270
+    """
+    adapter = _make_adapter()
+    adapter._polling_network_error_count = 0
+
+    # Build a fake app whose updater.stop() hangs forever.
+    app = MagicMock()
+    app.updater = MagicMock()
+    app.updater.running = True
+
+    async def _hanging_stop():
+        await asyncio.sleep(9999)  # simulate CLOSE-WAIT block
+
+    app.updater.stop = _hanging_stop
+    app.updater.start_polling = AsyncMock()
+    adapter._app = app
+
+    drain_called = []
+
+    async def _fake_drain():
+        drain_called.append(True)
+
+    adapter._drain_polling_connections = _fake_drain
+
+    start_polling_called = []
+
+    async def _fake_start_polling(**kwargs):
+        start_polling_called.append(True)
+
+    app.updater.start_polling = AsyncMock(side_effect=_fake_start_polling)
+
+    # Patch the timeout constant so the test completes fast.
+    import plugins.platforms.telegram.adapter as _mod
+    original_wait_for = asyncio.wait_for
+
+    async def _fast_wait_for(coro, timeout):
+        # Substitute a 0.05s timeout so the test doesn't take 15s.
+        return await original_wait_for(coro, 0.05)
+
+    with patch("asyncio.wait_for", side_effect=_fast_wait_for):
+        await adapter._handle_polling_network_error(OSError("CLOSE-WAIT test"))
+
+    # The reconnect ladder must have advanced past the hung stop().
+    assert drain_called, "_drain_polling_connections was not called after stop() timeout"
+    assert start_polling_called, "start_polling was not called after stop() timeout"
+


### PR DESCRIPTION
## Problem

The `_polling_heartbeat_loop` (added in PR #48496) correctly detects a CLOSE-WAIT TCP socket and fires `_handle_polling_network_error`. However, inside the reconnect handler:

```python
# line 1874 — before this fix
if app and app.updater and app.updater.running:
    await app.updater.stop()  # ← NO timeout
```

When the TCP connection is in CLOSE-WAIT, PTB's polling task is blocked on `epoll` on the dead socket and never wakes. `updater.stop()` awaits that task — **it hangs indefinitely**.

Consequence:
- `_polling_error_task` stays alive-but-blocked forever
- Every subsequent heartbeat probe sees `_polling_error_task and not done()` → `continue` (guard at line 1988 in the heartbeat loop)
- **No further reconnect is ever triggered**
- Gateway silently drops messages for hours until manual restart

## Field Evidence

```
Jul 04 01:11:24 UTC  [Telegram] Polling heartbeat probe failed (); triggering reconnect
Jul 04 01:11:24 UTC  [Telegram] Telegram network error (attempt 1/10), reconnecting in 5s.
# 11 hours of total silence
# Manual SIGUSR1 restart at 12:36 UTC required to recover
```

CONFIRMED: CLOSE-WAIT on `149.154.166.110:443`, `wchan=ep_poll`. Reconnect coroutine was alive-but-hung for 11 hours inside `updater.stop()`.

## Fix

Wrap `updater.stop()` in `asyncio.wait_for(timeout=15.0)`. On `TimeoutError`, log a warning and fall through to `_drain_polling_connections()` + `start_polling()` — the same recovery path, just unblocked.

```python
try:
    await asyncio.wait_for(app.updater.stop(), timeout=15.0)
except asyncio.TimeoutError:
    logger.warning("[%s] updater.stop() timed out (CLOSE-WAIT); forcing drain", self.name)
```

The 15-second window is generous enough for a healthy clean stop (which takes <1s) but short enough to not materially delay reconnect in the CLOSE-WAIT scenario.

## Test

`test_handle_polling_network_error_updater_stop_timeout` in `tests/gateway/test_telegram_network_reconnect.py`:
- Makes `updater.stop()` sleep forever (simulating CLOSE-WAIT)
- Uses a 0.05s patched timeout so the test completes in <1s
- Asserts that `_drain_polling_connections()` and `start_polling()` are still called after the timeout fires

All 28 tests in `test_telegram_network_reconnect.py` pass.

## Relationship to Existing Work

- PR #48496 added the heartbeat loop (detection layer) — works correctly
- This PR fixes the reconnect handler (recovery layer) — completes the CLOSE-WAIT fix
- Without this fix, #48496 detects the problem but reconnect silently hangs, leaving the gateway in a worse state than before (alive, looks healthy, drops all messages)

Fixes #58270