### PR TITLE
RFC: Plugin observability hooks (worker lifecycle, task mutation events)

### DIFF
--- a/docs/rfcs/plugin-infrastructure-improvements.md
+++ b/docs/rfcs/plugin-infrastructure-improvements.md
@@ -1,0 +1,159 @@
+# Plugin Infrastructure Improvements — Design Proposal
+
+**Branch:** `feat/plugin-infrastructure-improvements`
+**Target:** `hermes_cli/plugins.py`, `plugin.yaml` schema
+**Concrete consumer:** kanban-advanced (dashboard sidecar, version gating, persistent state)
+
+---
+
+## Summary
+
+Three infrastructure improvements that reduce plugin boilerplate and improve
+the developer experience — driven by patterns observed across the plugin
+ecosystem and specifically in kanban-advanced's architecture.
+
+---
+
+## Proposal 1: Plugin API backend support
+
+### Current state (GHSA-5qr3-c538-wm9j workaround)
+
+Non-bundled plugins cannot import Python API backends. This forces any plugin
+with a dashboard or HTTP API to run a **standalone sidecar server** on a
+separate port, managed by the plugin itself:
+- PID file locking to prevent duplicate instances
+- Keepalive crons to restart crashed sidecars
+- Port conflict management
+- Health check endpoints
+
+kanban-advanced's dashboard runs as `scripts/dashboard_server.py` on
+`127.0.0.1:18900` — completely outside Hermes' plugin infrastructure.
+
+### Proposed: `api_backend` in `plugin.yaml`
+
+```yaml
+# plugin.yaml
+kind: standalone
+api_backend:
+  enabled: false           # default: off for security
+  module: dashboard.api    # Python module with a create_app() factory
+  require_user_approval: true  # prompt on first install
+```
+
+When enabled (and approved by the user), Hermes imports the module and mounts
+it at `/_plugin/<plugin_id>/` on the existing gateway HTTP server. The module
+must expose:
+
+```python
+# plugin/dashboard/api.py
+def create_app() -> "FastAPI | Flask | ASGI app":
+    """Return an ASGI/WSGI application. Called once at gateway startup."""
+```
+
+### Benefits
+- No separate port, no PID management, no keepalive crons
+- Inherits Hermes' existing auth (if gateway has auth configured)
+- Clean lifecycle: starts/stops with the gateway
+- User must explicitly opt in via `hermes plugins enable --with-api <name>`
+
+### Security
+- `require_user_approval: true` (default) — prompts on first install
+- API backend module is imported in a restricted context (no file system write access by default)
+- `plugins.entries.<id>.api_backend.enabled` in config.yaml for persistent toggle
+
+---
+
+## Proposal 2: Plugin version & dependency declaration
+
+### Current state
+
+Plugin manifests have `version` and `requires_env` but no way to declare:
+- Minimum Hermes version required
+- Dependencies on other plugins
+- Python package dependencies
+
+We document "Hermes ≥ 0.16.0" in 8 different files. Version upgrade audits
+are manual.
+
+### Proposed manifest fields
+
+```yaml
+# plugin.yaml
+version: 1.0.0
+requires_hermes: ">=0.17.0"          # semver constraint
+requires_plugins:                     # optional
+  kanban: ">=0.1.0"
+requires_python: ">=3.10"
+requires_packages:                    # pip packages
+  - "httpx>=0.24"
+  - "pydantic>=2.0"
+```
+
+Behavior:
+- **`requires_hermes`** — `hermes plugins install` warns on mismatch.
+  `hermes doctor` flags it. Plugin still loads (forward compat) but with
+  a warning in `hermes plugins list`.
+- **`requires_plugins`** — install blocks if dependency not present.
+  `hermes plugins install <name>` auto-installs missing deps with confirmation.
+- **`requires_packages`** — `hermes plugins install` offers to pip install.
+  Refused in gateway context (must be pre-installed).
+
+---
+
+## Proposal 3: `ctx.data_dir` — plugin-owned persistent state
+
+### Current state
+
+Plugins that need persistent state (logs, caches, databases) must resolve
+paths manually using `HERMES_HOME` or `~/.hermes/`. Paths aren't namespaced
+to the plugin, leading to collisions and cleanup difficulty.
+
+kanban-advanced writes:
+- `~/.hermes/logs/kanban/board_events.jsonl`
+- `.hermes/kanban-overrides/kanban-config.yaml`
+- `.hermes/kanban/preflight_cache.json`
+
+### Proposed API
+
+```python
+class PluginContext:
+    @property
+    def data_dir(self) -> Path:
+        """Return this plugin's persistent data directory.
+
+        Returns ~/.hermes/plugins/<plugin_id>/data/ — created on first access.
+        Guaranteed to exist and be writable. Cleaned up on plugin removal.
+        """
+        if self._data_dir is None:
+            plugin_id = self.manifest.key or self.manifest.name
+            safe_id = plugin_id.replace("/", "__")
+            self._data_dir = get_hermes_home() / "plugins" / safe_id / "data"
+            self._data_dir.mkdir(parents=True, exist_ok=True)
+        return self._data_dir
+```
+
+### Benefits
+- Automatic cleanup on `hermes plugins remove`
+- No path collision between plugins
+- Predictable location for debugging (`hermes plugins data-dir <name>`)
+
+---
+
+## Non-goals
+
+- **Plugin sandboxing/containerization** — out of scope. Hermes plugins run
+  with the same trust level as the agent.
+- **Plugin marketplace/discovery** — out of scope. This is about the
+  technical interface, not distribution.
+- **Hot-reload of plugin code** — out of scope. Plugin code changes require
+  a gateway restart (same as today).
+
+---
+
+## Related
+
+- PR #58541 — kanban lifecycle hooks
+- PR #58542 — plugin config & state bridge
+- PR #58547 — context injection hooks
+- PR #58548 — observability hooks
+- GHSA-5qr3-c538-wm9j — current API backend restriction

--- a/docs/rfcs/plugin-observability-hooks.md
+++ b/docs/rfcs/plugin-observability-hooks.md
@@ -1,0 +1,95 @@
+# Plugin Observability Hooks — Design Proposal
+
+**Branch:** `feat/plugin-observability-hooks`
+**Target:** `hermes_cli/plugins.py` (VALID_HOOKS), `hermes_cli/kanban_db.py`, `gateway/run.py`
+**Concrete consumer:** kanban-advanced (board_keeper, intervention tracking, postmortem data)
+
+---
+
+## Summary
+
+Today plugins that need to observe kanban worker lifecycle (spawn, crash, stale
+claim) or track manual card mutations must poll the board via cron. This adds
+latency (1-minute cron ticks) and burns tokens on polling queries.
+
+This proposal adds four observer hooks that let plugins react to events
+immediately instead of polling.
+
+---
+
+## Proposal 1: Worker lifecycle hooks
+
+### `kanban_worker_spawned`
+
+Fires in the **DISPATCHER** process after a worker subprocess is successfully
+spawned.
+
+```python
+# Kwargs: task_id, board, assignee, run_id, profile_name, worker_pid: int
+```
+
+### `kanban_worker_exited`
+
+Fires in the **DISPATCHER** process when a worker subprocess exits (whether
+success, failure, or crash).
+
+```python
+# Kwargs: task_id, board, assignee, run_id, profile_name,
+#         exit_code: int, outcome: str ("completed" | "failed" | "crashed")
+```
+
+### `kanban_worker_stale_claim`
+
+Fires in the **DISPATCHER** process when `release_stale_claims` reclaims a
+timed-out claim.
+
+```python
+# Kwargs: task_id, board, assignee, run_id, profile_name,
+#         seconds_stale: int
+```
+
+### Concrete use case (kanban-advanced)
+
+Our `board_keeper` cron polls the board every minute to detect:
+- Stale `running` cards → trigger salvage
+- Crashed workers → trigger re-dispatch
+- Worker exit → trigger auto_unblock
+
+With these hooks, `board_keeper` becomes event-driven — zero polling latency,
+zero token burn on "nothing changed" checks.
+
+---
+
+## Proposal 2: `kanban_task_updated` hook
+
+Fires after any UPDATE to a task row (body edit, assignee change, title
+change, description update). Observer-only — return values ignored.
+
+```python
+# Kwargs: task_id, board, assignee, profile_name,
+#         changed_fields: list[str]  # e.g. ["body", "assignee"]
+```
+
+### Concrete use case (kanban-advanced)
+
+Our intervention tracking requires operators to manually run
+`kanban_intervention_inc.sh` after editing a card. With this hook, the
+intervention counter increments automatically — no manual step, no forgotten
+increments.
+
+---
+
+## Implementation notes
+
+All four hooks follow the same pattern as existing kanban lifecycle hooks:
+- Fire AFTER the write txn commits (observer safety)
+- Swallowed exceptions (a misbehaving plugin can't break board state)
+- Standard kwargs: `task_id`, `board`, `assignee`, `run_id`, `profile_name`
+
+---
+
+## Related
+
+- PR #58541 — kanban lifecycle hooks (pre_complete, unblocked, created)
+- PR #58542 — plugin config & state bridge (cron API would obsolete polling)
+- kanban-advanced board_keeper architecture

--- a/docs/rfcs/plugin-observability-hooks.md
+++ b/docs/rfcs/plugin-observability-hooks.md
@@ -19,26 +19,30 @@ immediately instead of polling.
 
 ## Proposal 1: Worker lifecycle hooks
 
-### `kanban_worker_spawned`
+### `kanban_task_claimed` (pre-spawn observer)
 
-Fires in the **DISPATCHER** process after a worker subprocess is successfully
-spawned.
+Fires in the **DISPATCHER** process BEFORE `_default_spawn` at
+`kanban_db.py:3485`. Carries `task_id`, `assignee`, `board`.
+Observer-only — callbacks run before the worker subprocess is created
+and cannot affect the spawn decision.
 
-```python
-# Kwargs: task_id, board, assignee, run_id, profile_name, worker_pid: int
-```
+### `kanban_task_spawned` (post-spawn observer)
 
-### `kanban_worker_exited`
+Fires in the **DISPATCHER** process AFTER `_default_spawn` returns
+successfully and the worker PID is persisted in the tasks table at
+`kanban_db.py:8058-8069`. Carries `task_id`, `board`, `assignee`,
+`run_id`, `profile_name`, `worker_pid: int`. Use this for "worker is
+actually running" events.
 
-Fires in the **DISPATCHER** process when a worker subprocess exits (whether
-success, failure, or crash).
+### `kanban_worker_exited` (tick-derived observer)
 
-```python
-# Kwargs: task_id, board, assignee, run_id, profile_name,
-#         exit_code: int, outcome: str ("completed" | "failed" | "crashed")
-```
+Fires in the **DISPATCHER** process from `detect_crashed_workers`
+(`kanban_db.py:6641`) when a worker PID is discovered dead. Carries
+`task_id`, `board`, `assignee`, `run_id`, `profile_name`,
+`exit_kind` (`clean_exit` | `nonzero_exit` | `signaled`), `exit_code`.
+Rate-limited exits emit a separate `kanban_worker_rate_limited` event.
 
-### `kanban_worker_stale_claim`
+### `kanban_worker_stale_claim` (tick-derived observer)
 
 Fires in the **DISPATCHER** process when `release_stale_claims` reclaims a
 timed-out claim.
@@ -81,10 +85,52 @@ increments.
 
 ## Implementation notes
 
-All four hooks follow the same pattern as existing kanban lifecycle hooks:
+All hooks follow the same pattern as existing kanban lifecycle hooks:
 - Fire AFTER the write txn commits (observer safety)
 - Swallowed exceptions (a misbehaving plugin can't break board state)
 - Standard kwargs: `task_id`, `board`, `assignee`, `run_id`, `profile_name`
+
+### Mutation boundary
+
+`kanban_task_updated` must fire for every write path that mutates task
+state, regardless of which module performs the write:
+
+**kanban_db.py paths:**
+| Function | Changed fields |
+|----------|---------------|
+| `create_task` | All fields (initial) |
+| `complete_task` | status→done, summary, result, metadata |
+| `block_task` | status→blocked, last_failure_error |
+| `unblock_task` | status→ready/todo, block_recurrences |
+| `_set_status_direct` | status |
+| `recompute_ready` | status→ready (promotion) |
+| `_record_task_failure` | status→blocked, consecutive_failures |
+
+**Dashboard plugin_api.py paths:**
+| Endpoint | Changed fields |
+|----------|---------------|
+| `PATCH /tasks/:id` (L838) | priority, title, body |
+| Bulk update (L1254) | priority |
+
+**Payload contract:** `changed_fields` is a list of field names that were
+mutated, not just a generic "updated" signal. Consumers can filter on
+specific fields without diffing DB state.
+
+### Timing contract
+
+| Hook | Fires | Latency |
+|------|-------|---------|
+| `kanban_task_claimed` | Pre-spawn, before `_default_spawn` | Immediate |
+| `kanban_task_spawned` | Post-spawn, after `_default_spawn` + PID persistence | Immediate |
+| `kanban_worker_exited` | Tick-derived via `detect_crashed_workers` | ≤ dispatcher tick interval |
+| `kanban_worker_rate_limited` | Tick-derived, separate event kind | ≤ dispatcher tick interval |
+| `kanban_worker_stale_claim` | Tick-derived via `release_stale_claims` | ≤ dispatcher tick interval |
+| `kanban_task_updated` | Post-commit, after any task mutation write | Immediate |
+
+Exit events are NOT immediate — `_default_spawn` is fire-and-forget.
+Workers are discovered dead on the next dispatcher tick. Plugins
+requiring lower latency should combine hook observation with
+`kanban_heartbeat` liveness tracking.
 
 ---
 

--- a/docs/rfcs/plugin-observability-hooks.md
+++ b/docs/rfcs/plugin-observability-hooks.md
@@ -3,6 +3,7 @@
 **Branch:** `feat/plugin-observability-hooks`
 **Target:** `hermes_cli/plugins.py` (VALID_HOOKS), `hermes_cli/kanban_db.py`, `gateway/run.py`
 **Concrete consumer:** kanban-advanced (board_keeper, intervention tracking, postmortem data)
+**Status:** SALVAGE design basis per #64231 batch disposition (teknium1, 2026-08-13)
 
 ---
 
@@ -12,45 +13,69 @@ Today plugins that need to observe kanban worker lifecycle (spawn, crash, stale
 claim) or track manual card mutations must poll the board via cron. This adds
 latency (1-minute cron ticks) and burns tokens on polling queries.
 
-This proposal adds four observer hooks that let plugins react to events
-immediately instead of polling.
+This proposal adds observer hooks that let plugins react to events immediately
+instead of polling.
+
+## Upstream alignment (August 2026 expansion wave)
+
+The base `kanban_task_{claimed,completed,blocked}` hooks already shipped on
+`main` (see `VALID_HOOKS` in `hermes_cli/plugins.py`). This RFC now covers the
+**remaining** worker/mutation observers, renamed to the `on_<noun>_<event>`
+observer convention per the #64231 batch disposition, and optionally folded
+into the inter-plugin event bus.
+
+1. **Inter-plugin event bus** (`ctx.emit` / `ctx.subscribe`, #64164) — a plugin
+   that receives a lifecycle hook may re-publish it onto the event bus so
+   non-kanban plugins (telemetry, quotas) can subscribe without registering the
+   hook themselves. Manifest `emits:` / `listens:` declarations expose the
+   surface via `hermes plugins show`.
+2. **Manifest v2** (`manifest_version`, `api_version`, `requires_plugins`,
+   `python_dependencies`, `config_schema`, #64165) — this RFC's observers are
+   additive hook surface; no new manifest fields are required beyond the
+   optional `emits`/`listens` declarations.
 
 ---
 
-## Proposal 1: Worker lifecycle hooks
+## Proposal 1: Worker lifecycle observers
 
-### `kanban_task_claimed` (pre-spawn observer)
+> Naming follows the #64231 taxonomy: observer-only, `on_<noun>_<event>`, fires
+> AFTER durable state is written, exceptions swallowed. The already-shipped
+> `kanban_task_claimed` / `kanban_task_completed` / `kanban_task_blocked` keep
+> their names; everything below is new. Fire sites are referenced by function
+> name (line numbers are current against `origin/main` @ `1706502aa` and will
+> drift).
 
-Fires in the **DISPATCHER** process BEFORE `_default_spawn` at
-`kanban_db.py:3485`. Carries `task_id`, `assignee`, `board`.
-Observer-only — callbacks run before the worker subprocess is created
-and cannot affect the spawn decision.
+### `on_kanban_worker_spawned` (post-spawn observer)
 
-### `kanban_task_spawned` (post-spawn observer)
+Fires in the **DISPATCHER** process AFTER `_default_spawn` (`kanban_db.py:10027`)
+returns successfully and the worker PID is persisted in the tasks table.
+Carries `task_id`, `board`, `assignee`, `run_id`, `profile_name`,
+`worker_pid: int`. Use this for "worker is actually running" events.
 
-Fires in the **DISPATCHER** process AFTER `_default_spawn` returns
-successfully and the worker PID is persisted in the tasks table at
-`kanban_db.py:8058-8069`. Carries `task_id`, `board`, `assignee`,
-`run_id`, `profile_name`, `worker_pid: int`. Use this for "worker is
-actually running" events.
-
-### `kanban_worker_exited` (tick-derived observer)
+### `on_kanban_worker_exited` (tick-derived observer)
 
 Fires in the **DISPATCHER** process from `detect_crashed_workers`
-(`kanban_db.py:6641`) when a worker PID is discovered dead. Carries
-`task_id`, `board`, `assignee`, `run_id`, `profile_name`,
-`exit_kind` (`clean_exit` | `nonzero_exit` | `signaled`), `exit_code`.
-Rate-limited exits emit a separate `kanban_worker_rate_limited` event.
+(`kanban_db.py:8496`) when a worker PID is discovered dead. Carries `task_id`,
+`board`, `assignee`, `run_id`, `profile_name`, `exit_kind`
+(`clean_exit` | `nonzero_exit` | `signaled`), `exit_code`. Rate-limited exits
+emit a separate `on_kanban_worker_rate_limited` event.
 
-### `kanban_worker_stale_claim` (tick-derived observer)
+### `on_kanban_worker_stale_claim` (tick-derived observer)
 
-Fires in the **DISPATCHER** process when `release_stale_claims` reclaims a
-timed-out claim.
+Fires in the **DISPATCHER** process when `release_stale_claims`
+(`kanban_db.py:4701`) reclaims a timed-out claim.
 
 ```python
 # Kwargs: task_id, board, assignee, run_id, profile_name,
 #         seconds_stale: int
 ```
+
+### `on_kanban_dispatch_tick` (absorbs #56066)
+
+Fires in the **DISPATCHER** process after `_dispatch_tick_lock` exits (lock
+defined at `kanban_db.py:1534`, taken at `kanban_db.py:9279`), renamed from the
+#56066 `kanban_dispatch_tick` (which fired inside the lock). Carries `board`,
+`tick_start`, `tick_end`, `dispatched_count: int`, `blocked_count: int`.
 
 ### Concrete use case (kanban-advanced)
 
@@ -64,10 +89,13 @@ zero token burn on "nothing changed" checks.
 
 ---
 
-## Proposal 2: `kanban_task_updated` hook
+## Proposal 2: `on_kanban_task_updated` observer
 
-Fires after any UPDATE to a task row (body edit, assignee change, title
-change, description update). Observer-only — return values ignored.
+Fires after any UPDATE to a task row (body edit, assignee change, title change,
+description update). Observer-only — return values ignored. (The #64231 verdict
+phrases the rename as `on_kanban_worker_*` for the worker-lifecycle subset; this
+mutation observer follows the same `on_` convention under the `kanban_task`
+noun.)
 
 ```python
 # Kwargs: task_id, board, assignee, profile_name,
@@ -83,16 +111,41 @@ increments.
 
 ---
 
+## Proposal 3: Event-bus re-publish (optional, #64164)
+
+The lifecycle hooks fire through the plugin hook mechanism. A plugin that
+receives one (e.g. kanban-advanced) may additionally **re-publish** it onto the
+inter-plugin event bus so plugins that did not register the hook can still
+subscribe. Emission is plugin-initiated, best-effort, and additive:
+
+```python
+# Inside a kanban-advanced hook callback:
+ctx.emit("worker_exited", {"task_id": task_id, "exit_code": 0})
+```
+
+- `ctx.emit` takes the **bare** event name only; the namespace is forced to
+  `<plugin_key>:` (`manifest.key or manifest.name`). Passing an already-namespaced
+  name (any `:`) is rejected with `ValueError` — fail-closed. The `hermes:`
+  prefix is reserved for core.
+- The manifest declares `emits: ["worker_exited", "worker_spawned", ...]` and
+  `listens: [...]` for `hermes plugins show` discoverability. Declarations are
+  advisory in v1 — a plugin may emit/subscribe without declaring.
+- Delivery is fire-and-forget through a host-owned single-worker queue; dispatch
+  is bounded by `_EVENT_EMIT_DEPTH_CAP` (8) and `_EVENT_PENDING_CAP` (64), so a
+  blocked subscriber cannot back-pressure the emitter.
+
+---
+
 ## Implementation notes
 
-All hooks follow the same pattern as existing kanban lifecycle hooks:
+All hooks follow the same pattern as the shipped kanban lifecycle hooks:
 - Fire AFTER the write txn commits (observer safety)
 - Swallowed exceptions (a misbehaving plugin can't break board state)
 - Standard kwargs: `task_id`, `board`, `assignee`, `run_id`, `profile_name`
 
 ### Mutation boundary
 
-`kanban_task_updated` must fire for every write path that mutates task
+`on_kanban_task_updated` must fire for every write path that mutates task
 state, regardless of which module performs the write:
 
 **kanban_db.py paths:**
@@ -113,29 +166,31 @@ state, regardless of which module performs the write:
 | Bulk update (L1254) | priority |
 
 **Payload contract:** `changed_fields` is a list of field names that were
-mutated, not just a generic "updated" signal. Consumers can filter on
-specific fields without diffing DB state.
+mutated, not just a generic "updated" signal. Consumers can filter on specific
+fields without diffing DB state.
 
 ### Timing contract
 
 | Hook | Fires | Latency |
 |------|-------|---------|
-| `kanban_task_claimed` | Pre-spawn, before `_default_spawn` | Immediate |
-| `kanban_task_spawned` | Post-spawn, after `_default_spawn` + PID persistence | Immediate |
-| `kanban_worker_exited` | Tick-derived via `detect_crashed_workers` | ≤ dispatcher tick interval |
-| `kanban_worker_rate_limited` | Tick-derived, separate event kind | ≤ dispatcher tick interval |
-| `kanban_worker_stale_claim` | Tick-derived via `release_stale_claims` | ≤ dispatcher tick interval |
-| `kanban_task_updated` | Post-commit, after any task mutation write | Immediate |
+| `on_kanban_worker_spawned` | Post-spawn, after `_default_spawn` + PID persistence | Immediate |
+| `on_kanban_worker_exited` | Tick-derived via `detect_crashed_workers` | ≤ dispatcher tick interval |
+| `on_kanban_worker_rate_limited` | Tick-derived, separate event kind | ≤ dispatcher tick interval |
+| `on_kanban_worker_stale_claim` | Tick-derived via `release_stale_claims` | ≤ dispatcher tick interval |
+| `on_kanban_dispatch_tick` | Post-tick, after `_dispatch_tick_lock` exits | ≤ dispatcher tick interval |
+| `on_kanban_task_updated` | Post-commit, after any task mutation write | Immediate |
 
-Exit events are NOT immediate — `_default_spawn` is fire-and-forget.
-Workers are discovered dead on the next dispatcher tick. Plugins
-requiring lower latency should combine hook observation with
-`kanban_heartbeat` liveness tracking.
+Exit events are NOT immediate — `_default_spawn` is fire-and-forget. Workers are
+discovered dead on the next dispatcher tick. Plugins requiring lower latency
+should combine hook observation with `kanban_heartbeat` liveness tracking.
 
 ---
 
 ## Related
 
 - PR #58541 — kanban lifecycle hooks (pre_complete, unblocked, created)
-- PR #58542 — plugin config & state bridge (cron API would obsolete polling)
+- #64231 — hook taxonomy + batch disposition (SALVAGE verdict for this RFC)
+- #64164 — inter-plugin event bus (`ctx.emit` / `ctx.subscribe`)
+- #64165 — manifest v2 (`emits`/`listens` declarations)
+- #56066 — folded: `kanban_dispatch_tick` → `on_kanban_dispatch_tick`
 - kanban-advanced board_keeper architecture


### PR DESCRIPTION
## Summary

Design proposal for four observer hooks that let plugins react to kanban events immediately instead of polling the board via cron.

## Motivation

Today kanban-advanced's `board_keeper` cron polls the board every minute to detect worker crashes, stale claims, and card mutations. This adds latency and burns tokens on "nothing changed" checks.

## Proposals

1. **`kanban_worker_spawned`** — fires in dispatcher after worker subprocess spawns
2. **`kanban_worker_exited`** — fires in dispatcher when worker exits (with exit code + outcome)
3. **`kanban_worker_stale_claim`** — fires in dispatcher when a timed-out claim is reclaimed
4. **`kanban_task_updated`** — fires after any UPDATE to a task row (body edit, assignee change, etc.)

All four follow the existing kanban lifecycle hook pattern: fire after write txn commits, observer-only, swallowed exceptions.

Full design document: `docs/rfcs/plugin-observability-hooks.md`

## Related

- PR #58541 — kanban lifecycle hooks
- PR #58542 — plugin config & state bridge (cron API)
- PR #58547 — context injection hooks