### PR TITLE
Add ToolSnap MCP (deterministic web/data microtools) to the catalog

### DIFF
--- a/optional-mcps/toolsnap/manifest.yaml
+++ b/optional-mcps/toolsnap/manifest.yaml
@@ -1,0 +1,56 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: toolsnap
+description: Deterministic web/data microtools — clean page extraction (98% median token cut), HTML tables, PDFs, CSV/JSON query, sitemaps, RSS, link checks. Free core, no account.
+source: https://toolsnap.app/agents
+
+# ToolSnap is a remote MCP server on Cloudflare Workers (streamable HTTP).
+# Nothing to install locally; free tools work the moment the server connects.
+transport:
+  type: http
+  url: https://mcp.toolsnap.app/mcp
+
+# No credentials needed. Free tools (35 of 38) require no account, no API key,
+# no wallet. The three paid tools (screenshot_url, keyword_research,
+# remove_background, $0.03–$0.04/call) settle per call via x402 USDC on Base
+# and need an x402-capable client — see post_install.
+auth:
+  type: none
+
+# Curated default: the deterministic web/data extraction surface plus the
+# catalog helpers. Everything else (encoders, hashes, wallet/account tools,
+# paid tools) stays visible in the install-time checklist for opt-in.
+tools:
+  default_enabled:
+    - fetch_extract
+    - fetch_html
+    - fetch_metadata
+    - fetch_structured
+    - html_to_markdown
+    - html_table_extract
+    - page_links
+    - link_check
+    - rss_parse
+    - sitemap_parse
+    - csv_query
+    - json_query
+    - pdf_text_extract
+    - count_tokens
+    - tool_catalog
+    - use_tool
+    - task_recipes
+
+post_install: |
+  Free tools work immediately — try:
+    fetch_extract { "url": "https://example.com" }
+
+  Unlike LLM-based page summarization, ToolSnap extraction is pure parsing:
+  exact quotes, stable output, no auxiliary-model cost. Discover the full
+  38-tool catalog with tool_catalog() and run anything via use_tool.
+
+  Paid tools (screenshot_url, keyword_research, remove_background) return an
+  x402 402 Payment Required. To pay automatically, run the local pay-proxy
+  (wallet key never leaves your machine):
+    https://github.com/icosaedro-git/toolsnap-mcp#paid-tools--connect-through-the-pay-proxy

--- a/optional-skills/web/toolsnap/SKILL.md
+++ b/optional-skills/web/toolsnap/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: toolsnap
+description: Deterministic web/data extraction via the ToolSnap MCP server — exact parsing instead of LLM summarization, at near-zero context cost.
+version: 1.0.0
+author: Icosaedro (github.com/icosaedro-git)
+license: MIT
+platforms: [linux, macos, windows]
+prerequisites:
+  mcps: [toolsnap]
+metadata:
+  hermes:
+    tags: [web, scraping, extraction, pdf, csv, json, rss, sitemap, seo, x402, context-efficiency]
+    category: web
+    related_skills: []
+    homepage: https://toolsnap.app/agents
+---
+
+# toolsnap
+
+Use the ToolSnap MCP server (`hermes mcp install official/toolsnap`) when a task needs
+**deterministic** extraction from the web or from documents — exact quotes, structured data,
+reproducible output — rather than an LLM-written summary. ToolSnap does the heavy lifting
+server-side (Cloudflare edge) and returns only the answer, so large pages and documents never
+enter your context window and no auxiliary-model tokens are spent.
+
+## When to reach for ToolSnap instead of web_extract / browser
+
+| Task | Tool | Why |
+|---|---|---|
+| Quote or cite a page exactly | `fetch_extract` | Pure parsing — what you get is what the page said. Median 98.1% token reduction vs raw HTML. |
+| Rebuild / migrate a page | `fetch_html` | Clean DOM (tags/classes/ids kept, scripts/styles stripped). |
+| Tables on a page → data | `html_table_extract` | Returns JSON or CSV directly — no transcription errors. |
+| Query a big CSV/JSON without loading it | `csv_query` / `json_query` | Filter/sort/select server-side; only matching rows come back. |
+| PDF text | `pdf_text_extract` | URL in, text out. |
+| Feeds, sitemaps, link audits | `rss_parse` / `sitemap_parse` / `link_check` | Structured JSON, deterministic. |
+| SEO metadata | `fetch_metadata` / `fetch_structured` | title/canonical/og:* and JSON-LD as data. |
+| Budget check before ingesting | `count_tokens` | Know the cost before you pay it. |
+
+Keep using Hermes-native `web_search` for discovery (ToolSnap does not search) and
+`browser_navigate` for JS-heavy SPAs, logins, and interactions — ToolSnap fetches server-side
+and will tell you (without failing silently) when a page needs a real browser.
+
+## The long tail — 38 tools behind 2 calls
+
+Only a curated core appears in `tools/list`. For anything else:
+
+1. `tool_catalog()` → families overview; `tool_catalog(family="...")` or `tool_catalog(tool="...")` → schema.
+2. `use_tool(name="...", args={...})` → execute it, same behavior as a direct call.
+3. `task_recipes()` → ready multi-tool plans (clone a site, SEO audit, …).
+
+## Paid tools (optional)
+
+`screenshot_url` ($0.04), `keyword_research` ($0.04), `remove_background` ($0.03) settle
+per call with USDC on Base via x402 — no account, no API key. A funded wallet alone is not
+enough: the client must answer the `402` by signing an EIP-3009 transfer and retrying.
+Easiest path is the local pay-proxy (key never leaves the machine):
+<https://github.com/icosaedro-git/toolsnap-mcp#paid-tools--connect-through-the-pay-proxy>.
+For repeat use, prepaid is cheaper: deposit once with `account_deposit` (≥ $0.50), then calls
+debit off-chain. Check `pricing()` first; never authorize above the shown price.
+
+## Habits
+
+- Before loading any external URL or document into context, try the matching ToolSnap tool first.
+- Prefer one targeted query (`csv_query`, `html_table_extract`) over fetching a whole document.
+- If ToolSnap reports a JS-rendered SPA, switch to `browser_navigate` — do not retry blindly.

--- a/optional-skills/web/toolsnap/SKILL.md
+++ b/optional-skills/web/toolsnap/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: toolsnap
-description: Deterministic web/data extraction via the ToolSnap MCP server — exact parsing instead of LLM summarization, at near-zero context cost.
-version: 1.0.0
+description: Deterministic extraction from web pages and documents.
+version: 1.1.0
 author: Icosaedro (github.com/icosaedro-git)
 license: MIT
 platforms: [linux, macos, windows]
@@ -15,51 +15,88 @@ metadata:
     homepage: https://toolsnap.app/agents
 ---
 
-# toolsnap
+# ToolSnap Skill
 
-Use the ToolSnap MCP server (`hermes mcp install official/toolsnap`) when a task needs
-**deterministic** extraction from the web or from documents — exact quotes, structured data,
-reproducible output — rather than an LLM-written summary. ToolSnap does the heavy lifting
-server-side (Cloudflare edge) and returns only the answer, so large pages and documents never
-enter your context window and no auxiliary-model tokens are spent.
+Extract exact, reproducible data from web pages and documents through the
+ToolSnap MCP server, which parses server-side and returns only the answer —
+large pages never enter the context window. It does not search the web and
+does not drive a browser; discovery and interaction stay with native tools.
 
-## When to reach for ToolSnap instead of web_extract / browser
+## When to Use
 
-| Task | Tool | Why |
-|---|---|---|
-| Quote or cite a page exactly | `fetch_extract` | Pure parsing — what you get is what the page said. Median 98.1% token reduction vs raw HTML. |
-| Rebuild / migrate a page | `fetch_html` | Clean DOM (tags/classes/ids kept, scripts/styles stripped). |
-| Tables on a page → data | `html_table_extract` | Returns JSON or CSV directly — no transcription errors. |
-| Query a big CSV/JSON without loading it | `csv_query` / `json_query` | Filter/sort/select server-side; only matching rows come back. |
-| PDF text | `pdf_text_extract` | URL in, text out. |
-| Feeds, sitemaps, link audits | `rss_parse` / `sitemap_parse` / `link_check` | Structured JSON, deterministic. |
-| SEO metadata | `fetch_metadata` / `fetch_structured` | title/canonical/og:* and JSON-LD as data. |
-| Budget check before ingesting | `count_tokens` | Know the cost before you pay it. |
+- Quoting or citing a page exactly, where an LLM summary could drift
+- Turning HTML tables, CSV/JSON files, PDFs, RSS feeds, or sitemaps into structured data
+- Querying a large dataset for a few rows instead of loading the whole file
+- Auditing SEO metadata (title/canonical/og:*, JSON-LD) as data
+- Checking token cost of a document before ingesting it
 
-Keep using Hermes-native `web_search` for discovery (ToolSnap does not search) and
-`browser_navigate` for JS-heavy SPAs, logins, and interactions — ToolSnap fetches server-side
-and will tell you (without failing silently) when a page needs a real browser.
+Keep native `web_search` for discovery (ToolSnap does not search) and
+`browser_navigate` for JS-heavy SPAs, logins, and page interaction.
 
-## The long tail — 38 tools behind 2 calls
+## Prerequisites
 
-Only a curated core appears in `tools/list`. For anything else:
+The `toolsnap` MCP server, installed from the catalog:
 
-1. `tool_catalog()` → families overview; `tool_catalog(family="...")` or `tool_catalog(tool="...")` → schema.
-2. `use_tool(name="...", args={...})` → execute it, same behavior as a direct call.
-3. `task_recipes()` → ready multi-tool plans (clone a site, SEO audit, …).
+```
+hermes mcp install official/toolsnap
+```
 
-## Paid tools (optional)
+It is a remote server on Cloudflare Workers (streamable HTTP) — nothing runs
+locally and the free tools need no account, API key, or configuration.
 
-`screenshot_url` ($0.04), `keyword_research` ($0.04), `remove_background` ($0.03) settle
-per call with USDC on Base via x402 — no account, no API key. A funded wallet alone is not
-enough: the client must answer the `402` by signing an EIP-3009 transfer and retrying.
-Easiest path is the local pay-proxy (key never leaves the machine):
-<https://github.com/icosaedro-git/toolsnap-mcp#paid-tools--connect-through-the-pay-proxy>.
-For repeat use, prepaid is cheaper: deposit once with `account_deposit` (≥ $0.50), then calls
-debit off-chain. Check `pricing()` first; never authorize above the shown price.
+## How to Run
 
-## Habits
+Call the MCP tools directly. Only a curated core appears in `tools/list`;
+the rest of the catalog is reachable through two meta-tools:
 
-- Before loading any external URL or document into context, try the matching ToolSnap tool first.
-- Prefer one targeted query (`csv_query`, `html_table_extract`) over fetching a whole document.
-- If ToolSnap reports a JS-rendered SPA, switch to `browser_navigate` — do not retry blindly.
+1. `tool_catalog()` — families overview; `tool_catalog(family="...")` or
+   `tool_catalog(tool="...")` returns a tool's schema.
+2. `use_tool(name="...", args={...})` — execute any cataloged tool, same
+   behavior as a direct call.
+3. `task_recipes()` — ready multi-tool plans (clone a site, SEO audit, …).
+
+## Quick Reference
+
+| Task | Tool |
+|---|---|
+| Quote or cite a page exactly | `fetch_extract` |
+| Rebuild / migrate a page (clean DOM) | `fetch_html` |
+| Tables on a page → JSON/CSV | `html_table_extract` |
+| Query a big CSV/JSON without loading it | `csv_query` / `json_query` |
+| PDF text | `pdf_text_extract` |
+| Feeds, sitemaps, link audits | `rss_parse` / `sitemap_parse` / `link_check` |
+| SEO metadata and JSON-LD | `fetch_metadata` / `fetch_structured` |
+| Token budget check before ingesting | `count_tokens` |
+
+## Procedure
+
+1. Before loading any external URL or document into context, check the
+   Quick Reference for a matching tool and call it instead.
+2. Prefer one targeted query (`csv_query`, `html_table_extract`) over
+   fetching a whole document and filtering in-context.
+3. For tools not in `tools/list`, resolve the schema with `tool_catalog`
+   and execute with `use_tool`.
+4. Paid tools (`screenshot_url` $0.04, `keyword_research` $0.04,
+   `remove_background` $0.03) settle per call with USDC on Base via x402.
+   Check `pricing()` first and never authorize above the shown price. A
+   funded wallet alone is not enough — the client must answer the `402`
+   by signing an EIP-3009 transfer and retrying; the local pay-proxy
+   (linked from the homepage above) handles this with the key kept on
+   the machine, and `account_deposit` (≥ $0.50) makes repeat use cheaper.
+
+## Pitfalls
+
+- ToolSnap fetches server-side: JS-rendered SPAs come back flagged as such,
+  not silently empty. When it reports one, switch to `browser_navigate` —
+  do not retry blindly.
+- There is no search tool; resolving "find the page about X" needs
+  `web_search` first, then ToolSnap on the resulting URL.
+- Paid calls have real cost per invocation — no first-call-free. Do not
+  loop them without checking `pricing()` and the budget.
+
+## Verification
+
+- `tool_catalog()` returns the families overview — the server is reachable
+  and the catalog loads.
+- `fetch_metadata(url="https://toolsnap.app")` returns the site title as
+  structured JSON — end-to-end extraction works without an account.

--- a/tests/skills/test_toolsnap_skill.py
+++ b/tests/skills/test_toolsnap_skill.py
@@ -1,0 +1,97 @@
+"""
+Smoke tests for the toolsnap optional skill.
+
+The skill is prose-only (it drives a remote MCP server, no shipped scripts),
+so these tests verify — without any network calls — that:
+  - SKILL.md frontmatter conforms to the hardline format
+  - the body follows the modern title/section sequence
+  - the skill declares its MCP prerequisite and matches the catalog manifest
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_DIR = REPO_ROOT / "optional-skills" / "web" / "toolsnap"
+MANIFEST = REPO_ROOT / "optional-mcps" / "toolsnap" / "manifest.yaml"
+
+
+@pytest.fixture(scope="module")
+def skill_src() -> str:
+    return (SKILL_DIR / "SKILL.md").read_text()
+
+
+@pytest.fixture(scope="module")
+def frontmatter(skill_src) -> dict:
+    m = re.search(r"^---\n(.*?)\n---", skill_src, re.DOTALL)
+    assert m, "SKILL.md missing YAML frontmatter"
+    return yaml.safe_load(m.group(1))
+
+
+def test_skill_md_present() -> None:
+    assert (SKILL_DIR / "SKILL.md").is_file()
+
+
+def test_description_hardline(frontmatter) -> None:
+    desc = frontmatter["description"]
+    assert len(desc) <= 60, f"description is {len(desc)} chars (hardline ≤60): {desc!r}"
+    assert desc.endswith("."), "description must end with a period"
+    assert "toolsnap" not in desc.lower(), "description must not repeat the skill name"
+
+
+def test_name_matches_dir(frontmatter) -> None:
+    assert frontmatter["name"] == "toolsnap"
+
+
+def test_platforms_all(frontmatter) -> None:
+    # Remote MCP server over HTTP — nothing platform-bound runs locally.
+    assert set(frontmatter["platforms"]) == {"linux", "macos", "windows"}
+
+
+def test_author_credits_contributor(frontmatter) -> None:
+    assert "icosaedro" in frontmatter["author"].lower()
+
+
+def test_license_mit(frontmatter) -> None:
+    assert frontmatter["license"] == "MIT"
+
+
+def test_declares_mcp_prerequisite(frontmatter) -> None:
+    assert frontmatter["prerequisites"]["mcps"] == ["toolsnap"]
+
+
+def test_modern_section_sequence(skill_src) -> None:
+    body = skill_src.split("---", 2)[2]
+    assert body.lstrip().startswith("# ToolSnap Skill"), "modern '# <Skill> Skill' title required"
+    headings = [
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ]
+    positions = [body.find(h) for h in headings]
+    assert all(p >= 0 for p in positions), (
+        f"missing sections: {[h for h, p in zip(headings, positions) if p < 0]}"
+    )
+    assert positions == sorted(positions), "sections out of the mandated order"
+
+
+def test_references_precise_native_tools(skill_src) -> None:
+    # Handoffs must name the precise native tools, not a generic "browser".
+    assert "`browser_navigate`" in skill_src
+    assert "`web_search`" in skill_src
+    assert "`browser`" not in skill_src
+
+
+def test_manifest_present_and_matches() -> None:
+    manifest = yaml.safe_load(MANIFEST.read_text())
+    assert manifest["name"] == "toolsnap"
+    assert manifest["transport"]["type"] == "http"
+    assert manifest["transport"]["url"].startswith("https://")


### PR DESCRIPTION
## What

Adds **ToolSnap MCP** to the Nous-approved catalog (`optional-mcps/toolsnap/`) plus a companion
skill (`optional-skills/web/toolsnap/`) that teaches Hermes when to prefer it.

ToolSnap is a remote MCP server (Cloudflare Workers, streamable HTTP) with 38 deterministic
web/data microtools: clean page extraction, HTML tables → JSON/CSV, PDF text, CSV/JSON query,
sitemaps, RSS, link checks, SEO metadata. 35 of 38 tools are free with no account, no API key,
no wallet. Endpoint: `https://mcp.toolsnap.app/mcp` · Server card:
[`/.well-known/mcp.json`](https://mcp.toolsnap.app/.well-known/mcp.json).

## Why it complements Hermes

- **Deterministic, no LLM in the loop.** Hermes' `web_extract` compresses big pages with an
  auxiliary model. ToolSnap is pure parsing: exact quotes, stable output, zero added inference
  cost. For citations, tables, and structured data the two approaches are complementary — the
  skill spells out when to use which (and defers to `web_search`/`browser_navigate` where those
  are the right tool).
- **Context-frugal by design.** Work happens server-side; a 372 KB docs page comes back as
  2.5 KB of text (median 98.1% token reduction over 11 real pages). `tools/list` stays small —
  the long tail is behind `tool_catalog()`/`use_tool`, so the default checklist enables a
  curated 17-tool surface.
- **No credentials.** `auth: type: none`. The three paid tools ($0.03–$0.04) settle per call
  via x402 USDC on Base for users who opt in; everything in the default set is free.

## Testing

Tested against a local Hermes Agent install (v0.18.0) with `toolsnap` added as an MCP server
(`hermes mcp add`, `url: https://mcp.toolsnap.app/mcp`, `auth: none`):

- `hermes mcp test toolsnap` → `✓ Connected (1949ms)`, `✓ Tools discovered: 18` (curated core
  from `tools/list`, matching the manifest's default selection).
- `fetch_extract` on `https://example.com` → clean text, no HTML noise, single tool call.
- `tool_catalog()` (no args) → 9 families, `total_tools: 38`, correct `how_to_run` guidance
  pointing to `use_tool`.
- `html_table_extract` (not in the curated 18, called via `use_tool(name="html_table_extract",
  args={...})` per the manifest's documented pattern) on a Wikipedia population table →
  `total_tables: 2`, 238 rows parsed with headers, as structured JSON.

All three calls round-tripped through the live production endpoint (server v1.1.0, deployed
2026-07-04) with correct, deterministic output — no LLM in the loop on ToolSnap's side.

Happy to adjust the default tool selection or manifest fields to whatever the catalog
maintainers prefer.
