### PR TITLE
fix(compression): register both id/call_id variants in _sanitize_tool_pairs

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2160,10 +2160,33 @@ This compaction should PRIORITISE preserving all information related to the focu
 
     @staticmethod
     def _get_tool_call_id(tc) -> str:
-        """Extract the call ID from a tool_call entry (dict or SimpleNamespace)."""
+        """Extract the canonical call ID from a tool_call entry (dict or
+        SimpleNamespace), for logging/display only. Matching logic must use
+        :meth:`_tool_call_id_variants` instead — see its docstring."""
         if isinstance(tc, dict):
             return tc.get("call_id", "") or tc.get("id", "") or ""
         return getattr(tc, "call_id", "") or getattr(tc, "id", "") or ""
+
+    @staticmethod
+    def _tool_call_id_variants(tc) -> set:
+        """Return every id variant a tool result might reference *tc* by.
+
+        A tool result's ``tool_call_id`` may be keyed on either ``id`` or
+        ``call_id`` depending on which code path built it — in the Codex
+        Responses API format they are distinct (``id`` is the ``fc_...``
+        response-item id, ``call_id`` is the ``call_...`` function-call id).
+        Matching on a single value (the old ``call_id || id`` precedence)
+        misclassified a genuinely matching pair as orphaned whenever the
+        result used the field that precedence didn't pick, dropping BOTH the
+        valid result and its tool_call. Registering the superset of both ids
+        is the same fix #58168 applied to ``repair_message_sequence``'s
+        known-id set.
+        """
+        if isinstance(tc, dict):
+            get = tc.get
+        else:
+            get = lambda key: getattr(tc, key, None)
+        return {v for v in (get("id"), get("call_id")) if v}
 
     def _sanitize_tool_pairs(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Fix orphaned tool_call / tool_result pairs after compression.
@@ -2191,9 +2214,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         for msg in messages:
             if msg.get("role") == "assistant":
                 for tc in msg.get("tool_calls") or []:
-                    cid = self._get_tool_call_id(tc)
-                    if cid:
-                        surviving_call_ids.add(cid)
+                    surviving_call_ids |= self._tool_call_id_variants(tc)
 
         result_call_ids: set = set()
         for msg in messages:
@@ -2216,16 +2237,20 @@ This compaction should PRIORITISE preserving all information related to the focu
         #    were dropped.  Stripping is preferred over inserting stub results
         #    because stubs can be dropped by downstream repair_message_sequence
         #    when call_id != id (Codex Responses API format), re-exposing orphans.
-        missing_results = surviving_call_ids - result_call_ids
-        if missing_results:
+        #    A tool_call survives if ANY of its id variants still has a
+        #    matching result — checking only one variant per side is exactly
+        #    the mismatch this method exists to avoid.
+        stripped_count = 0
+        if surviving_call_ids - result_call_ids:
             for msg in messages:
                 if msg.get("role") != "assistant":
                     continue
                 tcs = msg.get("tool_calls")
                 if not tcs:
                     continue
-                kept = [tc for tc in tcs if self._get_tool_call_id(tc) not in missing_results]
+                kept = [tc for tc in tcs if self._tool_call_id_variants(tc) & result_call_ids]
                 if len(kept) != len(tcs):
+                    stripped_count += len(tcs) - len(kept)
                     if kept:
                         msg["tool_calls"] = kept
                     else:
@@ -2235,10 +2260,10 @@ This compaction should PRIORITISE preserving all information related to the focu
                         content = msg.get("content")
                         if not content or (isinstance(content, str) and not content.strip()):
                             msg["content"] = "(tool call removed)"
-            if not self.quiet_mode:
+            if stripped_count and not self.quiet_mode:
                 logger.info(
                     "Compression sanitizer: stripped %d orphaned tool_call(s) from assistant messages",
-                    len(missing_results),
+                    stripped_count,
                 )
 
         return messages

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -3155,6 +3155,72 @@ class TestSanitizerStripsOrphanedToolCalls:
         assert not asst.get("tool_calls")
         # No stub tool messages (which would have call_id != id mismatch)
 
+    def test_sanitizer_keeps_valid_pair_matching_on_id_not_call_id(self, compressor):
+        """A genuinely matching Codex-format pair must survive when the
+        result's tool_call_id matches ``id`` rather than ``call_id`` (#58168
+        class). ``_get_tool_call_id``'s ``call_id || id`` precedence picks
+        ``call_id`` first, so building the known-id set from a single value
+        per tool_call misclassified this valid pair as orphaned on BOTH
+        sides — dropping the result AND stripping the tool_call, even though
+        neither was actually orphaned."""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "fc_777",
+                        "call_id": "call_777",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "{}"},
+                    },
+                ],
+            },
+            {"role": "tool", "tool_call_id": "fc_777", "content": "result"},
+        ]
+
+        sanitized = compressor._sanitize_tool_pairs(msgs)
+
+        asst = next(m for m in sanitized if m.get("role") == "assistant")
+        assert asst.get("tool_calls"), "valid tool_call must not be stripped"
+        assert asst["tool_calls"][0]["id"] == "fc_777"
+        tool_msgs = [m for m in sanitized if m.get("role") == "tool"]
+        assert len(tool_msgs) == 1, "valid tool result must not be dropped as orphaned"
+        assert tool_msgs[0]["tool_call_id"] == "fc_777"
+
+    def test_sanitizer_still_drops_genuine_orphan_with_dual_ids(self, compressor):
+        """Negative control: registering both id and call_id must not
+        over-relax orphan detection. A genuinely orphaned tool_call (no
+        result matching either id variant) is still stripped, while a valid
+        dual-id pair in the same window survives."""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "fc_1",
+                        "call_id": "call_1",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "{}"},
+                    },
+                    {
+                        "id": "fc_2",
+                        "call_id": "call_2",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "{}"},
+                    },
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+        ]
+
+        sanitized = compressor._sanitize_tool_pairs(msgs)
+
+        asst = next(m for m in sanitized if m.get("role") == "assistant")
+        surviving_ids = {tc["id"] for tc in asst.get("tool_calls") or []}
+        assert surviving_ids == {"fc_1"}
+
 
 class TestCooldownReentryAbort:
     """Regression: a second compress() call during the failure cooldown must


### PR DESCRIPTION
## Summary

`_sanitize_tool_pairs()` fixes orphaned tool_call/tool_result pairs after compression, matching them via `_get_tool_call_id`, which extracts a **single** value per tool_call using `call_id || id` precedence. In the Codex Responses API format an assistant tool_call carries both a distinct `id` (`fc_...`) and `call_id` (`call_...`); a tool result's `tool_call_id` may be keyed on either depending on which code path built it. Whenever a genuinely matching pair used the field the precedence didn't pick, the sanitizer misclassified it as orphaned on **both sides**: it dropped the valid tool result *and* stripped the tool_call from the assistant message, even though neither was orphaned.

Live-verified before this fix: `{"id": "fc_777", "call_id": "call_777"}` + a tool result with `tool_call_id="fc_777"` (a valid pair) was fully removed on current `main` — both the assistant's `tool_calls` and the matching `tool` message disappeared.

## Changes

- Added `_tool_call_id_variants(tc)` — returns the **set** of every id variant for a tool_call (both `id` and `call_id`, non-empty), instead of picking one.
- `surviving_call_ids` is now built from the union of variants across all assistant tool_calls, not a single value per tool_call.
- Orphaned tool_call stripping now checks `_tool_call_id_variants(tc) & result_call_ids` (non-empty intersection = keep) instead of comparing a single extracted id against a `missing_results` set — a tool_call survives if **any** of its id variants has a matching result.
- `_get_tool_call_id` is kept for logging/display only, with an updated docstring pointing to the new method for matching logic.

This mirrors the fix `#58168` (merged today) applied to `repair_message_sequence`'s known-id set for the identical bug class — register the superset of both ids as valid matches, which is not vulnerable to precedence order at all.

## Relationship to #56425 (open, unreviewed)

`#56425` touches this same function for the same underlying issue (`#55626`) by swapping the `call_id || id` precedence to `id || call_id`. That fixes the specific sub-case where a result matches `id` (which is exactly what a swapped precedence picks first) but does **not** fix the mirror-image case — a result matching `call_id` while `id` is also present would still be misclassified as orphaned, just for the opposite reason. A precedence swap can only relocate which sub-case is broken, not fix the class.

This PR instead registers both id variants as valid matches (matching the already-merged `#58168` pattern), which has no such blind spot regardless of which field a given provider/builder happens to populate `tool_call_id` from. Flagging this explicitly so review doesn't need to reconcile two overlapping PRs blind — happy to close this in favor of `#56425` if a maintainer prefers the smaller diff despite the residual gap, or to have `#56425` closed in favor of this one.

## Test plan

- [x] `test_sanitizer_keeps_valid_pair_matching_on_id_not_call_id` — the exact previously-mismatched case (`tool_call_id` matches `id`, not `call_id`) — both the tool_call and tool result now survive
- [x] `test_sanitizer_still_drops_genuine_orphan_with_dual_ids` — negative control: a genuinely orphaned tool_call (no result matching either id variant) is still stripped, while a valid dual-id pair in the same window survives
- [x] Mutation-verified against a bare reproduction script: the exact valid pair above is dropped on current `main`, survives with the fix
- [x] `scripts/run_tests.sh tests/agent/test_context_compressor.py tests/run_agent/test_agent_guardrails.py` — 184 passed, plus the full compression test suite (`tests/agent/test_context_compressor*.py` and related, `tests/run_agent/test_compression_*.py`, `tests/run_agent/test_message_sequence_repair.py`, `tests/gateway/test_compress*.py`) — 418 passed total, no regressions
- [x] `ruff check` clean on all changed files
- [x] `ty check` before/after diff on changed files — only line-number shifts, no new diagnostics