### PR TITLE
fix(agent): deliver /steer during a text-only answer instead of after it

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2403,6 +2403,27 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             if agent._interrupt_requested:
                 break
 
+            # A /steer that arrives while the model is generating a text-only
+            # final answer has no tool result to piggyback on: it sits pending
+            # until the whole answer finishes and only then runs as a queued
+            # follow-up turn.  Break the stream at the steer point instead —
+            # the partial answer commits normally (effective_finish_reason
+            # falls back to "stop") and the leftover steer is handed back by
+            # the turn finalizer in result["pending_steer"] for immediate
+            # redelivery as the next turn.  Tool-call generation is untouched
+            # (the injection path already owns it), and the size floor keeps a
+            # just-started answer streaming: breaking on the first token would
+            # commit a bare sentence fragment as a real message, while an
+            # answer that never reaches the floor finishes quickly and the
+            # steer still lands through the leftover path.
+            if (
+                getattr(agent, "_pending_steer", None)
+                and not tool_calls_acc
+                and sum(len(_p) for _p in content_parts) >= 120
+            ):
+                finish_reason = "stop"
+                break
+
             if not chunk.choices:
                 if hasattr(chunk, "model") and chunk.model:
                     model_name = chunk.model

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9517,7 +9517,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         return f"⚠️ Steer failed: {exc}"
                     if accepted:
                         preview = steer_text[:60] + ("..." if len(steer_text) > 60 else "")
-                        return f"⏩ Steer queued — arrives after the next tool call: '{preview}'"
+                        return f"⏩ Steering — lands at the next tool call or pause: '{preview}'"
                     return "Steer rejected (empty payload)."
                 # Running agent is missing or lacks steer() — fall back to queue.
                 adapter = self._adapter_for_source(source)

--- a/tests/agent/test_turn_finalizer_final_response_persistence.py
+++ b/tests/agent/test_turn_finalizer_final_response_persistence.py
@@ -196,3 +196,75 @@ def test_final_response_closes_tool_tail_before_persistence(monkeypatch):
     assert result["messages"][-1] == {"role": "assistant", "content": "Done."}
     assert agent.persisted_messages is not None
     assert agent.persisted_messages[-1] == {"role": "assistant", "content": "Done."}
+
+
+def test_finalizer_hands_leftover_steer_to_caller(monkeypatch):
+    """A /steer that landed after the last tool batch (e.g. during a text-only
+    final answer, which the streaming loop now breaks at the steer point) has
+    no tool result to drain into. The finalizer must hand it back in
+    result["pending_steer"] so the caller (gateway/TUI) can deliver it as the
+    next turn instead of dropping it."""
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = FakeAgent()
+    # The drain returns the pending steer exactly once (the real
+    # _drain_pending_steer clears the slot on read).
+    drained = {"n": 0}
+
+    def _drain_once():
+        drained["n"] += 1
+        return "check the logs instead" if drained["n"] == 1 else None
+
+    agent._drain_pending_steer = _drain_once
+    messages = [
+        {"role": "user", "content": "write the summary"},
+        {"role": "assistant", "content": "Here is the summary..."},
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response="Here is the summary...",
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="write the summary",
+        original_user_message="write the summary",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(finish_reason=stop)",
+    )
+
+    assert result["pending_steer"] == "check the logs instead"
+    # Drained exactly once — the slot is not read twice within a turn.
+    assert drained["n"] == 1
+
+
+def test_finalizer_omits_pending_steer_when_none(monkeypatch):
+    """No pending steer → the key is absent, so the caller's
+    ``result.get("pending_steer")`` delivery guard stays inert."""
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = FakeAgent()  # FakeAgent._drain_pending_steer returns None
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response="hello",
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="hi",
+        original_user_message="hi",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(finish_reason=stop)",
+    )
+
+    assert "pending_steer" not in result

--- a/tests/run_agent/test_steer_stream_break.py
+++ b/tests/run_agent/test_steer_stream_break.py
@@ -1,0 +1,158 @@
+"""Regression tests for the live-/steer stream break.
+
+A /steer that arrives while the model is generating a text-only final
+answer has no tool result to piggyback on, so it used to sit pending
+until the whole answer finished and only then ran as a queued follow-up
+turn ("responds, then keeps going"). The streaming loop now breaks at
+the steer point once enough of the answer has accumulated: the partial
+answer commits normally and the leftover steer is delivered as the
+immediate next turn via result["pending_steer"] (see
+turn_finalizer.finalize_turn -> gateway/run.py and tui_gateway/server.py
+for the caller-side delivery).
+
+Pins the contract:
+
+- pending steer + text-only stream past the 120-char floor → the stream
+  ends with finish_reason="stop" and the tail is never consumed;
+- pending steer + short answer → no break, the answer completes intact
+  (the steer lands through the leftover path instead);
+- pending steer + tool-call generation → never breaks, the injection
+  path owns delivery;
+- no steer → streaming is untouched.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ── Helpers (mirrors test_partial_stream_finish_reason.py) ────────────────
+
+def _make_stream_chunk(content=None, tool_calls=None, finish_reason=None):
+    delta = SimpleNamespace(
+        content=content, tool_calls=tool_calls,
+        reasoning_content=None, reasoning=None,
+    )
+    choice = SimpleNamespace(index=0, delta=delta, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model=None, usage=None)
+
+
+def _make_tool_call_delta(index=0, tc_id=None, name=None, arguments=None):
+    func = SimpleNamespace(name=name, arguments=arguments)
+    return SimpleNamespace(index=index, id=tc_id, function=func)
+
+
+def _make_agent():
+    from run_agent import AIAgent
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://example.com/v1",
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.api_mode = "chat_completions"
+    agent._interrupt_requested = False
+    return agent
+
+
+def _run_stream(agent, chunks):
+    consumed = {"n": 0}
+
+    def _stream():
+        for c in chunks:
+            consumed["n"] += 1
+            yield c
+
+    with patch("run_agent.AIAgent._create_request_openai_client") as mock_create, \
+            patch("run_agent.AIAgent._close_request_openai_client"):
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = lambda *a, **kw: _stream()
+        mock_create.return_value = mock_client
+        response = agent._interruptible_streaming_api_call({})
+    return response, consumed["n"]
+
+
+class TestSteerStreamBreak:
+    def test_pending_steer_breaks_text_stream_past_floor(self):
+        """Once ≥120 chars of answer have streamed, a pending steer ends the
+        stream: the partial answer keeps finish_reason=stop and the tail is
+        never pulled from the wire."""
+        agent = _make_agent()
+        agent.steer("stop the essay and check the logs instead")
+
+        chunks = [
+            _make_stream_chunk(content="x" * 50),
+            _make_stream_chunk(content="y" * 50),
+            _make_stream_chunk(content="z" * 50),   # crosses the 120 floor
+            _make_stream_chunk(content="TAIL_MARKER"),
+            _make_stream_chunk(content=None, finish_reason="stop"),
+        ]
+        response, consumed = _run_stream(agent, chunks)
+
+        content = response.choices[0].message.content
+        assert "TAIL_MARKER" not in content
+        assert content == "x" * 50 + "y" * 50 + "z" * 50
+        assert response.choices[0].finish_reason == "stop"
+        # The break happens at the top of the loop: the marker chunk is the
+        # last one pulled, the stop chunk is never consumed.
+        assert consumed == 4
+        # The steer itself is NOT consumed here — the turn finalizer drains it
+        # into result["pending_steer"] for immediate redelivery.
+        assert agent._pending_steer == "stop the essay and check the logs instead"
+
+    def test_pending_steer_below_floor_lets_short_answer_finish(self):
+        """A short answer never reaches the floor: it completes intact and
+        the steer waits for the leftover-delivery path — breaking on the
+        first tokens committed bare sentence fragments as real messages."""
+        agent = _make_agent()
+        agent.steer("and then check the logs")
+
+        chunks = [
+            _make_stream_chunk(content="Sure — done."),
+            _make_stream_chunk(content=" Anything else?"),
+            _make_stream_chunk(content=None, finish_reason="stop"),
+        ]
+        response, consumed = _run_stream(agent, chunks)
+
+        assert response.choices[0].message.content == "Sure — done. Anything else?"
+        assert consumed == len(chunks)
+
+    def test_pending_steer_never_breaks_tool_call_generation(self):
+        """Tool-call turns are owned by the injection path: once tool-call
+        deltas accumulate, the stream must run to completion so the call
+        arrives whole."""
+        agent = _make_agent()
+        agent.steer("prefer the staging database")
+
+        chunks = [
+            _make_stream_chunk(content="Let me check."),
+            _make_stream_chunk(tool_calls=[_make_tool_call_delta(
+                index=0, tc_id="call_1", name="terminal", arguments='{"comman')]),
+            _make_stream_chunk(tool_calls=[_make_tool_call_delta(
+                index=0, arguments='d": "ls"}')]),
+            _make_stream_chunk(content=None, finish_reason="tool_calls"),
+        ]
+        response, consumed = _run_stream(agent, chunks)
+
+        assert consumed == len(chunks)
+        tool_calls = response.choices[0].message.tool_calls
+        assert tool_calls and tool_calls[0].function.name == "terminal"
+        assert tool_calls[0].function.arguments == '{"command": "ls"}'
+
+    def test_no_steer_streams_untouched(self):
+        agent = _make_agent()
+
+        chunks = [
+            _make_stream_chunk(content="x" * 200),
+            _make_stream_chunk(content="TAIL_MARKER"),
+            _make_stream_chunk(content=None, finish_reason="stop"),
+        ]
+        response, consumed = _run_stream(agent, chunks)
+
+        assert consumed == len(chunks)
+        assert response.choices[0].message.content.endswith("TAIL_MARKER")

--- a/tests/test_tui_leftover_steer_delivery.py
+++ b/tests/test_tui_leftover_steer_delivery.py
@@ -1,0 +1,157 @@
+"""End-to-end: the TUI gateway delivers a leftover /steer as the next turn.
+
+A /steer that arrives during a text-only final answer is broken out of the
+stream (see agent/chat_completion_helpers.py) and handed back by the turn
+finalizer in result["pending_steer"] (see agent/turn_finalizer.py). The
+gateway path re-fires it as the next user turn (gateway/run.py). The TUI
+consumes the SAME run_conversation() result, so it must re-fire it too — the
+shared stream break would otherwise truncate the answer AND drop the steer on
+the TUI, since the finalizer already drained the slot.
+
+Drives ``_run_prompt_submit`` end to end via ``handle_request`` with the
+``_ImmediateThread`` pattern so the leftover-steer re-fire (which calls
+``_run_prompt_submit`` again) runs inline within a single request.
+"""
+
+import threading
+import types
+
+import pytest
+
+from tui_gateway import server
+
+
+def _tui_session(agent, session_key="sid-key", **extra):
+    return {
+        "agent": agent,
+        "session_key": session_key,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "attached_images": [],
+        "image_counter": 0,
+        "cols": 80,
+        "slash_worker": None,
+        "show_reasoning": False,
+        "tool_progress_mode": "all",
+        "pending_title": None,
+        **extra,
+    }
+
+
+class _ImmediateThread:
+    """Run the turn worker synchronously so the whole re-fire chain unwinds
+    inside the handle_request() call."""
+
+    def __init__(self, target=None, daemon=None, **kw):
+        self._target = target
+
+    def start(self):
+        if self._target is not None:
+            self._target()
+
+
+def _patch_common(monkeypatch):
+    monkeypatch.setattr(server, "_emit", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+    monkeypatch.setattr(
+        server, "_sync_session_key_after_compress", lambda *a, **kw: None
+    )
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+
+
+def test_leftover_steer_delivered_as_next_turn(monkeypatch):
+    """First turn comes back with pending_steer → a second turn fires
+    automatically carrying the steer text."""
+    prompts = []
+
+    class _Agent:
+        session_id = "sid-key"
+        _cached_system_prompt = ""
+
+        def run_conversation(self, prompt, **kw):
+            prompts.append(prompt)
+            result = {
+                "final_response": "answer",
+                "messages": [
+                    {"role": "user", "content": prompt},
+                    {"role": "assistant", "content": "answer"},
+                ],
+            }
+            # Only the first (text-only-answer) turn leaves a leftover steer.
+            if len(prompts) == 1:
+                result["pending_steer"] = "check the logs instead"
+            return result
+
+    session = _tui_session(_Agent())
+    _patch_common(monkeypatch)
+    server._sessions["sid"] = session
+    try:
+        server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "write the summary"},
+        })
+
+        assert prompts == ["write the summary", "check the logs instead"], (
+            "the leftover steer must be delivered as the immediate next turn, "
+            "not dropped"
+        )
+        # The chain settles idle (no third turn, session released).
+        assert session["running"] is False
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_queued_user_prompt_outranks_leftover_steer(monkeypatch):
+    """A real user message that queued mid-turn wins over the leftover steer
+    (mirrors gateway/run.py, which only delivers pending_steer when nothing
+    else is pending). The steer is not re-fired."""
+    prompts = []
+
+    class _Agent:
+        session_id = "sid-key"
+        _cached_system_prompt = ""
+
+        def __init__(self):
+            self._queued = False
+
+        def run_conversation(self, prompt, **kw):
+            prompts.append(prompt)
+            result = {
+                "final_response": "answer",
+                "messages": [
+                    {"role": "user", "content": prompt},
+                    {"role": "assistant", "content": "answer"},
+                ],
+            }
+            if len(prompts) == 1:
+                # A user prompt lands mid-turn and is queued (as _handle_busy_submit
+                # would), AND the turn also comes back with a leftover steer.
+                server._enqueue_prompt(_session_ref["s"], "user typed this", None)
+                result["pending_steer"] = "check the logs instead"
+            return result
+
+    _session_ref = {}
+    session = _tui_session(_Agent())
+    _session_ref["s"] = session
+    _patch_common(monkeypatch)
+    server._sessions["sid"] = session
+    try:
+        server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "write the summary"},
+        })
+
+        assert prompts == ["write the summary", "user typed this"], (
+            "the queued user prompt must win; the leftover steer is dropped "
+            "(never re-fired) when a real message is waiting"
+        )
+        assert "check the logs instead" not in prompts
+        assert session.get("queued_prompt") is None
+        assert session["running"] is False
+    finally:
+        server._sessions.pop("sid", None)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8971,6 +8971,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
         session_tokens = []
         home_token = None  # per-turn HERMES_HOME override for a resumed remote profile
         goal_followup = None  # set by the post-turn goal hook below
+        leftover_steer = None  # set from result["pending_steer"] below
         try:
             from tools.approval import (
                 reset_current_session_key,
@@ -9207,6 +9208,16 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 lr = result.get("last_reasoning")
                 if isinstance(lr, str) and lr.strip():
                     last_reasoning = lr.strip()
+                # A /steer that landed after the last tool batch (e.g. during a
+                # text-only final answer, which the streaming loop now breaks at
+                # the steer point) couldn't be injected into a tool result and
+                # came back here. The gateway path delivers it as the next turn;
+                # the TUI must too, or it is silently dropped. Stash it and fire
+                # it in the tail below, after the queued-prompt drain so a real
+                # user message still wins (mirrors gateway/run.py).
+                _ls = result.get("pending_steer")
+                if isinstance(_ls, str) and _ls.strip():
+                    leftover_steer = _ls
             else:
                 raw = str(result)
                 status = "complete"
@@ -9381,6 +9392,32 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
         # every auto follow-up below — drain it first and skip them this cycle;
         # the goal judge / notifications re-evaluate at the end of that turn.
         if _drain_queued_prompt(rid, sid, session):
+            return
+
+        # Leftover /steer: a steer that arrived during the final text-only
+        # answer couldn't be injected into a tool result and came back in
+        # result["pending_steer"]. Deliver it as the next turn so it isn't
+        # silently dropped. A real user prompt that queued mid-turn already
+        # won above (it returned), so this only runs when nothing else is
+        # waiting; a steer is user intent, so it also outranks the auto
+        # goal-continuation below. Claim running under the lock like the
+        # goal re-fire so a racing prompt.submit wins cleanly.
+        if leftover_steer:
+            with session["history_lock"]:
+                if session.get("running"):
+                    return
+                session["running"] = True
+            try:
+                _emit("message.start", sid)
+                _run_prompt_submit(rid, sid, session, leftover_steer)
+            except Exception as _steer_exc:
+                print(
+                    f"[tui_gateway] leftover steer dispatch failed: "
+                    f"{type(_steer_exc).__name__}: {_steer_exc}",
+                    file=sys.stderr,
+                )
+                with session["history_lock"]:
+                    session["running"] = False
             return
 
         # Chain a goal-continuation turn if the judge said so. We do


### PR DESCRIPTION
## Problem

`steer()` only injects into the **next tool result**. A `/steer` sent while the model is generating a text-only final answer has nothing to attach to, so it sits pending until the whole answer finishes and then runs as a queued follow-up turn. On a long answer the user watches a full essay complete before their correction lands — the ack even promised "arrives after the next tool call", which may never come.

## Fix

Break the token stream at the steer point: the partial answer commits normally, and the leftover steer is delivered as the **immediate next turn** through the existing `result["pending_steer"]` path in the turn finalizer and gateway (no new delivery machinery).

Two guards keep the break conservative:

- **Never break once tool-call deltas are accumulating** — mid-tool-call steers stay with the classic injection path, so calls always arrive whole.
- **Require 120 chars of accumulated answer first.** Breaking on the first token commits bare sentence fragments (a message that is literally just `"The"`) as real messages. An answer that never reaches the floor finishes quickly on its own and the steer still arrives via the leftover path, so nothing is lost — the floor only decides *where* the steer lands, never *whether*.

Also rewords the `/steer` ack to "lands at the next tool call or pause", since the next tool call is no longer the only landing point.

## Testing

`tests/run_agent/test_steer_stream_break.py` (same stub-stream harness as `test_partial_stream_finish_reason.py`) pins all four behaviors:

- pending steer + text past the floor → stream ends with `finish_reason="stop"`, the tail chunk is never consumed, and the steer is left pending for the finalizer to drain;
- pending steer + short answer → completes intact, no fragment;
- pending steer + tool-call generation → runs to completion, call assembled whole;
- no steer → streaming untouched.

The break test fails on the previous code. `tests/run_agent/test_steer.py`, `test_streaming.py`, and `test_partial_stream_finish_reason.py` all pass alongside (80 tests).

Verified live on my own gateway (vLLM backend, Matrix platform): steering mid-essay commits the partial answer and the correction executes within seconds instead of after the essay; steering early in a short answer no longer leaves a fragment message behind.