### PR TITLE
docs(xai): warn grok-4.3 drops optional multiline string args from MCP tool calls

### DIFF
--- a/optional-skills/email/agentmail/SKILL.md
+++ b/optional-skills/email/agentmail/SKILL.md
@@ -111,6 +111,7 @@ All 11 AgentMail tools are now available automatically.
 - Node.js (18+) is required for the MCP server (`npx -y agentmail-mcp`)
 - The `mcp` Python package must be installed: `pip install mcp`
 - Real-time inbound email (webhooks) requires a public server — use `list_threads` polling via cronjob instead for personal use
+- **xAI Grok drops optional multiline string args:** on `provider: xai` / `xai-oauth` with `grok-4.3`, optional string parameters whose values contain newlines (e.g. `send_message` `subject` / `text`, `reply_to_message` `text`) are silently stripped from the model's tool call, so `send_message` delivers blank emails with no error. See the [xAI Grok OAuth guide](https://hermes-agent.nousresearch.com/docs/guides/xai-grok-oauth) troubleshooting section for workarounds (mark the fields `required`, or patch the MCP server's zod schema to drop `.optional()` on those fields).
 
 ## Verification
 After setup, test with:

--- a/website/docs/guides/xai-grok-oauth.md
+++ b/website/docs/guides/xai-grok-oauth.md
@@ -216,6 +216,22 @@ hermes config set model.provider xai
 
 Or upgrade your subscription at [x.ai/grok](https://x.ai/grok) if the OAuth route is required.
 
+### Tool calls drop optional multiline string args (blank emails / empty bodies)
+
+xAI Grok (`grok-4.3` and adjacent variants) silently drops **optional** string function-call arguments whose values contain newlines. The tool call succeeds (no HTTP 400), but the dropped parameter is absent from the call — for MCP tools whose schema only marks a few fields `required`, this means content is lost with no error.
+
+Most commonly hit with the AgentMail MCP server (`agentmail-mcp`), where `send_message` only marks `inboxId` / `to` as required: `subject` and `text` are optional, so a multiline body is stripped and the email goes out blank. Single-line values survive; only multiline values are dropped. The model also tends to emit 2–3 duplicate calls when this happens.
+
+This is a provider-side behavior, not a Hermes bug — it reproduces against `api.x.ai/v1/responses` directly with no Hermes in the loop. The same family of xAI schema quirks already worked around in Hermes (`pattern`/`format` stripping for HTTP 400s) doesn't catch this case because the request succeeds.
+
+**Workarounds** (in order of appeal):
+
+1. **Mark the affected fields `required` in the tool schema.** For the AgentMail MCP server, patch `send_message.subject` / `.text` and `reply_to_message.text` by unwrapping the zod `.optional()` — grok emits required fields correctly every time. See [agentmail-mcp#18](https://github.com/agentmail-to/agentmail-mcp/issues/18).
+2. **Avoid multiline string values in optional args.** Concatenate into a single line (e.g. replace `\n` with `\\n` or spaces) and let the tool handler normalize back, or split into multiple shorter args if the schema allows.
+3. **Switch the model.** `grok-build-0.1` (the OAuth default) is not affected; only `grok-4.3` exhibits the drop. Use `hermes model` to pick a non-affected variant.
+
+The AgentMail skill docs call this out in its Pitfalls section. Any MCP tool with optional multiline string params under grok-4.3 can hit the same silent content loss — the diagnosis is the same.
+
 ### "No xAI credentials found" error at runtime
 
 The auth store has no `xai-oauth` entry and no `XAI_API_KEY` is set. You haven't logged in yet, or the credential file was deleted.

--- a/website/docs/guides/xai-grok-oauth.md
+++ b/website/docs/guides/xai-grok-oauth.md
@@ -218,7 +218,7 @@ Or upgrade your subscription at [x.ai/grok](https://x.ai/grok) if the OAuth rout
 
 ### Tool calls drop optional multiline string args (blank emails / empty bodies)
 
-xAI Grok (`grok-4.3` and adjacent variants) silently drops **optional** string function-call arguments whose values contain newlines. The tool call succeeds (no HTTP 400), but the dropped parameter is absent from the call — for MCP tools whose schema only marks a few fields `required`, this means content is lost with no error.
+xAI Grok (`grok-4.3`) silently drops **optional** string function-call arguments whose values contain newlines. The tool call succeeds (no HTTP 400), but the dropped parameter is absent from the call — for MCP tools whose schema only marks a few fields `required`, this means content is lost with no error.
 
 Most commonly hit with the AgentMail MCP server (`agentmail-mcp`), where `send_message` only marks `inboxId` / `to` as required: `subject` and `text` are optional, so a multiline body is stripped and the email goes out blank. Single-line values survive; only multiline values are dropped. The model also tends to emit 2–3 duplicate calls when this happens.
 

--- a/website/docs/user-guide/skills/optional/email/email-agentmail.md
+++ b/website/docs/user-guide/skills/optional/email/email-agentmail.md
@@ -128,6 +128,7 @@ All 11 AgentMail tools are now available automatically.
 - Node.js (18+) is required for the MCP server (`npx -y agentmail-mcp`)
 - The `mcp` Python package must be installed: `pip install mcp`
 - Real-time inbound email (webhooks) requires a public server — use `list_threads` polling via cronjob instead for personal use
+- **xAI Grok drops optional multiline string args:** on `provider: xai` / `xai-oauth` with `grok-4.3`, optional string parameters whose values contain newlines (e.g. `send_message` `subject` / `text`, `reply_to_message` `text`) are silently stripped from the model's tool call, so `send_message` delivers blank emails with no error. See the [xAI Grok OAuth guide](https://hermes-agent.nousresearch.com/docs/guides/xai-grok-oauth) troubleshooting section for workarounds (mark the fields `required`, or patch the MCP server's zod schema to drop `.optional()` on those fields).
 
 ## Verification
 After setup, test with:

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/xai-grok-oauth.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/xai-grok-oauth.md
@@ -216,6 +216,22 @@ hermes config set model.provider xai
 
 或在 [x.ai/grok](https://x.ai/grok) 升级订阅（如果必须使用 OAuth 路径）。
 
+### 工具调用丢弃可选的多行字符串参数（空白邮件 / 空正文）
+
+xAI Grok（`grok-4.3` 及相邻变体）会静默丢弃**可选**的、值包含换行符的字符串函数调用参数。工具调用成功（无 HTTP 400），但被丢弃的参数不会出现在调用中——对于 schema 中仅将少量字段标记为 `required` 的 MCP 工具，这意味着内容丢失且无任何错误。
+
+最常见于 AgentMail MCP 服务器（`agentmail-mcp`）：`send_message` 仅将 `inboxId` / `to` 标记为 required，因此 `subject` 和 `text` 是可选的，多行正文被剥离，邮件发出为空白。单行值不受影响；仅多行值被丢弃。发生此情况时，模型还倾向于发出 2–3 次重复调用。
+
+这是 provider 端行为，而非 Hermes bug——它可在无 Hermes 的情况下直接针对 `api.x.ai/v1/responses` 复现。Hermes 中已对同类 xAI schema 怪癖进行了规避（针对 HTTP 400 的 `pattern`/`format` 剥离），但此处无法捕获，因为请求本身成功。
+
+**变通方案**（按优先级）：
+
+1. **在工具 schema 中将受影响字段标记为 `required`。** 对于 AgentMail MCP 服务器，通过解包 zod `.optional()` 修补 `send_message.subject` / `.text` 和 `reply_to_message.text`——grok 每次都能正确发出 required 字段。参见 [agentmail-mcp#18](https://github.com/agentmail-to/agentmail-mcp/issues/18)。
+2. **避免在可选参数中使用多行字符串值。** 合并为单行（例如将 `\n` 替换为 `\\n` 或空格）并让工具处理程序还原，或在 schema 允许时拆分为多个较短的参数。
+3. **切换模型。** `grok-build-0.1`（OAuth 默认值）不受影响；仅 `grok-4.3` 表现出此丢弃行为。使用 `hermes model` 选择不受影响的变体。
+
+AgentMail skill 文档在其 Pitfalls 部分对此进行了说明。在 grok-4.3 下任何带有可选多行字符串参数的 MCP 工具都可能遇到同样的静默内容丢失——诊断方法相同。
+
 ### 运行时出现"No xAI credentials found"错误
 
 auth 存储中没有 `xai-oauth` 条目，也未设置 `XAI_API_KEY`。你尚未登录，或凭据文件已被删除。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/xai-grok-oauth.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/xai-grok-oauth.md
@@ -218,7 +218,7 @@ hermes config set model.provider xai
 
 ### 工具调用丢弃可选的多行字符串参数（空白邮件 / 空正文）
 
-xAI Grok（`grok-4.3` 及相邻变体）会静默丢弃**可选**的、值包含换行符的字符串函数调用参数。工具调用成功（无 HTTP 400），但被丢弃的参数不会出现在调用中——对于 schema 中仅将少量字段标记为 `required` 的 MCP 工具，这意味着内容丢失且无任何错误。
+xAI Grok（`grok-4.3`）会静默丢弃**可选**的、值包含换行符的字符串函数调用参数。工具调用成功（无 HTTP 400），但被丢弃的参数不会出现在调用中——对于 schema 中仅将少量字段标记为 `required` 的 MCP 工具，这意味着内容丢失且无任何错误。
 
 最常见于 AgentMail MCP 服务器（`agentmail-mcp`）：`send_message` 仅将 `inboxId` / `to` 标记为 required，因此 `subject` 和 `text` 是可选的，多行正文被剥离，邮件发出为空白。单行值不受影响；仅多行值被丢弃。发生此情况时，模型还倾向于发出 2–3 次重复调用。
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/optional/email/email-agentmail.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/optional/email/email-agentmail.md
@@ -128,6 +128,7 @@ hermes
 - MCP 服务器需要 Node.js（18+）（`npx -y agentmail-mcp`）
 - 必须安装 `mcp` Python 包：`pip install mcp`
 - 实时入站邮件（webhook）需要公网服务器 — 个人使用时建议改用 `list_threads` 轮询配合 cronjob
+- **xAI Grok 丢弃可选的多行字符串参数：** 在 `provider: xai` / `xai-oauth` 与 `grok-4.3` 下，值包含换行符的可选字符串参数（例如 `send_message` 的 `subject` / `text`，`reply_to_message` 的 `text`）会被静默剥离，导致 `send_message` 发出空白邮件且无错误。参见 [xAI Grok OAuth 指南](https://hermes-agent.nousresearch.com/docs/guides/xai-grok-oauth) 故障排查部分了解变通方案（将字段标记为 `required`，或修补 MCP 服务器的 zod schema 去除这些字段的 `.optional()`）。
 
 ## 验证
 配置完成后，使用以下命令测试：


### PR DESCRIPTION
Fixes #58345

## Description

xAI grok-4.3 silently drops **optional** string function-call arguments whose values contain newlines (no HTTP 400 — the request succeeds, the param is just absent). The most common victim is the AgentMail MCP server, where `send_message` only marks `inboxId`/`to` as required, so a multiline `subject`/`text` is stripped and the email goes out blank with no error. This is provider-side behavior (reproduces against `api.x.ai/v1/responses` directly with no Hermes in the loop) and affects any MCP tool with optional multiline string params under grok-4.3.

Per the issue's stated mitigation order, this PR ships the docs warning (#1): a new troubleshooting section in the xAI Grok OAuth guide plus a cross-referenced Pitfalls entry in the AgentMail skill (EN + zh-Hans). The generic schema-override escape hatch (#2) and detection heuristic (#3) are deliberately not implemented — the reporter explicitly notes "blanket auto-promotion of optional→required in the sanitizer is probably wrong," so a code change would overreach.

## Changes

- `website/docs/guides/xai-grok-oauth.md`: new "Tool calls drop optional multiline string args" troubleshooting section with root cause, reproduction notes, and 3 ordered workarounds.
- `website/i18n/zh-Hans/.../guides/xai-grok-oauth.md`: mirrored zh-Hans translation.
- `optional-skills/email/agentmail/SKILL.md`: Pitfalls bullet cross-referencing the guide.
- `website/docs/user-guide/skills/optional/email/email-agentmail.md`: mirrored Pitfalls bullet.
- `website/i18n/zh-Hans/.../skills/optional/email/email-agentmail.md`: mirrored zh-Hans Pitfalls bullet.

## Verification

- No code changes — markdown only.
- S1 (Secrets): clean.
- S2 (Personal refs): clean.
- C1 (Conventional commits): `docs(xai): ...` passes.
- F1 (Focused): only the 5 doc files touched, no unrelated changes.
- AgentMail skill `description` frontmatter unchanged (pre-existing 172-char value not introduced by this PR).