### PR TITLE
fix(redact): don't mask programmatic env lookups in KEY=value redaction (salvage #2854)

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -137,6 +137,14 @@ _ENV_ASSIGN_RE = re.compile(
 # The colon-form URL guard (skip when ``://`` present) lives at the call site.
 _SECRET_CFG_NAMES = r"(?:api[ _.\-]?key|token|secret|passwd|password|credential|auth)"
 _CFG_VALUE = r"(['\"]?)([^\s&]+?)\2(?=[\s&]|$)"
+
+# Programmatic env lookups (``os.getenv(...)``, ``os.environ[...]``,
+# ``os.environ.get(...)``, ``process.env.X``, ``$ENV{X}``) reference variable
+# *names*, not secret values. When one appears as the VALUE of a KEY=... match
+# it's a code snippet, not a leaked secret — skip redaction (issue #2852).
+_ENV_LOOKUP_VALUE_RE = re.compile(
+    r"^(?:os\.(?:getenv|environ)|process\.env|\$ENV\{)"
+)
 # Namespaced (dotted) key: the secret word may sit anywhere in a dotted path.
 _CFG_DOTTED_RE = re.compile(
     rf"((?:[A-Za-z0-9_\-]+\.)+[A-Za-z0-9_.\-]*{_SECRET_CFG_NAMES}[A-Za-z0-9_.\-]*"
@@ -541,6 +549,11 @@ def redact_sensitive_text(
         if "=" in text:
             def _redact_env(m):
                 name, quote, value = m.group(1), m.group(2), m.group(3)
+                # Programmatic env lookups reference variable *names*, not
+                # secret values — masking them corrupts code snippets in
+                # prose/log contexts (issue #2852): ``KEY=os.getenv('X')``.
+                if _ENV_LOOKUP_VALUE_RE.match(value):
+                    return m.group(0)
                 return f"{name}={quote}{_mask_token(value)}{quote}"
             text = _ENV_ASSIGN_RE.sub(_redact_env, text)
             # Lowercase/dotted config keys (issue #16413). Skip URLs entirely —

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -124,6 +124,52 @@ class TestEnvAssignments:
         assert "mypassword" not in result
 
 
+class TestEnvLookupPreserved:
+    """Programmatic env var lookups must not be corrupted (issue #2852)."""
+
+    def test_os_getenv_single_quote_uppercase_key(self):
+        text = "MY_API_KEY=os.getenv('OPENAI_API_KEY')"
+        assert redact_sensitive_text(text, force=True) == text
+
+    def test_os_getenv_lowercase_config_key(self):
+        text = "ha_token=os.getenv('HOMEASSISTANT_TOKEN')"
+        assert redact_sensitive_text(text, force=True) == text
+
+    def test_os_getenv_double_quote(self):
+        text = 'API_TOKEN=os.getenv("MY_API_TOKEN")'
+        assert redact_sensitive_text(text, force=True) == text
+
+    def test_os_environ_get(self):
+        text = "HA_TOKEN=os.environ.get('HOMEASSISTANT_TOKEN')"
+        assert redact_sensitive_text(text, force=True) == text
+
+    def test_os_environ_bracket(self):
+        text = "MY_SECRET=os.environ['MY_SECRET']"
+        assert redact_sensitive_text(text, force=True) == text
+
+    def test_process_env(self):
+        text = "api_key=process.env.API_KEY"
+        assert redact_sensitive_text(text, force=True) == text
+
+    def test_real_env_value_still_redacted(self):
+        text = "HOMEASSISTANT_TOKEN=eyJhbGciOiJIUzI1NiJ9.abc123.xyz"
+        result = redact_sensitive_text(text, force=True)
+        assert "eyJhbGciOiJIUzI1NiJ9" not in result
+
+    def test_real_lowercase_value_still_redacted(self):
+        text = "password=hunter2hunter2"
+        result = redact_sensitive_text(text, force=True)
+        assert "hunter2hunter2" not in result
+
+    def test_multiline_prose_with_code_snippet(self):
+        text = """Set it up like this:
+    HA_TOKEN=os.getenv('HOMEASSISTANT_TOKEN')
+    if not HA_TOKEN:
+        raise ValueError('Missing credentials')"""
+        result = redact_sensitive_text(text, force=True)
+        assert "os.getenv('HOMEASSISTANT_TOKEN')" in result
+
+
 class TestJsonFields:
     def test_json_api_key(self):
         text = '{"apiKey": "sk-proj-abc123def456ghi789jkl012"}'


### PR DESCRIPTION
## Summary
The secret redactor no longer corrupts pasted code that assigns from environment lookups — `ha_token=os.getenv('HOMEASSISTANT_TOKEN')` stays intact instead of becoming `ha_token=os.get...EN')`. Fixes #2852.

Salvage of #2854 by @crazywriter1 — same intent, relocated: the PR inserted an unconditional redaction pass *before* the `code_file` gate that grew after it branched, which would have reintroduced the code-file false-positive class and duplicated the env pass. The skip now lives inside the existing gated `_redact_env` closure, which all three relevant regex passes share (`_ENV_ASSIGN_RE`, `_CFG_DOTTED_RE`, `_CFG_ANCHORED_RE`) — so the lowercase `ha_token=` corruption the issue reported is fixed too, which the PR's placement missed. Tests adapted from the PR; co-authored credit on the commit.

## Changes
- `agent/redact.py`: `_ENV_LOOKUP_VALUE_RE` (`os.getenv` / `os.environ[...]` / `os.environ.get` / `process.env` / `$ENV{`) + skip inside `_redact_env` (+13).
- `tests/agent/test_redact.py`: `TestEnvLookupPreserved` — 9 tests incl. negatives proving real secrets still mask (+46).

## Validation
| | Before (main, live repro) | After |
|---|---|---|
| `MY_API_KEY=os.getenv('OPENAI_API_KEY')` | `MY_API_KEY=***` | unchanged |
| `ha_token=os.getenv("HOMEASSISTANT_TOKEN")` | `ha_token=os.get...EN")` | unchanged |
| `OPENAI_API_KEY=sk-abc123...` | masked | still masked |
| `tests/agent/test_redact.py` (full file) | — | pass |

## Infographic

![pr-2854-salvage](https://v3b.fal.media/files/b/0aa0f40d/P3PGnOfqpXmyd6IdoVNai_5WvsQdZD.png)
