### PR TITLE
fix(gateway): refresh drain timeout before restart wait

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7840,6 +7840,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _phase_elapsed(),
             )
 
+            # Re-read the operator-configured drain window for restart flows so
+            # a just-applied safety bump does not require an extra preliminary
+            # restart to take effect. Plain shutdown keeps its startup value to
+            # avoid unexpectedly lengthening operator/system stop commands.
+            if self._restart_requested:
+                try:
+                    self._restart_drain_timeout = self._load_restart_drain_timeout()
+                except Exception as _e:
+                    logger.debug("Failed to refresh restart_drain_timeout at shutdown: %s", _e)
             timeout = self._restart_drain_timeout
 
             # Pre-mark sessions as resume_pending BEFORE the drain wait.

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -73,6 +73,7 @@ def make_restart_runner(
     runner._detached_restart_helper_started = False
     runner._restart_command_source = None
     runner._restart_drain_timeout = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
+    runner._load_restart_drain_timeout = lambda: runner._restart_drain_timeout
     runner._stop_task = None
     runner._busy_input_mode = "interrupt"
     runner._update_prompt_pending = {}

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -119,6 +119,29 @@ async def test_gateway_stop_drains_running_agents_before_disconnect():
 
 
 @pytest.mark.asyncio
+async def test_gateway_stop_refreshes_drain_timeout_before_wait():
+    runner, adapter = make_restart_runner()
+    runner._restart_drain_timeout = 0.01
+    runner._load_restart_drain_timeout = lambda: 5.0
+    adapter.disconnect = AsyncMock()
+
+    running_agent = MagicMock()
+    runner._running_agents = {"session": running_agent}
+
+    async def finish_agent():
+        await asyncio.sleep(0.05)
+        runner._running_agents.clear()
+
+    asyncio.create_task(finish_agent())
+
+    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
+        await runner.stop(restart=True, detached_restart=False, service_restart=True)
+
+    running_agent.interrupt.assert_not_called()
+    assert runner._restart_drain_timeout == 5.0
+
+
+@pytest.mark.asyncio
 async def test_gateway_stop_interrupts_after_drain_timeout():
     runner, adapter = make_restart_runner()
     runner._restart_drain_timeout = 0.05


### PR DESCRIPTION
## What does this PR do?

Re-reads the configured gateway restart drain timeout immediately before the restart drain wait begins.

Previously, `agent.restart_drain_timeout` was loaded once when the gateway runner was created. If an operator increased the timeout as part of an update/restart safety bump, the already-running gateway could still enter the next restart with the stale shorter timeout and interrupt active sessions before the new value ever took effect.

This keeps plain shutdown behavior unchanged: the refresh is gated to restart flows only.

## Related Issue

Related to #56524

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/run.py`: refresh `_restart_drain_timeout` from the normal env/config loader when a restart shutdown reaches the drain phase.
- `tests/gateway/restart_test_helpers.py`: make partial restart-runner tests provide the same timeout-loader surface as real runners.
- `tests/gateway/test_gateway_shutdown.py`: add a regression test proving a restart flow uses the refreshed timeout before deciding whether to interrupt active agents.

## How to Test

1. Configure or stub an already-running gateway with a short stale `_restart_drain_timeout`.
2. Make the restart-time config loader return a longer timeout.
3. Trigger `stop(restart=True, ...)` with an active agent that finishes after the stale timeout but before the refreshed timeout.
4. Verify the agent is not interrupted and the refreshed timeout is stored on the runner.

Validated locally on Ubuntu 24.04 / Linux 6.8:

```text
bash scripts/run_tests.sh tests/gateway/test_gateway_shutdown.py tests/gateway/test_restart_resume_pending.py
# 102 passed

git diff --check
# passed

python scripts/check-windows-footguns.py --diff origin/main
# ✓ No Windows footguns found (3 file(s) scanned)
```

## Scope notes

This is a narrow mitigation, not the full idle/deferred restart design for #56524. It makes a configured drain-timeout safety bump take effect for the current restart instead of requiring a preliminary restart. A config edit made during an already-running drain wait is still not picked up live.

Existing precedence is unchanged: `HERMES_RESTART_DRAIN_TIMEOUT` still overrides `agent.restart_drain_timeout`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / Linux 6.8

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable.
