### PR TITLE
fix(unbroker): read email/browser creds from $HERMES_HOME/.env in send, poll, next, plan

### DIFF
--- a/optional-skills/security/unbroker/scripts/pdd.py
+++ b/optional-skills/security/unbroker/scripts/pdd.py
@@ -442,7 +442,7 @@ def cmd_plan(args) -> None:
     dossier_mod.require_authorized(d)
     cfg = config_mod.load_config()
     bl = brokers_mod.by_priority(*(args.priority or [])) if args.priority else brokers_mod.load_all()
-    bcc = config_mod.browser_clears_captcha(cfg)
+    bcc = config_mod.browser_clears_captcha(cfg, config_mod.dotenv_env())
     if getattr(args, "batch", False):
         _out(tiers.batch_plan(d, bl, cfg, ledger_mod.load(args.subject), bcc))
     else:
@@ -608,7 +608,7 @@ def cmd_send_email(args) -> None:
               "note": "recipient is locked to the broker's declared address"})
         return
 
-    result = emailer.send(b, body, to=args.to,
+    result = emailer.send(b, body, to=args.to, env=config_mod.dotenv_env(),
                           min_interval=float(cfg.get("email_min_interval_seconds", 0) or 0))
     ledger_mod.log_disclosure(args.subject, args.broker, list(disclosed), f"email_sent:{kind}")
     case = ledger_mod.transition(args.subject, args.broker, "submitted",
@@ -667,7 +667,7 @@ def cmd_poll_verification(args) -> None:
         return
     results = []
     for bid, case, b in targets:
-        hit = emailer.find_verification_link(b, since_days=args.since_days)
+        hit = emailer.find_verification_link(b, env=config_mod.dotenv_env(), since_days=args.since_days)
         if hit:
             if case.get("state") == "submitted":
                 ledger_mod.transition(args.subject, bid, "verification_pending",
@@ -688,7 +688,7 @@ def cmd_next(args) -> None:
     dossier_mod.require_authorized(d)
     cfg = config_mod.load_config()
     bl = brokers_mod.by_priority(*(args.priority or [])) if args.priority else brokers_mod.load_all()
-    _out(autopilot.next_actions(d, bl, cfg, ledger_mod.load(args.subject)))
+    _out(autopilot.next_actions(d, bl, cfg, ledger_mod.load(args.subject), env=config_mod.dotenv_env()))
 
 
 def cmd_tasks(args) -> None:

--- a/tests/skills/test_unbroker_skill.py
+++ b/tests/skills/test_unbroker_skill.py
@@ -1388,6 +1388,42 @@ def test_dotenv_env_fills_missing_creds_and_shell_wins():
                     os.environ[k] = v
 
 
+def test_cli_send_lane_reads_creds_from_hermes_home_dotenv():
+    """setup/doctor read creds from $HERMES_HOME/.env; the send/next commands must too.
+
+    With EMAIL creds only in $HERMES_HOME/.env (not exported to the shell) and email_mode
+    programmatic, `next` must route an email-lane broker to an autonomous smtp send, not to
+    the human draft digest. On the pre-fix code cmd_next resolved capabilities from os.environ
+    only, so it saw no SMTP and demoted the lane.
+    """
+    prev = {k: os.environ.get(k) for k in
+            ("HERMES_HOME", "EMAIL_ADDRESS", "EMAIL_PASSWORD", "EMAIL_SMTP_HOST", "EMAIL_IMAP_HOST")}
+    with tempfile.TemporaryDirectory() as home, temp_env():
+        os.environ["HERMES_HOME"] = home
+        (Path(home) / ".env").write_text(
+            "EMAIL_ADDRESS=vault@gmail.com\nEMAIL_PASSWORD=app-secret\n"
+            "EMAIL_SMTP_HOST=smtp.gmail.com\nEMAIL_IMAP_HOST=imap.gmail.com\n",
+            encoding="utf-8")
+        try:
+            for k in ("EMAIL_ADDRESS", "EMAIL_PASSWORD", "EMAIL_SMTP_HOST", "EMAIL_IMAP_HOST"):
+                os.environ.pop(k, None)
+            assert emailer.available(os.environ)["smtp"] is False   # shell alone sees nothing
+            config.save_config({"email_mode": "programmatic"})
+            sid = _run(["intake", "--full-name", "Jane Q. Public",
+                        "--email", "jane@example.com", "--consent"])["subject_id"]
+            _run(["record", sid, "whitepages", "found", "--found", "true"])
+            q = _run(["next", sid])
+            sends = [a for a in q["actions"]
+                     if a.get("type") == "optout_email_send" and a.get("send_via") == "smtp"]
+            assert sends and sends[0]["broker_id"] == "whitepages"
+        finally:
+            for k, v in prev.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+
+
 def test_cdp_cli_check_reports_not_running():
     orig = cdp.endpoint_status
     cdp.endpoint_status = lambda *a, **k: None


### PR DESCRIPTION
## What does this PR do?

Makes the unbroker skill's `send-email`, `poll-verification`, `next`, and `plan` commands read credentials from `$HERMES_HOME/.env`, so they match what `setup` and `doctor` already do.

`setup --auto` and `doctor` were changed to resolve capabilities through `config.dotenv_env()` (shell env overlaid on `$HERMES_HOME/.env`), because the terminal-tool shell does not export the creds Hermes keeps in that file. The commands that actually consume those creds were not updated and still resolved from `os.environ` only:

- `cmd_send_email` -> `emailer.send(...)` (SMTP settings from `os.environ`)
- `cmd_poll_verification` -> `emailer.find_verification_link(...)` (IMAP settings from `os.environ`)
- `cmd_next` -> `autopilot.next_actions(...)` (`emailer.available()` + browser-backend detection from `os.environ`)
- `cmd_plan` -> `config.browser_clears_captcha(cfg)` (browser key from `os.environ`)

So when `EMAIL_ADDRESS`/`EMAIL_PASSWORD` (or `BROWSERBASE_API_KEY`) live only in `$HERMES_HOME/.env`:

- `setup --auto` picks `email_mode = programmatic` and `doctor` reports SMTP available;
- `send-email` fails with "programmatic email not configured";
- `poll-verification` fails with "IMAP not configured";
- `next` computes SMTP/IMAP unavailable and demotes every email-lane broker to the human draft digest, so full autonomy is silently lost while `doctor` says it is on.

The fix passes `config.dotenv_env()` through the four consumer call sites. `dotenv_env()` overlays the shell env on top of `.env` with the shell winning, so this only fills gaps and never overrides a value the shell did export.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `optional-skills/security/unbroker/scripts/pdd.py`:
  - `cmd_send_email`: `emailer.send(..., env=config_mod.dotenv_env())`
  - `cmd_poll_verification`: `emailer.find_verification_link(..., env=config_mod.dotenv_env())`
  - `cmd_next`: `autopilot.next_actions(..., env=config_mod.dotenv_env())`
  - `cmd_plan`: `config_mod.browser_clears_captcha(cfg, config_mod.dotenv_env())`
- `tests/skills/test_unbroker_skill.py`: added a test that, with EMAIL creds only in `$HERMES_HOME/.env` and `email_mode = programmatic`, `next` routes an email-lane broker (whitepages) to an autonomous SMTP send rather than the draft digest.

## How to Test

1. Put `EMAIL_ADDRESS` / `EMAIL_PASSWORD` (and SMTP/IMAP host) only in `$HERMES_HOME/.env`, not in your shell. Run `pdd.py setup --auto` (picks `programmatic`) and `pdd.py doctor` (reports SMTP on).
2. On `main`: `pdd.py send-email <subject> <broker> --listing <url>` fails "programmatic email not configured", and `pdd.py next <subject>` shows the broker in the draft digest. With this change both use the SMTP lane.
3. `scripts/run_tests.sh tests/skills/test_unbroker_skill.py` (98 pass). The new test fails on `main` and passes with the fix.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the unbroker test file and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
