### PR TITLE
fix(desktop): gate messaging session polling

### DIFF
--- a/apps/desktop/src/app/desktop-controller-utils.test.ts
+++ b/apps/desktop/src/app/desktop-controller-utils.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { SessionInfo } from '@/hermes'
 
-import { sameCronSignature } from './desktop-controller-utils'
+import { sameCronSignature, shouldPollMessagingSessions } from './desktop-controller-utils'
 
 const session = (id: string, title: string | null): SessionInfo => ({ id, title }) as SessionInfo
 
@@ -27,5 +27,44 @@ describe('sameCronSignature', () => {
     const a = [session('a', 't'), session('b', 't')]
     const b = [session('b', 't'), session('a', 't')]
     expect(sameCronSignature(a, b)).toBe(false)
+  })
+})
+
+describe('shouldPollMessagingSessions', () => {
+  const base = {
+    activeIsMessaging: false,
+    gatewayPlatforms: null,
+    messagingSessionCount: 0,
+    messagingViewOpen: false
+  }
+
+  it('is false when nothing indicates messaging is in use', () => {
+    expect(shouldPollMessagingSessions(base)).toBe(false)
+  })
+
+  it('is true while the messaging view is open', () => {
+    expect(shouldPollMessagingSessions({ ...base, messagingViewOpen: true })).toBe(true)
+  })
+
+  it('is true when a messaging session is already loaded', () => {
+    expect(shouldPollMessagingSessions({ ...base, messagingSessionCount: 1 })).toBe(true)
+  })
+
+  it('is true when the active session is a messaging thread', () => {
+    expect(shouldPollMessagingSessions({ ...base, activeIsMessaging: true })).toBe(true)
+  })
+
+  it('is true when status reports a configured gateway platform', () => {
+    expect(
+      shouldPollMessagingSessions({
+        ...base,
+        gatewayPlatforms: {
+          telegram: {
+            state: 'connected',
+            updated_at: '2026-07-04T00:00:00+00:00'
+          }
+        }
+      })
+    ).toBe(true)
   })
 })

--- a/apps/desktop/src/app/desktop-controller-utils.ts
+++ b/apps/desktop/src/app/desktop-controller-utils.ts
@@ -1,4 +1,5 @@
 import type { SessionInfo } from '@/hermes'
+import type { PlatformStatus } from '@/types/hermes'
 
 // Cheap signature compare so a poll only swaps the atom (and re-renders the
 // sidebar) when the visible rows actually changed.
@@ -23,4 +24,22 @@ export function sameCronSignature(a: SessionInfo[], b: SessionInfo[]): boolean {
       session.ended_at === other.ended_at
     )
   })
+}
+
+export function shouldPollMessagingSessions({
+  activeIsMessaging,
+  gatewayPlatforms,
+  messagingSessionCount,
+  messagingViewOpen
+}: {
+  activeIsMessaging: boolean
+  gatewayPlatforms?: null | Record<string, PlatformStatus>
+  messagingSessionCount: number
+  messagingViewOpen: boolean
+}): boolean {
+  if (messagingViewOpen || activeIsMessaging || messagingSessionCount > 0) {
+    return true
+  }
+
+  return Object.keys(gatewayPlatforms ?? {}).length > 0
 }

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -88,6 +88,7 @@ import {
 } from './chat/right-rail'
 import { ChatSidebar } from './chat/sidebar'
 import { CommandPalette } from './command-palette'
+import { shouldPollMessagingSessions } from './desktop-controller-utils'
 import { useGatewayBoot } from './gateway/hooks/use-gateway-boot'
 import { useGatewayRequest } from './gateway/hooks/use-gateway-request'
 import { useKeybinds } from './hooks/use-keybinds'
@@ -919,11 +920,24 @@ export function DesktopController() {
     }
   }, [gatewayState, refreshCronJobs])
 
+  // Only keep the broad messaging session poll armed when the user has a
+  // messaging surface or the already-polled status endpoint reports a platform.
+  const activeIsMessaging =
+    !!selectedStoredSessionId &&
+    isMessagingSource(messagingSessions.find(s => sessionMatchesStoredId(s, selectedStoredSessionId))?.source)
+
+  const pollMessagingSessions = shouldPollMessagingSessions({
+    activeIsMessaging,
+    gatewayPlatforms: statusSnapshot?.gateway_platforms,
+    messagingSessionCount: messagingSessions.length,
+    messagingViewOpen: currentView === 'messaging'
+  })
+
   // Keep messaging-platform session lists live: inbound Telegram/WeChat/Discord
   // turns are written by the gateway, not the desktop websocket, so they won't
   // appear without polling.
   useEffect(() => {
-    if (gatewayState !== 'open') {
+    if (gatewayState !== 'open' || !pollMessagingSessions) {
       return
     }
 
@@ -940,14 +954,7 @@ export function DesktopController() {
       window.clearInterval(intervalId)
       document.removeEventListener('visibilitychange', tick)
     }
-  }, [gatewayState, refreshMessagingSessions])
-
-  // Only the open messaging transcript needs a poll — local chats are already
-  // live over the websocket, so arming a timer for them would just no-op every
-  // tick. Gate on the active session actually being a messaging source.
-  const activeIsMessaging =
-    !!selectedStoredSessionId &&
-    isMessagingSource(messagingSessions.find(s => sessionMatchesStoredId(s, selectedStoredSessionId))?.source)
+  }, [gatewayState, pollMessagingSessions, refreshMessagingSessions])
 
   // Keep the currently-viewed messaging transcript live.
   useEffect(() => {


### PR DESCRIPTION
## What does this PR do?

Gates the desktop's broad messaging-session polling so it only runs when there is evidence that messaging needs live updates: the Messaging view is open, the active stored session is a messaging thread, messaging rows are already loaded, or the existing `/api/status` snapshot reports a configured gateway platform.

This keeps inbound Telegram/WeChat/Discord sessions live for configured messaging users while avoiding the always-on 10s cross-profile session scan for desktop users who are not using messaging.

## Related Issue

Fixes #58309

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `shouldPollMessagingSessions` in `apps/desktop/src/app/desktop-controller-utils.ts`.
- Used that helper in `apps/desktop/src/app/desktop-controller.tsx` before arming the 10s messaging-session interval.
- Added focused Vitest coverage for the idle false case and the preserved live-update gates.

## How to Test

1. `npm --workspace apps/desktop run test:ui -- src/app/desktop-controller-utils.test.ts`
2. `npm --workspace apps/desktop exec eslint -- src/app/desktop-controller-utils.ts src/app/desktop-controller-utils.test.ts src/app/desktop-controller.tsx`
3. `git diff --check`

Note: `npm --workspace apps/desktop run typecheck` currently fails before this patch in this lane because workspace dependencies such as `@codemirror/*`, `@xterm/addon-serialize`, and `fflate` are not resolvable.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (desktop TS/Vitest checks)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Targeted validation:

```text
npm --workspace apps/desktop run test:ui -- src/app/desktop-controller-utils.test.ts
Test Files  1 passed (1)
Tests  9 passed (9)
```

```text
npm --workspace apps/desktop exec eslint -- src/app/desktop-controller-utils.ts src/app/desktop-controller-utils.test.ts src/app/desktop-controller.tsx
# no output / exit 0
```
