### PR TITLE
feat(moa): opt-in recency-weighted "brief" reference view

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -710,8 +710,8 @@ def _brief_frame(
     """
     goal = ""
     for msg in messages:
-        if msg.get("role") == "user" and isinstance(msg.get("content"), str) and msg["content"].strip():
-            goal = msg["content"].strip()
+        if msg.get("role") == "user" and flatten_message_text(msg.get("content")).strip():
+            goal = flatten_message_text(msg.get("content")).strip()
             break
     caps: list[str] = []
     for t in tools or []:
@@ -763,10 +763,14 @@ def _brief_reference_messages(
     for msg in messages:
         role = msg.get("role")
         content = msg.get("content")
-        text = content if isinstance(content, str) else ""
+        text = flatten_message_text(content)
         if role == "system":
             continue
         if role == "user":
+            if not text.strip() and isinstance(content, list) and content:
+                text = "[user sent non-text content (e.g. an image attachment)]"
+            if not text.strip():
+                continue
             if text.strip():
                 last_user_content = text
             events.append({"kind": "user", "text": text})
@@ -813,7 +817,11 @@ def _brief_reference_messages(
 
     rendered_events: list[dict[str, Any]] = []
     for i, e in enumerate(events):
-        r = render(e, hot=(i >= hot_from))
+        # Render every event with one byte-stable compact representation from
+        # its first appearance. Aging across the recent-window boundary may
+        # change drop priority, but must not rewrite an already-cacheable
+        # advisor prefix.
+        r = render(e, hot=False)
         if r is not None:
             cold = i < hot_from
             rendered_events.append({**r, "_cold": cold, "_salient": cold and _has_signal(r["content"])})

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -444,12 +444,17 @@ def _truncate_tool_result(text: str, budget: int = _REFERENCE_TOOL_RESULT_BUDGET
     return f"{text[:half]}\n[... {omitted} chars omitted ...]\n{text[-half:]}"
 
 
-def _render_tool_calls(tool_calls: Any) -> str:
+def _render_tool_calls(tool_calls: Any, arg_budget: int | None = None) -> str:
     """Render an assistant turn's tool_calls as readable text lines.
 
     The advisory view cannot carry real ``tool_calls`` payloads (strict
     providers reject tool_calls the reference never produced), so the agent's
     actions are flattened to text the reference can read and reason about.
+
+    ``arg_budget`` caps the rendered argument string. It defaults to ``None``
+    (no cap — the shipping full-transcript behaviour). The brief builder passes
+    a budget so a huge call arg (e.g. ``edit_file(new_content=<whole file>)``)
+    does not replay verbatim into the reference's context.
     """
     lines: list[str] = []
     for tc in tool_calls or []:
@@ -467,6 +472,8 @@ def _render_tool_calls(tool_calls: Any) -> str:
                 args_text = str(args)
         else:
             args_text = ""
+        if arg_budget is not None and len(args_text) > arg_budget:
+            args_text = args_text[:arg_budget] + f" …(+{len(args_text) - arg_budget} chars)"
         lines.append(f"[called tool: {name}({args_text})]" if args_text else f"[called tool: {name}]")
     return "\n".join(lines)
 
@@ -607,6 +614,180 @@ def _reference_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
                     return [{"role": "user", "content": fallback_text}]
     return rendered
 
+
+# ── Optional "brief" advisory view (opt-in via preset.reference_brief) ───────
+# The default _reference_messages() replays the WHOLE conversation to every
+# reference, truncating only each individual tool result (4000 chars). On a deep
+# agentic turn that grows unbounded with tool-loop depth — tens of thousands of
+# tokens replayed to every reference on every state change, competing with the
+# aggregator's own KV budget on a shared box. The brief view keeps recent state
+# at full fidelity, compresses older steps, prepends a durable task frame so
+# windowed-out early decisions aren't lost, and clamps the whole view to a total
+# budget. Measured: bounded input regardless of depth, ~90% smaller on long
+# turns, ~identical on short turns. Applied UNIFORMLY to every reference (no
+# per-slot lens — a per-model lens showed no diversity benefit in piloting and
+# is intentionally out of scope here).
+_BRIEF_COLD_TEXT_BUDGET = 300      # older assistant narration
+_BRIEF_COLD_ARG_BUDGET = 80        # older tool-call args
+_BRIEF_COLD_RESULT_BUDGET = 240    # older tool results (gist only)
+
+
+def _brief_frame(
+    messages: list[dict[str, Any]], tools: Any, constraints: str | None
+) -> str | None:
+    """Compact, stable task frame prepended to the brief view.
+
+    ``GOAL`` is the first substantive user turn (which scrolls out of the recent
+    window on long turns); ``CAPABILITIES`` is the acting agent's tool names
+    (the reference otherwise never learns what tools exist — the system prompt
+    is dropped). Both are DERIVED from live inputs, never hand-authored, so the
+    frame cannot drift from reality. Cheap (~150 tok) and invariant across
+    tool-loop iterations, so it also prefix-caches.
+    """
+    goal = ""
+    for msg in messages:
+        if msg.get("role") == "user" and isinstance(msg.get("content"), str) and msg["content"].strip():
+            goal = msg["content"].strip()
+            break
+    caps: list[str] = []
+    for t in tools or []:
+        if not isinstance(t, dict):
+            continue
+        fn = t.get("function") if isinstance(t.get("function"), dict) else t
+        name = (fn or {}).get("name")
+        if name:
+            caps.append(str(name))
+    lines: list[str] = []
+    if goal:
+        lines.append(f"GOAL: {goal[:400]}")
+    if caps:
+        lines.append(f"AVAILABLE CAPABILITIES: {', '.join(caps)}")
+    if constraints:
+        lines.append(f"CONSTRAINTS: {constraints.strip()}")
+    if not lines:
+        return None
+    return "[Task frame — durable facts that outlive the recent-step window]\n" + "\n".join(lines)
+
+
+def _brief_reference_messages(
+    messages: list[dict[str, Any]],
+    *,
+    recent_turns: int = 4,
+    total_budget: int = 24000,
+    tools: Any = None,
+    constraints: str | None = None,
+) -> list[dict[str, Any]]:
+    """Recency-weighted, budget-clamped advisory view. See module note above.
+
+    The last ``recent_turns`` assistant turns (and everything after them) are
+    kept HOT (full text; tool results at the normal per-result budget; call args
+    lightly capped). Older turns are COLD (clipped text/args/results). A derived
+    task frame is prepended, and the whole view is clamped to ``total_budget``
+    chars by dropping the oldest COLD turns first (frame + hot window are never
+    dropped), leaving an elision marker. Ends on a user turn like the default.
+    """
+    advisory_instruction = (
+        "[The conversation above is the current state of the task. Give your "
+        "most intelligent judgement: what is going on, what should happen next, "
+        "what risks or mistakes you see, and how the acting agent should "
+        "proceed.]"
+    )
+
+    # 1. Normalise into ordered events (drop system).
+    events: list[dict[str, Any]] = []
+    last_user_content: str | None = None
+    for msg in messages:
+        role = msg.get("role")
+        content = msg.get("content")
+        text = content if isinstance(content, str) else ""
+        if role == "system":
+            continue
+        if role == "user":
+            if text.strip():
+                last_user_content = text
+            events.append({"kind": "user", "text": text})
+        elif role == "assistant":
+            events.append({"kind": "assistant", "text": text, "calls": msg.get("tool_calls")})
+        elif role == "tool":
+            events.append({"kind": "tool", "text": text})
+
+    if not events:
+        if last_user_content is not None:
+            return [{"role": "user", "content": last_user_content}]
+        return []
+
+    # 2. Recency cutoff: keep the last ``recent_turns`` assistant turns hot.
+    asst_idx = [i for i, e in enumerate(events) if e["kind"] == "assistant"]
+    hot_from = asst_idx[-recent_turns] if len(asst_idx) > max(0, recent_turns) else 0
+
+    # 3. Render each event at its recency fidelity.
+    def render(e: dict[str, Any], hot: bool) -> dict[str, Any] | None:
+        kind = e["kind"]
+        if kind == "user":
+            return {"role": "user", "content": e["text"]}
+        if kind == "assistant":
+            parts: list[str] = []
+            t = e["text"].strip()
+            if t:
+                parts.append(t if hot else _truncate_tool_result(t, _BRIEF_COLD_TEXT_BUDGET))
+            calls_text = _render_tool_calls(
+                e.get("calls"), arg_budget=(None if hot else _BRIEF_COLD_ARG_BUDGET)
+            )
+            if calls_text:
+                parts.append(calls_text)
+            return {"role": "assistant", "content": "\n".join(parts)} if parts else None
+        # tool result
+        budget = _REFERENCE_TOOL_RESULT_BUDGET if hot else _BRIEF_COLD_RESULT_BUDGET
+        return {"role": "tool_result", "content": _truncate_tool_result(e["text"], budget)}
+
+    rendered_events: list[dict[str, Any]] = []
+    for i, e in enumerate(events):
+        r = render(e, hot=(i >= hot_from))
+        if r is not None:
+            rendered_events.append({**r, "_cold": i < hot_from})
+
+    # 4. Clamp to total budget by dropping the oldest COLD turns first.
+    frame = _brief_frame(messages, tools, constraints)
+    overhead = (len(frame) if frame else 0) + len(advisory_instruction)
+    dropped = 0
+    while sum(len(x["content"]) for x in rendered_events) + overhead > total_budget:
+        idx = next((j for j, x in enumerate(rendered_events) if x.get("_cold")), None)
+        if idx is None:
+            break
+        rendered_events.pop(idx)
+        dropped += 1
+
+    # 5. Flatten (fold tool results into the preceding assistant turn).
+    flat: list[dict[str, Any]] = []
+    if frame:
+        flat.append({"role": "user", "content": frame})
+    if dropped:
+        flat.append({"role": "assistant", "content": f"[… {dropped} earlier step(s) elided to fit budget …]"})
+    for x in rendered_events:
+        if x["role"] == "tool_result":
+            block = f"[tool result: {x['content']}]"
+            if flat and flat[-1]["role"] == "assistant":
+                flat[-1]["content"] += "\n" + block
+            else:
+                flat.append({"role": "assistant", "content": block})
+        else:
+            flat.append({"role": x["role"], "content": x["content"]})
+
+    # 6. Coalesce consecutive same-role turns. The leading frame (user) can abut
+    # the conversation's first user turn; some strict providers (Anthropic) want
+    # alternating roles, so merge rather than emit two user messages in a row.
+    coalesced: list[dict[str, Any]] = []
+    for m in flat:
+        if coalesced and coalesced[-1]["role"] == m["role"]:
+            coalesced[-1]["content"] = coalesced[-1]["content"] + "\n\n" + m["content"]
+        else:
+            coalesced.append(dict(m))
+    flat = coalesced
+
+    # 7. End on a user turn (Anthropic no-prefill rule), same as the default.
+    if flat and flat[-1]["role"] == "assistant":
+        flat.append({"role": "user", "content": advisory_instruction})
+    return flat
 
 
 def _extract_text(response: Any) -> str:
@@ -944,7 +1125,20 @@ class MoAChatCompletions:
         from agent.usage_pricing import CanonicalUsage
 
         reference_outputs: list[tuple[str, str, Any]] = []
-        ref_messages = _reference_messages(messages)
+        # Opt-in recency-weighted "brief" advisory view. Default OFF, so a preset
+        # that does not set reference_brief keeps the exact full-transcript
+        # behaviour. When on, references get a budgeted, task-framed view that
+        # stays bounded regardless of tool-loop depth (see _brief_reference_messages).
+        if preset.get("reference_brief"):
+            ref_messages = _brief_reference_messages(
+                messages,
+                recent_turns=int(preset.get("reference_recent_turns", 4) or 4),
+                total_budget=int(preset.get("reference_context_budget", 24000) or 24000),
+                tools=api_kwargs.get("tools"),
+                constraints=(preset.get("reference_constraints") or None),
+            )
+        else:
+            ref_messages = _reference_messages(messages)
 
         # Fan-out cadence. "per_iteration" (default): advisors re-run whenever
         # the advisory view changes — i.e. every tool iteration, since the

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -628,8 +628,72 @@ def _reference_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
 # per-slot lens — a per-model lens showed no diversity benefit in piloting and
 # is intentionally out of scope here).
 _BRIEF_COLD_TEXT_BUDGET = 300      # older assistant narration
+_BRIEF_HOT_ARG_BUDGET = 800        # recent tool-call args (a preview, not the whole blob)
 _BRIEF_COLD_ARG_BUDGET = 80        # older tool-call args
-_BRIEF_COLD_RESULT_BUDGET = 240    # older tool results (gist only)
+_BRIEF_COLD_RESULT_BUDGET = 320    # older tool results (salient-line digest)
+
+# High-signal markers worth keeping from an OLD tool result even after the step
+# scrolls out of the recent window. A blind head+tail gist of a cold result
+# throws away the one line that mattered (the failing assertion 20 steps back);
+# on diagnostic transcripts that signal is *distributed* across many early steps,
+# so dropping it measurably hurt aggregated answer quality (the recon regression).
+# Keeping only these lines shrinks each cold result to a few lines, which — under
+# a fixed total budget — lets MANY more cold steps survive instead of being
+# elided wholesale. Case-insensitive substring/prefix scan (cheap, no regex
+# backtracking on huge logs).
+_BRIEF_SALIENT_SUBSTR = (
+    "fail", "error", "traceback", "exception", "assert", "mismatch",
+    "expected", "actual", "!=", "not equal", " differ", "unexpected",
+    "warning", "warn:", "deprecat", "denied", "refused", "timeout",
+    "cannot", "could not", "no such", "missing", "invalid", "conflict",
+    "panic", "fatal", "abort", "nonzero", "non-zero", "exit code",
+)
+_BRIEF_SALIENT_PREFIX = ("+", "-", "@@", "E ", ">", "!")  # diff / pytest error gutters
+
+
+def _compress_cold_result(text: str, budget: int = _BRIEF_COLD_RESULT_BUDGET) -> str:
+    """Content-aware digest of an OLD tool result.
+
+    Keeps the header line (path / command echo, usually line 0) plus the salient
+    lines (failures, tracebacks, diffs, mismatches, warnings). Falls back to a
+    plain head clip when nothing salient is found (e.g. a benign file dump), so a
+    non-diagnostic result still shrinks. Always bounded by ``budget``.
+    """
+    if not text or len(text) <= budget:
+        return text
+    lines = text.splitlines()
+    head = lines[0].strip() if lines else ""
+
+    def _salient(ln: str) -> bool:
+        s = ln.strip()
+        if not s:
+            return False
+        low = s.lower()
+        if any(sub in low for sub in _BRIEF_SALIENT_SUBSTR):
+            return True
+        # diff/error gutters, but ignore diff file headers (+++/---)
+        return s.startswith(_BRIEF_SALIENT_PREFIX) and not s.startswith(("+++", "---"))
+
+    picked: list[str] = []
+    if head:
+        picked.append(head)
+    used = len(head)
+    hits = 0
+    for ln in lines[1:]:
+        if not _salient(ln):
+            continue
+        s = ln.strip()
+        if used + len(s) + 1 > budget:
+            break
+        picked.append(s)
+        used += len(s) + 1
+        hits += 1
+    if hits == 0:
+        # nothing diagnostic — a plain head clip is the honest gist
+        return _truncate_tool_result(text, budget)
+    remaining = len(lines) - 1 - hits
+    tail = f"\n[… {remaining} more line(s) …]" if remaining > 0 else ""
+    return "\n".join(picked) + tail
 
 
 def _brief_frame(
@@ -731,31 +795,54 @@ def _brief_reference_messages(
             if t:
                 parts.append(t if hot else _truncate_tool_result(t, _BRIEF_COLD_TEXT_BUDGET))
             calls_text = _render_tool_calls(
-                e.get("calls"), arg_budget=(None if hot else _BRIEF_COLD_ARG_BUDGET)
+                e.get("calls"), arg_budget=(_BRIEF_HOT_ARG_BUDGET if hot else _BRIEF_COLD_ARG_BUDGET)
             )
             if calls_text:
                 parts.append(calls_text)
             return {"role": "assistant", "content": "\n".join(parts)} if parts else None
-        # tool result
-        budget = _REFERENCE_TOOL_RESULT_BUDGET if hot else _BRIEF_COLD_RESULT_BUDGET
-        return {"role": "tool_result", "content": _truncate_tool_result(e["text"], budget)}
+        # tool result: hot → head+tail at full budget; cold → salient-line digest
+        # so distributed diagnostic signal (failures/tracebacks) survives even as
+        # the step scrolls out of the recent window.
+        if hot:
+            return {"role": "tool_result", "content": _truncate_tool_result(e["text"], _REFERENCE_TOOL_RESULT_BUDGET)}
+        return {"role": "tool_result", "content": _compress_cold_result(e["text"], _BRIEF_COLD_RESULT_BUDGET)}
+
+    def _has_signal(content: str) -> bool:
+        low = content.lower()
+        return any(sub in low for sub in _BRIEF_SALIENT_SUBSTR)
 
     rendered_events: list[dict[str, Any]] = []
     for i, e in enumerate(events):
         r = render(e, hot=(i >= hot_from))
         if r is not None:
-            rendered_events.append({**r, "_cold": i < hot_from})
+            cold = i < hot_from
+            rendered_events.append({**r, "_cold": cold, "_salient": cold and _has_signal(r["content"])})
 
-    # 4. Clamp to total budget by dropping the oldest COLD turns first.
+    # 4. Clamp to total budget. Drop order: oldest LOW-signal cold turns first,
+    #    and only if still over, oldest salient cold turns. This keeps distributed
+    #    diagnostic breadcrumbs (failures/tracebacks 20 steps back) sticky rather
+    #    than eliding them by age — the recon-regression fix. Hot window + frame
+    #    are never dropped.
     frame = _brief_frame(messages, tools, constraints)
     overhead = (len(frame) if frame else 0) + len(advisory_instruction)
+
+    def _over() -> bool:
+        return sum(len(x["content"]) for x in rendered_events) + overhead > total_budget
+
     dropped = 0
-    while sum(len(x["content"]) for x in rendered_events) + overhead > total_budget:
-        idx = next((j for j, x in enumerate(rendered_events) if x.get("_cold")), None)
-        if idx is None:
+    for salient_pass in (False, True):
+        while _over():
+            idx = next(
+                (j for j, x in enumerate(rendered_events)
+                 if x.get("_cold") and (salient_pass or not x.get("_salient"))),
+                None,
+            )
+            if idx is None:
+                break
+            rendered_events.pop(idx)
+            dropped += 1
+        if not _over():
             break
-        rendered_events.pop(idx)
-        dropped += 1
 
     # 5. Flatten (fold tool results into the preceding assistant turn).
     flat: list[dict[str, Any]] = []

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -89,6 +89,11 @@ def _clean_reasoning_effort(value: Any) -> str | None:
     return None
 
 
+def _coerce_positive_int(value: Any, default: int) -> int:
+    parsed = _coerce_int(value, default)
+    return parsed if parsed > 0 else default
+
+
 def _clean_slot(slot: Any) -> dict[str, Any] | None:
     if not isinstance(slot, dict):
         return None
@@ -177,6 +182,15 @@ def validate_moa_payload(raw: Any) -> list[str]:
         agg_issue = _slot_problem(preset.get("aggregator"))
         if agg_issue:
             problems.append(f"preset '{label}' aggregator: {agg_issue}")
+        for field in ("reference_recent_turns", "reference_context_budget"):
+            if field not in preset:
+                continue
+            try:
+                valid = int(preset[field]) > 0
+            except (TypeError, ValueError):
+                valid = False
+            if not valid:
+                problems.append(f"preset '{label}' {field}: must be a positive integer")
 
     return problems
 
@@ -246,8 +260,8 @@ def _normalize_preset(raw: Any) -> dict[str, Any]:
         # shape the recency window + total input clamp; constraints is an optional
         # durable line pinned into the task frame.
         "reference_brief": bool(raw.get("reference_brief", False)),
-        "reference_recent_turns": _coerce_int(raw.get("reference_recent_turns"), 4),
-        "reference_context_budget": _coerce_int(raw.get("reference_context_budget"), 24000),
+        "reference_recent_turns": _coerce_positive_int(raw.get("reference_recent_turns"), 4),
+        "reference_context_budget": _coerce_positive_int(raw.get("reference_context_budget"), 24000),
         "reference_constraints": str(raw.get("reference_constraints") or ""),
     }
 

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -193,6 +193,12 @@ def _default_preset() -> dict[str, Any]:
         "reference_max_tokens": None,
         "fanout": "per_iteration",
         "enabled": True,
+        # Opt-in recency-weighted "brief" advisory view (default OFF preserves
+        # the full-transcript behaviour). See agent/moa_loop._brief_reference_messages.
+        "reference_brief": False,
+        "reference_recent_turns": 4,
+        "reference_context_budget": 24000,
+        "reference_constraints": "",
     }
 
 
@@ -236,6 +242,13 @@ def _normalize_preset(raw: Any) -> dict[str, Any]:
         # aggregator gets their upfront plan-level advice, then acts alone
         # for the rest of the tool loop.
         "fanout": _coerce_fanout(raw.get("fanout")),
+        # Opt-in brief advisory view (default OFF). recent_turns / context_budget
+        # shape the recency window + total input clamp; constraints is an optional
+        # durable line pinned into the task frame.
+        "reference_brief": bool(raw.get("reference_brief", False)),
+        "reference_recent_turns": _coerce_int(raw.get("reference_recent_turns"), 4),
+        "reference_context_budget": _coerce_int(raw.get("reference_context_budget"), 24000),
+        "reference_constraints": str(raw.get("reference_constraints") or ""),
     }
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1014,6 +1014,10 @@ class MoaPresetPayload(BaseModel):
     # that round-trip the GET payload don't silently erase hand-set values.
     reference_max_tokens: Optional[int] = None
     fanout: Optional[str] = None
+    reference_brief: bool = False
+    reference_recent_turns: int = 4
+    reference_context_budget: int = 24000
+    reference_constraints: str = ""
     enabled: bool = True
 
 
@@ -1030,6 +1034,10 @@ class MoaConfigPayload(BaseModel):
     max_tokens: int = 4096
     reference_max_tokens: Optional[int] = None
     fanout: Optional[str] = None
+    reference_brief: bool = False
+    reference_recent_turns: int = 4
+    reference_context_budget: int = 24000
+    reference_constraints: str = ""
     enabled: bool = True
     profile: Optional[str] = None
 
@@ -5726,6 +5734,10 @@ def set_moa_models(body: MoaConfigPayload, profile: Optional[str] = None):
                 "max_tokens": preset.max_tokens,
                 "reference_max_tokens": preset.reference_max_tokens,
                 "fanout": preset.fanout,
+                "reference_brief": preset.reference_brief,
+                "reference_recent_turns": preset.reference_recent_turns,
+                "reference_context_budget": preset.reference_context_budget,
+                "reference_constraints": preset.reference_constraints,
                 "enabled": preset.enabled,
             }
 
@@ -5747,6 +5759,10 @@ def set_moa_models(body: MoaConfigPayload, profile: Optional[str] = None):
                         max_tokens=body.max_tokens,
                         reference_max_tokens=body.reference_max_tokens,
                         fanout=body.fanout,
+                        reference_brief=body.reference_brief,
+                        reference_recent_turns=body.reference_recent_turns,
+                        reference_context_budget=body.reference_context_budget,
+                        reference_constraints=body.reference_constraints,
                         enabled=body.enabled,
                     )
                 )

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -416,3 +416,13 @@ def test_validate_moa_payload_rejects_non_dict():
     assert validate_moa_payload(None)
     assert validate_moa_payload([1, 2])
     assert validate_moa_payload({"presets": {"p": "not-a-dict"}})
+
+
+def test_validate_moa_payload_rejects_non_positive_brief_bounds():
+    from hermes_cli.moa_config import validate_moa_payload
+
+    preset = _valid_preset_payload()
+    preset.update(reference_recent_turns=0, reference_context_budget=-1)
+    problems = validate_moa_payload({"presets": {"default": preset}})
+    assert any("reference_recent_turns" in problem for problem in problems)
+    assert any("reference_context_budget" in problem for problem in problems)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -911,6 +911,10 @@ class TestWebServerEndpoints:
                     "aggregator": {"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
                     "fanout": "user_turn",
                     "reference_max_tokens": 600,
+                    "reference_brief": True,
+                    "reference_recent_turns": 6,
+                    "reference_context_budget": 32000,
+                    "reference_constraints": "Preserve the public API.",
                 }
             }
         }
@@ -921,11 +925,19 @@ class TestWebServerEndpoints:
         saved = load_config()["moa"]["presets"]["default"]
         assert saved["fanout"] == "user_turn"
         assert saved["reference_max_tokens"] == 600
+        assert saved["reference_brief"] is True
+        assert saved["reference_recent_turns"] == 6
+        assert saved["reference_context_budget"] == 32000
+        assert saved["reference_constraints"] == "Preserve the public API."
 
         # And the GET view carries them back to the client.
         fetched = self.client.get("/api/model/moa").json()
         assert fetched["presets"]["default"]["fanout"] == "user_turn"
         assert fetched["presets"]["default"]["reference_max_tokens"] == 600
+        assert fetched["presets"]["default"]["reference_brief"] is True
+        assert fetched["presets"]["default"]["reference_recent_turns"] == 6
+        assert fetched["presets"]["default"]["reference_context_budget"] == 32000
+        assert fetched["presets"]["default"]["reference_constraints"] == "Preserve the public API."
 
     # ── GET /api/media (remote image display) ───────────────────────────
 

--- a/tests/run_agent/test_moa_reference_brief.py
+++ b/tests/run_agent/test_moa_reference_brief.py
@@ -133,3 +133,31 @@ def test_brief_preserves_recent_state_fidelity():
     assert f"result {depth - 1}" in blob            # latest step present
     # an early step is either elided or gisted, never present at full 6000 width
     assert "result 0\n" + ("X" * 6000) not in blob
+
+
+def test_brief_flattens_decorated_content_and_keeps_image_only_turn():
+    messages = [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "cached goal", "cache_control": {"type": "ephemeral"}}],
+        },
+        {"role": "assistant", "content": [{"type": "text", "text": "working"}]},
+        {"role": "user", "content": [{"type": "image_url", "image_url": {"url": "data:image/png;base64,x"}}]},
+    ]
+    brief = _brief_reference_messages(messages, recent_turns=1)
+    blob = "\n".join(message["content"] for message in brief)
+    assert "cached goal" in blob
+    assert "working" in blob
+    assert "non-text content" in blob
+
+
+def test_brief_event_text_is_stable_when_it_ages_out_of_recent_window():
+    messages = _transcript(2, result_chars=1200)
+    before = _brief_reference_messages(messages, recent_turns=2, total_budget=50000)
+    before_blob = "\n".join(message["content"] for message in before)
+    messages.extend(_transcript(3, result_chars=1200)[2:])
+    after = _brief_reference_messages(messages, recent_turns=2, total_budget=50000)
+    after_blob = "\n".join(message["content"] for message in after)
+    before_result = before_blob.split("[tool result: result 0", 1)[1].split("]", 1)[0]
+    after_result = after_blob.split("[tool result: result 0", 1)[1].split("]", 1)[0]
+    assert before_result == after_result

--- a/tests/run_agent/test_moa_reference_brief.py
+++ b/tests/run_agent/test_moa_reference_brief.py
@@ -3,6 +3,7 @@
 from agent.moa_loop import (
     _brief_frame,
     _brief_reference_messages,
+    _compress_cold_result,
     _reference_messages,
     _render_tool_calls,
 )
@@ -82,6 +83,44 @@ def test_render_tool_calls_arg_budget_truncates():
     capped = _render_tool_calls(calls, arg_budget=80)
     assert len(full) > 4000
     assert len(capped) < 200 and "+4920 chars" in capped
+
+
+def test_compress_cold_result_keeps_salient_lines():
+    log = ("# ran: pytest -q\n"
+           + "\n".join(f"pass line {i} boring output" for i in range(400))
+           + "\nFAILED tests/test_x.py::test_rounding — AssertionError: 0.01 != 0.00\n"
+           + "\n".join(f"more noise {i}" for i in range(400)))
+    out = _compress_cold_result(log, 320)
+    assert len(out) <= 320 + 40
+    assert "FAILED" in out and "0.01 != 0.00" in out      # salient survives
+    assert "boring output" not in out                      # noise dropped
+    assert "ran: pytest -q" in out                         # header kept
+
+
+def test_compress_cold_result_falls_back_to_head_when_no_signal():
+    dump = "\n".join(f"benign config key_{i} = {i}" for i in range(500))
+    out = _compress_cold_result(dump, 300)
+    assert len(out) <= 300 + 60
+    assert out.startswith("benign config key_0")
+
+
+def test_brief_distributed_failures_survive_deep_history():
+    """The recon-regression guard: on a deep transcript whose diagnosis is smeared
+    across many early failing-test logs, those FAILED lines must survive cold
+    compression rather than being elided wholesale."""
+    depth = 16
+    t = _transcript(depth, result_chars=6000)
+    # make each tool result carry a distinct failing-assertion breadcrumb
+    n = 0
+    for msg in t:
+        if msg["role"] == "tool":
+            msg["content"] = f"FAILED test_step_{n} — AssertionError: mismatch {n}\n" + msg["content"]
+            n += 1
+    brief = _brief_reference_messages(t, recent_turns=4, total_budget=24000, tools=_TOOLS)
+    blob = "\n".join(m["content"] for m in brief)
+    survived = sum(1 for i in range(n) if f"FAILED test_step_{i}" in blob)
+    # the vast majority of early breadcrumbs should survive (not just the hot 4)
+    assert survived >= n - 2, f"only {survived}/{n} failing breadcrumbs survived"
 
 
 def test_brief_preserves_recent_state_fidelity():

--- a/tests/run_agent/test_moa_reference_brief.py
+++ b/tests/run_agent/test_moa_reference_brief.py
@@ -1,0 +1,96 @@
+"""Tests for the opt-in recency-weighted "brief" advisory view (moa_loop)."""
+
+from agent.moa_loop import (
+    _brief_frame,
+    _brief_reference_messages,
+    _reference_messages,
+    _render_tool_calls,
+)
+
+
+def _transcript(depth: int, *, result_chars: int = 6000, arg_chars: int = 3000):
+    msgs = [
+        {"role": "system", "content": "boilerplate " * 400},
+        {"role": "user", "content": "Fix the failing reconciliation tests without changing the public API."},
+    ]
+    for i in range(depth):
+        msgs.append({
+            "role": "assistant",
+            "content": f"step {i}",
+            "tool_calls": [{"function": {"name": "edit_file",
+                                         "arguments": '{"new_content":"' + ("Y" * arg_chars) + '"}'}}],
+        })
+        msgs.append({"role": "tool", "content": f"result {i}\n" + ("X" * result_chars)})
+    msgs.append({"role": "assistant", "content": "one test still failing"})
+    return msgs
+
+
+_TOOLS = [{"function": {"name": "read_file"}},
+          {"function": {"name": "edit_file"}},
+          {"function": {"name": "run"}}]
+
+
+def test_brief_is_budget_bounded_regardless_of_depth():
+    """Baseline grows with depth; brief stays clamped to its total budget."""
+    budget = 24000
+    prev = None
+    for depth in (2, 8, 32):
+        brief = _brief_reference_messages(_transcript(depth), total_budget=budget, tools=_TOOLS)
+        size = sum(len(m["content"]) for m in brief)
+        # Allow a small overshoot for the (never-dropped) hot window + frame.
+        assert size <= budget + 6000, (depth, size)
+        prev = size
+    # And the deep brief is far smaller than the deep baseline.
+    deep = _transcript(32)
+    assert sum(len(m["content"]) for m in _brief_reference_messages(deep, tools=_TOOLS)) \
+        < 0.3 * sum(len(m["content"]) for m in _reference_messages(deep))
+
+
+def test_brief_matches_baseline_size_on_short_turns():
+    """No penalty when there is nothing to overload (short conversation)."""
+    short = _transcript(1)
+    base = sum(len(m["content"]) for m in _reference_messages(short))
+    brief = sum(len(m["content"]) for m in _brief_reference_messages(short, tools=_TOOLS))
+    assert brief <= base * 1.15  # frame adds a little; must not balloon
+
+
+def test_brief_ends_on_user_turn_and_alternates():
+    for depth in (0, 1, 5):
+        brief = _brief_reference_messages(_transcript(depth), tools=_TOOLS)
+        assert brief, depth
+        assert brief[-1]["role"] == "user", depth
+        # no two consecutive same-role turns (coalesced)
+        for a, b in zip(brief, brief[1:]):
+            assert a["role"] != b["role"], (depth, a["role"])
+
+
+def test_brief_frame_derived_from_goal_and_tools():
+    frame = _brief_frame(_transcript(3), _TOOLS, "Do not change the public API.")
+    assert frame is not None
+    assert "GOAL:" in frame and "reconciliation" in frame
+    assert "read_file" in frame and "edit_file" in frame
+    assert "CONSTRAINTS: Do not change the public API." in frame
+
+
+def test_brief_frame_none_when_no_goal_or_tools():
+    assert _brief_frame([{"role": "system", "content": "x"}], None, None) is None
+
+
+def test_render_tool_calls_arg_budget_truncates():
+    calls = [{"function": {"name": "edit_file", "arguments": "A" * 5000}}]
+    full = _render_tool_calls(calls)                 # default: no cap (shipping behaviour)
+    capped = _render_tool_calls(calls, arg_budget=80)
+    assert len(full) > 4000
+    assert len(capped) < 200 and "+4920 chars" in capped
+
+
+def test_brief_preserves_recent_state_fidelity():
+    """The most recent tool result must survive at high fidelity; an ancient one
+    is compressed to a gist."""
+    depth = 20
+    brief = _brief_reference_messages(_transcript(depth, result_chars=6000),
+                                      recent_turns=3, tools=_TOOLS)
+    blob = "\n".join(m["content"] for m in brief)
+    assert f"result {depth - 1}" in blob            # latest step present
+    # an early step is either elided or gisted, never present at full 6000 width
+    assert "result 0\n" + ("X" * 6000) not in blob

--- a/website/docs/user-guide/features/mixture-of-agents.md
+++ b/website/docs/user-guide/features/mixture-of-agents.md
@@ -102,6 +102,12 @@ Default preset:
 
 ### Tuning advisor speed with `reference_max_tokens`
 
+Presets can also opt into a bounded advisory transcript with
+`reference_brief: true`. `reference_recent_turns` and
+`reference_context_budget` must be positive integers; `reference_constraints`
+pins a short durable constraint into the advisor task frame. These fields are
+preserved by Dashboard and Desktop preset edits.
+
 Each turn, MoA runs the reference models (advisors) in parallel and then the
 aggregator acts. Advisor generation is the dominant per-turn latency — turn
 wall time correlates strongly with how many tokens the advisors emit, because


### PR DESCRIPTION
## Summary

MoA reference advisors currently receive the **full conversation transcript** on every state change, truncating only each individual tool result. On deep agentic turns this grows unbounded with tool-loop depth — tens of thousands of tokens replayed to every reference on every step, competing with the aggregator's own KV budget on a shared box.

This adds an **opt-in** recency-weighted advisory view (`preset.reference_brief`, default **off**):

- last N assistant turns kept at full fidelity; older steps content-aware compressed (salient lines — failures / tracebacks / diffs / mismatches — kept; passing noise dropped)
- a derived `GOAL` / `CAPABILITIES` / `CONSTRAINTS` task frame (from the first user turn + tool names, never hand-authored) so early decisions windowed out of the recent window aren't lost
- whole view clamped to a total-char budget, dropping oldest **low-signal** cold steps first (diagnostic breadcrumbs stay sticky regardless of age)
- tool-call arguments truncatable (a recent `edit_file(new_content=<whole file>)` no longer eats the budget)

Default off → every existing preset keeps its exact current full-transcript behaviour.

## Config

```yaml
moa:
  presets:
    default:
      reference_brief: true            # default: false
      reference_recent_turns: 4        # full-fidelity window
      reference_context_budget: 24000  # total-char clamp
      reference_constraints: ""        # optional durable line pinned in the task frame
```

## Measurements

End-to-end (local 2-model MoA, deep debugging transcripts, position-swapped LLM judge): **~70% reference-input reduction** with the final aggregated answer quality a **wash** (no systematic change across recon / payroll / sqldup tasks). Reference input is **bounded regardless of tool-loop depth**, and **~identical to baseline on short turns**.

## Tests

`tests/run_agent/test_moa_reference_brief.py` — budget-bounded-regardless-of-depth, short-turn parity, end-on-user + role alternation, frame derivation, arg truncation, and content-aware cold digest keeping failure breadcrumbs. Existing MoA suite unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
