### PR TITLE
fix(gateway): allow cross-platform /resume for unowned sessions, add --cross-platform flag

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -763,7 +763,9 @@ class GatewaySlashCommandsMixin:
             return False
 
     async def _resume_target_allowed(
-        self, source: SessionSource, target_id: str, allow_override: bool = False
+        self, source: SessionSource, target_id: str,
+        allow_override: bool = False,
+        allow_cross_platform: bool = False,
     ) -> bool:
         """Whether *source* may resume the persisted session *target_id*.
 
@@ -791,10 +793,20 @@ class GatewaySlashCommandsMixin:
             row = await self._session_db.get_session(target_id) or {}
         except Exception:
             return False
-        caller_src = source.platform.value if source.platform else None
         row_src = row.get("source")
+        caller_src = source.platform.value if source.platform else None
         if row_src and caller_src and str(row_src) != str(caller_src):
-            return False  # different platform / source
+            # Cross-platform resume: the target session is on a different
+            # platform (e.g. TUI session resumed from Telegram). Allow when:
+            # 1) The caller explicitly opted in via --cross-platform, OR
+            # 2) The target session has no user_id — unowned local session
+            #    with no owner to IDOR against.
+            if not (allow_cross_platform or not row.get("user_id")):
+                return False  # different platform / source
+        # Unowned local sessions (e.g. TUI, no user_id) have no owner
+        # to protect — any authenticated gateway user may resume them.
+        if not row.get("user_id"):
+            return True
         caller_uid = str(getattr(source, "user_id", "") or "")
         row_uid = str(row.get("user_id") or "")
         # Chat/thread origin recorded at session creation (see
@@ -3497,7 +3509,8 @@ class GatewaySlashCommandsMixin:
             return t("gateway.resume.parse_error", error=exc)
         allow_all = "--all" in parts
         allow_cross_room = "--cross-room" in parts
-        name = " ".join(p for p in parts if p not in {"--all", "--cross-room"}).strip()
+        allow_cross_platform = "--cross-platform" in parts
+        name = " ".join(p for p in parts if p not in {"--all", "--cross-room", "--cross-platform"}).strip()
 
         # Strip common outer brackets/quotes users may type literally from the
         # usage hint (e.g. ``/resume <abc123>``). Mirrors the CLI behavior.
@@ -3587,7 +3600,9 @@ class GatewaySlashCommandsMixin:
                     name=name,
                 )
         elif not await self._resume_target_allowed(
-            source, target_id, allow_override=(allow_all or allow_cross_room)
+            source, target_id,
+            allow_override=(allow_all or allow_cross_room),
+            allow_cross_platform=allow_cross_platform,
         ):
             # IDOR guard: a session id/title is a routing handle, not authority.
             # Bind /resume to the caller's own platform/user/chat on every


### PR DESCRIPTION
## Problem

`/resume` blocks cross-platform session resume (e.g. resuming a **TUI** session from **Telegram**) with an IDOR guard that requires matching source platforms. The error:

> ⚠️ /resume blocked: "Session Title" belongs to a different user or chat. You can only resume sessions from this chat.

This is a legitimate UX break: local TUI sessions (which have no `user_id` — they are unowned) cannot be resumed from any gateway channel. The IDOR guard is over-broad because a session with **no owner** has no owner to protect.

## Solution

Two-part fix governed by the **same principle**: the IDOR guard should not block cross-platform resume when there is no IDOR risk.

### 1. Auto-allow unowned sessions (no `user_id`)

When the target session has no `user_id` (e.g. TUI sessions, which are inherently local/single-user), the IDOR guard is meaningless — there is no owner to protect. These sessions are now automatically resumable from any platform:

```
/resume "401 Error Investigation"   # works from Telegram even though source is "tui"
```

### 2. `--cross-platform` flag

Adds an explicit `--cross-platform` flag to `/resume`, analogous to Matrixs existing `--cross-room` flag. This gives users a deliberate opt-in for cross-platform resume when the session *does* have a user_id:

```
/resume --cross-platform "Session Name"
```

## Changes

- `gateway/slash_commands.py`:
  - Parse `--cross-platform` flag alongside `--all` and `--cross-room`
  - Pass `allow_cross_platform` through to `_resume_target_allowed()`
  - In `_resume_target_allowed()`: skip the platform-source check when `allow_cross_platform` is set OR the row has no `user_id` (unowned local session)
  - Early-return `True` for unowned sessions after the platform check

## Testing

- `/resume "Session Title"` from Telegram → previously blocked for TUI sessions, now allowed (unowned)
- `/resume --cross-platform "Session Title"` → explicitly allowed
- `/resume "Session Title"` for same-platform sessions → unchanged (platform check passes)
- `--all` + admin still works as before (super-admin bypass)
- Matrix `--cross-room` path unchanged