### PR TITLE
fix(slack): avoid logging block text previews

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2662,8 +2662,8 @@ class SlackAdapter(BasePlatformAdapter):
                 if stripped_blocks and stripped_blocks not in text.strip():
                     logger.debug(
                         "Slack: extracted additional text from blocks "
-                        "(likely quoted/forwarded content): %s",
-                        stripped_blocks[:300],
+                        "(likely quoted/forwarded content; chars=%d)",
+                        len(stripped_blocks),
                     )
                     text = (text.strip() + "\n" + stripped_blocks).strip()
 

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -6,7 +6,10 @@ Follows the same pattern as test_whatsapp_group_gating.py.
 
 import sys
 import inspect
+import logging
 from unittest.mock import MagicMock
+
+import pytest
 
 from gateway.config import Platform, PlatformConfig
 
@@ -797,6 +800,49 @@ def test_allowed_channels_env_var_blocks_channel(monkeypatch):
     adapter = _make_adapter()  # no config value → falls back to env
     assert _would_process(adapter, channel_id=OTHER_CHANNEL_ID, text="hello") is False
     assert _would_process(adapter, channel_id=CHANNEL_ID, mentioned=True) is True
+
+
+@pytest.mark.asyncio
+async def test_block_extraction_debug_log_does_not_include_message_preview(caplog):
+    secret_block_text = "private incident token: customer-id-12345"
+    adapter = _make_adapter(allowed_channels=[CHANNEL_ID])
+    adapter._dedup = MagicMock(is_duplicate=MagicMock(return_value=False))
+    adapter._lookup_assistant_thread_metadata = MagicMock(return_value={})
+    adapter._channel_team = {}
+
+    event = {
+        "channel": OTHER_CHANNEL_ID,
+        "channel_type": "channel",
+        "ts": "1710000000.000100",
+        "team": "T1",
+        "user": "U_USER",
+        "text": "<@U_BOT_123> see quoted message",
+        "blocks": [
+            {
+                "type": "rich_text",
+                "elements": [
+                    {
+                        "type": "rich_text_quote",
+                        "elements": [
+                            {
+                                "type": "rich_text_section",
+                                "elements": [
+                                    {"type": "text", "text": secret_block_text}
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+    with caplog.at_level(logging.DEBUG, logger="plugins.platforms.slack.adapter"):
+        await adapter._handle_slack_message(event)
+
+    assert "extracted additional text from blocks" in caplog.text
+    assert "chars=" in caplog.text
+    assert secret_block_text not in caplog.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Stops Slack inbound rich-text block extraction from logging user message previews at debug level. The handler still logs that extra block text was extracted, but it now records only the extracted character count instead of `stripped_blocks[:300]`.

This keeps the useful operational signal without copying quoted/forwarded Slack message content into gateway logs.

## Related Issue

Fixes #58477

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/slack/adapter.py`: replace the debug log's extracted block-text preview with a character count.
- `tests/gateway/test_slack_mention.py`: add a regression test that drives `_handle_slack_message()` with sensitive rich-text block content and asserts the log contains metadata but not the message text.

## How to Test

1. Send a Slack event whose `blocks` contain quoted rich-text content not already present in the plain `text` field.
2. Enable debug logging for `plugins.platforms.slack.adapter`.
3. Verify the log reports the extraction event without including the quoted message content.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, `uv` environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
$ uv run --locked pytest tests/gateway/test_slack_mention.py::test_block_extraction_debug_log_does_not_include_message_preview -q
.                                                                        [100%]
1 passed in 0.39s

$ uv run --locked pytest tests/gateway/test_slack_mention.py -q
........................................................................ [ 97%]
..                                                                       [100%]
74 passed in 5.31s

$ git diff --check
(no output; Windows only printed LF/CRLF working-copy warnings)
```