### PR TITLE
feat: route Gateway execution through AgentAdapter

### DIFF
--- a/gateway/agent_adapter.py
+++ b/gateway/agent_adapter.py
@@ -1,0 +1,277 @@
+"""AgentAdapter — single execution interface between Gateway and Runtime.
+
+The Gateway executes exclusively through AgentAdapter.  Runtime-specific
+logic (AIAgent construction, run_conversation dispatch, lifecycle) lives
+only inside HermesAdapter.
+
+Protocol
+--------
+    AgentAdapter  (Protocol)   — what the Gateway codes against
+    HermesAdapter (concrete)   — wraps AIAgent from run_agent
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, List, Optional, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Protocol — the Gateway's contract with the Runtime
+# ---------------------------------------------------------------------------
+
+@runtime_checkable
+class AgentAdapter(Protocol):
+    """Interface the Gateway uses for agent execution.
+
+    Every attribute/method here is a direct delegate to the underlying
+    AIAgent.  The Gateway must never import or reference AIAgent directly;
+    all Runtime access goes through this surface.
+    """
+
+    # -- post-run introspection (read by Gateway after run()) ----------------
+    @property
+    def session_id(self) -> Optional[str]: ...
+
+    @property
+    def model(self) -> Optional[str]: ...
+
+    @property
+    def context_compressor(self) -> Any: ...
+
+    @property
+    def session_prompt_tokens(self) -> int: ...
+
+    @property
+    def session_completion_tokens(self) -> int: ...
+
+    @property
+    def is_interrupted(self) -> bool: ...
+
+    @property
+    def _last_compaction_in_place(self) -> bool: ...
+
+    # -- callbacks (set by Gateway before run()) ----------------------------
+    tool_progress_callback: Optional[Callable[..., None]]
+    tool_start_callback: Optional[Callable[..., None]]
+    step_callback: Optional[Callable[..., None]]
+    stream_delta_callback: Optional[Callable[..., None]]
+    interim_assistant_callback: Optional[Callable[..., None]]
+    status_callback: Optional[Callable[..., None]]
+
+    # -- lifecycle -----------------------------------------------------------
+    max_iterations: int
+
+    def run(
+        self,
+        user_message: Any,
+        *,
+        conversation_history: Optional[List[Dict[str, Any]]] = None,
+        task_id: Optional[str] = None,
+        persist_user_message: Optional[str] = None,
+        persist_user_timestamp: Optional[float] = None,
+        moa_config: Optional[dict] = None,
+    ) -> Dict[str, Any]:
+        """Execute one conversation turn.  Returns the full result dict."""
+        ...
+
+    def interrupt(self, reason: str = "") -> None: ...
+
+    def steer(self, text: str) -> bool: ...
+
+    def get_activity_summary(self) -> dict: ...
+
+    def close(self) -> None: ...
+
+    def shutdown_memory_provider(
+        self, session_messages: Optional[List[Dict[str, Any]]] = None,
+    ) -> None: ...
+
+    @property
+    def api_mode(self) -> Optional[str]: ...
+
+    @property
+    def provider(self) -> Optional[str]: ...
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+def create_adapter(**kwargs: Any) -> AgentAdapter:
+    """Create a HermesAdapter from AIAgent constructor kwargs.
+
+    This is the single entry-point the Gateway calls to obtain an adapter.
+    All Runtime-specific imports happen inside HermesAdapter.__init__.
+    """
+    return HermesAdapter(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Concrete adapter — wraps AIAgent
+# ---------------------------------------------------------------------------
+
+class HermesAdapter:
+    """Thin wrapper around AIAgent that satisfies the AgentAdapter protocol.
+
+    Lifecycle:
+        1. Gateway calls ``create_adapter(...)`` → HermesAdapter constructed
+        2. Gateway sets callbacks on the adapter
+        3. Gateway calls ``adapter.run(user_message, ...)`` → delegates to
+           ``AIAgent.run_conversation()``
+        4. Gateway reads post-run properties (session_id, token counts, etc.)
+        5. Gateway calls ``adapter.close()`` when the session is evicted
+
+    All AIAgent imports are deferred to __init__ so the Gateway module never
+    imports ``run_agent`` directly.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        # Deferred import — keeps the Gateway free of Runtime coupling.
+        from run_agent import AIAgent as _AIAgent
+
+        self._agent = _AIAgent(**kwargs)
+
+    # -- property pass-throughs --------------------------------------------
+
+    @property
+    def session_id(self) -> Optional[str]:
+        return getattr(self._agent, "session_id", None)
+
+    @property
+    def model(self) -> Optional[str]:
+        return getattr(self._agent, "model", None)
+
+    @property
+    def context_compressor(self) -> Any:
+        return getattr(self._agent, "context_compressor", None)
+
+    @property
+    def session_prompt_tokens(self) -> int:
+        return getattr(self._agent, "session_prompt_tokens", 0)
+
+    @property
+    def session_completion_tokens(self) -> int:
+        return getattr(self._agent, "session_completion_tokens", 0)
+
+    @property
+    def is_interrupted(self) -> bool:
+        return getattr(self._agent, "is_interrupted", False)
+
+    @property
+    def _last_compaction_in_place(self) -> bool:
+        return bool(getattr(self._agent, "_last_compaction_in_place", False))
+
+    # -- callback delegates -------------------------------------------------
+
+    @property
+    def tool_progress_callback(self):
+        return getattr(self._agent, "tool_progress_callback", None)
+
+    @tool_progress_callback.setter
+    def tool_progress_callback(self, value):
+        self._agent.tool_progress_callback = value
+
+    @property
+    def tool_start_callback(self):
+        return getattr(self._agent, "tool_start_callback", None)
+
+    @tool_start_callback.setter
+    def tool_start_callback(self, value):
+        self._agent.tool_start_callback = value
+
+    @property
+    def step_callback(self):
+        return getattr(self._agent, "step_callback", None)
+
+    @step_callback.setter
+    def step_callback(self, value):
+        self._agent.step_callback = value
+
+    @property
+    def stream_delta_callback(self):
+        return getattr(self._agent, "stream_delta_callback", None)
+
+    @stream_delta_callback.setter
+    def stream_delta_callback(self, value):
+        self._agent.stream_delta_callback = value
+
+    @property
+    def interim_assistant_callback(self):
+        return getattr(self._agent, "interim_assistant_callback", None)
+
+    @interim_assistant_callback.setter
+    def interim_assistant_callback(self, value):
+        self._agent.interim_assistant_callback = value
+
+    @property
+    def status_callback(self):
+        return getattr(self._agent, "status_callback", None)
+
+    @status_callback.setter
+    def status_callback(self, value):
+        self._agent.status_callback = value
+
+    # -- lifecycle ----------------------------------------------------------
+
+    @property
+    def max_iterations(self) -> int:
+        return getattr(self._agent, "max_iterations", 90)
+
+    @max_iterations.setter
+    def max_iterations(self, value: int) -> None:
+        self._agent.max_iterations = value
+
+    def run(
+        self,
+        user_message: Any,
+        *,
+        conversation_history: Optional[List[Dict[str, Any]]] = None,
+        task_id: Optional[str] = None,
+        persist_user_message: Optional[str] = None,
+        persist_user_timestamp: Optional[float] = None,
+        moa_config: Optional[dict] = None,
+    ) -> Dict[str, Any]:
+        """Delegate to AIAgent.run_conversation()."""
+        kwargs: Dict[str, Any] = {}
+        if conversation_history is not None:
+            kwargs["conversation_history"] = conversation_history
+        if task_id is not None:
+            kwargs["task_id"] = task_id
+        if persist_user_message is not None:
+            kwargs["persist_user_message"] = persist_user_message
+        if persist_user_timestamp is not None:
+            kwargs["persist_user_timestamp"] = persist_user_timestamp
+        if moa_config is not None:
+            kwargs["moa_config"] = moa_config
+        return self._agent.run_conversation(user_message, **kwargs)
+
+    def interrupt(self, reason: str = "") -> None:
+        self._agent.interrupt(reason)
+
+    def steer(self, text: str) -> bool:
+        return self._agent.steer(text)
+
+    def get_activity_summary(self) -> dict:
+        return self._agent.get_activity_summary()
+
+    def close(self) -> None:
+        self._agent.close()
+
+    def shutdown_memory_provider(
+        self, session_messages: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        if session_messages is not None:
+            self._agent.shutdown_memory_provider(session_messages)
+        else:
+            self._agent.shutdown_memory_provider()
+
+    @property
+    def api_mode(self) -> Optional[str]:
+        return getattr(self._agent, "api_mode", None)
+
+    @property
+    def provider(self) -> Optional[str]:
+        return getattr(self._agent, "provider", None)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12765,7 +12765,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         media_types: Optional[List[str]] = None,
     ) -> None:
         """Execute a background agent task and deliver the result to the chat."""
-        from run_agent import AIAgent
+        from gateway.agent_adapter import create_adapter
 
         media_urls = media_urls or []
         media_types = media_types or []
@@ -12823,7 +12823,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         logger.warning("Background task vision enrichment failed: %s", e)
 
             def run_sync():
-                agent = AIAgent(
+                agent = create_adapter(
                     model=turn_route["model"],
                     **turn_route["runtime"],
                     max_iterations=max_iterations,
@@ -12853,7 +12853,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     fallback_model=self._fallback_model,
                 )
                 try:
-                    return agent.run_conversation(
+                    return agent.run(
                         user_message=enriched_prompt,
                         task_id=task_id,
                     )
@@ -16324,7 +16324,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 event_message_id=event_message_id,
             )
 
-        from run_agent import AIAgent
+        from gateway.agent_adapter import create_adapter
         import queue
 
         def _run_still_current() -> bool:
@@ -17533,7 +17533,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             if agent is None:
                 # Config changed or first message — create fresh agent
-                agent = AIAgent(
+                agent = create_adapter(
                     model=turn_route["model"],
                     **turn_route["runtime"],
                     max_iterations=max_iterations,
@@ -18142,7 +18142,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _conversation_kwargs["moa_config"] = moa_config
                 if _persist_user_timestamp_override is not None:
                     _conversation_kwargs["persist_user_timestamp"] = _persist_user_timestamp_override
-                result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
+                result = agent.run(_api_run_message, **_conversation_kwargs)
             finally:
                 unregister_gateway_notify(_approval_session_key)
                 # Cancel any pending clarify entries so blocked agent

--- a/tests/gateway/test_agent_adapter.py
+++ b/tests/gateway/test_agent_adapter.py
@@ -1,0 +1,497 @@
+"""Tests for gateway.agent_adapter — Gateway → AgentAdapter → HermesAdapter → Response.
+
+Verifies:
+1. AgentAdapter protocol satisfaction
+2. HermesAdapter delegates to AIAgent correctly
+3. create_adapter factory produces a valid adapter
+4. Post-run properties propagate from AIAgent
+5. Callbacks set on adapter reach the underlying AIAgent
+6. Gateway dispatch path uses adapter (not direct AIAgent)
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gateway.agent_adapter import AgentAdapter, HermesAdapter, create_adapter
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_stub_agent(**overrides):
+    """Create a minimal stub that duck-types AIAgent for testing."""
+    stub = MagicMock()
+    stub.session_id = overrides.get("session_id", "test-session-123")
+    stub.model = overrides.get("model", "test-model")
+    stub.context_compressor = overrides.get("context_compressor", MagicMock(
+        last_prompt_tokens=100, context_length=8192
+    ))
+    stub.session_prompt_tokens = overrides.get("session_prompt_tokens", 500)
+    stub.session_completion_tokens = overrides.get("session_completion_tokens", 200)
+    stub.is_interrupted = overrides.get("is_interrupted", False)
+    stub._last_compaction_in_place = overrides.get("_last_compaction_in_place", False)
+    stub.max_iterations = overrides.get("max_iterations", 90)
+    stub.api_mode = overrides.get("api_mode", "chat_completions")
+    stub.provider = overrides.get("provider", "openrouter")
+
+    stub.run_conversation.return_value = overrides.get(
+        "run_result",
+        {"final_response": "Hello from the agent", "completed": True, "api_calls": 1},
+    )
+    stub.steer.return_value = True
+    stub.get_activity_summary.return_value = {
+        "current_tool": None,
+        "api_call_count": 1,
+    }
+    return stub
+
+
+# ---------------------------------------------------------------------------
+# Protocol satisfaction
+# ---------------------------------------------------------------------------
+
+class TestAgentAdapterProtocol:
+    """AgentAdapter is a runtime_checkable Protocol."""
+
+    def test_hermes_adapter_satisfies_protocol(self):
+        """HermesAdapter instances satisfy the AgentAdapter protocol."""
+        with patch("run_agent.AIAgent", return_value=_make_stub_agent()):
+            adapter = create_adapter(model="test")
+        assert isinstance(adapter, AgentAdapter)
+
+    def test_stub_satisfies_protocol(self):
+        """A duck-typed stub can satisfy the protocol."""
+        stub = _make_stub_agent()
+        # Protocol structural check: all protocol members are present
+        for member in dir(AgentAdapter):
+            if member.startswith("_"):
+                continue
+            assert hasattr(stub, member) or member in (
+                "run", "interrupt", "steer", "get_activity_summary",
+                "close", "shutdown_memory_provider",
+            )
+
+
+# ---------------------------------------------------------------------------
+# create_adapter factory
+# ---------------------------------------------------------------------------
+
+class TestCreateAdapter:
+    """Factory function produces a HermesAdapter."""
+
+    def test_returns_hermes_adapter(self):
+        with patch("run_agent.AIAgent", return_value=_make_stub_agent()):
+            adapter = create_adapter(model="test-model")
+        assert isinstance(adapter, HermesAdapter)
+
+    def test_passes_kwargs_to_aianagent(self):
+        with patch("run_agent.AIAgent", return_value=_make_stub_agent()) as MockAgent:
+            create_adapter(
+                model="my-model",
+                max_iterations=42,
+                quiet_mode=True,
+                session_id="sess-1",
+            )
+        MockAgent.assert_called_once_with(
+            model="my-model",
+            max_iterations=42,
+            quiet_mode=True,
+            session_id="sess-1",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Delegation: run() → run_conversation()
+# ---------------------------------------------------------------------------
+
+class TestRunDelegation:
+    """adapter.run() delegates to AIAgent.run_conversation()."""
+
+    def test_run_delegates_to_run_conversation(self):
+        stub = _make_stub_agent()
+        with patch("run_agent.AIAgent", return_value=stub):
+            adapter = create_adapter(model="test")
+
+        result = adapter.run(
+            "Hello",
+            conversation_history=[{"role": "user", "content": "Hi"}],
+            task_id="task-1",
+        )
+
+        stub.run_conversation.assert_called_once_with(
+            "Hello",
+            conversation_history=[{"role": "user", "content": "Hi"}],
+            task_id="task-1",
+        )
+        assert result["final_response"] == "Hello from the agent"
+
+    def test_run_with_all_kwargs(self):
+        stub = _make_stub_agent()
+        with patch("run_agent.AIAgent", return_value=stub):
+            adapter = create_adapter(model="test")
+
+        adapter.run(
+            "msg",
+            conversation_history=[],
+            task_id="t",
+            persist_user_message="orig",
+            persist_user_timestamp=1234567890.0,
+            moa_config={"enabled": True},
+        )
+
+        stub.run_conversation.assert_called_once_with(
+            "msg",
+            conversation_history=[],
+            task_id="t",
+            persist_user_message="orig",
+            persist_user_timestamp=1234567890.0,
+            moa_config={"enabled": True},
+        )
+
+    def test_run_minimal_kwargs(self):
+        stub = _make_stub_agent()
+        with patch("run_agent.AIAgent", return_value=stub):
+            adapter = create_adapter(model="test")
+
+        adapter.run("msg")
+
+        stub.run_conversation.assert_called_once_with("msg")
+
+
+# ---------------------------------------------------------------------------
+# Post-run property pass-through
+# ---------------------------------------------------------------------------
+
+class TestPostRunProperties:
+    """Adapter exposes AIAgent state after run()."""
+
+    def test_session_id(self):
+        stub = _make_stub_agent(session_id="compressed-child-id")
+        with patch("run_agent.AIAgent", return_value=stub):
+            adapter = create_adapter(model="test")
+        assert adapter.session_id == "compressed-child-id"
+
+    def test_model(self):
+        stub = _make_stub_agent(model="anthropic/claude-sonnet-4")
+        with patch("run_agent.AIAgent", return_value=stub):
+            adapter = create_adapter(model="test")
+        assert adapter.model == "anthropic/claude-sonnet-4"
+
+    def test_context_compressor(self):
+        cc = MagicMock(last_prompt_tokens=42, context_length=16384)
+        stub = _make_stub_agent(context_compressor=cc)
+        with patch("run_agent.AIAgent", return_value=stub):
+            adapter = create_adapter(model="test")
+        assert adapter.context_compressor is cc
+        assert adapter.context_compressor.last_prompt_tokens == 42
+
+    def test_session_prompt_tokens(self):
+        stub = _make_stub_agent(session_prompt_tokens=1234)
+        with patch("run_agent.AIAgent", return_value=stub):
+            adapter = create_adapter(model="test")
+        assert adapter.session_prompt_tokens == 1234
+
+    def test_session_completion_tokens(self):
+        stub = _make_stub_agent(session_completion_tokens=567)
+        with patch("run_agent.AIAgent", return_value=stub):
+            adapter = create_adapter(model="test")
+        assert adapter.session_completion_tokens == 567
+
+    def test_is_interrupted(self):
+        stub = _make_stub_agent(is_interrupted=True)
+        with patch("run_agent.AIAgent", return_value=stub):
+            adapter = create_adapter(model="test")
+        assert adapter.is_interrupted is True
+
+    def test_compaction_in_place(self):
+        stub = _make_stub_agent(_last_compaction_in_place=True)
+        with patch("run_agent.AIAgent", return_value=stub):
+            adapter = create_adapter(model="test")
+        assert adapter._last_compaction_in_place is True
+
+    def test_api_mode(self):
+        stub = _make_stub_agent(api_mode="anthropic_messages")
+        with patch("run_agent.AIAgent", return_value=stub):
+            adapter = create_adapter(model="test")
+        assert adapter.api_mode == "anthropic_messages"
+
+    def test_provider(self):
+        stub = _make_stub_agent(provider="anthropic")
+        with patch("run_agent.AIAgent", return_value=stub):
+            adapter = create_adapter(model="test")
+        assert adapter.provider == "anthropic"
+
+
+# ---------------------------------------------------------------------------
+# Callback pass-through
+# ---------------------------------------------------------------------------
+
+class TestCallbackPassthrough:
+    """Callbacks set on the adapter reach the underlying AIAgent."""
+
+    def test_tool_progress_callback(self):
+        stub = _make_stub_agent()
+        with patch("run_agent.AIAgent", return_value=stub):
+            adapter = create_adapter(model="test")
+
+        cb = lambda *a, **kw: None
+        adapter.tool_progress_callback = cb
+        assert adapter.tool_progress_callback is cb
+        assert stub.tool_progress_callback is cb
+
+    def test_stream_delta_callback(self):
+        stub = _make_stub_agent()
+        with patch("run_agent.AIAgent", return_value=stub):
+            adapter = create_adapter(model="test")
+
+        cb = lambda *a, **kw: None
+        adapter.stream_delta_callback = cb
+        assert adapter.stream_delta_callback is cb
+
+    def test_status_callback(self):
+        stub = _make_stub_agent()
+        with patch("run_agent.AIAgent", return_value=stub):
+            adapter = create_adapter(model="test")
+
+        cb = lambda *a, **kw: None
+        adapter.status_callback = cb
+        assert adapter.status_callback is cb
+
+    def test_max_iterations_passthrough(self):
+        stub = _make_stub_agent(max_iterations=30)
+        with patch("run_agent.AIAgent", return_value=stub):
+            adapter = create_adapter(model="test")
+        assert adapter.max_iterations == 30
+
+        adapter.max_iterations = 50
+        assert adapter.max_iterations == 50
+        assert stub.max_iterations == 50
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle methods
+# ---------------------------------------------------------------------------
+
+class TestLifecycleMethods:
+    """Lifecycle methods delegate correctly."""
+
+    def test_interrupt(self):
+        stub = _make_stub_agent()
+        with patch("run_agent.AIAgent", return_value=stub):
+            adapter = create_adapter(model="test")
+
+        adapter.interrupt("user stopped")
+        stub.interrupt.assert_called_once_with("user stopped")
+
+    def test_steer(self):
+        stub = _make_stub_agent()
+        with patch("run_agent.AIAgent", return_value=stub):
+            adapter = create_adapter(model="test")
+
+        result = adapter.steer("new direction")
+        stub.steer.assert_called_once_with("new direction")
+        assert result is True
+
+    def test_get_activity_summary(self):
+        stub = _make_stub_agent()
+        with patch("run_agent.AIAgent", return_value=stub):
+            adapter = create_adapter(model="test")
+
+        summary = adapter.get_activity_summary()
+        stub.get_activity_summary.assert_called_once()
+        assert "current_tool" in summary
+
+    def test_close(self):
+        stub = _make_stub_agent()
+        with patch("run_agent.AIAgent", return_value=stub):
+            adapter = create_adapter(model="test")
+
+        adapter.close()
+        stub.close.assert_called_once()
+
+    def test_shutdown_memory_provider_no_args(self):
+        stub = _make_stub_agent()
+        with patch("run_agent.AIAgent", return_value=stub):
+            adapter = create_adapter(model="test")
+
+        adapter.shutdown_memory_provider()
+        stub.shutdown_memory_provider.assert_called_once_with()
+
+    def test_shutdown_memory_provider_with_messages(self):
+        stub = _make_stub_agent()
+        msgs = [{"role": "user", "content": "hi"}]
+        with patch("run_agent.AIAgent", return_value=stub):
+            adapter = create_adapter(model="test")
+
+        adapter.shutdown_memory_provider(msgs)
+        stub.shutdown_memory_provider.assert_called_once_with(msgs)
+
+
+# ---------------------------------------------------------------------------
+# Gateway dispatch path uses adapter (integration-level)
+# ---------------------------------------------------------------------------
+
+class TestGatewayUsesAdapter:
+    """Gateway's _run_agent_inner imports adapter, not AIAgent directly."""
+
+    def test_run_agent_inner_imports_adapter(self):
+        """The main execution path imports from gateway.agent_adapter."""
+        import ast
+        from pathlib import Path
+
+        run_py = Path("/usr/local/lib/hermes-agent/gateway/run.py")
+        source = run_py.read_text()
+
+        # Find the _run_agent_inner method's import line
+        # It should import create_adapter, not AIAgent
+        lines = source.splitlines()
+
+        # Search for the import inside _run_agent_inner context
+        in_run_agent_inner = False
+        found_adapter_import = False
+        found_direct_aian_import = False
+
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+            if "async def _run_agent_inner(" in stripped:
+                in_run_agent_inner = True
+            if in_run_agent_inner and stripped.startswith("from gateway.agent_adapter import create_adapter"):
+                found_adapter_import = True
+            if in_run_agent_inner and stripped.startswith("from run_agent import AIAgent"):
+                found_direct_aian_import = True
+            if in_run_agent_inner and stripped.startswith("async def ") and "_run_agent_inner" not in stripped:
+                break  # next method
+
+        assert found_adapter_import, "Gateway _run_agent_inner must import create_adapter"
+        assert not found_direct_aian_import, "Gateway _run_agent_inner must NOT import AIAgent directly"
+
+    def test_background_task_uses_adapter(self):
+        """The background task path imports adapter, not AIAgent directly."""
+        import ast
+        from pathlib import Path
+
+        run_py = Path("/usr/local/lib/hermes-agent/gateway/run.py")
+        source = run_py.read_text()
+        lines = source.splitlines()
+
+        in_background = False
+        found_adapter = False
+        found_direct = False
+
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+            if "_run_background_task" in stripped and "async def" in stripped:
+                in_background = True
+            if in_background and "from gateway.agent_adapter import create_adapter" in stripped:
+                found_adapter = True
+            if in_background and "from run_agent import AIAgent" in stripped:
+                found_direct = True
+            if in_background and i > 0 and stripped.startswith("async def ") and "_run_background_task" not in stripped:
+                break
+
+        assert found_adapter, "Background task must import create_adapter"
+        assert not found_direct, "Background task must NOT import AIAgent directly"
+
+    def test_run_conversation_replaced_with_run(self):
+        """The main path calls adapter.run(), not agent.run_conversation()."""
+        from pathlib import Path
+
+        run_py = Path("/usr/local/lib/hermes-agent/gateway/run.py")
+        source = run_py.read_text()
+
+        # Find _run_agent_inner and search forward for the run call
+        marker = "async def _run_agent_inner("
+        start = source.find(marker)
+        assert start != -1, "_run_agent_inner not found in run.py"
+
+        # Search the next 200000 chars (the method is ~1700 lines, ~170KB)
+        section = source[start:start + 200000]
+
+        found_adapter_run = "result = agent.run(" in section
+        found_direct_run_conv = "result = agent.run_conversation(" in section
+
+        assert found_adapter_run, "Main path must call agent.run()"
+        assert not found_direct_run_conv, "Main path must NOT call agent.run_conversation()"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: Gateway → Adapter → AIAgent → Response
+# ---------------------------------------------------------------------------
+
+class TestEndToEndFlow:
+    """Full flow: Gateway creates adapter → adapter delegates → response returned."""
+
+    def test_full_flow_returns_response(self):
+        """Simulates the Gateway's _run_agent_inner dispatch flow."""
+        expected_result = {
+            "final_response": "The agent responded successfully",
+            "completed": True,
+            "api_calls": 3,
+            "messages": [],
+        }
+        stub = _make_stub_agent(run_result=expected_result)
+
+        with patch("run_agent.AIAgent", return_value=stub) as MockAgent:
+            # Step 1: Gateway creates adapter (via factory)
+            adapter = create_adapter(
+                model="test-model",
+                max_iterations=90,
+                quiet_mode=True,
+                session_id="test-session",
+            )
+
+            # Step 2: Gateway sets callbacks
+            progress_cb = MagicMock()
+            adapter.tool_progress_callback = progress_cb
+
+            # Step 3: Gateway calls adapter.run()
+            result = adapter.run(
+                user_message="What is 2+2?",
+                conversation_history=[],
+                task_id="test-session",
+            )
+
+            # Step 4: Verify delegation chain
+            MockAgent.assert_called_once()
+            stub.run_conversation.assert_called_once()
+
+            # Step 5: Verify response propagation
+            assert result["final_response"] == "The agent responded successfully"
+            assert result["completed"] is True
+            assert result["api_calls"] == 3
+
+            # Step 6: Verify callback was set on the stub
+            assert stub.tool_progress_callback is progress_cb
+
+    def test_post_run_state_accessible(self):
+        """After run(), Gateway can read agent state through the adapter."""
+        stub = _make_stub_agent(
+            session_id="compressed-new-id",
+            session_prompt_tokens=2048,
+            session_completion_tokens=512,
+            _last_compaction_in_place=True,
+        )
+
+        with patch("run_agent.AIAgent", return_value=stub):
+            adapter = create_adapter(model="test")
+
+        # Simulate post-run state reading (same pattern as gateway/run.py)
+        agent_session_id = adapter.session_id or "original-id"
+        assert agent_session_id == "compressed-new-id"
+
+        prompt_toks = getattr(adapter.context_compressor, "last_prompt_tokens", 0)
+        assert prompt_toks == 100
+
+        input_toks = adapter.session_prompt_tokens
+        assert input_toks == 2048
+
+        output_toks = adapter.session_completion_tokens
+        assert output_toks == 512
+
+        compacted = bool(getattr(adapter, "_last_compaction_in_place", False))
+        assert compacted is True

--- a/tests/gateway/test_reasoning_command.py
+++ b/tests/gateway/test_reasoning_command.py
@@ -48,12 +48,30 @@ def _make_runner():
 
 class _CapturingAgent:
     """Fake agent that records init kwargs for assertions."""
-
     last_init = None
 
     def __init__(self, *args, **kwargs):
         type(self).last_init = dict(kwargs)
         self.tools = []
+        self.session_id = kwargs.get("session_id")
+        self.model = kwargs.get("model")
+        self.context_compressor = None
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.is_interrupted = False
+        self._last_compaction_in_place = False
+        self.max_iterations = kwargs.get("max_iterations", 90)
+        self.api_mode = kwargs.get("api_mode")
+        self.provider = kwargs.get("provider")
+        self.tool_progress_callback = None
+        self.tool_start_callback = None
+        self.step_callback = None
+        self.stream_delta_callback = None
+        self.interim_assistant_callback = None
+        self.status_callback = None
+
+    def run(self, user_message, **kwargs):
+        return self.run_conversation(user_message, **kwargs)
 
     def run_conversation(self, user_message: str, conversation_history=None, task_id=None):
         return {
@@ -61,6 +79,21 @@ class _CapturingAgent:
             "messages": [],
             "api_calls": 1,
         }
+
+    def interrupt(self, reason=""):
+        pass
+
+    def steer(self, text):
+        return True
+
+    def get_activity_summary(self):
+        return {"current_tool": None, "api_call_count": 0}
+
+    def close(self):
+        pass
+
+    def shutdown_memory_provider(self, messages=None):
+        pass
 
 
 class TestReasoningCommand:


### PR DESCRIPTION
## Summary

Add `AgentAdapter` protocol and `HermesAdapter` so the Gateway no longer imports `AIAgent` directly. The two main execution paths (`_run_agent_inner` and `_run_background_task`) now create adapters via `create_adapter()` and call `adapter.run()` instead of `agent.run_conversation()`.

## Changes

- **`gateway/agent_adapter.py`** (new) — `AgentAdapter` protocol + `HermesAdapter` wrapper
- **`gateway/run.py`** — replace 2 direct `AIAgent` imports with adapter
- **`tests/gateway/test_agent_adapter.py`** (new) — 31 tests
- **`tests/gateway/test_reasoning_command.py`** — updated fake agent to satisfy adapter interface

## Verification

- 31/31 adapter tests pass
- 236/236 gateway tests pass  
- 406/406 run_agent tests pass