### PR TITLE
fix(send_message): preserve home thread for bare targets

### DIFF
--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -90,3 +90,46 @@ def test_send_message_routes_whatsapp_group_jid_without_home_fallback() -> None:
         force_document=False,
     )
 
+
+def test_bare_platform_home_fallback_preserves_thread_id() -> None:
+    telegram_cfg = SimpleNamespace(enabled=True, token="tok", extra={})
+    home = SimpleNamespace(chat_id="12345", thread_id="777")
+    config = SimpleNamespace(
+        platforms={Platform.TELEGRAM: telegram_cfg},
+        get_home_channel=lambda _platform: home,
+    )
+
+    with patch("gateway.config.load_gateway_config", return_value=config), \
+         patch("tools.interrupt.is_interrupted", return_value=False), \
+         patch("model_tools._run_async", side_effect=_run_async_immediately), \
+         patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+         patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+        result = json.loads(
+            send_message_tool(
+                {
+                    "action": "send",
+                    "target": "telegram",
+                    "message": "hello topic",
+                }
+            )
+        )
+
+    assert result["success"] is True
+    assert result["note"] == "Sent to telegram home channel (chat_id: 12345)"
+    send_mock.assert_awaited_once_with(
+        Platform.TELEGRAM,
+        telegram_cfg,
+        "12345",
+        "hello topic",
+        thread_id="777",
+        media_files=[],
+        force_document=False,
+    )
+    mirror_mock.assert_called_once_with(
+        "telegram",
+        "12345",
+        "hello topic",
+        source_label="cli",
+        thread_id="777",
+        user_id=None,
+    )

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -393,6 +393,8 @@ def _handle_send(args):
                 home = HomeChannel(platform=platform, chat_id=wx_home, name="Weixin Home")
         if home:
             chat_id = home.chat_id
+            if thread_id is None and getattr(home, "thread_id", None):
+                thread_id = home.thread_id
             used_home_channel = True
         else:
             home_env = _HOME_CHANNEL_ENV_OVERRIDES.get(


### PR DESCRIPTION
## What does this PR do?

Preserves the configured home-channel thread when `send_message` resolves a bare platform target such as `telegram`. Before this change, `hermes send --to telegram ...` copied `home.chat_id` but left `thread_id=None`, so Telegram DM-topic home channels could receive the message in the root/lobby instead of the configured topic.

The fix keeps explicit target precedence intact: `home.thread_id` is inherited only when the target did not already provide a thread. The regression test also verifies the mirrored gateway session receives the same thread id.

## Related Issue

Fixes #58299

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tools/send_message_tool.py` — inherit `home.thread_id` in the bare-platform home-channel fallback when no explicit thread was provided.
- `tests/tools/test_send_message_target_parse.py` — add lightweight regression coverage for send dispatch and mirror writes preserving the inherited home thread.

## How to Test

1. `python -m pytest tests/tools/test_send_message_target_parse.py -q`
2. `python -m pytest tests/tools/test_send_message_tool.py::TestSendMessageTool::test_cron_duplicate_target_is_skipped_and_explained tests/tools/test_send_message_tool.py::TestSendMessageTool::test_resolved_telegram_topic_name_preserves_thread_id tests/tools/test_send_message_tool.py::TestSendMessageTool::test_mirror_receives_current_session_user_id -q`
3. `python -m ruff check tools/send_message_tool.py tests/tools/test_send_message_target_parse.py`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS / local Hermes lane 1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact — no platform-specific code beyond existing routing fields
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

The pre-fix regression assertion failed with `_send_to_platform(..., thread_id=None, ...)` for a bare `telegram` target despite `home.thread_id="777"`. After the fix, the same path passes with `thread_id="777"` for both send dispatch and session mirror.
