### PR TITLE
fix(honcho): cleanly shutdown one-shot memory

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1211,11 +1211,45 @@ def _notify_single_query_session_finalize(cli, *, reason: str = "shutdown") -> N
 
 def _finalize_single_query(cli) -> None:
     """Close one-shot CLI resources before releasing the active session lease."""
+    def _honcho_memory_active() -> bool:
+        try:
+            agent = getattr(cli, "agent", None) or _active_agent_ref
+            manager = getattr(agent, "_memory_manager", None)
+            providers = getattr(manager, "providers", []) if manager else []
+            if any(getattr(provider, "name", "") == "honcho" for provider in providers):
+                return True
+        except Exception:
+            pass
+        try:
+            from hermes_cli.config import cfg_get, load_config
+            return str(cfg_get(load_config(), "memory", "provider", default="")).strip() == "honcho"
+        except Exception:
+            return False
+
+    force_exit_after_release = _honcho_memory_active()
     try:
         _notify_single_query_session_finalize(cli)
         _run_cleanup(notify_session_finalize=False)
     finally:
         cli._release_active_session()
+        # In WSL, one-shot Hermes runs that exercise the Honcho SDK can abort
+        # during CPython interpreter teardown after the final answer has already
+        # been printed and all explicit cleanup has run (SIGABRT/exit 134, no
+        # Python frame).  Avoid Py_FinalizeEx for this one-shot/Honcho path by
+        # performing the same deliberate hard-exit pattern used by the cleanup
+        # watchdog, but only after the active-session lease is released.
+        if force_exit_after_release and not os.environ.get("PYTEST_CURRENT_TEST"):
+            try:
+                import logging as _lg
+                _lg.shutdown()
+            except Exception:
+                pass
+            for _stream in (sys.stdout, sys.stderr):
+                try:
+                    _stream.flush()
+                except Exception:
+                    pass
+            os._exit(0)
 
 
 def _reset_terminal_input_modes_on_exit() -> None:

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -369,8 +369,24 @@ def _run_agent(
     agent.stream_delta_callback = None
     agent.tool_gen_callback = None
 
-    result = agent.run_conversation(prompt)
-    return (result.get("final_response") or "", result)
+    try:
+        result = agent.run_conversation(prompt)
+        return (result.get("final_response") or "", result)
+    finally:
+        # Oneshot bypasses cli.py's normal _run_cleanup() path.  External
+        # memory providers such as Honcho can leave background sync/session
+        # threads alive after a successful response; under WSL that has been
+        # observed to abort during interpreter teardown (SIGABRT/exit 134).
+        # Mirror the normal CLI session-boundary shutdown here so providers get
+        # on_session_end() + shutdown_all() before run_oneshot returns.
+        try:
+            messages = getattr(agent, "_session_messages", None)
+            if isinstance(messages, list):
+                agent.shutdown_memory_provider(messages)
+            else:
+                agent.shutdown_memory_provider()
+        except Exception:
+            pass
 
 
 def _oneshot_clarify_callback(question: str, choices=None) -> str:

--- a/plugins/memory/honcho/README.md
+++ b/plugins/memory/honcho/README.md
@@ -194,6 +194,7 @@ Pick **[e]** at the prompt to set the three keys directly instead of going throu
 |-----|------|---------|-------------|
 | `writeFrequency` | string/int | `"async"` | `"async"` (background), `"turn"` (sync per turn), `"session"` (batch on end), or integer N (every N turns) |
 | `saveMessages` | bool | `true` | Persist messages to Honcho API |
+| `syncIgnorePatterns` | array | `[]` | Regex patterns for turns that should not be persisted. Built-in guards already skip exact-response probes like `Reply exactly: OK` → `OK` and known temporary Honcho smoke-test markers. Add site-specific probe IDs here. |
 
 ### Session Resolution
 

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -28,6 +28,50 @@ from tools.registry import tool_error
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_SYNC_IGNORE_PATTERNS = (
+    r"\btemporary test-only\b",
+    r"\bPROD-PILOT-TOOLS-LAZY-[A-Z0-9-]+\b",
+    r"\bPASS HONCHO ACTIVE CLEAN EXIT\b",
+    r"\bDefault-profile Honcho SIGABRT fix verification\b",
+)
+_EXACT_RESPONSE_PROBE_RE = re.compile(
+    r"^\s*(?:reply|respond|say)\s+exactly\s*:?\s*[\"'`“”‘’]?(.{1,120}?)[\"'`“”‘’]?\s*[.!]?\s*$",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _normalize_probe_text(value: str) -> str:
+    return re.sub(r"\s+", " ", value.strip().strip("\"'`“”‘’")).casefold()
+
+
+def _is_exact_response_probe(user_content: str, assistant_content: str) -> bool:
+    """Return True for exact-response smoke tests like 'Reply exactly: OK' → 'OK'."""
+    match = _EXACT_RESPONSE_PROBE_RE.match(user_content or "")
+    if not match:
+        return False
+    expected = _normalize_probe_text(match.group(1))
+    actual = _normalize_probe_text(assistant_content or "")
+    return bool(expected and actual == expected)
+
+
+def _should_skip_honcho_sync_turn(
+    user_content: str,
+    assistant_content: str,
+    extra_patterns: Optional[List[str]] = None,
+) -> bool:
+    """Filter temporary verification turns before they become Honcho memories."""
+    if _is_exact_response_probe(user_content, assistant_content):
+        return True
+
+    combined = f"{user_content}\n{assistant_content}"
+    for pattern in (*_DEFAULT_SYNC_IGNORE_PATTERNS, *(extra_patterns or [])):
+        try:
+            if re.search(pattern, combined, re.IGNORECASE | re.DOTALL):
+                return True
+        except re.error:
+            logger.debug("Ignoring invalid Honcho syncIgnorePatterns regex: %s", pattern)
+    return False
+
 
 # ---------------------------------------------------------------------------
 # Tool schemas (moved from tools/honcho_tools.py)
@@ -154,11 +198,12 @@ CONTEXT_SCHEMA = {
 CONCLUDE_SCHEMA = {
     "name": "honcho_conclude",
     "description": (
-        "Write or delete a conclusion about a peer in Honcho's memory. "
+        "Write, inspect, or delete conclusions about a peer in Honcho's memory. "
         "Conclusions are persistent facts that build a peer's profile. "
-        "You MUST pass exactly one of: `conclusion` (to create) or `delete_id` (to delete). "
-        "Passing neither is an error. "
-        "Deletion is only for PII removal — Honcho self-heals incorrect conclusions over time."
+        "Pass exactly one action: `conclusion` to create, `delete_id` to delete one known ID, "
+        "`delete_text` to delete exact-content matches, `delete_tag` to delete conclusions containing a cleanup tag, "
+        "or `list_recent=true` to inspect recent conclusions with IDs. "
+        "Use dry_run=true before broad/tag cleanup unless the user explicitly requested deletion."
     ),
     "parameters": {
         "type": "object",
@@ -169,7 +214,27 @@ CONCLUDE_SCHEMA = {
             },
             "delete_id": {
                 "type": "string",
-                "description": "Conclusion ID to delete for PII removal. Provide this when deleting a conclusion. Do not send it together with conclusion.",
+                "description": "Conclusion ID to delete. Prefer IDs returned by honcho_search or list_recent.",
+            },
+            "delete_text": {
+                "type": "string",
+                "description": "Exact conclusion content to delete. Matches must equal this text after trimming whitespace.",
+            },
+            "delete_tag": {
+                "type": "string",
+                "description": "Cleanup tag/substr to delete matching conclusions, e.g. a synthetic stress-test run ID. Use dry_run first for broad tags.",
+            },
+            "dry_run": {
+                "type": "boolean",
+                "description": "If true, show matching conclusions without deleting. Recommended before delete_text/delete_tag unless deletion was explicitly requested.",
+            },
+            "list_recent": {
+                "type": "boolean",
+                "description": "If true, list recent conclusions with IDs for the selected peer.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum conclusions to inspect/list for list_recent/delete_text/delete_tag. Default 50, max 100.",
             },
             "peer": {
                 "type": "string",
@@ -1228,6 +1293,14 @@ class HonchoMemoryProvider(MemoryProvider):
         msg_limit = self._config.message_max_chars if self._config else 25000
         clean_user_content = sanitize_context(user_content or "").strip()
         clean_assistant_content = sanitize_context(assistant_content or "").strip()
+        ignore_patterns = getattr(self._config, "sync_ignore_patterns", []) if self._config else []
+        if _should_skip_honcho_sync_turn(
+            clean_user_content,
+            clean_assistant_content,
+            ignore_patterns,
+        ):
+            logger.debug("Skipping Honcho sync for temporary verification turn")
+            return
 
         def _sync():
             try:
@@ -1387,22 +1460,72 @@ class HonchoMemoryProvider(MemoryProvider):
 
             elif tool_name == "honcho_conclude":
                 delete_id = (args.get("delete_id") or "").strip()
+                delete_text = (args.get("delete_text") or "").strip()
+                delete_tag = (args.get("delete_tag") or "").strip()
                 conclusion = args.get("conclusion", "").strip()
                 peer = args.get("peer", "user")
+                dry_run = bool(args.get("dry_run", False))
+                list_recent = bool(args.get("list_recent", False))
+                limit = max(1, min(int(args.get("limit", 50)), 100))
 
-                has_delete_id = bool(delete_id)
-                has_conclusion = bool(conclusion)
-                if has_delete_id == has_conclusion:
-                    return tool_error("Exactly one of conclusion or delete_id must be provided.")
+                actions = [bool(conclusion), bool(delete_id), bool(delete_text), bool(delete_tag), list_recent]
+                if sum(1 for item in actions if item) != 1:
+                    return tool_error("Exactly one action must be provided: conclusion, delete_id, delete_text, delete_tag, or list_recent=true.")
 
-                if has_delete_id:
+                if list_recent:
+                    items = self._manager.list_conclusions(self._session_key, peer=peer, size=limit)
+                    return json.dumps({"result": items or [], "count": len(items)})
+
+                if has_delete_id := bool(delete_id):
                     ok = self._manager.delete_conclusion(self._session_key, delete_id, peer=peer)
                     if ok:
-                        return json.dumps({"result": f"Conclusion {delete_id} deleted."})
+                        return json.dumps({"result": f"Conclusion {delete_id} deleted.", "deleted_ids": [delete_id]})
                     return tool_error(f"Failed to delete conclusion {delete_id}.")
+
+                if delete_text or delete_tag:
+                    items = self._manager.list_conclusions(self._session_key, peer=peer, size=limit)
+                    if delete_text:
+                        matches = [item for item in items if (item.get("content") or "").strip() == delete_text]
+                        mode = "delete_text"
+                    else:
+                        matches = [item for item in items if delete_tag in (item.get("content") or "")]
+                        mode = "delete_tag"
+                    if dry_run:
+                        return json.dumps({"result": "dry_run", "mode": mode, "count": len(matches), "matches": matches})
+                    deleted = []
+                    failed = []
+                    for item in matches:
+                        cid = item.get("id")
+                        if not cid:
+                            failed.append(item)
+                            continue
+                        if self._manager.delete_conclusion(self._session_key, cid, peer=peer):
+                            deleted.append(cid)
+                        else:
+                            failed.append(item)
+                    return json.dumps({
+                        "result": f"Deleted {len(deleted)} matching conclusions.",
+                        "mode": mode,
+                        "deleted_ids": deleted,
+                        "failed": failed,
+                        "matched_count": len(matches),
+                    })
+
                 ok = self._manager.create_conclusion(self._session_key, conclusion, peer=peer)
                 if ok:
-                    return json.dumps({"result": f"Conclusion saved for {peer}: {conclusion}"})
+                    response: dict[str, Any] = {"result": f"Conclusion saved for {peer}: {conclusion}"}
+                    query_conclusions = getattr(self._manager, "query_conclusions", None)
+                    if callable(query_conclusions):
+                        matches = query_conclusions(self._session_key, conclusion, peer=peer, top_k=5)
+                        if isinstance(matches, list):
+                            exact = [
+                                item
+                                for item in matches
+                                if isinstance(item, dict)
+                                and (item.get("content") or "").strip() == conclusion
+                            ]
+                            response["matching_conclusions"] = exact or matches
+                    return json.dumps(response)
                 return tool_error("Failed to save conclusion.")
 
             return tool_error(f"Unknown tool: {tool_name}")
@@ -1415,10 +1538,21 @@ class HonchoMemoryProvider(MemoryProvider):
         for t in (self._prefetch_thread, self._sync_thread):
             if t and t.is_alive():
                 t.join(timeout=5.0)
-        # Flush any remaining messages
+        # Flush any remaining messages and stop the session manager's async
+        # writer.  HonchoSessionManager starts a daemon writer thread whenever
+        # writeFrequency=async.  Leaving that thread alive across interpreter
+        # teardown can abort the Hermes CLI after a successful response on WSL
+        # (SIGABRT/exit 134), because the thread may still be inside SDK/HTTP
+        # cleanup while Python finalizes.  Use the manager's graceful shutdown
+        # path instead of flush_all() so the sentinel is sent and the writer is
+        # joined before process exit.
         if self._manager and not (self._init_thread and self._init_thread.is_alive() and not self._session_initialized):
             try:
-                self._manager.flush_all()
+                shutdown = getattr(self._manager, "shutdown", None)
+                if callable(shutdown):
+                    shutdown()
+                else:
+                    self._manager.flush_all()
             except Exception:
                 pass
 

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -173,6 +173,20 @@ def _parse_optional_string(
     return str(value).strip()
 
 
+def _parse_string_list(host_obj: dict, root_obj: dict, key: str) -> list[str]:
+    """Parse a list of non-empty strings with host-level whole-list override."""
+    source = host_obj[key] if key in host_obj else root_obj.get(key)
+    if not isinstance(source, list):
+        return []
+    result = []
+    for item in source:
+        if isinstance(item, str):
+            value = item.strip()
+            if value:
+                result.append(value)
+    return result
+
+
 def _parse_dialectic_depth(host_val, root_val) -> int:
     """Parse dialecticDepth: host wins, then root, then 1. Clamped to 1-3."""
     for val in (host_val, root_val):
@@ -319,6 +333,10 @@ class HonchoClientConfig:
     # Toggles
     enabled: bool = False
     save_messages: bool = True
+    # Regex patterns for turns that should not be written to Honcho at all.
+    # Useful for exact-response smoke tests, provider probes, and other
+    # temporary verification chatter that would otherwise pollute conclusions.
+    sync_ignore_patterns: list[str] = field(default_factory=list)
     # Write frequency: "async" (background thread), "turn" (sync per turn),
     # "session" (flush on session end), or int (every N turns)
     write_frequency: str | int = "async"
@@ -535,6 +553,11 @@ class HonchoClientConfig:
             ),
             enabled=enabled,
             save_messages=save_messages,
+            sync_ignore_patterns=_parse_string_list(
+                host_block,
+                raw,
+                "syncIgnorePatterns",
+            ),
             write_frequency=write_frequency,
             context_tokens=_parse_context_tokens(
                 host_block.get("contextTokens"),

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -1102,6 +1102,83 @@ class HonchoSessionManager:
             logger.debug("Failed to fetch peer card from Honcho: %s", e)
             return []
 
+    def _conclusion_scope(self, session: HonchoSession, peer: str = "user"):
+        """Return the SDK conclusion scope matching create/delete semantics."""
+        target_peer_id = self._resolve_peer_id(session, peer)
+        if target_peer_id is None:
+            return None
+        if target_peer_id == session.assistant_peer_id:
+            observer = self._get_or_create_peer(session.assistant_peer_id)
+            return observer.conclusions_of(session.assistant_peer_id)
+        if self._ai_observe_others:
+            observer = self._get_or_create_peer(session.assistant_peer_id)
+            return observer.conclusions_of(target_peer_id)
+        target_peer = self._get_or_create_peer(target_peer_id)
+        return target_peer.conclusions_of(target_peer_id)
+
+    @staticmethod
+    def _format_conclusion_record(conclusion: Any) -> dict[str, Any]:
+        """Normalize SDK conclusion objects/dicts for tool output."""
+        if isinstance(conclusion, dict):
+            data = conclusion
+        else:
+            data = {}
+            for key in ("id", "content", "observer_id", "observed_id", "session_id", "level", "created_at"):
+                if hasattr(conclusion, key):
+                    value = getattr(conclusion, key)
+                    data[key] = str(value) if key == "created_at" and value is not None else value
+        return {
+            "id": data.get("id"),
+            "content": data.get("content", ""),
+            "observer_id": data.get("observer_id"),
+            "observed_id": data.get("observed_id"),
+            "session_id": data.get("session_id"),
+            "level": data.get("level"),
+            "created_at": data.get("created_at"),
+        }
+
+    def query_conclusions(
+        self,
+        session_key: str,
+        query: str,
+        peer: str = "user",
+        top_k: int = 10,
+    ) -> list[dict[str, Any]]:
+        """Semantic-search conclusions and return IDs for safe deletion/correction."""
+        session = self._cache.get(session_key)
+        if not session or not query.strip():
+            return []
+        try:
+            scope = self._conclusion_scope(session, peer)
+            if scope is None:
+                return []
+            results = scope.query(query.strip(), top_k=max(1, min(int(top_k), 50)))
+            return [self._format_conclusion_record(item) for item in results]
+        except Exception as e:
+            logger.debug("Honcho query_conclusions failed: %s", e)
+            return []
+
+    def list_conclusions(
+        self,
+        session_key: str,
+        peer: str = "user",
+        size: int = 50,
+    ) -> list[dict[str, Any]]:
+        """List recent conclusions with IDs for inspection and cleanup."""
+        session = self._cache.get(session_key)
+        if not session:
+            return []
+        try:
+            scope = self._conclusion_scope(session, peer)
+            if scope is None:
+                return []
+            page = scope.list(size=max(1, min(int(size), 100)))
+            items = getattr(page, "items", page)
+            return [self._format_conclusion_record(item) for item in items]
+        except Exception as e:
+            logger.debug("Honcho list_conclusions failed: %s", e)
+            return []
+
     def search_context(
         self,
         session_key: str,
@@ -1143,6 +1220,21 @@ class HonchoSessionManager:
             card = ctx["card"] or []
             if card:
                 parts.append("\n".join(f"- {f}" for f in card))
+
+            matches = self.query_conclusions(session_key, query, peer=peer, top_k=10)
+            if matches:
+                lines = ["## Matching conclusions (with IDs)"]
+                for item in matches:
+                    cid = item.get("id") or "unknown-id"
+                    content = (item.get("content") or "").strip()
+                    meta = []
+                    if item.get("level"):
+                        meta.append(f"level={item['level']}")
+                    if item.get("created_at"):
+                        meta.append(f"created_at={item['created_at']}")
+                    suffix = f" ({', '.join(meta)})" if meta else ""
+                    lines.append(f"- id={cid}{suffix}: {content}")
+                parts.append("\n".join(lines))
             return "\n\n".join(parts)
         except Exception as e:
             logger.debug("Honcho search_context failed: %s", e)

--- a/tests/cli/test_single_query_session_finalize.py
+++ b/tests/cli/test_single_query_session_finalize.py
@@ -55,6 +55,70 @@ def test_finalize_single_query_releases_session_when_cleanup_fails(monkeypatch):
     assert calls == ["finalize", "cleanup", "release"]
 
 
+def test_finalize_single_query_honcho_hard_exits_after_release(monkeypatch):
+    calls = []
+    honcho_provider = SimpleNamespace(name="honcho")
+    manager = SimpleNamespace(providers=[honcho_provider])
+    fake_agent = SimpleNamespace(_memory_manager=manager)
+    fake_cli = SimpleNamespace(
+        agent=fake_agent,
+        _release_active_session=lambda: calls.append("release"),
+    )
+
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setattr(
+        cli,
+        "_notify_single_query_session_finalize",
+        lambda _cli: calls.append("finalize"),
+    )
+    monkeypatch.setattr(cli, "_run_cleanup", lambda **kwargs: calls.append(("cleanup", kwargs)))
+
+    def fake_exit(code):
+        calls.append(("exit", code))
+        raise SystemExit(code)
+
+    monkeypatch.setattr(cli.os, "_exit", fake_exit)
+
+    with pytest.raises(SystemExit) as exc:
+        cli._finalize_single_query(fake_cli)
+
+    assert exc.value.code == 0
+    assert calls == [
+        "finalize",
+        ("cleanup", {"notify_session_finalize": False}),
+        "release",
+        ("exit", 0),
+    ]
+
+
+def test_finalize_single_query_pytest_env_suppresses_honcho_hard_exit(monkeypatch):
+    calls = []
+    honcho_provider = SimpleNamespace(name="honcho")
+    manager = SimpleNamespace(providers=[honcho_provider])
+    fake_agent = SimpleNamespace(_memory_manager=manager)
+    fake_cli = SimpleNamespace(
+        agent=fake_agent,
+        _release_active_session=lambda: calls.append("release"),
+    )
+
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "tests::test (call)")
+    monkeypatch.setattr(
+        cli,
+        "_notify_single_query_session_finalize",
+        lambda _cli: calls.append("finalize"),
+    )
+    monkeypatch.setattr(cli, "_run_cleanup", lambda **kwargs: calls.append(("cleanup", kwargs)))
+    monkeypatch.setattr(cli.os, "_exit", lambda code: calls.append(("exit", code)))
+
+    cli._finalize_single_query(fake_cli)
+
+    assert calls == [
+        "finalize",
+        ("cleanup", {"notify_session_finalize": False}),
+        "release",
+    ]
+
+
 def test_finalize_single_query_runs_cleanup_when_finalize_hook_fails(monkeypatch):
     calls = []
     fake_agent = SimpleNamespace(session_id="agent-session", platform="cli")

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -11,6 +11,7 @@ from plugins.memory.honcho.session import (
     HonchoSessionManager,
 )
 from plugins.memory.honcho import HonchoMemoryProvider
+from plugins.memory.honcho.client import HonchoClientConfig
 
 
 # ---------------------------------------------------------------------------
@@ -516,7 +517,7 @@ class TestConcludeToolDispatch:
         result = provider.handle_tool_call("honcho_conclude", {})
 
         parsed = json.loads(result)
-        assert parsed == {"error": "Exactly one of conclusion or delete_id must be provided."}
+        assert parsed == {"error": "Exactly one action must be provided: conclusion, delete_id, delete_text, delete_tag, or list_recent=true."}
         provider._manager.create_conclusion.assert_not_called()
         provider._manager.delete_conclusion.assert_not_called()
 
@@ -532,7 +533,7 @@ class TestConcludeToolDispatch:
             {"conclusion": "User prefers dark mode", "delete_id": "conc-123"},
         )
         parsed = json.loads(result)
-        assert parsed == {"error": "Exactly one of conclusion or delete_id must be provided."}
+        assert parsed == {"error": "Exactly one action must be provided: conclusion, delete_id, delete_text, delete_tag, or list_recent=true."}
         provider._manager.create_conclusion.assert_not_called()
         provider._manager.delete_conclusion.assert_not_called()
 
@@ -545,7 +546,7 @@ class TestConcludeToolDispatch:
         provider._manager = MagicMock()
         result = provider.handle_tool_call("honcho_conclude", {"conclusion": "   "})
         parsed = json.loads(result)
-        assert parsed == {"error": "Exactly one of conclusion or delete_id must be provided."}
+        assert parsed == {"error": "Exactly one action must be provided: conclusion, delete_id, delete_text, delete_tag, or list_recent=true."}
         provider._manager.create_conclusion.assert_not_called()
 
     def test_honcho_conclude_rejects_whitespace_only_delete_id(self):
@@ -557,7 +558,7 @@ class TestConcludeToolDispatch:
         provider._manager = MagicMock()
         result = provider.handle_tool_call("honcho_conclude", {"delete_id": "  "})
         parsed = json.loads(result)
-        assert parsed == {"error": "Exactly one of conclusion or delete_id must be provided."}
+        assert parsed == {"error": "Exactly one action must be provided: conclusion, delete_id, delete_text, delete_tag, or list_recent=true."}
         provider._manager.delete_conclusion.assert_not_called()
 
     def test_sync_turn_strips_leaked_memory_context_before_honcho_ingest(self):
@@ -592,6 +593,48 @@ class TestConcludeToolDispatch:
 
         assert session.add_message.call_args_list[0].args == ("user", "hello")
         assert session.add_message.call_args_list[1].args == ("assistant", "Visible answer")
+
+    def test_sync_turn_skips_exact_response_smoke_test(self):
+        provider = HonchoMemoryProvider()
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+        provider._cron_skipped = False
+        provider._config = HonchoClientConfig(message_max_chars=25000, sync_ignore_patterns=[])
+
+        provider.sync_turn("Reply exactly: OK", "OK")
+
+        provider._manager.get_or_create.assert_not_called()
+        assert provider._sync_thread is None
+
+    def test_sync_turn_skips_default_temporary_test_markers(self):
+        provider = HonchoMemoryProvider()
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+        provider._cron_skipped = False
+        provider._config = HonchoClientConfig(message_max_chars=25000, sync_ignore_patterns=[])
+
+        provider.sync_turn(
+            "Default-profile Honcho SIGABRT fix verification",
+            "PASS HONCHO ACTIVE CLEAN EXIT",
+        )
+
+        provider._manager.get_or_create.assert_not_called()
+        assert provider._sync_thread is None
+
+    def test_sync_turn_honors_custom_sync_ignore_patterns(self):
+        provider = HonchoMemoryProvider()
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+        provider._cron_skipped = False
+        provider._config = HonchoClientConfig(
+            message_max_chars=25000,
+            sync_ignore_patterns=[r"CUSTOM-PROBE-\d+"],
+        )
+
+        provider.sync_turn("run CUSTOM-PROBE-42", "done")
+
+        provider._manager.get_or_create.assert_not_called()
+        assert provider._sync_thread is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_honcho_client_config.py
+++ b/tests/test_honcho_client_config.py
@@ -105,6 +105,33 @@ class TestHonchoClientConfigAutoEnable:
         assert cfg.api_key == "fallback-key"
         assert cfg.enabled is True  # from_env() sets enabled=True
 
+    def test_sync_ignore_patterns_parse_from_root_config(self, tmp_path):
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps({
+            "apiKey": "test-api-key-12345",
+            "syncIgnorePatterns": ["CUSTOM-PROBE", "  ", 123],
+        }))
+
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+
+        assert cfg.sync_ignore_patterns == ["CUSTOM-PROBE"]
+
+    def test_sync_ignore_patterns_host_overrides_root_config(self, tmp_path):
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps({
+            "apiKey": "test-api-key-12345",
+            "syncIgnorePatterns": ["ROOT-PROBE"],
+            "hosts": {
+                "hermes": {
+                    "syncIgnorePatterns": ["HOST-PROBE"],
+                },
+            },
+        }))
+
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+
+        assert cfg.sync_ignore_patterns == ["HOST-PROBE"]
+
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits not enforced on Windows")
 def test_save_config_sets_owner_only_permissions(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- flush/shutdown Honcho memory provider from oneshot paths before process exit
- gracefully stop Honcho session async writer during shutdown
- expose safer `honcho_conclude` cleanup helpers (`list_recent`, `delete_text`, `delete_tag`, dry-run, IDs)
- add regression coverage for one-shot active-session release before hard exit
- add Honcho sync hygiene guard: exact-response probes and configured temporary verification patterns are not persisted

## Verification
- `source .venv/bin/activate && python -m pytest tests/honcho_plugin/test_session.py::TestConcludeToolDispatch tests/test_honcho_client_config.py tests/test_honcho_session_context.py tests/test_honcho_startup_fail_open.py tests/agent/test_oneshot.py tests/cli/test_cli_shutdown_memory_messages.py tests/cli/test_single_query_session_finalize.py -q -o 'addopts=' --tb=short` → 65 passed in 1.06s
- `source .venv/bin/activate && ruff check plugins/memory/honcho/__init__.py plugins/memory/honcho/client.py tests/honcho_plugin/test_session.py tests/test_honcho_client_config.py` → passed
- `python scripts/check-windows-footguns.py --all` → passed
- `git diff --check` → passed
- Live smoke: `hermes chat -q 'Reply exactly: SKIPMEM-20260704' --toolsets safe -Q` → SKIPMEM-20260704, EXIT_CODE=0
- `hermes honcho status` → Enabled True, workspace `fernando-ai-memory`, recall hybrid, write freq async, connection OK

## Notes
- Upstream GitHub Actions currently requires maintainer approval for the fork PR (`action_required` / no jobs started).
