### PR TITLE
fix(security): guard native image routing with file-safety policy

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -633,6 +633,17 @@ def _file_to_data_url(path: Path) -> Optional[str]:
     proceeds.
     """
     try:
+        from agent.file_safety import raise_if_read_blocked
+
+        raise_if_read_blocked(str(path))
+    except ValueError as exc:
+        logger.warning("image_routing: blocked local image attachment %s -- %s", path, exc)
+        return None
+    except Exception:
+        # Keep attachment routing best-effort if the guard itself is unavailable.
+        pass
+
+    try:
         raw = path.read_bytes()
     except Exception as exc:
         logger.warning("image_routing: failed to read %s — %s", path, exc)

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -780,6 +780,44 @@ class TestFormatCompatibility:
         b64 = url.split(",", 1)[1]
         assert base64.b64decode(b64) == _png_bytes()
 
+    def test_file_to_data_url_blocks_read_denied_image_path(self, tmp_path: Path):
+        """Native image routing must honor the shared credential read guard."""
+        from agent.image_routing import _file_to_data_url
+
+        img_path = tmp_path / ".env"
+        img_path.write_bytes(_png_bytes())
+
+        assert _file_to_data_url(img_path) is None
+
+    def test_native_content_parts_skip_read_denied_local_image(self, tmp_path: Path):
+        from agent.image_routing import build_native_content_parts
+
+        img_path = tmp_path / ".env.local"
+        img_path.write_bytes(_png_bytes())
+
+        parts, skipped = build_native_content_parts("inspect this", [str(img_path)])
+
+        assert skipped == [str(img_path)]
+        assert all(part.get("type") != "image_url" for part in parts)
+
+    def test_native_content_parts_blocks_image_symlink_to_read_denied_file(self, tmp_path: Path):
+        from agent.image_routing import build_native_content_parts
+        import os
+        import pytest
+
+        secret = tmp_path / ".env"
+        secret.write_bytes(_png_bytes())
+        img_link = tmp_path / "secret.png"
+        try:
+            os.symlink(secret, img_link)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"symlinks unavailable: {exc}")
+
+        parts, skipped = build_native_content_parts("inspect this", [str(img_link)])
+
+        assert skipped == [str(img_link)]
+        assert all(part.get("type") != "image_url" for part in parts)
+
     def test_jpeg_passes_through_no_transcode(self, tmp_path: Path):
         from agent.image_routing import _file_to_data_url
 


### PR DESCRIPTION
## Summary

Native image routing now honors the shared file-safety read guard before embedding local image bytes into the model-provider request.

## Problem

`agent.image_routing.build_native_content_parts()` reads local image paths through `_file_to_data_url()` and converts them into base64 `data:` URLs for native multimodal model input.

That path did not call the shared `agent.file_safety` read guard. As a result, a protected target could still be embedded into the outbound model request if it reached native image routing as a local image attachment, including the symlink case where an image-looking path points at a read-denied credential file.

This is the same boundary shape as other local media/provider-input fixes: local file bytes cross from Hermes into an external model provider request, so the shared file-safety policy should be applied at the final byte-loading chokepoint.

## Changes

- Call `raise_if_read_blocked()` inside `_file_to_data_url()` before reading local image bytes.
- Treat blocked files like unreadable/unsupported attachments: skip them and continue the turn.
- Add regression coverage for:
  - direct read-denied local image paths
  - native content parts skipping blocked images
  - image-looking symlinks whose resolved target is read-denied

## Tests

```text
python -m pytest tests/agent/test_image_routing.py -q -k "read_denied or symlink or png_passes" --timeout-method=thread
4 passed, 93 deselected