### PR TITLE
fix: prune stale toolsets during config migration

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3014,7 +3014,7 @@ DEFAULT_CONFIG = {
 
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 32,
+    "_config_version": 33,
 }
 
 # =============================================================================
@@ -5489,6 +5489,61 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                     "the old default was written into your config as a literal "
                     "true. Set it to true again to re-enable, or \"auto\" for the "
                     "legacy surface-aware behavior."
+                )
+
+    # ── Version 32 → 33: prune stale persisted toolset names ──
+    # Removed or renamed toolsets should not linger in user configs forever.
+    # If a stale name stays in agent.enabled_toolsets or platform_toolsets.*,
+    # startup prints an "Unknown toolsets" warning on every launch until the
+    # user manually edits config.yaml. Drop names that no longer resolve and
+    # are not configured MCP servers.
+    if current_ver < 33:
+        config = read_raw_config()
+        mcp_names = set((config.get("mcp_servers") or {}).keys())
+        removed: List[str] = []
+        from toolsets import validate_toolset
+
+        def _keep_toolset(name: Any) -> bool:
+            return isinstance(name, str) and bool(name) and (
+                validate_toolset(name) or name in mcp_names
+            )
+
+        raw_agent = config.get("agent")
+        if isinstance(raw_agent, dict):
+            enabled = raw_agent.get("enabled_toolsets")
+            if isinstance(enabled, list):
+                filtered_enabled = [name for name in enabled if _keep_toolset(name)]
+                if filtered_enabled != enabled:
+                    removed.extend(
+                        name for name in enabled
+                        if isinstance(name, str) and name and name not in filtered_enabled
+                    )
+                    raw_agent["enabled_toolsets"] = filtered_enabled
+                    config["agent"] = raw_agent
+
+        platform_toolsets = config.get("platform_toolsets")
+        if isinstance(platform_toolsets, dict):
+            for platform, raw_toolsets in list(platform_toolsets.items()):
+                toolset_names = raw_toolsets if isinstance(raw_toolsets, list) else [raw_toolsets]
+                filtered_toolsets = [name for name in toolset_names if _keep_toolset(name)]
+                if filtered_toolsets != toolset_names:
+                    removed.extend(
+                        name for name in toolset_names
+                        if isinstance(name, str) and name and name not in filtered_toolsets
+                    )
+                    platform_toolsets[platform] = filtered_toolsets
+                    config["platform_toolsets"] = platform_toolsets
+
+        if removed:
+            unique_removed = sorted(set(removed))
+            save_config(config, strip_defaults=False)
+            results["config_added"].append(
+                f"pruned stale toolsets ({', '.join(unique_removed)})"
+            )
+            if not quiet:
+                print(
+                    "  ✓ Pruned stale toolset name(s) from agent.enabled_toolsets "
+                    f"and platform_toolsets: {', '.join(unique_removed)}"
                 )
 
     # ── Post-migration: disable exfiltration-shaped MCP stdio entries ──

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -808,6 +808,31 @@ class TestConfigVersionDetection:
             assert check_config_version() == (latest, latest)
 
 
+class TestStaleToolsetMigration:
+    def test_prunes_removed_toolsets_from_enabled_and_platform_toolsets(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 32,
+                    "agent": {"enabled_toolsets": ["terminal", "messaging"]},
+                    "platform_toolsets": {"cli": ["messaging", "terminal"]},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            results = migrate_config(interactive=False, quiet=True)
+            raw = read_raw_config()
+
+        assert raw["_config_version"] == DEFAULT_CONFIG["_config_version"]
+        assert raw["agent"]["enabled_toolsets"] == ["terminal"]
+        assert raw["platform_toolsets"]["cli"] == ["terminal"]
+        assert any("pruned stale toolsets" in item for item in results["config_added"])
+        assert not results["warnings"]
+
+
 class TestAnthropicTokenMigration:
     """Test that config version 8→9 clears ANTHROPIC_TOKEN."""
 


### PR DESCRIPTION
Fixes #52382.

Summary:
- Config migration now prunes stale persisted toolset names from agent.enabled_toolsets and platform_toolsets.
- Valid toolsets and MCP server names are preserved.
- Config version bumped to 33 so the migration runs on upgrade.

Validation:
- Real worker/script repro confirmed the stale messaging entry persisted before the fix and triggered the warning path.
- Direct runtime validation confirmed the migration now removes messaging and leaves terminal intact.
- pytest is unavailable in this sandbox, so the focused test file could not be run here.

Status:
- Draft PR intentionally left pending until dependency-complete validation can run.