### PR TITLE
fix(agent): harden compressor tool arg summaries

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -555,12 +555,23 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
     except (json.JSONDecodeError, TypeError):
         args = {}
 
+    def _arg_text(name: str, default: str = "") -> str:
+        value = args.get(name, default)
+        if value is None:
+            return default
+        if isinstance(value, str):
+            return value
+        try:
+            return json.dumps(value, ensure_ascii=False, sort_keys=True)
+        except (TypeError, ValueError):
+            return str(value)
+
     content = tool_content or ""
     content_len = len(content)
     line_count = content.count("\n") + 1 if content.strip() else 0
 
     if tool_name == "terminal":
-        cmd = args.get("command", "")
+        cmd = _arg_text("command")
         if len(cmd) > 80:
             cmd = cmd[:77] + "..."
         exit_match = re.search(r'"exit_code"\s*:\s*(-?\d+)', content)
@@ -574,7 +585,8 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
 
     if tool_name == "write_file":
         path = args.get("path", "?")
-        written_lines = args.get("content", "").count("\n") + 1 if args.get("content") else "?"
+        written_content = _arg_text("content")
+        written_lines = written_content.count("\n") + 1 if written_content else "?"
         return f"[write_file] wrote to {path} ({written_lines} lines)"
 
     if tool_name == "search_files":
@@ -609,14 +621,15 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
         return f"[web_extract] {url_desc} ({content_len:,} chars)"
 
     if tool_name == "delegate_task":
-        goal = args.get("goal", "")
+        goal = _arg_text("goal")
         if len(goal) > 60:
             goal = goal[:57] + "..."
         return f"[delegate_task] '{goal}' ({content_len:,} chars result)"
 
     if tool_name == "execute_code":
-        code_preview = (args.get("code") or "")[:60].replace("\n", " ")
-        if len(args.get("code", "")) > 60:
+        code = _arg_text("code")
+        code_preview = code[:60].replace("\n", " ")
+        if len(code) > 60:
             code_preview += "..."
         return f"[execute_code] `{code_preview}` ({line_count} lines output)"
 
@@ -625,7 +638,7 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
         return f"[{tool_name}] name={name} ({content_len:,} chars)"
 
     if tool_name == "vision_analyze":
-        question = args.get("question", "")[:50]
+        question = _arg_text("question")[:50]
         return f"[vision_analyze] '{question}' ({content_len:,} chars)"
 
     if tool_name == "memory":

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2755,6 +2755,59 @@ class TestUpdateModelResetsCalibration:
         assert comp.should_defer_preflight_to_real_usage(comp.threshold_tokens + 5_000) is False
 
 
+class TestSummarizeToolResultArgs:
+    """Regression guards for non-string historical tool arguments."""
+
+    def test_write_file_dict_content_does_not_crash_pruning(self):
+        import json as _json
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="test/model",
+                threshold_percent=0.85,
+                protect_first_n=1,
+                protect_last_n=1,
+                quiet_mode=True,
+            )
+        messages = [
+            {"role": "user", "content": "please write"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "call_1", "type": "function",
+                 "function": {"name": "write_file", "arguments": _json.dumps({
+                     "path": "x.txt",
+                     "content": {"nested": "value"},
+                 })}},
+            ]},
+            {"role": "tool", "tool_call_id": "call_1",
+             "content": '{"error":"content must be string","detail":"' + ("x" * 240) + '"}'},
+            {"role": "user", "content": "continue"},
+            {"role": "assistant", "content": "ok"},
+        ]
+
+        result, pruned = c._prune_old_tool_results(messages, protect_tail_count=2)
+
+        assert pruned == 1
+        assert result[2]["content"] == "[write_file] wrote to x.txt (1 lines)"
+
+    def test_preview_tools_coerce_non_string_args(self):
+        import json as _json
+        from agent.context_compressor import _summarize_tool_result
+
+        code_summary = _summarize_tool_result(
+            "execute_code",
+            _json.dumps({"code": {"snippet": "print(1)"}}),
+            "ok",
+        )
+        vision_summary = _summarize_tool_result(
+            "vision_analyze",
+            _json.dumps({"question": {"text": "what is this?"}}),
+            "analysis",
+        )
+
+        assert code_summary == '[execute_code] `{"snippet": "print(1)"}` (1 lines output)'
+        assert vision_summary == '[vision_analyze] \'{"text": "what is this?"}\' (8 chars)'
+
+
 class TestTruncateToolCallArgsJson:
     """Regression tests for #11762.
 


### PR DESCRIPTION
## What does this PR do?

Fixes a context-compression crash when `_summarize_tool_result()` summarizes historical tool calls whose arguments contain non-string JSON values.

In issue #58317, a `write_file` tool call had `arguments.content` parsed as a dict. The live `write_file` handler correctly rejects non-string content, but the historical tool call remains in the transcript. Later compression reads that old argument and called `.count("\n")` directly on the dict, raising `AttributeError` before compression can complete.

This patch adds a small local coercion helper inside `_summarize_tool_result()` and uses it before string operations on summary preview fields. That fixes the reported `write_file.content` crash and the sibling preview fields that also sliced, counted, or measured raw `args.get(...)` values.

Overlap note: PR #52431 covers the same general type-safety area. This PR is intentionally narrower and adds an end-to-end pruning regression for the concrete #58317 `write_file` failure path.

## Related Issue

Fixes #58317
Related: #52431

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/context_compressor.py`
  - Adds `_arg_text()` inside `_summarize_tool_result()` to coerce historical tool arguments safely before display-oriented string operations.
  - Applies it to `write_file.content`, plus sibling preview fields for `terminal.command`, `delegate_task.goal`, `execute_code.code`, and `vision_analyze.question`.
- `tests/agent/test_context_compressor.py`
  - Adds a regression test for `write_file` with dict `content` through `_prune_old_tool_results()`.
  - Adds coverage for non-string `execute_code.code` and `vision_analyze.question` previews.

## How to Test

1. Baseline reproduction on `86a0c5553e2da418ffa1b05844691ebd0b6b0b94`: the minimal `_prune_old_tool_results()` probe raised `AttributeError: 'dict' object has no attribute 'count'`.
2. After this patch, the same probe returns `pruned=1` and summarizes the old tool result as `[write_file] wrote to x.txt (1 lines)`.
3. Ran:
   - `python -m compileall -q agent/context_compressor.py tests/agent/test_context_compressor.py`
   - `scripts/run_tests.sh tests/agent/test_context_compressor.py -q`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS / local Hermes worktree

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — pure Python, no platform-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Targeted test result:

```text
=== Summary: 1 files, 147 tests passed, 0 failed (100% complete) in 14.4s (20 workers) ===
```
