### PR TITLE
fix(kanban): save default profile description to default home

### DIFF
--- a/hermes_cli/profile_describer.py
+++ b/hermes_cli/profile_describer.py
@@ -171,18 +171,18 @@ def describe_profile(
     ``description_auto: false`` to protect curated text. Auto-generated
     descriptions (``description_auto: true``) are always replaceable.
     """
-    canon = profiles_mod.normalize_profile_name(profile_name)
+    try:
+        canon = profiles_mod.normalize_profile_name(profile_name)
+        profiles_mod.validate_profile_name(canon)
+    except ValueError as exc:
+        fallback = str(profile_name).strip()
+        return DescribeOutcome(fallback, False, str(exc))
+
     if not profiles_mod.profile_exists(canon):
-        # Special case: "default" exists as a virtual profile name
-        # mapped to the default home dir. profile_exists() handles it.
         return DescribeOutcome(canon, False, "profile not found")
 
     try:
-        if canon == "default":
-            from hermes_constants import get_hermes_home  # type: ignore
-            profile_dir = Path(get_hermes_home())
-        else:
-            profile_dir = profiles_mod.get_profile_dir(canon)
+        profile_dir = profiles_mod.get_profile_dir(canon)
     except Exception as exc:
         return DescribeOutcome(canon, False, f"cannot resolve profile dir: {exc}")
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -2154,12 +2154,9 @@ def update_profile_description(profile_name: str, payload: DescribeBody):
     try:
         from hermes_cli import profiles as profiles_mod
         canon = profiles_mod.normalize_profile_name(profile_name)
-        if canon == "default":
-            from hermes_constants import get_hermes_home  # type: ignore
-            from pathlib import Path as _Path
-            profile_dir = _Path(get_hermes_home())
-        else:
-            profile_dir = profiles_mod.get_profile_dir(canon)
+        # get_profile_dir resolves "default" to the canonical ~/.hermes root
+        # independent of which profile the dashboard process is running under.
+        profile_dir = profiles_mod.get_profile_dir(canon)
         if not profile_dir.is_dir():
             raise HTTPException(status_code=404, detail=f"profile '{profile_name}' not found")
         text = (payload.description or "").strip()

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -2154,6 +2154,10 @@ def update_profile_description(profile_name: str, payload: DescribeBody):
     try:
         from hermes_cli import profiles as profiles_mod
         canon = profiles_mod.normalize_profile_name(profile_name)
+        try:
+            profiles_mod.validate_profile_name(canon)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
         # get_profile_dir resolves "default" to the canonical ~/.hermes root
         # independent of which profile the dashboard process is running under.
         profile_dir = profiles_mod.get_profile_dir(canon)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -236,6 +236,7 @@ AUTHOR_MAP = {
     "alberto.regalado@ymail.com": "ARegalado1",
     "alchemistchaos@protonmail.com": "AlchemistChaos",  # co-author only
     "gilad@smiti.ai": "giladbau",
+    "pasevin@gmail.com": "pasevin",
     "yusufalweshdemir@gmail.com": "Dusk1e",
     "804436395@qq.com": "LaPhilosophie",
     "maxmitcham@mac.home": "maxtrigify",

--- a/tests/hermes_cli/test_profile_describer.py
+++ b/tests/hermes_cli/test_profile_describer.py
@@ -87,6 +87,17 @@ def _patch_aux_client(content: str):
     )
 
 
+@pytest.fixture
+def multi_profile_env(tmp_path, monkeypatch):
+    """Default profile root plus one active named profile."""
+    default_home = tmp_path / ".hermes"
+    worker_dir = default_home / "profiles" / "worker"
+    worker_dir.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(worker_dir))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    return {"default": default_home, "worker": worker_dir}
+
+
 def test_describer_writes_description_with_auto_true(profile_env, monkeypatch):
     # Pretend "myprof" is a registered profile pointing at profile_env.
     monkeypatch.setattr(
@@ -166,3 +177,40 @@ def test_describer_returns_false_when_profile_missing(profile_env, monkeypatch):
     outcome = describer.describe_profile("ghost")
     assert outcome.ok is False
     assert "not found" in outcome.reason
+
+
+def test_describer_default_profile_uses_canonical_default_home_under_named_profile(
+    multi_profile_env,
+):
+    """Auto-describing default must not write to the active named profile."""
+    payload = jsonlib.dumps({"description": "default route planner"})
+    with _patch_aux_client(payload), patch(
+        "agent.auxiliary_client.get_auxiliary_extra_body", return_value={}
+    ):
+        outcome = describer.describe_profile("default", overwrite=True)
+
+    assert outcome.ok, outcome.reason
+    default_yaml = multi_profile_env["default"] / "profile.yaml"
+    worker_yaml = multi_profile_env["worker"] / "profile.yaml"
+    assert default_yaml.exists(), "default profile.yaml was not written"
+    assert not worker_yaml.exists(), "active named profile was incorrectly written"
+    meta = profiles_mod.read_profile_meta(multi_profile_env["default"])
+    assert meta == {"description": "default route planner", "description_auto": True}
+
+
+@pytest.mark.parametrize("bad_name", ["..", "bad.name"])
+def test_describer_invalid_profile_name_returns_false_without_writing_metadata(
+    multi_profile_env,
+    bad_name,
+):
+    payload = jsonlib.dumps({"description": "should not be written"})
+    with _patch_aux_client(payload), patch(
+        "agent.auxiliary_client.get_auxiliary_extra_body", return_value={}
+    ):
+        outcome = describer.describe_profile(bad_name, overwrite=True)
+
+    assert outcome.profile_name == bad_name
+    assert outcome.ok is False
+    assert "Invalid profile name" in outcome.reason
+    assert not (multi_profile_env["default"] / "profile.yaml").exists()
+    assert not (multi_profile_env["worker"] / "profile.yaml").exists()

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -2409,3 +2409,28 @@ def test_patch_unknown_profile_returns_404(profile_client):
         json={"description": "whatever"},
     )
     assert res.status_code == 404
+
+
+@pytest.mark.parametrize("profile_path", ["%2E%2E", "bad.name"])
+def test_patch_invalid_profile_name_returns_400_without_writing_metadata(
+    profile_client,
+    profile_path,
+):
+    """Invalid profile path segments must not resolve to profile dirs."""
+    client, dirs = profile_client
+    default_yaml = dirs["default"] / "profile.yaml"
+    worker_yaml = dirs["worker"] / "profile.yaml"
+
+    res = client.patch(
+        f"/api/plugins/kanban/profiles/{profile_path}",
+        json={"description": "pwn"},
+    )
+
+    failures = []
+    if res.status_code != 400:
+        failures.append(f"expected HTTP 400, got {res.status_code}: {res.text}")
+    if default_yaml.exists():
+        failures.append("default profile.yaml was written for an invalid profile name")
+    if worker_yaml.exists():
+        failures.append("worker profile.yaml was written for an invalid profile name")
+    assert not failures, "; ".join(failures)

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -2265,3 +2265,147 @@ def test_dashboard_failed_card_highlight_class_exists():
     assert "hermes-kanban-card--failed" in js
     assert "hermes-kanban-card--failed" in css
     assert "failedIds" in js
+
+
+# ---------------------------------------------------------------------------
+# Profile description endpoint — regression tests for get_profile_dir fix
+#
+# The bug: update_profile_description() used get_hermes_home() for the
+# "default" profile, which returns the *active process* HERMES_HOME.  When
+# the dashboard runs under a non-default profile the write landed in the
+# wrong directory.  These tests lock in the correct behaviour: the "default"
+# profile always writes to the canonical ~/.hermes root, not to whatever
+# profile HERMES_HOME is currently pointing at.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def multi_profile_home(tmp_path, monkeypatch):
+    """Two-profile isolated environment.
+
+    Layout:
+        tmp_path/
+          .hermes/              <- default profile root  (canonical ~/.hermes)
+          .hermes/profiles/
+            worker/             <- a named non-default profile
+
+    HERMES_HOME is set to the *worker* profile directory to simulate the
+    dashboard running under a non-default profile — the exact scenario that
+    triggered the bug.
+    """
+    default_home = tmp_path / ".hermes"
+    default_home.mkdir(parents=True)
+    (default_home / "profiles").mkdir()
+    worker_dir = default_home / "profiles" / "worker"
+    worker_dir.mkdir()
+
+    # Point HERMES_HOME at the worker profile (non-default active profile).
+    monkeypatch.setenv("HERMES_HOME", str(worker_dir))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    # Initialise a kanban DB so the router mounts without errors.
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    kb.init_db()
+    monkeypatch.setenv("HERMES_HOME", str(worker_dir))
+
+    return {"default": default_home, "worker": worker_dir}
+
+
+@pytest.fixture
+def profile_client(multi_profile_home):
+    app = FastAPI()
+    app.include_router(_load_plugin_router(), prefix="/api/plugins/kanban")
+    return TestClient(app), multi_profile_home
+
+
+def test_patch_default_profile_description_writes_to_default_home(profile_client):
+    """PATCH /profiles/default must write to ~/.hermes/profile.yaml.
+
+    Regression: when HERMES_HOME points to a non-default profile the old
+    code wrote to the active profile's directory instead.
+    """
+    client, dirs = profile_client
+    default_home = dirs["default"]
+    worker_dir = dirs["worker"]
+
+    res = client.patch(
+        "/api/plugins/kanban/profiles/default",
+        json={"description": "default role description"},
+    )
+    assert res.status_code == 200, res.text
+    data = res.json()
+    assert data["ok"] is True
+    assert data["description"] == "default role description"
+
+    # profile.yaml must exist in the default profile root.
+    default_yaml = default_home / "profile.yaml"
+    assert default_yaml.exists(), "profile.yaml not written to default profile root"
+
+    import yaml
+    written = yaml.safe_load(default_yaml.read_text())
+    assert written["description"] == "default role description"
+
+    # The worker profile must NOT have been touched.
+    worker_yaml = worker_dir / "profile.yaml"
+    assert not worker_yaml.exists(), (
+        "profile.yaml was incorrectly written to the worker profile directory"
+    )
+
+
+def test_patch_named_profile_description_writes_to_correct_dir(profile_client):
+    """PATCH /profiles/worker must write to the worker profile directory only."""
+    client, dirs = profile_client
+    default_home = dirs["default"]
+    worker_dir = dirs["worker"]
+
+    res = client.patch(
+        "/api/plugins/kanban/profiles/worker",
+        json={"description": "specialist worker role"},
+    )
+    assert res.status_code == 200, res.text
+
+    worker_yaml = worker_dir / "profile.yaml"
+    assert worker_yaml.exists(), "profile.yaml not written to worker profile directory"
+
+    import yaml
+    written = yaml.safe_load(worker_yaml.read_text())
+    assert written["description"] == "specialist worker role"
+
+    # The default profile must NOT have been touched.
+    default_yaml = default_home / "profile.yaml"
+    assert not default_yaml.exists(), (
+        "profile.yaml was incorrectly written to the default profile root"
+    )
+
+
+def test_patch_default_and_named_profile_descriptions_are_independent(profile_client):
+    """Saving both profiles writes to separate files with independent content."""
+    client, dirs = profile_client
+    default_home = dirs["default"]
+    worker_dir = dirs["worker"]
+
+    client.patch(
+        "/api/plugins/kanban/profiles/default",
+        json={"description": "orchestrator"},
+    )
+    client.patch(
+        "/api/plugins/kanban/profiles/worker",
+        json={"description": "implementer"},
+    )
+
+    import yaml
+    default_written = yaml.safe_load((default_home / "profile.yaml").read_text())
+    worker_written = yaml.safe_load((worker_dir / "profile.yaml").read_text())
+
+    assert default_written["description"] == "orchestrator"
+    assert worker_written["description"] == "implementer"
+
+
+def test_patch_unknown_profile_returns_404(profile_client):
+    """PATCH /profiles/<nonexistent> must return 404."""
+    client, _ = profile_client
+    res = client.patch(
+        "/api/plugins/kanban/profiles/does-not-exist",
+        json={"description": "whatever"},
+    )
+    assert res.status_code == 404

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -8,6 +8,7 @@ REST surface without spinning up the whole dashboard.
 from __future__ import annotations
 
 import importlib.util
+import json
 import os
 import sys
 import time
@@ -18,6 +19,26 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from hermes_cli import kanban_db as kb
+
+
+def _patch_auto_describe_aux(monkeypatch, description: str):
+    """Patch the profile describer's auxiliary client with a deterministic reply."""
+    from unittest.mock import MagicMock
+
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = json.dumps({"description": description})
+    client = MagicMock()
+    client.chat.completions.create = MagicMock(return_value=response)
+    import agent.auxiliary_client as aux_client
+
+    monkeypatch.setattr(
+        aux_client,
+        "get_text_auxiliary_client",
+        lambda purpose: (client, "test-model"),
+    )
+    monkeypatch.setattr(aux_client, "get_auxiliary_extra_body", lambda: {})
+    return client
 
 
 # ---------------------------------------------------------------------------
@@ -2434,3 +2455,50 @@ def test_patch_invalid_profile_name_returns_400_without_writing_metadata(
     if worker_yaml.exists():
         failures.append("worker profile.yaml was written for an invalid profile name")
     assert not failures, "; ".join(failures)
+
+
+def test_auto_describe_default_profile_writes_to_default_home(profile_client, monkeypatch):
+    """POST /profiles/default/describe-auto must use the canonical default root."""
+    client, dirs = profile_client
+    default_home = dirs["default"]
+    worker_dir = dirs["worker"]
+    _patch_auto_describe_aux(monkeypatch, "auto generated default role")
+
+    res = client.post(
+        "/api/plugins/kanban/profiles/default/describe-auto",
+        json={"overwrite": True},
+    )
+
+    assert res.status_code == 200, res.text
+    data = res.json()
+    assert data["ok"] is True
+    assert data["description"] == "auto generated default role"
+    default_yaml = default_home / "profile.yaml"
+    worker_yaml = worker_dir / "profile.yaml"
+    assert default_yaml.exists(), "profile.yaml not written to default profile root"
+    assert not worker_yaml.exists(), (
+        "profile.yaml was incorrectly written to the worker profile directory"
+    )
+
+
+@pytest.mark.parametrize("profile_path", ["%2E%2E", "bad.name"])
+def test_auto_describe_invalid_profile_name_returns_not_ok_without_writing_metadata(
+    profile_client,
+    monkeypatch,
+    profile_path,
+):
+    """Invalid auto-describe path segments must not resolve to profile dirs."""
+    client, dirs = profile_client
+    _patch_auto_describe_aux(monkeypatch, "should not be written")
+
+    res = client.post(
+        f"/api/plugins/kanban/profiles/{profile_path}/describe-auto",
+        json={"overwrite": True},
+    )
+
+    assert res.status_code == 200, res.text
+    data = res.json()
+    assert data["ok"] is False
+    assert "Invalid profile name" in data["reason"]
+    assert not (dirs["default"] / "profile.yaml").exists()
+    assert not (dirs["worker"] / "profile.yaml").exists()


### PR DESCRIPTION
## Summary
- Fixes Kanban dashboard profile-description saves so `default` always resolves to the canonical `~/.hermes` profile root, not the dashboard process profile.
- Adds regression coverage for default-profile save, named-profile save, independent default/named saves, and unknown-profile 404.
- Preserves contributor authorship by cherry-picking the existing external fix/test commits from #41428.

Fixes #41422
References #41428

## Root cause
`plugins/kanban/dashboard/plugin_api.py::update_profile_description()` special-cased `default` with `get_hermes_home()`. Under `hermes -p <named> dashboard`, `get_hermes_home()` is the named profile's `HERMES_HOME`, so saving the default profile description from Kanban → Orchestration settings wrote to the active named profile instead of `~/.hermes/profile.yaml`.

The normal profile resolver already handles this correctly: `profiles_mod.get_profile_dir("default")` returns the canonical default profile root independent of the process profile.

## Why prior regression coverage missed it
Existing dashboard/web-server profile tests covered `/api/profiles/{name}/description`, not the Kanban plugin endpoint `/api/plugins/kanban/profiles/{profile_name}`. The missing case was specifically "plugin save for `default` while process `HERMES_HOME` points at a named profile".

## TDD proof
RED:
`HOME=/home/fardochebot scripts/run_tests.sh tests/plugins/test_kanban_dashboard_plugin.py -k 'patch_default_profile_description_writes_to_default_home' -q`

Failed before the fix with:
`AssertionError: profile.yaml not written to default profile root`

GREEN:
`HOME=/home/fardochebot scripts/run_tests.sh tests/plugins/test_kanban_dashboard_plugin.py -k 'patch_default_profile_description_writes_to_default_home or patch_named_profile_description_writes_to_correct_dir or patch_default_and_named_profile_descriptions_are_independent or patch_unknown_profile_returns_404' -q`

Result: 4 passed.

REGRESSION:
`HOME=/home/fardochebot scripts/run_tests.sh tests/plugins/test_kanban_dashboard_plugin.py -q`

Result: 100 passed.

Additional checks:
- `HOME=/home/fardochebot /home/fardochebot/.hermes/hermes-agent/venv/bin/python -m py_compile plugins/kanban/dashboard/plugin_api.py scripts/release.py tests/plugins/test_kanban_dashboard_plugin.py`
- `git diff --check`
