### PR TITLE
fix(cron): don't tear down the session db while a timed-out job's worker is still running

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2322,6 +2322,137 @@ def _guard_job_credential_exfil(job: dict) -> None:
         raise RuntimeError(f"Cron job '{job_id}' blocked for safety: {err}")
 
 
+def _teardown_cron_job_resources(
+    session_db,
+    cron_session_id: str,
+    agent,
+    job_id: str,
+    job_name: str,
+    cron_future=None,
+) -> str:
+    """Release a finished cron job's SessionDB and agent resources.
+
+    Normal path (*cron_future* is None or already done): teardown runs
+    inline, exactly as the historical ``finally:`` block did. Returns
+    ``"inline"``.
+
+    Orphaned-worker path: after an inactivity timeout the submitted future
+    is by definition still executing, because
+    ``ThreadPoolExecutor.shutdown(wait=False, cancel_futures=True)`` cannot
+    stop an already-running future. Closing ``session_db`` / ``agent``
+    inline at that point races the worker thread's own message flush
+    (``_flush_messages_to_session_db`` -> ``SessionDB._execute_write``) and
+    silently drops that turn's message row(s); the observable symptom is
+    "Session DB append_message failed: 'NoneType' object has no attribute
+    'execute'". Instead, ownership of the teardown transfers to the future
+    itself via ``add_done_callback``: the close runs on the worker thread
+    the moment ``run_conversation`` actually returns, after its final
+    writes have landed. A daemon ``Timer`` bounds the deferral
+    (``HERMES_CRON_TEARDOWN_HARDCAP`` seconds, default 900) so a worker
+    that never finishes cannot leak the SQLite handle, subprocesses, or
+    httpx sockets forever; if the cap fires first, the residual race window
+    is accepted, and with ``_execute_write``'s closed-connection guard a
+    late write fails as a typed ``RuntimeError`` instead of an opaque
+    ``AttributeError``. Returns ``"deferred"``.
+
+    Teardown is idempotent across the two triggers (future completion vs
+    hard cap); whichever fires first wins, the other becomes a no-op.
+    """
+
+    def _do_teardown() -> None:
+        if session_db:
+            # Title the cron session from the job (name → short prompt → id) so
+            # sidebars/history show a meaningful label instead of the injected
+            # "[IMPORTANT: …]" hint that is the session's first message. Set here
+            # (not at create time) so the agent's own INSERT keeps model /
+            # system_prompt; this only UPDATEs the title column. The run-time
+            # suffix keeps it unique against the sessions.title index across runs.
+            try:
+                _title_base = " ".join(job_name.split())[:60].strip() or f"cron {job_id}"
+                _cron_title = f"{_title_base} · {_hermes_now().strftime('%b %d %H:%M')}"
+                session_db.set_session_title(cron_session_id, _cron_title)
+            except (Exception, KeyboardInterrupt) as e:
+                logger.debug("Job '%s': failed to set cron session title: %s", job_id, e)
+            try:
+                session_db.end_session(cron_session_id, "cron_complete")
+            except (Exception, KeyboardInterrupt) as e:
+                logger.debug("Job '%s': failed to end session: %s", job_id, e)
+            try:
+                session_db.close()
+            except (Exception, KeyboardInterrupt) as e:
+                logger.debug("Job '%s': failed to close SQLite session store: %s", job_id, e)
+        # Release subprocesses, terminal sandboxes, browser daemons, and the
+        # main OpenAI/httpx client held by this ephemeral cron agent. Without
+        # this, a gateway that ticks cron every N minutes leaks fds per job
+        # until it hits EMFILE (#10200 / "too many open files").
+        try:
+            if agent is not None:
+                agent.close()
+        except (Exception, KeyboardInterrupt) as e:
+            logger.debug("Job '%s': failed to close agent resources: %s", job_id, e)
+        # Each cron run spins up a short-lived worker thread whose event loop
+        # dies as soon as the ``ThreadPoolExecutor`` shuts down. Any async
+        # httpx clients cached under that loop are now unusable — reap them
+        # so their transports don't accumulate in the process-global cache.
+        try:
+            from agent.auxiliary_client import cleanup_stale_async_clients
+            cleanup_stale_async_clients()
+        except Exception as e:
+            logger.debug("Job '%s': failed to reap stale auxiliary clients: %s", job_id, e)
+
+    if cron_future is None or cron_future.done():
+        _do_teardown()
+        return "inline"
+
+    _once_lock = threading.Lock()
+    _teardown_ran = [False]
+
+    def _teardown_once(trigger: str) -> None:
+        with _once_lock:
+            if _teardown_ran[0]:
+                return
+            _teardown_ran[0] = True
+        if trigger == "hard-cap":
+            logger.warning(
+                "Job '%s': orphaned worker never completed within the teardown "
+                "hard cap; forcing session-db/agent close now (bounded leak; a "
+                "late write will fail typed instead of dropping silently)",
+                job_id,
+            )
+        _do_teardown()
+
+    _raw_cap = os.getenv("HERMES_CRON_TEARDOWN_HARDCAP", "").strip()
+    try:
+        _hard_cap = float(_raw_cap) if _raw_cap else 900.0
+    except (ValueError, TypeError):
+        logger.warning(
+            "Invalid HERMES_CRON_TEARDOWN_HARDCAP=%r; using default 900s",
+            _raw_cap,
+        )
+        _hard_cap = 900.0
+    if _hard_cap <= 0:
+        _hard_cap = 900.0
+
+    _cap_timer = threading.Timer(_hard_cap, _teardown_once, args=("hard-cap",))
+    _cap_timer.daemon = True
+
+    def _on_future_done(_fut) -> None:
+        _cap_timer.cancel()
+        _teardown_once("future-done")
+
+    _cap_timer.start()
+    # If the future completed between the .done() check above and here,
+    # add_done_callback invokes _on_future_done immediately on this thread;
+    # teardown still runs exactly once and the timer is cancelled.
+    cron_future.add_done_callback(_on_future_done)
+    logger.warning(
+        "Job '%s': worker thread still running at teardown; deferring "
+        "session-db/agent close to future completion (hard cap %.0fs)",
+        job_id, _hard_cap,
+    )
+    return "deferred"
+
+
 def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     """
     Execute a single cron job.
@@ -2509,6 +2640,10 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     logger.info("Prompt: %s", prompt[:100])
 
     agent = None
+    # Future running agent.run_conversation on the cron worker thread.
+    # Pre-bound so the finally: teardown below can consult it safely even
+    # when an exception fires before the executor is created.
+    _cron_future = None
 
     # Mark this as a cron session so the approval system can apply cron_mode.
     # This env var is process-wide and persists for the lifetime of the
@@ -2986,6 +3121,25 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             )
             if hasattr(agent, "interrupt"):
                 agent.interrupt("Cron job timed out (inactivity)")
+            # The interrupt flag alone cannot unblock a tool stuck in a
+            # blocking subprocess wait (observed: a git command hung on a
+            # dead SSL connection for 1000s+). Historically the finally:
+            # block's agent.close() did that unblocking as a side effect of
+            # its process_registry.kill_all call, at the cost of also
+            # closing _session_db out from under the still-running worker
+            # thread. Kill this job's registered subprocesses here instead,
+            # so the worker can observe the interrupt and wind down; the
+            # full resource teardown now runs when the worker actually
+            # finishes (see _teardown_cron_job_resources in the finally:
+            # block).
+            try:
+                from tools.process_registry import process_registry
+                process_registry.kill_all(task_id=_cron_session_id)
+            except Exception as _kill_exc:
+                logger.debug(
+                    "Job '%s': failed to kill subprocesses after inactivity "
+                    "timeout: %s", job_id, _kill_exc,
+                )
             raise TimeoutError(
                 f"Cron job '{job_name}' idle for "
                 f"{int(_secs_ago)}s (limit {int(_cron_inactivity_limit)}s) "
@@ -3115,45 +3269,24 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         clear_session_vars(_ctx_tokens)
         for _var_name in _cron_delivery_vars:
             _VAR_MAP[_var_name].set("")
-        if _session_db:
-            # Title the cron session from the job (name → short prompt → id) so
-            # sidebars/history show a meaningful label instead of the injected
-            # "[IMPORTANT: …]" hint that is the session's first message. Set here
-            # (not at create time) so the agent's own INSERT keeps model /
-            # system_prompt; this only UPDATEs the title column. The run-time
-            # suffix keeps it unique against the sessions.title index across runs.
-            try:
-                _title_base = " ".join(job_name.split())[:60].strip() or f"cron {job_id}"
-                _cron_title = f"{_title_base} · {_hermes_now().strftime('%b %d %H:%M')}"
-                _session_db.set_session_title(_cron_session_id, _cron_title)
-            except (Exception, KeyboardInterrupt) as e:
-                logger.debug("Job '%s': failed to set cron session title: %s", job_id, e)
-            try:
-                _session_db.end_session(_cron_session_id, "cron_complete")
-            except (Exception, KeyboardInterrupt) as e:
-                logger.debug("Job '%s': failed to end session: %s", job_id, e)
-            try:
-                _session_db.close()
-            except (Exception, KeyboardInterrupt) as e:
-                logger.debug("Job '%s': failed to close SQLite session store: %s", job_id, e)
-        # Release subprocesses, terminal sandboxes, browser daemons, and the
-        # main OpenAI/httpx client held by this ephemeral cron agent. Without
-        # this, a gateway that ticks cron every N minutes leaks fds per job
-        # until it hits EMFILE (#10200 / "too many open files").
-        try:
-            if agent is not None:
-                agent.close()
-        except (Exception, KeyboardInterrupt) as e:
-            logger.debug("Job '%s': failed to close agent resources: %s", job_id, e)
-        # Each cron run spins up a short-lived worker thread whose event loop
-        # dies as soon as the ``ThreadPoolExecutor`` shuts down. Any async
-        # httpx clients cached under that loop are now unusable — reap them
-        # so their transports don't accumulate in the process-global cache.
-        try:
-            from agent.auxiliary_client import cleanup_stale_async_clients
-            cleanup_stale_async_clients()
-        except Exception as e:
-            logger.debug("Job '%s': failed to reap stale auxiliary clients: %s", job_id, e)
+        # Session-db/agent teardown. On the normal path (worker finished, or
+        # it never started) this runs inline, exactly as before. After an
+        # inactivity timeout the submitted future is still executing
+        # (ThreadPoolExecutor.shutdown(wait=False, cancel_futures=True) does
+        # not stop a running future), and closing _session_db / agent here
+        # raced that worker thread's own message flush, dropping the turn's
+        # rows ("Session DB append_message failed: 'NoneType' object has no
+        # attribute 'execute'"). The helper transfers teardown ownership to
+        # the future via add_done_callback, bounded by a hard-cap timer. See
+        # _teardown_cron_job_resources.
+        _teardown_cron_job_resources(
+            session_db=_session_db,
+            cron_session_id=_cron_session_id,
+            agent=agent,
+            job_id=job_id,
+            job_name=job_name,
+            cron_future=_cron_future,
+        )
 
 
 def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -> bool:


### PR DESCRIPTION
## Problem

After a cron job hits the inactivity timeout, the job's final message rows can be silently dropped from the session store. Log signature:

```
WARNING [cron_...] run_agent: Session DB append_message failed: 'NoneType' object has no attribute 'execute'
```

Observed in the wild on a job whose terminal tool sat 1000+ seconds in a git command on a dead SSL connection.

## Mechanism

1. `_run_job_impl` submits `agent.run_conversation` to a single-worker `ThreadPoolExecutor` and polls it against the inactivity limit (`cron/scheduler.py`).
2. On timeout it calls `pool.shutdown(wait=False, cancel_futures=True)`. That cannot stop a future that is already running, so the worker thread stays alive, blocked in the tool call.
3. The function's `finally:` block then runs unconditionally: `_session_db.close()` sets `SessionDB._conn = None`, and `agent.close()` kills the job's registered subprocesses via `process_registry.kill_all`.
4. That kill is what unblocks the stuck tool. The worker thread resumes, and its normal message flush (`_flush_messages_to_session_db` -> `SessionDB._execute_write`) runs `self._conn.execute("BEGIN IMMEDIATE")` on a connection that is now `None`. The resulting `AttributeError` is caught by the broad handler in `run_agent.py` and logged as a warning, and the tool-result row is dropped.

The teardown manufactures its own failure: it first closes the database out from under the worker, then wakes the worker up.

## Fix

Three coordinated changes in `cron/scheduler.py`, with no behavior change on the normal path:

- The inactivity-timeout branch now calls `process_registry.kill_all(task_id=...)` directly, right after `agent.interrupt(...)`. Unblocking the stuck tool no longer depends on `agent.close()` running early.
- The `finally:` teardown body moves into a new module-level helper, `_teardown_cron_job_resources`. When the future is `None` or already done (every path except an orphaned worker), it runs inline, exactly as before.
- When the future is still running, teardown ownership transfers to the future via `add_done_callback`: the session close, `agent.close()`, and stale-async-client reaping run on the worker thread the moment `run_conversation` actually returns, after its final writes have landed. A daemon `threading.Timer` bounds the deferral (`HERMES_CRON_TEARDOWN_HARDCAP`, default 900s) so a worker that never finishes cannot leak the SQLite handle, subprocesses, or httpx sockets indefinitely. Teardown is idempotent; future completion and the hard cap race safely and the first trigger wins.

## Validation

Standalone reproduction (single-worker executor plus a SessionDB-shaped sqlite fake mirroring `_execute_write` and `close`), run before and after the patch:

- Before: the current teardown ordering reproduces the exact log signature deterministically; the tool-result row is dropped.
- After: the teardown defers, the write lands (row present), teardown runs at future completion on the worker thread, and no file descriptors remain open on the db file.
- Hard cap: with a worker that never completes and a 1s cap, teardown is forced at ~1s while the future is still running, so the leak is bounded.

`python -m py_compile cron/scheduler.py` passes. Happy to add a regression test under `tests/` if you want one; the fake-SessionDB harness ports over cleanly.

## Notes for reviewers

- Deferred `end_session` means a timed-out job's session row stays open until its worker actually exits (or the cap fires). Arguably more accurate than before, but it is a visibility change worth knowing about.
- A small companion hardening in `hermes_state.py` (an explicit closed-connection check at the top of `_execute_write` that raises a typed `RuntimeError` instead of the bare `AttributeError`) makes the residual hard-cap race fail loudly and clearly. I can fold that into this PR or file it separately, whichever you prefer.
