### PR TITLE
fix(agent): add debug logging to silent exception fallbacks in four agent modules

### DIFF
--- a/agent/jiter_preload.py
+++ b/agent/jiter_preload.py
@@ -11,6 +11,9 @@ SDK error path for genuinely missing or broken installs.
 from __future__ import annotations
 
 import importlib
+import logging
+
+logger = logging.getLogger(__name__)
 
 _JITER_PRELOADED = False
 _JITER_PRELOAD_ERROR: Exception | None = None
@@ -29,6 +32,11 @@ def preload_jiter_native_extension() -> bool:
         from jiter import from_json as _from_json  # noqa: F401
     except Exception as exc:
         _JITER_PRELOAD_ERROR = exc
+        logger.debug(
+            "Failed to preload optional jiter native extension: %s",
+            exc,
+            exc_info=True,
+        )
         return False
 
     _JITER_PRELOADED = True

--- a/agent/message_content.py
+++ b/agent/message_content.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
 from typing import Any
 
+
+logger = logging.getLogger(__name__)
 
 _NON_TEXT_PART_TYPES = {"image", "image_url", "input_image", "audio", "input_audio"}
 _TEXT_KEYS = ("text", "content", "input_text", "output_text", "summary_text")
@@ -46,5 +49,11 @@ def flatten_message_text(content: Any, *, sep: str = "\n") -> str:
         return text
     try:
         return str(content)
-    except Exception:
+    except Exception as exc:
+        logger.debug(
+            "Failed to stringify message content of type %s; returning empty text: %s",
+            type(content).__name__,
+            exc,
+            exc_info=True,
+        )
         return ""

--- a/agent/tool_result_classification.py
+++ b/agent/tool_result_classification.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
 
+
+logger = logging.getLogger(__name__)
 
 FILE_MUTATING_TOOL_NAMES = frozenset({"write_file", "patch"})
 
@@ -15,7 +18,13 @@ def file_mutation_result_landed(tool_name: str, result: Any) -> bool:
         return False
     try:
         data = json.loads(result.strip())
-    except Exception:
+    except Exception as exc:
+        logger.debug(
+            "Ignoring non-JSON file mutation tool result for %s: %s",
+            tool_name,
+            exc,
+            exc_info=True,
+        )
         return False
     if not isinstance(data, dict) or data.get("error"):
         return False

--- a/agent/verify_hooks.py
+++ b/agent/verify_hooks.py
@@ -14,9 +14,12 @@ decision while preserving ``pre_verify`` for user/plugin policy.
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Optional
 
 from utils import is_truthy_value
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_VERIFY_NUDGES = 3
 
@@ -55,7 +58,12 @@ def _agent_cfg(config: Optional[dict[str, Any]]) -> dict[str, Any]:
             from hermes_cli.config import load_config
 
             config = load_config()
-        except Exception:
+        except Exception as exc:
+            logger.debug(
+                "Failed to load verification hook config; using verification defaults: %s",
+                exc,
+                exc_info=True,
+            )
             config = {}
     agent_cfg = (config or {}).get("agent") if isinstance(config, dict) else None
     return agent_cfg if isinstance(agent_cfg, dict) else {}

--- a/tests/agent/test_jiter_preload.py
+++ b/tests/agent/test_jiter_preload.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import logging
 import sys
 
 from agent import jiter_preload
@@ -21,5 +22,33 @@ def test_preload_jiter_native_extension_is_best_effort(monkeypatch):
     monkeypatch.setattr(importlib, "import_module", _raise_missing)
 
     assert jiter_preload.preload_jiter_native_extension() is False
+    assert jiter_preload._JITER_PRELOADED is False
+    assert isinstance(jiter_preload._JITER_PRELOAD_ERROR, ModuleNotFoundError)
+
+
+def test_preload_jiter_native_extension_logs_debug_on_best_effort_failure(
+    monkeypatch,
+    caplog,
+):
+    monkeypatch.setattr(jiter_preload, "_JITER_PRELOADED", False)
+
+    def _raise_missing(name: str):
+        assert name == "jiter.jiter"
+        raise ModuleNotFoundError("jiter fixture missing")
+
+    monkeypatch.setattr(importlib, "import_module", _raise_missing)
+
+    with caplog.at_level(logging.DEBUG, logger="agent.jiter_preload"):
+        assert jiter_preload.preload_jiter_native_extension() is False
+
+    records = [
+        record
+        for record in caplog.records
+        if record.name == "agent.jiter_preload"
+    ]
+    assert len(records) == 1
+    assert records[0].levelno == logging.DEBUG
+    assert "Failed to preload optional jiter native extension" in records[0].getMessage()
+    assert "jiter fixture missing" in records[0].getMessage()
     assert jiter_preload._JITER_PRELOADED is False
     assert isinstance(jiter_preload._JITER_PRELOAD_ERROR, ModuleNotFoundError)

--- a/tests/agent/test_message_content.py
+++ b/tests/agent/test_message_content.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 
 from agent.message_content import flatten_message_text
@@ -23,3 +24,26 @@ def test_flatten_message_text_accepts_object_parts():
     ]
 
     assert flatten_message_text(content) == "object text\nlegacy content"
+
+
+def test_flatten_message_text_logs_debug_when_str_fallback_raises(caplog):
+    class PathologicalContent:
+        def __str__(self):
+            raise RuntimeError("c2 string conversion fixture")
+
+        def __repr__(self):
+            return "SECRET_USER_MESSAGE_CONTENT"
+
+    with caplog.at_level(logging.DEBUG, logger="agent.message_content"):
+        assert flatten_message_text(PathologicalContent()) == ""
+
+    records = [
+        record
+        for record in caplog.records
+        if record.name == "agent.message_content"
+    ]
+    assert len(records) == 1
+    assert records[0].levelno == logging.DEBUG
+    assert "PathologicalContent" in records[0].getMessage()
+    assert "c2 string conversion fixture" in records[0].getMessage()
+    assert "SECRET_USER_MESSAGE_CONTENT" not in records[0].getMessage()

--- a/tests/agent/test_tool_result_classification.py
+++ b/tests/agent/test_tool_result_classification.py
@@ -1,6 +1,7 @@
 """Tests for shared tool result classification helpers."""
 
 import json
+import logging
 
 from agent.tool_result_classification import file_mutation_result_landed
 
@@ -28,3 +29,17 @@ def test_top_level_file_mutation_error_does_not_count_as_landed():
     result = json.dumps({"success": True, "error": "post-write verification failed"})
 
     assert file_mutation_result_landed("patch", result) is False
+
+
+def test_non_json_result_returns_false_and_logs_debug(caplog):
+    with caplog.at_level(logging.DEBUG, logger="agent.tool_result_classification"):
+        assert file_mutation_result_landed("patch", "not json") is False
+
+    records = [
+        record
+        for record in caplog.records
+        if record.name == "agent.tool_result_classification"
+    ]
+    assert len(records) == 1
+    assert records[0].levelno == logging.DEBUG
+    assert "non-JSON" in records[0].getMessage()

--- a/tests/agent/test_verify_hooks.py
+++ b/tests/agent/test_verify_hooks.py
@@ -7,6 +7,8 @@ The `pre_verify` user-hook aggregation lives in `hermes_cli.plugins`
 
 from __future__ import annotations
 
+import logging
+
 from agent import verify_hooks
 
 
@@ -31,6 +33,26 @@ class TestMaxVerifyNudges:
             verify_hooks.max_verify_nudges({"agent": {"max_verify_nudges": "x"}})
             == verify_hooks.DEFAULT_MAX_VERIFY_NUDGES
         )
+
+    def test_config_load_failure_falls_back_and_logs_debug(self, monkeypatch, caplog):
+        import hermes_cli.config as config_mod
+
+        def fail_load_config():
+            raise RuntimeError("c2 verify-hooks fixture")
+
+        monkeypatch.setattr(config_mod, "load_config", fail_load_config)
+
+        with caplog.at_level(logging.DEBUG, logger="agent.verify_hooks"):
+            assert verify_hooks.max_verify_nudges(None) == verify_hooks.DEFAULT_MAX_VERIFY_NUDGES
+
+        records = [
+            record
+            for record in caplog.records
+            if record.name == "agent.verify_hooks"
+        ]
+        assert len(records) == 1
+        assert records[0].levelno == logging.DEBUG
+        assert "using verification defaults" in records[0].getMessage()
 
 
 class TestCodingVerifyGuidance:


### PR DESCRIPTION
## What does this PR do?

Makes four silent exception-swallow sites in agent/ observable by adding debug-level logging, without changing catch breadth, fallback values, or any control flow. Today these paths hide real failures (e.g. a broken verify-hook config or a failed jiter preload) with no trace in logs, which makes field debugging unnecessarily hard.
Per module:
agent/tool_result_classification.py — log when a tool result payload fails JSON parsing and falls back to plain-text classification.
agent/verify_hooks.py — log when verify-hook configuration loading fails and silently falls back (previously a genuinely error-hiding path).
agent/message_content.py — log when message content extraction hits its exception fallback.
agent/jiter_preload.py — log when the optional jiter native parser preload fails; the stored preload error (_JITER_PRELOAD_ERROR) is preserved unchanged.
All logging is logger.debug(..., exc_info=True) style — zero noise at default log levels, full traceback available when debugging.
This is the same direction as other open observability fixes for swallowed exceptions (e.g. #44018, #53336, #44834), applied to four small core agent modules with focused tests.

## Related Issue

No single tracking issue; this addresses the "error-hiding silent except" class also targeted by #44018 / #53336 / #44834.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- agent/tool_result_classification.py (+11/−1) — debug log on non-JSON fallback
- agent/verify_hooks.py (+10/−1) — debug log on config load fallback
- agent/message_content.py (+11/−1) — debug log on extraction fallback
- agent/jiter_preload.py (+8/−0) — debug log on preload failure
- tests/agent/test_tool_result_classification.py (+15) — pins fallback behavior + log emission
- tests/agent/test_verify_hooks.py (+22) — pins fallback behavior + log emission
- tests/agent/test_message_content.py (+24) — pins fallback behavior + log emission
- tests/agent/test_jiter_preload.py (+29) — pins fallback behavior + log emission

- Total: 8 files, +127/−3. One commit per module for reviewable, revertible units.

## How to Test

1. scripts/run_tests.sh tests/agent/test_tool_result_classification.py tests/agent/test_verify_hooks.py tests/agent/test_message_content.py tests/agent/test_jiter_preload.py -q
2. All new tests assert both the preserved fallback behavior (return values / catch breadth unchanged) and the new debug log emission (caplog).
3. Behavior check: no public API, return value, or exception-propagation change in any of the four modules — the diffs are logging additions only.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits(fix(agent): ...)
- [x] I searched existing PRs — related open PRs (#44018, #53336, #44834) target different files; no overlap with these four modules
- [x] My PR contains only changes related to this fix (4 modules + their tests)
- [x] I've run `pytest tests/ -q` and tests pass — ran via scripts/run_tests.sh (repo's canonical CI-parity runner) on the four affected test files; TDD red-green applied during development (new tests failed before the logging change, pass after)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (Linux 6.8)

### Documentation & Housekeeping

- [x] Documentation — N/A (debug-level logging only, no user-facing behavior change)
- [x] cli-config.yaml.example — N/A (no config keys)
- [x] CONTRIBUTING.md / AGENTS.md — N/A (no architecture change)
- [x] Cross-platform impact — N/A (pure-Python logging, no platform primitives)
- [x] Tool descriptions/schemas — N/A (no tool behavior change)

## Screenshots / Logs

$ scripts/run_tests.sh tests/agent/test_tool_result_classification.py \
    tests/agent/test_verify_hooks.py tests/agent/test_message_content.py \
    tests/agent/test_jiter_preload.py -q

=== Per-file subprocess time distribution ===
  Files:   4
  Total subprocess CPU-wall: 1.7s  (runner wall: 0.4s, parallelism: 16x)
  <1s: 4 files (100%)  <2s: 4 files (100%)
      0.43s  tests/agent/test_message_content.py
      0.42s  tests/agent/test_tool_result_classification.py
      0.42s  tests/agent/test_verify_hooks.py
      0.42s  tests/agent/test_jiter_preload.py

exit code: 0 (all passed, 0 failures)