### PR TITLE
fix(compression): rebind context engine before compaction

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2721,10 +2721,20 @@ def compress_context(
     # state, make sure it is bound to the host session whose messages are being
     # compressed; otherwise DAG/store rows can be attributed to a stale session
     # and the later compression-boundary carry-over has no matching source.
+    #
+    # Precedence for reading the engine's bound session id:
+    #   bound_session_id (public, contract-respecting) →
+    #   _session_id (legacy private) →
+    #   current_session_id (older public fallback).
+    #
+    # Fail-closed: if the rebind attempt raises, compression is skipped
+    # (messages returned unchanged) rather than running under a stale binding.
     try:
-        _bound_sid = getattr(agent.context_compressor, "current_session_id", None)
-        if not isinstance(_bound_sid, str):
-            _bound_sid = getattr(agent.context_compressor, "_session_id", "")
+        _bound_sid = getattr(agent.context_compressor, "bound_session_id", None)
+        if not isinstance(_bound_sid, str) or not _bound_sid:
+            _bound_sid = getattr(agent.context_compressor, "_session_id", None)
+        if not isinstance(_bound_sid, str) or not _bound_sid:
+            _bound_sid = getattr(agent.context_compressor, "current_session_id", None)
         if (
             isinstance(_bound_sid, str)
             and _bound_sid
@@ -2736,9 +2746,22 @@ def compress_context(
                 agent.session_id,
                 platform=getattr(agent, "platform", None) or "cli",
                 conversation_id=getattr(agent, "_gateway_session_key", None),
+                boundary_reason="rebind",
             )
     except Exception as _bind_err:
-        logger.debug("context engine pre-compression rebind skipped: %s", _bind_err)
+        # Fail-closed: do NOT compress under a stale binding.  Return messages
+        # unchanged so the caller sees a no-op and can retry on the next tick.
+        logger.warning(
+            "context engine pre-compression rebind FAILED (session=%s): %s — "
+            "skipping compression to avoid stale-binding attribution",
+            agent.session_id or "none",
+            _bind_err,
+        )
+        _release_lock()
+        _existing_sp = getattr(agent, "_cached_system_prompt", None)
+        if not _existing_sp:
+            _existing_sp = agent._build_system_prompt(system_message)
+        return messages, _existing_sp
 
     _activity_heartbeat: Optional[_CompressionActivityHeartbeat] = None
     messages_before_compression = None

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2716,6 +2716,30 @@ def compress_context(
                 existing_prompt = agent._build_system_prompt(system_message)
             return messages, existing_prompt
 
+    # External context engines can be shared across side channels (subagents,
+    # background review, gateway workers).  Before asking one to write compaction
+    # state, make sure it is bound to the host session whose messages are being
+    # compressed; otherwise DAG/store rows can be attributed to a stale session
+    # and the later compression-boundary carry-over has no matching source.
+    try:
+        _bound_sid = getattr(agent.context_compressor, "current_session_id", None)
+        if not isinstance(_bound_sid, str):
+            _bound_sid = getattr(agent.context_compressor, "_session_id", "")
+        if (
+            isinstance(_bound_sid, str)
+            and _bound_sid
+            and agent.session_id
+            and _bound_sid != agent.session_id
+            and hasattr(agent.context_compressor, "on_session_start")
+        ):
+            agent.context_compressor.on_session_start(
+                agent.session_id,
+                platform=getattr(agent, "platform", None) or "cli",
+                conversation_id=getattr(agent, "_gateway_session_key", None),
+            )
+    except Exception as _bind_err:
+        logger.debug("context engine pre-compression rebind skipped: %s", _bind_err)
+
     _activity_heartbeat: Optional[_CompressionActivityHeartbeat] = None
     messages_before_compression = None
     try:

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -249,6 +249,62 @@ class TestCompressionBoundaryHook:
             )
             assert compressed
             assert agent.session_id != original_sid
+    def test_stale_bound_engine_rebinds_before_compress(self):
+        """Compression must write plugin state under the host's active session.
+
+        LCM instances can be rebound by side channels before a foreground
+        compaction fires.  If compress() runs while the engine is still bound to
+        that stale session, DAG nodes are attributed to the wrong session and
+        the subsequent old->new compression-boundary carry-over cannot find the
+        source.  The host owns the active session_id, so it must rebind before
+        invoking compress().
+        """
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(db)
+            messages = [{"role": "user", "content": f"m{i}"} for i in range(10)]
+
+            compressor = MagicMock()
+            compressor.current_session_id = "stale-side-channel"
+            compressor.compression_count = 1
+            compressor.last_prompt_tokens = 0
+            compressor.last_completion_tokens = 0
+            compressor._last_summary_error = None
+            compressor._last_compress_aborted = False
+
+            def _on_session_start(session_id, **_kwargs):
+                compressor.current_session_id = session_id
+
+            def _compress(*_args, **_kwargs):
+                assert compressor.current_session_id == agent.session_id
+                return [
+                    {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                    {"role": "user", "content": "tail question"},
+                ]
+
+            compressor.on_session_start.side_effect = _on_session_start
+            compressor.compress.side_effect = _compress
+            agent.context_compressor = compressor
+
+            original_sid = agent.session_id
+            agent._compress_context(messages, "sys", approx_tokens=10_000)
+
+            rebind_calls = [
+                c for c in compressor.on_session_start.call_args_list
+                if c.args and c.args[0] == original_sid
+                and c.kwargs.get("boundary_reason") != "compression"
+            ]
+            assert rebind_calls, compressor.on_session_start.call_args_list
+
+            comp_calls = [
+                c for c in compressor.on_session_start.call_args_list
+                if c.kwargs.get("boundary_reason") == "compression"
+            ]
+            assert comp_calls
+            assert comp_calls[-1].args[0] == agent.session_id
+            assert comp_calls[-1].kwargs.get("old_session_id") == original_sid
 
 
 class TestSessionCompressEvent:

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -294,7 +294,7 @@ class TestCompressionBoundaryHook:
             rebind_calls = [
                 c for c in compressor.on_session_start.call_args_list
                 if c.args and c.args[0] == original_sid
-                and c.kwargs.get("boundary_reason") != "compression"
+                and c.kwargs.get("boundary_reason") == "rebind"
             ]
             assert rebind_calls, compressor.on_session_start.call_args_list
 
@@ -305,6 +305,71 @@ class TestCompressionBoundaryHook:
             assert comp_calls
             assert comp_calls[-1].args[0] == agent.session_id
             assert comp_calls[-1].kwargs.get("old_session_id") == original_sid
+
+    def test_rebind_failure_skips_compression_fail_closed(self):
+        """If on_session_start raises during the pre-compress rebind,
+        compression must be skipped (fail-closed) rather than running
+        under a stale binding."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(db)
+            messages = [{"role": "user", "content": f"m{i}"} for i in range(10)]
+
+            compressor = MagicMock()
+            compressor.bound_session_id = "stale-session"
+            compressor.compression_count = 0
+            compressor.last_prompt_tokens = 0
+            compressor.last_completion_tokens = 0
+            compressor._last_summary_error = None
+            compressor._last_compress_aborted = False
+            compressor.on_session_start.side_effect = RuntimeError("engine offline")
+            agent.context_compressor = compressor
+
+            compressed, _prompt = agent._compress_context(
+                messages, "sys", approx_tokens=10_000
+            )
+
+            # Fail-closed: messages returned unchanged, compress() never called.
+            assert compressed == messages
+            compressor.compress.assert_not_called()
+
+    def test_rebind_uses_bound_session_id_precedence(self):
+        """bound_session_id (public) takes precedence over _session_id
+        and current_session_id when detecting a stale binding."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(db)
+            messages = [{"role": "user", "content": f"m{i}"} for i in range(10)]
+
+            compressor = MagicMock()
+            # bound_session_id matches → no rebind needed, even though
+            # _session_id and current_session_id are stale.
+            compressor.bound_session_id = agent.session_id
+            compressor._session_id = "stale-private"
+            compressor.current_session_id = "stale-public"
+            compressor.compression_count = 1
+            compressor.last_prompt_tokens = 0
+            compressor.last_completion_tokens = 0
+            compressor._last_summary_error = None
+            compressor._last_compress_aborted = False
+            compressor.compress.return_value = [
+                {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                {"role": "user", "content": "tail"},
+            ]
+            agent.context_compressor = compressor
+
+            agent._compress_context(messages, "sys", approx_tokens=10_000)
+
+            # No rebind call because bound_session_id already matches.
+            rebind_calls = [
+                c for c in compressor.on_session_start.call_args_list
+                if c.kwargs.get("boundary_reason") == "rebind"
+            ]
+            assert not rebind_calls
 
 
 class TestSessionCompressEvent:


### PR DESCRIPTION
## Summary
- Rebind external context engines to the host agent session before invoking `compress()` when they are still bound to a stale side-channel session.
- Add a regression test that asserts the stale-bound engine is rebound before compression and still receives the normal old->new compression-boundary hook afterward.

## Why
LCM compaction writes DAG/store state under the engine's current session id. Reverse-engineer profile logs show compression can run while the shared LCM engine is still bound to an older/side-channel session, causing summary nodes to be attributed to the wrong session and later carry-over to skip because `old_session_id` does not match the bound session.

## Tests
- `python -m py_compile agent/conversation_compression.py tests/run_agent/test_compression_boundary_hook.py`
- `python -m pytest tests/run_agent/test_compression_boundary_hook.py -q`
- `python -m pytest tests/run_agent/test_infinite_compaction_loop.py tests/run_agent/test_compression_persistence.py -q`
- `python -m ruff check agent/conversation_compression.py tests/run_agent/test_compression_boundary_hook.py`
