### PR TITLE
Add agent.skill_auto_patch config gate for skill_manage patches

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1549,6 +1549,12 @@ def init_agent(
     # single turn; the runtime already executes such batches concurrently.
     agent._parallel_tool_call_guidance = bool(_agent_section.get("parallel_tool_call_guidance", True))
 
+    # Skill self-patching guidance toggle.  Default True (existing behavior:
+    # model may call skill_manage(action='patch') on its own initiative).
+    # False switches the injected guidance to require an explicit user
+    # instruction before any skill_manage patch call in the current turn.
+    agent._skill_auto_patch = bool(_agent_section.get("skill_auto_patch", True))
+
     # Local Python toolchain probe toggle.  Default True.  When False,
     # the probe is skipped entirely (no subprocess calls, no system-prompt
     # line).  Useful for users on exotic setups where the probe heuristics

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -187,6 +187,23 @@ SKILLS_GUIDANCE = (
     "Skills that aren't maintained become liabilities."
 )
 
+# Used instead of SKILLS_GUIDANCE when config.yaml's agent.skill_auto_patch
+# is False. Same "save new skills" behavior, but a skill_manage patch call
+# requires the user to explicitly ask for that change in the current turn —
+# noticing a skill is outdated is not by itself authorization to edit it,
+# and neither is the user being satisfied with a task's output.
+SKILLS_GUIDANCE_CONFIRM = (
+    "After completing a complex task (5+ tool calls), fixing a tricky error, "
+    "or discovering a non-trivial workflow, save the approach as a "
+    "skill with skill_manage so you can reuse it next time.\n"
+    "When using a skill and finding it outdated, incomplete, or wrong, tell "
+    "the user what you found — but only call skill_manage(action='patch') "
+    "when the user explicitly asks you to modify/update/fix the skill in "
+    "the current turn. Noticing an issue is not authorization to fix it, "
+    "and neither is the user being happy with the task's output; wait for "
+    "an explicit instruction to change the skill file itself."
+)
+
 KANBAN_GUIDANCE = (
     "# Kanban task execution protocol\n"
     "You have been assigned ONE task from "

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1477,8 +1477,16 @@ def build_skills_system_prompt(
     available_tools: "set[str] | None" = None,
     available_toolsets: "set[str] | None" = None,
     compact_categories: "frozenset[str] | None" = None,
+    skill_auto_patch: bool = True,
 ) -> str:
     """Build a compact skill index for the system prompt.
+
+    ``skill_auto_patch`` (config.yaml ``agent.skill_auto_patch``, default
+    True) gates the index's own "fix it with skill_manage(action='patch')"
+    line — the same setting SKILLS_GUIDANCE/SKILLS_GUIDANCE_CONFIRM key off
+    of in system_prompt.py. Both instructions must agree: setting the
+    config False and only silencing one of them still leaves the model an
+    unqualified "patch it" directive to follow.
 
     Two-layer cache:
       1. In-process LRU dict keyed by (skills_dir, tools, toolsets, hidden)
@@ -1517,6 +1525,7 @@ def build_skills_system_prompt(
         _platform_hint,
         tuple(sorted(disabled)),
         tuple(sorted(compact_categories or ())),
+        bool(skill_auto_patch),
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
@@ -1714,7 +1723,13 @@ def build_skills_system_prompt(
             "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill "
             "first. It has the actual commands (e.g. `hermes config set …`, `hermes tools`, "
             "`hermes setup`) so you don't have to guess or invent workarounds.\n"
-            "If a skill has issues, fix it with skill_manage(action='patch').\n"
+            + (
+                "If a skill has issues, fix it with skill_manage(action='patch').\n"
+                if skill_auto_patch else
+                "If a skill has issues, tell the user — only call "
+                "skill_manage(action='patch') when they explicitly ask you to "
+                "change it in the current turn.\n"
+            ) +
             "After difficult/iterative tasks, offer to save as a skill. "
             "If a skill you loaded was missing steps, had wrong commands, or needed "
             "pitfalls you discovered, update it before finishing.\n"

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -38,6 +38,7 @@ from agent.prompt_builder import (
     PLATFORM_HINTS,
     SESSION_SEARCH_GUIDANCE,
     SKILLS_GUIDANCE,
+    SKILLS_GUIDANCE_CONFIRM,
     STEER_CHANNEL_NOTE,
     TASK_COMPLETION_GUIDANCE,
     TELEGRAM_RICH_MESSAGES_HINT,
@@ -224,7 +225,10 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if "session_search" in agent.valid_tool_names:
         tool_guidance.append(SESSION_SEARCH_GUIDANCE)
     if "skill_manage" in agent.valid_tool_names:
-        tool_guidance.append(SKILLS_GUIDANCE)
+        if getattr(agent, "_skill_auto_patch", True):
+            tool_guidance.append(SKILLS_GUIDANCE)
+        else:
+            tool_guidance.append(SKILLS_GUIDANCE_CONFIRM)
     # Kanban worker/orchestrator lifecycle — only present when the
     # dispatcher spawned this process (kanban_show check_fn gates on
     # HERMES_KANBAN_TASK env var). Normal chat sessions never see

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -320,6 +320,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             available_tools=agent.valid_tool_names,
             available_toolsets=avail_toolsets,
             compact_categories=_compact_cats or None,
+            skill_auto_patch=getattr(agent, "_skill_auto_patch", True),
         )
     else:
         skills_prompt = ""

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1052,6 +1052,16 @@ DEFAULT_CONFIG = {
         # compounds over a long conversation.  Costs ~70 tokens in the cached
         # system prompt.  Set False to disable globally.
         "parallel_tool_call_guidance": True,
+        # Skill self-patching guidance — controls whether the model is told
+        # to call skill_manage(action='patch') on its own initiative when it
+        # notices a loaded skill is outdated/incomplete/wrong (True, default
+        # — preserves existing behavior), or told to only patch a skill when
+        # the user explicitly asks for that change in the current turn
+        # (False). Positive feedback on a task's *output* ("that worked",
+        # "nice job") is not treated as authorization to edit skill files
+        # either way once this is False. Set False for a more deterministic,
+        # no-surprise-edits posture.
+        "skill_auto_patch": True,
         # Local-environment toolchain probe — surfaces Python/pip/uv/PEP-668
         # state in the system prompt when something non-default is detected
         # (e.g. python3 has no pip module, pip→python version mismatch, PEP

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -415,6 +415,54 @@ class TestBuildSkillsSystemPrompt:
         assert "Debug Python scripts" in result
         assert "available_skills" in result
 
+    def test_default_includes_autonomous_patch_instruction(self, monkeypatch, tmp_path):
+        """skill_auto_patch defaults True — preserves existing behavior."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_dir = tmp_path / "skills" / "coding" / "python-debug"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text(
+            "---\nname: python-debug\ndescription: Debug Python scripts\n---\n"
+        )
+        result = build_skills_system_prompt()
+        assert "fix it with skill_manage(action='patch')" in result
+        assert "only call skill_manage(action='patch') when" not in result
+
+    def test_skill_auto_patch_false_requires_explicit_ask(self, monkeypatch, tmp_path):
+        """skill_auto_patch=False must fully remove the autonomous-patch
+        directive from the skills index, not just soften SKILLS_GUIDANCE
+        elsewhere in the prompt — a leftover "fix it" line here would still
+        tell the model to self-patch unprompted (the exact gap this covers)."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_dir = tmp_path / "skills" / "coding" / "python-debug"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text(
+            "---\nname: python-debug\ndescription: Debug Python scripts\n---\n"
+        )
+        result = build_skills_system_prompt(skill_auto_patch=False)
+        assert "fix it with skill_manage(action='patch')" not in result
+        assert "only call skill_manage(action='patch') when" in result
+        assert "explicitly ask" in result
+
+    def test_skill_auto_patch_true_and_false_cache_independently(self, monkeypatch, tmp_path):
+        """The two variants must not collide in the in-process cache — a
+        call with skill_auto_patch=False right after a True call (or vice
+        versa) must not silently serve the other's cached text."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_dir = tmp_path / "skills" / "coding" / "python-debug"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text(
+            "---\nname: python-debug\ndescription: Debug Python scripts\n---\n"
+        )
+        auto = build_skills_system_prompt(skill_auto_patch=True)
+        confirm = build_skills_system_prompt(skill_auto_patch=False)
+        assert auto != confirm
+        assert "fix it with skill_manage(action='patch')" in auto
+        assert "fix it with skill_manage(action='patch')" not in confirm
+        # Re-fetch each — cache must still return the right variant, not
+        # whichever was computed most recently.
+        assert build_skills_system_prompt(skill_auto_patch=True) == auto
+        assert build_skills_system_prompt(skill_auto_patch=False) == confirm
+
     def test_deduplicates_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         cat_dir = tmp_path / "skills" / "tools"


### PR DESCRIPTION
## Summary
- The always-on `SKILLS_GUIDANCE` prompt block tells the model to call `skill_manage(action='patch')` "immediately... don't wait to be asked" whenever it notices a loaded skill is outdated/incomplete/wrong.
- That's fine for users who want autonomous skill maintenance, but it means positive feedback on a task's *output* can get (mis)read as license to edit the skill file behind it — no explicit ask required.
- Adds `agent.skill_auto_patch` (default `True`, no behavior change out of the box). When set `False`, the injected guidance switches to a variant (`SKILLS_GUIDANCE_CONFIRM`) that still has the model surface what it noticed, but requires an explicit user instruction before any `skill_manage(action='patch')` call.
- Follows the existing `task_completion_guidance` / `parallel_tool_call_guidance` pattern in `agent_init.py` / `system_prompt.py`.

## Test plan
- [x] All touched files parse clean (`ast.parse`)
- [x] Simulated the branch logic directly for both `skill_auto_patch=True` and `=False`, confirmed correct guidance text is selected in each case, and that `True` reproduces the original wording verbatim (no regression for users who don't set the flag)
- [ ] Reviewer: confirm this reads cleanly against current `agent_init.py`/`system_prompt.py` conventions