### PR TITLE
feat(custom-provider) Support opt-in preserve thinking

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4501,7 +4501,7 @@ def _normalize_custom_provider_entry(
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models", "extra_body", "extra_headers",
-        "ssl_ca_cert", "ssl_verify",
+        "ssl_ca_cert", "ssl_verify", "needs_reasoning_content",
     }
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:
@@ -4604,6 +4604,10 @@ def _normalize_custom_provider_entry(
     if isinstance(discover_models, bool):
         normalized["discover_models"] = discover_models
 
+    needs_reasoning_content = entry.get("needs_reasoning_content")
+    if isinstance(needs_reasoning_content, bool):
+        normalized["needs_reasoning_content"] = needs_reasoning_content
+
     extra_body = entry.get("extra_body")
     if isinstance(extra_body, dict):
         normalized["extra_body"] = dict(extra_body)
@@ -4655,6 +4659,7 @@ def _custom_provider_entry_to_provider_config(
         "extra_headers",
         "ssl_ca_cert",
         "ssl_verify",
+        "needs_reasoning_content",
     ):
         if field in normalized:
             provider_entry[field] = normalized[field]
@@ -4846,6 +4851,37 @@ def get_custom_provider_extra_headers(
             continue
         return normalize_extra_headers(entry.get("extra_headers"))
     return {}
+
+
+def get_custom_provider_needs_reasoning_content(
+    base_url: str,
+    custom_providers: Optional[List[Dict[str, Any]]] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> bool:
+    """Return whether a matching custom provider needs reasoning_content echoed back.
+
+    Matches the entry whose ``base_url`` equals *base_url* (trailing-slash and
+    case insensitive, mirroring :func:`get_custom_provider_tls_settings`). Opt-in
+    via ``needs_reasoning_content: true`` — there's no reliable host/model
+    heuristic for self-hosted deployments the way there is for DeepSeek/Kimi/MiMo.
+    """
+    if custom_providers is None:
+        try:
+            custom_providers = get_compatible_custom_providers(config)
+        except Exception:
+            custom_providers = []
+    if not base_url or not isinstance(custom_providers, list):
+        return False
+
+    target_url = (base_url or "").rstrip("/").lower()
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        entry_url = (entry.get("base_url") or "").rstrip("/").lower()
+        if not entry_url or entry_url != target_url:
+            continue
+        return bool(entry.get("needs_reasoning_content"))
+    return False
 
 
 def apply_custom_provider_extra_headers_to_client_kwargs(

--- a/run_agent.py
+++ b/run_agent.py
@@ -5415,6 +5415,7 @@ class AIAgent:
             self._needs_deepseek_tool_reasoning()
             or self._needs_kimi_tool_reasoning()
             or self._needs_mimo_tool_reasoning()
+            or self._needs_custom_provider_tool_reasoning()
         )
         self._thinking_pad_cache = (key, result)
         return result
@@ -5469,6 +5470,32 @@ class AIAgent:
             or base_url_host_matches(self.base_url, "api.xiaomimimo.com")
             or base_url_host_matches(self.base_url, "xiaomimimo.com")
         )
+
+    def _needs_custom_provider_tool_reasoning(self) -> bool:
+        """Return True when the matching custom-provider config opts into reasoning_content echo.
+
+        Unlike DeepSeek/Kimi/MiMo, self-hosted backends have no reliable
+        host/model signal, so this reads the explicit
+        ``needs_reasoning_content`` opt-in from the matching
+        ``custom_providers`` / ``providers`` entry.
+        """
+        try:
+            from hermes_cli.config import (
+                get_compatible_custom_providers,
+                get_custom_provider_needs_reasoning_content,
+                load_config_readonly,
+            )
+
+            # Read from live config (not the init-time snapshot on
+            # ``self._custom_providers``) so edits are honored when
+            # switching mid-session, matching the TLS-settings reload
+            # in ``switch_model()`` (#15779).
+            return get_custom_provider_needs_reasoning_content(
+                str(self.base_url or ""),
+                get_compatible_custom_providers(load_config_readonly()),
+            )
+        except Exception:
+            return False
 
     def _copy_reasoning_content_for_api(self, source_msg: dict, api_msg: dict) -> None:
         """Forwarder — see ``agent.agent_runtime_helpers.copy_reasoning_content_for_api``."""

--- a/tests/hermes_cli/test_custom_provider_needs_reasoning_content.py
+++ b/tests/hermes_cli/test_custom_provider_needs_reasoning_content.py
@@ -1,0 +1,61 @@
+"""Tests for the per-provider ``needs_reasoning_content`` config knob.
+
+These only cover config parsing and provider-matching by base_url. For the
+test that actually proves reasoning_content survives onto the outgoing
+request, see tests/run_agent/test_custom_provider_reasoning_content_echo.py.
+"""
+
+from hermes_cli.config import (
+    _normalize_custom_provider_entry,
+    get_custom_provider_needs_reasoning_content,
+)
+
+
+def test_normalize_entry_reads_needs_reasoning_content():
+    normalized = _normalize_custom_provider_entry({
+        "name": "local-llamacpp",
+        "base_url": "http://localhost:8080/v1",
+        "needs_reasoning_content": True,
+    })
+    assert normalized["needs_reasoning_content"] is True
+
+
+def test_normalize_entry_omits_field_when_not_set_in_yaml():
+    normalized = _normalize_custom_provider_entry({
+        "name": "local-llamacpp",
+        "base_url": "http://localhost:8080/v1",
+    })
+    assert "needs_reasoning_content" not in normalized
+
+
+def test_normalize_entry_ignores_non_boolean_values():
+    """Only real YAML booleans count; junk values are dropped rather than
+    silently coerced (mirrors discover_models handling)."""
+    normalized = _normalize_custom_provider_entry({
+        "name": "local-llamacpp",
+        "base_url": "http://localhost:8080/v1",
+        "needs_reasoning_content": "yes",
+    })
+    assert "needs_reasoning_content" not in normalized
+
+
+def test_lookup_matches_provider_by_base_url():
+    providers = [{
+        "name": "local-llamacpp",
+        "base_url": "http://localhost:8080/v1",
+        "needs_reasoning_content": True,
+    }]
+    assert get_custom_provider_needs_reasoning_content(
+        "http://localhost:8080/v1", custom_providers=providers,
+    ) is True
+
+
+def test_lookup_returns_false_for_a_different_provider():
+    providers = [{
+        "name": "local-llamacpp",
+        "base_url": "http://localhost:8080/v1",
+        "needs_reasoning_content": True,
+    }]
+    assert get_custom_provider_needs_reasoning_content(
+        "http://other-host:8080/v1", custom_providers=providers,
+    ) is False

--- a/tests/hermes_cli/test_custom_provider_needs_reasoning_content.py
+++ b/tests/hermes_cli/test_custom_provider_needs_reasoning_content.py
@@ -12,6 +12,7 @@ from hermes_cli.config import (
 
 
 def test_normalize_entry_reads_needs_reasoning_content():
+    """needs_reasoning_content: true survives config normalization."""
     normalized = _normalize_custom_provider_entry({
         "name": "local-llamacpp",
         "base_url": "http://localhost:8080/v1",
@@ -21,6 +22,7 @@ def test_normalize_entry_reads_needs_reasoning_content():
 
 
 def test_normalize_entry_omits_field_when_not_set_in_yaml():
+    """No key in YAML means no key in the normalized entry (not False)."""
     normalized = _normalize_custom_provider_entry({
         "name": "local-llamacpp",
         "base_url": "http://localhost:8080/v1",
@@ -40,6 +42,7 @@ def test_normalize_entry_ignores_non_boolean_values():
 
 
 def test_lookup_matches_provider_by_base_url():
+    """The runtime lookup helper finds the flag by matching base_url."""
     providers = [{
         "name": "local-llamacpp",
         "base_url": "http://localhost:8080/v1",
@@ -51,6 +54,7 @@ def test_lookup_matches_provider_by_base_url():
 
 
 def test_lookup_returns_false_for_a_different_provider():
+    """A base_url with no matching entry defaults to False, not an error."""
     providers = [{
         "name": "local-llamacpp",
         "base_url": "http://localhost:8080/v1",

--- a/tests/run_agent/test_custom_provider_reasoning_content_echo.py
+++ b/tests/run_agent/test_custom_provider_reasoning_content_echo.py
@@ -41,6 +41,7 @@ def _tool_call_turn() -> dict:
 
 
 def test_reasoning_content_preserved_when_provider_opts_in(monkeypatch) -> None:
+    """needs_reasoning_content: true keeps reasoning_content on replay."""
     _stub_custom_providers(monkeypatch, [
         {
             "name": "local-llamacpp",
@@ -55,6 +56,7 @@ def test_reasoning_content_preserved_when_provider_opts_in(monkeypatch) -> None:
 
 
 def test_reasoning_content_stripped_when_provider_does_not_opt_in(monkeypatch) -> None:
+    """No flag set — reasoning_content is dropped, like any other custom provider."""
     _stub_custom_providers(monkeypatch, [
         {"name": "local-llamacpp", "base_url": "http://localhost:8080/v1"},
     ])
@@ -65,6 +67,7 @@ def test_reasoning_content_stripped_when_provider_does_not_opt_in(monkeypatch) -
 
 
 def test_reasoning_content_stripped_for_unmatched_base_url(monkeypatch) -> None:
+    """The flag on a different provider entry must not leak onto this one."""
     _stub_custom_providers(monkeypatch, [
         {
             "name": "other",

--- a/tests/run_agent/test_custom_provider_reasoning_content_echo.py
+++ b/tests/run_agent/test_custom_provider_reasoning_content_echo.py
@@ -1,0 +1,78 @@
+"""End-to-end test for the ``needs_reasoning_content`` custom-provider opt-in.
+
+Drives the actual replay path (AIAgent._copy_reasoning_content_for_api, via
+_needs_thinking_reasoning_pad) rather than just the config-parsing layer
+covered in tests/hermes_cli/test_custom_provider_needs_reasoning_content.py.
+"""
+
+from __future__ import annotations
+
+import hermes_cli.config as hermes_config
+from run_agent import AIAgent
+
+
+def _make_agent(base_url: str) -> AIAgent:
+    agent = object.__new__(AIAgent)
+    agent.provider = "custom"
+    agent.model = "unsloth/Qwen3.6-35B-A3B-MTP-GGUF:Q4_K_XL"
+    agent.base_url = base_url
+    agent.verbose_logging = False
+    agent.reasoning_callback = None
+    agent.stream_delta_callback = None
+    agent._stream_callback = None
+    return agent
+
+
+def _stub_custom_providers(monkeypatch, custom_providers: list[dict]) -> None:
+    monkeypatch.setattr(hermes_config, "load_config_readonly", lambda: {})
+    monkeypatch.setattr(
+        hermes_config,
+        "get_compatible_custom_providers",
+        lambda _config=None: custom_providers,
+    )
+
+
+def _tool_call_turn() -> dict:
+    return {
+        "role": "assistant",
+        "reasoning_content": "<think>plan the next tool call</think>",
+        "tool_calls": [{"id": "c1", "function": {"name": "terminal"}}],
+    }
+
+
+def test_reasoning_content_preserved_when_provider_opts_in(monkeypatch) -> None:
+    _stub_custom_providers(monkeypatch, [
+        {
+            "name": "local-llamacpp",
+            "base_url": "http://localhost:8080/v1",
+            "needs_reasoning_content": True,
+        },
+    ])
+    agent = _make_agent(base_url="http://localhost:8080/v1")
+    api_msg: dict = {}
+    agent._copy_reasoning_content_for_api(_tool_call_turn(), api_msg)
+    assert api_msg["reasoning_content"] == "<think>plan the next tool call</think>"
+
+
+def test_reasoning_content_stripped_when_provider_does_not_opt_in(monkeypatch) -> None:
+    _stub_custom_providers(monkeypatch, [
+        {"name": "local-llamacpp", "base_url": "http://localhost:8080/v1"},
+    ])
+    agent = _make_agent(base_url="http://localhost:8080/v1")
+    api_msg: dict = {}
+    agent._copy_reasoning_content_for_api(_tool_call_turn(), api_msg)
+    assert "reasoning_content" not in api_msg
+
+
+def test_reasoning_content_stripped_for_unmatched_base_url(monkeypatch) -> None:
+    _stub_custom_providers(monkeypatch, [
+        {
+            "name": "other",
+            "base_url": "http://other.local:8080/v1",
+            "needs_reasoning_content": True,
+        },
+    ])
+    agent = _make_agent(base_url="http://localhost:8080/v1")
+    api_msg: dict = {}
+    agent._copy_reasoning_content_for_api(_tool_call_turn(), api_msg)
+    assert "reasoning_content" not in api_msg

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1222,6 +1222,16 @@ extra_body:
     enable_thinking: false
 ```
 
+**Reasoning-content echo for self-hosted thinking models.** Backends like llama.cpp serving a thinking model (e.g. Qwen) expect the prior assistant turn's `reasoning_content` to be replayed back on the next request. This isn't an official requirement from any single vendor, but it's widely considered community best practice for multi-turn tool use with thinking models — dropping it tends to degrade reasoning quality across turns. Hosted vendors that require this (DeepSeek, Kimi/Moonshot, Xiaomi MiMo) are detected automatically by host/model name, but Hermes has no reliable way to detect this for an arbitrary self-hosted endpoint, so opt in explicitly with `needs_reasoning_content: true`:
+
+```yaml
+custom_providers:
+  - name: local-llamacpp
+    base_url: http://localhost:8080/v1
+    model: unsloth/Qwen3.6-35B-A3B-MTP-GGUF:Q4_K_XL
+    needs_reasoning_content: true   # echo reasoning_content back on replay (community best practice for llama.cpp + Qwen)
+```
+
 The `hermes model` → Custom Endpoint wizard now prompts for `api_mode` explicitly and persists your answer to `config.yaml`. URL-based auto-detection (e.g. `/anthropic` paths → `anthropic_messages`) still happens as a fallback when the field is left blank.
 
 **Native vision for custom-provider models.** If your custom endpoint serves a vision-capable model that isn't in models.dev, set `model.supports_vision: true` so Hermes routes attached images natively (as `image_url` parts) instead of pre-processing them through `vision_analyze`. Single knob — no need to also set `agent.image_input_mode: native`.


### PR DESCRIPTION
## What does this PR do?

For local deployments of Qwen (via llama.cpp and the likes) enabling preserve_thinking is considered a best practice.
See https://www.reddit.com/r/LocalLLaMA/comments/1sne4gh/psa_qwen36_ships_with_preserve_thinking_make_sure/ for Qwen
Or https://www.reddit.com/r/LocalLLaMA/comments/1u084qi/gemma_4_chat_template_now_has_preserve_thinking/ for Gemma.

However, Hermes strips the reasoning content for all providers but the ones that require it to work.

This PR adds an opt-in (disabled by default) option to honor `preserve_thinking` on custom providers:

```
custom_providers:
  - api_key: XXXXXX
    base_url: http://localhost:8080/v1
    models:
      unsloth/Qwen3.6-35B-A3B-MTP-GGUF:Q6_K_XL:
        context_length: 200000
    name: localhost
    needs_reasoning_content: true
```

You can see the difference in my test below.

I'm not actually convinced about the "needs_reasoning_content" name, but it's consistent with the existing codebase that detected the provider to determine if the content was indeed required.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #56004

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

Added a new config key for `custom_providers:
```
custom_providers:
  - api_key: XXXXXX
    base_url: http://localhost:8080/v1
    models:
      unsloth/Qwen3.6-35B-A3B-MTP-GGUF:Q6_K_XL:
        context_length: 200000
    name: localhost
    needs_reasoning_content: true
```

This was only added to custom_providers since the "known" ones already handle this via a hardcoded list.

## How to Test

1. Run llama.cpp with any Qwen 3.6 model and `preserve_thining` enabled. For example: `llama-serve -hf unsloth/Qwen3.6-35B-A3B-MTP-GGUF:Q6_K_XL --chat-template-kwargs={"preserve_thinking":true}`
2. Set `needs_reasoning_content: true` on your config.yml
3. Repeat my test (look below for t he screenshots), ask the LLM to think about something but don't echo back. In the next turn, make it remember what it thought.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate:
Yes, found #56020 but I honestly think this implementation is more  in-line with the current codebase, which already acknowledges this problem in specific providers.
There's also #56019 which proposes to match by model name. But I think that solution is brittle as it needs to be updated for new models (e.g. Gemma 4, which already supports this via a custom template).
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [X] I've run `pytest tests/ -q` and all tests pass
- [X] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [X] I've tested on my platform: Fedora 43

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [X] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

As an example of the difference this does make, here on Qwen 3.6 35B Q6, *without* my change:

<img width="1898" height="423" alt="Screenshot From 2026-07-04 18-14-00" src="https://github.com/user-attachments/assets/499a2746-2f41-4a72-814f-0d253085b412" />

I ask it to think about five numbers and tell me only three. The next turn I ask for the other two. The LLM reasons that "since this is a game, it's ok to hallucinate" and invents two new numbers.

With `needs_reasoning: true`, it echoes back the original numbers:

<img width="1898" height="423" alt="Screenshot From 2026-07-04 18-14-37" src="https://github.com/user-attachments/assets/fd79fcb7-1c44-40ce-988d-f18e2a0e494a" />