### PR TITLE
Gate gateway heartbeat on event loop liveness

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19563,6 +19563,36 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     InProcessCronScheduler().start(stop_event, adapters=adapters, loop=loop, interval=interval)
 
 
+# External supervisors may watch this process-level gateway heartbeat. Keep it
+# distinct from cron/ticker_heartbeat, which reports only the cron ticker thread.
+_GATEWAY_HEARTBEAT_FILENAME = ".gateway.heartbeat"
+
+
+def _start_heartbeat_bumper(
+    stop_event: threading.Event,
+    hb_file: "Path",
+    interval: int = 30,
+    loop_alive: Optional[Callable[[], bool]] = None,
+):
+    """Touch .gateway.heartbeat while the gateway event loop is fresh."""
+    try:
+        hb_file.parent.mkdir(parents=True, exist_ok=True)
+        hb_file.touch(exist_ok=True)
+    except Exception as e:
+        logger.debug("Heartbeat init error: %s", e)
+    while not stop_event.is_set():
+        stop_event.wait(timeout=interval)
+        if stop_event.is_set():
+            break
+        try:
+            if loop_alive is not None and not loop_alive():
+                logger.debug("Heartbeat skipped: event loop not beating")
+                continue
+            hb_file.touch(exist_ok=True)
+        except Exception as e:
+            logger.debug("Heartbeat bump error: %s", e)
+
+
 async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = False, verbosity: Optional[int] = 0) -> bool:
     """
     Start the gateway and run until interrupted.
@@ -20030,6 +20060,64 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     )
     cron_thread.start()
 
+    # Touch a gateway heartbeat file for external health monitors, but only
+    # while the asyncio loop itself is still making progress. A plain background
+    # thread heartbeat would keep looking healthy after a loop deadlock.
+    hb_stop = threading.Event()
+    hb_file = _hermes_home / "cron" / _GATEWAY_HEARTBEAT_FILENAME
+    _last_loop_beat = [time.monotonic()]
+
+    async def _loop_beat_refresher():
+        while True:
+            _last_loop_beat[0] = time.monotonic()
+            await asyncio.sleep(15)
+
+    async def _stop_gateway_heartbeat():
+        hb_stop.set()
+        hb_thread.join(timeout=5)
+        _loop_beat_task.cancel()
+        try:
+            await _loop_beat_task
+        except asyncio.CancelledError:
+            pass
+
+    async def _cleanup_post_start_backgrounds():
+        await _stop_gateway_heartbeat()
+
+        try:
+            from hermes_cli.nous_auth_keepalive import stop_nous_auth_keepalive
+
+            stop_nous_auth_keepalive()
+        except Exception:
+            pass
+
+        cron_stop.set()
+        try:
+            cron_provider.stop()
+        except Exception as e:
+            logger.debug("Cron provider stop() error: %s", e)
+        cron_thread.join(timeout=5)
+        housekeeping_thread.join(timeout=5)
+
+        _planned_stop_watcher_stop.set()
+        _planned_stop_watcher_thread.join(timeout=2)
+
+        try:
+            from tools.mcp_tool import shutdown_mcp_servers
+            shutdown_mcp_servers()
+        except Exception:
+            pass
+
+    _loop_beat_task = loop.create_task(_loop_beat_refresher())
+    hb_thread = threading.Thread(
+        target=_start_heartbeat_bumper,
+        args=(hb_stop, hb_file),
+        kwargs={"loop_alive": lambda: (time.monotonic() - _last_loop_beat[0]) < 90},
+        daemon=True,
+        name="gateway-heartbeat",
+    )
+    hb_thread.start()
+
     # Gateway-only periodic housekeeping (channel dir, cache cleanup, paste
     # sweep, curator) — runs independently of which cron provider is active.
     # Shares cron_stop as the shutdown signal.
@@ -20042,41 +20130,18 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     )
     housekeeping_thread.start()
     
-    # Wait for shutdown
-    await runner.wait_for_shutdown()
-
+    # Wait for shutdown. Background cleanup lives in a finally so cancellation or
+    # unexpected shutdown exceptions cannot leave liveness/cron machinery behind.
     try:
-        from hermes_cli.nous_auth_keepalive import stop_nous_auth_keepalive
-
-        stop_nous_auth_keepalive()
-    except Exception:
-        pass
+        await runner.wait_for_shutdown()
+    finally:
+        await _cleanup_post_start_backgrounds()
 
     if runner.should_exit_with_failure:
         if runner.exit_reason:
             logger.error("Gateway exiting with failure: %s", runner.exit_reason)
         return False
     
-    # Stop cron scheduler + housekeeping cleanly
-    cron_stop.set()
-    try:
-        cron_provider.stop()
-    except Exception as e:
-        logger.debug("Cron provider stop() error: %s", e)
-    cron_thread.join(timeout=5)
-    housekeeping_thread.join(timeout=5)
-
-    # Stop the planned-stop watcher (daemon=True so this is belt-and-suspenders).
-    _planned_stop_watcher_stop.set()
-    _planned_stop_watcher_thread.join(timeout=2)
-
-    # Close MCP server connections
-    try:
-        from tools.mcp_tool import shutdown_mcp_servers
-        shutdown_mcp_servers()
-    except Exception:
-        pass
-
     if runner.exit_code is not None:
         raise SystemExit(runner.exit_code)
 

--- a/tests/gateway/test_gateway_runtime_heartbeat.py
+++ b/tests/gateway/test_gateway_runtime_heartbeat.py
@@ -1,0 +1,304 @@
+import asyncio
+import threading
+import time
+
+import pytest
+
+from gateway import run as gateway_run
+
+
+class _FakeParent:
+    def mkdir(self, *args, **kwargs):
+        return None
+
+
+class _FakeHeartbeatFile:
+    parent = _FakeParent()
+
+    def __init__(self):
+        self.touches = 0
+
+    def touch(self, *args, **kwargs):
+        self.touches += 1
+
+
+def _wait_until(predicate, timeout=0.5):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.005)
+    return predicate()
+
+
+class _ThreadProbe:
+    def __init__(self):
+        self.started = threading.Event()
+        self.stopped = threading.Event()
+        self.thread = None
+
+    def run(self, stop_event, *args, **kwargs):
+        self.thread = threading.current_thread()
+        self.started.set()
+        stop_event.wait()
+        self.stopped.set()
+
+
+class _RecordingCronProvider:
+    def __init__(self):
+        self.stop_called = threading.Event()
+        self.probe = _ThreadProbe()
+
+    def start(self, stop_event, *, adapters=None, loop=None, interval=60):
+        self.probe.run(stop_event)
+
+    def stop(self):
+        self.stop_called.set()
+
+
+def _patch_start_gateway_basics(
+    monkeypatch, tmp_path, cron_provider, housekeeping_probe, planned_stop_probe
+):
+    cleanup_calls = {"mcp_shutdown": 0}
+
+    def shutdown_mcp_servers():
+        cleanup_calls["mcp_shutdown"] += 1
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr("gateway.code_skew.record_boot_fingerprint", lambda: None)
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr("gateway.status.acquire_gateway_runtime_lock", lambda: True)
+    monkeypatch.setattr("gateway.status.write_pid_file", lambda: None)
+    monkeypatch.setattr("gateway.status.remove_pid_file", lambda: None)
+    monkeypatch.setattr("gateway.status.release_gateway_runtime_lock", lambda: None)
+    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
+    monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: None)
+    monkeypatch.setattr(gateway_run, "_ensure_windows_gateway_venv_imports", lambda: None)
+    monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", lambda: None)
+    monkeypatch.setattr("tools.mcp_tool.shutdown_mcp_servers", shutdown_mcp_servers)
+    monkeypatch.setattr("cron.scheduler_provider.resolve_cron_scheduler", lambda: cron_provider)
+    monkeypatch.setattr(gateway_run, "_start_gateway_housekeeping", housekeeping_probe.run)
+    monkeypatch.setattr(gateway_run, "_run_planned_stop_watcher", planned_stop_probe.run)
+    return cleanup_calls
+
+
+def _capture_heartbeat_threads(monkeypatch):
+    original = gateway_run._start_heartbeat_bumper
+    threads = []
+
+    def wrapped(stop_event, hb_file, interval=30, loop_alive=None):
+        threads.append(threading.current_thread())
+        return original(stop_event, hb_file, interval=0.01, loop_alive=loop_alive)
+
+    monkeypatch.setattr(gateway_run, "_start_heartbeat_bumper", wrapped)
+    return threads
+
+
+def _heartbeat_path(tmp_path):
+    return tmp_path / "cron" / gateway_run._GATEWAY_HEARTBEAT_FILENAME
+
+
+def _assert_heartbeat_stopped(threads, heartbeat_path):
+    assert threads
+    assert all(not thread.is_alive() for thread in threads)
+    assert heartbeat_path.exists()
+    modified_at = heartbeat_path.stat().st_mtime_ns
+    time.sleep(0.03)
+    assert heartbeat_path.stat().st_mtime_ns == modified_at
+
+
+def _assert_backgrounds_stopped(
+    cron_provider, housekeeping_probe, planned_stop_probe, cleanup_calls
+):
+    assert cron_provider.stop_called.is_set()
+    for probe in (cron_provider.probe, housekeeping_probe, planned_stop_probe):
+        assert probe.started.is_set()
+        assert probe.stopped.is_set()
+        assert probe.thread is not None
+        assert not probe.thread.is_alive()
+    assert cleanup_calls["mcp_shutdown"] == 1
+
+
+def test_heartbeat_bumper_skips_touches_when_loop_is_not_alive():
+    stop = threading.Event()
+    hb_file = _FakeHeartbeatFile()
+
+    thread = threading.Thread(
+        target=gateway_run._start_heartbeat_bumper,
+        args=(stop, hb_file),
+        kwargs={"interval": 0.01, "loop_alive": lambda: False},
+        daemon=True,
+    )
+    thread.start()
+
+    assert _wait_until(lambda: hb_file.touches == 1)
+    time.sleep(0.05)
+
+    stop.set()
+    thread.join(timeout=0.2)
+
+    assert not thread.is_alive()
+    assert hb_file.touches == 1
+
+
+def test_heartbeat_bumper_resumes_touches_when_loop_is_alive():
+    stop = threading.Event()
+    hb_file = _FakeHeartbeatFile()
+    alive = threading.Event()
+
+    def loop_alive():
+        return alive.is_set()
+
+    thread = threading.Thread(
+        target=gateway_run._start_heartbeat_bumper,
+        args=(stop, hb_file),
+        kwargs={"interval": 0.01, "loop_alive": loop_alive},
+        daemon=True,
+    )
+    thread.start()
+
+    assert _wait_until(lambda: hb_file.touches == 1)
+    time.sleep(0.03)
+    assert hb_file.touches == 1
+
+    alive.set()
+    assert _wait_until(lambda: hb_file.touches >= 2)
+
+    stop.set()
+    thread.join(timeout=0.2)
+    assert not thread.is_alive()
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_stops_backgrounds_after_clean_shutdown(monkeypatch, tmp_path):
+    cron_provider = _RecordingCronProvider()
+    housekeeping_probe = _ThreadProbe()
+    planned_stop_probe = _ThreadProbe()
+    cleanup_calls = _patch_start_gateway_basics(
+        monkeypatch, tmp_path, cron_provider, housekeeping_probe, planned_stop_probe
+    )
+    threads = _capture_heartbeat_threads(monkeypatch)
+
+    class CleanRunner:
+        def __init__(self, config):
+            self.config = config
+            self.adapters = {}
+            self._running = True
+            self.should_exit_cleanly = False
+            self.should_exit_with_failure = False
+            self.exit_reason = None
+            self.exit_code = None
+            self._restart_requested = False
+            self._restart_via_service = False
+
+        async def start(self):
+            return True
+
+        async def wait_for_shutdown(self):
+            return None
+
+        async def stop(self):
+            return None
+
+    monkeypatch.setattr(gateway_run, "GatewayRunner", CleanRunner)
+
+    assert await gateway_run.start_gateway(config=None, replace=False, verbosity=None) is True
+
+    _assert_heartbeat_stopped(threads, _heartbeat_path(tmp_path))
+    _assert_backgrounds_stopped(
+        cron_provider, housekeeping_probe, planned_stop_probe, cleanup_calls
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_stops_backgrounds_after_failed_shutdown(monkeypatch, tmp_path):
+    cron_provider = _RecordingCronProvider()
+    housekeeping_probe = _ThreadProbe()
+    planned_stop_probe = _ThreadProbe()
+    cleanup_calls = _patch_start_gateway_basics(
+        monkeypatch, tmp_path, cron_provider, housekeeping_probe, planned_stop_probe
+    )
+    threads = _capture_heartbeat_threads(monkeypatch)
+
+    class FailedRunner:
+        def __init__(self, config):
+            self.config = config
+            self.adapters = {}
+            self._running = True
+            self.should_exit_cleanly = False
+            self.should_exit_with_failure = False
+            self.exit_reason = None
+            self.exit_code = None
+            self._restart_requested = False
+            self._restart_via_service = False
+
+        async def start(self):
+            return True
+
+        async def wait_for_shutdown(self):
+            self.should_exit_with_failure = True
+            self.exit_reason = "shutdown failed"
+
+        async def stop(self):
+            return None
+
+    monkeypatch.setattr(gateway_run, "GatewayRunner", FailedRunner)
+
+    assert await gateway_run.start_gateway(config=None, replace=False, verbosity=None) is False
+
+    _assert_heartbeat_stopped(threads, _heartbeat_path(tmp_path))
+    _assert_backgrounds_stopped(
+        cron_provider, housekeeping_probe, planned_stop_probe, cleanup_calls
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_stops_backgrounds_when_shutdown_wait_is_cancelled(
+    monkeypatch, tmp_path
+):
+    cron_provider = _RecordingCronProvider()
+    housekeeping_probe = _ThreadProbe()
+    planned_stop_probe = _ThreadProbe()
+    cleanup_calls = _patch_start_gateway_basics(
+        monkeypatch, tmp_path, cron_provider, housekeeping_probe, planned_stop_probe
+    )
+    threads = _capture_heartbeat_threads(monkeypatch)
+    wait_started = asyncio.Event()
+
+    class BlockingRunner:
+        def __init__(self, config):
+            self.config = config
+            self.adapters = {}
+            self._running = True
+            self.should_exit_cleanly = False
+            self.should_exit_with_failure = False
+            self.exit_reason = None
+            self.exit_code = None
+            self._restart_requested = False
+            self._restart_via_service = False
+
+        async def start(self):
+            return True
+
+        async def wait_for_shutdown(self):
+            wait_started.set()
+            await asyncio.Event().wait()
+
+        async def stop(self):
+            return None
+
+    monkeypatch.setattr(gateway_run, "GatewayRunner", BlockingRunner)
+
+    task = asyncio.create_task(gateway_run.start_gateway(config=None, replace=False, verbosity=None))
+    await asyncio.wait_for(wait_started.wait(), timeout=1)
+    assert _wait_until(lambda: threads)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    _assert_heartbeat_stopped(threads, _heartbeat_path(tmp_path))
+    _assert_backgrounds_stopped(
+        cron_provider, housekeeping_probe, planned_stop_probe, cleanup_calls
+    )


### PR DESCRIPTION
## Summary
- add a process-level gateway heartbeat at `cron/.gateway.heartbeat` for external supervisors
- gate heartbeat bumps on a monotonic asyncio loop beat so a deadlocked loop stops looking healthy
- move post-start background cleanup into a shared `finally` path for clean, failure, and cancellation shutdowns

## Tests
- `/Users/tjkang/.hermes/hermes-agent/.venv/bin/python -m pytest tests/gateway/test_gateway_runtime_heartbeat.py -q`
- `/Users/tjkang/.hermes/hermes-agent/.venv/bin/python -m pytest tests/gateway/test_gateway_runtime_heartbeat.py tests/gateway/test_runner_startup_failures.py tests/gateway/test_startup_restart_race.py tests/gateway/test_gateway_process_exit.py -q`
- `uvx ruff check gateway/run.py tests/gateway/test_gateway_runtime_heartbeat.py`
- `git diff --check`