### PR TITLE
fix: replace GNU-only %-d strftime with dt.day in learning graph render (#56640 salvage)

### DIFF
--- a/agent/learning_graph_render.py
+++ b/agent/learning_graph_render.py
@@ -255,7 +255,7 @@ def _period_key(ts: float, granularity: str) -> tuple[int, ...]:
 def _period_label(ts: float, granularity: str) -> str:
     dt = datetime.fromtimestamp(ts, tz=timezone.utc)
     if granularity == "day":
-        return dt.strftime("%-d %b")
+        return f"{dt.day} {dt.strftime('%b')}"
     if granularity == "month":
         return dt.strftime("%b %Y")
     return dt.strftime("%Y")

--- a/agent/learning_graph_render.py
+++ b/agent/learning_graph_render.py
@@ -73,7 +73,8 @@ def format_date(ts: Optional[float]) -> str:
     if not ts:
         return "unknown"
     try:
-        return datetime.fromtimestamp(float(ts), tz=timezone.utc).strftime("%-d %b %Y")
+        dt = datetime.fromtimestamp(float(ts), tz=timezone.utc)
+        return f"{dt.day} {dt.strftime('%b %Y')}"
     except (ValueError, OSError, OverflowError):
         return "unknown"
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -53,6 +53,7 @@ AUTHOR_MAP = {
     "root@vmi3351581.contaboserver.net": "ostravajih",  # PR #58374 salvage (poolside: coerce integer finish_reason and tool_call id to strings)
     "hello@sahil-shubham.in": "sahil-shubham",  # PR #58448 salvage (whatsapp_cloud: honor documented WHATSAPP_CLOUD_ALLOWED_USERS / ALLOW_ALL_USERS in the DM intake gate)
     "ahmet.tunc@gmail.com": "Ahmett101",  # PR #58445 salvage (profiles: allowlist default-export roots + preserve symlinks)
+    "wyuebei@gmail.com": "wyuebei-cloud",  # PR #56640 salvage (hermes journey: replace GNU-only %-d strftime with dt.day for Windows)
     "yingwaizhiying@gmail.com": "msh01",  # PR #58250 salvage (telegram: wall-clock init timeout via daemon-thread deadline + abandon the shielded initialize task on timeout so the retry ladder advances instead of hanging on attempt 1/8 under s6 supervision; #58236). Also covers PR #58276 salvage (compression: preserve a real user turn after compaction; #55677).
     "danilo@falcao.org": "danilofalcao",  # PR #56674 salvage (update: skip unsupported platform.matrix lazy refresh on native Windows — python-olm has no Windows wheel)
     "huanshan5195@users.noreply.github.com": "huanshan5195",  # PR #57601 salvage (custom-provider: emit reasoning_effort at the live CustomProfile path so GLM-5.2/ARK/vLLM/Ollama endpoints receive it; + "max" reasoning level)


### PR DESCRIPTION
## Summary
`hermes journey` (learning graph render) stops crashing on Windows: both GNU-only `%-d` strftime sites are replaced with `dt.day`, which is portable.

Salvages #56640 (@wyuebei-cloud — earliest of five PRs targeting this bug) onto current main with authorship preserved, and widens it to the second `%-d` site in `format_date()` that #56640 missed (flagged by @x7peeps in #58480).

## Changes
- `agent/learning_graph_render.py`: axis-label site (contributor's commit) + `format_date()` site (follow-up) now use `dt.day` f-strings

## Validation
| | Before | After |
|---|---|---|
| Windows strftime("%-d ...") | ValueError / literal `%-d` | renders "4 Jul 2026" |

`format_date(1751500000.0)` → `2 Jul 2025` verified live; learning-graph test suites pass.

Closes #56640. Closes #56710. Closes #56711. Closes #56649.

## Infographic

![windows-strftime](https://v3b.fal.media/files/b/0aa0f2b3/o3j2XPHKf6sf3DFkZt-It_CN1ArUD8.png)
