### PR TITLE
fix(compression): preserve user turn after compaction (salvage #58276)

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -392,15 +392,35 @@ def conversation_history_after_compression(agent: Any, messages: list) -> Option
 
 
 def _ensure_compressed_has_user_turn(original_messages: list, compressed: list) -> None:
-    """Preserve a real user turn when a compressor returns assistant/tool-only context."""
+    """Preserve a real user turn when a compressor returns assistant/tool-only context.
+
+    On repeated compaction the protected head decays to the system prompt only,
+    the middle summary can land as ``role="assistant"``, and a tool-heavy tail
+    can be all assistant/tool — so the compacted transcript can legitimately
+    contain zero user messages. Strict chat templates (LM Studio / llama.cpp
+    Jinja) then fail with "No user query found in messages" (#55677).
+
+    The restored turn is appended at the END: the guard only runs when
+    ``compressed`` currently ends with an assistant/tool message (any existing
+    user turn — including a todo-snapshot append — short-circuits the
+    ``any()`` check), so appending a user message never creates consecutive
+    same-role messages. ``_fresh_compaction_message_copy`` copies the message
+    and strips the ``_db_persisted`` marker so the rotation/in-place flush
+    still persists the restored row to the new session (#57491).
+
+    If the pre-compression transcript itself carried no user turn at all
+    (near-impossible — every real conversation opens with a user request —
+    but kept as a defensive backstop), a minimal continuation marker is
+    appended instead so strict templates still see a user message.
+    """
     if any(isinstance(msg, dict) and msg.get("role") == "user" for msg in compressed):
         return
+    from agent.context_compressor import _fresh_compaction_message_copy
+
     for msg in reversed(original_messages):
         if not isinstance(msg, dict) or msg.get("role") != "user":
             continue
-        restored = dict(msg)
-        restored.pop("_db_persisted", None)
-        compressed.append(restored)
+        compressed.append(_fresh_compaction_message_copy(msg))
         return
     compressed.append({
         "role": "user",

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -391,6 +391,27 @@ def conversation_history_after_compression(agent: Any, messages: list) -> Option
     return None
 
 
+def _ensure_compressed_has_user_turn(original_messages: list, compressed: list) -> None:
+    """Preserve a real user turn when a compressor returns assistant/tool-only context."""
+    if any(isinstance(msg, dict) and msg.get("role") == "user" for msg in compressed):
+        return
+    for msg in reversed(original_messages):
+        if not isinstance(msg, dict) or msg.get("role") != "user":
+            continue
+        restored = dict(msg)
+        restored.pop("_db_persisted", None)
+        compressed.append(restored)
+        return
+    compressed.append({
+        "role": "user",
+        "content": (
+            "Continue from the compressed conversation context above. "
+            "This marker exists because the compacted transcript contained "
+            "no preserved user turn."
+        ),
+    })
+
+
 def compress_context(
     agent: Any,
     messages: list,
@@ -647,6 +668,7 @@ def compress_context(
         todo_snapshot = agent._todo_store.format_for_injection()
         if todo_snapshot:
             compressed.append({"role": "user", "content": todo_snapshot})
+        _ensure_compressed_has_user_turn(messages, compressed)
 
         agent._invalidate_system_prompt()
         new_system_prompt = agent._build_system_prompt(system_message)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,7 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
-    "yingwaizhiying@gmail.com": "msh01",  # PR #58250 salvage (telegram: wall-clock init timeout via daemon-thread deadline + abandon the shielded initialize task on timeout so the retry ladder advances instead of hanging on attempt 1/8 under s6 supervision; #58236)
+    "yingwaizhiying@gmail.com": "msh01",  # PR #58250 salvage (telegram: wall-clock init timeout via daemon-thread deadline + abandon the shielded initialize task on timeout so the retry ladder advances instead of hanging on attempt 1/8 under s6 supervision; #58236). Also covers PR #58276 salvage (compression: preserve a real user turn after compaction; #55677).
     "huanshan5195@users.noreply.github.com": "huanshan5195",  # PR #57601 salvage (custom-provider: emit reasoning_effort at the live CustomProfile path so GLM-5.2/ARK/vLLM/Ollama endpoints receive it; + "max" reasoning level)
     "infinitycrew39@gmail.com": "infinitycrew39",  # PR #56431 salvage (honor live vLLM context limits on local endpoints)
     "jonathan.kovacs999@gmail.com": "CocaKova",  # PR #57692 salvage (cron: run jobs under the profile secret scope so get_secret does not fail-close with UnscopedSecretError under profile isolation)

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -202,6 +202,40 @@ def test_skipped_compression_returns_messages_unchanged(tmp_path: Path) -> None:
     agent.context_compressor.compress.assert_not_called()
 
 
+def test_compression_restores_user_turn_when_compressor_drops_all_users(tmp_path: Path) -> None:
+    """Provider chat templates need at least one user message after compaction.
+
+    A plugin or future compressor can legally return a compacted context made
+    only of assistant/tool summary rows.  Before the guard in
+    ``compress_context``, that transcript went straight into the next API call;
+    LM Studio / llama.cpp Jinja templates then failed with "No user query found
+    in messages."  Preserve the last real user turn from the pre-compression
+    transcript instead of inventing a new active request.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_sid = "NO_USER_AFTER_COMPRESS"
+    db.create_session(parent_sid, source="cli")
+
+    agent = _build_agent_with_db(db, parent_sid)
+    agent.context_compressor.compress.side_effect = lambda *_a, **_kw: [
+        {
+            "role": "assistant",
+            "content": "[CONTEXT COMPACTION] earlier work was summarized",
+        }
+    ]
+    messages = [
+        {"role": "user", "content": "first request"},
+        {"role": "assistant", "content": "first answer"},
+        {"role": "user", "content": "please continue from here"},
+        {"role": "assistant", "content": "working"},
+    ]
+
+    compressed, _sp = agent._compress_context(messages, "sys", approx_tokens=120_000)
+
+    user_messages = [msg for msg in compressed if msg.get("role") == "user"]
+    assert user_messages == [{"role": "user", "content": "please continue from here"}]
+
+
 def test_lock_refresh_keeps_owner_live_past_initial_ttl(tmp_path: Path, monkeypatch) -> None:
     """The owning compression call must keep its lease alive while it runs."""
     real_try_acquire = SessionDB.try_acquire_compression_lock


### PR DESCRIPTION
## Summary
Context compaction can hand the next model call a transcript with **zero user turns**, and strict LM Studio / llama.cpp Jinja chat templates then reject it with `"No user query found in messages"`, corrupting the session (#55677). This restores a real user turn after compaction so the compacted transcript always satisfies those templates.

Root cause: on repeated compaction the protected head decays to the system prompt only (`_protect_head_size`), the middle summary can be assigned `role="assistant"`, and a tool-heavy tail can be all assistant/tool — so the assembled compacted transcript legitimately contains no `role="user"` message.

## Changes
- `agent/conversation_compression.py`: new `_ensure_compressed_has_user_turn()` called inside `compress_context()` (runs in both in-place and rotation modes, before the DB persist). Restores the last real pre-compression user turn, or appends a minimal continuation marker only if the original transcript had no user turn at all.
- Follow-up (maintainer): reuse the canonical `_fresh_compaction_message_copy()` helper for the copy + `_db_persisted` strip so the persistence-marker contract stays consistent across all compaction copy sites (#57491).
- Follow-up (maintainer): AUTHOR_MAP mapping for the contributor.

## Validation
| | Before | After |
|---|---|---|
| Compaction returns assistant/tool-only transcript | Jinja template error, session corrupted | Last real user turn restored |
| Message role alternation | — | Preserved (guard only appends `user` when the list ends assistant/tool) |
| DB persistence of restored turn | — | Persisted in both in-place + rotation modes (no `_db_persisted` leak) |
| Tests | — | `test_compression_concurrent_fork.py` 14/14, `test_compressor_assistant_tail_anchor.py` 24/24 |
| ruff + ty (net-new) | — | clean |

Salvaged from #58276 by @msh01 — fix commit cherry-picked with authorship preserved.

Fixes #55677
Closes #58276
