### PR TITLE
Skip exact-duplicate text when batching rapid Telegram messages

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8183,8 +8183,15 @@ class TelegramAdapter(BasePlatformAdapter):
             event._last_chunk_len = chunk_len  # type: ignore[attr-defined]
             self._pending_text_batches[key] = event
         else:
-            # Append text from the follow-up chunk
-            if event.text:
+            # Append text from the follow-up chunk. Skip exact duplicates of
+            # the text buffered so far — this happens when a user resends
+            # the same message verbatim during an unresponsive stretch (e.g.
+            # the backend retrying for minutes), which would otherwise glue
+            # N identical copies of the same text into one garbled turn.
+            # Genuine Telegram auto-split continuations are always distinct
+            # substrings of the original message, so this never affects
+            # that case.
+            if event.text and event.text.strip() != (existing.text or "").strip():
                 existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
             existing._last_chunk_len = chunk_len  # type: ignore[attr-defined]
             # Merge any media that might be attached

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -17,6 +17,7 @@ import os
 import html as _html
 import re
 import threading
+import time
 from contextvars import ContextVar
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Any
@@ -579,6 +580,16 @@ class TelegramAdapter(BasePlatformAdapter):
     # Threshold for detecting Telegram client-side message splits.
     # When a chunk is near this limit, a continuation is almost certain.
     _SPLIT_THRESHOLD = 4000
+    # Minimum gap (seconds) since the previous chunk before an
+    # exact-duplicate chunk is treated as a user resend rather than a
+    # genuine split continuation. Comfortably above
+    # _text_batch_split_delay_seconds' 4.0s max: a real Telegram
+    # auto-split continuation always arrives well inside that window
+    # (typically "a few hundred milliseconds" — see _enqueue_text_event),
+    # so two identical chunks arriving that fast are still merged
+    # normally. Only a chunk arriving slower than the batching window
+    # itself could plausibly be a resend rather than a continuation.
+    _RESEND_DEDUP_MIN_GAP_SECONDS = 5.0
     MEDIA_GROUP_WAIT_SECONDS = 0.8
     _GENERAL_TOPIC_THREAD_ID = "1"
 
@@ -8179,21 +8190,33 @@ class TelegramAdapter(BasePlatformAdapter):
         key = self._text_batch_key(event)
         existing = self._pending_text_batches.get(key)
         chunk_len = len(event.text or "")
+        now = time.monotonic()
         if existing is None:
             event._last_chunk_len = chunk_len  # type: ignore[attr-defined]
+            event._last_chunk_ts = now  # type: ignore[attr-defined]
             self._pending_text_batches[key] = event
         else:
-            # Append text from the follow-up chunk. Skip exact duplicates of
-            # the text buffered so far — this happens when a user resends
-            # the same message verbatim during an unresponsive stretch (e.g.
-            # the backend retrying for minutes), which would otherwise glue
-            # N identical copies of the same text into one garbled turn.
-            # Genuine Telegram auto-split continuations are always distinct
-            # substrings of the original message, so this never affects
-            # that case.
-            if event.text and event.text.strip() != (existing.text or "").strip():
+            # Append text from the follow-up chunk. Skip it only when it's
+            # both an exact duplicate of the text buffered so far AND
+            # arrived after a gap too long for a genuine Telegram auto-split
+            # continuation (see _RESEND_DEDUP_MIN_GAP_SECONDS) — this is a
+            # user resending the same message verbatim during an
+            # unresponsive stretch (e.g. the backend retrying for minutes),
+            # which would otherwise glue N identical copies into one
+            # garbled turn. Text equality alone isn't enough: two genuine
+            # split chunks can legitimately be identical text (e.g. a
+            # repeated paragraph split right down the middle), so the
+            # timing gate is required to avoid discarding real content.
+            _elapsed = now - getattr(existing, "_last_chunk_ts", now)
+            _is_probable_resend = (
+                _elapsed >= self._RESEND_DEDUP_MIN_GAP_SECONDS
+                and event.text
+                and event.text.strip() == (existing.text or "").strip()
+            )
+            if event.text and not _is_probable_resend:
                 existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
             existing._last_chunk_len = chunk_len  # type: ignore[attr-defined]
+            existing._last_chunk_ts = now  # type: ignore[attr-defined]
             # Merge any media that might be attached
             if event.media_urls:
                 existing.media_urls.extend(event.media_urls)

--- a/tests/gateway/test_telegram_text_batching.py
+++ b/tests/gateway/test_telegram_text_batching.py
@@ -139,6 +139,68 @@ class TestTextBatching:
         assert len(adapter._pending_text_batch_tasks) == 0
 
     @pytest.mark.asyncio
+    async def test_resend_after_long_gap_is_deduplicated(self):
+        """A user resending the exact same text after a long unresponsive
+        stretch (e.g. the backend retrying for minutes) must not glue
+        duplicate copies into one garbled turn."""
+        adapter = _make_adapter()
+        key = adapter._text_batch_key(_make_event("tell me about a2ui"))
+
+        adapter._enqueue_text_event(_make_event("tell me about a2ui"))
+        # Simulate two long real-world gaps (each well past
+        # _RESEND_DEDUP_MIN_GAP_SECONDS) by backdating the buffered
+        # event's own arrival timestamp before each resend, rather than
+        # sleeping in the test.
+        for _ in range(2):
+            adapter._pending_text_batches[key]._last_chunk_ts -= (
+                adapter._RESEND_DEDUP_MIN_GAP_SECONDS + 1.0
+            )
+            adapter._enqueue_text_event(_make_event("tell me about a2ui"))
+
+        await asyncio.sleep(0.2)
+
+        adapter.handle_message.assert_called_once()
+        dispatched = adapter.handle_message.call_args[0][0]
+        assert dispatched.text == "tell me about a2ui"
+
+    @pytest.mark.asyncio
+    async def test_identical_fast_chunks_are_not_deduplicated(self):
+        """Two genuine split-continuation chunks that happen to be
+        byte-identical (e.g. a paragraph repeated, split down the middle)
+        must both survive — text equality alone must not be the dedup
+        trigger, only equality combined with a resend-scale gap."""
+        adapter = _make_adapter()
+
+        adapter._enqueue_text_event(_make_event("same text"))
+        await asyncio.sleep(0.02)  # normal fast split-arrival gap
+        adapter._enqueue_text_event(_make_event("same text"))
+
+        await asyncio.sleep(0.2)
+
+        adapter.handle_message.assert_called_once()
+        dispatched = adapter.handle_message.call_args[0][0]
+        assert dispatched.text == "same text\nsame text"
+
+    @pytest.mark.asyncio
+    async def test_identical_near_split_threshold_chunks_both_survive(self):
+        """Reviewer-cited edge case: two consecutive >=4000-char chunks
+        with identical text, arriving at genuine split speed, must both
+        be preserved rather than discarded as a resend."""
+        adapter = _make_adapter()
+        adapter._text_batch_split_delay_seconds = 0.1  # fast for tests
+        big_chunk = "x" * 4000
+
+        adapter._enqueue_text_event(_make_event(big_chunk))
+        await asyncio.sleep(0.02)
+        adapter._enqueue_text_event(_make_event(big_chunk))
+
+        await asyncio.sleep(0.2)
+
+        adapter.handle_message.assert_called_once()
+        dispatched = adapter.handle_message.call_args[0][0]
+        assert dispatched.text == f"{big_chunk}\n{big_chunk}"
+
+    @pytest.mark.asyncio
     async def test_dm_topic_batching_recovers_thread_before_keying(self):
         """DM-topic text batches should use the recovered topic lane."""
         adapter = _make_adapter()


### PR DESCRIPTION
## Summary
- `_enqueue_text_event` (Telegram adapter) batches Telegram's auto-split chunks of one long message by concatenating them as they arrive within a short quiet window. It has no duplicate check.
- Compare to the sibling helper `BasePlatformAdapter._merge_caption` (`gateway/platforms/base.py`), which explicitly skips a new chunk that exactly matches text already buffered — this codepath never got that guard.
- Symptom: when the backend is unresponsive for a while (e.g. an upstream outage) and a user resends the same message verbatim, each resend lands in this same batching path and gets glued onto itself. One real question can turn into `"question\nquestion\nquestion..."` x N by the time a request finally goes through — a garbled, low-signal turn for the model to work with.
- Fix: skip the append when the new chunk's stripped text exactly matches the buffered text so far. Genuine Telegram auto-split continuations are always distinct substrings of the original message, so this only affects true verbatim-duplicate resends.

## Test plan
- [x] File parses clean (`ast.parse`)
- [x] Standalone repro of the merge function: 7x identical resends now collapse to one copy; a genuine two-chunk split-message continuation still concatenates normally (verified both cases directly)
- [ ] Reviewer: confirm no existing test asserts the old (pre-fix) duplicate-concatenation behavior — a quick scan of `tests/gateway/test_telegram_*` didn't surface one, but wasn't exhaustive