### PR TITLE
fix(whatsapp_cloud): honor documented WHATSAPP_CLOUD_ALLOWED_USERS / ALLOW_ALL_USERS

### DIFF
--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -225,18 +225,35 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         import os
 
         self._reply_prefix: Optional[str] = extra.get("reply_prefix")
-        self._dm_policy: str = str(
-            extra.get("dm_policy")
-            or os.getenv("WHATSAPP_CLOUD_DM_POLICY")
-            or os.getenv("WHATSAPP_DM_POLICY", "open")
-        ).strip().lower()
+        # Allowlist: honor the *documented* WHATSAPP_CLOUD_ALLOWED_USERS (the
+        # var the setup wizard writes) in addition to WHATSAPP_CLOUD_ALLOW_FROM.
+        # The adapter historically read only ALLOW_FROM, so an allowlist
+        # configured via the documented var silently dropped every inbound.
         self._allow_from: set[str] = self._normalize_allow_ids(
             self._coerce_allow_list(
                 extra.get("allow_from")
                 or extra.get("allowFrom")
                 or os.getenv("WHATSAPP_CLOUD_ALLOW_FROM")
+                or os.getenv("WHATSAPP_CLOUD_ALLOWED_USERS")
             )
         )
+        # DM policy: explicit config wins; otherwise choose a safe, working
+        # default -- "open" if the operator opted into allow-all, else
+        # "allowlist" when an allowlist is configured (so it is actually
+        # enforced instead of silently dropping), else "open".
+        _allow_all_optin = str(
+            os.getenv("WHATSAPP_CLOUD_ALLOW_ALL_USERS", "")
+        ).strip().lower() in {"true", "1", "yes"}
+        _default_dm_policy = (
+            "open" if _allow_all_optin
+            else ("allowlist" if self._allow_from else "open")
+        )
+        self._dm_policy: str = str(
+            extra.get("dm_policy")
+            or os.getenv("WHATSAPP_CLOUD_DM_POLICY")
+            or os.getenv("WHATSAPP_DM_POLICY")
+            or _default_dm_policy
+        ).strip().lower()
         self._group_policy: str = str(
             extra.get("group_policy")
             or os.getenv("WHATSAPP_CLOUD_GROUP_POLICY")
@@ -346,6 +363,17 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             bare = re.sub(r"\D", "", str(sender_id).split("@", 1)[0])
             return (bare or sender_id) in self._allow_from
         return super()._is_dm_allowed(sender_id)
+
+    def _open_dm_opted_in(self) -> bool:
+        """Also honor the documented WHATSAPP_CLOUD_ALLOW_ALL_USERS opt-in.
+
+        The shared mixin only checks GATEWAY_ALLOW_ALL_USERS /
+        WHATSAPP_ALLOW_ALL_USERS; the Cloud adapter's documented open-access
+        opt-in is WHATSAPP_CLOUD_ALLOW_ALL_USERS, so honor it here too.
+        """
+        if str(os.getenv("WHATSAPP_CLOUD_ALLOW_ALL_USERS", "")).strip().lower() in {"true", "1", "yes"}:
+            return True
+        return super()._open_dm_opted_in()
 
     # ------------------------------------------------------------------ lifecycle
     async def connect(self, *, is_reconnect: bool = False) -> bool:


### PR DESCRIPTION
## Problem

The WhatsApp Cloud setup wizard (`hermes whatsapp-cloud`) and the [Cloud API docs](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/whatsapp-cloud) tell operators to set `WHATSAPP_CLOUD_ALLOWED_USERS` (and optionally `WHATSAPP_CLOUD_ALLOW_ALL_USERS`).

But the adapter's DM intake gate — `_should_process_message` → `_is_dm_intake_allowed` in `whatsapp_common.py` — only reads `WHATSAPP_CLOUD_ALLOW_FROM` + `WHATSAPP_CLOUD_DM_POLICY` (default `open`, opted-in only via `GATEWAY_ALLOW_ALL_USERS` / `WHATSAPP_ALLOW_ALL_USERS`).

So an allowlist configured **exactly as documented** silently drops every inbound message:
`_build_message_event_from_cloud` → `_should_process_message` returns `False` → returns `None` → webhook responds `HTTP 200`, nothing is dispatched, and **no log line is emitted**.

This is very hard to diagnose: the webhook verification, `X-Hub-Signature-256`, app subscription, and WABA `subscribed_apps` all look correct, and `/health` shows `accepted: 0` with `rejected_signature: 0`. It reads exactly like "Meta isn't delivering," when in fact Meta *is* delivering and the message is dropped at the adapter gate.

## Fix

`gateway/platforms/whatsapp_cloud.py`:
- `_allow_from` now also reads `WHATSAPP_CLOUD_ALLOWED_USERS` (in addition to `WHATSAPP_CLOUD_ALLOW_FROM`).
- `dm_policy` now defaults to `allowlist` when an allowlist is configured (else `open`), so a documented allowlist is actually enforced instead of silently dropping.
- `_open_dm_opted_in()` is overridden to also honor `WHATSAPP_CLOUD_ALLOW_ALL_USERS`.

Explicit `WHATSAPP_CLOUD_DM_POLICY` / `WHATSAPP_CLOUD_ALLOW_FROM` still take precedence, so this is fully backward compatible.

## Testing

Verified on a live Cloud API test number:

- **Documented config only** (`WHATSAPP_CLOUD_ALLOWED_USERS=<listed>`, no `DM_POLICY`/`ALLOW_FROM`): listed sender is processed, a non-listed sender is dropped, `accepted` increments only for the listed one. *(Before this patch: both dropped, `accepted: 0`.)*
- `WHATSAPP_CLOUD_ALLOW_ALL_USERS=true` opens intake via the new `_open_dm_opted_in()` override.
- Explicit `WHATSAPP_CLOUD_DM_POLICY=allowlist` + `WHATSAPP_CLOUD_ALLOW_FROM` still works unchanged.

## Note

Either the docs/wizard should point at `WHATSAPP_CLOUD_ALLOW_FROM`/`WHATSAPP_CLOUD_DM_POLICY`, or (this PR) the adapter should honor the documented vars. Honoring the documented vars seems least-surprising for operators. Happy to also add a debug log when a DM is dropped by the intake gate if that's preferred — the silent drop was the hardest part to diagnose.
