### PR TITLE
fix(model): default --provider switches to session-only persistence

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7947,7 +7947,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # config-gated default, --global forces persist, otherwise defer to
         # model.persist_switch_by_default (defaults to True so /model survives
         # across sessions).
-        persist_global = resolve_persist_behavior(is_global_flag, is_session)
+        persist_global = resolve_persist_behavior(
+            is_global_flag, is_session, explicit_provider
+        )
 
         # --refresh: wipe the on-disk picker cache before building the
         # provider list. Forces a live re-fetch of every authed provider's

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1399,7 +1399,9 @@ class GatewaySlashCommandsMixin:
             force_refresh,
             is_session,
         ) = parse_model_flags(raw_args)
-        persist_global = resolve_persist_behavior(is_global_flag, is_session)
+        persist_global = resolve_persist_behavior(
+            is_global_flag, is_session, explicit_provider
+        )
 
         # --refresh: bust the disk cache so the picker shows live data.
         if force_refresh:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -365,14 +365,22 @@ def parse_model_flags(raw_args: str) -> tuple[str, str, bool, bool, bool]:
     return (model_input, explicit_provider, is_global, force_refresh, is_session)
 
 
-def resolve_persist_behavior(is_global: bool, is_session: bool) -> bool:
+def resolve_persist_behavior(
+    is_global: bool,
+    is_session: bool,
+    explicit_provider: str = "",
+) -> bool:
     """Decide whether a ``/model`` switch should persist to ``config.yaml``.
 
     Resolution order:
 
     1. ``--session`` explicitly opts out → ``False`` (this session only).
     2. ``--global`` explicitly opts in → ``True``.
-    3. Otherwise defer to ``model.persist_switch_by_default`` in
+    3. ``--provider`` given without an explicit persist flag → ``False``
+       (session only).  Provider switches are typically exploratory — the
+       user is trying a different backend for this conversation, not
+       reconfiguring the default.  ``--global`` can still force persist.
+    4. Otherwise defer to ``model.persist_switch_by_default`` in
        ``config.yaml`` (defaults to ``True``, so a plain ``/model <name>``
        survives across sessions — the behavior users expect).
 
@@ -384,6 +392,8 @@ def resolve_persist_behavior(is_global: bool, is_session: bool) -> bool:
         return False
     if is_global:
         return True
+    if explicit_provider:
+        return False
     try:
         from hermes_cli.config import load_config
 

--- a/tests/hermes_cli/test_model_switch_persist_default.py
+++ b/tests/hermes_cli/test_model_switch_persist_default.py
@@ -96,6 +96,26 @@ class TestResolvePersistBehavior:
         with _config({"model": {"persist_switch_by_default": True}}):
             assert resolve_persist_behavior(True, True) is False
 
+    def test_provider_flag_defaults_to_session_only(self):
+        # --provider without --global/--session → session only.
+        with _config({"model": {"persist_switch_by_default": True}}):
+            assert resolve_persist_behavior(False, False, "anthropic") is False
+
+    def test_provider_with_global_still_persists(self):
+        # --provider + --global → persists.
+        with _config({"model": {"persist_switch_by_default": False}}):
+            assert resolve_persist_behavior(True, False, "anthropic") is True
+
+    def test_provider_with_session_still_session_only(self):
+        # --provider + --session → session only.
+        with _config({"model": {"persist_switch_by_default": True}}):
+            assert resolve_persist_behavior(False, True, "anthropic") is False
+
+    def test_no_provider_uses_config_default(self):
+        # No --provider → respects config default (True).
+        with _config({"model": {"persist_switch_by_default": True}}):
+            assert resolve_persist_behavior(False, False, "") is True
+
 
 # ---------------------------------------------------------------------------
 # helper

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2628,7 +2628,9 @@ def _apply_model_switch(
         _force_refresh,
         is_session,
     ) = parsed_flags
-    persist_global = resolve_persist_behavior(is_global_flag, is_session)
+    persist_global = resolve_persist_behavior(
+        is_global_flag, is_session, explicit_provider
+    )
     if not model_input:
         raise ValueError("model value required")
 


### PR DESCRIPTION
## What does this PR do?

When `/model` is called with `--provider` but without `--global` or `--session`, the switch now defaults to **session-only** instead of persisting to `config.yaml`.

Before this change, `/model sonnet --provider anthropic` would overwrite `model.default` and `model.provider` in `config.yaml`, which is unexpected when the user is just trying a different provider for the current conversation. The `--global` flag still forces persistence when explicitly desired.

## Related Issue

Fixes #58290

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/model_switch.py`: Added `explicit_provider` parameter to `resolve_persist_behavior()`. When a provider is explicitly specified without `--global`/`--session`, returns `False` (session-only).
- `gateway/slash_commands.py`: Pass `explicit_provider` to `resolve_persist_behavior()` in the gateway `/model` handler.
- `tui_gateway/server.py`: Pass `explicit_provider` to `resolve_persist_behavior()` in the TUI `/model` handler.
- `cli.py`: Pass `explicit_provider` to `resolve_persist_behavior()` in the CLI `/model` handler.
- `tests/hermes_cli/test_model_switch_persist_default.py`: Added 4 test cases covering `--provider` flag behavior with and without `--global`/`--session`.

## How to Test

1. Run `pytest tests/hermes_cli/test_model_switch_persist_default.py -v` — all 17 tests should pass.
2. In a gateway session, send `/model sonnet --provider anthropic` — the model should switch for this session only, and `config.yaml` should remain unchanged.
3. Send `/model sonnet --provider anthropic --global` — this should persist to `config.yaml` as before.
4. Send `/model sonnet` (no `--provider`) — this should persist to `config.yaml` (existing behavior unchanged).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_model_switch_persist_default.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
