### PR TITLE
Add HSE operating-copy bridge

### DIFF
--- a/hermes_cli/hse.py
+++ b/hermes_cli/hse.py
@@ -1,0 +1,162 @@
+"""Hermes Self-Evolution (HSE) operating-copy bridge.
+
+This module intentionally keeps the optimizer implementation outside the Hermes
+core checkout.  It resolves the standalone ``hermes-agent-self-evolution`` repo
+and exposes small, explicit subprocess entrypoints for ``evolution.*`` modules.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+try:  # normal runtime path
+    from hermes_constants import get_hermes_home
+except Exception:  # pragma: no cover - defensive for partial import contexts
+    def get_hermes_home() -> str:  # type: ignore[misc]
+        return str(Path.home() / ".hermes")
+
+_EVOLUTION_MODULE_RE = re.compile(r"^evolution(?:\.[A-Za-z_][A-Za-z0-9_]*)+$")
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _default_hse_repo() -> Path:
+    env = os.environ.get("HERMES_SELF_EVOLUTION_REPO")
+    if env:
+        return Path(env).expanduser()
+    return Path(get_hermes_home()).expanduser() / "evolution" / "repos" / "hermes-agent-self-evolution"
+
+
+def _default_active_repo() -> Path:
+    env = os.environ.get("HERMES_AGENT_REPO")
+    if env:
+        return Path(env).expanduser()
+    return _repo_root()
+
+
+def _resolve_hse_python(hse_repo: Path) -> Path | None:
+    candidates = [
+        hse_repo / ".venv" / "bin" / "python",
+        hse_repo / "venv" / "bin" / "python",
+        Path(get_hermes_home()).expanduser() / "evolution" / "venvs" / "self-evolution" / "bin" / "python",
+    ]
+    for candidate in candidates:
+        if candidate.exists() and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def _git_head(repo: Path) -> str | None:
+    if not (repo / ".git").exists():
+        return None
+    proc = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo, text=True, capture_output=True)
+    return proc.stdout.strip() if proc.returncode == 0 else None
+
+
+def _git_status_count(repo: Path) -> int | None:
+    if not (repo / ".git").exists():
+        return None
+    proc = subprocess.run(["git", "status", "--porcelain=v1"], cwd=repo, text=True, capture_output=True)
+    if proc.returncode != 0:
+        return None
+    return 0 if not proc.stdout else len(proc.stdout.splitlines())
+
+
+def build_status_payload(*, hse_repo: Path | None = None, active_repo: Path | None = None) -> dict[str, Any]:
+    """Return a read-only HSE bridge status payload."""
+
+    hse = (hse_repo or _default_hse_repo()).expanduser().resolve()
+    active = (active_repo or _default_active_repo()).expanduser().resolve()
+    hse_python = _resolve_hse_python(hse)
+    return {
+        "schema_version": "hermes-hse-bridge-status-v1",
+        "status": "ready" if hse.exists() and hse_python is not None else "not_ready",
+        "hse_repo": {
+            "path": str(hse),
+            "exists": hse.exists(),
+            "git_head": _git_head(hse),
+            "git_status_count": _git_status_count(hse),
+        },
+        "active_hermes_repo": {
+            "path": str(active),
+            "exists": active.exists(),
+            "git_head": _git_head(active),
+            "git_status_count": _git_status_count(active),
+        },
+        "hse_python": str(hse_python) if hse_python is not None else None,
+        "boundary": {
+            "default_read_only": True,
+            "active_apply_performed": False,
+            "github_write_performed": False,
+            "cron_or_gateway_mutation_performed": False,
+            "provider_or_model_spend_performed": False,
+            "deploy_or_publication_performed": False,
+            "arbitrary_module_execution_allowed": False,
+        },
+    }
+
+
+def _module_env(hse_repo: Path, active_repo: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env["HERMES_SELF_EVOLUTION_REPO"] = str(hse_repo)
+    env["HERMES_AGENT_REPO"] = str(active_repo)
+    existing = env.get("PYTHONPATH", "")
+    parts = [str(hse_repo)] + ([existing] if existing else [])
+    env["PYTHONPATH"] = os.pathsep.join(parts)
+    return env
+
+
+def _normalized_module_args(module_args: list[str]) -> list[str]:
+    if module_args and module_args[0] == "--":
+        return module_args[1:]
+    return module_args
+
+
+def run_evolution_module(args: Any) -> int:
+    module = str(getattr(args, "module", ""))
+    if not _EVOLUTION_MODULE_RE.match(module):
+        print(f"Refusing non-evolution module: {module}", file=sys.stderr)
+        return 2
+
+    hse_repo = Path(getattr(args, "hse_repo", None) or _default_hse_repo()).expanduser().resolve()
+    active_repo = Path(getattr(args, "active_hermes_repo", None) or _default_active_repo()).expanduser().resolve()
+    hse_python = _resolve_hse_python(hse_repo)
+    if hse_python is None:
+        print(f"HSE Python not found under {hse_repo}", file=sys.stderr)
+        return 2
+    if not hse_repo.exists():
+        print(f"HSE repo not found: {hse_repo}", file=sys.stderr)
+        return 2
+
+    command = [str(hse_python), "-m", module, *_normalized_module_args(list(getattr(args, "module_args", []) or []))]
+    proc = subprocess.run(command, cwd=str(hse_repo), env=_module_env(hse_repo, active_repo), shell=False)
+    return int(proc.returncode)
+
+
+def hse_command(args: Any) -> int:
+    command = getattr(args, "hse_command", None)
+    if command in (None, "status"):
+        payload = build_status_payload(
+            hse_repo=Path(args.hse_repo).expanduser() if getattr(args, "hse_repo", None) else None,
+            active_repo=Path(args.active_hermes_repo).expanduser() if getattr(args, "active_hermes_repo", None) else None,
+        )
+        if getattr(args, "json", False):
+            print(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            print(f"HSE bridge status: {payload['status']}")
+            print(f"HSE repo: {payload['hse_repo']['path']}")
+            print(f"Active Hermes repo: {payload['active_hermes_repo']['path']}")
+            print(f"HSE Python: {payload['hse_python']}")
+        return 0 if payload["status"] == "ready" else 1
+    if command == "module":
+        return run_evolution_module(args)
+    print(f"Unknown HSE subcommand: {command}", file=sys.stderr)
+    return 2

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -303,6 +303,7 @@ from hermes_cli.subcommands.pairing import build_pairing_parser
 from hermes_cli.subcommands.plugins import build_plugins_parser
 from hermes_cli.subcommands.mcp import build_mcp_parser
 from hermes_cli.subcommands.claw import build_claw_parser
+from hermes_cli.subcommands.hse import build_hse_parser
 
 
 def _require_tty(command_name: str) -> None:
@@ -4215,6 +4216,13 @@ def cmd_cron(args):
     from hermes_cli.cron import cron_command
 
     cron_command(args)
+
+
+def cmd_hse(args):
+    """Hermes Self-Evolution operating-copy bridge."""
+    from hermes_cli.hse import hse_command
+
+    return hse_command(args)
 
 
 def cmd_webhook(args):
@@ -12662,6 +12670,11 @@ def main():
     # cron command  (parser built in hermes_cli/subcommands/cron.py)
     # =========================================================================
     build_cron_parser(subparsers, cmd_cron=cmd_cron)
+
+    # =========================================================================
+    # HSE/evolve command  (parser built in hermes_cli/subcommands/hse.py)
+    # =========================================================================
+    build_hse_parser(subparsers, cmd_hse=cmd_hse)
 
     # =========================================================================
     # webhook command  (parser built in hermes_cli/subcommands/webhook.py)

--- a/hermes_cli/subcommands/hse.py
+++ b/hermes_cli/subcommands/hse.py
@@ -1,0 +1,63 @@
+"""``hermes hse`` / ``hermes evolve`` parser.
+
+Thin operating-copy bridge into the standalone ``hermes-agent-self-evolution``
+repository.  The default status command is read-only; module execution is
+restricted to explicit ``evolution.*`` modules.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+
+
+def _add_common_repo_flags(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--hse-repo",
+        help="Path to hermes-agent-self-evolution repo (default: ~/.hermes/evolution/repos/hermes-agent-self-evolution)",
+    )
+    parser.add_argument(
+        "--active-hermes-repo",
+        help="Path to target Hermes checkout (default: this Hermes source checkout or HERMES_AGENT_REPO)",
+    )
+
+
+def _build_single_parser(subparsers, name: str, *, cmd_hse: Callable, help_text: str) -> None:
+    parser = subparsers.add_parser(name, help=help_text, description=help_text)
+    parser.set_defaults(func=cmd_hse, hse_command="status")
+    _add_common_repo_flags(parser)
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON status")
+
+    nested = parser.add_subparsers(dest="hse_command")
+
+    status = nested.add_parser("status", help="Show read-only HSE bridge status")
+    _add_common_repo_flags(status)
+    status.add_argument("--json", action="store_true", help="Emit machine-readable JSON status")
+    status.set_defaults(func=cmd_hse)
+
+    module = nested.add_parser(
+        "module",
+        help="Run an explicit evolution.* module from the HSE repo",
+        description="Run an explicit evolution.* module from the HSE repo. Use -- before module arguments.",
+    )
+    _add_common_repo_flags(module)
+    module.add_argument("module", help="Python module name; must start with evolution.")
+    module.add_argument("module_args", nargs=argparse.REMAINDER, help="Arguments passed through to the evolution module")
+    module.set_defaults(func=cmd_hse)
+
+
+def build_hse_parser(subparsers, *, cmd_hse: Callable) -> None:
+    """Attach ``hse`` and ``evolve`` top-level commands."""
+
+    _build_single_parser(
+        subparsers,
+        "hse",
+        cmd_hse=cmd_hse,
+        help_text="Hermes Self-Evolution operating-copy bridge",
+    )
+    _build_single_parser(
+        subparsers,
+        "evolve",
+        cmd_hse=cmd_hse,
+        help_text="Alias for `hermes hse`",
+    )

--- a/tests/hermes_cli/test_hse_cli.py
+++ b/tests/hermes_cli/test_hse_cli.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from argparse import Namespace
+from pathlib import Path
+
+from hermes_cli import hse
+from hermes_cli.subcommands.hse import build_hse_parser
+
+
+def test_hse_status_payload_is_read_only(tmp_path):
+    hse_repo = tmp_path / "hse"
+    active_repo = tmp_path / "hermes"
+    hse_repo.mkdir()
+    active_repo.mkdir()
+    py = hse_repo / ".venv" / "bin" / "python"
+    py.parent.mkdir(parents=True)
+    py.write_text("#!/usr/bin/env python\n")
+    py.chmod(0o755)
+
+    payload = hse.build_status_payload(hse_repo=hse_repo, active_repo=active_repo)
+
+    assert payload["status"] == "ready"
+    assert payload["hse_repo"]["path"] == str(hse_repo.resolve())
+    assert payload["active_hermes_repo"]["path"] == str(active_repo.resolve())
+    assert payload["hse_python"] == str(py.resolve())
+    assert payload["boundary"] == {
+        "default_read_only": True,
+        "active_apply_performed": False,
+        "github_write_performed": False,
+        "cron_or_gateway_mutation_performed": False,
+        "provider_or_model_spend_performed": False,
+        "deploy_or_publication_performed": False,
+        "arbitrary_module_execution_allowed": False,
+    }
+
+
+def test_hse_module_refuses_non_evolution_module(capsys):
+    rc = hse.run_evolution_module(Namespace(module="os", module_args=[]))
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "Refusing non-evolution module" in captured.err
+
+
+def test_hse_module_runs_explicit_evolution_module_with_shell_disabled(monkeypatch, tmp_path):
+    hse_repo = tmp_path / "hse"
+    active_repo = tmp_path / "active"
+    hse_repo.mkdir()
+    active_repo.mkdir()
+    py = hse_repo / ".venv" / "bin" / "python"
+    py.parent.mkdir(parents=True)
+    py.write_text("#!/usr/bin/env python\n")
+    py.chmod(0o755)
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(hse.subprocess, "run", fake_run)
+
+    rc = hse.run_evolution_module(
+        Namespace(
+            module="evolution.monitor.strict_unattended_loop",
+            module_args=["--", "--help"],
+            hse_repo=str(hse_repo),
+            active_hermes_repo=str(active_repo),
+        )
+    )
+
+    assert rc == 0
+    command, kwargs = calls[0]
+    assert command == [str(py.resolve()), "-m", "evolution.monitor.strict_unattended_loop", "--help"]
+    assert kwargs["cwd"] == str(hse_repo.resolve())
+    assert kwargs["shell"] is False
+    assert kwargs["env"]["HERMES_SELF_EVOLUTION_REPO"] == str(hse_repo.resolve())
+    assert kwargs["env"]["HERMES_AGENT_REPO"] == str(active_repo.resolve())
+    assert str(hse_repo.resolve()) in kwargs["env"]["PYTHONPATH"].split(os.pathsep)
+
+
+def test_hse_and_evolve_parsers_share_handler():
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    build_hse_parser(subparsers, cmd_hse=lambda args: 0)
+
+    hse_args = parser.parse_args(["hse", "status", "--json"])
+    evolve_args = parser.parse_args(["evolve", "module", "evolution.foo", "--", "--help"])
+
+    assert hse_args.command == "hse"
+    assert hse_args.hse_command == "status"
+    assert hse_args.json is True
+    assert evolve_args.command == "evolve"
+    assert evolve_args.hse_command == "module"
+    assert evolve_args.module == "evolution.foo"
+    assert evolve_args.module_args == ["--help"]
+
+
+def test_hse_status_command_outputs_json(tmp_path, capsys):
+    hse_repo = tmp_path / "hse"
+    active_repo = tmp_path / "active"
+    hse_repo.mkdir()
+    active_repo.mkdir()
+    py = hse_repo / ".venv" / "bin" / "python"
+    py.parent.mkdir(parents=True)
+    py.write_text("#!/usr/bin/env python\n")
+    py.chmod(0o755)
+
+    rc = hse.hse_command(
+        Namespace(
+            hse_command="status",
+            hse_repo=str(hse_repo),
+            active_hermes_repo=str(active_repo),
+            json=True,
+        )
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "ready"
+    assert payload["boundary"]["default_read_only"] is True


### PR DESCRIPTION
## Summary

- Adds a thin Hermes operating-copy bridge for HSE: `hermes hse status` and `hermes evolve status`.
- Keeps HSE optimizer internals in the standalone `hermes-agent-self-evolution` repo.
- Defaults to read-only status and only permits explicit `evolution.*` module execution through shell-disabled argv vectors.

## Verification

- Active Hermes HSE CLI tests: `5 passed in 0.12s`
- `hermes hse status --json`: `status=ready`
- Active Hermes commit: `418f7f5499c39b85b582b6bd63a3d24e1ff1356b`
- HSE repo status observed through bridge: `ready`

## Safety boundary

- No auto-merge requested or enabled.
- No deploy performed.
- No provider/model spend performed.
- Bridge status path is read-only by default.
- Human review required before merge/deploy.
