### PR TITLE
fix(tools): add actionable guidance to web_search/web_extract error messages

### DIFF
--- a/skills/email/himalaya/SKILL.md
+++ b/skills/email/himalaya/SKILL.md
@@ -236,13 +236,13 @@ himalaya message delete 42
 Add flag:
 
 ```bash
-himalaya flag add 42 --flag seen
+himalaya flag add 42 seen
 ```
 
 Remove flag:
 
 ```bash
-himalaya flag remove 42 --flag seen
+himalaya flag remove 42 seen
 ```
 
 ## Multiple Accounts

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -676,7 +676,8 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                 "success": False,
                 "error": (
                     "No web search provider configured. "
-                    "Run `hermes tools` to set one up."
+                    "Run `hermes tools` to set one up, or install the free "
+                    "ddgs backend: pip install ddgs (no API key required)."
                 ),
             }
         else:
@@ -845,7 +846,7 @@ async def web_extract_tool(
                             "error": (
                                 "No web extract provider configured. "
                                 "Set web.extract_backend to firecrawl, "
-                                "tavily, exa, or parallel."
+                                "tavily, exa, or parallel. Run `hermes tools` to configure."
                             ),
                         },
                         ensure_ascii=False,
@@ -925,7 +926,11 @@ async def web_extract_tool(
         trimmed_response = {"results": trimmed_results}
 
         if trimmed_response.get("results") == []:
-            result_json = tool_error("Content was inaccessible or not found")
+            result_json = tool_error(
+                "No content could be extracted from the provided URLs. "
+                "Try: 1) Check cache/web/ for cached content. "
+                "2) Use browser_navigate for direct page access."
+            )
         else:
             result_json = json.dumps(trimmed_response, indent=2, ensure_ascii=False)
 


### PR DESCRIPTION
Closes #58320

Improves error messages returned by web_search and web_extract tools when they fail, giving users actionable next steps.

Changes:
1. **web_search "no provider" error**: now suggests `pip install ddgs` as a free no-API-key option alongside `hermes tools`
2. **web_extract "no provider" error**: adds `Run `hermes tools` to configure` 
3. **web_extract "no content" error**: replaces generic "Content was inaccessible or not found" with actionable guidance: "Check cache/web/ for cached content" and "Use browser_navigate for direct page access"