### PR TITLE
fix(mem0): pass top_k to SDK in OSSBackend.get_all (salvage #52973)

### DIFF
--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -194,7 +194,10 @@ class OSSBackend(Mem0Backend):
         return _unwrap_results(response)
 
     def get_all(self, *, filters: dict, page: int = 1, page_size: int = 100) -> dict:
-        response = self._memory.get_all(filters=filters)
+        # The SDK's default top_k is 20, which silently truncates results —
+        # pass a high value so the full set is available for accurate counting
+        # and client-side pagination (salvage #52973, credit @luxuguang-leo).
+        response = self._memory.get_all(filters=filters, top_k=10000)
         all_results = _unwrap_results(response)
         total = len(all_results)
         start = (page - 1) * page_size

--- a/tests/plugins/memory/test_mem0_v3.py
+++ b/tests/plugins/memory/test_mem0_v3.py
@@ -547,3 +547,63 @@ class TestMem0WriteMetadata:
         adds = [c for c in provider._backend.captured if c[0] == "add"]
         assert adds, "expected an add call from sync_turn"
         assert adds[-1][2]["metadata"] == {"channel": "discord"}
+
+
+class TestOSSBackendGetAll:
+    """OSSBackend.get_all() must pass top_k to the SDK so the result
+    count is not truncated by the default limit of 20.
+    Salvage of #52973, credit @luxuguang-leo."""
+
+    def _make_backend(self, memory_mock=None):
+        from unittest import mock
+        from plugins.memory.mem0._backend import OSSBackend
+
+        oss_config = {
+            "vector_store": {"provider": "qdrant", "config": {"path": "/tmp"}},
+            "llm": {"provider": "openai", "config": {"model": "gpt-4o-mini"}},
+            "embedder": {"provider": "openai", "config": {"model": "text-embedding-3-small"}},
+        }
+        backend = OSSBackend.__new__(OSSBackend)
+        backend._memory = memory_mock or mock.MagicMock()
+        return backend
+
+    def test_passes_top_k_to_sdk(self):
+        from unittest import mock
+        memory = mock.MagicMock()
+        memory.get_all.return_value = {"results": [], "count": 0}
+        backend = self._make_backend(memory)
+        backend.get_all(filters={"user_id": "u1"})
+        memory.get_all.assert_called_once()
+        assert memory.get_all.call_args.kwargs.get("top_k") == 10000
+
+    def test_count_reflects_total_not_sdk_default(self):
+        from unittest import mock
+        all_memories = [{"id": f"mem-{i}", "memory": f"fact {i}"} for i in range(50)]
+        memory = mock.MagicMock()
+        memory.get_all.return_value = {"results": all_memories, "count": 50}
+        backend = self._make_backend(memory)
+        result = backend.get_all(filters={"user_id": "u1"})
+        assert result["count"] == 50
+        assert len(result["results"]) == 50
+
+    def test_client_side_pagination(self):
+        from unittest import mock
+        all_memories = [{"id": f"mem-{i}", "memory": f"fact {i}"} for i in range(50)]
+        memory = mock.MagicMock()
+        memory.get_all.return_value = {"results": all_memories, "count": 50}
+        backend = self._make_backend(memory)
+        result = backend.get_all(filters={"user_id": "u1"}, page=2, page_size=10)
+        assert result["count"] == 50
+        assert len(result["results"]) == 10
+        assert result["results"][0]["id"] == "mem-10"
+        assert result["results"][-1]["id"] == "mem-19"
+
+    def test_pagination_beyond_total_returns_empty(self):
+        from unittest import mock
+        all_memories = [{"id": f"mem-{i}", "memory": f"fact {i}"} for i in range(5)]
+        memory = mock.MagicMock()
+        memory.get_all.return_value = {"results": all_memories, "count": 5}
+        backend = self._make_backend(memory)
+        result = backend.get_all(filters={"user_id": "u1"}, page=10, page_size=10)
+        assert result["count"] == 5
+        assert result["results"] == []


### PR DESCRIPTION
Salvage of #52973 by @luxuguang-leo.

## Summary

The Mem0 SDK defaults `top_k` to 20, which silently truncated `OSSBackend.get_all()` results. Users with >20 memories got wrong counts and missing results. The pagination layer computed counts from the truncated set, so memory listing appeared complete when it was not.

## Root cause

`OSSBackend.get_all()` called `self._memory.get_all(filters=filters)` without passing `top_k`. The SDK defaulted to 20, capping results before the client-side pagination layer.

## Fix

+4 lines: pass `top_k=10000` to the SDK call so the full result set is returned. The existing client-side pagination layer then operates on the complete data.

## Tests

`TestOSSBackendGetAll` — 4 cases:
- `test_passes_top_k_to_sdk` — verifies top_k=10000 is passed
- `test_count_reflects_total_not_sdk_default` — 50 memories, count=50
- `test_client_side_pagination` — page slicing on full set
- `test_pagination_beyond_total_returns_empty` — beyond-total page

## Credits

- Original PR: @luxuguang-leo (#52973, open since June 26 with 0 maintainer feedback)
- Production verification: @bvisible (#58323, confirmed 47/47 memories instead of 20)

## Changes

`plugins/memory/mem0/_backend.py` — OSSBackend.get_all() +3/-1
`tests/plugins/memory/test_mem0_v3.py` — TestOSSBackendGetAll +61/-0