### PR TITLE
Failover to fallback_providers on plain server_error (500/502)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4233,11 +4233,15 @@ def run_conversation(
                     # is exhausted or didn't help.
 
                 # Eager fallback for rate-limit errors (429 or quota exhaustion)
-                # and transport errors (connection failure / timeout / provider
-                # overloaded).  Rate limits and billing: switch immediately —
-                # the primary provider won't recover within the retry window.
-                # Transport errors: allow 1 retry first (transient hiccups
-                # recover), then fall back if the provider is truly unreachable.
+                # and transport/server errors (connection failure / timeout /
+                # provider overloaded / 500-502 internal server error).
+                # Rate limits and billing: switch immediately — the primary
+                # provider won't recover within the retry window.
+                # Transport/server errors: allow 1 retry first (transient
+                # hiccups recover), then fall back if the provider keeps
+                # failing. Includes server_error (500/502) so a primary that's
+                # erroring out doesn't retry to exhaustion with a configured
+                # fallback chain sitting unused.
                 is_rate_limited = classified.reason in {
                     FailoverReason.rate_limit,
                     FailoverReason.billing,
@@ -4246,6 +4250,7 @@ def run_conversation(
                 _is_transport_failure = classified.reason in {
                     FailoverReason.timeout,
                     FailoverReason.overloaded,
+                    FailoverReason.server_error,
                 }
                 # Z.AI Coding Plan GLM-5.2 overload 429s classify as
                 # `overloaded` (to spare the credential pool), but `overloaded`
@@ -4291,6 +4296,10 @@ def run_conversation(
                         elif classified.reason == FailoverReason.billing:
                             agent._buffer_status(
                                 "⚠️ Billing or credits exhausted — switching to fallback provider..."
+                            )
+                        elif classified.reason == FailoverReason.server_error:
+                            agent._buffer_status(
+                                "⚠️ Provider server error — switching to fallback provider..."
                             )
                         elif _is_transport_failure:
                             agent._buffer_status(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -197,6 +197,24 @@ def _apply_active_turn_redirect(agent: Any, messages: List[Dict[str, Any]], text
     agent._stream_needs_break = True
 
 
+def _is_eager_fallback_transport_reason(reason: FailoverReason) -> bool:
+    """True for transport/server-error reasons eligible for eager fallback.
+
+    Used by the main retry loop's ``_should_fallback`` gate: these reasons
+    get one retry first (transient hiccups recover), then fail over to
+    ``fallback_providers`` once ``retry_count >= 2`` — instead of only
+    reaching a configured fallback chain via the separate max-retry-
+    exhaustion fallback attempt later in the same loop. Extracted to a
+    plain function so the reason set is unit-testable without driving the
+    full conversation loop.
+    """
+    return reason in {
+        FailoverReason.timeout,
+        FailoverReason.overloaded,
+        FailoverReason.server_error,
+    }
+
+
 def _image_error_max_dimension(error: Exception) -> Optional[int]:
     """Extract a provider-reported image dimension ceiling, if present."""
     parts = []
@@ -4239,19 +4257,19 @@ def run_conversation(
                 # provider won't recover within the retry window.
                 # Transport/server errors: allow 1 retry first (transient
                 # hiccups recover), then fall back if the provider keeps
-                # failing. Includes server_error (500/502) so a primary that's
-                # erroring out doesn't retry to exhaustion with a configured
-                # fallback chain sitting unused.
+                # failing. server_error (500/502) joining this set moves its
+                # failover earlier (after 2 retries, matching timeout/
+                # overloaded) instead of waiting for the max-retry-exhaustion
+                # fallback attempt further down this loop — a primary that's
+                # erroring with 500s now hands off sooner rather than
+                # spending its whole retry budget on a provider that's
+                # already failing.
                 is_rate_limited = classified.reason in {
                     FailoverReason.rate_limit,
                     FailoverReason.billing,
                     FailoverReason.upstream_rate_limit,
                 }
-                _is_transport_failure = classified.reason in {
-                    FailoverReason.timeout,
-                    FailoverReason.overloaded,
-                    FailoverReason.server_error,
-                }
+                _is_transport_failure = _is_eager_fallback_transport_reason(classified.reason)
                 # Z.AI Coding Plan GLM-5.2 overload 429s classify as
                 # `overloaded` (to spare the credential pool), but `overloaded`
                 # is excluded from `is_rate_limited` — the gate for the adaptive

--- a/tests/agent/test_server_error_fallback.py
+++ b/tests/agent/test_server_error_fallback.py
@@ -1,0 +1,67 @@
+"""Regression tests for eager fallback on plain server_error (500/502).
+
+_is_eager_fallback_transport_reason() decides whether an error reason
+qualifies for the main retry loop's eager-fallback gate (one retry, then
+fail over to fallback_providers) rather than only reaching a configured
+fallback chain via the separate max-retry-exhaustion attempt later in the
+same loop. server_error (500/502) joining timeout/overloaded here means
+that failover happens sooner — after 2 retries — instead of waiting out
+the full retry budget on a primary that's already failing.
+"""
+import inspect
+
+from agent import conversation_loop
+from agent.conversation_loop import _is_eager_fallback_transport_reason
+from agent.error_classifier import FailoverReason
+
+
+def test_server_error_is_eager_fallback_eligible():
+    assert _is_eager_fallback_transport_reason(FailoverReason.server_error) is True
+
+
+def test_overloaded_is_eager_fallback_eligible():
+    assert _is_eager_fallback_transport_reason(FailoverReason.overloaded) is True
+
+
+def test_timeout_is_eager_fallback_eligible():
+    assert _is_eager_fallback_transport_reason(FailoverReason.timeout) is True
+
+
+def test_rate_limit_is_not_transport_eligible():
+    # rate_limit takes the separate, immediate is_rate_limited path in the
+    # loop's _should_fallback gate - it must not double-count here.
+    assert _is_eager_fallback_transport_reason(FailoverReason.rate_limit) is False
+
+
+def test_billing_is_not_transport_eligible():
+    assert _is_eager_fallback_transport_reason(FailoverReason.billing) is False
+
+
+def test_unknown_is_not_transport_eligible():
+    assert _is_eager_fallback_transport_reason(FailoverReason.unknown) is False
+
+
+def test_should_fallback_activates_at_retry_count_two():
+    """Reproduces the loop's _should_fallback expression directly: eager
+    fallback for a transport/server-error reason requires retry_count >= 2,
+    matching the existing overloaded/timeout threshold - not retry 0 or 1."""
+    is_rate_limited = False  # server_error never sets this
+    for retry_count in (0, 1):
+        _is_transport_failure = _is_eager_fallback_transport_reason(FailoverReason.server_error)
+        should_fallback = is_rate_limited or (_is_transport_failure and retry_count >= 2)
+        assert should_fallback is False, f"retry_count={retry_count} must not eager-fallback yet"
+
+    _is_transport_failure = _is_eager_fallback_transport_reason(FailoverReason.server_error)
+    should_fallback = is_rate_limited or (_is_transport_failure and 2 >= 2)
+    assert should_fallback is True
+
+
+def test_run_conversation_uses_extracted_reason_helper():
+    """The loop's eager-fallback gate must actually call the extracted,
+    unit-tested helper rather than an inline literal set that could drift
+    out of sync with it (e.g. a future edit adding a reason to one but not
+    the other)."""
+    source = inspect.getsource(conversation_loop.run_conversation)
+
+    assert "_is_transport_failure = _is_eager_fallback_transport_reason(classified.reason)" in source
+    assert "retry_count >= 2" in source

--- a/tests/agent/test_server_error_fallback.py
+++ b/tests/agent/test_server_error_fallback.py
@@ -9,10 +9,13 @@ that failover happens sooner — after 2 retries — instead of waiting out
 the full retry budget on a primary that's already failing.
 """
 import inspect
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 from agent import conversation_loop
 from agent.conversation_loop import _is_eager_fallback_transport_reason
 from agent.error_classifier import FailoverReason
+from run_agent import AIAgent
 
 
 def test_server_error_is_eager_fallback_eligible():
@@ -65,3 +68,111 @@ def test_run_conversation_uses_extracted_reason_helper():
 
     assert "_is_transport_failure = _is_eager_fallback_transport_reason(classified.reason)" in source
     assert "retry_count >= 2" in source
+
+
+class _MockServerError(Exception):
+    """Simulates an OpenAI SDK APIStatusError for a plain 500/502."""
+
+    def __init__(self, status_code):
+        super().__init__(f"Error code: {status_code} - internal server error")
+        self.status_code = status_code
+        self.body = {"error": {"message": "internal server error"}}
+
+
+def _mock_response(content):
+    msg = SimpleNamespace(content=content, tool_calls=None)
+    choice = SimpleNamespace(message=msg, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], model="glm-4.7", usage=None)
+
+
+def _make_agent_with_fallback(fb_chain):
+    """Build a minimal AIAgent with the given fallback chain configured.
+
+    Mirrors ``tests/run_agent/test_32646_fallback_429_after_timeout.py``'s
+    ``_make_agent_with_fallback`` helper.
+    """
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI", return_value=MagicMock()),
+    ):
+        agent = AIAgent(
+            api_key="primary-key-abcdef12",
+            base_url="https://open.bigmodel.cn/api/coding/paas/v4",
+            provider="zai",
+            model="glm-5.1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=fb_chain,
+        )
+        agent.client = MagicMock()
+        return agent
+
+
+def test_run_conversation_activates_fallback_after_two_server_errors():
+    """Full loop regression for PR #58355's requested coverage.
+
+    Both teknium1's original review and the 2026-07-29 automated cross-PR
+    triage flagged that only the extracted helper and an
+    ``inspect.getsource`` wiring check existed — no test drove the actual
+    ``run_conversation`` loop. This reproduces the real scenario: two
+    plain HTTP 500s on the primary provider, then a successful response
+    from the configured ``fallback_providers`` entry, asserting fallback
+    activates after the second failure (``retry_count >= 2``) rather than
+    waiting for the max-retry-exhaustion path.
+    """
+    fb_chain = [
+        {
+            "provider": "zai",
+            "model": "glm-4.7",
+            "base_url": "https://open.bigmodel.cn/api/coding/paas/v4",
+        }
+    ]
+    agent = _make_agent_with_fallback(fb_chain)
+    agent._api_max_retries = 2
+
+    calls = []
+
+    def fake_api_call(api_kwargs):
+        calls.append((agent.provider, agent.model))
+        attempt = len(calls)
+        if attempt <= 2:
+            raise _MockServerError(500)
+        return _mock_response("Recovered via fallback")
+
+    mock_fb_client = MagicMock()
+    mock_fb_client.api_key = "primary-key-abcdef12"
+    mock_fb_client.base_url = "https://open.bigmodel.cn/api/coding/paas/v4"
+    mock_fb_client._custom_headers = None
+    mock_fb_client.default_headers = None
+
+    with (
+        patch.object(agent, "_interruptible_api_call", side_effect=fake_api_call),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+        patch("run_agent.OpenAI", return_value=MagicMock()),
+        patch.object(conversation_loop, "jittered_backoff", return_value=0.0),
+        patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_fb_client, "glm-4.7"),
+        ) as mock_resolve,
+        patch(
+            "hermes_cli.model_normalize.normalize_model_for_provider",
+            side_effect=lambda m, p: m,
+        ),
+        patch("agent.model_metadata.get_model_context_length", return_value=200000),
+    ):
+        result = agent.run_conversation("hello")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "Recovered via fallback"
+    assert calls == [
+        ("zai", "glm-5.1"),
+        ("zai", "glm-5.1"),
+        ("zai", "glm-4.7"),
+    ]
+    mock_resolve.assert_called_once()
+    assert agent._fallback_activated is True
+    assert agent.model == "glm-4.7"


### PR DESCRIPTION
## Summary
- The eager-fallback gate in the main retry loop (`conversation_loop.py`) only treats `FailoverReason.timeout` and `.overloaded` (503/529) as transport failures eligible to fail over to `fallback_providers` after 2 retries.
- Plain `server_error` (500/502) wasn't in that set.
- **Correction (per review):** the fallback chain was *not* sitting completely unused for 500/502 — `run_conversation`'s max-retry-exhaustion handler already calls `agent._try_activate_fallback()` unconditionally once `retry_count >= max_retries`, for any error reason. The actual improvement here is timing: `server_error` now joins `timeout`/`overloaded` in the *eager* gate, so failover happens after 2 retries instead of only once the full retry budget (`api_max_retries`, default 3) is exhausted — less time spent retrying a primary that's already failing with a configured fallback available.
- Also gives `server_error` its own status message ("Provider server error...") instead of reusing the transport "Provider unreachable" text, since a 500 means the provider responded, just with an error.

## Test plan
- [x] File parses clean (`ast.parse`)
- [x] Extracted the eager-fallback reason set into `_is_eager_fallback_transport_reason()`, a plain testable function, matching the codebase's existing pattern for logic embedded in `run_conversation` (see `test_gemini_fast_fallback.py`'s treatment of `_pool_may_recover_from_rate_limit`)
- [x] `tests/agent/test_server_error_fallback.py`: unit coverage of the extracted helper (server_error/overloaded/timeout eligible; rate_limit/billing/unknown not), a reproduction of `_should_fallback` confirming eager fallback activates at `retry_count >= 2` and not before, and an `inspect.getsource()` regression confirming `run_conversation` actually calls the extracted helper rather than a drift-prone inline literal
- [x] Full suite: 212 passed (this file + `test_gemini_fast_fallback.py`, `test_error_classifier.py`, `test_credential_pool_routing.py`)