### PR TITLE
fix: allow suppressing Codex gpt-5.5 autoraise notice (salvage #58240)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1403,9 +1403,14 @@ def init_agent(
     # compact at ~136K — half the usable context). Gated by an opt-out config
     # flag so the user can fall back to the global threshold; when the override
     # fires we stash a one-time notification (replayed on the first turn) that
-    # tells the user what changed and how to revert.
+    # tells the user what changed and how to revert. The notice has its own
+    # display gate so users can keep the threshold autoraise without getting
+    # the banner on gateway turns.
     _codex_gpt55_autoraise = str(
         _compression_cfg.get("codex_gpt55_autoraise", True)
+    ).lower() in {"true", "1", "yes"}
+    _codex_gpt55_autoraise_notice = str(
+        _compression_cfg.get("codex_gpt55_autoraise_notice", True)
     ).lower() in {"true", "1", "yes"}
     agent._compression_threshold_autoraised = None
     try:
@@ -1891,7 +1896,7 @@ def init_agent(
         # gateway users get the same text replayed via _compression_warning on
         # turn 1 (set below, after the warning slot is initialized).
         _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-        if _autoraise and compression_enabled:
+        if _autoraise and compression_enabled and _codex_gpt55_autoraise_notice:
             print(_build_codex_gpt55_autoraise_notice(_autoraise))
 
     # Check immediately so CLI users see the warning at startup.
@@ -1902,7 +1907,7 @@ def init_agent(
     # above only reaches the CLI, so stash the same text here to be replayed
     # through status_callback on the first turn (Telegram/Discord/Slack/etc.).
     _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-    if _autoraise and compression_enabled:
+    if _autoraise and compression_enabled and _codex_gpt55_autoraise_notice:
         agent._compression_warning = _build_codex_gpt55_autoraise_notice(_autoraise)
     # Lazy feasibility check: deferred to the first turn that approaches the
     # compression threshold. Running it eagerly here costs ~400ms cold (network

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1367,6 +1367,10 @@ DEFAULT_CONFIG = {
                                       # exact route is affected — gpt-5.5 on OpenAI's
                                       # direct API, OpenRouter, and Copilot keep the
                                       # global threshold regardless.
+        "codex_gpt55_autoraise_notice": True,  # Display the one-time Codex gpt-5.5
+                                      # autoraise banner. Set False to keep the
+                                      # 85% threshold autoraise but suppress the
+                                      # user-facing notice in CLI/gateway output.
         "in_place": True,             # When True, compaction rewrites the message
                                       # list and rebuilds the system prompt WITHOUT
                                       # rotating the session id — the conversation

--- a/tests/agent/test_codex_gpt55_autoraise_notice.py
+++ b/tests/agent/test_codex_gpt55_autoraise_notice.py
@@ -1,0 +1,77 @@
+"""Regression tests for the Codex gpt-5.5 autoraise notice gate."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+from pathlib import Path
+
+from hermes_state import SessionDB
+from run_agent import AIAgent
+
+
+def _config(*, show_notice: bool) -> dict:
+    return {
+        "compression": {
+            "enabled": True,
+            "threshold": 0.50,
+            "target_ratio": 0.20,
+            "protect_first_n": 3,
+            "protect_last_n": 20,
+            "codex_gpt55_autoraise": True,
+            "codex_gpt55_autoraise_notice": show_notice,
+        },
+        "prompt_caching": {"cache_ttl": "5m"},
+        "sessions": {},
+        "bedrock": {},
+    }
+
+
+def _make_codex_agent(monkeypatch, tmp_path: Path, *, show_notice: bool):
+    """Construct a real Codex gpt-5.5 agent under an isolated config."""
+    from hermes_cli import config as config_mod
+
+    monkeypatch.setattr(config_mod, "load_config", lambda: _config(show_notice=show_notice))
+    db = SessionDB(db_path=tmp_path / "state.db")
+    stdout = io.StringIO()
+
+    with contextlib.redirect_stdout(stdout):
+        agent = AIAgent(
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_key="test-key",
+            provider="openai-codex",
+            model="gpt-5.5",
+            enabled_toolsets=[],
+            disabled_toolsets=[],
+            quiet_mode=False,
+            skip_memory=True,
+            session_db=db,
+            session_id="codex-notice-test",
+        )
+
+    return agent, stdout.getvalue()
+
+
+def _threshold_ratio(agent: AIAgent) -> float:
+    compressor = getattr(agent, "context_compressor")
+    return round(compressor.threshold_tokens / compressor.context_length, 2)
+
+
+def test_codex_gpt55_autoraise_notice_enabled_by_default(monkeypatch, tmp_path):
+    agent, stdout = _make_codex_agent(monkeypatch, tmp_path, show_notice=True)
+
+    assert _threshold_ratio(agent) == 0.85
+    warning = getattr(agent, "_compression_warning")
+    assert warning is not None
+    assert "auto-compaction was raised" in warning
+    assert "auto-compaction was raised" in stdout
+
+
+def test_codex_gpt55_autoraise_notice_can_be_suppressed_without_disabling_autoraise(
+    monkeypatch, tmp_path
+):
+    agent, stdout = _make_codex_agent(monkeypatch, tmp_path, show_notice=False)
+
+    assert _threshold_ratio(agent) == 0.85
+    assert getattr(agent, "_compression_warning") is None
+    assert "auto-compaction was raised" not in stdout

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -85,6 +85,7 @@ compression:
   target_ratio: 0.20         # How much of threshold to keep as tail (default: 0.20)
   protect_last_n: 20         # Minimum protected tail messages (default: 20)
   codex_gpt55_autoraise: true  # gpt-5.5 on Codex OAuth: raise trigger to 85% (default: true)
+  codex_gpt55_autoraise_notice: true  # Show the one-time autoraise notice (default: true)
 
 # Summarization model/provider configured under auxiliary:
 auxiliary:
@@ -103,6 +104,7 @@ auxiliary:
 | `protect_last_n` | `20` | ≥1 | Minimum number of recent messages always preserved |
 | `protect_first_n` | `3` | (hardcoded) | System prompt + first exchange always preserved |
 | `codex_gpt55_autoraise` | `true` | bool | Raise the trigger to 85% for gpt-5.5 on the ChatGPT Codex OAuth route (see below). Set `false` to keep the global `threshold` |
+| `codex_gpt55_autoraise_notice` | `true` | bool | Show the one-time Codex gpt-5.5 autoraise notice. Set `false` to keep the 85% autoraise but suppress the banner |
 
 ### Codex gpt-5.5 threshold autoraise
 
@@ -117,6 +119,12 @@ your global `threshold`. To opt back down to the global value:
 
 ```bash
 hermes config set compression.codex_gpt55_autoraise false
+```
+
+To keep the 85% autoraise but hide only the one-time notice:
+
+```bash
+hermes config set compression.codex_gpt55_autoraise_notice false
 ```
 
 ### Computed Values (for a 200K context model at defaults)


### PR DESCRIPTION
## Summary
Adds `compression.codex_gpt55_autoraise_notice` (default `true`) so operators can keep the Codex gpt-5.5 85% compaction auto-raise while suppressing the one-time startup notice.

Previously the only way to silence the notice was `codex_gpt55_autoraise false`, which also disables the useful 85% threshold raise. This separates the threshold policy from the user-facing banner — important for gateway/cron-heavy installs where the notice reprints in chat on every fresh agent init.

## Changes
- `agent/agent_init.py`: gate both notice emit sites (CLI `print` + gateway `_compression_warning` replay) on the new flag; 85% raise itself unchanged.
- `hermes_cli/config.py`: `codex_gpt55_autoraise_notice: True` in `DEFAULT_CONFIG` under `compression`.
- `website/docs/developer-guide/context-compression-and-caching.md`: document the notice-only opt-out.
- `tests/agent/test_codex_gpt55_autoraise_notice.py`: regression coverage (default-on shows notice; suppressed keeps 85% + hides both CLI and gateway output).

## Validation
| | threshold | gateway warn | CLI notice |
|---|---|---|---|
| default (notice=true) | 0.85 | set | printed |
| notice=false | 0.85 | none | hidden |

E2E: real `AIAgent` on `openai-codex`/`gpt-5.5` under a temp `HERMES_HOME`, both paths verified. Targeted tests pass; ruff clean.

## Credit
Salvaged from #58240 by @shashwatgokhe (cherry-picked, authorship preserved). This closes out a duplicate cluster targeting the same UX issue — see closure comments crediting the other contributors.

Closes #58240
