### PR TITLE
fix(cli): handle empty/null 'terminal:' YAML key in load_cli_config

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -580,7 +580,11 @@ def load_cli_config() -> Dict[str, Any]:
     defaults = managed_scope.apply_managed_overlay(defaults)
 
     # Apply terminal config to environment variables (so terminal_tool picks them up)
-    terminal_config = defaults.get("terminal", {})
+    terminal_config = defaults.get("terminal") or {}
+    # Guard: empty/null "terminal:" in config.yaml parses as None, which
+    # crashes downstream.  Treat missing/null the same as an empty dict.
+    if not isinstance(defaults.get("terminal"), dict):
+        defaults["terminal"] = terminal_config
     
     # Normalize config key: the new config system (hermes_cli/config.py) and all
     # documentation use "backend", the legacy cli-config.yaml uses "env_type".

--- a/tests/cli/test_empty_terminal_key.py
+++ b/tests/cli/test_empty_terminal_key.py
@@ -1,0 +1,65 @@
+"""Tests: empty/null ``terminal:`` YAML key in config.yaml crashes load_cli_config.
+
+Regression test for #58277 — when a profile's config.yaml contains an empty
+``terminal:`` line, YAML parses it as ``None``.  The old code
+``defaults.get("terminal", {})`` returns ``None`` because the key *exists*
+(just with a null value), and ``"backend" in None`` raises TypeError.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def homes(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import hermes_cli.config as cfg
+
+    cfg._LOAD_CONFIG_CACHE.clear()
+    cfg._RAW_CONFIG_CACHE.clear()
+    return home
+
+
+def _load_cli_config(home):
+    import cli
+
+    cli._hermes_home = home
+    from hermes_cli import managed_scope
+
+    managed_scope.invalidate_managed_cache()
+    return cli.load_cli_config()
+
+
+def test_empty_terminal_key_does_not_crash(homes):
+    """Empty ``terminal:`` (YAML null) must not crash load_cli_config()."""
+    home = homes
+
+    # Simulate the exact user config that triggers #58277
+    (home / "config.yaml").write_text(
+        "model:\n  provider: deepseek\n  default: deepseek-v4-flash\n"
+        "terminal:\n"
+        "toolsets:\n  - kanban\n",
+        encoding="utf-8",
+    )
+
+    cfg = _load_cli_config(home)
+    terminal = cfg.get("terminal")
+    # Should be a dict (fallback), not None
+    assert isinstance(terminal, dict), (
+        f"terminal config should be a dict, got {type(terminal).__name__}: {terminal!r}"
+    )
+
+
+def test_terminal_config_preserved_when_present(homes):
+    """Normal non-null terminal config still works."""
+    home = homes
+    (home / "config.yaml").write_text(
+        "terminal:\n  backend: docker\n  cwd: /workspace\n",
+        encoding="utf-8",
+    )
+
+    cfg = _load_cli_config(home)
+    terminal = cfg.get("terminal", {})
+    assert isinstance(terminal, dict)
+    assert "env_type" in terminal or "backend" in terminal


### PR DESCRIPTION
## Description

When a profile's `config.yaml` contains an empty `terminal:` line (present but with no value), YAML parses it as `None`. At startup, `load_cli_config()` reads this value with `defaults.get("terminal", {})`, which returns `None` instead of the fallback `{}` because the key *exists* — it merely has a null value. Line 588 then tries `"backend" in terminal_config`, which raises:

```
TypeError: argument of type 'NoneType' is not iterable
```

### Root cause

`cli.py:583` uses `dict.get()` with a default:

```python
terminal_config = defaults.get("terminal", {})
```

`dict.get(key, default)` only returns the default when the key is **absent**, not when it's present with a `None` value. YAML's `terminal:` with no value creates `{"terminal": None}`.

### Fix

Two safeguards (1 line each):

1. `defaults.get("terminal") or {}` — the `or` catches `None` where `.get`'s default doesn't
2. Guard to sync `defaults["terminal"]` back so the later write at line 601 (`defaults["terminal"]["cwd"]`) also works

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- New test `test_empty_terminal_key_does_not_crash` — creates a config with empty `terminal:` and verifies `load_cli_config()` returns a dict, not None
- New test `test_terminal_config_preserved_when_present` — verifies normal configs still work
- All existing tests in `tests/cli/` and `tests/hermes_cli/` pass (14/14)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective
- [x] All existing and new tests pass
- [ ] I have updated the documentation (not applicable — no behavior change, just a null-safety fix)

---

> **Note:** This PR was created by an autonomous AI agent (nicoware-dev/dev-agent) as part of an open-source contribution pipeline.

Closes #58277