### PR TITLE
fix(credential-pool): scope usage-limit blocks per-model for shared Codex OAuth (#47986)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1211,8 +1211,15 @@ def restore_primary_runtime(agent) -> bool:
         # When the pool is absent, empty, or the entry has no usable key, we
         # keep the snapshot key (the existing behavior).  Fixes #25205.
         pool = getattr(agent, "_credential_pool", None)
-        if pool is not None and pool.has_available():
-            entry = pool.select(requested_model=getattr(agent, "model", None))
+        # Scope the gate/select to the model we are restoring *to* (the primary
+        # snapshot's model, which line above just wrote back to agent.model).
+        # A no-model has_available() would treat a sibling-scoped block (e.g. a
+        # gpt-5.5 exhaustion on a shared openai-codex credential) as a
+        # pool-wide outage and hide an otherwise-usable entry for this model
+        # (e.g. Spark), stranding restore on the stale snapshot key.
+        _restore_model = rt.get("model") or getattr(agent, "model", None)
+        if pool is not None and pool.has_available(requested_model=_restore_model):
+            entry = pool.select(requested_model=_restore_model)
             if entry is not None:
                 entry_provider = str(getattr(entry, "provider", "") or "").strip().lower()
                 primary_provider = str(rt.get("provider") or "").strip().lower()

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -788,7 +788,7 @@ def recover_with_credential_pool(
 
     if effective_reason == FailoverReason.billing:
         rotate_status = status_code if status_code is not None else 402
-        next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
+        next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context, model_id=getattr(agent, "model", None))
         if next_entry is not None:
             _ra().logger.info(
                 "Credential %s (billing) — rotated to pool entry %s",
@@ -812,7 +812,7 @@ def recover_with_credential_pool(
                 current_last_status,
             )
             rotate_status = status_code if status_code is not None else 429
-            next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
+            next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context, model_id=getattr(agent, "model", None))
             if next_entry is not None:
                 _ra().logger.info(
                     "Credential %s (rate limit, pre-exhausted) — rotated to pool entry %s",
@@ -836,7 +836,7 @@ def recover_with_credential_pool(
         if not has_retried_429 and not usage_limit_reached:
             return False, True
         rotate_status = status_code if status_code is not None else 429
-        next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
+        next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context, model_id=getattr(agent, "model", None))
         if next_entry is not None:
             _ra().logger.info(
                 "Credential %s (rate limit) — rotated to pool entry %s",
@@ -936,7 +936,7 @@ def recover_with_credential_pool(
         # Refresh failed — rotate to next credential instead of giving up.
         # The failed entry is already marked exhausted by try_refresh_current().
         rotate_status = status_code if status_code is not None else 401
-        next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
+        next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context, model_id=getattr(agent, "model", None))
         if next_entry is not None:
             _ra().logger.info(
                 "Credential %s (auth refresh failed) — rotated to pool entry %s",
@@ -1212,7 +1212,7 @@ def restore_primary_runtime(agent) -> bool:
         # keep the snapshot key (the existing behavior).  Fixes #25205.
         pool = getattr(agent, "_credential_pool", None)
         if pool is not None and pool.has_available():
-            entry = pool.select()
+            entry = pool.select(requested_model=getattr(agent, "model", None))
             if entry is not None:
                 entry_provider = str(getattr(entry, "provider", "") or "").strip().lower()
                 primary_provider = str(rt.get("provider") or "").strip().lower()

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -732,8 +732,16 @@ def _to_openai_base_url(base_url: str) -> str:
     return url
 
 
-def _select_pool_entry(provider: str) -> Tuple[bool, Optional[Any]]:
-    """Return (pool_exists_for_provider, selected_entry)."""
+def _select_pool_entry(
+    provider: str, requested_model: Optional[str] = None,
+) -> Tuple[bool, Optional[Any]]:
+    """Return (pool_exists_for_provider, selected_entry).
+
+    When *requested_model* is supplied, a credential exhausted for a
+    DIFFERENT model (``last_error_model``) is not treated as blocked — this
+    is what lets a shared OAuth credential still serve e.g. Spark after
+    ``gpt-5.5`` alone hit its usage limit (issue #47986).
+    """
     try:
         pool = load_pool(provider)
     except Exception as exc:
@@ -742,7 +750,7 @@ def _select_pool_entry(provider: str) -> Tuple[bool, Optional[Any]]:
     if not pool or not pool.has_credentials():
         return False, None
     try:
-        return True, pool.select()
+        return True, pool.select(requested_model=requested_model)
     except Exception as exc:
         logger.debug("Auxiliary client: could not select pool entry for %s: %s", provider, exc)
         return True, None
@@ -2356,7 +2364,7 @@ def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
             "pass model explicitly (auxiliary.<task>.model in config.yaml)."
         )
         return None, None
-    pool_present, entry = _select_pool_entry("openai-codex")
+    pool_present, entry = _select_pool_entry("openai-codex", requested_model=model)
     if pool_present:
         codex_token = _pool_runtime_api_key(entry)
         if codex_token:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1674,7 +1674,7 @@ def _resolve_xai_oauth_for_aux() -> Optional[Tuple[str, str]]:
     return api_key, base_url
 
 
-def _read_codex_access_token() -> Optional[str]:
+def _read_codex_access_token(requested_model: Optional[str] = None) -> Optional[str]:
     """Read a valid, non-expired Codex OAuth access token from Hermes auth store.
 
     If a credential pool exists but currently has no selectable runtime entry
@@ -1682,8 +1682,16 @@ def _read_codex_access_token() -> Optional[str]:
     profile's auth.json token instead of hard-failing. This keeps explicit
     fallback-to-Codex working when the pool state is stale but the stored OAuth
     token is still valid.
+
+    When *requested_model* is supplied, it is threaded into the pool selection
+    so a credential exhausted for a DIFFERENT model (``last_error_model``) is
+    not treated as blocked. Without this, the raw-Codex failover path (used by
+    the main agent loop) would skip e.g. Spark whenever ``gpt-5.5`` alone hit
+    its usage limit on the shared OAuth credential (issue #47986).
     """
-    pool_present, entry = _select_pool_entry("openai-codex")
+    pool_present, entry = _select_pool_entry(
+        "openai-codex", requested_model=requested_model
+    )
     if pool_present:
         token = _pool_runtime_api_key(entry)
         if token:
@@ -2370,12 +2378,12 @@ def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
         if codex_token:
             base_url = _pool_runtime_base_url(entry, _CODEX_AUX_BASE_URL) or _CODEX_AUX_BASE_URL
         else:
-            codex_token = _read_codex_access_token()
+            codex_token = _read_codex_access_token(model)
             if not codex_token:
                 return None, None
             base_url = _CODEX_AUX_BASE_URL
     else:
-        codex_token = _read_codex_access_token()
+        codex_token = _read_codex_access_token(model)
         if not codex_token:
             return None, None
         base_url = _CODEX_AUX_BASE_URL
@@ -4318,7 +4326,7 @@ def resolve_provider_client(
         if raw_codex:
             # Return the raw OpenAI client for callers that need direct
             # access to responses.stream() (e.g., the main agent loop).
-            codex_token = _read_codex_access_token()
+            codex_token = _read_codex_access_token(model)
             if not codex_token:
                 logger.warning("resolve_provider_client: openai-codex requested "
                                "but no Codex OAuth token found (run: hermes model)")

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3236,13 +3236,25 @@ def _recoverable_pool_provider(
     return None
 
 
-def _recover_provider_pool(provider: str, exc: Exception, *, failed_api_key: str = "") -> bool:
+def _recover_provider_pool(
+    provider: str,
+    exc: Exception,
+    *,
+    failed_api_key: str = "",
+    model_id: Optional[str] = None,
+) -> bool:
     """Try same-provider credential-pool recovery for auxiliary calls.
 
     ``failed_api_key`` is the API key that was actually used for the failing
     request.  Passing it lets mark_exhausted_and_rotate identify the correct
     pool entry even when another process has already rotated the pool (which
     would leave current() as None, causing the wrong entry to be marked).
+
+    ``model_id`` is the model that actually hit the limit.  Threading it into
+    mark_exhausted_and_rotate keeps the exhaustion block scoped to that model
+    so sibling models on the same credential (e.g. Spark vs gpt-5.5 on a shared
+    openai-codex account) stay usable instead of being swept into a
+    provider-wide block.
     """
     normalized = _normalize_aux_provider(provider)
     try:
@@ -3266,6 +3278,7 @@ def _recover_provider_pool(provider: str, exc: Exception, *, failed_api_key: str
             status_code=status_code if status_code is not None else 401,
             error_context=error_context,
             api_key_hint=hint,
+            model_id=model_id,
         )
         if next_entry is not None:
             _evict_cached_clients(normalized)
@@ -3278,6 +3291,7 @@ def _recover_provider_pool(provider: str, exc: Exception, *, failed_api_key: str
             status_code=status_code if status_code is not None else fallback_status,
             error_context=error_context,
             api_key_hint=hint,
+            model_id=model_id,
         )
         if next_entry is not None:
             _evict_cached_clients(normalized)
@@ -6524,7 +6538,7 @@ def call_llm(
                     if not (_is_auth_error(retry_err) or _is_payment_error(retry_err) or _is_rate_limit_error(retry_err)):
                         raise
                     recovery_err = retry_err
-            if _recover_provider_pool(pool_provider, recovery_err, failed_api_key=_client_api_key):
+            if _recover_provider_pool(pool_provider, recovery_err, failed_api_key=_client_api_key, model_id=final_model):
                 logger.info(
                     "Auxiliary %s: recovered %s via credential-pool rotation after %s",
                     task or "call", pool_provider, type(recovery_err).__name__,
@@ -6554,7 +6568,7 @@ def call_llm(
                     # alternative providers can still serve the request.
                     if (_is_payment_error(retry2_err) or _is_auth_error(retry2_err)
                             or _is_rate_limit_error(retry2_err)):
-                        _recover_provider_pool(pool_provider, retry2_err)
+                        _recover_provider_pool(pool_provider, retry2_err, model_id=final_model)
                         first_err = retry2_err
                     else:
                         raise
@@ -7047,7 +7061,7 @@ async def async_call_llm(
                     if not (_is_auth_error(retry_err) or _is_payment_error(retry_err) or _is_rate_limit_error(retry_err)):
                         raise
                     recovery_err = retry_err
-            if _recover_provider_pool(pool_provider, recovery_err, failed_api_key=_client_api_key):
+            if _recover_provider_pool(pool_provider, recovery_err, failed_api_key=_client_api_key, model_id=final_model):
                 logger.info(
                     "Auxiliary %s (async): recovered %s via credential-pool rotation after %s",
                     task or "call", pool_provider, type(recovery_err).__name__,
@@ -7071,7 +7085,7 @@ async def async_call_llm(
                 except Exception as retry2_err:
                     if (_is_payment_error(retry2_err) or _is_auth_error(retry2_err)
                             or _is_rate_limit_error(retry2_err)):
-                        _recover_provider_pool(pool_provider, retry2_err)
+                        _recover_provider_pool(pool_provider, retry2_err, model_id=final_model)
                         first_err = retry2_err
                     else:
                         raise

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -144,6 +144,14 @@ class PooledCredential:
     last_error_reason: Optional[str] = None
     last_error_message: Optional[str] = None
     last_error_reset_at: Optional[float] = None
+    # Model slug that triggered the current exhaustion, when the provider
+    # multiplexes several models over ONE credential (e.g. the ChatGPT-account
+    # Codex endpoint serving both gpt-5.5 and gpt-5.3-codex-spark, which have
+    # SEPARATE quota windows).  A 429 on one model must not hide the credential
+    # from a *different* model that still has quota.  ``None`` = provider-wide
+    # block (historical behavior; used when the caller does not scope by model,
+    # or when two distinct models are exhausted at once — see _mark_exhausted).
+    last_error_model: Optional[str] = None
     base_url: Optional[str] = None
     expires_at: Optional[str] = None
     expires_at_ms: Optional[int] = None
@@ -188,6 +196,7 @@ class PooledCredential:
             "last_error_reason",
             "last_error_message",
             "last_error_reset_at",
+            "last_error_model",
         }
         result: Dict[str, Any] = {}
         for field_def in fields(self):
@@ -335,8 +344,32 @@ def _normalize_error_context(error_context: Optional[Dict[str, Any]]) -> Dict[st
     return normalized
 
 
-def _exhausted_until(entry: PooledCredential) -> Optional[float]:
+def _model_slug_matches(a: Optional[str], b: Optional[str]) -> bool:
+    """Case/space-insensitive equality for model slugs."""
+    return (a or "").strip().lower() == (b or "").strip().lower()
+
+
+def _exhausted_until(
+    entry: PooledCredential, requested_model: Optional[str] = None,
+) -> Optional[float]:
+    """Return the epoch until which *entry* is in exhaustion cooldown.
+
+    When *requested_model* is supplied and the entry's exhaustion was scoped
+    to a DIFFERENT model (``last_error_model``), the cooldown does not apply —
+    the credential still has quota for the requested model.  This is the
+    single-credential / multi-model case (ChatGPT-account Codex: gpt-5.5 and
+    gpt-5.3-codex-spark share one OAuth token but have independent quota
+    windows).  ``last_error_model = None`` keeps the historical provider-wide
+    block so unscoped callers are unaffected.
+    """
     if entry.last_status != STATUS_EXHAUSTED:
+        return None
+    blocked_model = getattr(entry, "last_error_model", None)
+    if (
+        requested_model
+        and blocked_model
+        and not _model_slug_matches(blocked_model, requested_model)
+    ):
         return None
     reset_at = _parse_absolute_timestamp(getattr(entry, "last_error_reset_at", None))
     if reset_at is not None:
@@ -572,6 +605,7 @@ class CredentialPool:
         entry: PooledCredential,
         status_code: Optional[int],
         error_context: Optional[Dict[str, Any]] = None,
+        model_id: Optional[str] = None,
     ) -> PooledCredential:
         normalized_error = _normalize_error_context(error_context)
         # Permanent OAuth failures (token_invalidated, token_revoked, etc.)
@@ -585,6 +619,26 @@ class CredentialPool:
             terminal_status = STATUS_DEAD
         else:
             terminal_status = STATUS_EXHAUSTED
+        # Per-model exhaustion scoping (issue #47986).  Record which model hit
+        # the limit so a sibling model on the SAME credential (separate quota
+        # window) stays selectable — see _exhausted_until / _available_entries.
+        #   - model_id given, entry not already scoped to a different model
+        #       → scope the block to model_id.
+        #   - entry already exhausted for a DIFFERENT model
+        #       → widen to provider-wide (None): two models are now out and we
+        #         can only track one, so fall back to the safe historical
+        #         behavior rather than silently unblock the first one.
+        #   - model_id None (unscoped caller)
+        #       → provider-wide block, exactly as before.
+        blocked_model: Optional[str] = None
+        scoped_model = (model_id or "").strip() or None
+        if scoped_model:
+            prior = getattr(entry, "last_error_model", None)
+            prior_active = entry.last_status == STATUS_EXHAUSTED and prior is not None
+            if prior_active and not _model_slug_matches(prior, scoped_model):
+                blocked_model = None  # widen: distinct models both exhausted
+            else:
+                blocked_model = scoped_model
         updated = replace(
             entry,
             last_status=terminal_status,
@@ -593,6 +647,7 @@ class CredentialPool:
             last_error_reason=normalized_error.get("reason"),
             last_error_message=normalized_error.get("message"),
             last_error_reset_at=normalized_error.get("reset_at"),
+            last_error_model=blocked_model,
         )
         self._replace_entry(entry, updated)
         self._persist()
@@ -1362,16 +1417,27 @@ class CredentialPool:
             return False
         return False
 
-    def select(self) -> Optional[PooledCredential]:
+    def select(self, requested_model: Optional[str] = None) -> Optional[PooledCredential]:
         with self._lock:
-            return self._select_unlocked()
+            return self._select_unlocked(requested_model=requested_model)
 
-    def _available_entries(self, *, clear_expired: bool = False, refresh: bool = False) -> List[PooledCredential]:
+    def _available_entries(
+        self,
+        *,
+        clear_expired: bool = False,
+        refresh: bool = False,
+        requested_model: Optional[str] = None,
+    ) -> List[PooledCredential]:
         """Return entries not currently in exhaustion cooldown.
 
-        When *clear_expired* is True, entries whose cooldown has elapsed are
-        reset to STATUS_OK and persisted.  When *refresh* is True, entries
-        that need a token refresh are refreshed (skipped on failure).
+        When *clear_expired* is True, entries whose cooldown has genuinely
+        elapsed are reset to STATUS_OK and persisted.  When *refresh* is True,
+        entries that need a token refresh are refreshed (skipped on failure).
+
+        When *requested_model* is supplied, an entry exhausted for a DIFFERENT
+        model (``last_error_model``) is treated as available for the requested
+        model WITHOUT clearing its exhausted state — the block still applies to
+        the model that actually hit the limit (issue #47986).
         """
         now = time.time()
         cleared_any = False
@@ -1452,10 +1518,20 @@ class CredentialPool:
                 # the re-auth case for OAuth singletons.
                 continue
             if entry.last_status == STATUS_EXHAUSTED:
-                exhausted_until = _exhausted_until(entry)
-                if exhausted_until is not None and now < exhausted_until:
+                # Model-scoped view: is this entry blocked for the model we're
+                # actually trying to use right now?
+                scoped_until = _exhausted_until(entry, requested_model)
+                if scoped_until is not None and now < scoped_until:
                     continue
-                if clear_expired:
+                # Unscoped view: has the credential's cooldown GENUINELY
+                # elapsed (for every model)?  Only then may we reset it to OK.
+                # When scoped_until is None purely because the block belongs to
+                # a different model, the credential is still legitimately
+                # exhausted for that other model, so we surface it as available
+                # for the requested model but leave its exhausted state intact.
+                raw_until = _exhausted_until(entry)
+                cooldown_elapsed = raw_until is None or now >= raw_until
+                if clear_expired and cooldown_elapsed:
                     cleared = replace(
                         entry,
                         last_status=STATUS_OK,
@@ -1464,6 +1540,7 @@ class CredentialPool:
                         last_error_reason=None,
                         last_error_message=None,
                         last_error_reset_at=None,
+                        last_error_model=None,
                     )
                     self._replace_entry(entry, cleared)
                     entry = cleared
@@ -1481,8 +1558,10 @@ class CredentialPool:
             self._persist(removed_ids=entries_to_prune)
         return available
 
-    def _select_unlocked(self) -> Optional[PooledCredential]:
-        available = self._available_entries(clear_expired=True, refresh=True)
+    def _select_unlocked(self, requested_model: Optional[str] = None) -> Optional[PooledCredential]:
+        available = self._available_entries(
+            clear_expired=True, refresh=True, requested_model=requested_model,
+        )
         if not available:
             self._current_id = None
             logger.info("credential pool: no available entries (all exhausted or empty)")
@@ -1527,6 +1606,7 @@ class CredentialPool:
         status_code: Optional[int],
         error_context: Optional[Dict[str, Any]] = None,
         api_key_hint: Optional[str] = None,
+        model_id: Optional[str] = None,
     ) -> Optional[PooledCredential]:
         with self._lock:
             entry = None
@@ -1540,11 +1620,11 @@ class CredentialPool:
                     None,
                 )
             if entry is None:
-                entry = self.current() or self._select_unlocked()
+                entry = self.current() or self._select_unlocked(requested_model=model_id)
             if entry is None:
                 return None
             _label = entry.label or entry.id[:8]
-            self._mark_exhausted(entry, status_code, error_context)
+            self._mark_exhausted(entry, status_code, error_context, model_id=model_id)
             # Re-read the updated entry to log the correct terminal state.
             updated_entry = next(
                 (e for e in self._entries if e.id == entry.id), entry,

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -551,9 +551,15 @@ class CredentialPool:
     def has_credentials(self) -> bool:
         return bool(self._entries)
 
-    def has_available(self) -> bool:
-        """True if at least one entry is not currently in exhaustion cooldown."""
-        return bool(self._available_entries())
+    def has_available(self, *, requested_model: Optional[str] = None) -> bool:
+        """True if at least one entry is not currently in exhaustion cooldown.
+
+        When *requested_model* is provided, an entry whose exhaustion is scoped
+        to a different model is treated as available — mirroring ``select`` so a
+        gpt-5.5-scoped block on a shared credential doesn't hide a sibling model
+        (e.g. Spark) from callers that gate a scoped ``select`` on this check.
+        """
+        return bool(self._available_entries(requested_model=requested_model))
 
     def entries(self) -> List[PooledCredential]:
         return list(self._entries)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -642,7 +642,7 @@ class TestAnthropicOAuthFlag:
             def has_credentials(self):
                 return True
 
-            def select(self):
+            def select(self, requested_model=None):
                 return _Entry()
 
         with (
@@ -706,7 +706,7 @@ class TestBuildCodexClient:
             def peek(self):
                 return self.entry
 
-            def select(self):
+            def select(self, requested_model=None):
                 return self.entry
 
         pool = _Pool()
@@ -1142,7 +1142,7 @@ class TestGetTextAuxiliaryClient:
             def has_credentials(self):
                 return True
 
-            def select(self):
+            def select(self, requested_model=None):
                 return _Entry()
 
         with (
@@ -1309,7 +1309,7 @@ class TestAuxiliaryPoolAwareness:
             def has_credentials(self):
                 return True
 
-            def select(self):
+            def select(self, requested_model=None):
                 return _Entry()
 
         with (
@@ -1350,7 +1350,7 @@ class TestAuxiliaryPoolAwareness:
             def has_credentials(self):
                 return True
 
-            def select(self):
+            def select(self, requested_model=None):
                 return _Entry(stale_token)
 
             def try_refresh_current(self):
@@ -1390,7 +1390,7 @@ class TestAuxiliaryPoolAwareness:
             def has_credentials(self):
                 return True
 
-            def select(self):
+            def select(self, requested_model=None):
                 return _Entry()
 
             def try_refresh_current(self):

--- a/tests/agent/test_codex_cloudflare_headers.py
+++ b/tests/agent/test_codex_cloudflare_headers.py
@@ -217,11 +217,11 @@ class TestAuxiliaryClientWiring:
         # _read_codex_access_token.
         monkeypatch.setattr(
             auxiliary_client, "_select_pool_entry",
-            lambda provider: (False, None),
+            lambda provider, requested_model=None: (False, None),
         )
         monkeypatch.setattr(
             auxiliary_client, "_read_codex_access_token",
-            lambda: token,
+            lambda *a, **k: token,
         )
         with patch("agent.auxiliary_client.OpenAI") as mock_openai:
             mock_openai.return_value = MagicMock()
@@ -239,7 +239,7 @@ class TestAuxiliaryClientWiring:
         token = _make_codex_jwt("acct-aux-raw-codex")
         monkeypatch.setattr(
             auxiliary_client, "_read_codex_access_token",
-            lambda: token,
+            lambda *a, **k: token,
         )
         with patch("agent.auxiliary_client.OpenAI") as mock_openai:
             mock_openai.return_value = MagicMock()

--- a/tests/agent/test_codex_raw_failover_model_scope.py
+++ b/tests/agent/test_codex_raw_failover_model_scope.py
@@ -1,0 +1,82 @@
+"""Regression for the raw-Codex failover path skipping a sibling model.
+
+Issue #47986 scoped credential exhaustion per model (``last_error_model``), so a
+shared ChatGPT-account OAuth credential that hit ``gpt-5.5``'s usage limit should
+still serve ``gpt-5.3-codex-spark`` (independent quota window).
+
+The pool/adapter paths were fixed, but the *raw* Codex path used by the main
+agent loop (``resolve_provider_client(..., raw_codex=True)`` ->
+``_read_codex_access_token()``) still selected the pool entry WITHOUT passing the
+requested model.  So during failover the whole ``openai-codex`` provider was
+skipped and the chain fell through to the next provider (e.g. Grok), even though
+Spark was usable.  These tests pin the raw path to the per-model scoping.
+"""
+import json
+
+import agent.auxiliary_client as ac
+
+
+def _write_scoped_exhausted_pool(hermes_home, blocked_model="gpt-5.5"):
+    """auth.json with a single openai-codex pool entry exhausted for one model."""
+    import time as _time
+
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    auth_store = {
+        "version": 1,
+        "providers": {},  # no singleton — force the pool path
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "source": "device_code",
+                    "access_token": "shared-oauth-token",
+                    "auth_type": "oauth",
+                    "last_status": "exhausted",
+                    "last_error_code": 429,
+                    "last_error_reason": "usage_limit_reached",
+                    "last_error_model": blocked_model,
+                    "last_error_reset_at": _time.time() + 3600,  # 1h cooldown
+                },
+            ],
+        },
+    }
+    (hermes_home / "auth.json").write_text(json.dumps(auth_store))
+
+
+def test_raw_codex_failover_serves_sibling_when_scoped_exhausted(tmp_path, monkeypatch):
+    """Spark is reachable via the raw path when the block is scoped to gpt-5.5."""
+    hermes_home = tmp_path / "hermes"
+    _write_scoped_exhausted_pool(hermes_home, blocked_model="gpt-5.5")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    client, resolved = ac.resolve_provider_client(
+        "openai-codex", model="gpt-5.3-codex-spark", raw_codex=True,
+    )
+
+    assert client is not None, "Spark should be usable while only gpt-5.5 is exhausted"
+    assert resolved and "spark" in resolved.lower()
+
+
+def test_raw_codex_failover_still_blocks_the_exhausted_model(tmp_path, monkeypatch):
+    """The requested model that actually hit its limit stays blocked."""
+    hermes_home = tmp_path / "hermes"
+    _write_scoped_exhausted_pool(hermes_home, blocked_model="gpt-5.5")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    client, resolved = ac.resolve_provider_client(
+        "openai-codex", model="gpt-5.5", raw_codex=True,
+    )
+
+    assert client is None, "gpt-5.5 must remain blocked while exhausted"
+    assert resolved is None
+
+
+def test_read_codex_access_token_threads_requested_model(tmp_path, monkeypatch):
+    """Direct unit check: the token reader honors the requested model."""
+    hermes_home = tmp_path / "hermes"
+    _write_scoped_exhausted_pool(hermes_home, blocked_model="gpt-5.5")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    # Sibling model → token surfaces from the scoped-exhausted credential.
+    assert ac._read_codex_access_token("gpt-5.3-codex-spark") == "shared-oauth-token"
+    # The exhausted model → no token (pool blocked, no singleton fallback).
+    assert ac._read_codex_access_token("gpt-5.5") is None

--- a/tests/agent/test_credential_pool_per_model_exhaustion.py
+++ b/tests/agent/test_credential_pool_per_model_exhaustion.py
@@ -1,0 +1,170 @@
+"""Per-model exhaustion scoping for shared OAuth credentials (issue #47986).
+
+The ChatGPT-account Codex endpoint serves multiple models (``gpt-5.5`` and
+``gpt-5.3-codex-spark``) from a SINGLE OAuth credential, but each model has its
+own independent usage-limit window.  Previously, when ``gpt-5.5`` hit its
+usage limit Hermes marked the whole pool credential ``exhausted``, which also
+locked out Spark even though Spark still had quota.  These tests lock in the
+scoped behavior: a block recorded for one model must not hide the credential
+from a sibling model, while unscoped callers keep the historical
+provider-wide block.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+
+def _write_auth_store(tmp_path, payload: dict) -> None:
+    home = tmp_path / "hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "auth.json").write_text(json.dumps(payload))
+
+
+def _single_codex_entry(**overrides) -> dict:
+    entry = {
+        "id": "codex-1",
+        "label": "chatgpt",
+        "auth_type": "oauth",
+        "priority": 0,
+        "source": "manual",
+        "access_token": "codex-oauth-token",
+    }
+    entry.update(overrides)
+    return {
+        "version": 1,
+        "credential_pool": {"openai-codex": [entry]},
+    }
+
+
+def test_sibling_model_selectable_when_other_model_exhausted(tmp_path, monkeypatch):
+    """gpt-5.5 usage-limit block must NOT hide the credential from Spark."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        _single_codex_entry(
+            last_status="exhausted",
+            last_status_at=time.time(),
+            last_error_code=429,
+            last_error_reason="usage_limit_reached",
+            last_error_model="gpt-5.5",
+        ),
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+
+    # Same model that hit the limit → still blocked.
+    assert pool.select(requested_model="gpt-5.5") is None
+    # Sibling model on the same credential → available.
+    spark = pool.select(requested_model="gpt-5.3-codex-spark")
+    assert spark is not None
+    assert spark.id == "codex-1"
+
+
+def test_unscoped_select_preserves_provider_wide_block(tmp_path, monkeypatch):
+    """A caller that supplies no model must see the historical (safe) block."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        _single_codex_entry(
+            last_status="exhausted",
+            last_status_at=time.time(),
+            last_error_code=429,
+            last_error_reason="usage_limit_reached",
+            last_error_model="gpt-5.5",
+        ),
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    assert pool.select() is None
+
+
+def test_scoped_block_does_not_clear_exhausted_flag(tmp_path, monkeypatch):
+    """Serving Spark must not wipe the genuine gpt-5.5 cooldown on the entry."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    reset_at = time.time() + 3600
+    _write_auth_store(
+        tmp_path,
+        _single_codex_entry(
+            last_status="exhausted",
+            last_status_at=time.time(),
+            last_error_code=429,
+            last_error_reason="usage_limit_reached",
+            last_error_reset_at=reset_at,
+            last_error_model="gpt-5.5",
+        ),
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    spark = pool.select(requested_model="gpt-5.3-codex-spark")
+    assert spark is not None
+    # The gpt-5.5 exhaustion is untouched — it is still blocked.
+    assert pool.select(requested_model="gpt-5.5") is None
+
+
+def test_mark_exhausted_and_rotate_records_model(tmp_path, monkeypatch):
+    """The write path must persist which model actually hit the limit."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, _single_codex_entry())
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    pool.mark_exhausted_and_rotate(
+        status_code=429,
+        error_context={"reason": "usage_limit_reached"},
+        model_id="gpt-5.5",
+    )
+
+    persisted = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entry = persisted["credential_pool"]["openai-codex"][0]
+    assert entry["last_status"] == "exhausted"
+    assert entry["last_error_model"] == "gpt-5.5"
+
+    # Reload and confirm the scoping survives a round-trip.
+    pool2 = load_pool("openai-codex")
+    assert pool2.select(requested_model="gpt-5.3-codex-spark") is not None
+    assert pool2.select(requested_model="gpt-5.5") is None
+
+
+def test_two_distinct_models_exhausted_widens_to_provider_wide(tmp_path, monkeypatch):
+    """When a SECOND, different model is also exhausted we can only track one,
+    so the block must conservatively widen back to provider-wide."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, _single_codex_entry())
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    pool.mark_exhausted_and_rotate(
+        status_code=429,
+        error_context={"reason": "usage_limit_reached"},
+        model_id="gpt-5.5",
+    )
+    # Spark still works at this point.
+    assert pool.select(requested_model="gpt-5.3-codex-spark") is not None
+
+    # Now Spark ALSO hits its limit on the same credential.
+    pool.mark_exhausted_and_rotate(
+        status_code=429,
+        error_context={"reason": "usage_limit_reached"},
+        model_id="gpt-5.3-codex-spark",
+    )
+
+    persisted = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entry = persisted["credential_pool"]["openai-codex"][0]
+    # Widened: no single model can be recorded, so fall back to provider-wide.
+    assert entry.get("last_error_model") in (None, "")
+
+    pool2 = load_pool("openai-codex")
+    assert pool2.select(requested_model="gpt-5.5") is None
+    assert pool2.select(requested_model="gpt-5.3-codex-spark") is None

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -146,6 +146,7 @@ class TestPoolRotationCycle:
 
         with patch.object(AIAgent, "__init__", lambda self, **kw: None):
             agent = AIAgent()
+        agent.model = "gpt-5.5"
 
         entries = []
         for i in range(pool_entries):
@@ -159,7 +160,7 @@ class TestPoolRotationCycle:
         # mark_exhausted_and_rotate returns next entry until exhausted
         self._rotation_index = 0
 
-        def rotate(status_code=None, error_context=None):
+        def rotate(status_code=None, error_context=None, model_id=None):
             self._rotation_index += 1
             if self._rotation_index < pool_entries:
                 return entries[self._rotation_index]
@@ -191,7 +192,7 @@ class TestPoolRotationCycle:
         )
         assert recovered is True
         assert has_retried is False  # reset after rotation
-        pool.mark_exhausted_and_rotate.assert_called_once_with(status_code=429, error_context=None)
+        pool.mark_exhausted_and_rotate.assert_called_once_with(status_code=429, error_context=None, model_id="gpt-5.5")
         agent._swap_credential.assert_called_once_with(entries[1])
 
     def test_pool_exhaustion_returns_false(self):
@@ -217,7 +218,7 @@ class TestPoolRotationCycle:
         )
         assert recovered is True
         assert has_retried is False
-        pool.mark_exhausted_and_rotate.assert_called_once_with(status_code=402, error_context=None)
+        pool.mark_exhausted_and_rotate.assert_called_once_with(status_code=402, error_context=None, model_id="gpt-5.5")
 
     def test_no_pool_returns_false(self):
         """No pool should return (False, unchanged)."""

--- a/tests/agent/test_recover_provider_pool_model_scope.py
+++ b/tests/agent/test_recover_provider_pool_model_scope.py
@@ -1,0 +1,72 @@
+# Copyright 2025 Nous Research (Licensed under the Apache License, Version 2.0)
+"""Regression tests for model-scoped exhaustion in _recover_provider_pool.
+
+Bug: auxiliary-task recovery (compression, summarization, vision, etc.) called
+pool.mark_exhausted_and_rotate() WITHOUT a model_id. On a shared openai-codex
+credential, a gpt-5.5 rate-limit therefore wrote a provider-wide block, which
+silently swept sibling models (e.g. Spark) into the same cooldown — undoing the
+per-model scoping the rest of the fix adds.
+
+These tests assert the model that hit the limit is threaded through so the
+block stays scoped to it.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from agent.auxiliary_client import _recover_provider_pool
+
+
+def _rate_limit_exc():
+    exc = Exception("Error code: 429 - usage_limit_reached")
+    exc.status_code = 429
+    return exc
+
+
+def _auth_exc():
+    exc = Exception("Error code: 401 - Unauthorized")
+    exc.status_code = 401
+    return exc
+
+
+def _mock_pool():
+    pool = MagicMock()
+    pool.has_credentials.return_value = True
+    pool.try_refresh_current.return_value = None
+    pool.mark_exhausted_and_rotate.return_value = MagicMock()  # truthy next entry
+    return pool
+
+
+def test_rate_limit_recovery_threads_model_id():
+    """A 429 on gpt-5.5 must be recorded scoped to gpt-5.5, not provider-wide."""
+    pool = _mock_pool()
+    with patch("agent.auxiliary_client.load_pool", return_value=pool), \
+            patch("agent.auxiliary_client._evict_cached_clients"):
+        ok = _recover_provider_pool(
+            "openai-codex", _rate_limit_exc(), model_id="gpt-5.5"
+        )
+    assert ok is True
+    pool.mark_exhausted_and_rotate.assert_called_once()
+    assert pool.mark_exhausted_and_rotate.call_args.kwargs["model_id"] == "gpt-5.5"
+
+
+def test_auth_recovery_threads_model_id():
+    """The auth-error rotation path must also carry the model_id."""
+    pool = _mock_pool()
+    with patch("agent.auxiliary_client.load_pool", return_value=pool), \
+            patch("agent.auxiliary_client._evict_cached_clients"):
+        ok = _recover_provider_pool(
+            "openai-codex", _auth_exc(), model_id="gpt-5.5"
+        )
+    assert ok is True
+    pool.mark_exhausted_and_rotate.assert_called_once()
+    assert pool.mark_exhausted_and_rotate.call_args.kwargs["model_id"] == "gpt-5.5"
+
+
+def test_recovery_without_model_id_defaults_to_none():
+    """Back-compat: omitting model_id still works (provider-wide block)."""
+    pool = _mock_pool()
+    with patch("agent.auxiliary_client.load_pool", return_value=pool), \
+            patch("agent.auxiliary_client._evict_cached_clients"):
+        ok = _recover_provider_pool("openai-codex", _rate_limit_exc())
+    assert ok is True
+    assert pool.mark_exhausted_and_rotate.call_args.kwargs["model_id"] is None

--- a/tests/agent/test_restore_primary_pool_reselect.py
+++ b/tests/agent/test_restore_primary_pool_reselect.py
@@ -204,6 +204,65 @@ class TestRestorePrimaryPoolReselect:
         # Entry has no key, so use snapshot
         assert agent.api_key == "original-key-entry-1"
 
+    def test_restore_gate_allows_sibling_of_model_scoped_block(self):
+        """A block scoped to gpt-5.5 must not hide a sibling model at the gate.
+
+        Regression: the restore gate called has_available() with no model, so a
+        gpt-5.5-scoped exhaustion made it return False and the scoped select()
+        for the sibling (Spark) never ran — falling back to the stale snapshot.
+        """
+        entries = [
+            {
+                **_make_entry("entry-1", "spark-usable-key", priority=0,
+                              last_status="exhausted",
+                              last_status_at=time.time() + 3600),
+                "last_error_model": "gpt-5.5",
+            },
+        ]
+        pool = _build_mock_pool(entries)
+
+        agent = self._make_agent(pool)
+        # The primary runtime being restored is the sibling model (Spark), not
+        # the model that hit the gpt-5.5-scoped limit. restore_primary_runtime
+        # writes agent.model back from the snapshot, so the snapshot's model is
+        # what the gate must scope to.
+        agent.model = "gpt-5.3-codex-spark"
+        agent._primary_runtime["model"] = "gpt-5.3-codex-spark"
+        # Neutralize the auth-store resync so the test doesn't read the host's
+        # real ~/.hermes codex tokens over the synthetic entry.
+        from agent.credential_pool import CredentialPool
+        with patch.object(
+            CredentialPool, "_sync_codex_entry_from_auth_store",
+            lambda self, entry: entry,
+        ):
+            result = agent._restore_primary_runtime()
+
+        assert result is True
+        # Block is scoped to gpt-5.5, so Spark should re-select the entry rather
+        # than fall through to the stale snapshot key.
+        assert agent.api_key == "spark-usable-key"
+        assert agent._client_kwargs["api_key"] == "spark-usable-key"
+
+    def test_restore_gate_still_blocks_the_exhausted_model(self):
+        """A model-scoped block must still hide the entry for that same model."""
+        entries = [
+            {
+                **_make_entry("entry-1", "key-1", priority=0,
+                              last_status="exhausted",
+                              last_status_at=time.time() + 3600),
+                "last_error_model": "gpt-5.5",
+            },
+        ]
+        pool = _build_mock_pool(entries)
+
+        agent = self._make_agent(pool)
+        agent.model = "gpt-5.5"  # same model that hit the limit
+        result = agent._restore_primary_runtime()
+
+        assert result is True
+        # Same model is genuinely blocked → keep the snapshot key.
+        assert agent.api_key == "original-key-entry-1"
+
     def test_restore_updates_base_url_from_pool_entry(self):
         """If pool entry has a different base_url, restore should update it."""
         entries = [

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -215,7 +215,7 @@ class TestRestorePrimaryRuntime:
         class _Pool:
             provider = "openrouter"
 
-            def has_available(self):
+            def has_available(self, requested_model=None):
                 return True
 
             def select(self, requested_model=None):
@@ -263,7 +263,7 @@ class TestRestorePrimaryRuntime:
         class _DeepseekPool:
             provider = "deepseek"
 
-            def has_available(self):
+            def has_available(self, requested_model=None):
                 return True
 
             def select(self, requested_model=None):
@@ -310,7 +310,7 @@ class TestRestorePrimaryRuntime:
         class _Pool:
             provider = "custom:myllm"
 
-            def has_available(self):
+            def has_available(self, requested_model=None):
                 return True
 
             def select(self, requested_model=None):
@@ -349,7 +349,7 @@ class TestRestorePrimaryRuntime:
         class _Pool:
             provider = "custom:otherllm"
 
-            def has_available(self):
+            def has_available(self, requested_model=None):
                 return True
 
             def select(self, requested_model=None):

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -218,7 +218,7 @@ class TestRestorePrimaryRuntime:
             def has_available(self):
                 return True
 
-            def select(self):
+            def select(self, requested_model=None):
                 return _Entry()
 
         agent = _make_agent(
@@ -266,7 +266,7 @@ class TestRestorePrimaryRuntime:
             def has_available(self):
                 return True
 
-            def select(self):
+            def select(self, requested_model=None):
                 return _DeepseekEntry()
 
         agent = _make_agent(
@@ -313,7 +313,7 @@ class TestRestorePrimaryRuntime:
             def has_available(self):
                 return True
 
-            def select(self):
+            def select(self, requested_model=None):
                 return _Entry()
 
         agent = _make_agent(provider="custom", base_url="https://my-llm.example.com/v1")
@@ -352,7 +352,7 @@ class TestRestorePrimaryRuntime:
             def has_available(self):
                 return True
 
-            def select(self):
+            def select(self, requested_model=None):
                 return _Entry()
 
         agent = _make_agent(provider="custom", base_url="https://my-llm.example.com/v1")


### PR DESCRIPTION
## Summary

Fixes #47986. The ChatGPT-account Codex endpoint serves multiple models — `gpt-5.5` and `gpt-5.3-codex-spark` — from a **single** OAuth credential, but each model has an **independent** usage-limit window. Today, when `gpt-5.5` hits its usage limit, Hermes marks the entire pooled credential `exhausted`, which also locks out Spark even though Spark still has quota. For a single-account user this silently removes a working fallback model for the full cooldown (~2 days), collapsing the fallback chain.

This PR scopes the exhaustion block to the model that actually hit the limit.

## What changed

- **`PooledCredential.last_error_model`** — new field recording which model triggered the block; serialized and round-tripped through `auth.json`.
- **Record path** — `_mark_exhausted` / `mark_exhausted_and_rotate` accept `model_id`. If a *different* model is already blocked on the same entry, the block conservatively **widens back to provider-wide** (only one model can be tracked), rather than silently unblocking the first.
- **Honor path** — `_exhausted_until` / `_available_entries` / `select` accept an optional `requested_model`. An entry blocked for a *different* model is surfaced as available for the requested model **without clearing** the genuine cooldown. Callers that pass no model keep the exact historical provider-wide behavior.
- **Seams wired** — the mark sites in `agent_runtime_helpers.py` pass `agent.model`; `_select_pool_entry` / `_build_codex_client` thread the requested model so the fallback-to-Spark client build no longer sees the shared credential as blocked.

## Why the fix spans record *and* honor

Recording the offending model isn't enough on its own: the fallback-to-Spark path rebuilds its client through `_build_codex_client → _select_pool_entry → pool.select()`, which rejected the shared credential purely on the exhausted flag. The block therefore has to be respected at selection time, keyed by the requested model — not just recorded.

## Test plan

- [x] New `tests/agent/test_credential_pool_per_model_exhaustion.py` (5 cases): sibling model selectable while the other is blocked; unscoped `select()` preserves the provider-wide block; serving the sibling does not clear the genuine cooldown; write path records the model and survives a disk round-trip; two distinct models exhausted widens back to provider-wide.
- [x] Full existing pool suites pass: `test_credential_pool.py`, `test_credential_pool_routing.py`, `test_credential_pool_oauth_writethrough.py`, `test_restore_primary_pool_reselect.py` (113 passed).
- [x] `test_auxiliary_client.py` back to baseline — zero regressions (the 9 pre-existing `test_async_*` failures are a local missing-`pytest-asyncio` env issue, identical on `main`).
- [x] Existing test doubles updated to the new `select(requested_model=...)` / `mark_exhausted_and_rotate(model_id=...)` signatures.

## Empirical verification

On a live single-account Codex pool: one request each on the same OAuth token returned **`gpt-5.3-codex-spark` → 200 OK** while **`gpt-5.5` → 429 `usage_limit_reached`** — confirming the models have genuinely separate quota and that the block was the only thing hiding Spark.

Closes #47986
