### PR TITLE
fix(telegram): keep polling conflict counter across successful retries

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2428,7 +2428,6 @@ class TelegramAdapter(BasePlatformAdapter):
                     "[%s] Telegram polling resumed after conflict retry %d/%d",
                     self.name, self._polling_conflict_count, MAX_CONFLICT_RETRIES,
                 )
-                self._polling_conflict_count = 0  # reset counter on success
                 return
             except Exception as retry_err:
                 logger.warning(

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -868,3 +868,41 @@ async def test_handle_polling_network_error_updater_stop_timeout():
     assert drain_called, "_drain_polling_connections was not called after stop() timeout"
     assert start_polling_called, "start_polling was not called after stop() timeout"
 
+
+@pytest.mark.asyncio
+async def test_polling_conflict_counter_not_reset_on_success():
+    """The retry counter must NOT reset to 0 after start_polling() succeeds.
+
+    If the counter resets, a recurring 409 conflict (Telegram server-side
+    session not yet expired) loops at (1/5) forever because the retry ladder
+    never escalates past the first rung.  Keeping the counter means the second
+    conflict enters at (2/5) with a longer back-off, eventually exhausting
+    retries and surfacing a fatal error.
+
+    Regression test for #58484.
+    """
+    adapter = _make_adapter()
+    adapter._polling_conflict_count = 2  # simulate two prior conflicts
+
+    mock_updater = MagicMock()
+    mock_updater.running = True
+    mock_updater.stop = AsyncMock()
+    mock_updater.start_polling = AsyncMock()  # succeeds
+
+    mock_app = MagicMock()
+    mock_app.updater = mock_updater
+    adapter._app = mock_app
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await adapter._handle_polling_conflict(
+            Exception("Conflict: terminated by other getUpdates request")
+        )
+
+    # Counter was 2 before, +1 in the handler = 3, and must remain 3 after
+    # start_polling() succeeds.  It must NOT be reset to 0.
+    assert adapter._polling_conflict_count == 3, (
+        f"Counter should be 3 (preserved after success), "
+        f"got {adapter._polling_conflict_count}"
+    )
+    assert not adapter.has_fatal_error, "Should not be fatal after successful retry"
+


### PR DESCRIPTION
## What does this PR do?

Fixes an infinite reconnect loop in the Telegram polling conflict retry handler. When `start_polling()` succeeds but Telegram immediately returns another 409 Conflict (server-side session not yet expired), the retry counter was reset to 0 on each success — causing the adapter to loop at `(1/5)` forever with a fixed 15-second back-off, never escalating to a fatal error.

The fix removes the counter reset so the retry ladder accumulates: the second conflict enters at `(2/5)` with a 25-second back-off, eventually exhausting all 5 retries and declaring a fatal error.

## Related Issue

Fixes #58484

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/telegram/adapter.py`: Remove `self._polling_conflict_count = 0` after successful `start_polling()` in `_handle_polling_conflict()`. The counter now persists across retries so the back-off ladder escalates correctly.
- `tests/gateway/test_telegram_network_reconnect.py`: Add `test_polling_conflict_counter_not_reset_on_success` — verifies the counter is preserved (not reset) after a successful retry, ensuring the next conflict enters at a higher back-off level.

## How to Test

1. Run the new regression test: `python -m pytest tests/gateway/test_telegram_network_reconnect.py::test_polling_conflict_counter_not_reset_on_success -xvs`
2. Run the full test file: `python -m pytest tests/gateway/test_telegram_network_reconnect.py -x`
3. All 29 tests should pass (28 existing + 1 new).

**Expected behavior**: With the fix, a Telegram bot that repeatedly hits 409 conflicts will see the retry counter increment `(1/5 → 2/5 → ... → 5/5)`, with increasing back-off delays (15s, 25s, 35s, 45s, 55s). After 5 retries, the adapter declares a fatal error instead of looping indefinitely.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
