### PR TITLE
feat(skill): add session-health — agent self-diagnostic skill

### DIFF
--- a/skills/session-health/DESCRIPTION.md
+++ b/skills/session-health/DESCRIPTION.md
@@ -1,0 +1,3 @@
+---
+description: Self-diagnostic skills that audit past sessions via the session_search tool — health reports, failure patterns, and tool-call loop detection.
+---

--- a/skills/session-health/session-health-check/SKILL.md
+++ b/skills/session-health/session-health-check/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: session-health-check
+description: Audit past sessions for failure patterns and context loss.
+version: 1.1.0
+author: 黄云龙 (@nankingjing) + Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [diagnostic, session, health, monitoring]
+    category: session-health
+    related_skills: [session-loop-detection]
+---
+
+# Session Health Check Skill
+
+Audit one or more PAST sessions for failure patterns — tool errors, empty
+assistant turns, provider throttling, runaway message counts — using only the
+`session_search` tool, and produce an operator-facing report. This skill is
+read-only and cannot inspect the live session: browse and discovery exclude
+the active session lineage, and scroll rejects it. Diagnose the current
+conversation from the context already in your window instead.
+
+## When to Use
+
+- The user reports a past session that got stuck, degraded, or ended abruptly
+- After a long or crashed run, to find out what went wrong
+- Periodic audit of recent sessions on a profile
+
+Don't use for: the current conversation, or for inspecting external systems —
+the session DB only records what was said, not present-day world state.
+
+## Prerequisites
+
+- The `session_search` tool (part of the default toolset; needs the local
+  session DB). No network access, no extra dependencies.
+- Optional: pass `profile="<name>"` on any call to audit another profile.
+
+## How to Run
+
+Every step is one `session_search` call. The tool has four shapes, inferred
+from which arguments are set — never invent other parameters or shapes.
+
+## Quick Reference
+
+| Goal | Call | Returns |
+| --- | --- | --- |
+| List recent past sessions | `session_search(limit=10)` | per-session metadata: session_id, title, message_count, last_active, preview |
+| Read one session | `session_search(session_id="<id>")` | session_meta, message_count, truncated, first 20 + last 10 messages when large |
+| Find failure text across sessions | `session_search(query="error OR exception", role_filter="tool", limit=5, sort="newest")` | snippet, match_message_id, ±5 message window, bookends |
+| Drill into a flagged spot | `session_search(session_id="<id>", around_message_id=<id>, window=10)` | ±window messages centered on the anchor |
+
+## Procedure
+
+1. **Pick target sessions.** Browse with `session_search(limit=10)` (no
+   query). Flag anomalies visible in metadata alone: unusually high
+   `message_count` for the task, missing `title`, or a `preview` that ends
+   mid-error. Done when you hold an explicit list of session ids to audit.
+
+2. **Read each target.** `session_search(session_id="<id>")` returns the
+   head and tail of the transcript plus `message_count` and `truncated`.
+   In the messages, look for: assistant entries with empty `content` and no
+   `tool_calls` (empty turns), tool entries containing error text, and an
+   abrupt final message (session died mid-task). Done when every target id
+   has been read.
+
+3. **Scan for failure signatures across sessions.** Use discovery, scoped to
+   tool output, newest first:
+   - Tool failures: `session_search(query="error OR failed OR exception", role_filter="tool", limit=5, sort="newest")`
+   - Provider throttling: `session_search(query="rate OR overloaded OR quota", role_filter="tool", limit=5, sort="newest")`
+   FTS5 syntax: AND is implicit between words, so use explicit OR chains.
+   Keep each hit's `session_id` and `match_message_id` for step 4.
+
+4. **Drill into hits.** For each hit that needs context,
+   `session_search(session_id="<id>", around_message_id=<id>, window=10)`
+   shows what led up to the failure and whether the session recovered.
+   Scroll onward by re-anchoring on `messages[-1].id` (forward) or
+   `messages[0].id` (backward).
+
+5. **Report.** Emit:
+
+   ```
+   ## Session Health Report
+   **Sessions audited**: <ids>
+   **Issues found**: <count>
+
+   ### Issues
+   1. <session_id> @ message <id>: <what happened> => <recommendation>
+
+   ### Recommendations
+   - <actionable step>
+   ```
+
+   Done when every audited session has either a "healthy" verdict or at
+   least one issue entry citing a session_id and message id as evidence.
+
+## Pitfalls
+
+- `sort` accepts only `"newest"` or `"oldest"`; any other value (e.g.
+  `"recent"`) is silently dropped and you get relevance ordering.
+- The read shape (`session_id` alone) ignores `role_filter` and `limit`;
+  those apply to discovery (`query=`). `limit` also caps browse (max 10).
+- `session_id` + `around_message_id` is always the scroll shape — `query`
+  is ignored when an anchor is set.
+- Browse skips the current session and delegation children by design; an
+  empty browse result does not mean the DB is empty.
+- A truncated read shows only head + tail; the middle is reachable only via
+  scroll. Never report "no issues" from a truncated read alone.
+
+## Verification
+
+- Every reported issue cites a `session_id` and a message id you actually saw.
+- Every call used one of the four shapes with only documented parameters.
+- No session data was modified — all calls are `session_search` reads.

--- a/skills/session-health/session-loop-detection/SKILL.md
+++ b/skills/session-health/session-loop-detection/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: session-loop-detection
+description: Spot repeated tool-call loops in past agent sessions.
+version: 1.1.0
+author: 黄云龙 (@nankingjing) + Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [diagnostic, session, loop, anti-pattern]
+    category: session-health
+    related_skills: [session-health-check]
+---
+
+# Session Loop Detection Skill
+
+Find turn-level loops — the same tool called with identical or
+near-identical arguments across consecutive assistant turns — in a PAST
+session, classify the root cause, and recommend a mitigation. Uses only the
+read-only `session_search` tool; it cannot inspect the live session (that
+transcript is already in your context — scan it there directly).
+
+## When to Use
+
+- The user reports a session that was "stuck in a loop" or burned tokens
+  without making progress
+- A past session shows an oversized `message_count` for a simple task
+- After `session-health-check` flags repeated tool errors in one session
+
+## Prerequisites
+
+- The `session_search` tool (part of the default toolset; needs the local
+  session DB). No network access, no extra dependencies.
+- The suspect session's id, or enough topic keywords to find it.
+
+## How to Run
+
+Every step is one `session_search` call (browse, discovery, read, or
+scroll — inferred from arguments). There is no per-turn filter shape:
+enumerate messages via read/scroll and compare the turns yourself.
+
+## Quick Reference
+
+Loop signature — flag only when ALL three hold:
+
+1. Same `tool_name` with identical or trivially-different arguments on >=3
+   consecutive assistant turns
+2. The intervening tool results did not change (or kept failing identically)
+3. No user message between the repeats
+
+| Goal | Call |
+| --- | --- |
+| Find the suspect session | `session_search(limit=10)` or `session_search(query="<task keywords>", sort="newest")` |
+| Read head + tail | `session_search(session_id="<id>")` |
+| Walk the transcript | `session_search(session_id="<id>", around_message_id=<id>, window=20)` |
+
+## Procedure
+
+1. **Locate the session.** Browse recent past sessions with
+   `session_search(limit=10)` — a looping session usually stands out by
+   `message_count` — or discover by topic with
+   `session_search(query="<task keywords>", sort="newest")`. Done when you
+   hold the target `session_id`.
+
+2. **Read the tail.** `session_search(session_id="<id>")`. Assistant
+   entries carry `tool_calls` (tool name + arguments); tool entries carry
+   `tool_name`. Compare consecutive assistant turns in the tail against the
+   loop signature — loops usually persist to the end of the session, so the
+   last 10 messages give a first verdict.
+
+3. **Walk backward if truncated.** For a large session (`truncated: true`),
+   anchor on the earliest tail message id:
+   `session_search(session_id="<id>", around_message_id=<id>, window=20)`,
+   then keep re-anchoring on `messages[0].id`. When `messages_before` is
+   less than the window you have reached the session start. Done when you
+   have found the first repeated call, or ruled the loop out back to the
+   last user message.
+
+4. **Classify the root cause** from the surrounding messages:
+   - **Perception failure** — tool results changed, but the agent repeated
+     the call anyway (misread output)
+   - **Goal ambiguity** — the last user message is underspecified; the agent
+     oscillates between interpretations
+   - **Tool failure** — the tool returned the same error every time and the
+     agent never treated it as terminal
+   - **Context saturation** — repeats begin right after a compaction or
+     summary marker in the transcript
+
+5. **Report and recommend.** State the session id, the repeated tool, the
+   argument diff, first/last message ids of the repetition, the root-cause
+   class, and one mitigation:
+   - Perception failure => quote the misread tool result; add an explicit
+     check of that field before retrying
+   - Goal ambiguity => split the request into discrete, verifiable sub-goals
+   - Tool failure => surface the error verbatim; stop after two identical
+     failures instead of retrying
+   - Context saturation => start a fresh session or compact before retrying
+
+## Pitfalls
+
+- `role_filter` and `limit` apply only to discovery (`query=`); the read
+  shape ignores them and browse ignores `role_filter`. Filtering assistant
+  turns is your job after reading.
+- `sort` accepts only `"newest"` or `"oldest"` — `"recent"` is silently
+  dropped.
+- Scroll rejects the current session lineage; this workflow is for past
+  sessions only.
+- Two similar calls are often a legitimate retry. Require >=3 repeats with
+  an unchanged result before declaring a loop.
+
+## Verification
+
+- The verdict cites message ids for the first and last repeated call.
+- The root-cause class is backed by a quoted message from the transcript.
+- No session data was modified — all calls are `session_search` reads.

--- a/tests/skills/test_session_health_skill.py
+++ b/tests/skills/test_session_health_skill.py
@@ -1,0 +1,285 @@
+"""Tests for the session-health bundled skill pair.
+
+Covers SKILL.md frontmatter invariants (AGENTS.md skill authoring
+standards), validates every ``session_search(...)`` example documented in
+the two SKILL.md files against the tool's real schema and calling shapes,
+and grounds the workflows' core assumptions against the actual tool:
+browse excludes the current session, the read shape ignores
+role_filter/limit, unsupported sort values are dropped, and scroll rejects
+the active session lineage. No live network calls — everything runs on a
+temp SQLite session DB.
+"""
+from __future__ import annotations
+
+import ast
+import json
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_state import SessionDB
+from tools.session_search_tool import SESSION_SEARCH_SCHEMA, session_search
+
+CATEGORY_DIR = Path(__file__).resolve().parents[2] / "skills" / "session-health"
+SKILL_NAMES = ["session-health-check", "session-loop-detection"]
+SCHEMA_PARAMS = set(SESSION_SEARCH_SCHEMA["parameters"]["properties"])
+SORT_ENUM = set(SESSION_SEARCH_SCHEMA["parameters"]["properties"]["sort"]["enum"])
+
+_CALL_RE = re.compile(r"session_search\(([^()]*)\)")
+
+
+def _read_skill(name: str) -> str:
+    return (CATEGORY_DIR / name / "SKILL.md").read_text(encoding="utf-8")
+
+
+def _frontmatter(name: str) -> dict:
+    yaml = pytest.importorskip("yaml")
+    content = _read_skill(name)
+    assert content.startswith("---\n"), "frontmatter must start at byte 0"
+    match = re.search(r"^---\n(.*?)\n---", content, re.DOTALL)
+    assert match, "frontmatter must close with ---"
+    return yaml.safe_load(match.group(1))
+
+
+def _documented_calls(name: str) -> list[dict]:
+    """Extract every session_search(...) example as a kwarg dict.
+
+    Angle-bracket placeholders (``<id>``, ``"<task keywords>"``) are
+    replaced with ``0`` / ``"0"`` so each example parses as real Python.
+    """
+    calls = []
+    for raw_args in _CALL_RE.findall(_read_skill(name)):
+        cleaned = re.sub(r"<[^<>]+>", "0", raw_args)
+        node = ast.parse(f"session_search({cleaned})", mode="eval").body
+        assert not node.args, f"example must be keyword-only: ({raw_args})"
+        kwargs = {}
+        for kw in node.keywords:
+            assert kw.arg is not None, f"no **kwargs in examples: ({raw_args})"
+            kwargs[kw.arg] = (
+                kw.value.value if isinstance(kw.value, ast.Constant) else None
+            )
+        calls.append(kwargs)
+    assert len(calls) >= 4, f"{name}: expected several documented calls"
+    return calls
+
+
+# =========================================================================
+# Frontmatter invariants (AGENTS.md skill authoring standards)
+# =========================================================================
+
+
+@pytest.mark.parametrize("name", SKILL_NAMES)
+def test_frontmatter_required_fields(name):
+    fm = _frontmatter(name)
+    for field in ("name", "description", "version", "author", "license"):
+        assert field in fm, f"missing frontmatter field: {field}"
+    assert fm["name"] == name  # matches directory name
+
+
+@pytest.mark.parametrize("name", SKILL_NAMES)
+def test_description_within_hardline_limit(name):
+    desc = _frontmatter(name)["description"]
+    assert len(desc) <= 60, f"description is {len(desc)} chars (limit 60)"
+    assert desc.endswith("."), "description must end with a period"
+    assert ". " not in desc, "description must be a single sentence"
+
+
+@pytest.mark.parametrize("name", SKILL_NAMES)
+def test_author_credits_contributor_first(name):
+    author = _frontmatter(name)["author"]
+    first = re.split(r"[,+]", author)[0].strip()
+    assert first != "Hermes Agent", "human contributor must be credited first"
+    assert "Hermes Agent" in author  # secondary collaborator
+
+
+@pytest.mark.parametrize("name", SKILL_NAMES)
+def test_platforms_declared(name):
+    fm = _frontmatter(name)
+    assert "platforms" in fm and len(fm["platforms"]) >= 1
+
+
+def test_category_description_exists():
+    content = (CATEGORY_DIR / "DESCRIPTION.md").read_text(encoding="utf-8")
+    assert content.startswith("---\n")
+    assert "description:" in content
+
+
+# =========================================================================
+# Documented session_search examples match the real tool contract
+# =========================================================================
+
+
+@pytest.mark.parametrize("name", SKILL_NAMES)
+def test_examples_use_only_schema_parameters(name):
+    for kwargs in _documented_calls(name):
+        unknown = set(kwargs) - SCHEMA_PARAMS
+        assert not unknown, f"undocumented parameters {unknown} in {kwargs}"
+
+
+@pytest.mark.parametrize("name", SKILL_NAMES)
+def test_examples_use_supported_sort_values(name):
+    for kwargs in _documented_calls(name):
+        if "sort" in kwargs:
+            assert kwargs["sort"] in SORT_ENUM, f"unsupported sort in {kwargs}"
+
+
+@pytest.mark.parametrize("name", SKILL_NAMES)
+def test_examples_use_supported_role_filter_values(name):
+    for kwargs in _documented_calls(name):
+        if "role_filter" in kwargs:
+            roles = {r.strip() for r in kwargs["role_filter"].split(",")}
+            assert roles <= {"user", "assistant", "tool"}, kwargs
+
+
+@pytest.mark.parametrize("name", SKILL_NAMES)
+def test_examples_match_a_real_calling_shape(name):
+    """Each example must be exactly one of browse/discovery/read/scroll.
+
+    Guards the failure mode from review: role_filter/limit on the read
+    shape or browse shape are silently ignored by the tool, so documenting
+    them there teaches a call that does not do what the prose claims.
+    """
+    for kwargs in _documented_calls(name):
+        keys = set(kwargs) - {"profile"}
+        if "around_message_id" in keys:  # scroll
+            assert "session_id" in keys, f"scroll needs session_id: {kwargs}"
+            assert keys <= {"session_id", "around_message_id", "window"}, kwargs
+        elif "session_id" in keys:  # read — role_filter/limit/sort ignored
+            assert keys == {"session_id"}, (
+                f"read shape ignores every other parameter: {kwargs}"
+            )
+        elif "query" in keys:  # discovery
+            assert keys <= {"query", "role_filter", "limit", "sort"}, kwargs
+        else:  # browse — only limit applies
+            assert keys <= {"limit"}, f"browse ignores {keys - {'limit'}}"
+
+
+# =========================================================================
+# Workflow assumptions grounded against the actual tool behavior
+# =========================================================================
+
+
+@pytest.fixture
+def db(tmp_path):
+    d = SessionDB(tmp_path / "state.db")
+    yield d
+    d.close()
+
+
+@pytest.fixture
+def seeded(db):
+    """One live session + one past session that looped on a failing tool."""
+    db.create_session("s_current", source="cli")
+    db.append_message("s_current", role="user", content="live task")
+    live_mid = db.append_message("s_current", role="assistant", content="working")
+
+    db.create_session("s_past", source="cli")
+    db.append_message("s_past", role="user", content="fix the deploy")
+    first_loop_mid = None
+    for _ in range(3):
+        mid = db.append_message(
+            "s_past",
+            role="assistant",
+            content="",
+            tool_calls=[{"name": "terminal", "arguments": {"cmd": "deploy"}}],
+        )
+        first_loop_mid = first_loop_mid or mid
+        db.append_message(
+            "s_past", role="tool", tool_name="terminal",
+            content="error: deploy failed",
+        )
+    db._conn.commit()
+    return {"db": db, "live_mid": live_mid, "loop_mid": first_loop_mid}
+
+
+def test_browse_excludes_current_session(seeded):
+    """Step 'pick target sessions': browse lists PAST sessions only."""
+    out = json.loads(
+        session_search(db=seeded["db"], current_session_id="s_current", limit=10)
+    )
+    assert out["success"] and out["mode"] == "browse"
+    ids = [r["session_id"] for r in out["results"]]
+    assert "s_past" in ids
+    assert "s_current" not in ids
+
+
+def test_browse_returns_triage_metadata(seeded):
+    """The health-check triage relies on message_count/preview metadata."""
+    out = json.loads(
+        session_search(db=seeded["db"], current_session_id="s_current", limit=10)
+    )
+    row = next(r for r in out["results"] if r["session_id"] == "s_past")
+    assert row["message_count"] == 7
+    for key in ("title", "last_active", "preview"):
+        assert key in row
+
+
+def test_read_shape_ignores_role_filter_and_limit(seeded):
+    """The tool has no per-turn filter shape — the skills must not claim one."""
+    out = json.loads(
+        session_search(db=seeded["db"], session_id="s_past",
+                       role_filter="assistant", limit=1)
+    )
+    assert out["success"] and out["mode"] == "read"
+    assert out["message_count"] == 7  # limit=1 had no effect
+    assert {m["role"] for m in out["messages"]} == {"user", "assistant", "tool"}
+
+
+def test_read_shape_exposes_tool_calls_for_loop_detection(seeded):
+    """Loop detection compares tool_calls across consecutive assistant turns."""
+    out = json.loads(session_search(db=seeded["db"], session_id="s_past"))
+    repeated = [
+        m for m in out["messages"]
+        if m["role"] == "assistant" and m.get("tool_calls")
+    ]
+    assert len(repeated) == 3
+    names = {c["name"] for m in repeated for c in m["tool_calls"]}
+    assert names == {"terminal"}
+
+
+def test_unsupported_sort_value_is_dropped(seeded):
+    """`sort="recent"` (rejected in review) silently degrades to relevance."""
+    db = seeded["db"]
+    with patch.object(db, "search_messages", wraps=db.search_messages) as spy:
+        session_search(db=db, query="deploy", sort="recent")
+        assert spy.call_args.kwargs["sort"] is None
+        session_search(db=db, query="deploy", sort="newest")
+        assert spy.call_args.kwargs["sort"] == "newest"
+
+
+def test_discovery_finds_tool_errors_in_past_sessions(seeded):
+    """Step 'scan for failure signatures': discovery scoped to tool output."""
+    out = json.loads(
+        session_search(db=seeded["db"], query="error OR failed",
+                       role_filter="tool", limit=5, sort="newest",
+                       current_session_id="s_current")
+    )
+    assert out["success"] and out["mode"] == "discover"
+    assert out["count"] >= 1
+    hit = out["results"][0]
+    assert hit["session_id"] == "s_past"
+    assert isinstance(hit["match_message_id"], int)
+
+
+def test_scroll_drills_into_past_session(seeded):
+    """Step 'drill into hits': anchor on match_message_id in a past session."""
+    out = json.loads(
+        session_search(db=seeded["db"], session_id="s_past",
+                       around_message_id=seeded["loop_mid"], window=10,
+                       current_session_id="s_current")
+    )
+    assert out["success"] and out["mode"] == "scroll"
+    assert any(m.get("anchor") for m in out["messages"])
+
+
+def test_scroll_rejects_current_session_lineage(seeded):
+    """Grounds the 'past sessions only' pitfall both skills document."""
+    out = json.loads(
+        session_search(db=seeded["db"], session_id="s_current",
+                       around_message_id=seeded["live_mid"],
+                       current_session_id="s_current")
+    )
+    assert out.get("success") is False
+    assert "scroll rejected" in out["error"]


### PR DESCRIPTION
## Summary

New bundled skill category that teaches the agent to audit the health of PAST sessions, detect failure patterns, and recommend mitigations — using only the `session_search` tool.

## What it teaches

### session-health-check
A structured diagnostic workflow over past sessions:
1. Triage recent past sessions from browse metadata (message counts, previews, timestamps)
2. Read flagged sessions (head + tail) for empty turns, tool errors, abrupt endings
3. Scan across sessions for failure signatures via discovery scoped to tool output
4. Drill into hits with scroll windows, then emit a structured health report with actionable recommendations

### session-loop-detection
Teaches the agent to detect and classify turn-level loops in a past session:
- Identifies repeated tool calls (same `tool_name`, identical/near-identical arguments, >=3 consecutive assistant turns, unchanged results) via read + backward scroll over `tool_calls`
- Categorizes root causes (perception failure, goal ambiguity, tool failure, context saturation)
- Prescribes specific mitigations per category

## Why this is useful

Session health issues (loops, context loss, silent failures) are common user complaints. This skill gives the agent a systematic way to diagnose them after the fact, reducing operator burden.

## Design

- Read-only by design: every step is a `session_search` call; never modifies session data
- Past sessions only: browse/discovery exclude the active lineage and scroll rejects it — the live conversation is diagnosed from in-context transcript, and both skills say so explicitly
- Operator-facing: the report is for the human, not for autonomous agent action
- Every documented call uses one of the four real `session_search` shapes (browse / discovery / read / scroll) with only documented parameters

## Tests

`tests/skills/test_session_health_skill.py` (25 tests): frontmatter invariants per the AGENTS.md skill authoring standards, ast-validation of every documented `session_search(...)` example against the tool schema and calling shapes, and behavioral grounding of the workflow assumptions on a temp SQLite session DB.

## Files

```
skills/session-health/DESCRIPTION.md
skills/session-health/session-health-check/SKILL.md
skills/session-health/session-loop-detection/SKILL.md
tests/skills/test_session_health_skill.py
```
