### PR TITLE
fix(website-policy): key blocklist cache on real default config path (salvage #3923)

### DIFF
--- a/tools/website_policy.py
+++ b/tools/website_policy.py
@@ -137,7 +137,8 @@ def load_website_blocklist(config_path: Optional[Path] = None) -> Dict[str, Any]
     """
     global _cached_policy, _cached_policy_path, _cached_policy_time
 
-    resolved_path = str(config_path) if config_path else "__default__"
+    default_path = str(_get_default_config_path())
+    resolved_path = str(config_path) if config_path else default_path
     now = time.monotonic()
 
     # Return cached policy if still fresh and same path
@@ -193,7 +194,7 @@ def load_website_blocklist(config_path: Optional[Path] = None) -> Dict[str, Any]
     if config_path == _get_default_config_path():
         with _cache_lock:
             _cached_policy = result
-            _cached_policy_path = "__default__"
+            _cached_policy_path = resolved_path
             _cached_policy_time = now
 
     return result


### PR DESCRIPTION
## Summary
The website blocklist cache no longer serves a stale policy after `HERMES_HOME` / default-config-path changes within one process (profile switches, tests): the cache is now keyed on the real resolved default config path instead of a `"__default__"` sentinel.

Trimmed salvage of bundled PR #3923 by @aydnOktay — this was the one sub-fix still valid; commit carries the contributor's authorship.

## Changes
- `tools/website_policy.py` `load_website_blocklist()`: cache key = `str(_get_default_config_path())`; a home/config-path change now naturally misses the cache (+3/−2).

## Validation
| | Before (main) | After |
|---|---|---|
| Load policy under home1, switch HERMES_HOME to home2, load again | serves home1's rules (stale, reproduced live) | serves home2's rules |
| `tests/tools/test_website_policy.py` | — | pass |

## Not salvaged from #3923 (superseded/wrong direction)
- Matrix voice caching → main's plugin adapter already caches audio/voice incl. encrypted media (strictly better)
- Slack `auth_test` sync/coroutine shim → written to appease test mocks; #3928 covers the real connect() issues
- Codex empty-model default → main deliberately fails loud in `_preflight_codex_api_kwargs`
- supply-chain `gh pr comment || true` → main already uses `|| echo ::warning`

## Infographic

![pr-3923-salvage](https://v3b.fal.media/files/b/0aa0f3b5/mK2oOEH9hCNkVI6AuqBf8_c6JOi2o3.png)
