### PR TITLE
fix(memory): guard provider uploads against credential reads

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -576,6 +576,8 @@ _TOOL_STATUS_COMPLETED_ALIASES = {"completed", "complete", "success", "succeeded
 
 def _zip_directory(dir_path: Path) -> Path:
     """Create a temporary zip file containing a directory tree."""
+    from agent.file_safety import raise_if_read_blocked
+
     root = dir_path.resolve()
     zip_path = Path(tempfile.gettempdir()) / f"openviking_upload_{uuid.uuid4().hex}.zip"
     with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:
@@ -584,7 +586,12 @@ def _zip_directory(dir_path: Path) -> Path:
                 continue
             if file_path.is_file():
                 try:
-                    file_path.resolve().relative_to(root)
+                    resolved = file_path.resolve()
+                    resolved.relative_to(root)
+                except ValueError:
+                    continue
+                try:
+                    raise_if_read_blocked(str(resolved))
                 except ValueError:
                     continue
                 arcname = str(file_path.relative_to(dir_path)).replace("\\", "/")
@@ -3645,6 +3652,8 @@ class OpenVikingMemoryProvider(MemoryProvider):
         return json.dumps(payload, ensure_ascii=False)
 
     def _tool_add_resource(self, args: dict) -> str:
+        from agent.file_safety import raise_if_read_blocked
+
         url = args.get("url", "")
         if not url:
             return tool_error("url is required")
@@ -3678,6 +3687,10 @@ class OpenVikingMemoryProvider(MemoryProvider):
                         cleanup_path = _zip_directory(source_path)
                         upload_path = cleanup_path
                     elif source_path.is_file():
+                        try:
+                            raise_if_read_blocked(str(source_path))
+                        except ValueError as exc:
+                            return tool_error(str(exc))
                         payload["source_name"] = source_path.name
                         upload_path = source_path
                     else:

--- a/plugins/memory/retaindb/__init__.py
+++ b/plugins/memory/retaindb/__init__.py
@@ -34,6 +34,7 @@ from typing import Any, Dict, List
 from urllib.parse import quote
 
 from agent.memory_provider import MemoryProvider
+from agent.file_safety import raise_if_read_blocked
 from tools.registry import tool_error
 
 logger = logging.getLogger(__name__)
@@ -702,6 +703,10 @@ class RetainDBMemoryProvider(MemoryProvider):
             path_obj = Path(local_path)
             if not path_obj.exists():
                 return {"error": f"File not found: {local_path}"}
+            try:
+                raise_if_read_blocked(str(path_obj))
+            except ValueError as exc:
+                return {"error": str(exc)}
             data = path_obj.read_bytes()
             import mimetypes
             mime = mimetypes.guess_type(path_obj.name)[0] or "application/octet-stream"

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1298,6 +1298,26 @@ def test_tool_add_resource_uploads_file_uri(tmp_path):
     assert result["root_uri"] == "viking://resources/sample"
 
 
+def test_tool_add_resource_rejects_hermes_credential_file_upload(tmp_path, monkeypatch):
+    import agent.file_safety as fs
+
+    hermes_home = tmp_path / "hermes_home"
+    hermes_home.mkdir()
+    auth_json = hermes_home / "auth.json"
+    auth_json.write_text('{"OPENROUTER_API_KEY":"sk-test-secret"}', encoding="utf-8")
+    monkeypatch.setattr(fs, "_hermes_home_path", lambda: hermes_home)
+
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+
+    result = json.loads(provider._tool_add_resource({"url": str(auth_json)}))
+
+    assert "error" in result
+    assert "credential store" in result["error"]
+    provider._client.upload_temp_file.assert_not_called()
+    provider._client.post.assert_not_called()
+
+
 def test_tool_add_resource_uploads_existing_local_directory_and_cleans_zip(tmp_path):
     docs = tmp_path / "docs"
     docs.mkdir()
@@ -1370,6 +1390,44 @@ def test_tool_add_resource_directory_zip_skips_symlink_escape(tmp_path):
 
     assert archive_entries["names"] == ["guide.md"]
     assert b"do not upload" not in b"".join(archive_entries["payloads"].values())
+
+
+def test_tool_add_resource_directory_zip_skips_hermes_credential_files(tmp_path, monkeypatch):
+    import agent.file_safety as fs
+
+    hermes_home = tmp_path / "hermes_home"
+    hermes_home.mkdir()
+    (hermes_home / "guide.md").write_text("# Guide\n", encoding="utf-8")
+    (hermes_home / "auth.json").write_text(
+        '{"OPENROUTER_API_KEY":"sk-test-secret"}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(fs, "_hermes_home_path", lambda: hermes_home)
+
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+    archive_entries = {}
+
+    def inspect_upload(path):
+        with zipfile.ZipFile(path) as archive:
+            archive_entries["names"] = archive.namelist()
+            archive_entries["payloads"] = {
+                name: archive.read(name)
+                for name in archive.namelist()
+            }
+        return "upload_hermes_home.zip"
+
+    provider._client.upload_temp_file.side_effect = inspect_upload
+    provider._client.post.return_value = {
+        "status": "ok",
+        "result": {"root_uri": "viking://resources/hermes_home"},
+    }
+
+    result = json.loads(provider._tool_add_resource({"url": str(hermes_home)}))
+
+    assert result["status"] == "added"
+    assert archive_entries["names"] == ["guide.md"]
+    assert b"sk-test-secret" not in b"".join(archive_entries["payloads"].values())
 
 
 def test_tool_add_resource_cleans_local_directory_zip_when_add_fails(tmp_path):

--- a/tests/plugins/memory/test_retaindb_provider.py
+++ b/tests/plugins/memory/test_retaindb_provider.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import agent.file_safety as fs
+
+from plugins.memory.retaindb import RetainDBMemoryProvider
+
+
+def test_upload_file_rejects_hermes_credential_store(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes_home"
+    hermes_home.mkdir()
+    auth_json = hermes_home / "auth.json"
+    auth_json.write_text('{"OPENAI_API_KEY":"sk-test-secret"}', encoding="utf-8")
+    monkeypatch.setattr(fs, "_hermes_home_path", lambda: hermes_home)
+
+    provider = RetainDBMemoryProvider()
+    provider._client = MagicMock()
+
+    result = provider._dispatch("retaindb_upload_file", {"local_path": str(auth_json)})
+
+    assert "error" in result
+    assert "credential store" in result["error"]
+    provider._client.upload_file.assert_not_called()
+
+
+def test_upload_file_allows_regular_file(tmp_path):
+    note = tmp_path / "note.md"
+    note.write_text("# Note\n", encoding="utf-8")
+    provider = RetainDBMemoryProvider()
+    provider._client = MagicMock()
+    provider._client.upload_file.return_value = {
+        "file": {"id": "file-1", "name": "note.md"},
+    }
+
+    result = provider._dispatch("retaindb_upload_file", {"local_path": str(note)})
+
+    provider._client.upload_file.assert_called_once()
+    assert provider._client.upload_file.call_args.args[0] == note.read_bytes()
+    assert result["file"]["id"] == "file-1"


### PR DESCRIPTION
## What does this PR do?

Prevents memory-provider local upload tools from reading Hermes credential files before sending data to an external backend.

Hermes already has a shared local-file safety guard for credential stores such as `~/.hermes/auth.json` and `~/.hermes/.env`. RetainDB and OpenViking local upload paths were bypassing that guard: a model-supplied local path could be read directly and then uploaded through the provider API.

This PR applies the existing `agent.file_safety.raise_if_read_blocked()` guard at the provider upload boundary:

- `retaindb_upload_file(local_path=...)` checks the path before `Path(local_path).read_bytes()`.
- `viking_add_resource(url=<local path/file://...>)` checks local files before OpenViking temp upload.
- OpenViking directory uploads skip blocked credential files while still archiving allowed files from the selected tree.

The functional commit is cherry-picked from #57841 with original authorship preserved.

## Related PRs

Supersedes #57841 by carrying the same focused fix on top of current `main` with preserved commit authorship.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/openviking/__init__.py`
  - Checks direct local-file uploads with `raise_if_read_blocked()` before `temp_upload`.
  - Applies the same guard while building directory upload zip files and skips blocked credential files.
- `plugins/memory/retaindb/__init__.py`
  - Checks `retaindb_upload_file` paths before reading bytes.
- `tests/plugins/memory/test_openviking_provider.py`
  - Adds regressions for blocked credential file uploads, blocked files inside directory uploads, and ordinary upload behavior.
- `tests/plugins/memory/test_retaindb_provider.py`
  - Adds regressions for blocked credential-store uploads and ordinary file uploads.

## How to Test

1. Red-state evidence on current `main`: applied only the regression tests from #57841 and confirmed the guard tests fail before the production change.
2. `scripts/run_tests.sh tests/plugins/memory/test_openviking_provider.py tests/plugins/memory/test_retaindb_provider.py -- -o addopts=`
3. `scripts/run_tests.sh tests/plugins/memory/test_openviking_provider.py tests/plugins/memory/test_retaindb_provider.py -- -k "credential_file_upload or skips_hermes_credential_files or rejects_hermes_credential_store or allows_regular_file" -o addopts=`
4. `.venv/bin/python -m py_compile plugins/memory/openviking/__init__.py plugins/memory/retaindb/__init__.py tests/plugins/memory/test_openviking_provider.py tests/plugins/memory/test_retaindb_provider.py`
5. `git diff --check upstream/main...HEAD`

Local result: full targeted provider run passed with `137 tests, 0 failures`; focused guard subset passed with `4 passed, 0 failed`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS / Darwin local checkout

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
Red-state check on main: 3 guard regressions failed before the production fix.
Full targeted provider run: 137 tests, 0 failures.
Focused guard subset: 4 tests passed, 0 failed.
py_compile: pass
git diff --check upstream/main...HEAD: pass
```
