### PR TITLE
fix: show account limits in desktop and TUI /usage

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -740,3 +740,204 @@ def test_unregister_live_transport_stops_delivery(capture):
     # No live transports left → fell back to stdio.
     assert json.loads(buf.getvalue())["params"]["type"] == "skin.changed"
 
+
+def test_usage_live_and_session_output_include_provider_limits(server, monkeypatch):
+    from agent import account_usage
+
+    class Agent:
+        provider = "openai-codex"
+        base_url = "https://example.invalid/v1"
+        api_key = "secret"
+        model = "gpt-test"
+        session_input_tokens = 123
+        session_output_tokens = 45
+        session_total_tokens = 168
+        session_api_calls = 2
+        session_reasoning_tokens = 0
+        session_prompt_tokens = 123
+        session_completion_tokens = 45
+        context_compressor = None
+
+        def get_rate_limit_state(self):
+            return types.SimpleNamespace(has_data=True)
+
+    fetch = MagicMock(return_value=object())
+    monkeypatch.setattr(account_usage, "fetch_account_usage", fetch)
+    monkeypatch.setattr(
+        account_usage,
+        "render_account_usage_lines",
+        lambda _: ["Account limits", "Session: 93% remaining"],
+    )
+    monkeypatch.setattr(account_usage, "nous_credits_lines", lambda: [])
+    monkeypatch.setattr(
+        "agent.rate_limit_tracker.format_rate_limit_display",
+        lambda _: "Requests: 50% remaining",
+    )
+    server._sessions["usage-live"] = {
+        "session_key": "usage-live",
+        "agent": Agent(),
+        "history": [],
+        "history_lock": threading.Lock(),
+    }
+    desktop = server.handle_request(
+        {
+            "id": 1,
+            "method": "slash.exec",
+            "params": {"session_id": "usage-live", "command": "usage"},
+        }
+    )
+    tui = server.handle_request(
+        {
+            "id": 2,
+            "method": "session.usage",
+            "params": {"session_id": "usage-live"},
+        }
+    )
+    assert "Session Token Usage" in desktop["result"]["output"]
+    assert "Session: 93% remaining" in desktop["result"]["output"]
+    assert "Requests: 50% remaining" in desktop["result"]["output"]
+    assert "secret" not in desktop["result"]["output"]
+    assert tui["result"]["account_lines"] == ["Account limits", "Session: 93% remaining"]
+    assert tui["result"]["rate_limit_lines"] == ["Requests: 50% remaining"]
+    assert fetch.call_args.args == ("openai-codex",)
+
+
+def test_usage_no_agent_uses_metadata_and_codex_pool_fallback(server, monkeypatch):
+    from agent import account_usage
+
+    seen = []
+
+    def fetch(provider, **kwargs):
+        seen.append({"provider": provider, **kwargs})
+        return object()
+
+    monkeypatch.setattr(account_usage, "fetch_account_usage", fetch)
+    monkeypatch.setattr(
+        account_usage,
+        "render_account_usage_lines",
+        lambda _: ["Weekly: 80% remaining"],
+    )
+    monkeypatch.setattr(account_usage, "nous_credits_lines", lambda: [])
+    server._sessions["usage-mirror"] = {
+        "session_key": "usage-mirror",
+        "agent": None,
+        "_metadata_mirror": {
+            "provider": "openai-codex",
+            "usage": {"calls": 1},
+        },
+        "history": [],
+        "history_lock": threading.Lock(),
+    }
+    desktop = server.handle_request(
+        {
+            "id": 1,
+            "method": "slash.exec",
+            "params": {"session_id": "usage-mirror", "command": "usage"},
+        }
+    )
+    tui = server.handle_request(
+        {
+            "id": 2,
+            "method": "session.usage",
+            "params": {"session_id": "usage-mirror"},
+        }
+    )
+    assert "Session Token Usage" in desktop["result"]["output"]
+    assert "Weekly: 80% remaining" in desktop["result"]["output"]
+    assert tui["result"]["account_lines"] == ["Weekly: 80% remaining"]
+    assert seen == [
+        {"provider": "openai-codex", "base_url": None, "api_key": None},
+        {"provider": "openai-codex", "base_url": None, "api_key": None},
+    ]
+
+
+def test_usage_provider_failure_is_fail_open(server, monkeypatch):
+    from agent import account_usage
+
+    monkeypatch.setattr(
+        account_usage,
+        "fetch_account_usage",
+        MagicMock(side_effect=RuntimeError("offline")),
+    )
+    monkeypatch.setattr(account_usage, "nous_credits_lines", lambda: [])
+    server._sessions["usage-fail"] = {
+        "session_key": "usage-fail",
+        "agent": None,
+        "_metadata_mirror": {
+            "provider": "openai-codex",
+            "usage": {"calls": 0},
+        },
+        "history": [],
+        "history_lock": threading.Lock(),
+    }
+    response = server.handle_request(
+        {
+            "id": 1,
+            "method": "session.usage",
+            "params": {"session_id": "usage-fail"},
+        }
+    )
+    assert "error" not in response and "account_lines" not in response["result"]
+
+
+def test_usage_provider_timeout_is_prompt_and_fail_open(server, monkeypatch):
+    from agent import account_usage
+
+    release_fetch = threading.Event()
+    fetch_started = threading.Event()
+
+    def fetch(*args, **kwargs):
+        fetch_started.set()
+        release_fetch.wait()
+        return object()
+
+    monkeypatch.setattr(server, "_ACCOUNT_USAGE_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(account_usage, "fetch_account_usage", fetch)
+    monkeypatch.setattr(account_usage, "nous_credits_lines", lambda: [])
+    server._sessions["usage-timeout"] = {
+        "session_key": "usage-timeout",
+        "agent": None,
+        "_metadata_mirror": {
+            "provider": "openai-codex",
+            "usage": {"calls": 0},
+        },
+        "history": [],
+        "history_lock": threading.Lock(),
+    }
+
+    started = time.monotonic()
+    try:
+        response = server.handle_request(
+            {
+                "id": 1,
+                "method": "session.usage",
+                "params": {"session_id": "usage-timeout"},
+            }
+        )
+        elapsed = time.monotonic() - started
+    finally:
+        release_fetch.set()
+
+    assert fetch_started.is_set()
+    assert elapsed < 0.5
+    assert "error" not in response
+    assert "account_lines" not in response["result"]
+
+
+@pytest.mark.parametrize("command", ["usage reset --force", "usage unexpected"])
+def test_usage_subcommands_fall_through_to_worker(server, command):
+    worker = MagicMock(run=MagicMock(return_value="worker result"))
+    server._sessions["usage-worker"] = {
+        "session_key": "usage-worker",
+        "agent": None,
+        "slash_worker": worker,
+    }
+    response = server.handle_request(
+        {
+            "id": 1,
+            "method": "slash.exec",
+            "params": {"session_id": "usage-worker", "command": command},
+        }
+    )
+    assert response["result"] == {"output": "worker result"}
+    worker.run.assert_called_once_with(command)

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -1504,3 +1504,207 @@ def test_unregister_live_transport_stops_delivery(capture):
     assert a.frames == []
     # No live transports left → fell back to stdio.
     assert json.loads(buf.getvalue())["params"]["type"] == "skin.changed"
+
+
+def test_usage_live_and_session_output_include_provider_limits(server, monkeypatch):
+    from agent import account_usage
+
+    class Agent:
+        provider = "openai-codex"
+        base_url = "https://example.invalid/v1"
+        api_key = "secret"
+        model = "gpt-test"
+        session_input_tokens = 123
+        session_output_tokens = 45
+        session_total_tokens = 168
+        session_api_calls = 2
+        session_reasoning_tokens = 0
+        session_prompt_tokens = 123
+        session_completion_tokens = 45
+        context_compressor = None
+
+        def get_rate_limit_state(self):
+            return types.SimpleNamespace(has_data=True)
+
+    fetch = MagicMock(return_value=object())
+    monkeypatch.setattr(account_usage, "fetch_account_usage", fetch)
+    monkeypatch.setattr(
+        account_usage,
+        "render_account_usage_lines",
+        lambda _: ["Account limits", "Session: 93% remaining"],
+    )
+    monkeypatch.setattr(account_usage, "nous_credits_lines", lambda: [])
+    monkeypatch.setattr(
+        "agent.rate_limit_tracker.format_rate_limit_display",
+        lambda _: "Requests: 50% remaining",
+    )
+    server._sessions["usage-live"] = {
+        "session_key": "usage-live",
+        "agent": Agent(),
+        "history": [],
+        "history_lock": threading.Lock(),
+    }
+    desktop = server.handle_request(
+        {
+            "id": 1,
+            "method": "slash.exec",
+            "params": {"session_id": "usage-live", "command": "usage"},
+        }
+    )
+    tui = server.handle_request(
+        {
+            "id": 2,
+            "method": "session.usage",
+            "params": {"session_id": "usage-live"},
+        }
+    )
+    assert "Session Token Usage" in desktop["result"]["output"]
+    assert "Session: 93% remaining" in desktop["result"]["output"]
+    assert "Requests: 50% remaining" in desktop["result"]["output"]
+    assert "secret" not in desktop["result"]["output"]
+    assert tui["result"]["account_lines"] == ["Account limits", "Session: 93% remaining"]
+    assert tui["result"]["rate_limit_lines"] == ["Requests: 50% remaining"]
+    assert fetch.call_args.args == ("openai-codex",)
+
+
+def test_usage_no_agent_uses_metadata_and_codex_pool_fallback(server, monkeypatch):
+    from agent import account_usage
+
+    seen = []
+
+    def fetch(provider, **kwargs):
+        seen.append({"provider": provider, **kwargs})
+        return object()
+
+    monkeypatch.setattr(account_usage, "fetch_account_usage", fetch)
+    monkeypatch.setattr(
+        account_usage,
+        "render_account_usage_lines",
+        lambda _: ["Weekly: 80% remaining"],
+    )
+    monkeypatch.setattr(account_usage, "nous_credits_lines", lambda: [])
+    server._sessions["usage-mirror"] = {
+        "session_key": "usage-mirror",
+        "agent": None,
+        "_metadata_mirror": {
+            "provider": "openai-codex",
+            "usage": {"calls": 1},
+        },
+        "history": [],
+        "history_lock": threading.Lock(),
+    }
+    desktop = server.handle_request(
+        {
+            "id": 1,
+            "method": "slash.exec",
+            "params": {"session_id": "usage-mirror", "command": "usage"},
+        }
+    )
+    tui = server.handle_request(
+        {
+            "id": 2,
+            "method": "session.usage",
+            "params": {"session_id": "usage-mirror"},
+        }
+    )
+    assert "Session Token Usage" in desktop["result"]["output"]
+    assert "Weekly: 80% remaining" in desktop["result"]["output"]
+    assert tui["result"]["account_lines"] == ["Weekly: 80% remaining"]
+    assert seen == [
+        {"provider": "openai-codex", "base_url": None, "api_key": None},
+        {"provider": "openai-codex", "base_url": None, "api_key": None},
+    ]
+
+
+def test_usage_provider_failure_is_fail_open(server, monkeypatch):
+    from agent import account_usage
+
+    monkeypatch.setattr(
+        account_usage,
+        "fetch_account_usage",
+        MagicMock(side_effect=RuntimeError("offline")),
+    )
+    monkeypatch.setattr(account_usage, "nous_credits_lines", lambda: [])
+    server._sessions["usage-fail"] = {
+        "session_key": "usage-fail",
+        "agent": None,
+        "_metadata_mirror": {
+            "provider": "openai-codex",
+            "usage": {"calls": 0},
+        },
+        "history": [],
+        "history_lock": threading.Lock(),
+    }
+    response = server.handle_request(
+        {
+            "id": 1,
+            "method": "session.usage",
+            "params": {"session_id": "usage-fail"},
+        }
+    )
+    assert "error" not in response and "account_lines" not in response["result"]
+
+
+def test_usage_provider_timeout_is_prompt_and_fail_open(server, monkeypatch):
+    from agent import account_usage
+
+    release_fetch = threading.Event()
+    fetch_started = threading.Event()
+
+    def fetch(*args, **kwargs):
+        fetch_started.set()
+        release_fetch.wait()
+        return object()
+
+    from tui_gateway import usage_provider
+
+    monkeypatch.setattr(usage_provider, "_ACCOUNT_USAGE_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(account_usage, "fetch_account_usage", fetch)
+    monkeypatch.setattr(account_usage, "nous_credits_lines", lambda: [])
+    server._sessions["usage-timeout"] = {
+        "session_key": "usage-timeout",
+        "agent": None,
+        "_metadata_mirror": {
+            "provider": "openai-codex",
+            "usage": {"calls": 0},
+        },
+        "history": [],
+        "history_lock": threading.Lock(),
+    }
+
+    started = time.monotonic()
+    try:
+        response = server.handle_request(
+            {
+                "id": 1,
+                "method": "session.usage",
+                "params": {"session_id": "usage-timeout"},
+            }
+        )
+        elapsed = time.monotonic() - started
+    finally:
+        release_fetch.set()
+
+    assert fetch_started.is_set()
+    assert elapsed < 2.0
+    assert "error" not in response
+    assert "account_lines" not in response["result"]
+
+
+@pytest.mark.parametrize("command", ["usage reset", "usage reset --force", "usage unexpected"])
+def test_usage_subcommands_fall_through_to_worker(server, command):
+    worker = MagicMock(run=MagicMock(return_value="worker result"))
+    server._sessions["usage-worker"] = {
+        "session_key": "usage-worker",
+        "agent": None,
+        "slash_worker": worker,
+    }
+    response = server.handle_request(
+        {
+            "id": 1,
+            "method": "slash.exec",
+            "params": {"session_id": "usage-worker", "command": command},
+        }
+    )
+    assert response["result"] == {"output": "worker result"}
+    worker.run.assert_called_once_with(command)

--- a/tests/tui_gateway/test_usage_provider_integration.py
+++ b/tests/tui_gateway/test_usage_provider_integration.py
@@ -1,0 +1,132 @@
+"""Exercise usage RPCs through real config/auth resolution and loopback HTTP."""
+
+import json
+import queue
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def usage_runtime(tmp_path, monkeypatch):
+    launch = tmp_path / "launch"
+    profile = tmp_path / "profile"
+    launch.mkdir()
+    profile.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(launch))
+    # Distinct credentials catch accidentally consulting the launch profile.
+    for home, token in ((launch, "wrong-launch-token"), (profile, "profile-pool-token")):
+        (home / "auth.json").write_text(json.dumps({
+            "version": 1,
+            "providers": {},
+            "credential_pool": {"openai-codex": [{
+                "source": "device_code", "access_token": token,
+                "refresh_token": "unused-test-refresh", "last_status": "ok", "auth_type": "oauth",
+            }]},
+        }))
+    (profile / "config.yaml").write_text("model:\n  provider: openai-codex\n")
+    requests = []
+    entered = threading.Event()
+    release = threading.Event()
+    release.set()
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            requests.append((self.path, self.headers.get("Authorization")))
+            entered.set()
+            release.wait(5)
+            payload = json.dumps({
+                "plan_type": "plus",
+                "rate_limit": {
+                    "primary_window": {"used_percent": 7},
+                    "secondary_window": {"used_percent": 20},
+                },
+            }).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *args):
+            pass
+
+    http = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=http.serve_forever, daemon=True)
+    thread.start()
+    base_url = f"http://127.0.0.1:{http.server_port}"
+    monkeypatch.setenv("HERMES_CODEX_BASE_URL", base_url)
+    stdout = sys.stdout
+    from tui_gateway import server
+    sys.stdout = stdout
+    session = {
+        "session_key": "usage-integration", "agent": None,
+        "history": [], "history_lock": threading.Lock(), "profile_home": str(profile),
+    }
+    server._sessions["usage-integration"] = session
+    try:
+        yield SimpleNamespace(server=server, session=session, requests=requests,
+                              base_url=base_url, entered=entered, release=release)
+    finally:
+        release.set()
+        http.shutdown()
+        http.server_close()
+        thread.join(timeout=5)
+        server._close_session_by_id("usage-integration", end_reason="test_cleanup")
+
+
+@pytest.mark.parametrize("identity", ["live", "mirror", "config"])
+def test_usage_windows_resolve_real_profile_credentials(usage_runtime, identity):
+    runtime = usage_runtime
+    if identity == "live":
+        runtime.session["agent"] = SimpleNamespace(
+            provider="openai-codex", base_url=runtime.base_url, api_key="live-test-token")
+    elif identity == "mirror":
+        # No usage snapshot yet: provider limits must still be visible.
+        runtime.session["_metadata_mirror"] = {"provider": "openai-codex"}
+    params = {"session_id": "usage-integration"}
+    desktop = runtime.server.handle_request({
+        "id": 1, "method": "slash.exec", "params": {**params, "command": "usage"}})
+    tui = runtime.server.handle_request({"id": 2, "method": "session.usage", "params": params})
+    text = desktop["result"]["output"]
+    lines = "\n".join(tui["result"]["account_lines"])
+    for rendered in (text, lines):
+        assert "Session: 93% remaining" in rendered
+        assert "Weekly: 80% remaining" in rendered
+        assert all(token not in rendered for token in (
+            "live-test-token", "profile-pool-token", "wrong-launch-token"))
+    expected_token = "live-test-token" if identity == "live" else "profile-pool-token"
+    assert runtime.requests == [("/api/codex/usage", f"Bearer {expected_token}")] * 2
+    assert "api_key" not in runtime.session
+    from hermes_constants import get_hermes_home_override
+    assert get_hermes_home_override() is None
+
+
+@pytest.mark.parametrize("method", ["session.usage", "slash.exec"])
+def test_slow_usage_endpoint_does_not_block_rpc_reader(usage_runtime, monkeypatch, method):
+    from tui_gateway import usage_provider
+
+    runtime = usage_runtime
+    runtime.release.clear()
+    monkeypatch.setattr(usage_provider, "_ACCOUNT_USAGE_TIMEOUT_SECONDS", 0.2)
+    frames = queue.Queue()
+
+    class Transport:
+        def write(self, frame):
+            frames.put(frame)
+
+    params = {"session_id": "usage-integration", "command": "usage"}
+    try:
+        assert runtime.server.dispatch({"id": 1, "method": method, "params": params}, Transport()) is None
+        assert runtime.entered.wait(5), "real account request never started"
+        ping = runtime.server.dispatch({"id": 2, "method": "ping", "params": {}}, Transport())
+        assert ping["id"] == 2 and "result" in ping
+        response = frames.get(timeout=5)
+        assert response["id"] == 1 and "result" in response
+        assert "account_lines" not in response["result"]
+        assert not runtime.release.is_set(), "usage should time out before HTTP is released"
+    finally:
+        runtime.release.set()

--- a/tests/tui_gateway/test_usage_provider_integration.py
+++ b/tests/tui_gateway/test_usage_provider_integration.py
@@ -78,6 +78,33 @@ def usage_runtime(tmp_path, monkeypatch):
         server._close_session_by_id("usage-integration", end_reason="test_cleanup")
 
 
+@pytest.mark.parametrize("multiplex", [False, True])
+def test_quota_worker_binds_and_resets_selected_profile_secrets(tmp_path, monkeypatch, multiplex):
+    from concurrent.futures import ThreadPoolExecutor
+    from agent import account_usage, secret_scope
+    from tui_gateway import usage_provider
+
+    profile = tmp_path / "quota-profile"
+    profile.mkdir()
+    (profile / ".env").write_text("OPENROUTER_API_KEY=profile-only-key\n")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "wrong-launch-key")
+    monkeypatch.setattr(secret_scope, "_MULTIPLEX_ACTIVE", multiplex)
+    seen = []
+
+    def fetch(*args, **kwargs):
+        seen.append(secret_scope.get_secret("OPENROUTER_API_KEY"))
+        raise RuntimeError("quota endpoint unavailable")
+
+    monkeypatch.setattr(account_usage, "fetch_account_usage", fetch)
+    session = {"profile_home": str(profile), "agent": SimpleNamespace(
+        provider="openrouter", base_url="https://openrouter.ai/api/v1", api_key=None)}
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        monkeypatch.setattr(usage_provider, "_account_usage_pool", pool)
+        assert usage_provider._usage_provider_lines(session) == ([], [])
+        assert seen == ["profile-only-key"]
+        assert pool.submit(secret_scope.current_secret_scope).result(timeout=5) is None
+
+
 @pytest.mark.parametrize("identity", ["live", "mirror", "config"])
 def test_usage_windows_resolve_real_profile_credentials(usage_runtime, identity):
     runtime = usage_runtime

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -1363,6 +1363,11 @@ def _(rid, params: dict) -> dict:
     usage: dict = _session_usage_snapshot(session)
     if agent is None and not usage:
         usage = {"calls": 0, "input": 0, "output": 0, "total": 0}
+    account_lines, rate_limit_lines = _usage_provider_lines(session)
+    if account_lines:
+        usage["account_lines"] = account_lines
+    if rate_limit_lines:
+        usage["rate_limit_lines"] = rate_limit_lines
     # Nous credits block — agent-independent (a portal fetch), so it shows even
     # with zero API calls or on a resumed session. The TUI /usage panel renders
     # these lines regardless of `calls`. Fail-open: [] when not logged into Nous

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -1135,6 +1135,13 @@ def _(rid, params: dict, session: dict) -> dict:
     usage: dict = _session_usage_snapshot(session)
     if session.get("agent") is None and not usage:
         usage = {"calls": 0, "input": 0, "output": 0, "total": 0}
+    from tui_gateway.usage_provider import _usage_provider_lines
+
+    account_lines, rate_limit_lines = _usage_provider_lines(session)
+    if account_lines:
+        usage["account_lines"] = account_lines
+    if rate_limit_lines:
+        usage["rate_limit_lines"] = rate_limit_lines
     # Nous credits are agent-independent (portal fetch); fail-open when absent.
     with contextlib.suppress(Exception):
         from agent.account_usage import nous_credits_lines

--- a/tui_gateway/methods_slash.py
+++ b/tui_gateway/methods_slash.py
@@ -58,8 +58,6 @@ def _format_live_review_output(sid: str, session: Optional[dict], arg: str) -> s
 def _format_live_usage_output(sid: str, session: dict, arg: str) -> str:
     agent = session.get("agent")
     usage = _session_usage_snapshot(session)
-    if agent is None and not usage:
-        return _NO_AGENT_USAGE
     if session.get("_metadata_message_count") is not None:
         message_count = int(session.get("_metadata_message_count") or 0)
     else:
@@ -80,7 +78,15 @@ def _format_live_usage_output(sid: str, session: dict, arg: str) -> str:
     rows += [("Messages:", f"{message_count:,}"), ("Compressions:", n("compressions"))]
     model = usage.get("model") or _metadata_mirror(session).get("model") or getattr(agent, "model", "") or "(unknown)"
     lines = ["Session Token Usage", "────────────────────────────────────────", f"Model: {model}"]
-    return "\n".join(lines + [f"{label:<30}{value}" for label, value in rows])
+    lines.extend(f"{label:<30}{value}" for label, value in rows)
+    from tui_gateway.usage_provider import _usage_provider_lines
+
+    account_lines, rate_limit_lines = _usage_provider_lines(session)
+    if account_lines:
+        lines.extend(["", *account_lines])
+    if rate_limit_lines:
+        lines.extend(["", *rate_limit_lines])
+    return "\n".join(lines)
 
 
 def _live_session_messages(session: dict) -> Optional[list]:
@@ -217,6 +223,8 @@ def _live_slash_command_output(sid: str, session: Optional[dict], name: str, arg
     """Answer a slash command from the live session instead of the slash worker; None = not ours."""
     name = (name or "").lstrip("/").lower()
     arg = arg or ""
+    if name == "usage" and arg.strip():
+        return None
     if name == "model" and not arg.strip():
         return _format_live_model_output(session or {})
     if name in _ISOLATED_SESSION_READ_COMMANDS and not (session is not None and _session_uses_compute_host(session)):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -283,6 +283,16 @@ _LONG_HANDLERS = frozenset(
     }
 )
 
+# Quota endpoints are remote and cosmetic. Keep timed-out calls off both the
+# RPC reader and the general long-handler pool.
+_account_usage_pool = concurrent.futures.ThreadPoolExecutor(
+    max_workers=2, thread_name_prefix="hermes-account-usage"
+)
+atexit.register(
+    lambda: _account_usage_pool.shutdown(wait=False, cancel_futures=True)
+)
+_ACCOUNT_USAGE_TIMEOUT_SECONDS = 10.0
+
 try:
     _rpc_pool_workers = max(
         2, int(os.environ.get("HERMES_TUI_RPC_POOL_WORKERS") or "8")
@@ -12509,7 +12519,81 @@ def _format_live_usage_output(session: dict) -> str:
             f"Compressions:                 {int(usage.get('compressions') or 0):,}",
         ]
     )
+    account_lines, rate_limit_lines = _usage_provider_lines(session)
+    if account_lines:
+        lines.extend(["", *account_lines])
+    if rate_limit_lines:
+        lines.extend(["", *rate_limit_lines])
     return "\n".join(lines)
+
+
+def _usage_provider_identity(session: dict) -> tuple[str, str, Any]:
+    """Resolve quota inputs without persisting or returning credentials."""
+    agent = session.get("agent")
+    mirror = _metadata_mirror(session)
+    provider = str(getattr(agent, "provider", "") if agent else "").strip() or str(mirror.get("provider") or "").strip()
+    base_url = str(getattr(agent, "base_url", "") if agent else "").strip() or str(mirror.get("base_url") or "").strip()
+    api_key = getattr(agent, "api_key", None) if agent else None
+    if not provider or not base_url:
+        token = None
+        try:
+            if session.get("profile_home"):
+                token = set_hermes_home_override(Path(session["profile_home"]))
+            cfg = _load_cfg()
+            model_cfg = cfg.get("model") if isinstance(cfg, dict) else {}
+            model_cfg = model_cfg if isinstance(model_cfg, dict) else {}
+            configured_provider = str(model_cfg.get("provider") or "").strip()
+            if not provider:
+                provider = configured_provider
+            # Never combine a mirrored provider with another provider's URL.
+            if not base_url and provider == configured_provider:
+                base_url = str(model_cfg.get("base_url") or "").strip()
+        except Exception:
+            pass
+        finally:
+            if token is not None:
+                reset_hermes_home_override(token)
+    return provider, base_url, api_key
+
+
+def _usage_provider_lines(session: dict) -> tuple[list[str], list[str]]:
+    """Return bounded, fail-open provider account and rate-limit lines."""
+    account_lines: list[str] = []
+    rate_limit_lines: list[str] = []
+    provider, base_url, api_key = _usage_provider_identity(session)
+    if provider:
+        try:
+            from agent.account_usage import fetch_account_usage, render_account_usage_lines
+
+            def fetch():
+                token = None
+                try:
+                    if session.get("profile_home"):
+                        token = set_hermes_home_override(Path(session["profile_home"]))
+                    return fetch_account_usage(provider, base_url=base_url or None, api_key=api_key)
+                finally:
+                    if token is not None:
+                        reset_hermes_home_override(token)
+
+            future = _account_usage_pool.submit(fetch)
+            try:
+                snapshot = future.result(timeout=_ACCOUNT_USAGE_TIMEOUT_SECONDS)
+            except concurrent.futures.TimeoutError:
+                future.cancel()
+                raise
+            account_lines = list(render_account_usage_lines(snapshot) or [])
+        except Exception:
+            account_lines = []
+    agent = session.get("agent")
+    if agent is not None:
+        try:
+            state = agent.get_rate_limit_state()
+            if state and getattr(state, "has_data", False):
+                from agent.rate_limit_tracker import format_rate_limit_display
+                rate_limit_lines = format_rate_limit_display(state).splitlines()
+        except Exception:
+            rate_limit_lines = []
+    return account_lines, rate_limit_lines
 
 
 def _format_live_history_output(session: dict) -> str:
@@ -12665,6 +12749,8 @@ def _live_slash_command_output(sid: str, session: Optional[dict], name: str, arg
             return "no active session for /compress"
         return _mirror_slash_side_effects(sid, session, f"/compress {arg}".strip())
     if name == "usage":
+        if arg.strip():
+            return None
         if session is None:
             return "(._.) No active agent -- send a message first."
         return _format_live_usage_output(session)

--- a/tui_gateway/usage_provider.py
+++ b/tui_gateway/usage_provider.py
@@ -1,0 +1,90 @@
+"""Bounded, fail-open account limits shared by desktop slash and TUI usage."""
+
+from __future__ import annotations
+
+import atexit
+import concurrent.futures
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+# Quota endpoints are remote and cosmetic. Timed-out calls must not occupy the
+# RPC reader or the general long-handler pool indefinitely.
+_account_usage_pool = concurrent.futures.ThreadPoolExecutor(
+    max_workers=2, thread_name_prefix="hermes-account-usage"
+)
+atexit.register(lambda: _account_usage_pool.shutdown(wait=False, cancel_futures=True))
+_ACCOUNT_USAGE_TIMEOUT_SECONDS = 10.0
+
+
+def _usage_provider_identity(session: dict) -> tuple[str, str, Any]:
+    """Resolve quota inputs without persisting or returning credentials."""
+    from tui_gateway.server import _load_cfg
+    from tui_gateway.compute_host_bridge import _metadata_mirror
+
+    agent = session.get("agent")
+    mirror = _metadata_mirror(session)
+    provider = str(getattr(agent, "provider", "") if agent else "").strip() or str(mirror.get("provider") or "").strip()
+    base_url = str(getattr(agent, "base_url", "") if agent else "").strip() or str(mirror.get("base_url") or "").strip()
+    api_key = getattr(agent, "api_key", None) if agent else None
+    if not provider or not base_url:
+        token = None
+        try:
+            if session.get("profile_home"):
+                token = set_hermes_home_override(Path(session["profile_home"]))
+            cfg = _load_cfg()
+            model_cfg = cfg.get("model") if isinstance(cfg, dict) else {}
+            model_cfg = model_cfg if isinstance(model_cfg, dict) else {}
+            configured_provider = str(model_cfg.get("provider") or "").strip()
+            if not provider:
+                provider = configured_provider
+            # Never combine a mirrored provider with another provider's URL.
+            if not base_url and provider == configured_provider:
+                base_url = str(model_cfg.get("base_url") or "").strip()
+        except Exception:
+            pass
+        finally:
+            if token is not None:
+                reset_hermes_home_override(token)
+    return provider, base_url, api_key
+
+
+def _usage_provider_lines(session: dict) -> tuple[list[str], list[str]]:
+    """Return bounded, fail-open provider account and rate-limit lines."""
+    account_lines: list[str] = []
+    rate_limit_lines: list[str] = []
+    provider, base_url, api_key = _usage_provider_identity(session)
+    if provider:
+        try:
+            from agent.account_usage import fetch_account_usage, render_account_usage_lines
+
+            def fetch():
+                token = None
+                try:
+                    if session.get("profile_home"):
+                        token = set_hermes_home_override(Path(session["profile_home"]))
+                    return fetch_account_usage(provider, base_url=base_url or None, api_key=api_key)
+                finally:
+                    if token is not None:
+                        reset_hermes_home_override(token)
+
+            future = _account_usage_pool.submit(fetch)
+            try:
+                snapshot = future.result(timeout=_ACCOUNT_USAGE_TIMEOUT_SECONDS)
+            except concurrent.futures.TimeoutError:
+                future.cancel()
+                raise
+            account_lines = list(render_account_usage_lines(snapshot) or [])
+        except Exception:
+            account_lines = []
+    agent = session.get("agent")
+    if agent is not None:
+        try:
+            state = agent.get_rate_limit_state()
+            if state and getattr(state, "has_data", False):
+                from agent.rate_limit_tracker import format_rate_limit_display
+                rate_limit_lines = format_rate_limit_display(state).splitlines()
+        except Exception:
+            rate_limit_lines = []
+    return account_lines, rate_limit_lines

--- a/tui_gateway/usage_provider.py
+++ b/tui_gateway/usage_provider.py
@@ -60,12 +60,21 @@ def _usage_provider_lines(session: dict) -> tuple[list[str], list[str]]:
             from agent.account_usage import fetch_account_usage, render_account_usage_lines
 
             def fetch():
+                from agent.secret_scope import (
+                    build_profile_secret_scope, reset_secret_scope, set_secret_scope,
+                )
+                from hermes_constants import get_hermes_home
+
                 token = None
+                secret_token = None
                 try:
                     if session.get("profile_home"):
                         token = set_hermes_home_override(Path(session["profile_home"]))
+                    secret_token = set_secret_scope(build_profile_secret_scope(get_hermes_home()))
                     return fetch_account_usage(provider, base_url=base_url or None, api_key=api_key)
                 finally:
+                    if secret_token is not None:
+                        reset_secret_scope(secret_token)
                     if token is not None:
                         reset_hermes_home_override(token)
 

--- a/ui-tui/src/__tests__/usageCommand.test.ts
+++ b/ui-tui/src/__tests__/usageCommand.test.ts
@@ -121,4 +121,22 @@ describe('/usage slash command', () => {
     expect(body).toContain('free models only')
     expect(body).toContain('/subscription')
   })
+
+  it('renders provider account and rate-limit lines before balance and token usage', async () => {
+    const { panel, run, sys } = buildCtx({
+      'session.usage': baseUsage({
+        calls: 2,
+        account_lines: ['Account limits', 'Weekly: 80% remaining'],
+        rate_limit_lines: ['Requests: 50% remaining'],
+        usage: { available: true, status: 'free', plan_name: null }
+      })
+    })
+
+    await run('')
+
+    expect(printed(sys)).toContain('Weekly: 80% remaining')
+    expect(printed(sys)).toContain('Requests: 50% remaining')
+    expect(panel.mock.calls.map(call => call[0])).toEqual(['Balance', 'Usage'])
+    expect(sys.mock.invocationCallOrder[0]).toBeLessThan(panel.mock.invocationCallOrder[0])
+  })
 })

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -659,6 +659,17 @@ export const sessionCommands: SlashCommand[] = [
           })
         }
 
+        const accountLines = r?.account_lines ?? []
+        const rateLimitLines = r?.rate_limit_lines ?? []
+
+        if (accountLines.length) {
+          sys(accountLines.join('\n'))
+        }
+
+        if (rateLimitLines.length) {
+          sys(rateLimitLines.join('\n'))
+        }
+
         // Nous balance block is agent-independent (a portal fetch), so it shows
         // even with zero API calls or on a resumed session. Prefer the shared
         // dollar usage model (two-bar view, dollars-only); fall back to the

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -679,6 +679,17 @@ export const sessionCommands: SlashCommand[] = [
           })
         }
 
+        const accountLines = r?.account_lines ?? []
+        const rateLimitLines = r?.rate_limit_lines ?? []
+
+        if (accountLines.length) {
+          sys(accountLines.join('\n'))
+        }
+
+        if (rateLimitLines.length) {
+          sys(rateLimitLines.join('\n'))
+        }
+
         // Nous balance block is agent-independent (a portal fetch), so it shows
         // even with zero API calls or on a resumed session. Prefer the shared
         // dollar usage model (two-bar view, dollars-only); fall back to the

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -259,6 +259,7 @@ export interface SessionUndoResponse {
 }
 
 export interface SessionUsageResponse {
+  account_lines?: string[]
   active_subagents?: number
   cache_read?: number
   cache_write?: number
@@ -273,6 +274,7 @@ export interface SessionUsageResponse {
   input?: number
   model?: string
   output?: number
+  rate_limit_lines?: string[]
   total?: number
   // Shared dollar usage model (two-bar view) so /usage renders the same bars
   // as /subscription. Dollars only — never "credits".

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -274,6 +274,7 @@ export interface SessionUndoResponse {
 }
 
 export interface SessionUsageResponse {
+  account_lines?: string[]
   active_subagents?: number
   avg_latency_s?: number
   avg_tps?: number
@@ -293,6 +294,7 @@ export interface SessionUsageResponse {
   input?: number
   model?: string
   output?: number
+  rate_limit_lines?: string[]
   total?: number
   // Shared dollar usage model (two-bar view) so /usage renders the same bars
   // as /subscription. Dollars only — never "credits".


### PR DESCRIPTION
## Summary
- show provider account limits and available rate-limit lines in Desktop and Ink TUI `/usage`
- resolve provider identity from the live agent or compute-host metadata/profile context, including OpenAI Codex credential-pool fallback
- keep account-usage reads bounded, fail-open, and off the gateway RPC reader
- intercept only bare `/usage`, preserving `/usage reset [--force]` and invalid-subcommand handling through the CLI worker
- retain the current Nous balance model and session-token presentation

## Verification
- `uv run pytest tests/tui_gateway/test_protocol.py -q` — 46 passed
- `npm --workspace ui-tui run check` — 1,530 passed, 1 skipped; typecheck/build/lint passed (one unrelated pre-existing hook warning)
- `uv run ruff check tui_gateway/server.py tui_gateway/methods_session.py tests/tui_gateway/test_protocol.py`
- `uv run python -m py_compile tui_gateway/server.py tui_gateway/methods_session.py`
- `git diff --check`
- live OpenAI Codex credential-pool smoke test confirmed Desktop output contains session usage and account limits

Closes #45713