### PR TITLE
fix(unbroker): let a reappeared/still-listed case be re-filed with legal transitions

### DIFF
--- a/optional-skills/security/unbroker/references/state-machine.md
+++ b/optional-skills/security/unbroker/references/state-machine.md
@@ -32,9 +32,10 @@ indirect_exposure    -> submitted | human_task_queued | not_found | found | bloc
 action_selected      -> submitted | human_task_queued | blocked
 submitted            -> verification_pending | awaiting_processing | human_task_queued | blocked
 verification_pending -> awaiting_processing | confirmed_removed | human_task_queued | blocked
-awaiting_processing  -> confirmed_removed | human_task_queued | blocked
+awaiting_processing  -> confirmed_removed | reappeared | human_task_queued | blocked
 confirmed_removed    -> reappeared | confirmed_removed   (recheck refreshes the date)
-reappeared           -> found | indirect_exposure
+reappeared           -> found | not_found | indirect_exposure | action_selected | submitted
+                        | human_task_queued | blocked
 human_task_queued    -> found | indirect_exposure | action_selected | submitted | verification_pending
                         | awaiting_processing | confirmed_removed | blocked
 blocked              -> searching | found | not_found | indirect_exposure | action_selected
@@ -50,6 +51,11 @@ A transition to the same state is always allowed (idempotent field updates).
   opt-out whose matcher says "no results" after you have already submitted is recorded
   `awaiting_processing`, not `not_found`.)
 - **`blocked -> submitted` is ILLEGAL directly** - go `blocked -> action_selected -> submitted`.
+- **`reappeared` re-files like a fresh `found`.** A reappearance re-scan already confirmed the listing
+  is back, so `reappeared` re-enters the opt-out flow directly (`-> submitted` / `-> action_selected`),
+  is routed to a human, or is reclassified by a closer re-scan; it does not have to walk back through
+  `found` first. A verify_removal that finds an `awaiting_processing` listing still up after the
+  processing window records `reappeared` (the removal did not take), the same "still listed" outcome.
 - **Recording an operator's manual verdict:** attach an `operator_manual_check` evidence note. A
   dead / 404 site, or an operator-confirmed "no results" search, is a valid `not_found`.
 - **`--evidence` shell gotcha:** an `--evidence` JSON string containing a literal `&` trips the shell's

--- a/optional-skills/security/unbroker/scripts/ledger.py
+++ b/optional-skills/security/unbroker/scripts/ledger.py
@@ -36,9 +36,17 @@ TRANSITIONS: dict[str, set[str]] = {
     # broker is now processing the removal (their stated window). confirmed_removed still requires a
     # verifying re-scan, never the submission flow's own say-so.
     "verification_pending": {"awaiting_processing", "confirmed_removed", "human_task_queued", "blocked"},
-    "awaiting_processing": {"confirmed_removed", "human_task_queued", "blocked"},
+    # awaiting_processing -> reappeared: the verifying re-scan after the processing window found the
+    # listing still up (the removal did not take). That is the same "still listed" outcome as a
+    # reappearance, so it routes back through `reappeared` to be re-filed.
+    "awaiting_processing": {"confirmed_removed", "reappeared", "human_task_queued", "blocked"},
     "confirmed_removed": {"reappeared", "confirmed_removed"},
-    "reappeared": {"found", "indirect_exposure"},
+    # reappeared: a listing that came back (or a submission whose processing did not clear it). The
+    # re-scan already confirmed it is present, so it is re-actioned exactly like a fresh `found` --
+    # re-file the opt-out (-> action_selected / submitted), route to a human, mark blocked, or
+    # reclassify on a closer re-scan (-> found / not_found / indirect_exposure).
+    "reappeared": {"found", "not_found", "indirect_exposure", "action_selected", "submitted",
+                   "human_task_queued", "blocked"},
     "human_task_queued": {
         "found", "indirect_exposure", "action_selected", "submitted", "verification_pending",
         "awaiting_processing", "confirmed_removed", "blocked",

--- a/optional-skills/security/unbroker/scripts/pdd.py
+++ b/optional-skills/security/unbroker/scripts/pdd.py
@@ -589,6 +589,13 @@ def cmd_send_email(args) -> None:
         _out({"skipped": True, "broker": args.broker, "state": current,
               "note": "already submitted; not re-sending (idempotent). Use --force to re-send."})
         return
+    # A send is an irreversible legal request, so never let it outrun the ledger record: refuse if
+    # `current -> submitted` is not a legal transition (the recording step at the end would raise
+    # after the email had already gone out, leaving the case unrecorded and re-sendable).
+    if not ledger_mod.can_transition(current, "submitted"):
+        sys.exit(f"error: cannot file an opt-out from state {current!r} (no "
+                 f"{current} -> submitted transition); re-scan the broker to a `found`/`reappeared` "
+                 "verdict first")
     kind = getattr(args, "kind", "generic") or "generic"
     fields, disclosed = _email_request(d, b, kind, args.listing, getattr(args, "identifier", None))
     body = legal.render_optout_email(b, fields) if kind == "generic" else legal.render_request(kind, b, fields)

--- a/tests/skills/test_unbroker_skill.py
+++ b/tests/skills/test_unbroker_skill.py
@@ -1351,6 +1351,68 @@ def test_send_email_is_idempotent_browser_mode():
         assert again.get("skipped") is True         # not re-sent
 
 
+def _drive_to_reappeared(sid, broker):
+    ledger.transition(sid, broker, "found", found=True)
+    ledger.transition(sid, broker, "submitted")
+    ledger.transition(sid, broker, "awaiting_processing")
+    ledger.transition(sid, broker, "confirmed_removed")
+    ledger.transition(sid, broker, "reappeared")
+
+
+def test_ledger_reappeared_can_be_refiled():
+    # A reappearance re-scan already confirmed the listing is back, so the opt-out is re-filed
+    # straight from `reappeared`. Before this fix `reappeared -> submitted` raised.
+    with temp_env():
+        sid = "sub_test01"
+        _drive_to_reappeared(sid, "radaris")
+        assert ledger.transition(sid, "radaris", "submitted")["state"] == "submitted"
+
+
+def test_ledger_awaiting_processing_can_reappear():
+    # A verify_removal that finds an awaiting_processing listing still up after the window records
+    # reappeared. Before this fix `awaiting_processing -> reappeared` raised.
+    with temp_env():
+        sid = "sub_test01"
+        ledger.transition(sid, "radaris", "found", found=True)
+        ledger.transition(sid, "radaris", "submitted")
+        ledger.transition(sid, "radaris", "awaiting_processing")
+        assert ledger.transition(sid, "radaris", "reappeared")["state"] == "reappeared"
+
+
+def test_send_email_refiles_reappeared_case():
+    # The autopilot re-queues a reappeared case as an opt-out; send-email must record it as submitted
+    # (and then the idempotency guard prevents a duplicate). Before this fix the transition raised
+    # after the send, leaving the case stuck in `reappeared` and re-sendable.
+    with temp_env():
+        config.save_config({"email_mode": "browser"})
+        sid = _run(["intake", "--full-name", "Jane Q. Public",
+                    "--email", "jane@example.com", "--consent"])["subject_id"]
+        _drive_to_reappeared(sid, "radaris")
+        out = _run(["send-email", sid, "radaris", "--listing", "https://radaris.com/p/x"])
+        assert out.get("state") == "submitted"
+        again = _run(["send-email", sid, "radaris", "--listing", "https://radaris.com/p/x"])
+        assert again.get("skipped") is True
+
+
+def test_send_email_refuses_unfilable_state_before_sending():
+    # A send is an irreversible legal request; from a state with no `-> submitted` transition the
+    # command must exit (SystemExit) up front, not raise mid-record after the send/disclosure.
+    with temp_env():
+        config.save_config({"email_mode": "browser"})
+        sid = _run(["intake", "--full-name", "Jane Q. Public",
+                    "--email", "jane@example.com", "--consent"])["subject_id"]
+        ledger.transition(sid, "radaris", "not_found")
+        try:
+            _run(["send-email", sid, "radaris", "--listing", "https://radaris.com/p/x"])
+        except SystemExit:
+            pass
+        else:
+            raise AssertionError("send-email from an unfilable state should exit")
+        case = ledger.get_case(sid, "radaris")
+        assert case["state"] == "not_found"                  # unchanged
+        assert not case.get("disclosure_log")                # exited before any disclosure/send
+
+
 def test_show_reads_back_case_state_and_evidence():
     with temp_env():
         sid = _run(["intake", "--full-name", "Jane Q. Public",


### PR DESCRIPTION
## What does this PR do?

Fixes the reappearance / requeue path in the unbroker skill, which recorded state transitions the ledger table forbids. The worst case sent an opt-out email that was then never recorded, so it was re-sent on the next run.

`next_actions` treats a `reappeared` case as actionable: `tiers.batch_plan` puts it in the `found` group (`_ACTIONABLE_STATES` includes `reappeared`), and section 4 emits an opt-out whose completion records `submitted`. But the transition table only allowed:

```python
"reappeared": {"found", "indirect_exposure"},
```

So recording `submitted` for a re-filed reappeared case raised `illegal transition 'reappeared' -> 'submitted'`. In programmatic email mode `cmd_send_email` sends the request first and records afterwards:

```python
result = emailer.send(b, body, ...)          # email goes out
ledger_mod.transition(..., "submitted", ...)  # then raises for a reappeared case
```

so the email was sent while the case stayed `reappeared`. `reappeared` is not in the `_POST_SUBMIT` idempotency set, so the next run re-sent the same request: duplicate legal requests, with the submission never recorded.

The same defect has a sibling. The `verify_removal` action's how-text is shared between `awaiting_processing` and `confirmed_removed` cases and says "if still listed record reappeared and requeue the opt-out." From `confirmed_removed -> reappeared` is legal, but from `awaiting_processing` it was not (`awaiting_processing -> {confirmed_removed, human_task_queued, blocked}`), so a re-scan finding an `awaiting_processing` listing still up after the processing window also raised.

Changes:

- `reappeared` now has the same action edges as a fresh `found` (`action_selected`, `submitted`, `human_task_queued`, `indirect_exposure`, `blocked`, `not_found`, keeping `found`). A reappearance re-scan already confirmed the listing is present, so it is re-filed directly rather than walking back through `found`.
- `awaiting_processing -> reappeared` is allowed (the "still listed after the window" outcome).
- `cmd_send_email` refuses up front when `current -> submitted` is not a legal transition, so an irreversible send can never outrun its ledger record.
- `references/state-machine.md` updated to match.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `optional-skills/security/unbroker/scripts/ledger.py`: expand `TRANSITIONS["reappeared"]` to the action edges of `found`; add `reappeared` to `TRANSITIONS["awaiting_processing"]`.
- `optional-skills/security/unbroker/scripts/pdd.py`: in `cmd_send_email`, exit before sending if `current -> submitted` is not a legal transition.
- `optional-skills/security/unbroker/references/state-machine.md`: document the new edges.
- `tests/skills/test_unbroker_skill.py`: tests that `reappeared -> submitted` and `awaiting_processing -> reappeared` are legal, that a reappeared case re-files as `submitted` (then the idempotency guard blocks a duplicate), and that a send from an unfilable state exits before logging any disclosure.

## How to Test

1. Drive a case to `reappeared` (`found -> submitted -> awaiting_processing -> confirmed_removed -> reappeared`), then `pdd.py send-email <subject> <broker> --listing <url>`. On `main` this raises `illegal transition 'reappeared' -> 'submitted'` after the send; with this change it records `submitted` and a second call is skipped as idempotent.
2. `pdd.py send-email` on a `not_found` case exits before sending on this branch; on `main` it logs a disclosure and then raises.
3. `scripts/run_tests.sh tests/skills/test_unbroker_skill.py` (101 pass). The four new tests fail on `main` and pass with the fix.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the unbroker test file and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`references/state-machine.md`)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
