### PR TITLE
fix(agent): dedup duplicate tool_call_id after compaction (#58327)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -390,6 +390,9 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
          any preceding assistant tool_call — dropped.
       2. Consecutive ``user`` messages — merged with newline separator
          so no user input is lost.
+      3. Duplicate ``tool`` messages for the same live tool_call_id are
+         dropped; distinct consecutive tool results from parallel calls are
+         preserved.
 
     Deliberately does NOT rewind orphan ``assistant(tool_calls)+tool``
     pairs that precede a user message — that pattern IS valid when the
@@ -486,6 +489,7 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
     # ``_get_tool_call_id_static``'s ``call_id || id`` — a match set must
     # accept every legitimate reference, not just the canonical one (#58168).
     known_tool_ids: set = set()
+    seen_tool_ids: set = set()
     filtered: List[Dict] = []
     for msg in collapsed:
         if not isinstance(msg, dict):
@@ -494,6 +498,7 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
         role = msg.get("role")
         if role == "assistant":
             known_tool_ids = set()
+            seen_tool_ids = set()
             for tc in (msg.get("tool_calls") or []):
                 if not isinstance(tc, dict):
                     continue
@@ -504,8 +509,9 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
             filtered.append(msg)
         elif role == "tool":
             tc_id = msg.get("tool_call_id")
-            if tc_id and tc_id in known_tool_ids:
+            if tc_id and tc_id in known_tool_ids and tc_id not in seen_tool_ids:
                 filtered.append(msg)
+                seen_tool_ids.add(tc_id)
             else:
                 repairs += 1
         else:
@@ -514,6 +520,7 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
                 # tool messages without a fresh assistant tool_call
                 # are orphans.
                 known_tool_ids = set()
+                seen_tool_ids = set()
             filtered.append(msg)
 
     # Pass 2: merge consecutive user messages. Preserves all user input

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2485,6 +2485,61 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             "Pre-call sanitizer: added %d stub tool result(s)",
             len(missing_results),
         )
+
+    # 3. Enforce unique tool_call_id. Strict providers (DeepSeek) reject any
+    # tool_call_id that appears more than once — either as two tool results or
+    # as two assistant tool_calls — with HTTP 400 "Duplicate value for
+    # 'tool_call_id' of ... in message[N]". Context compaction / session-merge
+    # paths can leave the SAME assistant(tool_calls) group duplicated across two
+    # messages; the stub injection above then doubles a dropped result into two
+    # identical stubs, so both sides can end up with repeated ids. The orphan
+    # repair passes only fix missing/dangling links — never a genuine duplicate —
+    # so this dedup is the piece that keeps the pairing invariant atomic. First
+    # occurrence wins (assistant call and its first matching result are kept),
+    # so the surviving pair stays well-formed.
+    seen_assistant_ids: set = set()
+    seen_result_ids: set = set()
+    deduped: List[Dict[str, Any]] = []
+    dropped_dup_calls = 0
+    dropped_dup_results = 0
+    for msg in messages:
+        role = msg.get("role")
+        if role == "assistant" and msg.get("tool_calls"):
+            kept_tcs = []
+            for tc in msg["tool_calls"]:
+                cid = _ra().AIAgent._get_tool_call_id_static(tc)
+                if cid and cid in seen_assistant_ids:
+                    dropped_dup_calls += 1
+                    continue
+                if cid:
+                    seen_assistant_ids.add(cid)
+                kept_tcs.append(tc)
+            if len(kept_tcs) != len(msg["tool_calls"]):
+                msg = {**msg, "tool_calls": kept_tcs}
+                if not kept_tcs:
+                    msg.pop("tool_calls", None)
+                    content = msg.get("content")
+                    if not content or (isinstance(content, str) and not content.strip()):
+                        msg["content"] = "(tool call removed)"
+            deduped.append(msg)
+        elif role == "tool":
+            cid = (msg.get("tool_call_id") or "").strip()
+            if cid and cid in seen_result_ids:
+                dropped_dup_results += 1
+                continue
+            if cid:
+                seen_result_ids.add(cid)
+            deduped.append(msg)
+        else:
+            deduped.append(msg)
+    if dropped_dup_calls or dropped_dup_results:
+        messages = deduped
+        _ra().logger.debug(
+            "Pre-call sanitizer: dropped %d duplicate tool_call(s) and %d "
+            "duplicate tool result(s)",
+            dropped_dup_calls,
+            dropped_dup_results,
+        )
     return messages
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "enzo.eliott.adami@gmail.com": "enzo-adami",  # PR #54594 fold (agent: drop duplicate tool results for the same live tool_call_id during repair_message_sequence; folded under the sanitize_api_messages send-path dedup for #58327)
     "yingwaizhiying@gmail.com": "msh01",  # PR #58250 salvage (telegram: wall-clock init timeout via daemon-thread deadline + abandon the shielded initialize task on timeout so the retry ladder advances instead of hanging on attempt 1/8 under s6 supervision; #58236). Also covers PR #58276 salvage (compression: preserve a real user turn after compaction; #55677).
     "huanshan5195@users.noreply.github.com": "huanshan5195",  # PR #57601 salvage (custom-provider: emit reasoning_effort at the live CustomProfile path so GLM-5.2/ARK/vLLM/Ollama endpoints receive it; + "max" reasoning level)
     "infinitycrew39@gmail.com": "infinitycrew39",  # PR #56431 salvage (honor live vLLM context limits on local endpoints)

--- a/tests/run_agent/test_agent_guardrails.py
+++ b/tests/run_agent/test_agent_guardrails.py
@@ -132,6 +132,68 @@ class TestSanitizeApiMessages:
         assert len(tool_msgs) == 1
         assert tool_msgs[0]["tool_call_id"] == "c_valid"
 
+    def test_duplicate_tool_result_deduped(self):
+        """Two tool results sharing a tool_call_id → keep first, drop the rest.
+
+        Strict providers (DeepSeek) reject the second with HTTP 400
+        "Duplicate value for 'tool_call_id' ... in message[N]" (#58327).
+        """
+        msgs = [
+            {"role": "assistant", "tool_calls": [assistant_dict_call("dup")]},
+            tool_result("dup", "first"),
+            tool_result("dup", "second"),
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        tool_msgs = [m for m in out if m["role"] == "tool"]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0]["content"] == "first"
+
+    def test_duplicate_assistant_tool_call_deduped(self):
+        """Same tool_call_id declared by two assistant messages → keep first."""
+        msgs = [
+            {"role": "assistant", "tool_calls": [assistant_dict_call("dup")]},
+            tool_result("dup"),
+            {"role": "assistant", "tool_calls": [assistant_dict_call("dup")]},
+            tool_result("dup"),
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        call_ids = [
+            AIAgent._get_tool_call_id_static(tc)
+            for m in out
+            if m.get("role") == "assistant"
+            for tc in (m.get("tool_calls") or [])
+        ]
+        assert call_ids == ["dup"]
+        assert len([m for m in out if m.get("role") == "tool"]) == 1
+
+    def test_duplicate_call_leaving_empty_assistant_gets_placeholder(self):
+        """Dropping the only (duplicate) tool_call must not leave an empty turn."""
+        msgs = [
+            {"role": "assistant", "tool_calls": [assistant_dict_call("dup")]},
+            tool_result("dup"),
+            {"role": "assistant", "tool_calls": [assistant_dict_call("dup")]},
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        # Second assistant loses its duplicate call → keeps visible content,
+        # no dangling tool_calls, and no duplicate tool result.
+        assert all(m.get("tool_calls") != [] for m in out)
+        empty_asst = [
+            m for m in out
+            if m.get("role") == "assistant" and not m.get("tool_calls")
+        ]
+        assert empty_asst and empty_asst[0]["content"]
+
+    def test_distinct_ids_not_treated_as_duplicates(self):
+        """A valid assistant-call + matching result pair is NOT a duplicate."""
+        msgs = [
+            {"role": "assistant", "tool_calls": [assistant_dict_call("a")]},
+            tool_result("a"),
+            {"role": "assistant", "tool_calls": [assistant_dict_call("b")]},
+            tool_result("b"),
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert out == msgs
+
 
 # ---------------------------------------------------------------------------
 # Phase 2a — _cap_delegate_task_calls

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -259,6 +259,55 @@ def test_repair_leaves_valid_conversation_unchanged():
     assert messages == original
 
 
+def test_repair_preserves_parallel_tool_results():
+    """One assistant turn may legitimately produce multiple consecutive tool results."""
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "inspect both"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [
+             {"id": "t1", "type": "function",
+              "function": {"name": "read_file", "arguments": '{"path":"a"}'}},
+             {"id": "t2", "type": "function",
+              "function": {"name": "read_file", "arguments": '{"path":"b"}'}},
+         ]},
+        {"role": "tool", "tool_call_id": "t1", "content": "A"},
+        {"role": "tool", "tool_call_id": "t2", "content": "B"},
+        {"role": "assistant", "content": "A and B"},
+    ]
+    original = [dict(m) for m in messages]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs == 0
+    assert messages == original
+
+
+def test_repair_drops_duplicate_tool_result_for_same_call_id():
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "inspect"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [{"id": "t1", "type": "function",
+                         "function": {"name": "read_file", "arguments": '{"path":"a"}'}}]},
+        {"role": "tool", "tool_call_id": "t1", "content": "A"},
+        {"role": "tool", "tool_call_id": "t1", "content": "A retry duplicate"},
+        {"role": "assistant", "content": "A"},
+    ]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs == 1
+    assert messages == [
+        {"role": "user", "content": "inspect"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [{"id": "t1", "type": "function",
+                         "function": {"name": "read_file", "arguments": '{"path":"a"}'}}]},
+        {"role": "tool", "tool_call_id": "t1", "content": "A"},
+        {"role": "assistant", "content": "A"},
+    ]
+
+
 def test_repair_preserves_multimodal_user_content():
     """Multimodal (list) content must NOT be merged — risks mangling attachments."""
     agent = _bare_agent()


### PR DESCRIPTION
## What does this PR do?

Fixes the strict-provider **HTTP 400 `Duplicate value for 'tool_call_id' of ... in message[N]`** (DeepSeek) that wedges a session immediately after context compaction (#58327).

When compaction cuts through a multi-turn tool sequence it can leave the **same** `assistant(tool_calls)` group duplicated across two messages. The pre-call stub-injection step then doubles a dropped result into two identical `tool` results. Strict providers reject any repeated `tool_call_id`; lenient providers (OpenAI/Anthropic) silently tolerate it, masking the bug. The reporter's debug log shows the session going permanently unrecoverable right after a `1047 → 643` compaction, with both an orphaned-`tool` 400 and the duplicate-`tool_call_id` 400.

The fix closes **both routes** to the duplicate, at the two distinct message-repair layers:

1. **Live send path** — `sanitize_api_messages` is the unconditional last guard before every provider call (`agent/conversation_loop.py`, `agent/chat_completion_helpers.py`). It already repaired *orphaned* pairs but never *duplicates*. Added a pass that enforces unique `tool_call_id`: a repeated assistant `tool_call` is dropped (first wins; a resulting empty turn keeps a `(tool call removed)` placeholder) and a repeated `tool` result is dropped. **Separate** seen-sets for assistant calls vs. results, so a legitimate call+result pair is never misread as a duplicate.
2. **Reload / persistence path** — `repair_message_sequence` now drops a duplicate `tool` result for the same live `tool_call_id` while preserving distinct parallel results (folded from @enzo-adami's #54594 — see Credits).

## Related Issue

Fixes #58327

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/agent_runtime_helpers.py`
  - `sanitize_api_messages`: new step 3 — enforce unique `tool_call_id` on the send path (assistant-call dedup + tool-result dedup, separate seen-sets, placeholder for emptied turns).
  - `repair_message_sequence`: drop duplicate `tool` result for the same live `tool_call_id`, keep distinct parallel results (@enzo-adami, #54594).
- `tests/run_agent/test_agent_guardrails.py`: 4 cases — duplicate result deduped, duplicate assistant call deduped, emptied-turn placeholder, distinct-ids-not-treated-as-duplicate.
- `tests/run_agent/test_message_sequence_repair.py`: regression for the reload-path dedup (@enzo-adami).
- `scripts/release.py`: `AUTHOR_MAP` entry for the folded author.

## How to Test

```
scripts/run_tests.sh tests/run_agent/test_agent_guardrails.py tests/run_agent/test_message_sequence_repair.py -q
```

Result: **44 passed**. Ruff clean; `check-windows-footguns.py` clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected tests and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A (pure Python, no OS-specific calls)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Credits

- Builds on **@enzo-adami**'s [#54594](https://github.com/NousResearch/hermes-agent/pull/54594) — the `repair_message_sequence` duplicate-`tool` result dedup (reload/persistence path) is folded in verbatim, preserving their commit authorship. This PR adds the complementary **send-path** guard in `sanitize_api_messages` so the live request is deduped too.
- Related sibling PRs that tackle the same duplicate-`tool_call_id` 400 on the base repair layer: **@enzo-adami**'s [#58024](https://github.com/NousResearch/hermes-agent/pull/58024) and **@Robinlovelace**'s [#55436](https://github.com/NousResearch/hermes-agent/pull/55436) (the latter also bundles a separate #860 DB-write dedup). Maintainers may prefer to close those in favour of this consolidated PR, trim this one back, or land a different combination — entirely their call.
