### PR TITLE
fix(gateway): add POSIX system dirs to PATH for UV Python (salvage #3850)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -12,19 +12,20 @@ import shlex
 import shutil
 import signal
 import subprocess
-
-# Ensure /bin and /usr/bin are on PATH so launchctl/systemctl are discoverable
-# when running under UV's bundled Python which ships a minimal PATH.
-_sys_dirs = {"/bin", "/usr/bin", "/usr/sbin", "/sbin"}
-_path_dirs = set(os.environ.get("PATH", "").split(os.pathsep))
-_missing = _sys_dirs - _path_dirs
-if _missing:
-    os.environ["PATH"] = os.environ.get("PATH", "") + os.pathsep + os.pathsep.join(sorted(_missing))
 import sys
 import textwrap
 import time
 from dataclasses import dataclass
 from pathlib import Path
+
+# Ensure /bin and /usr/bin are on PATH so launchctl/systemctl are discoverable
+# when running under UV's bundled Python which ships a minimal PATH (#3849).
+if os.name == "posix":
+    _sys_dirs = {"/bin", "/usr/bin", "/usr/sbin", "/sbin"}
+    _path_dirs = set(os.environ.get("PATH", "").split(os.pathsep))
+    _missing = _sys_dirs - _path_dirs
+    if _missing:
+        os.environ["PATH"] = os.environ.get("PATH", "") + os.pathsep + os.pathsep.join(sorted(_missing))
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -12,6 +12,14 @@ import shlex
 import shutil
 import signal
 import subprocess
+
+# Ensure /bin and /usr/bin are on PATH so launchctl/systemctl are discoverable
+# when running under UV's bundled Python which ships a minimal PATH.
+_sys_dirs = {"/bin", "/usr/bin", "/usr/sbin", "/sbin"}
+_path_dirs = set(os.environ.get("PATH", "").split(os.pathsep))
+_missing = _sys_dirs - _path_dirs
+if _missing:
+    os.environ["PATH"] = os.environ.get("PATH", "") + os.pathsep + os.pathsep.join(sorted(_missing))
 import sys
 import textwrap
 import time


### PR DESCRIPTION
## Summary
`hermes gateway start/stop/restart` no longer crashes with `FileNotFoundError: launchctl` (or `systemctl`) when Hermes runs under UV's bundled Python, which ships a minimal PATH missing `/bin:/usr/bin:/usr/sbin:/sbin`. Fixes #3849.

Salvage of #3850 by @kevinrajaram — commit cherry-picked with authorship preserved.

## Changes
- `hermes_cli/gateway.py`: module-level PATH bootstrap appends missing POSIX system dirs; one-point fix covering all 21 `launchctl` + 2 `systemctl` bare subprocess call sites (contributor commit).
- Follow-up commit (ours): moved the block below the import section (E402 wart) and gated it to `os.name == "posix"` so Windows PATH is untouched.
- `scripts/release.py`: AUTHOR_MAP entry for @kevinrajaram.

## Validation
| | Before | After |
|---|---|---|
| `PATH=/tmp/fakeonly` then `import hermes_cli.gateway` | launchctl/systemctl unresolvable | PATH gains `/bin:/sbin:/usr/bin:/usr/sbin`; `shutil.which("systemctl")` resolves |
| `tests/hermes_cli/test_gateway.py`, `test_gateway_service.py` | — | pass |

Note: #3878 attacks the same issue by hardcoding absolute launchctl paths at 12 of 21 call sites with a wrong fallback (`/usr/sbin/launchctl`; real path is `/bin/launchctl`) and ignores the systemctl half — recommending close as duplicate once this lands.

## Infographic

![pr-3850-salvage](https://v3b.fal.media/files/b/0aa1030f/jRHDZVRnuwujlM4caAA4o_m6jycrqC.png)

