### PR TITLE
feat: surface context pressure status

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -50,6 +50,77 @@ COMPACTION_STATUS_MARKER = "Compacting context"
 COMPACTION_STATUS = (
     f"🗜️ {COMPACTION_STATUS_MARKER} — summarizing earlier conversation so I can continue..."
 )
+CONTEXT_LIMIT_STATUS_MARKER = "Context limit approaching"
+CONTEXT_LIMIT_WARNING_RATIO = 0.90
+
+
+def _pct(numerator: int, denominator: int) -> int:
+    if denominator <= 0:
+        return 0
+    return max(0, min(100, round((numerator / denominator) * 100)))
+
+
+def format_context_limit_status(
+    current_tokens: int,
+    threshold_tokens: int,
+    context_length: int = 0,
+) -> str:
+    """Render a short user-facing warning as context nears compression.
+
+    Messaging platforms do not have the CLI/TUI status bar, so this string is
+    intentionally standalone and plaintext. Keep
+    ``CONTEXT_LIMIT_STATUS_MARKER`` intact if rewording so gateways/frontends can
+    recognize the lifecycle event without brittle full-string matching.
+    """
+    threshold_pct = _pct(current_tokens, threshold_tokens)
+    remaining = max(threshold_tokens - current_tokens, 0)
+    ctx_suffix = ""
+    if context_length > 0:
+        ctx_suffix = f" ({_pct(current_tokens, context_length)}% of model context)"
+    return (
+        f"⚠️ {CONTEXT_LIMIT_STATUS_MARKER} — ~{current_tokens:,} tokens, "
+        f"{threshold_pct}% of the ~{threshold_tokens:,} compression threshold"
+        f"{ctx_suffix}. About {remaining:,} tokens before compaction."
+    )
+
+
+def maybe_emit_context_limit_status(agent: Any, current_tokens: Optional[int]) -> None:
+    """Emit a deduped lifecycle status when a session is close to compaction.
+
+    The normal CLI status bar already shows context pressure continuously, but
+    Slack/Discord/etc. users otherwise only learn about it once compression has
+    started. This helper sends a visible status when the request is at least
+    90% of the compression threshold, then dedupes by 5% bands so tool loops do
+    not spam chat on every iteration.
+    """
+    try:
+        if not getattr(agent, "compression_enabled", False):
+            return
+        tokens = int(current_tokens or 0)
+        if tokens <= 0:
+            return
+        compressor = getattr(agent, "context_compressor", None)
+        if compressor is None:
+            return
+        threshold = int(getattr(compressor, "threshold_tokens", 0) or 0)
+        if threshold <= 0:
+            return
+        # Once the threshold has been crossed, the explicit compaction status is
+        # clearer and is emitted by compress_context().
+        if tokens >= threshold:
+            return
+        ratio = tokens / threshold
+        if ratio < CONTEXT_LIMIT_WARNING_RATIO:
+            return
+        band = int(ratio * 100) // 5
+        key = (getattr(agent, "session_id", "") or "", threshold, band)
+        if getattr(agent, "_last_context_limit_status_key", None) == key:
+            return
+        agent._last_context_limit_status_key = key
+        context_length = int(getattr(compressor, "context_length", 0) or 0)
+        agent._emit_status(format_context_limit_status(tokens, threshold, context_length))
+    except Exception:
+        logger.debug("context-limit status emission failed", exc_info=True)
 
 
 def _compression_lock_holder(agent: Any) -> str:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -28,7 +28,10 @@ import uuid
 from typing import Any, Dict, List, Optional
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
-from agent.conversation_compression import conversation_history_after_compression
+from agent.conversation_compression import (
+    conversation_history_after_compression,
+    maybe_emit_context_limit_status,
+)
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.iteration_budget import IterationBudget
@@ -1051,6 +1054,7 @@ def run_conversation(
             agent._api_call_count = api_call_count
             agent.iteration_budget.refund()
             continue
+        maybe_emit_context_limit_status(agent, request_pressure_tokens)
         
         # Thinking spinner for quiet mode (animated during API call)
         thinking_spinner = None

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -28,7 +28,10 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
-from agent.conversation_compression import conversation_history_after_compression
+from agent.conversation_compression import (
+    conversation_history_after_compression,
+    maybe_emit_context_limit_status,
+)
 from agent.iteration_budget import IterationBudget
 from agent.model_metadata import (
     estimate_messages_tokens_rough,
@@ -427,6 +430,8 @@ def build_turn_context(
                 agent._mute_post_response = False
                 if not _compressor.should_compress(_preflight_tokens):
                     break
+        else:
+            maybe_emit_context_limit_status(agent, _preflight_tokens)
 
     # Plugin hook: pre_llm_call (context injected into user message, not system prompt).
     plugin_user_context = ""

--- a/tests/agent/test_context_limit_status.py
+++ b/tests/agent/test_context_limit_status.py
@@ -1,0 +1,61 @@
+from types import SimpleNamespace
+
+from agent.conversation_compression import (
+    CONTEXT_LIMIT_STATUS_MARKER,
+    format_context_limit_status,
+    maybe_emit_context_limit_status,
+)
+
+
+def _agent(tokens=0, threshold=100_000, context_length=200_000):
+    events = []
+
+    def emit_status(message: str) -> None:
+        events.append(message)
+
+    agent = SimpleNamespace(
+        compression_enabled=True,
+        session_id="session-1",
+        context_compressor=SimpleNamespace(
+            last_prompt_tokens=tokens,
+            threshold_tokens=threshold,
+            context_length=context_length,
+        ),
+        _emit_status=emit_status,
+    )
+    return agent, events
+
+
+def test_context_limit_status_format_includes_marker_and_pressure():
+    text = format_context_limit_status(90_000, 100_000, 200_000)
+
+    assert CONTEXT_LIMIT_STATUS_MARKER in text
+    assert "~90,000 tokens" in text
+    assert "90% of the ~100,000 compression threshold" in text
+    assert "45% of model context" in text
+    assert "About 10,000 tokens before compaction" in text
+
+
+def test_context_limit_status_emits_once_per_pressure_band():
+    agent, events = _agent()
+
+    maybe_emit_context_limit_status(agent, 89_999)
+    assert events == []
+
+    maybe_emit_context_limit_status(agent, 90_000)
+    assert len(events) == 1
+    assert CONTEXT_LIMIT_STATUS_MARKER in events[0]
+
+    maybe_emit_context_limit_status(agent, 91_000)
+    assert len(events) == 1
+
+    maybe_emit_context_limit_status(agent, 95_000)
+    assert len(events) == 2
+
+
+def test_context_limit_status_skips_when_compaction_is_due():
+    agent, events = _agent()
+
+    maybe_emit_context_limit_status(agent, 100_000)
+
+    assert events == []


### PR DESCRIPTION
## Summary
- add a deduped lifecycle status when context usage reaches 90% of the compression threshold
- emit the warning from preflight and pre-API pressure checks so Slack/gateway users see it before compaction starts
- keep existing compaction status delivery for the actual compacting phase

## Test Plan
- uv run --extra dev python -m pytest tests/agent/test_context_limit_status.py -q
- uv run --extra dev python -m pytest tests/agent/test_preflight_compression_gate.py tests/tui_gateway/test_compaction_status.py tests/agent/test_context_limit_status.py -q
- uv run --extra dev ruff check agent/conversation_compression.py agent/conversation_loop.py agent/turn_context.py tests/agent/test_context_limit_status.py