### PR TITLE
fix(tests): skip symlink tests without privilege, relax oauth chmod on Windows (#57883)

### DIFF
--- a/tests/hermes_cli/test_web_server_oauth_write.py
+++ b/tests/hermes_cli/test_web_server_oauth_write.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import pytest
@@ -33,7 +34,13 @@ def test_dashboard_oauth_write_uses_owner_only_permissions(oauth_file):
 
     assert oauth_file.exists()
     mode = oauth_file.stat().st_mode & 0o777
-    assert mode == 0o600
+    if os.name != "nt":
+        assert mode == 0o600
+    else:
+        assert oauth_file.read_text() == json.dumps(
+            {"access_token": "access-token", "refresh_token": "refresh-token",
+             "expires_at": 123456}
+        )
 
 
 def test_dashboard_oauth_write_uses_atomic_replace_and_cleans_temp_files(oauth_file, monkeypatch):

--- a/tests/test_atomic_replace_symlinks.py
+++ b/tests/test_atomic_replace_symlinks.py
@@ -34,6 +34,24 @@ from utils import (
 )
 
 
+import tempfile
+
+def _can_symlink():
+    """Check if we can create symlinks (needs admin/dev-mode on Windows)."""
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            src = Path(d) / "src"
+            src.write_text("x")
+            lnk = Path(d) / "lnk"
+            lnk.symlink_to(src)
+            return True
+    except OSError:
+        return False
+
+
+_SYMLINK_SKIP = not _can_symlink()
+
+
 # ─── Direct helper ────────────────────────────────────────────────────────────
 
 
@@ -42,6 +60,8 @@ def _write_tmp(dir_: Path, content: str) -> Path:
     tmp.write_text(content, encoding="utf-8")
     return tmp
 
+
+    @pytest.mark.skipif(_SYMLINK_SKIP, reason="Symlinks need elevated privileges")
 
 def test_atomic_replace_preserves_symlink(tmp_path: Path) -> None:
     real = tmp_path / "real.yaml"
@@ -100,6 +120,8 @@ def test_atomic_replace_accepts_pathlike_and_str(tmp_path: Path) -> None:
 # ─── atomic_json_write / atomic_yaml_write wiring ──────────────────────────
 
 
+    @pytest.mark.skipif(_SYMLINK_SKIP, reason="Symlinks need elevated privileges")
+
 def test_atomic_json_write_preserves_symlink(tmp_path: Path) -> None:
     real = tmp_path / "real.json"
     link = tmp_path / "link.json"
@@ -112,6 +134,8 @@ def test_atomic_json_write_preserves_symlink(tmp_path: Path) -> None:
     loaded = json.loads(real.read_text(encoding="utf-8"))
     assert loaded == {"hello": "world"}
 
+
+    @pytest.mark.skipif(_SYMLINK_SKIP, reason="Symlinks need elevated privileges")
 
 def test_atomic_yaml_write_preserves_symlink(tmp_path: Path) -> None:
     real = tmp_path / "real.yaml"
@@ -220,6 +244,8 @@ def test_atomic_roundtrip_yaml_update_restores_owner(
 # ─── Broken-symlink edge case ─────────────────────────────────────────────
 
 
+    @pytest.mark.skipif(_SYMLINK_SKIP, reason="Symlinks need elevated privileges")
+
 def test_atomic_replace_broken_symlink_creates_target(tmp_path: Path) -> None:
     """A symlink pointing at a missing file: the write should create the
     real target (resolving via realpath) rather than leaving the dangling
@@ -259,6 +285,8 @@ def test_atomic_replace_copy_fallback(
     assert target.read_text(encoding="utf-8") == "new\n"
     assert not tmp.exists()
 
+
+    @pytest.mark.skipif(_SYMLINK_SKIP, reason="Symlinks need elevated privileges")
 
 def test_atomic_replace_copy_fallback_preserves_symlink(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Closes #57883

## Summary

Fixes 6 tests that fail on native Windows due to environmental differences:

**5 symlink tests (test_atomic_replace_symlinks.py):**
- Add `_can_symlink()` probe and `@pytest.mark.skipif` for the five tests that create real symlinks
- On Windows without Developer Mode (the default), symlink creation raises OSError 1314
- Uses the same pattern already established in `test_skills_guard.py` and `test_symlink_prefix_confusion.py`

**1 oauth permissions test:**
- `test_dashboard_oauth_write_uses_owner_only_permissions` asserted `st_mode & 0o777 == 0o600`
- On Windows, `os.chmod` only toggles the read-only bit, so the mode reads 0o666 instead of 0o600
- On Windows: assert file content round-trips correctly instead of checking POSIX permission bits
- On POSIX: keep the existing 0o600 assertion

## Files

- `tests/test_atomic_replace_symlinks.py` — +24 lines (probe + 5 skip decorators)
- `tests/hermes_cli/test_web_server_oauth_write.py` — +12/-1 (platform-conditional assertion + json import)