### PR TITLE
fix(memory): add rebuild_provider_tools() for async tool discovery race

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -439,6 +439,52 @@ class MemoryManager:
             len(provider.get_tool_schemas()),
         )
 
+    def rebuild_provider_tools(self, provider: MemoryProvider) -> None:
+        """Re-scan a provider's tool schemas and refresh the routing table.
+
+        Call this after a provider completes asynchronous tool discovery so
+        that tools which were not available at ``add_provider()`` time are
+        picked up.  Idempotent — safe to call multiple times.
+
+        Only the given provider's entries in ``_tool_to_provider`` are
+        touched; other providers' mappings are preserved.
+        """
+        from toolsets import _HERMES_CORE_TOOLS
+
+        _core_tool_names = set(_HERMES_CORE_TOOLS)
+
+        # Remove stale entries that point to this provider.
+        stale = [
+            name
+            for name, prov in self._tool_to_provider.items()
+            if prov is provider
+        ]
+        for name in stale:
+            del self._tool_to_provider[name]
+
+        # Re-index.
+        added = 0
+        for raw_schema in provider.get_tool_schemas():
+            schema = normalize_tool_schema(raw_schema)
+            if schema is None:
+                continue
+            tool_name = schema["name"]
+            if tool_name in _core_tool_names:
+                continue
+            if tool_name and tool_name not in self._tool_to_provider:
+                self._tool_to_provider[tool_name] = provider
+                added += 1
+
+        if stale or added:
+            logger.info(
+                "Memory provider '%s' tools rebuilt: removed %d stale, "
+                "added %d new (%d total)",
+                provider.name,
+                len(stale),
+                added,
+                len(provider.get_tool_schemas()),
+            )
+
     @property
     def providers(self) -> List[MemoryProvider]:
         """All registered providers in order."""

--- a/tests/run_agent/test_memory_provider_init.py
+++ b/tests/run_agent/test_memory_provider_init.py
@@ -165,3 +165,124 @@ def test_aiagent_forwards_warning_callback_to_cli_memory_provider():
     assert provider.init_kwargs["platform"] == "cli"
     assert provider.init_kwargs["warning_callback"] == agent._emit_warning
     assert provider.init_kwargs["status_callback"] == agent._emit_status
+
+
+class AsyncDiscoveryProvider:
+    """Provider that discovers tools asynchronously (starts with 0 tools)."""
+
+    name = "async-discovery"
+
+    def __init__(self):
+        self._schemas = []
+        self._discovered = False
+
+    def is_available(self):
+        return True
+
+    def initialize(self, session_id, **kwargs):
+        pass
+
+    def get_tool_schemas(self):
+        return list(self._schemas)
+
+    def discover_tools(self, schemas):
+        """Simulate async tool discovery completing."""
+        self._schemas = schemas
+        self._discovered = True
+
+    def shutdown(self):
+        pass
+
+
+def test_rebuild_provider_tools_populates_after_async_discovery():
+    """Providers with async tool discovery can call rebuild_provider_tools()
+
+    after discovery completes so that tools registered as 0 at add_provider()
+    time are picked up for dispatch routing (#58360).
+    """
+    from agent.memory_manager import MemoryManager
+
+    mm = MemoryManager()
+    provider = AsyncDiscoveryProvider()
+
+    # Register while provider has no tools (pre-discovery).
+    mm.add_provider(provider)
+    assert mm.get_all_tool_names() == set()
+    assert not mm.has_tool("mimir_remember")
+
+    # Simulate async discovery completing.
+    provider.discover_tools([
+        {"name": "mimir_remember", "description": "Store a memory", "parameters": {}},
+        {"name": "mimir_search", "description": "Search memories", "parameters": {}},
+    ])
+
+    # Rebuild picks up the newly-discovered tools.
+    mm.rebuild_provider_tools(provider)
+    assert mm.has_tool("mimir_remember")
+    assert mm.has_tool("mimir_search")
+    assert mm.get_all_tool_names() == {"mimir_remember", "mimir_search"}
+
+
+def test_rebuild_provider_tools_is_idempotent():
+    """Calling rebuild_provider_tools() multiple times is safe."""
+    from agent.memory_manager import MemoryManager
+
+    mm = MemoryManager()
+    provider = AsyncDiscoveryProvider()
+    mm.add_provider(provider)
+
+    provider.discover_tools([
+        {"name": "tool_a", "description": "A", "parameters": {}},
+    ])
+    mm.rebuild_provider_tools(provider)
+    assert mm.has_tool("tool_a")
+
+    # Second call with same tools — no duplicates, no errors.
+    mm.rebuild_provider_tools(provider)
+    assert mm.has_tool("tool_a")
+    assert len(mm.get_all_tool_names()) == 1
+
+
+def test_rebuild_provider_tools_preserves_other_providers():
+    """rebuild_provider_tools() only touches the given provider's entries."""
+    from agent.memory_manager import MemoryManager
+
+    mm = MemoryManager()
+
+    # First provider with static tools.
+    static = CoreShadowProvider()  # has honcho_search
+    mm.add_provider(static)
+    assert mm.has_tool("honcho_search")
+
+    # Second provider with async discovery.
+    async_prov = AsyncDiscoveryProvider()
+    mm.add_provider(async_prov)
+    assert not mm.has_tool("new_tool")
+
+    # Discover and rebuild only the async provider.
+    async_prov.discover_tools([
+        {"name": "new_tool", "description": "New", "parameters": {}},
+    ])
+    mm.rebuild_provider_tools(async_prov)
+
+    # Both providers' tools present.
+    assert mm.has_tool("honcho_search")
+    assert mm.has_tool("new_tool")
+
+
+def test_rebuild_provider_tools_respects_core_tool_names():
+    """rebuild_provider_tools() still rejects core tool name shadows."""
+    from agent.memory_manager import MemoryManager
+
+    mm = MemoryManager()
+    provider = AsyncDiscoveryProvider()
+    mm.add_provider(provider)
+
+    provider.discover_tools([
+        {"name": "clarify", "description": "shadows core", "parameters": {}},
+        {"name": "legit_tool", "description": "legit", "parameters": {}},
+    ])
+    mm.rebuild_provider_tools(provider)
+
+    assert not mm.has_tool("clarify")
+    assert mm.has_tool("legit_tool")


### PR DESCRIPTION
## What does this PR do?

Adds `MemoryManager.rebuild_provider_tools()` — a method that re-scans a provider's tool schemas and refreshes the routing table after asynchronous tool discovery completes.

When a memory provider (e.g. Mimir/Perseus Vault via MCP stdio) does tool discovery asynchronously, `add_provider()` sees 0 tools at registration time. The `_tool_to_provider` routing table stays empty, so sessions born before discovery completes get a frozen zero-tool registry. All `mimir_*` tool calls fail with `Unknown tool` for the session lifetime.

`rebuild_provider_tools()` lets the provider signal "my tools are ready now" and the manager re-indexes without requiring a restart or new session.

## Related Issue

Fixes #58360

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/memory_manager.py`: Added `rebuild_provider_tools(provider)` method (46 lines) that removes stale tool mappings for the given provider and re-indexes from `get_tool_schemas()`. Respects core tool name reservation. Idempotent and safe to call multiple times.
- `tests/run_agent/test_memory_provider_init.py`: Added 4 regression tests:
  - `test_rebuild_provider_tools_populates_after_async_discovery` — verifies tools appear after async discovery
  - `test_rebuild_provider_tools_is_idempotent` — verifies repeated calls don't duplicate entries
  - `test_rebuild_provider_tools_preserves_other_providers` — verifies only the target provider's entries are touched
  - `test_rebuild_provider_tools_respects_core_tool_names` — verifies core tool shadowing is still rejected

## How to Test

1. Run `python -m pytest tests/run_agent/test_memory_provider_init.py -q` — all 8 tests should pass
2. The new method is additive (no existing behavior changed); existing tests continue to pass
3. External memory providers with async tool discovery can call `manager.rebuild_provider_tools(self)` after discovery completes to populate the routing table

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
2026-07-04 11:05:41,975 INFO agent.memory_manager: Memory provider 'mimir' registered (0 tools)
2026-07-04 11:05:41,992 INFO _hermes_user_memory.mimir: Mimir memory provider ready — 55 tools
# After fix, provider calls rebuild_provider_tools():
2026-07-04 11:05:41,993 INFO agent.memory_manager: Memory provider 'mimir' tools rebuilt: removed 0 stale, added 55 new (55 total)
```
