### PR TITLE
fix: preserve explicit leaf tools when disabling coding

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -388,6 +388,32 @@ def _compute_tool_definitions(
         for ts_name in get_all_toolsets():
             tools_to_include.update(resolve_toolset(ts_name))
 
+    # Track only the toolsets the caller explicitly enabled. This lets a
+    # disabled composite toolset remove its own unique tools without
+    # stripping a leaf toolset that was also requested directly.
+    explicitly_enabled_toolsets: set = set()
+    if enabled_toolsets is not None:
+        for toolset_name in effective_enabled_toolsets:
+            if validate_toolset(toolset_name):
+                explicitly_enabled_toolsets.add(toolset_name)
+            elif toolset_name in _LEGACY_TOOLSET_MAP:
+                for tool_name in _LEGACY_TOOLSET_MAP[toolset_name]:
+                    canonical_toolset = TOOL_TO_TOOLSET_MAP.get(tool_name)
+                    if canonical_toolset:
+                        explicitly_enabled_toolsets.add(canonical_toolset)
+
+    def _tool_is_protected_from_disable(tool_name: str, disabled_toolset_name: str) -> bool:
+        canonical_toolset = TOOL_TO_TOOLSET_MAP.get(tool_name)
+        if not canonical_toolset:
+            return False
+        # Preserve explicitly enabled leaf toolsets when disabling a
+        # different composite toolset. If the same toolset is disabled,
+        # keep the existing "disable wins" behavior.
+        return (
+            canonical_toolset in explicitly_enabled_toolsets
+            and canonical_toolset != disabled_toolset_name
+        )
+
     # Always apply disabled toolsets as a subtraction step at the end.
     # This ensures that even if a composite toolset (like hermes-cli)
     # is enabled, any tools belonging to a disabled toolset are strictly
@@ -417,14 +443,24 @@ def _compute_tool_definitions(
                         )
                 else:
                     resolved = resolve_toolset(toolset_name)
-                    tools_to_include.difference_update(resolved)
+                    to_remove = {
+                        tool_name for tool_name in resolved
+                        if not _tool_is_protected_from_disable(tool_name, toolset_name)
+                    }
+                    tools_to_include.difference_update(to_remove)
+                    resolved = sorted(to_remove)
                 if not quiet_mode:
                     print(f"🚫 Disabled toolset '{toolset_name}': {', '.join(resolved) if resolved else 'no tools'}")
             elif toolset_name in _LEGACY_TOOLSET_MAP:
                 legacy_tools = _LEGACY_TOOLSET_MAP[toolset_name]
-                tools_to_include.difference_update(legacy_tools)
+                to_remove = {
+                    tool_name for tool_name in legacy_tools
+                    if not _tool_is_protected_from_disable(tool_name, toolset_name)
+                }
+                tools_to_include.difference_update(to_remove)
+                resolved = sorted(to_remove)
                 if not quiet_mode:
-                    print(f"🚫 Disabled legacy toolset '{toolset_name}': {', '.join(legacy_tools)}")
+                    print(f"🚫 Disabled legacy toolset '{toolset_name}': {', '.join(resolved) if resolved else 'no tools'}")
             elif not quiet_mode:
                 print(f"⚠️  Unknown toolset: {toolset_name}")
 

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -459,8 +459,69 @@ class TestCoerceNumberInfNan:
         assert _coerce_number("1e3") == 1000
 
 class TestDisabledToolsetsPlatformBundle:
-    """Regression test for #33924: disabling a platform bundle (hermes-*)
-    must not remove core tools from other enabled toolsets."""
+    """Regression tests for disabled-toolset subtraction.
+
+    #33924 covered hermes-* bundle preservation. #58281 extends that
+    # behavior: disabling the coding posture bundle must not strip
+    # explicitly enabled leaf toolsets.
+    """
+
+    def test_disabling_coding_preserves_explicit_terminal_and_file_tools(self):
+        """Disabling coding should not remove separately enabled terminal/file tools."""
+        from model_tools import get_tool_definitions
+
+        tools = get_tool_definitions(
+            enabled_toolsets=["coding", "terminal", "file"],
+            disabled_toolsets=["coding"],
+            quiet_mode=True,
+        )
+        names = {t["function"]["name"] for t in tools}
+
+        expected_present = {
+            "terminal",
+            "process",
+            "read_file",
+            "write_file",
+            "patch",
+            "search_files",
+        }
+        expected_absent = {
+            "web_search",
+            "web_extract",
+            "read_terminal",
+            "close_terminal",
+            "vision_analyze",
+            "skills_list",
+            "skill_view",
+            "skill_manage",
+            "browser_navigate",
+            "browser_snapshot",
+            "browser_click",
+            "browser_type",
+            "browser_scroll",
+            "browser_back",
+            "browser_press",
+            "browser_get_images",
+            "browser_vision",
+            "browser_console",
+            "browser_cdp",
+            "browser_dialog",
+            "todo",
+            "memory",
+            "session_search",
+            "clarify",
+            "execute_code",
+            "delegate_task",
+        }
+
+        assert expected_present <= names, (
+            f"Explicit terminal/file tools were lost after disabling coding: "
+            f"{expected_present - names}"
+        )
+        assert expected_absent.isdisjoint(names), (
+            f"Coding-only tools should have been removed: "
+            f"{expected_absent & names}"
+        )
 
     def test_disabling_platform_bundle_preserves_core_tools(self):
         """Disabling hermes-yuanbao should not strip core tools from hermes-telegram."""


### PR DESCRIPTION
Fixes #58281.

Summary:
- Disabling coding now removes only tools it uniquely contributes.
- Explicitly enabled terminal / file tools are preserved.
- Existing hermes-* bundle subtraction behavior is unchanged.

Validation:
- Direct runtime check confirmed enabled_toolsets=[terminal,file] with disabled_toolsets=[coding] now returns the expected leaf tools instead of collapsing to zero.
- Syntax-only validation passed on the modified files.
- Full pytest is still blocked in this sandbox because pytest runtime deps are unavailable here.

Status:
- Draft PR intentionally left pending until dependency-complete validation can run.