### PR TITLE
fix(teams): authenticate pasted-image fetches, and restore emoji as Unicode

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -27,7 +27,8 @@ import html
 import json
 import logging
 import os
-from typing import Any, Dict, Optional
+import time
+from typing import Any, Dict, Optional, Tuple
 from urllib.parse import quote
 
 # httpx is imported lazily — only the ``_write_summary_via_incoming_webhook``
@@ -95,6 +96,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
+    cache_image_from_bytes,
     cache_image_from_url,
     cache_media_bytes,
 )
@@ -466,6 +468,14 @@ _ALLOWED_TEAMS_SERVICE_HOSTS = frozenset({
     "smba.infra.gov.teams.microsoft.us",
 })
 
+# A freshly-pasted Teams inline image briefly returns 401/403 from the Bot
+# Connector: at the instant the message is delivered the bot is not yet
+# authorized to read the just-created attachment, and it becomes readable a few
+# seconds later (observed in prod). Without a retry the transient window drops a
+# valid image permanently, so we re-GET with backoff. Worst case ~15s across 5
+# attempts; steady-state the first attempt succeeds.
+_IMAGE_FETCH_RETRY_DELAYS = (0.0, 1.0, 2.0, 4.0, 8.0)
+
 # Conservative pattern for Bot Framework conversation IDs.  Real values
 # combine digits, colons, hyphens, dots, '@', and the ``thread.skype`` /
 # ``thread.tacv2`` suffixes; reject anything outside this set so a hostile
@@ -495,6 +505,56 @@ def _validate_teams_service_url(raw: str) -> Optional[str]:
         return None
     normalized = raw if raw.endswith("/") else raw + "/"
     return normalized
+
+
+async def _mint_bot_connector_token(
+    *,
+    tenant_id: str,
+    client_id: str,
+    client_secret: str,
+    timeout: float = 15.0,
+) -> Tuple[str, int]:
+    """Mint a Bot Framework Connector bearer token (client_credentials).
+
+    Returns ``(access_token, expires_in_seconds)``; raises ``RuntimeError`` on
+    any failure.  The token has audience ``https://api.botframework.com`` and
+    is used both to POST outbound activities and to fetch token-gated inbound
+    attachment URLs (pasted inline images) on ``smba.trafficmanager.net``.
+    Single shared minter so the standalone-send and inbound-image-fetch paths
+    stay in lock-step (same tenant endpoint, scope, and failure handling).
+    """
+    if not (tenant_id and client_id and client_secret):
+        raise RuntimeError("missing Teams client credentials")
+    # A malformed tenant must never be interpolated into the STS URL (mirrors
+    # the guard _standalone_send applies), so both mint paths stay in lock-step.
+    if not _TEAMS_CONV_ID_RE.match(tenant_id):
+        raise RuntimeError("Teams tenant_id has unexpected characters")
+    token_url = f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
+    import httpx
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        resp = await client.post(
+            token_url,
+            data={
+                "grant_type": "client_credentials",
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "scope": "https://api.botframework.com/.default",
+            },
+        )
+    if resp.status_code >= 400:
+        raise RuntimeError(
+            f"token request failed ({resp.status_code}): {resp.text[:200]}"
+        )
+    payload = resp.json()
+    access_token = payload.get("access_token")
+    if not access_token:
+        raise RuntimeError("token response missing access_token")
+    try:
+        expires_in = int(payload.get("expires_in", 3600) or 3600)
+    except (TypeError, ValueError):
+        expires_in = 3600
+    return access_token, expires_in
 
 
 async def _standalone_send(
@@ -558,38 +618,26 @@ async def _standalone_send(
     if not _TEAMS_CONV_ID_RE.match(tenant_id):
         return {"error": "Teams standalone send: TEAMS_TENANT_ID contains characters outside the expected set"}
 
-    token_url = f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
     activities_url = f"{service_url}v3/conversations/{chat_id}/activities"
 
     if not AIOHTTP_AVAILABLE:
         return {"error": "Teams standalone send: aiohttp not installed"}
 
     try:
+        access_token, _ = await _mint_bot_connector_token(
+            tenant_id=tenant_id,
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+    except Exception as e:
+        return {"error": f"Teams standalone send: {e}"}
+
+    try:
         import aiohttp as _aiohttp
 
-        # Per-request timeouts so a slow STS endpoint cannot starve the
-        # subsequent activity POST of its budget.
+        # Per-request timeout so a slow Connector cannot hang the send.
         per_request_timeout = _aiohttp.ClientTimeout(total=15.0)
         async with _aiohttp.ClientSession(trust_env=True) as session:
-            async with session.post(
-                token_url,
-                data={
-                    "grant_type": "client_credentials",
-                    "client_id": client_id,
-                    "client_secret": client_secret,
-                    "scope": "https://api.botframework.com/.default",
-                },
-                headers={"Content-Type": "application/x-www-form-urlencoded"},
-                timeout=per_request_timeout,
-            ) as token_resp:
-                if token_resp.status >= 400:
-                    body = await token_resp.text()
-                    return {"error": f"Teams standalone send: token request failed ({token_resp.status}): {body[:300]}"}
-                token_payload = await token_resp.json()
-            access_token = token_payload.get("access_token")
-            if not access_token:
-                return {"error": "Teams standalone send: token response missing access_token"}
-
             activity = {
                 "type": "message",
                 "text": message,
@@ -711,6 +759,11 @@ class TeamsAdapter(BasePlatformAdapter):
         # Maps chat_id → ConversationReference captured from incoming messages.
         # Used to send cards with the correct conversation type (personal/group/channel).
         self._conv_refs: Dict[str, Any] = {}
+        # Cached Bot Connector bearer (audience api.botframework.com), reused to
+        # fetch token-gated inbound image attachments. Refreshed before expiry.
+        self._bot_token: Optional[str] = None
+        self._bot_token_expiry: float = 0.0
+        self._bot_token_lock = asyncio.Lock()
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         # Lazy-install the Teams SDK on demand (parity with Slack/Discord/etc.),
@@ -803,6 +856,125 @@ class TeamsAdapter(BasePlatformAdapter):
         self._app = None
         self._mark_disconnected()
         logger.info("[teams] Disconnected")
+
+    async def _acquire_bot_connector_token(self) -> Optional[str]:
+        """Return a cached Bot Connector bearer, minting one if needed.
+
+        Returns ``None`` (rather than raising) when credentials are missing or
+        the STS call fails, so the image fetch can fall back gracefully instead
+        of dropping the turn.  The token is cached until ~60s before its
+        advertised expiry.
+        """
+        now = time.monotonic()
+        if self._bot_token and now < self._bot_token_expiry:
+            return self._bot_token
+        if not (self._client_id and self._client_secret and self._tenant_id):
+            return None
+        async with self._bot_token_lock:
+            # Re-check under the lock: a concurrent caller may have minted so a
+            # burst of pasted images shares a single STS round-trip.
+            now = time.monotonic()
+            if self._bot_token and now < self._bot_token_expiry:
+                return self._bot_token
+            try:
+                token, expires_in = await _mint_bot_connector_token(
+                    tenant_id=self._tenant_id,
+                    client_id=self._client_id,
+                    client_secret=self._client_secret,
+                )
+            except Exception as e:
+                logger.warning(
+                    "[teams] Failed to acquire Bot Connector token: %s", e
+                )
+                return None
+            # Refresh a minute early to avoid racing the expiry on a slow fetch.
+            self._bot_token = token
+            self._bot_token_expiry = now + max(0.0, expires_in - 60)
+            return token
+
+    async def _fetch_teams_image_bytes(self, url: str, timeout: float = 30.0) -> bytes:
+        """Fetch inline-image bytes, authenticating to the Bot Connector.
+
+        Unlike file uploads (pre-signed SharePoint ``downloadUrl``), a pasted
+        inline image arrives as a token-gated Bot Framework attachment URL on
+        ``smba.trafficmanager.net`` (``contentType image/*``, no ``downloadUrl``).
+        Fetching it requires the bot's ``api.botframework.com`` bearer — an
+        anonymous GET returns 401, which is why such images were previously
+        dropped.  The bearer is attached ONLY for known Bot Framework hosts so
+        a tampered ``contentUrl`` cannot exfiltrate the token to an arbitrary
+        origin.  ``data:`` URIs are decoded inline (no network).
+        """
+        if url.startswith("data:"):
+            import base64
+            import binascii
+
+            header, _, b64 = url.partition(",")
+            if ";base64" not in header:
+                raise ValueError("unsupported non-base64 data: image URI")
+            try:
+                return base64.b64decode(b64, validate=True)
+            except (binascii.Error, ValueError) as e:
+                raise ValueError(f"invalid data: image URI: {e}")
+
+        from tools.url_safety import is_safe_url
+        from gateway.platforms.base import (
+            _read_httpx_body_with_limit,
+            _ssrf_redirect_guard,
+        )
+
+        if not is_safe_url(url):
+            raise ValueError("Blocked unsafe image URL (SSRF protection)")
+
+        from urllib.parse import urlparse
+
+        headers = {
+            "User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)",
+            "Accept": "image/*",
+        }
+        # Attach the bot bearer ONLY for Bot Framework hosts — never leak it to
+        # an arbitrary origin a hostile contentUrl might point at.
+        bearer_attached = False
+        if (urlparse(url).hostname or "") in _ALLOWED_TEAMS_SERVICE_HOSTS:
+            token = await self._acquire_bot_connector_token()
+            if token:
+                headers["Authorization"] = f"Bearer {token}"
+                bearer_attached = True
+
+        import httpx
+
+        delays = _IMAGE_FETCH_RETRY_DELAYS
+        async with httpx.AsyncClient(
+            timeout=timeout,
+            follow_redirects=True,
+            event_hooks={"response": [_ssrf_redirect_guard]},
+        ) as client:
+            for attempt, delay in enumerate(delays):
+                if delay:
+                    await asyncio.sleep(delay)
+                async with client.stream("GET", url, headers=headers) as response:
+                    if response.status_code < 400:
+                        # Bounded streaming read: an oversized body is rejected
+                        # mid-stream instead of buffered whole via .content.
+                        return await _read_httpx_body_with_limit(
+                            response, media_type="image"
+                        )
+                    # Transient auth window on a freshly-pasted attachment
+                    # (401/403 only worth retrying when we actually
+                    # authenticated), plus the usual rate-limit / server-error
+                    # retryables.
+                    retryable = (
+                        (bearer_attached and response.status_code in (401, 403))
+                        or response.status_code in (408, 429)
+                        or response.status_code >= 500
+                    )
+                    if not retryable or attempt == len(delays) - 1:
+                        response.raise_for_status()
+                    logger.info(
+                        "[teams] image fetch got HTTP %s (attempt %d/%d), retrying",
+                        response.status_code, attempt + 1, len(delays),
+                    )
+        # The loop always returns bytes or raises; this is unreachable.
+        raise RuntimeError("image fetch retry loop exited without result")
 
     async def _fetch_attachment_bytes(self, url: str, timeout: float = 30.0) -> bytes:
         """Download attachment bytes with SSRF protection.
@@ -931,14 +1103,34 @@ class TeamsAdapter(BasePlatformAdapter):
                 continue
 
             if content_url and content_type.startswith("image/"):
+                # Pasted inline images are token-gated Bot Connector URLs and
+                # need the bot bearer (see _fetch_teams_image_bytes); fetch the
+                # bytes ourselves and cache to a local path so run.py's native
+                # image pipeline (which keys off local file paths) can attach
+                # them. Falls back to the anonymous URL cache for the rare
+                # public/pre-authed image URL.
+                subtype = content_type.split("/", 1)[-1].split(";", 1)[0].strip()
+                ext = f".{subtype}" if subtype.isalnum() else ".jpg"
                 try:
-                    cached = await cache_image_from_url(content_url)
+                    data = await self._fetch_teams_image_bytes(content_url)
+                    cached = cache_image_from_bytes(data, ext=ext)
                     if cached:
                         media_urls.append(cached)
                         media_types.append(content_type)
                         media_kinds.append("image")
                 except Exception as e:
                     logger.warning("[teams] Failed to cache image attachment: %s", e)
+                    try:
+                        cached = await cache_image_from_url(content_url)
+                        if cached:
+                            media_urls.append(cached)
+                            media_types.append(content_type)
+                            media_kinds.append("image")
+                    except Exception as e2:
+                        logger.warning(
+                            "[teams] Anonymous fallback for image attachment also failed: %s",
+                            e2,
+                        )
                 continue
 
             if content_url:

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -28,6 +28,7 @@ import html
 import json
 import logging
 import os
+import re
 import sys
 import time
 from contextlib import contextmanager
@@ -132,6 +133,90 @@ _MAX_BODY_BYTES = 1_048_576
 # (d542894ad). Pin a host via TEAMS_HOST or extra.host.
 _DEFAULT_HOST = None
 _WEBHOOK_PATH = "/api/messages"
+# ── Teams emoji → Unicode ────────────────────────────────────────────────
+# Teams never sends an emoji as a Unicode character. It sends a 20x20 PNG
+# from its CDN as an ordinary image attachment, and mirrors the message body
+# as a ``text/html`` attachment where the emoji carries the real character in
+# the ``alt`` of an ``<img itemtype="http://schema.skype.com/Emoji">``.
+#
+# Reading only ``activity.text`` therefore drops the emoji outright and hands
+# the model an unreadable 20x20 "screenshot" in its place. It also breaks the
+# turn on providers that enforce a minimum image size: xAI rejects anything
+# under 512 total pixels with a 400 ``invalid_image``, which the retry loop
+# escalates into a model failover the fallback provider cannot "fix" — the
+# request is malformed, not the provider.
+#
+# The HTML mirror is authoritative: ``alt`` carries the character, ``itemid``
+# the shortcode fallback for tenant-custom emoji that have no Unicode
+# equivalent, and ``src`` identifies exactly which image attachments to drop
+# (no CDN-hostname heuristic, so custom emoji hosted elsewhere are covered).
+_TEAMS_EMOJI_ITEMTYPE = "http://schema.skype.com/Emoji"
+_TEAMS_MENTION_ITEMTYPE = "http://schema.skype.com/Mention"
+
+_HTML_IMG_RE = re.compile(r"<img\b[^>]*>", re.IGNORECASE)
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_HTML_ATTR_RE = re.compile(r'''([\w:-]+)\s*=\s*(?:"([^"]*)"|\'([^\']*)\')''')
+_HTML_BREAK_RE = re.compile(r"</p\s*>|<br\s*/?>", re.IGNORECASE)
+_HTML_MENTION_RE = re.compile(
+    r"<span\b[^>]*itemtype=[\"\']" + re.escape(_TEAMS_MENTION_ITEMTYPE)
+    + r"[\"\'][^>]*>.*?</span\s*>",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _html_tag_attrs(tag: str) -> Dict[str, str]:
+    """Parse the attributes of a single HTML tag into a lowercased-key dict."""
+    return {
+        m.group(1).lower(): (m.group(2) if m.group(2) is not None else m.group(3))
+        for m in _HTML_ATTR_RE.finditer(tag)
+    }
+
+
+def _teams_html_to_text(html_body: str) -> Tuple[str, list, set]:
+    """Flatten a Teams ``text/html`` body mirror, restoring emoji as Unicode.
+
+    Returns ``(text, emoji_chars, emoji_srcs)``:
+    - ``text`` — the body as plain text, each emoji back **in place**;
+    - ``emoji_chars`` — the substituted characters, in document order;
+    - ``emoji_srcs`` — the ``src`` URLs of the emoji images, so the caller can
+      drop the matching attachments instead of forwarding 20x20 sprites.
+
+    Non-emoji ``<img>`` tags (genuinely pasted images) are removed from the
+    text and deliberately left in ``attachments`` — they are real content and
+    the existing inline-image path already handles them.
+    """
+    emoji_chars: list = []
+    emoji_srcs: set = set()
+
+    def _swap_img(match: "re.Match") -> str:
+        attrs = _html_tag_attrs(match.group(0))
+        if attrs.get("itemtype", "").strip().lower() != _TEAMS_EMOJI_ITEMTYPE.lower():
+            return ""
+        src = (attrs.get("src") or "").strip()
+        if src:
+            emoji_srcs.add(src)
+        char = html.unescape(attrs.get("alt") or "").strip()
+        if not char:
+            itemid = (attrs.get("itemid") or "").strip()
+            char = f":{itemid}:" if itemid else ""
+        if char:
+            emoji_chars.append(char)
+        return char
+
+    body = _HTML_MENTION_RE.sub("", html_body)
+    body = _HTML_IMG_RE.sub(_swap_img, body)
+    body = _HTML_BREAK_RE.sub("\n", body)
+    body = _HTML_TAG_RE.sub("", body)
+    text = html.unescape(body).replace("\u00a0", " ")
+    lines = [" ".join(line.split()) for line in text.split("\n")]
+    return "\n".join(lines).strip(), emoji_chars, emoji_srcs
+
+
+def _collapse_ws(value: str) -> str:
+    """Whitespace-insensitive form, for comparing two renderings of one body."""
+    return " ".join((value or "").split())
+
+
 
 
 def _parse_bool(value: Any, *, default: bool = False) -> bool:
@@ -1072,8 +1157,38 @@ class TeamsAdapter(BasePlatformAdapter):
             text = activity.text
         # Strip <at>BotName</at> HTML tags that Teams prepends for @mentions
         if "<at>" in text:
-            import re
             text = re.sub(r"<at>[^<]*</at>\s*", "", text).strip()
+
+        # Restore Teams emoji as Unicode from the text/html body mirror that
+        # Teams attaches to every message (see _teams_html_to_text). Without
+        # this the emoji is lost from the text and forwarded as an unreadable
+        # 20x20 sprite attachment instead.
+        emoji_srcs: set = set()
+        html_mirror = ""
+        for att in getattr(activity, "attachments", None) or []:
+            att_type = (getattr(att, "content_type", None) or "").lower()
+            if att_type.startswith("text/html") and not getattr(att, "content_url", None):
+                content = getattr(att, "content", None)
+                if isinstance(content, str):
+                    html_mirror = content
+                break
+
+        if html_mirror and _TEAMS_EMOJI_ITEMTYPE.lower() in html_mirror.lower():
+            html_text, emoji_chars, emoji_srcs = _teams_html_to_text(html_mirror)
+            if emoji_chars:
+                without_emoji = html_text
+                for char in emoji_chars:
+                    without_emoji = without_emoji.replace(char, "", 1)
+                if _collapse_ws(without_emoji) == _collapse_ws(text):
+                    # The mirror is a faithful rendering of activity.text, so
+                    # adopting it puts every emoji back at its exact position.
+                    text = html_text
+                else:
+                    # The two renderings disagree — an unhandled Teams
+                    # construct, or formatting that survives in one and not
+                    # the other. Never drop the emoji over a position we
+                    # cannot place with confidence: append it instead.
+                    text = f"{text} {''.join(emoji_chars)}".strip()
 
         # Determine chat type from conversation
         conv = activity.conversation
@@ -1109,6 +1224,13 @@ class TeamsAdapter(BasePlatformAdapter):
             content_url = getattr(att, "content_url", None)
             content_type = (getattr(att, "content_type", None) or "").lower()
             att_name = getattr(att, "name", None) or ""
+
+            # Teams emoji sprite: already restored as a Unicode character in
+            # the message text above. Forwarding the 20x20 PNG would hand the
+            # model an unreadable "screenshot" and trips providers that
+            # enforce a minimum image size.
+            if content_url and content_url in emoji_srcs:
+                continue
 
             # Skip non-file payloads: Teams mirrors the message body as a
             # text/html attachment on every message, and adaptive/hero cards

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -29,8 +29,9 @@ import json
 import logging
 import os
 import sys
+import time
 from contextlib import contextmanager
-from typing import Any, Dict, Iterator, Optional
+from typing import Any, Dict, Iterator, Optional, Tuple
 from urllib.parse import quote
 
 # httpx is imported lazily — only the ``_write_summary_via_incoming_webhook``
@@ -89,6 +90,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
+    cache_image_from_bytes,
     cache_image_from_url,
     cache_media_bytes,
 )
@@ -495,6 +497,14 @@ _ALLOWED_TEAMS_SERVICE_HOSTS = frozenset({
     "smba.infra.gov.teams.microsoft.us",
 })
 
+# A freshly-pasted Teams inline image briefly returns 401/403 from the Bot
+# Connector: at the instant the message is delivered the bot is not yet
+# authorized to read the just-created attachment, and it becomes readable a few
+# seconds later (observed in prod). Without a retry the transient window drops a
+# valid image permanently, so we re-GET with backoff. Worst case ~15s across 5
+# attempts; steady-state the first attempt succeeds.
+_IMAGE_FETCH_RETRY_DELAYS = (0.0, 1.0, 2.0, 4.0, 8.0)
+
 # Conservative pattern for Bot Framework conversation IDs.  Real values
 # combine digits, colons, hyphens, dots, '@', and the ``thread.skype`` /
 # ``thread.tacv2`` suffixes; reject anything outside this set so a hostile
@@ -524,6 +534,52 @@ def _validate_teams_service_url(raw: str) -> Optional[str]:
         return None
     normalized = raw if raw.endswith("/") else raw + "/"
     return normalized
+
+
+async def _mint_bot_connector_token(
+    *,
+    tenant_id: str,
+    client_id: str,
+    client_secret: str,
+    timeout: float = 15.0,
+) -> Tuple[str, int]:
+    """Mint a Bot Framework Connector bearer token (client_credentials).
+
+    Returns ``(access_token, expires_in_seconds)``; raises ``RuntimeError`` on
+    any failure.  The token has audience ``https://api.botframework.com`` and
+    is used both to POST outbound activities and to fetch token-gated inbound
+    attachment URLs (pasted inline images) on ``smba.trafficmanager.net``.
+    Single shared minter so the standalone-send and inbound-image-fetch paths
+    stay in lock-step (same tenant endpoint, scope, and failure handling).
+    """
+    if not (tenant_id and client_id and client_secret):
+        raise RuntimeError("missing Teams client credentials")
+    token_url = f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
+    import httpx
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        resp = await client.post(
+            token_url,
+            data={
+                "grant_type": "client_credentials",
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "scope": "https://api.botframework.com/.default",
+            },
+        )
+    if resp.status_code >= 400:
+        raise RuntimeError(
+            f"token request failed ({resp.status_code}): {resp.text[:200]}"
+        )
+    payload = resp.json()
+    access_token = payload.get("access_token")
+    if not access_token:
+        raise RuntimeError("token response missing access_token")
+    try:
+        expires_in = int(payload.get("expires_in", 3600) or 3600)
+    except (TypeError, ValueError):
+        expires_in = 3600
+    return access_token, expires_in
 
 
 async def _standalone_send(
@@ -587,38 +643,26 @@ async def _standalone_send(
     if not _TEAMS_CONV_ID_RE.match(tenant_id):
         return {"error": "Teams standalone send: TEAMS_TENANT_ID contains characters outside the expected set"}
 
-    token_url = f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
     activities_url = f"{service_url}v3/conversations/{chat_id}/activities"
 
     if not AIOHTTP_AVAILABLE:
         return {"error": "Teams standalone send: aiohttp not installed"}
 
     try:
+        access_token, _ = await _mint_bot_connector_token(
+            tenant_id=tenant_id,
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+    except Exception as e:
+        return {"error": f"Teams standalone send: {e}"}
+
+    try:
         import aiohttp as _aiohttp
 
-        # Per-request timeouts so a slow STS endpoint cannot starve the
-        # subsequent activity POST of its budget.
+        # Per-request timeout so a slow Connector cannot hang the send.
         per_request_timeout = _aiohttp.ClientTimeout(total=15.0)
         async with _aiohttp.ClientSession(trust_env=True) as session:
-            async with session.post(
-                token_url,
-                data={
-                    "grant_type": "client_credentials",
-                    "client_id": client_id,
-                    "client_secret": client_secret,
-                    "scope": "https://api.botframework.com/.default",
-                },
-                headers={"Content-Type": "application/x-www-form-urlencoded"},
-                timeout=per_request_timeout,
-            ) as token_resp:
-                if token_resp.status >= 400:
-                    body = await token_resp.text()
-                    return {"error": f"Teams standalone send: token request failed ({token_resp.status}): {body[:300]}"}
-                token_payload = await token_resp.json()
-            access_token = token_payload.get("access_token")
-            if not access_token:
-                return {"error": "Teams standalone send: token response missing access_token"}
-
             activity = {
                 "type": "message",
                 "text": message,
@@ -774,6 +818,10 @@ class TeamsAdapter(BasePlatformAdapter):
         # Maps chat_id → ConversationReference captured from incoming messages.
         # Used to send cards with the correct conversation type (personal/group/channel).
         self._conv_refs: Dict[str, Any] = {}
+        # Cached Bot Connector bearer (audience api.botframework.com), reused to
+        # fetch token-gated inbound image attachments. Refreshed before expiry.
+        self._bot_token: Optional[str] = None
+        self._bot_token_expiry: float = 0.0
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         # Defensive re-check: create_adapter() already ran the installer
@@ -869,6 +917,109 @@ class TeamsAdapter(BasePlatformAdapter):
         self._app = None
         self._mark_disconnected()
         logger.info("[teams] Disconnected")
+
+    async def _acquire_bot_connector_token(self) -> Optional[str]:
+        """Return a cached Bot Connector bearer, minting one if needed.
+
+        Returns ``None`` (rather than raising) when credentials are missing or
+        the STS call fails, so the image fetch can fall back gracefully instead
+        of dropping the turn.  The token is cached until ~60s before its
+        advertised expiry.
+        """
+        now = time.monotonic()
+        if self._bot_token and now < self._bot_token_expiry:
+            return self._bot_token
+        if not (self._client_id and self._client_secret and self._tenant_id):
+            return None
+        try:
+            token, expires_in = await _mint_bot_connector_token(
+                tenant_id=self._tenant_id,
+                client_id=self._client_id,
+                client_secret=self._client_secret,
+            )
+        except Exception as e:
+            logger.warning("[teams] Failed to acquire Bot Connector token: %s", e)
+            return None
+        # Refresh a minute early to avoid racing the expiry on a slow fetch.
+        self._bot_token = token
+        self._bot_token_expiry = now + max(0.0, expires_in - 60)
+        return token
+
+    async def _fetch_teams_image_bytes(self, url: str, timeout: float = 30.0) -> bytes:
+        """Fetch inline-image bytes, authenticating to the Bot Connector.
+
+        Unlike file uploads (pre-signed SharePoint ``downloadUrl``), a pasted
+        inline image arrives as a token-gated Bot Framework attachment URL on
+        ``smba.trafficmanager.net`` (``contentType image/*``, no ``downloadUrl``).
+        Fetching it requires the bot's ``api.botframework.com`` bearer — an
+        anonymous GET returns 401, which is why such images were previously
+        dropped.  The bearer is attached ONLY for known Bot Framework hosts so
+        a tampered ``contentUrl`` cannot exfiltrate the token to an arbitrary
+        origin.  ``data:`` URIs are decoded inline (no network).
+        """
+        if url.startswith("data:"):
+            import base64
+            import binascii
+
+            header, _, b64 = url.partition(",")
+            if ";base64" not in header:
+                raise ValueError("unsupported non-base64 data: image URI")
+            try:
+                return base64.b64decode(b64, validate=True)
+            except (binascii.Error, ValueError) as e:
+                raise ValueError(f"invalid data: image URI: {e}")
+
+        from tools.url_safety import is_safe_url
+        from gateway.platforms.base import _ssrf_redirect_guard
+
+        if not is_safe_url(url):
+            raise ValueError("Blocked unsafe image URL (SSRF protection)")
+
+        from urllib.parse import urlparse
+
+        headers = {
+            "User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)",
+            "Accept": "image/*",
+        }
+        # Attach the bot bearer ONLY for Bot Framework hosts — never leak it to
+        # an arbitrary origin a hostile contentUrl might point at.
+        bearer_attached = False
+        if (urlparse(url).hostname or "") in _ALLOWED_TEAMS_SERVICE_HOSTS:
+            token = await self._acquire_bot_connector_token()
+            if token:
+                headers["Authorization"] = f"Bearer {token}"
+                bearer_attached = True
+
+        import httpx
+
+        delays = _IMAGE_FETCH_RETRY_DELAYS
+        async with httpx.AsyncClient(
+            timeout=timeout,
+            follow_redirects=True,
+            event_hooks={"response": [_ssrf_redirect_guard]},
+        ) as client:
+            for attempt, delay in enumerate(delays):
+                if delay:
+                    await asyncio.sleep(delay)
+                response = await client.get(url, headers=headers)
+                if response.status_code < 400:
+                    return response.content
+                # Transient auth window on a freshly-pasted attachment (401/403
+                # only worth retrying when we actually authenticated), plus the
+                # usual rate-limit / server-error retryables.
+                retryable = (
+                    (bearer_attached and response.status_code in (401, 403))
+                    or response.status_code in (408, 429)
+                    or response.status_code >= 500
+                )
+                if not retryable or attempt == len(delays) - 1:
+                    response.raise_for_status()
+                logger.info(
+                    "[teams] image fetch got HTTP %s (attempt %d/%d), retrying",
+                    response.status_code, attempt + 1, len(delays),
+                )
+        # The loop always returns bytes or raises; this is unreachable.
+        raise RuntimeError("image fetch retry loop exited without result")
 
     async def _fetch_attachment_bytes(self, url: str, timeout: float = 30.0) -> bytes:
         """Download attachment bytes with SSRF protection.
@@ -995,14 +1146,34 @@ class TeamsAdapter(BasePlatformAdapter):
                 continue
 
             if content_url and content_type.startswith("image/"):
+                # Pasted inline images are token-gated Bot Connector URLs and
+                # need the bot bearer (see _fetch_teams_image_bytes); fetch the
+                # bytes ourselves and cache to a local path so run.py's native
+                # image pipeline (which keys off local file paths) can attach
+                # them. Falls back to the anonymous URL cache for the rare
+                # public/pre-authed image URL.
+                subtype = content_type.split("/", 1)[-1].split(";", 1)[0].strip()
+                ext = f".{subtype}" if subtype.isalnum() else ".jpg"
                 try:
-                    cached = await cache_image_from_url(content_url)
+                    data = await self._fetch_teams_image_bytes(content_url)
+                    cached = cache_image_from_bytes(data, ext=ext)
                     if cached:
                         media_urls.append(cached)
                         media_types.append(content_type)
                         media_kinds.append("image")
                 except Exception as e:
                     logger.warning("[teams] Failed to cache image attachment: %s", e)
+                    try:
+                        cached = await cache_image_from_url(content_url)
+                        if cached:
+                            media_urls.append(cached)
+                            media_types.append(content_type)
+                            media_kinds.append("image")
+                    except Exception as e2:
+                        logger.warning(
+                            "[teams] Anonymous fallback for image attachment also failed: %s",
+                            e2,
+                        )
                 continue
 
             if content_url:

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -835,12 +835,10 @@ class TestTeamsAttachmentClassification:
 
         adapter = self._make_adapter()
         adapter._fetch_attachment_bytes = AsyncMock(return_value=b"%PDF-1.4 fake")
-
-        async def fake_cache_image(url, *a, **kw):
-            return "/tmp/img.png"
+        adapter._fetch_teams_image_bytes = AsyncMock(return_value=b"\x89PNGfake")
 
         with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(_teams_mod, "cache_image_from_url", fake_cache_image)
+            mp.setattr(_teams_mod, "cache_image_from_bytes", lambda data, **kw: "/tmp/img.png")
             activity = self._make_activity([
                 self._image_attachment(),
                 self._file_download_attachment(),
@@ -868,12 +866,10 @@ class TestTeamsAttachmentClassification:
         from gateway.platforms.base import MessageType
 
         adapter = self._make_adapter()
-
-        async def fake_cache_image(url, *a, **kw):
-            return "/tmp/img.png"
+        adapter._fetch_teams_image_bytes = AsyncMock(return_value=b"\x89PNGfake")
 
         with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(_teams_mod, "cache_image_from_url", fake_cache_image)
+            mp.setattr(_teams_mod, "cache_image_from_bytes", lambda data, **kw: "/tmp/img.png")
             activity = self._make_activity([self._image_attachment()])
             await adapter._on_message(self._make_ctx(activity))
 
@@ -889,6 +885,467 @@ class TestTeamsAttachmentClassification:
         adapter._fetch_attachment_bytes = AsyncMock(side_effect=Exception("boom"))
 
         activity = self._make_activity([self._file_download_attachment()])
+        await adapter._on_message(self._make_ctx(activity))
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.TEXT
+        assert event.media_urls == []
+
+
+# ── inbound image auth (pasted-image fetch) ──────────────────────────────
+
+
+def _httpx_response(status, *, content=b"", json_data=None):
+    """Build a real httpx.Response so .json()/.text/.raise_for_status() work."""
+    req = httpx.Request("GET", "https://smba.trafficmanager.net/x")
+    if json_data is not None:
+        body = json.dumps(json_data).encode()
+        return httpx.Response(
+            status, content=body, request=req,
+            headers={"content-type": "application/json"},
+        )
+    return httpx.Response(status, content=content, request=req)
+
+
+def _patch_httpx(monkeypatch, *, get_response=None, post_response=None, get_responses=None):
+    """Replace httpx.AsyncClient with a fake capturing get/post calls.
+
+    ``get_responses`` (a list) returns responses in sequence across successive
+    GETs — used to exercise the retry loop; ``get_response`` returns the same
+    response every call.
+    """
+    calls = {"get": [], "post": [], "init_kwargs": None}
+    seq = list(get_responses) if get_responses is not None else None
+
+    class _FakeClient:
+        def __init__(self, **kwargs):
+            calls["init_kwargs"] = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, url, **kw):
+            calls["get"].append((url, kw))
+            if seq is not None:
+                return seq.pop(0)
+            return get_response
+
+        async def post(self, url, **kw):
+            calls["post"].append((url, kw))
+            return post_response
+
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeClient)
+    return calls
+
+
+def _patch_httpx_transport(monkeypatch, handler):
+    """Drive a REAL httpx.AsyncClient through a MockTransport.
+
+    Unlike ``_patch_httpx`` (which stubs ``.get``), this lets the adapter's
+    ``client.stream(...)`` + the shared bounded reader + httpx's redirect/auth
+    semantics all run for real. ``handler(request) -> httpx.Response``.
+    """
+    real = httpx.AsyncClient
+
+    def _mk(**kw):
+        return real(**kw, transport=httpx.MockTransport(handler))
+
+    monkeypatch.setattr(httpx, "AsyncClient", _mk)
+
+
+_PNG_BYTES = b"\x89PNG\r\n\x1a\nfake-image-payload"
+
+
+class TestTeamsInboundImageAuth:
+    """Pasted inline images are token-gated Bot Connector URLs; the adapter
+    must fetch them with the bot's api.botframework.com bearer (an anonymous
+    GET 401s and the image was silently dropped) and cache to a local path
+    so run.py's native image pipeline attaches them."""
+
+    def _make_adapter(self, **creds):
+        cfg = _make_config(**(creds or dict(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+        )))
+        adapter = TeamsAdapter(cfg)
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+        adapter.handle_message = AsyncMock()
+        return adapter
+
+    def _image_attachment(self, content_url="https://smba.trafficmanager.net/fr/v3/attachments/abc/views/original"):
+        att = MagicMock()
+        att.content_type = "image/png"
+        att.content_url = content_url
+        att.name = "pasted.png"
+        return att
+
+    def _make_activity(self, attachments, text="look at this"):
+        activity = MagicMock()
+        activity.text = text
+        activity.id = "activity-img-001"
+        activity.from_ = MagicMock()
+        activity.from_.id = "user-123"
+        activity.from_.aad_object_id = "aad-456"
+        activity.from_.name = "Test User"
+        activity.conversation = MagicMock()
+        activity.conversation.id = "19:abc@thread.v2"
+        activity.conversation.conversation_type = "personal"
+        activity.conversation.name = "Test Chat"
+        activity.conversation.tenant_id = "tenant-789"
+        activity.attachments = attachments
+        return activity
+
+    def _make_ctx(self, activity):
+        ctx = MagicMock()
+        ctx.activity = activity
+        return ctx
+
+    # -- _mint_bot_connector_token --------------------------------------
+
+    @pytest.mark.anyio
+    async def test_mint_token_success(self, monkeypatch):
+        calls = _patch_httpx(
+            monkeypatch,
+            post_response=_httpx_response(200, json_data={"access_token": "tok", "expires_in": 1234}),
+        )
+        token, expires = await _teams_mod._mint_bot_connector_token(
+            tenant_id="t", client_id="c", client_secret="s",
+        )
+        assert token == "tok"
+        assert expires == 1234
+        url, kw = calls["post"][0]
+        assert "login.microsoftonline.com/t/oauth2/v2.0/token" in url
+        assert kw["data"]["grant_type"] == "client_credentials"
+        assert kw["data"]["scope"] == "https://api.botframework.com/.default"
+
+    @pytest.mark.anyio
+    async def test_mint_token_http_error_raises(self, monkeypatch):
+        _patch_httpx(
+            monkeypatch,
+            post_response=_httpx_response(401, json_data={"error": "unauthorized_client"}),
+        )
+        with pytest.raises(RuntimeError):
+            await _teams_mod._mint_bot_connector_token(
+                tenant_id="t", client_id="c", client_secret="s",
+            )
+
+    @pytest.mark.anyio
+    async def test_mint_token_missing_creds_raises(self):
+        with pytest.raises(RuntimeError):
+            await _teams_mod._mint_bot_connector_token(
+                tenant_id="", client_id="c", client_secret="s",
+            )
+
+    # -- _acquire_bot_connector_token (caching) -------------------------
+
+    @pytest.mark.anyio
+    async def test_acquire_token_caches(self, monkeypatch):
+        adapter = self._make_adapter()
+        mint = AsyncMock(return_value=("tok", 3600))
+        monkeypatch.setattr(_teams_mod, "_mint_bot_connector_token", mint)
+
+        t1 = await adapter._acquire_bot_connector_token()
+        t2 = await adapter._acquire_bot_connector_token()
+
+        assert t1 == t2 == "tok"
+        mint.assert_awaited_once()  # second call served from cache
+
+    @pytest.mark.anyio
+    async def test_acquire_token_none_when_creds_missing(self, monkeypatch):
+        for var in ("TEAMS_CLIENT_ID", "TEAMS_CLIENT_SECRET", "TEAMS_TENANT_ID"):
+            monkeypatch.delenv(var, raising=False)
+        adapter = TeamsAdapter(_make_config())
+        adapter._app = MagicMock()
+        assert await adapter._acquire_bot_connector_token() is None
+
+    @pytest.mark.anyio
+    async def test_acquire_token_none_on_mint_failure(self, monkeypatch):
+        adapter = self._make_adapter()
+
+        async def _boom(**kwargs):
+            raise RuntimeError("sts down")
+
+        monkeypatch.setattr(_teams_mod, "_mint_bot_connector_token", _boom)
+        assert await adapter._acquire_bot_connector_token() is None
+
+    # -- _fetch_teams_image_bytes ---------------------------------------
+
+    @pytest.mark.anyio
+    async def test_fetch_image_attaches_bearer_for_bot_framework_host(self, monkeypatch):
+        adapter = self._make_adapter()
+        monkeypatch.setattr(_teams_mod, "_mint_bot_connector_token", AsyncMock(return_value=("tok", 3600)))
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda u: True)
+        seen = []
+
+        def handler(request):
+            seen.append(request)
+            return httpx.Response(200, content=_PNG_BYTES)
+
+        _patch_httpx_transport(monkeypatch, handler)
+
+        data = await adapter._fetch_teams_image_bytes(
+            "https://smba.trafficmanager.net/fr/v3/attachments/abc/views/original"
+        )
+
+        assert data == _PNG_BYTES
+        assert seen[0].headers.get("Authorization") == "Bearer tok"
+
+    @pytest.mark.anyio
+    async def test_fetch_image_no_bearer_for_foreign_host(self, monkeypatch):
+        adapter = self._make_adapter()
+        mint = AsyncMock(return_value=("tok", 3600))
+        monkeypatch.setattr(_teams_mod, "_mint_bot_connector_token", mint)
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda u: True)
+        seen = []
+
+        def handler(request):
+            seen.append(request)
+            return httpx.Response(200, content=_PNG_BYTES)
+
+        _patch_httpx_transport(monkeypatch, handler)
+
+        data = await adapter._fetch_teams_image_bytes("https://evil.example.com/img.png")
+
+        assert data == _PNG_BYTES
+        assert seen[0].headers.get("Authorization") is None
+        mint.assert_not_awaited()  # token never minted for a non-Bot-Framework host
+
+    @pytest.mark.anyio
+    async def test_fetch_image_data_uri_decodes_inline(self, monkeypatch):
+        import base64
+
+        adapter = self._make_adapter()
+
+        class _NoNetwork:
+            def __init__(self, **kw):
+                raise AssertionError("data: URI must not hit the network")
+
+        monkeypatch.setattr(httpx, "AsyncClient", _NoNetwork)
+
+        uri = "data:image/png;base64," + base64.b64encode(_PNG_BYTES).decode()
+        data = await adapter._fetch_teams_image_bytes(uri)
+        assert data == _PNG_BYTES
+
+    @pytest.mark.anyio
+    async def test_fetch_image_unsafe_url_raises(self, monkeypatch):
+        adapter = self._make_adapter()
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda u: False)
+        with pytest.raises(ValueError):
+            await adapter._fetch_teams_image_bytes("https://smba.trafficmanager.net/x")
+
+    @pytest.mark.anyio
+    async def test_fetch_image_strips_bearer_on_cross_host_redirect(self, monkeypatch):
+        # Security-critical: a token-gated smba URL commonly 302-redirects to a
+        # pre-signed blob host. The bot bearer must NOT follow cross-host, or it
+        # leaks. This drives a REAL httpx AsyncClient (via MockTransport) so both
+        # the SSRF redirect guard and httpx's own cross-origin Authorization
+        # stripping actually run — the property the whole design relies on.
+        adapter = self._make_adapter()
+        monkeypatch.setattr(_teams_mod, "_mint_bot_connector_token", AsyncMock(return_value=("tok", 3600)))
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda u: True)
+
+        seen = []
+
+        def handler(request):
+            seen.append((str(request.url), request.headers.get("Authorization")))
+            if len(seen) == 1:
+                return httpx.Response(302, headers={"location": "https://blob.example.com/signed"})
+            return httpx.Response(200, content=_PNG_BYTES)
+
+        real_client = httpx.AsyncClient
+
+        def _client_with_mock(**kw):
+            return real_client(**kw, transport=httpx.MockTransport(handler))
+
+        monkeypatch.setattr(httpx, "AsyncClient", _client_with_mock)
+
+        data = await adapter._fetch_teams_image_bytes(
+            "https://smba.trafficmanager.net/fr/v3/attachments/abc/views/original"
+        )
+
+        assert data == _PNG_BYTES
+        assert len(seen) == 2, "expected one redirect hop"
+        # Hop 1 (smba, allowlisted) carries the bearer; hop 2 (foreign host) must not.
+        assert seen[0][1] == "Bearer tok"
+        assert seen[1][0].startswith("https://blob.example.com/")
+        assert seen[1][1] is None
+
+    # -- retry on the transient post-paste auth window ------------------
+
+    @pytest.mark.anyio
+    async def test_fetch_image_retries_transient_403_then_succeeds(self, monkeypatch):
+        adapter = self._make_adapter()
+        monkeypatch.setattr(_teams_mod, "_IMAGE_FETCH_RETRY_DELAYS", (0.0, 0.0, 0.0))
+        monkeypatch.setattr(_teams_mod, "_mint_bot_connector_token", AsyncMock(return_value=("tok", 3600)))
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda u: True)
+        seq = [
+            httpx.Response(403, json={"message": "Authorization has been denied for this request."}),
+            httpx.Response(200, content=_PNG_BYTES),
+        ]
+        n = {"i": 0}
+
+        def handler(request):
+            r = seq[min(n["i"], len(seq) - 1)]
+            n["i"] += 1
+            return r
+
+        _patch_httpx_transport(monkeypatch, handler)
+
+        data = await adapter._fetch_teams_image_bytes(
+            "https://smba.trafficmanager.net/fr/v3/attachments/abc/views/original"
+        )
+        assert data == _PNG_BYTES
+        assert n["i"] == 2  # one transient 403, then success
+
+    @pytest.mark.anyio
+    async def test_fetch_image_exhausts_retries_and_raises(self, monkeypatch):
+        adapter = self._make_adapter()
+        monkeypatch.setattr(_teams_mod, "_IMAGE_FETCH_RETRY_DELAYS", (0.0, 0.0, 0.0))
+        monkeypatch.setattr(_teams_mod, "_mint_bot_connector_token", AsyncMock(return_value=("tok", 3600)))
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda u: True)
+        n = {"i": 0}
+
+        def handler(request):
+            n["i"] += 1
+            return httpx.Response(403, json={"message": "denied"})
+
+        _patch_httpx_transport(monkeypatch, handler)
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await adapter._fetch_teams_image_bytes(
+                "https://smba.trafficmanager.net/fr/v3/attachments/abc/views/original"
+            )
+        assert n["i"] == 3  # all attempts consumed, then raised
+
+    @pytest.mark.anyio
+    async def test_fetch_image_permanent_404_not_retried(self, monkeypatch):
+        adapter = self._make_adapter()
+        monkeypatch.setattr(_teams_mod, "_IMAGE_FETCH_RETRY_DELAYS", (0.0, 0.0, 0.0))
+        monkeypatch.setattr(_teams_mod, "_mint_bot_connector_token", AsyncMock(return_value=("tok", 3600)))
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda u: True)
+        n = {"i": 0}
+
+        def handler(request):
+            n["i"] += 1
+            return httpx.Response(404, json={"message": "not found"})
+
+        _patch_httpx_transport(monkeypatch, handler)
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await adapter._fetch_teams_image_bytes(
+                "https://smba.trafficmanager.net/fr/v3/attachments/abc/views/original"
+            )
+        assert n["i"] == 1  # 404 is permanent — no retry
+
+    @pytest.mark.anyio
+    async def test_fetch_image_403_not_retried_when_unauthenticated(self, monkeypatch):
+        # Foreign host → no bearer attached → a 403 is genuinely permanent, so
+        # we must NOT burn the retry budget on it.
+        adapter = self._make_adapter()
+        monkeypatch.setattr(_teams_mod, "_IMAGE_FETCH_RETRY_DELAYS", (0.0, 0.0, 0.0))
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda u: True)
+        n = {"i": 0}
+
+        def handler(request):
+            n["i"] += 1
+            return httpx.Response(403, json={"message": "forbidden"})
+
+        _patch_httpx_transport(monkeypatch, handler)
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await adapter._fetch_teams_image_bytes("https://evil.example.com/img.png")
+        assert n["i"] == 1  # unauthenticated 403 → no retry
+
+    @pytest.mark.anyio
+    async def test_fetch_image_oversized_rejected_via_streaming_reader(self, monkeypatch):
+        # The bounded streaming reader must reject an oversized body mid-stream:
+        # no Content-Length → the pre-check is skipped, so only the per-chunk
+        # running-total guard can catch it (proving we stream, not buffer
+        # .content). Spy confirms the bounded reader was actually invoked.
+        import gateway.platforms.base as _base
+
+        adapter = self._make_adapter()
+        monkeypatch.setattr(_teams_mod, "_mint_bot_connector_token", AsyncMock(return_value=("tok", 3600)))
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda u: True)
+        monkeypatch.setattr(_base, "get_inbound_media_max_bytes", lambda: 16)
+
+        seen = {"n": 0}
+        _orig = _base._read_httpx_body_with_limit
+
+        async def _spy(response, **kw):
+            seen["n"] += 1
+            return await _orig(response, **kw)
+
+        monkeypatch.setattr(_base, "_read_httpx_body_with_limit", _spy)
+
+        async def _chunks():
+            yield b"\x89PNG\r\n\x1a\n" + b"\x00" * 40
+            yield b"\x00" * 40
+
+        def handler(request):
+            return httpx.Response(200, content=_chunks())
+
+        _patch_httpx_transport(monkeypatch, handler)
+
+        with pytest.raises(ValueError):
+            await adapter._fetch_teams_image_bytes(
+                "https://smba.trafficmanager.net/fr/v3/attachments/abc/views/original"
+            )
+        assert seen["n"] >= 1  # the bounded streaming reader was on the path
+
+    # -- end-to-end image branch in _on_message -------------------------
+
+    @pytest.mark.anyio
+    async def test_pasted_image_sets_photo_with_local_path(self, monkeypatch):
+        from gateway.platforms.base import MessageType
+
+        adapter = self._make_adapter()
+        adapter._fetch_teams_image_bytes = AsyncMock(return_value=_PNG_BYTES)
+        monkeypatch.setattr(_teams_mod, "cache_image_from_bytes", lambda data, **kw: "/tmp/pasted.png")
+
+        activity = self._make_activity([self._image_attachment()])
+        await adapter._on_message(self._make_ctx(activity))
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_urls == ["/tmp/pasted.png"]
+        assert event.media_types == ["image/png"]
+
+    @pytest.mark.anyio
+    async def test_image_fetch_failure_falls_back_to_url_cache(self, monkeypatch):
+        from gateway.platforms.base import MessageType
+
+        adapter = self._make_adapter()
+        adapter._fetch_teams_image_bytes = AsyncMock(side_effect=Exception("401 Unauthorized"))
+
+        async def _fake_url_cache(url, *a, **kw):
+            return "/tmp/fallback.png"
+
+        monkeypatch.setattr(_teams_mod, "cache_image_from_url", _fake_url_cache)
+
+        activity = self._make_activity([self._image_attachment()])
+        await adapter._on_message(self._make_ctx(activity))
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_urls == ["/tmp/fallback.png"]
+
+    @pytest.mark.anyio
+    async def test_image_fetch_and_fallback_both_fail_degrade_to_text(self, monkeypatch):
+        from gateway.platforms.base import MessageType
+
+        adapter = self._make_adapter()
+        adapter._fetch_teams_image_bytes = AsyncMock(side_effect=Exception("401"))
+
+        async def _boom_url_cache(url, *a, **kw):
+            raise Exception("also 401")
+
+        monkeypatch.setattr(_teams_mod, "cache_image_from_url", _boom_url_cache)
+
+        activity = self._make_activity([self._image_attachment()])
         await adapter._on_message(self._make_ctx(activity))
 
         event = adapter.handle_message.call_args[0][0]
@@ -958,9 +1415,13 @@ class TestTeamsStandaloneSend:
         monkeypatch.setenv("TEAMS_TENANT_ID", "tenant")
         monkeypatch.delenv("TEAMS_SERVICE_URL", raising=False)
 
-        token_resp = _FakeAiohttpResponse(200, {"access_token": "the-token"})
+        # The token is minted via the shared helper (httpx); only the activity
+        # POST goes through aiohttp now.
+        mint = AsyncMock(return_value=("the-token", 3600))
+        monkeypatch.setattr(_teams_mod, "_mint_bot_connector_token", mint)
+
         activity_resp = _FakeAiohttpResponse(200, {"id": "msg-99"})
-        session = _FakeAiohttpSession([token_resp, activity_resp])
+        session = _FakeAiohttpSession([activity_resp])
         _install_fake_aiohttp(monkeypatch, session)
 
         result = await _teams_mod._standalone_send(
@@ -970,15 +1431,15 @@ class TestTeamsStandaloneSend:
         )
 
         assert result == {"success": True, "message_id": "msg-99"}
-        assert len(session.calls) == 2
 
-        token_url, token_kwargs = session.calls[0]
-        assert "login.microsoftonline.com/tenant/oauth2/v2.0/token" in token_url
-        assert token_kwargs["data"]["client_id"] == "client-id"
-        assert token_kwargs["data"]["client_secret"] == "secret"
-        assert token_kwargs["data"]["scope"] == "https://api.botframework.com/.default"
+        # Token minted once with the resolved tenant credentials.
+        mint.assert_awaited_once()
+        assert mint.await_args.kwargs["tenant_id"] == "tenant"
+        assert mint.await_args.kwargs["client_id"] == "client-id"
+        assert mint.await_args.kwargs["client_secret"] == "secret"
 
-        activity_url, activity_kwargs = session.calls[1]
+        assert len(session.calls) == 1
+        activity_url, activity_kwargs = session.calls[0]
         # Default service URL when TEAMS_SERVICE_URL is unset
         assert "smba.trafficmanager.net" in activity_url
         assert "/v3/conversations/19:abc@thread.skype/activities" in activity_url
@@ -1005,13 +1466,15 @@ class TestTeamsStandaloneSend:
         monkeypatch.setenv("TEAMS_CLIENT_ID", "client-id")
         monkeypatch.setenv("TEAMS_CLIENT_SECRET", "secret")
         monkeypatch.setenv("TEAMS_TENANT_ID", "tenant")
+        monkeypatch.delenv("TEAMS_SERVICE_URL", raising=False)
 
-        token_resp = _FakeAiohttpResponse(
-            401,
-            {"error": "unauthorized_client"},
-            text_body='{"error":"unauthorized_client"}',
-        )
-        session = _FakeAiohttpSession([token_resp])
+        async def _boom(**kwargs):
+            raise RuntimeError("token request failed (401): unauthorized_client")
+
+        monkeypatch.setattr(_teams_mod, "_mint_bot_connector_token", _boom)
+
+        # The activity POST must never fire when the token can't be minted.
+        session = _FakeAiohttpSession([])
         _install_fake_aiohttp(monkeypatch, session)
 
         result = await _teams_mod._standalone_send(
@@ -1023,6 +1486,7 @@ class TestTeamsStandaloneSend:
         assert "error" in result
         assert "401" in result["error"]
         assert "token" in result["error"].lower()
+        assert len(session.calls) == 0
 
     @pytest.mark.asyncio
     async def test_standalone_send_rejects_off_allowlist_service_url(self, monkeypatch):

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -581,12 +581,10 @@ class TestTeamsAttachmentClassification:
 
         adapter = self._make_adapter()
         adapter._fetch_attachment_bytes = AsyncMock(return_value=b"%PDF-1.4 fake")
-
-        async def fake_cache_image(url, *a, **kw):
-            return "/tmp/img.png"
+        adapter._fetch_teams_image_bytes = AsyncMock(return_value=b"\x89PNGfake")
 
         with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(_teams_mod, "cache_image_from_url", fake_cache_image)
+            mp.setattr(_teams_mod, "cache_image_from_bytes", lambda data, **kw: "/tmp/img.png")
             activity = self._make_activity([
                 self._image_attachment(),
                 self._file_download_attachment(),
@@ -596,6 +594,389 @@ class TestTeamsAttachmentClassification:
         event = adapter.handle_message.call_args[0][0]
         assert event.message_type == MessageType.DOCUMENT
         assert len(event.media_urls) == 2
+
+
+# ── inbound image auth (pasted-image fetch) ──────────────────────────────
+
+
+def _httpx_response(status, *, content=b"", json_data=None):
+    """Build a real httpx.Response so .json()/.text/.raise_for_status() work."""
+    req = httpx.Request("GET", "https://smba.trafficmanager.net/x")
+    if json_data is not None:
+        body = json.dumps(json_data).encode()
+        return httpx.Response(
+            status, content=body, request=req,
+            headers={"content-type": "application/json"},
+        )
+    return httpx.Response(status, content=content, request=req)
+
+
+def _patch_httpx(monkeypatch, *, get_response=None, post_response=None, get_responses=None):
+    """Replace httpx.AsyncClient with a fake capturing get/post calls.
+
+    ``get_responses`` (a list) returns responses in sequence across successive
+    GETs — used to exercise the retry loop; ``get_response`` returns the same
+    response every call.
+    """
+    calls = {"get": [], "post": [], "init_kwargs": None}
+    seq = list(get_responses) if get_responses is not None else None
+
+    class _FakeClient:
+        def __init__(self, **kwargs):
+            calls["init_kwargs"] = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, url, **kw):
+            calls["get"].append((url, kw))
+            if seq is not None:
+                return seq.pop(0)
+            return get_response
+
+        async def post(self, url, **kw):
+            calls["post"].append((url, kw))
+            return post_response
+
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeClient)
+    return calls
+
+
+_PNG_BYTES = b"\x89PNG\r\n\x1a\nfake-image-payload"
+
+
+class TestTeamsInboundImageAuth:
+    """Pasted inline images are token-gated Bot Connector URLs; the adapter
+    must fetch them with the bot's api.botframework.com bearer (an anonymous
+    GET 401s and the image was silently dropped) and cache to a local path
+    so run.py's native image pipeline attaches them."""
+
+    def _make_adapter(self, **creds):
+        cfg = _make_config(**(creds or dict(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+        )))
+        adapter = TeamsAdapter(cfg)
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+        adapter.handle_message = AsyncMock()
+        return adapter
+
+    def _image_attachment(self, content_url="https://smba.trafficmanager.net/fr/v3/attachments/abc/views/original"):
+        att = MagicMock()
+        att.content_type = "image/png"
+        att.content_url = content_url
+        att.name = "pasted.png"
+        return att
+
+    def _make_activity(self, attachments, text="look at this"):
+        activity = MagicMock()
+        activity.text = text
+        activity.id = "activity-img-001"
+        activity.from_ = MagicMock()
+        activity.from_.id = "user-123"
+        activity.from_.aad_object_id = "aad-456"
+        activity.from_.name = "Test User"
+        activity.conversation = MagicMock()
+        activity.conversation.id = "19:abc@thread.v2"
+        activity.conversation.conversation_type = "personal"
+        activity.conversation.name = "Test Chat"
+        activity.conversation.tenant_id = "tenant-789"
+        activity.attachments = attachments
+        return activity
+
+    def _make_ctx(self, activity):
+        ctx = MagicMock()
+        ctx.activity = activity
+        return ctx
+
+    # -- _mint_bot_connector_token --------------------------------------
+
+    @pytest.mark.anyio
+    async def test_mint_token_success(self, monkeypatch):
+        calls = _patch_httpx(
+            monkeypatch,
+            post_response=_httpx_response(200, json_data={"access_token": "tok", "expires_in": 1234}),
+        )
+        token, expires = await _teams_mod._mint_bot_connector_token(
+            tenant_id="t", client_id="c", client_secret="s",
+        )
+        assert token == "tok"
+        assert expires == 1234
+        url, kw = calls["post"][0]
+        assert "login.microsoftonline.com/t/oauth2/v2.0/token" in url
+        assert kw["data"]["grant_type"] == "client_credentials"
+        assert kw["data"]["scope"] == "https://api.botframework.com/.default"
+
+    @pytest.mark.anyio
+    async def test_mint_token_http_error_raises(self, monkeypatch):
+        _patch_httpx(
+            monkeypatch,
+            post_response=_httpx_response(401, json_data={"error": "unauthorized_client"}),
+        )
+        with pytest.raises(RuntimeError):
+            await _teams_mod._mint_bot_connector_token(
+                tenant_id="t", client_id="c", client_secret="s",
+            )
+
+    @pytest.mark.anyio
+    async def test_mint_token_missing_creds_raises(self):
+        with pytest.raises(RuntimeError):
+            await _teams_mod._mint_bot_connector_token(
+                tenant_id="", client_id="c", client_secret="s",
+            )
+
+    # -- _acquire_bot_connector_token (caching) -------------------------
+
+    @pytest.mark.anyio
+    async def test_acquire_token_caches(self, monkeypatch):
+        adapter = self._make_adapter()
+        mint = AsyncMock(return_value=("tok", 3600))
+        monkeypatch.setattr(_teams_mod, "_mint_bot_connector_token", mint)
+
+        t1 = await adapter._acquire_bot_connector_token()
+        t2 = await adapter._acquire_bot_connector_token()
+
+        assert t1 == t2 == "tok"
+        mint.assert_awaited_once()  # second call served from cache
+
+    @pytest.mark.anyio
+    async def test_acquire_token_none_when_creds_missing(self, monkeypatch):
+        for var in ("TEAMS_CLIENT_ID", "TEAMS_CLIENT_SECRET", "TEAMS_TENANT_ID"):
+            monkeypatch.delenv(var, raising=False)
+        adapter = TeamsAdapter(_make_config())
+        adapter._app = MagicMock()
+        assert await adapter._acquire_bot_connector_token() is None
+
+    @pytest.mark.anyio
+    async def test_acquire_token_none_on_mint_failure(self, monkeypatch):
+        adapter = self._make_adapter()
+
+        async def _boom(**kwargs):
+            raise RuntimeError("sts down")
+
+        monkeypatch.setattr(_teams_mod, "_mint_bot_connector_token", _boom)
+        assert await adapter._acquire_bot_connector_token() is None
+
+    # -- _fetch_teams_image_bytes ---------------------------------------
+
+    @pytest.mark.anyio
+    async def test_fetch_image_attaches_bearer_for_bot_framework_host(self, monkeypatch):
+        adapter = self._make_adapter()
+        monkeypatch.setattr(_teams_mod, "_mint_bot_connector_token", AsyncMock(return_value=("tok", 3600)))
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda u: True)
+        calls = _patch_httpx(monkeypatch, get_response=_httpx_response(200, content=_PNG_BYTES))
+
+        data = await adapter._fetch_teams_image_bytes(
+            "https://smba.trafficmanager.net/fr/v3/attachments/abc/views/original"
+        )
+
+        assert data == _PNG_BYTES
+        _, kw = calls["get"][0]
+        assert kw["headers"]["Authorization"] == "Bearer tok"
+
+    @pytest.mark.anyio
+    async def test_fetch_image_no_bearer_for_foreign_host(self, monkeypatch):
+        adapter = self._make_adapter()
+        mint = AsyncMock(return_value=("tok", 3600))
+        monkeypatch.setattr(_teams_mod, "_mint_bot_connector_token", mint)
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda u: True)
+        calls = _patch_httpx(monkeypatch, get_response=_httpx_response(200, content=_PNG_BYTES))
+
+        data = await adapter._fetch_teams_image_bytes("https://evil.example.com/img.png")
+
+        assert data == _PNG_BYTES
+        _, kw = calls["get"][0]
+        assert "Authorization" not in kw["headers"]
+        mint.assert_not_awaited()  # token never minted for a non-Bot-Framework host
+
+    @pytest.mark.anyio
+    async def test_fetch_image_data_uri_decodes_inline(self, monkeypatch):
+        import base64
+
+        adapter = self._make_adapter()
+
+        class _NoNetwork:
+            def __init__(self, **kw):
+                raise AssertionError("data: URI must not hit the network")
+
+        monkeypatch.setattr(httpx, "AsyncClient", _NoNetwork)
+
+        uri = "data:image/png;base64," + base64.b64encode(_PNG_BYTES).decode()
+        data = await adapter._fetch_teams_image_bytes(uri)
+        assert data == _PNG_BYTES
+
+    @pytest.mark.anyio
+    async def test_fetch_image_unsafe_url_raises(self, monkeypatch):
+        adapter = self._make_adapter()
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda u: False)
+        with pytest.raises(ValueError):
+            await adapter._fetch_teams_image_bytes("https://smba.trafficmanager.net/x")
+
+    @pytest.mark.anyio
+    async def test_fetch_image_strips_bearer_on_cross_host_redirect(self, monkeypatch):
+        # Security-critical: a token-gated smba URL commonly 302-redirects to a
+        # pre-signed blob host. The bot bearer must NOT follow cross-host, or it
+        # leaks. This drives a REAL httpx AsyncClient (via MockTransport) so both
+        # the SSRF redirect guard and httpx's own cross-origin Authorization
+        # stripping actually run — the property the whole design relies on.
+        adapter = self._make_adapter()
+        monkeypatch.setattr(_teams_mod, "_mint_bot_connector_token", AsyncMock(return_value=("tok", 3600)))
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda u: True)
+
+        seen = []
+
+        def handler(request):
+            seen.append((str(request.url), request.headers.get("Authorization")))
+            if len(seen) == 1:
+                return httpx.Response(302, headers={"location": "https://blob.example.com/signed"})
+            return httpx.Response(200, content=_PNG_BYTES)
+
+        real_client = httpx.AsyncClient
+
+        def _client_with_mock(**kw):
+            return real_client(**kw, transport=httpx.MockTransport(handler))
+
+        monkeypatch.setattr(httpx, "AsyncClient", _client_with_mock)
+
+        data = await adapter._fetch_teams_image_bytes(
+            "https://smba.trafficmanager.net/fr/v3/attachments/abc/views/original"
+        )
+
+        assert data == _PNG_BYTES
+        assert len(seen) == 2, "expected one redirect hop"
+        # Hop 1 (smba, allowlisted) carries the bearer; hop 2 (foreign host) must not.
+        assert seen[0][1] == "Bearer tok"
+        assert seen[1][0].startswith("https://blob.example.com/")
+        assert seen[1][1] is None
+
+    # -- retry on the transient post-paste auth window ------------------
+
+    @pytest.mark.anyio
+    async def test_fetch_image_retries_transient_403_then_succeeds(self, monkeypatch):
+        adapter = self._make_adapter()
+        monkeypatch.setattr(_teams_mod, "_IMAGE_FETCH_RETRY_DELAYS", (0.0, 0.0, 0.0))
+        monkeypatch.setattr(_teams_mod, "_mint_bot_connector_token", AsyncMock(return_value=("tok", 3600)))
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda u: True)
+        calls = _patch_httpx(monkeypatch, get_responses=[
+            _httpx_response(403, json_data={"message": "Authorization has been denied for this request."}),
+            _httpx_response(200, content=_PNG_BYTES),
+        ])
+
+        data = await adapter._fetch_teams_image_bytes(
+            "https://smba.trafficmanager.net/fr/v3/attachments/abc/views/original"
+        )
+        assert data == _PNG_BYTES
+        assert len(calls["get"]) == 2  # one transient 403, then success
+
+    @pytest.mark.anyio
+    async def test_fetch_image_exhausts_retries_and_raises(self, monkeypatch):
+        adapter = self._make_adapter()
+        monkeypatch.setattr(_teams_mod, "_IMAGE_FETCH_RETRY_DELAYS", (0.0, 0.0, 0.0))
+        monkeypatch.setattr(_teams_mod, "_mint_bot_connector_token", AsyncMock(return_value=("tok", 3600)))
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda u: True)
+        calls = _patch_httpx(monkeypatch, get_responses=[
+            _httpx_response(403, json_data={"message": "denied"}),
+            _httpx_response(403, json_data={"message": "denied"}),
+            _httpx_response(403, json_data={"message": "denied"}),
+        ])
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await adapter._fetch_teams_image_bytes(
+                "https://smba.trafficmanager.net/fr/v3/attachments/abc/views/original"
+            )
+        assert len(calls["get"]) == 3  # all attempts consumed, then raised
+
+    @pytest.mark.anyio
+    async def test_fetch_image_permanent_404_not_retried(self, monkeypatch):
+        adapter = self._make_adapter()
+        monkeypatch.setattr(_teams_mod, "_IMAGE_FETCH_RETRY_DELAYS", (0.0, 0.0, 0.0))
+        monkeypatch.setattr(_teams_mod, "_mint_bot_connector_token", AsyncMock(return_value=("tok", 3600)))
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda u: True)
+        calls = _patch_httpx(monkeypatch, get_responses=[
+            _httpx_response(404, json_data={"message": "not found"}),
+            _httpx_response(200, content=_PNG_BYTES),  # must never be reached
+        ])
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await adapter._fetch_teams_image_bytes(
+                "https://smba.trafficmanager.net/fr/v3/attachments/abc/views/original"
+            )
+        assert len(calls["get"]) == 1  # 404 is permanent — no retry
+
+    @pytest.mark.anyio
+    async def test_fetch_image_403_not_retried_when_unauthenticated(self, monkeypatch):
+        # Foreign host → no bearer attached → a 403 is genuinely permanent, so
+        # we must NOT burn the retry budget on it.
+        adapter = self._make_adapter()
+        monkeypatch.setattr(_teams_mod, "_IMAGE_FETCH_RETRY_DELAYS", (0.0, 0.0, 0.0))
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda u: True)
+        calls = _patch_httpx(monkeypatch, get_responses=[
+            _httpx_response(403, json_data={"message": "forbidden"}),
+            _httpx_response(200, content=_PNG_BYTES),
+        ])
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await adapter._fetch_teams_image_bytes("https://evil.example.com/img.png")
+        assert len(calls["get"]) == 1  # unauthenticated 403 → no retry
+
+    # -- end-to-end image branch in _on_message -------------------------
+
+    @pytest.mark.anyio
+    async def test_pasted_image_sets_photo_with_local_path(self, monkeypatch):
+        from gateway.platforms.base import MessageType
+
+        adapter = self._make_adapter()
+        adapter._fetch_teams_image_bytes = AsyncMock(return_value=_PNG_BYTES)
+        monkeypatch.setattr(_teams_mod, "cache_image_from_bytes", lambda data, **kw: "/tmp/pasted.png")
+
+        activity = self._make_activity([self._image_attachment()])
+        await adapter._on_message(self._make_ctx(activity))
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_urls == ["/tmp/pasted.png"]
+        assert event.media_types == ["image/png"]
+
+    @pytest.mark.anyio
+    async def test_image_fetch_failure_falls_back_to_url_cache(self, monkeypatch):
+        from gateway.platforms.base import MessageType
+
+        adapter = self._make_adapter()
+        adapter._fetch_teams_image_bytes = AsyncMock(side_effect=Exception("401 Unauthorized"))
+
+        async def _fake_url_cache(url, *a, **kw):
+            return "/tmp/fallback.png"
+
+        monkeypatch.setattr(_teams_mod, "cache_image_from_url", _fake_url_cache)
+
+        activity = self._make_activity([self._image_attachment()])
+        await adapter._on_message(self._make_ctx(activity))
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_urls == ["/tmp/fallback.png"]
+
+    @pytest.mark.anyio
+    async def test_image_fetch_and_fallback_both_fail_degrade_to_text(self, monkeypatch):
+        from gateway.platforms.base import MessageType
+
+        adapter = self._make_adapter()
+        adapter._fetch_teams_image_bytes = AsyncMock(side_effect=Exception("401"))
+
+        async def _boom_url_cache(url, *a, **kw):
+            raise Exception("also 401")
+
+        monkeypatch.setattr(_teams_mod, "cache_image_from_url", _boom_url_cache)
+
+        activity = self._make_activity([self._image_attachment()])
+        await adapter._on_message(self._make_ctx(activity))
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.TEXT
+        assert event.media_urls == []
 
 
 # ── _standalone_send (out-of-process cron delivery) ──────────────────────
@@ -660,9 +1041,13 @@ class TestTeamsStandaloneSend:
         monkeypatch.setenv("TEAMS_TENANT_ID", "tenant")
         monkeypatch.delenv("TEAMS_SERVICE_URL", raising=False)
 
-        token_resp = _FakeAiohttpResponse(200, {"access_token": "the-token"})
+        # The token is minted via the shared helper (httpx); only the activity
+        # POST goes through aiohttp now.
+        mint = AsyncMock(return_value=("the-token", 3600))
+        monkeypatch.setattr(_teams_mod, "_mint_bot_connector_token", mint)
+
         activity_resp = _FakeAiohttpResponse(200, {"id": "msg-99"})
-        session = _FakeAiohttpSession([token_resp, activity_resp])
+        session = _FakeAiohttpSession([activity_resp])
         _install_fake_aiohttp(monkeypatch, session)
 
         result = await _teams_mod._standalone_send(
@@ -672,15 +1057,15 @@ class TestTeamsStandaloneSend:
         )
 
         assert result == {"success": True, "message_id": "msg-99"}
-        assert len(session.calls) == 2
 
-        token_url, token_kwargs = session.calls[0]
-        assert "login.microsoftonline.com/tenant/oauth2/v2.0/token" in token_url
-        assert token_kwargs["data"]["client_id"] == "client-id"
-        assert token_kwargs["data"]["client_secret"] == "secret"
-        assert token_kwargs["data"]["scope"] == "https://api.botframework.com/.default"
+        # Token minted once with the resolved tenant credentials.
+        mint.assert_awaited_once()
+        assert mint.await_args.kwargs["tenant_id"] == "tenant"
+        assert mint.await_args.kwargs["client_id"] == "client-id"
+        assert mint.await_args.kwargs["client_secret"] == "secret"
 
-        activity_url, activity_kwargs = session.calls[1]
+        assert len(session.calls) == 1
+        activity_url, activity_kwargs = session.calls[0]
         # Default service URL when TEAMS_SERVICE_URL is unset
         assert "smba.trafficmanager.net" in activity_url
         assert "/v3/conversations/19:abc@thread.skype/activities" in activity_url
@@ -694,13 +1079,15 @@ class TestTeamsStandaloneSend:
         monkeypatch.setenv("TEAMS_CLIENT_ID", "client-id")
         monkeypatch.setenv("TEAMS_CLIENT_SECRET", "secret")
         monkeypatch.setenv("TEAMS_TENANT_ID", "tenant")
+        monkeypatch.delenv("TEAMS_SERVICE_URL", raising=False)
 
-        token_resp = _FakeAiohttpResponse(
-            401,
-            {"error": "unauthorized_client"},
-            text_body='{"error":"unauthorized_client"}',
-        )
-        session = _FakeAiohttpSession([token_resp])
+        async def _boom(**kwargs):
+            raise RuntimeError("token request failed (401): unauthorized_client")
+
+        monkeypatch.setattr(_teams_mod, "_mint_bot_connector_token", _boom)
+
+        # The activity POST must never fire when the token can't be minted.
+        session = _FakeAiohttpSession([])
         _install_fake_aiohttp(monkeypatch, session)
 
         result = await _teams_mod._standalone_send(
@@ -712,6 +1099,7 @@ class TestTeamsStandaloneSend:
         assert "error" in result
         assert "401" in result["error"]
         assert "token" in result["error"].lower()
+        assert len(session.calls) == 0
 
 
 class TestTeamsMediaAttachments:

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -1137,3 +1137,211 @@ class TestTeamsMediaAttachments:
         adapter._app.send.assert_awaited_once()
 
 
+class TestTeamsEmojiUnicode:
+    """Teams sends emoji as 20x20 CDN sprites plus a text/html body mirror
+    carrying the real character in the img's ``alt``. The adapter must restore
+    the character into the text and drop the sprite attachment: forwarding it
+    loses the meaning and 400s on providers with a minimum image size."""
+
+    # Captured verbatim from production on 2026-08-19 (Teams, DM, 👍).
+    REAL_MIRROR = (
+        '<p>OK <span title="Oui" type="(yes)" class="animated-emoticon-20-yes" itemscope="">'
+        '<img itemscope="" itemtype="http://schema.skype.com/Emoji" itemid="yes" '
+        'src="https://statics.teams.cdn.office.net/evergreen-assets/personal-expressions/v2/'
+        'assets/emoticons/yes/default/20_f.png" title="Oui" alt="\U0001F44D" '
+        'style="width:20px; height:20px"></span>&nbsp;Pas grave; merci d\'avoir cherché.</p>'
+    )
+    REAL_SRC = (
+        "https://statics.teams.cdn.office.net/evergreen-assets/personal-expressions/v2/"
+        "assets/emoticons/yes/default/20_f.png"
+    )
+
+    # -- _teams_html_to_text --------------------------------------------
+
+    def test_real_production_mirror(self):
+        text, chars, srcs = _teams_mod._teams_html_to_text(self.REAL_MIRROR)
+        assert text == "OK \U0001F44D Pas grave; merci d'avoir cherché."
+        assert chars == ["\U0001F44D"]
+        assert srcs == {self.REAL_SRC}
+
+    def test_emoji_position_is_preserved(self):
+        html_body = (
+            '<p>avant <img itemtype="http://schema.skype.com/Emoji" itemid="yes" '
+            'src="https://cdn/y.png" alt="\U0001F44D"> apres</p>'
+        )
+        text, _, _ = _teams_mod._teams_html_to_text(html_body)
+        assert text == "avant \U0001F44D apres"
+
+    def test_custom_emoji_without_alt_falls_back_to_shortcode(self):
+        html_body = (
+            '<p>ship it <img itemtype="http://schema.skype.com/Emoji" '
+            'itemid="tenantrocket" src="https://cdn/custom.png" alt=""></p>'
+        )
+        text, chars, srcs = _teams_mod._teams_html_to_text(html_body)
+        assert text == "ship it :tenantrocket:"
+        assert chars == [":tenantrocket:"]
+        # Custom emoji live off the Teams CDN — matching on itemtype, not on
+        # the hostname, is what makes them work.
+        assert srcs == {"https://cdn/custom.png"}
+
+    def test_pasted_image_is_not_treated_as_emoji(self):
+        html_body = '<p>regarde <img src="https://smba.trafficmanager.net/x/views/original"></p>'
+        text, chars, srcs = _teams_mod._teams_html_to_text(html_body)
+        assert text == "regarde"
+        assert chars == []
+        assert srcs == set()  # stays in attachments, real content
+
+    def test_multiple_emoji_in_order(self):
+        html_body = (
+            '<p><img itemtype="http://schema.skype.com/Emoji" itemid="yes" src="https://c/a.png" '
+            'alt="\U0001F44D"> et <img itemtype="http://schema.skype.com/Emoji" itemid="think" '
+            'src="https://c/b.png" alt="\U0001F914"></p>'
+        )
+        text, chars, srcs = _teams_mod._teams_html_to_text(html_body)
+        assert text == "\U0001F44D et \U0001F914"
+        assert chars == ["\U0001F44D", "\U0001F914"]
+        assert srcs == {"https://c/a.png", "https://c/b.png"}
+
+    def test_entities_and_breaks(self):
+        html_body = '<p>a&nbsp;&amp;&nbsp;b<br>ligne 2</p>'
+        text, _, _ = _teams_mod._teams_html_to_text(html_body)
+        assert text == "a & b\nligne 2"
+
+    def test_mention_span_is_dropped(self):
+        html_body = (
+            '<p><span itemtype="http://schema.skype.com/Mention" itemid="0"><at>Hermes</at></span>'
+            ' salut <img itemtype="http://schema.skype.com/Emoji" itemid="yes" '
+            'src="https://c/a.png" alt="\U0001F44D"></p>'
+        )
+        text, chars, _ = _teams_mod._teams_html_to_text(html_body)
+        assert text == "salut \U0001F44D"
+        assert chars == ["\U0001F44D"]
+
+    # -- end to end through _on_message ---------------------------------
+
+    def _make_adapter(self):
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+        ))
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+        adapter.handle_message = AsyncMock()
+        return adapter
+
+    def _html_attachment(self, content):
+        att = MagicMock()
+        att.content_type = "text/html"
+        att.content_url = None
+        att.content = content
+        att.name = ""
+        return att
+
+    def _sprite_attachment(self, content_url):
+        att = MagicMock()
+        att.content_type = "image/png"
+        att.content_url = content_url
+        att.name = "20_f.png"
+        return att
+
+    def _make_activity(self, attachments, text):
+        activity = MagicMock()
+        activity.text = text
+        activity.id = "activity-emoji-001"
+        activity.from_ = MagicMock()
+        activity.from_.id = "user-123"
+        activity.from_.aad_object_id = "aad-456"
+        activity.from_.name = "Test User"
+        activity.conversation = MagicMock()
+        activity.conversation.id = "19:abc@thread.v2"
+        activity.conversation.conversation_type = "personal"
+        activity.conversation.name = "Test Chat"
+        activity.conversation.tenant_id = "tenant-789"
+        activity.attachments = attachments
+        return activity
+
+    @pytest.mark.anyio
+    async def test_sprite_dropped_and_emoji_restored_in_text(self, monkeypatch):
+        adapter = self._make_adapter()
+        fetch = AsyncMock(return_value=b"never-called")
+        monkeypatch.setattr(adapter, "_fetch_teams_image_bytes", fetch)
+
+        activity = self._make_activity(
+            [self._html_attachment(self.REAL_MIRROR), self._sprite_attachment(self.REAL_SRC)],
+            text="OK  Pas grave; merci d'avoir cherché.",
+        )
+        ctx = MagicMock()
+        ctx.activity = activity
+        await adapter._on_message(ctx)
+
+        event = adapter.handle_message.await_args.args[0]
+        assert event.text == "OK \U0001F44D Pas grave; merci d'avoir cherché."
+        assert not (event.media_urls or [])
+        fetch.assert_not_awaited()  # the sprite was never fetched
+
+    @pytest.mark.anyio
+    async def test_real_pasted_image_still_attached(self, monkeypatch):
+        adapter = self._make_adapter()
+        monkeypatch.setattr(
+            adapter, "_fetch_teams_image_bytes", AsyncMock(return_value=b"\x89PNG-bytes"),
+        )
+        # cache_image_from_bytes returns the absolute path as a string.
+        monkeypatch.setattr(
+            _teams_mod, "cache_image_from_bytes", lambda *a, **k: "/cache/img_1.png",
+        )
+
+        pasted = "https://smba.trafficmanager.net/fr/v3/attachments/abc/views/original"
+        mirror = (
+            '<p>vois <img itemtype="http://schema.skype.com/Emoji" itemid="yes" '
+            f'src="{self.REAL_SRC}" alt="\U0001F44D"> ca <img src="{pasted}"></p>'
+        )
+        activity = self._make_activity(
+            [
+                self._html_attachment(mirror),
+                self._sprite_attachment(self.REAL_SRC),
+                self._sprite_attachment(pasted),
+            ],
+            text="vois  ca",
+        )
+        ctx = MagicMock()
+        ctx.activity = activity
+        await adapter._on_message(ctx)
+
+        event = adapter.handle_message.await_args.args[0]
+        assert event.text == "vois \U0001F44D ca"
+        assert event.media_urls == ["/cache/img_1.png"]  # sprite out, real image in
+
+    @pytest.mark.anyio
+    async def test_mismatched_mirror_appends_rather_than_dropping(self, monkeypatch):
+        """When the two renderings disagree the emoji must still survive."""
+        adapter = self._make_adapter()
+        monkeypatch.setattr(adapter, "_fetch_teams_image_bytes", AsyncMock(return_value=b""))
+
+        mirror = (
+            '<p>un corps qui ne correspond pas <img itemtype="http://schema.skype.com/Emoji" '
+            f'itemid="yes" src="{self.REAL_SRC}" alt="\U0001F44D"></p>'
+        )
+        activity = self._make_activity(
+            [self._html_attachment(mirror), self._sprite_attachment(self.REAL_SRC)],
+            text="texte totalement different",
+        )
+        ctx = MagicMock()
+        ctx.activity = activity
+        await adapter._on_message(ctx)
+
+        event = adapter.handle_message.await_args.args[0]
+        assert event.text == "texte totalement different \U0001F44D"
+
+    @pytest.mark.anyio
+    async def test_message_without_emoji_is_untouched(self, monkeypatch):
+        adapter = self._make_adapter()
+        activity = self._make_activity(
+            [self._html_attachment("<p>rien de special</p>")],
+            text="rien de special",
+        )
+        ctx = MagicMock()
+        ctx.activity = activity
+        await adapter._on_message(ctx)
+
+        event = adapter.handle_message.await_args.args[0]
+        assert event.text == "rien de special"
+


### PR DESCRIPTION
> **Updated 2026-08-19** — rebased onto current `main` (the previous revision was ~7000 commits behind) and **extended with a second, causally linked fix**: see *Emoji sprites* below. The authentication bug is still reproducible against `main` as of this rebase — `_fetch_attachment_bytes` sends no `Authorization` header and the image path still calls `cache_image_from_url(content_url)` bare.

## Relation to existing PRs

This bug overlaps with prior work — flagging it up front. Several open PRs authenticate Teams inbound image attachments (#47015, #55054) or touch Teams image handling (#48458). This PR covers the same authentication fix **and adds a piece none of them handle: a retry over the transient post-paste authorization window** (see below). Happy to fold this into an existing PR instead if a maintainer prefers — the retry is the part worth keeping regardless of which auth change lands.

## Problem

A pasted (inline) image in Microsoft Teams never reached the model — the agent replied as if it only received text, even with a multimodal model. File *uploads* worked fine.

## Root cause

A pasted inline image arrives as a Bot Framework attachment with `contentType image/*` and a **token-gated** `contentUrl` on `smba.trafficmanager.net` (`/v3/attachments/{id}/views/original`). The Teams adapter fetched it via `cache_image_from_url(content_url)` with **no `Authorization` header**, so the Connector returned **401**, the image was skipped, and `event.media_urls` stayed empty → `run.py`'s native image pipeline (gated on `media_urls`) was skipped → text only. File uploads use a pre-signed SharePoint `downloadUrl`, which is why they worked.

## Fix

- Fetch inline images with the bot's `api.botframework.com/.default` bearer and cache the bytes to a **local path** (mirrors the Discord/Telegram byte-cache path), so the native image pipeline attaches them.
- The client-credentials token mint is factored into a shared helper (`_mint_bot_connector_token`) reused by the standalone/cron send path; the adapter caches the token.
- **Transient window (the part unique to this PR):** a freshly-pasted attachment briefly returns 401/403 until the Connector authorizes the read — reproduced in production, where a `contentUrl` that returns 403 at the instant the message is delivered returns 200 a few seconds later (with the tenant-specific bearer; the `botframework.com`-issued token is rejected, i.e. the tenant-specific mint is the correct one). Without a retry the image is dropped permanently. The fetch retries with bounded backoff (`0/1/2/4/8s`) on an authenticated 401/403 plus the usual 408/429/5xx.
- `data:` URIs are decoded inline; falls back to the anonymous URL cache for genuinely public image URLs.

## Emoji sprites — why this fix ships in the same PR

Authenticating the fetch **unmasks a second bug**, so shipping the auth fix alone would trade a dropped image for a worse failure. This is not unrelated scope; it is the consequence of the change above.

Teams never sends an emoji as a Unicode character. It sends a **20×20 PNG** from its CDN as an ordinary `image/*` attachment, and mirrors the message body as a `text/html` attachment where the emoji carries the real character in the `alt` of an `<img itemtype="http://schema.skype.com/Emoji">`.

On `main` today that sprite is silently dropped — because the fetch 401s. The emoji meaning is lost either way (`activity.text` never contains it), but nothing else breaks. **Once the fetch is authenticated, every emoji becomes a successfully-cached 20×20 image handed to the model.** Observed in production on this branch: a single 👍 produced a `400 invalid_image` from the provider and triggered a model failover mid-conversation, because several providers enforce a minimum image dimension. The user had sent one character.

The fix reads the `text/html` mirror the client already attaches:

- emoji `<img>` tags are replaced **in place** by their `alt` character, so `"ok 👍"` stays `"ok 👍"` rather than losing the emoji or appending it at the end;
- the mirror is adopted as the message text **only** when its emoji-stripped rendering matches `activity.text` (whitespace-insensitive). Otherwise the characters are appended instead — meaning is never silently lost to a mirror we misparsed;
- the emoji `src` URLs are collected so the matching attachments are skipped, and **only those**: genuinely pasted images stay in `attachments` and keep going through the inline-image path above;
- `<span itemtype=".../Mention">` blocks are stripped first, so the existing `<at>` mention handling is unaffected.

Falls back to `activity.text` unchanged when there is no HTML mirror, so non-Teams-client senders and plain-text messages behave exactly as before.

## Security

- The bearer is attached **only** when the URL host is a known Bot Framework host, so a tampered `contentUrl` cannot exfiltrate the token to an arbitrary origin.
- On the cross-host redirect to blob storage, httpx strips `Authorization` and the existing SSRF redirect guard re-validates each hop. A regression test drives a real 302 and asserts the second hop carries no bearer.

## Tests

`tests/gateway/test_teams.py` (52 passing on this branch): token mint/cache, host-gated bearer attach/no-attach, `data:` decode, SSRF reject, cross-host redirect strip, retry (transient→success / exhaustion / non-retryable 404 / unauthenticated 403), and end-to-end `_on_message` classification (PHOTO + local path). Existing attachment/standalone tests updated for the new path. A dedicated `TestTeamsEmojiUnicode` class covers the emoji path: in-place substitution, the position guard and its append fallback, mention stripping, `alt`-less fallback to `:itemid:`, attachment skipping limited to emoji `src`s, and end-to-end `_on_message` runs including the verbatim HTML mirror captured from a real production message.
