### PR TITLE
fix(compression): skip session split on plugin no-op

### DIFF
--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -96,7 +96,7 @@ class ContextEngine(ABC):
     def name(self) -> str:
         """Short identifier (e.g. 'compressor', 'lcm')."""
 
-    # -- Token state (read by run_agent.py for display/logging) ------------
+    # -- Token state (read by run_agent.py for display/logging) -----------
     #
     # Engines MUST maintain these. run_agent.py reads them directly.
 
@@ -106,6 +106,30 @@ class ContextEngine(ABC):
     threshold_tokens: int = 0
     context_length: int = 0
     compression_count: int = 0
+
+    # -- Compression result status (read by run_agent.py for boundary) -----
+    #
+    # After ``compress()`` returns, engines SHOULD expose the outcome of the
+    # pass so the host can decide whether to rotate/split the session:
+    #
+    #   * ``"noop"``  -> the engine made no structural change (e.g. LCM was
+    #                    above the host token threshold but had no eligible
+    #                    leaf backlog outside its protected fresh tail). The
+    #                    host MUST NOT treat this as a successful compression:
+    #                    it skips the session split so the continuation keeps
+    #                    its summary/DAG state and the prompt-cache prefix.
+    #   * anything else (or attribute absent) -> normal handling; the host
+    #                    proceeds to the existing identity-empty checks and,
+    #                    if ``compress()`` returned a new list, rotates the
+    #                    session.
+    #
+    # The host reads this via ``getattr(engine, "last_compression_status",
+    # getattr(engine, "_last_compression_status", ""))`` — public attribute
+    # preferred, legacy ``_last_compression_status`` private field honored for
+    # backward compatibility with older engines. See
+    # ``agent/conversation_compression.py`` (``_compress_context``).
+
+    last_compression_status: str = ""
 
     # -- Compaction parameters (read by run_agent.py for preflight) --------
     #

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1769,13 +1769,6 @@ def compress_context(
                 )
 
         messages_before_compression = copy.deepcopy(messages)
-        # Reset the per-pass status flag so a stale "noop" from a previous
-        # pass cannot suppress a legitimate split on this pass.  The engine
-        # contract asks plugins to report per-pass; the host-side reset makes
-        # the gate self-defending when a plugin forgets to clear it.
-        for _attr in ("last_compression_status", "_last_compression_status"):
-            if hasattr(agent.context_compressor, _attr):
-                setattr(agent.context_compressor, _attr, "")
         _activity_heartbeat = _CompressionActivityHeartbeat(agent).start()
         # Publish forward progress to the commit fence while the summary LLM
         # call streams. Async hosts (gateway session hygiene) poll

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1769,6 +1769,13 @@ def compress_context(
                 )
 
         messages_before_compression = copy.deepcopy(messages)
+        # Reset the per-pass status flag so a stale "noop" from a previous
+        # pass cannot suppress a legitimate split on this pass.  The engine
+        # contract asks plugins to report per-pass; the host-side reset makes
+        # the gate self-defending when a plugin forgets to clear it.
+        for _attr in ("last_compression_status", "_last_compression_status"):
+            if hasattr(agent.context_compressor, _attr):
+                setattr(agent.context_compressor, _attr, "")
         _activity_heartbeat = _CompressionActivityHeartbeat(agent).start()
         # Publish forward progress to the commit fence while the summary LLM
         # call streams. Async hosts (gateway session hygiene) poll

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1858,6 +1858,31 @@ def compress_context(
             finally:
                 _release_lock()
 
+        # Plugin no-op: engine reports it made no structural change.
+        # Check this BEFORE the semantic equality test so a plugin that
+        # returns a freshly-built equal list (not the input object) is
+        # still recognized as a no-op via its status flag.
+        if (
+            getattr(
+                agent.context_compressor,
+                "last_compression_status",
+                getattr(agent.context_compressor, "_last_compression_status", ""),
+            )
+            == "noop"
+        ):
+            try:
+                logger.info(
+                    "context compression no-op: session=%s messages=%d unchanged; skipping session boundary",
+                    agent.session_id or "none",
+                    _pre_msg_count,
+                )
+                _existing_sp = getattr(agent, "_cached_system_prompt", None)
+                if not _existing_sp:
+                    _existing_sp = agent._build_system_prompt(system_message)
+                return compressed, _existing_sp
+            finally:
+                _release_lock()
+
         # Compare against the pre-dispatch semantic state, not object identity:
         # legacy/plugin engines may return an equal copy for a no-op, or mutate
         # the live list while returning an unchanged snapshot. Neither case may

--- a/contributors/emails/turgut.kural@outlook.com
+++ b/contributors/emails/turgut.kural@outlook.com
@@ -1,2 +1,3 @@
 TurgutKural
+# PR #61499 (delegation: resolve Nous auth before direct endpoint)
 # PR #58495 (compression: skip session split on plugin no-op)

--- a/contributors/emails/turgut.kural@outlook.com
+++ b/contributors/emails/turgut.kural@outlook.com
@@ -1,0 +1,2 @@
+TurgutKural
+# PR #58495 (compression: skip session split on plugin no-op)

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -322,6 +322,95 @@ class TestCompressionBoundaryHook:
             assert compressed
             assert agent.session_id != original_sid
 
+    def test_plugin_noop_does_not_rotate_or_emit_boundary(self):
+        """A plugin no-op must not create a compression child session.
+
+        External context engines such as LCM can be above the host token
+        threshold while having no eligible leaf backlog outside their protected
+        fresh tail.  In that case they report a no-op and return the unchanged
+        active context.  Treating that as a successful compression would split
+        the session without creating summary/DAG state for the continuation.
+        """
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(db)
+
+            messages = [{"role": "user", "content": "tail-only pressure"}]
+            compressor = MagicMock()
+            # Return a *new* equal list, not the input object.  If we returned
+            # the exact ``messages`` object, the identity no-op check
+            # (``compressed is messages``) would short-circuit and the test
+            # would pass without ever exercising the status-based no-op branch
+            # this PR adds.  A distinct object forces the ``last_compression_status
+            # == "noop"`` path to be the thing that prevents session rotation.
+            compressor.compress.return_value = list(messages)
+            compressor.compression_count = 0
+            compressor.last_prompt_tokens = 0
+            compressor.last_completion_tokens = 0
+            compressor._last_summary_error = None
+            compressor._last_compress_aborted = False
+            compressor.last_compression_status = "noop"
+            agent.context_compressor = compressor
+
+            original_sid = agent.session_id
+            compressed, _prompt = agent._compress_context(
+                messages, "sys", approx_tokens=10_000
+            )
+
+            # Distinct object returned unchanged — proves the status branch
+            # caught it rather than the identity check.
+            assert compressed is not messages
+            assert compressed == messages
+            assert agent.session_id == original_sid
+            comp_calls = [
+                c for c in compressor.on_session_start.call_args_list
+                if c.kwargs.get("boundary_reason") == "compression"
+            ]
+            assert not comp_calls
+
+    def test_plugin_noop_private_field_fallback_does_not_rotate(self):
+        """The legacy ``_last_compression_status`` private field is honored.
+
+        Older context engines / compressors may not yet expose the public
+        ``last_compression_status`` attribute.  The fix must fall back to the
+        private ``_last_compression_status`` field so the no-op boundary skip
+        still applies for those engines.
+        """
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(db)
+
+            messages = [{"role": "user", "content": "tail-only pressure"}]
+            compressor = MagicMock()
+            compressor.compress.return_value = list(messages)
+            compressor.compression_count = 0
+            compressor.last_prompt_tokens = 0
+            compressor.last_completion_tokens = 0
+            compressor._last_summary_error = None
+            compressor._last_compress_aborted = False
+            # Public attribute absent; only the legacy private field set.
+            del compressor.last_compression_status
+            compressor._last_compression_status = "noop"
+            agent.context_compressor = compressor
+
+            original_sid = agent.session_id
+            compressed, _prompt = agent._compress_context(
+                messages, "sys", approx_tokens=10_000
+            )
+
+            assert compressed is not messages
+            assert compressed == messages
+            assert agent.session_id == original_sid
+            comp_calls = [
+                c for c in compressor.on_session_start.call_args_list
+                if c.kwargs.get("boundary_reason") == "compression"
+            ]
+            assert not comp_calls
+
 
 class TestSessionCompressEvent:
     """The session:compress event_callback fires after a compression split."""

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -345,13 +345,20 @@ class TestCompressionBoundaryHook:
             # would pass without ever exercising the status-based no-op branch
             # this PR adds.  A distinct object forces the ``last_compression_status
             # == "noop"`` path to be the thing that prevents session rotation.
-            compressor.compress.return_value = list(messages)
+            #
+            # The host resets last_compression_status before calling compress(),
+            # so the engine must set it DURING compress() — use a side-effect
+            # to simulate a real plugin engine reporting per-pass status.
+            def _compress_noop(msgs, **kw):
+                compressor.last_compression_status = "noop"
+                return list(msgs)
+            compressor.compress.side_effect = _compress_noop
             compressor.compression_count = 0
             compressor.last_prompt_tokens = 0
             compressor.last_completion_tokens = 0
             compressor._last_summary_error = None
             compressor._last_compress_aborted = False
-            compressor.last_compression_status = "noop"
+            compressor.last_compression_status = ""
             agent.context_compressor = compressor
 
             original_sid = agent.session_id
@@ -369,6 +376,18 @@ class TestCompressionBoundaryHook:
                 if c.kwargs.get("boundary_reason") == "compression"
             ]
             assert not comp_calls
+            # Verify no child session was created in the DB (matches PR
+            # description: "no DB child session is created").
+            import sqlite3
+            conn = sqlite3.connect(str(Path(tmpdir) / "test.db"))
+            try:
+                row = conn.execute(
+                    "SELECT COUNT(*) FROM sessions WHERE parent_session_id = ?",
+                    (original_sid,),
+                ).fetchone()
+                assert row[0] == 0, f"Expected no child session, found {row[0]}"
+            finally:
+                conn.close()
 
     def test_plugin_noop_private_field_fallback_does_not_rotate(self):
         """The legacy ``_last_compression_status`` private field is honored.
@@ -386,7 +405,12 @@ class TestCompressionBoundaryHook:
 
             messages = [{"role": "user", "content": "tail-only pressure"}]
             compressor = MagicMock()
-            compressor.compress.return_value = list(messages)
+            # Host resets _last_compression_status before compress(); the
+            # engine must set it DURING compress() via side-effect.
+            def _compress_noop_private(msgs, **kw):
+                compressor._last_compression_status = "noop"
+                return list(msgs)
+            compressor.compress.side_effect = _compress_noop_private
             compressor.compression_count = 0
             compressor.last_prompt_tokens = 0
             compressor.last_completion_tokens = 0
@@ -394,7 +418,7 @@ class TestCompressionBoundaryHook:
             compressor._last_compress_aborted = False
             # Public attribute absent; only the legacy private field set.
             del compressor.last_compression_status
-            compressor._last_compression_status = "noop"
+            compressor._last_compression_status = ""
             agent.context_compressor = compressor
 
             original_sid = agent.session_id


### PR DESCRIPTION
## Summary
- Treat external context-engine `last_compression_status == "noop"` as a non-boundary result in `_compress_context` (falling back to the legacy private field for compatibility)
- Return the compressor output and existing system prompt without rotating/splitting the session
- Add a regression test proving plugin no-op compression does not emit a compression-boundary hook
- Add the contributor email mapping required by the attribution check

## Why
LCM can be above the host token threshold while having no eligible leaf backlog outside its protected fresh tail. In that case it returns a no-op. Previously the host still proceeded through the successful-compression session split path, creating continuation sessions without summary/DAG state.

## Tests
- `python -m py_compile agent/conversation_compression.py tests/run_agent/test_compression_boundary_hook.py scripts/release.py`
- `python -m pytest tests/run_agent/test_compression_boundary_hook.py -q`
- `python -m pytest tests/run_agent/test_infinite_compaction_loop.py tests/run_agent/test_compression_persistence.py -q`
