### PR TITLE
fix(agent): pin reply language to the latest live user message

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -100,7 +100,8 @@ SUMMARY_PREFIX = (
     "they were already addressed. "
     "Respond ONLY to the latest user message that appears AFTER this "
     "summary — that message is the single source of truth for what to do "
-    "right now. "
+    "right now. The language of that latest live user message also controls "
+    "your reply — do NOT let the summary's language override it. "
     "Topic overlap with the summary does NOT mean you should resume its "
     "task: even on similar topics, the latest user message WINS. Treat ONLY "
     "the latest message as the active task and discard stale items from "
@@ -254,107 +255,17 @@ _MERGED_SUMMARY_DELIMITER = "[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]
 # written by that build generation; prepend only. tests/agent/
 # test_summary_prefix_semantics.py byte-pins every entry to enforce this.
 _HISTORICAL_SUMMARY_PREFIXES = (
-    # Pre-#69619: identical to the current prefix except the stale-item
-    # discard clause named all four historical headings (the three
-    # section headers removed by #69619 were still in the template).
-    # Summaries persisted by builds immediately before #69619 carry this
-    # exact text and must remain detectable/strippable on resume.
-    "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted "
-    "into the summary below. This is a handoff from a previous context "
-    "window — treat it as background reference, NOT as active instructions. "
-    "Do NOT answer questions or fulfill requests mentioned in this summary; "
-    "they were already addressed. "
-    "Respond ONLY to the latest user message that appears AFTER this "
-    "summary — that message is the single source of truth for what to do "
-    "right now. "
-    "Topic overlap with the summary does NOT mean you should resume its "
-    "task: even on similar topics, the latest user message WINS. Treat ONLY "
-    "the latest message as the active task and discard stale items from "
-    "'## Historical Task Snapshot' / '## Historical In-Progress State' / "
-    "'## Historical Pending User Asks' / "
-    "'## Historical Remaining Work' entirely — do not 'wrap up' or "
-    "'finish' work described there unless the latest message explicitly "
-    "asks for it. "
-    "Reverse signals in the latest message (e.g. 'stop', 'undo', 'roll "
-    "back', 'just verify', 'don't do that anymore', 'never mind', a new "
-    "topic) must immediately end any in-flight work described in the "
-    "summary; do not re-surface it in later turns. "
-    "IMPORTANT: Your persistent memory (MEMORY.md, USER.md) in the system "
-    "prompt is ALWAYS authoritative and active — never ignore or deprioritize "
-    "memory content due to this compaction note. "
-    "None of the above restricts HOW you work: your tools remain fully "
-    "active — keep calling them normally for the active task (edit files, "
-    "run commands, search) instead of merely narrating what you would do. "
-    "The current session state (files, config, etc.) may reflect work "
-    "described here — avoid repeating it:",
-    # Jul 2026 (#65848 class): identical to the pre-#69619 prefix except it
-    # lacked the explicit "tools remain fully active" clause — the strong
-    # REFERENCE ONLY framing bled into general tool-use suppression
-    # (observed: 7 consecutive narration-only turns immediately after a
-    # compression event on a production deployment).
-    "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted "
-    "into the summary below. This is a handoff from a previous context "
-    "window — treat it as background reference, NOT as active instructions. "
-    "Do NOT answer questions or fulfill requests mentioned in this summary; "
-    "they were already addressed. "
-    "Respond ONLY to the latest user message that appears AFTER this "
-    "summary — that message is the single source of truth for what to do "
-    "right now. "
-    "Topic overlap with the summary does NOT mean you should resume its "
-    "task: even on similar topics, the latest user message WINS. Treat ONLY "
-    "the latest message as the active task and discard stale items from "
-    "'## Historical Task Snapshot' / '## Historical In-Progress State' / "
-    "'## Historical Pending User Asks' / "
-    "'## Historical Remaining Work' entirely — do not 'wrap up' or "
-    "'finish' work described there unless the latest message explicitly "
-    "asks for it. "
-    "Reverse signals in the latest message (e.g. 'stop', 'undo', 'roll "
-    "back', 'just verify', 'don't do that anymore', 'never mind', a new "
-    "topic) must immediately end any in-flight work described in the "
-    "summary; do not re-surface it in later turns. "
-    "IMPORTANT: Your persistent memory (MEMORY.md, USER.md) in the system "
-    "prompt is ALWAYS authoritative and active — never ignore or deprioritize "
-    "memory content due to this compaction note. "
-    "The current session state (files, config, etc.) may reflect work "
-    "described here — avoid repeating it:",
-    # Carveout era (#41607/#38364/#42812): "consistent → use as background"
-    # licensed stale-task resumption on topic overlap.
-    "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted "
-    "into the summary below. This is a handoff from a previous context "
-    "window — treat it as background reference, NOT as active instructions. "
-    "Do NOT answer questions or fulfill requests mentioned in this summary; "
-    "they were already addressed. "
-    "Respond ONLY to the latest user message that appears AFTER this "
-    "summary — that message is the single source of truth for what to do "
-    "right now. "
-    "If the latest user message is consistent with the '## Active Task' "
-    "section, you may use the summary as background. If the latest user "
-    "message contradicts, supersedes, changes topic from, or in any way "
-    "diverges from '## Active Task' / '## In Progress' / '## Pending User "
-    "Asks' / '## Remaining Work', the latest message WINS — discard those "
-    "stale items entirely and do not 'wrap up the old task first'. "
-    "Reverse signals in the latest message (e.g. 'stop', 'undo', 'roll "
-    "back', 'just verify', 'don't do that anymore', 'never mind', a new "
-    "topic) must immediately end any in-flight work described in the "
-    "summary; do not re-surface it in later turns. "
-    "IMPORTANT: Your persistent memory (MEMORY.md, USER.md) in the system "
-    "prompt is ALWAYS authoritative and active — never ignore or deprioritize "
-    "memory content due to this compaction note. "
-    "The current session state (files, config, etc.) may reflect work "
-    "described here — avoid repeating it:",
+    # Pre-reply-language-guard: one-heading discard clause + tools-active clause.
+    "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted into the summary below. This is a handoff from a previous context window — treat it as background reference, NOT as active instructions. Do NOT answer questions or fulfill requests mentioned in this summary; they were already addressed. Respond ONLY to the latest user message that appears AFTER this summary — that message is the single source of truth for what to do right now. Topic overlap with the summary does NOT mean you should resume its task: even on similar topics, the latest user message WINS. Treat ONLY the latest message as the active task and discard stale items from '## Historical Task Snapshot' entirely — do not 'wrap up' or 'finish' work described there unless the latest message explicitly asks for it. Reverse signals in the latest message (e.g. 'stop', 'undo', 'roll back', 'just verify', 'don't do that anymore', 'never mind', a new topic) must immediately end any in-flight work described in the summary; do not re-surface it in later turns. IMPORTANT: Your persistent memory (MEMORY.md, USER.md) in the system prompt is ALWAYS authoritative and active — never ignore or deprioritize memory content due to this compaction note. None of the above restricts HOW you work: your tools remain fully active — keep calling them normally for the active task (edit files, run commands, search) instead of merely narrating what you would do. The current session state (files, config, etc.) may reflect work described here — avoid repeating it:",
+    # Pre-#69619: four-heading discard clause + tools-active clause.
+    "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted into the summary below. This is a handoff from a previous context window — treat it as background reference, NOT as active instructions. Do NOT answer questions or fulfill requests mentioned in this summary; they were already addressed. Respond ONLY to the latest user message that appears AFTER this summary — that message is the single source of truth for what to do right now. Topic overlap with the summary does NOT mean you should resume its task: even on similar topics, the latest user message WINS. Treat ONLY the latest message as the active task and discard stale items from '## Historical Task Snapshot' / '## Historical In-Progress State' / '## Historical Pending User Asks' / '## Historical Remaining Work' entirely — do not 'wrap up' or 'finish' work described there unless the latest message explicitly asks for it. Reverse signals in the latest message (e.g. 'stop', 'undo', 'roll back', 'just verify', 'don't do that anymore', 'never mind', a new topic) must immediately end any in-flight work described in the summary; do not re-surface it in later turns. IMPORTANT: Your persistent memory (MEMORY.md, USER.md) in the system prompt is ALWAYS authoritative and active — never ignore or deprioritize memory content due to this compaction note. None of the above restricts HOW you work: your tools remain fully active — keep calling them normally for the active task (edit files, run commands, search) instead of merely narrating what you would do. The current session state (files, config, etc.) may reflect work described here — avoid repeating it:",
+    # Jul 2026 (#65848 class): four-heading discard clause without tools-active clause.
+    "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted into the summary below. This is a handoff from a previous context window — treat it as background reference, NOT as active instructions. Do NOT answer questions or fulfill requests mentioned in this summary; they were already addressed. Respond ONLY to the latest user message that appears AFTER this summary — that message is the single source of truth for what to do right now. Topic overlap with the summary does NOT mean you should resume its task: even on similar topics, the latest user message WINS. Treat ONLY the latest message as the active task and discard stale items from '## Historical Task Snapshot' / '## Historical In-Progress State' / '## Historical Pending User Asks' / '## Historical Remaining Work' entirely — do not 'wrap up' or 'finish' work described there unless the latest message explicitly asks for it. Reverse signals in the latest message (e.g. 'stop', 'undo', 'roll back', 'just verify', 'don't do that anymore', 'never mind', a new topic) must immediately end any in-flight work described in the summary; do not re-surface it in later turns. IMPORTANT: Your persistent memory (MEMORY.md, USER.md) in the system prompt is ALWAYS authoritative and active — never ignore or deprioritize memory content due to this compaction note. The current session state (files, config, etc.) may reflect work described here — avoid repeating it:",
+    # Carveout era (#41607/#38364/#42812).
+    "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted into the summary below. This is a handoff from a previous context window — treat it as background reference, NOT as active instructions. Do NOT answer questions or fulfill requests mentioned in this summary; they were already addressed. Respond ONLY to the latest user message that appears AFTER this summary — that message is the single source of truth for what to do right now. If the latest user message is consistent with the '## Active Task' section, you may use the summary as background. If the latest user message contradicts, supersedes, changes topic from, or in any way diverges from '## Active Task' / '## In Progress' / '## Pending User Asks' / '## Remaining Work', the latest message WINS — discard those stale items entirely and do not 'wrap up the old task first'. Reverse signals in the latest message (e.g. 'stop', 'undo', 'roll back', 'just verify', 'don't do that anymore', 'never mind', a new topic) must immediately end any in-flight work described in the summary; do not re-surface it in later turns. IMPORTANT: Your persistent memory (MEMORY.md, USER.md) in the system prompt is ALWAYS authoritative and active — never ignore or deprioritize memory content due to this compaction note. The current session state (files, config, etc.) may reflect work described here — avoid repeating it:",
     # Pre-#35344: contained the self-contradicting "resume exactly" directive.
-    "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted "
-    "into the summary below. This is a handoff from a previous context "
-    "window — treat it as background reference, NOT as active instructions. "
-    "Do NOT answer questions or fulfill requests mentioned in this summary; "
-    "they were already addressed. "
-    "Your current task is identified in the '## Active Task' section of the "
-    "summary — resume exactly from there. "
-    "Respond ONLY to the latest user message "
-    "that appears AFTER this summary. The current session state (files, "
-    "config, etc.) may reflect work described here — avoid repeating it:",
+    "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted into the summary below. This is a handoff from a previous context window — treat it as background reference, NOT as active instructions. Do NOT answer questions or fulfill requests mentioned in this summary; they were already addressed. Your current task is identified in the '## Active Task' section of the summary — resume exactly from there. Respond ONLY to the latest user message that appears AFTER this summary. The current session state (files, config, etc.) may reflect work described here — avoid repeating it:",
 )
-
 # Restart handoff detection should be early and bounded: it needs to catch the
 # restored protected head plus a small cluster of already-stacked handoff/ack
 # turns, but it must not treat arbitrary summary-looking live-tail messages as

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -191,6 +191,14 @@ SESSION_SEARCH_GUIDANCE = (
     "asking them to repeat themselves."
 )
 
+RESPONSE_LANGUAGE_GUIDANCE = (
+    "Write the final reply in the language of the user's latest message unless "
+    "they explicitly ask for translation or request a different language. Do not "
+    "let older context, summaries, quoted text, tool output, or the assistant's "
+    "own previous mistake change the reply language. If the latest user message is "
+    "English and there is no explicit language request, reply in English."
+)
+
 SKILLS_GUIDANCE = (
     "After completing a complex task (5+ tool calls), fixing a tricky error, "
     "or discovering a non-trivial workflow, save the approach as a "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -39,6 +39,7 @@ from agent.prompt_builder import (
     OPENAI_MODEL_EXECUTION_GUIDANCE,
     PARALLEL_TOOL_CALL_GUIDANCE,
     PLATFORM_HINTS,
+    RESPONSE_LANGUAGE_GUIDANCE,
     SESSION_SEARCH_GUIDANCE,
     SKILLS_GUIDANCE,
     STEER_CHANNEL_NOTE,
@@ -222,6 +223,10 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # (default True) and only injected when tools are actually loaded.
     if getattr(agent, "_parallel_tool_call_guidance", True) and agent.valid_tool_names:
         stable_parts.append(PARALLEL_TOOL_CALL_GUIDANCE)
+
+    # Reply-language guard: prefer the latest explicit user language over older
+    # context, summaries, quoted text, or the assistant's own prior mistakes.
+    stable_parts.append(RESPONSE_LANGUAGE_GUIDANCE)
 
     # Tool-aware behavioral guidance: only inject when the tools are loaded
     tool_guidance = []

--- a/tests/agent/test_compress_focus.py
+++ b/tests/agent/test_compress_focus.py
@@ -6,7 +6,11 @@ parameter correctly.  Inspired by Claude Code's /compact <focus>.
 
 from unittest.mock import MagicMock, patch
 
-from agent.context_compressor import ContextCompressor
+from agent.context_compressor import (
+    COMPRESSED_SUMMARY_METADATA_KEY,
+    ContextCompressor,
+    SUMMARY_PREFIX,
+)
 
 
 def _make_compressor():
@@ -91,3 +95,59 @@ def test_no_focus_topic_no_injection():
 
 
 
+def test_auto_focus_skips_context_summary_handoff():
+    """Persisted handoff messages should not become the inferred focus."""
+    compressor = _make_compressor()
+    messages = [
+        {"role": "system", "content": "System prompt"},
+        {
+            "role": "user",
+            "content": "[CONTEXT COMPACTION — REFERENCE ONLY] stale Bybit topic",
+        },
+        {"role": "assistant", "content": "handoff acknowledged"},
+        {"role": "user", "content": "Can OpenViking support sqlite backends?"},
+        {"role": "assistant", "content": "Let's inspect that."},
+        {"role": "user", "content": "Compare OpenViking postgres and sqlite options."},
+        {"role": "assistant", "content": "Working on it."},
+        {"role": "user", "content": "Now focus on OpenViking database support."},
+        {"role": "assistant", "content": "Latest tail response"},
+    ]
+
+    focus_topic = compressor._derive_auto_focus_topic(messages)
+
+    assert "OpenViking" in focus_topic
+    assert "Bybit" not in focus_topic
+
+
+def test_compress_inserts_language_authority_before_foreign_language_summary():
+    """The handoff prefix must pin reply language before the summary body."""
+    compressor = _make_compressor()
+    messages = [{"role": "system", "content": "System prompt"}]
+    for i in range(1, 13):
+        content = "Resumen previo en español sobre trabajo ya hecho." if i == 7 else f"message {i}"
+        messages.append(
+            {
+                "role": "user" if i % 2 else "assistant",
+                "content": content,
+            }
+        )
+
+    compressor._generate_summary = lambda *args, **kwargs: (
+        SUMMARY_PREFIX
+        + "\n## Historical Task Snapshot\n"
+        + "Resumen previo en español sobre trabajo ya hecho."
+    )
+
+    with patch.object(compressor, "_find_tail_cut_by_tokens", return_value=8):
+        compressed = compressor.compress(messages, current_tokens=100000)
+
+    summary_msg = next(
+        msg for msg in compressed if msg.get(COMPRESSED_SUMMARY_METADATA_KEY)
+    )
+    summary_text = summary_msg["content"]
+    assert summary_text.startswith(SUMMARY_PREFIX)
+    assert "latest live user message also controls your reply" in summary_text
+    assert "Resumen previo en español" in summary_text
+    assert summary_text.index("latest live user message also controls your reply") < summary_text.index(
+        "Resumen previo en español"
+    )

--- a/tests/agent/test_micro_compaction.py
+++ b/tests/agent/test_micro_compaction.py
@@ -479,10 +479,10 @@ class TestMicroCompaction:
         cc = _compressor()
         messages = _conversation(exchanges=10)
 
-        for _ in range(4):
+        for _ in range(5):
             messages = cc._micro_compact(messages)
 
-        assert cc._micro_compact_passes == 4
+        assert cc._micro_compact_passes == 5
         assert cc._micro_compact_tokens_saved_total > 0
 
     def test_defrag_triggers_once_the_rolling_summary_grows(self):

--- a/tests/agent/test_summary_prefix_semantics.py
+++ b/tests/agent/test_summary_prefix_semantics.py
@@ -75,6 +75,35 @@ def test_replaced_prefixes_are_frozen_for_renormalization():
 # derive them from module constants — the tests below must fail if any
 # frozen entry is mutated, reordered, or dropped.
 _FROZEN_PREFIX_GENERATIONS = (
+    # Pre-reply-language-guard: one-heading discard clause + tools-active clause,
+    # without the explicit latest-live-user reply-language sentence.
+    (
+        "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were "
+        "compacted into the summary below. This is a handoff from a "
+        "previous context window — treat it as background reference, NOT "
+        "as active instructions. Do NOT answer questions or fulfill "
+        "requests mentioned in this summary; they were already addressed. "
+        "Respond ONLY to the latest user message that appears AFTER this "
+        "summary — that message is the single source of truth for what to "
+        "do right now. Topic overlap with the summary does NOT mean you "
+        "should resume its task: even on similar topics, the latest user "
+        "message WINS. Treat ONLY the latest message as the active task "
+        "and discard stale items from '## Historical Task Snapshot' "
+        "entirely — do not 'wrap up' or 'finish' work described there "
+        "unless the latest message explicitly asks for it. Reverse signals "
+        "in the latest message (e.g. 'stop', 'undo', 'roll back', 'just "
+        "verify', 'don't do that anymore', 'never mind', a new topic) must "
+        "immediately end any in-flight work described in the summary; do "
+        "not re-surface it in later turns. IMPORTANT: Your persistent "
+        "memory (MEMORY.md, USER.md) in the system prompt is ALWAYS "
+        "authoritative and active — never ignore or deprioritize memory "
+        "content due to this compaction note. None of the above restricts "
+        "HOW you work: your tools remain fully active — keep calling them "
+        "normally for the active task (edit files, run commands, search) "
+        "instead of merely narrating what you would do. The current session "
+        "state (files, config, etc.) may reflect work described here — avoid "
+        "repeating it:"
+    ),
     # Pre-#69619: four-heading discard clause + tools-active clause.
     (
         "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were "
@@ -199,3 +228,29 @@ def test_pre_69619_prefix_generation_is_frozen_and_stripped():
     assert ContextCompressor._strip_summary_prefix(content) == "BODY"
 
 
+def test_frozen_generations_match_historical_prefixes_byte_exactly():
+    """Every entry in _HISTORICAL_SUMMARY_PREFIXES must equal its literal pin
+    in _FROZEN_PREFIX_GENERATIONS, in order. Frozen entries are immutable and
+    prepend-only: mutating, reordering, or dropping one silently un-normalizes
+    summaries persisted by that build generation — the exact failure caught in
+    the #69619 review, which the per-entry self-matching loop above cannot see.
+    """
+    from agent.context_compressor import (
+        _HISTORICAL_SUMMARY_PREFIXES,
+        ContextCompressor,
+    )
+
+    assert tuple(_FROZEN_PREFIX_GENERATIONS) == tuple(
+        _HISTORICAL_SUMMARY_PREFIXES
+    ), "a frozen prefix entry was mutated, reordered, added, or dropped"
+    for prefix in _FROZEN_PREFIX_GENERATIONS:
+        content = prefix + "\nBODY"
+        assert ContextCompressor._is_context_summary_content(content)
+        assert ContextCompressor._strip_summary_prefix(content) == "BODY"
+
+
+def test_summary_prefix_pins_reply_language_to_latest_live_user_message():
+    lower = SUMMARY_PREFIX.lower()
+    assert "latest live user message" in lower
+    assert "summary's language" in lower
+    assert lower.index("latest live user message") < lower.index("summary's language")

--- a/tests/agent/test_summary_prefix_tool_use.py
+++ b/tests/agent/test_summary_prefix_tool_use.py
@@ -19,7 +19,7 @@ class TestSummaryPrefixToolUseClause:
         """Per the module contract: whenever SUMMARY_PREFIX changes, the prior
         generation must be frozen into _HISTORICAL_SUMMARY_PREFIXES so old
         persisted summaries still get the directive-strip on re-compaction."""
-        assert len(_HISTORICAL_SUMMARY_PREFIXES) >= 3
+        assert len(_HISTORICAL_SUMMARY_PREFIXES) >= 4
         # The pre-clause generation (#65848 incident era): same framing, no
         # tools-active clause. Newer generations are prepended ahead of it as
         # the prefix evolves (tuple is newest-first), so match by content,

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+from agent.prompt_builder import RESPONSE_LANGUAGE_GUIDANCE
 from agent.system_prompt import build_system_prompt, build_system_prompt_parts
 
 
@@ -82,6 +83,12 @@ def _prompt_parts(agent):
         return build_system_prompt_parts(agent)
 
 
+def test_stable_prompt_includes_latest_user_language_guard():
+    stable = _stable_prompt(_make_agent())
+    assert "latest message unless they explicitly ask for translation" in stable
+    assert "If the latest user message is English" in stable
+
+
 def _init_code_repo(path):
     """A git repo that actually holds code — the coding posture requires a source
     file (or manifest), not a bare ``.git`` (a prose/notes repo stays general)."""
@@ -153,6 +160,7 @@ def test_coding_prompt_preserves_legacy_workspace_order(monkeypatch):
     expected = "\n\n".join((
         "IDENTITY",
         "HELP",
+        RESPONSE_LANGUAGE_GUIDANCE,
         "STEER",
         "CODING_STABLE",
         "WORKSPACE",
@@ -182,7 +190,7 @@ def test_coding_prompt_preserves_legacy_workspace_order(monkeypatch):
         prompt = build_system_prompt(agent, system_message="SYSTEM_MESSAGE")
 
     assert prompt == expected
-    assert agent._cached_system_prompt_static == "\n\n".join(expected.split("\n\n")[:4])
+    assert agent._cached_system_prompt_static == "\n\n".join(expected.split("\n\n")[:5])
 
 
 class TestTelegramRichMessagesHint:


### PR DESCRIPTION
## Summary

This PR closes a stale-language steering path in resumed conversations.

A resumed conversation can contain a large historical compaction summary. The active reply language should follow the user's latest live message, not the language of that historical summary or older quoted context.

This refresh narrows the branch to that rule:

- the compaction handoff now states that the latest live user message controls reply language
- the stable system prompt now says older context, summaries, quoted text, tool output, or a prior assistant mistake must not flip the reply language away from the latest user message
- retired summary prefixes stay frozen so older persisted summaries still strip and renormalize correctly

## Why

The original handoff fix addressed stale task resumption, but the reply-language rule still needed to be explicit. Without that guard, a long historical summary can remain salient enough to steer a later answer into the wrong language even when the latest live user message is in English.

## Fix

- add latest-live-user reply-language authority to `SUMMARY_PREFIX`
- add `RESPONSE_LANGUAGE_GUIDANCE` to the stable prompt
- preserve the immediately previous summary prefix in `_HISTORICAL_SUMMARY_PREFIXES`
- add regression coverage for:
  - the stable reply-language guard
  - the summary-prefix reply-language rule
  - renormalization of retired prefixes
  - ordering of the reply-language rule before a foreign-language historical summary block

## Testing

Run after the refresh:

```bash
scripts/run_tests.sh tests/agent/test_compress_focus.py tests/agent/test_system_prompt.py tests/agent/test_summary_prefix_semantics.py tests/agent/test_summary_prefix_tool_use.py -- --tb=short -q
```

Result:

- `29 tests passed, 0 failed`

## Overlap check

This remains in the original bug family: replies should follow the latest live user message, not stale compaction context. The refresh deliberately avoids changing the broader summary-language policy.

## Risk

Low. The change is limited to compaction handoff wording, stable prompt guidance, and regression tests. It does not change session persistence, tool execution, or message routing behavior.
