### PR TITLE
fix(schema): promote optional string params to required for xAI (#58345)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -680,12 +680,14 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             try:
                 import copy as _copy
                 from tools.schema_sanitizer import (
+                    promote_xai_optional_strings,
                     strip_pattern_and_format,
                     strip_slash_enum,
                 )
                 tools_for_api = _copy.deepcopy(tools_for_api)
                 tools_for_api, _ = strip_pattern_and_format(tools_for_api)
                 tools_for_api, _ = strip_slash_enum(tools_for_api)
+                tools_for_api, _ = promote_xai_optional_strings(tools_for_api)
             except Exception as exc:
                 logger.warning(
                     "%s⚠️ Failed to sanitize tool schemas for xAI: %s",

--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import copy
 
 from tools.schema_sanitizer import (
+    promote_xai_optional_strings,
     sanitize_tool_schemas,
     strip_pattern_and_format,
     strip_slash_enum,
@@ -700,3 +701,168 @@ def test_strip_slash_enum_ignores_non_string_enum_values():
     props = tools[0]["function"]["parameters"]["properties"]
     assert props["level"]["enum"] == [1, 2, 3]
     assert props["flag"]["enum"] == [True, False]
+
+
+# ── promote_xai_optional_strings ────────────────────────────────────────────
+
+
+def test_promote_optional_strings_basic():
+    """Optional string params should be promoted to required."""
+    tools = [_tool("send_message", {
+        "type": "object",
+        "properties": {
+            "inboxId": {"type": "string"},
+            "to": {"type": "array", "items": {"type": "string"}},
+            "subject": {"type": "string"},
+            "text": {"type": "string"},
+            "html": {"type": "string"},
+        },
+        "required": ["inboxId", "to"],
+    })]
+    result, promoted = promote_xai_optional_strings(tools)
+    assert promoted == 3, f"Expected 3 promoted (subject, text, html), got {promoted}"
+    required = result[0]["function"]["parameters"]["required"]
+    assert "subject" in required
+    assert "text" in required
+    assert "html" in required
+    assert "inboxId" in required  # already required, still there
+    assert "to" in required
+
+
+def test_promote_optional_strings_skips_non_string():
+    """Non-string top-level properties should not be promoted; nested strings are."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "count": {"type": "integer"},
+            "flag": {"type": "boolean"},
+            "items": {"type": "array", "items": {"type": "string"}},
+            "nested": {"type": "object", "properties": {"x": {"type": "string"}}},
+        },
+        "required": [],
+    })]
+    result, promoted = promote_xai_optional_strings(tools)
+    # name (top-level string) + x (nested string inside nested object) = 2
+    assert promoted == 2, f"Expected 2 promoted (name + nested x), got {promoted}"
+    required = result[0]["function"]["parameters"]["required"]
+    assert "name" in required
+    assert "count" not in required
+    assert "flag" not in required
+    assert "items" not in required
+    assert "nested" not in required
+    # Nested string property also promoted
+    nested = result[0]["function"]["parameters"]["properties"]["nested"]
+    assert "x" in nested["required"]
+
+
+def test_promote_optional_strings_already_required_noop():
+    """Already-required string params should not double-count."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "a": {"type": "string"},
+            "b": {"type": "string"},
+        },
+        "required": ["a", "b"],
+    })]
+    _, promoted = promote_xai_optional_strings(tools)
+    assert promoted == 0, f"Expected 0 promoted, got {promoted}"
+
+
+def test_promote_optional_strings_idempotent():
+    """Second call on already-promoted tools is a no-op."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {"x": {"type": "string"}},
+        "required": [],
+    })]
+    _, first = promote_xai_optional_strings(tools)
+    _, second = promote_xai_optional_strings(tools)
+    assert first == 1
+    assert second == 0
+
+
+def test_promote_optional_strings_empty():
+    tools, promoted = promote_xai_optional_strings([])
+    assert tools == []
+    assert promoted == 0
+
+
+def test_promote_optional_strings_none():
+    tools, promoted = promote_xai_optional_strings(None)
+    assert tools is None
+    assert promoted == 0
+
+
+def test_promote_optional_strings_responses_format():
+    """Responses-format tools (no function wrapper) should also be promoted."""
+    tools = [{
+        "name": "send_message",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "inboxId": {"type": "string"},
+                "text": {"type": "string"},
+            },
+            "required": ["inboxId"],
+        },
+        "type": "function",
+    }]
+    result, promoted = promote_xai_optional_strings(tools)
+    assert promoted == 1
+    assert "text" in result[0]["parameters"]["required"]
+
+
+def test_promote_optional_strings_nested_object():
+    """String properties inside nested objects should be promoted."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "config": {
+                "type": "object",
+                "properties": {
+                    "label": {"type": "string"},
+                    "count": {"type": "integer"},
+                },
+            },
+        },
+        "required": [],
+    })]
+    result, promoted = promote_xai_optional_strings(tools)
+    assert promoted == 1, f"Expected 1 promoted (label), got {promoted}"
+    nested = result[0]["function"]["parameters"]["properties"]["config"]
+    assert "label" in nested["required"]
+    assert "count" not in nested.get("required", [])
+
+
+def test_promote_optional_strings_anyof_combinator():
+    """String properties inside anyOf should be promoted."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "value": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"type": "null"},
+                ]
+            },
+        },
+        "required": [],
+    })]
+    # anyOf with string should NOT be promoted (type is not "string" at top level)
+    _, promoted = promote_xai_optional_strings(tools)
+    assert promoted == 0
+
+
+def test_promote_optional_strings_array_type():
+    """Properties with type: ["string", "null"] should be promoted."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "text": {"type": ["string", "null"]},
+        },
+        "required": [],
+    })]
+    _, promoted = promote_xai_optional_strings(tools)
+    assert promoted == 1

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -481,3 +481,104 @@ def strip_slash_enum(tools: list[dict]) -> tuple[list[dict], int]:
             stripped,
         )
     return tools, stripped
+
+
+def promote_xai_optional_strings(tools: list[dict]) -> tuple[list[dict], int]:
+    """Promote optional string parameters to required for xAI compatibility.
+
+    xAI's grok-4.3 model silently drops **optional** string arguments whose
+    values contain newlines from function calls.  The model emits the tool
+    call but omits the optional parameter entirely — producing a valid (but
+    content-free) invocation that the tool accepts without error.  Making
+    the parameter ``required`` in the tool schema forces the model to emit
+    it correctly every time (verified via direct API matrix test).
+
+    This is a *reactive* workaround in the same family as
+    ``strip_pattern_and_format`` (issue #27197) and ``strip_slash_enum``,
+    but it addresses argument-level corruption rather than schema-level
+    HTTP 400 rejections.
+
+    Only properties with an explicit ``type: "string"`` (or
+    ``type: ["string", ...]`` array form) are promoted.  Object/array
+    properties are skipped to avoid forcing complex nested structures that
+    the model might not be able to produce for all call sites.
+
+    Args:
+        tools: OpenAI-format or Responses-format tool list, mutated in
+            place.  Callers that need to preserve the original should
+            deep-copy first.
+
+    Returns:
+        ``(tools, promoted_count)`` — the same list reference plus a count
+        of how many optional string parameters were promoted to required.
+    """
+    if not tools:
+        return tools, 0
+
+    promoted = 0
+
+    def _walk_schema(node: dict) -> None:
+        nonlocal promoted
+        if not isinstance(node, dict):
+            return
+
+        props = node.get("properties")
+        if isinstance(props, dict):
+            required = node.get("required")
+            if not isinstance(required, list):
+                required = []
+            new_required = list(required)
+            for prop_name, prop_schema in props.items():
+                if prop_name in new_required:
+                    continue
+                if not isinstance(prop_schema, dict):
+                    continue
+                # Match explicit "string" type (scalar or array form).
+                ptype = prop_schema.get("type")
+                is_string = ptype == "string" or (
+                    isinstance(ptype, list) and "string" in ptype
+                )
+                if is_string:
+                    new_required.append(prop_name)
+                    promoted += 1
+            if len(new_required) > len(required):
+                node["required"] = new_required
+
+        # Recurse into nested schemas.
+        for key in ("properties", "items", "additionalProperties"):
+            child = node.get(key)
+            if isinstance(child, dict):
+                if key == "properties":
+                    for v in child.values():
+                        _walk_schema(v)
+                else:
+                    _walk_schema(child)
+        # Handle anyOf / oneOf / allOf combinators.
+        for key in ("anyOf", "oneOf", "allOf"):
+            children = node.get(key)
+            if isinstance(children, list):
+                for child in children:
+                    _walk_schema(child)
+
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        # OpenAI-format: {"function": {"parameters": {...}}}
+        fn = tool.get("function")
+        if isinstance(fn, dict):
+            params = fn.get("parameters")
+            if isinstance(params, dict):
+                _walk_schema(params)
+                continue
+        # Responses-format: {"name": "...", "parameters": {...}}
+        params = tool.get("parameters")
+        if isinstance(params, dict):
+            _walk_schema(params)
+
+    if promoted:
+        logger.info(
+            "schema_sanitizer: promoted %d optional string parameter(s) "
+            "to required for xAI multiline-arg drop workaround (#58345)",
+            promoted,
+        )
+    return tools, promoted


### PR DESCRIPTION
## What does this PR do?

xAI's codex_responses endpoint silently strips multiline function-call arguments that are not in the `required` list. This causes MCP tools (e.g. AgentMail `send_message`) to produce blank emails — the model emits the call but omits `subject`/`text` parameters whose values contain newlines. Making these schema properties `required` forces correct emission every time.

This adds `promote_xai_optional_strings()` to the schema sanitizer chain in `build_api_kwargs()`, following the same pattern as `strip_pattern_and_format` (#27197) and `strip_slash_enum`. A docs-only companion PR (#58351) adds troubleshooting guidance; this PR is the actual code mitigation.

## Related Issue

Fixes #58345

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/schema_sanitizer.py` — Added `promote_xai_optional_strings()` that walks tool schemas and promotes properties with `type: "string"` to the parent object's `required` list. Handles both OpenAI-format and Responses-format tools, nested objects, and array-form types (`["string", "null"]`).
- `agent/chat_completion_helpers.py` — Added the new sanitizer call in the `is_xai_responses` block of `build_api_kwargs()`, after existing sanitizers.
- `tests/tools/test_schema_sanitizer.py` — 10 new tests covering basic promotion, non-string skipping, idempotency, empty/None inputs, Responses-format, nested objects, anyOf combinators, and array-form types.

## How to Test

1. `python -m pytest tests/tools/test_schema_sanitizer.py -q` — all 53 tests should pass (43 existing + 10 new).
2. The fix is verified by the issue's direct API matrix: multiline content in a non-required param → silently stripped; same content in a required param → present and correctly escaped. This change promotes all string params to required for xAI, which the issue confirmed resolves the behavior. Observed result: all 53 tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A (workaround is code-level, no user-facing config)
- [x] I've updated `cli-config.yaml.example` — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — or N/A
- [x] I've considered cross-platform impact — or N/A (schema manipulation is pure Python, platform-independent)
- [x] I've updated tool descriptions/schemas — or N/A

## Screenshots / Logs

N/A — schema transformation is transparent at runtime. Verified by 10 new unit tests for the sanitizer function.
