### PR TITLE
fix(delegate): keep child credential pools provider-scoped

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1853,14 +1853,28 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
     def test_same_provider_shares_parent_pool(self):
         parent = _make_mock_parent()
         mock_pool = MagicMock()
+        mock_pool.provider = "openrouter"
         parent._credential_pool = mock_pool
 
         result = _resolve_child_credential_pool("openrouter", parent)
         self.assertIs(result, mock_pool)
 
+    def test_same_provider_rejects_mismatched_parent_pool(self):
+        parent = _make_mock_parent()
+        parent.provider = "deepseek"
+        parent._credential_pool = MagicMock()
+        parent._credential_pool.provider = "zai"
+
+        with patch("agent.credential_pool.load_pool", return_value=None) as load_mock:
+            result = _resolve_child_credential_pool("deepseek", parent)
+
+        self.assertIsNone(result)
+        load_mock.assert_called_once_with("deepseek")
+
     def test_no_provider_inherits_parent_pool(self):
         parent = _make_mock_parent()
         mock_pool = MagicMock()
+        mock_pool.provider = "openrouter"
         parent._credential_pool = mock_pool
 
         result = _resolve_child_credential_pool(None, parent)
@@ -1906,6 +1920,7 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
         parent.provider = "custom"
         parent.base_url = "https://endpoint-a.example.com/v1"
         parent._credential_pool = MagicMock(name="parent_custom_a_pool")
+        parent._credential_pool.provider = "custom:endpoint-a"
 
         child_pool = MagicMock(name="endpoint_b_pool")
         child_pool.has_credentials.return_value = True
@@ -1934,6 +1949,7 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
         parent.provider = "custom"
         parent.base_url = "https://endpoint-a.example.com/v1"
         parent._credential_pool = MagicMock(name="parent_custom_a_pool")
+        parent._credential_pool.provider = "custom:endpoint-a"
 
         with patch(
             "agent.credential_pool.get_custom_provider_pool_key",
@@ -1944,6 +1960,24 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
             )
 
         self.assertIs(result, parent._credential_pool)
+
+    def test_custom_endpoint_rejects_parent_pool_for_different_endpoint(self):
+        parent = _make_mock_parent()
+        parent.provider = "custom"
+        parent.base_url = "https://endpoint-a.example.com/v1"
+        parent._credential_pool = MagicMock()
+        parent._credential_pool.provider = "custom:endpoint-b"
+
+        with patch(
+            "agent.credential_pool.get_custom_provider_pool_key",
+            return_value="custom:endpoint-a",
+        ), patch("agent.credential_pool.load_pool", return_value=None) as load_mock:
+            result = _resolve_child_credential_pool(
+                "custom", parent, "https://endpoint-a.example.com/v1"
+            )
+
+        self.assertIsNone(result)
+        load_mock.assert_called_once_with("custom:endpoint-a")
 
     def test_custom_unregistered_endpoint_returns_none(self):
         """A raw delegation.base_url with no matching custom_providers entry
@@ -1967,6 +2001,7 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
     def test_build_child_agent_assigns_parent_pool_when_shared(self):
         parent = _make_mock_parent()
         mock_pool = MagicMock()
+        mock_pool.provider = "openrouter"
         parent._credential_pool = mock_pool
 
         with patch("run_agent.AIAgent") as MockAgent:
@@ -2048,7 +2083,10 @@ class TestChildCredentialLeasing(unittest.TestCase):
         leased_entry.id = "cred-b"
 
         child = MagicMock()
+        child.provider = "openrouter"
+        child.base_url = "https://openrouter.ai/api/v1"
         child._credential_pool = MagicMock()
+        child._credential_pool.provider = "openrouter"
         child._credential_pool.acquire_lease.return_value = "cred-b"
         child._credential_pool.current.return_value = leased_entry
         child.run_conversation.return_value = {
@@ -2071,11 +2109,75 @@ class TestChildCredentialLeasing(unittest.TestCase):
         child._swap_credential.assert_called_once_with(leased_entry)
         child._credential_pool.release_lease.assert_called_once_with("cred-b")
 
+    def test_run_single_child_skips_mismatched_credential_pool(self):
+        from tools.delegate_tool import _run_single_child
+
+        child = MagicMock()
+        child.provider = "deepseek"
+        child._credential_pool = MagicMock()
+        child._credential_pool.provider = "zai"
+        child._credential_pool.acquire_lease.return_value = "zai-cred"
+        child.run_conversation.return_value = {
+            "final_response": "done",
+            "completed": True,
+            "interrupted": False,
+            "api_calls": 1,
+            "messages": [],
+        }
+
+        result = _run_single_child(
+            task_index=0,
+            goal="Use delegated model",
+            child=child,
+            parent_agent=_make_mock_parent(),
+        )
+
+        self.assertEqual(result["status"], "completed")
+        child._credential_pool.acquire_lease.assert_not_called()
+        child._swap_credential.assert_not_called()
+        child._credential_pool.release_lease.assert_not_called()
+
+    def test_run_single_child_skips_custom_pool_for_different_endpoint(self):
+        from tools.delegate_tool import _run_single_child
+
+        child = MagicMock()
+        child.provider = "custom"
+        child.base_url = "https://endpoint-a.example.com/v1"
+        child._credential_pool = MagicMock()
+        child._credential_pool.provider = "custom:endpoint-b"
+        child._credential_pool.acquire_lease.return_value = "endpoint-b-cred"
+        child.run_conversation.return_value = {
+            "final_response": "done",
+            "completed": True,
+            "interrupted": False,
+            "api_calls": 1,
+            "messages": [],
+        }
+
+        with patch(
+            "agent.credential_pool.get_custom_provider_pool_key",
+            return_value="custom:endpoint-a",
+        ):
+            result = _run_single_child(
+                task_index=0,
+                goal="Use endpoint A",
+                child=child,
+                parent_agent=_make_mock_parent(),
+            )
+
+        self.assertEqual(result["status"], "completed")
+        child._credential_pool.acquire_lease.assert_not_called()
+        child._swap_credential.assert_not_called()
+        child._credential_pool.release_lease.assert_not_called()
+
     def test_run_single_child_releases_lease_after_failure(self):
         from tools.delegate_tool import _run_single_child
 
         child = MagicMock()
+        child.provider = "openrouter"
+        child.base_url = "https://openrouter.ai/api/v1"
         child._credential_pool = MagicMock()
+        child._credential_pool.provider = "openrouter"
         child._credential_pool.acquire_lease.return_value = "cred-a"
         child._credential_pool.current.return_value = MagicMock(id="cred-a")
         child.run_conversation.side_effect = RuntimeError("boom")

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -31,6 +31,7 @@ from concurrent.futures import (
 )
 from typing import Any, Dict, List, Optional
 
+from agent.credential_pool import credential_pool_matches_provider
 from toolsets import TOOLSETS
 
 # Sentinel value used by the runtime provider system for providers that are
@@ -1813,6 +1814,17 @@ def _run_single_child(
     )
 
     child_pool = getattr(child, "_credential_pool", None)
+    if child_pool is not None and not credential_pool_matches_provider(
+        child_pool,
+        getattr(child, "provider", None),
+        base_url=getattr(child, "base_url", None),
+    ):
+        logger.debug(
+            "Skipping child credential pool for provider mismatch: child=%r pool=%r",
+            getattr(child, "provider", None),
+            getattr(child_pool, "provider", None),
+        )
+        child_pool = None
     leased_cred_id = None
     if child_pool is not None:
         leased_cred_id = child_pool.acquire_lease()
@@ -3036,11 +3048,18 @@ def _resolve_child_credential_pool(
     ``custom:<name>`` pool key derived from the base_url) and only share the
     parent's pool when both resolve to the *same* custom endpoint.
     """
-    if not effective_provider:
-        return getattr(parent_agent, "_credential_pool", None)
-
     parent_provider = getattr(parent_agent, "provider", None) or ""
     parent_pool = getattr(parent_agent, "_credential_pool", None)
+    if not effective_provider:
+        return (
+            parent_pool
+            if credential_pool_matches_provider(
+                parent_pool,
+                parent_provider,
+                base_url=effective_base_url,
+            )
+            else None
+        )
 
     # Custom endpoints: distinguish by endpoint identity, not the bare "custom"
     # provider string. Two custom runtimes are only interchangeable when they
@@ -3066,6 +3085,11 @@ def _resolve_child_credential_pool(
                 and parent_provider == "custom"
                 and parent_key is not None
                 and parent_key == child_key
+                and credential_pool_matches_provider(
+                    parent_pool,
+                    effective_provider,
+                    base_url=effective_base_url,
+                )
             ):
                 return parent_pool
 
@@ -3080,7 +3104,15 @@ def _resolve_child_credential_pool(
             )
         return None
 
-    if parent_pool is not None and effective_provider == parent_provider:
+    if (
+        parent_pool is not None
+        and effective_provider == parent_provider
+        and credential_pool_matches_provider(
+            parent_pool,
+            effective_provider,
+            base_url=effective_base_url,
+        )
+    ):
         return parent_pool
 
     try:


### PR DESCRIPTION
## What does this PR do?

Fixes delegated subagents accidentally reusing a parent credential pool whose concrete provider does not match the delegated child provider. When delegation is configured for a different provider/model, a mismatched pool lease can call `_swap_credential()` and overwrite the child runtime back to the pool provider.

This keeps same-provider pool sharing intact for cooldown/rotation state, but refuses concrete provider mismatches before pool resolution and before child leasing.

## Related Issue

Fixes #58298

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/delegate_tool.py`: add a provider-match guard for child credential pools and apply it when resolving parent pool reuse and when leasing in `_run_single_child()`.
- `tests/tools/test_delegate.py`: cover rejecting a mismatched parent pool and skipping lease/swap/release when a child has a mismatched pool attached.

## How to Test

1. Reproduce the pre-fix resolver behavior on `upstream/main` (`5daa5a0f2f218d2f5c8391dffbc47fe57f76232f`): a `deepseek` parent with a `zai` credential pool returns the parent pool for a `deepseek` child.
2. Run the after-fix resolver probe: `deepseek` child + `zai` parent pool resolves to `None` and does not return the parent pool.
3. Run the targeted tests listed below.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.7 (Darwin 24.6.0, arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — provider/pool matching is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A

## Screenshots / Logs

```text
python -m compileall -q tools/delegate_tool.py tests/tools/test_delegate.py
```

```text
scripts/run_tests.sh tests/tools/test_delegate.py -q
=== Summary: 1 files, 153 tests passed, 0 failed (100% complete) in 18.9s (20 workers) ===
```

```text
scripts/run_tests.sh tests/agent/test_credential_pool_routing.py tests/run_agent/test_fallback_credential_isolation.py -q
=== Summary: 2 files, 18 tests passed, 0 failed (100% complete) in 1.7s (20 workers) ===
```