### PR TITLE
test(agent): isolate anthropic oauth setup token from macos keychain

### DIFF
--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -658,6 +658,20 @@ class TestResolveWithRefresh:
 
 
 class TestRunOauthSetupToken:
+    @pytest.fixture(autouse=True)
+    def _no_keychain_credentials(self, monkeypatch):
+        """These tests mock subprocess.run for `claude setup-token`.
+
+        On macOS, Claude Code credential resolution also shells out to the
+        Keychain via subprocess.run. Keep that independent path out of this
+        setup-token test seam so the MagicMock meant for the Claude CLI does
+        not become fake Keychain JSON.
+        """
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
+
     def test_raises_when_claude_not_installed(self, monkeypatch):
         monkeypatch.setattr("shutil.which", lambda _: None)
         with pytest.raises(FileNotFoundError, match="claude.*CLI.*not installed"):


### PR DESCRIPTION
Fixes #58415

The setup-token tests mock `subprocess.run` to cover the `claude setup-token` subprocess. On macOS, credential resolution also shells out through `subprocess.run` to read Claude Code credentials from Keychain, so those tests were feeding the Claude CLI MagicMock into the Keychain JSON parser.

This keeps the setup-token seam focused by stubbing the Keychain credential reader to return `None` for the `TestRunOauthSetupToken` class. File credentials and env-var fallbacks remain exercised, but macOS Keychain subprocess behavior is tested independently.

Tests:
- `scripts/run_tests.sh tests/agent/test_anthropic_adapter.py`
