### PR TITLE
fix: handle /usage without slash-worker agent

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -1296,6 +1296,112 @@ def test_slash_exec_handles_plugin_commands_in_live_gateway(server):
     assert worker.calls == []
 
 
+def test_slash_exec_usage_uses_live_session_without_worker(server):
+    """/usage should read gateway live usage instead of the worker-local CLI agent.
+
+    The slash-worker can have ``self.agent is None`` after dashboard/desktop resume,
+    which used to print "No active agent -- send a message first" even when the
+    live gateway session had already made API calls.
+    """
+    sid = "usage-session"
+
+    class Agent:
+        model = "test-model"
+        provider = "openai-codex"
+        base_url = "https://example.invalid/v1"
+        api_key = "test-key"
+        session_input_tokens = 123
+        session_output_tokens = 45
+        session_reasoning_tokens = 0
+        session_prompt_tokens = 123
+        session_completion_tokens = 45
+        session_total_tokens = 168
+        session_api_calls = 2
+        context_compressor = None
+
+    class Worker:
+        def run(self, _cmd):  # pragma: no cover - the assertion below is clearer
+            raise AssertionError("/usage must not reach the slash worker")
+
+    server._sessions[sid] = {
+        "session_key": sid,
+        "agent": Agent(),
+        "slash_worker": Worker(),
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+    }
+
+    fake_account_usage = types.SimpleNamespace(
+        fetch_account_usage=MagicMock(return_value=object()),
+        render_account_usage_lines=MagicMock(return_value=[
+            "📈 Account limits",
+            "Provider: openai-codex (Prolite)",
+            "Session: 93% remaining (7% used)",
+        ]),
+        nous_credits_lines=MagicMock(return_value=[]),
+    )
+    with patch.dict(sys.modules, {"agent.account_usage": fake_account_usage}):
+        resp = server.handle_request({
+            "id": "r-usage",
+            "method": "slash.exec",
+            "params": {"command": "usage", "session_id": sid},
+        })
+        usage_resp = server.handle_request({
+            "id": "r-session-usage",
+            "method": "session.usage",
+            "params": {"session_id": sid},
+        })
+
+    fetch_usage = fake_account_usage.fetch_account_usage
+    assert fetch_usage.call_count == 2
+    assert fetch_usage.call_args.args[0] == "openai-codex"
+    assert fetch_usage.call_args.kwargs["base_url"] == "https://example.invalid/v1"
+    assert fetch_usage.call_args.kwargs["api_key"] == "test-key"
+
+    assert "error" not in resp
+    output = resp["result"]["output"]
+    assert "Usage" in output
+    assert "Model: test-model" in output
+    assert "Input tokens: 123" in output
+    assert "API calls: 2" in output
+    assert "📈 Account limits" in output
+    assert "Provider: openai-codex (Prolite)" in output
+    assert "Session: 93% remaining (7% used)" in output
+    assert "No active agent" not in output
+
+    assert "error" not in usage_resp
+    usage = usage_resp["result"]
+    assert usage["account_lines"] == [
+        "📈 Account limits",
+        "Provider: openai-codex (Prolite)",
+        "Session: 93% remaining (7% used)",
+    ]
+
+
+def test_slash_exec_usage_without_agent_reports_no_calls(server):
+    """A resumed session with no live agent should still render a useful /usage."""
+    sid = "usage-no-agent"
+    server._sessions[sid] = {
+        "session_key": sid,
+        "agent": None,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+    }
+
+    resp = server.handle_request({
+        "id": "r-usage-empty",
+        "method": "slash.exec",
+        "params": {"command": "usage", "session_id": sid},
+    })
+
+    assert "error" not in resp
+    output = resp["result"]["output"]
+    assert "no api calls yet" in output.lower()
+    assert "No active agent" not in output
+
+
 def test_slash_exec_plugin_lookup_failure_falls_back_to_worker(server):
     """Plugin discovery failures must not break ordinary slash-worker commands."""
     sid = "test-session"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6217,6 +6217,43 @@ def _(rid, params: dict) -> dict:
         if agent is not None
         else {"calls": 0, "input": 0, "output": 0, "total": 0}
     )
+    provider = getattr(agent, "provider", None) if agent is not None else None
+    base_url = getattr(agent, "base_url", None) if agent is not None else None
+    api_key = getattr(agent, "api_key", None) if agent is not None else None
+    if provider:
+        try:
+            from agent.account_usage import fetch_account_usage, render_account_usage_lines
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as _pool:
+                try:
+                    snapshot = _pool.submit(
+                        fetch_account_usage,
+                        provider,
+                        base_url=base_url,
+                        api_key=api_key,
+                    ).result(timeout=10.0)
+                except (concurrent.futures.TimeoutError, Exception):
+                    snapshot = None
+            account_lines = render_account_usage_lines(snapshot)
+            if account_lines:
+                usage["account_lines"] = account_lines
+        except Exception:
+            pass
+
+    # Rate limits from provider headers, when available.
+    if agent is not None:
+        try:
+            rl_state = agent.get_rate_limit_state()
+        except Exception:
+            rl_state = None
+        if rl_state and getattr(rl_state, "has_data", False):
+            try:
+                from agent.rate_limit_tracker import format_rate_limit_display
+
+                usage["rate_limit_lines"] = format_rate_limit_display(rl_state).splitlines()
+            except Exception:
+                pass
+
     # Nous credits block — agent-independent (a portal fetch), so it shows even
     # with zero API calls or on a resumed session. The TUI /usage panel renders
     # these lines regardless of `calls`. Fail-open: [] when not logged into Nous
@@ -12556,11 +12593,102 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
     return ""
 
 
+def _format_usage_slash_output(session: dict) -> str:
+    """Format /usage without requiring the slash-worker's live CLI agent."""
+    agent = session.get("agent")
+    usage = (
+        _get_usage(agent)
+        if agent is not None
+        else {"calls": 0, "input": 0, "output": 0, "total": 0}
+    )
+    account_lines: list[str] = []
+    credits: list[str] = []
+
+    provider = getattr(agent, "provider", None) if agent is not None else None
+    base_url = getattr(agent, "base_url", None) if agent is not None else None
+    api_key = getattr(agent, "api_key", None) if agent is not None else None
+    if provider:
+        try:
+            from agent.account_usage import fetch_account_usage, render_account_usage_lines
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as _pool:
+                try:
+                    snapshot = _pool.submit(
+                        fetch_account_usage,
+                        provider,
+                        base_url=base_url,
+                        api_key=api_key,
+                    ).result(timeout=10.0)
+                except (concurrent.futures.TimeoutError, Exception):
+                    snapshot = None
+            account_lines = render_account_usage_lines(snapshot)
+        except Exception:
+            account_lines = []
+
+    try:
+        from agent.account_usage import nous_credits_lines
+
+        credits = nous_credits_lines()
+    except Exception:
+        credits = []
+
+    lines: list[str] = []
+    if not usage.get("calls"):
+        lines.append("No API calls yet" if (account_lines or credits) else "no API calls yet")
+        if account_lines:
+            lines.extend(["", *account_lines])
+        if credits:
+            lines.extend(["", "Nous credits", *credits])
+        return "\n".join(lines).strip()
+
+    if agent is not None:
+        try:
+            rl_state = agent.get_rate_limit_state()
+        except Exception:
+            rl_state = None
+        if rl_state and getattr(rl_state, "has_data", False):
+            try:
+                from agent.rate_limit_tracker import format_rate_limit_display
+
+                lines.append(format_rate_limit_display(rl_state))
+                lines.append("")
+            except Exception:
+                pass
+
+    def f(value) -> str:
+        return f"{int(value or 0):,}"
+
+    lines.extend(
+        [
+            "Usage",
+            f"Model: {usage.get('model', '')}",
+            f"Input tokens: {f(usage.get('input'))}",
+            f"Output tokens: {f(usage.get('output'))}",
+            f"Total tokens: {f(usage.get('total'))}",
+            f"API calls: {f(usage.get('calls'))}",
+        ]
+    )
+    if usage.get("context_max"):
+        lines.append(
+            "Context: "
+            f"{f(usage.get('context_used'))} / {f(usage.get('context_max'))} "
+            f"({usage.get('context_percent', 0)}%)"
+        )
+    if usage.get("compressions"):
+        lines.append(f"Compressions: {usage.get('compressions')}")
+    if account_lines:
+        lines.extend(["", *account_lines])
+    if credits:
+        lines.extend(["", "Nous credits", *credits])
+    return "\n".join(lines)
+
+
 @method("slash.exec")
 def _(rid, params: dict) -> dict:
     session, err = _sess(params, rid)
     if err:
         return err
+    assert session is not None
 
     cmd = params.get("command", "").strip()
     if not cmd:
@@ -12574,6 +12702,9 @@ def _(rid, params: dict) -> dict:
     _cmd_parts = _cmd_text.split(maxsplit=1)
     _cmd_base = (_cmd_parts[0] if _cmd_parts else "").lower()
     _cmd_arg = _cmd_parts[1] if len(_cmd_parts) > 1 else ""
+
+    if _cmd_base == "usage":
+        return _ok(rid, {"output": _format_usage_slash_output(session)})
 
     if _cmd_base in _PENDING_INPUT_COMMANDS:
         # Route directly to command.dispatch instead of returning an error

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -579,11 +579,24 @@ export const sessionCommands: SlashCommand[] = [
           })
         }
 
+        // Account limits are provider-specific (for example openai-codex
+        // Pro/Prolite session + weekly windows). Render them before credits and
+        // token usage when the gateway can fetch them.
+        const accountLines = r?.account_lines ?? []
+        const rateLimitLines = r?.rate_limit_lines ?? []
+        const creditsLines = r?.credits_lines ?? []
+
+        if (accountLines.length) {
+          ctx.transcript.sys(accountLines.join('\n'))
+        }
+
+        if (rateLimitLines.length) {
+          ctx.transcript.sys(rateLimitLines.join('\n'))
+        }
+
         // Nous credits block is agent-independent (a portal fetch), so it shows
         // even with zero API calls or on a resumed session. Render it whenever
         // present, before the token panel.
-        const creditsLines = r?.credits_lines ?? []
-
         if (creditsLines.length) {
           ctx.transcript.panel('Nous credits', [{ text: creditsLines.join('\n') }])
         }

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -325,7 +325,9 @@ export interface SessionUsageResponse {
   context_used?: number
   cost_status?: 'estimated' | 'exact'
   cost_usd?: number
+  account_lines?: string[]
   credits_lines?: string[]
+  rate_limit_lines?: string[]
   input?: number
   model?: string
   output?: number


### PR DESCRIPTION
## Summary
- handle /usage directly in the TUI gateway slash.exec path before it reaches the slash-worker
- format usage from the live gateway session, preserving Nous credits and no-call output
- add regression coverage for live-agent usage and resumed/no-agent sessions

## Tests
- scripts/run_tests.sh tests/tui_gateway/test_protocol.py
- python -m py_compile tui_gateway/server.py