### PR TITLE
fix(codex): recover app-server text without completion

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -604,6 +604,19 @@ class CodexAppServerSession:
                                 f"turn ended status={turn_status}", err_msg
                             )
 
+        if (
+            not turn_complete
+            and not result.interrupted
+            and result.final_text
+            and result.error is None
+        ):
+            logger.warning(
+                "codex app-server turn reached deadline after a completed "
+                "assistant message but before turn/completed; accepting "
+                "the assistant text as the terminal response"
+            )
+            turn_complete = True
+
         if not turn_complete and not result.interrupted:
             # Hit the deadline. Issue interrupt to stop wasted compute, and
             # tell the caller to retire the session — a turn that never

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -728,6 +728,33 @@ class TestSessionRetirement:
         r = s.run_turn("hi", turn_timeout=1.0)
         assert r.should_retire is False
 
+    def test_final_agent_message_without_turn_completed_is_recovered(self):
+        """A completed assistant item is still a usable terminal response when
+        codex omits turn/completed and then goes quiet.
+        """
+        client = FakeClient()
+        client.queue_notification(
+            "item/completed",
+            item={"type": "agentMessage", "id": "m1", "text": "done"},
+            threadId="t",
+            turnId="tu1",
+        )
+        s = make_session(client)
+        r = s.run_turn(
+            "hi",
+            turn_timeout=0.05,
+            notification_poll_timeout=0.01,
+        )
+        assert r.final_text == "done"
+        assert r.interrupted is False
+        assert r.error is None
+        assert r.should_retire is False
+        assert any(
+            msg["role"] == "assistant" and msg.get("content") == "done"
+            for msg in r.projected_messages
+        )
+        assert not any(method == "turn/interrupt" for method, _ in client.requests)
+
     def test_post_tool_quiet_watchdog_trips_and_retires(self):
         client = FakeClient()
         # One tool completion, then total silence — no further events,


### PR DESCRIPTION
﻿Fixes #58432

## Summary

- accept a completed Codex app-server assistant message as the terminal result when the turn deadline arrives without `turn/completed`
- keep the existing timeout/interrupt/retire path for turns that never produced assistant text or already reported an error
- add regression coverage for the missing-completion path

## Why

`CodexAppServerSession.run_turn()` already records completed `agentMessage` items into `result.final_text` and `projected_messages`. If the subprocess omits `turn/completed` afterward, the previous deadline path still marked the turn as interrupted and timed out, losing the successful completion state.

## Proof

- `uv run --extra dev python -m py_compile agent\transports\codex_app_server_session.py tests\agent\transports\test_codex_app_server_session.py`
- `$env:TMP='F:\Codex\tmp\pytest-hermes'; $env:TEMP='F:\Codex\tmp\pytest-hermes'; uv run --extra dev pytest tests\agent\transports\test_codex_app_server_session.py -k "final_agent_message_without_turn_completed or deadline_marks_session_for_retirement or post_tool_quiet_watchdog or turn_aborted_marker" -q` -> `4 passed, 55 deselected`
- `$env:TMP='F:\Codex\tmp\pytest-hermes'; $env:TEMP='F:\Codex\tmp\pytest-hermes'; uv run --extra dev pytest tests\agent\transports\test_codex_app_server_session.py -q` -> `59 passed`

## Duplicate search

Checked open and closed Hermes PRs/issues for `codex app-server missing turn completed final response`, `codex app-server turn completed timeout assistant`, `turn/completed codex final_text`, and `turn timed out after codex final_text`. Existing matches were older Codex Responses stream issues, not this app-server session completion path.
