### PR TITLE
fix(windows): pass hermes_home to load_hermes_dotenv in main.py

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -516,7 +516,7 @@ _apply_profile_override()
 from hermes_cli.config import get_hermes_home
 from hermes_cli.env_loader import load_hermes_dotenv
 
-load_hermes_dotenv(project_env=PROJECT_ROOT / ".env")
+load_hermes_dotenv(hermes_home=get_hermes_home(), project_env=PROJECT_ROOT / ".env")
 
 # Bridge security.redact_secrets from config.yaml → HERMES_REDACT_SECRETS env
 # var BEFORE hermes_logging imports agent.redact (which snapshots the flag at


### PR DESCRIPTION
Fixes the native-Windows .env-not-loaded bug. main.py:519 omitted hermes_home; mirrors cli.py:182. One-line change.

Closes #58573