### PR TITLE
fix(lazy_deps): only treat primary spec as activation trigger

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -317,14 +317,76 @@ class TestActiveFeatures:
         assert "platform.slack" not in active
 
     def test_multi_package_feature_active_if_any_present(self, monkeypatch):
-        # platform.slack has 3 packages; only one needs to be present
-        # for the feature to count as active (user activated it before,
-        # one transitive may have been uninstalled separately).
+        # platform.slack primary is ``slack-bolt``; only that one needs to
+        # be present for the feature to count as active (user activated
+        # it before, one transitive may have been uninstalled separately).
         monkeypatch.setattr(
             ld, "_is_present",
             lambda spec: ld._pkg_name_from_spec(spec) == "slack-bolt",
         )
         assert "platform.slack" in ld.active_features()
+
+    def test_supporting_pin_does_not_activate_feature(self, monkeypatch):
+        """Supporting pins (e.g. shared aiohttp CVE-floor) must not count
+        as activation for a feature the user never enabled (#58458).
+
+        Several messaging backends (``platform.matrix``, ``platform.slack``,
+        ``platform.discord``, ``platform.teams``, ``homeassistant``, ``sms``)
+        share an ``aiohttp==3.14.1`` CVE-floor pin. ``aiohttp`` ships as a
+        transitive of common core deps (edge-tts, firecrawl-py, discord.py),
+        so the historical ``any(_is_present(s) for s in specs)`` check
+        flipped every one of those backends to *active* for users who
+        never opted in — and ``hermes update`` proceeded to install their
+        full stacks, surfacing on Windows because ``mautrix[encryption]``
+        needs ``make`` for its libolm build.
+        """
+        # Trigger aiohttp-only as the installed package (case-insensitive
+        # match against any aiohttp-flavoured spec). With the new primary
+        # dispatch, *no* feature with aiohttp as a secondary pin should
+        # activate.
+        monkeypatch.setattr(
+            ld, "_is_present",
+            lambda spec: "aiohttp" in spec.lower(),
+        )
+        active = ld.active_features()
+        # None of the messaging/SMS/Home Assistant features should appear.
+        for feature in (
+            "platform.matrix",
+            "platform.slack",
+            "platform.discord",
+            "platform.teams",
+            "homeassistant",
+            "sms",
+        ):
+            assert feature not in active, (
+                f"{feature!r} was falsely activated by the shared aiohttp "
+                f"pin (got active={active!r}, expected aiohttp presence to "
+                f"be ignored in supporting-pins)"
+            )
+
+    def test_primary_spec_alone_activates(self, monkeypatch):
+        """Sanity: only the primary spec matters for activation (#58458)."""
+        # platform.matrix primary is ``mautrix[encryption]==0.21.0``.
+        monkeypatch.setattr(
+            ld, "_is_present",
+            lambda spec: ld._pkg_name_from_spec(spec) == "mautrix",
+        )
+        assert "platform.matrix" in ld.active_features()
+        # And the inverse: aiohttp-only present does NOT activate matrix
+        # (covered above but pinned explicitly for the matrix case the
+        # reporter hit on Windows).
+        monkeypatch.setattr(
+            ld, "_is_present",
+            lambda spec: "aiohttp" in spec.lower(),
+        )
+        # Build a minimal LAZY_DEPS subset for matrix so the assertion
+        # is self-contained.
+        monkeypatch.setitem(
+            ld.LAZY_DEPS,
+            "platform.matrix",
+            ld.LAZY_DEPS["platform.matrix"],
+        )
+        assert "platform.matrix" not in ld.active_features()
 
 
 class TestRefreshActiveFeatures:

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -836,16 +836,27 @@ def feature_install_command(feature: str) -> Optional[str]:
 def active_features() -> list[str]:
     """Return the list of features the user has ever lazy-installed.
 
-    A feature counts as "active" if at least one of its declared packages
-    is currently installed in the venv (presence check, ignoring version).
-    Features the user has never enabled stay quiet.
+    A feature is considered "active" when its *primary* package — the
+    first entry in :data:`LAZY_DEPS` for that feature — is installed.
+    Subsequent entries are typically supporting pins (a CVE-floor version
+    constraint on a transitive dependency like ``aiohttp==3.14.1``) that
+    can already be satisfied by packages installed for unrelated
+    features. Treatment of supporting pins as activation triggers caused
+    false positives on Windows: every messaging platform that shared the
+    CVE-floor pin read as "active" for users who never enabled them, and
+    ``hermes update`` proceeded to install their full stacks — including
+    ``mautrix[encryption]`` whose ``python-olm`` build requires ``make``
+    and isn't installable on stock Windows (#58458).
 
     Used by ``hermes update`` to figure out which lazy backends need a
     refresh pass when pins move in :data:`LAZY_DEPS`.
     """
     active = []
     for feature, specs in LAZY_DEPS.items():
-        if any(_is_present(s) for s in specs):
+        # ``specs`` is always non-empty by construction of LAZY_DEPS, so
+        # the first spec is the feature's primary identifier (mautrix,
+        # discord.py[voice], slack-bolt, anthropic, boto3, mistralai, …).
+        if _is_present(specs[0]):
             active.append(feature)
     return active
 


### PR DESCRIPTION
## Summary

`tools/lazy_deps.py::active_features()` dispatched on `any(_is_present(s) for s in specs)`. Several messaging backends (`platform.matrix`, `platform.slack`, `platform.discord`, `platform.teams`, `homeassistant`, `sms`) share a CVE-floor pin `aiohttp==3.14.1` as a *secondary* entry — `aiohttp` ships as a transitive of common core deps (`edge-tts`, `firecrawl-py`, `discord.py`), so on a stock Windows install every one of those backends flipped to *active* without the user opting in. `hermes update` then proceeded to install their full stacks — including `mautrix[encryption]` whose `python-olm` build shells out to `make` (not present on stock Windows), surfacing as a perpetual refresh failure.

Switch `active_features()` to **primary-spec dispatch**: only the first spec — the feature's distinctive SDK (`mautrix[encryption]`, `discord.py[voice]`, `slack-bolt`, `anthropic`, `boto3`, `mistralai`, …) — drives activation. Subsequent entries are supporting pins for the actual `pip install` refresher and remain in `LAZY_DEPS` so refresh still picks them up when the primary is correctly activated.

## Changes

- `tools/lazy_deps.py` — `active_features()` rewritten to check `specs[0]` only. Docstring explains the supporting-pins/primary distinction with reference to #58458.
- `tests/tools/test_lazy_deps.py` — two regression tests:
  - `test_supporting_pin_does_not_activate_feature` — a simulated `aiohttp`-only install must NOT register `platform.matrix` / `platform.slack` / `platform.discord` / `platform.teams` / `homeassistant` / `sms` as active.
  - `test_primary_spec_alone_activates` — installing `mautrix` alone IS enough to register `platform.matrix`.

## How to Test

```
venv/bin/python -m pytest tests/tools/test_lazy_deps.py -q
# 63/63 passed
```

Pinned by stash: with `tools/lazy_deps.py` reverted, the two new regression tests fail exactly the way the issue report described — `platform.matrix` (and the other aiohttp-pinned features) appear in `active_features()` even though the user never opted in.

## Checklist

- [x] Tests pass — 63/63
- [x] Follows Conventional Commits
- [x] Cross-platform impact — pure Python (`tools/lazy_deps.py`); the bug manifests on Windows but the fix doesn't touch platform-specific code
- [x] profile-safe paths used (no path code modified)
- [x] `.env` not used for non-credential settings (no config surface touched)

## Risk & Impact

Low. The semantic change is strictly more conservative: a feature that was previously activated by its supporting pins stays inactive until its **primary** SDK is genuinely present. Side-effects:

- Existing users who followed the workaround (`uv pip install mautrix==0.21.0 aiosqlite==0.22.1 …`) still keep `platform.matrix` active — primary is satisfied, so refresh continues to bump pins.
- Users who installed `aiohttp` only as a transitive now stop paying the Discord/Slack/Matrix/etc. refresh on every `hermes update`. If they ever *do* opt in later (e.g. `hermes setup` enables Matrix), `mautrix` becomes satisfied and refresh resumes normally.
- The `install_all_in_one` path and individual `ensure()` calls are unaffected — they still install all listed specs from `LAZY_DEPS`, not just `specs[0]`.

Type: Bug fix
Closes: #58458