### PR TITLE
fix(qqbot): add is_reconnect kwarg to QQAdapter.connect()

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,8 +278,13 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
-        """Authenticate, obtain gateway URL, and open the WebSocket."""
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        """Authenticate, obtain gateway URL, and open the WebSocket.""
+
+        Args:
+            is_reconnect: Whether this is a reconnection attempt (unused by QQBot
+                         but required by BasePlatformAdapter signature).
+        """
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"
             self._set_fatal_error("qq_missing_dependency", message, retryable=True)


### PR DESCRIPTION
## Summary

Fixes the QQBot adapter to accept the `is_reconnect` keyword argument that `BasePlatformAdapter.connect()` and the gateway runner expect.

## Problem

On every gateway startup and reconnection attempt, the runner calls `adapter.connect(is_reconnect=False/True)`, which raised:

```
TypeError: QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'
```

This made the qqbot platform completely unable to connect.

## Solution

Added `*, is_reconnect: bool = False` to the method signature to align with the base class.

## Related Issues

- Fixes #53443
- Fixes #52914  
- Fixes #57266
- Fixes #54679
- Related PRs: #55419, #54165, #53546

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My changes are minimal and focused on the fix