### PR TITLE
fix(kanban): recover stale blocked handoff on unblock

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4829,10 +4829,11 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
 
     Defensively closes any stale ``current_run_id`` pointer before flipping
     status. In the common path (``block_task`` closed the run already) this
-    is a no-op. If a future or external write left the pointer dangling,
-    the leaked run is closed as ``reclaimed`` inside the same txn so the
-    runs invariant (``current_run_id IS NULL`` ⇔ run row in terminal
-    state) holds for the rest of this function's lifetime.
+    is a no-op. If an external write left a matching ``blocked`` event but
+    forgot to close the active run, recover it as a blocked handoff; unknown
+    dangling runs are still closed as ``reclaimed``. Either way the runs
+    invariant (``current_run_id IS NULL`` ⇔ run row in terminal state) holds
+    for the rest of this function's lifetime.
     """
     now = int(time.time())
     with write_txn(conn):
@@ -4841,16 +4842,48 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
             (task_id,),
         ).fetchone()
         if stale and stale["current_run_id"]:
+            stale_run_id = int(stale["current_run_id"])
+            # If an external writer/direct-DB path moved the task to
+            # ``blocked`` and emitted the blocked event but forgot to close the
+            # active run, treat the run as a successful block handoff rather
+            # than a reclaim. This keeps the history semantic and avoids
+            # confusing operator/debug tooling with a spurious reclaimed run on
+            # the normal review unblock path. Unknown dangling runs still get
+            # reclaimed below.
+            latest_block = conn.execute(
+                "SELECT run_id, payload FROM task_events "
+                "WHERE task_id = ? AND kind = 'blocked' "
+                "ORDER BY id DESC LIMIT 1",
+                (task_id,),
+            ).fetchone()
+            recover_as_blocked = bool(
+                latest_block and latest_block["run_id"] == stale_run_id
+            )
+            recovered_summary = "invariant recovery on unblock"
+            if recover_as_blocked:
+                recovered_summary = "blocked handoff recovered on unblock"
+                try:
+                    payload = json.loads(latest_block["payload"] or "{}")
+                    if payload.get("reason"):
+                        recovered_summary = str(payload["reason"])
+                except Exception:
+                    pass
             conn.execute(
                 """
                 UPDATE task_runs
-                   SET status = 'reclaimed', outcome = 'reclaimed',
-                       summary = COALESCE(summary, 'invariant recovery on unblock'),
+                   SET status = ?, outcome = ?,
+                       summary = COALESCE(summary, ?),
                        ended_at = ?,
                        claim_lock = NULL, claim_expires = NULL, worker_pid = NULL
                  WHERE id = ? AND ended_at IS NULL
                 """,
-                (now, int(stale["current_run_id"])),
+                (
+                    "blocked" if recover_as_blocked else "reclaimed",
+                    "blocked" if recover_as_blocked else "reclaimed",
+                    recovered_summary,
+                    now,
+                    stale_run_id,
+                ),
             )
         # Re-gate on parent completion before flipping 'blocked' back to
         # 'ready'. Unconditionally setting status='ready' here bypasses the

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -425,6 +425,107 @@ def test_unblock_scheduled_rechecks_parent_gate(kanban_home):
         assert kb.get_task(conn, child).status == "ready"
 
 
+def test_unblock_recovers_direct_db_block_as_blocked_and_respawns(
+    kanban_home, monkeypatch,
+):
+    """If a non-tool writer leaves a blocked handoff with an open run,
+    unblock should preserve the run as ``blocked`` and the next dispatcher
+    tick should be able to reclaim the task for follow-up work.
+
+    This mirrors the Codex app-server fallback failure mode: the task row
+    looked blocked and had a ``blocked`` event, but ``current_run_id`` still
+    pointed at an active run. The recovery path must be tolerant rather than
+    producing a confusing ``reclaimed`` history or stranding the ready task.
+    """
+    import hermes_cli.profiles as profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda _profile: True)
+
+    spawned: list[tuple[str, int | None, str]] = []
+
+    def _spawn(task, workspace, board=None):
+        spawned.append((task.id, task.current_run_id, task.status))
+        return 12345
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="needs review", assignee="coder")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        run_id = claimed.current_run_id
+        assert run_id is not None
+
+        # Simulate the bad external/SQLite lifecycle write: status + event were
+        # written, but the run row was never closed and current_run_id leaked.
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status='blocked', claim_lock=NULL, "
+                "claim_expires=NULL, worker_pid=NULL WHERE id=?",
+                (tid,),
+            )
+            kb._append_event(
+                conn,
+                tid,
+                "blocked",
+                {"reason": "review-required: ready"},
+                run_id=run_id,
+            )
+
+        assert kb.unblock_task(conn, tid) is True
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "ready"
+        assert task.current_run_id is None
+
+        recovered = conn.execute(
+            "SELECT status, outcome, summary, ended_at FROM task_runs "
+            "WHERE id=?",
+            (run_id,),
+        ).fetchone()
+        assert recovered["status"] == "blocked"
+        assert recovered["outcome"] == "blocked"
+        assert recovered["summary"] == "review-required: ready"
+        assert recovered["ended_at"] is not None
+
+        result = kb.dispatch_once(conn, spawn_fn=_spawn, max_spawn=1)
+        running = kb.get_task(conn, tid)
+        assert running is not None
+        assert result.spawned == [(tid, "coder", running.workspace_path)]
+        assert spawned == [(tid, running.current_run_id, "running")]
+        assert running.status == "running"
+
+
+def test_unblock_unknown_dangling_run_still_reclaims(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="unknown stale run", assignee="coder")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        run_id = claimed.current_run_id
+        assert run_id is not None
+
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status='blocked', claim_lock=NULL, "
+                "claim_expires=NULL, worker_pid=NULL WHERE id=?",
+                (tid,),
+            )
+
+        assert kb.unblock_task(conn, tid) is True
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "ready"
+        assert task.current_run_id is None
+
+        recovered = conn.execute(
+            "SELECT status, outcome, summary, ended_at FROM task_runs "
+            "WHERE id=?",
+            (run_id,),
+        ).fetchone()
+        assert recovered["status"] == "reclaimed"
+        assert recovered["outcome"] == "reclaimed"
+        assert recovered["summary"] == "invariant recovery on unblock"
+        assert recovered["ended_at"] is not None
+
+
 def test_stale_claim_reclaimed(kanban_home, monkeypatch):
     import signal
     import hermes_cli.kanban_db as _kb


### PR DESCRIPTION
## Problem

`unblock_task()` already defensively closes a dangling `current_run_id` when a task is in `blocked`/`scheduled` state. Today every dangling run is recovered as `reclaimed`.

That is correct for unknown stale state, but it is misleading when the task has a matching `blocked` event for the same run: the worker did perform a blocked handoff, but an external/non-tool lifecycle write failed to close the run row.

## Fix

When unblocking a task with a dangling `current_run_id`:

- look at the latest `blocked` task event
- if its `run_id` matches the dangling run, recover the run as `blocked`
- preserve the block reason as the run summary when available
- keep the existing `reclaimed` fallback for unknown dangling runs

This keeps the run history semantic while preserving the defensive invariant cleanup.

## Tests

- `test_unblock_recovers_direct_db_block_as_blocked_and_respawns`
- `test_unblock_unknown_dangling_run_still_reclaims`

Ran:

```bash
python3 -m pytest tests/hermes_cli/test_kanban_db.py::test_unblock_recovers_direct_db_block_as_blocked_and_respawns tests/hermes_cli/test_kanban_db.py::test_unblock_unknown_dangling_run_still_reclaims -q
python3 -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_blocked_sticky.py tests/tools/test_kanban_tools.py -q
```

Result: `328 passed` for the focused Kanban/tool regression set.
