### PR TITLE
fix(console): handle string SystemExit code in _capture_output

### DIFF
--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -62,16 +62,24 @@ def _capture_output(fn: Callable[[], object]) -> str:
     stdout = io.StringIO()
     stderr = io.StringIO()
     code = 0
+    message = ""
     with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
         try:
             result = fn()
             if isinstance(result, int) and result:
                 raise SystemExit(result)
         except SystemExit as exc:
-            code = int(exc.code or 0)
+            # sys.exit("msg") / raise SystemExit("msg") is the standard non-zero-exit idiom:
+            # exc.code is the message string, not an int. int() would raise ValueError here,
+            # which escapes execute()'s ConsoleCommandError handler and crashes the REPL.
+            if isinstance(exc.code, str):
+                message = exc.code
+                code = 1
+            else:
+                code = int(exc.code or 0)
     text = stdout.getvalue() + stderr.getvalue()
     if code:
-        raise ConsoleCommandError(text.strip() or f"Command exited with status {code}")
+        raise ConsoleCommandError(message.strip() or text.strip() or f"Command exited with status {code}")
     return text.rstrip()
 
 

--- a/tests/hermes_cli/test_console_engine.py
+++ b/tests/hermes_cli/test_console_engine.py
@@ -664,6 +664,36 @@ def test_repl_refuses_non_interactive_confirmation(_isolate_hermes_home):
     assert "Confirmation required" in stderr.getvalue()
 
 
+def test_capture_output_surfaces_string_exit_code_as_command_error():
+    from hermes_cli.console_engine import ConsoleCommandError, _capture_output
+
+    def _boom():
+        sys.exit("No credential matching \"nope\".")
+
+    with pytest.raises(ConsoleCommandError) as exc_info:
+        _capture_output(_boom)
+
+    assert "No credential matching" in str(exc_info.value)
+
+
+def test_capture_output_preserves_integer_exit_code_message():
+    from hermes_cli.console_engine import ConsoleCommandError, _capture_output
+
+    with pytest.raises(ConsoleCommandError) as exc_info:
+        _capture_output(lambda: sys.exit(3))
+
+    assert "status 3" in str(exc_info.value)
+
+
+def test_execute_handler_string_exit_returns_error_not_crash(_isolate_hermes_home):
+    result = HermesConsoleEngine().execute(
+        "auth remove openrouter __no_such_credential__", confirmed=True
+    )
+
+    assert result.status == "error"
+    assert result.output
+
+
 def test_main_console_subcommand_smoke(_isolate_hermes_home):
     import subprocess
 


### PR DESCRIPTION
## What does this PR do?

Fixes a crash in the Hermes Console when a dispatched command exits with a string message.

`_capture_output` in `hermes_cli/console_engine.py` runs a console command and inspects `SystemExit`:

```python
except SystemExit as exc:
    code = int(exc.code or 0)
```

`sys.exit("message")` and `raise SystemExit("message")` are the normal way CLI handlers report an error: `exc.code` is the message string, not an int. `int(exc.code or 0)` then raises `ValueError`. That `ValueError` is not a `ConsoleCommandError`, so `execute()`'s `except ConsoleCommandError` does not catch it.

Several dispatched handlers do exactly this. For example `auth remove <provider> <target>` calls `sys.exit('No credential matching "<target>". Provider: <provider>.')` when the credential is not found. In the local `hermes console` REPL (`run_console_repl` calls `engine.execute` with no guard) this uncaught `ValueError` ends the REPL with a traceback on an ordinary user mistake. On the dashboard websocket the generic `except Exception` catches it but shows `invalid literal for int() with base 10: 'No credential matching...'` instead of the intended message.

The fix treats a string exit code as a status-1 failure that carries the message, so it surfaces as a normal `ConsoleCommandError` (clean error line in the REPL, correct message on the dashboard).

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/console_engine.py`: in `_capture_output`, when `SystemExit.code` is a string, record it as the failure message and use exit status 1 instead of calling `int()` on it.
- `tests/hermes_cli/test_console_engine.py`: added regression tests for a string exit code (unit) and for `auth remove` on a missing credential through `execute()` (end to end).

## How to Test

1. In the repo: `hermes console`, then run `auth remove openrouter some-name-that-does-not-exist`. On `main` this crashes the REPL with `ValueError: invalid literal for int()`. With this change it prints `No credential matching "some-name-that-does-not-exist". Provider: openrouter.` and the REPL keeps running.
2. `scripts/run_tests.sh tests/hermes_cli/test_console_engine.py` (113 pass). The two new string-exit tests fail on `main` and pass with the fix.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the console test file and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
