### PR TITLE
fix(feishu): consume batch flush task errors

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3632,8 +3632,8 @@ class FeishuAdapter(BasePlatformAdapter):
             self._flush_text_batch,
         )
 
-    @staticmethod
     def _reschedule_batch_task(
+        self,
         task_map: Dict[str, asyncio.Task],
         key: str,
         flush_fn: Any,
@@ -3641,7 +3641,9 @@ class FeishuAdapter(BasePlatformAdapter):
         prior_task = task_map.get(key)
         if prior_task and not prior_task.done():
             prior_task.cancel()
-        task_map[key] = asyncio.create_task(flush_fn(key))
+        task = asyncio.create_task(flush_fn(key))
+        task.add_done_callback(self._log_background_failure)
+        task_map[key] = task
 
     async def _flush_text_batch(self, key: str) -> None:
         """Flush a pending text batch after the quiet period.
@@ -4167,6 +4169,8 @@ class FeishuAdapter(BasePlatformAdapter):
     def _log_background_failure(future: Any) -> None:
         try:
             future.result()
+        except (asyncio.CancelledError, concurrent.futures.CancelledError):
+            return
         except Exception:
             logger.exception("[Feishu] Background inbound processing failed")
 

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3794,8 +3794,8 @@ class FeishuAdapter(BasePlatformAdapter):
             self._flush_text_batch,
         )
 
-    @staticmethod
     def _reschedule_batch_task(
+        self,
         task_map: Dict[str, asyncio.Task],
         key: str,
         flush_fn: Any,
@@ -3803,7 +3803,9 @@ class FeishuAdapter(BasePlatformAdapter):
         prior_task = task_map.get(key)
         if prior_task and not prior_task.done():
             prior_task.cancel()
-        task_map[key] = asyncio.create_task(flush_fn(key))
+        task = asyncio.create_task(flush_fn(key))
+        task.add_done_callback(self._log_background_failure)
+        task_map[key] = task
 
     async def _flush_text_batch(self, key: str) -> None:
         """Flush a pending text batch after the quiet period.
@@ -4337,6 +4339,8 @@ class FeishuAdapter(BasePlatformAdapter):
     def _log_background_failure(future: Any) -> None:
         try:
             future.result()
+        except (asyncio.CancelledError, concurrent.futures.CancelledError):
+            return
         except Exception:
             logger.exception("[Feishu] Background inbound processing failed")
 

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1705,6 +1705,69 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(first.text, "A\nB")
         self.assertEqual(second.text, "C")
 
+    def test_text_batch_flush_task_consumes_dispatch_errors(self):
+        from gateway.config import Platform, PlatformConfig
+        from gateway.platforms.base import MessageEvent, MessageType
+        from plugins.platforms.feishu.adapter import FeishuAdapter, FeishuBatchState
+        from gateway.session import SessionSource
+
+        adapter = object.__new__(FeishuAdapter)
+        adapter._platform = Platform.FEISHU
+        adapter.config = PlatformConfig()
+        batch_state = FeishuBatchState()
+        adapter._pending_text_batches = batch_state.events
+        adapter._pending_text_batch_tasks = batch_state.tasks
+        adapter._pending_text_batch_counts = batch_state.counts
+        adapter._text_batch_max_messages = 20
+        adapter._text_batch_max_chars = 50000
+        adapter._text_batch_delay_seconds = 0
+        adapter._text_batch_split_delay_seconds = 0
+        adapter._handle_message_with_guards = AsyncMock(
+            side_effect=RuntimeError("dispatch failed")
+        )
+        source = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_chat",
+            chat_name="Feishu DM",
+            chat_type="dm",
+            user_id="ou_user",
+            user_name="Zhang San",
+        )
+
+        async def _run() -> list[dict]:
+            loop = asyncio.get_running_loop()
+            previous_handler = loop.get_exception_handler()
+            loop_errors: list[dict] = []
+            loop.set_exception_handler(
+                lambda _loop, context: loop_errors.append(context)
+            )
+            try:
+                with patch(
+                    "plugins.platforms.feishu.adapter.logger.exception"
+                ) as log_exception:
+                    await adapter._dispatch_inbound_event(
+                        MessageEvent(
+                            text="A",
+                            message_type=MessageType.TEXT,
+                            source=source,
+                            message_id="om_1",
+                        )
+                    )
+                    await asyncio.sleep(0)
+                    await asyncio.sleep(0)
+                    await asyncio.sleep(0)
+                log_exception.assert_called_once_with(
+                    "[Feishu] Background inbound processing failed"
+                )
+            finally:
+                loop.set_exception_handler(previous_handler)
+            return loop_errors
+
+        loop_errors = asyncio.run(_run())
+
+        adapter._handle_message_with_guards.assert_awaited_once()
+        self.assertEqual(loop_errors, [])
+
     @patch.dict(os.environ, {}, clear=True)
     def test_media_batch_merges_rapid_photo_messages(self):
         from gateway.config import PlatformConfig

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1001,6 +1001,69 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(first.text, "A\nB")
         self.assertEqual(second.text, "C")
 
+    def test_text_batch_flush_task_consumes_dispatch_errors(self):
+        from gateway.config import Platform, PlatformConfig
+        from gateway.platforms.base import MessageEvent, MessageType
+        from plugins.platforms.feishu.adapter import FeishuAdapter, FeishuBatchState
+        from gateway.session import SessionSource
+
+        adapter = object.__new__(FeishuAdapter)
+        adapter._platform = Platform.FEISHU
+        adapter.config = PlatformConfig()
+        batch_state = FeishuBatchState()
+        adapter._pending_text_batches = batch_state.events
+        adapter._pending_text_batch_tasks = batch_state.tasks
+        adapter._pending_text_batch_counts = batch_state.counts
+        adapter._text_batch_max_messages = 20
+        adapter._text_batch_max_chars = 50000
+        adapter._text_batch_delay_seconds = 0
+        adapter._text_batch_split_delay_seconds = 0
+        adapter._handle_message_with_guards = AsyncMock(
+            side_effect=RuntimeError("dispatch failed")
+        )
+        source = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_chat",
+            chat_name="Feishu DM",
+            chat_type="dm",
+            user_id="ou_user",
+            user_name="Zhang San",
+        )
+
+        async def _run() -> list[dict]:
+            loop = asyncio.get_running_loop()
+            previous_handler = loop.get_exception_handler()
+            loop_errors: list[dict] = []
+            loop.set_exception_handler(
+                lambda _loop, context: loop_errors.append(context)
+            )
+            try:
+                with patch(
+                    "plugins.platforms.feishu.adapter.logger.exception"
+                ) as log_exception:
+                    await adapter._dispatch_inbound_event(
+                        MessageEvent(
+                            text="A",
+                            message_type=MessageType.TEXT,
+                            source=source,
+                            message_id="om_1",
+                        )
+                    )
+                    await asyncio.sleep(0)
+                    await asyncio.sleep(0)
+                    await asyncio.sleep(0)
+                log_exception.assert_called_once_with(
+                    "[Feishu] Background inbound processing failed"
+                )
+            finally:
+                loop.set_exception_handler(previous_handler)
+            return loop_errors
+
+        loop_errors = asyncio.run(_run())
+
+        adapter._handle_message_with_guards.assert_awaited_once()
+        self.assertEqual(loop_errors, [])
+
     @patch.dict(os.environ, {}, clear=True)
     def test_media_batch_merges_rapid_photo_messages(self):
         from gateway.config import PlatformConfig


### PR DESCRIPTION
﻿## Summary

Fixes #58425.

Feishu text/media batch flushes are scheduled as background asyncio tasks. If a delayed flush reaches the dispatch path and that dispatch raises, the task could finish with an unconsumed exception.

This PR attaches the existing Feishu background-failure logger to scheduled batch flush tasks, and treats task cancellation as a quiet outcome so normal rescheduling/disconnect cancellation does not become noisy.

## Changes

- Attach `_log_background_failure` to Feishu scheduled batch flush tasks.
- Ignore `asyncio.CancelledError` and `concurrent.futures.CancelledError` in the shared background failure logger.
- Add a regression test that forces a scheduled text-batch flush to raise during dispatch and verifies the exception is logged/consumed instead of reaching the event loop exception handler.

## Tests

- `uv run --extra dev python -m py_compile plugins\platforms\feishu\adapter.py tests\gateway\test_feishu.py`
- `uv run --extra dev pytest tests\gateway\test_feishu.py -k "test_text_batch_flush_task_consumes_dispatch_errors" -q`
- `uv run --extra dev pytest tests\gateway\test_text_batching.py -k "Feishu" -q`

Note: on this Windows machine, the older constructor-based Feishu batch tests that clear the entire environment can fail before assertions because `Path.home()` cannot resolve a home directory after `os.environ` is emptied. The new regression uses a minimal adapter fixture and the existing `test_text_batching.py` Feishu fixture path passed.
