### PR TITLE
fix: prefer explicit anthropic api key

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1277,19 +1277,27 @@ def resolve_anthropic_token() -> Optional[str]:
     Priority:
       1. ANTHROPIC_TOKEN env var (OAuth/setup token saved by Hermes)
       2. CLAUDE_CODE_OAUTH_TOKEN env var
-      3. Claude Code credentials (~/.claude.json or ~/.claude/.credentials.json)
+      3. ANTHROPIC_API_KEY env var (explicit regular API key)
+      4. Claude Code credentials (~/.claude.json or ~/.claude/.credentials.json)
          — with automatic refresh if expired and a refresh token is available
-      4. Anthropic credential_pool OAuth entry (~/.hermes/auth.json)
-      5. ANTHROPIC_API_KEY env var (regular API key, or legacy fallback)
+      5. Anthropic credential_pool OAuth entry (~/.hermes/auth.json)
 
     Returns the token string or None.
     """
-    creds = read_claude_code_credentials()
+    creds: Optional[Dict[str, Any]] = None
+    creds_loaded = False
+
+    def _read_creds() -> Optional[Dict[str, Any]]:
+        nonlocal creds, creds_loaded
+        if not creds_loaded:
+            creds = read_claude_code_credentials()
+            creds_loaded = True
+        return creds
 
     # 1. Hermes-managed OAuth/setup token env var
     token = os.getenv("ANTHROPIC_TOKEN", "").strip()
     if token:
-        preferred = _prefer_refreshable_claude_code_token(token, creds)
+        preferred = _prefer_refreshable_claude_code_token(token, _read_creds())
         if preferred:
             return preferred
         return token
@@ -1297,26 +1305,26 @@ def resolve_anthropic_token() -> Optional[str]:
     # 2. CLAUDE_CODE_OAUTH_TOKEN (used by Claude Code for setup-tokens)
     cc_token = os.getenv("CLAUDE_CODE_OAUTH_TOKEN", "").strip()
     if cc_token:
-        preferred = _prefer_refreshable_claude_code_token(cc_token, creds)
+        preferred = _prefer_refreshable_claude_code_token(cc_token, _read_creds())
         if preferred:
             return preferred
         return cc_token
 
-    # 3. Claude Code credential file
-    resolved_claude_token = _resolve_claude_code_token_from_credentials(creds)
-    if resolved_claude_token:
-        return resolved_claude_token
-
-    # 4. Hermes credential_pool OAuth entry.
-    resolved_pool_token = _resolve_anthropic_pool_token()
-    if resolved_pool_token:
-        return resolved_pool_token
-
-    # 5. Regular API key, or a legacy OAuth token saved in ANTHROPIC_API_KEY.
-    # This remains as a compatibility fallback for pre-migration Hermes configs.
+    # 3. Regular API key. An explicit user-configured key must not be shadowed
+    # by auto-discovered Claude Code or credential-pool OAuth credentials.
     api_key = os.getenv("ANTHROPIC_API_KEY", "").strip()
     if api_key:
         return api_key
+
+    # 4. Claude Code credential file
+    resolved_claude_token = _resolve_claude_code_token_from_credentials(_read_creds())
+    if resolved_claude_token:
+        return resolved_claude_token
+
+    # 5. Hermes credential_pool OAuth entry.
+    resolved_pool_token = _resolve_anthropic_pool_token()
+    if resolved_pool_token:
+        return resolved_pool_token
 
     return None
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -316,6 +316,38 @@ class TestResolveAnthropicToken:
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
         assert resolve_anthropic_token() == "sk-ant-api03-mykey"
 
+    def test_api_key_wins_over_auto_discovered_claude_code_credentials(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-mykey")
+        monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        cred_file = tmp_path / ".claude" / ".credentials.json"
+        cred_file.parent.mkdir(parents=True)
+        cred_file.write_text(json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "cc-auto-token",
+                "refreshToken": "refresh",
+                "expiresAt": int(time.time() * 1000) + 3600_000,
+            }
+        }))
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+
+        assert resolve_anthropic_token() == "sk-ant-api03-mykey"
+
+    def test_api_key_path_does_not_read_auto_discovered_credentials(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-mykey")
+        monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.read_claude_code_credentials",
+            lambda: (_ for _ in ()).throw(
+                AssertionError("Claude Code credentials should not be read")
+            ),
+        )
+
+        assert resolve_anthropic_token() == "sk-ant-api03-mykey"
+
     def test_falls_back_to_token(self, monkeypatch, tmp_path):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-mytoken")
@@ -374,26 +406,25 @@ class TestResolveAnthropicToken:
 
         assert resolve_anthropic_token() == "pool-oauth-token"
 
-    def test_prefers_anthropic_credential_pool_oauth_over_api_key(self, monkeypatch, tmp_path):
+    def test_api_key_wins_over_anthropic_credential_pool_oauth(self, monkeypatch, tmp_path):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant...ykey")
         monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
-        # Pool (source #4) must win over ANTHROPIC_API_KEY (source #5); also
-        # isolate source #3 so a machine-local Claude Code creds / keychain
-        # entry can't short-circuit before the pool.
-        monkeypatch.setattr("agent.anthropic_adapter.read_claude_code_credentials", lambda: None)
-
-        pool_entry = SimpleNamespace(
-            auth_type="oauth",
-            access_token="pool-oauth-token",
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.read_claude_code_credentials",
+            lambda: (_ for _ in ()).throw(
+                AssertionError("Claude Code credentials should not be read")
+            ),
         )
-        pool = SimpleNamespace(
-            _available_entries=lambda **_kwargs: [pool_entry],
+        monkeypatch.setattr(
+            "agent.credential_pool.load_pool",
+            lambda provider: (_ for _ in ()).throw(
+                AssertionError("credential_pool should not be read")
+            ),
         )
-        monkeypatch.setattr("agent.credential_pool.load_pool", lambda provider: pool)
 
-        assert resolve_anthropic_token() == "pool-oauth-token"
+        assert resolve_anthropic_token() == "sk-ant...ykey"
 
     def test_pool_entry_with_null_access_token_does_not_crash(self, monkeypatch, tmp_path):
         """A persisted OAuth entry with access_token=None must not crash the


### PR DESCRIPTION
Summary
- Check ANTHROPIC_API_KEY before auto-discovered Claude Code credentials and credential-pool OAuth entries.
- Keep explicit OAuth env vars as the highest-priority token sources.
- Add regression coverage for Claude Code credential and pool shadowing.

Problem
resolve_anthropic_token() could pick an auto-discovered Claude Code OAuth token before a user-configured ANTHROPIC_API_KEY, so users who selected the API-key path could still be routed through Claude Code OAuth.

Validation
- $HOME/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/agent/test_anthropic_adapter.py::TestResolveAnthropicToken
- $HOME/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/agent/test_credential_pool.py::test_load_pool_api_key_path_skips_oauth_autodiscovery tests/agent/test_credential_pool.py::test_load_pool_api_key_path_prunes_stale_oauth_entries tests/agent/test_credential_pool.py::test_load_pool_oauth_path_still_autodiscovers
- $HOME/.hermes/hermes-agent/venv/bin/ruff check agent/anthropic_adapter.py tests/agent/test_anthropic_adapter.py

Fixes #58546