### PR TITLE
fix(chat-completions): coerce integer tool_call id in non-streaming normalize_response

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -773,9 +773,16 @@ class ChatCompletionsTransport(ProviderTransport):
                         except Exception:
                             pass
                     tc_provider_data["extra_content"] = extra
+                # Poolside returns an integer tool_call.id (mirrors the integer
+                # finish_reason coercion above); ToolCall.id is typed str | None
+                # and downstream id-pairing (_split_responses_tool_id /
+                # make_tool_result_message) assumes str, so coerce it here.
+                _tc_id = tc.id
+                if isinstance(_tc_id, int):
+                    _tc_id = str(_tc_id)
                 tool_calls.append(
                     ToolCall(
-                        id=tc.id,
+                        id=_tc_id,
                         name=tc.function.name,
                         arguments=tc.function.arguments,
                         provider_data=tc_provider_data or None,

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -437,6 +437,28 @@ class TestChatCompletionsNormalize:
         assert nr.tool_calls[0].name == "terminal"
         assert nr.tool_calls[0].id == "call_123"
 
+    def test_tool_call_integer_id_coerced_to_string(self, transport):
+        """Poolside returns an integer tool_call.id on the non-streaming path.
+        ToolCall.id is typed str | None and downstream id-pairing
+        (_split_responses_tool_id / make_tool_result_message) assumes str, so
+        the transport must coerce it — mirroring the integer finish_reason
+        coercion.  Left as an int, the assistant message's synthetic string id
+        diverges from the paired tool result's raw-int tool_call_id and the
+        next replay turn is rejected with HTTP 400."""
+        tc = SimpleNamespace(
+            id=24,
+            function=SimpleNamespace(name="terminal", arguments='{"command": "ls"}'),
+        )
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(content=None, tool_calls=[tc], reasoning_content=None),
+                finish_reason="tool_calls",
+            )],
+            usage=None,
+        )
+        nr = transport.normalize_response(r)
+        assert nr.tool_calls[0].id == "24"
+        assert isinstance(nr.tool_calls[0].id, str)
 
 
     def test_empty_reasoning_content_preserved(self, transport):


### PR DESCRIPTION
## This is a sibling follow-up to #58502 (commit 55e798689)

- #58502 coerced Poolside's integer wire types: `finish_reason` in `normalize_response`, and `tool_call.id` **in the streaming path** (`chat_completion_helpers.py`).
- #58502 did NOT touch the **non-streaming** `normalize_response` tool_call.id at `agent/transports/chat_completions.py:639` — the same integer-id shape reaches it there.
- This PR adds the same `int → str` coercion for the non-streaming path, mirroring the `finish_reason` coercion 25 lines above.

## What does this PR do?

Coerces an integer `tool_call.id` to `str` in `ChatCompletionsTransport.normalize_response` so a Poolside tool turn on the non-streaming path (stream-unsupported fallback via `agent._disable_streaming`, ACP/MoA-no-consumer callers, gateway/health-check probes) does not persist an int id.

Left uncoerced, the assistant message's `tool_calls[].id` becomes a synthetic `_deterministic_call_id` string (because `_split_responses_tool_id` guards `isinstance(raw_id, str)` and falls through on a non-str id), while the paired tool result stores the raw int via `make_tool_result_message`. The two diverge, and the next replay turn is rejected by the provider with HTTP 400 ("tool_call_id did not match a preceding tool_calls"). Poolside is a first-class `CANONICAL_PROVIDERS` entry (CLI/TUI/desktop picker), so this path is user-reachable.

## Related Issue

Sibling follow-up to #58502 (commit 55e798689). No separate issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/transports/chat_completions.py`: in `normalize_response`, coerce an integer `tool_call.id` to `str` before constructing `ToolCall`, mirroring the existing integer `finish_reason` coercion.
- `tests/agent/transports/test_chat_completions.py`: add `test_tool_call_integer_id_coerced_to_string` regression test.

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/agent/transports/test_chat_completions.py -q` → 83 passed.
2. Fail-before / pass-after: the new test asserts `nr.tool_calls[0].id == "24"` and `isinstance(... , str)`. With the coercion reverted it fails (`assert 24 == '24'`); with the fix it passes.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/agent/transports/test_chat_completions.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (py3.9 parse-safety verified via `ast.parse(feature_version=(3,9))`)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A (pure Python type coercion)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

> Sibling code paths that may need the same fix: the streaming path already coerces this (`chat_completion_helpers.py`, #58502); no other normalize path constructs a ToolCall from a raw provider id. No further widening needed.