### PR TITLE
fix(kanban): refresh dispatch-lock mtime every tick

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1468,6 +1468,18 @@ def _dispatch_tick_lock(db_path: Path):
                 acquired = True
             except (BlockingIOError, OSError):
                 acquired = False
+        # Liveness heartbeat: refresh mtime while we hold the lock so external
+        # watchdogs can distinguish a healthy dispatcher (mtime advancing on
+        # every tick) from a stuck one (mtime frozen). The lock is opened with
+        # "a+b" and never written to, so without this utime the mtime would
+        # only advance on first creation — causing every long-lived dispatcher
+        # to look "stale" to a naive mtime-based watchdog. Best-effort: a
+        # utime failure (e.g. read-only filesystem) must not degrade dispatch.
+        if acquired:
+            try:
+                os.utime(lock_path, None)
+            except OSError:
+                pass
     except OSError:
         # Could not even open the lock file (permissions, read-only FS).
         # Degrade to a no-op so a probe failure never blocks dispatch.

--- a/tests/hermes_cli/test_kanban_dispatch_lock.py
+++ b/tests/hermes_cli/test_kanban_dispatch_lock.py
@@ -101,3 +101,70 @@ def test_reentrant_same_path_lock_is_exclusive(conn):
         assert held_a is True
         with kb._dispatch_tick_lock(db_path) as held_b:
             assert held_b is False, "same-board lock must be exclusive"
+
+
+def test_held_lock_refreshes_mtime_for_external_watchdogs(conn, tmp_path):
+    """Each successful acquire must advance the lock file's mtime so external
+    watchdogs (e.g. ``kanban_dispatcher_watchdog.py``) can detect a stuck
+    dispatcher by mtime-freeze instead of false-positive every TTL.
+
+    Regression guard for the post-#50331 follow-up: the original implementation
+    opened the lock with ``"a+b"`` and never wrote to it, so mtime was set only
+    on first open and froze forever — making every long-lived dispatcher look
+    stale to a naive mtime-based watchdog. The fix refreshes mtime inside the
+    critical section, after flock succeeds.
+    """
+    import os
+    import time
+
+    db_path = kb.kanban_db_path(board="default")
+    lock_path = db_path.with_name(db_path.name + ".dispatch.lock")
+
+    mtimes: list[float] = []
+    # Five sequential acquire/release cycles must yield five distinct mtimes.
+    # Sleep > filesystem mtime resolution (1s on most filesystems) — but
+    # ext4/APFS sub-second resolution supports distinguishing 0.2s gaps.
+    for _ in range(5):
+        with kb._dispatch_tick_lock(db_path) as held:
+            assert held is True
+            assert lock_path.exists(), "lock file must be created on acquire"
+            mtimes.append(lock_path.stat().st_mtime)
+            time.sleep(0.2)
+
+    assert len(set(mtimes)) == 5, (
+        f"lock mtime must advance on every acquire; got {mtimes}"
+    )
+    assert mtimes == sorted(mtimes), "mtimes must be monotonically increasing"
+
+    # Sanity: a non-blocking loser does NOT refresh mtime (it didn't acquire).
+    stale_mtime = lock_path.stat().st_mtime
+    time.sleep(0.2)
+    with kb._dispatch_tick_lock(db_path) as held_a:
+        assert held_a is True
+        first_holder_mtime = lock_path.stat().st_mtime
+        with kb._dispatch_tick_lock(db_path) as held_b:
+            assert held_b is False, "loser must not acquire"
+            assert lock_path.stat().st_mtime == first_holder_mtime, (
+                "loser must not touch the mtime while holder still holds"
+            )
+    # After release, the next acquire refreshes again.
+    time.sleep(0.2)
+    with kb._dispatch_tick_lock(db_path) as held_c:
+        assert held_c is True
+        assert lock_path.stat().st_mtime > first_holder_mtime, (
+            "subsequent acquire must refresh mtime"
+        )
+
+
+def test_utime_failure_does_not_break_acquire(conn, monkeypatch):
+    """If ``os.utime`` fails (e.g. read-only FS), acquire must still yield True
+    so dispatch continues. Best-effort heartbeat, not a hard requirement."""
+    db_path = kb.kanban_db_path(board="default")
+
+    def boom(*_args, **_kwargs):
+        raise OSError("simulated read-only filesystem")
+
+    monkeypatch.setattr("hermes_cli.kanban_db.os.utime", boom)
+    # Must not raise, must yield True.
+    with kb._dispatch_tick_lock(db_path) as held:
+        assert held is True


### PR DESCRIPTION
## Problem

The single-writer dispatch lock introduced in #50331 opens the lock file with `"a+b"` and never writes to it. mtime is set only on first creation and freezes forever afterwards — making every long-lived dispatcher look "stale" to any external watchdog that uses mtime to detect stuck processes.

In practice this caused 30-minute false-positive alerts on every healthy dispatcher tick. The local `kanban_dispatcher_watchdog.py` had to be softened (TTL 1800s → 7200s, alert floor 3h, profile-silence 4h) just to mask the symptom — but the root cause is in the lock itself.

## Fix

Refresh mtime via `os.utime(lock_path, None)` inside the critical section, right after `fcntl.flock` succeeds (same place on POSIX and Windows paths). The heartbeat is best-effort: a `utime` failure (e.g. read-only filesystem, EACCES on NFS) is caught and does not degrade dispatch semantics.

`os` is already imported at the top of `kanban_db.py`, no new dependency.

## Why inside the critical section (not before/after)

- **After** flock: only the actual holder refreshes. A non-blocking loser (`BlockingIOError`) returns early without touching mtime, so mtime stays attributable to the real holder.
- **Inside the try**: the `if acquired:` guard scopes the utime to successful acquires only, including the OSError-degrade branch (where `acquired=True` but `handle=None` — utime on a missing path raises FileNotFoundError, which IS an OSError and is swallowed by the inner try/except).

## Acceptance

- ✅ 5 sequential acquire/release cycles produce 5 distinct mtimes (`test_held_lock_refreshes_mtime_for_external_watchdogs`)
- ✅ Concurrent acquire still serializes (1 winner + N-1 non-blocking losers return False immediately) — verified via 4-thread race
- ✅ utime failure does not break acquire (`test_utime_failure_does_not_break_acquire`)
- ✅ All 5 pre-existing tests in `test_kanban_dispatch_lock.py` still pass
- ✅ Full `test_kanban_db.py` (239 tests) passes — no regressions

## Files

- `hermes_cli/kanban_db.py`: +12 lines (1 heartbeat block, best-effort)
- `tests/hermes_cli/test_kanban_dispatch_lock.py`: +67 lines (2 new tests)

## Risk

GREEN. Single atomic syscall, inside an existing try/except. Backwards-compatible with all existing callers — no public API change. Watchdogs that currently use mtime will start getting correct liveness data; watchdogs that already use PID/process checks are unaffected.