### PR TITLE
fix(gateway): preserve lazy reset after session expiry

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6135,7 +6135,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         if agent is None:
             return
-        if context.startswith("shutdown"):
+        if context.startswith("shutdown") or context == "session expiry":
             try:
                 agent._end_session_on_close = False
             except Exception:

--- a/tests/gateway/test_clean_shutdown_marker.py
+++ b/tests/gateway/test_clean_shutdown_marker.py
@@ -245,6 +245,33 @@ class TestCleanShutdownMarker:
         assert agent._end_session_on_close is False
         agent.close.assert_called_once()
 
+    def test_session_expiry_cleanup_preserves_lazy_reset_boundary(self, tmp_path, monkeypatch):
+        """Session expiry cleanup must not turn an expired chat into an agent_close row.
+
+        The expiry watcher only tears down cached resources. The next inbound
+        message owns the reset boundary, creating a fresh session with the
+        normal auto-reset notice. If cleanup lets ``agent.close()`` end the
+        SQLite row as ``agent_close``, stale-route recovery treats it as
+        recoverable and resurrects the expired session instead.
+        """
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        agent = MagicMock()
+        agent._end_session_on_close = True
+
+        async def _run():
+            await GatewayRunner._cleanup_agent_resources_off_loop(
+                runner, agent, context="session expiry"
+            )
+
+        import asyncio
+        asyncio.get_event_loop().run_until_complete(_run())
+
+        assert agent._end_session_on_close is False
+        agent.close.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # resume_pending freshness gate (#46934)


### PR DESCRIPTION
## Summary
- keep session expiry resource cleanup from marking live gateway conversations as `agent_close`
- preserve the existing lazy reset path so the next inbound message rotates the expired session normally
- add a regression test covering the exact cleanup boundary

## Why
The expiry watcher is supposed to tear down cached agent resources after an idle or daily reset deadline, then let `get_or_create_session()` create the fresh session on the next inbound message with the auto reset notice.

Before this fix, expiry cleanup called `agent.close()` with `_end_session_on_close=True`, which ended the durable row as `agent_close`. The stale route guard then treated that row as recoverable, reopened it, and resumed the expired session instead of rotating it.

## Tests
- `.venv/bin/python -m pytest tests/gateway/test_clean_shutdown_marker.py::TestCleanShutdownMarker::test_session_expiry_cleanup_preserves_lazy_reset_boundary -q -o 'addopts='` - failed before the fix
- `.venv/bin/python -m pytest tests/gateway/test_clean_shutdown_marker.py tests/gateway/test_session_boundary_hooks.py tests/gateway/test_session_store_runtime_stale_guard.py tests/test_hermes_state.py::test_gateway_session_recovery_reopens_legacy_agent_close_rows -q -o 'addopts='` - 30 passed
- `.venv/bin/python -m py_compile gateway/run.py tests/gateway/test_clean_shutdown_marker.py`
