### PR TITLE
fix(profiles): allowlist default-export paths + preserve symlinks

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -224,6 +224,25 @@ _DEFAULT_EXPORT_EXCLUDE_ROOT = frozenset({
     "logs",                 # gateway logs
 })
 
+# Allow-list for ``export_profile("default")``: when HERMES_HOME equals the
+# cwd (Docker/custom deployments), the default profile home is the working
+# directory and contains arbitrary user files that should NOT be bundled
+# into the export. The set below identifies the *known Hermes profile
+# artifacts* at the root of HERMES_HOME; everything else is excluded.
+# Sensitive runtime infrastructure (``state.db``, ``logs/``, ``auth.*``,
+# other profiles) is intentionally *not* in this list so the export stays
+# a portable, credential-free snapshot of the user-facing surface
+# (#58394). Add new artifacts here when introduced in ``hermes_constants``.
+_DEFAULT_EXPORT_INCLUDE_ROOT = frozenset({
+    # Configuration / persona
+    "config.yaml", "SOUL.md", "MEMORY.md", "USER.md", "todo.json",
+    "system_prompt.md", "AGENTS.md", "CLAUDE.md", ".cursorrules",
+    # User-facing skill, cron, and session artifacts
+    "skills", "cron", "scripts", "sessions",
+    # Plugin / memory surfaces (per-profile overrides live here)
+    "plugins", "memories", "knowledge", "preferences",
+})
+
 # Names that cannot be used as profile aliases
 _RESERVED_NAMES = frozenset({
     "hermes", "default", "test", "tmp", "root", "sudo",
@@ -1843,8 +1862,18 @@ def get_active_profile_name() -> str:
 def _default_export_ignore(root_dir: Path):
     """Return an *ignore* callable for :func:`shutil.copytree`.
 
-    At the root level it excludes everything in ``_DEFAULT_EXPORT_EXCLUDE_ROOT``.
-    At all levels it excludes ``__pycache__``, sockets, and temp files.
+    Two-tier filtering:
+
+    * **Root-level allow-list** — only entries whose name appears in
+      ``_DEFAULT_EXPORT_INCLUDE_ROOT`` survive. Everything else (such as
+      an unrelated ``x11-dev/`` directory in a Docker deployment where
+      HERMES_HOME equals the cwd) is excluded. Blacklisting was tried
+      first and proved unable to anticipate every non-Hermes file the
+      user may have lying alongside HERMES_HOME (#58394).
+    * **Universal exclusions at any depth** — ``__pycache__``, sockets,
+      temp files; plus npm lockfiles, which may appear at the root.
+
+    All other profile artifacts are copied through untouched.
     """
 
     def _ignore(directory: str, contents: list) -> set:
@@ -1856,9 +1885,12 @@ def _default_export_ignore(root_dir: Path):
             # npm lockfiles can appear at root
             elif entry in {"package.json", "package-lock.json"}:
                 ignored.add(entry)
-        # Root-level exclusions
+        # Root-level allow-list: drop everything that isn't a known
+        # Hermes profile artifact.
         if Path(directory) == root_dir:
-            ignored.update(c for c in contents if c in _DEFAULT_EXPORT_EXCLUDE_ROOT)
+            ignored.update(
+                entry for entry in contents if entry not in _DEFAULT_EXPORT_INCLUDE_ROOT
+            )
         return ignored
 
     return _ignore
@@ -1890,6 +1922,7 @@ def export_profile(name: str, output_path: str) -> Path:
             shutil.copytree(
                 profile_dir,
                 staged,
+                symlinks=True,
                 ignore=_default_export_ignore(profile_dir),
             )
             result = shutil.make_archive(base, "gztar", tmpdir, "default")
@@ -1902,6 +1935,7 @@ def export_profile(name: str, output_path: str) -> Path:
         shutil.copytree(
             profile_dir,
             staged,
+            symlinks=True,
             ignore=lambda d, contents: _CREDENTIAL_FILES & set(contents),
         )
         result = shutil.make_archive(base, "gztar", tmpdir, canon)

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -1385,6 +1385,84 @@ class TestExportImport:
 
         assert not any("__pycache__" in n for n in names)
 
+    def test_export_default_uses_allowlist_for_unrelated_dirs(self, profile_env, tmp_path):
+        """Unrelated directories under HERMES_HOME are excluded by allow-list (#58394).
+
+        Docker/custom deployments often set HERMES_HOME to a working
+        directory that also contains unrelated user projects (``x11-dev/``,
+        etc.).  The root-level allow-list filters those out so only known
+        Hermes artifacts end up in the archive. Replaces the old
+        exhaustive blacklist.
+        """
+        default_dir = get_profile_dir("default")
+        (default_dir / "config.yaml").write_text("ok")
+        (default_dir / "SOUL.md").write_text("soul")
+        # Allowed subdirectory with content
+        (default_dir / "skills" / "demo").mkdir(parents=True)
+        (default_dir / "skills" / "demo" / "SKILL.md").write_text("hi")
+        # Unrelated directory — should NOT appear in the archive
+        unrelated = default_dir / "x11-dev" / "usr" / "lib"
+        unrelated.mkdir(parents=True)
+        (unrelated / "libXi.so").write_text("data")
+
+        output = tmp_path / "export" / "default.tar.gz"
+        output.parent.mkdir(parents=True, exist_ok=True)
+        result = export_profile("default", str(output))
+
+        with tarfile.open(str(result), "r:gz") as tf:
+            names = set(tf.getnames())
+
+        # Allowed artifacts present
+        assert any(n.endswith("config.yaml") for n in names)
+        assert any(n.endswith("SOUL.md") for n in names)
+        assert any(n.endswith("skills/demo/SKILL.md") for n in names)
+        # Unrelated artifact excluded
+        assert not any("x11-dev" in n for n in names)
+        assert not any("libXi.so" in n for n in names)
+
+    def test_export_default_handles_broken_symlinks(self, profile_env, tmp_path):
+        """Broken symlinks inside allowed artifacts are preserved, not crashed (#58394).
+
+        ``shutil.copytree``'s default is ``symlinks=False``, which follows
+        symlinks and crashes on broken ones. Use ``symlinks=True`` so stale
+        symlinks inside *allowed* artifacts (e.g. ``skills/``) survive as
+        symlinks; the link and its target are both retained.
+        """
+        default_dir = get_profile_dir("default")
+        (default_dir / "config.yaml").write_text("ok")
+        # Place broken symlink *inside* the allowed ``skills/`` tree so the
+        # root-level allow-list passes the directory through; the
+        # symlinks=True flag must then preserve the link instead of
+        # following and crashing.
+        broken_dir = default_dir / "skills" / "with-broken-links"
+        broken_dir.mkdir(parents=True)
+        (broken_dir / "broken_link").symlink_to("/nonexistent/path")
+        # Valid symlink for comparison
+        (broken_dir / "valid_target.txt").write_text("real data")
+        (broken_dir / "valid_link").symlink_to(
+            broken_dir / "valid_target.txt"
+        )
+
+        output = tmp_path / "export" / "default.tar.gz"
+        output.parent.mkdir(parents=True, exist_ok=True)
+        result = export_profile("default", str(output))
+
+        assert result.exists()
+        with tarfile.open(str(result), "r:gz") as tf:
+            names = set(tf.getnames())
+        # Allowed artifact survived
+        assert any(n.endswith("config.yaml") for n in names)
+        # Broken symlink inside an allowed dir was preserved as a symlink
+        # (without crashing) — tar entry name recorded as the link path.
+        assert any(
+            "with-broken-links/broken_link" in n for n in names
+        ), (
+            f"broken_link should survive; tarfile names: {sorted(names)[:30]}"
+        )
+        # Valid symlink + target also kept
+        assert any("valid_link" in n for n in names)
+        assert any("valid_target.txt" in n for n in names)
+
     def test_import_default_without_name_raises(self, profile_env, tmp_path):
         """Importing a default export without --name gives clear guidance."""
         default_dir = get_profile_dir("default")


### PR DESCRIPTION
## Summary

`hermes profile export default` crashes with `shutil.Error` when `HERMES_HOME` points outside `~/.hermes` (Docker deployments) and the directory tree contains broken symlinks. Two distinct root causes:

1. **`symlinks=False` default** — `shutil.copytree` follows link targets and crashes on broken ones. #58397 (liuhao1024) drafted a minimal `symlinks=True` fix; this PR adopts it.
2. **Blacklist can't anticipate non-Hermes artifacts** — when `HERMES_HOME` equals the cwd (the Docker layout the reporter hit), `copytree` sees the *entire* working directory. The fixed `_DEFAULT_EXPORT_EXCLUDE_ROOT` blacklist enumerates known infrastructure but can't scale to every unrelated user file lying alongside the workspace.

Replaces the root-level exclusion with a positive allow-list at `_DEFAULT_EXPORT_INCLUDE_ROOT`, enumerating the known Hermes profile artifacts (config, persona, skills, cron, scripts, sessions, plugins, memories, knowledge, preferences). Sensitive runtime surfaces (`state.db`, `logs/`, auth files, other profiles) are intentionally *not* in the allow-list so the export stays a portable, credential-free snapshot of the user-facing surface — `test_export_default_excludes_infrastructure` and friends remain green.

## Changes

- `hermes_cli/profiles.py`:
  - New frozen-set `_DEFAULT_EXPORT_INCLUDE_ROOT` of known Hermes profile-artifact names.
  - `_DEFAULT_EXPORT_ignore` rewritten: root level now drops anything not on the allow-list; universal `__pycache__`/`.sock`/`.tmp`/npm lockfile exclusions unchanged at any depth.
  - `export_profile()` passes `symlinks=True` to both copytree calls (default + named) — broken symlinks stay as links, not followed.
- `tests/hermes_cli/test_profiles.py` (2 new tests):
  - `test_export_default_uses_allowlist_for_unrelated_dirs` — sibling `x11-dev/` dir is excluded, `config.yaml` / `SOUL.md` / `skills/...` survive.
  - `test_export_default_handles_broken_symlinks` — broken link inside `skills/` survives (regression for the crash).

## How to Test

```
venv/bin/python -m pytest tests/hermes_cli/test_profiles.py -q
# 155/155 passed (existing suite + 2 new regression tests)
```

Verified by stashing `hermes_cli/profiles.py`: the 2 new tests fail with the exact symptoms in the issue report (`shutil.Error: ... [Errno 2] No such file or directory` for the broken symlink; x11-dev leaking into the archive). Confirms the tests pin the bug class and not just the new code path.

## Superseed

#58397 (`liuhao1024: fix(profiles): preserve symlinks during profile export`) is fully covered by this PR's `symlinks=True` change. Suggest closing that one as superseded once this lands — its author did the gating investigation pointing at this issue.

## Checklist

- [x] Tests pass — 155/155
- [x] Follows Conventional Commits
- [x] Cross-platform impact — Linux/macOS path semantics; archive extraction uses `PurePosixPath`/`PureWindowsPath` (unchanged)
- [x] profile-safe paths used (no path code modified; allowlist operates on top-level names)
- [x] `.env` not used for non-credential settings (no config surface touched)

## Risk & Impact

Low-medium. The blacklist→allow-list switch changes the *visible content* of `hermes profile export default`:
- Files that *were* on the blacklist and *are* on the allow-list (none in the current set) silently transition from excluded to included.
- Files that *were not* on the blacklist (any unrelated sibling directory in Docker layouts) silently transition from included to excluded.

The second is exactly the bug fix. The first is a non-issue at the moment. The existing `test_export_default_excludes_infrastructure` regression suite verifies the sensitive-runtime-filenames surface remains *excluded* under the new logic. Users upgrading will notice only that old export archives with stale sibling cruft (`x11-dev/`, etc.) no longer carry that cruft forward — which is the desired behavior.

Type: Bug fix
Closes: #58394