### PR TITLE
fix(compression): prevent AttributeError crash on dict tool arguments in _summarize_tool_result (#58317)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -537,6 +537,15 @@ def _strip_historical_media(messages: List[Dict[str, Any]]) -> List[Dict[str, An
     return result if changed else messages
 
 
+def _safe_str(val, default=""):
+    """Coerce a value to str safely (#58317)."""
+    if isinstance(val, str):
+        return val
+    if val is None:
+        return default
+    return str(val)
+
+
 def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) -> str:
     """Create an informative 1-line summary of a tool call + result.
 
@@ -573,8 +582,11 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
         return f"[read_file] read {path} from line {offset} ({content_len:,} chars)"
 
     if tool_name == "write_file":
-        path = args.get("path", "?")
-        written_lines = args.get("content", "").count("\n") + 1 if args.get("content") else "?"
+        path = _safe_str(args.get("path"), "?")
+        _content = args.get("content", "")
+        if isinstance(_content, (dict, list)):
+            _content = str(_content)
+        written_lines = _content.count(chr(10)) + 1 if _content else "?"
         return f"[write_file] wrote to {path} ({written_lines} lines)"
 
     if tool_name == "search_files":
@@ -615,7 +627,10 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
         return f"[delegate_task] '{goal}' ({content_len:,} chars result)"
 
     if tool_name == "execute_code":
-        code_preview = (args.get("code") or "")[:60].replace("\n", " ")
+        _code = args.get("code", "")
+        if isinstance(_code, (dict, list)):
+            _code = str(_code)
+        code_preview = (_code or "")[:60].replace(chr(10), " ")
         if len(args.get("code", "")) > 60:
             code_preview += "..."
         return f"[execute_code] `{code_preview}` ({line_count} lines output)"
@@ -625,7 +640,7 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
         return f"[{tool_name}] name={name} ({content_len:,} chars)"
 
     if tool_name == "vision_analyze":
-        question = args.get("question", "")[:50]
+        question = _safe_str(args.get("question"), "?")[:50]
         return f"[vision_analyze] '{question}' ({content_len:,} chars)"
 
     if tool_name == "memory":

--- a/tests/run_agent/test_summarize_tool_result_dict_args.py
+++ b/tests/run_agent/test_summarize_tool_result_dict_args.py
@@ -1,0 +1,49 @@
+"""Tests for _summarize_tool_result dict coercion (#58317)."""
+import pytest
+from agent.context_compressor import _summarize_tool_result
+
+
+class TestSummarizeToolResultDictArgs:
+    def test_write_file_with_dict_content(self):
+        """write_file with content as a dict should coerce to str."""
+        args = '{"path": "/tmp/out.txt", "content": {"key": "value"}}'
+        result = _summarize_tool_result("write_file", args, "ok")
+        assert "write_file" in result
+        assert "lines" in result
+
+    def test_write_file_with_list_content(self):
+        """write_file with content as a list should coerce to str."""
+        args = '{"path": "/tmp/out.txt", "content": [1, 2, 3]}'
+        result = _summarize_tool_result("write_file", args, "ok")
+        assert "write_file" in result
+        assert "lines" in result
+
+    def test_write_file_with_string_content(self):
+        """write_file with normal string content should work unchanged."""
+        args = '{"path": "/tmp/out.txt", "content": "hello\nworld"}'
+        result = _summarize_tool_result("write_file", args, "ok")
+        assert "write_file" in result
+
+    def test_execute_code_with_dict_code(self):
+        """execute_code with code as a dict should coerce to str."""
+        args = '{"code": {"language": "python", "content": "print(1)"}}'
+        result = _summarize_tool_result("execute_code", args, "ok")
+        assert "execute_code" in result
+
+    def test_execute_code_with_string_code(self):
+        """execute_code with normal string code should work unchanged."""
+        args = '{"code": "print(1)"}'
+        result = _summarize_tool_result("execute_code", args, "ok")
+        assert "execute_code" in result
+
+    def test_vision_analyze_with_dict_question(self):
+        """vision_analyze with question as a dict should coerce to str."""
+        args = '{"question": {"text": "what is this?"}}'
+        result = _summarize_tool_result("vision_analyze", args, "ok")
+        assert "vision_analyze" in result
+
+    def test_vision_analyze_with_none_question(self):
+        """vision_analyze with missing question should use default."""
+        args = '{}'
+        result = _summarize_tool_result("vision_analyze", args, "ok")
+        assert "vision_analyze" in result


### PR DESCRIPTION
Closes #58317

## Summary

Context compression crashes with `AttributeError: 'dict' object has no attribute 'count'` when `_summarize_tool_result()` encounters a tool argument that is a dict or list instead of a string. This blocks compression entirely — the session grows past the threshold and every subsequent compression attempt hits the same crash, causing context window overflow.

**Reproduced on main:** trigger compression in a session where `write_file` content was parsed as ```json {"key": "value"}``` (dict) instead of a plain string. The crash trace:

```
File "agent/context_compressor.py", line 577, in _summarize_tool_result
    written_lines = args.get("content", "").count("\n") + 1
AttributeError: 'dict' object has no attribute 'count'
```

## Root Cause

`_summarize_tool_result()` assumed all tool arguments are strings. Three branches are affected:

1. **write_file** (line 577): `args.get("content").count()` — dict crashes
2. **execute_code** (line 618): `(args.get("code") or "")[:60]` — dict silently produces `{}` display
3. **vision_analyze** (line 628): `args.get("question", "")[:50]` — dict crashes

## Changes

**`agent/context_compressor.py`** (+16/-4):
- Add `_safe_str()` helper — coerces non-string types via `str()`, None to default
- Fix `write_file`: coerce dict/list content before `.count()`
- Fix `execute_code`: coerce dict/list code before `[:60].replace()`
- Fix `vision_analyze`: use `_safe_str` for question

**`tests/run_agent/test_summarize_tool_result_dict_args.py`** (+52 lines, 7 tests):
- Dict content → coerced correctly
- List content → coerced correctly
- String content → unchanged (no regression)
- Dict code → coerced
- String code → unchanged
- Dict question → coerced
- None question → default used

## Verification

```
python -m pytest tests/run_agent/test_compression_feasibility.py tests/run_agent/test_summarize_tool_result_dict_args.py -x -q
24 passed in 3.92s
```

All 17 existing compression tests pass unchanged.