### PR TITLE
test(hermes_cli): add unit tests for coerce_max_concurrent_sessions

### DIFF
--- a/tests/hermes_cli/test_active_sessions.py
+++ b/tests/hermes_cli/test_active_sessions.py
@@ -36,6 +36,32 @@ def test_resolve_max_concurrent_sessions_values(caplog):
     )
 
 
+def test_coerce_max_concurrent_sessions_valid_values():
+    coerce = active_sessions.coerce_max_concurrent_sessions
+    assert coerce(16) == 16
+    assert coerce("8") == 8
+    assert coerce("  20  ") == 20
+    assert coerce(4.0) == 4  # integer-valued float is accepted
+
+
+def test_coerce_max_concurrent_sessions_disabled_values():
+    coerce = active_sessions.coerce_max_concurrent_sessions
+    assert coerce(None) is None
+    assert coerce(0) is None
+    assert coerce(-5) is None
+
+
+def test_coerce_max_concurrent_sessions_rejects_bool_and_invalid(caplog):
+    coerce = active_sessions.coerce_max_concurrent_sessions
+    caplog.set_level(logging.WARNING)
+    # bool is an int subclass but is never a valid session cap
+    assert coerce(True) is None
+    assert coerce(False) is None
+    assert coerce("abc") is None
+    assert coerce(3.5) is None  # non-integer float is rejected
+    assert any("Ignoring invalid" in r.message for r in caplog.records)
+
+
 def test_active_session_lease_blocks_until_release(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     monkeypatch.setenv("HERMES_HOME", str(home))


### PR DESCRIPTION
﻿## What does this PR do?

Adds direct unit test coverage for `coerce_max_concurrent_sessions` in `hermes_cli/active_sessions.py`. The wrapper `resolve_max_concurrent_sessions` is already tested, but the underlying coercion helper — which gates the global active-session cap across CLI, TUI, and the gateway — had no direct tests for its own edge cases.

The added tests pin the contract:
- Valid values: positive int (`16`), numeric string (`"8"`, `"  20  "` with surrounding whitespace), and an integer-valued float (`4.0` → `4`)
- Disabled/unbounded: `None`, `0`, and negatives all return `None`
- **`bool` rejection**: `True`/`False` return `None` even though `bool` is an `int` subclass — a real trap the function deliberately guards against
- Invalid inputs (`"abc"`, non-integer float `3.5`) return `None` and emit the "Ignoring invalid" warning

## Type of Change

- [x] Test coverage (no production code changed)

## Why

`coerce_max_concurrent_sessions` decides the concurrency cap for every surface. The `bool`-is-an-`int`-subclass edge in particular is easy to regress — a future refactor to a plain `int(value)` cast would silently accept `True` as a cap of `1`. These tests lock the intended behavior.

## How to Test

```bash
scripts/run_tests.sh tests/hermes_cli/test_active_sessions.py -v
```

## Notes

- 1 existing test file changed (+26 lines, 3 new test functions). No production code touched.
- Pure input→output assertions plus `caplog` for the warning path — no mocks, no network, no filesystem.
- Follows the existing plain-function + `caplog` style already in the file.
