### PR TITLE
feat: allow gateway restart via systemd-run escape hatch

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -45,6 +45,15 @@ class GatewayLifecycleBlocked(ValueError):
 # Shell-level command shapes that target the gateway lifecycle. Each branch
 # is anchored on a concrete command identifier so a match can only fire on
 # actual shell-command-shaped strings, not on prose.
+# Prefix patterns that dispatch the command in a separate systemd cgroup
+# or process tree, making it immune to SIGTERM propagation.
+# systemd-run creates a transient timer unit outside the caller's cgroup.
+_SAFE_DISPATCH_PREFIX = re.compile(
+    r"(?i)"
+    r"(?:systemd-run\s+(?:-\S+\s+)*(?:--\S+(?:=\S+)?\s+)*)"
+)
+
+
 _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     r"(?i)"
     # Branch A: `hermes gateway restart|stop` — the canonical foot-gun.
@@ -67,8 +76,16 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
 
 
 def contains_gateway_lifecycle_command(text: str) -> bool:
-    """Return True if *text* contains a gateway lifecycle command pattern."""
+    """Return True if *text* contains a gateway lifecycle command pattern.
+
+    Safe dispatch wrappers (systemd-run) isolate the wrapped command into a
+    separate systemd scope/cgroup, making it immune to SIGTERM propagation
+    when the gateway process is killed.  If any safe dispatch prefix is
+    found, the command is allowed.
+    """
     if not text:
+        return False
+    if _SAFE_DISPATCH_PREFIX.search(text.strip()):
         return False
     return bool(_GATEWAY_LIFECYCLE_PATTERN.search(text))
 

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -55,6 +55,14 @@ class TestGatewayLifecyclePattern:
         assert _contains_gateway_lifecycle_command(text), f"Should match: {text!r}"
 
     @pytest.mark.parametrize("text", [
+        # `systemd-run` wraps the command in a transient systemd scope unit —
+        # separate cgroup, immune to SIGTERM propagation from the gateway kill.
+        # See lifecyle_guard.py:_SAFE_DISPATCH_PREFIX for the full pattern.
+        "systemd-run --on-active=15 systemctl --user restart hermes-gateway",
+        "systemd-run --unit=hermes-restart --collect systemctl --user restart hermes-gateway",
+        "systemd-run --on-active=5 systemctl stop hermes-gateway",
+        "systemd-run --user --unit=foo --on-active=10 systemctl --user start hermes-gateway",
+        # Existing safe commands
         "restart the server application",
         "hermes cron list",
         "hermes update",
@@ -357,6 +365,28 @@ class TestTerminalToolGatewayLifecycleGuard:
 
         assert result["exit_code"] == 0
         assert calls == ["systemctl status nginx"]
+
+    def test_systemd_run_bypasses_lifecycle_guard(self, monkeypatch):
+        """systemd-run wraps in a separate cgroup, must not be blocked."""
+        import tools.terminal_tool as tt
+
+        calls = []
+
+        class _FakeEnv:
+            env = {}
+            def execute(self, command, **kwargs):
+                calls.append(command)
+                return {"output": "Running as unit hermes-restart.service", "returncode": 0}
+
+        self._patch_env(monkeypatch, _FakeEnv(), inside_gateway=True)
+        monkeypatch.setattr(tt, "_check_all_guards", lambda cmd, env, **kwargs: {"approved": True})
+
+        result = json.loads(tt.terminal_tool(
+            command="systemd-run --on-active=15 systemctl --user restart hermes-gateway"
+        ))
+
+        assert result["exit_code"] == 0, f"Should allow systemd-run wrapper: {result.get('error')}"
+        assert calls == ["systemd-run --on-active=15 systemctl --user restart hermes-gateway"]
 
     def test_guard_inactive_outside_gateway(self, monkeypatch):
         """Without _HERMES_GATEWAY=1 the lifecycle guard must not fire."""

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2253,13 +2253,21 @@ def terminal_tool(
         if os.environ.get("_HERMES_GATEWAY") == "1":
             from hermes_cli.cron import _contains_gateway_lifecycle_command
             if _contains_gateway_lifecycle_command(command):
+                safe_hint = ""
+                if "systemctl" in command or "systemd" in command:
+                    safe_hint = (
+                        " To restart safely from inside the gateway, wrap with "
+                        "`systemd-run`:\n"
+                        "  systemd-run --on-active=15 systemctl --user restart hermes-gateway"
+                    )
                 return json.dumps({
                     "output": "",
                     "exit_code": 1,
                     "error": (
                         "Blocked: cannot restart or stop the gateway from inside the "
                         "gateway process. The gateway would kill this command before "
-                        "it could complete (SIGTERM propagates to child processes). "
+                        "it could complete (SIGTERM propagates to child processes)."
+                        f"{safe_hint}\n"
                         "Run `hermes gateway restart` from a separate shell outside "
                         "the running gateway."
                     ),


### PR DESCRIPTION
The gateway lifecycle guard in terminal_tool.py blocks systemctl
restart/stop commands inside the gateway to prevent SIGTERM-respawn
loops (systemd sends SIGTERM to the entire cgroup, killing the child
process running systemctl before it can complete restart).

systemd-run wraps a command in a transient systemd scope unit —
a separate cgroup. SIGTERM to the gateway cgroup does not propagate
there, making this a safe escape hatch.

Changes:
- cron/lifecycle_guard.py: add _SAFE_DISPATCH_PREFIX regex matching
  systemd-run. Commands wrapped with it are exempt from the lifecycle
  guard since they run in an isolated cgroup.
- tools/terminal_tool.py: update block error message to suggest
  systemd-run as escape hatch when systemctl is detected.
- tests/hermes_cli/test_gateway_restart_loop.py: add 5 test cases
  covering systemd-run exemption at pattern + terminal levels.

Usage from inside gateway:
  systemd-run --on-active=15 systemctl --user restart hermes-gateway
