### PR TITLE
fix(auth): fail fast on Spotify PKCE login when non-interactive

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2948,6 +2948,26 @@ def login_spotify_command(args) -> None:
         else:
             print("Could not open the browser automatically; use the URL above.")
 
+    # Fail fast instead of blocking when no one can complete the browser
+    # authorization. The dashboard spawns `hermes tools post-setup spotify`
+    # detached with stdin=DEVNULL and HERMES_NONINTERACTIVE=1 (see
+    # hermes_cli/web_server.py::_spawn_hermes_action) -- unlike a genuinely
+    # supervised GUI flow, there is no one watching to open the URL above, so
+    # binding the callback listener would just block for the full timeout and
+    # then, on retry, collide on the still-bound port. `_is_remote_session()`
+    # covers a different case (a human present but on another machine, e.g.
+    # SSH/Cloud Shell -- the loopback-tunnel hint above already handles that);
+    # this checks whether anyone can act on the URL at all.
+    from hermes_cli.setup import is_noninteractive
+
+    if is_noninteractive():
+        raise SystemExit(
+            "Spotify authorization requires a browser but no interactive "
+            "session is available (non-interactive/background context). "
+            "Run `hermes auth spotify` interactively to authorize, then "
+            "retry."
+        )
+
     callback = _spotify_wait_for_callback(
         redirect_uri,
         timeout_seconds=float(getattr(args, "timeout", None) or 180.0),

--- a/tests/hermes_cli/test_spotify_auth.py
+++ b/tests/hermes_cli/test_spotify_auth.py
@@ -164,6 +164,65 @@ def test_spotify_interactive_setup_persists_client_id(
     assert auth_mod.SPOTIFY_DOCS_URL in output
 
 
+def test_login_spotify_fails_fast_when_noninteractive(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`hermes tools post-setup spotify` spawns detached with stdin=DEVNULL
+    and HERMES_NONINTERACTIVE=1 (hermes_cli/web_server.py::_spawn_hermes_action).
+    Before this fix, login_spotify_command would still print the authorize
+    URL and block in _spotify_wait_for_callback for the full timeout with no
+    one able to complete the browser flow, then fail with "Address already in
+    use" on the next retry. It must instead fail fast with an actionable
+    message and never bind the callback listener."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_SPOTIFY_CLIENT_ID", "test-client")
+    monkeypatch.setenv("HERMES_NONINTERACTIVE", "1")
+
+    def _fail_if_called(*_a, **_k):
+        raise AssertionError(
+            "_spotify_wait_for_callback must not be reached when non-interactive"
+        )
+
+    monkeypatch.setattr(auth_mod, "_spotify_wait_for_callback", _fail_if_called)
+    monkeypatch.setattr(auth_mod, "webbrowser", SimpleNamespace(open=lambda *_a, **_k: False))
+
+    with pytest.raises(SystemExit, match="non-interactive"):
+        auth_mod.login_spotify_command(SimpleNamespace(
+            client_id=None, redirect_uri=None, scope=None,
+            no_browser=False, timeout=None,
+        ))
+
+
+def test_login_spotify_waits_for_callback_when_interactive(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Positive control: an interactive session must still reach the
+    callback wait — the non-interactive guard must not over-fire."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_SPOTIFY_CLIENT_ID", "test-client")
+    monkeypatch.delenv("HERMES_NONINTERACTIVE", raising=False)
+
+    called = {}
+
+    def _fake_wait(redirect_uri, timeout_seconds):
+        called["reached"] = True
+        return {"error": "access_denied", "error_description": "user cancelled"}
+
+    monkeypatch.setattr(auth_mod, "_spotify_wait_for_callback", _fake_wait)
+    monkeypatch.setattr(auth_mod, "webbrowser", SimpleNamespace(open=lambda *_a, **_k: False))
+    monkeypatch.setattr(auth_mod, "_is_remote_session", lambda: True)
+
+    with pytest.raises(SystemExit, match="user cancelled"):
+        auth_mod.login_spotify_command(SimpleNamespace(
+            client_id=None, redirect_uri=None, scope=None,
+            no_browser=False, timeout=None,
+        ))
+
+    assert called.get("reached") is True
+
+
 def test_spotify_interactive_setup_empty_aborts(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

`755194ffe`/`af0ce1cf8` added a fail-fast guard to MCP OAuth's redirect/callback boundary so a non-interactive context (systemd gateway, cron, background discovery) raises an actionable error instead of printing an unreachable auth URL and blocking on a callback listener no one can complete. Spotify's PKCE login has the identical loopback-listener shape (`_spotify_wait_for_callback` binds a local HTTP server and blocks up to 180s) but has no equivalent guard.

`hermes_cli/web_server.py::_spawn_hermes_action` — the mechanism behind `hermes tools post-setup <key>`, which `POST /api/tools/toolsets/{name}/post-setup` uses to run "the stable, scriptable target the dashboard spawns" — launches the child with `stdin=DEVNULL` and `HERMES_NONINTERACTIVE=1` specifically because no human is attached. Every other post-setup hook in that dispatcher (npm install for browser/Camofox, pip install for KittenTTS/Piper/ddgs, cua-driver fetch) is a one-shot install command; Spotify's is the only one that also blocks waiting on a browser callback. `hermes tools post-setup spotify` therefore reproduces the pre-fix MCP OAuth failure mode: prints a URL no one is watching for, binds the callback port, blocks for the full timeout, then on the next retry gets `OSError: [Errno 98] Address already in use`.

`_is_remote_session()` covers a different, already-handled case (a human present but on another machine over SSH/Cloud Shell — the loopback tunnel hint already guides them through a port-forward). This adds the missing check for whether anyone can act on the printed URL *at all*, reusing the existing `hermes_cli.setup.is_noninteractive()` helper (the same `HERMES_NONINTERACTIVE` signal `prompt_yes_no()` already honors elsewhere in the setup flow) rather than introducing a new interactivity heuristic.

Raises `SystemExit`, which `hermes_cli/tools_config.py::_run_post_setup`'s `spotify` branch already catches and handles gracefully ("Spotify login did not complete... Run later: `hermes auth spotify`") — no caller change needed.

## Test plan

- [x] `test_login_spotify_fails_fast_when_noninteractive` — with `HERMES_NONINTERACTIVE=1` set, asserts `SystemExit` is raised and mutation-verifies `_spotify_wait_for_callback` is never reached (fails with an `AssertionError` if it is)
- [x] Mutation-verified against the pre-fix code: the same test fails by actually reaching `_spotify_wait_for_callback` (confirming the bug is live on current `main`), then passes once the guard is added
- [x] `test_login_spotify_waits_for_callback_when_interactive` — positive control: without the env var, the flow still reaches the callback wait, proving the guard doesn't over-fire
- [x] `scripts/run_tests.sh tests/hermes_cli/test_spotify_auth.py tests/hermes_cli/test_auth_loopback_ssh_hint.py tests/hermes_cli/test_auth_commands.py` — 76 passed
- [x] `ruff check` clean on all changed files
- [x] `ty check` before/after diff on changed files — only line-number shifts, no new diagnostics