### PR TITLE
fix(compression): skip auto-lower when aux context comes from user override (#58407)

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -264,7 +264,19 @@ def check_compression_model_feasibility(agent: Any) -> None:
             )
 
         threshold = agent.context_compressor.threshold_tokens
-        if aux_context < threshold:
+        # Only auto-lower when the detected model context is genuinely
+        # smaller than the threshold — not when the user explicitly
+        # configured `auxiliary.compression.context_length`.  A
+        # user override is a deliberate choice; silently re-deriving
+        # the threshold from it causes compression to fire on almost
+        # every turn in long-running sessions (#58407).
+        user_override = getattr(
+            agent, "_aux_compression_context_length_config", None
+        )
+        if (
+            aux_context < threshold
+            and (user_override is None or user_override != aux_context)
+        ):
             # Auto-correct: lower the live session threshold so
             # compression actually works this session.  The hard floor
             # above guarantees aux_context >= MINIMUM_CONTEXT_LENGTH,

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -504,3 +504,82 @@ def test_run_conversation_clears_warning_after_replay(mock_get_client, mock_ctx_
         agent._compression_warning = None
 
     assert len(callback_events) == 0
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=128_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_no_auto_lower_when_user_configured_context_length(mock_get_client, mock_ctx_len):
+    """When auxiliary.compression.context_length is set by the user,
+    the detected aux_context comes from the user override — NOT from
+    model probing.  Auto-lowering the threshold based on a value the
+    user deliberately chose causes compression to fire on nearly every
+    turn (#58407).  The auto-lower must only fire when the context
+    comes from real model detection."""
+    agent = _make_agent(main_context=200_000, threshold_percent=0.80)
+    # threshold = 160,000 — aux would be 128,000 (below threshold)
+    agent._aux_compression_context_length_config = 128_000
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "sk-aux"
+    mock_get_client.return_value = (mock_client, "deepseek/deepseek-v4-flash")
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+
+    agent._check_compression_model_feasibility()
+
+    # No warning emitted — auto-lower must not fire
+    assert len(messages) == 0
+    assert agent._compression_warning is None
+    # Threshold stays at the original value, NOT lowered to 128,000
+    assert agent.context_compressor.threshold_tokens == 160_000
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=128_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_no_auto_lower_preserves_original_warning_message(mock_get_client, mock_ctx_len):
+    """The auto-lower warning is a user-visible status message.  When
+    the user configured a context_length override, no warning should
+    be emitted at all — the session should operate silently."""
+    agent = _make_agent(main_context=200_000, threshold_percent=0.75)
+    # threshold = 150,000
+    agent._aux_compression_context_length_config = 128_000
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "sk-aux"
+    mock_get_client.return_value = (mock_client, "deepseek/deepseek-v4-flash")
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+    agent._check_compression_model_feasibility()
+
+    assert len(messages) == 0, (
+        f"expected no status messages when user override is set, got: {messages}"
+    )
+    assert agent._compression_warning is None
+    # _emit_status should not have been called with any auto-lower message
+    assert not any("Auto-lowered" in m for m in messages)
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=80_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_auto_lower_still_fires_when_no_user_override(mock_get_client, mock_ctx_len):
+    """Regression guard: when no user-configured context_length exists,
+    auto-lower must continue to fire for genuinely small aux models.
+    This is the original behaviour and must not regress (#58407)."""
+    agent = _make_agent(main_context=200_000, threshold_percent=0.85)
+    # threshold = 170,000 — aux has 80,000
+    agent._aux_compression_context_length_config = None
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "sk-aux"
+    mock_get_client.return_value = (mock_client, "google/gemini-3-flash-preview")
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+    agent._check_compression_model_feasibility()
+
+    assert len(messages) == 1
+    assert "Auto-lowered" in messages[0]
+    assert agent._compression_warning is not None
+    assert agent.context_compressor.threshold_tokens == 80_000


### PR DESCRIPTION
Closes #58407

## Summary

When `auxiliary.compression.context_length` is set in config.yaml, `_check_compression_model_feasibility()` silently lowers the session's compression threshold to match that user-configured value. This causes compression to fire on nearly every turn in long-running sessions.

**Reproduced on main:** a session with ~734 messages using deepseek-v4-flash (context_length=128000) with main model threshold=400000 (800000 * 0.50). The agent log showed:

```
Auxiliary compression model deepseek-v4-flash has 128000 token context,
below the main model's compression threshold of 400000 tokens ---
auto-lowered session threshold to 128000 to keep compression working.
```

After lowering, the session compressed on almost every turn, burning tokens and degrading throughput.

## Root Cause

`agent/conversation_compression.py` line 267-279:

1. `get_model_context_length()` receives `config_context_length=128000` and returns it immediately (user knows best)
2. `aux_context (128000) < threshold (400000)` → auto-lower fires
3. Threshold becomes 128000 → every turn triggers compression

The auto-lower is designed for genuinely-small detected model contexts, **not** user-configured overrides. A user who sets `auxiliary.compression.context_length` deliberately chose that value — it should not silently change compression frequency.

## Changes

**`agent/conversation_compression.py`** (+11/-1):
- Guard the auto-lower: skip when `aux_context` came from a user-configured `_aux_compression_context_length_config` override
- The auto-lower still fires when no user override exists (original behavior preserved)

**`tests/run_agent/test_compression_feasibility.py`** (+81 lines, 3 new tests):
- `test_no_auto_lower_when_user_configured_context_length` — threshold stays at original, no warning emitted
- `test_no_auto_lower_preserves_original_warning_message` — no Auto-lowered message when override set
- `test_auto_lower_still_fires_when_no_user_override` — regression guard: original behavior preserved

## Verification

```
python -m pytest tests/run_agent/test_compression_feasibility.py -x -q
20 passed in 3.57s
```

All 17 existing compression tests pass unchanged — the fix only adds guard logic for the user-override path.