### PR TITLE
fix(cli): ignore empty config sections

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -541,6 +541,8 @@ def load_cli_config() -> Dict[str, Any]:
                 if key == "model":
                     continue  # Already handled above
                 if key in file_config:
+                    if isinstance(defaults[key], dict) and file_config[key] is None:
+                        continue
                     if isinstance(defaults[key], dict) and isinstance(file_config[key], dict):
                         defaults[key].update(file_config[key])
                     else:

--- a/tests/hermes_cli/test_config_env_expansion.py
+++ b/tests/hermes_cli/test_config_env_expansion.py
@@ -97,6 +97,18 @@ class TestLoadConfigExpansion:
 class TestLoadCliConfigExpansion:
     """Verify that load_cli_config() also expands ${VAR} references."""
 
+    def test_cli_config_ignores_empty_terminal_section(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("terminal:\n")
+
+        monkeypatch.setattr("cli._hermes_home", tmp_path)
+
+        from cli import load_cli_config
+        config = load_cli_config()
+
+        assert isinstance(config["terminal"], dict)
+        assert config["terminal"]["env_type"] == "local"
+
     def test_cli_config_expands_auxiliary_api_key(self, tmp_path, monkeypatch):
         config_yaml = (
             "auxiliary:\n"


### PR DESCRIPTION
## Summary
- Treat empty YAML sections for dict-backed CLI config blocks as no-op overrides instead of replacing defaults with `None`.
- Add a regression test for `terminal:` in `config.yaml` so `load_cli_config()` keeps the default terminal config and does not crash.

## Root Cause
An empty YAML key such as `terminal:` parses as `None`. `load_cli_config()` deep-merged that value by replacing the default terminal dict, then later evaluated `"backend" in terminal_config`, raising `TypeError` because `terminal_config` was `None`.

## Duplicate Audit
- Searched open/closed PRs for `58277`: no results.
- Searched open/closed PRs for `"Empty YAML key" "load_cli_config"`: no results.
- Searched open/closed PRs for `"NoneType" "terminal" "config.yaml"`: no open results; closed hit #27390 is unrelated MoA empty-content handling.
- Searched open/closed PRs for `"cli.py" "load_cli_config" "terminal"`: hits are terminal cwd/env bridge PRs (#40161, #50649, #42984, #45288, #16807, #4982 and older closed variants), not empty/null config-section handling.
- Issue #58277 timeline had no comments or cross-referenced PRs.
- Closed/merged #15274 handles null sections in the TUI gateway path only; current `origin/main` still reproduces the `cli.load_cli_config()` crash fixed here.

## Tests
- `scripts/run_tests.sh tests/hermes_cli/test_config_env_expansion.py -- -q`
- `python -m py_compile cli.py tests/hermes_cli/test_config_env_expansion.py`
- `git diff --check origin/main...HEAD`

Fixes #58277
