### PR TITLE
Add run-message steering for API runs

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -17,6 +17,7 @@ Exposes an HTTP server with endpoints:
 - POST /v1/runs                    — start a run, returns run_id immediately (202)
 - GET  /v1/runs/{run_id}           — retrieve current run status
 - GET  /v1/runs/{run_id}/events    — SSE stream of structured lifecycle events
+- POST /v1/runs/{run_id}/messages  - steer a running agent
 - POST /v1/runs/{run_id}/approval — resolve a pending run approval
 - POST /v1/runs/{run_id}/stop       — interrupt a running agent
 - GET  /health                     — health check
@@ -1509,6 +1510,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "runs": {"method": "POST", "path": "/v1/runs"},
                 "run_status": {"method": "GET", "path": "/v1/runs/{run_id}"},
                 "run_events": {"method": "GET", "path": "/v1/runs/{run_id}/events"},
+                "run_messages": {"method": "POST", "path": "/v1/runs/{run_id}/messages"},
                 "run_approval": {"method": "POST", "path": "/v1/runs/{run_id}/approval"},
                 "run_stop": {"method": "POST", "path": "/v1/runs/{run_id}/stop"},
                 "skills": {"method": "GET", "path": "/v1/skills"},
@@ -4382,6 +4384,14 @@ class APIServerAdapter(BasePlatformAdapter):
                     )
                 else:
                     final_response = result.get("final_response", "") if isinstance(result, dict) else ""
+                    pending_steer = result.get("pending_steer") if isinstance(result, dict) else None
+                    if pending_steer:
+                        q.put_nowait({
+                            "event": "pending_steer_leftover",
+                            "run_id": run_id,
+                            "timestamp": time.time(),
+                            "text": str(pending_steer),
+                        })
                     q.put_nowait({
                         "event": "run.completed",
                         "run_id": run_id,
@@ -4530,6 +4540,74 @@ class APIServerAdapter(BasePlatformAdapter):
             self._run_streams_created.pop(run_id, None)
 
         return response
+
+    async def _handle_run_message(self, request: "web.Request") -> "web.Response":
+        """POST /v1/runs/{run_id}/messages - steer a live run."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        run_id = request.match_info["run_id"]
+        agent = self._active_run_agents.get(run_id)
+        task = self._active_run_tasks.get(run_id)
+        if agent is None and task is None:
+            return web.json_response(
+                _openai_error(f"Run not found: {run_id}", code="run_not_found"),
+                status=404,
+            )
+
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response(_openai_error("Invalid JSON"), status=400)
+
+        mode = str(body.get("mode", "steer") or "steer").strip().lower()
+        if mode != "steer":
+            return web.json_response(
+                _openai_error("Invalid message mode; expected: steer", code="invalid_message_mode"),
+                status=400,
+            )
+
+        message = str(body.get("message") or body.get("input") or "").strip()
+        if not message:
+            return web.json_response(
+                _openai_error("Missing 'message' field", code="missing_message"),
+                status=400,
+            )
+        if agent is None or not hasattr(agent, "steer"):
+            return web.json_response(
+                _openai_error(f"Run does not support steer: {run_id}", code="steer_not_supported"),
+                status=409,
+            )
+
+        try:
+            accepted = bool(agent.steer(message))
+        except Exception as exc:
+            logger.exception("[api_server] steer failed for run %s", run_id)
+            return web.json_response(_openai_error(_redact_api_error_text(exc)), status=500)
+        if not accepted:
+            return web.json_response(
+                _openai_error(f"Run rejected steer: {run_id}", code="steer_rejected"),
+                status=409,
+            )
+
+        self._set_run_status(run_id, "running", last_event="message.steered")
+        q = self._run_streams.get(run_id)
+        if q is not None:
+            try:
+                q.put_nowait({
+                    "event": "message.steered",
+                    "run_id": run_id,
+                    "timestamp": time.time(),
+                })
+            except Exception:
+                pass
+        return web.json_response({
+            "object": "hermes.run.message",
+            "run_id": run_id,
+            "mode": "steer",
+            "status": "steered",
+        })
 
 
     async def _handle_run_approval(self, request: "web.Request") -> "web.Response":
@@ -4796,6 +4874,7 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_post("/v1/runs", self._handle_runs)
             self._app.router.add_get("/v1/runs/{run_id}", self._handle_get_run)
             self._app.router.add_get("/v1/runs/{run_id}/events", self._handle_run_events)
+            self._app.router.add_post("/v1/runs/{run_id}/messages", self._handle_run_message)
             self._app.router.add_post("/v1/runs/{run_id}/approval", self._handle_run_approval)
             self._app.router.add_post("/v1/runs/{run_id}/stop", self._handle_stop_run)
             # Store the adapter after native routes are registered. Local Hermes-Relay

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -48,6 +48,7 @@ def _create_runs_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_post("/v1/runs", adapter._handle_runs)
     app.router.add_get("/v1/runs/{run_id}", adapter._handle_get_run)
     app.router.add_get("/v1/runs/{run_id}/events", adapter._handle_run_events)
+    app.router.add_post("/v1/runs/{run_id}/messages", adapter._handle_run_message)
     app.router.add_post("/v1/runs/{run_id}/approval", adapter._handle_run_approval)
     app.router.add_post("/v1/runs/{run_id}/stop", adapter._handle_stop_run)
     return app
@@ -305,6 +306,33 @@ class TestRunEvents:
                 assert "run.completed" in body
                 assert "Hello!" in body
 
+    @pytest.mark.asyncio
+    async def test_events_stream_returns_pending_steer_leftover(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {
+                    "final_response": "done",
+                    "pending_steer": "no two",
+                }
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+
+                events_resp = await cli.get(f"/v1/runs/{run_id}/events")
+                assert events_resp.status == 200
+                body = await events_resp.text()
+
+                assert "pending_steer_leftover" in body
+                assert "no two" in body
+                assert body.index("pending_steer_leftover") < body.index("run.completed")
+
 
 
     @pytest.mark.asyncio
@@ -439,6 +467,79 @@ class TestRunEvents:
         app = _create_runs_app(auth_adapter)
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.get("/v1/runs/run_any/events")
+        assert resp.status == 401
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/runs/{run_id}/messages - steer a running agent
+# ---------------------------------------------------------------------------
+
+
+class TestRunMessages:
+    @pytest.mark.asyncio
+    async def test_steer_running_agent(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent, agent_ready, interrupted = _make_slow_agent()
+                mock_agent.steer = MagicMock(return_value=True)
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+
+                agent_ready.wait(timeout=3.0)
+                steer_resp = await cli.post(
+                    f"/v1/runs/{run_id}/messages",
+                    json={"message": "check the logs", "mode": "steer"},
+                )
+                data = await steer_resp.json()
+
+                assert steer_resp.status == 200
+                assert data["status"] == "steered"
+                mock_agent.steer.assert_called_once_with("check the logs")
+                status_resp = await cli.get(f"/v1/runs/{run_id}")
+                status = await status_resp.json()
+                assert status["last_event"] == "message.steered"
+
+                interrupted.set()
+
+    @pytest.mark.asyncio
+    async def test_steer_nonexistent_run_returns_404(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/runs/run_missing/messages",
+                json={"message": "hello", "mode": "steer"},
+            )
+        assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_steer_mode(self, adapter):
+        app = _create_runs_app(adapter)
+        run_id = "run_mode"
+        adapter._active_run_agents[run_id] = MagicMock()
+        adapter._active_run_tasks[run_id] = MagicMock()
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/v1/runs/{run_id}/messages",
+                json={"message": "hello", "mode": "queue"},
+            )
+            data = await resp.json()
+
+        assert resp.status == 400
+        assert data["error"]["code"] == "invalid_message_mode"
+
+    @pytest.mark.asyncio
+    async def test_steer_requires_auth(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/runs/run_any/messages",
+                json={"message": "hello", "mode": "steer"},
+            )
         assert resp.status == 401
 
 


### PR DESCRIPTION
## Summary

- Add `POST /v1/runs/{run_id}/messages` to let API clients steer an active runs-API agent.
- Emit `pending_steer_leftover` before `run.completed` when a steer was accepted but the turn ended without a tool boundary.
- Cover steering, auth, invalid mode, missing run, and leftover SSE behavior in the runs API tests.

## Why

Hermes WebUI can own the browser session while Hermes Gateway owns the live runs-API agent. Without this endpoint, the WebUI cannot deliver steer messages to the active gateway run. Without the leftover event, text-only runs can accept steer and then silently drop it when no tool result exists to receive the marker.

## Tests

- `pytest tests/gateway/test_api_server_runs.py -q --timeout=60`
