### PR TITLE
fix(skills): retry rate-limited Contents API directory listings (salvage #3033)

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -909,12 +909,13 @@ class GitHubSource(SkillSource):
     def _download_directory_recursive(self, repo: str, path: str) -> Dict[str, str]:
         """Recursively download via Contents API (fallback)."""
         url = f"https://api.github.com/repos/{repo}/contents/{path.rstrip('/')}"
-        try:
-            resp = httpx.get(url, headers=self.auth.get_headers(), timeout=15, follow_redirects=True)
-            if resp.status_code != 200:
-                logger.debug("Contents API returned %d for %s/%s", resp.status_code, repo, path)
-                return {}
-        except httpx.HTTPError:
+        # Route through _github_get so directory listing gets the same
+        # 429/403-rate-limit retry + backoff as file fetches (#3033).
+        resp = self._github_get(url)
+        if resp is None:
+            return {}
+        if resp.status_code != 200:
+            logger.debug("Contents API returned %d for %s/%s", resp.status_code, repo, path)
             return {}
 
         entries = resp.json()


### PR DESCRIPTION
## Summary
Skill downloads via the GitHub Contents API fallback no longer abort on a single 429: the directory-listing call now goes through the same retry/backoff helper (`_github_get`) that file fetches already use. Fixes the gap #3033 reported.

Salvage-with-redirect of #3033 by @0xbyt4 — the PR's ad-hoc retry loops were superseded by the `_github_get` helper that landed after it was opened, so the fix is rerouted through that helper instead (co-authored credit preserved; the PR's `_fetch_file_content` half is already covered on main).

## Changes
- `tools/skills_hub.py` `_download_directory_recursive()`: raw `httpx.get` → `self._github_get(url)` (429/403 rate-limit backoff with Retry-After/reset awareness, 5xx retry, rate-limit flagging). +7/−6.

## Validation
| | Before | After |
|---|---|---|
| Dir listing gets 429 then 200 | `{}` — whole skill download fails | retried, listing succeeds (E2E-verified) |
| `tests/tools/test_skills_hub.py` | — | pass |

## Infographic

![pr-3033-salvage](https://v3b.fal.media/files/b/0aa0f3d0/2gVyunyoSaCDK6b-C0-K__WqZIHfX9.png)
