### PR TITLE
fix(profiles): preserve symlinks during profile export

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1890,6 +1890,7 @@ def export_profile(name: str, output_path: str) -> Path:
             shutil.copytree(
                 profile_dir,
                 staged,
+                symlinks=True,
                 ignore=_default_export_ignore(profile_dir),
             )
             result = shutil.make_archive(base, "gztar", tmpdir, "default")
@@ -1902,6 +1903,7 @@ def export_profile(name: str, output_path: str) -> Path:
         shutil.copytree(
             profile_dir,
             staged,
+            symlinks=True,
             ignore=lambda d, contents: _CREDENTIAL_FILES & set(contents),
         )
         result = shutil.make_archive(base, "gztar", tmpdir, canon)

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -1385,6 +1385,33 @@ class TestExportImport:
 
         assert not any("__pycache__" in n for n in names)
 
+    def test_export_default_handles_broken_symlinks(self, profile_env, tmp_path):
+        """Export succeeds when the profile directory contains broken symlinks.
+
+        In Docker/custom HERMES_HOME deployments, unrelated directories may
+        contain stale symlinks.  copytree must not follow them.
+        """
+        default_dir = get_profile_dir("default")
+        (default_dir / "config.yaml").write_text("ok")
+        # Create a broken symlink (target does not exist)
+        (default_dir / "broken_link").symlink_to("/nonexistent/path")
+        # Create a valid symlink for comparison
+        (default_dir / "valid_target.txt").write_text("real data")
+        (default_dir / "valid_link").symlink_to(default_dir / "valid_target.txt")
+
+        output = tmp_path / "export" / "default.tar.gz"
+        output.parent.mkdir(parents=True, exist_ok=True)
+        result = export_profile("default", str(output))
+
+        assert result.exists()
+        with tarfile.open(str(result), "r:gz") as tf:
+            names = tf.getnames()
+            # Broken symlink is preserved as a symlink entry
+            assert any("broken_link" in n for n in names)
+            # Valid symlink and its target are both present
+            assert any("valid_link" in n for n in names)
+            assert any("valid_target.txt" in n for n in names)
+
     def test_import_default_without_name_raises(self, profile_env, tmp_path):
         """Importing a default export without --name gives clear guidance."""
         default_dir = get_profile_dir("default")


### PR DESCRIPTION
## What does this PR do?

Adds `symlinks=True` to both `shutil.copytree()` calls in `export_profile()` so that broken symlinks in the profile directory are preserved as symlink entries rather than followed (which crashes with `shutil.Error`).

This fixes profile export in Docker and custom `HERMES_HOME` deployments where unrelated directories may contain stale symlinks (e.g. `x11-dev/` in a Docker image).

## Related Issue

Fixes #58394

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/profiles.py`: Added `symlinks=True` to both `copytree()` calls in `export_profile()` — the default-profile path (line 1890) and the named-profile path (line 1902).
- `tests/hermes_cli/test_profiles.py`: Added `test_export_default_handles_broken_symlinks` — creates a broken symlink, a valid symlink, and a regular file in the profile directory, then verifies the export succeeds and all entries are preserved in the archive.

## How to Test

1. Run the new test: `python -m pytest tests/hermes_cli/test_profiles.py::TestExportImport::test_export_default_handles_broken_symlinks -xvs` — should pass.
2. Run all export/import tests: `python -m pytest tests/hermes_cli/test_profiles.py::TestExportImport -xvs` — all 16 should pass.
3. Manual verification: create a profile directory with a broken symlink (`ln -s /nonexistent link`) and run `hermes profile export default -o /tmp/test.tar.gz` — should succeed instead of raising `shutil.Error`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_profiles.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `symlinks=True` is cross-platform safe
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
