### PR TITLE
fix(kanban): validate log tail bounds

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -132,6 +132,17 @@ def _parse_branch_flag(value: Optional[str]) -> Optional[str]:
     return branch
 
 
+def _parse_positive_int(value: str) -> int:
+    """Parse a positive integer CLI value."""
+    try:
+        parsed = int(value, 10)
+    except ValueError:
+        raise argparse.ArgumentTypeError("must be a positive integer") from None
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
 def _check_dispatcher_presence() -> tuple[bool, str]:
     """Return ``(running, message)``.
 
@@ -728,7 +739,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="Print the worker log for a task (from <kanban-root>/kanban/logs/)",
     )
     p_log.add_argument("task_id")
-    p_log.add_argument("--tail", type=int, default=None,
+    p_log.add_argument("--tail", type=_parse_positive_int, default=None,
                        help="Only print the last N bytes")
 
     # --- runs (per-attempt history for a task) ---

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -133,6 +133,17 @@ def _parse_branch_flag(value: Optional[str]) -> Optional[str]:
     return branch
 
 
+def _parse_positive_int(value: str) -> int:
+    """Parse a positive integer CLI value."""
+    try:
+        parsed = int(value, 10)
+    except ValueError:
+        raise argparse.ArgumentTypeError("must be a positive integer") from None
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
 def _check_dispatcher_presence(
     hermes_home: Optional[Path] = None,
 ) -> tuple[bool, str]:
@@ -844,7 +855,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="Print the worker log for a task (from <kanban-root>/kanban/logs/)",
     )
     p_log.add_argument("task_id")
-    p_log.add_argument("--tail", type=int, default=None,
+    p_log.add_argument("--tail", type=_parse_positive_int, default=None,
                        help="Only print the last N bytes")
 
     # --- runs (per-attempt history for a task) ---

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8517,18 +8517,25 @@ def read_worker_log(
     try:
         if tail_bytes is None:
             return path.read_text(encoding="utf-8", errors="replace")
+        if tail_bytes <= 0:
+            return ""
         size = path.stat().st_size
         with open(path, "rb") as f:
             if size > tail_bytes:
-                f.seek(size - tail_bytes)
+                start = size - tail_bytes
+                f.seek(start)
                 # Skip a partial line if we tailed mid-line. But if the
                 # window has no newline at all (one giant log line),
                 # readline() would eat everything — in that case don't
                 # skip and return the raw tail.
-                probe = f.tell()
-                partial = f.readline()
-                if not partial.endswith(b"\n") and f.tell() >= size:
-                    f.seek(probe)
+                if start > 0:
+                    f.seek(start - 1)
+                    starts_at_line_boundary = f.read(1) == b"\n"
+                    f.seek(start)
+                    if not starts_at_line_boundary:
+                        partial = f.readline()
+                        if not partial.endswith(b"\n") and f.tell() >= size:
+                            f.seek(start)
             data = f.read()
         return data.decode("utf-8", errors="replace")
     except OSError:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -11114,18 +11114,25 @@ def read_worker_log(
     try:
         if tail_bytes is None:
             return path.read_text(encoding="utf-8", errors="replace")
+        if tail_bytes <= 0:
+            return ""
         size = path.stat().st_size
         with open(path, "rb") as f:
             if size > tail_bytes:
-                f.seek(size - tail_bytes)
+                start = size - tail_bytes
+                f.seek(start)
                 # Skip a partial line if we tailed mid-line. But if the
                 # window has no newline at all (one giant log line),
                 # readline() would eat everything — in that case don't
                 # skip and return the raw tail.
-                probe = f.tell()
-                partial = f.readline()
-                if not partial.endswith(b"\n") and f.tell() >= size:
-                    f.seek(probe)
+                if start > 0:
+                    f.seek(start - 1)
+                    starts_at_line_boundary = f.read(1) == b"\n"
+                    f.seek(start)
+                    if not starts_at_line_boundary:
+                        partial = f.readline()
+                        if not partial.endswith(b"\n") and f.tell() >= size:
+                            f.seek(start)
             data = f.read()
         return data.decode("utf-8", errors="replace")
     except OSError:

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -70,6 +70,24 @@ def test_kanban_show_text_renders_graph_with_open_connection(kanban_home):
     assert "Cannot operate on a closed database" not in output
 
 
+def test_cli_log_rejects_non_positive_tail(kanban_home):
+    out = kc.run_slash("log t_beef --tail -1")
+    assert "usage error" in out.lower()
+    assert "--tail" in out
+    assert "positive integer" in out
+
+
+def test_cli_log_accepts_positive_tail(kanban_home):
+    log_dir = kanban_home / "kanban" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / "t_beef.log").write_bytes(b"alpha\nomega\n")
+
+    out = kc.run_slash("log t_beef --tail 6")
+
+    assert "omega" in out
+    assert "alpha" not in out
+
+
 def test_board_override_is_isolated_per_concurrent_call(kanban_home, monkeypatch):
     kb.create_board("alpha")
     kb.create_board("beta")

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -875,6 +875,24 @@ def test_cli_log_missing_task(kanban_home):
     assert "no log" in out.lower()
 
 
+def test_cli_log_rejects_non_positive_tail(kanban_home):
+    out = run_slash("log t_beef --tail -1")
+    assert "usage error" in out.lower()
+    assert "--tail" in out
+    assert "positive integer" in out
+
+
+def test_cli_log_accepts_positive_tail(kanban_home):
+    log_dir = kanban_home / "kanban" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / "t_beef.log").write_bytes(b"alpha\nomega\n")
+
+    out = run_slash("log t_beef --tail 6")
+
+    assert "omega" in out
+    assert "alpha" not in out
+
+
 def test_cli_gc_reports_counts(kanban_home):
     conn = kb.connect()
     try:


### PR DESCRIPTION
﻿## Summary
- Reject non-positive `hermes kanban log --tail` values at CLI parse time.
- Preserve the first tailed line when the byte window starts exactly at a log line boundary.
- Add run_slash regression coverage for invalid and valid `--tail` values.

Fixes #58411.

## Why
The dashboard log route already constrains `tail` to positive values, but the CLI accepted `--tail -1` and returned an empty successful response. The lower-level reader also skipped the first line after seeking even when the seek offset was already on a line boundary, so a valid positive tail could return no recent log content.

## Proof
- `uv run --extra dev python -m py_compile hermes_cli\kanban.py hermes_cli\kanban_db.py tests\hermes_cli\test_kanban_core_functionality.py`
- `uv run --extra dev pytest tests\hermes_cli\test_kanban_core_functionality.py -k "cli_log or read_worker_log_tail" -q` -> `4 passed, 167 deselected`

## Duplicate check
- `kanban log tail negative tail_bytes` found no matching Hermes PR or issue.
- `kanban log tail line boundary positive integer` found no matching Hermes PR or issue.
