### PR TITLE
feat: add alibaba-cn provider for China DashScope endpoint

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -166,6 +166,7 @@ PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "minimax-cn": "minimax-cn",
     "deepseek": "deepseek",
     "alibaba": "alibaba",
+    "alibaba-cn": "alibaba-cn",
     "qwen-oauth": "alibaba",
     "copilot": "github-copilot",
     "ai-gateway": "vercel",

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -368,12 +368,20 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("DASHSCOPE_API_KEY",),
         base_url_env_var="DASHSCOPE_BASE_URL",
     ),
+    "alibaba-cn": ProviderConfig(
+        id="alibaba-cn",
+        name="Alibaba (China)",
+        auth_type="api_key",
+        inference_base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        api_key_env_vars=("DASHSCOPE_API_KEY",),
+        base_url_env_var="DASHSCOPE_BASE_URL",
+    ),
     "alibaba-coding-plan": ProviderConfig(
         id="alibaba-coding-plan",
         name="Alibaba Cloud (Coding Plan)",
         auth_type="api_key",
         inference_base_url="https://coding-intl.dashscope.aliyuncs.com/v1",
-        api_key_env_vars=("ALIBABA_CODING_PLAN_API_KEY", "DASHSCOPE_API_KEY"),
+        api_key_env_vars=("ALIBABA_CODING_PLAN_API_KEY",),
         base_url_env_var="ALIBABA_CODING_PLAN_BASE_URL",
     ),
     "minimax-cn": ProviderConfig(

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1121,6 +1121,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("openai-codex",   "OpenAI Codex",             "OpenAI Codex (Codex CLI via ChatGPT subscription or API key)"),
     ProviderEntry("openai-api",     "OpenAI API",               "OpenAI API (api.openai.com, API key)"),
     ProviderEntry("alibaba",        "Qwen Cloud",               "Qwen Cloud / DashScope (Qwen + multi-provider)"),
+    ProviderEntry("alibaba-cn",     "Alibaba (China)",          "Qwen Cloud / DashScope China (Qwen + multi-provider)"),
     ProviderEntry("xai-oauth",      "xAI Grok OAuth (SuperGrok / Premium+)", "xAI Grok OAuth (SuperGrok / Premium+ subscription)"),
     ProviderEntry("xiaomi",         "Xiaomi MiMo",              "Xiaomi MiMo (MiMo-V2.5 and V2 models: pro, omni, flash)"),
     ProviderEntry("tencent-tokenhub", "Tencent TokenHub",       "Tencent TokenHub (Hy3 Preview via tokenhub.tencentmaas.com)"),
@@ -1314,6 +1315,8 @@ _PROVIDER_ALIASES = {
     "aci": "actual",
     "minimax-china": "minimax-cn",
     "minimax_cn": "minimax-cn",
+    "alibaba-china": "alibaba-cn",
+    "alibaba_cn": "alibaba-cn",
     "minimax-portal": "minimax-oauth",
     "minimax-global": "minimax-oauth",
     "minimax_oauth": "minimax-oauth",
@@ -2732,6 +2735,8 @@ _MODELS_DEV_PREFERRED: frozenset[str] = frozenset({
     "zai",
     "gemini",
     "google",
+    "alibaba",
+    "alibaba-cn",
 })
 
 

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -138,6 +138,10 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="openai_chat",
         base_url_env_var="DASHSCOPE_BASE_URL",
     ),
+    "alibaba-cn": HermesOverlay(
+        transport="openai_chat",
+        base_url_env_var="DASHSCOPE_BASE_URL",
+    ),
     "alibaba-coding-plan": HermesOverlay(
         transport="openai_chat",
         base_url_env_var="ALIBABA_CODING_PLAN_BASE_URL",
@@ -345,6 +349,8 @@ ALIASES: Dict[str, str] = {
     "aliyun": "alibaba",
     "qwen": "alibaba",
     "alibaba-cloud": "alibaba",
+    "alibaba-china": "alibaba-cn",
+    "alibaba_cn": "alibaba-cn",
     "alibaba_coding": "alibaba-coding-plan",
     "alibaba-coding": "alibaba-coding-plan",
     "alibaba_coding_plan": "alibaba-coding-plan",


### PR DESCRIPTION
## What

Add `alibaba-cn` provider for users with China-based Alibaba Bailian (百炼) API keys.
Mirrors the existing minimax / minimax-cn pattern.

models.dev already has `alibaba-cn` data (79 models including deepseek/glm/kimi)
with the correct China endpoint (`dashscope.aliyuncs.com`), but Hermes code was
missing the necessary wiring to expose it.

## Changes

- `auth.py`: register `alibaba-cn` ProviderConfig with China endpoint
- `providers.py`: add HermesOverlay and aliases
- `models_dev.py`: add PROVIDER_TO_MODELS_DEV mapping
- `models.py`: add to CANONICAL_PROVIDERS and _MODELS_DEV_PREFERRED

## Also fixes

Fix `alibaba-coding-plan` incorrectly using `DASHSCOPE_API_KEY` as fallback
(`api_key_env_vars` tuple), causing Coding Plan to appear in model picker
without its own key configured.

## Tested

- Model picker shows Alibaba (China) with 79 models
- MoA with qwen3.7-max via alibaba-cn works
- Original alibaba (intl) unaffected
- All existing tests pass
