### PR TITLE
fix(yuanbao): restore active singleton after WS reconnect

### DIFF
--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -3868,6 +3868,7 @@ class ConnectionManager:
                     "[%s] Reconnected on attempt %d. connectId=%s",
                     adapter.name, attempt + 1, self._connect_id,
                 )
+                YuanbaoAdapter.set_active(adapter)
                 return True
 
             except asyncio.TimeoutError:

--- a/tests/test_yuanbao_reconnect_set_active.py
+++ b/tests/test_yuanbao_reconnect_set_active.py
@@ -1,0 +1,106 @@
+"""test_yuanbao_reconnect_set_active.py - Verify _do_reconnect restores the active singleton.
+
+Regression test for #58363: after a WS disconnect/reconnect cycle,
+``get_active_adapter()`` must return the live adapter (not ``None``).
+The original ``_do_reconnect()`` succeeded but never called
+``YuanbaoAdapter.set_active()``, leaving the singleton permanently
+``None`` until a full gateway restart.
+"""
+
+import sys
+import os
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+import pytest
+from gateway.platforms.yuanbao import (
+    YuanbaoAdapter,
+    ConnectionManager,
+    get_active_adapter,
+)
+
+
+def _make_adapter(**kwargs):
+    """Create a minimal YuanbaoAdapter mock."""
+    adapter = MagicMock(spec=YuanbaoAdapter)
+    adapter.name = "yuanbao"
+    adapter._app_key = "test_key"
+    adapter._app_secret = "test_secret"
+    adapter._api_domain = "https://test.example.com"
+    adapter._route_env = None
+    adapter._bot_id = "test_bot"
+    adapter._ws_url = "wss://test.example.com/ws"
+    adapter._mark_connected = MagicMock()
+    adapter._mark_disconnected = MagicMock()
+    adapter._release_platform_lock = MagicMock()
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_do_reconnect_calls_set_active_on_success():
+    """After a successful reconnect, set_active(adapter) must be called."""
+    adapter = _make_adapter()
+    cm = ConnectionManager(adapter)
+
+    # Mock the reconnect internals to succeed on first attempt
+    mock_ws = AsyncMock()
+    mock_ws.close = AsyncMock()
+
+    with (
+        patch.object(cm, "_cleanup_ws", new_callable=AsyncMock) as mock_cleanup,
+        patch(
+            "gateway.platforms.yuanbao.SignManager.force_refresh",
+            new_callable=AsyncMock,
+            return_value={"bot_id": "test_bot", "token": "test_token"},
+        ),
+        patch("gateway.platforms.yuanbao.websockets.connect", new_callable=AsyncMock, return_value=mock_ws),
+        patch.object(cm, "_authenticate", new_callable=AsyncMock, return_value=True),
+        patch.object(cm, "_heartbeat_loop", new_callable=AsyncMock),
+        patch.object(cm, "_receive_loop", new_callable=AsyncMock),
+        patch("gateway.platforms.yuanbao.MAX_RECONNECT_ATTEMPTS", 1),
+    ):
+        # Clear any existing active instance
+        YuanbaoAdapter.set_active(None)
+        assert get_active_adapter() is None
+
+        # Run reconnect
+        result = await cm._do_reconnect()
+
+        # Reconnect should succeed
+        assert result is True
+
+        # After successful reconnect, get_active() must return the adapter
+        assert get_active_adapter() is adapter
+
+
+@pytest.mark.asyncio
+async def test_do_reconnect_does_not_set_active_on_failure():
+    """When all reconnect attempts fail, set_active should NOT be called."""
+    adapter = _make_adapter()
+    cm = ConnectionManager(adapter)
+
+    with (
+        patch.object(cm, "_cleanup_ws", new_callable=AsyncMock),
+        patch(
+            "gateway.platforms.yuanbao.SignManager.force_refresh",
+            new_callable=AsyncMock,
+            side_effect=Exception("auth failed"),
+        ),
+        patch("gateway.platforms.yuanbao.MAX_RECONNECT_ATTEMPTS", 1),
+    ):
+        # Clear any existing active instance
+        YuanbaoAdapter.set_active(None)
+        assert get_active_adapter() is None
+
+        # Run reconnect - should fail
+        result = await cm._do_reconnect()
+
+        # Reconnect should fail
+        assert result is False
+
+        # get_active() should still be None
+        assert get_active_adapter() is None


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where Yuanbao cron delivery silently fails after any WS disconnect/reconnect cycle. The `_do_reconnect()` method successfully reconnects but never calls `YuanbaoAdapter.set_active(adapter)`, leaving `get_active_adapter()` permanently returning `None`. This causes `_send_yuanbao()` in `send_message_tool.py` to fail immediately with "Yuanbao adapter is not running" on every subsequent cron delivery attempt.

## Related Issue

Fixes #58363

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/yuanbao.py`: Added `YuanbaoAdapter.set_active(adapter)` call in `_do_reconnect()` after successful reconnect, matching the pattern already used in `connect()`.
- `tests/test_yuanbao_reconnect_set_active.py`: Added regression tests verifying that `get_active_adapter()` returns the adapter after successful reconnect and remains `None` after failed reconnect.

## How to Test

1. Set up a recurring cron job with `deliver` pointing at Yuanbao.
2. Let it run a few ticks — works fine initially.
3. Trigger a Yuanbao WS disconnect (network blip, server restart, etc.).
4. After reconnect, subsequent cron ticks should deliver successfully.
5. Run `pytest tests/test_yuanbao_reconnect_set_active.py -v` — both tests should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

The fix is a single line addition that restores the active singleton after reconnect:

```python
# In _do_reconnect(), after successful reconnect:
YuanbaoAdapter.set_active(adapter)  # ← added
return True
```

This matches the existing pattern in `connect()` (line 3377) and `disconnect()` (line 5189, which calls `set_active(None)`).
