### PR TITLE
fix(lazy_deps): use sentinel package for active-feature detection

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -316,15 +316,29 @@ class TestActiveFeatures:
         assert "memory.hindsight" not in active
         assert "platform.slack" not in active
 
-    def test_multi_package_feature_active_if_any_present(self, monkeypatch):
-        # platform.slack has 3 packages; only one needs to be present
-        # for the feature to count as active (user activated it before,
-        # one transitive may have been uninstalled separately).
+    def test_multi_package_feature_active_if_sentinel_present(self, monkeypatch):
+        # platform.slack has 3 packages; only the sentinel (first entry,
+        # slack-bolt) determines activity.  A user who installed slack-bolt
+        # is detected; a user who only has aiohttp (shared CVE pin) is not.
         monkeypatch.setattr(
             ld, "_is_present",
             lambda spec: ld._pkg_name_from_spec(spec) == "slack-bolt",
         )
         assert "platform.slack" in ld.active_features()
+
+    def test_shared_pin_does_not_trigger_false_positive(self, monkeypatch):
+        # aiohttp==3.14.1 is a CVE-floor pin shared by discord, slack,
+        # matrix, and teams.  If only aiohttp is installed (transitively
+        # by edge-tts, firecrawl-py, etc.), none of those backends should
+        # appear active.
+        monkeypatch.setattr(
+            ld, "_is_present",
+            lambda spec: ld._pkg_name_from_spec(spec) == "aiohttp",
+        )
+        active = ld.active_features()
+        for feat in ("platform.discord", "platform.slack",
+                     "platform.matrix", "platform.teams"):
+            assert feat not in active, f"{feat} false-positive on shared aiohttp pin"
 
 
 class TestRefreshActiveFeatures:

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -856,16 +856,23 @@ def feature_install_command(feature: str) -> Optional[str]:
 def active_features() -> list[str]:
     """Return the list of features the user has ever lazy-installed.
 
-    A feature counts as "active" if at least one of its declared packages
-    is currently installed in the venv (presence check, ignoring version).
+    A feature counts as "active" if its **sentinel** package (the first
+    entry in the spec tuple) is currently installed in the venv.
     Features the user has never enabled stay quiet.
+
+    Earlier versions checked *any* package, but shared CVE-floor pins
+    (``aiohttp==3.14.1`` across discord/slack/matrix/teams) caused every
+    backend that listed the pin to appear active even when the user never
+    enabled it.  Checking only the sentinel — the feature's own SDK —
+    avoids the false positive while still detecting a user who manually
+    installed the main package.
 
     Used by ``hermes update`` to figure out which lazy backends need a
     refresh pass when pins move in :data:`LAZY_DEPS`.
     """
     active = []
     for feature, specs in LAZY_DEPS.items():
-        if any(_is_present(s) for s in specs):
+        if specs and _is_present(specs[0]):
             active.append(feature)
     return active
 


### PR DESCRIPTION
fix(lazy_deps): use sentinel package for active-feature detection

## What does this PR do?

Fixes a false-positive in `active_features()` where shared CVE-floor
pins (notably `aiohttp==3.14.1` listed by discord, slack, matrix, and
teams) caused every backend that listed the pin to appear "active" even
when the user never enabled it.  `hermes update` then tried to refresh
those never-enabled backends, pulling in heavy dependency trees
(Discord, Slack, Matrix stacks) and failing on platforms where certain
builds are impossible (e.g. `python-olm` on Windows).

The fix changes `active_features()` to check only the **sentinel**
(first) package in each feature's spec tuple — the feature's own SDK —
instead of any package.  The sentinel is the package that uniquely
identifies a feature (e.g. `discord.py` for `platform.discord`,
`slack-bolt` for `platform.slack`); shared transitive pins are always
listed after it.

## Related Issue

Fixes #58458

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/lazy_deps.py`: Change `active_features()` to check only the
  sentinel (first) package instead of any package.  Updated docstring
  explaining the rationale.
- `tests/tools/test_lazy_deps.py`: Updated
  `test_multi_package_feature_active_if_sentinel_present` to reflect
  sentinel-only semantics.  Added `test_shared_pin_does_not_trigger_false_positive`
  covering the exact scenario from #58458 (only `aiohttp` installed →
  discord/slack/matrix/teams should NOT appear active).

## How to Test

1. `python -m pytest tests/tools/test_lazy_deps.py -q` — all 65 tests
   should pass, including the new `test_shared_pin_does_not_trigger_false_positive`.
2. On a fresh venv with only core deps installed (no Discord/Slack/Matrix
   enabled), `python -c "from tools.lazy_deps import active_features;
   print(active_features())"` should return an empty list.  Before this
   fix it would list every backend that pins `aiohttp`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — this fix is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
