### PR TITLE
Add dashboard skill deletion

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11535,6 +11535,11 @@ class SkillContentUpdate(BaseModel):
     profile: Optional[str] = None
 
 
+class SkillDelete(BaseModel):
+    profile: Optional[str] = None
+    absorbed_into: Optional[str] = ""
+
+
 def _clear_skills_prompt_cache() -> None:
     """Best-effort: invalidate the skills system-prompt snapshot after a write.
 
@@ -11595,6 +11600,35 @@ async def update_skill_content(body: SkillContentUpdate):
         result = _edit_skill(body.name, body.content)
     if not result.get("success"):
         err = result.get("error", "Failed to update skill.")
+        status = 404 if "not found" in str(err).lower() else 400
+        raise HTTPException(status_code=status, detail=err)
+    _clear_skills_prompt_cache()
+    return result
+
+
+@app.delete("/api/skills/{name}")
+async def delete_skill(name: str, body: Optional[SkillDelete] = None, profile: Optional[str] = None):
+    """Delete a skill from the dashboard using the validated skill_manage path.
+
+    Default ``absorbed_into`` to the explicit-prune value (``""``), not the
+    legacy undeclared value, so dashboard deletes carry the same lifecycle
+    intent as ``skill_manage(action='delete', absorbed_into='')``.
+    """
+    from hermes_cli.skills_config import get_disabled_skills, save_disabled_skills
+    from tools.skill_manager_tool import _delete_skill
+
+    effective_profile = (body.profile if body else None) or profile
+    absorbed_into = body.absorbed_into if body else ""
+    with _profile_scope(effective_profile):
+        result = _delete_skill(name, absorbed_into=absorbed_into)
+        if result.get("success"):
+            config = load_config()
+            disabled = get_disabled_skills(config)
+            if name in disabled:
+                disabled.discard(name)
+                save_disabled_skills(config, disabled)
+    if not result.get("success"):
+        err = result.get("error", "Failed to delete skill.")
         status = 404 if "not found" in str(err).lower() else 400
         raise HTTPException(status_code=status, detail=err)
     _clear_skills_prompt_cache()

--- a/tests/hermes_cli/test_web_server_skill_editor.py
+++ b/tests/hermes_cli/test_web_server_skill_editor.py
@@ -8,6 +8,7 @@ gap for headless/VPS users. These tests pin:
 - POST /api/skills creates a skill through the same validated write path
   as the agent's ``skill_manage`` tool (frontmatter validation enforced).
 - PUT /api/skills/content rewrites an existing SKILL.md (404 on unknown).
+- DELETE /api/skills/{name} removes a skill through the same guarded delete path.
 - POST /api/cron/jobs accepts ``skills`` and persists it on the job;
   PUT /api/cron/jobs/{id} can update the list.
 """
@@ -195,6 +196,41 @@ class TestSkillUpdate:
         assert resp.status_code == 400
 
 
+class TestSkillDelete:
+    def test_delete_removes_skill(self, client, isolated_profiles):
+        resp = client.request("DELETE", "/api/skills/dashboard-skill", json={})
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+        assert not (isolated_profiles["default"] / "skills" / "dashboard-skill").exists()
+
+        listed = client.get("/api/skills").json()
+        assert "dashboard-skill" not in {skill["name"] for skill in listed}
+
+    def test_delete_scopes_to_profile(self, client, isolated_profiles):
+        resp = client.request(
+            "DELETE",
+            "/api/skills/worker-skill",
+            json={"profile": "worker_alpha"},
+        )
+        assert resp.status_code == 200
+        assert not (isolated_profiles["worker_alpha"] / "skills" / "worker-skill").exists()
+        assert (isolated_profiles["default"] / "skills" / "dashboard-skill").exists()
+
+    def test_delete_unknown_skill_404(self, client, isolated_profiles):
+        resp = client.request("DELETE", "/api/skills/nope", json={})
+        assert resp.status_code == 404
+
+    def test_delete_pinned_skill_refuses(self, client, isolated_profiles, monkeypatch):
+        monkeypatch.setattr(
+            "tools.skill_manager_tool._pinned_guard",
+            lambda name: "Skill is pinned and cannot be deleted.",
+        )
+        resp = client.request("DELETE", "/api/skills/dashboard-skill", json={})
+        assert resp.status_code == 400
+        assert "pinned" in resp.json()["detail"]
+        assert (isolated_profiles["default"] / "skills" / "dashboard-skill").exists()
+
+
 class TestEditorEndpointsAuth:
     @pytest.mark.parametrize(
         "method,path,kwargs",
@@ -202,6 +238,7 @@ class TestEditorEndpointsAuth:
             ("get", "/api/skills/content?name=dashboard-skill", {}),
             ("post", "/api/skills", {"json": {"name": "x", "content": "y"}}),
             ("put", "/api/skills/content", {"json": {"name": "x", "content": "y"}}),
+            ("delete", "/api/skills/dashboard-skill", {}),
         ],
     )
     def test_endpoints_401_without_token(

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -700,6 +700,12 @@ export const api = {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name, content, profile: profile || undefined }),
     }),
+  deleteSkill: (name: string, profile?: string) =>
+    fetchJSON<SkillWriteResult>(`/api/skills/${encodeURIComponent(name)}`, {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ profile: profile || undefined, absorbed_into: "" }),
+    }),
   getToolsets: (profile?: string) =>
     fetchJSON<ToolsetInfo[]>(`/api/tools/toolsets${profileQuery(profile)}`),
   toggleToolset: (name: string, enabled: boolean, profile?: string) =>

--- a/web/src/pages/SkillsPage.tsx
+++ b/web/src/pages/SkillsPage.tsx
@@ -28,6 +28,7 @@ import {
   Loader2,
   Pencil,
   Plus,
+  Trash2,
 } from "lucide-react";
 import { api } from "@/lib/api";
 import type {
@@ -42,7 +43,9 @@ import type {
 import { useProfileScope } from "@/contexts/useProfileScope";
 import { ToolsetConfigDrawer } from "@/components/ToolsetConfigDrawer";
 import { SkillEditorDialog } from "@/components/SkillEditorDialog";
+import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
 import { useToast } from "@nous-research/ui/hooks/use-toast";
+import { useConfirmDelete } from "@nous-research/ui/hooks/use-confirm-delete";
 import { Toast } from "@nous-research/ui/ui/components/toast";
 import { Card, CardContent, CardHeader, CardTitle } from "@nous-research/ui/ui/components/card";
 import { Badge } from "@nous-research/ui/ui/components/badge";
@@ -260,6 +263,26 @@ export default function SkillsPage() {
     },
     [selectedProfile, showToast],
   );
+
+  const skillDelete = useConfirmDelete({
+    onDelete: useCallback(
+      async (skillName: string) => {
+        try {
+          await api.deleteSkill(skillName, selectedProfile || undefined);
+          setSkills((prev) => prev.filter((skill) => skill.name !== skillName));
+          showToast(`${skillName} deleted`, "success");
+        } catch (e) {
+          showToast(`Delete failed: ${e}`, "error");
+          throw e;
+        }
+      },
+      [selectedProfile, showToast],
+    ),
+  });
+
+  const pendingDeleteSkill = skillDelete.pendingId
+    ? skills.find((skill) => skill.name === skillDelete.pendingId)
+    : null;
 
   /* ---- Derived data ---- */
   const lowerSearch = search.toLowerCase();
@@ -497,6 +520,7 @@ export default function SkillsPage() {
                         toggling={togglingSkills.has(skill.name)}
                         onToggle={() => handleToggleSkill(skill)}
                         onEdit={() => openEditEditor(skill.name)}
+                        onDelete={() => skillDelete.requestDelete(skill.name)}
                         noDescriptionLabel={t.skills.noDescription}
                       />
                     ))}
@@ -559,6 +583,7 @@ export default function SkillsPage() {
                         toggling={togglingSkills.has(skill.name)}
                         onToggle={() => handleToggleSkill(skill)}
                         onEdit={() => openEditEditor(skill.name)}
+                        onDelete={() => skillDelete.requestDelete(skill.name)}
                         noDescriptionLabel={t.skills.noDescription}
                       />
                     ))}
@@ -670,6 +695,18 @@ export default function SkillsPage() {
         onClose={() => setEditorOpen(false)}
         onSaved={handleEditorSaved}
       />
+      <DeleteConfirmDialog
+        open={skillDelete.isOpen}
+        onCancel={skillDelete.cancel}
+        onConfirm={skillDelete.confirm}
+        title="Delete skill"
+        description={
+          pendingDeleteSkill
+            ? `Delete "${pendingDeleteSkill.name}"? This removes its skill directory and cannot be undone.`
+            : "Delete this skill? This removes its skill directory and cannot be undone."
+        }
+        loading={skillDelete.isDeleting}
+      />
       <Dialog open={learnOpen} onOpenChange={setLearnOpen}>
         <DialogContent className="max-w-lg">
           <DialogHeader>
@@ -738,6 +775,7 @@ function SkillRow({
   toggling,
   onToggle,
   onEdit,
+  onDelete,
   noDescriptionLabel,
 }: SkillRowProps) {
   return (
@@ -773,6 +811,16 @@ function SkillRow({
       >
         <Pencil />
       </Button>
+      <Button
+        ghost
+        size="icon"
+        className="shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 hover:text-destructive"
+        title="Delete skill"
+        aria-label={`Delete ${skill.name}`}
+        onClick={onDelete}
+      >
+        <Trash2 />
+      </Button>
     </div>
   );
 }
@@ -805,6 +853,7 @@ interface SkillRowProps {
   noDescriptionLabel: string;
   onToggle: () => void;
   onEdit: () => void;
+  onDelete: () => void;
   skill: SkillInfo;
   toggling: boolean;
 }


### PR DESCRIPTION
## Summary
- add authenticated DELETE /api/skills/{name} endpoint wired through the existing skill manager delete guard
- remove deleted skills from disabled-skill config and invalidate the prompt cache
- add dashboard API client support plus Skills page delete button and confirmation dialog
- cover delete success, profile scoping, missing skills, pinned-skill refusal, and auth protection

## Verification
- `python -m pytest tests/hermes_cli/test_web_server_skill_editor.py -q` → 22 passed
- `python -m pytest tests/hermes_cli/test_web_server_skill_editor.py tests/tools/test_skill_manager_tool.py -q -o 'addopts='` → 129 passed
- `python -m ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server_skill_editor.py` → passed
- `npm ci` → installed dependencies, 0 vulnerabilities
- `npm run typecheck` → passed
- `npm run build` → passed
