### PR TITLE
fix: route cost_router through agent runtime

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -57,7 +57,7 @@ def _ra():
 
 
 AGENT_RUNTIME_POST_HOOK_TOOL_NAMES = frozenset(
-    {"todo", "session_search", "memory", "clarify", "read_terminal", "delegate_task"}
+    {"todo", "session_search", "memory", "clarify", "read_terminal", "delegate_task", "cost_router"}
 )
 
 
@@ -2211,6 +2211,13 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
     elif function_name == "delegate_task":
         def _execute(next_args: dict) -> Any:
             return _finish_agent_tool(agent._dispatch_delegate_task(next_args), next_args)
+    elif function_name == "cost_router":
+        def _execute(next_args: dict) -> Any:
+            from tools.delegate_tool import _handle_cost_router
+            result = _handle_cost_router(next_args, parent_agent=agent)
+            if not isinstance(result, str):
+                result = json.dumps(result, ensure_ascii=False)
+            return _finish_agent_tool(result, next_args)
     else:
         def _execute(next_args: dict) -> Any:
             return _ra().handle_function_call(

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -43,6 +43,7 @@ _NEVER_PARALLEL_TOOLS = frozenset({"clarify"})
 
 # Read-only tools with no shared mutable session state.
 _PARALLEL_SAFE_TOOLS = frozenset({
+    "cost_router",
     "ha_get_state",
     "ha_list_entities",
     "ha_list_services",

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1325,6 +1325,24 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     spinner.stop(cute_msg)
                 elif agent._should_emit_quiet_tool_messages():
                     agent._vprint(f"  {cute_msg}")
+        elif function_name == "cost_router":
+            def _execute(next_args: dict) -> Any:
+                from tools.delegate_tool import _handle_cost_router
+                result = _handle_cost_router(next_args, parent_agent=agent)
+                if not isinstance(result, str):
+                    result = json.dumps(result, ensure_ascii=False)
+                return result
+            function_result, function_args = _run_agent_tool_execution_middleware(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+                execute=_execute,
+            )
+            tool_duration = time.time() - tool_start_time
+            if agent._should_emit_quiet_tool_messages():
+                agent._vprint(f"  {_get_cute_tool_message_impl('cost_router', function_args, tool_duration, result=function_result)}")
         elif agent._context_engine_tool_names and function_name in agent._context_engine_tool_names:
             # Context engine tools (lcm_grep, lcm_describe, lcm_expand, etc.)
             spinner = None

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2537,6 +2537,18 @@ class TestConcurrentToolExecution:
                 mock_con.assert_called_once()
                 mock_seq.assert_not_called()
 
+    def test_cost_router_batch_uses_concurrent_path(self, agent):
+        """Cost-router batches should keep the concurrent dispatch path."""
+        tc1 = _mock_tool_call(name="cost_router", arguments='{"goal":"summarize"}', call_id="c1")
+        tc2 = _mock_tool_call(name="web_search", arguments='{"query":"x"}', call_id="c2")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
+        messages = []
+        with patch.object(agent, "_execute_tool_calls_sequential") as mock_seq:
+            with patch.object(agent, "_execute_tool_calls_concurrent") as mock_con:
+                agent._execute_tool_calls(mock_msg, messages, "task-1")
+                mock_con.assert_called_once()
+                mock_seq.assert_not_called()
+
     def test_terminal_batch_forces_sequential(self, agent):
         """Stateful tools should not share the concurrent execution path."""
         tc1 = _mock_tool_call(name="web_search", arguments='{}', call_id="c1")
@@ -2779,6 +2791,27 @@ class TestConcurrentToolExecution:
         assert [batch[-1]["tool_call_id"] for batch in flushed] == ["c1", "c2"]
         assert "fast-result" in flushed[0][-1]["content"]
         assert "timed out after" in flushed[1][-1]["content"]
+
+    def test_concurrent_cost_router_receives_parent_agent_and_preserves_order(self, agent):
+        """The concurrent path must dispatch cost_router with controller context."""
+        tc1 = _mock_tool_call(name="cost_router", arguments='{"goal":"summarize"}', call_id="c1")
+        tc2 = _mock_tool_call(name="web_search", arguments='{"query":"x"}', call_id="c2")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
+        messages = []
+
+        def fake_cost_router(args, parent_agent=None):
+            assert args == {"goal": "summarize"}
+            assert parent_agent is agent
+            return {"status": "dispatched", "route": "worker-dsflash"}
+
+        with patch("tools.delegate_tool._handle_cost_router", side_effect=fake_cost_router) as router:
+            with patch("run_agent.handle_function_call", side_effect=lambda name, args, task_id, **k: "ordinary-result"):
+                agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
+
+        router.assert_called_once()
+        assert [m["tool_call_id"] for m in messages] == ["c1", "c2"]
+        assert "worker-dsflash" in messages[0]["content"]
+        assert "ordinary-result" in messages[1]["content"]
 
     def test_concurrent_timeout_prefers_late_real_result_over_timeout_message(self, agent, monkeypatch):
         """A worker that finishes in the window between the deadline snapshot

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3426,6 +3426,19 @@ def _strip_model_hidden_task_fields(tasks: Any) -> Any:
     return stripped_tasks if changed else tasks
 
 
+def _handle_cost_router(args: dict[str, Any], parent_agent: Any = None) -> str:
+    """Route cost_router through the same runtime-aware delegation path."""
+    return delegate_task(
+        goal=args.get("goal"),
+        context=args.get("context"),
+        tasks=_strip_model_hidden_task_fields(args.get("tasks")),
+        max_iterations=args.get("max_iterations"),
+        role=args.get("role"),
+        background=_model_background_value(args, parent_agent),
+        parent_agent=parent_agent,
+    )
+
+
 registry.register(
     name="delegate_task",
     toolset="delegation",


### PR DESCRIPTION
## Summary
- allow cost_router batches to use the concurrent tool execution path
- route cost_router through the agent runtime in both concurrent and sequential dispatchers
- add regressions for parent_agent propagation, ordering, and dispatch path selection

## Test Plan
- python3 -m py_compile agent/tool_dispatch_helpers.py tools/delegate_tool.py agent/agent_runtime_helpers.py agent/tool_executor.py tests/run_agent/test_run_agent.py
- python3 -m pytest tests/run_agent/test_run_agent.py::TestAgentRuntimePostHookOwnershipSync -q
- python3 -m pytest tests/run_agent/test_run_agent.py -k 'cost_router or delegate_task or ConcurrentToolExecution' -q
- python3 -m pytest tests/run_agent/test_run_agent.py -q

## Docs
- README/docs not updated: this is an internal runtime dispatch fix with no public command, config, or user-facing behavior change.

## Notes
- Scoped added-line security scan found no matching secret/injection/deserialization patterns.