### PR TITLE
docs(memory-providers): add Memra community provider

### DIFF
--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -85,7 +85,7 @@ Speech-to-text supports six providers: local faster-whisper (free, runs on-devic
 ## Memory & Personalization
 
 - **[Built-in Memory](/user-guide/features/memory)** — Persistent, curated memory via `MEMORY.md` and `USER.md` files. The agent maintains bounded stores of personal notes and user profile data that survive across sessions.
-- **[Memory Providers](/user-guide/features/memory-providers)** — Plug in external memory backends for deeper personalization. Eight providers are supported: Honcho (dialectic reasoning), OpenViking (tiered retrieval), Mem0 (cloud extraction), Hindsight (knowledge graphs), Holographic (local SQLite), RetainDB (hybrid search), ByteRover (CLI-based), and Supermemory.
+- **[Memory Providers](/user-guide/features/memory-providers)** — Plug in external memory backends for deeper personalization. Eight providers ship with Hermes: Honcho (dialectic reasoning), OpenViking (tiered retrieval), Mem0 (cloud extraction), Hindsight (knowledge graphs), Holographic (local SQLite), RetainDB (hybrid search), ByteRover (CLI-based), and Supermemory — plus pip-installable community providers such as Memori and Memra (EU-native).
 
 ## Messaging Platforms
 

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -587,6 +587,33 @@ hermes config set memory.provider memori
 hermes memory setup
 ```
 
+### Memra
+
+EU-native persistent memory with hybrid semantic + lexical (BM25) recall, typed memories, supersede chains with audit trails, and staleness signals on every result. Cloud or fully-local via the same plugin.
+
+| | |
+|---|---|
+| **Best for** | EU/privacy-focused teams and agents that need auditable memory hygiene (supersede, trust states, tombstoned deletes) |
+| **Requires** | `pip install hermes-memra` + [Memra API key](https://usememra.com) (free tier) — or fully local via `pip install memra-local`, no cloud account |
+| **Data storage** | Memra Cloud (Hetzner, Helsinki — EU) or local SQLite (memra-local) |
+| **Cost** | Free tier / flat monthly plans (no per-token metering) |
+
+**Tools:** `memra_search` (hybrid semantic + lexical recall), `memra_remember` (store or supersede a fact), `memra_profile` (user/project profile context)
+
+**Setup:**
+```bash
+pip install hermes-memra
+echo "MEMRA_API_KEY=memra_live_your-key" >> ~/.hermes/.env
+hermes config set memory.provider memra
+```
+
+**Key features:**
+- Curated-by-default capture (`capture_mode`) — stores what matters instead of every turn
+- Pre-compression rescue: context about to be discarded by window compression is shipped to Memra and compressed server-side
+- Supersede-aware writes: correcting a fact retires the old version (with an audit chain) instead of leaving both in recall
+- Fully-local mode (`mode: local`) against [memra-local](https://pypi.org/project/memra-local/) — same tools, zero external calls
+- Circuit breaker on all network calls — a Memra outage never blocks the agent loop
+
 ---
 
 ## Provider Comparison
@@ -602,6 +629,7 @@ hermes memory setup
 | **ByteRover** | Local/Cloud | Free/Paid | 3 | `brv` CLI | Pre-compression extraction |
 | **Supermemory** | Cloud | Paid | 4 | `supermemory` | Context fencing + session graph ingest + multi-container |
 | **Memori** | Cloud | Free/Paid | 5 | `hermes-memori` | Tool-aware memory + structured recall |
+| **Memra** | Cloud (EU)/Local | Free/Paid | 3 | `hermes-memra` | Memory hygiene: supersede chains + staleness signals, EU-native |
 
 ## Profile Isolation
 


### PR DESCRIPTION
Adds **[Memra](https://usememra.com)** to the community memory providers, following the Memori precedent (standalone pip package + docs-only listing, per the policy in #54001).

**Package:** [`hermes-memra` on PyPI](https://pypi.org/project/hermes-memra/) — exports `register` via the `hermes_agent.plugins` entry point ([source](https://github.com/usememra/hermes-memra), MIT). Implements `prefetch`, `sync_turn`, `on_pre_compress`, `on_memory_write`, `on_session_end`; 3 tools (`memra_search`, `memra_remember`, `memra_profile`) — the doc's tool list matches the shipped code exactly.

**What it adds to the lineup:**
- The only **EU-native** provider (Hetzner Helsinki; per-project PII masking with 7 EU language models)
- **Memory hygiene** as the focus: supersede chains with audit trails, trust states, tombstoned deletes, staleness signals on every recall result — correcting a fact retires the old one instead of leaving both in recall
- Hybrid semantic + lexical (BM25) recall, sub-100ms, no LLM in the recall path
- **Fully-local mode** against [`memra-local`](https://pypi.org/project/memra-local/) (SQLite + ONNX embeddings, zero cloud calls) via the same plugin
- Free tier, flat monthly plans (no per-token metering)

**Diff scope:** `memory-providers.md` (provider section + comparison-table row) and one sentence in `integrations/index.md` clarifying shipped vs community providers (also makes Memori's pip-based status explicit). No code changes. zh-Hans untouched, matching the Memori precedent.

I'm the author and happy to adjust anything about the entry.