### PR TITLE
[codex] Compact API server session persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,3 @@ apps/desktop/demo/
 # PR body is the archive. See the hermes-agent-dev skill's
 # pr-infographic-workflow reference (storage rule + lapse #8 / #COMMIT-1).
 infographic/
-
-devsession/
-.hooks_wal_*

--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ apps/desktop/demo/
 # PR body is the archive. See the hermes-agent-dev skill's
 # pr-infographic-workflow reference (storage rule + lapse #8 / #COMMIT-1).
 infographic/
+
+devsession/
+.hooks_wal_*

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1676,7 +1676,9 @@ class APIServerAdapter(BasePlatformAdapter):
         if db is None:
             return []
         try:
-            return db.get_messages_as_conversation(session_id)
+            # chat_text_only: match the write-path compaction so sessions
+            # persisted by earlier versions don't replay raw tool rows.
+            return db.get_messages_as_conversation(session_id, chat_text_only=True)
         except Exception as exc:
             logger.warning("Failed to load session history for %s: %s", session_id, exc)
             return []
@@ -2161,7 +2163,9 @@ class APIServerAdapter(BasePlatformAdapter):
             try:
                 db = self._ensure_session_db()
                 if db is not None:
-                    history = db.get_messages_as_conversation(session_id)
+                    history = db.get_messages_as_conversation(
+                        session_id, chat_text_only=True
+                    )
             except Exception as e:
                 logger.warning("Failed to load session history for %s: %s", session_id, e)
                 history = []

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3759,10 +3759,19 @@ class SessionDB:
         session_id: str,
         include_ancestors: bool = False,
         include_inactive: bool = False,
+        chat_text_only: bool = False,
     ) -> List[Dict[str, Any]]:
         """
         Load messages in the OpenAI conversation format (role + content dicts).
         Used by the gateway to restore conversation history.
+
+        ``chat_text_only=True`` mirrors the api_server write-path compaction
+        on load: only user messages and non-empty assistant text are
+        returned, and tool plumbing (tool_calls/tool_call_id/tool_name) is
+        stripped. This keeps sessions persisted by earlier versions -- whose
+        rows still contain raw tool transcripts -- from replaying hidden
+        tool bloat (or dangling tool_calls, which providers reject) into
+        future context.
 
         By default only active messages are returned. Pass
         ``include_inactive=True`` to load soft-deleted (rewound) rows
@@ -3797,14 +3806,21 @@ class SessionDB:
             content = self._decode_content(row["content"])
             if row["role"] in {"user", "assistant"} and isinstance(content, str):
                 content = sanitize_context(content).strip()
+            if chat_text_only:
+                if row["role"] not in {"user", "assistant"}:
+                    continue
+                if row["role"] == "assistant" and not (
+                    isinstance(content, str) and content.strip()
+                ):
+                    continue
             msg = {"role": row["role"], "content": content}
             if row["timestamp"]:
                 msg["timestamp"] = row["timestamp"]
-            if row["tool_call_id"]:
+            if row["tool_call_id"] and not chat_text_only:
                 msg["tool_call_id"] = row["tool_call_id"]
-            if row["tool_name"]:
+            if row["tool_name"] and not chat_text_only:
                 msg["tool_name"] = row["tool_name"]
-            if row["tool_calls"]:
+            if row["tool_calls"] and not chat_text_only:
                 try:
                     msg["tool_calls"] = json.loads(row["tool_calls"])
                 except (json.JSONDecodeError, TypeError):

--- a/run_agent.py
+++ b/run_agent.py
@@ -1802,6 +1802,7 @@ class AIAgent:
                 id(item) for item in (conversation_history or [])
                 if isinstance(item, dict)
             }
+            compact_api_session = getattr(self, "platform", None) == "api_server"
 
             for _msg_idx, msg in enumerate(messages):
                 if not isinstance(msg, dict):
@@ -1828,6 +1829,12 @@ class AIAgent:
                 role = msg.get("role", "unknown")
                 content = msg.get("content")
                 _row_timestamp = msg.get("timestamp")
+                if compact_api_session and role not in {"user", "assistant"}:
+                    # API/browser clients receive live tool progress over the
+                    # stream and own their visible chat history. Persisting raw
+                    # tool rows here silently balloons future resumed context.
+                    msg[_DB_PERSISTED_MARKER] = True
+                    continue
                 # Apply the persist override to THIS row's written values only
                 # (never to the live dict). Match the original guard: text-only
                 # content is replaced; multimodal (list) content is left intact
@@ -1851,21 +1858,31 @@ class AIAgent:
                         elif isinstance(p, dict) and p.get("type") in {"image", "image_url", "input_image"}:
                             _txt.append("[screenshot]")
                     content = "\n".join(_txt) if _txt else None
+                if (
+                    compact_api_session
+                    and role == "assistant"
+                    and not (isinstance(content, str) and content.strip())
+                ):
+                    # Assistant tool-call stubs are useful during a live turn,
+                    # but make a poor durable transcript when replayed later.
+                    msg[_DB_PERSISTED_MARKER] = True
+                    continue
                 tool_calls_data = None
-                if hasattr(msg, "tool_calls") and isinstance(msg.tool_calls, list) and msg.tool_calls:
-                    tool_calls_data = [
-                        {"name": tc.function.name, "arguments": tc.function.arguments}
-                        for tc in msg.tool_calls
-                    ]
-                elif isinstance(msg.get("tool_calls"), list):
-                    tool_calls_data = msg["tool_calls"]
+                if not compact_api_session:
+                    if hasattr(msg, "tool_calls") and isinstance(msg.tool_calls, list) and msg.tool_calls:
+                        tool_calls_data = [
+                            {"name": tc.function.name, "arguments": tc.function.arguments}
+                            for tc in msg.tool_calls
+                        ]
+                    elif isinstance(msg.get("tool_calls"), list):
+                        tool_calls_data = msg["tool_calls"]
                 self._session_db.append_message(
                     session_id=self.session_id,
                     role=role,
                     content=content,
-                    tool_name=msg.get("tool_name"),
+                    tool_name=None if compact_api_session else msg.get("tool_name"),
                     tool_calls=tool_calls_data,
-                    tool_call_id=msg.get("tool_call_id"),
+                    tool_call_id=None if compact_api_session else msg.get("tool_call_id"),
                     finish_reason=msg.get("finish_reason"),
                     reasoning=msg.get("reasoning") if role == "assistant" else None,
                     reasoning_content=msg.get("reasoning_content") if role == "assistant" else None,

--- a/tests/run_agent/test_api_server_session_compaction.py
+++ b/tests/run_agent/test_api_server_session_compaction.py
@@ -1,0 +1,85 @@
+from unittest.mock import MagicMock
+
+from run_agent import AIAgent
+
+
+def _agent_for_platform(platform: str) -> AIAgent:
+    agent = object.__new__(AIAgent)
+    agent._persist_disabled = False
+    agent._session_db = MagicMock()
+    agent._session_db_created = True
+    agent._last_flushed_db_idx = 0
+    agent._flushed_db_message_ids = set()
+    agent._flushed_db_message_session_id = None
+    agent.session_id = f"{platform}-session"
+    agent.platform = platform
+    return agent
+
+
+def test_api_server_session_db_persists_only_chat_text():
+    agent = _agent_for_platform("api_server")
+    messages = [
+        {"role": "user", "content": "run the build"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "call_1", "function": {"name": "terminal", "arguments": "{}"}}
+            ],
+        },
+        {
+            "role": "tool",
+            "content": "large build log",
+            "tool_name": "terminal",
+            "tool_call_id": "call_1",
+        },
+        {"role": "assistant", "content": "Build passed.", "finish_reason": "stop"},
+    ]
+
+    agent._flush_messages_to_session_db(messages, conversation_history=[])
+
+    appends = agent._session_db.append_message.call_args_list
+    assert [call.kwargs["role"] for call in appends] == ["user", "assistant"]
+    assert [call.kwargs["content"] for call in appends] == [
+        "run the build",
+        "Build passed.",
+    ]
+    assert all(call.kwargs["tool_name"] is None for call in appends)
+    assert all(call.kwargs["tool_calls"] is None for call in appends)
+    assert all(call.kwargs["tool_call_id"] is None for call in appends)
+
+
+def test_non_api_server_session_db_keeps_tool_metadata():
+    agent = _agent_for_platform("cli")
+    messages = [
+        {"role": "user", "content": "run the build"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "call_1", "function": {"name": "terminal", "arguments": "{}"}}
+            ],
+        },
+        {
+            "role": "tool",
+            "content": "large build log",
+            "tool_name": "terminal",
+            "tool_call_id": "call_1",
+        },
+        {"role": "assistant", "content": "Build passed.", "finish_reason": "stop"},
+    ]
+
+    agent._flush_messages_to_session_db(messages, conversation_history=[])
+
+    appends = agent._session_db.append_message.call_args_list
+    assert [call.kwargs["role"] for call in appends] == [
+        "user",
+        "assistant",
+        "tool",
+        "assistant",
+    ]
+    assistant_tool_call = appends[1].kwargs
+    tool_result = appends[2].kwargs
+    assert assistant_tool_call["tool_calls"] == messages[1]["tool_calls"]
+    assert tool_result["tool_name"] == "terminal"
+    assert tool_result["tool_call_id"] == "call_1"

--- a/tests/test_api_server_replay_compaction.py
+++ b/tests/test_api_server_replay_compaction.py
@@ -1,0 +1,71 @@
+"""Read-path counterpart to api_server write compaction.
+
+Sessions persisted before the write-path filter existed still hold raw tool
+rows in state.db. api_server replay must skip them on load (and strip
+dangling tool_calls from kept assistant rows, which providers reject),
+while the default load keeps full fidelity for CLI/audit flows.
+"""
+
+from hermes_state import SessionDB
+
+
+def _seed_legacy_session(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(session_id="s1", source="api_server")
+    db.append_message("s1", role="user", content="run the build")
+    # Legacy empty assistant tool-call stub.
+    db.append_message(
+        "s1",
+        role="assistant",
+        content="",
+        tool_calls=[{"name": "terminal", "arguments": "{}"}],
+    )
+    # Legacy narrated assistant row that still carries tool plumbing.
+    db.append_message(
+        "s1",
+        role="assistant",
+        content="Checking the build...",
+        tool_calls=[{"name": "terminal", "arguments": "{}"}],
+    )
+    db.append_message(
+        "s1",
+        role="tool",
+        content="large build log",
+        tool_name="terminal",
+        tool_call_id="call_1",
+    )
+    db.append_message("s1", role="assistant", content="Build passed.")
+    return db
+
+
+def test_chat_text_only_replay_filters_legacy_tool_rows(tmp_path):
+    db = _seed_legacy_session(tmp_path)
+
+    compact = db.get_messages_as_conversation("s1", chat_text_only=True)
+
+    assert [m["role"] for m in compact] == ["user", "assistant", "assistant"]
+    assert [m["content"] for m in compact] == [
+        "run the build",
+        "Checking the build...",
+        "Build passed.",
+    ]
+    for m in compact:
+        assert "tool_calls" not in m
+        assert "tool_call_id" not in m
+        assert "tool_name" not in m
+
+
+def test_default_replay_keeps_full_fidelity(tmp_path):
+    db = _seed_legacy_session(tmp_path)
+
+    full = db.get_messages_as_conversation("s1")
+
+    assert [m["role"] for m in full] == [
+        "user",
+        "assistant",
+        "assistant",
+        "tool",
+        "assistant",
+    ]
+    assert full[1]["tool_calls"] == [{"name": "terminal", "arguments": "{}"}]
+    assert full[3]["tool_name"] == "terminal"


### PR DESCRIPTION
## Summary

Compact API-server session DB persistence so browser/API clients do not silently store raw tool result rows or assistant tool-call stubs in durable resumed history.

API clients already receive live tool progress over SSE and keep their own visible chat history. Persisting every raw tool row in `state.db` makes future resumed turns expensive and noisy without adding durable user-visible value.

## Changes

- For `platform="api_server"`, persist only user messages and non-empty assistant text into the session DB.
- Skip tool/result rows and empty assistant tool-call stubs for API-server sessions.
- Strip tool metadata from persisted API-server assistant/user rows.
- Preserve existing non-API behavior, including CLI tool metadata persistence.
- Add focused regression coverage for API compaction and non-API tool metadata preservation.

## Validation

- `python -m py_compile run_agent.py`
- `pytest tests/run_agent/test_api_server_session_compaction.py tests/run_agent/test_tool_name_db_persistence.py tests/run_agent/test_860_dedup.py tests/agent/test_codex_app_server_persist.py tests/run_agent/test_message_sequence_repair.py::test_flush_guard_clamps_overshooting_cursor`
