### PR TITLE
fix(security): add timestamp-bound V2 signature for generic webhook r…

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -870,9 +870,28 @@ class WebhookAdapter(BasePlatformAdapter):
         # Checked independently of (and before) legacy V1 below — a sender
         # that only ever sends V2 headers must still validate here; nesting
         # this inside `if generic_sig:` would silently skip V2-only senders.
+        #
+        # The presence of X-Webhook-Signature-V2 alone selects V2 mode and
+        # commits to it — it must NOT fall through to the V1 branch just
+        # because the timestamp is missing/malformed/expired. A sender
+        # migrating to V2 typically sends both V1 and V2 headers together
+        # for compatibility; if incomplete V2 fell through to V1, an
+        # attacker who captured one such mixed request could strip the
+        # X-Webhook-Timestamp header from a replay and have it validate
+        # against the still-present, still-unprotected V1 signature instead
+        # — silently downgrading a V2-protected request back to the replay
+        # hole V2 exists to close.
         v2_sig = request.headers.get("X-Webhook-Signature-V2", "")
-        v2_timestamp = request.headers.get("X-Webhook-Timestamp", "")
-        if v2_sig and v2_timestamp:
+        if v2_sig:
+            v2_timestamp = request.headers.get("X-Webhook-Timestamp", "")
+            if not v2_timestamp:
+                logger.warning(
+                    "[webhook] Route '%s' sent X-Webhook-Signature-V2 with "
+                    "no X-Webhook-Timestamp — rejecting rather than "
+                    "falling back to legacy V1",
+                    request.match_info.get("route_name", ""),
+                )
+                return False
             try:
                 ts = int(v2_timestamp)
             except (TypeError, ValueError):
@@ -893,6 +912,8 @@ class WebhookAdapter(BasePlatformAdapter):
         # (deprecated — no replay protection, since the signature only
         # covers the body: a captured (body, signature) pair replays
         # indefinitely with no timestamp binding it to a specific delivery.)
+        # Only reachable when X-Webhook-Signature-V2 was not sent at all —
+        # see the guard above.
         generic_sig = request.headers.get("X-Webhook-Signature", "")
         if generic_sig:
             expected = hmac.new(

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -23,6 +23,10 @@ Security:
   - Rate limiting per route (fixed-window, configurable)
   - Idempotency cache prevents duplicate agent runs on webhook retries
   - Body size limits checked before reading payload
+  - Generic HMAC supports a V2 signature (X-Webhook-Signature-V2) that
+    binds a timestamp into the signed data for replay protection; the
+    legacy body-only V1 (X-Webhook-Signature) is deprecated but still
+    accepted with a warning, since it has no replay protection
   - Set secret to "INSECURE_NO_AUTH" to skip validation (testing only)
 """
 
@@ -861,12 +865,47 @@ class WebhookAdapter(BasePlatformAdapter):
         if gl_token:
             return hmac.compare_digest(gl_token, secret)
 
-        # Generic: X-Webhook-Signature = <hex HMAC-SHA256>
+        # Generic V2: X-Webhook-Signature-V2 = <hex HMAC-SHA256 of "<timestamp>.<body>">
+        #             X-Webhook-Timestamp = <unix seconds> (required for V2)
+        # Checked independently of (and before) legacy V1 below — a sender
+        # that only ever sends V2 headers must still validate here; nesting
+        # this inside `if generic_sig:` would silently skip V2-only senders.
+        v2_sig = request.headers.get("X-Webhook-Signature-V2", "")
+        v2_timestamp = request.headers.get("X-Webhook-Timestamp", "")
+        if v2_sig and v2_timestamp:
+            try:
+                ts = int(v2_timestamp)
+            except (TypeError, ValueError):
+                return False
+            if abs(int(time.time()) - ts) > 300:
+                logger.warning(
+                    "[webhook] Route '%s' generic HMAC V2 timestamp outside replay window",
+                    request.match_info.get("route_name", ""),
+                )
+                return False
+            signed_content = v2_timestamp.encode() + b"." + body
+            expected_v2 = hmac.new(
+                secret.encode(), signed_content, hashlib.sha256
+            ).hexdigest()
+            return hmac.compare_digest(v2_sig, expected_v2)
+
+        # Generic V1 (legacy): X-Webhook-Signature = <hex HMAC-SHA256 of body>
+        # (deprecated — no replay protection, since the signature only
+        # covers the body: a captured (body, signature) pair replays
+        # indefinitely with no timestamp binding it to a specific delivery.)
         generic_sig = request.headers.get("X-Webhook-Signature", "")
         if generic_sig:
             expected = hmac.new(
                 secret.encode(), body, hashlib.sha256
             ).hexdigest()
+            logger.warning(
+                "[webhook] Route '%s' uses legacy body-only HMAC (no "
+                "timestamp), which is vulnerable to replay attacks. Add "
+                "an 'X-Webhook-Timestamp' header and switch to "
+                "'X-Webhook-Signature-V2' (HMAC-SHA256 of "
+                "'<timestamp>.<body>').",
+                request.match_info.get("route_name", ""),
+            )
             return hmac.compare_digest(generic_sig, expected)
 
         # No recognised signature header but secret is configured → reject

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -276,6 +276,34 @@ class TestValidateSignature:
         })
         assert adapter._validate_signature(req, body, secret) is True
 
+    def test_validate_generic_v2_stripped_timestamp_does_not_downgrade_to_v1(self):
+        """Regression test for a downgrade attack found in review: a sender
+        migrating to V2 typically sends BOTH the V1 and V2 signatures
+        together (for compatibility while both ends update). If an
+        attacker captures one such mixed request and replays it with the
+        X-Webhook-Timestamp header stripped, the presence of
+        X-Webhook-Signature-V2 must still commit to V2 validation and
+        reject — it must NOT silently fall through to validating the
+        still-present, still-unprotected V1 signature instead. Falling
+        through would let an attacker downgrade a V2-protected request
+        back into the exact replay hole V2 exists to close, just by
+        deleting one header from a captured request."""
+        adapter = _make_adapter()
+        body = b'{"event": "push"}'
+        secret = "generic-secret"
+        timestamp = str(int(time.time()))
+        v2_sig = _generic_v2_signature(body, secret, timestamp)
+        v1_sig = _generic_signature(body, secret)
+        # Simulates a captured mixed V1+V2 request replayed with the
+        # timestamp header stripped — V1 signature is still valid on its
+        # own, but must not be reachable via this path.
+        req = _mock_request(headers={
+            "X-Webhook-Signature-V2": v2_sig,
+            "X-Webhook-Signature": v1_sig,
+            # X-Webhook-Timestamp deliberately omitted.
+        })
+        assert adapter._validate_signature(req, body, secret) is False
+
     def test_v1_replay_attack_succeeds_demonstrating_the_hole_v2_closes(self):
         """Regression/documentation test: a captured (body, signature) V1
         pair replays successfully no matter how much time has passed,

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -102,6 +102,12 @@ def _generic_signature(body: bytes, secret: str) -> str:
     return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
 
 
+def _generic_v2_signature(body: bytes, secret: str, timestamp: str) -> str:
+    """Compute X-Webhook-Signature-V2 (HMAC-SHA256 of "<timestamp>.<body>")."""
+    signed_content = timestamp.encode() + b"." + body
+    return hmac.new(secret.encode(), signed_content, hashlib.sha256).hexdigest()
+
+
 def _svix_signature(body: bytes, secret: str, msg_id: str, timestamp: str) -> str:
     """Compute a Svix v1 signature header for *body* using *secret*."""
     key = (
@@ -183,6 +189,111 @@ class TestValidateSignature:
         sig = _generic_signature(body, secret)
         req = _mock_request(headers={"X-Webhook-Signature": sig})
         assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_generic_v2_signature_valid(self):
+        """Valid X-Webhook-Signature-V2 (timestamp-bound) is accepted."""
+        adapter = _make_adapter()
+        body = b'{"event": "push"}'
+        secret = "generic-secret"
+        timestamp = str(int(time.time()))
+        sig = _generic_v2_signature(body, secret, timestamp)
+        req = _mock_request(headers={
+            "X-Webhook-Signature-V2": sig,
+            "X-Webhook-Timestamp": timestamp,
+        })
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_generic_v2_old_timestamp_rejects(self):
+        """A V2 signature outside the replay window is rejected even though
+        the HMAC itself would otherwise be valid for that (stale) timestamp
+        — this is the actual replay-protection guarantee: an attacker who
+        captured (body, signature, timestamp) once cannot resubmit it after
+        the window closes."""
+        adapter = _make_adapter()
+        body = b'{"event": "push"}'
+        secret = "generic-secret"
+        timestamp = str(int(time.time()) - 301)
+        sig = _generic_v2_signature(body, secret, timestamp)
+        req = _mock_request(headers={
+            "X-Webhook-Signature-V2": sig,
+            "X-Webhook-Timestamp": timestamp,
+        })
+        assert adapter._validate_signature(req, body, secret) is False
+
+    def test_validate_generic_v2_wrong_timestamp_rejects(self):
+        """The timestamp is cryptographically bound into the V2 signature —
+        this is the actual fix for the V1 replay hole. An attacker who only
+        has a captured (body, signature) pair for V1 (no timestamp binding)
+        cannot forge a valid V2 signature for a fresh timestamp without the
+        secret, unlike V1 where the signature covers the body alone and a
+        forged/fresh timestamp would otherwise sail through unverified."""
+        adapter = _make_adapter()
+        body = b'{"event": "push"}'
+        secret = "generic-secret"
+        real_timestamp = str(int(time.time()))
+        sig = _generic_v2_signature(body, secret, real_timestamp)
+        forged_timestamp = str(int(time.time()) + 1)
+        req = _mock_request(headers={
+            "X-Webhook-Signature-V2": sig,
+            "X-Webhook-Timestamp": forged_timestamp,
+        })
+        assert adapter._validate_signature(req, body, secret) is False
+
+    def test_validate_generic_v2_malformed_timestamp_rejects(self):
+        adapter = _make_adapter()
+        body = b'{"event": "push"}'
+        secret = "generic-secret"
+        req = _mock_request(headers={
+            "X-Webhook-Signature-V2": "deadbeef",
+            "X-Webhook-Timestamp": "not-a-number",
+        })
+        assert adapter._validate_signature(req, body, secret) is False
+
+    def test_validate_generic_v1_still_works_without_timestamp(self):
+        """Legacy V1 (body-only) senders that never send X-Webhook-Timestamp
+        must keep working — this is the backward-compatibility guarantee for
+        existing integrations that predate the V2 scheme."""
+        adapter = _make_adapter()
+        body = b'{"event": "push"}'
+        secret = "generic-secret"
+        sig = _generic_signature(body, secret)
+        req = _mock_request(headers={"X-Webhook-Signature": sig})
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_generic_v2_preferred_when_both_sent(self):
+        """If a sender sends both V1 and V2 headers (mid-migration), V2 must
+        win — a stale/wrong V1 must not be able to override a valid V2."""
+        adapter = _make_adapter()
+        body = b'{"event": "push"}'
+        secret = "generic-secret"
+        timestamp = str(int(time.time()))
+        v2_sig = _generic_v2_signature(body, secret, timestamp)
+        req = _mock_request(headers={
+            "X-Webhook-Signature-V2": v2_sig,
+            "X-Webhook-Timestamp": timestamp,
+            # Deliberately wrong V1 — must be ignored since V2 is checked first.
+            "X-Webhook-Signature": "0" * 64,
+        })
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_v1_replay_attack_succeeds_demonstrating_the_hole_v2_closes(self):
+        """Regression/documentation test: a captured (body, signature) V1
+        pair replays successfully no matter how much time has passed,
+        because the V1 signature has no timestamp binding at all. This is
+        the exact vulnerability V2 fixes — it is not asserting desired
+        behavior, it is pinning the known, accepted-with-warning legacy
+        gap so a future change to V1's semantics doesn't silently alter it
+        without a deliberate decision."""
+        adapter = _make_adapter()
+        body = b'{"event": "push"}'
+        secret = "generic-secret"
+        sig = _generic_signature(body, secret)
+        original_request = _mock_request(headers={"X-Webhook-Signature": sig})
+        assert adapter._validate_signature(original_request, body, secret) is True
+        # "Time passes" — nothing about a V1 signature depends on time, so
+        # a captured pair replayed much later still validates.
+        replayed_request = _mock_request(headers={"X-Webhook-Signature": sig})
+        assert adapter._validate_signature(replayed_request, body, secret) is True
 
     def test_validate_svix_signature_valid(self):
         """Valid Svix/AgentMail v1 signature headers are accepted."""


### PR DESCRIPTION
## Summary
Fixes the generic HMAC webhook route having no replay protection. The
signature only covers the request body, so a captured (body, signature)
pair from any single legitimate delivery validates again indefinitely,
with no dependency on time or a delivery identifier. GitHub, GitLab, and
Svix routes already have their own replay-resistant mechanisms; the
generic route (the only option for custom, non-GitHub/GitLab/Svix
integrations) did not.

---

## Root cause
`_validate_signature()`'s generic branch computed
`hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()` and
compared it against the `X-Webhook-Signature` header — the signature is
a pure function of the body and the shared secret, with no timestamp or
nonce involved anywhere in the computation.

The idempotency check elsewhere in the handler relies on a delivery ID
(`X-GitHub-Delivery`, falling back to `svix-id`, falling back to
`X-Request-ID`, falling back to a server-generated
`str(int(time.time() * 1000))` if none of those headers are present). A
generic-route sender has no reason to send any of the first three
headers, so a captured request replays with the server generating a
fresh, always-different fallback ID each time, meaning idempotency
provides no protection either.

Unlike Svix's `signed_content = msg_id.encode() + b"." + timestamp.encode() + b"." + body`,
where the timestamp is cryptographically bound into what gets signed,
a timestamp checked as a separate, unsigned header would not actually
fix this: an attacker replaying a captured (body, signature) pair could
simply attach a fresh timestamp value to the replay, since nothing ties
the timestamp to the signature.

---

## Behavioral change
Before: a generic-route (body, signature) pair captured once (via a
sender-side log, a debugging proxy, or similar) replays successfully at
any later time, triggering a full agent dispatch each time.

After: a new V2 signature (`X-Webhook-Signature-V2`, paired with a
required `X-Webhook-Timestamp` header) binds the timestamp into the
signed content, matching Svix's approach. A V2 request outside a
5-minute window is rejected, and the timestamp cannot be freely changed
by a replay attempt without invalidating the signature. The legacy
body-only V1 (`X-Webhook-Signature`) continues to work unchanged for
backward compatibility, since this project is self-hosted with no
control over when operators update either end of an existing
integration — but each V1 request now logs a warning naming the
specific replay risk and the migration path. If a sender sends both
headers, V2 is checked first and wins.

---

## What changed
**`gateway/platforms/webhook.py`**: `_validate_signature()`'s generic
branch now checks `X-Webhook-Signature-V2` + `X-Webhook-Timestamp`
first (independently of, not nested inside, the legacy check — a V2-only
sender that never sends the legacy header must still validate). The
signed content is `timestamp.encode() + b"." + body`. Falls through to
the unchanged legacy V1 check (body-only) if V2 headers are absent,
now with a warning naming the route and the migration path. Updated the
module docstring's security summary to mention V2.

**`tests/gateway/test_webhook_adapter.py`**: added a
`_generic_v2_signature()` helper and tests for a valid V2 signature, an
expired V2 timestamp, a V2 signature with a mismatched (forged)
timestamp, a malformed timestamp, V1 continuing to work with no
timestamp header at all, V2 winning when both are sent, and a
documentation/regression test pinning the exact V1 replay behavior this
PR does not change (so a future change to V1's semantics is a
deliberate decision, not an accidental one).

---

## What is NOT changed
- GitHub, GitLab, and Svix signature validation are untouched — each
  already has its own replay-resistant mechanism
- The legacy V1 generic signature continues to validate exactly as
  before; this PR does not set or imply any removal timeline for it,
  since that is an operator/migration decision, not something this
  code can enforce for a self-hosted project
- Idempotency, rate limiting, and body size limits are untouched
- All existing webhook tests pass