### PR TITLE
fix(kanban): validate --tail > 0 and preserve complete first line on log tail (#58411)

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -728,8 +728,13 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="Print the worker log for a task (from <kanban-root>/kanban/logs/)",
     )
     p_log.add_argument("task_id")
-    p_log.add_argument("--tail", type=int, default=None,
-                       help="Only print the last N bytes")
+    def _positive_tail(value):
+        v = int(value)
+        if v <= 0:
+            raise argparse.ArgumentTypeError("--tail must be > 0")
+        return v
+    p_log.add_argument("--tail", type=_positive_tail, default=None,
+                       help="Only print the last N bytes (must be > 0)")
 
     # --- runs (per-attempt history for a task) ---
     p_runs = sub.add_parser(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8522,6 +8522,11 @@ def read_worker_log(
             if size > tail_bytes:
                 f.seek(size - tail_bytes)
                 # Skip a partial line if we tailed mid-line. But if the
+                # If seek landed at a newline, readline() would discard
+                # a complete first line. Peek past it (#58411).
+                if f.peek(1)[:1] == b'\n':
+                    f.read(1)
+
                 # window has no newline at all (one giant log line),
                 # readline() would eat everything — in that case don't
                 # skip and return the raw tail.


### PR DESCRIPTION
Closes #58411

## Summary

Two fixes for `hermes kanban log --tail`:

1. **CLI validation**: --tail now rejects non-positive values (0, -1, etc.) with a clear ArgumentTypeError instead of silently returning an empty log.

2. **Line boundary**: when seeking into the tail window lands exactly at a newline (0x0A), peek and advance past it so readline() doesn't discard the complete first line as if it were a mid-line partial.

## Files

- `hermes_cli/kanban.py` — `_positive_tail` type validator +6/-1
- `hermes_cli/kanban_db.py` — newline guard in `read_worker_log()` +6/-1