### PR TITLE
fix(dashboard-auth): prevent 500 crash on GET /auth/login?provider=basic (#58166)

### DIFF
--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -193,6 +193,12 @@ async def auth_login(request: Request, provider: str, next: str = ""):
             detail=f"Provider does not support interactive login: {provider!r}",
         )
 
+    # Password-only providers (BasicAuthProvider) have no OAuth redirect
+    # flow — render the login form directly instead of calling start_login()
+    # which would raise NotImplementedError → 500 (#58166).
+    if getattr(p, "supports_password", False):
+        return RedirectResponse(url="/login", status_code=302)
+
     try:
         ls = p.start_login(redirect_uri=_redirect_uri(request))
     except ProviderError as e:


### PR DESCRIPTION
Closes #58166

## Summary

`GET /auth/login?provider=basic` returns HTTP 500 because BasicAuthProvider.start_login() always raises NotImplementedError. The handler only catches ProviderError, so the raw NotImplementedError becomes a 500.

## Root Cause

`BasicAuthProvider` is password-only — it has no OAuth redirect flow. It correctly raises NotImplementedError when start_login() is called. But `auth_login()` in `dashboard_auth/routes.py` called `p.start_login()` unconditionally for every provider that passed the `supports_session` check.

## Fix

+6/-0: add a `supports_password` guard before the `start_login()` call. Password-only providers redirect directly to `/login` instead of attempting the OAuth flow.

The `POST /auth/password-login` endpoint already handles username+password authentication correctly.

## Files

`hermes_cli/dashboard_auth/routes.py` — `auth_login()` handler