### PR TITLE
fix: support confidential self-hosted OIDC clients

### DIFF
--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -32,11 +32,11 @@ only choice that is universally correct across self-hosted IDPs. (The ``nous``
 provider verifies its *access* token because Nous Portal mints a custom JWT
 access token with the dashboard claims baked in — a non-OIDC shortcut.)
 
-Public PKCE clients only. Confidential clients (with a ``client_secret``) are
-not yet supported — see the ``# TODO(confidential-client)`` seam in
-``complete_login`` / ``refresh_session``. Self-hosters configuring a CLI/SPA
-client almost always register a public + PKCE client, which is the smaller,
-simpler surface.
+Public PKCE clients remain the default. Confidential clients (with a
+``client_secret``) are also supported for IDPs that require token-endpoint
+authentication. Self-hosters configuring a CLI/SPA client still usually
+register a public + PKCE client, but the plugin now accepts a secret when the
+deployment needs one.
 
 Configuration surfaces (env wins over config.yaml when set non-empty, so a
 provisioned-but-not-populated secret can't shadow a valid config.yaml entry —
@@ -49,11 +49,13 @@ same precedence convention as the ``nous`` plugin)::
         self_hosted:
           issuer: https://auth.example.com/application/o/hermes/   # required
           client_id: hermes-dashboard                              # required
+          client_secret: <optional>                                # optional
           scopes: "openid profile email"                           # optional
 
     # Environment overrides (Docker/Fly secret injection)
     HERMES_DASHBOARD_OIDC_ISSUER
     HERMES_DASHBOARD_OIDC_CLIENT_ID
+    HERMES_DASHBOARD_OIDC_CLIENT_SECRET   # optional
     HERMES_DASHBOARD_OIDC_SCOPES        # optional; defaults to "openid profile email"
 
 Skip reasons: when the plugin loads but can't register (missing issuer /
@@ -172,6 +174,7 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
         issuer: str,
         client_id: str,
         scopes: str = _DEFAULT_SCOPES,
+        client_secret: str = "",
     ) -> None:
         if not issuer:
             raise ValueError("issuer is required")
@@ -186,6 +189,7 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
         _require_https_or_loopback(self._issuer, field="issuer")
         self._client_id = client_id
         self._scopes = scopes.strip() or _DEFAULT_SCOPES
+        self._client_secret = client_secret.strip()
 
         # Discovery + JWKS are lazily resolved on first use so plugin
         # registration never makes a network call (the IDP may be down at
@@ -245,9 +249,6 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
             "client_id": self._client_id,
             "code_verifier": code_verifier,
         }
-        # TODO(confidential-client): when client_secret support lands, add it
-        # here (and switch to HTTP Basic auth if the IDP's
-        # token_endpoint_auth_methods_supported prefers client_secret_basic).
         return self._exchange(
             disco["token_endpoint"], data, bad_request_exc=InvalidCodeError
         )
@@ -265,7 +266,6 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
             # identity claims (some IDPs narrow scope on refresh otherwise).
             "scope": self._scopes,
         }
-        # TODO(confidential-client): add client_secret here when supported.
         return self._exchange(
             disco["token_endpoint"],
             data,
@@ -305,15 +305,23 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
         if not endpoint:
             return None
         try:
+            request_kwargs: Dict[str, Any] = {
+                "data": self._token_request_data(
+                    {
+                        "token": refresh_token,
+                        "token_type_hint": "refresh_token",
+                        "client_id": self._client_id,
+                    }
+                ),
+                "headers": {"Accept": "application/json"},
+                "timeout": _TOKEN_ENDPOINT_TIMEOUT_SEC,
+            }
+            auth = self._token_request_auth()
+            if auth is not None:
+                request_kwargs["auth"] = auth
             httpx.post(
                 endpoint,
-                data={
-                    "token": refresh_token,
-                    "token_type_hint": "refresh_token",
-                    "client_id": self._client_id,
-                },
-                headers={"Accept": "application/json"},
-                timeout=_TOKEN_ENDPOINT_TIMEOUT_SEC,
+                **request_kwargs,
             )
         except Exception as exc:  # noqa: BLE001 — best-effort
             logger.debug("self-hosted OIDC: revoke failed (ignored): %s", exc)
@@ -337,11 +345,18 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
         for the refresh path — preserving the middleware's distinct handling.
         """
         try:
+            request_data = self._token_request_data(data)
+            request_kwargs: Dict[str, Any] = {
+                "data": request_data,
+                "headers": {"Accept": "application/json"},
+                "timeout": _TOKEN_ENDPOINT_TIMEOUT_SEC,
+            }
+            auth = self._token_request_auth()
+            if auth is not None:
+                request_kwargs["auth"] = auth
             response = httpx.post(
                 token_endpoint,
-                data=data,
-                headers={"Accept": "application/json"},
-                timeout=_TOKEN_ENDPOINT_TIMEOUT_SEC,
+                **request_kwargs,
             )
         except httpx.RequestError as exc:
             raise ProviderError(
@@ -489,6 +504,9 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
             "token_endpoint": token_endpoint,
             "jwks_uri": jwks_uri,
             "revocation_endpoint": revocation_endpoint,
+            "token_endpoint_auth_methods_supported": self._normalize_auth_methods(
+                payload.get("token_endpoint_auth_methods_supported")
+            ),
         }
 
     # ---- internals: JWT verification --------------------------------------
@@ -631,6 +649,43 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
                 f"got {redirect_uri!r}"
             )
 
+    def _token_request_data(self, data: Dict[str, str]) -> Dict[str, str]:
+        """Return token request form data, adding a secret when needed."""
+        if not self._client_secret or self._token_endpoint_prefers_basic():
+            return data
+        request_data = dict(data)
+        request_data["client_secret"] = self._client_secret
+        return request_data
+
+    def _token_request_auth(self) -> Optional[tuple[str, str]]:
+        """Return HTTP Basic auth when discovery prefers client_secret_basic."""
+        if not self._client_secret:
+            return None
+        if self._token_endpoint_prefers_basic():
+            return (self._client_id, self._client_secret)
+        return None
+
+    def _token_endpoint_prefers_basic(self) -> bool:
+        """Return True when discovery lists client_secret_basic before post."""
+        auth_methods = self._normalize_auth_methods(
+            self._get_discovery().get("token_endpoint_auth_methods_supported")
+        )
+        if not auth_methods:
+            return False
+        if "client_secret_basic" not in auth_methods:
+            return False
+        if "client_secret_post" not in auth_methods:
+            return True
+        return auth_methods.index("client_secret_basic") < auth_methods.index(
+            "client_secret_post"
+        )
+
+    @staticmethod
+    def _normalize_auth_methods(value: Any) -> list[str]:
+        if not isinstance(value, list):
+            return []
+        return [str(item).strip() for item in value if str(item).strip()]
+
     def _parse_json_body(self, response: httpx.Response) -> Dict[str, Any]:
         ctype = response.headers.get("content-type", "")
         if not ctype.startswith("application/json"):
@@ -696,7 +751,7 @@ def register(ctx) -> None:
     client_id are configured (via ``HERMES_DASHBOARD_OIDC_*`` env vars or the
     ``dashboard.oauth.self_hosted`` block in config.yaml). Operator-owned
     loopback / ``--insecure`` dashboards leave these unset, so the plugin is a
-    no-op for them.
+    no-op for them. ``client_secret`` is optional and only used when present.
 
     On skip, writes a reason to :data:`LAST_SKIP_REASON` that names BOTH
     configuration surfaces so operators don't guess wrong about which to set.
@@ -712,6 +767,9 @@ def register(ctx) -> None:
     )
     client_id = _resolve_setting(
         "HERMES_DASHBOARD_OIDC_CLIENT_ID", oidc_cfg.get("client_id")
+    )
+    client_secret = _resolve_setting(
+        "HERMES_DASHBOARD_OIDC_CLIENT_SECRET", oidc_cfg.get("client_secret")
     )
     scopes = (
         _resolve_setting("HERMES_DASHBOARD_OIDC_SCOPES", oidc_cfg.get("scopes"))
@@ -733,7 +791,10 @@ def register(ctx) -> None:
 
     try:
         provider = SelfHostedOIDCProvider(
-            issuer=issuer, client_id=client_id, scopes=scopes
+            issuer=issuer,
+            client_id=client_id,
+            scopes=scopes,
+            client_secret=client_secret,
         )
     except (ValueError, ProviderError) as exc:
         LAST_SKIP_REASON = (

--- a/plugins/dashboard_auth/self_hosted/plugin.yaml
+++ b/plugins/dashboard_auth/self_hosted/plugin.yaml
@@ -1,6 +1,6 @@
 name: self-hosted
 version: 1.0.0
-description: "Dashboard auth provider — generic self-hosted OpenID Connect (authorization-code + PKCE, public client). Works against any conformant OIDC identity provider (Authentik, Keycloak, Zitadel, Authelia, Auth0, Okta, Google, …) via OIDC discovery. Auto-activates when an issuer + client_id are configured, either under dashboard.oauth.self_hosted.{issuer,client_id} in config.yaml (canonical surface) or via the HERMES_DASHBOARD_OIDC_ISSUER + HERMES_DASHBOARD_OIDC_CLIENT_ID env vars (operator override / secret injection). Scopes default to 'openid profile email'. Verifies the OIDC ID token (RS256/ES256) against the discovered jwks_uri."
+description: "Dashboard auth provider — generic self-hosted OpenID Connect (authorization-code + PKCE, public client by default). Works against any conformant OIDC identity provider (Authentik, Keycloak, Zitadel, Authelia, Auth0, Okta, Google, …) via OIDC discovery. Auto-activates when an issuer + client_id are configured, either under dashboard.oauth.self_hosted.{issuer,client_id} in config.yaml (canonical surface) or via the HERMES_DASHBOARD_OIDC_ISSUER + HERMES_DASHBOARD_OIDC_CLIENT_ID env vars (operator override / secret injection). Optional client_secret is supported via dashboard.oauth.self_hosted.client_secret or HERMES_DASHBOARD_OIDC_CLIENT_SECRET. Scopes default to 'openid profile email'. Verifies the OIDC ID token (RS256/ES256) against the discovered jwks_uri."
 author: NousResearch
 kind: backend
 requires_env:

--- a/tests/plugins/dashboard_auth/test_self_hosted_provider.py
+++ b/tests/plugins/dashboard_auth/test_self_hosted_provider.py
@@ -9,6 +9,7 @@ Covers, by analogy with ``test_nous_provider.py``:
    pinning, standard OIDC claim mapping (sub/email/name/groups).
 5. ``refresh_session`` rotation + error mapping, ``revoke_session`` (RFC 7009).
 6. OIDC discovery: endpoint extraction, issuer pinning, https enforcement.
+7. Confidential-client support: client_secret request auth selection.
 
 All HTTP is mocked: nothing here talks to a real IDP.
 """
@@ -127,14 +128,28 @@ def _mint_id_token(
     )
 
 
-def _make_provider(rsa_keypair, *, scopes: str | None = None):
+def _make_provider(
+    rsa_keypair,
+    *,
+    scopes: str | None = None,
+    client_secret: str = "",
+    token_endpoint_auth_methods_supported: list[str] | None = None,
+):
     """Construct a provider with discovery + JWKS stubbed (no network)."""
-    kwargs: Dict[str, Any] = {"issuer": _ISSUER, "client_id": _CLIENT_ID}
+    kwargs: Dict[str, Any] = {
+        "issuer": _ISSUER,
+        "client_id": _CLIENT_ID,
+        "client_secret": client_secret,
+    }
     if scopes is not None:
         kwargs["scopes"] = scopes
     p = oidc_plugin.SelfHostedOIDCProvider(**kwargs)
     # Pre-seed discovery so nothing hits the network.
     p._discovery = dict(_DISCOVERY_DOC)
+    if token_endpoint_auth_methods_supported is not None:
+        p._discovery["token_endpoint_auth_methods_supported"] = (
+            token_endpoint_auth_methods_supported
+        )
     p._discovery_fetched_at = time.time()
     # Patch the JWKS client to return our fixture key.
     fake_key = MagicMock()
@@ -210,6 +225,14 @@ class TestConstruction:
             issuer=_ISSUER, client_id=_CLIENT_ID, scopes="   "
         )
         assert p._scopes == "openid profile email"
+
+    def test_client_secret_is_optional_and_trimmed(self):
+        p = oidc_plugin.SelfHostedOIDCProvider(
+            issuer=_ISSUER,
+            client_id=_CLIENT_ID,
+            client_secret="  secret-value  ",
+        )
+        assert p._client_secret == "secret-value"
 
 
 # ---------------------------------------------------------------------------
@@ -644,6 +667,55 @@ class TestCompleteLogin:
         assert kwargs["data"]["code_verifier"] == "the-verifier"
         assert kwargs["data"]["client_id"] == _CLIENT_ID
 
+    def test_uses_client_secret_post_when_discovery_prefers_post(
+        self, rsa_keypair
+    ):
+        provider = _make_provider(
+            rsa_keypair,
+            client_secret="secret-post",
+            token_endpoint_auth_methods_supported=["client_secret_post"],
+        )
+        id_token = _mint_id_token(rsa_keypair)
+        mock_resp = _mock_post(200, {"id_token": id_token, "token_type": "Bearer"})
+        with patch(
+            "plugins.dashboard_auth.self_hosted.httpx.post", return_value=mock_resp
+        ) as mock_post:
+            provider.complete_login(
+                code="the-code",
+                state="s",
+                code_verifier="the-verifier",
+                redirect_uri="https://hermes.example/auth/callback",
+            )
+        _, kwargs = mock_post.call_args
+        assert kwargs["data"]["client_secret"] == "secret-post"
+        assert "auth" not in kwargs
+
+    def test_uses_http_basic_when_discovery_prefers_basic(
+        self, rsa_keypair
+    ):
+        provider = _make_provider(
+            rsa_keypair,
+            client_secret="secret-basic",
+            token_endpoint_auth_methods_supported=[
+                "client_secret_basic",
+                "client_secret_post",
+            ],
+        )
+        id_token = _mint_id_token(rsa_keypair)
+        mock_resp = _mock_post(200, {"id_token": id_token, "token_type": "Bearer"})
+        with patch(
+            "plugins.dashboard_auth.self_hosted.httpx.post", return_value=mock_resp
+        ) as mock_post:
+            provider.complete_login(
+                code="the-code",
+                state="s",
+                code_verifier="the-verifier",
+                redirect_uri="https://hermes.example/auth/callback",
+            )
+        _, kwargs = mock_post.call_args
+        assert kwargs["auth"] == ("hermes-dashboard", "secret-basic")
+        assert "client_secret" not in kwargs["data"]
+
 
 # ---------------------------------------------------------------------------
 # verify_session
@@ -765,6 +837,30 @@ class TestRefreshAndRevoke:
         assert kwargs["data"]["refresh_token"] == "rt_old"
         assert kwargs["data"]["client_id"] == _CLIENT_ID
 
+    def test_refresh_uses_client_secret_post_when_configured(
+        self, rsa_keypair
+    ):
+        provider = _make_provider(
+            rsa_keypair,
+            client_secret="refresh-secret",
+            token_endpoint_auth_methods_supported=["client_secret_post"],
+        )
+        id_token = _mint_id_token(rsa_keypair)
+        mock_resp = _mock_post(
+            200,
+            {
+                "id_token": id_token,
+                "token_type": "Bearer",
+            },
+        )
+        with patch(
+            "plugins.dashboard_auth.self_hosted.httpx.post", return_value=mock_resp
+        ) as mock_post:
+            provider.refresh_session(refresh_token="rt_old")
+        _, kwargs = mock_post.call_args
+        assert kwargs["data"]["client_secret"] == "refresh-secret"
+        assert "auth" not in kwargs
+
     def test_refresh_keeps_previous_rt_when_idp_omits(self, provider, rsa_keypair):
         # Some IDPs don't rotate; keep the caller's existing RT alive.
         id_token = _mint_id_token(rsa_keypair)
@@ -842,6 +938,7 @@ class TestPluginRegister:
         for var in (
             "HERMES_DASHBOARD_OIDC_ISSUER",
             "HERMES_DASHBOARD_OIDC_CLIENT_ID",
+            "HERMES_DASHBOARD_OIDC_CLIENT_SECRET",
             "HERMES_DASHBOARD_OIDC_SCOPES",
         ):
             monkeypatch.delenv(var, raising=False)
@@ -875,6 +972,7 @@ class TestPluginRegister:
         patch_config(None)
         monkeypatch.setenv("HERMES_DASHBOARD_OIDC_ISSUER", _ISSUER)
         monkeypatch.setenv("HERMES_DASHBOARD_OIDC_CLIENT_ID", _CLIENT_ID)
+        monkeypatch.setenv("HERMES_DASHBOARD_OIDC_CLIENT_SECRET", "env-secret")
         ctx = MagicMock()
         oidc_plugin.register(ctx)
         ctx.register_dashboard_auth_provider.assert_called_once()
@@ -882,12 +980,19 @@ class TestPluginRegister:
         assert isinstance(registered, oidc_plugin.SelfHostedOIDCProvider)
         assert registered._issuer == _ISSUER
         assert registered._client_id == _CLIENT_ID
+        assert registered._client_secret == "env-secret"
         assert registered._scopes == "openid profile email"
         assert oidc_plugin.LAST_SKIP_REASON == ""
 
     def test_registers_from_config_yaml(self, patch_config):
         patch_config(
-            {"self_hosted": {"issuer": _ISSUER, "client_id": _CLIENT_ID}}
+            {
+                "self_hosted": {
+                    "issuer": _ISSUER,
+                    "client_id": _CLIENT_ID,
+                    "client_secret": "cfg-secret",
+                }
+            }
         )
         ctx = MagicMock()
         oidc_plugin.register(ctx)
@@ -895,6 +1000,7 @@ class TestPluginRegister:
         registered = ctx.register_dashboard_auth_provider.call_args.args[0]
         assert registered._issuer == _ISSUER
         assert registered._client_id == _CLIENT_ID
+        assert registered._client_secret == "cfg-secret"
 
     def test_env_overrides_config(self, patch_config, monkeypatch):
         patch_config(
@@ -902,28 +1008,39 @@ class TestPluginRegister:
                 "self_hosted": {
                     "issuer": "https://config.example",
                     "client_id": "config-client",
+                    "client_secret": "config-secret",
                 }
             }
         )
         monkeypatch.setenv("HERMES_DASHBOARD_OIDC_ISSUER", _ISSUER)
         monkeypatch.setenv("HERMES_DASHBOARD_OIDC_CLIENT_ID", _CLIENT_ID)
+        monkeypatch.setenv("HERMES_DASHBOARD_OIDC_CLIENT_SECRET", "env-secret")
         ctx = MagicMock()
         oidc_plugin.register(ctx)
         registered = ctx.register_dashboard_auth_provider.call_args.args[0]
         assert registered._issuer == _ISSUER
         assert registered._client_id == _CLIENT_ID
+        assert registered._client_secret == "env-secret"
 
     def test_empty_env_does_not_shadow_config(self, patch_config, monkeypatch):
         patch_config(
-            {"self_hosted": {"issuer": _ISSUER, "client_id": _CLIENT_ID}}
+            {
+                "self_hosted": {
+                    "issuer": _ISSUER,
+                    "client_id": _CLIENT_ID,
+                    "client_secret": "cfg-secret",
+                }
+            }
         )
         monkeypatch.setenv("HERMES_DASHBOARD_OIDC_ISSUER", "")
         monkeypatch.setenv("HERMES_DASHBOARD_OIDC_CLIENT_ID", "")
+        monkeypatch.setenv("HERMES_DASHBOARD_OIDC_CLIENT_SECRET", "")
         ctx = MagicMock()
         oidc_plugin.register(ctx)
         ctx.register_dashboard_auth_provider.assert_called_once()
         registered = ctx.register_dashboard_auth_provider.call_args.args[0]
         assert registered._issuer == _ISSUER
+        assert registered._client_secret == "cfg-secret"
 
     def test_custom_scopes_from_config(self, patch_config):
         patch_config(


### PR DESCRIPTION
# Work Package
Objective: add optional client_secret support to the bundled self-hosted OIDC dashboard auth plugin.

Scope:
- Read client_secret from config.yaml or HERMES_DASHBOARD_OIDC_CLIENT_SECRET.
- Pass the secret through token exchange and refresh flows.
- Use HTTP Basic when discovery prefers client_secret_basic; otherwise use client_secret_post.

Non-goals:
- No auth-provider redesign.
- No new UI.
- No new dashboard control plane.

Acceptance criteria:
- Confidential-client registration works.
- Request shaping matches discovery auth-method preference.
- Public-client behavior stays unchanged when no secret is configured.

Tests / evidence:
- compileall on the touched Python files.
- direct runtime assertions using the shared project interpreter, covering post/basic selection and env override precedence.

Worker suitability:
- Small, isolated change. Safe to implement directly; no worker delegation needed.
