### PR TITLE
fix(dashboard): skip auto-sso for password auth

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -185,6 +185,13 @@ def _auto_sso_response(request: Request) -> Response | None:
     from hermes_cli.dashboard_auth.prefix import prefix_from_request
 
     provider = providers[0]
+    # Password-only providers do not have an OAuth initiation endpoint.
+    # Let /login render the username/password form instead of auto-SSO
+    # redirecting to /auth/login?provider=basic, which would call
+    # start_login() and raise NotImplementedError.
+    if getattr(provider, "supports_password", False):
+        return None
+
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote

--- a/tests/hermes_cli/test_dashboard_auth_401_reauth.py
+++ b/tests/hermes_cli/test_dashboard_auth_401_reauth.py
@@ -406,6 +406,30 @@ class TestAutoSsoRedirect:
         assert r.headers["location"].startswith("/login")
         assert "/auth/login" not in r.headers["location"]
 
+    def test_single_password_provider_renders_login_not_oauth(self, gated_app):
+        """Password-only auth has no OAuth start_login flow. With only a
+        basic/password provider registered, unauthenticated HTML loads must
+        fall back to /login so the password form can POST to
+        /auth/password-login instead of bouncing to /auth/login?provider=basic.
+        """
+        from hermes_cli.dashboard_auth import clear_providers, register_provider
+        from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+
+        class _PasswordStub(StubAuthProvider):
+            name = "basic"
+            display_name = "Username & Password"
+            supports_password = True
+
+            def start_login(self, *, redirect_uri: str):  # pragma: no cover
+                raise AssertionError("password provider must not start OAuth")
+
+        clear_providers()
+        register_provider(_PasswordStub())
+        r = gated_app.get("/sessions", follow_redirects=False)
+        assert r.status_code == 302
+        assert r.headers["location"].startswith("/login")
+        assert "/auth/login" not in r.headers["location"]
+
 
 # ---------------------------------------------------------------------------
 # Gate middleware: same-origin next= validation


### PR DESCRIPTION
## Summary
- Avoid auto-SSO redirects for password-only dashboard auth providers
- Let the `/login` page render the username/password form instead of calling OAuth `start_login()` on the basic provider
- Add regression coverage for single password-provider dashboard auth

## Test Plan
- `python -m pytest tests/hermes_cli/test_dashboard_auth_401_reauth.py::TestAutoSsoRedirect tests/plugins/dashboard_auth/test_basic_provider.py -q -o 'addopts='`
