### PR TITLE
fix(journey): replace %-d strftime code for Windows compatibility (`/journey` crash)

### DIFF
--- a/agent/learning_graph_render.py
+++ b/agent/learning_graph_render.py
@@ -73,7 +73,8 @@ def format_date(ts: Optional[float]) -> str:
     if not ts:
         return "unknown"
     try:
-        return datetime.fromtimestamp(float(ts), tz=timezone.utc).strftime("%-d %b %Y")
+        dt = datetime.fromtimestamp(float(ts), tz=timezone.utc)
+        return f"{dt.day} {dt:%b} {dt.year}"
     except (ValueError, OSError, OverflowError):
         return "unknown"
 
@@ -255,7 +256,7 @@ def _period_key(ts: float, granularity: str) -> tuple[int, ...]:
 def _period_label(ts: float, granularity: str) -> str:
     dt = datetime.fromtimestamp(ts, tz=timezone.utc)
     if granularity == "day":
-        return dt.strftime("%-d %b")
+        return f"{dt.day} {dt:%b}"
     if granularity == "month":
         return dt.strftime("%b %Y")
     return dt.strftime("%Y")


### PR DESCRIPTION
## Bug

`/journey` in the TUI and `hermes journey` on the CLI both crash on Windows with:

```
ValueError: Invalid format string
  File ".../agent/learning_graph_render.py", line 258, in _period_label
    return dt.strftime("%-d %b")
```

## Root cause

Two sites in `agent/learning_graph_render.py` use the `%-d` strftime modifier:
- Line 76: `datetime.fromtimestamp(...).strftime("%-d %b %Y")` — node tooltip summary
- Line 258: `dt.strftime("%-d %b")` — `_period_label` day-granularity bucket label (also feeds the "busiest day" summary on line 590)

`%-d` is a glibc-only extension that strips the leading zero. Windows `strftime` does not recognize the `-` modifier and raises `ValueError`. Any code path that calls these functions crashes on Windows, which kills `hermes journey` (and TUI `/journey`) before it can render the chart. `hermes journey --json` works because it bypasses rendering.

## Fix

Replace both `strftime` calls with f-strings using `dt.day` (int, no leading-zero concern) plus `%b` (abbreviated month name, portable across platforms):

```python
# was: datetime.fromtimestamp(float(ts), tz=timezone.utc).strftime("%-d %b %Y")
dt = datetime.fromtimestamp(float(ts), tz=timezone.utc)
return f"{dt.day} {dt:%b} {dt.year}"

# was: dt.strftime("%-d %b")
return f"{dt.day} {dt:%b}"
```

`%b` and `%Y` are standard POSIX strftime codes and work on Windows, macOS, and Linux. The output format (e.g. `4 Jul` / `4 Jul 2026`) is unchanged.

## Verification

Tested on Windows 10 (Python 3.11.12). Before: `hermes journey` threw `ValueError: Invalid format string` with the traceback above. After: `hermes journey --no-color` renders the full timeline chart correctly:

```
4 Jul │ ✦━━━━━━  7+25  ◀
...
53 learned skills · 25 memories · 33 skill links
```

`hermes journey --json` was unaffected both before and after (it bypasses rendering entirely).

## Scope

Only `agent/learning_graph_render.py` is touched — two lines of formatting logic. No behavioral changes, no new surface, no cache impact.