### PR TITLE
fix(unbroker): re-verify submitted opt-outs with no email-verification loop

### DIFF
--- a/optional-skills/security/unbroker/references/state-machine.md
+++ b/optional-skills/security/unbroker/references/state-machine.md
@@ -30,7 +30,7 @@ not_found            -> searching | found | indirect_exposure | blocked
 found                -> action_selected | submitted | human_task_queued | indirect_exposure | blocked
 indirect_exposure    -> submitted | human_task_queued | not_found | found | blocked
 action_selected      -> submitted | human_task_queued | blocked
-submitted            -> verification_pending | awaiting_processing | human_task_queued | blocked
+submitted            -> verification_pending | awaiting_processing | confirmed_removed | human_task_queued | blocked
 verification_pending -> awaiting_processing | confirmed_removed | human_task_queued | blocked
 awaiting_processing  -> confirmed_removed | human_task_queued | blocked
 confirmed_removed    -> reappeared | confirmed_removed   (recheck refreshes the date)
@@ -50,6 +50,12 @@ A transition to the same state is always allowed (idempotent field updates).
   opt-out whose matcher says "no results" after you have already submitted is recorded
   `awaiting_processing`, not `not_found`.)
 - **`blocked -> submitted` is ILLEGAL directly** - go `blocked -> action_selected -> submitted`.
+- **`submitted -> confirmed_removed` is for no-verification submissions only.** A plain web form or a
+  right-to-delete email with no email-confirmation loop is re-verified straight from `submitted` by the
+  due-recheck re-scan, and if the listing is gone that re-scan records `confirmed_removed` directly.
+  Brokers that verify by email still go `submitted -> verification_pending -> awaiting_processing ->
+  confirmed_removed`; `confirmed_removed` is still only ever recorded by a verifying re-scan, never by
+  the submission flow's own say-so.
 - **Recording an operator's manual verdict:** attach an `operator_manual_check` evidence note. A
   dead / 404 site, or an operator-confirmed "no results" search, is a valid `not_found`.
 - **`--evidence` shell gotcha:** an `--evidence` JSON string containing a literal `&` trips the shell's

--- a/optional-skills/security/unbroker/scripts/autopilot.py
+++ b/optional-skills/security/unbroker/scripts/autopilot.py
@@ -312,8 +312,25 @@ def next_actions(dossier: dict, brokers_list: list[dict], cfg: dict,
                 "how": "re-run this broker's search_vectors; if gone record confirmed_removed; "
                        "if still listed record reappeared and requeue the opt-out",
             })
-        elif st in ("submitted", "verification_pending") and not mail["imap"]:
-            pass  # already covered by the digest entry above
+        elif st in ("submitted", "verification_pending"):
+            broker = by_id.get(bid) or {}
+            needs_email_verification = bool(
+                (((broker.get("optout") or {}).get("requires")) or {}).get("email_verification"))
+            if not needs_email_verification:
+                # A plain web form (or a right-to-delete email with no confirmation loop) lands in
+                # `submitted` with a processing-window recheck, but section 2 only polls
+                # email-verification brokers. Without this, the case is never re-scanned, so it can
+                # never reach confirmed_removed: it stays in `due()` forever while `fully_done`
+                # reports True and the autonomous loop and cron both stop.
+                actions.append({
+                    "type": "verify_removal",
+                    "broker_id": bid,
+                    "why": "processing window elapsed (submitted opt-out awaiting confirmation)",
+                    "how": "re-run this broker's search_vectors; if gone record confirmed_removed; "
+                           "if still listed re-send the opt-out (record submitted)",
+                })
+            # else: an email-verification broker is handled by section 2 (poll, or the human digest
+            # in draft mode), so it is not stranded here.
 
     # 4) Phase 2 opt-outs: parents first (batch_plan already ordered them)
     for row in groups.get("found") or []:

--- a/optional-skills/security/unbroker/scripts/ledger.py
+++ b/optional-skills/security/unbroker/scripts/ledger.py
@@ -31,7 +31,11 @@ TRANSITIONS: dict[str, set[str]] = {
     # direct listing (-> found).
     "indirect_exposure": {"submitted", "human_task_queued", "not_found", "found", "blocked"},
     "action_selected": {"submitted", "human_task_queued", "blocked"},
-    "submitted": {"verification_pending", "awaiting_processing", "human_task_queued", "blocked"},
+    # submitted -> confirmed_removed: a submission with no verification loop (a plain web form or a
+    # right-to-delete email that never confirms by email) is re-verified straight from `submitted` by
+    # the due-recheck re-scan; if the listing is gone that re-scan records confirmed_removed directly.
+    "submitted": {"verification_pending", "awaiting_processing", "confirmed_removed",
+                  "human_task_queued", "blocked"},
     # verification_pending -> awaiting_processing: the verify link was opened/acknowledged and the
     # broker is now processing the removal (their stated window). confirmed_removed still requires a
     # verifying re-scan, never the submission flow's own say-so.

--- a/tests/skills/test_unbroker_skill.py
+++ b/tests/skills/test_unbroker_skill.py
@@ -957,6 +957,46 @@ def test_next_actions_poll_verification_and_due_rechecks():
         assert any("verification email" in t["reason"] for t in q2["human_digest"])
 
 
+def test_next_actions_reverifies_due_submitted_web_form():
+    # A plain web-form opt-out (no email_verification) lands in `submitted` with a processing-window
+    # recheck. Once that window elapses it must be re-scanned, or it can never reach confirmed_removed.
+    with temp_env():
+        d = _consenting()
+        b = _mini_broker("webform")                      # requires={} -> no email_verification
+        led = {"webform": {"broker_id": "webform", "state": "submitted",
+                           "next_recheck_at": "2000-01-01T00:00:00Z"}}   # window elapsed
+        q = autopilot.next_actions(d, [b], _auto_cfg(), led, env={})
+        assert any(a["type"] == "verify_removal" and a["broker_id"] == "webform"
+                   for a in q["actions"])
+        assert q["fully_done"] is False
+
+
+def test_next_actions_due_submitted_email_verification_not_double_handled():
+    # An email-verification broker's due `submitted` case is polled by section 2; the due-recheck
+    # loop must not also emit a verify_removal for it.
+    with temp_env():
+        d = _consenting()
+        b = _mini_broker("verifier", requires={"email_verification": True})
+        led = {"verifier": {"broker_id": "verifier", "state": "submitted",
+                            "next_recheck_at": "2000-01-01T00:00:00Z"}}
+        env = {"EMAIL_ADDRESS": "agent@gmail.com", "EMAIL_PASSWORD": "p"}
+        q = autopilot.next_actions(d, [b], _auto_cfg(email_mode="programmatic"), led, env=env)
+        assert any(a["type"] == "poll_verification" for a in q["actions"])
+        assert not any(a["type"] == "verify_removal" and a["broker_id"] == "verifier"
+                       for a in q["actions"])
+
+
+def test_ledger_submitted_can_confirm_removed_after_rescan():
+    # A no-verification submission is re-verified straight from `submitted`; a re-scan that finds the
+    # listing gone records confirmed_removed directly.
+    with temp_env():
+        sid = "sub_test01"
+        ledger.transition(sid, "webform", "found", found=True)
+        ledger.transition(sid, "webform", "submitted")
+        case = ledger.transition(sid, "webform", "confirmed_removed")
+        assert case["state"] == "confirmed_removed"
+
+
 def test_next_actions_blocked_stealth_or_operator_browser():
     with temp_env():
         d = _consenting()


### PR DESCRIPTION
## What does this PR do?

Fixes submitted opt-outs with no email-verification step never being re-verified, so they can never be confirmed as removed.

`next_actions` section 3 walks the due-recheck queue and emits a `verify_removal` re-scan only for cases in `awaiting_processing` or `confirmed_removed`. A due `submitted` / `verification_pending` case hit this branch:

```python
elif st in ("submitted", "verification_pending") and not mail["imap"]:
    pass  # already covered by the digest entry above
```

The comment is wrong for the common case. Section 2 only handles `submitted` / `verification_pending` cases whose broker's opt-out `requires.email_verification` is true (it polls the inbox, or in draft mode adds a human digest entry). A plain web-form opt-out, or a right-to-delete email with no email-confirmation loop, has no `email_verification` requirement. It records `submitted`, `followup_fields("submitted")` stamps a processing-window `next_recheck_at`, and when that window elapses the due case produces no action and no digest entry. It is never re-scanned, so it can never move to `confirmed_removed`.

The result: the case stays in `ledger.due()` indefinitely, while `next_actions` reports `done_for_now` / `fully_done` (because `_min_future_recheck` only looks at strictly-future recheck timestamps). The autonomous loop stops and the cron wake time is `None`, so the removal is silently never confirmed. Both audit passes of this skill flagged the same gap.

The fix emits a `verify_removal` for a due `submitted` / `verification_pending` case whose broker does not require email verification. Email-verification brokers are left to section 2, so they are not double-handled. Because a no-verification submission is re-verified straight from `submitted`, `submitted -> confirmed_removed` is added to the transition table for the gone outcome (a verifying re-scan is still what records `confirmed_removed`, never the submission flow itself); the state-machine reference is updated to match.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `optional-skills/security/unbroker/scripts/autopilot.py`: in `next_actions` section 3, emit a `verify_removal` recheck for a due `submitted` / `verification_pending` case whose broker has no `email_verification` requirement, instead of the no-op branch.
- `optional-skills/security/unbroker/scripts/ledger.py`: add `confirmed_removed` to `TRANSITIONS["submitted"]` so the re-scan can record the gone outcome.
- `optional-skills/security/unbroker/references/state-machine.md`: document the `submitted -> confirmed_removed` edge and when it applies.
- `tests/skills/test_unbroker_skill.py`: tests that a due web-form `submitted` case gets re-verified, that an email-verification broker is not double-handled, and that `submitted -> confirmed_removed` is legal.

## How to Test

1. Create a subject, record a web-form broker (no email verification) as `submitted`, and set its `next_recheck_at` to a past time. On `main`, `pdd.py next <subject>` returns no action for it and reports `fully_done: true` while `pdd.py` still lists it as due. With this change, `next` emits a `verify_removal` for it.
2. `scripts/run_tests.sh tests/skills/test_unbroker_skill.py` (100 pass). The two new positive tests fail on `main` and pass with the fix.

Adjacent but different open PRs (checked, no overlap): #58214 adds a regulator-complaint feature for overdue cases (does not fix the due-loop), #58225 verifies fanout ledger writes (does not touch `autopilot.py` / `ledger.py`).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the unbroker test file and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`references/state-machine.md`)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
