### PR TITLE
fix(skills/himalaya): correct flag add/remove syntax for v1.2.0

### DIFF
--- a/skills/email/himalaya/SKILL.md
+++ b/skills/email/himalaya/SKILL.md
@@ -236,13 +236,13 @@ himalaya message delete 42
 Add flag:
 
 ```bash
-himalaya flag add 42 --flag seen
+himalaya flag add 42 seen
 ```
 
 Remove flag:
 
 ```bash
-himalaya flag remove 42 --flag seen
+himalaya flag remove 42 seen
 ```
 
 ## Multiple Accounts


### PR DESCRIPTION
Closes #58239

himalaya v1.2.0 uses positional arguments for flag names (not the --flag flag). This corrects the documented syntax in the Manage Flags section of the skill.

Before:
```bash
himalaya flag add 42 --flag seen
himalaya flag remove 42 --flag seen
```

After:
```bash
himalaya flag add 42 seen
himalaya flag remove 42 seen
```

Verified against `himalaya flag add --help` which shows `<ID-OR-FLAG>...` positional args.