### PR TITLE
fix(security): timestamp-bound V2 signature for generic webhook routes (#58461 salvage)

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -23,6 +23,10 @@ Security:
   - Rate limiting per route (fixed-window, configurable)
   - Idempotency cache prevents duplicate agent runs on webhook retries
   - Body size limits checked before reading payload
+  - Generic HMAC supports a V2 signature (X-Webhook-Signature-V2) that
+    binds a timestamp into the signed data for replay protection; the
+    legacy body-only V1 (X-Webhook-Signature) is deprecated but still
+    accepted with a warning, since it has no replay protection
   - Set secret to "INSECURE_NO_AUTH" to skip validation (testing only)
 """
 
@@ -876,12 +880,47 @@ class WebhookAdapter(BasePlatformAdapter):
         if gl_token:
             return hmac.compare_digest(gl_token, secret)
 
-        # Generic: X-Webhook-Signature = <hex HMAC-SHA256>
+        # Generic V2: X-Webhook-Signature-V2 = <hex HMAC-SHA256 of "<timestamp>.<body>">
+        #             X-Webhook-Timestamp = <unix seconds> (required for V2)
+        # Checked independently of (and before) legacy V1 below — a sender
+        # that only ever sends V2 headers must still validate here; nesting
+        # this inside `if generic_sig:` would silently skip V2-only senders.
+        v2_sig = request.headers.get("X-Webhook-Signature-V2", "")
+        v2_timestamp = request.headers.get("X-Webhook-Timestamp", "")
+        if v2_sig and v2_timestamp:
+            try:
+                ts = int(v2_timestamp)
+            except (TypeError, ValueError):
+                return False
+            if abs(int(time.time()) - ts) > 300:
+                logger.warning(
+                    "[webhook] Route '%s' generic HMAC V2 timestamp outside replay window",
+                    request.match_info.get("route_name", ""),
+                )
+                return False
+            signed_content = v2_timestamp.encode() + b"." + body
+            expected_v2 = hmac.new(
+                secret.encode(), signed_content, hashlib.sha256
+            ).hexdigest()
+            return hmac.compare_digest(v2_sig, expected_v2)
+
+        # Generic V1 (legacy): X-Webhook-Signature = <hex HMAC-SHA256 of body>
+        # (deprecated — no replay protection, since the signature only
+        # covers the body: a captured (body, signature) pair replays
+        # indefinitely with no timestamp binding it to a specific delivery.)
         generic_sig = request.headers.get("X-Webhook-Signature", "")
         if generic_sig:
             expected = hmac.new(
                 secret.encode(), body, hashlib.sha256
             ).hexdigest()
+            logger.warning(
+                "[webhook] Route '%s' uses legacy body-only HMAC (no "
+                "timestamp), which is vulnerable to replay attacks. Add "
+                "an 'X-Webhook-Timestamp' header and switch to "
+                "'X-Webhook-Signature-V2' (HMAC-SHA256 of "
+                "'<timestamp>.<body>').",
+                request.match_info.get("route_name", ""),
+            )
             return hmac.compare_digest(generic_sig, expected)
 
         # No recognised signature header but secret is configured → reject

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -121,6 +121,9 @@ class WebhookAdapter(BasePlatformAdapter):
         self._dynamic_routes_mtime: float = 0.0
         self._routes: Dict[str, dict] = dict(self._static_routes)
         self._runner = None
+        # Routes already warned about legacy V1 body-only signatures
+        # (once-per-route so a busy sender doesn't spam the log).
+        self._v1_signature_warned: set[str] = set()
 
         # Delivery info keyed by session chat_id.
         #
@@ -913,14 +916,17 @@ class WebhookAdapter(BasePlatformAdapter):
             expected = hmac.new(
                 secret.encode(), body, hashlib.sha256
             ).hexdigest()
-            logger.warning(
-                "[webhook] Route '%s' uses legacy body-only HMAC (no "
-                "timestamp), which is vulnerable to replay attacks. Add "
-                "an 'X-Webhook-Timestamp' header and switch to "
-                "'X-Webhook-Signature-V2' (HMAC-SHA256 of "
-                "'<timestamp>.<body>').",
-                request.match_info.get("route_name", ""),
-            )
+            route_name = request.match_info.get("route_name", "")
+            if route_name not in self._v1_signature_warned:
+                self._v1_signature_warned.add(route_name)
+                logger.warning(
+                    "[webhook] Route '%s' uses legacy body-only HMAC (no "
+                    "timestamp), which is vulnerable to replay attacks. Add "
+                    "an 'X-Webhook-Timestamp' header and switch to "
+                    "'X-Webhook-Signature-V2' (HMAC-SHA256 of "
+                    "'<timestamp>.<body>').",
+                    route_name,
+                )
             return hmac.compare_digest(generic_sig, expected)
 
         # No recognised signature header but secret is configured → reject

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -103,6 +103,12 @@ def _generic_signature(body: bytes, secret: str) -> str:
     return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
 
 
+def _generic_v2_signature(body: bytes, secret: str, timestamp: str) -> str:
+    """Compute X-Webhook-Signature-V2 (HMAC-SHA256 of "<timestamp>.<body>")."""
+    signed_content = timestamp.encode() + b"." + body
+    return hmac.new(secret.encode(), signed_content, hashlib.sha256).hexdigest()
+
+
 def _svix_signature(body: bytes, secret: str, msg_id: str, timestamp: str) -> str:
     """Compute a Svix v1 signature header for *body* using *secret*."""
     key = (
@@ -184,6 +190,111 @@ class TestValidateSignature:
         sig = _generic_signature(body, secret)
         req = _mock_request(headers={"X-Webhook-Signature": sig})
         assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_generic_v2_signature_valid(self):
+        """Valid X-Webhook-Signature-V2 (timestamp-bound) is accepted."""
+        adapter = _make_adapter()
+        body = b'{"event": "push"}'
+        secret = "generic-secret"
+        timestamp = str(int(time.time()))
+        sig = _generic_v2_signature(body, secret, timestamp)
+        req = _mock_request(headers={
+            "X-Webhook-Signature-V2": sig,
+            "X-Webhook-Timestamp": timestamp,
+        })
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_generic_v2_old_timestamp_rejects(self):
+        """A V2 signature outside the replay window is rejected even though
+        the HMAC itself would otherwise be valid for that (stale) timestamp
+        — this is the actual replay-protection guarantee: an attacker who
+        captured (body, signature, timestamp) once cannot resubmit it after
+        the window closes."""
+        adapter = _make_adapter()
+        body = b'{"event": "push"}'
+        secret = "generic-secret"
+        timestamp = str(int(time.time()) - 301)
+        sig = _generic_v2_signature(body, secret, timestamp)
+        req = _mock_request(headers={
+            "X-Webhook-Signature-V2": sig,
+            "X-Webhook-Timestamp": timestamp,
+        })
+        assert adapter._validate_signature(req, body, secret) is False
+
+    def test_validate_generic_v2_wrong_timestamp_rejects(self):
+        """The timestamp is cryptographically bound into the V2 signature —
+        this is the actual fix for the V1 replay hole. An attacker who only
+        has a captured (body, signature) pair for V1 (no timestamp binding)
+        cannot forge a valid V2 signature for a fresh timestamp without the
+        secret, unlike V1 where the signature covers the body alone and a
+        forged/fresh timestamp would otherwise sail through unverified."""
+        adapter = _make_adapter()
+        body = b'{"event": "push"}'
+        secret = "generic-secret"
+        real_timestamp = str(int(time.time()))
+        sig = _generic_v2_signature(body, secret, real_timestamp)
+        forged_timestamp = str(int(time.time()) + 1)
+        req = _mock_request(headers={
+            "X-Webhook-Signature-V2": sig,
+            "X-Webhook-Timestamp": forged_timestamp,
+        })
+        assert adapter._validate_signature(req, body, secret) is False
+
+    def test_validate_generic_v2_malformed_timestamp_rejects(self):
+        adapter = _make_adapter()
+        body = b'{"event": "push"}'
+        secret = "generic-secret"
+        req = _mock_request(headers={
+            "X-Webhook-Signature-V2": "deadbeef",
+            "X-Webhook-Timestamp": "not-a-number",
+        })
+        assert adapter._validate_signature(req, body, secret) is False
+
+    def test_validate_generic_v1_still_works_without_timestamp(self):
+        """Legacy V1 (body-only) senders that never send X-Webhook-Timestamp
+        must keep working — this is the backward-compatibility guarantee for
+        existing integrations that predate the V2 scheme."""
+        adapter = _make_adapter()
+        body = b'{"event": "push"}'
+        secret = "generic-secret"
+        sig = _generic_signature(body, secret)
+        req = _mock_request(headers={"X-Webhook-Signature": sig})
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_generic_v2_preferred_when_both_sent(self):
+        """If a sender sends both V1 and V2 headers (mid-migration), V2 must
+        win — a stale/wrong V1 must not be able to override a valid V2."""
+        adapter = _make_adapter()
+        body = b'{"event": "push"}'
+        secret = "generic-secret"
+        timestamp = str(int(time.time()))
+        v2_sig = _generic_v2_signature(body, secret, timestamp)
+        req = _mock_request(headers={
+            "X-Webhook-Signature-V2": v2_sig,
+            "X-Webhook-Timestamp": timestamp,
+            # Deliberately wrong V1 — must be ignored since V2 is checked first.
+            "X-Webhook-Signature": "0" * 64,
+        })
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_v1_replay_attack_succeeds_demonstrating_the_hole_v2_closes(self):
+        """Regression/documentation test: a captured (body, signature) V1
+        pair replays successfully no matter how much time has passed,
+        because the V1 signature has no timestamp binding at all. This is
+        the exact vulnerability V2 fixes — it is not asserting desired
+        behavior, it is pinning the known, accepted-with-warning legacy
+        gap so a future change to V1's semantics doesn't silently alter it
+        without a deliberate decision."""
+        adapter = _make_adapter()
+        body = b'{"event": "push"}'
+        secret = "generic-secret"
+        sig = _generic_signature(body, secret)
+        original_request = _mock_request(headers={"X-Webhook-Signature": sig})
+        assert adapter._validate_signature(original_request, body, secret) is True
+        # "Time passes" — nothing about a V1 signature depends on time, so
+        # a captured pair replayed much later still validates.
+        replayed_request = _mock_request(headers={"X-Webhook-Signature": sig})
+        assert adapter._validate_signature(replayed_request, body, secret) is True
 
     def test_validate_svix_signature_valid(self):
         """Valid Svix/AgentMail v1 signature headers are accepted."""

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -387,7 +387,8 @@ The adapter validates incoming webhook signatures using the appropriate method f
 
 - **GitHub**: `X-Hub-Signature-256` header — HMAC-SHA256 hex digest prefixed with `sha256=`
 - **GitLab**: `X-Gitlab-Token` header — plain secret string match
-- **Generic**: `X-Webhook-Signature` header — raw HMAC-SHA256 hex digest
+- **Generic (V2, recommended)**: `X-Webhook-Signature-V2` + `X-Webhook-Timestamp` headers — HMAC-SHA256 hex digest of `<timestamp>.<body>`. The timestamp (Unix seconds) must be within ±300 seconds of the server clock, which prevents captured requests from being replayed later.
+- **Generic (V1, legacy)**: `X-Webhook-Signature` header — raw HMAC-SHA256 hex digest of the body only. Still accepted for backward compatibility, but it has no replay protection (a captured request replays indefinitely); the gateway logs a deprecation warning once per route. Switch senders to V2.
 
 If a secret is configured but no recognized signature header is present, the request is rejected.
 


### PR DESCRIPTION
## Summary
The generic webhook route gains replay protection: a V2 signature (`X-Webhook-Signature-V2` = HMAC-SHA256 of `<timestamp>.<body>`, ±300s window) closes the hole where a captured (body, signature) pair could be replayed forever against the V1 body-only HMAC. V1 stays accepted for backward compatibility with a once-per-route deprecation warning.

Salvages #58461 by @MorAlekss onto current main, authorship preserved.

## Changes
- `gateway/platforms/webhook.py`: V2 timestamp-bound verification (constant-time compare, Svix-convention ±300s window); V1 kept, deprecation warning rate-limited to once per route (follow-up — the original warned on every request)
- `website/docs/user-guide/messaging/webhooks.md`: document V2/V1 signature schemes (follow-up)
- Tests incl. forged-timestamp, replay-window, and V1-pinning cases

## Validation
| | Before | After |
|---|---|---|
| replayed captured request | accepted forever | rejected outside ±300s |
| GitHub/GitLab/Svix routes | unchanged | unchanged |
| existing V1 senders | work | work + one-time deprecation warning |

Targeted suite: tests/gateway/test_webhook_adapter.py — 75 tests, all pass.

Closes #58461.

## Infographic

![webhook-v2-signature](https://v3b.fal.media/files/b/0aa0f2e7/aq6ciPm9SwBiH3QAraazh_MM5mX8en.png)
