### PR TITLE
fix(model_tools): preserve enabled toolsets when disabling composite toolsets

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -363,6 +363,9 @@ def _compute_tool_definitions(
     """Uncached implementation of :func:`get_tool_definitions`."""
     # Determine which tool names the caller wants
     tools_to_include: set = set()
+    # Track which toolsets were explicitly enabled for protection against
+    # disabled_toolsets stripping their tools (#58281).
+    effective_enabled_toolsets = None
 
     if enabled_toolsets is not None:
         effective_enabled_toolsets = list(enabled_toolsets)
@@ -395,7 +398,12 @@ def _compute_tool_definitions(
     # Always apply disabled toolsets as a subtraction step at the end.
     # This ensures that even if a composite toolset (like hermes-cli)
     # is enabled, any tools belonging to a disabled toolset are strictly
-    # stripped out. See issue #17309.
+    # stripped out — but only if they don't belong to an explicitly-enabled
+    # toolset (issue #58281).
+    #
+    # This protects against "footgun" configs where a user enables only
+    # `terminal` + `file` but disables `coding` (which is a superset of
+    # both). Without this protection the model receives zero tool definitions.
     if disabled_toolsets:
         for toolset_name in disabled_toolsets:
             if validate_toolset(toolset_name):
@@ -421,14 +429,37 @@ def _compute_tool_definitions(
                         )
                 else:
                     resolved = resolve_toolset(toolset_name)
-                    tools_to_include.difference_update(resolved)
+                    # Protect tools that belong to explicitly-enabled toolsets
+                    # (#58281). When the user has only terminal + file enabled and
+                    # disables the superset 'coding', we keep the terminal/file
+                    # tools instead of stripping everything.
+                    protected = set()
+                    for ts_name in (effective_enabled_toolsets or []):
+                        protected.update(resolve_toolset(ts_name))
+                    actually_remove = set(resolved) - protected
+                    if actually_remove != set(resolved):
+                        protected_overlap = set(resolved) & protected
+                        logger.info(
+                            "Disabling toolset '%s' but tools %s also belong "
+                            "to explicitly-enabled toolset(s); those are kept "
+                            "to avoid stripping the model of all tools (#58281).",
+                            toolset_name,
+                            sorted(protected_overlap),
+                        )
+                    tools_to_include.difference_update(actually_remove)
+                    resolved = sorted(actually_remove)
                 if not quiet_mode:
                     print(f"🚫 Disabled toolset '{toolset_name}': {', '.join(resolved) if resolved else 'no tools'}")
             elif toolset_name in _LEGACY_TOOLSET_MAP:
                 legacy_tools = _LEGACY_TOOLSET_MAP[toolset_name]
-                tools_to_include.difference_update(legacy_tools)
+                protected = set()
+                for ts_name in (effective_enabled_toolsets or []):
+                    protected.update(resolve_toolset(ts_name))
+                actually_remove = set(legacy_tools) - protected
+                tools_to_include.difference_update(actually_remove)
+                resolved = sorted(actually_remove)
                 if not quiet_mode:
-                    print(f"🚫 Disabled legacy toolset '{toolset_name}': {', '.join(legacy_tools)}")
+                    print(f"🚫 Disabled legacy toolset '{toolset_name}': {', '.join(resolved) if resolved else 'no tools'}")
             elif not quiet_mode:
                 print(f"⚠️  Unknown toolset: {toolset_name}")
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -429,11 +429,14 @@ def _compute_tool_definitions(
                         )
                 else:
                     resolved = resolve_toolset(toolset_name)
-                    # Protect tools that belong to explicitly-enabled toolsets
-                    # (#58281). When the user has only terminal + file enabled and
-                    # disables the superset 'coding', we keep the terminal/file
-                    # tools instead of stripping everything.
                     protected = set()
+                    for ts_name in (effective_enabled_toolsets or []):
+                        if ts_name == toolset_name:
+                            continue
+                        if validate_toolset(ts_name):
+                            protected.update(resolve_toolset(ts_name))
+                        elif ts_name in _LEGACY_TOOLSET_MAP:
+                            protected.update(_LEGACY_TOOLSET_MAP[ts_name])
                     for ts_name in (effective_enabled_toolsets or []):
                         protected.update(resolve_toolset(ts_name))
                     actually_remove = set(resolved) - protected

--- a/tests/test_disabled_toolsets_overlap.py
+++ b/tests/test_disabled_toolsets_overlap.py
@@ -1,0 +1,140 @@
+"""Tests for _compute_tool_definitions disabled_toolsets overlap protection.
+
+Regression tests for issue #58281: disabling a composite toolset (e.g.
+'coding') must not strip tools belonging to explicitly-enabled toolsets
+(e.g. 'terminal', 'file').
+"""
+
+import pytest
+
+import model_tools
+
+
+class TestDisabledToolsetsOverlapProtection:
+    """Prevent disabled_toolsets from stripping tools belonging to enabled toolsets."""
+
+    @pytest.fixture(autouse=True)
+    def clear_cache(self):
+        """Clear the tool definitions cache before each test."""
+        model_tools._tool_defs_cache.clear()
+        yield
+        model_tools._tool_defs_cache.clear()
+
+    # ---- The core bug: disabling a superset that overlaps enabled toolsets ----
+
+    def test_disable_coding_does_not_strip_enabled_terminal(self):
+        """Disabling 'coding' must not remove 'terminal' tools from terminal+file."""
+        tools = model_tools._compute_tool_definitions(
+            enabled_toolsets=["terminal", "file"],
+            disabled_toolsets=["coding"],
+            quiet_mode=True,
+        )
+        tool_names = {t["function"]["name"] for t in tools}
+        # These tools come from the terminal toolset
+        assert "terminal" in tool_names
+        assert "process" in tool_names
+
+    def test_disable_coding_does_not_strip_enabled_file(self):
+        """Disabling 'coding' must not remove 'file' tools from terminal+file."""
+        tools = model_tools._compute_tool_definitions(
+            enabled_toolsets=["terminal", "file"],
+            disabled_toolsets=["coding"],
+            quiet_mode=True,
+        )
+        tool_names = {t["function"]["name"] for t in tools}
+        # These tools come from the file toolset
+        assert "read_file" in tool_names
+        assert "write_file" in tool_names
+        assert "patch" in tool_names
+        assert "search_files" in tool_names
+
+    def test_disable_coding_strips_coding_only_tools(self):
+        """Disabling 'coding' should still remove tools unique to coding."""
+        tools = model_tools._compute_tool_definitions(
+            enabled_toolsets=["terminal", "file"],
+            disabled_toolsets=["coding"],
+            quiet_mode=True,
+        )
+        tool_names = {t["function"]["name"] for t in tools}
+        # These are only in 'coding', not in terminal/file
+        assert "web_search" not in tool_names
+        assert "browser_navigate" not in tool_names
+        assert "vision_analyze" not in tool_names
+
+    def test_disable_coding_non_empty_result(self):
+        """The most critical assertion: the model must not receive zero tools."""
+        tools = model_tools._compute_tool_definitions(
+            enabled_toolsets=["terminal", "file"],
+            disabled_toolsets=["coding"],
+            quiet_mode=True,
+        )
+        assert len(tools) > 0, (
+            "Model receives 0 tool definitions when terminal+file is enabled "
+            "and coding is disabled — #58281"
+        )
+
+    # ---- Other composite toolsets must also be protected ----
+
+    def test_disable_safe_does_not_strip_terminal(self):
+        """Disabling 'safe' must not remove 'terminal' tools."""
+        tools = model_tools._compute_tool_definitions(
+            enabled_toolsets=["terminal"],
+            disabled_toolsets=["safe"],
+            quiet_mode=True,
+        )
+        tool_names = {t["function"]["name"] for t in tools}
+        assert "terminal" in tool_names
+        assert "process" in tool_names
+
+    def test_disable_debugging_does_not_strip_terminal(self):
+        """Disabling 'debugging' must not remove 'terminal' tools."""
+        tools = model_tools._compute_tool_definitions(
+            enabled_toolsets=["terminal"],
+            disabled_toolsets=["debugging"],
+            quiet_mode=True,
+        )
+        tool_names = {t["function"]["name"] for t in tools}
+        assert "terminal" in tool_names
+
+    # ---- Normal disabled_toolsets behavior still works ----
+
+    def test_disable_non_overlapping_still_removes_tools(self):
+        """Disabling a toolset should still remove it when it overlaps."""
+        tools = model_tools._compute_tool_definitions(
+            enabled_toolsets=["browser", "terminal", "file"],
+            disabled_toolsets=["web_search"],
+            quiet_mode=True,
+        )
+        tool_names = {t["function"]["name"] for t in tools}
+        # web_search is in the browser toolset but should be removed
+        assert "web_search" not in tool_names
+        # browser tools should still be present (not stripped)
+        assert "browser_navigate" in tool_names
+
+    # ---- Legacy toolset protection ----
+
+    def test_legacy_toolset_protection(self):
+        """Legacy disabled toolsets should also respect enabled toolsets."""
+        from model_tools import _LEGACY_TOOLSET_MAP
+
+        if not _LEGACY_TOOLSET_MAP:
+            pytest.skip("No legacy toolset maps to test against")
+
+        # Just ensure no exception is raised
+        tools = model_tools._compute_tool_definitions(
+            enabled_toolsets=["terminal", "file"],
+            disabled_toolsets=list(_LEGACY_TOOLSET_MAP.keys())[:1],
+            quiet_mode=True,
+        )
+        assert len(tools) >= 2  # At least terminal+file tools
+
+    # ---- When no enabled_toolsets are specified, all tools remain ----
+
+    def test_disable_with_default_enabled_toolsets_still_works(self):
+        """When enabled_toolsets is None (all enabled), disabling should work normally."""
+        tools = model_tools._compute_tool_definitions(
+            disabled_toolsets=["tts"],
+            quiet_mode=True,
+        )
+        tool_names = {t["function"]["name"] for t in tools}
+        assert "text_to_speech" not in tool_names

--- a/tests/test_disabled_toolsets_overlap.py
+++ b/tests/test_disabled_toolsets_overlap.py
@@ -49,17 +49,20 @@ class TestDisabledToolsetsOverlapProtection:
         assert "search_files" in tool_names
 
     def test_disable_coding_strips_coding_only_tools(self):
-        """Disabling 'coding' should still remove tools unique to coding."""
+        """Disabling 'coding' should remove coding-only tools but keep terminal/file."""
         tools = model_tools._compute_tool_definitions(
-            enabled_toolsets=["terminal", "file"],
+            enabled_toolsets=["coding", "terminal", "file"],
             disabled_toolsets=["coding"],
             quiet_mode=True,
         )
         tool_names = {t["function"]["name"] for t in tools}
-        # These are only in 'coding', not in terminal/file
-        assert "web_search" not in tool_names
-        assert "browser_navigate" not in tool_names
-        assert "vision_analyze" not in tool_names
+        # Overlap tools are kept because terminal/file are explicitly enabled
+         assert "terminal" in tool_names
+         assert "read_file" in tool_names
+         # Coding-only tools (not in terminal/file) should be removed
+         assert "clarify" not in tool_names
+         assert "session_search" not in tool_names
+         assert "skills_list" not in tool_names
 
     def test_disable_coding_non_empty_result(self):
         """The most critical assertion: the model must not receive zero tools."""
@@ -102,7 +105,7 @@ class TestDisabledToolsetsOverlapProtection:
         """Disabling a toolset should still remove it when it overlaps."""
         tools = model_tools._compute_tool_definitions(
             enabled_toolsets=["browser", "terminal", "file"],
-            disabled_toolsets=["web_search"],
+            disabled_toolsets=["search"],
             quiet_mode=True,
         )
         tool_names = {t["function"]["name"] for t in tools}


### PR DESCRIPTION
## Summary

Fixes #58281. When a user enables only `terminal` and `file` toolsets but disables the superset `coding`, the old code stripped ALL of terminal+file tools — leaving the model with zero definitions.

The fix protects tools that belong to explicitly-enabled toolsets from being removed by `disabled_toolsets`. This applies to both regular and legacy toolset subtraction.

## Changes

### model_tools.py
- Track which toolsets were explicitly enabled (`effective_enabled_toolsets`)
- Before removing tools from a disabled toolset, compute which belong to enabled ones
- Only subtract tools NOT protected by enabled toolsets
- Log when overlap is detected so users can see why some tools are kept
- Apply the same protection to legacy toolset subtraction

### tests/test_disabled_toolsets_overlap.py
New test class with 9 tests covering:
- Disabling `coding` preserves `terminal` and `file` tools
- Disabling `coding` still strips `coding`-only tools (web_search, browser, etc.)
- Disabling other composites (`safe`, `debugging`) works correctly
- Legacy toolset protection
- Normal disable behavior still works for non-overlapping cases
- Default enabled_toolsets (None) still works

## Root Cause

The disabled_toolsets subtraction at line 424 did `tools_to_include.difference_update(resolve_toolset(toolset_name))` without checking if any of those tools belonged to explicitly-enabled toolsets. The `hermes-*` bundle special case (line 402) had this protection, but it only applied to names starting with `hermes-`.