### PR TITLE
Force Grok tool call on action-stall retry

### DIFF
--- a/agent/action_stall.py
+++ b/agent/action_stall.py
@@ -1,0 +1,91 @@
+"""Action-stall continuation helpers.
+
+This module is the tiny shared contract between the conversation loop that
+inserts an internal corrective continuation and transports that can mechanically
+force tool emission for that single retry. Keep the marker stable: it is a
+wire-protocol string in in-memory message history, not user-facing prose.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+ACTION_STALL_CONTINUATION_PREFIX = "[System corrective continuation: tool execution required]"
+
+
+def build_action_stall_continuation() -> str:
+    """Return the internal user message used after an action-ack/no-tool stall."""
+    return (
+        f"{ACTION_STALL_CONTINUATION_PREFIX}\n"
+        "Continue now. Execute the required tool calls and only send your "
+        "final answer after completing the task."
+    )
+
+
+def latest_user_message_is_stall_continuation(messages: Sequence[Mapping[str, Any]] | None) -> bool:
+    """True when the latest user message is the action-stall continuation.
+
+    Defensive loop guard: walk backward from that latest user message to the
+    nearest prior assistant turn. If it already had tool_calls, do not force
+    another required-tool turn. The corrective continuation is meant only for
+    the failure mode where the model narrated intent/progress but emitted zero
+    tool calls.
+    """
+    if not messages:
+        return False
+
+    latest_user_idx: int | None = None
+    latest_user: Mapping[str, Any] | None = None
+    for idx in range(len(messages) - 1, -1, -1):
+        msg = messages[idx]
+        if isinstance(msg, Mapping) and msg.get("role") == "user":
+            latest_user_idx = idx
+            latest_user = msg
+            break
+
+    if latest_user_idx is None or latest_user is None:
+        return False
+    if latest_user_idx != len(messages) - 1:
+        # The corrective marker only forces the immediate retry request. Once
+        # an assistant tool-call turn or tool result has been appended after it,
+        # the follow-up request must return to auto so the model can stop.
+        return False
+
+    content = latest_user.get("content")
+    if isinstance(content, str):
+        text = content.lstrip()
+    elif isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, str):
+                parts.append(part)
+            elif isinstance(part, Mapping):
+                part_text = part.get("text") or part.get("content")
+                if isinstance(part_text, str):
+                    parts.append(part_text)
+        text = "\n".join(parts).lstrip()
+    else:
+        return False
+
+    if not text.startswith(ACTION_STALL_CONTINUATION_PREFIX):
+        return False
+
+    saw_plain_assistant = False
+    for idx in range(latest_user_idx - 1, -1, -1):
+        msg = messages[idx]
+        if not isinstance(msg, Mapping):
+            continue
+        role = msg.get("role")
+        if role == "tool":
+            return False
+        if role == "assistant":
+            if msg.get("tool_calls"):
+                return False
+            saw_plain_assistant = True
+            continue
+        if role == "user":
+            # Force only when the current segment is user → assistant(no tools)
+            # → corrective user marker, with no tool evidence in between.
+            return saw_plain_assistant
+
+    return False

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5020,12 +5020,11 @@ def run_conversation(
                     messages.append(interim_msg)
                     agent._emit_interim_assistant_message(interim_msg)
 
+                    from agent.action_stall import build_action_stall_continuation
+
                     continue_msg = {
                         "role": "user",
-                        "content": (
-                            "[System: Continue now. Execute the required tool calls and only "
-                            "send your final answer after completing the task.]"
-                        ),
+                        "content": build_action_stall_continuation(),
                     }
                     messages.append(continue_msg)
                     agent._session_messages = messages

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -249,6 +249,23 @@ class ResponsesApiTransport(ProviderTransport):
             kwargs["tool_choice"] = "auto"
             kwargs["parallel_tool_calls"] = True
 
+            # Grok/xAI sometimes narrates an action ("I'll check...") but emits
+            # no structured tool call. The conversation loop already detects
+            # that action-stall shape and appends a private corrective
+            # continuation. For that *single retry turn*, make xAI/Grok use a
+            # tool mechanically. Do not force globally: after a tool result the
+            # model must be free to stop with a final text answer, and caller
+            # request_overrides still win below.
+            model_lower = str(model or "").lower()
+            if is_xai_responses or "grok" in model_lower:
+                try:
+                    from agent.action_stall import latest_user_message_is_stall_continuation
+
+                    if latest_user_message_is_stall_continuation(payload_messages):
+                        kwargs["tool_choice"] = "required"
+                except Exception:
+                    pass
+
         session_id = params.get("session_id")
         # prompt_cache_key is content-addressed from the static prefix
         # (instructions + tools), NOT session_id — recurring cron jobs carry a

--- a/tests/agent/test_action_stall.py
+++ b/tests/agent/test_action_stall.py
@@ -1,0 +1,96 @@
+from agent.action_stall import (
+    ACTION_STALL_CONTINUATION_PREFIX,
+    build_action_stall_continuation,
+    latest_user_message_is_stall_continuation,
+)
+
+
+def test_build_action_stall_continuation_has_stable_prefix():
+    text = build_action_stall_continuation()
+    assert text.startswith(ACTION_STALL_CONTINUATION_PREFIX)
+    assert "Execute the required tool calls" in text
+
+
+def test_latest_user_message_detects_stall_after_no_tool_assistant():
+    messages = [
+        {"role": "user", "content": "Inspect the repo."},
+        {"role": "assistant", "content": "I'll inspect the repo now."},
+        {"role": "user", "content": build_action_stall_continuation()},
+    ]
+
+    assert latest_user_message_is_stall_continuation(messages) is True
+
+
+def test_latest_user_message_does_not_force_after_assistant_tool_calls():
+    messages = [
+        {"role": "user", "content": "Run date."},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "name": "terminal", "content": "ok"},
+        {"role": "assistant", "content": "Done."},
+        {"role": "user", "content": build_action_stall_continuation()},
+    ]
+
+    assert latest_user_message_is_stall_continuation(messages) is False
+
+
+def test_latest_user_message_does_not_force_when_tool_result_is_in_segment():
+    messages = [
+        {"role": "user", "content": "Run date."},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "name": "terminal", "content": "ok"},
+        {"role": "user", "content": build_action_stall_continuation()},
+    ]
+
+    assert latest_user_message_is_stall_continuation(messages) is False
+
+
+def test_latest_user_message_ignores_non_marker_user_message():
+    messages = [
+        {"role": "user", "content": "Inspect the repo."},
+        {"role": "assistant", "content": "I'll inspect it."},
+        {"role": "user", "content": "continue please"},
+    ]
+
+    assert latest_user_message_is_stall_continuation(messages) is False
+
+
+def test_marker_only_forces_when_it_is_the_request_tail():
+    messages = [
+        {"role": "user", "content": "Inspect the repo."},
+        {"role": "assistant", "content": "I'll inspect it."},
+        {"role": "user", "content": build_action_stall_continuation()},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "name": "terminal", "content": "ok"},
+    ]
+
+    assert latest_user_message_is_stall_continuation(messages) is False

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -4,6 +4,7 @@ import json
 import pytest
 from types import SimpleNamespace
 
+from agent.action_stall import build_action_stall_continuation
 from agent.transports import get_transport
 from agent.transports.types import NormalizedResponse
 
@@ -163,6 +164,136 @@ class TestCodexBuildKwargs:
         eb = kw.get("extra_body", {})
         assert eb.get("prompt_cache_key") == "caller-override"
         assert eb.get("other_field") == 42
+
+    def test_xai_grok_action_stall_continuation_forces_required_tool_choice(self, transport):
+        messages = [
+            {"role": "user", "content": "Inspect the repo."},
+            {"role": "assistant", "content": "I'll inspect the repo now."},
+            {"role": "user", "content": build_action_stall_continuation()},
+        ]
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "terminal",
+                "description": "Run a command",
+                "parameters": {"type": "object", "properties": {"command": {"type": "string"}}},
+            },
+        }]
+
+        kw = transport.build_kwargs(
+            model="grok-4.3",
+            messages=messages,
+            tools=tools,
+            is_xai_responses=True,
+        )
+
+        assert kw["tool_choice"] == "required"
+
+    def test_non_grok_action_stall_continuation_stays_auto(self, transport):
+        messages = [
+            {"role": "user", "content": "Inspect the repo."},
+            {"role": "assistant", "content": "I'll inspect the repo now."},
+            {"role": "user", "content": build_action_stall_continuation()},
+        ]
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "terminal",
+                "description": "Run a command",
+                "parameters": {"type": "object", "properties": {"command": {"type": "string"}}},
+            },
+        }]
+
+        kw = transport.build_kwargs(
+            model="gpt-5.5",
+            messages=messages,
+            tools=tools,
+            is_xai_responses=False,
+        )
+
+        assert kw["tool_choice"] == "auto"
+
+    def test_grok_named_responses_model_forces_required_even_without_xai_flag(self, transport):
+        messages = [
+            {"role": "user", "content": "Inspect the repo."},
+            {"role": "assistant", "content": "I'll inspect the repo now."},
+            {"role": "user", "content": build_action_stall_continuation()},
+        ]
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "terminal",
+                "description": "Run a command",
+                "parameters": {"type": "object", "properties": {"command": {"type": "string"}}},
+            },
+        }]
+
+        kw = transport.build_kwargs(
+            model="x-ai/grok-4.3",
+            messages=messages,
+            tools=tools,
+            is_xai_responses=False,
+        )
+
+        assert kw["tool_choice"] == "required"
+
+    def test_xai_action_stall_does_not_force_after_tool_evidence(self, transport):
+        messages = [
+            {"role": "user", "content": "Run date."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": "{}"},
+                }],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "name": "terminal", "content": "ok"},
+            {"role": "user", "content": build_action_stall_continuation()},
+        ]
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "terminal",
+                "description": "Run a command",
+                "parameters": {"type": "object", "properties": {"command": {"type": "string"}}},
+            },
+        }]
+
+        kw = transport.build_kwargs(
+            model="grok-4.3",
+            messages=messages,
+            tools=tools,
+            is_xai_responses=True,
+        )
+
+        assert kw["tool_choice"] == "auto"
+
+    def test_request_override_still_wins_over_action_stall_tool_choice(self, transport):
+        messages = [
+            {"role": "user", "content": "Inspect the repo."},
+            {"role": "assistant", "content": "I'll inspect the repo now."},
+            {"role": "user", "content": build_action_stall_continuation()},
+        ]
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "terminal",
+                "description": "Run a command",
+                "parameters": {"type": "object", "properties": {"command": {"type": "string"}}},
+            },
+        }]
+
+        kw = transport.build_kwargs(
+            model="grok-4.3",
+            messages=messages,
+            tools=tools,
+            is_xai_responses=True,
+            request_overrides={"tool_choice": "auto"},
+        )
+
+        assert kw["tool_choice"] == "auto"
 
     def test_max_tokens(self, transport):
         messages = [{"role": "user", "content": "Hi"}]


### PR DESCRIPTION
## Summary

- add a private action-stall continuation marker for fake progress/ack responses that should have emitted tool calls
- make the Codex Responses transport set `tool_choice="required"` only for the immediate xAI/Grok corrective retry
- return to `tool_choice="auto"` after tool execution so Grok can produce a final text answer instead of looping on required tool calls
- add focused regression tests for xAI/Grok scoping, override precedence, post-tool no-loop behavior, and the marker helper

## Verification

- `python -m py_compile agent/action_stall.py agent/conversation_loop.py agent/transports/codex.py`
- `pytest -q tests/agent/test_action_stall.py tests/agent/test_intent_ack_continuation.py tests/agent/transports/test_codex_transport.py tests/run_agent/test_run_agent_codex_responses.py::test_run_conversation_codex_continues_after_ack_stop_message tests/run_agent/test_run_agent_codex_responses.py::test_run_conversation_codex_continues_after_ack_for_directory_listing_prompt tests/run_agent/test_codex_no_tools_nonetype.py`
- live `xai-oauth/grok-4.3` smoke on this branch: first request used `tool_choice='required'`, Grok executed exactly one `terminal` call returning `GROK_ACTION_STALL_PR_OK`, follow-up request used `tool_choice='auto'`, and the turn completed with final text

## Safety

This does not set `required` globally. The helper only returns true when the corrective marker is the actual request tail and there is no tool evidence in the current segment. Caller `request_overrides` still win after this default is set.
