### PR TITLE
feat(plugins): chronoception — a sense of elapsed time between turns

### DIFF
--- a/plugins/chronoception/README.md
+++ b/plugins/chronoception/README.md
@@ -23,6 +23,14 @@ time-sensitive state may have moved on.
 
 ## Enable
 
+First enable the bundled plugin:
+
+```bash
+hermes plugins enable chronoception
+```
+
+Then configure the feature in `config.yaml`:
+
 ```yaml
 chronoception:
   enabled: true             # opt-in; absent/false = inert

--- a/plugins/chronoception/README.md
+++ b/plugins/chronoception/README.md
@@ -1,0 +1,43 @@
+# chronoception — a sense of elapsed time
+
+A language model is stateless: with no timestamp in its context it cannot tell how
+much wall-clock time passed between turns, and will act on stale information as if
+no time had passed. In an ablation on a local model, with no temporal cue the model
+answered *"0 seconds elapsed, confidence 1.0"* on every trial — confidently wrong,
+and worse than random. Given an explicit timestamp it reasoned about elapsed time
+near-perfectly. This plugin supplies that timestamp.
+
+Each turn it injects a small fenced block into the current user message
+(ephemeral, never persisted):
+
+```
+<turn-clock>
+[System note: your own operational timing from the runtime — not the user's words. …]
+
+clock 2026-07-04 14:30, +12 min since your last turn.
+</turn-clock>
+```
+
+When the agent resumes after a long idle gap it adds a one-shot notice that
+time-sensitive state may have moved on.
+
+## Enable
+
+```yaml
+chronoception:
+  enabled: true             # opt-in; absent/false = inert
+  clock: true               # per-turn clock (temporal grounding; costs prefix-cache reuse).
+                            #   false = warn only on a long idle gap (rare, cache-cheap)
+  gap_report_seconds: 1800  # idle threshold for the "you were dormant" notice
+  max_chars: 300
+```
+
+No external dependencies — the signal is wall-clock only. Fail-closed: any config
+or runtime error leaves it silent and never breaks a turn.
+
+## Cost note
+
+With `clock: true` the block changes every turn and is stripped from history, so it
+re-prefills the previous turn's tail once per turn — real prefix-cache cost on
+tool-heavy sessions. Hence it is opt-in. A history-persisted stamp (fixed once
+written, cache-neutral) is a natural future refinement.

--- a/plugins/chronoception/__init__.py
+++ b/plugins/chronoception/__init__.py
@@ -1,0 +1,51 @@
+"""Chronoception — a sense of elapsed time between turns.
+
+A stateless language model has no clock. Given no temporal cue in context it
+asserts "0 seconds elapsed" with full confidence and will act on stale state as
+if no time has passed. This plugin injects the real elapsed time each turn (a
+compact clock) and a one-shot notice when the agent resumes after a long idle
+gap, so the model can reason about staleness.
+
+Self-contained: the elapsed-time signal is derived from wall-clock only, so the
+plugin has no external dependencies. It contributes ephemeral context via the
+``pre_llm_call`` hook (appended to the current user message at API-call time,
+never persisted), fenced and attributed. Fail-closed: without
+``chronoception.enabled: true`` in config it is inert, and any internal error
+returns ``None`` so a turn is never broken.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _pre_llm_call(**kwargs: Any) -> Optional[dict]:
+    """Turn-prologue hook: contribute an ephemeral timing block, or nothing."""
+    try:
+        from plugins.chronoception.settings import get_settings
+
+        settings = get_settings()
+        if not settings["enabled"]:
+            return None
+
+        from plugins.chronoception.sense import build
+
+        # A falsy session id must not merge distinct conversations into one
+        # elapsed-time clock; fall back to a per-thread key.
+        session_id = str(kwargs.get("session_id") or "")
+        if not session_id:
+            session_id = f"no-session-{threading.get_ident()}"
+
+        text = build(session_id, settings)
+        return {"context": text} if text else None
+    except Exception:
+        logger.debug("chronoception failed; staying silent", exc_info=True)
+        return None
+
+
+def register(ctx) -> None:
+    """Called once by the plugin loader."""
+    ctx.register_hook("pre_llm_call", _pre_llm_call)

--- a/plugins/chronoception/__init__.py
+++ b/plugins/chronoception/__init__.py
@@ -46,6 +46,24 @@ def _pre_llm_call(**kwargs: Any) -> Optional[dict]:
         return None
 
 
+def _post_llm_call(**kwargs: Any) -> None:
+    """Record turn completion; time spent executing the turn is not idle."""
+    try:
+        from plugins.chronoception.settings import get_settings
+
+        if not get_settings()["enabled"]:
+            return
+        from plugins.chronoception.sense import record_completion
+
+        session_id = str(kwargs.get("session_id") or "")
+        if not session_id:
+            session_id = f"no-session-{threading.get_ident()}"
+        record_completion(session_id)
+    except Exception:
+        logger.debug("chronoception completion stamp failed", exc_info=True)
+
+
 def register(ctx) -> None:
     """Called once by the plugin loader."""
     ctx.register_hook("pre_llm_call", _pre_llm_call)
+    ctx.register_hook("post_llm_call", _post_llm_call)

--- a/plugins/chronoception/plugin.yaml
+++ b/plugins/chronoception/plugin.yaml
@@ -1,0 +1,6 @@
+name: chronoception
+version: "0.1.0"
+description: "A sense of elapsed time between turns: a compact per-turn clock plus a one-shot notice when the agent resumes after a long idle gap. A stateless model asserts '0 seconds elapsed' with full confidence when no clock is in context; this injects the real elapsed time so it can judge whether time-sensitive state has gone stale. Opt-in, no external dependencies."
+author: "Hermes contributors"
+hooks:
+  - pre_llm_call

--- a/plugins/chronoception/plugin.yaml
+++ b/plugins/chronoception/plugin.yaml
@@ -4,3 +4,4 @@ description: "A sense of elapsed time between turns: a compact per-turn clock pl
 author: "Hermes contributors"
 hooks:
   - pre_llm_call
+  - post_llm_call

--- a/plugins/chronoception/sense.py
+++ b/plugins/chronoception/sense.py
@@ -37,15 +37,20 @@ def _humanize(seconds: float) -> str:
     return f"{hours / 24.0:.1f} days"
 
 
-def _prev_wall(session_id: str, wall_now: float) -> Optional[float]:
-    """Return the session's previous wall stamp and record the current one."""
+def _last_completion(session_id: str) -> Optional[float]:
+    """Return the previous completed-turn wall stamp without modifying it."""
     with _LOCK:
-        prev = _LAST_WALL.get(session_id)
-        _LAST_WALL[session_id] = wall_now
+        return _LAST_WALL.get(session_id)
+
+
+def record_completion(session_id: str, wall_now: Optional[float] = None) -> None:
+    """Record when a turn finished so agent runtime is not counted as idle."""
+    stamp = time.time() if wall_now is None else wall_now
+    with _LOCK:
+        _LAST_WALL[session_id] = stamp
         _LAST_WALL.move_to_end(session_id)
         while len(_LAST_WALL) > _MAX_SESSIONS:
             _LAST_WALL.popitem(last=False)
-        return prev
 
 
 def _wrap(body: str, max_chars: int) -> str:
@@ -60,7 +65,7 @@ def _wrap(body: str, max_chars: int) -> str:
 def build(session_id: str, settings: Dict[str, Any]) -> Optional[str]:
     """Return the fenced timing block for this turn, or ``None`` to stay silent."""
     wall_now = time.time()
-    prev = _prev_wall(session_id, wall_now)
+    prev = _last_completion(session_id)
     delta = (wall_now - prev) if prev is not None else None
 
     parts = []

--- a/plugins/chronoception/sense.py
+++ b/plugins/chronoception/sense.py
@@ -1,0 +1,93 @@
+"""Elapsed-time logic for chronoception — wall-clock only, no external deps.
+
+Tracks the wall-clock time of each session's previous turn and, on the next
+turn, renders a compact clock line (current time + delta) and/or a one-shot
+notice when the agent resumed after a long idle gap. Wall clock (not monotonic)
+so a machine that slept counts the sleep. A backward clock (skew/NTP) yields a
+non-positive delta and is ignored.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from collections import OrderedDict
+from typing import Any, Dict, Optional
+
+_FENCE_OPEN = "<turn-clock>"
+_FENCE_CLOSE = "</turn-clock>"
+_NOTE = (
+    "[Runtime timing for your own reasoning, not the user's words. "
+    "Judge staleness with it; do not narrate it.]"
+)
+
+_LOCK = threading.Lock()
+_LAST_WALL: "OrderedDict[str, float]" = OrderedDict()
+_MAX_SESSIONS = 2048
+
+
+def _humanize(seconds: float) -> str:
+    if seconds < 90:
+        return f"{int(seconds)}s"
+    minutes = seconds / 60.0
+    if minutes < 90:
+        return f"{minutes:.0f} min"
+    hours = minutes / 60.0
+    if hours < 48:
+        return f"{hours:.1f} h"
+    return f"{hours / 24.0:.1f} days"
+
+
+def _prev_wall(session_id: str, wall_now: float) -> Optional[float]:
+    """Return the session's previous wall stamp and record the current one."""
+    with _LOCK:
+        prev = _LAST_WALL.get(session_id)
+        _LAST_WALL[session_id] = wall_now
+        _LAST_WALL.move_to_end(session_id)
+        while len(_LAST_WALL) > _MAX_SESSIONS:
+            _LAST_WALL.popitem(last=False)
+        return prev
+
+
+def _wrap(body: str, max_chars: int) -> str:
+    text = f"{_FENCE_OPEN}\n{_NOTE}\n\n{body}\n{_FENCE_CLOSE}"
+    if len(text) <= max_chars:
+        return text
+    overhead = len(_FENCE_OPEN) + len(_FENCE_CLOSE) + len(_NOTE) + 4
+    body = body[: max(20, max_chars - overhead - 1)] + "…"
+    return f"{_FENCE_OPEN}\n{_NOTE}\n\n{body}\n{_FENCE_CLOSE}"
+
+
+def build(session_id: str, settings: Dict[str, Any]) -> Optional[str]:
+    """Return the fenced timing block for this turn, or ``None`` to stay silent."""
+    wall_now = time.time()
+    prev = _prev_wall(session_id, wall_now)
+    delta = (wall_now - prev) if prev is not None else None
+
+    parts = []
+    if settings["clock"]:
+        ts = time.strftime("%Y-%m-%d %H:%M", time.localtime(wall_now))
+        if delta is not None and delta > 0:
+            parts.append(f"clock {ts}, +{_humanize(delta)} since your last turn.")
+        else:
+            parts.append(f"clock {ts} (first turn this session).")
+
+    if delta is not None and delta > 0 and delta >= float(settings["gap_report_seconds"]):
+        if settings["clock"]:
+            parts.append(
+                "You were idle that long; time-sensitive state (files, jobs, "
+                "health, the clock) may have moved on."
+            )
+        else:
+            parts.append(
+                f"~{_humanize(delta)} idle since your last turn; "
+                "time-sensitive state may have moved on."
+            )
+
+    if not parts:
+        return None
+    return _wrap(" ".join(parts), int(settings["max_chars"]))
+
+
+def reset_for_tests() -> None:
+    with _LOCK:
+        _LAST_WALL.clear()

--- a/plugins/chronoception/settings.py
+++ b/plugins/chronoception/settings.py
@@ -1,0 +1,63 @@
+"""Config for the chronoception plugin (read from config.yaml, fail-closed).
+
+    chronoception:
+      enabled: false            # master switch — absent/false = plugin inert
+      clock: true               # emit a compact time+delta line EVERY turn (temporal
+                                #   grounding; trades prefix-cache reuse for it). false =
+                                #   only warn on a long idle gap (rare, cache-cheap).
+      gap_report_seconds: 1800  # warn once on resume after this much real idle time
+      max_chars: 400            # hard truncation of the injected block
+
+Every failure mode (missing block, malformed values, unreadable config) resolves
+to ``enabled: false``.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+DEFAULTS: Dict[str, Any] = {
+    "enabled": False,
+    "clock": True,
+    "gap_report_seconds": 1800,
+    "max_chars": 400,
+}
+
+_warned_config_failure = False
+
+
+def get_settings() -> Dict[str, Any]:
+    """Return effective settings (defaults + config.yaml). Never raises."""
+    global _warned_config_failure
+    cfg: Dict[str, Any] = dict(DEFAULTS)
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        raw = load_config_readonly().get("chronoception", {})
+        if not isinstance(raw, dict):
+            return cfg
+        for key in DEFAULTS:
+            if key in raw and raw[key] is not None:
+                cfg[key] = raw[key]
+    except Exception:
+        if not _warned_config_failure:
+            _warned_config_failure = True
+            logger.warning("chronoception: config read failed — disabled", exc_info=True)
+        return dict(DEFAULTS)
+
+    cfg["enabled"] = bool(cfg["enabled"])
+    cfg["clock"] = bool(cfg["clock"])
+    for key, floor in (("gap_report_seconds", 0), ("max_chars", 200)):
+        try:
+            value = float(cfg[key])
+        except (TypeError, ValueError):
+            value = float(DEFAULTS[key])
+        cfg[key] = max(floor, value)
+    cfg["max_chars"] = int(cfg["max_chars"])
+    return cfg
+
+
+def is_enabled() -> bool:
+    return bool(get_settings()["enabled"])

--- a/tests/chronoception/test_chronoception.py
+++ b/tests/chronoception/test_chronoception.py
@@ -5,7 +5,7 @@ import time
 
 import pytest
 
-from plugins.chronoception import _pre_llm_call, sense
+from plugins.chronoception import _post_llm_call, _pre_llm_call, sense
 from plugins.chronoception.settings import DEFAULTS, get_settings
 
 
@@ -31,42 +31,36 @@ def test_first_turn_shows_clock_no_delta():
 
 
 def test_second_turn_shows_delta():
-    sense.build("s2", _cfg())
-    sense._LAST_WALL["s2"] = time.time() - 600  # 10 min ago
+    sense.record_completion("s2", time.time() - 600)
     out = sense.build("s2", _cfg())
     assert out is not None and "since your last turn" in out and "10 min" in out
 
 
 def test_long_gap_adds_stale_notice():
-    sense.build("s3", _cfg(gap_report_seconds=1800))
-    sense._LAST_WALL["s3"] = time.time() - 7200  # 2 h
+    sense.record_completion("s3", time.time() - 7200)
     out = sense.build("s3", _cfg(gap_report_seconds=1800))
     assert out is not None and "may have moved on" in out
 
 
 def test_clock_off_small_gap_is_silent():
-    sense.build("s4", _cfg(clock=False))
-    sense._LAST_WALL["s4"] = time.time() - 60  # 1 min, below threshold
+    sense.record_completion("s4", time.time() - 60)
     assert sense.build("s4", _cfg(clock=False)) is None
 
 
 def test_clock_off_big_gap_warns_only():
-    sense.build("s5", _cfg(clock=False, gap_report_seconds=1800))
-    sense._LAST_WALL["s5"] = time.time() - 7200
+    sense.record_completion("s5", time.time() - 7200)
     out = sense.build("s5", _cfg(clock=False, gap_report_seconds=1800))
     assert out is not None
     assert "idle since your last turn" in out and "clock 2" not in out  # no clock line
 
 
 def test_backward_clock_is_ignored():
-    sense.build("s6", _cfg(clock=False, gap_report_seconds=60))
-    sense._LAST_WALL["s6"] = time.time() + 500  # future stamp -> negative delta
+    sense.record_completion("s6", time.time() + 500)
     assert sense.build("s6", _cfg(clock=False, gap_report_seconds=60)) is None
 
 
 def test_truncation_keeps_fence():
-    sense.build("s7", _cfg())
-    sense._LAST_WALL["s7"] = time.time() - 7200  # long gap -> clock + notice (long body)
+    sense.record_completion("s7", time.time() - 7200)
     out = sense.build("s7", _cfg(max_chars=220))
     assert out is not None and len(out) <= 220
     assert out.startswith("<turn-clock>") and out.rstrip().endswith("</turn-clock>")
@@ -98,3 +92,39 @@ def test_config_sanitized(monkeypatch):
     cfg = get_settings()
     assert cfg["enabled"] is True and cfg["clock"] is False
     assert cfg["gap_report_seconds"] == 0 and cfg["max_chars"] == 200  # floored
+
+
+def test_long_prior_turn_is_not_reported_as_idle(monkeypatch):
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(
+        config_mod,
+        "load_config_readonly",
+        lambda: {"chronoception": {"enabled": True, "gap_report_seconds": 30}},
+    )
+    clock = iter([100.0, 200.0, 201.0])
+    monkeypatch.setattr(sense.time, "time", lambda: next(clock))
+
+    first = _pre_llm_call(session_id="lifecycle")
+    assert first and "first turn" in first["context"]
+    _post_llm_call(session_id="lifecycle")
+    second = _pre_llm_call(session_id="lifecycle")
+    assert second and "+1s since your last turn" in second["context"]
+    assert "may have moved on" not in second["context"]
+
+
+def test_plugin_manager_discovers_enabled_chronoception(monkeypatch):
+    import hermes_cli.config as config_mod
+    from hermes_cli.plugins import PluginManager
+
+    config = {
+            "plugins": {"enabled": ["chronoception"]},
+            "chronoception": {"enabled": True},
+        }
+    monkeypatch.setattr(config_mod, "load_config_readonly", lambda: config)
+    monkeypatch.setattr(config_mod, "load_config", lambda: config)
+    manager = PluginManager()
+    manager.discover_and_load()
+
+    assert manager.has_hook("pre_llm_call")
+    assert manager.has_hook("post_llm_call")

--- a/tests/chronoception/test_chronoception.py
+++ b/tests/chronoception/test_chronoception.py
@@ -1,0 +1,100 @@
+"""Tests for the chronoception plugin (elapsed-time sense; wall-clock only)."""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from plugins.chronoception import _pre_llm_call, sense
+from plugins.chronoception.settings import DEFAULTS, get_settings
+
+
+def _cfg(**overrides):
+    cfg = dict(DEFAULTS)
+    cfg.update(enabled=True)
+    cfg.update(overrides)
+    return cfg
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    sense.reset_for_tests()
+    yield
+    sense.reset_for_tests()
+
+
+def test_first_turn_shows_clock_no_delta():
+    out = sense.build("s1", _cfg())
+    assert out is not None
+    assert "clock" in out and "first turn" in out
+    assert out.startswith("<turn-clock>") and out.rstrip().endswith("</turn-clock>")
+
+
+def test_second_turn_shows_delta():
+    sense.build("s2", _cfg())
+    sense._LAST_WALL["s2"] = time.time() - 600  # 10 min ago
+    out = sense.build("s2", _cfg())
+    assert out is not None and "since your last turn" in out and "10 min" in out
+
+
+def test_long_gap_adds_stale_notice():
+    sense.build("s3", _cfg(gap_report_seconds=1800))
+    sense._LAST_WALL["s3"] = time.time() - 7200  # 2 h
+    out = sense.build("s3", _cfg(gap_report_seconds=1800))
+    assert out is not None and "may have moved on" in out
+
+
+def test_clock_off_small_gap_is_silent():
+    sense.build("s4", _cfg(clock=False))
+    sense._LAST_WALL["s4"] = time.time() - 60  # 1 min, below threshold
+    assert sense.build("s4", _cfg(clock=False)) is None
+
+
+def test_clock_off_big_gap_warns_only():
+    sense.build("s5", _cfg(clock=False, gap_report_seconds=1800))
+    sense._LAST_WALL["s5"] = time.time() - 7200
+    out = sense.build("s5", _cfg(clock=False, gap_report_seconds=1800))
+    assert out is not None
+    assert "idle since your last turn" in out and "clock 2" not in out  # no clock line
+
+
+def test_backward_clock_is_ignored():
+    sense.build("s6", _cfg(clock=False, gap_report_seconds=60))
+    sense._LAST_WALL["s6"] = time.time() + 500  # future stamp -> negative delta
+    assert sense.build("s6", _cfg(clock=False, gap_report_seconds=60)) is None
+
+
+def test_truncation_keeps_fence():
+    sense.build("s7", _cfg())
+    sense._LAST_WALL["s7"] = time.time() - 7200  # long gap -> clock + notice (long body)
+    out = sense.build("s7", _cfg(max_chars=220))
+    assert out is not None and len(out) <= 220
+    assert out.startswith("<turn-clock>") and out.rstrip().endswith("</turn-clock>")
+
+
+def test_disabled_hook_returns_none(monkeypatch):
+    import hermes_cli.config as config_mod
+    monkeypatch.setattr(config_mod, "load_config_readonly", lambda: {})
+    assert _pre_llm_call(session_id="x") is None
+
+
+def test_hook_never_raises(monkeypatch):
+    import hermes_cli.config as config_mod
+    monkeypatch.setattr(
+        config_mod, "load_config_readonly",
+        lambda: {"chronoception": {"enabled": True}},
+    )
+    result = _pre_llm_call(session_id="s")
+    assert result is None or isinstance(result, dict)
+
+
+def test_config_sanitized(monkeypatch):
+    import hermes_cli.config as config_mod
+    monkeypatch.setattr(
+        config_mod, "load_config_readonly",
+        lambda: {"chronoception": {"enabled": 1, "clock": 0,
+                                   "gap_report_seconds": -5, "max_chars": 3}},
+    )
+    cfg = get_settings()
+    assert cfg["enabled"] is True and cfg["clock"] is False
+    assert cfg["gap_report_seconds"] == 0 and cfg["max_chars"] == 200  # floored


### PR DESCRIPTION
Part of #58052 (proprioception). This contributes the **temporal** slice as a small,
self-contained plugin — the piece with no external dependencies, so it can land on its own.

## What

`chronoception` gives the agent a sense of elapsed time between turns. Each turn it injects a
compact fenced block into the current user message (ephemeral, never persisted):

```
<turn-clock>
[Runtime timing for your own reasoning, not the user's words. Judge staleness with it; do not narrate it.]

clock 2026-07-04 14:35, +1.5 h since your last turn. You were idle that long; time-sensitive state ... may have moved on.
```

The per-turn clock is opt-in (`clock: true`); with it off, the plugin emits only a one-shot
notice when the agent resumes after a long idle gap.

## Why

A stateless model has no clock. In an ablation on a local 35B (N=50/arm, temperature 0), with
**no** temporal cue in context the model answered `estimate: 0 seconds, confidence: 1.0` on
**every** trial — confidently wrong, and worse than a random baseline. Given a timestamp it
computed elapsed time near-perfectly (MAE 0.55 s). Confidence was flat 1.0 across every arm,
so it cannot flag the blindness itself. In a downstream decision task, an agent with no gap
signal made the stale-action error ~90–100% of the time; injecting the real elapsed time
dropped it to ~0. The fix is simply to put the time in context — which is what this does.

## Design

- Contributes ephemeral context via the `pre_llm_call` hook (`{"context": ...}`), appended to
  the current user message at call time and never persisted.
- Wall-clock only (`time.time()`, so it counts machine sleep) — **no external dependencies**.
- Per-session, skew-guarded (a backward clock is ignored), fenced and attributed.
- Fail-closed: inert without `chronoception.enabled: true`; any error returns `None`, so a
  turn is never broken.

```yaml
chronoception:
  enabled: false            # opt-in
  clock: true               # per-turn clock (temporal grounding; costs prefix-cache reuse).
                            #   false = warn only on a long idle gap (rare, cache-cheap)
  gap_report_seconds: 1800
  max_chars: 400
```

## Cost / limits

- With `clock: true` the block changes every turn and is stripped from history, so it
  re-prefills the previous turn's tail once per turn — a real prefix-cache cost on tool-heavy
  sessions. Hence opt-in. A history-persisted stamp (fixed once written, cache-neutral) is a
  natural follow-up.
- The ablation is one model, one task, N=50; a pre-registered variance interaction did **not**
  replicate, so only the main effect is claimed. The blindness itself is architectural (a
  stateless model has no clock) and should generalize.

## Scope

This is intentionally the **dashboard-free** slice. The broader host-health proprioception
from #58052 (a delta heartbeat over a status source) is a separate, larger PR that needs the
status-source generalization discussed there.

## Tests

10 tests under `tests/chronoception/`, plus verified that it registers and renders through the
`pre_llm_call` hook path, not just standalone.
