### PR TITLE
fix(env): strip CONDA_DEFAULT_ENV from managed subprocess environments (#58382)

### DIFF
--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -236,7 +236,7 @@ _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
 # to a different Python version overwrites it and breaks the gateway). The
 # Hermes venv stays reachable via PATH (its bin dir is first), so stripping
 # these markers is safe and only prevents the cross-project clobber (#23473).
-_ACTIVE_VENV_MARKER_VARS = ("VIRTUAL_ENV", "CONDA_PREFIX")
+_ACTIVE_VENV_MARKER_VARS = ("VIRTUAL_ENV", "CONDA_PREFIX", "CONDA_DEFAULT_ENV")
 
 
 def _is_hermes_internal_secret(key: str) -> bool:


### PR DESCRIPTION
Closes #58382

## Summary

Hermes already strips `VIRTUAL_ENV` and `CONDA_PREFIX` from `hermes_subprocess_env()`, but `CONDA_DEFAULT_ENV` was missed. A Conda-launched gateway leaks the active Conda environment selector into terminal/local subprocesses.

## Fix

+1/-1: add `CONDA_DEFAULT_ENV` to `_ACTIVE_VENV_MARKER_VARS` tuple. The variable is already stripped in 3 call sites via a loop over that tuple — this change just adds one more name.

## Impact

Prevents `uv`/`poetry`/`pip` in agent-spawned subprocesses from misidentifying the active environment based on leaked Conda state from the gateway parent process.

## Files

`tools/environments/local.py` — `_ACTIVE_VENV_MARKER_VARS` tuple