### PR TITLE
fix(gateway): pass full transcript to compressor instead of filtered messages (salvage #3854)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10762,11 +10762,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             user_config=_hyg_data if isinstance(_hyg_data, dict) else None,
                         )
                         if _hyg_runtime.get("api_key"):
+                            # Pass the FULL transcript (tool results included).
+                            # Filtering to user/assistant-only starved the
+                            # compressor: tool results are usually the bulk of
+                            # the context, _prune_old_tool_results never saw
+                            # them, and short filtered histories tripped the
+                            # protect-first/last early-return so nothing was
+                            # compressed at all (#3854). The agent loop passes
+                            # its full message list to _compress_context — the
+                            # gateway now matches.
                             _hyg_msgs = [
-                                {"role": m.get("role"), "content": m.get("content")}
-                                for m in history
-                                if m.get("role") in {"user", "assistant"}
-                                and m.get("content")
+                                m for m in history
+                                if m.get("role") in {"user", "assistant", "tool"}
                             ]
 
                             if len(_hyg_msgs) >= 4:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3133,10 +3133,14 @@ class GatewaySlashCommandsMixin:
             if not runtime_kwargs.get("api_key"):
                 return t("gateway.compress.no_provider")
 
+            # Pass the FULL transcript (tool results included) — same
+            # rationale as the session-hygiene auto-compress in
+            # gateway/run.py (#3854): filtering to user/assistant-only
+            # starves the compressor's tool-result pruning and can trip the
+            # protect-first/last early-return on short filtered histories.
             msgs = [
-                {"role": m.get("role"), "content": m.get("content")}
-                for m in history
-                if m.get("role") in {"user", "assistant"} and m.get("content")
+                m for m in history
+                if m.get("role") in {"user", "assistant", "tool"}
             ]
 
             # Boundary-aware split: only the head is summarized; the most

--- a/tests/gateway/test_compress_command.py
+++ b/tests/gateway/test_compress_command.py
@@ -483,3 +483,51 @@ async def test_compress_command_overrides_stale_resolver_identity():
     # Source-derived identity overrides the stale resolver values, passed once.
     assert kwargs["platform"] == "telegram"
     assert kwargs["gateway_session_key"] == runner._session_key_for_source(_make_source())
+
+
+@pytest.mark.asyncio
+async def test_compress_command_passes_tool_messages_to_compressor():
+    """Tool results must reach _compress_context (#3854).
+
+    Filtering the transcript to user/assistant-only starved the
+    compressor's tool-result pruning — tool messages are usually the bulk
+    of the context.
+    """
+    history = [
+        {"role": "user", "content": "run it"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"id": "t1", "type": "function",
+                            "function": {"name": "x", "arguments": "{}"}}],
+        },
+        {"role": "tool", "content": "BIG RESULT " * 50, "tool_call_id": "t1"},
+        {"role": "assistant", "content": "done"},
+        {"role": "user", "content": "thanks"},
+        {"role": "assistant", "content": "np"},
+    ]
+    runner = _make_runner(history)
+    agent_instance = MagicMock()
+    agent_instance.shutdown_memory_provider = MagicMock()
+    agent_instance.close = MagicMock()
+    agent_instance._cached_system_prompt = ""
+    agent_instance.tools = None
+    agent_instance.context_compressor.has_content_to_compress.return_value = True
+    agent_instance.session_id = "sess-1"
+    agent_instance._compress_context.return_value = (list(history), "")
+
+    with (
+        patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}),
+        patch("gateway.run._resolve_gateway_model", return_value="test-model"),
+        patch("run_agent.AIAgent", return_value=agent_instance),
+        patch("agent.model_metadata.estimate_request_tokens_rough", return_value=100),
+    ):
+        await runner._handle_compress_command(_make_event())
+
+    args, _kwargs = agent_instance._compress_context.call_args
+    passed = args[0]
+    roles = [m.get("role") for m in passed]
+    assert "tool" in roles, f"tool messages filtered out: {roles}"
+    # Assistant tool_calls stubs (content=None) must survive too, or the
+    # tool message would dangle without its call.
+    assert any(m.get("tool_calls") for m in passed), "assistant tool_calls stub dropped"


### PR DESCRIPTION
## Summary
Gateway compression (session-hygiene auto-compress and manual `/compress`) now passes the full transcript — tool results included — to `_compress_context`, matching what the agent loop itself feeds the compressor. Previously both entry points filtered to user/assistant-only content-bearing messages, so the compressor's tool-result pruning never saw the messages that make up the bulk of the context, and short filtered histories tripped the protect-first/last early-return, making compression a silent no-op on huge sessions.

Salvage of #3854 by @Git-on-my-level (David Zhang) — ported onto current main (the manual-compress handler moved from `gateway/run.py` to `gateway/slash_commands.py` since the PR branched); contributor authorship on the commit.

## Changes
- `gateway/run.py` (session-hygiene auto-compress): pass `user/assistant/tool` messages intact, including assistant `tool_calls` stubs (`content=None`) that were previously dropped.
- `gateway/slash_commands.py` (manual `/compress`): same change at the moved handler site. The `/compress --preview` estimate path keeps its filtered shape (display-only).
- `tests/gateway/test_compress_command.py`: regression test asserting tool messages and tool_calls stubs reach `_compress_context`.

## Validation
| | Before | After |
|---|---|---|
| Transcript with tool results → `/compress` | tool messages filtered before compressor | tool messages + tool_calls stubs reach compressor (regression test) |
| `test_session_hygiene.py`, `test_compress_command.py`, `test_compress_focus.py`, `test_compress_preview.py` | — | 43 passed |
| Partial-compress split on full-shape history | — | tail still snaps to a user turn (verified) |

## Infographic

![pr-3854-salvage](https://v3b.fal.media/files/b/0aa0f4f3/LO1hMuo8256xodX_QEWZD_QFyd8qLM.png)
