### PR TITLE
fix(kanban): persist completion artifacts before cleanup

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -337,6 +337,118 @@ def test_complete_metadata_round_trips_through_show(worker_env):
     assert shown["runs"][-1]["metadata"] == handoff
 
 
+def test_complete_persists_artifacts_before_scratch_cleanup(worker_env):
+    """Explicit completion artifacts survive scratch workspace deletion."""
+    from pathlib import Path
+
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, worker_env)
+        assert task is not None
+        ws = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, worker_env, ws)
+    finally:
+        conn.close()
+
+    report = Path(ws) / "report.md"
+    report.write_text("durable evidence", encoding="utf-8")
+
+    complete_out = kt._handle_complete({
+        "summary": "finished with artifact",
+        "artifacts": [str(report)],
+    })
+    assert json.loads(complete_out)["ok"] is True
+    assert not report.exists(), "scratch workspace should still be cleaned up"
+
+    conn = kb.connect()
+    try:
+        run = kb.latest_run(conn, worker_env)
+        assert run is not None
+        stored = run.metadata["artifacts"][0]
+        event = conn.execute(
+            "SELECT payload FROM task_events WHERE task_id = ? AND kind = 'completed'",
+            (worker_env,),
+        ).fetchone()
+        assert event is not None
+    finally:
+        conn.close()
+
+    stored_path = Path(stored)
+    assert stored_path.is_file()
+    assert stored_path.read_text(encoding="utf-8") == "durable evidence"
+    stored_path.resolve(strict=True).relative_to(
+        (kb.task_attachments_dir(worker_env) / "outputs").resolve(strict=True)
+    )
+    assert str(stored_path).endswith(f"kanban/attachments/{worker_env}/outputs/report.md")
+    assert json.loads(event["payload"])["artifacts"] == [str(stored_path)]
+
+
+def test_complete_invalid_task_id_with_artifacts_has_no_filesystem_side_effect(
+    monkeypatch, tmp_path, worker_env
+):
+    """An orchestrator typo/traversal task_id must not create output dirs."""
+    from pathlib import Path
+
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    artifact = tmp_path / "artifact.txt"
+    artifact.write_text("should not be copied", encoding="utf-8")
+
+    invalid_tid = "../../escape-review"
+    old_escape_dir = (kb.task_attachments_dir(invalid_tid) / "outputs").resolve(
+        strict=False
+    )
+    assert not old_escape_dir.exists()
+
+    out = kt._handle_complete({
+        "task_id": invalid_tid,
+        "summary": "should not complete",
+        "artifacts": [str(artifact)],
+    })
+    d = json.loads(out)
+
+    assert "error" in d
+    assert "could not complete" in d["error"]
+    assert artifact.read_text(encoding="utf-8") == "should not be copied"
+    assert not old_escape_dir.exists()
+    assert not (Path(old_escape_dir) / artifact.name).exists()
+
+
+def test_complete_rejected_created_cards_with_artifacts_has_no_copy_side_effect(
+    tmp_path, worker_env
+):
+    """Failed completion gates must not persist artifacts before rejection."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    artifact = tmp_path / "artifact.txt"
+    artifact.write_text("should not be copied", encoding="utf-8")
+    out_dir = kb.task_attachments_dir(worker_env) / "outputs"
+
+    out = kt._handle_complete({
+        "summary": "claimed a phantom card",
+        "created_cards": ["t_phantomdeadbeef"],
+        "artifacts": [str(artifact)],
+    })
+    d = json.loads(out)
+
+    assert "error" in d
+    assert "still in-flight" in d["error"]
+    assert not out_dir.exists()
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, worker_env)
+        assert task is not None
+        assert task.status == "running"
+    finally:
+        conn.close()
+
+
 def test_complete_stamps_worker_session_id_from_env(monkeypatch, worker_env):
     from tools import kanban_tools as kt
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -132,6 +132,111 @@ def _stamp_worker_session_metadata(
     return stamped
 
 
+def _persist_completion_artifacts(
+    kb: Any,
+    task_id: str,
+    artifacts: Optional[list[str]],
+    *,
+    board: Optional[str] = None,
+) -> Optional[list[str]]:
+    """Copy completion artifact files to durable Kanban storage.
+
+    Scratch workspaces are deleted by ``kanban_db.complete_task()`` before the
+    gateway notifier can poll the completed event and upload any paths listed
+    in ``event_payload['artifacts']``.  When a worker explicitly passes
+    ``kanban_complete(artifacts=[...])``, preserve existing files under the
+    board's durable attachments tree first, then publish those durable paths in
+    the completion metadata/event.  Missing paths are left unchanged so the
+    handoff still records what the worker tried to provide.
+    """
+    if not artifacts:
+        return artifacts
+
+    try:
+        import shutil
+        from pathlib import Path
+    except Exception:
+        return artifacts
+
+    try:
+        attachments_root = kb.attachments_root(board=board).resolve(strict=False)
+        task_dir = kb.task_attachments_dir(task_id, board=board).resolve(strict=False)
+        try:
+            task_dir.relative_to(attachments_root)
+        except ValueError:
+            raise ValueError(
+                f"resolved attachment directory escapes board storage: {task_dir}"
+            )
+        out_dir = (task_dir / "outputs").resolve(strict=False)
+        try:
+            out_dir.relative_to(task_dir)
+        except ValueError:
+            raise ValueError(
+                f"resolved output directory escapes task storage: {out_dir}"
+            )
+        out_dir.mkdir(parents=True, exist_ok=True)
+    except Exception:
+        logger.warning(
+            "kanban_complete: could not create durable artifact directory for %s",
+            task_id,
+            exc_info=True,
+        )
+        return artifacts
+
+    persisted: list[str] = []
+    for idx, raw in enumerate(artifacts, start=1):
+        path = str(raw).strip()
+        if not path:
+            continue
+        try:
+            src = Path(os.path.expanduser(path)).resolve(strict=False)
+            if not src.is_file():
+                persisted.append(path)
+                continue
+            try:
+                # If the worker already points at durable Kanban storage, keep it.
+                src.relative_to(out_dir.resolve(strict=False))
+            except ValueError:
+                name = src.name or f"artifact-{idx}"
+                dest = (out_dir / name).resolve(strict=False)
+                try:
+                    dest.relative_to(out_dir)
+                except ValueError:
+                    persisted.append(path)
+                    continue
+                if dest.exists() and dest.resolve(strict=False) != src:
+                    stem = dest.stem or f"artifact-{idx}"
+                    suffix = dest.suffix
+                    n = 2
+                    while True:
+                        candidate = (out_dir / f"{stem}-{n}{suffix}").resolve(
+                            strict=False
+                        )
+                        try:
+                            candidate.relative_to(out_dir)
+                        except ValueError:
+                            persisted.append(path)
+                            break
+                        if not candidate.exists():
+                            dest = candidate
+                            break
+                        n += 1
+                if dest.resolve(strict=False) != src:
+                    shutil.copy2(src, dest)
+                persisted.append(str(dest))
+            else:
+                persisted.append(str(src))
+        except Exception:
+            logger.warning(
+                "kanban_complete: could not persist artifact %r for %s",
+                path,
+                task_id,
+                exc_info=True,
+            )
+            persisted.append(path)
+    return persisted
+
+
 def _enforce_worker_task_ownership(tid: str) -> Optional[str]:
     """Reject worker-driven destructive calls on foreign task IDs.
 
@@ -592,12 +697,28 @@ def _handle_complete(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
+            task = kb.get_task(conn, tid)
+            if task is None:
+                return tool_error(
+                    f"could not complete {tid} (unknown id or already terminal)"
+                )
+            if task.status not in {"running", "ready", "blocked"}:
+                return tool_error(
+                    f"could not complete {tid} (unknown id or already terminal)"
+                )
+            expected_run_id = _worker_run_id(tid)
+            if (
+                expected_run_id is not None
+                and task.current_run_id != expected_run_id
+            ):
+                return tool_error(
+                    f"could not complete {tid} (unknown id or already terminal)"
+                )
             # Goal-mode pre-completion judge gate (Issue #38367).
             # Prevent workers from bypassing the auxiliary judge by
             # calling kanban_complete before acceptance criteria are met.
             # Only enforce when a judge is actually reachable — see
             # _goal_judge_available for why an unavailable judge fails open.
-            task = kb.get_task(conn, tid)
             if task and task.goal_mode and _goal_judge_available():
                 verdict = "done"
                 reason = ""
@@ -623,12 +744,47 @@ def _handle_complete(args: dict, **kw) -> str:
                         f"and keep this task alive."
                     )
 
+            if created_cards:
+                _, phantom_cards = kb._verify_created_cards(conn, tid, created_cards)
+                if phantom_cards:
+                    try:
+                        kb.complete_task(
+                            conn, tid,
+                            result=result, summary=summary, metadata=metadata,
+                            created_cards=created_cards,
+                            expected_run_id=expected_run_id,
+                        )
+                    except kb.HallucinatedCardsError as hall_err:
+                        return tool_error(
+                            f"kanban_complete blocked: the following created_cards "
+                            f"do not exist or were not created by this worker: "
+                            f"{', '.join(hall_err.phantom)}. "
+                            f"Your task is still in-flight (no state change). "
+                            f"Retry kanban_complete with the same summary/metadata "
+                            f"and either drop these ids from created_cards, or pass "
+                            f"created_cards=[] to skip the card-claim check entirely."
+                        )
+                    return tool_error(
+                        "kanban_complete blocked: created_cards verification failed"
+                    )
+
+            if (
+                isinstance(metadata, dict)
+                and isinstance(metadata.get("artifacts"), (list, tuple))
+            ):
+                metadata["artifacts"] = _persist_completion_artifacts(
+                    kb,
+                    tid,
+                    [str(p) for p in metadata["artifacts"]],
+                    board=board,
+                )
+
             try:
                 ok = kb.complete_task(
                     conn, tid,
                     result=result, summary=summary, metadata=metadata,
                     created_cards=created_cards,
-                    expected_run_id=_worker_run_id(tid),
+                    expected_run_id=expected_run_id,
                 )
             except kb.HallucinatedCardsError as hall_err:
                 # Structured rejection — surface the phantom ids so the


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

