### PR TITLE
fix(env): strip Conda default env marker

### DIFF
--- a/tests/tools/test_hermes_subprocess_env.py
+++ b/tests/tools/test_hermes_subprocess_env.py
@@ -78,6 +78,16 @@ class TestStripByDefault:
         result = _build()
         assert result.get("PYTHONUTF8") == "1"
 
+    def test_active_env_markers_stripped(self):
+        result = _build({
+            "VIRTUAL_ENV": "/venv",
+            "CONDA_PREFIX": "/conda",
+            "CONDA_DEFAULT_ENV": "hermes",
+        })
+        assert "VIRTUAL_ENV" not in result
+        assert "CONDA_PREFIX" not in result
+        assert "CONDA_DEFAULT_ENV" not in result
+
 
 class TestInheritCredentials:
     def test_provider_keys_preserved_when_inheriting(self):

--- a/tests/tools/test_hermes_subprocess_env.py
+++ b/tests/tools/test_hermes_subprocess_env.py
@@ -67,6 +67,16 @@ class TestStripByDefault:
         result = _build()
         assert result.get("PYTHONUTF8") == "1"
 
+    def test_active_env_markers_stripped(self):
+        result = _build({
+            "VIRTUAL_ENV": "/venv",
+            "CONDA_PREFIX": "/conda",
+            "CONDA_DEFAULT_ENV": "hermes",
+        })
+        assert "VIRTUAL_ENV" not in result
+        assert "CONDA_PREFIX" not in result
+        assert "CONDA_DEFAULT_ENV" not in result
+
 
 class TestInheritCredentials:
     def test_provider_keys_preserved_when_inheriting(self):

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -265,7 +265,8 @@ class TestActiveVenvMarkerStripping:
     """Active-virtualenv markers must not leak into terminal subprocesses (#23473).
 
     The gateway runs inside its own venv, so its process environment carries
-    VIRTUAL_ENV (and possibly CONDA_PREFIX). If those leak into commands the
+    VIRTUAL_ENV (and possibly Conda's CONDA_PREFIX/CONDA_DEFAULT_ENV selectors).
+    If those leak into commands the
     agent runs against ANOTHER Python project, ``uv``/``poetry`` treat the
     inherited value as the active environment and build that project's deps
     into the Hermes venv path instead of the project's own ``.venv`` —
@@ -286,27 +287,49 @@ class TestActiveVenvMarkerStripping:
         })
         assert "CONDA_PREFIX" not in result_env
 
+    def test_conda_default_env_marker_stripped_end_to_end(self):
+        result_env = _run_with_env(extra_os_env={
+            "CONDA_DEFAULT_ENV": "hermes",
+        })
+        assert "CONDA_DEFAULT_ENV" not in result_env
+
     def test_make_run_env_strips_markers(self):
         from tools.environments.local import _make_run_env
-        poison = {"VIRTUAL_ENV": "/venv", "CONDA_PREFIX": "/conda", "PATH": "/usr/bin"}
+        poison = {
+            "VIRTUAL_ENV": "/venv",
+            "CONDA_PREFIX": "/conda",
+            "CONDA_DEFAULT_ENV": "hermes",
+            "PATH": "/usr/bin",
+        }
         with patch.dict(os.environ, poison, clear=True):
             result = _make_run_env({})
         assert "VIRTUAL_ENV" not in result
         assert "CONDA_PREFIX" not in result
+        assert "CONDA_DEFAULT_ENV" not in result
 
     def test_sanitize_subprocess_env_strips_markers(self):
         from tools.environments.local import _sanitize_subprocess_env
-        base = {"VIRTUAL_ENV": "/venv", "CONDA_PREFIX": "/conda", "HOME": "/home/user"}
+        base = {
+            "VIRTUAL_ENV": "/venv",
+            "CONDA_PREFIX": "/conda",
+            "CONDA_DEFAULT_ENV": "hermes",
+            "HOME": "/home/user",
+        }
         # Even an explicitly-passed extra marker is stripped.
-        result = _sanitize_subprocess_env(base, {"VIRTUAL_ENV": "/also/venv"})
+        result = _sanitize_subprocess_env(
+            base,
+            {"VIRTUAL_ENV": "/also/venv", "CONDA_DEFAULT_ENV": "also-hermes"},
+        )
         assert "VIRTUAL_ENV" not in result
         assert "CONDA_PREFIX" not in result
+        assert "CONDA_DEFAULT_ENV" not in result
         assert result.get("HOME") == "/home/user"
 
     def test_markers_constant_contents(self):
         from tools.environments.local import _ACTIVE_VENV_MARKER_VARS
         assert "VIRTUAL_ENV" in _ACTIVE_VENV_MARKER_VARS
         assert "CONDA_PREFIX" in _ACTIVE_VENV_MARKER_VARS
+        assert "CONDA_DEFAULT_ENV" in _ACTIVE_VENV_MARKER_VARS
 
 
 class TestBlocklistCoverage:

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -269,7 +269,8 @@ class TestActiveVenvMarkerStripping:
     """Active-virtualenv markers must not leak into terminal subprocesses (#23473).
 
     The gateway runs inside its own venv, so its process environment carries
-    VIRTUAL_ENV (and possibly CONDA_PREFIX). If those leak into commands the
+    VIRTUAL_ENV (and possibly Conda's CONDA_PREFIX/CONDA_DEFAULT_ENV selectors).
+    If those leak into commands the
     agent runs against ANOTHER Python project, ``uv``/``poetry`` treat the
     inherited value as the active environment and build that project's deps
     into the Hermes venv path instead of the project's own ``.venv`` —
@@ -290,27 +291,49 @@ class TestActiveVenvMarkerStripping:
         })
         assert "CONDA_PREFIX" not in result_env
 
+    def test_conda_default_env_marker_stripped_end_to_end(self):
+        result_env = _run_with_env(extra_os_env={
+            "CONDA_DEFAULT_ENV": "hermes",
+        })
+        assert "CONDA_DEFAULT_ENV" not in result_env
+
     def test_make_run_env_strips_markers(self):
         from tools.environments.local import _make_run_env
-        poison = {"VIRTUAL_ENV": "/venv", "CONDA_PREFIX": "/conda", "PATH": "/usr/bin"}
+        poison = {
+            "VIRTUAL_ENV": "/venv",
+            "CONDA_PREFIX": "/conda",
+            "CONDA_DEFAULT_ENV": "hermes",
+            "PATH": "/usr/bin",
+        }
         with patch.dict(os.environ, poison, clear=True):
             result = _make_run_env({})
         assert "VIRTUAL_ENV" not in result
         assert "CONDA_PREFIX" not in result
+        assert "CONDA_DEFAULT_ENV" not in result
 
     def test_sanitize_subprocess_env_strips_markers(self):
         from tools.environments.local import _sanitize_subprocess_env
-        base = {"VIRTUAL_ENV": "/venv", "CONDA_PREFIX": "/conda", "HOME": "/home/user"}
+        base = {
+            "VIRTUAL_ENV": "/venv",
+            "CONDA_PREFIX": "/conda",
+            "CONDA_DEFAULT_ENV": "hermes",
+            "HOME": "/home/user",
+        }
         # Even an explicitly-passed extra marker is stripped.
-        result = _sanitize_subprocess_env(base, {"VIRTUAL_ENV": "/also/venv"})
+        result = _sanitize_subprocess_env(
+            base,
+            {"VIRTUAL_ENV": "/also/venv", "CONDA_DEFAULT_ENV": "also-hermes"},
+        )
         assert "VIRTUAL_ENV" not in result
         assert "CONDA_PREFIX" not in result
+        assert "CONDA_DEFAULT_ENV" not in result
         assert result.get("HOME") == "/home/user"
 
     def test_markers_constant_contents(self):
         from tools.environments.local import _ACTIVE_VENV_MARKER_VARS
         assert "VIRTUAL_ENV" in _ACTIVE_VENV_MARKER_VARS
         assert "CONDA_PREFIX" in _ACTIVE_VENV_MARKER_VARS
+        assert "CONDA_DEFAULT_ENV" in _ACTIVE_VENV_MARKER_VARS
 
 
 class TestProfileScopedPassthrough:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -228,7 +228,8 @@ _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
 
 # Active-virtualenv markers that must NOT leak into terminal subprocesses.
 # The gateway runs inside its own venv, so its process environment carries
-# VIRTUAL_ENV (and possibly CONDA_PREFIX). If those leak into commands the
+# VIRTUAL_ENV (and possibly Conda's CONDA_PREFIX/CONDA_DEFAULT_ENV selectors).
+# If those leak into commands the
 # agent runs against OTHER Python projects, tools like ``uv``/``poetry`` treat
 # the inherited value as the active environment and build/sync that other
 # project's dependencies into the Hermes venv path instead of the project's own
@@ -236,7 +237,7 @@ _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
 # to a different Python version overwrites it and breaks the gateway). The
 # Hermes venv stays reachable via PATH (its bin dir is first), so stripping
 # these markers is safe and only prevents the cross-project clobber (#23473).
-_ACTIVE_VENV_MARKER_VARS = ("VIRTUAL_ENV", "CONDA_PREFIX")
+_ACTIVE_VENV_MARKER_VARS = ("VIRTUAL_ENV", "CONDA_PREFIX", "CONDA_DEFAULT_ENV")
 
 
 def _is_hermes_internal_secret(key: str) -> bool:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -338,7 +338,8 @@ _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
 
 # Active-virtualenv markers that must NOT leak into terminal subprocesses.
 # The gateway runs inside its own venv, so its process environment carries
-# VIRTUAL_ENV (and possibly CONDA_PREFIX). If those leak into commands the
+# VIRTUAL_ENV (and possibly Conda's CONDA_PREFIX/CONDA_DEFAULT_ENV selectors).
+# If those leak into commands the
 # agent runs against OTHER Python projects, tools like ``uv``/``poetry`` treat
 # the inherited value as the active environment and build/sync that other
 # project's dependencies into the Hermes venv path instead of the project's own
@@ -346,7 +347,7 @@ _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
 # to a different Python version overwrites it and breaks the gateway). The
 # Hermes venv stays reachable via PATH (its bin dir is first), so stripping
 # these markers is safe and only prevents the cross-project clobber (#23473).
-_ACTIVE_VENV_MARKER_VARS = ("VIRTUAL_ENV", "CONDA_PREFIX")
+_ACTIVE_VENV_MARKER_VARS = ("VIRTUAL_ENV", "CONDA_PREFIX", "CONDA_DEFAULT_ENV")
 
 
 def _is_hermes_internal_secret(key: str) -> bool:


### PR DESCRIPTION
## Summary

- add `CONDA_DEFAULT_ENV` to the shared active-env marker strip list
- cover the terminal/local env helpers and `hermes_subprocess_env()` with regression tests

Fixes #58382

## Why

Hermes already strips `VIRTUAL_ENV` and `CONDA_PREFIX` before spawning managed local subprocesses so a gateway-launched virtualenv cannot bleed into unrelated project commands. Conda can still expose the active/default target through `CONDA_DEFAULT_ENV`, so stripping only `CONDA_PREFIX` leaves the same class of marker leak open.

## Proof

```text
uv run --extra dev python -m py_compile tools\environments\local.py tests\tools\test_local_env_blocklist.py tests\tools\test_hermes_subprocess_env.py
```

```text
$env:TMP='F:\Codex\tmp\pytest-hermes'; $env:TEMP='F:\Codex\tmp\pytest-hermes'; uv run --extra dev pytest tests\tools\test_local_env_blocklist.py::TestActiveVenvMarkerStripping tests\tools\test_hermes_subprocess_env.py -q
25 passed in 3.11s
```

I also tried the full `tests\tools\test_local_env_blocklist.py` file on Windows after redirecting `TMP/TEMP`; the active-marker tests passed, but unrelated Homebrew/POSIX PATH assertions failed under Windows, so the focused proof above is the meaningful gate for this change.