### PR TITLE
security(console): confine hosted sessions export to the managed files root

### DIFF
--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -1652,6 +1652,25 @@ def _sessions_export(_engine: HermesConsoleEngine, args: list[str]) -> str:
     parser.add_argument("--session-id")
     ns = parser.parse_args(args)
 
+    output_path = ns.output
+    if _engine.context == "hosted" and output_path != "-":
+        # `sessions export` writes an arbitrary file to disk, which had no
+        # path restriction of its own — an authenticated hosted console
+        # session could write outside the managed data root the dashboard's
+        # Files page is locked to. Route it through the same
+        # ManagedFilesPolicy root-lock so the two surfaces can't drift.
+        from fastapi import HTTPException
+        from hermes_cli.web_server import _resolve_managed_path
+
+        try:
+            _, _resolved, output_path = _resolve_managed_path(
+                output_path, None, for_write=True
+            )
+        except HTTPException as exc:
+            raise ConsoleCommandError(
+                f"`sessions export` in hosted Hermes Console: {exc.detail}"
+            ) from exc
+
     def _run() -> None:
         from hermes_state import SessionDB
 
@@ -1672,11 +1691,11 @@ def _sessions_export(_engine: HermesConsoleEngine, args: list[str]) -> str:
             text = "\n".join(lines)
             if text:
                 text += "\n"
-            if ns.output == "-":
+            if output_path == "-":
                 sys.stdout.write(text)
             else:
-                Path(ns.output).expanduser().write_text(text, encoding="utf-8")
-                print(f"Exported {len(rows)} session(s) to {ns.output}")
+                Path(output_path).expanduser().write_text(text, encoding="utf-8")
+                print(f"Exported {len(rows)} session(s) to {output_path}")
         finally:
             db.close()
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1516,7 +1516,7 @@ def _dashboard_local_update_managed_externally() -> bool:
     return True
 
 
-def _managed_files_policy(request: Request, *, create_root: bool = True) -> ManagedFilesPolicy:
+def _managed_files_policy(request: Request | None, *, create_root: bool = True) -> ManagedFilesPolicy:
     raw_forced_root = os.environ.get(_MANAGED_FILES_ROOT_ENV, "").strip()
     if raw_forced_root:
         root = _ensure_managed_root(raw_forced_root) if create_root else _canonical_path(Path(raw_forced_root))
@@ -1537,7 +1537,7 @@ def _managed_files_policy(request: Request, *, create_root: bool = True) -> Mana
 
 def _resolve_managed_path(
     raw_path: str | None,
-    request: Request,
+    request: Request | None,
     *,
     for_write: bool = False,
 ) -> tuple[ManagedFilesPolicy, Path, str]:

--- a/tests/hermes_cli/test_console_engine.py
+++ b/tests/hermes_cli/test_console_engine.py
@@ -601,6 +601,69 @@ def test_sessions_list_and_stats_use_isolated_session_store(_isolate_hermes_home
     assert "Listable sessions: 1" in stats.output
 
 
+def test_hosted_sessions_export_blocks_path_outside_managed_root(
+    _isolate_hermes_home, monkeypatch, tmp_path
+):
+    """A hosted console session must not be able to write ``sessions export``
+    output outside the dashboard's managed-files root, the same way the
+    Files page's ManagedFilesPolicy locks path-browsing/writes for hosted
+    deployments."""
+    managed_root = tmp_path / "managed"
+    managed_root.mkdir()
+    monkeypatch.setenv("HERMES_DASHBOARD_FILES_ROOT", str(managed_root))
+    outside_target = tmp_path / "outside" / "escaped.jsonl"
+
+    engine = HermesConsoleEngine(context="hosted")
+    result = engine.execute(
+        f"sessions export {outside_target}", confirmed=True
+    )
+
+    assert result.status == "error"
+    assert not outside_target.exists()
+
+
+def test_hosted_sessions_export_allows_path_inside_managed_root(
+    _isolate_hermes_home, monkeypatch, tmp_path
+):
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    try:
+        db.create_session("chat-session", source="cli", model="test/model")
+    finally:
+        db.close()
+
+    managed_root = tmp_path / "managed"
+    managed_root.mkdir()
+    monkeypatch.setenv("HERMES_DASHBOARD_FILES_ROOT", str(managed_root))
+    inside_target = managed_root / "export.jsonl"
+
+    engine = HermesConsoleEngine(context="hosted")
+    result = engine.execute(
+        f"sessions export {inside_target}", confirmed=True
+    )
+
+    assert result.status == "ok"
+    assert inside_target.exists()
+
+
+def test_local_sessions_export_is_not_restricted_to_managed_root(
+    _isolate_hermes_home, monkeypatch, tmp_path
+):
+    """The local console keeps full filesystem access — only the hosted
+    context is confined to the managed-files root."""
+    managed_root = tmp_path / "managed"
+    managed_root.mkdir()
+    monkeypatch.setenv("HERMES_DASHBOARD_FILES_ROOT", str(managed_root))
+    outside_target = tmp_path / "escaped.jsonl"
+
+    engine = HermesConsoleEngine(context="local")
+    result = engine.execute(f"sessions export {outside_target}", confirmed=True)
+
+    assert result.status == "ok"
+    assert outside_target.exists()
+
+
 def test_cron_pause_resume_and_run_require_confirmation(_isolate_hermes_home):
     from cron.jobs import create_job, get_job
 


### PR DESCRIPTION
## Summary

`sessions export <output>` writes an arbitrary file to disk with no path restriction of its own. In hosted Hermes Console, `EXPECTED_HOSTED_PATHS` allows the command, but `_enforce_hosted_line_policy` has no rule for it (unlike `config set`, `mcp add`, and `cron create/edit`, which each get a hosted-specific restriction). This means an authenticated hosted console session can write outside the managed-files root the dashboard's Files page (`ManagedFilesPolicy`) is otherwise locked to — a defense-in-depth inconsistency between two surfaces that are supposed to share the same root-lock.

Verified live: `HermesConsoleEngine(context="hosted").execute("sessions export /tmp/outside.json", confirmed=True)` writes the file with no restriction on current `main`.

## Changes

- `hermes_cli/web_server.py`: widen `_managed_files_policy` / `_resolve_managed_path`'s `request` parameter to `Request | None`. Neither function actually reads `request` in its body — it's unused in both — so this is a type-only, backward-compatible widening that lets a non-HTTP caller (the console) reuse the exact same root-lock policy instead of duplicating it.
- `hermes_cli/console_engine.py`: in `_sessions_export`, when `context == "hosted"` and the output isn't `-` (stdout), resolve the path through `_resolve_managed_path(..., for_write=True)` and raise `ConsoleCommandError` if it falls outside the locked root. The `hermes_cli.web_server` import is local to the hosted branch — hosted console context is only reachable from within the running dashboard, which has already loaded FastAPI, so this adds no import-time dependency (and no risk of triggering `web_server.py`'s lazy fastapi-install fallback) for local console sessions.

Local console sessions are unaffected — they keep full filesystem access, matching the existing single-operator threat model. Explicit absolute/relative paths continue to work exactly as before outside hosted mode.

## Test plan

- [x] `test_hosted_sessions_export_blocks_path_outside_managed_root` — a hosted session writing outside a `HERMES_DASHBOARD_FILES_ROOT`-locked root gets `status == "error"` and the file is never created
- [x] `test_hosted_sessions_export_allows_path_inside_managed_root` — a hosted session writing inside the locked root still works and the file is created
- [x] `test_local_sessions_export_is_not_restricted_to_managed_root` — local console context is unaffected by the same env var
- [x] `scripts/run_tests.sh tests/hermes_cli/test_console_engine.py tests/hermes_cli/test_web_server_fs.py tests/hermes_cli/test_web_server_files.py tests/hermes_cli/test_web_server_console_ws.py tests/test_web_server.py tests/hermes_cli/test_web_server.py` — 497 passed
- [x] `ruff check` clean on all changed files
- [x] `ty check` before/after diff on changed files — zero new diagnostics