### PR TITLE
feat: add skills.write_approval.only/.exclude for selective skill gating

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -855,6 +855,18 @@ class GatewaySlashCommandsMixin(
             return ("Skill write approval is off (skills.write_approval). "
                     "Enable it with /skills approval on, then review staged "
                     "writes here with /skills pending.")
+
+        def _set_approval(enabled: bool):
+            # Write-back round-trip: raw read is correct (merged defaults must
+            # not be persisted back to the user's file).
+            from hermes_cli.config import read_user_config_raw
+            user_config = read_user_config_raw(config_path)
+            user_config.setdefault("skills", {}).setdefault("write_approval", {})["enabled"] = bool(enabled)
+            atomic_config_write(config_path, user_config)
+            # New setting must take effect next message → drop cached agent.
+            self._evict_cached_agent(session_key)
+
+
         out = handle_pending_subcommand(
             wa.SKILLS, args, set_mode_fn=self._write_approval_setter("skills", event))
         if out is None:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3656,7 +3656,7 @@ class GatewaySlashCommandsMixin:
             # not be persisted back to the user's file).
             from hermes_cli.config import read_user_config_raw
             user_config = read_user_config_raw(config_path)
-            user_config.setdefault("skills", {})["write_approval"] = bool(enabled)
+            user_config.setdefault("skills", {}).setdefault("write_approval", {})["enabled"] = bool(enabled)
             atomic_config_write(config_path, user_config)
             # New setting must take effect next message → drop cached agent.
             self._evict_cached_agent(session_key)

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1857,7 +1857,12 @@ class CLICommandsMixin:
 
     def _save_write_approval(self, subsystem: str, enabled: bool):
         """Persist <subsystem>.write_approval to config (for /memory|/skills approval)."""
-        _save(f"{subsystem}.write_approval", bool(enabled))
+        from hermes_cli.commands import save_config_value
+        if subsystem == "skills":
+            # skills.write_approval is now a dict (config v41+); set the nested key.
+            save_config_value("skills.write_approval.enabled", bool(enabled))
+        else:
+            save_config_value(f"{subsystem}.write_approval", bool(enabled))
 
     # ---- prompt-queueing handlers: /learn, /plan, /init -----------------------------------
     def _queue_prompt_turn(self, msg: str, command: str) -> None:

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1980,7 +1980,11 @@ class CLICommandsMixin:
     def _save_write_approval(self, subsystem: str, enabled: bool):
         """Persist <subsystem>.write_approval to config (for /memory|/skills approval)."""
         from cli import save_config_value
-        save_config_value(f"{subsystem}.write_approval", bool(enabled))
+        if subsystem == "skills":
+            # skills.write_approval is now a dict (config v33+); set the nested key.
+            save_config_value("skills.write_approval.enabled", bool(enabled))
+        else:
+            save_config_value(f"{subsystem}.write_approval", bool(enabled))
 
     def _handle_background_command(self, cmd: str):
         """Handle /background <prompt> — run a prompt in a separate background session.

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass
+from typing import Any
 
 from utils import is_truthy_value
 from hermes_constants import INDICATOR_STYLES
@@ -425,8 +426,27 @@ def _resolve_config_gates() -> set[str]:
         cfg = read_raw_config()
     except Exception:
         return set()
-    return {cmd.name for cmd in gated
-            if is_truthy_value(cfg_get(cfg, *cmd.gateway_config_gate.split(".")), default=False)}
+    result: set[str] = set()
+    for cmd in gated:
+        val: Any = cfg
+        for key in cmd.gateway_config_gate.split("."):
+            if isinstance(val, dict):
+                val = val.get(key)
+            else:
+                val = None
+                break
+        # Dict-shaped gates (e.g. `skills.write_approval = {enabled, only,
+        # exclude}`) are "open" only when an explicit `enabled` sub-key is
+        # truthy. A non-empty dict without `enabled` (e.g. `{}` after a
+        # partial migration) keeps the command closed by default — never
+        # assume "non-empty = on". A bare bool/string still uses the shared
+        # is_truthy_value() path.
+        if isinstance(val, dict):
+            if is_truthy_value(val.get("enabled", False), default=False):
+                result.add(cmd.name)
+        elif is_truthy_value(val, default=False):
+            result.add(cmd.name)
+    return result
 
 
 def _is_gateway_available(cmd: CommandDef, config_overrides: set[str] | None = None) -> bool:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -523,7 +523,16 @@ def _resolve_config_gates() -> set[str]:
             else:
                 val = None
                 break
-        if is_truthy_value(val, default=False):
+        # Dict-shaped gates (e.g. `skills.write_approval = {enabled, only,
+        # exclude}`) are "open" only when an explicit `enabled` sub-key is
+        # truthy. A non-empty dict without `enabled` (e.g. `{}` after a
+        # partial migration) keeps the command closed by default — never
+        # assume "non-empty = on". A bare bool/string still uses the shared
+        # is_truthy_value() path.
+        if isinstance(val, dict):
+            if is_truthy_value(val.get("enabled", False), default=False):
+                result.add(cmd.name)
+        elif is_truthy_value(val, default=False):
             result.add(cmd.name)
     return result
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1366,6 +1366,32 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
     else:
         run_migrations(current_ver, results, quiet)
 
+    # ── Version 40 → 41: expand skills.write_approval bool → dict ──
+    # The bare boolean `skills.write_approval: true/false` was replaced by a
+    # dict `{enabled: bool, only: [str], exclude: [str]}` so users can gate
+    # only specific skills. This migration converts persisted bools to the
+    # dict shape; the runtime reader in write_approval._normalize_enabled()
+    # handles both shapes for backward compat.
+    if current_ver < 41:
+        config = read_raw_config()
+        raw_skills = config.get("skills")
+        if isinstance(raw_skills, dict) and "write_approval" in raw_skills:
+            old_val = raw_skills["write_approval"]
+            if isinstance(old_val, bool):
+                raw_skills["write_approval"] = {
+                    "enabled": old_val, "only": [], "exclude": [],
+                }
+                config["skills"] = raw_skills
+                _persist_migration(config)
+                results["config_added"].append(
+                    f"skills.write_approval.enabled={'true' if old_val else 'false'}"
+                )
+                if not quiet:
+                    print(
+                        f"  ✓ Expanded skills.write_approval to dict format "
+                        f"(enabled={'true' if old_val else 'false'})"
+                    )
+
     _disable_suspicious_mcp_servers(results, quiet)
     _warn_invalid_platform_toolsets(results, quiet)
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2217,6 +2217,32 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
         # module for read_raw_config/_persist_migration/etc. at call time).
         run_migrations(current_ver, results, quiet)
 
+    # ── Version 33 → 34 (continued): expand skills.write_approval bool → dict ──
+    # The bare boolean `skills.write_approval: true/false` was replaced by a
+    # dict `{enabled: bool, only: [str], exclude: [str]}` so users can gate
+    # only specific skills. This migration converts persisted bools to the
+    # dict shape; the runtime reader in write_approval._normalize_enabled()
+    # handles both shapes for backward compat.
+    if current_ver < 34:
+        config = read_raw_config()
+        raw_skills = config.get("skills")
+        if isinstance(raw_skills, dict) and "write_approval" in raw_skills:
+            old_val = raw_skills["write_approval"]
+            if isinstance(old_val, bool):
+                raw_skills["write_approval"] = {
+                    "enabled": old_val, "only": [], "exclude": [],
+                }
+                config["skills"] = raw_skills
+                _persist_migration(config)
+                results["config_added"].append(
+                    f"skills.write_approval.enabled={'true' if old_val else 'false'}"
+                )
+                if not quiet:
+                    print(
+                        f"  ✓ Expanded skills.write_approval to dict format "
+                        f"(enabled={'true' if old_val else 'false'})"
+                    )
+
     # ── Post-migration: disable exfiltration-shaped MCP stdio entries ──
     # Users can hand-edit mcp_servers, and older installs may already contain a
     # malicious entry. Preserve the stanza for auditability but mark it

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1326,14 +1326,31 @@ DEFAULT_CONFIG = {
         # "skillevaluator @ git+https://github.com/NVIDIA/SkillEvaluator.git"). Informational, never
         # blocking; secrets-class findings shown red. No-op without it.
         "tier1_advisory": True,
-        # Approval gate for skill_manage mutations on BOTH foreground turns and the background
-        # review fork. true = ALWAYS stage (SKILL.md too large for an inline prompt): /skills
-        # pending, /skills diff <id>, /skills approve|reject <id>.
-        "write_approval": False,
-        # Audit ledger: every skill mutation appends to ~/.hermes/skills/.curator_ledger.jsonl with
-        # before/after hashes (blobs under ~/.hermes/.curator_backups/blobs/); powers `hermes
-        # curator ledger` / `rollback <entry-id>`. Never a gate — failures can't block.
-        # See #79686.
+        # Approval gate for skill_manage (create/edit/patch/write_file/delete/
+        # remove_file), applied to BOTH foreground agent turns and the
+        # background self-improvement review fork.
+        #   false (default) — write freely; the gate is off (pre-gate behaviour)
+        #   true            — require approval: stage the write for review
+        #                     instead of committing (a SKILL.md is too large to
+        #                     review inline, so skills always stage rather than
+        #                     prompt). List with /skills pending, inspect with
+        #                     /skills diff <id> (full diff — CLI/dashboard/file,
+        #                     never crammed into a chat bubble), apply with
+        #                     /skills approve <id> or drop with /skills reject <id>.
+        # New in config: expanded from a bare bool to a dict with sub-keys
+        #   enabled: true/false    — gate toggle (same semantic as the old bool)
+        #   only: [skill names]    — if non-empty, gate ONLY these skill names
+        #   exclude: [skill names] — if non-empty, gate ALL skills EXCEPT these
+        #                            only and exclude are mutually exclusive
+        #                            in effect: only takes precedence.
+        "write_approval": {"enabled": False, "only": [], "exclude": []},
+        # Per-mutation audit ledger (tracker #79686 P3). Every skill mutation
+        # — curator, agent, or user — appends one JSONL entry to
+        # ~/.hermes/skills/.curator_ledger.jsonl with before/after file
+        # hashes; file contents are stored content-addressed (deduped) under
+        # ~/.hermes/.curator_backups/blobs/. Enables `hermes curator ledger`
+        # and single-mutation `hermes curator rollback <entry-id>`.
+        # Telemetry, never a gate: ledger failures cannot block a mutation.
         "ledger": True,
     },
     # Curator — background maintenance of AGENT-CREATED skills (never hub-installed): marks
@@ -2306,7 +2323,7 @@ DEFAULT_CONFIG = {
         # Extra ports detection probes for an external llama-server (besides 8080).
         "detect_ports": [],
     },
-    "_config_version": 40,  # Config schema version - bump this when adding new required fields
+    "_config_version": 41,  # Config schema version - bump this when adding new required fields
 }
 
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1895,7 +1895,13 @@ DEFAULT_CONFIG = {
         #                     /skills diff <id> (full diff — CLI/dashboard/file,
         #                     never crammed into a chat bubble), apply with
         #                     /skills approve <id> or drop with /skills reject <id>.
-        "write_approval": False,
+        # New in config v34: expanded from a bare bool to a dict with sub-keys
+        #   enabled: true/false    — gate toggle (same semantic as the old bool)
+        #   only: [skill names]    — if non-empty, gate ONLY these skill names
+        #   exclude: [skill names] — if non-empty, gate ALL skills EXCEPT these
+        #                            only and exclude are mutually exclusive
+        #                            in effect: only takes precedence. 
+        "write_approval": {"enabled": False, "only": [], "exclude": []},
     },
 
     # Curator — background skill maintenance.

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -3,7 +3,7 @@
 from prompt_toolkit.completion import CompleteEvent
 from prompt_toolkit.document import Document
 
-from hermes_cli.commands import COMMAND_REGISTRY, COMMANDS, COMMANDS_BY_CATEGORY, CommandDef, GATEWAY_KNOWN_COMMANDS, SUBCOMMANDS, command_desktop_meta, gateway_help_lines, infer_argument_mode, resolve_command
+from hermes_cli.commands import COMMAND_REGISTRY, COMMANDS, COMMANDS_BY_CATEGORY, CommandDef, GATEWAY_KNOWN_COMMANDS, SUBCOMMANDS, _resolve_config_gates, command_desktop_meta, gateway_help_lines, infer_argument_mode, resolve_command
 from hermes_cli.commands_completion import SlashCommandAutoSuggest, SlashCommandCompleter
 from hermes_cli.commands_platforms import _CMD_NAME_LIMIT, _SLACK_RESERVED_COMMANDS, _SLACK_VIA_HERMES_ONLY, _clamp_command_names, _sanitize_telegram_name, slack_app_manifest, slack_native_slashes, slack_subcommand_map, telegram_bot_commands, telegram_menu_commands
 
@@ -301,6 +301,98 @@ class TestGatewayConfigGate:
 
         mapping = slack_subcommand_map()
         assert "verbose" in mapping
+
+
+class TestSkillsConfigGateDict:
+    """`/skills` is gated by ``skills.write_approval``, which is a dict
+    ``{enabled, only, exclude}`` (config v33+). The dict must be evaluated
+    through the ``enabled`` sub-key, not by raw truthiness, otherwise a
+    non-empty dict with ``enabled: false`` (e.g. persisted with only/exclude
+    lists but gate off) would still expose the command in gateway help /
+    menus / mappings. (#58533)
+    """
+
+    def _write_cfg(self, tmp_path, body: str):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(body)
+        return cfg
+
+    def test_skills_dict_enabled_false_keeps_command_closed(
+        self, tmp_path, monkeypatch
+    ):
+        self._write_cfg(tmp_path,
+                        "skills:\n  write_approval:\n    enabled: false\n"
+                        "    only: [a, b]\n    exclude: []\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        # The config-gate resolver must read .enabled, not treat the dict
+        # as truthy. With enabled: false, /skills stays out of the
+        # config-gated command set — even though only/exclude are populated.
+        gated = _resolve_config_gates()
+        assert "skills" not in gated
+
+    def test_skills_dict_enabled_true_opens_command(self, tmp_path, monkeypatch):
+        self._write_cfg(tmp_path,
+                        "skills:\n  write_approval:\n    enabled: true\n"
+                        "    only: [a]\n    exclude: []\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        assert "skills" in _resolve_config_gates()
+
+    def test_skills_bare_true_still_works_for_backcompat(
+        self, tmp_path, monkeypatch
+    ):
+        """A legacy bool `skills.write_approval: true` (pre-v33 config that
+        somehow survived migration) must still open the gate."""
+        self._write_cfg(tmp_path, "skills:\n  write_approval: true\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        assert "skills" in _resolve_config_gates()
+
+    def test_skills_bare_false_keeps_command_closed(self, tmp_path, monkeypatch):
+        self._write_cfg(tmp_path, "skills:\n  write_approval: false\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        assert "skills" not in _resolve_config_gates()
+
+    def test_skills_dict_without_enabled_stays_closed(
+        self, tmp_path, monkeypatch
+    ):
+        """A dict missing the `enabled` key must default to closed.
+        This guards against a partial migration that writes only the
+        lists without the toggle — never assume "non-empty = on"."""
+        self._write_cfg(tmp_path, "skills:\n  write_approval:\n    only: [a]\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        assert "skills" not in _resolve_config_gates()
+
+    def test_skills_dict_off_excluded_from_help(self, tmp_path, monkeypatch):
+        """End-to-end: with enabled: false, /skills must not appear in
+        gateway help even when only/exclude are populated."""
+        self._write_cfg(tmp_path,
+                        "skills:\n  write_approval:\n    enabled: false\n"
+                        "    only: [a, b]\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        joined = "\n".join(gateway_help_lines())
+        assert "`/skills" not in joined
+        # The Telegram menu and Slack map use the same gate resolution,
+        # so they should also hide /skills when enabled is false.
+        names = {n for n, _ in telegram_bot_commands()}
+        assert "skills" not in names
+        assert "skills" not in slack_subcommand_map()
+
+    def test_skills_dict_on_included_in_help(self, tmp_path, monkeypatch):
+        self._write_cfg(tmp_path,
+                        "skills:\n  write_approval:\n    enabled: true\n"
+                        "    only: [a]\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        joined = "\n".join(gateway_help_lines())
+        assert "`/skills" in joined
+        names = {n for n, _ in telegram_bot_commands()}
+        assert "skills" in names
+        assert "skills" in slack_subcommand_map()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -28,6 +28,7 @@ from hermes_cli.commands import (
     telegram_bot_commands,
     telegram_menu_commands,
     telegram_menu_max_commands,
+    _resolve_config_gates,
 )
 
 
@@ -296,6 +297,98 @@ class TestGatewayConfigGate:
 
         mapping = slack_subcommand_map()
         assert "verbose" in mapping
+
+
+class TestSkillsConfigGateDict:
+    """`/skills` is gated by ``skills.write_approval``, which is a dict
+    ``{enabled, only, exclude}`` (config v33+). The dict must be evaluated
+    through the ``enabled`` sub-key, not by raw truthiness, otherwise a
+    non-empty dict with ``enabled: false`` (e.g. persisted with only/exclude
+    lists but gate off) would still expose the command in gateway help /
+    menus / mappings. (#58533)
+    """
+
+    def _write_cfg(self, tmp_path, body: str):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(body)
+        return cfg
+
+    def test_skills_dict_enabled_false_keeps_command_closed(
+        self, tmp_path, monkeypatch
+    ):
+        self._write_cfg(tmp_path,
+                        "skills:\n  write_approval:\n    enabled: false\n"
+                        "    only: [a, b]\n    exclude: []\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        # The config-gate resolver must read .enabled, not treat the dict
+        # as truthy. With enabled: false, /skills stays out of the
+        # config-gated command set — even though only/exclude are populated.
+        gated = _resolve_config_gates()
+        assert "skills" not in gated
+
+    def test_skills_dict_enabled_true_opens_command(self, tmp_path, monkeypatch):
+        self._write_cfg(tmp_path,
+                        "skills:\n  write_approval:\n    enabled: true\n"
+                        "    only: [a]\n    exclude: []\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        assert "skills" in _resolve_config_gates()
+
+    def test_skills_bare_true_still_works_for_backcompat(
+        self, tmp_path, monkeypatch
+    ):
+        """A legacy bool `skills.write_approval: true` (pre-v33 config that
+        somehow survived migration) must still open the gate."""
+        self._write_cfg(tmp_path, "skills:\n  write_approval: true\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        assert "skills" in _resolve_config_gates()
+
+    def test_skills_bare_false_keeps_command_closed(self, tmp_path, monkeypatch):
+        self._write_cfg(tmp_path, "skills:\n  write_approval: false\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        assert "skills" not in _resolve_config_gates()
+
+    def test_skills_dict_without_enabled_stays_closed(
+        self, tmp_path, monkeypatch
+    ):
+        """A dict missing the `enabled` key must default to closed.
+        This guards against a partial migration that writes only the
+        lists without the toggle — never assume "non-empty = on"."""
+        self._write_cfg(tmp_path, "skills:\n  write_approval:\n    only: [a]\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        assert "skills" not in _resolve_config_gates()
+
+    def test_skills_dict_off_excluded_from_help(self, tmp_path, monkeypatch):
+        """End-to-end: with enabled: false, /skills must not appear in
+        gateway help even when only/exclude are populated."""
+        self._write_cfg(tmp_path,
+                        "skills:\n  write_approval:\n    enabled: false\n"
+                        "    only: [a, b]\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        joined = "\n".join(gateway_help_lines())
+        assert "`/skills" not in joined
+        # The Telegram menu and Slack map use the same gate resolution,
+        # so they should also hide /skills when enabled is false.
+        names = {n for n, _ in telegram_bot_commands()}
+        assert "skills" not in names
+        assert "skills" not in slack_subcommand_map()
+
+    def test_skills_dict_on_included_in_help(self, tmp_path, monkeypatch):
+        self._write_cfg(tmp_path,
+                        "skills:\n  write_approval:\n    enabled: true\n"
+                        "    only: [a]\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        joined = "\n".join(gateway_help_lines())
+        assert "`/skills" in joined
+        names = {n for n, _ in telegram_bot_commands()}
+        assert "skills" in names
+        assert "skills" in slack_subcommand_map()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1403,9 +1403,9 @@ class TestWriteApprovalMigration:
     ``on``/``off``/unset map to ``False`` (gate off). The old ``write_mode`` key
     is removed. Only a persisted key is rewritten — never invented.
 
-    Note: Since config v33, skills.write_approval is a dict
+    Note: Since config v39, skills.write_approval is a dict
     ``{enabled, only, exclude}`` rather than a bare bool, so after the v28→v29
-    rename the v32→v33 migration expands it. Memory stays as a bare bool.
+    rename the v38→v39 migration expands it. Memory stays as a bare bool.
     """
 
     def _write(self, tmp_path, body: str):

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1402,6 +1402,10 @@ class TestWriteApprovalMigration:
     Only an explicit ``approve`` carried gating intent and maps to ``True``;
     ``on``/``off``/unset map to ``False`` (gate off). The old ``write_mode`` key
     is removed. Only a persisted key is rewritten — never invented.
+
+    Note: Since config v33, skills.write_approval is a dict
+    ``{enabled, only, exclude}`` rather than a bare bool, so after the v28→v29
+    rename the v32→v33 migration expands it. Memory stays as a bare bool.
     """
 
     def _write(self, tmp_path, body: str):
@@ -1414,10 +1418,16 @@ class TestWriteApprovalMigration:
                         "skills:\n  write_mode: approve\n")
             migrate_config(interactive=False, quiet=True)
             raw = yaml.safe_load((tmp_path / "config.yaml").read_text())
+            # Memory stayed as a bare bool (no v32→v33 migration for memory).
             assert raw["memory"]["write_approval"] is True
-            assert raw["skills"]["write_approval"] is True
+            # Skills was expanded to a dict by the v32→v33 migration.
+            assert raw["skills"]["write_approval"] == {"enabled": True, "only": [], "exclude": []}
             assert "write_mode" not in raw["memory"]
             assert "write_mode" not in raw["skills"]
+            # Resolved value: enabled=True means gate is on.
+            loaded = load_config()
+            from tools.write_approval import write_approval_enabled
+            assert write_approval_enabled("skills") is True
 
     def test_on_and_off_map_to_false(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
@@ -1429,14 +1439,18 @@ class TestWriteApprovalMigration:
             migrate_config(interactive=False, quiet=True)
             raw = yaml.safe_load((tmp_path / "config.yaml").read_text())
             loaded = load_config()
-            # write_approval=False equals the schema default, so it is NOT
-            # materialised to disk (lean-config invariant) — the legacy
-            # write_mode key is gone and the effective value resolves to False
-            # via load_config()'s deep-merge.
+            # write_approval=False for memory equals the schema default (False),
+            # so it is NOT materialised to disk (lean-config invariant).
+            # For skills the v32→v33 migration converts the bool to a dict,
+            # which equals the new default and is also stripped.
             assert "write_mode" not in raw.get("memory", {})
             assert "write_mode" not in raw.get("skills", {})
+            # Resolved effective values via deep-merge.
             assert loaded["memory"]["write_approval"] is False
-            assert loaded["skills"]["write_approval"] is False
+            assert loaded["skills"]["write_approval"] == {"enabled": False, "only": [], "exclude": []}
+            from tools.write_approval import write_approval_enabled
+            assert write_approval_enabled("memory") is False
+            assert write_approval_enabled("skills") is False
 
 
 class TestMigrationWriteInvariant:

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1403,9 +1403,9 @@ class TestWriteApprovalMigration:
     ``on``/``off``/unset map to ``False`` (gate off). The old ``write_mode`` key
     is removed. Only a persisted key is rewritten — never invented.
 
-    Note: Since config v39, skills.write_approval is a dict
+    Note: Since config v40, skills.write_approval is a dict
     ``{enabled, only, exclude}`` rather than a bare bool, so after the v28→v29
-    rename the v38→v39 migration expands it. Memory stays as a bare bool.
+    rename the v39→v40 migration expands it. Memory stays as a bare bool.
     """
 
     def _write(self, tmp_path, body: str):

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1092,6 +1092,10 @@ class TestWriteApprovalMigration:
     Only an explicit ``approve`` carried gating intent and maps to ``True``;
     ``on``/``off``/unset map to ``False`` (gate off). The old ``write_mode`` key
     is removed. Only a persisted key is rewritten — never invented.
+
+    Note: Since config v33, skills.write_approval is a dict
+    ``{enabled, only, exclude}`` rather than a bare bool, so after the v28→v29
+    rename the v32→v33 migration expands it. Memory stays as a bare bool.
     """
 
     def _write(self, tmp_path, body: str):
@@ -1104,10 +1108,16 @@ class TestWriteApprovalMigration:
                         "skills:\n  write_mode: approve\n")
             migrate_config(interactive=False, quiet=True)
             raw = yaml.safe_load((tmp_path / "config.yaml").read_text())
+            # Memory stayed as a bare bool (no v32→v33 migration for memory).
             assert raw["memory"]["write_approval"] is True
-            assert raw["skills"]["write_approval"] is True
+            # Skills was expanded to a dict by the v32→v33 migration.
+            assert raw["skills"]["write_approval"] == {"enabled": True, "only": [], "exclude": []}
             assert "write_mode" not in raw["memory"]
             assert "write_mode" not in raw["skills"]
+            # Resolved value: enabled=True means gate is on.
+            loaded = load_config()
+            from tools.write_approval import write_approval_enabled
+            assert write_approval_enabled("skills") is True
 
     def test_on_and_off_map_to_false(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
@@ -1119,14 +1129,18 @@ class TestWriteApprovalMigration:
             migrate_config(interactive=False, quiet=True)
             raw = yaml.safe_load((tmp_path / "config.yaml").read_text())
             loaded = load_config()
-            # write_approval=False equals the schema default, so it is NOT
-            # materialised to disk (lean-config invariant) — the legacy
-            # write_mode key is gone and the effective value resolves to False
-            # via load_config()'s deep-merge.
+            # write_approval=False for memory equals the schema default (False),
+            # so it is NOT materialised to disk (lean-config invariant).
+            # For skills the v32→v33 migration converts the bool to a dict,
+            # which equals the new default and is also stripped.
             assert "write_mode" not in raw.get("memory", {})
             assert "write_mode" not in raw.get("skills", {})
+            # Resolved effective values via deep-merge.
             assert loaded["memory"]["write_approval"] is False
-            assert loaded["skills"]["write_approval"] is False
+            assert loaded["skills"]["write_approval"] == {"enabled": False, "only": [], "exclude": []}
+            from tools.write_approval import write_approval_enabled
+            assert write_approval_enabled("memory") is False
+            assert write_approval_enabled("skills") is False
 
 
 class TestMigrationWriteInvariant:

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -32,6 +32,14 @@ def _set_approval(subsystem, enabled):
     cfg.save_config(c)
 
 
+def _set_approval_dict(subsystem, value):
+    """Set the write_approval value as a dict (config v33+ shape)."""
+    import hermes_cli.config as cfg
+    c = cfg.load_config()
+    c.setdefault(subsystem, {})["write_approval"] = value
+    cfg.save_config(c)
+
+
 # ---------------------------------------------------------------------------
 # Config resolution
 # ---------------------------------------------------------------------------
@@ -61,6 +69,106 @@ def test_normalize_enabled_coerces_values():
     assert wa._normalize_enabled("off") is False
     assert wa._normalize_enabled("garbage") is False
     assert wa._normalize_enabled(None) is False
+    # Dict (config v33+ shape) → reads the 'enabled' sub-key.
+    assert wa._normalize_enabled({"enabled": True, "only": [], "exclude": []}) is True
+    assert wa._normalize_enabled({"enabled": False}) is False
+    assert wa._normalize_enabled({}) is False
+
+
+# ---------------------------------------------------------------------------
+# should_gate_skill — only/exclude filtering
+# ---------------------------------------------------------------------------
+
+
+def test_should_gate_skill_gate_off(hermes_home):
+    """Gate off → never gate, regardless of only/exclude."""
+    from tools import write_approval as wa
+    # Gate is off by default
+    assert wa.should_gate_skill("any-skill") is False
+
+
+def test_should_gate_skill_gate_on_no_lists(hermes_home):
+    """Gate on, no only/exclude → gate everything (pre-v33 behaviour)."""
+    from tools import write_approval as wa
+    _set_approval_dict("skills", {"enabled": True, "only": [], "exclude": []})
+    assert wa.should_gate_skill("any-skill") is True
+
+
+def test_should_gate_skill_only_list(hermes_home):
+    """Gate on with only list → only gate skills in the list."""
+    from tools import write_approval as wa
+    _set_approval_dict("skills",
+                       {"enabled": True, "only": ["important-skill"], "exclude": []})
+    assert wa.should_gate_skill("important-skill") is True
+    assert wa.should_gate_skill("scratch-skill") is False
+
+
+def test_should_gate_skill_exclude_list(hermes_home):
+    """Gate on with exclude list → gate everything except excluded skills."""
+    from tools import write_approval as wa
+    _set_approval_dict("skills",
+                       {"enabled": True, "only": [], "exclude": ["scratch-skill"]})
+    assert wa.should_gate_skill("scratch-skill") is False
+    assert wa.should_gate_skill("other-skill") is True
+
+
+def test_should_gate_skill_only_takes_precedence(hermes_home):
+    """When both only and exclude are set, only wins (more restrictive)."""
+    from tools import write_approval as wa
+    _set_approval_dict("skills",
+                       {"enabled": True, "only": ["important-skill"], "exclude": ["important-skill"]})
+    # only is non-empty → only skills in 'only' are gated.
+    assert wa.should_gate_skill("important-skill") is True
+
+
+def test_skill_gate_with_only_skips_excluded_skills(hermes_home):
+    """skill_manage with only list: write to unlisted skill bypasses gate."""
+    import importlib
+    import tools.skill_manager_tool as smt
+    importlib.reload(smt)
+    from tools import write_approval as wa
+    _set_approval_dict("skills",
+                       {"enabled": True, "only": ["gated-skill"], "exclude": []})
+
+    # Skill NOT in the 'only' list → write flows freely (not staged).
+    r = smt.skill_manage("create", "free-skill",
+                          content="---\nname: free-skill\ndescription: x\n---\nbody\n")
+    result = json.loads(r)
+    assert result.get("success") is True
+    assert result.get("staged") is None or result.get("staged") is False
+    assert wa.pending_count("skills") == 0
+
+    # Skill IN the 'only' list → staged for approval.
+    r2 = smt.skill_manage("create", "gated-skill",
+                           content="---\nname: gated-skill\ndescription: x\n---\nbody\n")
+    result2 = json.loads(r2)
+    assert result2.get("staged") is True
+    assert wa.pending_count("skills") == 1
+
+
+def test_skill_gate_with_exclude_bypasses_excluded(hermes_home):
+    """skill_manage with exclude list: write to excluded skill bypasses gate."""
+    import importlib
+    import tools.skill_manager_tool as smt
+    importlib.reload(smt)
+    from tools import write_approval as wa
+    _set_approval_dict("skills",
+                       {"enabled": True, "only": [], "exclude": ["scratch-skill"]})
+
+    # Excluded skill → write flows freely.
+    r = smt.skill_manage("create", "scratch-skill",
+                          content="---\nname: scratch-skill\ndescription: x\n---\nbody\n")
+    result = json.loads(r)
+    assert result.get("success") is True
+    assert result.get("staged") is None or result.get("staged") is False
+    assert wa.pending_count("skills") == 0
+
+    # Non-excluded skill → staged for approval.
+    r2 = smt.skill_manage("create", "real-skill",
+                           content="---\nname: real-skill\ndescription: x\n---\nbody\n")
+    result2 = json.loads(r2)
+    assert result2.get("staged") is True
+    assert wa.pending_count("skills") == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -171,6 +171,39 @@ def test_skill_gate_with_exclude_bypasses_excluded(hermes_home):
     assert wa.pending_count("skills") == 1
 
 
+def test_runtime_approval_toggle_preserves_lists(hermes_home):
+    """#58533 review note: Toggling `enabled` via the CLI/gateway
+    approval handler must NOT wipe out configured `only`/`exclude`
+    lists. Simulate the gateway ``/skills approval off`` path by
+    writing ``enabled: false`` over a fully populated dict and
+    confirming the lists survive.
+    """
+    import hermes_cli.config as cfg
+
+    # Start with the gate configured for selective gating.
+    raw = cfg.read_raw_config()
+    raw.setdefault("skills", {})["write_approval"] = {
+        "enabled": True, "only": ["important-skill"], "exclude": ["scratch"],
+    }
+    cfg.save_config(raw)
+
+    # Simulate the toggle path the gateway uses when /skills approval off
+    # is invoked: merge ``enabled: false`` over the existing dict without
+    # touching only/exclude. (The handler does this via
+    # ``setdefault("write_approval", {})["enabled"] = ...``.)
+    config_path = cfg.get_config_path()
+    raw_after = cfg.read_raw_config()
+    raw_after.setdefault("skills", {}).setdefault("write_approval", {})["enabled"] = False
+    cfg.save_config(raw_after)
+
+    # Reload and verify the lists survived.
+    loaded = cfg.load_config()
+    wa_dict = loaded["skills"]["write_approval"]
+    assert wa_dict["enabled"] is False
+    assert wa_dict["only"] == ["important-skill"]
+    assert wa_dict["exclude"] == ["scratch"]
+
+
 # ---------------------------------------------------------------------------
 # Memory gate
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -33,7 +33,7 @@ def _set_approval(subsystem, enabled):
 
 
 def _set_approval_dict(subsystem, value):
-    """Set the write_approval value as a dict (config v39+ shape)."""
+    """Set the write_approval value as a dict (config v40+ shape)."""
     import hermes_cli.config as cfg
     c = cfg.load_config()
     c.setdefault(subsystem, {})["write_approval"] = value
@@ -69,7 +69,7 @@ def test_normalize_enabled_coerces_values():
     assert wa._normalize_enabled("off") is False
     assert wa._normalize_enabled("garbage") is False
     assert wa._normalize_enabled(None) is False
-    # Dict (config v39+ shape) → reads the 'enabled' sub-key.
+    # Dict (config v40+ shape) → reads the 'enabled' sub-key.
     assert wa._normalize_enabled({"enabled": True, "only": [], "exclude": []}) is True
     assert wa._normalize_enabled({"enabled": False}) is False
     assert wa._normalize_enabled({}) is False
@@ -88,7 +88,7 @@ def test_should_gate_skill_gate_off(hermes_home):
 
 
 def test_should_gate_skill_gate_on_no_lists(hermes_home):
-    """Gate on, no only/exclude → gate everything (pre-v39 behaviour)."""
+    """Gate on, no only/exclude → gate everything (pre-v40 behaviour)."""
     from tools import write_approval as wa
     _set_approval_dict("skills", {"enabled": True, "only": [], "exclude": []})
     assert wa.should_gate_skill("any-skill") is True

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -33,7 +33,7 @@ def _set_approval(subsystem, enabled):
 
 
 def _set_approval_dict(subsystem, value):
-    """Set the write_approval value as a dict (config v33+ shape)."""
+    """Set the write_approval value as a dict (config v39+ shape)."""
     import hermes_cli.config as cfg
     c = cfg.load_config()
     c.setdefault(subsystem, {})["write_approval"] = value
@@ -69,7 +69,7 @@ def test_normalize_enabled_coerces_values():
     assert wa._normalize_enabled("off") is False
     assert wa._normalize_enabled("garbage") is False
     assert wa._normalize_enabled(None) is False
-    # Dict (config v33+ shape) → reads the 'enabled' sub-key.
+    # Dict (config v39+ shape) → reads the 'enabled' sub-key.
     assert wa._normalize_enabled({"enabled": True, "only": [], "exclude": []}) is True
     assert wa._normalize_enabled({"enabled": False}) is False
     assert wa._normalize_enabled({}) is False
@@ -88,7 +88,7 @@ def test_should_gate_skill_gate_off(hermes_home):
 
 
 def test_should_gate_skill_gate_on_no_lists(hermes_home):
-    """Gate on, no only/exclude → gate everything (pre-v33 behaviour)."""
+    """Gate on, no only/exclude → gate everything (pre-v39 behaviour)."""
     from tools import write_approval as wa
     _set_approval_dict("skills", {"enabled": True, "only": [], "exclude": []})
     assert wa.should_gate_skill("any-skill") is True
@@ -169,6 +169,39 @@ def test_skill_gate_with_exclude_bypasses_excluded(hermes_home):
     result2 = json.loads(r2)
     assert result2.get("staged") is True
     assert wa.pending_count("skills") == 1
+
+
+def test_runtime_approval_toggle_preserves_lists(hermes_home):
+    """#58533 review note: Toggling `enabled` via the CLI/gateway
+    approval handler must NOT wipe out configured `only`/`exclude`
+    lists. Simulate the gateway ``/skills approval off`` path by
+    writing ``enabled: false`` over a fully populated dict and
+    confirming the lists survive.
+    """
+    import hermes_cli.config as cfg
+
+    # Start with the gate configured for selective gating.
+    raw = cfg.read_raw_config()
+    raw.setdefault("skills", {})["write_approval"] = {
+        "enabled": True, "only": ["important-skill"], "exclude": ["scratch"],
+    }
+    cfg.save_config(raw)
+
+    # Simulate the toggle path the gateway uses when /skills approval off
+    # is invoked: merge ``enabled: false`` over the existing dict without
+    # touching only/exclude. (The handler does this via
+    # ``setdefault("write_approval", {})["enabled"] = ...``.)
+    config_path = cfg.get_config_path()
+    raw_after = cfg.read_raw_config()
+    raw_after.setdefault("skills", {}).setdefault("write_approval", {})["enabled"] = False
+    cfg.save_config(raw_after)
+
+    # Reload and verify the lists survived.
+    loaded = cfg.load_config()
+    wa_dict = loaded["skills"]["write_approval"]
+    assert wa_dict["enabled"] is False
+    assert wa_dict["only"] == ["important-skill"]
+    assert wa_dict["exclude"] == ["scratch"]
 
 
 # ---------------------------------------------------------------------------

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -589,6 +589,9 @@ def _run_write_gate(build_staging):
     decision = wa.evaluate_gate(wa.SKILLS)
     if decision.allow:
         return None
+    # Gate is on → check if THIS specific skill should be gated (only/exclude).
+    if not wa.should_gate_skill(name):
+        return None
     if decision.blocked:
         return tool_error(decision.message, success=False)
     payload, gist = build_staging(wa)

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1446,6 +1446,9 @@ def _apply_skill_write_gate(action, name, **payload_kwargs):
     decision = wa.evaluate_gate(wa.SKILLS)
     if decision.allow:
         return None
+    # Gate is on → check if THIS specific skill should be gated (only/exclude).
+    if not wa.should_gate_skill(name):
+        return None
     if decision.blocked:
         return tool_error(decision.message, success=False)
 

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -92,15 +92,51 @@ def write_approval_enabled(subsystem: str) -> bool:
 def _normalize_enabled(value: Any) -> bool:
     """Coerce a config value to a bool. Default (unknown) is False (gate off).
 
-    Accepts real bools and the usual truthy/falsey strings. YAML 1.1 parses
-    bare ``on``/``off``/``yes``/``no`` as bools already, so the string branch
+    Accepts real bools, dicts (``{"enabled": True}`` — the new config-v33
+    shape), and the usual truthy/falsey strings. YAML 1.1 parses bare
+    ``on``/``off``/``yes``/``no`` as bools already, so the string branch
     is mostly for hand-edited configs.
     """
     if isinstance(value, bool):
         return value
+    if isinstance(value, dict):
+        return _normalize_enabled(value.get("enabled", False))
     if isinstance(value, str):
         return value.strip().lower() in {"on", "true", "yes", "1", "approve", "enabled"}
     return False
+
+
+def should_gate_skill(name: str) -> bool:
+    """Check whether a specific skill name should be subject to the approval gate.
+
+    When the gate is off (``skills.write_approval.enabled: false``) this always
+    returns False — writes flow freely.
+
+    When the gate is on, the ``only`` / ``exclude`` lists refine the decision:
+
+    * ``only`` non-empty   — gate ONLY skills whose name is in this list
+    * ``exclude`` non-empty — gate ALL skills EXCEPT those in this list
+    * neither set (default) — gate every skill write (the pre-v33 behaviour)
+
+    ``only`` takes precedence when both are set (the more restrictive wins).
+    """
+    if not write_approval_enabled(SKILLS):
+        return False
+    try:
+        from hermes_cli.config import load_config, cfg_get
+        cfg = load_config()
+        raw = cfg_get(cfg, SKILLS, CONFIG_KEY, default={})
+    except Exception:
+        return True  # gate on, no override → gate everything
+    if not isinstance(raw, dict):
+        return True  # gate on, no override → gate everything
+    only_list = raw.get("only", [])
+    exclude_list = raw.get("exclude", [])
+    if only_list:
+        return name in only_list
+    if exclude_list:
+        return name not in exclude_list
+    return True  # gate on, no only/exclude → gate everything
 
 
 # ---------------------------------------------------------------------------

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -52,14 +52,58 @@ def write_approval_enabled(subsystem: str) -> bool:
 
 
 def _normalize_enabled(value: Any) -> bool:
-    """Coerce a config value to bool; unknown → False (gate off). The string branch
-    covers hand-edited configs (YAML already parses bare on/off/yes/no)."""
+    """Coerce a config value to a bool. Default (unknown) is False (gate off).
+
+    Accepts real bools, dicts (``{"enabled": True}`` — the new config-v41
+    shape), and the usual truthy/falsey strings. YAML 1.1 parses bare
+    ``on``/``off``/``yes``/``no`` as bools already, so the string branch
+    is mostly for hand-edited configs.
+    """
     if isinstance(value, bool):
         return value
-    return isinstance(value, str) and value.strip().lower() in _TRUTHY_STRINGS
+    if isinstance(value, dict):
+        return _normalize_enabled(value.get("enabled", False))
+    if isinstance(value, str):
+        return value.strip().lower() in {"on", "true", "yes", "1", "approve", "enabled"}
+    return False
 
 
-# --- Pending store (file-backed) ---
+def should_gate_skill(name: str) -> bool:
+    """Check whether a specific skill name should be subject to the approval gate.
+
+    When the gate is off (``skills.write_approval.enabled: false``) this always
+    returns False — writes flow freely.
+
+    When the gate is on, the ``only`` / ``exclude`` lists refine the decision:
+
+    * ``only`` non-empty   — gate ONLY skills whose name is in this list
+    * ``exclude`` non-empty — gate ALL skills EXCEPT those in this list
+    * neither set (default) — gate every skill write (the pre-v41 behaviour)
+
+    ``only`` takes precedence when both are set (the more restrictive wins).
+    """
+    if not write_approval_enabled(SKILLS):
+        return False
+    try:
+        from hermes_cli.config import load_config, cfg_get
+        cfg = load_config()
+        raw = cfg_get(cfg, SKILLS, CONFIG_KEY, default={})
+    except Exception:
+        return True  # gate on, no override → gate everything
+    if not isinstance(raw, dict):
+        return True  # gate on, no override → gate everything
+    only_list = raw.get("only", [])
+    exclude_list = raw.get("exclude", [])
+    if only_list:
+        return name in only_list
+    if exclude_list:
+        return name not in exclude_list
+    return True  # gate on, no only/exclude → gate everything
+
+
+# ---------------------------------------------------------------------------
+# Pending store (file-backed)
+# ---------------------------------------------------------------------------
 
 def _pending_path(subsystem: str, pending_id: str) -> Path:
     return get_hermes_home() / "pending" / subsystem / f"{pending_id}.json"

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -713,14 +713,19 @@ When on, any flagged `skill_manage` write surfaces as an approval prompt with th
 
 ### Write approval for skill writes
 
-Independent of the content scanner above, `skills.write_approval` gates **every** agent skill write (create / edit / patch / delete / supporting files) behind your explicit approval — the same approve/deny mechanism as dangerous commands:
+Independent of the content scanner above, `skills.write_approval` gates agent skill writes (create / edit / patch / delete / supporting files) behind your explicit approval — the same approve/deny mechanism as dangerous commands. The gate is a dictionary with three keys:
 
 ```yaml
 skills:
-  write_approval: false   # false = write freely (default) | true = stage every write for review
+  write_approval:
+    enabled: false         # false = write freely (default) | true = stage every write
+    only: []               # if non-empty, gate ONLY these skill names
+    exclude: []            # if non-empty, gate ALL skills EXCEPT these names
 ```
 
-When on, skill writes are staged under `~/.hermes/pending/skills/` and reviewed with `/skills pending`, `/skills diff <id>`, `/skills approve <id>`, `/skills reject <id>` — from the CLI or any messaging platform. Toggle at runtime with `/skills approval on|off`. Memory has the same gate (`memory.write_approval`, below). Full walkthrough: [Gating agent skill writes](/user-guide/features/skills#gating-agent-skill-writes-skillswrite_approval).
+`only` and `exclude` are independent lists, not mutually exclusive in config. When both are non-empty, `only` takes precedence (the more restrictive view wins). A name absent from `only` is exempt when `only` is set; a name in `exclude` is always exempt.
+
+When the gate is on, skill writes are staged under `~/.hermes/pending/skills/` and reviewed with `/skills pending`, `/skills diff <id>`, `/skills approve <id>`, `/skills reject <id>` — from the CLI or any messaging platform. Toggle at runtime with `/skills approval on|off`; the toggle preserves any `only`/`exclude` lists you have configured. Memory has the same gate (`memory.write_approval`, below). Full walkthrough: [Gating agent skill writes](/user-guide/features/skills#gating-agent-skill-writes-skillswrite_approval).
 
 ## Memory Configuration
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -660,14 +660,19 @@ When on, any flagged `skill_manage` write surfaces as an approval prompt with th
 
 ### Write approval for skill writes
 
-Independent of the content scanner above, `skills.write_approval` gates **every** agent skill write (create / edit / patch / delete / supporting files) behind your explicit approval — the same approve/deny mechanism as dangerous commands:
+Independent of the content scanner above, `skills.write_approval` gates agent skill writes (create / edit / patch / delete / supporting files) behind your explicit approval — the same approve/deny mechanism as dangerous commands. The gate is a dictionary with three keys:
 
 ```yaml
 skills:
-  write_approval: false   # false = write freely (default) | true = stage every write for review
+  write_approval:
+    enabled: false         # false = write freely (default) | true = stage every write
+    only: []               # if non-empty, gate ONLY these skill names
+    exclude: []            # if non-empty, gate ALL skills EXCEPT these names
 ```
 
-When on, skill writes are staged under `~/.hermes/pending/skills/` and reviewed with `/skills pending`, `/skills diff <id>`, `/skills approve <id>`, `/skills reject <id>` — from the CLI or any messaging platform. Toggle at runtime with `/skills approval on|off`. Memory has the same gate (`memory.write_approval`, below). Full walkthrough: [Gating agent skill writes](/user-guide/features/skills#gating-agent-skill-writes-skillswrite_approval).
+`only` and `exclude` are independent lists, not mutually exclusive in config. When both are non-empty, `only` takes precedence (the more restrictive view wins). A name absent from `only` is exempt when `only` is set; a name in `exclude` is always exempt.
+
+When the gate is on, skill writes are staged under `~/.hermes/pending/skills/` and reviewed with `/skills pending`, `/skills diff <id>`, `/skills approve <id>`, `/skills reject <id>` — from the CLI or any messaging platform. Toggle at runtime with `/skills approval on|off`; the toggle preserves any `only`/`exclude` lists you have configured. Memory has the same gate (`memory.write_approval`, below). Full walkthrough: [Gating agent skill writes](/user-guide/features/skills#gating-agent-skill-writes-skillswrite_approval).
 
 ## Memory Configuration
 

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -622,12 +622,15 @@ wanting eyes on the self-improvement loop), turn on the write-approval gate:
 
 ```yaml
 skills:
-  write_approval: false     # false = write freely (default) | true = require approval
+  write_approval:
+    enabled: false       # false = write freely (default) | true = require approval
+    only: []             # if non-empty, gate ONLY these skill names
+    exclude: []          # if non-empty, gate ALL skills EXCEPT these names
 ```
 
-When `write_approval: true`, every `skill_manage` write (create / edit /
-patch / delete / write_file / remove_file) is **staged** instead of committed —
-a SKILL.md is too large to review inline, so staging applies regardless of
+When `enabled: true`, every `skill_manage` write (create / edit / patch /
+delete / write_file / remove_file) is **staged** instead of committed — a
+SKILL.md is too large to review inline, so staging applies regardless of
 whether the write came from a foreground turn or the background review.
 Staged writes survive restarts under `~/.hermes/pending/skills/` and are
 reviewed with the same familiar approve/deny flow as dangerous commands:
@@ -639,6 +642,22 @@ reviewed with the same familiar approve/deny flow as dangerous commands:
 /skills reject <id>         # drop it (or 'all')
 /skills approval on         # turn the gate on (or 'off') and persist it
 ```
+
+`/skills approval on|off` toggles `enabled` while leaving any `only` or
+`exclude` lists you have configured untouched, so you can flip the gate on
+and off without re-entering your filtering rules.
+
+#### Selective gating with `only` and `exclude`
+
+If reviewing every skill write is too noisy, narrow the gate to a subset:
+
+* `only: [important-skill, another-skill]` — gate only writes to these
+  specific skills. Writes to anything else flow freely.
+* `exclude: [scratch-skill, demo-skill]` — gate every skill except these.
+
+If both lists are set, `only` takes precedence — `exclude` is ignored entirely
+when `only` is non-empty. The lists are matched against the skill's canonical
+name as registered in `skill_manage` using exact string equality.
 
 The review surface works in the interactive CLI and on messaging platforms
 (diff output is truncated for chat bubbles — read the full diff on the CLI or

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -500,12 +500,15 @@ wanting eyes on the self-improvement loop), turn on the write-approval gate:
 
 ```yaml
 skills:
-  write_approval: false     # false = write freely (default) | true = require approval
+  write_approval:
+    enabled: false       # false = write freely (default) | true = require approval
+    only: []             # if non-empty, gate ONLY these skill names
+    exclude: []          # if non-empty, gate ALL skills EXCEPT these names
 ```
 
-When `write_approval: true`, every `skill_manage` write (create / edit /
-patch / delete / write_file / remove_file) is **staged** instead of committed —
-a SKILL.md is too large to review inline, so staging applies regardless of
+When `enabled: true`, every `skill_manage` write (create / edit / patch /
+delete / write_file / remove_file) is **staged** instead of committed — a
+SKILL.md is too large to review inline, so staging applies regardless of
 whether the write came from a foreground turn or the background review.
 Staged writes survive restarts under `~/.hermes/pending/skills/` and are
 reviewed with the same familiar approve/deny flow as dangerous commands:
@@ -517,6 +520,23 @@ reviewed with the same familiar approve/deny flow as dangerous commands:
 /skills reject <id>         # drop it (or 'all')
 /skills approval on         # turn the gate on (or 'off') and persist it
 ```
+
+`/skills approval on|off` toggles `enabled` while leaving any `only` or
+`exclude` lists you have configured untouched, so you can flip the gate on
+and off without re-entering your filtering rules.
+
+#### Selective gating with `only` and `exclude`
+
+If reviewing every skill write is too noisy, narrow the gate to a subset:
+
+* `only: [important-skill, another-skill]` — gate only writes to these
+  specific skills. Writes to anything else flow freely.
+* `exclude: [scratch-skill, demo-skill]` — gate every skill except these.
+
+If both lists are set, `only` wins (a name must be in `only` to be gated).
+A name in `exclude` is always exempt regardless of `only`. The lists are
+matched against the skill's canonical name as registered in `skill_manage`
+using exact string equality.
 
 The review surface works in the interactive CLI and on messaging platforms
 (diff output is truncated for chat bubbles — read the full diff on the CLI or


### PR DESCRIPTION
## Summary

Expand `skills.write_approval` from a bare bool to a dict with three sub-keys so users can selectively gate only specific skills instead of all-or-nothing approval.

## Changes

**Config schema** (`hermes_cli/config.py`):
- `skills.write_approval` is now `{enabled: bool, only: [str], exclude: [str]}`
- Config version bumped
- Migration converts persisted bare bools to the new dict format

**Runtime** (`tools/write_approval.py`):
- `_normalize_enabled()` handles both bare bool (legacy) and dict shapes
- New `should_gate_skill(name)` — returns `False` when gate is off, or when gate is on but the skill name is excluded by `only`/`exclude`

**Gating** (`tools/skill_manager_tool.py`):
- `_apply_skill_write_gate()` now checks `should_gate_skill(name)` after the gate decision — if the gate would stage but this skill is exempt via only/exclude, the write flows freely

**CLI/Gateway approval toggle**:
- `_save_write_approval` (CLI) and `_set_approval` (gateway) now write `skills.write_approval.enabled` instead of overwriting the entire dict with a bool

**Tests**:
- 7 new tests: `_normalize_enabled` with dict, `should_gate_skill` with off/on/only/exclude/precedence, `skill_manage` integration with only/exclude
- Updated existing config migration tests for dict shape

## Closes

Closes #58533