### PR TITLE
fix(signal): inject recent chat history per turn

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -13,6 +13,7 @@ Requires:
 
 import asyncio
 import base64
+from collections import OrderedDict, deque
 import json
 import logging
 import os
@@ -22,7 +23,6 @@ import subprocess
 import tempfile
 import time
 import uuid
-from collections import OrderedDict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -70,6 +70,8 @@ SSE_RETRY_DELAY_INITIAL = 2.0
 SSE_RETRY_DELAY_MAX = 60.0
 HEALTH_CHECK_INTERVAL = 30.0  # seconds between health checks
 HEALTH_CHECK_STALE_THRESHOLD = 120.0  # seconds without SSE activity before concern
+SIGNAL_CHAT_HISTORY_MAX = 100  # recent messages retained per chat during runtime
+SIGNAL_CHAT_HISTORY_MAX_CHATS = 256  # distinct chats retained during runtime
 
 
 # ---------------------------------------------------------------------------
@@ -335,6 +337,8 @@ class SignalAdapter(BasePlatformAdapter):
         self._recipient_uuid_by_number: Dict[str, str] = {}
         self._recipient_number_by_uuid: Dict[str, str] = {}
         self._recipient_cache_lock = asyncio.Lock()
+        self._chat_history: OrderedDict[str, deque] = OrderedDict()
+        self._max_chat_history_chats = SIGNAL_CHAT_HISTORY_MAX_CHATS
 
         logger.info("Signal adapter initialized: url=%s account=%s groups=%s",
                      self.http_url, redact_phone(self.account),
@@ -766,6 +770,13 @@ class SignalAdapter(BasePlatformAdapter):
         logger.debug("Signal: message from %s in %s: %s",
                       redact_phone(sender), chat_id[:20], (text or "")[:50])
 
+        self._append_to_chat_history(
+            chat_id=chat_id,
+            ts_ms=ts_ms,
+            sender=sender,
+            name=sender_name or sender,
+            text=text or "",
+        )
         await self.handle_message(event)
 
     def _remember_recipient_identifiers(self, number: Optional[str], service_id: Optional[str]) -> None:
@@ -824,6 +835,46 @@ class SignalAdapter(BasePlatformAdapter):
         # FIFO-evict the oldest entry once over the cap.
         while len(self._sent_message_timestamps) > self._max_sent_message_timestamps:
             self._sent_message_timestamps.popitem(last=False)
+
+    def _append_to_chat_history(
+        self,
+        chat_id: str,
+        ts_ms: Any,
+        sender: str,
+        name: str,
+        text: str,
+        *,
+        from_self: bool = False,
+    ) -> None:
+        """Retain a bounded recent chat transcript for backlog-aware prompts."""
+        if not chat_id or not text:
+            return
+        history = self._chat_history.get(chat_id)
+        if history is None:
+            history = deque(maxlen=SIGNAL_CHAT_HISTORY_MAX)
+            self._chat_history[chat_id] = history
+        self._chat_history.move_to_end(chat_id)
+        try:
+            ts_value = int(ts_ms) if ts_ms else int(time.time() * 1000)
+        except (TypeError, ValueError):
+            ts_value = int(time.time() * 1000)
+        history.append({
+            "ts": ts_value,
+            "sender": sender,
+            "name": name or sender,
+            "text": text,
+            "from_self": from_self,
+        })
+        while len(self._chat_history) > self._max_chat_history_chats:
+            self._chat_history.popitem(last=False)
+
+    def get_recent_chat_messages(self, chat_id: str, n: int = 20) -> List[Dict[str, Any]]:
+        """Return up to the last ``n`` retained chat messages for a Signal chat."""
+        history = self._chat_history.get(chat_id)
+        if not history or n <= 0:
+            return []
+        self._chat_history.move_to_end(chat_id)
+        return list(history)[-n:]
 
     def _extract_contact_uuid(self, contact: Any, phone_number: str) -> Optional[str]:
         """Best-effort extraction of a Signal service ID from listContacts output."""
@@ -1086,6 +1137,15 @@ class SignalAdapter(BasePlatformAdapter):
             if not success:
                 return SendResult(success=False, error=err_msg, raw_response=result)
             self._track_sent_timestamp(result)
+            sent_ts = (result.get("timestamp") if isinstance(result, dict) else None) or int(time.time() * 1000)
+            self._append_to_chat_history(
+                chat_id=chat_id,
+                ts_ms=sent_ts,
+                sender=self.account,
+                name="me",
+                text=plain_text,
+                from_self=True,
+            )
             # Signal has no editable message identifier. Returning None keeps the
             # stream consumer on the non-edit fallback path instead of pretending
             # future edits can remove an in-progress cursor from the chat thread.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -512,6 +512,34 @@ def _gateway_provider_error_reply(text: str) -> str:
     )
 
 
+def _format_recent_signal_chat_history(
+    recent_messages: List[Dict[str, Any]],
+    *,
+    redact_pii: bool = False,
+) -> str:
+    """Render recent Signal messages for per-turn user-message injection."""
+    if not recent_messages:
+        return ""
+
+    recent_lines: List[str] = []
+    for message in recent_messages:
+        timestamp_ms = message.get("ts")
+        try:
+            dt = datetime.fromtimestamp(int(timestamp_ms) / 1000.0)
+            ts_label = dt.strftime("%H:%M")
+        except (TypeError, ValueError, OSError):
+            ts_label = "??:??"
+
+        sender = str(message.get("sender") or "")
+        label = str(message.get("name") or sender or "unknown")
+        if redact_pii and sender and label == sender:
+            label = _hash_sender_id(sender)
+
+        recent_lines.append(f"[{ts_label}] {label}: {message.get('text', '')}")
+
+    return "[Recent Signal chat history]\n" + "\n".join(recent_lines) + "\n\n"
+
+
 _GATEWAY_PROVIDER_ERROR_SHAPE_RE = re.compile(
     r"^\s*(\W*\s*)?("
     r"api\s+(?:call\s+)?failed"
@@ -2193,6 +2221,7 @@ from gateway.session import (
     build_session_key,
     is_shared_multi_user_session,
     neutralize_untrusted_inline_text,
+    _hash_sender_id,
 )
 from gateway.delivery import (
     DeliveryRouter,
@@ -15292,6 +15321,68 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     f"`message_id` for reply/react/pin via the discord tools.]\n\n"
                     f"{message_text}"
                 )
+
+        if source is not None and getattr(source, "platform", None) == Platform.SIGNAL:
+            signal_adapter = self.adapters.get(source.platform)
+            if signal_adapter and hasattr(signal_adapter, "get_recent_chat_messages"):
+                recent_messages = signal_adapter.get_recent_chat_messages(source.chat_id, n=30)
+                if recent_messages:
+                    watermark_by_session = getattr(self, "_signal_recent_history_watermark_by_session", None)
+                    if watermark_by_session is None:
+                        watermark_by_session = {}
+                        self._signal_recent_history_watermark_by_session = watermark_by_session
+                    history_key = session_key or source.chat_id
+                    watermark = watermark_by_session.get(history_key)
+                    filtered_recent_messages = []
+                    current_text = event.text or ""
+                    current_sender = str(getattr(source, "user_id", None) or "")
+                    try:
+                        current_ts = int(event.timestamp.timestamp() * 1000) if getattr(event, "timestamp", None) else None
+                    except Exception:
+                        current_ts = None
+                    newest_seen_ts = watermark
+                    for recent_message in recent_messages:
+                        try:
+                            recent_ts = int(recent_message.get("ts"))
+                        except Exception:
+                            recent_ts = None
+                        if recent_ts is not None and (newest_seen_ts is None or recent_ts > newest_seen_ts):
+                            newest_seen_ts = recent_ts
+                        if watermark is not None and recent_ts is not None and recent_ts <= watermark:
+                            continue
+                        if recent_message.get("from_self"):
+                            continue
+                        recent_text = str(recent_message.get("text") or "")
+                        recent_sender = str(recent_message.get("sender") or "")
+                        if (
+                            recent_text == current_text
+                            and recent_sender == current_sender
+                            and (
+                                current_ts is None
+                                or recent_ts is None
+                                or abs(recent_ts - current_ts) <= 5_000
+                            )
+                        ):
+                            continue
+                        filtered_recent_messages.append(recent_message)
+
+                    if newest_seen_ts is not None:
+                        watermark_by_session[history_key] = newest_seen_ts
+
+                    if filtered_recent_messages:
+                        _redact_pii = False
+                        try:
+                            _pcfg = _load_gateway_config()
+                            _redact_pii = bool((_pcfg.get("privacy") or {}).get("redact_pii", False))
+                        except Exception:
+                            pass
+                        message_text = (
+                            _format_recent_signal_chat_history(
+                                filtered_recent_messages,
+                                redact_pii=_redact_pii,
+                            )
+                            + message_text
+                        )
 
         if getattr(event, "reply_to_text", None) and event.reply_to_message_id:
             # Always inject the reply-to pointer — even when the quoted text

--- a/tests/gateway/test_run_signal_recent_history.py
+++ b/tests/gateway/test_run_signal_recent_history.py
@@ -1,0 +1,231 @@
+"""Tests for Signal recent-history prompt rendering and per-turn injection."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner, _format_recent_signal_chat_history
+from gateway.session import SessionSource, _hash_sender_id
+
+
+class _SignalAdapterStub:
+    def __init__(self, messages):
+        self._messages = list(messages)
+
+    def get_recent_chat_messages(self, chat_id: str, n: int = 20):
+        return list(self._messages)[-n:]
+
+    def set_recent_chat_messages(self, messages):
+        self._messages = list(messages)
+
+
+def _make_signal_runner(messages):
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.SIGNAL: PlatformConfig(enabled=True, token="fake")},
+    )
+    adapter = _SignalAdapterStub(messages)
+    runner.adapters = {Platform.SIGNAL: adapter}
+    runner._model = "openai/gpt-4.1-mini"
+    runner._base_url = None
+    runner._consume_pending_native_image_paths = lambda _session_key: []
+    return runner, adapter
+
+
+def _signal_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.SIGNAL,
+        chat_id="group:abc",
+        chat_name="Test Group",
+        chat_type="group",
+        user_id="+15550001111",
+        user_name="Alice",
+    )
+
+
+def test_format_recent_signal_chat_history_hashes_raw_sender_when_redacting():
+    prompt = _format_recent_signal_chat_history(
+        [
+            {
+                "ts": 1712345678000,
+                "sender": "+15550004567",
+                "name": "+15550004567",
+                "text": "hello",
+            }
+        ],
+        redact_pii=True,
+    )
+
+    assert "+15550004567" not in prompt
+    assert _hash_sender_id("+15550004567") in prompt
+    assert "hello" in prompt
+
+
+def test_format_recent_signal_chat_history_preserves_display_name_when_redacting():
+    prompt = _format_recent_signal_chat_history(
+        [
+            {
+                "ts": 1712345678000,
+                "sender": "+15550004567",
+                "name": "Alice",
+                "text": "hello",
+            }
+        ],
+        redact_pii=True,
+    )
+
+    assert "Alice" in prompt
+    assert _hash_sender_id("+15550004567") not in prompt
+
+
+def test_format_recent_signal_chat_history_returns_empty_for_no_messages():
+    assert _format_recent_signal_chat_history([], redact_pii=True) == ""
+
+
+@pytest.mark.asyncio
+async def test_prepare_inbound_message_injects_prior_signal_history_without_current_turn():
+    source = _signal_source()
+    current_ts = datetime.fromtimestamp(1712345682, tz=timezone.utc)
+    runner, _adapter = _make_signal_runner(
+        [
+            {"ts": 1712345678000, "sender": "+15550002222", "name": "Bob", "text": "Earlier backlog"},
+            {"ts": 1712345682000, "sender": "+15550001111", "name": "Alice", "text": "Latest live message"},
+        ]
+    )
+    event = MessageEvent(text="Latest live message", source=source, timestamp=current_ts)
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    assert result.startswith("[Recent Signal chat history]\n[")
+    assert "Bob: Earlier backlog" in result
+    assert result.endswith("Latest live message")
+    assert result.count("Latest live message") == 1
+
+
+@pytest.mark.asyncio
+async def test_prepare_inbound_message_keeps_recent_signal_history_before_reply_pointer():
+    source = _signal_source()
+    runner, _adapter = _make_signal_runner(
+        [
+            {"ts": 1712345678000, "sender": "+15550002222", "name": "Bob", "text": "Earlier backlog"},
+        ]
+    )
+    event = MessageEvent(
+        text="What about this one?",
+        source=source,
+        timestamp=datetime.fromtimestamp(1712345682, tz=timezone.utc),
+        reply_to_message_id="42",
+        reply_to_text="Use the direct train.",
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    assert result.startswith('[Replying to: "Use the direct train."]\n\n[Recent Signal chat history]')
+    assert "Earlier backlog" in result
+    assert result.endswith("What about this one?")
+
+
+@pytest.mark.asyncio
+async def test_prepare_inbound_message_only_injects_unseen_signal_history_after_watermark():
+    source = _signal_source()
+    runner, adapter = _make_signal_runner(
+        [
+            {"ts": 1712345678000, "sender": "+15550002222", "name": "Bob", "text": "Earlier backlog"},
+            {"ts": 1712345682000, "sender": "+15550001111", "name": "Alice", "text": "Latest live message"},
+        ]
+    )
+
+    first = await runner._prepare_inbound_message_text(
+        event=MessageEvent(
+            text="Latest live message",
+            source=source,
+            timestamp=datetime.fromtimestamp(1712345682, tz=timezone.utc),
+        ),
+        source=source,
+        history=[],
+        session_key="signal-session",
+    )
+
+    assert first is not None
+    assert "Earlier backlog" in first
+
+    adapter.set_recent_chat_messages(
+        [
+            {"ts": 1712345678000, "sender": "+15550002222", "name": "Bob", "text": "Earlier backlog"},
+            {"ts": 1712345682000, "sender": "+15550001111", "name": "Alice", "text": "Latest live message"},
+            {"ts": 1712345690000, "sender": "+15550003333", "name": "Carol", "text": "Cross-talk while Hermes was busy"},
+            {"ts": 1712345695000, "sender": "+15550001111", "name": "Alice", "text": "Second live message"},
+        ]
+    )
+
+    second = await runner._prepare_inbound_message_text(
+        event=MessageEvent(
+            text="Second live message",
+            source=source,
+            timestamp=datetime.fromtimestamp(1712345695, tz=timezone.utc),
+        ),
+        source=source,
+        history=[],
+        session_key="signal-session",
+    )
+
+    assert second is not None
+    assert "Cross-talk while Hermes was busy" in second
+    assert "Earlier backlog" not in second
+    assert second.count("Second live message") == 1
+
+
+@pytest.mark.asyncio
+async def test_prepare_inbound_message_skips_bot_reply_entries_after_watermark():
+    source = _signal_source()
+    runner, adapter = _make_signal_runner(
+        [
+            {"ts": 1712345682000, "sender": "+15550001111", "name": "Alice", "text": "Latest live message"},
+        ]
+    )
+
+    first = await runner._prepare_inbound_message_text(
+        event=MessageEvent(
+            text="Latest live message",
+            source=source,
+            timestamp=datetime.fromtimestamp(1712345682, tz=timezone.utc),
+        ),
+        source=source,
+        history=[],
+        session_key="signal-session",
+    )
+
+    assert first == "Latest live message"
+
+    adapter.set_recent_chat_messages(
+        [
+            {"ts": 1712345682000, "sender": "+15550001111", "name": "Alice", "text": "Latest live message"},
+            {"ts": 1712345688000, "sender": "+15550009999", "name": "me", "text": "Hermes reply", "from_self": True},
+            {"ts": 1712345695000, "sender": "+15550001111", "name": "Alice", "text": "Second live message"},
+        ]
+    )
+
+    second = await runner._prepare_inbound_message_text(
+        event=MessageEvent(
+            text="Second live message",
+            source=source,
+            timestamp=datetime.fromtimestamp(1712345695, tz=timezone.utc),
+        ),
+        source=source,
+        history=[],
+        session_key="signal-session",
+    )
+
+    assert second == "Second live message"

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -714,6 +714,196 @@ class TestSignalSendResultValidation:
 # stop_typing() delegates to _stop_typing_indicator (#4647)
 # ---------------------------------------------------------------------------
 
+class TestSignalRecentChatHistory:
+    @pytest.mark.asyncio
+    async def test_inbound_group_message_is_retained_for_recent_history(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch, group_allowed="*")
+
+        async def fake_handle(_event):
+            return None
+
+        adapter.handle_message = fake_handle
+
+        await adapter._handle_envelope({
+            "envelope": {
+                "sourceNumber": "+155****1111",
+                "sourceUuid": "uuid-sender",
+                "sourceName": "Tester",
+                "timestamp": 1712345678000,
+                "dataMessage": {
+                    "message": "recent group context",
+                    "groupInfo": {"groupId": "group-123", "groupName": "Test Sports"},
+                },
+            }
+        })
+
+        assert adapter.get_recent_chat_messages("group:group-123", n=5) == [{
+            "ts": 1712345678000,
+            "sender": "+155****1111",
+            "name": "Tester",
+            "text": "recent group context",
+            "from_self": False,
+        }]
+
+    @pytest.mark.asyncio
+    async def test_send_retains_outbound_message_in_recent_history(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        mock_rpc, _ = _stub_rpc({"timestamp": 1712345678000})
+        adapter._rpc = mock_rpc
+        adapter._stop_typing_indicator = AsyncMock()
+
+        result = await adapter.send(chat_id="+155****4567", content="hello")
+
+        assert result.success is True
+        assert adapter.get_recent_chat_messages("+155****4567", n=5) == [{
+            "ts": 1712345678000,
+            "sender": adapter.account,
+            "name": "me",
+            "text": "hello",
+            "from_self": True,
+        }]
+
+    @pytest.mark.asyncio
+    async def test_inbound_dm_message_is_retained_under_sender_chat_id(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+
+        async def fake_handle(_event):
+            return None
+
+        adapter.handle_message = fake_handle
+
+        await adapter._handle_envelope({
+            "envelope": {
+                "sourceNumber": "+15559876543",
+                "sourceUuid": "uuid-dm-sender",
+                "sourceName": "Alice",
+                "timestamp": 1712300000000,
+                "dataMessage": {
+                    "message": "hello from DM",
+                },
+            }
+        })
+
+        assert adapter.get_recent_chat_messages("+15559876543", n=5) == [{
+            "ts": 1712300000000,
+            "sender": "+15559876543",
+            "name": "Alice",
+            "text": "hello from DM",
+            "from_self": False,
+        }]
+        # Groups must not bleed into DM slot
+        assert adapter.get_recent_chat_messages("group:anything", n=5) == []
+
+    @pytest.mark.asyncio
+    async def test_get_recent_chat_messages_caps_at_n(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        mock_rpc_fn, _ = _stub_rpc({"timestamp": 1000})
+        adapter._rpc = mock_rpc_fn
+        adapter._stop_typing_indicator = AsyncMock()
+
+        for i in range(5):
+            adapter._rpc = _stub_rpc({"timestamp": 1000 + i})[0]
+            await adapter.send(chat_id="+155****0001", content=f"msg {i}")
+
+        results = adapter.get_recent_chat_messages("+155****0001", n=3)
+        assert len(results) == 3
+        assert results[-1]["text"] == "msg 4"
+        assert results[0]["text"] == "msg 2"
+
+    def test_empty_text_is_not_stored_in_chat_history(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+
+        adapter._append_to_chat_history(
+            chat_id="group:grp1",
+            ts_ms=1712345678000,
+            sender="+15551234567",
+            name="Bob",
+            text="",
+        )
+
+        assert adapter.get_recent_chat_messages("group:grp1", n=10) == []
+
+    def test_get_recent_chat_messages_n_zero_returns_empty(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._append_to_chat_history(
+            chat_id="+155****0001",
+            ts_ms=1712345678000,
+            sender="+155****0001",
+            name="Carol",
+            text="something",
+        )
+
+        assert adapter.get_recent_chat_messages("+155****0001", n=0) == []
+
+    def test_chat_history_prunes_oldest_chats_when_global_cap_exceeded(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._max_chat_history_chats = 3
+
+        for i in range(4):
+            adapter._append_to_chat_history(
+                chat_id=f"group:grp{i}",
+                ts_ms=1712345678000 + i,
+                sender=f"+155****00{i}",
+                name=f"User {i}",
+                text=f"msg {i}",
+            )
+
+        assert adapter.get_recent_chat_messages("group:grp0", n=5) == []
+        assert adapter.get_recent_chat_messages("group:grp1", n=5) == [{
+            "ts": 1712345678001,
+            "sender": "+155****001",
+            "name": "User 1",
+            "text": "msg 1",
+            "from_self": False,
+        }]
+        assert adapter.get_recent_chat_messages("group:grp2", n=5) == [{
+            "ts": 1712345678002,
+            "sender": "+155****002",
+            "name": "User 2",
+            "text": "msg 2",
+            "from_self": False,
+        }]
+        assert adapter.get_recent_chat_messages("group:grp3", n=5) == [{
+            "ts": 1712345678003,
+            "sender": "+155****003",
+            "name": "User 3",
+            "text": "msg 3",
+            "from_self": False,
+        }]
+
+    def test_chat_history_read_promotes_chat_for_lru_eviction(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._max_chat_history_chats = 3
+
+        for i in range(3):
+            adapter._append_to_chat_history(
+                chat_id=f"group:grp{i}",
+                ts_ms=1712345678000 + i,
+                sender=f"+155****00{i}",
+                name=f"User {i}",
+                text=f"msg {i}",
+            )
+
+        assert adapter.get_recent_chat_messages("group:grp0", n=5)[0]["text"] == "msg 0"
+
+        adapter._append_to_chat_history(
+            chat_id="group:grp3",
+            ts_ms=1712345678003,
+            sender="+155****003",
+            name="User 3",
+            text="msg 3",
+        )
+
+        assert adapter.get_recent_chat_messages("group:grp1", n=5) == []
+        assert adapter.get_recent_chat_messages("group:grp0", n=5) == [{
+            "ts": 1712345678000,
+            "sender": "+155****000",
+            "name": "User 0",
+            "text": "msg 0",
+            "from_self": False,
+        }]
+
+
 class TestSignalStopTyping:
     """Signal must expose a public stop_typing() so base adapter's
     _keep_typing finally block can clean up platform-level typing tasks."""
@@ -887,6 +1077,86 @@ class TestSignalQuoteExtraction:
         assert "111222333" in adapter._sent_message_timestamps
         assert adapter._quote_references_own_message("111222333", None) is True
 
+    def test_sent_message_timestamps_evicts_oldest_first(self, monkeypatch):
+        """Over the cap, the OLDEST quote-cache timestamp is dropped (FIFO),
+        not an arbitrary one — so a recent reply-to-own-message is still
+        detected after a burst of sends."""
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._max_sent_message_timestamps = 3
+        for ts in (1, 2, 3):
+            adapter._remember_sent_message_timestamp(ts)
+        # Adding a 4th evicts the oldest (1), keeps the rest in order.
+        adapter._remember_sent_message_timestamp(4)
+        assert list(adapter._sent_message_timestamps.keys()) == ["2", "3", "4"]
+        assert "1" not in adapter._sent_message_timestamps
+
+    def test_sent_message_timestamps_reinsertion_promotes_entry(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._max_sent_message_timestamps = 2
+
+        for ts in ("1", "2", "1", "3"):
+            adapter._remember_sent_message_timestamp(ts)
+
+        assert list(adapter._sent_message_timestamps.keys()) == ["1", "3"]
+        assert "2" not in adapter._sent_message_timestamps
+
+
+    @pytest.mark.asyncio
+    async def test_handle_envelope_without_quote_leaves_reply_fields_none(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        captured = {}
+
+        async def fake_handle(event):
+            captured["event"] = event
+
+        adapter.handle_message = fake_handle
+
+        await adapter._handle_envelope({
+            "envelope": {
+                "sourceNumber": "+15550001111",
+                "sourceUuid": "uuid-sender",
+                "sourceName": "Tester",
+                "timestamp": 1000000000,
+                "dataMessage": {
+                    "message": "plain message",
+                },
+            }
+        })
+
+        event = captured["event"]
+        assert event.text == "plain message"
+        assert event.reply_to_message_id is None
+        assert event.reply_to_text is None
+
+    @pytest.mark.asyncio
+    async def test_handle_envelope_quote_without_text_sets_only_reply_id(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        captured = {}
+
+        async def fake_handle(event):
+            captured["event"] = event
+
+        adapter.handle_message = fake_handle
+
+        await adapter._handle_envelope({
+            "envelope": {
+                "sourceNumber": "+15550001111",
+                "sourceUuid": "uuid-sender",
+                "sourceName": "Tester",
+                "timestamp": 1000000000,
+                "dataMessage": {
+                    "message": "reply without quote text",
+                    "quote": {
+                        "id": 123,
+                        "author": "+15550002222",
+                    },
+                },
+            }
+        })
+
+        event = captured["event"]
+        assert event.reply_to_message_id == "123"
+        assert event.reply_to_text is None
 
 # ---------------------------------------------------------------------------
 # _rpc rate-limit detection


### PR DESCRIPTION
## Summary
- move Signal recent-history injection out of the cached session-context prompt and into per-turn inbound message assembly
- keep bounded in-memory recent Signal chat history in the Signal adapter for backlog awareness
- add watermarking plus current-event/bot-reply filtering so the same backlog is not blindly replayed every turn

## Why
The original `#46391` blocker was correct: recent Signal history is per-turn-varying data, so injecting it into `build_session_context_prompt()` breaks prompt-cache stability and forces unnecessary agent rebuilds.

This rewrite keeps the cached session context stable and attaches the recent-history block to the live inbound user turn instead, matching the existing per-turn injection pattern already used for Discord per-turn message-id injection (the comment block directly above the new code documents this invariant).

## Overlap check
- This is a direct rework of `#46391`, not a duplicate of any other open PR.
- `#49563` (already merged) covers the quoted-reply-context work, leaving the recent-history injection as the remaining follow-up.
- The public change here is the missing follow-up: keep the bounded Signal history behavior, but move the injection point onto the per-turn message path so prompt caching remains stable.

## Testing
- `python -m pytest tests/gateway/test_signal.py tests/gateway/test_reply_to_injection.py tests/gateway/test_run_signal_recent_history.py -q`
  - `158 passed`
- `python -m py_compile gateway/platforms/signal.py gateway/run.py tests/gateway/test_run_signal_recent_history.py`
  - passed

## Known limitations
1. Recent-history state is intentionally in-memory only; it resets on gateway restart.
2. A message that arrives while a prior turn is still processing can appear once inside the injected history block before also arriving as its own separate turn.
3. The per-session watermark advances during turn preparation, so if a turn fails downstream those messages will not be re-injected on the next attempt. Outbound bot replies are retained in the bounded history store but are excluded from the injected user-turn block.
