### PR TITLE
feat(memory): add installable provider catalog

### DIFF
--- a/hermes_cli/memory_provider_catalog.py
+++ b/hermes_cli/memory_provider_catalog.py
@@ -1,0 +1,21 @@
+"""Catalog of installable standalone memory-provider plugins.
+
+The catalog lets `hermes memory setup` offer providers that are distributed
+outside the core repository. Entries point at standalone plugin repos; the
+provider implementation still lives with its maintainer and is installed through
+the normal `hermes plugins install` path.
+"""
+
+from __future__ import annotations
+
+INSTALLABLE_MEMORY_PROVIDERS = [
+    {
+        "name": "openbrain",
+        "label": "openbrain",
+        "setup_hint": "install standalone plugin",
+        "identifier": "longman391/hermes-openbrain-memory-provider",
+        "description": "OpenBrain (OB1) over MCP Streamable HTTP",
+        "project_url": "https://github.com/NateBJones-Projects/OB1",
+        "plugin_url": "https://github.com/longman391/hermes-openbrain-memory-provider",
+    },
+]

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -237,6 +237,28 @@ def _get_available_providers() -> list:
         results.append((name, setup_hint, provider))
     return results
 
+def _get_installable_providers(installed: list) -> list[dict]:
+    """Return catalogued standalone providers that are not installed yet."""
+    from hermes_cli.memory_provider_catalog import INSTALLABLE_MEMORY_PROVIDERS
+
+    installed_names = {name for name, _desc, _provider in installed}
+    return [p for p in INSTALLABLE_MEMORY_PROVIDERS if p["name"] not in installed_names]
+
+
+def _install_standalone_provider(entry: dict) -> str | None:
+    """Install a catalogued standalone memory provider and return its plugin name."""
+    from hermes_cli.plugins_cmd import PluginOperationError, _install_plugin_core
+
+    identifier = entry["identifier"]
+    print(f"\n  Installing {entry['label']} from {identifier}...")
+    try:
+        _target, _manifest, installed_name = _install_plugin_core(identifier, force=False)
+    except PluginOperationError as exc:
+        print(f"  Install failed: {exc}\n")
+        return None
+    print(f"  Installed {installed_name}.\n")
+    return installed_name
+
 
 # ---------------------------------------------------------------------------
 # Setup wizard
@@ -254,9 +276,23 @@ def cmd_setup_provider(provider_name: str) -> None:
             break
 
     if not match:
-        print(f"\n  Memory provider '{provider_name}' not found.")
-        print("  Run 'hermes memory setup' to see available providers.\n")
-        return
+        installable = next(
+            (p for p in _get_installable_providers(providers) if p["name"] == provider_name),
+            None,
+        )
+        if installable:
+            installed_name = _install_standalone_provider(installable)
+            if not installed_name:
+                return
+            providers = _get_available_providers()
+            for name, desc, provider in providers:
+                if name == installed_name:
+                    match = (name, desc, provider)
+                    break
+        if not match:
+            print(f"\n  Memory provider '{provider_name}' not found.")
+            print("  Run 'hermes memory setup' to see available providers.\n")
+            return
 
     name, _, provider = match
 
@@ -285,16 +321,19 @@ def cmd_setup(args) -> None:
     from hermes_cli.config import load_config, save_config
 
     providers = _get_available_providers()
+    installable = _get_installable_providers(providers)
 
-    if not providers:
+    if not providers and not installable:
         print("\n  No memory provider plugins detected.")
-        print("  Install a plugin to ~/.hermes/plugins/ and try again.\n")
+        print("  Install a plugin to $HERMES_HOME/plugins/ and try again.\n")
         return
 
     # Build picker items
     items = []
     for name, desc, _ in providers:
         items.append((name, f"— {desc}"))
+    for entry in installable:
+        items.append((entry["label"], f"— {entry['setup_hint']}: {entry['description']}"))
     items.append(("Built-in only", "— MEMORY.md / USER.md (default)"))
 
     builtin_idx = len(items) - 1
@@ -308,14 +347,30 @@ def cmd_setup(args) -> None:
         config["memory"] = {}
 
     # Built-in only
-    if selected >= len(providers):
+    if selected >= len(providers) + len(installable):
         config["memory"]["provider"] = ""
         save_config(config)
         print("\n  ✓ Memory provider: built-in only")
         print("  Saved to config.yaml\n")
         return
 
-    name, _, provider = providers[selected]
+    if selected >= len(providers):
+        entry = installable[selected - len(providers)]
+        _clear_interactive_transition()
+        installed_name = _install_standalone_provider(entry)
+        if not installed_name:
+            return
+        providers = _get_available_providers()
+        provider_match = next(
+            ((name, desc, provider) for name, desc, provider in providers if name == installed_name),
+            None,
+        )
+        if not provider_match:
+            print(f"  Installed {installed_name}, but Hermes could not load it as a memory provider.\n")
+            return
+        name, _, provider = provider_match
+    else:
+        name, _, provider = providers[selected]
 
     _clear_interactive_transition()
 
@@ -554,7 +609,7 @@ def cmd_status(args) -> None:
                 )
         else:
             print("\n  Plugin:    NOT installed ✗")
-            print(f"  Install the '{provider_name}' memory plugin to ~/.hermes/plugins/")
+            print(f"  Install the '{provider_name}' memory plugin to $HERMES_HOME/plugins/")
 
     if providers:
         print("\n  Installed plugins:")

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -237,6 +237,28 @@ def _get_available_providers() -> list:
         results.append((name, setup_hint, provider))
     return results
 
+def _get_installable_providers(installed: list) -> list[dict]:
+    """Return catalogued standalone providers that are not installed yet."""
+    from hermes_cli.memory_provider_catalog import INSTALLABLE_MEMORY_PROVIDERS
+
+    installed_names = {name for name, _desc, _provider in installed}
+    return [p for p in INSTALLABLE_MEMORY_PROVIDERS if p["name"] not in installed_names]
+
+
+def _install_standalone_provider(entry: dict) -> str | None:
+    """Install a catalogued standalone memory provider and return its plugin name."""
+    from hermes_cli.plugins_cmd import PluginOperationError, _install_plugin_core
+
+    identifier = entry["identifier"]
+    print(f"\n  Installing {entry['label']} from {identifier}...")
+    try:
+        _target, _manifest, installed_name = _install_plugin_core(identifier, force=False)
+    except PluginOperationError as exc:
+        print(f"  Install failed: {exc}\n")
+        return None
+    print(f"  Installed {installed_name}.\n")
+    return installed_name
+
 
 # ---------------------------------------------------------------------------
 # Setup wizard
@@ -254,9 +276,23 @@ def cmd_setup_provider(provider_name: str) -> None:
             break
 
     if not match:
-        print(f"\n  Memory provider '{provider_name}' not found.")
-        print("  Run 'hermes memory setup' to see available providers.\n")
-        return
+        installable = next(
+            (p for p in _get_installable_providers(providers) if p["name"] == provider_name),
+            None,
+        )
+        if installable:
+            installed_name = _install_standalone_provider(installable)
+            if not installed_name:
+                return
+            providers = _get_available_providers()
+            for name, desc, provider in providers:
+                if name == installed_name:
+                    match = (name, desc, provider)
+                    break
+        if not match:
+            print(f"\n  Memory provider '{provider_name}' not found.")
+            print("  Run 'hermes memory setup' to see available providers.\n")
+            return
 
     name, _, provider = match
 
@@ -285,16 +321,19 @@ def cmd_setup(args) -> None:
     from hermes_cli.config import load_config, save_config
 
     providers = _get_available_providers()
+    installable = _get_installable_providers(providers)
 
-    if not providers:
+    if not providers and not installable:
         print("\n  No memory provider plugins detected.")
-        print("  Install a plugin to ~/.hermes/plugins/ and try again.\n")
+        print("  Install a plugin to $HERMES_HOME/plugins/ and try again.\n")
         return
 
     # Build picker items
     items = []
     for name, desc, _ in providers:
         items.append((name, f"— {desc}"))
+    for entry in installable:
+        items.append((entry["label"], f"— {entry['setup_hint']}: {entry['description']}"))
     items.append(("Built-in only", "— MEMORY.md / USER.md (default)"))
 
     builtin_idx = len(items) - 1
@@ -308,14 +347,30 @@ def cmd_setup(args) -> None:
         config["memory"] = {}
 
     # Built-in only
-    if selected >= len(providers):
+    if selected >= len(providers) + len(installable):
         config["memory"]["provider"] = ""
         save_config(config)
         print("\n  ✓ Memory provider: built-in only")
         print("  Saved to config.yaml\n")
         return
 
-    name, _, provider = providers[selected]
+    if selected >= len(providers):
+        entry = installable[selected - len(providers)]
+        _clear_interactive_transition()
+        installed_name = _install_standalone_provider(entry)
+        if not installed_name:
+            return
+        providers = _get_available_providers()
+        provider_match = next(
+            ((name, desc, provider) for name, desc, provider in providers if name == installed_name),
+            None,
+        )
+        if not provider_match:
+            print(f"  Installed {installed_name}, but Hermes could not load it as a memory provider.\n")
+            return
+        name, _, provider = provider_match
+    else:
+        name, _, provider = providers[selected]
 
     _clear_interactive_transition()
 
@@ -548,7 +603,7 @@ def cmd_status(args) -> None:
                         print(line)
         else:
             print("\n  Plugin:    NOT installed ✗")
-            print(f"  Install the '{provider_name}' memory plugin to ~/.hermes/plugins/")
+            print(f"  Install the '{provider_name}' memory plugin to $HERMES_HOME/plugins/")
 
     if providers:
         print("\n  Installed plugins:")

--- a/tests/hermes_cli/test_memory_setup.py
+++ b/tests/hermes_cli/test_memory_setup.py
@@ -1,5 +1,11 @@
+import os
+import shutil
+import subprocess
+import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock
+
+import pytest
 
 import hermes_cli.memory_setup as memory_setup
 from hermes_cli.memory_setup import _CANCELLED, _curses_select
@@ -9,6 +15,136 @@ from hermes_cli.memory_setup import _CANCELLED, _curses_select
 
 
 
+
+
+def test_get_installable_providers_filters_catalog_entries_already_installed():
+    installed = [("openbrain", "API key / local", object())]
+
+    assert memory_setup._get_installable_providers(installed) == []
+
+
+def test_cmd_setup_lists_catalogued_provider_when_not_installed(monkeypatch):
+    captured = {}
+    save_config = MagicMock()
+
+    monkeypatch.setattr(memory_setup, "_get_available_providers", lambda: [])
+
+    def select_cancel(title, items, **kwargs):
+        captured["items"] = items
+        return kwargs["cancel_returns"]
+
+    monkeypatch.setattr(memory_setup, "_curses_select", select_cancel)
+    monkeypatch.setattr("hermes_cli.config.load_config", MagicMock())
+    monkeypatch.setattr("hermes_cli.config.save_config", save_config)
+
+    memory_setup.cmd_setup(SimpleNamespace())
+
+    assert captured["items"][0][0] == "openbrain"
+    assert "install standalone plugin" in captured["items"][0][1]
+    save_config.assert_not_called()
+
+
+def test_cmd_setup_installs_catalogued_provider_then_runs_post_setup(monkeypatch):
+    events = []
+
+    class PostSetupProvider:
+        def post_setup(self, hermes_home, config):
+            events.append(("post_setup", hermes_home, config))
+
+    provider = PostSetupProvider()
+    calls = iter([[], [("openbrain", "API key / local", provider)]])
+
+    monkeypatch.setattr(memory_setup, "_get_available_providers", lambda: next(calls))
+    monkeypatch.setattr(memory_setup, "_curses_select", lambda *args, **kwargs: 0)
+    monkeypatch.setattr(memory_setup, "_clear_interactive_transition", lambda: events.append("clear"))
+    monkeypatch.setattr(
+        memory_setup,
+        "_install_standalone_provider",
+        lambda entry: events.append(("install", entry["name"])) or "openbrain",
+    )
+    monkeypatch.setattr(memory_setup, "_install_dependencies", lambda name: events.append(("deps", name)))
+    monkeypatch.setattr(memory_setup, "get_hermes_home", lambda: "/tmp/hermes-test")
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"memory": {}})
+
+    memory_setup.cmd_setup(SimpleNamespace())
+
+    assert events == [
+        "clear",
+        ("install", "openbrain"),
+        "clear",
+        ("deps", "openbrain"),
+        ("post_setup", "/tmp/hermes-test", {"memory": {}}),
+    ]
+
+
+def test_catalog_install_refreshes_real_discovery_then_runs_post_setup(tmp_path, monkeypatch):
+    if shutil.which("git") is None:
+        pytest.skip("git not available")
+
+    hermes_home = tmp_path / "hermes-home"
+    repo = tmp_path / "fixture-memory-provider"
+    repo.mkdir()
+    (repo / "plugin.yaml").write_text(
+        "name: fixture_memory\n"
+        "manifest_version: 1\n"
+        "description: Filesystem-backed memory fixture\n",
+        encoding="utf-8",
+    )
+    (repo / "__init__.py").write_text(
+        "from pathlib import Path\n\n"
+        "class FixtureMemoryProvider:\n"
+        "    def is_available(self):\n"
+        "        return True\n\n"
+        "    def get_config_schema(self):\n"
+        "        return []\n\n"
+        "    def post_setup(self, hermes_home, config):\n"
+        "        Path(hermes_home, 'post-setup-ran').write_text('ok')\n\n"
+        "def register(ctx):\n"
+        "    ctx.register_memory_provider(FixtureMemoryProvider())\n",
+        encoding="utf-8",
+    )
+
+    git_env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "Hermes test",
+        "GIT_AUTHOR_EMAIL": "hermes-test@example.invalid",
+        "GIT_COMMITTER_NAME": "Hermes test",
+        "GIT_COMMITTER_EMAIL": "hermes-test@example.invalid",
+    }
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True, env=git_env)
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True, env=git_env)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "fixture"],
+        cwd=repo,
+        check=True,
+        env=git_env,
+    )
+
+    from hermes_cli import memory_provider_catalog
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(
+        memory_provider_catalog,
+        "INSTALLABLE_MEMORY_PROVIDERS",
+        [{
+            "name": "fixture_memory",
+            "label": "fixture_memory",
+            "setup_hint": "install test plugin",
+            "identifier": repo.as_uri(),
+            "description": "Filesystem-backed memory fixture",
+        }],
+    )
+
+    module_prefix = "_hermes_user_memory.fixture_memory"
+    try:
+        memory_setup.cmd_setup_provider("fixture_memory")
+
+        assert (hermes_home / "plugins" / "fixture_memory" / "__init__.py").is_file()
+        assert (hermes_home / "post-setup-ran").read_text() == "ok"
+    finally:
+        for module_name in list(sys.modules):
+            if module_name == module_prefix or module_name.startswith(f"{module_prefix}."):
+                sys.modules.pop(module_name, None)
 
 
 def test_cmd_setup_generic_choice_cancel_writes_nothing(tmp_path, monkeypatch):

--- a/website/docs/developer-guide/memory-provider-plugin.md
+++ b/website/docs/developer-guide/memory-provider-plugin.md
@@ -14,14 +14,19 @@ Memory providers are one of two **provider plugin** types. The other is [Context
 
 ## Directory Structure
 
-Each memory provider lives in `plugins/memory/<name>/`:
+Standalone memory providers should ship as their own plugin repository. When installed with `hermes plugins install owner/repo`, Hermes places the repo under `$HERMES_HOME/plugins/<name>/`, and the memory discovery system treats it the same as an in-tree provider:
 
 ```
-plugins/memory/my-provider/
+my-provider/
 ├── __init__.py      # MemoryProvider implementation + register() entry point
 ├── plugin.yaml      # Metadata (name, description, hooks)
-└── README.md        # Setup instructions, config reference, tools
+├── README.md        # Setup instructions, config reference, tools
+└── tests/           # Provider tests with light Hermes stubs when needed
 ```
+
+For a fully implemented standalone provider, see [`longman391/hermes-openbrain-memory-provider`](https://github.com/longman391/hermes-openbrain-memory-provider), an OpenBrain (OB1) memory provider over MCP Streamable HTTP.
+
+Bundled providers in this repo still live under `plugins/memory/<name>/`, but new third-party backends should not be added there.
 
 ## The MemoryProvider ABC
 

--- a/website/docs/developer-guide/memory-provider-plugin.md
+++ b/website/docs/developer-guide/memory-provider-plugin.md
@@ -37,6 +37,8 @@ Discovery only *enumerates* — it never imports a provider. Nothing runs until
 
 ### Directory Provider
 
+Standalone memory providers should ship as their own plugin repositories. Installing one with `hermes plugins install owner/repo` places it under the profile-aware `$HERMES_HOME/plugins/<name>/` user location. For a complete example, see [`longman391/hermes-openbrain-memory-provider`](https://github.com/longman391/hermes-openbrain-memory-provider), an OpenBrain (OB1) provider over MCP Streamable HTTP.
+
 A directory provider lives in `plugins/memory/<name>/` when bundled with
 Hermes, in `$HERMES_HOME/plugins/<name>/` when installed by a user, or in
 `./.hermes/plugins/<name>/` for a project-local one:

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 4
 title: "Memory Providers"
-description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory"
+description: "External memory provider plugins — bundled providers plus catalogued standalone providers"
 ---
 
 # Memory Providers
 
-Hermes Agent ships with 8 external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
+Hermes Agent ships with bundled external memory provider plugins and can install catalogued standalone providers that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
 
 ## Quick Start
 
@@ -22,7 +22,7 @@ Or set manually in `~/.hermes/config.yaml`:
 
 ```yaml
 memory:
-  provider: openviking   # or honcho, mem0, hindsight, holographic, retaindb, byterover, supermemory
+  provider: openviking   # or honcho, mem0, hindsight, holographic, retaindb, byterover, supermemory, openbrain
 ```
 
 ## How It Works
@@ -652,6 +652,37 @@ hermes config set memory.provider memori
 hermes memory setup
 ```
 
+## Installable Standalone Providers
+
+Standalone providers live outside the Hermes core repository but can still be discovered from `hermes memory setup`. Selecting one installs its plugin repo through the normal plugin installer, then runs that provider's setup flow.
+
+### OpenBrain
+
+Standalone OpenBrain (OB1) memory provider over MCP Streamable HTTP, with explicit capture tools, recall prefetch, and additive mirroring of Hermes memory writes.
+
+| | |
+|---|---|
+| **Best for** | Sharing an OpenBrain memory backend across Hermes and other MCP-capable agents |
+| **Requires** | `hermes memory setup` can install the standalone plugin, then prompts for an OpenBrain MCP URL or API key |
+| **Data storage** | OpenBrain (OB1) deployment |
+| **Cost** | Depends on your OpenBrain deployment |
+
+**Tools (4):** `openbrain_search` (search thoughts), `openbrain_list` (list recent thoughts), `openbrain_capture` (capture compact facts or decisions), `openbrain_stats` (thought statistics)
+
+**Setup:**
+```bash
+hermes memory setup        # select "openbrain" to install and configure it
+```
+
+Manual install also works:
+```bash
+hermes plugins install longman391/hermes-openbrain-memory-provider --no-enable
+hermes config set memory.provider openbrain
+hermes memory setup
+```
+
+**Source:** [OpenBrain Hermes provider](https://github.com/longman391/hermes-openbrain-memory-provider) · [OpenBrain (OB1)](https://github.com/NateBJones-Projects/OB1)
+
 ---
 
 ## Provider Comparison
@@ -667,6 +698,7 @@ hermes memory setup
 | **ByteRover** | Local/Cloud | Free/Paid | 3 | `brv` CLI | Pre-compression extraction |
 | **Supermemory** | Cloud/Self-hosted | Free/Paid | 4 | `supermemory` | Context fencing + session graph ingest + multi-container |
 | **Memori** | Cloud | Free/Paid | 5 | `hermes-memori` | Tool-aware memory + structured recall |
+| **OpenBrain** | OpenBrain deployment | Varies | 4 | Standalone plugin | MCP-backed OpenBrain recall + capture |
 
 ## Profile Isolation
 
@@ -676,6 +708,7 @@ Each provider's data is isolated per [profile](/user-guide/profiles):
 - **Config file providers** (Honcho, Mem0, Hindsight, Supermemory) store config in `$HERMES_HOME/` so each profile has its own credentials
 - **Cloud providers** (RetainDB) auto-derive profile-scoped project names
 - **Env var providers** (OpenViking) are configured via each profile's `.env` file
+- **Standalone plugin providers** (OpenBrain) install into `$HERMES_HOME/plugins/` and read profile-local config/env values
 
 ## Building a Memory Provider
 


### PR DESCRIPTION
Adds a small installable memory-provider catalog so `hermes memory setup` can surface standalone providers without vendoring their implementation into Hermes core.

The setup picker now includes catalogued standalone providers that are not installed yet. Selecting one installs its plugin repo via the normal plugin installer, refreshes provider discovery, then runs that provider's existing setup flow.

OpenBrain is the initial catalog entry to validate the path. Its provider code remains in the standalone plugin repo; this PR only adds the generic setup/catalog plumbing plus docs/tests.

Tested:
- `python -m pytest -q tests/hermes_cli/test_memory_setup.py`
- `python -m ruff check hermes_cli/memory_setup.py hermes_cli/memory_provider_catalog.py tests/hermes_cli/test_memory_setup.py`
- `python -m py_compile hermes_cli/memory_setup.py hermes_cli/memory_provider_catalog.py`
- `git diff --check`