### PR TITLE
fix: case-insensitive provider matching in model picker

### DIFF
--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -202,7 +202,9 @@ function ModelResults({
               </div>
             )}
             {models.map(model => {
-              const isCurrent = model === currentModel && provider.slug === currentProvider
+              const isCurrent =
+                model === currentModel &&
+                normalize(provider.slug) === normalize(currentProvider)
               const price = provider.pricing?.[model]
               const locked = unavailable.has(model)
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1526,6 +1526,11 @@ def list_authenticated_providers(
     results: List[dict] = []
     seen_slugs: set = set()  # lowercase-normalized to catch case variants (#9545)
     seen_mdev_ids: set = set()  # prevent duplicate entries for aliases (e.g. kimi-coding + kimi-coding-cn)
+    # Normalised current provider for case-insensitive is_current matching.
+    # custom_provider_slug() lowercases the name, but model.provider in
+    # config.yaml may use mixed case (e.g. "custom:My-Provider"). Without
+    # this, a custom provider row's is_current check fails and the picker
+    # cannot reliably show or select the configured provider. (#58393)
     _current_provider_norm = str(current_provider or "").strip().lower()
     _current_base_url_norm = str(current_base_url or "").strip().rstrip("/").lower()
 
@@ -1725,7 +1730,7 @@ def list_authenticated_providers(
         results.append({
             "slug": slug,
             "name": display_name,
-            "is_current": slug == current_provider or mdev_id == current_provider,
+            "is_current": slug.lower() == _current_provider_norm or mdev_id == current_provider,
             "is_user_defined": False,
             "models": top,
             "total_models": total,
@@ -1887,7 +1892,7 @@ def list_authenticated_providers(
         results.append({
             "slug": hermes_slug,
             "name": get_label(hermes_slug),
-            "is_current": hermes_slug == current_provider or pid == current_provider,
+            "is_current": hermes_slug.lower() == _current_provider_norm or pid == current_provider,
             "is_user_defined": False,
             "models": top,
             "total_models": total,
@@ -1962,7 +1967,7 @@ def list_authenticated_providers(
         results.append({
             "slug": _cp.slug,
             "name": _cp.label,
-            "is_current": _cp.slug == current_provider,
+            "is_current": _cp.slug.lower() == _current_provider_norm,
             "is_user_defined": False,
             "models": _cp_top,
             "total_models": _cp_total,


### PR DESCRIPTION
Fixes #58393

## Description

Custom OpenAI-compatible providers configured with `model.provider: custom:<name>` could not be reliably shown or selected in the Desktop model picker when the configured provider name used mixed case (e.g. `custom:My-Provider`).

The root cause was a case-sensitivity mismatch: `custom_provider_slug()` lowercases the provider name to produce the picker row slug (e.g. `custom:my-provider`), but `model.provider` from `config.yaml` is passed raw to `list_authenticated_providers()`. The `is_current` comparison `slug == current_provider` failed when casing differed, causing:

1. The custom provider row to not be marked as current (so it wasn't sorted first in the picker)
2. The "surface current model" post-pass to skip the row (the current model wasn't injected)
3. The frontend's highlight check (`provider.slug === currentProvider`) to also fail

The fix normalises `current_provider` to lowercase once at the top of `list_authenticated_providers()` and uses it for all `is_current` comparisons across sections 1, 2, 2b, 3, and 4. The frontend model picker now also uses `normalize()` (trim + lowercase) for the `isCurrent` comparison.

## Verification

- Python compilation check passed for `hermes_cli/model_switch.py`
- `tests/gateway/test_model_command_custom_providers.py` — 2 passed
- `tests/tui_gateway/test_custom_provider_session_persistence.py` — 14 passed
- `tests/hermes_cli/test_model_switch_context_display.py` — passed
- `tests/hermes_cli/test_runtime_provider_resolution.py` — passed
- TypeScript typecheck passed for `apps/desktop`
- Pre-existing test failure in `test_current_custom_endpoint_passthrough_marks_current_row` confirmed on unmodified main (live Ollama discovery, unrelated)