### PR TITLE
fix(gateway): attach credential_pool to session /model overrides

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1859,6 +1859,23 @@ def _resolve_runtime_agent_kwargs_for_provider(provider: str) -> dict:
     }
 
 
+def _credential_pool_for_provider(provider: Optional[str]):
+    """Return the live credential pool for a provider id (e.g. ``custom:hyper``)."""
+    if not provider or not str(provider).strip():
+        return None
+    try:
+        return _resolve_runtime_agent_kwargs_for_provider(str(provider).strip()).get(
+            "credential_pool"
+        )
+    except Exception:
+        logger.debug(
+            "Failed to resolve credential pool for provider=%s",
+            provider,
+            exc_info=True,
+        )
+        return None
+
+
 def _try_resolve_fallback_provider() -> dict | None:
     """Attempt to resolve credentials from the fallback_model/fallback_providers config."""
     from hermes_cli.runtime_provider import resolve_runtime_provider
@@ -3655,8 +3672,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "base_url": override.get("base_url"),
                 "api_mode": override.get("api_mode"),
                 "max_tokens": override.get("max_tokens"),
+                "credential_pool": override.get("credential_pool"),
             }
             if override_runtime.get("api_key"):
+                if override_runtime.get("credential_pool") is None:
+                    override_runtime["credential_pool"] = _credential_pool_for_provider(
+                        override.get("provider")
+                    )
                 logger.debug(
                     "Session model override (fast): session=%s config_model=%s -> override_model=%s provider=%s",
                     resolved_session_key or "", model, override_model,
@@ -15264,6 +15286,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 runtime = _resolve_runtime_agent_kwargs_for_provider(provider)
                 override["api_key"] = runtime.get("api_key")
                 override["api_mode"] = runtime.get("api_mode")
+                override["credential_pool"] = runtime.get("credential_pool")
                 if not override.get("base_url"):
                     override["base_url"] = runtime.get("base_url")
             except Exception:
@@ -15293,10 +15316,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not override:
             return model, runtime_kwargs
         model = override.get("model", model)
-        for key in ("provider", "api_key", "base_url", "api_mode"):
+        for key in ("provider", "api_key", "base_url", "api_mode", "credential_pool"):
             val = override.get(key)
             if val is not None:
                 runtime_kwargs[key] = val
+        if (
+            runtime_kwargs.get("api_key")
+            and runtime_kwargs.get("credential_pool") is None
+            and override.get("provider")
+        ):
+            runtime_kwargs["credential_pool"] = _credential_pool_for_provider(
+                override.get("provider")
+            )
         return model, runtime_kwargs
 
     def _is_intentional_model_switch(self, session_key: str, agent_model: str) -> bool:

--- a/tests/gateway/test_session_model_override_credential_pool.py
+++ b/tests/gateway/test_session_model_override_credential_pool.py
@@ -1,0 +1,69 @@
+"""Session /model overrides must attach credential_pool for 402 rotation."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from gateway.run import GatewayRunner, _credential_pool_for_provider
+
+
+def test_fast_session_override_includes_credential_pool(monkeypatch):
+    runner = object.__new__(GatewayRunner)
+    runner._session_model_overrides = {
+        "sess-1": {
+            "model": "kimi-k2.7",
+            "provider": "custom:hyper",
+            "api_key": "sk-test",
+            "base_url": "https://hyper.charm.land/v1",
+            "api_mode": "chat_completions",
+        },
+    }
+    fake_pool = object()
+
+    monkeypatch.setattr(
+        "gateway.run._resolve_gateway_model",
+        lambda _uc=None: "default-model",
+    )
+    monkeypatch.setattr(
+        "gateway.run._credential_pool_for_provider",
+        lambda provider: fake_pool if provider == "custom:hyper" else None,
+    )
+
+    model, runtime = runner._resolve_session_agent_runtime(session_key="sess-1")
+
+    assert model == "kimi-k2.7"
+    assert runtime.get("credential_pool") is fake_pool
+
+
+def test_apply_session_override_backfills_credential_pool(monkeypatch):
+    runner = object.__new__(GatewayRunner)
+    fake_pool = MagicMock(name="pool")
+    runner._session_model_overrides = {
+        "sess-2": {
+            "model": "kimi-k2.7",
+            "provider": "custom:hyper",
+            "api_key": "sk-test",
+        },
+    }
+    monkeypatch.setattr(
+        "gateway.run._credential_pool_for_provider",
+        lambda provider: fake_pool,
+    )
+
+    model, runtime = runner._apply_session_model_override(
+        "sess-2",
+        "default-model",
+        {"api_key": "old", "provider": "x"},
+    )
+
+    assert model == "kimi-k2.7"
+    assert runtime["credential_pool"] is fake_pool
+
+
+def test_credential_pool_for_provider_delegates(monkeypatch):
+    sentinel = object()
+    monkeypatch.setattr(
+        "gateway.run._resolve_runtime_agent_kwargs_for_provider",
+        lambda p: {"credential_pool": sentinel, "provider": p},
+    )
+    assert _credential_pool_for_provider("custom:hyper") is sentinel


### PR DESCRIPTION
### What does this PR do?

When a gateway session uses `/model` (or a persisted per-session override), the runner builds a fresh agent with credentials from the override. That path copied `api_key`, `base_url`, and `provider` but omitted `credential_pool`, so `recover_with_credential_pool` no-oped and multi-key pools (including `custom:<name>` providers in `auth.json`) did not rotate on HTTP 402/429.

This PR attaches `credential_pool` on the gateway session-override paths (fast override, rehydrate, apply), reusing `_resolve_runtime_agent_kwargs_for_provider` — the same resolver already used to rehydrate `api_key`.

**Note:** #52727 fixed pool reload in `switch_model()` for in-process switches. This is a different entry path: agents reconstructed from persisted overrides without calling `switch_model()`.

### Related Issue

Fixes #25273
Addresses #16678

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

- `gateway/run.py` — pass `credential_pool` on session model override paths; backfill from provider when legacy overrides lack a stored pool
- `tests/gateway/test_session_model_override_credential_pool.py` — regression tests

### How to Test

1. Configure a `custom:` provider with a `credential_pool` in `auth.json` (2+ keys).
2. In a gateway session (e.g. Discord), `/model` to that provider.
3. Trigger billing exhaustion on the first key (HTTP 402).
4. **Before:** one failure, no rotation log, user sees billing error.
5. **After:** logs show pool mark exhausted + swap to next entry; request retries on second key.

```bash
pytest tests/gateway/test_session_model_override_credential_pool.py -q
```

### Checklist

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have searched existing issues and PRs to avoid duplicates
- [x] My PR contains only changes related to this fix
- [x] I have run the test suite and all tests pass
- [x] I have added tests that prove my fix is effective
- [x] I have tested this on Windows 11