### PR TITLE
fix(matrix): set CMake policy for Windows lazy install

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -12,6 +12,7 @@ call is mocked — we never actually shell out during unit tests.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 
 import pytest
 
@@ -205,6 +206,51 @@ class TestEnsure:
         )
         with pytest.raises(ld.FeatureUnavailable, match="still not importable"):
             ld.ensure("test.cache", prompt=False)
+
+
+class TestInstallEnvironment:
+    def test_matrix_encryption_sets_cmake_policy_on_windows(self, monkeypatch):
+        captured_envs = []
+
+        monkeypatch.setattr(ld.sys, "platform", "win32")
+        monkeypatch.setattr(ld.shutil, "which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+        monkeypatch.setattr(
+            "tools.environments.local.hermes_subprocess_env",
+            lambda inherit_credentials=False: {"BASE_ENV": "1"},
+        )
+
+        def fake_run(cmd, **kwargs):
+            captured_envs.append(kwargs.get("env") or {})
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(ld.subprocess, "run", fake_run)
+
+        result = ld._venv_pip_install(ld.LAZY_DEPS["platform.matrix"])
+
+        assert result.success is True
+        assert captured_envs[0]["CMAKE_POLICY_VERSION_MINIMUM"] == "3.5"
+        assert captured_envs[0]["VIRTUAL_ENV"]
+
+    def test_non_matrix_install_does_not_set_cmake_policy_on_windows(self, monkeypatch):
+        captured_envs = []
+
+        monkeypatch.setattr(ld.sys, "platform", "win32")
+        monkeypatch.setattr(ld.shutil, "which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+        monkeypatch.setattr(
+            "tools.environments.local.hermes_subprocess_env",
+            lambda inherit_credentials=False: {},
+        )
+
+        def fake_run(cmd, **kwargs):
+            captured_envs.append(kwargs.get("env") or {})
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(ld.subprocess, "run", fake_run)
+
+        result = ld._venv_pip_install(ld.LAZY_DEPS["platform.slack"])
+
+        assert result.success is True
+        assert "CMAKE_POLICY_VERSION_MINIMUM" not in captured_envs[0]
 
 
 # ---------------------------------------------------------------------------

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -600,6 +600,23 @@ def _core_constraints_file() -> Optional[Path]:
         return None
 
 
+def _install_env_for_specs(
+    specs: tuple[str, ...],
+    base_env: Optional[dict[str, str]] = None,
+) -> dict[str, str]:
+    """Return subprocess env overrides needed by specific lazy deps."""
+    env = dict(base_env or os.environ)
+    if (
+        sys.platform == "win32"
+        and any(
+            _pkg_name_from_spec(spec) == "mautrix" and "[encryption]" in spec
+            for spec in specs
+        )
+    ):
+        env.setdefault("CMAKE_POLICY_VERSION_MINIMUM", "3.5")
+    return env
+
+
 def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _InstallResult:
     """Install ``specs`` using the uv → pip → ensurepip ladder.
 
@@ -641,6 +658,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
         from tools.environments.local import hermes_subprocess_env
         uv_env = hermes_subprocess_env(inherit_credentials=False)
         uv_env["VIRTUAL_ENV"] = str(venv_root)
+        install_env = _install_env_for_specs(specs, uv_env)
 
         # Tier 1: uv (preferred — fast, doesn't need pip in the venv)
         uv_bin = shutil.which("uv")
@@ -648,7 +666,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
             try:
                 r = subprocess.run(
                     [uv_bin, "pip", "install", *target_args, *constraint_args, *specs],
-                    capture_output=True, text=True, timeout=timeout, env=uv_env,
+                    capture_output=True, text=True, timeout=timeout, env=install_env,
                     stdin=subprocess.DEVNULL,
                 )
                 if r.returncode == 0:
@@ -684,6 +702,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
             r = subprocess.run(
                 pip_cmd + ["install", *target_args, *constraint_args, *specs],
                 capture_output=True, text=True, timeout=timeout,
+                env=install_env,
                 stdin=subprocess.DEVNULL,
             )
             if r.returncode == 0 and target is not None:


### PR DESCRIPTION
## Summary
- set CMAKE_POLICY_VERSION_MINIMUM=3.5 when installing Matrix's mautrix[encryption] lazy dependency on Windows
- apply the install env to both uv and pip fallback install paths
- add regression coverage that the override is scoped to Matrix encryption installs and does not affect unrelated lazy deps

Fixes #58063.

## Tests
- .venv/bin/python -m pytest tests/tools/test_lazy_deps.py -q
- .venv/bin/python -m ruff check tools/lazy_deps.py tests/tools/test_lazy_deps.py
- git diff --check