### PR TITLE
fix(tui): keep process notifications out of agent turns

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3699,6 +3699,17 @@ def save_config_value(key_path: str, value: any) -> bool:
 # HermesCLI Class
 # ============================================================================
 
+
+class _QueuedSyntheticInput:
+    """Pending agent-generated input that must not rotate user-turn ownership."""
+
+    __slots__ = ("text", "expected_turn_id")
+
+    def __init__(self, text: str, expected_turn_id: str = ""):
+        self.text = text
+        self.expected_turn_id = str(expected_turn_id or "")
+
+
 class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
     """
     Interactive CLI for the Hermes Agent.
@@ -3768,6 +3779,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self.busy_input_mode = "steer"
         else:
             self.busy_input_mode = "interrupt"
+        self._user_turn_id = ""
 
         # self.verbose ONLY controls global DEBUG logging (root logger level).
         # display.tool_progress="verbose" controls tool-call rendering (full args,
@@ -9185,6 +9197,27 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
 
 
+    def _unwrap_queued_input(self, item):
+        """Return pending text and whether it represents a real user turn."""
+        if isinstance(item, _QueuedSyntheticInput):
+            current_turn_id = str(getattr(self, "_user_turn_id", "") or "")
+            if item.expected_turn_id and item.expected_turn_id != current_turn_id:
+                _cprint(f"\n{_DIM}⚙️  {item.text}{_RST}")
+                return "", False
+            return item.text, False
+        return item, True
+
+    def _queue_synthetic_input(self, text: str, expected_turn_id: str = "") -> None:
+        self._pending_input.put(_QueuedSyntheticInput(text, expected_turn_id))
+
+    def _should_chain_async_notification(self, event: dict) -> bool:
+        """Require a delegation to prove ownership of the current user turn."""
+        if event.get("type") != "async_delegation":
+            return False
+        dispatch_turn_id = str(event.get("dispatch_turn_id") or "")
+        current_turn_id = str(getattr(self, "_user_turn_id", "") or "")
+        return bool(dispatch_turn_id and current_turn_id and dispatch_turn_id == current_turn_id)
+
     def _owns_process_notification(self, event: dict) -> bool:
         """Return whether this CLI session provably owns a delegation event.
 
@@ -9210,17 +9243,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         return str(resolved_key) == current_key
 
     def _drain_process_notifications(self, consumer: str) -> None:
-        """Queue background notifications owned by this visible CLI session.
+        """Route owned notifications without forging process-status user turns.
 
-        ``process_registry`` restores durable delegation completions into every
-        process using the same Hermes profile.  Always pass this CLI's stable
-        session identity when draining so another window cannot claim and mark
-        delivered a completion that belongs to this one.
+        Process completion/watch events and stale delegation results are printed
+        as terminal status. Only a delegation that still owns the current real
+        user turn enters the typed follow-up queue.
         """
         from tools.process_registry import process_registry
         from tools.async_delegation import (
             claim_event_delivery,
             complete_event_delivery,
+            release_event_delivery,
         )
 
         session_key = getattr(self, "session_id", "") or ""
@@ -9228,11 +9261,30 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             session_key=session_key,
             owns_event=self._owns_process_notification,
         ):
-            claim = claim_event_delivery(event, consumer)
+            try:
+                claim = claim_event_delivery(event, consumer)
+            except Exception as exc:
+                process_registry.completion_queue.put(event)
+                logging.warning("notification delivery claim failed: %s", exc)
+                continue
             if claim is None:
                 continue
-            self._pending_input.put(synthetic_message)
-            complete_event_delivery(event, claim)
+            chained = False
+            try:
+                if self._should_chain_async_notification(event):
+                    self._queue_synthetic_input(
+                        synthetic_message,
+                        str(event.get("dispatch_turn_id") or ""),
+                    )
+                    chained = True
+                else:
+                    _cprint(f"\n{_DIM}⚙️  {synthetic_message}{_RST}")
+                complete_event_delivery(event, claim)
+            except Exception as exc:
+                if not chained:
+                    release_event_delivery(event, claim)
+                    process_registry.completion_queue.put(event)
+                logging.warning("notification delivery failed: %s", exc)
 
     def _drain_interrupt_queue_to_pending_input(self) -> None:
         """Move stray messages from ``_interrupt_queue`` into ``_pending_input``.
@@ -9301,6 +9353,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     # Queue.queue is the underlying deque — direct peek
                     # without disturbing FIFO order.
                     for entry in list(pending.queue):
+                        if isinstance(entry, _QueuedSyntheticInput):
+                            continue
                         # Bundled payloads are (text, images) tuples;
                         # unpack for inspection.
                         if isinstance(entry, tuple) and entry:
@@ -9381,7 +9435,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             prompt = decision.get("continuation_prompt")
             if prompt:
                 try:
-                    self._pending_input.put(prompt)
+                    self._queue_synthetic_input(
+                        prompt,
+                        str(getattr(self, "_user_turn_id", "") or ""),
+                    )
                 except Exception as exc:
                     logging.debug("goal continuation enqueue failed: %s", exc)
 
@@ -11751,6 +11808,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     "2-3 sentences max. No code blocks or markdown.] "
                 )
 
+            _run_turn_id = str(getattr(self, "_user_turn_id", "") or "")
+
             def run_agent():
                 nonlocal result
                 # Set callbacks inside the agent thread so thread-local storage
@@ -11781,6 +11840,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 except Exception:
                     reset_current_session_key = None  # type: ignore[assignment]
                     _approval_session_token = None
+                try:
+                    import importlib
+
+                    _turn_context = importlib.import_module("gateway.session_context")
+                    _turn_token = getattr(_turn_context, "set_current_turn_id")(_run_turn_id)
+                except Exception:
+                    _turn_context = None
+                    _turn_token = None
                 agent_message = _voice_prefix + message if _voice_prefix else message
                 # Prepend pending notes via _prepend_note_to_message, which
                 # handles both plain-string and multimodal content-parts list
@@ -11858,6 +11925,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     if _approval_session_token is not None and reset_current_session_key is not None:
                         try:
                             reset_current_session_key(_approval_session_token)
+                        except Exception:
+                            pass
+                    if _turn_token is not None and _turn_context is not None:
+                        try:
+                            getattr(_turn_context, "reset_current_turn_id")(_turn_token)
                         except Exception:
                             pass
 
@@ -14709,9 +14781,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                                 pass
                         continue
                     
+                    user_input, is_user_turn = self._unwrap_queued_input(user_input)
                     if not user_input:
                         continue
-
                     # The user has typed and submitted something, so any
                     # post-resize transient suppression should end here.
                     self._status_bar_suppressed_after_resize = False
@@ -14796,6 +14868,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         _cprint(f"  {_DIM}📎 {n} image{'s' if n > 1 else ''} attached{_RST}")
 
                     # Regular chat - run agent
+                    if is_user_turn:
+                        self._user_turn_id = uuid.uuid4().hex
                     self._agent_running = True
                     self._pet_turn_error = False
                     self._pet_reasoning = False

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -91,6 +91,13 @@ _SESSION_UI_SESSION_ID: ContextVar = ContextVar("HERMES_UI_SESSION_ID", default=
 # private-chat topic (those lanes route only with thread id + reply anchor).
 _SESSION_MESSAGE_ID: ContextVar = ContextVar("HERMES_SESSION_MESSAGE_ID", default=_UNSET)
 
+# Opaque identity of the real user turn currently running. Detached delegation
+# completions compare this token with the live session's token before they are
+# allowed to synthesize a follow-up agent turn. Unlike transcript/history
+# counters, the token is not advanced by goal/delegation auto-follow-ups and
+# cannot accidentally match after a process restart.
+_SESSION_TURN_ID: ContextVar = ContextVar("HERMES_SESSION_TURN_ID", default=_UNSET)
+
 _SESSION_PROFILE: ContextVar = ContextVar("HERMES_SESSION_PROFILE", default=_UNSET)
 
 # Whether the current session's delivery channel can route an ASYNC completion
@@ -132,6 +139,7 @@ _VAR_MAP = {
     "HERMES_SESSION_ID": _SESSION_ID,
     "HERMES_UI_SESSION_ID": _SESSION_UI_SESSION_ID,
     "HERMES_SESSION_MESSAGE_ID": _SESSION_MESSAGE_ID,
+    "HERMES_SESSION_TURN_ID": _SESSION_TURN_ID,
     "HERMES_SESSION_PROFILE": _SESSION_PROFILE,
     "HERMES_CRON_AUTO_DELIVER_PLATFORM": _CRON_AUTO_DELIVER_PLATFORM,
     "HERMES_CRON_AUTO_DELIVER_CHAT_ID": _CRON_AUTO_DELIVER_CHAT_ID,
@@ -152,6 +160,16 @@ def set_current_session_id(session_id: str) -> None:
 
     os.environ["HERMES_SESSION_ID"] = session_id
     _SESSION_ID.set(session_id)
+
+
+def set_current_turn_id(turn_id: str):
+    """Bind the current real-user-turn identity and return its reset token."""
+    return _SESSION_TURN_ID.set(str(turn_id or ""))
+
+
+def reset_current_turn_id(token) -> None:
+    """Restore the prior real-user-turn identity for this execution context."""
+    _SESSION_TURN_ID.reset(token)
 
 
 def set_session_vars(
@@ -237,6 +255,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_ID,
         _SESSION_UI_SESSION_ID,
         _SESSION_MESSAGE_ID,
+        _SESSION_TURN_ID,
         _SESSION_PROFILE,
     ):
         var.set("")

--- a/tests/cli/test_cli_async_delegation_delivery.py
+++ b/tests/cli/test_cli_async_delegation_delivery.py
@@ -10,11 +10,13 @@ def test_cli_completion_drain_uses_visible_session_identity(monkeypatch):
     cli = HermesCLI.__new__(HermesCLI)
     cli.session_id = "visible-session"
     cli._pending_input = queue.Queue()
+    cli._user_turn_id = "turn-current"
 
     event = {
         "type": "async_delegation",
         "delegation_id": "deleg_visible",
         "session_key": "visible-session",
+        "dispatch_turn_id": "turn-current",
     }
     calls = []
 
@@ -42,7 +44,8 @@ def test_cli_completion_drain_uses_visible_session_identity(monkeypatch):
     cli._drain_process_notifications("cli-idle")
 
     assert calls == [("visible-session", True)]
-    assert cli._pending_input.get_nowait() == "completion payload"
+    queued = cli._pending_input.get_nowait()
+    assert queued.text == "completion payload"
     assert claimed == [(event, "cli-idle")]
     assert completed == [(event, "claim-token")]
 

--- a/tests/cli/test_cli_background_tui_refresh.py
+++ b/tests/cli/test_cli_background_tui_refresh.py
@@ -4,6 +4,7 @@ Ensures the TUI is properly refreshed before printing background task output
 to prevent spinner/status bar overlap (#2718).
 """
 
+from queue import Queue
 from unittest.mock import MagicMock, patch
 
 
@@ -19,6 +20,8 @@ def _make_cli():
     cli_obj.conversation_history = []
     cli_obj.agent = None
     cli_obj._app = None
+    cli_obj._user_turn_id = "turn-current"
+    cli_obj._pending_input = Queue()
     return cli_obj
 
 
@@ -100,3 +103,166 @@ class TestBackgroundCommandTuiRefresh:
         # Clean up
         cli_obj._background_tasks.pop(task_id, None)
         assert task_id not in cli_obj._background_tasks
+
+
+def test_process_notification_is_displayed_without_queueing_agent_turn(monkeypatch):
+    cli_obj = _make_cli()
+    printed = []
+    monkeypatch.setattr("cli._cprint", printed.append)
+
+    with patch("tools.process_registry.process_registry.drain_notifications") as drain:
+        drain.return_value = [
+            (
+                {"type": "completion", "session_id": "proc_1"},
+                "[IMPORTANT: Background process proc_1 completed]",
+            )
+        ]
+        cli_obj._drain_process_notifications("test")
+
+    assert cli_obj._pending_input.empty()
+    assert len(printed) == 1
+    assert "Background process proc_1" in printed[0]
+
+
+def test_current_turn_delegation_queues_typed_followup(monkeypatch):
+    cli_obj = _make_cli()
+    monkeypatch.setattr("cli._cprint", lambda *_args: None)
+
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg_current",
+        "dispatch_turn_id": "turn-current",
+    }
+    with patch("tools.process_registry.process_registry.drain_notifications") as drain:
+        drain.return_value = [(event, "[ASYNC DELEGATION COMPLETE — deleg_current]")]
+        with patch("tools.async_delegation.claim_event_delivery", return_value="claim"):
+            with patch("tools.async_delegation.complete_event_delivery"):
+                cli_obj._drain_process_notifications("test")
+
+    queued = cli_obj._pending_input.get_nowait()
+    assert type(queued).__name__ == "_QueuedSyntheticInput"
+    assert queued.text == "[ASYNC DELEGATION COMPLETE — deleg_current]"
+
+
+def test_stale_delegation_is_displayed_and_acknowledged(monkeypatch):
+    cli_obj = _make_cli()
+    printed = []
+    monkeypatch.setattr("cli._cprint", printed.append)
+
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg_stale",
+        "dispatch_turn_id": "turn-old",
+    }
+    with patch("tools.process_registry.process_registry.drain_notifications") as drain:
+        drain.return_value = [(event, "[ASYNC DELEGATION COMPLETE — deleg_stale]")]
+        with patch("tools.async_delegation.claim_event_delivery", return_value="claim"):
+            with patch("tools.async_delegation.complete_event_delivery") as complete:
+                cli_obj._drain_process_notifications("test")
+
+    assert cli_obj._pending_input.empty()
+    assert printed and "deleg_stale" in printed[0]
+    complete.assert_called_once_with(event, "claim")
+
+
+def test_cli_requeues_notification_when_delivery_fails(monkeypatch):
+    from tools.process_registry import process_registry
+
+    cli_obj = _make_cli()
+    event = {"type": "completion", "session_id": "proc_retry"}
+    isolated_queue = Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr("cli._cprint", lambda *_args: None)
+
+    with patch.object(
+        process_registry,
+        "drain_notifications",
+        return_value=[(event, "process completed")],
+    ):
+        with patch("tools.async_delegation.claim_event_delivery", return_value="claim"):
+            with patch(
+                "tools.async_delegation.complete_event_delivery",
+                side_effect=RuntimeError("ack failed"),
+            ):
+                with patch("tools.async_delegation.release_event_delivery") as release:
+                    cli_obj._drain_process_notifications("test")
+
+    assert isolated_queue.get_nowait() == event
+    release.assert_called_once_with(event, "claim")
+
+
+def test_cli_does_not_requeue_fresh_delegation_after_it_was_queued(monkeypatch):
+    from tools.process_registry import process_registry
+
+    cli_obj = _make_cli()
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg_ack_failure",
+        "dispatch_turn_id": "turn-current",
+    }
+    isolated_queue = Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+
+    with patch.object(
+        process_registry,
+        "drain_notifications",
+        return_value=[(event, "delegation result")],
+    ):
+        with patch("tools.async_delegation.claim_event_delivery", return_value="claim"):
+            with patch(
+                "tools.async_delegation.complete_event_delivery",
+                side_effect=RuntimeError("ack failed"),
+            ):
+                with patch("tools.async_delegation.release_event_delivery") as release:
+                    cli_obj._drain_process_notifications("test")
+
+    assert cli_obj._pending_input.qsize() == 1
+    assert isolated_queue.empty()
+    release.assert_not_called()
+
+
+def test_cli_requeues_notification_when_claim_fails(monkeypatch):
+    from tools.process_registry import process_registry
+
+    cli_obj = _make_cli()
+    event = {"type": "completion", "session_id": "proc_claim_retry"}
+    isolated_queue = Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+
+    with patch.object(
+        process_registry,
+        "drain_notifications",
+        return_value=[(event, "process completed")],
+    ):
+        with patch(
+            "tools.async_delegation.claim_event_delivery",
+            side_effect=RuntimeError("db unavailable"),
+        ):
+            cli_obj._drain_process_notifications("test")
+
+    assert isolated_queue.get_nowait() == event
+
+
+def test_queued_delegation_does_not_advance_user_turn_generation():
+    cli_obj = _make_cli()
+
+    cli_obj._queue_synthetic_input("delegation result")
+    text, is_user_turn = cli_obj._unwrap_queued_input(cli_obj._pending_input.get_nowait())
+
+    assert text == "delegation result"
+    assert is_user_turn is False
+    assert cli_obj._user_turn_id == "turn-current"
+
+
+def test_queued_delegation_is_rechecked_before_agent_turn(monkeypatch):
+    cli_obj = _make_cli()
+    cli_obj._user_turn_id = "turn-new"
+    printed = []
+    monkeypatch.setattr("cli._cprint", printed.append)
+
+    cli_obj._queue_synthetic_input("old delegation result", "turn-old")
+    text, is_user_turn = cli_obj._unwrap_queued_input(cli_obj._pending_input.get_nowait())
+
+    assert text == ""
+    assert is_user_turn is False
+    assert printed and "old delegation result" in printed[0]

--- a/tests/cli/test_cli_goal_interrupt.py
+++ b/tests/cli/test_cli_goal_interrupt.py
@@ -176,8 +176,27 @@ class TestHealthyTurnStillRuns:
         # Continuation prompt must be queued.
         assert not cli._pending_input.empty()
         queued = cli._pending_input.get_nowait()
-        assert "Continuing toward your standing goal" in queued
+        assert "Continuing toward your standing goal" in queued.text
         assert mgr.state.status == "active"
+
+    def test_synthetic_pending_input_does_not_preempt_goal_judge(self, hermes_home):
+        sid = f"sid-synthetic-{uuid.uuid4().hex}"
+        cli, _mgr = _make_cli_with_goal(sid)
+        cli._last_turn_interrupted = False
+        cli._user_turn_id = "turn-current"
+        cli.conversation_history = [
+            {"role": "user", "content": "go"},
+            {"role": "assistant", "content": "more remains"},
+        ]
+        cli._queue_synthetic_input("delegation result", "turn-current")
+
+        with patch(
+            "hermes_cli.goals.judge_goal",
+            return_value=("continue", "keep going", False, None),
+        ):
+            cli._maybe_continue_goal_after_turn()
+
+        assert cli._pending_input.qsize() == 2
 
     def test_clean_response_marks_done_when_judge_says_done(self, hermes_home):
         sid = f"sid-done-{uuid.uuid4().hex}"

--- a/tests/test_tui_gateway_queue_on_busy.py
+++ b/tests/test_tui_gateway_queue_on_busy.py
@@ -102,13 +102,24 @@ def test_drain_fires_queued_prompt_and_claims_running(monkeypatch):
     fired = {}
     monkeypatch.setattr(
         server, "_run_prompt_submit",
-        lambda rid, sid, session, text: fired.update(rid=rid, sid=sid, text=text),
+        lambda rid, sid, session, text, **kwargs: fired.update(
+            rid=rid, sid=sid, text=text, **kwargs
+        ),
     )
-    session = _session(queued_prompt={"text": "go", "transport": "ws-9"})
+    session = _session(
+        user_turn_id="turn-old",
+        queued_prompt={"text": "go", "transport": "ws-9", "turn_id": "turn-queued"},
+    )
 
     assert server._drain_queued_prompt("r1", "sid", session) is True
-    assert fired == {"rid": "r1", "sid": "sid", "text": "go"}
+    assert fired == {
+        "rid": "r1",
+        "sid": "sid",
+        "text": "go",
+        "turn_id": "turn-queued",
+    }
     assert session["running"] is True
+    assert session["user_turn_id"] == "turn-queued"
     assert session["queued_prompt"] is None
     assert session["transport"] == "ws-9"
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -296,7 +296,9 @@ def test_prompt_submit_fails_open_inline_when_compute_host_dispatch_breaks(monke
     monkeypatch.setattr(
         server,
         "_run_prompt_submit",
-        lambda rid, sid, _session, text: inline_calls.append((rid, sid, text)),
+        lambda rid, sid, _session, text, **_kwargs: inline_calls.append(
+            (rid, sid, text)
+        ),
     )
     monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
 
@@ -2692,7 +2694,7 @@ class _StopAfterOneNotificationPoll:
         return self._checks > 1
 
 
-def test_notification_poller_live_loop_requeues_foreign_completion_for_owner(
+def test_notification_poller_live_loop_requeues_foreign_completion_for_owner_status(
     monkeypatch,
 ):
     """A foreign live-loop dequeue is handed back to its proven owner."""
@@ -2745,8 +2747,10 @@ def test_notification_poller_live_loop_requeues_foreign_completion_for_owner(
             _StopAfterOneNotificationPoll(), "sid-a-live-handoff", session_a
         )
 
-        assert len(delivered["a"]) == 1
-        assert "proc-live-handoff completed normally" in delivered["a"][0]
+        assert delivered["a"] == []
+        status_calls = [call for call in emitted if call[0] == "status.update"]
+        assert len(status_calls) == 1
+        assert "proc-live-handoff completed normally" in status_calls[0][2]["text"]
         assert delivered["b"] == []
         assert isolated_queue.empty()
     finally:
@@ -2914,7 +2918,7 @@ def test_notification_poller_drops_orphaned_events(monkeypatch, routing):
         ({"session_key": "old-parent-key"}, "session-a"),
     ],
 )
-def test_notification_poller_delivers_owned_events(
+def test_notification_poller_surfaces_owned_process_events_without_agent_turn(
     monkeypatch, routing, resolved_key
 ):
     """Direct, UI-origin, and compression-lineage owners are delivered."""
@@ -2961,8 +2965,8 @@ def test_notification_poller_delivers_owned_events(
         status_calls = [a for a in emitted if a[0] == "status.update"]
         assert len(status_calls) == 1
         assert status_calls[0][2]["kind"] == "process"
-        assert len(delivered) == 1
-        assert "proc_mine" in delivered[0]
+        assert delivered == []
+        assert "proc_mine" in status_calls[0][2]["text"]
     finally:
         server._sessions.pop("sid_a", None)
         while not process_registry.completion_queue.empty():
@@ -3063,7 +3067,7 @@ def test_run_prompt_submit_requeues_foreign_completion(
         process_registry._completion_consumed.discard(event["session_id"])
 
 
-def test_run_prompt_submit_delivers_completion_observed_by_poll(monkeypatch, tmp_path):
+def test_run_prompt_submit_surfaces_completion_observed_by_poll(monkeypatch, tmp_path):
     import queue as _queue_mod
 
     from tools.process_registry import process_registry
@@ -3093,9 +3097,7 @@ def test_run_prompt_submit_delivers_completion_observed_by_poll(monkeypatch, tmp
     try:
         server._run_prompt_submit("rid-a", "sid_a", session, "session-a-turn")
 
-        assert turns[0] == "session-a-turn"
-        assert len(turns) == 2
-        assert "proc_polled" in turns[1]
+        assert turns == ["session-a-turn"]
         assert isolated_queue.empty()
     finally:
         server._sessions.pop("sid_a", None)
@@ -3103,7 +3105,7 @@ def test_run_prompt_submit_delivers_completion_observed_by_poll(monkeypatch, tmp
         process_registry._poll_observed.discard(event["session_id"])
 
 
-def test_run_prompt_submit_requeues_all_unstarted_notifications_with_real_threading(
+def test_run_prompt_submit_surfaces_all_process_notifications_without_nested_turns(
     monkeypatch, tmp_path
 ):
     import queue as _queue_mod
@@ -3161,29 +3163,11 @@ def test_run_prompt_submit_requeues_all_unstarted_notifications_with_real_thread
     try:
         server._run_prompt_submit("rid-a", "sid_a", session, "session-a-turn")
 
-        assert nested_started.wait(timeout=5)
+        assert not nested_started.wait(timeout=0.1)
         threads[0].join(timeout=5)
         assert not threads[0].is_alive()
-        # Membership, not order: the completion_queue is process-global, and
-        # notification pollers leaked by earlier session.init tests in this
-        # file legitimately steal-and-requeue foreign-session events (see
-        # _notification_poller_loop's belongs-elsewhere branch), rotating the
-        # queue. The requeue contract is that batch_2 and batch_3 both remain
-        # queued (never consumed) while batch_1's turn is in flight — so drain
-        # with a deadline (an event may be transiently held by a poller
-        # mid-cycle) and assert exactly {batch_2, batch_3} come back.
-        queued: dict = {}
-        deadline = time.time() + 5.0
-        while time.time() < deadline and set(queued) != {
-            "proc_batch_2",
-            "proc_batch_3",
-        }:
-            try:
-                evt = isolated_queue.get(timeout=0.1)
-            except _queue_mod.Empty:
-                continue
-            queued[evt["session_id"]] = evt
-        assert set(queued) == {"proc_batch_2", "proc_batch_3"}
+        assert turns == ["session-a-turn"]
+        assert isolated_queue.empty()
     finally:
         release_nested.set()
         for thread in threads:
@@ -3196,7 +3180,7 @@ def test_run_prompt_submit_requeues_all_unstarted_notifications_with_real_thread
             process_registry._poll_observed.discard(event["session_id"])
 
 
-def test_run_prompt_submit_delivers_completion_owned_through_compression_lineage(
+def test_run_prompt_submit_surfaces_completion_owned_through_compression_lineage(
     monkeypatch, tmp_path
 ):
     import queue as _queue_mod
@@ -3241,9 +3225,7 @@ def test_run_prompt_submit_delivers_completion_owned_through_compression_lineage
     try:
         server._run_prompt_submit("rid-b", "sid_b", session, "session-b-turn")
 
-        assert turns[0] == "session-b-turn"
-        assert len(turns) == 2
-        assert "proc_precompression" in turns[1]
+        assert turns == ["session-b-turn"]
         assert ownership_checks == ["proc_precompression"]
         assert isolated_queue.empty()
     finally:
@@ -3251,7 +3233,7 @@ def test_run_prompt_submit_delivers_completion_owned_through_compression_lineage
         process_registry._completion_consumed.discard(event["session_id"])
 
 
-def test_run_prompt_submit_prefers_origin_ui_session_id(monkeypatch, tmp_path):
+def test_run_prompt_submit_status_prefers_origin_ui_session_id(monkeypatch, tmp_path):
     import queue as _queue_mod
 
     from tools.process_registry import process_registry
@@ -3290,9 +3272,7 @@ def test_run_prompt_submit_prefers_origin_ui_session_id(monkeypatch, tmp_path):
     try:
         server._run_prompt_submit("rid-b", "sid_b", session, "session-b-turn")
 
-        assert turns[0] == "session-b-turn"
-        assert len(turns) == 2
-        assert "proc_origin_owned" in turns[1]
+        assert turns == ["session-b-turn"]
         assert ownership_checks == ["proc_origin_owned"]
         assert isolated_queue.empty()
     finally:
@@ -9087,7 +9067,7 @@ def test_config_show_displays_nested_max_turns(monkeypatch):
 
 
 def test_notification_poller_delivers_completion(monkeypatch):
-    """Poller picks up completion events and triggers agent turns."""
+    """Poller surfaces process completions without triggering agent turns."""
     import queue as _queue_mod
 
     from tools.process_registry import process_registry
@@ -9149,9 +9129,7 @@ def test_notification_poller_delivers_completion(monkeypatch):
         assert len(status_calls) >= 1
         assert status_calls[0][2]["kind"] == "process"
 
-        # Should have triggered an agent turn
-        assert len(turns) == 1
-        assert "[IMPORTANT: Background process proc_poller_test completed normally" in turns[0]
+        assert turns == []
     finally:
         server._sessions.pop("sid_poll", None)
         while not process_registry.completion_queue.empty():
@@ -9214,7 +9192,7 @@ def test_notification_poller_skips_consumed(monkeypatch):
 
 
 def test_notification_poller_requeues_when_busy(monkeypatch):
-    """When the agent is busy, the poller requeues the event."""
+    """When busy, the poller requeues a fresh delegation follow-up."""
     import queue as _queue_mod
 
     from tools.process_registry import process_registry
@@ -9222,6 +9200,8 @@ def test_notification_poller_requeues_when_busy(monkeypatch):
     emitted = []
 
     sess = _session(running=True)  # agent is busy
+    sess["session_key"] = "owner-key"
+    sess["user_turn_id"] = "turn-current"
     server._sessions["sid_busy"] = sess
     monkeypatch.setattr(server, "_emit", lambda *a, **kw: emitted.append(a))
 
@@ -9235,11 +9215,12 @@ def test_notification_poller_requeues_when_busy(monkeypatch):
     process_registry._completion_consumed.discard("proc_busy_test")
 
     evt = {
-        "type": "completion",
-        "session_id": "proc_busy_test",
-        "command": "make build",
-        "exit_code": 0,
-        "output": "ok",
+        "type": "async_delegation",
+        "delegation_id": "deleg_busy_test",
+        "summary": "ok",
+        "status": "completed",
+        "dispatch_turn_id": "turn-current",
+        "session_key": sess["session_key"],
     }
     isolated_queue.put(evt)
 
@@ -9256,7 +9237,7 @@ def test_notification_poller_requeues_when_busy(monkeypatch):
         # Event was requeued (agent was busy, no turn triggered)
         assert not isolated_queue.empty()
         requeued = isolated_queue.get_nowait()
-        assert requeued["session_id"] == "proc_busy_test"
+        assert requeued["delegation_id"] == "deleg_busy_test"
     finally:
         server._sessions.pop("sid_busy", None)
         while not process_registry.completion_queue.empty():
@@ -9387,7 +9368,7 @@ def test_notification_poller_emits_distinct_watch_matches_once(monkeypatch):
         status_text = "\n".join(call[2]["text"] for call in status_calls)
         assert "READY on port 8000" in status_text
         assert "READY on port 9000" in status_text
-        assert len(turns) == 3
+        assert turns == []
     finally:
         server._sessions.pop("sid_watch_dedup", None)
         while not process_registry.completion_queue.empty():
@@ -9414,6 +9395,352 @@ def test_notification_event_dedup_key_keeps_completions_one_shot():
     assert server._notification_event_dedup_key(first) == server._notification_event_dedup_key(
         replay
     )
+
+
+def test_notification_generation_allows_multiple_results_from_same_user_turn():
+    session = {"user_turn_id": "turn-current"}
+
+    first = {"type": "async_delegation", "dispatch_turn_id": "turn-current"}
+    second = {"type": "async_delegation", "dispatch_turn_id": "turn-current"}
+
+    assert server._notification_event_should_chain_agent(first, session) is True
+    assert server._notification_event_should_chain_agent(second, session) is True
+
+
+def test_tui_session_context_binds_user_turn_identity():
+    from gateway.session_context import get_session_env
+
+    tokens = getattr(server, "_set_session_context")(
+        "session-key", turn_id="turn-owner"
+    )
+    try:
+        assert get_session_env("HERMES_SESSION_TURN_ID") == "turn-owner"
+    finally:
+        server._clear_session_context(tokens)
+
+
+def test_run_prompt_uses_explicit_immutable_turn_identity(monkeypatch):
+    observed = []
+
+    class _Agent:
+        def run_conversation(self, messages=None, **kwargs):
+            from gateway.session_context import get_session_env
+
+            observed.append(get_session_env("HERMES_SESSION_TURN_ID"))
+            return list(messages or [])
+
+    session = _session(agent=_Agent())
+    session["user_turn_id"] = "turn-newer"
+    server._sessions["sid-immutable"] = session
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "make_stream_renderer", lambda *args: lambda *a, **k: None)
+
+    try:
+        getattr(server, "_run_prompt_submit")(
+            "rid", "sid-immutable", session, "original", turn_id="turn-original"
+        )
+        assert observed == ["turn-original"]
+    finally:
+        server._sessions.pop("sid-immutable", None)
+
+
+def test_busy_submit_captures_queued_turn_identity(monkeypatch):
+    session = _session(running=True)
+    monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "queue")
+
+    result = server._handle_busy_submit(
+        "rid", "sid", session, "next topic", transport=None
+    )
+
+    assert result["result"]["status"] == "queued"
+    assert session["queued_prompt"]["turn_id"] == session["user_turn_id"]
+
+
+def test_status_only_notification_releases_claim_when_emit_fails(monkeypatch):
+    event = {"type": "async_delegation", "delegation_id": "deleg_emit_failure"}
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("transport down")),
+    )
+
+    with patch("tools.async_delegation.claim_event_delivery", return_value="claim"):
+        with patch("tools.async_delegation.complete_event_delivery") as complete:
+            with patch("tools.async_delegation.release_event_delivery") as release:
+                with pytest.raises(RuntimeError, match="transport down"):
+                    server._deliver_status_only_notification(
+                        event, "sid", "result", "test-status"
+                    )
+
+    complete.assert_not_called()
+    release.assert_called_once_with(event, "claim")
+
+
+def test_status_only_notification_treats_false_transport_write_as_failure(monkeypatch):
+    event = {"type": "async_delegation", "delegation_id": "deleg_write_false"}
+    monkeypatch.setattr(server, "write_json", lambda *_args, **_kwargs: False)
+
+    with patch("tools.async_delegation.claim_event_delivery", return_value="claim"):
+        with patch("tools.async_delegation.complete_event_delivery") as complete:
+            with patch("tools.async_delegation.release_event_delivery") as release:
+                with pytest.raises(RuntimeError, match="transport write failed"):
+                    server._deliver_status_only_notification(
+                        event, "sid", "result", "test-status"
+                    )
+
+    complete.assert_not_called()
+    release.assert_called_once_with(event, "claim")
+
+
+def test_shutdown_poller_requeues_fresh_delegation_when_dispatch_fails(monkeypatch):
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg_dispatch_failure",
+        "session_key": "owner-key",
+        "dispatch_turn_id": "turn-current",
+    }
+    session = _session(running=False)
+    session["session_key"] = "owner-key"
+    session["user_turn_id"] = "turn-current"
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue.put(event)
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("dispatch failed")),
+    )
+
+    stop = threading.Event()
+    stop.set()
+    with patch("tools.async_delegation.claim_event_delivery", return_value="claim"):
+        with patch("tools.async_delegation.release_event_delivery") as release:
+            server._notification_poller_loop(stop, "sid", session)
+
+    assert isolated_queue.get_nowait() == event
+    release.assert_called_once_with(event, "claim")
+
+
+def test_notification_poller_requeues_status_after_emit_failure(monkeypatch):
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    session = _session()
+    session["session_key"] = "owner-key"
+    event = {
+        "type": "completion",
+        "session_id": "proc-retry",
+        "session_key": "owner-key",
+        "command": "build",
+        "exit_code": 0,
+    }
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue.put(event)
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    stop = threading.Event()
+    attempts = []
+
+    def _deliver(*args, **kwargs):
+        attempts.append(args[0])
+        if len(attempts) == 1:
+            stop.set()
+            raise RuntimeError("emit failed")
+        return True
+
+    monkeypatch.setattr(server, "_deliver_status_only_notification", _deliver)
+
+    server._notification_poller_loop(stop, "sid", session)
+
+    assert attempts == [event, event]
+
+
+def test_notification_poller_claim_miss_does_not_leave_session_busy(monkeypatch):
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    session = _session()
+    session["session_key"] = "owner-key"
+    session["user_turn_id"] = "turn-current"
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-claimed-elsewhere",
+        "session_key": "owner-key",
+        "origin_ui_session_id": "sid",
+        "dispatch_turn_id": "turn-current",
+        "summary": "delegation",
+        "status": "completed",
+    }
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue.put(event)
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    stop = threading.Event()
+    stop.set()
+
+    monkeypatch.setattr("tools.async_delegation.claim_event_delivery", lambda *args: None)
+
+    server._notification_poller_loop(stop, "sid", session)
+
+    assert session["running"] is False
+
+
+def test_notification_poller_acknowledges_stale_delegation_as_status(monkeypatch):
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    emitted = []
+    turns = []
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg_stale",
+        "session_key": "owner-key",
+        "summary": "old result",
+        "status": "completed",
+        "dispatch_turn_id": "turn-old",
+    }
+    session = _session(running=False)
+    session["session_key"] = "owner-key"
+    session["user_turn_id"] = "turn-current"
+    server._sessions["sid_stale"] = session
+
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue.put(event)
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda *args, **kwargs: turns.append((args, kwargs)),
+    )
+
+    stop = threading.Event()
+    stop.set()
+    try:
+        with patch("tools.async_delegation.claim_event_delivery", return_value="claim"):
+            with patch("tools.async_delegation.complete_event_delivery") as complete:
+                server._notification_poller_loop(stop, "sid_stale", session)
+
+        assert turns == []
+        assert [call for call in emitted if call[0] == "status.update"]
+        complete.assert_called_once_with(event, "claim")
+    finally:
+        server._sessions.pop("sid_stale", None)
+
+
+def test_notification_poller_chains_fresh_delegation(monkeypatch):
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    turns = []
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg_fresh",
+        "session_key": "owner-key",
+        "summary": "fresh result",
+        "status": "completed",
+        "dispatch_turn_id": "turn-current",
+    }
+    session = _session(running=False)
+    session["session_key"] = "owner-key"
+    session["user_turn_id"] = "turn-current"
+    server._sessions["sid_fresh"] = session
+
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue.put(event)
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(server, "_emit", lambda *args: None)
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda _rid, _sid, _session, text, **_kwargs: turns.append(text),
+    )
+
+    stop = threading.Event()
+    stop.set()
+    try:
+        with patch("tools.async_delegation.claim_event_delivery", return_value="claim"):
+            with patch("tools.async_delegation.complete_event_delivery") as complete:
+                server._notification_poller_loop(stop, "sid_fresh", session)
+
+        assert len(turns) == 1
+        assert "fresh result" in turns[0]
+        complete.assert_called_once_with(event, "claim")
+    finally:
+        server._sessions.pop("sid_fresh", None)
+
+
+def test_post_turn_drain_keeps_process_notification_out_of_agent_history(monkeypatch):
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    turns = []
+    emitted = []
+
+    class _Agent:
+        session_id = "owner-key"
+
+        def clear_interrupt(self):
+            pass
+
+        def run_conversation(self, prompt, conversation_history=None, stream_callback=None):
+            turns.append(prompt)
+            return {
+                "final_response": "ok",
+                "messages": [
+                    {"role": "user", "content": prompt},
+                    {"role": "assistant", "content": "ok"},
+                ],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+        def is_alive(self):
+            return False
+
+    session = _session(agent=_Agent(), running=True)
+    session["session_key"] = "owner-key"
+    session["user_turn_id"] = "turn-current"
+    server._sessions["sid_post_turn"] = session
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue.put(
+        {
+            "type": "completion",
+            "session_id": "proc_post_turn",
+            "session_key": "owner-key",
+            "command": "pytest",
+            "exit_code": 0,
+            "output": "42 passed",
+        }
+    )
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: emitted.append(args))
+    monkeypatch.setattr(server, "make_stream_renderer", lambda _cols: None)
+    monkeypatch.setattr(server, "render_message", lambda *_args, **_kwargs: None)
+
+    try:
+        server._run_prompt_submit("rid", "sid_post_turn", session, "real user prompt")
+
+        assert turns == ["real user prompt"]
+        status = [call for call in emitted if call[0] == "status.update"]
+        assert status and "proc_post_turn" in status[0][2]["text"]
+    finally:
+        server._sessions.pop("sid_post_turn", None)
 
 
 # --- image.attach_bytes / pdf.attach (remote-client byte upload) -------------

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -46,6 +46,16 @@ def _drain_one(timeout=5.0):
     return None
 
 
+def test_complete_event_delivery_rejects_false_ack(monkeypatch):
+    monkeypatch.setattr(ad, "complete_completion_delivery", lambda *_args: False)
+
+    with pytest.raises(RuntimeError, match="acknowledgement was rejected"):
+        ad.complete_event_delivery(
+            {"type": "async_delegation", "delegation_id": "deleg_ack"},
+            "claim",
+        )
+
+
 def _drain_for(delegation_id, timeout=5.0):
     """Drain until the event for *delegation_id* appears (discarding others).
 
@@ -122,16 +132,22 @@ def test_async_executor_workers_are_daemon_threads():
 
 
 def test_completion_event_lands_on_shared_queue_with_session_key():
+    from gateway import session_context
+
     def runner():
         return {"status": "completed", "summary": "the result",
                 "api_calls": 3, "duration_seconds": 2.0, "model": "test-model"}
 
-    res = ad.dispatch_async_delegation(
-        goal="compute X", context="some context", toolsets=["web", "file"],
-        role="leaf", model="test-model", session_key="agent:main:cli:dm:local",
-        parent_session_id="20260703_parent_sid",
-        runner=runner, max_async_children=3,
-    )
+    turn_token = getattr(session_context, "set_current_turn_id")("turn-current")
+    try:
+        res = ad.dispatch_async_delegation(
+            goal="compute X", context="some context", toolsets=["web", "file"],
+            role="leaf", model="test-model", session_key="agent:main:cli:dm:local",
+            parent_session_id="20260703_parent_sid",
+            runner=runner, max_async_children=3,
+        )
+    finally:
+        getattr(session_context, "reset_current_turn_id")(turn_token)
     assert res["status"] == "dispatched"
 
     evt = _drain_one()
@@ -141,6 +157,7 @@ def test_completion_event_lands_on_shared_queue_with_session_key():
     assert evt["session_key"] == "agent:main:cli:dm:local"
     assert evt["parent_session_id"] == "20260703_parent_sid"
     assert evt["delegation_id"] == res["delegation_id"]
+    assert evt["dispatch_turn_id"] == "turn-current"
 
 
 def test_rich_reinjection_block_is_self_contained():
@@ -549,7 +566,7 @@ def test_delegate_task_background_uses_live_tui_agent_session_id(monkeypatch):
     assert evt["origin_ui_session_id"] == "origin-tab"
 
 
-def test_delegate_task_background_batch_runs_as_one_unit(monkeypatch):
+def test_delegate_task_background_batch_runs_as_one_unit(monkeypatch, request):
     """A multi-item batch with background=True dispatches the WHOLE fan-out as
     ONE background unit (one handle, one async slot). The children run in
     parallel and join; the consolidated results come back as a single
@@ -589,6 +606,12 @@ def test_delegate_task_background_batch_runs_as_one_unit(monkeypatch):
     monkeypatch.setattr(dt, "_build_child_agent", lambda **kw: fake_child)
     monkeypatch.setattr(dt, "_run_single_child", _blocking_child)
     monkeypatch.setattr(dt, "_resolve_delegation_credentials", lambda *a, **k: creds)
+    from gateway import session_context
+
+    turn_token = getattr(session_context, "set_current_turn_id")("turn-batch")
+    request.addfinalizer(
+        lambda: getattr(session_context, "reset_current_turn_id")(turn_token)
+    )
     out = dt.delegate_task(
         tasks=[{"goal": "a"}, {"goal": "b"}, {"goal": "c"}],
         background=True,
@@ -612,6 +635,7 @@ def test_delegate_task_background_batch_runs_as_one_unit(monkeypatch):
     assert evt is not None
     assert evt["type"] == "async_delegation"
     assert evt.get("is_batch") is True
+    assert evt["dispatch_turn_id"] == "turn-batch"
     assert len(evt["results"]) == 3
     summaries = sorted(r["summary"] for r in evt["results"])
     assert summaries == ["done: a", "done: b", "done: c"]

--- a/tests/tui_gateway/test_compute_host_phase1.py
+++ b/tests/tui_gateway/test_compute_host_phase1.py
@@ -16,6 +16,32 @@ from tui_gateway.host_supervisor import (
 )
 
 
+def test_compute_host_turn_frame_carries_user_turn_identity():
+    from tui_gateway import server
+
+    session = {
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "user_turn_id": "turn-newer",
+        "session_key": "session-key",
+        "cols": 80,
+        "cwd": os.getcwd(),
+        "attached_images": [],
+    }
+
+    frame = getattr(server, "_compute_host_turn_frame")(
+        "rid", "sid", session, "hello", turn_id="turn-owner"
+    )
+
+    assert frame["user_turn_id"] == "turn-owner"
+
+    legacy_frame = getattr(server, "_compute_host_turn_frame")(
+        "rid", "sid", session, "hello"
+    )
+    assert legacy_frame["user_turn_id"] == ""
+
+
 def _json_lines(out: io.StringIO) -> list[dict]:
     frames = []
     for line in out.getvalue().splitlines():

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -363,7 +363,10 @@ def complete_completion_delivery(delegation_id: str, claim_id: str) -> bool:
 
 def complete_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
     if claim_id and evt.get("type") == "async_delegation":
-        complete_completion_delivery(str(evt.get("delegation_id") or ""), claim_id)
+        if not complete_completion_delivery(
+            str(evt.get("delegation_id") or ""), claim_id
+        ):
+            raise RuntimeError("delegation delivery acknowledgement was rejected")
 
 
 def release_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
@@ -415,6 +418,16 @@ def active_count() -> int:
 
 def _new_delegation_id() -> str:
     return f"deleg_{uuid.uuid4().hex[:8]}"
+
+
+def _current_dispatch_turn_id() -> str:
+    """Return the opaque real-user-turn identity bound by the parent surface."""
+    try:
+        from gateway.session_context import get_session_env
+
+        return get_session_env("HERMES_SESSION_TURN_ID", "") or ""
+    except Exception:
+        return ""
 
 
 def _prune_completed_locked() -> None:
@@ -497,6 +510,7 @@ def dispatch_async_delegation(
         "parent_session_id": parent_session_id,
         "status": "running",
         "dispatched_at": dispatched_at,
+        "dispatch_turn_id": _current_dispatch_turn_id(),
         "completed_at": None,
         "interrupt_fn": interrupt_fn,
     }
@@ -628,6 +642,7 @@ def _push_completion_event(
             "duration_seconds", round(completed_at - dispatched_at, 2)
         ),
         "dispatched_at": dispatched_at,
+        "dispatch_turn_id": record.get("dispatch_turn_id"),
         "completed_at": completed_at,
         "exit_reason": result.get("exit_reason"),
     }
@@ -696,6 +711,7 @@ def dispatch_async_delegation_batch(
         "parent_session_id": parent_session_id,
         "status": "running",
         "dispatched_at": dispatched_at,
+        "dispatch_turn_id": _current_dispatch_turn_id(),
         "completed_at": None,
         "interrupt_fn": interrupt_fn,
         "is_batch": True,
@@ -808,6 +824,7 @@ def _finalize_batch(
         "error": combined.get("error"),
         "total_duration_seconds": combined.get("total_duration_seconds"),
         "dispatched_at": dispatched_at,
+        "dispatch_turn_id": event_record.get("dispatch_turn_id"),
         "completed_at": completed_at,
     }
     _persist_completion(evt, combined)

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -376,7 +376,13 @@ class ComputeHost:
             except Exception:
                 pass
             text = frame.get("text") if "text" in frame else frame.get("prompt", "")
-            server._run_prompt_submit(request_id, sid, session, text)
+            getattr(server, "_run_prompt_submit")(
+                request_id,
+                sid,
+                session,
+                text,
+                turn_id=str(frame.get("user_turn_id") or ""),
+            )
             run_thread = session.get("_run_thread")
             if run_thread is not None and hasattr(run_thread, "join"):
                 run_thread.join()
@@ -420,6 +426,7 @@ class ComputeHost:
         session = server._sessions.get(sid)
         if session is not None:
             session["transport"] = self._transport
+            session["user_turn_id"] = str(frame.get("user_turn_id") or "")
             if frame.get("cols") is not None:
                 session["cols"] = int(frame.get("cols") or 80)
             if frame.get("cwd"):
@@ -486,6 +493,7 @@ class ComputeHost:
                 "history": list(history),
                 "history_lock": threading.Lock(),
                 "history_version": int(frame.get("history_version") or 0),
+                "user_turn_id": str(frame.get("user_turn_id") or ""),
                 "inflight_turn": None,
                 "created_at": time.time(),
                 "last_active": time.time(),
@@ -505,6 +513,7 @@ class ComputeHost:
             }
         session = server._sessions[sid]
         session["transport"] = self._transport
+        session["user_turn_id"] = str(frame.get("user_turn_id") or "")
         session["profile_home"] = profile_home or session.get("profile_home")
         if isinstance(frame.get("attached_images"), list):
             session["attached_images"] = list(frame.get("attached_images") or [])

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1157,11 +1157,17 @@ def write_json(obj: dict) -> bool:
     return (current_transport() or _stdio_transport).write(obj)
 
 
-def _emit(event: str, sid: str, payload: dict | None = None):
+def _emit(event: str, sid: str, payload: dict | None = None) -> Any:
     params = {"type": event, "session_id": sid}
     if payload is not None:
         params["payload"] = payload
-    write_json({"jsonrpc": "2.0", "method": "event", "params": params})
+    return write_json({"jsonrpc": "2.0", "method": "event", "params": params})
+
+
+def _emit_notification(event: str, sid: str, payload: dict | None = None) -> None:
+    """Emit a claim-backed notification, failing when its transport rejects it."""
+    if _emit(event, sid, payload) is False:
+        raise RuntimeError("notification transport write failed")
 
 
 _compute_host_supervisor = None
@@ -1205,7 +1211,14 @@ def _get_compute_host_supervisor(cfg: dict | None = None):
         return _compute_host_supervisor
 
 
-def _compute_host_turn_frame(rid: str, sid: str, session: dict, text: Any) -> dict:
+def _compute_host_turn_frame(
+    rid: str,
+    sid: str,
+    session: dict,
+    text: Any,
+    *,
+    turn_id: str = "",
+) -> dict:
     with session["history_lock"]:
         history = list(session.get("history", []))
         history_version = int(session.get("history_version", 0))
@@ -1218,6 +1231,7 @@ def _compute_host_turn_frame(rid: str, sid: str, session: dict, text: Any) -> di
         "text": text,
         "history": history,
         "history_version": history_version,
+        "user_turn_id": str(turn_id or ""),
         "cols": int(session.get("cols", 80) or 80),
         "cwd": _session_cwd(session),
         "profile_home": session.get("profile_home") or "",
@@ -1296,9 +1310,16 @@ def _on_compute_host_turn_done(rid: str, sid: str, session: dict, frame: dict) -
     _drain_queued_prompt(rid, sid, session)
 
 
-def _submit_prompt_to_compute_host(rid: str, sid: str, session: dict, text: Any) -> dict:
+def _submit_prompt_to_compute_host(
+    rid: str,
+    sid: str,
+    session: dict,
+    text: Any,
+    *,
+    turn_id: str = "",
+) -> dict:
     cfg = _load_dashboard_process_isolation_config()
-    frame = _compute_host_turn_frame(rid, sid, session, text)
+    frame = _compute_host_turn_frame(rid, sid, session, text, turn_id=turn_id)
 
     def _complete(done: dict) -> None:
         # submit_turn reports a synchronous pipe failure through the callback
@@ -2245,6 +2266,7 @@ def _set_session_context(
     cwd: str | None = None,
     *,
     ui_session_id: str = "",
+    turn_id: str = "",
 ) -> list:
     try:
         from gateway.session_context import set_session_vars
@@ -2260,12 +2282,18 @@ def _set_session_context(
                 if sess.get("session_key") == session_key:
                     source = _session_source(sess)
                     break
-        return set_session_vars(
+        tokens = set_session_vars(
             session_key=session_key,
             source=source,
             cwd=resolved,
             ui_session_id=ui_session_id,
         )
+        if turn_id:
+            import importlib
+
+            context_module = importlib.import_module("gateway.session_context")
+            tokens.append(getattr(context_module, "set_current_turn_id")(turn_id))
+        return tokens
     except Exception:
         return []
 
@@ -5008,6 +5036,7 @@ def _init_session(
             "history": history,
             "history_lock": threading.Lock(),
             "history_version": 0,
+            "user_turn_id": "",
             "inflight_turn": None,
             "created_at": now,
             "last_active": now,
@@ -5404,6 +5433,13 @@ def _start_inflight_turn(session: dict, text: Any) -> None:
     }
 
 
+def _begin_user_turn(session: dict) -> str:
+    """Rotate the opaque identity only for an actual user-submitted turn."""
+    turn_id = uuid.uuid4().hex
+    session["user_turn_id"] = turn_id
+    return turn_id
+
+
 def _append_inflight_delta(session: dict, delta: Any) -> None:
     text = "" if delta is None else str(delta)
     if not text:
@@ -5475,7 +5511,9 @@ def _handle_busy_submit(rid, sid: str, session: dict, text: Any, transport: Any)
             _get_compute_host_supervisor().interrupt(sid)
         except Exception:
             pass
+    turn_id = _begin_user_turn(session)
     _enqueue_prompt(session, text, transport)
+    session["queued_prompt"]["turn_id"] = turn_id
     session["last_active"] = time.time()
     return _ok(rid, {"status": "queued"})
 
@@ -5493,11 +5531,15 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
             return False
         session["queued_prompt"] = None
         session["running"] = True
+        queued_turn_id = str(queued.get("turn_id") or "")
+        session["user_turn_id"] = queued_turn_id
         if queued.get("transport") is not None:
             session["transport"] = queued["transport"]
     try:
         if _session_uses_compute_host(session):
-            resp = _submit_prompt_to_compute_host(rid, sid, session, queued["text"])
+            resp = _submit_prompt_to_compute_host(
+                rid, sid, session, queued["text"], turn_id=queued_turn_id
+            )
             if resp.get("error"):
                 message = str(((resp.get("error") or {}).get("message")) or "queued prompt failed")
                 with session["history_lock"]:
@@ -5505,7 +5547,9 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
                     _clear_inflight_turn(session)
                 _emit("error", sid, {"message": message})
         else:
-            _run_prompt_submit(rid, sid, session, queued["text"])
+            _run_prompt_submit(
+                rid, sid, session, queued["text"], turn_id=queued_turn_id
+            )
     except Exception as exc:
         print(
             f"[tui_gateway] queued prompt dispatch failed: "
@@ -9200,12 +9244,15 @@ def _(rid, params: dict) -> dict:
                 except Exception as exc:
                     print(f"[tui_gateway] prompt.submit: replace_messages failed: {exc}", file=sys.stderr)
         session["running"] = True
+        turn_id = _begin_user_turn(session)
         session["_turn_cancel_requested"] = False
         session["last_active"] = time.time()
         _start_inflight_turn(session, text)
 
     if turn_isolation:
-        isolated_response = _submit_prompt_to_compute_host(rid, sid, session, text)
+        isolated_response = _submit_prompt_to_compute_host(
+            rid, sid, session, text, turn_id=turn_id
+        )
         if not isolated_response.get("error"):
             return isolated_response
         logger.warning(
@@ -9242,7 +9289,7 @@ def _(rid, params: dict) -> dict:
                 session["running"] = False
                 _clear_inflight_turn(session)
                 return
-        _run_prompt_submit(rid, sid, session, text)
+        _run_prompt_submit(rid, sid, session, text, turn_id=turn_id)
 
     run_thread = threading.Thread(target=run_after_agent_ready, daemon=True)
     # Keep a handle so session.interrupt can tell a live turn from a stuck
@@ -9420,6 +9467,43 @@ def _notification_event_dedup_key(evt: dict) -> tuple:
     return (evt_sid, evt_type)
 
 
+def _notification_event_should_chain_agent(evt: dict, session: dict | None = None) -> bool:
+    """Allow only a delegation owned by the current real user turn to chain."""
+    if evt.get("type") != "async_delegation" or session is None:
+        return False
+    dispatch_turn_id = str(evt.get("dispatch_turn_id") or "")
+    current_turn_id = str(session.get("user_turn_id") or "")
+    return bool(dispatch_turn_id and current_turn_id and dispatch_turn_id == current_turn_id)
+
+
+def _deliver_status_only_notification(
+    evt: dict,
+    sid: str,
+    text: str,
+    consumer: str,
+    *,
+    emit_status: bool = True,
+) -> bool:
+    """Atomically surface and acknowledge a notification without an agent turn."""
+    from tools.async_delegation import (
+        claim_event_delivery, complete_event_delivery, release_event_delivery,
+    )
+
+    claim = claim_event_delivery(evt, consumer)
+    if claim is None:
+        return False
+    try:
+        if emit_status:
+            _emit_notification(
+                "status.update", sid, {"kind": "process", "text": text}
+            )
+        complete_event_delivery(evt, claim)
+    except Exception:
+        release_event_delivery(evt, claim)
+        raise
+    return True
+
+
 def _notification_poller_loop(
     stop_event: threading.Event, sid: str, session: dict
 ) -> None:
@@ -9482,26 +9566,49 @@ def _notification_poller_loop(
         if not text:
             continue
 
+        _should_chain = _notification_event_should_chain_agent(evt, session)
+
         # Only emit the same notification identity to TUI once — re-queued
         # completions get re-emitted every 0.5s otherwise when session is busy,
         # while distinct watch_match events from the same process must remain
         # visible independently.
         _dedup_key = _notification_event_dedup_key(evt)
+        if not _should_chain:
+            _needs_status = _dedup_key not in _emitted
+            try:
+                _delivered = _deliver_status_only_notification(
+                    evt,
+                    sid,
+                    text,
+                    "tui-poller-status",
+                    emit_status=_needs_status,
+                )
+            except Exception as exc:
+                logger.warning("status-only notification delivery failed: %s", exc)
+                process_registry.completion_queue.put(evt)
+                continue
+            if _delivered and _needs_status:
+                _emitted.add(_dedup_key)
+            continue
+
         if _dedup_key not in _emitted:
-            _emit("status.update", sid, {"kind": "process", "text": text})
+            try:
+                _emit_notification(
+                    "status.update", sid, {"kind": "process", "text": text}
+                )
+            except Exception as exc:
+                logger.warning("notification status delivery failed: %s", exc)
+                process_registry.completion_queue.put(evt)
+                time.sleep(0.25)
+                continue
             _emitted.add(_dedup_key)
 
-        _requeued = False
         with session["history_lock"]:
-            if session.get("running"):
-                process_registry.completion_queue.put(evt)
-                _requeued = True
-            else:
-                session["running"] = True
-        if _requeued:
+            _busy = bool(session.get("running"))
+        if _busy:
+            process_registry.completion_queue.put(evt)
             # Back off before re-polling: the re-queued event keeps the queue
-            # non-empty, so without a sleep this loop spins at full speed
-            # (100% CPU, GIL churn) for as long as the session stays busy.
+            # non-empty, so without a sleep this loop spins at full speed.
             time.sleep(0.25)
             continue
 
@@ -9509,15 +9616,41 @@ def _notification_poller_loop(
         from tools.async_delegation import (
             claim_event_delivery, complete_event_delivery, release_event_delivery,
         )
-        _claim = claim_event_delivery(evt, "tui-poller")
+        try:
+            _claim = claim_event_delivery(evt, "tui-poller")
+        except Exception as exc:
+            logger.warning("notification delivery claim failed: %s", exc)
+            process_registry.completion_queue.put(evt)
+            continue
         if _claim is None:
             continue
+
+        with session["history_lock"]:
+            _busy_after_claim = bool(session.get("running"))
+            if not _busy_after_claim:
+                session["running"] = True
+        if _busy_after_claim:
+            release_event_delivery(evt, _claim)
+            process_registry.completion_queue.put(evt)
+            time.sleep(0.25)
+            continue
+        _turn_dispatched = False
         try:
-            _emit("message.start", sid)
-            _run_prompt_submit(rid, sid, session, text)
+            _emit_notification("message.start", sid)
+            _run_prompt_submit(
+                rid,
+                sid,
+                session,
+                text,
+                turn_id=str(evt.get("dispatch_turn_id") or ""),
+            )
+            _turn_dispatched = True
             complete_event_delivery(evt, _claim)
         except Exception as exc:
-            release_event_delivery(evt, _claim)
+            if not _turn_dispatched:
+                release_event_delivery(evt, _claim)
+                process_registry.completion_queue.put(evt)
+                time.sleep(0.25)
             print(
                 f"[tui_gateway] notification poller dispatch failed: "
                 f"{type(exc).__name__}: {exc}",
@@ -9562,30 +9695,80 @@ def _notification_poller_loop(
         if not text:
             continue
 
+        _should_chain = _notification_event_should_chain_agent(evt, session)
         _dedup_key = _notification_event_dedup_key(evt)
+        if not _should_chain:
+            _needs_status = _dedup_key not in _emitted
+            try:
+                _delivered = _deliver_status_only_notification(
+                    evt,
+                    sid,
+                    text,
+                    "tui-poller-status",
+                    emit_status=_needs_status,
+                )
+            except Exception as exc:
+                logger.warning("status-only notification delivery failed: %s", exc)
+                deferred.append(evt)
+                continue
+            if _delivered and _needs_status:
+                _emitted.add(_dedup_key)
+            continue
+
         if _dedup_key not in _emitted:
-            _emit("status.update", sid, {"kind": "process", "text": text})
+            try:
+                _emit_notification(
+                    "status.update", sid, {"kind": "process", "text": text}
+                )
+            except Exception as exc:
+                logger.warning("notification status delivery failed: %s", exc)
+                deferred.append(evt)
+                continue
             _emitted.add(_dedup_key)
 
         with session["history_lock"]:
-            if session.get("running"):
-                process_registry.completion_queue.put(evt)
-                break
-            session["running"] = True
+            _busy = bool(session.get("running"))
+        if _busy:
+            deferred.append(evt)
+            break
 
         rid = f"__notif__{int(time.time() * 1000)}"
         from tools.async_delegation import (
             claim_event_delivery, complete_event_delivery, release_event_delivery,
         )
-        _claim = claim_event_delivery(evt, "tui-poller")
+        try:
+            _claim = claim_event_delivery(evt, "tui-poller")
+        except Exception as exc:
+            logger.warning("notification delivery claim failed: %s", exc)
+            deferred.append(evt)
+            continue
         if _claim is None:
             continue
+
+        with session["history_lock"]:
+            _busy_after_claim = bool(session.get("running"))
+            if not _busy_after_claim:
+                session["running"] = True
+        if _busy_after_claim:
+            release_event_delivery(evt, _claim)
+            deferred.append(evt)
+            break
+        _turn_dispatched = False
         try:
-            _emit("message.start", sid)
-            _run_prompt_submit(rid, sid, session, text)
+            _emit_notification("message.start", sid)
+            _run_prompt_submit(
+                rid,
+                sid,
+                session,
+                text,
+                turn_id=str(evt.get("dispatch_turn_id") or ""),
+            )
+            _turn_dispatched = True
             complete_event_delivery(evt, _claim)
         except Exception as exc:
-            release_event_delivery(evt, _claim)
+            if not _turn_dispatched:
+                release_event_delivery(evt, _claim)
+                deferred.append(evt)
             print(
                 f"[tui_gateway] notification poller dispatch failed: "
                 f"{type(exc).__name__}: {exc}",
@@ -9657,7 +9840,15 @@ def _start_notification_poller(sid: str, session: dict) -> threading.Event:
     return stop
 
 
-def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
+def _run_prompt_submit(
+    rid,
+    sid: str,
+    session: dict,
+    text: Any,
+    *,
+    turn_id: str = "",
+) -> None:
+    turn_id = str(turn_id or "")
     with session["history_lock"]:
         history = list(session["history"])
         history_version = int(session.get("history_version", 0))
@@ -9688,6 +9879,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             session_tokens = _set_session_context(
                 session["session_key"],
                 ui_session_id=sid,
+                turn_id=turn_id,
             )
             _profile_home_str = session.get("profile_home")
             if _profile_home_str:
@@ -10122,7 +10314,9 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 session["running"] = True
             try:
                 _emit("message.start", sid)
-                _run_prompt_submit(rid, sid, session, goal_followup)
+                _run_prompt_submit(
+                    rid, sid, session, goal_followup, turn_id=turn_id
+                )
             except Exception as _cont_exc:
                 print(
                     f"[tui_gateway] goal continuation dispatch failed: "
@@ -10154,24 +10348,73 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 skip_poll_observed=False,
             )
             for index, (_evt, synth) in enumerate(drained):
-                with session["history_lock"]:
-                    if session.get("running"):
-                        for pending_evt, _pending_synth in drained[index:]:
-                            process_registry.completion_queue.put(pending_evt)
-                        break
-                    session["running"] = True
                 from tools.async_delegation import (
                     claim_event_delivery, complete_event_delivery, release_event_delivery,
                 )
-                _claim = claim_event_delivery(_evt, "tui-post-turn")
+
+                _should_chain = _notification_event_should_chain_agent(_evt, session)
+                if not _should_chain:
+                    try:
+                        _deliver_status_only_notification(
+                            _evt,
+                            sid,
+                            synth,
+                            "tui-post-turn-status",
+                        )
+                    except Exception:
+                        for pending_evt, _pending_synth in drained[index:]:
+                            process_registry.completion_queue.put(pending_evt)
+                        raise
+                    continue
+
+                try:
+                    _emit_notification(
+                        "status.update", sid, {"kind": "process", "text": synth}
+                    )
+                except Exception:
+                    for pending_evt, _pending_synth in drained[index:]:
+                        process_registry.completion_queue.put(pending_evt)
+                    raise
+                with session["history_lock"]:
+                    _busy = bool(session.get("running"))
+                if _busy:
+                    for pending_evt, _pending_synth in drained[index:]:
+                        process_registry.completion_queue.put(pending_evt)
+                    break
+                try:
+                    _claim = claim_event_delivery(_evt, "tui-post-turn")
+                except Exception:
+                    for pending_evt, _pending_synth in drained[index:]:
+                        process_registry.completion_queue.put(pending_evt)
+                    raise
                 if _claim is None:
                     continue
+                with session["history_lock"]:
+                    _busy_after_claim = bool(session.get("running"))
+                    if not _busy_after_claim:
+                        session["running"] = True
+                if _busy_after_claim:
+                    release_event_delivery(_evt, _claim)
+                    for pending_evt, _pending_synth in drained[index:]:
+                        process_registry.completion_queue.put(pending_evt)
+                    break
+                _turn_dispatched = False
                 try:
-                    _emit("message.start", sid)
-                    _run_prompt_submit(rid, sid, session, synth)
+                    _emit_notification("message.start", sid)
+                    _run_prompt_submit(
+                        rid,
+                        sid,
+                        session,
+                        synth,
+                        turn_id=str(_evt.get("dispatch_turn_id") or ""),
+                    )
+                    _turn_dispatched = True
                     complete_event_delivery(_evt, _claim)
                 except Exception as _n_exc:
-                    release_event_delivery(_evt, _claim)
+                    if not _turn_dispatched:
+                        release_event_delivery(_evt, _claim)
+                        for pending_evt, _pending_synth in drained[index:]:
+                            process_registry.completion_queue.put(pending_evt)
                     print(
                         f"[tui_gateway] completion notification dispatch failed: "
                         f"{type(_n_exc).__name__}: {_n_exc}",
@@ -10179,6 +10422,8 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     )
                     with session["history_lock"]:
                         session["running"] = False
+                    if not _turn_dispatched:
+                        break
         except Exception as _drain_exc:
             print(
                 f"[tui_gateway] completion queue drain failed: "


### PR DESCRIPTION
## Summary

- Keep process completion and watch notifications as UI/terminal status instead of synthetic agent user turns.
- Allow async delegation completions to auto-chain only when their opaque `dispatch_turn_id` still owns the current real user turn.
- Carry immutable turn identity through classic CLI, queued TUI prompts, inline TUI turns, compute-host isolation, goal follow-ups, and single/batch delegation producers.
- Preserve current owner-scoped routing, compression lineage, durable delivery claims, shutdown draining, and failure requeue behavior.

## Reimplementation

This replaces the previous patch with a clean implementation on current `main` (`b1fc65308`). It addresses the sweeper feedback on both modern TUI delivery paths and adds the equivalent stale-delegation guard to classic CLI.

The implementation is fail-closed: missing, restored, or stale turn tokens may still surface as status, but cannot create a new agent turn.

## Verification

- `504 passed` across the affected CLI, goal, delegation, TUI gateway, queued-prompt, and compute-host suites.
- `ruff check .`
- `python3 scripts/check-windows-footguns.py --all`
- `git diff --check`
- staged secret/credential scan: no matches

## Regression coverage

Includes coverage for:

- process/watch status-only delivery in live, shutdown, and post-turn paths;
- fresh vs stale delegation ownership;
- queued-user races and immutable turn capture;
- compute-host frame propagation and fail-closed empty tokens;
- claim failures, transport write failures, ack failures, and safe requeue/defer behavior;
- classic CLI goal/slash-command ownership;
- single and batch delegation producers.
