### PR TITLE
fix(tui): expose compressed session lineage in history

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3082,6 +3082,24 @@ class SessionDB:
             s["preview"] = ""
         return s
 
+    def get_session_lineage_rich(self, session_id: str) -> List[Dict[str, Any]]:
+        """Return the stored ancestor chain for a session, enriched for UIs.
+
+        Compression splits one logical conversation across several session rows:
+        the pre-compression parent keeps its full transcript, while the live tip
+        holds the continuation. ``list_sessions_rich`` normally projects the
+        root forward to the tip so resume lists stay uncluttered. This helper
+        gives history UIs a structured way to expose those hidden segments
+        without changing the default resume target.
+        """
+        lineage = self._session_lineage_root_to_tip(session_id)
+        rows: List[Dict[str, Any]] = []
+        for sid in lineage:
+            row = self._get_session_rich_row(sid)
+            if row:
+                rows.append(row)
+        return rows
+
     # =========================================================================
     # Message storage
     # =========================================================================

--- a/tests/gateway/test_session_list_allowed_sources.py
+++ b/tests/gateway/test_session_list_allowed_sources.py
@@ -21,11 +21,15 @@ from tui_gateway import server
 class _StubDB:
     def __init__(self, rows):
         self.rows = rows
+        self.lineages = {}
         self.calls: list[dict] = []
 
     def list_sessions_rich(self, **kwargs):
         self.calls.append(kwargs)
         return list(self.rows)
+
+    def get_session_lineage_rich(self, session_id):
+        return list(self.lineages.get(session_id, []))
 
 
 def _call(limit: int | None = None):
@@ -102,3 +106,35 @@ def test_session_list_preserves_ordering_after_filter(monkeypatch):
     ids = [s["id"] for s in resp["result"]["sessions"]]
 
     assert ids == ["newest", "middle", "also-visible", "oldest"]
+
+
+def test_session_list_expands_compression_lineage_segments(monkeypatch):
+    tip = {
+        "id": "tip-session",
+        "_lineage_root_id": "root-session",
+        "source": "tui",
+        "started_at": 30,
+        "message_count": 4,
+        "title": "Current work",
+    }
+    root = {
+        "id": "root-session",
+        "source": "tui",
+        "started_at": 10,
+        "message_count": 120,
+        "title": "Before compression",
+        "preview": "first prompt",
+    }
+    db = _StubDB([tip])
+    db.lineages["tip-session"] = [root, tip]
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+
+    resp = _call(limit=10)
+    sessions = resp["result"]["sessions"]
+
+    assert [s["id"] for s in sessions] == ["tip-session", "root-session"]
+    segment = sessions[1]
+    assert segment["lineage_kind"] == "compression_segment"
+    assert segment["lineage_index"] == 1
+    assert segment["lineage_tip_id"] == "tip-session"
+    assert segment["resume_id"] == "tip-session"

--- a/tests/test_session_lineage_rich.py
+++ b/tests/test_session_lineage_rich.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from hermes_state import SessionDB
+
+
+def test_get_session_lineage_rich_returns_compression_segments(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    root_id = db.create_session("root-session", "tui")
+    db.set_session_title(root_id, "Before compression")
+    db.append_message(root_id, "user", "first debugging prompt")
+    db.end_session(root_id, "compression")
+
+    tip_id = db.create_session("tip-session", "tui", parent_session_id=root_id)
+    db.set_session_title(tip_id, "After compression")
+    db.append_message(tip_id, "user", "continued debugging prompt")
+
+    lineage = db.get_session_lineage_rich(tip_id)
+
+    assert [row["id"] for row in lineage] == [root_id, tip_id]
+    assert [row["title"] for row in lineage] == ["Before compression", "After compression"]
+    assert lineage[0]["preview"] == "first debugging prompt"
+    assert lineage[1]["preview"] == "continued debugging prompt"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5075,22 +5075,46 @@ def _(rid, params: dict) -> dict:
             for s in db.list_sessions_rich(source=None, limit=fetch_limit, order_by_last_active=True)
             if (s.get("source") or "").strip().lower() not in deny
         ][:limit]
-        return _ok(
-            rid,
-            {
-                "sessions": [
-                    {
-                        "id": s["id"],
-                        "title": s.get("title") or "",
-                        "preview": s.get("preview") or "",
-                        "started_at": s.get("started_at") or 0,
-                        "message_count": s.get("message_count") or 0,
-                        "source": s.get("source") or "",
-                    }
-                    for s in rows
-                ]
-            },
-        )
+        sessions = []
+
+        def _session_list_row(s: dict, **extra: object) -> dict:
+            row = {
+                "id": s["id"],
+                "title": s.get("title") or "",
+                "preview": s.get("preview") or "",
+                "started_at": s.get("started_at") or 0,
+                "message_count": s.get("message_count") or 0,
+                "source": s.get("source") or "",
+            }
+            row.update(extra)
+            return row
+
+        for s in rows:
+            sessions.append(_session_list_row(s))
+            root_id = s.get("_lineage_root_id")
+            if not root_id or root_id == s.get("id"):
+                continue
+            try:
+                lineage = db.get_session_lineage_rich(s["id"])
+            except Exception:
+                logger.debug("session.list lineage expansion failed for %s", s.get("id"), exc_info=True)
+                continue
+            # Show hidden pre-compression segments directly under the live tip.
+            # Selecting one still resumes the tip: session.resume already
+            # displays ancestors, while reopening the ended parent would break
+            # the compression chain's list/resume projection.
+            for index, segment in enumerate(lineage[:-1], start=1):
+                sessions.append(
+                    _session_list_row(
+                        segment,
+                        lineage_kind="compression_segment",
+                        lineage_index=index,
+                        lineage_tip_id=s["id"],
+                        resume_id=s["id"],
+                    )
+                )
+
+        return _ok(rid, {"sessions": sessions})
     except Exception as e:
         return _err(rid, 5006, str(e))
 

--- a/ui-tui/src/__tests__/activeSessionSwitcher.test.ts
+++ b/ui-tui/src/__tests__/activeSessionSwitcher.test.ts
@@ -10,6 +10,9 @@ import {
   draftModelDisplayLabel,
   draftTitleFromPrompt,
   fixedSessionColumnStyle,
+  historySessionAgeLabel,
+  historySessionMessageLabel,
+  historySessionTitle,
   isNewSessionRow,
   newSessionMarkerColor,
   newSessionRowIndex,
@@ -184,13 +187,40 @@ describe('unified Sessions overlay helpers', () => {
     const history = [
       { id: 'a', message_count: 1, preview: '', started_at: 0, title: 'A' },
       { id: 'b', message_count: 2, preview: '', started_at: 0, title: 'B' },
-      { id: 'c', message_count: 3, preview: '', started_at: 0, title: 'C' }
+      { id: 'c', message_count: 3, preview: '', started_at: 0, title: 'C' },
+      {
+        id: 'b-parent',
+        lineage_kind: 'compression_segment',
+        message_count: 9,
+        preview: '',
+        resume_id: 'b',
+        started_at: 0,
+        title: 'B before compression'
+      }
     ] satisfies SessionListItem[]
 
     const live = [{ id: 'b', status: 'idle' }] satisfies SessionActiveItem[]
 
     expect(resumableHistory(history, live).map(h => h.id)).toEqual(['a', 'c'])
-    expect(resumableHistory(history, []).map(h => h.id)).toEqual(['a', 'b', 'c'])
+    expect(resumableHistory(history, []).map(h => h.id)).toEqual(['a', 'b', 'c', 'b-parent'])
+  })
+
+  it('labels compression lineage segments without changing the resume target', () => {
+    const segment = {
+      id: 'parent-session',
+      lineage_index: 2,
+      lineage_kind: 'compression_segment',
+      message_count: 42,
+      preview: '',
+      resume_id: 'tip-session',
+      started_at: 0,
+      title: 'Debugging run'
+    } satisfies SessionListItem
+
+    expect(historySessionAgeLabel(segment)).toBe('seg 2')
+    expect(historySessionMessageLabel(segment)).toBe('42 msgs · pre-cmp')
+    expect(historySessionTitle(segment)).toBe('Debugging run · before compression')
+    expect(segment.resume_id).toBe('tip-session')
   })
 
   it('labels live + resumable counts compactly', () => {

--- a/ui-tui/src/components/activeSessionSwitcher.tsx
+++ b/ui-tui/src/components/activeSessionSwitcher.tsx
@@ -86,7 +86,35 @@ export const relativeSessionAge = (ts?: number) => {
 export const resumableHistory = (history: readonly SessionListItem[], live: readonly SessionActiveItem[]) => {
   const liveIds = new Set(live.map(s => s.id))
 
-  return history.filter(h => !liveIds.has(h.id))
+  return history.filter(h => !liveIds.has(h.id) && !liveIds.has(h.resume_id ?? ''))
+}
+
+export const historySessionAgeLabel = (session: SessionListItem) => {
+  if (session.lineage_kind === 'compression_segment') {
+    return `seg ${session.lineage_index ?? 1}`
+  }
+
+  return relativeSessionAge(session.started_at)
+}
+
+export const historySessionMessageLabel = (session: SessionListItem) => {
+  const count = session.message_count ?? 0
+
+  if (session.lineage_kind === 'compression_segment') {
+    return `${count} msgs · pre-cmp`
+  }
+
+  return `${count} msgs`
+}
+
+export const historySessionTitle = (session: SessionListItem) => {
+  const title = session.title || session.preview || '(untitled)'
+
+  if (session.lineage_kind === 'compression_segment') {
+    return `${title} · before compression`
+  }
+
+  return title
 }
 
 export const resumeRowContextHintSegments: OrchestratorHintSegment[] = [
@@ -553,7 +581,8 @@ export function ActiveSessionSwitcher({
 
       if (kind === 'history') {
         setSel(clamped)
-        onResume(history[index - 1 - items.length]!.id)
+        const target = history[index - 1 - items.length]!
+        onResume(target.resume_id ?? target.id)
 
         return
       }
@@ -653,7 +682,9 @@ export function ActiveSessionSwitcher({
       }
 
       if (selectedKind === 'history' && history[sel - 1 - items.length]) {
-        return onResume(history[sel - 1 - items.length]!.id)
+        const target = history[sel - 1 - items.length]!
+
+        return onResume(target.resume_id ?? target.id)
       }
     }
   })
@@ -753,7 +784,7 @@ export function ActiveSessionSwitcher({
             ? 'press d again to delete'
             : deleting && selected
               ? 'deleting…'
-              : h.title || h.preview || '(untitled)'
+              : historySessionTitle(h)
 
           return (
             <Box
@@ -781,13 +812,13 @@ export function ActiveSessionSwitcher({
 
               <Box {...fixedSessionColumnStyle()} width={11}>
                 <Text color={rowTextColor ?? t.color.muted} wrap="truncate-end">
-                  {relativeSessionAge(h.started_at)}
+                  {historySessionAgeLabel(h)}
                 </Text>
               </Box>
 
               <Box {...fixedSessionColumnStyle()} width={18}>
                 <Text color={rowTextColor ?? t.color.muted} wrap="truncate-end">
-                  {h.message_count} msgs
+                  {historySessionMessageLabel(h)}
                 </Text>
               </Box>
 

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -278,8 +278,12 @@ export interface SessionActivateResponse {
 
 export interface SessionListItem {
   id: string
+  lineage_index?: number
+  lineage_kind?: 'compression_segment'
+  lineage_tip_id?: string
   message_count: number
   preview: string
+  resume_id?: string
   source?: string
   started_at: number
   title: string


### PR DESCRIPTION
## What does this PR do?

TUI session history now exposes hidden pre-compression segments as structured rows beneath the live continuation, so long-running compressed conversations have a navigable lineage instead of a single flat, opaque history entry.

## Related Issue

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Shared root cause

- The TUI history picker received only a flat `session.list` response. Storage already projected compression roots forward to the live tip, but the TUI had no structured lineage metadata to reveal the hidden pre-compression parent rows or distinguish them from ordinary resumable sessions.
- Resuming the raw parent directly would break the compression chain's projection, so the coordinated fix exposes segment rows for navigation while routing resume through the live tip, whose display transcript already includes ancestors.

## How this fixes each issue

- #42292: Adds the first structured navigation affordance for long sessions in the TUI by surfacing stored conversation segments as labeled history rows, instead of requiring manual scrolling or snippet-only search.
- #45117: Makes pre-compression session segments discoverable in the TUI history list and resumable through the current continuation, preserving the full ancestor transcript without corrupting the compression parent/child chain.

## Changes Made

- `hermes_state.py`: adds `SessionDB.get_session_lineage_rich()` to return an enriched root-to-tip session lineage for UI consumers.
- `tui_gateway/server.py`: expands `session.list` responses with `compression_segment` rows under projected compression tips.
- `ui-tui/src/components/activeSessionSwitcher.tsx`: labels compression segments (`seg N`, `pre-cmp`) and resumes them via `resume_id` pointing at the live continuation.
- Tests cover the gateway response contract, the storage lineage helper, and the TUI helper behavior.

## How to Test

1. `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/gateway/test_session_list_allowed_sources.py tests/test_session_lineage_rich.py -q --timeout=60'`
2. `BASE=$(git merge-base origin/main HEAD); { git diff --name-only --diff-filter=d "$BASE"; git ls-files --others --exclude-standard; } | grep -E '\.pyi?$' | sort -u | xargs -r ruff check`
3. Attempted full suite: `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh` aborted during collection because `fastapi` is not installed and the environment blocks lazy pip install with PEP 668 externally-managed-environment.
4. Attempted TUI tests/typecheck: `cd ui-tui && npm test -- --run src/__tests__/activeSessionSwitcher.test.ts` and `npm run typecheck` both failed because local Node dependencies are not installed (`vitest`/`tsc` not found).

## What platforms tested on

- macOS on darwin-arm64 (local)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (blocked locally by missing dashboard dependencies / PEP 668)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS darwin-arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) -- N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys -- N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows -- N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior -- N/A

---
_This coordinated PR bundles a fix that spans several issues. Happy to split it back into focused per-issue PRs if you'd prefer to review them separately._

Refs #42292
Refs #45117

<!-- autocontrib:worker-id=pr-spanning-256a3cb6 kind=pr-open -->