### PR TITLE
fix(anthropic): ignore non-string keychain payloads

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -908,7 +908,7 @@ def _read_claude_code_credentials_from_keychain() -> Optional[Dict[str, Any]]:
 
     try:
         data = json.loads(raw)
-    except json.JSONDecodeError:
+    except (TypeError, json.JSONDecodeError):
         logger.debug("Keychain: credentials payload is not valid JSON")
         return None
 


### PR DESCRIPTION
## Summary
- Treat non-string macOS Keychain payloads as invalid Claude Code credential JSON instead of letting `json.loads()` raise `TypeError`.
- Keeps the OAuth setup-token fallback path resilient when subprocess/keychain access is mocked or returns an unexpected object.

## Test Plan
- `python -m py_compile agent/anthropic_adapter.py`
- `python -m pytest -q -o 'addopts=' --tb=short tests/agent/test_anthropic_adapter.py::TestRunOauthSetupToken`
