### PR TITLE
fix(skill): remove stale toolsets param from delegate_task signature

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -706,7 +706,7 @@ here; full developer notes live in `AGENTS.md`, user-facing docs under
 
 Spawn a subagent with an isolated context + terminal session.
 
-- **Single:** `delegate_task(goal, context, toolsets)`.
+- **Single:** `delegate_task(goal, context)`.
 - **Batch:** `delegate_task(tasks=[{goal, ...}, ...])` runs children in
   parallel, capped by `delegation.max_concurrent_children` (default 3).
 - **Background:** `delegate_task(background=true)` returns a handle


### PR DESCRIPTION
## Problem

The `delegate_task` tool's `toolsets` argument was removed in commit `ba0bc01d1f` (feat(delegate): remove model-facing toolsets arg — subagents always inherit parent's), but the `hermes-agent` skill documentation still shows the old 3-argument signature:

```
delegate_task(goal, context, toolsets)
```

This causes the model to attempt passing a `toolsets` argument that no longer exists, which wastes tool budget on failed calls.

## Fix

Remove the `toolsets` parameter from the documented signature:

```
delegate_task(goal, context)
```

## Changes

- `skills/autonomous-ai-agents/hermes-agent/SKILL.md`: Updated delegate_task signature from 3 args to 2 args