### PR TITLE
fix(matrix): batch long commands and bypass active session for skill commands

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -405,7 +405,19 @@ def should_bypass_active_session(command_name: str | None) -> bool:
     ACTIVE_SESSION_BYPASS_COMMANDS remains the subset of commands with
     explicit Level-2 handlers; the rest fall through to the catch-all.
     """
-    return resolve_command(command_name) is not None if command_name else False
+    if not command_name:
+        return False
+    if resolve_command(command_name) is not None:
+        return True
+    # Skill commands (e.g. /arxiv) are resolved through a separate registry
+    # and must also bypass the active-session queue, matching how
+    # _resolve_matrix_bang_command already checks both registries.
+    try:
+        from agent.skill_commands import get_skill_commands
+
+        return f"/{command_name.lstrip('/')}" in (get_skill_commands() or {})
+    except Exception:  # pragma: no cover — defensive
+        return False
 
 
 def _resolve_config_gates() -> set[str]:

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2773,7 +2773,11 @@ class MatrixAdapter(BasePlatformAdapter):
             reply_to_message_id=reply_to,
         )
 
-        if msg_type == MessageType.TEXT and self._text_batch_delay_seconds > 0:
+        should_batch = self._text_batch_delay_seconds > 0 and (
+            msg_type == MessageType.TEXT
+            or (msg_type == MessageType.COMMAND and len(body) >= self._SPLIT_THRESHOLD)
+        )
+        if should_batch:
             self._enqueue_text_event(msg_event)
         else:
             await self.handle_message(msg_event)

--- a/tests/gateway/test_command_bypass_active_session.py
+++ b/tests/gateway/test_command_bypass_active_session.py
@@ -493,3 +493,38 @@ class TestBypassWithBotnameSuffix:
 
         assert sk not in adapter._pending_messages
         assert any("handled:new" in r for r in adapter.sent_responses)
+
+
+# ---------------------------------------------------------------------------
+# Regression: skill commands must also bypass active-session guard (#58559)
+# ---------------------------------------------------------------------------
+
+
+class TestSkillCommandBypass:
+    """Registered skill commands (e.g. /arxiv) must bypass the active-session
+    queue, matching how built-in slash commands are dispatched directly."""
+
+    def test_should_bypass_returns_true_for_skill_command(self):
+        """A registered skill command bypasses the active-session guard."""
+        from unittest.mock import patch as _patch
+
+        from hermes_cli.commands import should_bypass_active_session
+
+        with _patch(
+            "agent.skill_commands.get_skill_commands",
+            return_value={"/arxiv": {"description": "search arXiv papers"}},
+        ):
+            assert should_bypass_active_session("arxiv") is True
+
+    def test_should_bypass_returns_false_for_unregistered_skill(self):
+        """An unknown name that is neither a built-in nor a skill command
+        does NOT bypass."""
+        from unittest.mock import patch as _patch
+
+        from hermes_cli.commands import should_bypass_active_session
+
+        with _patch(
+            "agent.skill_commands.get_skill_commands",
+            return_value={"/arxiv": {"description": "search arXiv papers"}},
+        ):
+            assert should_bypass_active_session("not-a-skill") is False

--- a/tests/gateway/test_matrix_command_batching.py
+++ b/tests/gateway/test_matrix_command_batching.py
@@ -1,0 +1,120 @@
+"""Regression tests: Matrix long commands must be batched, not dispatched immediately.
+
+Matrix uses ``!command`` aliases that normalize to ``/command``.  Before the
+fix, any normalized command (MessageType.COMMAND) was dispatched immediately,
+bypassing the text-batching buffer.  Long commands near the client split
+threshold should still be batched so that continuation chunks from the Matrix
+client's own split arrive as a single aggregated message.
+
+Issue #58559.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+
+
+ROOM_ID = "!room:example"
+USER_ID = "@user:example"
+
+
+def _source(message_id: str) -> SessionSource:
+    return SessionSource(
+        platform=Platform.MATRIX,
+        chat_id=ROOM_ID,
+        chat_name="Element X DM",
+        chat_type="dm",
+        user_id=USER_ID,
+        user_name="User",
+        message_id=message_id,
+        scope_id="matrix.example",
+    )
+
+
+def _make_adapter(*, split_threshold: int = 3900, batch_delay: float = 0.02):
+    """Create a minimal MatrixAdapter for testing command batching."""
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    adapter = object.__new__(MatrixAdapter)
+    adapter.config = SimpleNamespace(
+        extra={
+            "group_sessions_per_user": True,
+            "thread_sessions_per_user": False,
+        }
+    )
+    adapter._text_batch_delay_seconds = batch_delay
+    adapter._text_batch_split_delay_seconds = batch_delay
+    adapter._pending_text_batches = {}
+    adapter._pending_text_batch_tasks = {}
+    adapter._SPLIT_THRESHOLD = split_threshold
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_long_matrix_command_is_batched():
+    """A Matrix ``!command`` whose normalized body exceeds ``_SPLIT_THRESHOLD``
+    must be held in the text batch, not dispatched immediately."""
+    adapter = _make_adapter()
+
+    async def resolve_context(room_id, sender, event_id, body, source_content, relates_to):
+        return body, True, "dm", None, "User", _source(event_id)
+
+    captured: list[MessageEvent] = []
+
+    async def capture(message: MessageEvent):
+        captured.append(message)
+
+    adapter._resolve_message_context = resolve_context
+    adapter.handle_message = capture
+
+    # First chunk: long command (>= _SPLIT_THRESHOLD)
+    await adapter._handle_text_message(
+        ROOM_ID, USER_ID, "$long-1", 0,
+        {"body": "!queue " + ("x" * 3900)}, {},
+    )
+    # Second chunk: continuation from client split
+    await adapter._handle_text_message(
+        ROOM_ID, USER_ID, "$long-2", 0,
+        {"body": "tail from client split"}, {},
+    )
+    await asyncio.sleep(0.08)
+
+    assert len(captured) == 1, (
+        f"Expected 1 batched message, got {len(captured)}: "
+        f"{[m.text[:60] for m in captured]}"
+    )
+    assert "tail from client split" in captured[0].text
+
+
+@pytest.mark.asyncio
+async def test_short_matrix_command_dispatches_immediately():
+    """A short Matrix ``!command`` (well below ``_SPLIT_THRESHOLD``) must
+    dispatch immediately, not be held in the text batch."""
+    adapter = _make_adapter()
+
+    async def resolve_context(room_id, sender, event_id, body, source_content, relates_to):
+        return body, True, "dm", None, "User", _source(event_id)
+
+    captured: list[MessageEvent] = []
+
+    async def capture(message: MessageEvent):
+        captured.append(message)
+
+    adapter._resolve_message_context = resolve_context
+    adapter.handle_message = capture
+
+    # Short command
+    await adapter._handle_text_message(
+        ROOM_ID, USER_ID, "$short-1", 0,
+        {"body": "!stop"}, {},
+    )
+    # Should dispatch immediately without waiting for batch flush
+    assert len(captured) == 1
+    assert captured[0].text == "/stop"
+    assert captured[0].message_type == MessageType.COMMAND


### PR DESCRIPTION
## What does this PR do?

Fixes two Matrix-specific command dispatch bugs:

1. **Long `!command` messages bypass text batching**: Matrix clients split long messages at ~3900 chars. When a `!command` normalizes to `/command`, the adapter sets `MessageType.COMMAND` and dispatches immediately, so the continuation chunk arrives as a separate plain-text message instead of being aggregated with the command body. Fix: batch `COMMAND` messages when the body length is at or above `_SPLIT_THRESHOLD`, while keeping short commands (e.g. `/stop`, `/status`) immediate.

2. **Skill commands don't bypass active-session queue**: `should_bypass_active_session()` only checks `resolve_command()` (built-in commands). Registered skill commands like `/arxiv` are resolved through a separate registry (`get_skill_commands()`), so they get queued as user text instead of being dispatched. This matches how `_resolve_matrix_bang_command()` already checks both registries.

## Related Issue

Fixes #58559

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/matrix/adapter.py`: Change `_handle_text_message()` batching condition to also enqueue `MessageType.COMMAND` when `len(body) >= _SPLIT_THRESHOLD` — short commands still dispatch immediately.
- `hermes_cli/commands.py`: Extend `should_bypass_active_session()` to check `get_skill_commands()` after the built-in command lookup, so skill commands bypass the active-session guard.
- `tests/gateway/test_command_bypass_active_session.py`: Add `TestSkillCommandBypass` class with two tests verifying skill commands bypass and unknown names don't.
- `tests/gateway/test_matrix_command_batching.py`: New test file with `test_long_matrix_command_is_batched` and `test_short_matrix_command_dispatches_immediately`.

## How to Test

1. Run the regression tests:
   ```bash
   python -m pytest tests/gateway/test_command_bypass_active_session.py tests/gateway/test_matrix_command_batching.py -q
   ```
   All tests should pass (42 existing + 2 new bypass tests + 2 new batching tests).

2. Reproduce the original issue with the script from #58559 on the patched tree — both checks should now return `True`:
   ```
   {'long_matrix_command_is_batched': True, 'captured_count': 1}
   {'skill_command_bypasses_active_session': True}
   ```

3. Run the full related test suite:
   ```bash
   python -m pytest tests/gateway/test_command_bypass_active_session.py tests/gateway/test_telegram_text_batching.py tests/gateway/test_matrix_command_batching.py -q
   ```
   Should pass: 58 tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (Python-only changes, no platform-specific behavior)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
