### PR TITLE
feat(fallback): resolve recommended:free sentinel to the Portal's current free model

### DIFF
--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -1,14 +1,37 @@
-"""Helpers for reading the effective fallback provider chain from config."""
+"""Helpers for reading the effective fallback chain from config."""
 
 from __future__ import annotations
 
+import logging
 from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Sentinel model name (nous provider only): resolves to the Portal's current
+# ``freeRecommendedModels[0]`` at chain-build time. Lets free-tier users say
+# "whatever is free right now" instead of hand-tracking Portal rotations.
+RECOMMENDED_FREE_SENTINEL = "recommended:free"
 
 
 def _normalized_base_url(value: Any) -> str:
     if not isinstance(value, str):
         return ""
     return value.strip().rstrip("/")
+
+
+def _resolve_recommended_free() -> str | None:
+    """Resolve the sentinel via the Portal recommended-models cache.
+
+    Import is local to avoid a module cycle and to keep this file cheap to
+    import. Any failure returns None — the caller drops the entry with a
+    warning and the rest of the chain still works.
+    """
+    try:
+        from hermes_cli.models import get_nous_recommended_free_model
+        return get_nous_recommended_free_model()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("recommended:free resolution failed: %s", exc)
+        return None
 
 
 def _iter_fallback_entries(raw: Any) -> list[dict[str, Any]]:
@@ -27,6 +50,18 @@ def _iter_fallback_entries(raw: Any) -> list[dict[str, Any]]:
         model = str(entry.get("model") or "").strip()
         if not provider or not model:
             continue
+
+        if model == RECOMMENDED_FREE_SENTINEL and provider == "nous":
+            resolved = _resolve_recommended_free()
+            if not resolved:
+                logger.warning(
+                    "fallback entry 'nous/%s' skipped: no free recommendation "
+                    "available from the Portal (network down and no cached "
+                    "answer). The rest of the chain is unaffected.",
+                    RECOMMENDED_FREE_SENTINEL,
+                )
+                continue
+            model = resolved
 
         normalized = dict(entry)
         normalized["provider"] = provider

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1011,6 +1011,38 @@ def get_nous_recommended_aux_model(
     return None
 
 
+def get_nous_recommended_free_model(
+    portal_base_url: str = "",
+    *,
+    force_refresh: bool = False,
+) -> Optional[str]:
+    """Return the Portal's current top free-tier model, or None.
+
+    Reads ``freeRecommendedModels[0]`` from the recommended-models payload.
+    The Portal rotates which model is free; this is the source of truth for
+    "whatever is free right now" — used to resolve the ``recommended:free``
+    sentinel in ``fallback_providers`` entries so free-tier users don't have
+    to hand-edit config.yaml (or silently start getting billed) every time
+    the free model changes.
+
+    Goes through :func:`fetch_nous_recommended_models`, so it inherits the
+    in-process TTL cache and the last-known-good disk cache — a Portal
+    hiccup degrades to the previous answer, not to ``None``.
+    """
+    base = portal_base_url or _resolve_nous_portal_url()
+    payload = fetch_nous_recommended_models(base, force_refresh=force_refresh)
+    if not isinstance(payload, dict) or not payload:
+        return None
+    block = payload.get("freeRecommendedModels")
+    if not isinstance(block, list):
+        return None
+    for entry in block:
+        name = _extract_model_name(entry)
+        if name:
+            return name
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Canonical provider list — single source of truth for provider identity.
 # Every code path that lists, displays, or iterates providers derives from

--- a/tests/hermes_cli/test_fallback_recommended_free.py
+++ b/tests/hermes_cli/test_fallback_recommended_free.py
@@ -1,0 +1,97 @@
+"""Tests for the ``recommended:free`` sentinel in fallback chain resolution."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from hermes_cli.fallback_config import (
+    RECOMMENDED_FREE_SENTINEL,
+    get_fallback_chain,
+)
+
+
+def _cfg(model: str, provider: str = "nous") -> dict:
+    return {"fallback_providers": [{"provider": provider, "model": model}]}
+
+
+class TestRecommendedFreeSentinel:
+    def test_sentinel_resolves_to_portal_free_model(self):
+        with patch(
+            "hermes_cli.models.get_nous_recommended_free_model",
+            return_value="stepfun/step-3.7-flash:free",
+        ):
+            chain = get_fallback_chain(_cfg(RECOMMENDED_FREE_SENTINEL))
+        assert chain == [
+            {"provider": "nous", "model": "stepfun/step-3.7-flash:free"}
+        ]
+
+    def test_sentinel_entry_dropped_when_no_recommendation(self):
+        """No cache, no network → entry skipped; rest of chain unaffected."""
+        cfg = {
+            "fallback_providers": [
+                {"provider": "nous", "model": RECOMMENDED_FREE_SENTINEL},
+                {"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"},
+            ]
+        }
+        with patch(
+            "hermes_cli.models.get_nous_recommended_free_model",
+            return_value=None,
+        ):
+            chain = get_fallback_chain(cfg)
+        assert chain == [
+            {"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"}
+        ]
+
+    def test_sentinel_on_other_provider_is_literal(self):
+        """The sentinel is nous-namespaced; elsewhere it's just a model name."""
+        with patch(
+            "hermes_cli.models.get_nous_recommended_free_model",
+        ) as resolver:
+            chain = get_fallback_chain(_cfg(RECOMMENDED_FREE_SENTINEL, "openrouter"))
+        resolver.assert_not_called()
+        assert chain == [
+            {"provider": "openrouter", "model": RECOMMENDED_FREE_SENTINEL}
+        ]
+
+    def test_resolved_duplicate_deduped_against_literal_entry(self):
+        """Sentinel resolving to a model already in the chain is deduped."""
+        cfg = {
+            "fallback_providers": [
+                {"provider": "nous", "model": "stepfun/step-3.7-flash:free"},
+                {"provider": "nous", "model": RECOMMENDED_FREE_SENTINEL},
+            ]
+        }
+        with patch(
+            "hermes_cli.models.get_nous_recommended_free_model",
+            return_value="stepfun/step-3.7-flash:free",
+        ):
+            chain = get_fallback_chain(cfg)
+        assert chain == [
+            {"provider": "nous", "model": "stepfun/step-3.7-flash:free"}
+        ]
+
+    def test_legacy_fallback_model_key_supports_sentinel(self):
+        cfg = {
+            "fallback_model": {"provider": "nous", "model": RECOMMENDED_FREE_SENTINEL}
+        }
+        with patch(
+            "hermes_cli.models.get_nous_recommended_free_model",
+            return_value="stepfun/step-3.7-flash:free",
+        ):
+            chain = get_fallback_chain(cfg)
+        assert chain == [
+            {"provider": "nous", "model": "stepfun/step-3.7-flash:free"}
+        ]
+
+    def test_resolver_exception_drops_entry_not_chain(self):
+        cfg = {
+            "fallback_providers": [
+                {"provider": "nous", "model": RECOMMENDED_FREE_SENTINEL},
+                {"provider": "nous", "model": "Hermes-4-Llama-3.1-405B"},
+            ]
+        }
+        with patch(
+            "hermes_cli.models.get_nous_recommended_free_model",
+            side_effect=RuntimeError("portal exploded"),
+        ):
+            chain = get_fallback_chain(cfg)
+        assert chain == [{"provider": "nous", "model": "Hermes-4-Llama-3.1-405B"}]

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -39,6 +39,28 @@ fallback_providers:
 
 Each entry requires both `provider` and `model`. Entries missing either field are ignored.
 
+### Tracking the Portal's Free Model (`recommended:free`)
+
+The Nous Portal rotates which model is free. Instead of hardcoding today's free
+model (and silently getting billed — or erroring — when it rotates), `nous`
+entries accept a sentinel model name that resolves to the Portal's current
+`freeRecommendedModels` pick at chain-build time:
+
+```yaml
+fallback_providers:
+  - provider: nous
+    model: recommended:free
+```
+
+Resolution goes through the same cached recommended-models lookup as the model
+picker: a short-TTL in-process cache backed by a last-known-good disk cache, so
+a Portal hiccup degrades to the previous answer rather than dropping the
+fallback. If no answer is available at all (first run, offline), the entry is
+skipped with a warning and the rest of the chain works normally.
+
+The sentinel is only special for `provider: nous` — on any other provider the
+string is treated as a literal model name.
+
 :::note `fallback_model` vs `fallback_providers`
 `fallback_providers` (plural, list) is the current config shape and supports multiple fallbacks tried in order. `fallback_model` (singular) is the legacy single-fallback key — Hermes still honors it for back-compat, but `hermes fallback` writes the current `fallback_providers` key and migrates legacy config on write. When both are set, `fallback_providers` takes priority.
 :::


### PR DESCRIPTION
## Problem

The Nous Portal rotates which model is free. `fallback_providers` entries are static ("Each entry requires both `provider` and `model`"), so free-tier users must hand-edit `config.yaml` on every rotation — or silently start getting billed when yesterday's free model moves to a paid tier.

Evidence this bites people: #24029 (free-only users billed via silent paid fallback — the *routing* half was fixed by #47235, but which model is free still rotates out from under a static config), #15176 (smarter fallback routing, open), and #58364 (the nous *silent default* is itself pinned to a model that is no longer free, open).

This PR is complementary to #47235: that change makes auxiliary tasks honor the user's configured fallback chain; this one keeps a free-tier chain entry *valid over time*. Because both route through `get_fallback_chain()`, the sentinel automatically benefits the auxiliary path #47235 fixed.

## What this adds

A nous-namespaced sentinel model name for fallback entries:

```yaml
fallback_providers:
  - provider: nous
    model: recommended:free
```

`get_fallback_chain()` resolves the sentinel at chain-build time via a new one-liner helper, `get_nous_recommended_free_model()`, which reads `freeRecommendedModels[0]` through the existing `fetch_nous_recommended_models()` machinery — so it inherits the in-process TTL cache and the last-known-good disk cache for free.

**Failure behaviour:** no cache and no network → the entry is dropped with a warning; the rest of the chain is unaffected (never worse than today's static config, self-heals on the next successful Portal fetch). On any provider other than `nous` the string is treated as a literal model name.

**Coverage:** both the `fallback_providers` list and the legacy `fallback_model` key; all consumers benefit automatically since CLI init, oneshot, `hermes fallback`, and the auxiliary capacity-error chain all route through `get_fallback_chain()`.

## Changes

- `hermes_cli/models.py` — add `get_nous_recommended_free_model()` beside the existing `get_nous_recommended_aux_model()`
- `hermes_cli/fallback_config.py` — sentinel constant + resolution in `_iter_fallback_entries()` (lazy import, defensive)
- `website/docs/user-guide/features/fallback-providers.md` — new section
- `tests/hermes_cli/test_fallback_recommended_free.py` — 6 tests: resolution, drop-on-unavailable, literal-on-other-providers, dedup against a literal entry, legacy key, resolver exception

## Testing

```
tests/hermes_cli/test_fallback_recommended_free.py  6 passed
tests/hermes_cli/test_fallback_cmd.py               passed (existing)
tests/hermes_cli/test_config_validation.py          passed (existing)
tests/agent/test_auxiliary_client.py                281 passed (existing)
```

Also running in production on my own gateway (the same cache→config resolution as an external sync script) — this PR replaces that workaround with native support.

## Design notes

- **Why cache-backed rather than a live Portal call on the hot path?** `fetch_nous_recommended_models` short-TTL-caches in process and persists last-known-good to disk; worst case on a cold start is one 5s-timeout public-endpoint request, same as the model picker already does.
- **Staleness window:** if the Portal rotates and the cache is stale, the resolved model may briefly no longer be free — identical failure mode to today's static config, never worse.
- **Scope:** nous-only; the sentinel is provider-namespaced so aggregators with `:free` variants (OpenRouter) could adopt the same pattern later.

Closes the fallback half of #58364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
