### PR TITLE
fix(website): use canonical ClawHub URL to avoid redirect duplication

### DIFF
--- a/tests/website/test_extract_skills.py
+++ b/tests/website/test_extract_skills.py
@@ -65,14 +65,14 @@ def test_source_url_synthesizes_github_root_when_no_subpath(mod):
 
 
 def test_source_url_synthesizes_clawhub(mod):
-    assert mod._source_url("clawhub", "go-music-skill", {}) == "https://clawhub.ai/skills/go-music-skill"
+    assert mod._source_url("clawhub", "go-music-skill", {}) == "https://clawhub.ai/skills/skills/go-music-skill"
 
 
 def test_source_url_synthesizes_clawhub_strips_prefix(mod):
     # identifier may arrive already prefixed; we must not double-prefix.
     assert (
         mod._source_url("clawhub", "clawhub/go-music-skill", {})
-        == "https://clawhub.ai/skills/go-music-skill"
+        == "https://clawhub.ai/skills/skills/go-music-skill"
     )
 
 

--- a/website/scripts/extract-skills.py
+++ b/website/scripts/extract-skills.py
@@ -226,9 +226,12 @@ def _source_url(source: str, identifier: str, extra: dict) -> str:
         return ""
 
     if src == "clawhub":
-        # identifier is a bare slug (the "clawhub/" prefix is added at install time)
+        # identifier is a bare slug (the "clawhub/" prefix is added at install time).
+        # ClawHub canonical URL is /skills/skills/<slug> (the /skills/<slug>
+        # path 307-redirects to /skills/skills/<slug>, producing a visible
+        # double-/skills/ in the browser address bar).
         slug = identifier[len("clawhub/"):] if identifier.startswith("clawhub/") else identifier
-        return f"https://clawhub.ai/skills/{slug}"
+        return f"https://clawhub.ai/skills/skills/{slug}"
 
     if src in {"skills.sh", "skills-sh"}:
         # "skills-sh/owner/repo/skill" -> the skills.sh detail page


### PR DESCRIPTION
## What does this PR do?

Fixes the "View source" links on ClawHub skill cards in the Skills Hub page. The current code generates `https://clawhub.ai/skills/{slug}`, but ClawHub's canonical URL is `https://clawhub.ai/skills/skills/{slug}`. The `/skills/{slug}` path returns a 307 redirect to `/skills/skills/{slug}`, causing a visible double-`/skills/` path in the browser address bar and a brief redirect hop on every click.

## Related Issue

Fixes #58555

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `website/scripts/extract-skills.py`: Updated `_source_url()` for ClawHub to emit `https://clawhub.ai/skills/skills/{slug}` (canonical URL) instead of `https://clawhub.ai/skills/{slug}` (redirect source). Added a comment explaining the redirect behavior.
- `tests/website/test_extract_skills.py`: Updated two ClawHub URL assertions to match the corrected canonical URL.

## How to Test

1. Run `python -m pytest tests/website/test_extract_skills.py -v` — all 13 tests should pass.
2. Verify the corrected URL resolves directly (HTTP 200) without redirect: `curl -sI https://clawhub.ai/skills/skills/go-music-skill | head -1` should show `HTTP/2 200`.
3. Verify the old URL redirects: `curl -sI https://clawhub.ai/skills/go-music-skill | head -3` should show `HTTP/2 307` with `location: /skills/skills/go-music-skill`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
