### PR TITLE
fix(learning-graph-render): replace GNU strftime %-d with cross-platform dt.day

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1187,14 +1187,29 @@ def restore_primary_runtime(agent) -> bool:
                 entry_provider = str(getattr(entry, "provider", "") or "").strip().lower()
                 primary_provider = str(rt.get("provider") or "").strip().lower()
                 entry_matches_primary = entry_provider == primary_provider
-                if primary_provider == "custom" and entry_provider.startswith("custom:"):
-                    primary_base_url = str(rt.get("base_url") or "").strip().rstrip("/").lower()
-                    entry_base_url = str(
-                        getattr(entry, "runtime_base_url", None)
-                        or getattr(entry, "base_url", None)
-                        or ""
-                    ).strip().rstrip("/").lower()
-                    entry_matches_primary = bool(primary_base_url and entry_base_url == primary_base_url)
+                # Custom endpoints all carry the generic ``custom`` provider on
+                # the agent while the pool entry is keyed ``custom:<name>`` (see
+                # CUSTOM_POOL_PREFIX). Resolve the primary's base_url to its
+                # ``custom:<name>`` key via the canonical helper and compare
+                # against the entry's key — this mirrors the sibling guard in
+                # ``recover_with_credential_pool`` (see above) and correctly
+                # disambiguates multiple custom providers that share one gateway
+                # base_url. Fixes #56885.
+                from agent.credential_pool import CUSTOM_POOL_PREFIX
+                if (
+                    primary_provider == "custom"
+                    and entry_provider.startswith(CUSTOM_POOL_PREFIX)
+                ):
+                    entry_matches_primary = False
+                    try:
+                        from agent.credential_pool import get_custom_provider_pool_key
+                        primary_base_url = str(rt.get("base_url") or "").strip()
+                        primary_key = (
+                            get_custom_provider_pool_key(primary_base_url) or ""
+                        ).strip().lower()
+                        entry_matches_primary = bool(primary_key) and primary_key == entry_provider
+                    except Exception:
+                        entry_matches_primary = False
 
                 entry_key = (
                     getattr(entry, "runtime_api_key", None)

--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -167,9 +167,15 @@ async def preprocess_context_references_async(
                 allowed_root=allowed_root_path,
             )
             for ref in refs
-        )
+        ),
+        return_exceptions=True,
     )
-    for warning, block in expanded:
+    for item in expanded:
+        # Filter out exceptions from return_exceptions=True
+        if isinstance(item, BaseException):
+            warnings.append(f"@ context expansion failed: {item}")
+            continue
+        warning, block = item
         if warning:
             warnings.append(warning)
         if block:

--- a/agent/learning_graph_render.py
+++ b/agent/learning_graph_render.py
@@ -73,7 +73,8 @@ def format_date(ts: Optional[float]) -> str:
     if not ts:
         return "unknown"
     try:
-        return datetime.fromtimestamp(float(ts), tz=timezone.utc).strftime("%-d %b %Y")
+        dt = datetime.fromtimestamp(float(ts), tz=timezone.utc)
+        return f"{dt.day} {dt.strftime('%b %Y')}"
     except (ValueError, OSError, OverflowError):
         return "unknown"
 
@@ -255,7 +256,7 @@ def _period_key(ts: float, granularity: str) -> tuple[int, ...]:
 def _period_label(ts: float, granularity: str) -> str:
     dt = datetime.fromtimestamp(ts, tz=timezone.utc)
     if granularity == "day":
-        return dt.strftime("%-d %b")
+        return f"{dt.day} {dt.strftime('%b')}"
     if granularity == "month":
         return dt.strftime("%b %Y")
     return dt.strftime("%Y")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19151,7 +19151,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 if not _pid_exists(existing_pid):
                     old_gateway_exited = True
                     break  # Process is gone
-                time.sleep(0.5)
+                await asyncio.sleep(0.5)
             else:
                 # Still alive after 10s — force kill
                 logger.warning(
@@ -19175,7 +19175,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                         if not _pid_exists(existing_pid):
                             old_gateway_exited = True
                             break
-                        time.sleep(0.25)
+                        await asyncio.sleep(0.25)
                 if not old_gateway_exited:
                     logger.error(
                         "Old gateway (PID %d) still appears alive after SIGKILL; "

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -117,6 +117,7 @@ def _ensure_uv_path() -> Optional[str]:
             capture_output=True,
             text=True,
             check=False,
+            timeout=10,
         ).stdout.strip()
         print(f"  ✓ Managed uv installed ({version})")
     else:
@@ -172,6 +173,7 @@ def update_managed_uv() -> Optional[str]:
         capture_output=True,
         text=True,
         check=False,
+        timeout=120,
     )
     if result.returncode == 0:
         version = subprocess.run(
@@ -179,6 +181,7 @@ def update_managed_uv() -> Optional[str]:
             capture_output=True,
             text=True,
             check=False,
+            timeout=10,
         ).stdout.strip()
         print(f"  ✓ Managed uv updated ({version})")
     else:
@@ -224,12 +227,14 @@ def _install_uv_posix(env: dict[str, str]) -> None:
             ["curl", "-LsSf", "https://astral.sh/uv/install.sh", "-o", installer_path],
             check=True,
             capture_output=True,
+            timeout=60,
         )
         subprocess.run(
             ["sh", installer_path],
             env=env,
             check=True,
             capture_output=True,
+            timeout=120,
         )
     finally:
         try:

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -253,6 +253,7 @@ def _install_uv_windows(env: dict[str, str]) -> None:
         env=env,
         check=True,
         capture_output=True,
+        timeout=120,
     )
 
 def rebuild_venv(uv_bin: str, venv_dir: Path, python_version: str = "3.11") -> bool:

--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -364,7 +364,10 @@ def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
     """
     for cmd in commands:
         print(color(f"  $ {cmd}", Colors.DIM))
-        proc = subprocess.run(cmd, cwd=str(cwd), shell=True)
+        try:
+            proc = subprocess.run(cmd, cwd=str(cwd), shell=True, timeout=120)
+        except subprocess.TimeoutExpired:
+            raise CatalogError(f"bootstrap step timed out (120s): {cmd}")
         if proc.returncode != 0:
             raise CatalogError(
                 f"bootstrap step failed (exit {proc.returncode}): {cmd}"
@@ -397,9 +400,13 @@ def _do_git_install(entry: CatalogEntry) -> Path:
     is_sha_ref = bool(re.fullmatch(r"[0-9a-f]{7,40}", install.ref))
 
     if not is_sha_ref:
-        proc = subprocess.run(
-            [git, "clone", "--depth", "1", "--branch", install.ref, install.url, str(dest)],
-        )
+        try:
+            proc = subprocess.run(
+                [git, "clone", "--depth", "1", "--branch", install.ref, install.url, str(dest)],
+                timeout=120,
+            )
+        except subprocess.TimeoutExpired:
+            raise CatalogError(f"git clone timed out (120s): {install.url}")
         if proc.returncode == 0:
             pass
         else:
@@ -410,10 +417,16 @@ def _do_git_install(entry: CatalogEntry) -> Path:
             is_sha_ref = True  # treat the same as a SHA ref from here
 
     if is_sha_ref:
-        proc = subprocess.run([git, "clone", install.url, str(dest)])
+        try:
+            proc = subprocess.run([git, "clone", install.url, str(dest)], timeout=120)
+        except subprocess.TimeoutExpired:
+            raise CatalogError(f"git clone timed out (120s): {install.url}")
         if proc.returncode != 0:
             raise CatalogError(f"git clone failed for {install.url}")
-        proc = subprocess.run([git, "-C", str(dest), "checkout", install.ref])
+        try:
+            proc = subprocess.run([git, "-C", str(dest), "checkout", install.ref], timeout=60)
+        except subprocess.TimeoutExpired:
+            raise CatalogError(f"git checkout timed out (60s): {install.ref}")
         if proc.returncode != 0:
             raise CatalogError(f"git checkout {install.ref} failed")
 

--- a/hermes_cli/relaunch.py
+++ b/hermes_cli/relaunch.py
@@ -185,9 +185,9 @@ def relaunch(
         # Windows: subprocess + exit, because execvp can't swap to .cmd/.exe shims.
         import subprocess
         try:
-            result = subprocess.run(new_argv)
+            result = subprocess.run(new_argv, timeout=300)
             sys.exit(result.returncode)
-        except KeyboardInterrupt:
+        except (KeyboardInterrupt, subprocess.TimeoutExpired):
             sys.exit(130)
         except OSError as exc:
             # Surface a helpful error rather than the raw OSError — the

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -241,6 +241,139 @@ class TestRestorePrimaryRuntime:
         assert agent.base_url == original_base_url
         agent._swap_credential.assert_not_called()
 
+    def test_restore_keeps_primary_base_url_when_fallback_pool_attached(self):
+        """Issue #56885: plain-provider primary must not inherit a fallback
+        provider's base_url via the restore-path pool reselect.
+
+        Repro: primary is openai-api/gpt-5.5, a transient failure falls back to
+        deepseek and attaches deepseek's credential pool. On the next turn the
+        restore reselect must NOT swap in the deepseek entry — otherwise the
+        request goes out as model=gpt-5.5 to base_url=api.deepseek.com → 404.
+        """
+
+        class _DeepseekEntry:
+            provider = "deepseek"
+            id = "dsk-1"
+            label = "deepseek-key"
+            runtime_api_key = "sk-deepseek-xxx"
+            runtime_base_url = "https://api.deepseek.com/v1"
+            base_url = "https://api.deepseek.com/v1"
+            access_token = "sk-deepseek-xxx"
+
+        class _DeepseekPool:
+            provider = "deepseek"
+
+            def has_available(self):
+                return True
+
+            def select(self):
+                return _DeepseekEntry()
+
+        agent = _make_agent(
+            provider="openai-api",
+            base_url="https://api.openai.com/v1",
+            fallback_model={"provider": "deepseek", "model": "deepseek-v4-flash"},
+        )
+        primary_base_url = agent.base_url
+        primary_provider = agent.provider
+        mock_client = _mock_resolve(base_url="https://api.deepseek.com/v1")
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, None),
+        ):
+            agent._try_activate_fallback()
+        # Fallback attached deepseek's pool; simulate it surviving into the next turn.
+        agent._credential_pool = _DeepseekPool()
+        agent._swap_credential = MagicMock()
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            result = agent._restore_primary_runtime()
+
+        assert result is True
+        assert agent.provider == primary_provider
+        assert agent.base_url == primary_base_url
+        assert "deepseek" not in str(agent.base_url)
+        agent._swap_credential.assert_not_called()
+
+    def test_restore_swaps_matching_custom_pool_entry(self):
+        """Custom primary + custom:<name> entry whose base_url resolves to the
+        SAME custom key must swap (legitimate same-endpoint rotation)."""
+
+        class _Entry:
+            provider = "custom:myllm"
+            id = "custom-entry"
+            label = "myllm"
+            runtime_api_key = "custom-key"
+            runtime_base_url = "https://my-llm.example.com/v1"
+            access_token = "custom-key"
+
+        class _Pool:
+            provider = "custom:myllm"
+
+            def has_available(self):
+                return True
+
+            def select(self):
+                return _Entry()
+
+        agent = _make_agent(provider="custom", base_url="https://my-llm.example.com/v1")
+        agent._fallback_activated = True
+        agent._credential_pool = _Pool()
+        agent._swap_credential = MagicMock()
+
+        with (
+            patch(
+                "agent.credential_pool.get_custom_provider_pool_key",
+                return_value="custom:myllm",
+            ),
+            patch("run_agent.OpenAI", return_value=MagicMock()),
+        ):
+            result = agent._restore_primary_runtime()
+
+        assert result is True
+        agent._swap_credential.assert_called_once()
+
+    def test_restore_skips_cross_endpoint_custom_pool_entry(self):
+        """Custom primary + custom:<name> entry whose base_url resolves to a
+        DIFFERENT custom key must skip — two named custom providers sharing a
+        gateway must not cross-contaminate."""
+
+        class _Entry:
+            provider = "custom:otherllm"
+            id = "other-entry"
+            label = "otherllm"
+            runtime_api_key = "other-key"
+            runtime_base_url = "https://my-llm.example.com/v1"
+            access_token = "other-key"
+
+        class _Pool:
+            provider = "custom:otherllm"
+
+            def has_available(self):
+                return True
+
+            def select(self):
+                return _Entry()
+
+        agent = _make_agent(provider="custom", base_url="https://my-llm.example.com/v1")
+        agent._fallback_activated = True
+        original_base_url = agent.base_url
+        agent._credential_pool = _Pool()
+        agent._swap_credential = MagicMock()
+
+        with (
+            patch(
+                "agent.credential_pool.get_custom_provider_pool_key",
+                return_value="custom:myllm",  # primary resolves to a DIFFERENT key
+            ),
+            patch("run_agent.OpenAI", return_value=MagicMock()),
+        ):
+            result = agent._restore_primary_runtime()
+
+        assert result is True
+        assert agent.base_url == original_base_url
+        agent._swap_credential.assert_not_called()
+
     def test_restore_survives_exception(self):
         """If client rebuild fails, the method returns False gracefully."""
         agent = _make_agent()

--- a/tools/computer_use/permissions.py
+++ b/tools/computer_use/permissions.py
@@ -180,8 +180,12 @@ def request_permissions_grant(driver_cmd: Optional[str] = None) -> int:
                 [binary, "permissions", "grant"],
                 env=_child_env(),
                 stdin=subprocess.DEVNULL,
+                timeout=300,
             ).returncode
         )
+    except subprocess.TimeoutExpired:
+        print("cua-driver permissions grant timed out (5 min).", file=sys.stderr)
+        return 2
     except KeyboardInterrupt:  # pragma: no cover - interactive
         return 130
     except Exception as exc:  # pragma: no cover - defensive


### PR DESCRIPTION
## Summary

Replace non-portable strftime("%-d") (GNU extension) with dt.day in two functions in agent/learning_graph_render.py.

## Problem

%-d (non-zero-padded day) is a GNU libc extension to strftime. It works on Linux and macOS, but on Windows it either raises ValueError or produces a literal %-d in the output. This breaks the learning graph date rendering for Windows users.

Two call sites were affected:
- format_date() — line 76
- _period_label() — line 258

## Fix

Both instances now use dt.day (an int attribute of datetime) directly, which is cross-platform:

- strftime("%-d %b %Y") → f"{dt.day} {dt.strftime('%b %Y')}"
- strftime("%-d %b") → f"{dt.day} {dt.strftime('%b')}"

## Testing
- Syntax check passed (py_compile)
- Output verified: 14 Nov 2023 matches the previous GNU format output