### PR TITLE
fix(console): stop rejecting quoted shell metacharacters as shell syntax

### DIFF
--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -14,6 +14,7 @@ import functools
 import importlib
 import io
 import json
+import re
 import shlex
 import sys
 from dataclasses import dataclass, replace
@@ -120,13 +121,21 @@ def _split_line(line: str) -> list[str]:
         raise ConsoleCommandError(f"Could not parse command: {exc}") from exc
 
 
+_QUOTED_SPAN_RE = re.compile(r"'[^']*'|\"[^\"]*\"")
+
+
 def _contains_shell_syntax(line: str, tokens: Sequence[str]) -> bool:
-    if "$(" in line or "`" in line:
+    # Real operators are caught by the token-level check below, because shlex splits a
+    # space-delimited operator into its own token. The raw-line scans (for $(, backtick,
+    # and the metacharacters) must ignore quoted spans, or an ordinary message argument
+    # like send --to x "is 5 > 3?" is wrongly rejected as shell syntax.
+    unquoted = _QUOTED_SPAN_RE.sub("", line)
+    if "$(" in unquoted or "`" in unquoted:
         return True
     shell_tokens = {"|", "||", "&", "&&", ";", ">", ">>", "<", "<<", "2>", "2>>"}
     if any(token in shell_tokens for token in tokens):
         return True
-    return any(ch in line for ch in "|<>;")
+    return any(ch in unquoted for ch in "|<>;")
 
 
 def _format_sessions(sessions: Sequence[dict]) -> str:

--- a/tests/hermes_cli/test_console_engine.py
+++ b/tests/hermes_cli/test_console_engine.py
@@ -545,6 +545,35 @@ def test_console_rejects_destructive_and_shell_like_commands(line):
     assert result.output
 
 
+@pytest.mark.parametrize(
+    "line",
+    [
+        'send --to telegram "Is 5 > 3?"',
+        'sessions rename abc123 "Meeting; notes"',
+        'kanban comment 5 "fixed a<b bug"',
+        'send --to slack "use a|b pipes"',
+        'send --to slack "run `id` first"',
+        'send --to slack "cost is $(price)"',
+    ],
+)
+def test_console_allows_shell_metachars_inside_quoted_args(line):
+    result = HermesConsoleEngine().execute(line)
+
+    # Shell metacharacters inside a quoted argument are ordinary message text; the console
+    # dispatches an in-process argparse tree, so there is no shell to protect against here.
+    assert not (result.status == "error" and "shell syntax" in result.output)
+
+
+@pytest.mark.parametrize(
+    "line",
+    ["logs | cat", "config show > out.txt", "logs|cat", "echo `id`", "run $(whoami)"],
+)
+def test_console_still_rejects_unquoted_shell_operators(line):
+    result = HermesConsoleEngine().execute(line)
+
+    assert result.status == "error"
+
+
 @pytest.mark.parametrize("line", MUTATING_CONFIRMATION_SMOKE_COMMANDS)
 def test_mutating_console_commands_require_confirmation(line):
     result = HermesConsoleEngine().execute(line)


### PR DESCRIPTION
## What does this PR do?

Fixes the Hermes Console rejecting legitimate quoted arguments that happen to contain a shell metacharacter.

`_contains_shell_syntax` in `hermes_cli/console_engine.py` guards against shell operator syntax. It has a token-level check and a raw-line scan:

```python
def _contains_shell_syntax(line: str, tokens: Sequence[str]) -> bool:
    if "$(" in line or "`" in line:
        return True
    shell_tokens = {"|", "||", "&", "&&", ";", ">", ">>", "<", "<<", "2>", "2>>"}
    if any(token in shell_tokens for token in tokens):
        return True
    return any(ch in line for ch in "|<>;")
```

The raw-line scans look at the unparsed line, so `$(`, a backtick, or any of `| < > ;` inside a quoted argument trips the guard. `shlex` has already parsed those characters as ordinary text inside a token, and there is no shell behind the console (it dispatches an in-process argparse tree), so the guard only produces false positives here. Real operators are already caught by the token-level check, because a space-delimited operator becomes its own `shlex` token.

Effect on real commands:

```
send --to telegram "Is 5 > 3?"        -> rejected ("does not run shell syntax")
sessions rename abc123 "Meeting; notes" -> rejected
kanban comment 5 "fixed a<b bug"      -> rejected
send --to slack "use a|b pipes"       -> rejected
```

`send` exists to send arbitrary messages to a platform, so it cannot send anything containing `; > < |` or a backtick / `$(` (common in code and markdown). `sessions rename` and `kanban comment` are broken the same way.

The fix blanks out quoted spans before the raw-line scans and keeps the token-level check unchanged, so quoted metacharacters pass while unquoted operators (including no-space forms like `logs|cat` and unquoted backticks / `$(`) are still rejected.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/console_engine.py`: added `_QUOTED_SPAN_RE` and applied it in `_contains_shell_syntax` so the `$(` / backtick / metacharacter scans run against the line with quoted spans removed. Token-level operator detection is unchanged.
- `tests/hermes_cli/test_console_engine.py`: added a test that quoted metacharacters are allowed and a test that unquoted operators are still rejected.

## How to Test

1. `hermes console`, then `send --to telegram "Is 5 > 3?"`. On `main` it returns the "does not run shell syntax" error. With this change it proceeds (asks for confirmation, since `send` is a mutating command).
2. Confirm operators are still blocked: `logs | cat`, `logs|cat`, `config show > out.txt`, `` echo `id` `` all still return an error.
3. `scripts/run_tests.sh tests/hermes_cli/test_console_engine.py` (121 pass). The new quoted-arg test fails on `main` and passes with the fix.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the console test file and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
