### PR TITLE
fix(telegram): bound all updater.stop() calls to prevent CLOSE-WAIT reconnect hang (salvage #58272, closes #58270)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1990,7 +1990,25 @@ class TelegramAdapter(BasePlatformAdapter):
 
         try:
             if app and app.updater and app.updater.running:
-                await app.updater.stop()
+                try:
+                    # Guard stop() with a timeout: when the underlying TCP
+                    # connection is in CLOSE-WAIT the PTB polling task is
+                    # blocked on epoll on the dead socket and never wakes up,
+                    # so an unguarded stop() hangs indefinitely.  The result
+                    # is that _polling_error_task stays alive-but-blocked
+                    # forever, every subsequent heartbeat probe sees it as
+                    # "in-flight" and skips triggering a new reconnect, and
+                    # the gateway silently drops messages for hours.
+                    # Bounding stop() lets the reconnect ladder always advance.
+                    # Refs: NousResearch/hermes-agent#58270
+                    await asyncio.wait_for(app.updater.stop(), timeout=15.0)
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "[%s] updater.stop() timed out during network-error "
+                        "reconnect (likely CLOSE-WAIT socket); forcing drain "
+                        "and restart without clean stop",
+                        self.name,
+                    )
         except Exception:
             pass
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -397,6 +397,14 @@ def _rich_normalize_linebreaks(text: str) -> str:
     return ''.join(out)
 
 
+# Watchdog bound for `await updater.stop()`. When the underlying TCP socket is
+# in CLOSE-WAIT the PTB polling task is blocked on epoll on the dead socket and
+# never wakes, so an unguarded stop() hangs indefinitely and wedges the whole
+# reconnect/teardown ladder. This is an internal safety bound (not a user knob),
+# applied identically at every stop() site so no path can hang on a dead socket.
+_UPDATER_STOP_TIMEOUT = 15.0
+
+
 class TelegramAdapter(BasePlatformAdapter):
     """
     Telegram bot adapter.
@@ -2001,7 +2009,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     # the gateway silently drops messages for hours.
                     # Bounding stop() lets the reconnect ladder always advance.
                     # Refs: NousResearch/hermes-agent#58270
-                    await asyncio.wait_for(app.updater.stop(), timeout=15.0)
+                    await asyncio.wait_for(app.updater.stop(), timeout=_UPDATER_STOP_TIMEOUT)
                 except asyncio.TimeoutError:
                     logger.warning(
                         "[%s] updater.stop() timed out during network-error "
@@ -2382,10 +2390,19 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             # Stop the local updater cleanly before sleeping.  If it's already
             # stopped (e.g. PTB raised before updater.running was set) this is
-            # a no-op.
+            # a no-op.  Bounded with a timeout for the same reason as the
+            # network-error path: a CLOSE-WAIT socket can wedge stop() on epoll
+            # forever, which would stall the conflict-retry ladder.
             try:
                 if self._app and self._app.updater and self._app.updater.running:
-                    await self._app.updater.stop()
+                    try:
+                        await asyncio.wait_for(self._app.updater.stop(), timeout=_UPDATER_STOP_TIMEOUT)
+                    except asyncio.TimeoutError:
+                        logger.warning(
+                            "[%s] updater.stop() timed out during conflict "
+                            "retry (likely CLOSE-WAIT socket); continuing",
+                            self.name,
+                        )
             except Exception:
                 pass
 
@@ -2453,16 +2470,33 @@ class TelegramAdapter(BasePlatformAdapter):
             "[%s] %s Original error: %s",
             self.name, message, error,
         )
+        # Snapshot whether we are the call that actually transitions to fatal.
+        # A concurrent retry task scheduled by an earlier conflict may already
+        # be suspended past the entry guard; once _set_fatal_error flips the
+        # flag, adding an await below (the bounded stop()) yields the loop and
+        # lets that task reach this branch too — double-notifying the fatal
+        # handler.  Only the first transition notifies.
+        _already_fatal = (
+            self.has_fatal_error
+            and self.fatal_error_code == "telegram_polling_conflict"
+        )
         self._set_fatal_error("telegram_polling_conflict", message, retryable=False)
         try:
             if self._app and self._app.updater:
-                await self._app.updater.stop()
+                await asyncio.wait_for(self._app.updater.stop(), timeout=_UPDATER_STOP_TIMEOUT)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "[%s] updater.stop() timed out after exhausting conflict "
+                "retries (likely CLOSE-WAIT socket); proceeding to fatal notify",
+                self.name,
+            )
         except Exception as stop_error:
             logger.warning(
                 "[%s] Failed stopping Telegram updater after exhausting conflict retries: %s",
                 self.name, stop_error, exc_info=True,
             )
-        await self._notify_fatal_error()
+        if not _already_fatal:
+            await self._notify_fatal_error()
 
     async def _create_dm_topic(
         self,
@@ -3352,9 +3386,20 @@ class TelegramAdapter(BasePlatformAdapter):
 
         if self._app:
             try:
-                # Only stop the updater if it's running
+                # Only stop the updater if it's running.  Bounded with a
+                # timeout: a CLOSE-WAIT socket can wedge stop() on epoll
+                # indefinitely, which would hang disconnect() (and any
+                # gateway shutdown/restart waiting on it) forever.  On timeout
+                # we fall through to app.stop()/shutdown() to force teardown.
                 if self._app.updater and self._app.updater.running:
-                    await self._app.updater.stop()
+                    try:
+                        await asyncio.wait_for(self._app.updater.stop(), timeout=_UPDATER_STOP_TIMEOUT)
+                    except asyncio.TimeoutError:
+                        logger.warning(
+                            "[%s] updater.stop() timed out during disconnect "
+                            "(likely CLOSE-WAIT socket); forcing app shutdown",
+                            self.name,
+                        )
                 if self._app.running:
                     await self._app.stop()
                 await self._app.shutdown()

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -220,6 +220,20 @@ async def test_polling_conflict_becomes_fatal_after_retries(monkeypatch):
             conflict("Conflict: terminated by other getUpdates request")
         )
 
+    # Retries 1-4 each schedule a background recovery task via
+    # loop.create_task(self._handle_polling_conflict(...)) that this test
+    # never awaits.  Cancel the last one so a leaked task can't get a
+    # scheduler turn under load and re-drive the counter into the fatal
+    # branch a second time — which would fire _notify_fatal_error twice and
+    # break assert_awaited_once() non-deterministically.
+    leaked = adapter._polling_error_task
+    if leaked is not None and not leaked.done():
+        leaked.cancel()
+        try:
+            await leaked
+        except (asyncio.CancelledError, Exception):
+            pass
+
     # After 5 failed retries (count 1-5 each enter the retry branch but
     # start_polling raises), the 6th conflict pushes count to 6 which
     # exceeds MAX_CONFLICT_RETRIES (5), entering the fatal branch.

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -856,15 +856,12 @@ async def test_handle_polling_network_error_updater_stop_timeout():
 
     app.updater.start_polling = AsyncMock(side_effect=_fake_start_polling)
 
-    # Patch the timeout constant so the test completes fast.
+    # Shrink the stop() watchdog bound so the test completes fast instead of
+    # waiting the full _UPDATER_STOP_TIMEOUT. Patching the named constant is
+    # cleaner than monkeypatching asyncio.wait_for process-wide.
     import plugins.platforms.telegram.adapter as _mod
-    original_wait_for = asyncio.wait_for
 
-    async def _fast_wait_for(coro, timeout):
-        # Substitute a 0.05s timeout so the test doesn't take 15s.
-        return await original_wait_for(coro, 0.05)
-
-    with patch("asyncio.wait_for", side_effect=_fast_wait_for):
+    with patch.object(_mod, "_UPDATER_STOP_TIMEOUT", 0.05):
         await adapter._handle_polling_network_error(OSError("CLOSE-WAIT test"))
 
     # The reconnect ladder must have advanced past the hung stop().

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -812,3 +812,62 @@ async def test_schedule_polling_recovery_tracks_background_task():
     await adapter._polling_error_task
     adapter._handle_polling_network_error.assert_awaited_once()
 
+
+@pytest.mark.asyncio
+async def test_handle_polling_network_error_updater_stop_timeout():
+    """updater.stop() hanging (CLOSE-WAIT) must not block the reconnect ladder.
+
+    When the underlying TCP connection is in CLOSE-WAIT, PTB's polling task is
+    blocked on epoll on the dead socket.  updater.stop() awaits that task and
+    therefore hangs indefinitely.  The fix wraps stop() in asyncio.wait_for()
+    with a 15-second timeout so the reconnect always advances.
+
+    This test simulates the hang by making stop() sleep forever and verifies
+    that _drain_polling_connections() and start_polling() are still called
+    after the timeout fires.
+    Refs: NousResearch/hermes-agent#58270
+    """
+    adapter = _make_adapter()
+    adapter._polling_network_error_count = 0
+
+    # Build a fake app whose updater.stop() hangs forever.
+    app = MagicMock()
+    app.updater = MagicMock()
+    app.updater.running = True
+
+    async def _hanging_stop():
+        await asyncio.sleep(9999)  # simulate CLOSE-WAIT block
+
+    app.updater.stop = _hanging_stop
+    app.updater.start_polling = AsyncMock()
+    adapter._app = app
+
+    drain_called = []
+
+    async def _fake_drain():
+        drain_called.append(True)
+
+    adapter._drain_polling_connections = _fake_drain
+
+    start_polling_called = []
+
+    async def _fake_start_polling(**kwargs):
+        start_polling_called.append(True)
+
+    app.updater.start_polling = AsyncMock(side_effect=_fake_start_polling)
+
+    # Patch the timeout constant so the test completes fast.
+    import plugins.platforms.telegram.adapter as _mod
+    original_wait_for = asyncio.wait_for
+
+    async def _fast_wait_for(coro, timeout):
+        # Substitute a 0.05s timeout so the test doesn't take 15s.
+        return await original_wait_for(coro, 0.05)
+
+    with patch("asyncio.wait_for", side_effect=_fast_wait_for):
+        await adapter._handle_polling_network_error(OSError("CLOSE-WAIT test"))
+
+    # The reconnect ladder must have advanced past the hung stop().
+    assert drain_called, "_drain_polling_connections was not called after stop() timeout"
+    assert start_polling_called, "start_polling was not called after stop() timeout"
+


### PR DESCRIPTION
## Summary

Bounds **every** `updater.stop()` call in the Telegram reconnect/teardown ladder with a 15s `asyncio.wait_for`, so a CLOSE-WAIT socket can no longer wedge the gateway.

Root cause: when the TCP connection is in CLOSE-WAIT, PTB's polling task is blocked on `epoll` on the dead socket and never wakes. An unguarded `await app.updater.stop()` awaits that task and hangs indefinitely — `_polling_error_task` stays alive-but-blocked, the heartbeat loop treats it as "in flight" and never fires another reconnect, and the gateway silently drops messages for hours until a manual restart (confirmed field incident, 11h silence on 2026-07-04).

## Changes

- `plugins/platforms/telegram/adapter.py`:
  - **Network-error handler** (contributor's fix, @terry197913): wrap `stop()` in `asyncio.wait_for(timeout=15.0)`; on `TimeoutError`, log and fall through to the existing `_drain_polling_connections()` + `start_polling()` recovery.
  - **Sibling sites** (follow-up): the same guard applied to the 3 other `updater.stop()` call paths flagged in #58270 — conflict-retry ladder, fatal-notify teardown, and `disconnect()`. Each keeps its own surrounding exception handling and gets a contextual timeout log. Completes the bug class rather than fixing only the one path the reporter hit. Timeout centralized in `_UPDATER_STOP_TIMEOUT`.
- `tests/gateway/test_telegram_network_reconnect.py`: `test_handle_polling_network_error_updater_stop_timeout` — makes `stop()` hang, patches the timeout small, asserts drain + `start_polling` still run.
- `tests/gateway/test_telegram_conflict.py`: cancel the leaked background conflict-retry task before the fatal assertion in `test_polling_conflict_becomes_fatal_after_retries`. That test schedules recovery tasks via `loop.create_task` and never cancelled the last one; the new `wait_for` yield surfaced the latent leak under CI's loaded scheduler (a leaked task could re-fire `_notify_fatal_error`, breaking `assert_awaited_once`). Cancelling it makes the test deterministic.

## Validation

| | Before | After |
|---|---|---|
| `updater.stop()` sites guarded | 0 / 4 | 4 / 4 (AST-verified, 0 unguarded) |
| CLOSE-WAIT hang recovery | never (manual restart) | reconnect ladder always advances |
| `test_telegram_network_reconnect.py` | — | 28/28 pass |
| conflict-retry fatal test under load | flaky (double-await race) | deterministic |

E2E (real imports, hung `stop()` simulating CLOSE-WAIT) verified on all four paths:
- network-error → reaches drain + restart
- conflict-retry → reaches drain + `start_polling`
- fatal → reaches `_notify_fatal_error`
- disconnect → reaches `app.stop()` / `app.shutdown()`

ruff clean; `ty` net-new diagnostics = 0; plugin-only (no core touches).

Closes #58270.

---

Salvaged from #58272 by @terry197913 (network-error path). Sibling-site widening + test hardening added on top. Authorship preserved via rebase merge.
