### PR TITLE
fix(tools): make json_parse tolerate UTF-8 BOM (salvage #57870)

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -422,17 +422,23 @@ print(f"Found {len(results.get('results', []))} results")
         self.assertIn("Found 1 results", result["output"])
 
     def test_json_parse_helper(self):
-        """json_parse handles control characters that json.loads(strict=True) rejects."""
+        """json_parse handles control characters and a leading UTF-8 BOM."""
         code = r"""
 from hermes_tools import json_parse
 # This JSON has a literal tab character which strict mode rejects
 text = '{"body": "line1\tline2\nline3"}'
 result = json_parse(text)
 print(result["body"])
+# A leading UTF-8 BOM (e.g. from Windows CLI output) must also parse (#57870)
+bom_text = "\ufeff" + '{"body": "bom-ok"}'
+bom_result = json_parse(bom_text)
+assert bom_result == {"body": "bom-ok"}, bom_result
+print("bom:" + bom_result["body"])
 """
         result = self._run(code)
         self.assertEqual(result["status"], "success")
         self.assertIn("line1", result["output"])
+        self.assertIn("bom:bom-ok", result["output"])
 
     def test_shell_quote_helper(self):
         """shell_quote properly escapes dangerous characters."""

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -310,9 +310,12 @@ _COMMON_HELPERS = '''\
 # ---------------------------------------------------------------------------
 
 def json_parse(text: str):
-    """Parse JSON tolerant of control characters (strict=False).
+    """Parse JSON tolerant of control characters and UTF-8 BOM (strict=False).
     Use this instead of json.loads() when parsing output from terminal()
-    or web_extract() that may contain raw tabs/newlines in strings."""
+    or web_extract() that may contain raw tabs/newlines in strings,
+    or from tools/files that prepend a UTF-8 BOM (salvage #57870, credit @woxinwuhen713-bit)."""
+    if isinstance(text, str) and text.startswith("﻿"):
+        text = text[1:]
     return json.loads(text, strict=False)
 
 


### PR DESCRIPTION
Salvage of #57870 by @woxinwuhen713-bit.

## Summary

`json_parse` (the sandbox JSON helper injected into execute_code) used `json.loads(strict=False)`. `strict=False` relaxes control characters but rejects a leading UTF-8 BOM, causing:

```
json.decoder.JSONDecodeError: Unexpected UTF-8 BOM
(decode using utf-8-sig): line 1 column 1 (char 0)
```

This hits any agent turn where the underlying shell command emits BOM-prefixed payload — common with Windows CLI tools and some file outputs.

## Fix

+5/-2: strip a leading U+FEFF BOM before calling `json.loads()` when the input is a string.

## Credit

Original PR by @woxinwuhen713-bit (#57870, closed 2026-07-03).

## Files

`tools/code_execution_tool.py` — `json_parse()` function