### PR TITLE
fix(gateway): improve Telegram auto-TTS replies

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2384,8 +2384,10 @@ class BasePlatformAdapter(ABC):
         # (``voice.auto_tts`` in config.yaml, pushed by GatewayRunner on connect).
         # Per-chat overrides live in two sets populated from ``_voice_mode``:
         #   - ``_auto_tts_enabled_chats``: chat explicitly opted in via ``/voice on``
-        #     or ``/voice tts`` (mode is ``voice_only`` or ``all``). Fires even when
-        #     the global default is False.
+        #     or ``/voice tts`` (mode is ``voice_only`` or ``all``). Fires for
+        #     Telegram voice-message input even when the global default is False.
+        #   - ``_auto_tts_all_chats``: chat explicitly opted in via ``/voice tts``
+        #     (mode is ``all``). Fires for any input type, including dictated text.
         #   - ``_auto_tts_disabled_chats``: chat explicitly opted out via
         #     ``/voice off`` (mode is ``off``). Suppresses auto-TTS even when the
         #     global default is True.
@@ -2394,6 +2396,7 @@ class BasePlatformAdapter(ABC):
         #     OR (_auto_tts_default and chat not in _auto_tts_disabled_chats)
         self._auto_tts_default: bool = False
         self._auto_tts_enabled_chats: set = set()
+        self._auto_tts_all_chats: set = set()
         self._auto_tts_disabled_chats: set = set()
         # Chats where typing indicator is paused (e.g. during approval waits).
         # _keep_typing skips send_typing when the chat_id is in this set.
@@ -4949,55 +4952,60 @@ class BasePlatformAdapter(ABC):
                 # thread-strict.
                 _final_thread_metadata = _mark_notify_metadata(_thread_metadata)
 
-                # Auto-TTS: if voice message, generate audio FIRST (before sending text)
+                # Auto-TTS: generate audio FIRST (before sending text).
                 # Gated via ``_should_auto_tts_for_chat``: fires when the chat has
                 # an explicit ``/voice on|tts`` opt-in OR when ``voice.auto_tts`` is
-                # True globally and no ``/voice off`` has been issued.
+                # True globally and no ``/voice off`` has been issued. ``/voice tts``
+                # additionally speaks typed/dictated text replies; ``/voice on`` stays
+                # voice-message-only.
                 _tts_path = None
+                _auto_tts_any_input = event.source.chat_id in getattr(self, "_auto_tts_all_chats", set())
                 if (self._should_auto_tts_for_chat(event.source.chat_id)
-                        and event.message_type == MessageType.VOICE
+                        and (event.message_type == MessageType.VOICE or _auto_tts_any_input)
                         and text_content
                         and not media_files):
                     try:
-                        from tools.tts_tool import text_to_speech_tool, check_tts_requirements
+                        from tools.tts_tool import text_to_speech_tool, check_tts_requirements, _convert_to_opus
                         if check_tts_requirements():
                             import json as _json
-                            speech_text = self.prepare_tts_text(text_content)
+                            # Auto-TTS must speak the same final text payload that
+                            # is sent to the chat. No summaries, no alternate draft,
+                            # no markdown-stripping rewrite, no gateway-side truncation.
+                            speech_text = text_content
                             if not speech_text:
-                                raise ValueError("Empty text after markdown cleanup")
+                                raise ValueError("Empty text for TTS")
                             tts_result_str = await asyncio.to_thread(
                                 text_to_speech_tool, text=speech_text
                             )
                             tts_data = _json.loads(tts_result_str)
                             _tts_path = tts_data.get("file_path")
+                            # Telegram's Bot API renders .ogg/.opus via sendVoice
+                            # (proper voice bubble). .mp3/.m4a goes through sendAudio,
+                            # which Telegram treats like a playlist and auto-continues
+                            # into prior tracks. Force auto-TTS replies to Opus here
+                            # instead of relying on session-env detection inside the
+                            # TTS tool's background thread.
+                            if (
+                                self.platform == Platform.TELEGRAM
+                                and _tts_path
+                                and not str(_tts_path).lower().endswith((".ogg", ".opus"))
+                            ):
+                                _original_tts_path = _tts_path
+                                _opus_path = await asyncio.to_thread(_convert_to_opus, _tts_path)
+                                if _opus_path:
+                                    _tts_path = _opus_path
+                                    try:
+                                        os.remove(_original_tts_path)
+                                    except OSError:
+                                        pass
                     except Exception as tts_err:
                         logger.warning("[%s] Auto-TTS failed: %s", self.name, tts_err)
 
-                # Play TTS audio before text (voice-first experience)
+                # Defer TTS until after text delivery so Telegram shows the play
+                # button below the readable reply. Do not use Telegram captions here:
+                # captions place the audio control above the text, which is bad for
+                # hands-busy/driving use.
                 _tts_caption_delivered = False
-                if _tts_path and Path(_tts_path).exists():
-                    try:
-                        telegram_tts_caption = None
-                        if (
-                            self.platform == Platform.TELEGRAM
-                            and text_content
-                            and text_content[:1024] == text_content
-                        ):
-                            telegram_tts_caption = text_content
-                        tts_result = await self.play_tts(
-                            chat_id=event.source.chat_id,
-                            audio_path=_tts_path,
-                            caption=telegram_tts_caption,
-                            metadata=_final_thread_metadata,
-                        )
-                        _tts_caption_delivered = bool(
-                            telegram_tts_caption and getattr(tts_result, "success", False)
-                        )
-                    finally:
-                        try:
-                            os.remove(_tts_path)
-                        except OSError:
-                            pass
 
                 # Send the text portion
                 if text_content and not _tts_caption_delivered:
@@ -5025,6 +5033,22 @@ class BasePlatformAdapter(ABC):
                             message_id=result.message_id,
                             ttl_seconds=_ephemeral_ttl,
                         )
+
+                # Send TTS audio after text, as a separate voice/audio bubble.
+                if _tts_path and Path(_tts_path).exists():
+                    try:
+                        tts_result = await self.play_tts(
+                            chat_id=event.source.chat_id,
+                            audio_path=_tts_path,
+                            caption=None,
+                            metadata=_final_thread_metadata,
+                        )
+                        _record_delivery(tts_result)
+                    finally:
+                        try:
+                            os.remove(_tts_path)
+                        except OSError:
+                            pass
 
                 # Human-like pacing delay between text and media
                 human_delay = self._get_human_delay()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3151,33 +3151,53 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             enabled_chats = getattr(adapter, "_auto_tts_enabled_chats", None)
             if isinstance(enabled_chats, set):
                 enabled_chats.discard(chat_id)
+            all_chats = getattr(adapter, "_auto_tts_all_chats", None)
+            if isinstance(all_chats, set):
+                all_chats.discard(chat_id)
         else:
             disabled_chats.discard(chat_id)
 
-    def _set_adapter_auto_tts_enabled(self, adapter, chat_id: str, enabled: bool) -> None:
+    def _set_adapter_auto_tts_enabled(
+        self,
+        adapter,
+        chat_id: str,
+        enabled: bool,
+        *,
+        all_inputs: bool = False,
+    ) -> None:
         """Update an adapter's per-chat auto-TTS opt-in set if present.
 
         Used for ``/voice on``/``/voice tts`` where the user explicitly wants
-        auto-TTS even when ``voice.auto_tts`` is False globally.
+        auto-TTS even when ``voice.auto_tts`` is False globally. ``all_inputs``
+        tracks the stronger ``/voice tts`` mode, which also speaks typed text.
         """
         enabled_chats = getattr(adapter, "_auto_tts_enabled_chats", None)
         if not isinstance(enabled_chats, set):
             return
+        all_chats = getattr(adapter, "_auto_tts_all_chats", None)
         if enabled:
             enabled_chats.add(chat_id)
+            if isinstance(all_chats, set):
+                if all_inputs:
+                    all_chats.add(chat_id)
+                else:
+                    all_chats.discard(chat_id)
             # An explicit opt-in clears any stale /voice off for this chat.
             disabled_chats = getattr(adapter, "_auto_tts_disabled_chats", None)
             if isinstance(disabled_chats, set):
                 disabled_chats.discard(chat_id)
         else:
             enabled_chats.discard(chat_id)
+            if isinstance(all_chats, set):
+                all_chats.discard(chat_id)
 
     def _sync_voice_mode_state_to_adapter(self, adapter) -> None:
         """Restore persisted /voice state into a live platform adapter.
 
-        Populates three fields from config + ``self._voice_mode``:
+        Populates adapter fields from config + ``self._voice_mode``:
           - ``_auto_tts_default``: global default from ``voice.auto_tts``
           - ``_auto_tts_enabled_chats``: chats with mode ``voice_only``/``all``
+          - ``_auto_tts_all_chats``: chats with mode ``all``
           - ``_auto_tts_disabled_chats``: chats with mode ``off``
         """
         platform = getattr(adapter, "platform", None)
@@ -3186,7 +3206,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         disabled_chats = getattr(adapter, "_auto_tts_disabled_chats", None)
         enabled_chats = getattr(adapter, "_auto_tts_enabled_chats", None)
-        if not isinstance(disabled_chats, set) and not isinstance(enabled_chats, set):
+        all_chats = getattr(adapter, "_auto_tts_all_chats", None)
+        if (
+            not isinstance(disabled_chats, set)
+            and not isinstance(enabled_chats, set)
+            and not isinstance(all_chats, set)
+        ):
             return
 
         # Push the global voice.auto_tts default (config.yaml) onto the adapter.
@@ -3214,6 +3239,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             enabled_chats.update(
                 key[len(prefix):] for key, mode in self._voice_mode.items()
                 if mode in {"voice_only", "all"} and key.startswith(prefix)
+            )
+        if isinstance(all_chats, set):
+            all_chats.clear()
+            all_chats.update(
+                key[len(prefix):] for key, mode in self._voice_mode.items()
+                if mode == "all" and key.startswith(prefix)
             )
 
     async def _safe_adapter_disconnect(self, adapter, platform) -> None:
@@ -12351,7 +12382,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 adapter._voice_sources[guild_id] = event.source.to_dict()
             self._voice_mode[self._voice_key(event.source.platform, event.source.chat_id)] = "all"
             self._save_voice_modes()
-            self._set_adapter_auto_tts_enabled(adapter, event.source.chat_id, enabled=True)
+            self._set_adapter_auto_tts_enabled(
+                adapter,
+                event.source.chat_id,
+                enabled=True,
+                all_inputs=True,
+            )
             return (
                 f"Joined voice channel **{voice_channel.name}**.\n"
                 f"I'll speak my replies and listen to you. Use /voice leave to disconnect."

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2438,7 +2438,7 @@ class GatewaySlashCommandsMixin:
             self._voice_mode[voice_key] = "voice_only"
             self._save_voice_modes()
             if adapter:
-                self._set_adapter_auto_tts_enabled(adapter, chat_id, enabled=True)
+                self._set_adapter_auto_tts_enabled(adapter, chat_id, enabled=True, all_inputs=False)
             return t("gateway.voice.enabled_voice_only")
         elif args in {"off", "disable"}:
             self._voice_mode[voice_key] = "off"
@@ -2450,7 +2450,7 @@ class GatewaySlashCommandsMixin:
             self._voice_mode[voice_key] = "all"
             self._save_voice_modes()
             if adapter:
-                self._set_adapter_auto_tts_enabled(adapter, chat_id, enabled=True)
+                self._set_adapter_auto_tts_enabled(adapter, chat_id, enabled=True, all_inputs=True)
             return t("gateway.voice.tts_enabled")
         elif args in {"channel", "join"}:
             return await self._handle_voice_channel_join(event)
@@ -2486,7 +2486,7 @@ class GatewaySlashCommandsMixin:
                 self._voice_mode[voice_key] = "voice_only"
                 self._save_voice_modes()
                 if adapter:
-                    self._set_adapter_auto_tts_enabled(adapter, chat_id, enabled=True)
+                    self._set_adapter_auto_tts_enabled(adapter, chat_id, enabled=True, all_inputs=False)
                 toggle_line = t("gateway.voice.enabled_short")
             else:
                 self._voice_mode[voice_key] = "off"

--- a/tests/gateway/test_telegram_voice_v0_regressions.py
+++ b/tests/gateway/test_telegram_voice_v0_regressions.py
@@ -99,6 +99,7 @@ async def test_voice_tts_is_explicit_audio_reply_opt_in():
     adapter = SimpleNamespace(
         _auto_tts_disabled_chats=set(),
         _auto_tts_enabled_chats=set(),
+        _auto_tts_all_chats=set(),
     )
     runner = _runner(adapter)
     runner._voice_mode = {}
@@ -114,4 +115,5 @@ async def test_voice_tts_is_explicit_audio_reply_opt_in():
 
     assert runner._voice_mode["telegram:12345"] == "all"
     assert "12345" in adapter._auto_tts_enabled_chats
+    assert "12345" in adapter._auto_tts_all_chats
     assert result

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -196,6 +196,7 @@ class TestHandleVoiceCommand:
             _auto_tts_default=False,
             _auto_tts_disabled_chats=set(),
             _auto_tts_enabled_chats=set(),
+            _auto_tts_all_chats=set(),
             platform=Platform.TELEGRAM,
         )
 
@@ -203,6 +204,45 @@ class TestHandleVoiceCommand:
 
         assert adapter._auto_tts_disabled_chats == {"off_chat"}
         assert adapter._auto_tts_enabled_chats == {"on_chat", "tts_chat"}
+        assert adapter._auto_tts_all_chats == {"tts_chat"}
+
+    @pytest.mark.asyncio
+    async def test_voice_tts_updates_live_all_inputs_set(self, runner):
+        from gateway.config import Platform
+
+        adapter = SimpleNamespace(
+            _auto_tts_disabled_chats=set(),
+            _auto_tts_enabled_chats=set(),
+            _auto_tts_all_chats=set(),
+            platform=Platform.TELEGRAM,
+        )
+        runner.adapters[Platform.TELEGRAM] = adapter
+        event = _make_event("/voice tts")
+        event.source.platform = Platform.TELEGRAM
+
+        await runner._handle_voice_command(event)
+
+        assert adapter._auto_tts_enabled_chats == {"123"}
+        assert adapter._auto_tts_all_chats == {"123"}
+
+    @pytest.mark.asyncio
+    async def test_voice_on_clears_stale_all_inputs_set(self, runner):
+        from gateway.config import Platform
+
+        adapter = SimpleNamespace(
+            _auto_tts_disabled_chats=set(),
+            _auto_tts_enabled_chats=set(),
+            _auto_tts_all_chats={"123"},
+            platform=Platform.TELEGRAM,
+        )
+        runner.adapters[Platform.TELEGRAM] = adapter
+        event = _make_event("/voice on")
+        event.source.platform = Platform.TELEGRAM
+
+        await runner._handle_voice_command(event)
+
+        assert adapter._auto_tts_enabled_chats == {"123"}
+        assert adapter._auto_tts_all_chats == set()
 
     def test_sync_pushes_config_default_onto_adapter(self, runner, monkeypatch):
         """Issue #16007: ``voice.auto_tts`` must propagate to ``_auto_tts_default``."""


### PR DESCRIPTION
## Summary
- speak the exact delivered reply text for gateway auto-TTS instead of a markdown-stripped/truncated variant
- track /voice tts as an all-input opt-in immediately on live adapters
- send Telegram auto-TTS as a separate post-text voice/audio bubble and force Opus when needed

## Test Plan
- scripts/run_tests.sh tests/gateway/test_voice_command.py tests/gateway/test_telegram_voice_v0_regressions.py