### PR TITLE
fix(compression): guard compressed continuations and tail persistence

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1600,7 +1600,10 @@ outstanding.)
 {_bullets(relevant_files, limit=12)}
 
 {HISTORICAL_REMAINING_WORK_HEADING}
-Continue from the most recent unfulfilled user ask and protected tail messages. Verify state with tools before making claims.
+For reference only: the most recent unfulfilled user ask may matter if the
+latest user message explicitly asks to continue it. Otherwise continue only
+from the protected recent messages after this summary. Verify state with tools
+before making claims.
 
 ## Last Dropped Turns
 {_bullets(last_dropped_turns, limit=8)}
@@ -1722,22 +1725,26 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
 
         # Shared structured template (used by both paths).
         _template_sections = f"""{HISTORICAL_TASK_HEADING}
-[THE SINGLE MOST IMPORTANT FIELD. Capture the user's most recent unfulfilled
-input verbatim — the exact words they used. This includes:
+[THE SINGLE MOST IMPORTANT FIELD. Record the user's most recent potentially
+unfulfilled input verbatim for historical continuity only — the exact words
+they used. This preserves context, but the downstream agent must act on it
+only if the latest user message after the summary explicitly asks to continue
+it or confirms it remains active. This includes:
 - Explicit task assignments ("refactor the auth module")
-- Questions awaiting an answer ("waarom staat X op Y?", "wat zijn de volgende stappen?")
-- Decisions awaiting input ("optie A of B?")
-- Ongoing discussions where the assistant owes the next substantive reply
-A conversation where the user just asked a question IS an active task — the
-task is "answer that question with full context". Do NOT write "None" merely
-because the user did not issue an imperative command; reserve "None" for the
-rare case where the last exchange was fully resolved and the user said
-something like "thanks, that's all".
-If multiple items are outstanding, list only the ones NOT yet completed.
-Continuation should pick up exactly here. Examples:
+- Questions that may have been awaiting an answer ("waarom staat X op Y?", "wat zijn de volgende stappen?")
+- Decisions that may have been awaiting input ("optie A of B?")
+- Ongoing discussions where the assistant may have owed the next substantive reply
+A conversation where the user just asked a question may be historical context
+for a possible active task, but the latest user message after the summary is
+still the only authority on what to do now. Do NOT write "None" merely because
+the user did not issue an imperative command; reserve "None" for the rare case
+where the last exchange was fully resolved and the user said something like
+"thanks, that's all".
+If multiple items appear outstanding, list only the ones NOT yet completed.
+Do not tell the downstream agent to continue automatically. Examples:
 "User asked: 'Now refactor the auth module to use JWT instead of sessions'"
-"User asked: 'Waarom stond provider ineens op openrouter?' — needs investigation + answer"
-"User chose option A; awaiting implementation of step 2"
+"User asked: 'Waarom stond provider ineens op openrouter?' — may need investigation + answer if the latest user message asks to continue"
+"User chose option A; step 2 may remain relevant if the latest user message confirms it"
 If the user's most recent message was a reverse signal (stop, undo, roll
 back, never mind, just verify, change of topic) that supersedes earlier
 work, write the reverse signal verbatim and DO NOT carry forward the

--- a/cli.py
+++ b/cli.py
@@ -9433,6 +9433,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 # adjacency, defending provider role-alternation rules.
                 if partial and tail:
                     compressed = rejoin_compressed_head_and_tail(compressed, tail)
+                # Compression rotation writes the new child transcript from
+                # `compressed`. Some verbatim carried-over messages may already
+                # be stamped as persisted in the parent session. Copy and clear
+                # that parent-session marker before the child flush; otherwise
+                # `_flush_messages_to_session_db()` skips those tail turns and
+                # the rotated child can lose the very exchanges `/compress here`
+                # promised to preserve.
+                compressed = [dict(m) if isinstance(m, dict) else m for m in compressed]
+                for _msg in compressed:
+                    if isinstance(_msg, dict):
+                        _msg.pop("_db_persisted", None)
                 self.conversation_history = compressed
                 # _compress_context ends the old session and creates a new child
                 # session on the agent (run_agent.py::_compress_context). Sync the

--- a/tests/agent/test_context_compressor_temporal_anchoring.py
+++ b/tests/agent/test_context_compressor_temporal_anchoring.py
@@ -15,7 +15,11 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import hermes_time
-from agent.context_compressor import ContextCompressor, HISTORICAL_TASK_HEADING
+from agent.context_compressor import (
+    ContextCompressor,
+    HISTORICAL_REMAINING_WORK_HEADING,
+    HISTORICAL_TASK_HEADING,
+)
 
 
 def _compressor() -> ContextCompressor:
@@ -112,3 +116,30 @@ def test_anchoring_rule_uses_date_from_hermes_time_now():
 
     prompt = mock_call.call_args.kwargs["messages"][0]["content"]
     assert "2025-12-31" in prompt
+
+
+def test_compaction_prompt_avoids_active_sounding_continuation_guardrail():
+    """The template should preserve possible work as historical context only."""
+    compressor = _compressor()
+    with patch.object(hermes_time, "now", _fixed_now), patch(
+        "agent.context_compressor.call_llm", return_value=_response("summary")
+    ) as mock_call:
+        compressor._generate_summary(_turns())
+
+    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    assert "Continuation should pick up exactly here" not in prompt
+    assert "for historical continuity only" in prompt
+    assert "latest user message after the summary explicitly asks to continue" in prompt
+    assert "Do not tell the downstream agent to continue automatically" in prompt
+
+
+def test_deterministic_fallback_remaining_work_is_reference_only():
+    compressor = _compressor()
+    summary = compressor._build_static_fallback_summary(_turns(), reason="test failure")
+
+    assert HISTORICAL_REMAINING_WORK_HEADING in summary
+    assert "For reference only" in summary
+    assert "latest user message explicitly asks to continue it" in summary
+    assert "Otherwise continue only" in summary
+    assert "protected recent messages" in summary
+    assert "Continue from the most recent unfulfilled user ask" not in summary

--- a/tests/cli/test_compress_here.py
+++ b/tests/cli/test_compress_here.py
@@ -5,14 +5,15 @@ only the head, and re-appends the verbatim tail. Inspired by Claude Code's
 Rewind "Summarize up to here" action (v2.1.139, May 2026).
 """
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from tests.cli.test_cli_init import _make_cli
 
 
-def _make_history() -> list[dict[str, str]]:
+def _make_history() -> list[dict[str, Any]]:
     # 8 messages = 4 exchanges.
-    h: list[dict[str, str]] = []
+    h: list[dict[str, Any]] = []
     for i in range(4):
         h.append({"role": "user", "content": f"u{i}"})
         h.append({"role": "assistant", "content": f"a{i}"})
@@ -71,6 +72,39 @@ def test_compress_here_reappends_verbatim_tail(capsys):
     roles = [m["role"] for m in shell.conversation_history
              if m["role"] in ("user", "assistant")]
     assert all(roles[i] != roles[i + 1] for i in range(len(roles) - 1))
+
+
+def test_compress_here_child_flush_repersists_previously_persisted_tail(capsys):
+    """Previously persisted tail turns must be written into the rotated child.
+
+    Live smoke caught a case where the pane showed final tail turns before
+    `/compress here 2`, but the rotated child session in state.db lacked them.
+    The tail dicts were already stamped as persisted in the parent session; the
+    child transcript must clear those parent-session markers before flushing.
+    """
+    shell = _make_cli()
+    shell.session_id = "parent"
+    history = _make_history()
+    for msg in history[4:]:
+        msg["_db_persisted"] = True
+    shell.conversation_history = history
+
+    summary = [{"role": "assistant", "content": "[summary]"}]
+    _wire_agent(shell, summary)
+    shell.agent.session_id = "parent"
+
+    def rotate_child(*args, **kwargs):
+        shell.agent.session_id = "child"
+        return summary, ""
+
+    shell.agent._compress_context.side_effect = rotate_child
+
+    with patch("agent.model_metadata.estimate_request_tokens_rough", return_value=100):
+        shell._manual_compress("/compress here 2")
+
+    flushed = shell.agent._flush_messages_to_session_db.call_args.args[0]
+    assert [m["content"] for m in flushed[-4:]] == ["u2", "a2", "u3", "a3"]
+    assert all("_db_persisted" not in m for m in flushed)
 
 
 def test_compress_here_banner_mentions_summarizing_up_to_here(capsys):


### PR DESCRIPTION
## Summary
- Treat potentially unfinished work in compression summaries as historical/reference-only unless the latest user message explicitly asks to continue it.
- Remove active-sounding continuation wording from the compression prompt and deterministic fallback summary.
- Clear parent-session `_db_persisted` markers before flushing rotated `/compress here` child transcripts so preserved tail turns are re-persisted into the child session.

## Verification
- `scripts/run_tests.sh tests/cli/test_compress_here.py tests/agent/test_context_compressor_temporal_anchoring.py tests/agent/test_context_compressor_summary_continuity.py tests/agent/test_context_compressor_cross_session_guard.py`
- Result: 4 files, 18 tests passed, 0 failed.

## Notes
- Controlled CLI compression smoke had previously verified wrapper/latest-message guard behavior, with a tail persistence warning that this patch addresses via regression coverage.
- External Slack/Discord channel round-trip smoke was not run.
