### PR TITLE
fix(redact): cover Fireworks token prefixes

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -107,7 +107,9 @@ _PREFIX_PATTERNS = [
     r"brv_[A-Za-z0-9]{10,}",            # ByteRover API key
     r"xai-[A-Za-z0-9]{30,}",            # xAI (Grok) API key
     r"ntn_[A-Za-z0-9]{10,}",            # Notion internal integration token
+    r"fw-[A-Za-z0-9]{30,}",             # Fireworks AI API key
     r"fw_[A-Za-z0-9]{30,}",             # Fireworks AI API key
+    r"fpk_[A-Za-z0-9]{30,}",            # Fireworks AI project key
 ]
 
 # ENV assignment patterns: KEY=value where KEY contains a secret-like name.

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -59,6 +59,22 @@ class TestKnownPrefixes:
         result = redact_sensitive_text("fal_abc123def456ghi789jkl")
         assert "abc123def456" not in result
 
+    def test_fireworks_keys(self):
+        samples = [
+            "fw-" + "A" * 40,
+            "fw_" + "B" * 40,
+            "fpk_" + "C" * 40,
+        ]
+
+        for token in samples:
+            result = redact_sensitive_text(f"provider error {token}")
+            assert token not in result
+            assert "..." in result
+
+    def test_short_fireworks_like_words_unchanged(self):
+        text = "fw-tooshort fw_tooshort fpk_tooshort"
+        assert redact_sensitive_text(text) == text
+
     def test_notion_internal_integration_token(self):
         result = redact_sensitive_text("ntn_abc123def456ghi789jkl")
         assert "abc123def456" not in result


### PR DESCRIPTION
Closes #58463

## Summary

- add the missing `fw-...` and `fpk_...` Fireworks bare-token prefixes to the shared redactor
- keep the existing `fw_...` behavior unchanged
- add regression coverage for all three Fireworks token shapes plus short non-key strings

## Proof

Synthetic in-memory token strings only; no real credentials were used.

Before the fix, the current redactor leaked `fw-...` and `fpk_...` while masking `fw_...`:

```text
fw_dash True provider error fw-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
fw_under False provider error fw_BBB...BBBB
fpk True provider error fpk_CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
```

After the fix, the same redactor masks all three Fireworks token shapes and still leaves short non-key words unchanged:

```text
fw_dash False provider error fw-AAA...AAAA
fw_under False provider error fw_BBB...BBBB
fpk False provider error fpk_CC...CCCC
short fw-tooshort fw_tooshort fpk_tooshort
```

## Tests

```text
$env:TMP=(Resolve-Path .pytest-tmp).Path; $env:TEMP=$env:TMP; uv run --locked pytest tests/agent/test_redact.py::TestKnownPrefixes::test_fireworks_keys tests/agent/test_redact.py::TestKnownPrefixes::test_short_fireworks_like_words_unchanged -q
..                                                                       [100%]
2 passed in 0.27s
```

```text
git diff --check
```

Note: bare `pytest` on this Windows host resolves to an older Anaconda Python and fails to import current Hermes syntax (`str | None`); the successful run above uses the repo's `uv run --locked` Python 3.11 environment.