### PR TITLE
fix: classify OpenRouter 'no endpoints found that support tool use' 404 as model_not_found with fallback

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -279,6 +279,15 @@ _MODEL_NOT_FOUND_PATTERNS = [
     "no such model",
     "unknown model",
     "unsupported model",
+    # OpenRouter returns 404 with this message when none of the candidate
+    # endpoints for the selected model support tool/function calling.
+    # Classifying this as model_not_found triggers fallback to a different
+    # model or provider that does support tools.  Without this entry the
+    # pattern falls through to ``unknown`` with ``retryable=True``, the
+    # retry loop burns all attempts on the same deterministic rejection,
+    # and the error surfaces as a confusing "model not found" message
+    # instead of automatically failing over.  See PR #58446.
+    "no endpoints found that support tool use",
 ]
 
 # Request-validation patterns — the request is malformed and will fail

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -516,6 +516,21 @@ class TestClassifyApiError:
         assert result.should_fallback is True
         assert result.retryable is False
 
+    def test_404_openrouter_tool_use_not_supported(self):
+        # OpenRouter returns 404 with this message when none of the
+        # candidate endpoints for the selected model support tool/function
+        # calling.  Classify as model_not_found so the agent fast-fallbacks
+        # to a model/provider that does support tools.
+        e = MockAPIError(
+            "No endpoints found that support tool use. "
+            "Try disabling \"browser_back\".",
+            status_code=404,
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.model_not_found
+        assert result.should_fallback is True
+        assert result.retryable is False
+
     def test_404_generic(self):
         # Generic 404 with no "model not found" signal — common for local
         # llama.cpp/Ollama/vLLM endpoints with slightly wrong paths.  Treat


### PR DESCRIPTION
## Problem

When OpenRouter routes to an endpoint that does not support tool/function calling, it returns HTTP 404:

```
No endpoints found that support tool use. Try disabling "browser_back".
To learn more about provider routing, visit:
https://openrouter.ai/docs/guides/routing/provider-selection
```

The raw error body does **not** contain `"model not found"` or any other `_MODEL_NOT_FOUND_PATTERNS` entry, so it falls through to `FailoverReason.unknown` with `retryable=True`. The retry loop wastes 3–5 attempts on the same deterministic rejection, then surfaces a confusing generic error instead of automatically failing over to a fallback model or provider.

## Fix

Added the OpenRouter phrase `"no endpoints found that support tool use"` to `_MODEL_NOT_FOUND_PATTERNS` in `agent/error_classifier.py`.

This classifies the error as `model_not_found` (`retryable=False`, `should_fallback=True`), which triggers the client-error fast-fallback path in `conversation_loop.py`: the agent switches to a configured fallback model/provider before the user ever sees the error.

### What doesn't change

- Existing buffered guidance in `conversation_loop.py` (the `"support tool use"` hint at line ~2967) remains intact — it surfaces only if every fallback exhausts.
- The `_PROVIDER_POLICY_BLOCKED_PATTERNS` are unaffected — those are distinct OpenRouter errors about data/privacy guardrails where fallback would not help.

## Testing

- ✅ Pattern matches the exact OpenRouter error body (confirmed from user reports)
- ✅ Classifier returns `model_not_found` → `retryable=False, should_fallback=True`
- ✅ This triggers `is_client_error` → `_try_activate_fallback()` in the retry loop
- ✅ The existing "support tool use" hint at `conversation_loop.py:2967` still fires as a fallback safeguard
