### PR TITLE
fix(desktop): ignore prototype session map keys

### DIFF
--- a/apps/desktop/src/store/compaction.test.ts
+++ b/apps/desktop/src/store/compaction.test.ts
@@ -21,6 +21,15 @@ describe('compaction store', () => {
     expect($compactingSessions.get()).toEqual({ 'session-a': true, 'session-b': true })
   })
 
+  it('tracks session ids that collide with object prototype keys', () => {
+    setSessionCompacting('toString', true)
+
+    expect($compactingSessions.get()).toEqual({ toString: true })
+
+    $activeSessionId.set('toString')
+    expect($compactionActive.get()).toBe(true)
+  })
+
   it('exposes only the active session via the focus-scoped view', () => {
     setSessionCompacting('session-a', true)
 

--- a/apps/desktop/src/store/compaction.test.ts
+++ b/apps/desktop/src/store/compaction.test.ts
@@ -14,6 +14,15 @@ describe('compaction store', () => {
     expect($compactingSessions.get()).toEqual({ 'session-a': true, 'session-b': true })
   })
 
+  it('tracks session ids that collide with object prototype keys', () => {
+    expect(sessionCompacting('toString').get()).toBe(false)
+
+    setSessionCompacting('toString', true)
+
+    expect(Object.hasOwn($compactingSessions.get(), 'toString')).toBe(true)
+    expect(sessionCompacting('toString').get()).toBe(true)
+  })
+
   it('scopes the view to the session asked for, not whichever is active', () => {
     setSessionCompacting('session-a', true)
 

--- a/apps/desktop/src/store/compaction.ts
+++ b/apps/desktop/src/store/compaction.ts
@@ -6,12 +6,13 @@ import { $activeSessionId } from './session'
 // transcript looks like it reset; per-session so a background chat can't
 // clobber the foreground view.
 const keyFor = (sessionId: string | null | undefined): string => sessionId ?? ''
+const hasSession = (sessions: Record<string, true>, key: string): boolean => Object.hasOwn(sessions, key)
 
 export const $compactingSessions = atom<Record<string, true>>({})
 
 export const $compactionActive = computed(
   [$compactingSessions, $activeSessionId],
-  (sessions, activeId) => keyFor(activeId) in sessions
+  (sessions, activeId) => hasSession(sessions, keyFor(activeId))
 )
 
 export function setSessionCompacting(sessionId: string | null | undefined, active: boolean): void {
@@ -19,7 +20,7 @@ export function setSessionCompacting(sessionId: string | null | undefined, activ
   const sessions = $compactingSessions.get()
 
   if (active) {
-    if (key in sessions) {
+    if (hasSession(sessions, key)) {
       return
     }
 
@@ -28,7 +29,7 @@ export function setSessionCompacting(sessionId: string | null | undefined, activ
     return
   }
 
-  if (!(key in sessions)) {
+  if (!hasSession(sessions, key)) {
     return
   }
 

--- a/apps/desktop/src/store/compaction.ts
+++ b/apps/desktop/src/store/compaction.ts
@@ -4,13 +4,14 @@ import { atom, computed } from 'nanostores'
 // transcript looks like it reset; per-session so a background chat can't
 // clobber the foreground view.
 const keyFor = (sessionId: string | null | undefined): string => sessionId ?? ''
+const hasSession = (sessions: Record<string, true>, key: string): boolean => Object.hasOwn(sessions, key)
 
 export const $compactingSessions = atom<Record<string, true>>({})
 
 /** Is `sessionId` compacting? Per-session because a transcript may be a tile,
  *  and a tile must never wear the primary chat's compaction state. */
 export function sessionCompacting(sessionId: null | string) {
-  return computed($compactingSessions, sessions => keyFor(sessionId) in sessions)
+  return computed($compactingSessions, sessions => hasSession(sessions, keyFor(sessionId)))
 }
 
 export function setSessionCompacting(sessionId: string | null | undefined, active: boolean): void {
@@ -18,7 +19,7 @@ export function setSessionCompacting(sessionId: string | null | undefined, activ
   const sessions = $compactingSessions.get()
 
   if (active) {
-    if (key in sessions) {
+    if (hasSession(sessions, key)) {
       return
     }
 
@@ -27,7 +28,7 @@ export function setSessionCompacting(sessionId: string | null | undefined, activ
     return
   }
 
-  if (!(key in sessions)) {
+  if (!hasSession(sessions, key)) {
     return
   }
 

--- a/apps/desktop/src/store/subagents.test.ts
+++ b/apps/desktop/src/store/subagents.test.ts
@@ -131,4 +131,12 @@ describe('subagent store', () => {
     expect($subagentsBySession.get().s1).toBeUndefined()
     expect($subagentsBySession.get().s2).toHaveLength(1)
   })
+
+  it('clears session ids that collide with object prototype keys', () => {
+    upsertSubagent('toString', { goal: 'proto', status: 'running', subagent_id: 'a1', task_index: 0 })
+
+    clearSessionSubagents('toString')
+
+    expect(Object.hasOwn($subagentsBySession.get(), 'toString')).toBe(false)
+  })
 })

--- a/apps/desktop/src/store/subagents.test.ts
+++ b/apps/desktop/src/store/subagents.test.ts
@@ -133,6 +133,17 @@ describe('subagent store', () => {
     expect($subagentsBySession.get().s2).toHaveLength(1)
   })
 
+  it('creates and clears a session id that collides with an object prototype key', () => {
+    expect(() =>
+      upsertSubagent('toString', { goal: 'proto', status: 'running', subagent_id: 'a1', task_index: 0 })
+    ).not.toThrow()
+    expect($subagentsBySession.get().toString).toHaveLength(1)
+
+    clearSessionSubagents('toString')
+
+    expect(Object.hasOwn($subagentsBySession.get(), 'toString')).toBe(false)
+  })
+
   // Regression test for #64015: still-RUNNING background subagents must survive
   // the per-turn wipe that previously dropped them at message.start. The fix
   // replaces clearSessionSubagents() with pruneFinishedSessionSubagents() at

--- a/apps/desktop/src/store/subagents.ts
+++ b/apps/desktop/src/store/subagents.ts
@@ -50,6 +50,13 @@ const TOOL_PREVIEW_MAX = 96
 
 export const $subagentsBySession = atom<Record<string, SubagentProgress[]>>({})
 
+const hasSubagentsForSession = (map: Record<string, SubagentProgress[]>, sid: string): boolean =>
+  Object.hasOwn(map, sid)
+const getSubagentsForSession = (
+  map: Record<string, SubagentProgress[]>,
+  sid: string
+): SubagentProgress[] | undefined => (hasSubagentsForSession(map, sid) ? map[sid] : undefined)
+
 const isStr = (v: unknown): v is string => typeof v === 'string'
 const str = (v: unknown) => (isStr(v) ? v : '')
 const num = (v: unknown) => (typeof v === 'number' && Number.isFinite(v) ? v : undefined)
@@ -181,7 +188,7 @@ function toProgress(payload: SubagentPayload, prev: SubagentProgress | undefined
 export function clearSessionSubagents(sid: string) {
   const map = $subagentsBySession.get()
 
-  if (!(sid in map)) {
+  if (!hasSubagentsForSession(map, sid)) {
     return
   }
 
@@ -191,7 +198,7 @@ export function clearSessionSubagents(sid: string) {
 
 export function pruneDelegateFallbackSubagents(sid: string) {
   const map = $subagentsBySession.get()
-  const list = map[sid]
+  const list = getSubagentsForSession(map, sid)
 
   if (!list?.length) {
     return
@@ -208,7 +215,7 @@ export function pruneDelegateFallbackSubagents(sid: string) {
 
 export function upsertSubagent(sid: string, payload: SubagentPayload, createIfMissing = true, eventType?: string) {
   const map = $subagentsBySession.get()
-  const list = map[sid] ?? []
+  const list = getSubagentsForSession(map, sid) ?? []
   const id = idOf(payload)
   const idx = list.findIndex(item => item.id === id)
 

--- a/apps/desktop/src/store/subagents.ts
+++ b/apps/desktop/src/store/subagents.ts
@@ -50,6 +50,14 @@ const TOOL_PREVIEW_MAX = 96
 
 export const $subagentsBySession = atom<Record<string, SubagentProgress[]>>({})
 
+const hasSubagentsForSession = (map: Record<string, SubagentProgress[]>, sid: string): boolean =>
+  Object.hasOwn(map, sid)
+
+const getSubagentsForSession = (
+  map: Record<string, SubagentProgress[]>,
+  sid: string
+): SubagentProgress[] | undefined => (hasSubagentsForSession(map, sid) ? map[sid] : undefined)
+
 const isStr = (v: unknown): v is string => typeof v === 'string'
 const str = (v: unknown) => (isStr(v) ? v : '')
 const num = (v: unknown) => (typeof v === 'number' && Number.isFinite(v) ? v : undefined)
@@ -181,7 +189,7 @@ function toProgress(payload: SubagentPayload, prev: SubagentProgress | undefined
 export function clearSessionSubagents(sid: string) {
   const map = $subagentsBySession.get()
 
-  if (!(sid in map)) {
+  if (!hasSubagentsForSession(map, sid)) {
     return
   }
 
@@ -203,7 +211,7 @@ export function clearSessionSubagents(sid: string) {
  */
 export function pruneFinishedSessionSubagents(sid: string) {
   const map = $subagentsBySession.get()
-  const list = map[sid]
+  const list = getSubagentsForSession(map, sid)
 
   if (!list?.length) {
     return
@@ -220,7 +228,7 @@ export function pruneFinishedSessionSubagents(sid: string) {
 
 export function pruneDelegateFallbackSubagents(sid: string) {
   const map = $subagentsBySession.get()
-  const list = map[sid]
+  const list = getSubagentsForSession(map, sid)
 
   if (!list?.length) {
     return
@@ -237,7 +245,7 @@ export function pruneDelegateFallbackSubagents(sid: string) {
 
 export function upsertSubagent(sid: string, payload: SubagentPayload, createIfMissing = true, eventType?: string) {
   const map = $subagentsBySession.get()
-  const list = map[sid] ?? []
+  const list = getSubagentsForSession(map, sid) ?? []
   const id = idOf(payload)
   const idx = list.findIndex(item => item.id === id)
 

--- a/apps/desktop/src/store/todos.test.ts
+++ b/apps/desktop/src/store/todos.test.ts
@@ -40,6 +40,14 @@ describe('setSessionTodos finished-list auto-clear', () => {
     expect($todosBySession.get().s1).toBeUndefined()
   })
 
+  it('clears finished lists for session ids that collide with object prototype keys', () => {
+    setSessionTodos('toString', [todo('a', 'completed')])
+
+    vi.advanceTimersByTime(5_000)
+
+    expect(Object.hasOwn($todosBySession.get(), 'toString')).toBe(false)
+  })
+
   it('cancels the pending clear when a new active list arrives', () => {
     setSessionTodos('s1', [todo('a', 'completed')])
     vi.advanceTimersByTime(2_000)

--- a/apps/desktop/src/store/todos.test.ts
+++ b/apps/desktop/src/store/todos.test.ts
@@ -40,6 +40,14 @@ describe('setSessionTodos finished-list auto-clear', () => {
     expect($todosBySession.get().s1).toBeUndefined()
   })
 
+  it('clears finished lists for session ids that collide with object prototype keys', () => {
+    setSessionTodos('toString', [todo('a', 'completed')])
+
+    vi.advanceTimersByTime(5_000)
+
+    expect(Object.hasOwn($todosBySession.get(), 'toString')).toBe(false)
+  })
+
   it('cancels the pending clear when a new active list arrives', () => {
     setSessionTodos('s1', [todo('a', 'completed')])
     vi.advanceTimersByTime(2_000)
@@ -84,6 +92,11 @@ describe('clearActiveSessionTodos (turn-end cleanup)', () => {
     clearActiveSessionTodos('s1')
 
     expect($todosBySession.get().s1).toBeUndefined()
+  })
+
+  it('ignores an inherited prototype key on an empty map', () => {
+    expect(() => clearActiveSessionTodos('toString')).not.toThrow()
+    expect(Object.hasOwn($todosBySession.get(), 'toString')).toBe(false)
   })
 })
 

--- a/apps/desktop/src/store/todos.ts
+++ b/apps/desktop/src/store/todos.ts
@@ -32,6 +32,9 @@ export function todosForHydration(todos: readonly TodoItem[] | null): TodoItem[]
 // drops out of the stack on its own.
 const FINISHED_LINGER_MS = 4_000
 const clearTimers = new Map<string, ReturnType<typeof setTimeout>>()
+const hasSessionTodos = (map: Record<string, TodoItem[]>, sid: string): boolean => Object.hasOwn(map, sid)
+const getSessionTodos = (map: Record<string, TodoItem[]>, sid: string): TodoItem[] | undefined =>
+  hasSessionTodos(map, sid) ? map[sid] : undefined
 
 function cancelScheduledClear(sid: string) {
   const timer = clearTimers.get(sid)
@@ -66,7 +69,7 @@ export function clearSessionTodos(sid: string) {
 
   const map = $todosBySession.get()
 
-  if (!(sid in map)) {
+  if (!hasSessionTodos(map, sid)) {
     return
   }
 
@@ -80,7 +83,7 @@ export function clearSessionTodos(sid: string) {
 // composer forever. A finished list is left untouched so its short linger
 // still shows the last checkmark landing.
 export function clearActiveSessionTodos(sid: string) {
-  const todos = $todosBySession.get()[sid]
+  const todos = getSessionTodos($todosBySession.get(), sid)
 
   if (!todos || !todoListActive(todos)) {
     return

--- a/apps/desktop/src/store/todos.ts
+++ b/apps/desktop/src/store/todos.ts
@@ -32,6 +32,10 @@ export function todosForHydration(todos: readonly TodoItem[] | null): TodoItem[]
 // drops out of the stack on its own.
 const FINISHED_LINGER_MS = 4_000
 const clearTimers = new Map<string, ReturnType<typeof setTimeout>>()
+const hasSessionTodos = (map: Record<string, TodoItem[]>, sid: string): boolean => Object.hasOwn(map, sid)
+
+const getSessionTodos = (map: Record<string, TodoItem[]>, sid: string): TodoItem[] | undefined =>
+  hasSessionTodos(map, sid) ? map[sid] : undefined
 
 function cancelScheduledClear(sid: string) {
   const timer = clearTimers.get(sid)
@@ -66,7 +70,7 @@ export function clearSessionTodos(sid: string) {
 
   const map = $todosBySession.get()
 
-  if (!(sid in map)) {
+  if (!hasSessionTodos(map, sid)) {
     return
   }
 
@@ -80,7 +84,7 @@ export function clearSessionTodos(sid: string) {
 // composer forever. A finished list is left untouched so its short linger
 // still shows the last checkmark landing.
 export function clearActiveSessionTodos(sid: string) {
-  const todos = $todosBySession.get()[sid]
+  const todos = getSessionTodos($todosBySession.get(), sid)
 
   if (!todos || !todoListActive(todos)) {
     return


### PR DESCRIPTION
## What does this PR do?

- Uses own-property checks for desktop session-scoped maps in compaction, todos, and subagents.
- Avoids treating inherited Object prototype properties as real session entries.
- Adds regression coverage for `toString` session ids across the affected stores.

Fixes #58441.

## Why?

Session ids are opaque strings, but these stores use plain objects keyed by session id. The previous `in` checks and direct reads could traverse `Object.prototype`; for example, a missing `toString` entry could be treated as present. In the subagent store that caused `upsertSubagent()` to read a function from the prototype and crash before it could create the session list.

## Tests

```bash
npm run test:ui -- src/store/compaction.test.ts src/store/todos.test.ts src/store/subagents.test.ts
# Test Files  3 passed (3)
# Tests       23 passed (23)
```

```bash
npm run typecheck --workspace apps/desktop
# passed
```

```bash
git diff --check
# passed
```