### PR TITLE
fix(desktop): classify OAuth ticket mint failures

### DIFF
--- a/apps/desktop/electron/connection-config.cjs
+++ b/apps/desktop/electron/connection-config.cjs
@@ -78,6 +78,72 @@ function buildGatewayWsUrlWithTicket(baseUrl, ticket) {
   return `${wsScheme}://${parsed.host}${prefix}/api/ws?ticket=${encodeURIComponent(ticket)}`
 }
 
+function statusCodeFromError(error) {
+  const explicit = Number(error?.statusCode)
+  if (Number.isInteger(explicit)) {
+    return explicit
+  }
+
+  const match = String(error?.message || '').match(/(?:^|\b)(\d{3})(?::|\b)/)
+  return match ? Number(match[1]) : null
+}
+
+function describeOauthTicketMintFailure(error) {
+  const statusCode = statusCodeFromError(error)
+  const rawMessage = String(error?.message || '')
+  const authFailure = statusCode === 401 || statusCode === 403
+  const timeoutFailure = /timed out|timeout|etimedout/i.test(rawMessage)
+  const serverFailure = statusCode !== null && statusCode >= 500
+  const missingEndpoint = statusCode === 404 || statusCode === 405
+
+  if (authFailure) {
+    return {
+      message:
+        'Your remote gateway session has expired or is no longer authorized. ' +
+        'Open Settings → Gateway and click "Sign in" again.',
+      needsOauthLogin: true,
+      transient: false
+    }
+  }
+
+  if (timeoutFailure || serverFailure) {
+    return {
+      message:
+        'Reached the remote Hermes gateway, but it did not mint a WebSocket ticket in time. ' +
+        'Retry after the gateway finishes starting, or switch back to Local if the outage continues.',
+      needsOauthLogin: false,
+      transient: true
+    }
+  }
+
+  if (missingEndpoint) {
+    return {
+      message:
+        'Reached the remote Hermes gateway, but it does not expose the OAuth WebSocket-ticket endpoint. ' +
+        'Update the remote backend or switch back to Local.',
+      needsOauthLogin: false,
+      transient: false
+    }
+  }
+
+  return {
+    message:
+      'Reached the remote Hermes gateway, but could not mint a WebSocket ticket for this OAuth session. ' +
+      'Retry, or open Settings → Gateway and sign in again if the problem persists.',
+    needsOauthLogin: false,
+    transient: true
+  }
+}
+
+function oauthTicketMintError(error) {
+  const details = describeOauthTicketMintFailure(error)
+  const err = new Error(details.message)
+  err.needsOauthLogin = details.needsOauthLogin
+  err.transientGatewayFailure = details.transient
+  err.cause = error
+  return err
+}
+
 /**
  * Build the WS URL the renderer would connect with, so the connection test can
  * exercise the same transport the app actually uses.
@@ -115,13 +181,7 @@ async function resolveTestWsUrl(baseUrl, authMode, token, deps = {}) {
     try {
       ticket = await mintTicket(baseUrl)
     } catch (error) {
-      const err = new Error(
-        'Reached the gateway over HTTP, but could not mint a WebSocket ticket for the OAuth session ' +
-          '(it may have expired). Open Settings → Gateway and sign in again.'
-      )
-      err.needsOauthLogin = true
-      err.cause = error
-      throw err
+      throw oauthTicketMintError(error)
     }
     return buildGatewayWsUrlWithTicket(baseUrl, ticket)
   }
@@ -270,10 +330,12 @@ module.exports = {
   authModeFromStatus,
   buildGatewayWsUrl,
   buildGatewayWsUrlWithTicket,
+  describeOauthTicketMintFailure,
   connectionScopeKey,
   cookiesHaveSession,
   cookiesHaveLiveSession,
   normAuthMode,
+  oauthTicketMintError,
   normalizeRemoteBaseUrl,
   pathWithGlobalRemoteProfile,
   profileRemoteOverride,

--- a/apps/desktop/electron/connection-config.test.cjs
+++ b/apps/desktop/electron/connection-config.test.cjs
@@ -19,10 +19,12 @@ const {
   authModeFromStatus,
   buildGatewayWsUrl,
   buildGatewayWsUrlWithTicket,
+  describeOauthTicketMintFailure,
   connectionScopeKey,
   cookiesHaveSession,
   cookiesHaveLiveSession,
   normAuthMode,
+  oauthTicketMintError,
   normalizeRemoteBaseUrl,
   pathWithGlobalRemoteProfile,
   profileRemoteOverride,
@@ -368,24 +370,59 @@ test('resolveTestWsUrl (oauth, mint ok) builds a ?ticket= URL', async () => {
   assert.equal(url, 'wss://gw.example.com/api/ws?ticket=tkt-9')
 })
 
-test('resolveTestWsUrl (oauth, mint FAILS) throws — must NOT skip WS validation', async () => {
+test('resolveTestWsUrl (oauth, auth failure) asks the user to sign in again', async () => {
   await assert.rejects(
     () =>
       resolveTestWsUrl('https://gw.example.com', 'oauth', null, {
         mintTicket: async () => {
-          throw new Error('401 ticket mint failed')
+          const err = new Error('401: session expired')
+          err.statusCode = 401
+          throw err
         }
       }),
     err => {
-      // Actionable, points the user at re-auth, and preserves the cause + flag
-      // the boot overlay uses to offer a sign-in prompt.
-      assert.match(err.message, /WebSocket ticket/i)
-      assert.match(err.message, /sign in again/i)
+      assert.match(err.message, /session has expired/i)
+      assert.match(err.message, /sign in/i)
       assert.equal(err.needsOauthLogin, true)
+      assert.equal(err.transientGatewayFailure, false)
       assert.ok(err.cause instanceof Error)
       return true
     }
   )
+})
+
+test('resolveTestWsUrl (oauth, timeout) does not mislabel gateway slowness as expired auth', async () => {
+  await assert.rejects(
+    () =>
+      resolveTestWsUrl('https://gw.example.com', 'oauth', null, {
+        mintTicket: async () => {
+          throw new Error('Timed out connecting to Hermes backend after 8000ms')
+        }
+      }),
+    err => {
+      assert.match(err.message, /did not mint a WebSocket ticket in time/i)
+      assert.equal(err.needsOauthLogin, false)
+      assert.equal(err.transientGatewayFailure, true)
+      assert.ok(err.cause instanceof Error)
+      return true
+    }
+  )
+})
+
+test('oauthTicketMintError maps 5xx failures to transient gateway failures', () => {
+  const cause = new Error('502: bad gateway')
+  const err = oauthTicketMintError(cause)
+  assert.match(err.message, /did not mint a WebSocket ticket in time/i)
+  assert.equal(err.needsOauthLogin, false)
+  assert.equal(err.transientGatewayFailure, true)
+  assert.equal(err.cause, cause)
+})
+
+test('describeOauthTicketMintFailure maps missing endpoints to backend upgrade guidance', () => {
+  const details = describeOauthTicketMintFailure(new Error('404: not found'))
+  assert.match(details.message, /does not expose the OAuth WebSocket-ticket endpoint/i)
+  assert.equal(details.needsOauthLogin, false)
+  assert.equal(details.transient, false)
 })
 
 test('resolveTestWsUrl (oauth) requires a mintTicket function', async () => {

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -111,6 +111,7 @@ const {
   cookiesHaveSession,
   cookiesHaveLiveSession,
   normAuthMode,
+  oauthTicketMintError,
   normalizeRemoteBaseUrl,
   pathWithGlobalRemoteProfile,
   profileRemoteOverride,
@@ -4899,12 +4900,7 @@ async function buildRemoteConnection(rawUrl, authMode, token, source) {
     try {
       ticket = await mintGatewayWsTicket(baseUrl)
     } catch (error) {
-      const err = new Error(
-        'Your remote gateway session has expired. ' + 'Open Settings → Gateway and click "Sign in" again.'
-      )
-      err.needsOauthLogin = true
-      err.cause = error
-      throw err
+      throw oauthTicketMintError(error)
     }
 
     return {


### PR DESCRIPTION
## Summary
- classify OAuth WebSocket ticket mint failures by status/failure type
- keep true 401/403 auth failures as sign-in-required
- stop labeling timeout/5xx gateway startup failures as expired sessions
- share the classification between the boot path and the Test Remote WS path

## Validation
- node --check electron/connection-config.cjs
- node --check electron/main.cjs
- node --test electron/connection-config.test.cjs
- npm run lint -- --quiet electron/connection-config.cjs electron/connection-config.test.cjs electron/main.cjs
- npm run test:desktop:platforms