### PR TITLE
feat: add kanban lifecycle hooks (pre_complete, unblocked, created)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2681,6 +2681,13 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                     },
                 )
+            _fire_kanban_lifecycle_hook(
+                "kanban_task_created",
+                task_id,
+                board=get_current_board(),
+                assignee=assignee,
+                run_id=None,
+            )
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:
@@ -4047,6 +4054,48 @@ def complete_task(
     else:
         verified_cards = []
 
+    # ── Pre-complete governance gate ──────────────────────────────────
+    # Plugins may veto a completion BEFORE the state transition commits.
+    # Fires with the proposed summary so governance hooks (attestation
+    # check, eval chain, compliance) can inspect the worker's output
+    # without holding the SQLite write lock.  The first callback that
+    # returns {"action": "block", "reason": "..."} wins; the completion
+    # is rejected with that reason surfaced to the caller.
+    try:
+        from hermes_cli.plugins import invoke_hook
+        from hermes_cli.profiles import get_active_profile_name
+        try:
+            profile_name = get_active_profile_name()
+        except Exception:
+            profile_name = "default"
+        # Read current assignee before firing — the task is still in its
+        # pre-completion state (running/ready/blocked).
+        _pre_task = get_task(conn, task_id)
+        pre_results = invoke_hook(
+            "kanban_pre_complete",
+            task_id=task_id,
+            board=get_current_board(),
+            assignee=_pre_task.assignee if _pre_task else None,
+            run_id=None,
+            profile_name=profile_name,
+            summary=summary if summary is not None else result,
+        )
+        for ret in pre_results:
+            if isinstance(ret, dict) and ret.get("action") == "block":
+                reason = ret.get("reason", "blocked by plugin governance hook")
+                _log.warning(
+                    "kanban_pre_complete blocked task %s: %s", task_id, reason,
+                )
+                # Record the veto as an event so it's auditable.
+                with write_txn(conn):
+                    _append_event(
+                        conn, task_id, "completion_blocked_governance",
+                        {"reason": reason, "source": "kanban_pre_complete"},
+                    )
+                return False
+    except Exception as exc:
+        _log.debug("kanban_pre_complete hook error (non-fatal): %s", exc)
+
     metadata = _merge_completion_prose_artifacts(
         conn, task_id, metadata, summary=summary, result=result,
     )
@@ -5111,7 +5160,18 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
             conn, task_id, "unblocked",
             {"status": new_status} if new_status != "ready" else None,
         )
-        return True
+        # Capture assignee for the lifecycle hook while still inside the txn.
+        _unblocked_assignee = conn.execute(
+            "SELECT assignee FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+    _fire_kanban_lifecycle_hook(
+        "kanban_task_unblocked",
+        task_id,
+        board=get_current_board(),
+        assignee=_unblocked_assignee["assignee"] if _unblocked_assignee else None,
+        run_id=None,
+    )
+    return True
 
 
 def specify_triage_task(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3324,6 +3324,7 @@ def recompute_ready(
     if failure_limit is None:
         failure_limit = DEFAULT_FAILURE_LIMIT
     promoted = 0
+    promoted_tasks: list[tuple[str, str | None]] = []
     with write_txn(conn):
         todo_rows = conn.execute(
             "SELECT id, status, consecutive_failures, max_retries "
@@ -3374,6 +3375,24 @@ def recompute_ready(
                     )
                 _append_event(conn, task_id, "promoted", None)
                 promoted += 1
+                # Capture task_id + assignee for post-commit hook.
+                # Read inside the txn so the value is durable.
+                _assignee_row = conn.execute(
+                    "SELECT assignee FROM tasks WHERE id = ?", (task_id,)
+                ).fetchone()
+                promoted_tasks.append(
+                    (task_id, _assignee_row["assignee"] if _assignee_row else None)
+                )
+    # Fire promotion hooks AFTER the write txn commits, matching the
+    # post-commit contract at _fire_kanban_lifecycle_hook (L141-148).
+    for _tid, _assignee in promoted_tasks:
+        _fire_kanban_lifecycle_hook(
+            "kanban_task_promoted",
+            _tid,
+            board=get_current_board(),
+            assignee=_assignee,
+            run_id=None,
+        )
     return promoted
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2681,6 +2681,10 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                     },
                 )
+            # Fire the created hook AFTER the write txn commits, matching the
+            # post-commit contract at `_fire_kanban_lifecycle_hook` (L141-148):
+            # plugin callbacks must observe durable board state and never hold
+            # the SQLite write lock.
             _fire_kanban_lifecycle_hook(
                 "kanban_task_created",
                 task_id,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5161,6 +5161,10 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
             {"status": new_status} if new_status != "ready" else None,
         )
         # Capture assignee for the lifecycle hook while still inside the txn.
+        # SQLite's SERIALIZABLE isolation (the default WAL mode) guarantees
+        # this read sees the row that was just committed — no other writer can
+        # mutate the row between our UPDATE above and this SELECT, so the
+        # value is not stale when the hook fires outside the txn.
         _unblocked_assignee = conn.execute(
             "SELECT assignee FROM tasks WHERE id = ?", (task_id,)
         ).fetchone()

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -238,6 +238,10 @@ VALID_HOOKS: Set[str] = {
     "kanban_task_blocked",
     "kanban_task_created",
     "kanban_task_unblocked",
+    # Fires after a task is promoted todo→ready by dependency resolution
+    # (recompute_ready). Distinct from kanban_task_unblocked which covers
+    # explicit unblock operations only.
+    "kanban_task_promoted",
     "kanban_pre_complete",
 }
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -188,9 +188,11 @@ VALID_HOOKS: Set[str] = {
     "pre_approval_request",
     "post_approval_response",
     # Kanban task lifecycle hooks. Fired by hermes_cli.kanban_db when a task
-    # transitions state, AFTER the change is committed to the board DB (so the
-    # hook always sees durable state and a slow plugin can never hold the
-    # SQLite write lock). Observers only: return values are ignored.
+    # transitions state.  Observer hooks ("kanban_task_claimed", "_unblocked",
+    # "_created") fire AFTER the write txn commits so a slow plugin can never
+    # hold the SQLite write lock and the hook always sees durable state.
+    # Governance hooks ("kanban_pre_complete") fire BEFORE the write txn and
+    # may block the transition.
     #
     # WHICH PROCESS each fires in matters, because kanban workers run as
     # separate `hermes -p <profile> chat -q` subprocesses:
@@ -201,17 +203,30 @@ VALID_HOOKS: Set[str] = {
     #                              kanban_complete (or a CLI/manual complete).
     #   - kanban_task_blocked   -> the WORKER process (worker-initiated block)
     #                              or whichever process drove the block.
+    #   - kanban_task_created   -> whichever process called create_task
+    #                              (CLI, dispatcher, or decomposer).
+    #   - kanban_task_unblocked -> whichever process called unblock_task.
+    #   - kanban_pre_complete   -> the WORKER (or CLI) process BEFORE the
+    #                              complete write txn.  Callbacks may return
+    #                              {"action": "block", "reason": "..."} to
+    #                              veto the transition.  First block wins;
+    #                              None / {"action": "allow"} permits.
     # A plugin that needs to observe every transition centrally should hook in
     # the dispatcher; one that needs per-task in-session context should hook in
     # the worker.
     #
-    # Common kwargs: task_id: str, board: str | None, assignee: str | None,
-    #   run_id: int | None, profile_name: str.
+    # Common kwargs (all hooks): task_id: str, board: str | None,
+    #   assignee: str | None, run_id: int | None, profile_name: str.
     # kanban_task_completed adds: summary: str | None.
     # kanban_task_blocked adds:   reason: str | None.
+    # kanban_pre_complete adds:   summary: str | None (the proposed summary;
+    #                              may differ from final stored value).
     "kanban_task_claimed",
     "kanban_task_completed",
     "kanban_task_blocked",
+    "kanban_task_created",
+    "kanban_task_unblocked",
+    "kanban_pre_complete",
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -221,6 +221,18 @@ VALID_HOOKS: Set[str] = {
     # kanban_task_blocked adds:   reason: str | None.
     # kanban_pre_complete adds:   summary: str | None (the proposed summary;
     #                              may differ from final stored value).
+    # ── Relationship to tool-layer hooks ─────────────────────────────
+    # Some kanban state transitions have hooks at BOTH the tool layer and
+    # the DB layer. They serve different purposes and are not redundant:
+    #   - Tool-layer hooks (e.g. on_task_block in tools/kanban_tools.py,
+    #     #42692) fire BEFORE any DB write — they can reject the tool
+    #     call early (returning a tool_error to the worker) without ever
+    #     touching the board DB.
+    #   - DB-layer hooks (kanban_task_blocked, etc.) fire AFTER the write
+    #     txn commits — they observe durable state and a slow plugin can
+    #     never hold the SQLite write lock.
+    # A policy plugin can use both: tool-layer to reject early, DB-layer
+    # to react to the confirmed, durable transition.
     "kanban_task_claimed",
     "kanban_task_completed",
     "kanban_task_blocked",

--- a/tests/hermes_cli/test_kanban_lifecycle_hooks.py
+++ b/tests/hermes_cli/test_kanban_lifecycle_hooks.py
@@ -1,9 +1,12 @@
 """Tests for kanban lifecycle plugin hooks.
 
-Verifies that claim/complete/block transitions fire the
-kanban_task_claimed / kanban_task_completed / kanban_task_blocked plugin
-hooks AFTER the board DB change is committed, with the documented kwargs,
-and that a misbehaving hook callback never breaks the transition.
+Verifies that create / claim / complete / block / unblock transitions fire the
+kanban_task_created / kanban_task_claimed / kanban_task_completed /
+kanban_task_blocked / kanban_task_unblocked plugin hooks AFTER the board DB
+change is committed (observer hooks), and that kanban_pre_complete fires
+BEFORE the write txn and can veto the transition (governance hooks).
+
+Also verifies that a misbehaving hook callback never breaks the transition.
 """
 
 from __future__ import annotations
@@ -28,7 +31,7 @@ def kanban_home(tmp_path, monkeypatch):
 
 @pytest.fixture
 def captured_hooks(monkeypatch):
-    """Register capturing callbacks for the three kanban lifecycle hooks.
+    """Register capturing callbacks for all six kanban lifecycle hooks.
 
     Patches the plugin manager's _hooks dict directly (the same registry
     invoke_hook reads) and restores it afterward.
@@ -36,7 +39,13 @@ def captured_hooks(monkeypatch):
     mgr = get_plugin_manager()
     events: list[tuple[str, dict]] = []
     saved = {k: list(v) for k, v in mgr._hooks.items()}
-    for hook in ("kanban_task_claimed", "kanban_task_completed", "kanban_task_blocked"):
+    for hook in (
+        "kanban_task_created",
+        "kanban_task_claimed",
+        "kanban_task_completed",
+        "kanban_task_blocked",
+        "kanban_task_unblocked",
+    ):
         mgr._hooks.setdefault(hook, []).append(
             lambda _h=hook, **kw: events.append((_h, kw))
         )
@@ -46,11 +55,35 @@ def captured_hooks(monkeypatch):
         mgr._hooks = saved
 
 
+# ── VALID_HOOKS registration ────────────────────────────────────────────
+
+
 def test_hooks_are_registered_as_valid():
-    """The three lifecycle hook names are part of VALID_HOOKS."""
+    """All six kanban lifecycle hook names are part of VALID_HOOKS."""
+    assert "kanban_task_created" in VALID_HOOKS
     assert "kanban_task_claimed" in VALID_HOOKS
     assert "kanban_task_completed" in VALID_HOOKS
     assert "kanban_task_blocked" in VALID_HOOKS
+    assert "kanban_task_unblocked" in VALID_HOOKS
+    assert "kanban_pre_complete" in VALID_HOOKS
+
+
+# ── Observer hooks ──────────────────────────────────────────────────────
+
+
+def test_create_fires_hook(kanban_home, captured_hooks):
+    """create_task fires kanban_task_created with the task id and assignee."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="test create", assignee="worker")
+    finally:
+        conn.close()
+    fired = [e for e in captured_hooks if e[0] == "kanban_task_created"]
+    assert len(fired) == 1
+    kw = fired[0][1]
+    assert kw["task_id"] == tid
+    assert kw["assignee"] == "worker"
+    assert "profile_name" in kw
 
 
 def test_claim_fires_hook(kanban_home, captured_hooks):
@@ -101,6 +134,142 @@ def test_block_fires_hook_with_reason(kanban_home, captured_hooks):
     assert kw["reason"] == "needs human"
 
 
+def test_unblock_fires_hook(kanban_home, captured_hooks):
+    """unblock_task fires kanban_task_unblocked with the task id and assignee."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="test unblock", assignee="worker")
+        kb.claim_task(conn, tid)
+        assert kb.block_task(conn, tid, reason="test block")
+        assert kb.unblock_task(conn, tid)
+    finally:
+        conn.close()
+    fired = [e for e in captured_hooks if e[0] == "kanban_task_unblocked"]
+    assert len(fired) == 1
+    kw = fired[0][1]
+    assert kw["task_id"] == tid
+    assert kw["assignee"] == "worker"
+    assert "profile_name" in kw
+
+
+# ── Governance hooks (kanban_pre_complete) ──────────────────────────────
+
+
+def test_pre_complete_allows_completion(kanban_home, monkeypatch):
+    """A pre_complete hook returning None/allow permits the transition."""
+    mgr = get_plugin_manager()
+    saved = {k: list(v) for k, v in mgr._hooks.items()}
+
+    calls: list[dict] = []
+
+    def _allow(**kw):
+        calls.append(kw)
+        return {"action": "allow"}
+
+    mgr._hooks.setdefault("kanban_pre_complete", []).append(_allow)
+    try:
+        conn = kb.connect()
+        try:
+            tid = kb.create_task(conn, title="t", assignee="worker")
+            kb.claim_task(conn, tid)
+            assert kb.complete_task(conn, tid, summary="ok") is True
+            assert kb.get_task(conn, tid).status == "done"
+        finally:
+            conn.close()
+    finally:
+        mgr._hooks = saved
+
+    assert len(calls) == 1
+    assert calls[0]["task_id"] == tid
+    assert calls[0]["summary"] == "ok"
+    assert calls[0]["assignee"] == "worker"
+
+
+def test_pre_complete_blocks_completion(kanban_home, monkeypatch):
+    """A pre_complete hook returning {"action": "block"} vetoes the
+    transition — the task stays in its current state and complete_task
+    returns False."""
+    mgr = get_plugin_manager()
+    saved = {k: list(v) for k, v in mgr._hooks.items()}
+
+    def _veto(**kw):
+        return {"action": "block", "reason": "attestation missing"}
+
+    mgr._hooks.setdefault("kanban_pre_complete", []).append(_veto)
+    try:
+        conn = kb.connect()
+        try:
+            tid = kb.create_task(conn, title="t", assignee="worker")
+            kb.claim_task(conn, tid)
+            # The completion is vetoed.
+            assert kb.complete_task(conn, tid, summary="should fail") is False
+            # Task is still in its pre-completion state (running).
+            assert kb.get_task(conn, tid).status == "running"
+        finally:
+            conn.close()
+    finally:
+        mgr._hooks = saved
+
+
+def test_pre_complete_block_is_auditable(kanban_home, monkeypatch):
+    """When kanban_pre_complete blocks, a completion_blocked_governance
+    event is recorded in the event log."""
+    mgr = get_plugin_manager()
+    saved = {k: list(v) for k, v in mgr._hooks.items()}
+
+    def _veto(**kw):
+        return {"action": "block", "reason": "attestation missing"}
+
+    mgr._hooks.setdefault("kanban_pre_complete", []).append(_veto)
+    try:
+        conn = kb.connect()
+        try:
+            tid = kb.create_task(conn, title="t", assignee="worker")
+            kb.claim_task(conn, tid)
+            assert kb.complete_task(conn, tid, summary="blocked") is False
+
+            events = kb.list_events(conn, tid)
+            blocked_events = [
+                e for e in events
+                if e.kind == "completion_blocked_governance"
+            ]
+            assert len(blocked_events) == 1
+            payload = blocked_events[0].payload
+            assert payload["reason"] == "attestation missing"
+            assert payload["source"] == "kanban_pre_complete"
+        finally:
+            conn.close()
+    finally:
+        mgr._hooks = saved
+
+
+def test_pre_complete_hook_error_non_fatal(kanban_home, monkeypatch):
+    """A pre_complete callback that raises does NOT block completion —
+    the exception is caught and the transition proceeds normally."""
+    mgr = get_plugin_manager()
+    saved = {k: list(v) for k, v in mgr._hooks.items()}
+
+    def _boom(**kw):
+        raise RuntimeError("plugin exploded")
+
+    mgr._hooks.setdefault("kanban_pre_complete", []).append(_boom)
+    try:
+        conn = kb.connect()
+        try:
+            tid = kb.create_task(conn, title="t", assignee="worker")
+            kb.claim_task(conn, tid)
+            # Completion succeeds despite the raising hook.
+            assert kb.complete_task(conn, tid, summary="ok") is True
+            assert kb.get_task(conn, tid).status == "done"
+        finally:
+            conn.close()
+    finally:
+        mgr._hooks = saved
+
+
+# ── Failed transition → no hook ─────────────────────────────────────────
+
+
 def test_no_hook_on_failed_transition(kanban_home, captured_hooks):
     """complete_task on an unclaimed/nonexistent task fires no hook."""
     conn = kb.connect()
@@ -110,6 +279,9 @@ def test_no_hook_on_failed_transition(kanban_home, captured_hooks):
     finally:
         conn.close()
     assert [e for e in captured_hooks if e[0] == "kanban_task_completed"] == []
+
+
+# ── Observer hook resilience ────────────────────────────────────────────
 
 
 def test_misbehaving_hook_does_not_break_transition(kanban_home, monkeypatch):


### PR DESCRIPTION
## Summary

Adds three new plugin hooks to the kanban task state machine, expanding the plugin interface for governance and observability use cases.

## Motivation

The current kanban lifecycle hooks (`kanban_task_claimed`, `kanban_task_completed`, `kanban_task_blocked`) are all observer-only — they fire AFTER the state transition commits and their return values are ignored. Real-world plugin use cases (kanban-advanced governance, compliance attestation, dependency-management automation) need two additional capabilities that the current surface doesn't provide:

1. **Pre-completion governance gates** — a hook that can structurally VETO a completion before it becomes durable
2. **Create/unblock observability** — hooks for the two remaining state transitions so plugins don't need to poll

## Changes

### `kanban_task_created` (observer)
- Fires AFTER `create_task` commits (outside the write txn, same pattern as existing hooks)
- Standard kanban lifecycle kwargs: `task_id`, `board`, `assignee`, `run_id`, `profile_name`
- Lets plugins react to new cards entering the board (auto-block, validation, logging)

### `kanban_task_unblocked` (observer)
- Fires AFTER `unblock_task` commits
- Captures the task's assignee inside the txn for the hook payload
- Eliminates the need for cron-based polling to detect dependency resolution

### `kanban_pre_complete` (governance)
- Fires BEFORE `complete_task`'s write txn — plugins can veto the transition
- Callbacks return `{"action": "block", "reason": "..."}` to block, or `None`/`{"action": "allow"}` to permit
- First block wins; blocked completions emit a `completion_blocked_governance` audit event
- Carries the proposed `summary` so governance plugins can inspect the worker's output
- Uses `invoke_hook` directly (not `_fire_kanban_lifecycle_hook`) because return values must be inspected

## Design decisions

- **pre_complete uses invoke_hook directly** rather than the best-effort `_fire_kanban_lifecycle_hook` wrapper, because the governance hook must inspect return values and potentially block. The existing wrapper silently discards return values.
- **All hooks are additive** — zero behavior change when no plugin registers for them. Backward compatible.
- **pre_complete fires outside any write lock** so a slow governance plugin (network call, subprocess) can't hold the SQLite lock. The veto event is written in a separate tiny txn.
- **Audit trail preserved** — blocked completions emit a `completion_blocked_governance` event so operators can see WHY a card was blocked.

## Non-goals

This PR does NOT add hooks for every possible kanban state transition. The three hooks added here are driven by concrete plugin use cases:

| Hook | Concrete consumer | Status |
|------|------------------|--------|
| `kanban_pre_complete` | kanban-advanced verify-deploy attestation gate | Blocked on this hook |
| `kanban_task_created` | kanban-advanced auto-block-on-create | Currently works around via script |
| `kanban_task_unblocked` | kanban-advanced event-driven auto-promotion | Currently polls via 1m cron |

## Testing

- [ ] Existing kanban lifecycle hook tests still pass
- [ ] New hooks fire at correct points in the state machine
- [ ] pre_complete block path: hook returns block → completion is rejected → audit event written
- [ ] pre_complete allow path: hook returns None → completion proceeds normally
- [ ] created hook fires with correct task_id and assignee
- [ ] unblocked hook fires with correct task_id and assignee

## Related

- Hermes plugin interface expansion discussion (Discord)
- kanban-advanced plugin: [thebizfixer/kanban-advanced](https://github.com/thebizfixer/kanban-advanced)
- Umbrella: #35986