### PR TITLE
fix(discord): gate tool targets by channel allowlist

### DIFF
--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -1039,6 +1039,92 @@ class TestRuntimeAllowlistEnforcement:
 
 
 # ---------------------------------------------------------------------------
+# Runtime target allowlist enforcement
+# ---------------------------------------------------------------------------
+
+class TestRuntimeTargetAllowlist:
+    @patch("tools.discord_tool._discord_request")
+    def test_channel_read_outside_allowed_channels_is_blocked(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+        monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "11")
+        monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"server_actions": ""}},
+        )
+
+        result = json.loads(discord_core(action="fetch_messages", channel_id="99"))
+
+        assert "error" in result
+        assert "DISCORD_ALLOWED_CHANNELS" in result["error"]
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    def test_channel_read_inside_allowed_channels_proceeds(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+        monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "11")
+        monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"server_actions": ""}},
+        )
+        mock_req.return_value = []
+
+        result = json.loads(discord_core(action="fetch_messages", channel_id="11"))
+
+        assert result == {"messages": [], "count": 0}
+        mock_req.assert_called_once()
+
+    @patch("tools.discord_tool._discord_request")
+    def test_ignored_channel_blocks_even_if_allowed(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+        monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "11")
+        monkeypatch.setenv("DISCORD_IGNORED_CHANNELS", "11")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"server_actions": ""}},
+        )
+
+        result = json.loads(discord_admin_handler(action="channel_info", channel_id="11"))
+
+        assert "error" in result
+        assert "DISCORD_IGNORED_CHANNELS" in result["error"]
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    def test_guild_wide_read_requires_wildcard_when_channels_are_scoped(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+        monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "11")
+        monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"server_actions": ""}},
+        )
+
+        result = json.loads(discord_admin_handler(action="list_channels", guild_id="111"))
+
+        assert "error" in result
+        assert "guild-wide Discord metadata" in result["error"]
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    def test_guild_wide_read_proceeds_with_wildcard_channel_allowlist(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+        monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "*")
+        monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"server_actions": ""}},
+        )
+        mock_req.return_value = []
+
+        result = json.loads(discord_admin_handler(action="list_channels", guild_id="111"))
+
+        assert result == {"channel_groups": [], "total_channels": 0}
+        mock_req.assert_called_once_with("GET", "/guilds/111/channels", "tok")
+
+
+# ---------------------------------------------------------------------------
 # 403 enrichment
 # ---------------------------------------------------------------------------
 

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -536,6 +536,66 @@ _REQUIRED_PARAMS: Dict[str, List[str]] = {
     "remove_role": ["guild_id", "user_id", "role_id"],
 }
 
+_CHANNEL_TARGETED_ACTIONS = frozenset({
+    "channel_info",
+    "fetch_messages",
+    "list_pins",
+    "pin_message",
+    "unpin_message",
+    "delete_message",
+    "create_thread",
+})
+
+_GUILD_WIDE_READ_ACTIONS = frozenset({
+    "list_guilds",
+    "server_info",
+    "list_channels",
+    "list_roles",
+    "member_info",
+    "search_members",
+})
+
+
+def _configured_allowed_channels() -> Optional[set[str]]:
+    raw = os.getenv("DISCORD_ALLOWED_CHANNELS", "").strip()
+    if not raw:
+        return None
+    allowed = {part.strip() for part in raw.split(",") if part.strip()}
+    return allowed or None
+
+
+def _configured_ignored_channels() -> set[str]:
+    raw = os.getenv("DISCORD_IGNORED_CHANNELS", "").strip()
+    return {part.strip() for part in raw.split(",") if part.strip()}
+
+
+def _authorize_target(action: str, *, channel_id: str = "") -> Optional[str]:
+    """Return an error string when Discord tool target policy denies a call."""
+    allowed_channels = _configured_allowed_channels()
+    ignored_channels = _configured_ignored_channels()
+    channel = str(channel_id or "").strip()
+
+    if action in _CHANNEL_TARGETED_ACTIONS and channel:
+        if "*" in ignored_channels or channel in ignored_channels:
+            return (
+                f"Discord channel {channel} is blocked by DISCORD_IGNORED_CHANNELS; "
+                "not calling the Discord API."
+            )
+        if allowed_channels is not None and "*" not in allowed_channels and channel not in allowed_channels:
+            return (
+                f"Discord channel {channel} is outside DISCORD_ALLOWED_CHANNELS; "
+                "not calling the Discord API."
+            )
+
+    if action in _GUILD_WIDE_READ_ACTIONS and allowed_channels is not None and "*" not in allowed_channels:
+        return (
+            f"Action '{action}' reads guild-wide Discord metadata, but "
+            "DISCORD_ALLOWED_CHANNELS is scoped to specific channels. "
+            "Set DISCORD_ALLOWED_CHANNELS=* or disable the channel allowlist to allow this read."
+        )
+
+    return None
+
 
 # ---------------------------------------------------------------------------
 # Config-based action allowlist
@@ -879,6 +939,10 @@ def _run_discord_action(
         return json.dumps({
             "error": f"Missing required parameters for '{action}': {', '.join(missing)}",
         })
+
+    target_error = _authorize_target(action, channel_id=channel_id)
+    if target_error:
+        return json.dumps({"error": target_error})
 
     try:
         return action_fn(


### PR DESCRIPTION
Fixes #58449.

## Summary
- add a runtime target-policy check before Discord REST tool calls are dispatched
- block channel-targeted actions when `channel_id` is outside `DISCORD_ALLOWED_CHANNELS`
- block ignored channels even when explicitly targeted
- require wildcard/no channel allowlist for guild-wide metadata reads that cannot be constrained to one channel

## Proof
- `DISCORD_ALLOWED_CHANNELS=11` + `discord_core(action=fetch_messages, channel_id=99)` returns an error and does not call `_discord_request`
- `DISCORD_ALLOWED_CHANNELS=11` + `discord_admin_handler(action=list_channels, guild_id=111)` returns an error and does not call `_discord_request`
- `DISCORD_ALLOWED_CHANNELS=*` keeps guild-wide reads working

## Tests
- `TEMP=./.tmp/pytest TMP=./.tmp/pytest ./.venv/Scripts/python.exe -m pytest tests/tools/test_discord_tool.py -q` -> 95 passed
- `./.venv/Scripts/python.exe -m py_compile tools/discord_tool.py tests/tools/test_discord_tool.py`
- `git diff --check`