### PR TITLE
[codex] Surface API tool output previews

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -95,6 +95,7 @@ MAX_REQUEST_BYTES = 10_000_000  # 10 MB — accommodates long agent conversation
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
+TOOL_PROGRESS_OUTPUT_PREVIEW_CHARS = 2_000
 
 
 def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
@@ -132,6 +133,23 @@ def _coerce_request_bool(value: Any, default: bool = False) -> bool:
     if isinstance(value, (int, float)):
         return bool(value)
     return default
+
+
+def _tool_result_preview(result: Any, limit: int = TOOL_PROGRESS_OUTPUT_PREVIEW_CHARS) -> str:
+    """Return a bounded, redacted text preview for tool-completion SSE events."""
+    if result is None:
+        return ""
+    if isinstance(result, str):
+        text = result
+    else:
+        try:
+            text = json.dumps(result, ensure_ascii=False, default=str)
+        except Exception:
+            text = str(result)
+    text = redact_sensitive_text(text.strip(), force=True)
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit]}... [truncated {len(text) - limit} chars]"
 
 
 def _normalize_chat_content(
@@ -2121,12 +2139,16 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Allow caller to continue an existing session by passing X-Hermes-Session-Id.
         # When provided, history is loaded from state.db instead of from the request body.
+        # If no stored transcript exists yet, keep the request history so a client
+        # can introduce a stable session id for an already-local conversation
+        # without losing context on the first keyed turn.
         #
         # Security: session continuation exposes conversation history, so it is
         # only allowed when the API key is configured and the request is
         # authenticated.  Without this gate, any unauthenticated client could
         # read arbitrary session history by guessing/enumerating session IDs.
         provided_session_id = request.headers.get("X-Hermes-Session-Id", "").strip()
+        request_history = list(history)
         if provided_session_id:
             if not self._api_key:
                 logger.warning(
@@ -2161,10 +2183,11 @@ class APIServerAdapter(BasePlatformAdapter):
             try:
                 db = self._ensure_session_db()
                 if db is not None:
-                    history = db.get_messages_as_conversation(session_id)
+                    stored_history = db.get_messages_as_conversation(session_id)
+                    history = stored_history or request_history
             except Exception as e:
                 logger.warning("Failed to load session history for %s: %s", session_id, e)
-                history = []
+                history = request_history
         else:
             # Derive a stable session ID from the conversation fingerprint so
             # that consecutive messages from the same Open WebUI (or similar)
@@ -2248,6 +2271,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "tool": function_name,
                     "toolCallId": tool_call_id,
                     "status": "completed",
+                    "output": _tool_result_preview(function_result),
                 }))
 
             # Start agent in background.  agent_ref is a mutable container
@@ -2435,6 +2459,7 @@ class APIServerAdapter(BasePlatformAdapter):
             }
             await response.write(f"data: {json.dumps(role_chunk)}\n\n".encode())
             last_activity = time.monotonic()
+            sent_content = False
 
             # Helper — route a queue item to the correct SSE event.
             async def _emit(item):
@@ -2447,12 +2472,15 @@ class APIServerAdapter(BasePlatformAdapter):
                 conversation history.  See #6972 for the original event,
                 #16588 for the ``toolCallId``/``status`` lifecycle fields.
                 """
+                nonlocal sent_content
                 if isinstance(item, tuple) and len(item) == 2 and item[0] == "__tool_progress__":
                     event_data = json.dumps(item[1])
                     await response.write(
                         f"event: hermes.tool.progress\ndata: {event_data}\n\n".encode()
                     )
                 else:
+                    if item:
+                        sent_content = True
                     content_chunk = {
                         "id": completion_id, "object": "chat.completion.chunk",
                         "created": created, "model": model,
@@ -2525,6 +2553,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 finish_reason = "error"
             else:
                 finish_reason = "stop"
+
+            if isinstance(result, dict) and not sent_content:
+                final_response = str(result.get("final_response") or "")
+                if final_response:
+                    last_activity = await _emit(final_response)
 
             # Finish chunk
             finish_chunk = {
@@ -4110,7 +4143,13 @@ class APIServerAdapter(BasePlatformAdapter):
         self._run_statuses[run_id] = current
         return current
 
-    def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
+    def _make_run_event_callback(
+        self,
+        run_id: str,
+        loop: "asyncio.AbstractEventLoop",
+        *,
+        emit_tool_lifecycle: bool = True,
+    ):
         """Return a tool_progress_callback that pushes structured events to the run's SSE queue."""
         def _push(event: Dict[str, Any]) -> None:
             self._set_run_status(
@@ -4129,6 +4168,8 @@ class APIServerAdapter(BasePlatformAdapter):
         def _callback(event_type: str, tool_name: str = None, preview: str = None, args=None, **kwargs):
             ts = time.time()
             if event_type == "tool.started":
+                if not emit_tool_lifecycle:
+                    return
                 _push({
                     "event": "tool.started",
                     "run_id": run_id,
@@ -4137,6 +4178,8 @@ class APIServerAdapter(BasePlatformAdapter):
                     "preview": preview,
                 })
             elif event_type == "tool.completed":
+                if not emit_tool_lifecycle:
+                    return
                 _push({
                     "event": "tool.completed",
                     "run_id": run_id,
@@ -4155,6 +4198,57 @@ class APIServerAdapter(BasePlatformAdapter):
             # _thinking and subagent_progress are intentionally not forwarded
 
         return _callback
+
+    def _make_run_tool_callbacks(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
+        """Return structured tool callbacks with call ids and bounded output previews."""
+        started_tool_call_ids: set[str] = set()
+
+        def _push(event: Dict[str, Any]) -> None:
+            self._set_run_status(
+                run_id,
+                self._run_statuses.get(run_id, {}).get("status", "running"),
+                last_event=event.get("event"),
+            )
+            q = self._run_streams.get(run_id)
+            if q is None:
+                return
+            try:
+                loop.call_soon_threadsafe(q.put_nowait, event)
+            except Exception:
+                pass
+
+        def _on_tool_start(tool_call_id, function_name, function_args):
+            if not tool_call_id or str(function_name or "").startswith("_"):
+                return
+            started_tool_call_ids.add(tool_call_id)
+            from agent.display import build_tool_preview
+            label = build_tool_preview(function_name, function_args) or function_name
+            _push({
+                "event": "tool.started",
+                "run_id": run_id,
+                "timestamp": time.time(),
+                "tool": function_name,
+                "preview": label,
+                "tool_call_id": tool_call_id,
+            })
+
+        def _on_tool_complete(tool_call_id, function_name, function_args, function_result):
+            if not tool_call_id or tool_call_id not in started_tool_call_ids:
+                return
+            started_tool_call_ids.discard(tool_call_id)
+            from agent.display import _detect_tool_failure
+            is_error, _ = _detect_tool_failure(function_name, function_result)
+            _push({
+                "event": "tool.completed",
+                "run_id": run_id,
+                "timestamp": time.time(),
+                "tool": function_name,
+                "tool_call_id": tool_call_id,
+                "error": is_error,
+                "output": _tool_result_preview(function_result),
+            })
+
+        return _on_tool_start, _on_tool_complete
 
     async def _handle_runs(self, request: "web.Request") -> "web.Response":
         """POST /v1/runs — start an agent run, return run_id immediately."""
@@ -4249,7 +4343,12 @@ class APIServerAdapter(BasePlatformAdapter):
         self._run_streams_created[run_id] = created_at
         self._run_approval_sessions[run_id] = approval_session_key
 
-        event_cb = self._make_run_event_callback(run_id, loop)
+        event_cb = self._make_run_event_callback(
+            run_id,
+            loop,
+            emit_tool_lifecycle=False,
+        )
+        tool_start_cb, tool_complete_cb = self._make_run_tool_callbacks(run_id, loop)
 
         # Also wire stream_delta_callback so message.delta events flow through.
         def _text_cb(delta: Optional[str]) -> None:
@@ -4284,6 +4383,8 @@ class APIServerAdapter(BasePlatformAdapter):
                     session_id=session_id,
                     stream_delta_callback=_text_cb,
                     tool_progress_callback=event_cb,
+                    tool_start_callback=tool_start_cb,
+                    tool_complete_callback=tool_complete_cb,
                     gateway_session_key=gateway_session_key,
                     route=route,
                 )

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1290,6 +1290,31 @@ class TestChatCompletionsEndpoint:
                 assert " about it..." in body
 
     @pytest.mark.asyncio
+    async def test_stream_falls_back_to_final_response_without_deltas(self, adapter):
+        """If the agent does not emit token deltas, stream final_response before DONE."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                return (
+                    {"final_response": "Fallback text", "messages": [], "api_calls": 1},
+                    {"input_tokens": 10, "output_tokens": 3, "total_tokens": 13},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+                assert "Fallback text" in body
+                assert "[DONE]" in body
+
+    @pytest.mark.asyncio
     async def test_stream_includes_tool_progress(self, adapter):
         """tool_start_callback fires → progress appears as custom SSE event, not in delta.content."""
         import asyncio
@@ -1444,11 +1469,11 @@ class TestChatCompletionsEndpoint:
                 assert resp.status == 200
                 body = await resp.text()
 
-            # Walk the SSE body and collect *(status, toolCallId)* pairs
+            # Walk the SSE body and collect *(status, toolCallId, output)* tuples
             # per event so the assertions verify per-event correlation —
             # an event missing ``toolCallId`` would not pass even if a
             # different event happens to carry the right id.
-            pairs: list[tuple[str | None, str | None]] = []
+            pairs: list[tuple[str | None, str | None, str | None]] = []
             lines = body.splitlines()
             for i, line in enumerate(lines):
                 if line.strip() != "event: hermes.tool.progress":
@@ -1459,7 +1484,11 @@ class TestChatCompletionsEndpoint:
                             payload = _json.loads(follow[len("data: "):])
                         except _json.JSONDecodeError:
                             break
-                        pairs.append((payload.get("status"), payload.get("toolCallId")))
+                        pairs.append((
+                            payload.get("status"),
+                            payload.get("toolCallId"),
+                            payload.get("output"),
+                        ))
                         break
 
             # Each tool start must emit exactly one event (no duplicate
@@ -1467,8 +1496,8 @@ class TestChatCompletionsEndpoint:
             # same toolCallId on every event — not just somewhere in the
             # aggregate.
             assert len(pairs) == 2, f"expected 2 events (running+completed), got {pairs}"
-            assert pairs[0] == ("running", "call_terminal_1"), pairs
-            assert pairs[1] == ("completed", "call_terminal_1"), pairs
+            assert pairs[0] == ("running", "call_terminal_1", None), pairs
+            assert pairs[1] == ("completed", "call_terminal_1", "ok"), pairs
 
     @pytest.mark.asyncio
     async def test_stream_tool_lifecycle_skips_internal_and_orphan_completes(self, adapter):
@@ -3596,8 +3625,41 @@ class TestSessionIdHeader:
             assert call_kwargs["user_message"] == "new question"
 
     @pytest.mark.asyncio
-    async def test_db_failure_falls_back_to_empty_history(self, auth_adapter):
-        """If SessionDB raises, history falls back to empty and request still succeeds."""
+    async def test_provided_session_id_with_empty_db_uses_request_history(self, auth_adapter):
+        """A new keyed session should keep client history until DB transcript state exists."""
+        mock_result = {"final_response": "OK", "messages": [], "api_calls": 1}
+        mock_db = MagicMock()
+        mock_db.get_messages_as_conversation.return_value = []
+        auth_adapter._session_db = mock_db
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"X-Hermes-Session-Id": "new-keyed-session", "Authorization": "Bearer sk-secret"},
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [
+                            {"role": "user", "content": "old msg from client"},
+                            {"role": "assistant", "content": "old reply from client"},
+                            {"role": "user", "content": "new question"},
+                        ],
+                    },
+                )
+
+            assert resp.status == 200
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["conversation_history"] == [
+                {"role": "user", "content": "old msg from client"},
+                {"role": "assistant", "content": "old reply from client"},
+            ]
+            assert call_kwargs["user_message"] == "new question"
+
+    @pytest.mark.asyncio
+    async def test_db_failure_falls_back_to_request_history(self, auth_adapter):
+        """If SessionDB raises, request history is retained and request still succeeds."""
         mock_result = {"final_response": "OK", "messages": [], "api_calls": 1}
         # Simulate DB failure: _session_db is None and SessionDB() constructor raises
         auth_adapter._session_db = None
@@ -3610,12 +3672,23 @@ class TestSessionIdHeader:
                 resp = await cli.post(
                     "/v1/chat/completions",
                     headers={"X-Hermes-Session-Id": "some-session", "Authorization": "Bearer sk-secret"},
-                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "Hi"}]},
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [
+                            {"role": "user", "content": "old msg from client"},
+                            {"role": "assistant", "content": "old reply from client"},
+                            {"role": "user", "content": "new question"},
+                        ],
+                    },
                 )
 
             assert resp.status == 200
             call_kwargs = mock_run.call_args.kwargs
-            assert call_kwargs["conversation_history"] == []
+            assert call_kwargs["conversation_history"] == [
+                {"role": "user", "content": "old msg from client"},
+                {"role": "assistant", "content": "old reply from client"},
+            ]
+            assert call_kwargs["user_message"] == "new question"
             assert call_kwargs["session_id"] == "some-session"
 
 

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -9,6 +9,7 @@ Covers:
 """
 
 import asyncio
+import json
 import threading
 from unittest.mock import MagicMock, patch
 
@@ -305,6 +306,55 @@ class TestRunEvents:
                 assert "run.completed" in body
                 assert "Hello!" in body
 
+    @pytest.mark.asyncio
+    async def test_events_stream_includes_tool_completed_output_preview(self, adapter):
+        """Completed tool events should include a bounded result preview."""
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            def _create_agent(**kwargs):
+                mock_agent = MagicMock()
+
+                def _run_conversation(user_message=None, conversation_history=None, task_id=None):
+                    start_cb = kwargs.get("tool_start_callback")
+                    complete_cb = kwargs.get("tool_complete_callback")
+                    if start_cb:
+                        start_cb("call_terminal_1", "terminal", {"command": "printf ok"})
+                    if complete_cb:
+                        complete_cb(
+                            "call_terminal_1",
+                            "terminal",
+                            {"command": "printf ok"},
+                            {"output": "RUN_TOOL_PREVIEW_OK", "exit_code": 0},
+                        )
+                    return {"final_response": "done"}
+
+                mock_agent.run_conversation.side_effect = _run_conversation
+                mock_agent.session_prompt_tokens = 4
+                mock_agent.session_completion_tokens = 2
+                mock_agent.session_total_tokens = 6
+                return mock_agent
+
+            with patch.object(adapter, "_create_agent", side_effect=_create_agent):
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                assert resp.status == 202
+                data = await resp.json()
+                run_id = data["run_id"]
+
+                events_resp = await cli.get(f"/v1/runs/{run_id}/events")
+                assert events_resp.status == 200
+                body = await events_resp.text()
+
+        events = [
+            json.loads(line[len("data: "):])
+            for line in body.splitlines()
+            if line.startswith("data: ")
+        ]
+        completed_tools = [event for event in events if event.get("event") == "tool.completed"]
+        assert len(completed_tools) == 1
+        assert completed_tools[0]["tool_call_id"] == "call_terminal_1"
+        assert "RUN_TOOL_PREVIEW_OK" in completed_tools[0]["output"]
+        assert completed_tools[0]["error"] is False
+        assert [event.get("event") for event in events].count("tool.started") == 1
 
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This PR hardens the OpenAI-compatible API server streaming paths used by browser/front-end clients:

- includes a bounded, redacted tool result preview on `hermes.tool.progress` completion events for `/v1/chat/completions`
- includes correlated `tool.started` / `tool.completed` events with bounded output previews for `/v1/runs/{run_id}/events`
- preserves request history when `X-Hermes-Session-Id` is introduced before the session DB has transcript state
- falls back to streaming `final_response` before `[DONE]` when the agent returns final text without token deltas

## Why

A browser client can otherwise look like it silently stopped during tool-heavy turns such as planning: useful work may happen through tools, but clients only see an empty assistant message or a completed tool with no result preview. Durable run clients also need enough tool output to show what happened without dumping full logs.

## Validation

```bash
python3.11 -m venv .venv
.venv/bin/python -m pip install -q -U pip
.venv/bin/python -m pip install -q -e '.[dev]'
.venv/bin/python -m pip install -q aiohttp pytest-asyncio
ulimit -n 4096 && .venv/bin/python -m pytest tests/gateway/test_api_server_runs.py -q
ulimit -n 4096 && .venv/bin/python -m pytest tests/gateway/test_api_server.py -q
```

Results:

- `tests/gateway/test_api_server_runs.py`: 24 passed
- `tests/gateway/test_api_server.py`: 195 passed
