### PR TITLE
fix(mem0): OSSBackend.get_all silently capped at 20 memories

### DIFF
--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -194,7 +194,13 @@ class OSSBackend(Mem0Backend):
         return _unwrap_results(response)
 
     def get_all(self, *, filters: dict, page: int = 1, page_size: int = 100) -> dict:
-        response = self._memory.get_all(filters=filters)
+        # //// Neoffice — mem0 v3's Memory.get_all defaults to top_k=20, which
+        # silently caps this "list EVERYTHING then paginate in memory" call to
+        # the first 20 memories of the bucket (mem0_list looked complete on
+        # small test stores and truncated in production). Ask for effectively
+        # all rows; the in-memory pagination below stays authoritative.
+        response = self._memory.get_all(filters=filters, top_k=100000)
+        # //// END Neoffice ////
         all_results = _unwrap_results(response)
         total = len(all_results)
         start = (page - 1) * page_size


### PR DESCRIPTION
mem0 v3's `Memory.get_all` defaults to `top_k=20`. The OSS backend's `get_all` never passes `top_k`, so its "fetch everything, then paginate in memory" contract only ever sees the first 20 memories — users with more silently lose access to the rest (we hit this migrating a 47-memory store: only 20 came back).

Fix: pass an effectively-unbounded `top_k` in `OSSBackend.get_all` so pagination happens on the full set, as the surrounding code already assumes.

Found while running the OSS backend (qdrant embedded) in production on the v2026.7.1 tag.