### PR TITLE
fix(gateway): enforce body-size limits on chunked requests (salvage #3955 + #3949)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -669,7 +669,16 @@ if AIOHTTP_AVAILABLE:
                         return web.json_response(_openai_error("Request body too large.", code="body_too_large"), status=413)
                 except ValueError:
                     return web.json_response(_openai_error("Invalid Content-Length header.", code="invalid_content_length"), status=400)
-        return await handler(request)
+        try:
+            return await handler(request)
+        except web.HTTPRequestEntityTooLarge:
+            # aiohttp's client_max_size tripped mid-read (chunked bodies carry
+            # no Content-Length) — return a proper 413 instead of letting the
+            # handler's broad JSON except turn it into 400 "Invalid JSON".
+            return web.json_response(
+                _openai_error("Request body too large.", code="body_too_large"),
+                status=413,
+            )
 else:
     body_limit_middleware = None  # type: ignore[assignment]
 

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -191,7 +191,10 @@ class WebhookAdapter(BasePlatformAdapter):
                         f"real target (telegram, discord, slack, github_comment, etc.)."
                     )
 
-        app = web.Application()
+        # client_max_size makes aiohttp enforce the cap on every read path,
+        # including Transfer-Encoding: chunked bodies that carry no
+        # Content-Length and would otherwise bypass the header check below.
+        app = web.Application(client_max_size=self._max_body_bytes)
         app.router.add_get("/health", self._handle_health)
         app.router.add_post("/webhooks/{route_name}", self._handle_webhook)
         # Multi-profile multiplexing: a /p/<profile>/webhooks/<route> prefix
@@ -479,9 +482,21 @@ class WebhookAdapter(BasePlatformAdapter):
         # Read body (must be done before any validation)
         try:
             raw_body = await request.read()
+        except web.HTTPRequestEntityTooLarge:
+            # aiohttp's client_max_size tripped — chunked or lying
+            # Content-Length. Same 413 as the header check above.
+            return web.json_response(
+                {"error": "Payload too large"}, status=413
+            )
         except Exception as e:
             logger.error("[webhook] Failed to read body: %s", e)
             return web.json_response({"error": "Bad request"}, status=400)
+        if len(raw_body) > self._max_body_bytes:
+            # Defense in depth: enforce the cap on the actual bytes read even
+            # if the server-level limit was bypassed or misconfigured.
+            return web.json_response(
+                {"error": "Payload too large"}, status=413
+            )
 
         # Validate HMAC signature FIRST (skip only for the explicit local-test
         # INSECURE_NO_AUTH mode). Missing/empty secrets must fail closed here,

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -69,7 +69,8 @@ def _make_adapter(routes=None, **kwargs):
 
 def _create_app(adapter: WebhookAdapter) -> web.Application:
     """Build the aiohttp Application from the adapter (without starting a full server)."""
-    app = web.Application()
+    # Mirror connect(): client_max_size enforces the cap on chunked bodies.
+    app = web.Application(client_max_size=adapter._max_body_bytes)
     app.router.add_get("/health", adapter._handle_health)
     app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
     return app
@@ -740,6 +741,29 @@ class TestBodySize:
                 headers={"Content-Length": "999999"},
             )
             assert resp.status == 413
+
+    @pytest.mark.asyncio
+    async def test_chunked_oversized_payload_rejected(self):
+        """Chunked request bodies (no Content-Length) over the limit return 413."""
+        routes = {"big": {"secret": _INSECURE_NO_AUTH, "prompt": "test"}}
+        adapter = _make_adapter(routes=routes, max_body_bytes=100)
+        adapter.handle_message = AsyncMock()
+
+        async def _chunked_body():
+            payload = json.dumps({"data": "x" * 500}).encode("utf-8")
+            for i in range(0, len(payload), 64):
+                yield payload[i : i + 64]
+                await asyncio.sleep(0)
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/big",
+                data=_chunked_body(),
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 413
+            adapter.handle_message.assert_not_awaited()
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary
The generic webhook adapter's `max_body_bytes` limit can no longer be bypassed with `Transfer-Encoding: chunked` (or a spoofed small Content-Length): aiohttp now enforces the cap on every read path, and oversized bodies return a proper 413. The api_server gets the matching 413 status polish for its (already-capped) chunked reads.

Cluster salvage of #3955 (webhook, full fix) + #3949 (api_server, status-code piece) by @Gutslabs — both commits carry the contributor's authorship.

## Changes
- `gateway/platforms/webhook.py`: `web.Application(client_max_size=self._max_body_bytes)`; catch `HTTPRequestEntityTooLarge` → 413 (was a generic 400); post-read length re-check as defense in depth. Manual port — the handler was restructured (HMAC fail-closed, multi-profile routes) since the PR branched.
- `gateway/platforms/api_server.py`: `body_limit_middleware` catches `HTTPRequestEntityTooLarge` → OpenAI-style 413 (was 400 "Invalid JSON"). The PR's core `client_max_size` change already exists on main, so only this piece was taken.
- `tests/gateway/test_webhook_adapter.py`: chunked-oversized-payload regression test; test app factory mirrors `connect()`.

## Validation
| | Before | After |
|---|---|---|
| Chunked 500-byte body vs `max_body_bytes=100` (webhook) | read in full, processed | 413, handler never invoked (regression test) |
| Oversized chunked body (api_server) | 400 "Invalid JSON" | 413 body_too_large |
| `tests/gateway/test_webhook_adapter.py` | — | pass |
| `tests/gateway/test_api_server.py` (193 tests) | — | pass |

Note: #56829 (Tamsi, Jul 2) and #13336 report/fix the same webhook bypass — recommend closing them with credit pointers once this lands (#3955 was first, Mar 30).

## Infographic

![pr-3955-3949-salvage](https://v3b.fal.media/files/b/0aa0f445/cHg3UH4KTQwFrR2F8v-Ev_YEX0Alr6.png)
