### PR TITLE
fix(ci): degrade gracefully on fork timing-report 403s

### DIFF
--- a/scripts/ci/timings_report.py
+++ b/scripts/ci/timings_report.py
@@ -121,6 +121,18 @@ def _normalize_job(raw: dict) -> dict:
     }
 
 
+def _format_http_warning(*, label: str, resource_id: str, err: urllib.error.HTTPError) -> str:
+    reason = err.reason or ""
+    return (
+        f"Could not list {label} for {resource_id} "
+        f"(HTTP {err.code}{f' {reason}' if reason else ''}); generated a partial report without those jobs."
+    )
+
+
+def _allow_partial_jobs(err: urllib.error.HTTPError) -> bool:
+    return err.code == 403
+
+
 def collect_timings(token: str, repo: str, run_id: str, head_sha: str) -> dict:
     """Collect job/step timings from the GitHub API.
 
@@ -128,16 +140,36 @@ def collect_timings(token: str, repo: str, run_id: str, head_sha: str) -> dict:
        Skip workflow-call placeholder jobs (step name starts with "Run ./.github/").
     2. Find sub-workflow runs via head_sha + event=workflow_call.
     3. Get each sub-workflow run's jobs with full step timing.
+
+    Some fork PR contexts can read the run metadata but receive HTTP 403 when
+    listing jobs. In that case we keep the report non-fatal, emit a warning,
+    and return the partial data we could still collect.
     """
     owner, repo_name = repo.split("/")
+    warnings: list[str] = []
 
     # Orchestrator run info
     run_info = api_get(f"/repos/{owner}/{repo_name}/actions/runs/{run_id}", token)
     created_at = run_info.get("created_at", "")
 
     # Orchestrator direct jobs
-    orch_jobs = api_get(f"/repos/{owner}/{repo_name}/actions/runs/{run_id}/jobs",
-                        token, list_key="jobs")
+    try:
+        orch_jobs = api_get(
+            f"/repos/{owner}/{repo_name}/actions/runs/{run_id}/jobs",
+            token,
+            list_key="jobs",
+        )
+    except urllib.error.HTTPError as err:
+        if not _allow_partial_jobs(err):
+            raise
+        orch_jobs = []
+        warnings.append(
+            _format_http_warning(
+                label="orchestrator jobs",
+                resource_id=f"run {run_id}",
+                err=err,
+            )
+        )
 
     direct = []
     for job in orch_jobs:
@@ -149,19 +181,46 @@ def collect_timings(token: str, repo: str, run_id: str, head_sha: str) -> dict:
         direct.append(job)
 
     # Sub-workflow runs
-    sub_runs = api_get(f"/repos/{owner}/{repo_name}/actions/runs", token, params={
-        "head_sha": head_sha,
-        "event": "workflow_call",
-        "per_page": 100,
-    }, list_key="workflow_runs")
+    try:
+        sub_runs = api_get(f"/repos/{owner}/{repo_name}/actions/runs", token, params={
+            "head_sha": head_sha,
+            "event": "workflow_call",
+            "per_page": 100,
+        }, list_key="workflow_runs")
+    except urllib.error.HTTPError as err:
+        if not _allow_partial_jobs(err):
+            raise
+        sub_runs = []
+        warnings.append(
+            _format_http_warning(
+                label="sub-workflow runs",
+                resource_id=f"head {head_sha}",
+                err=err,
+            )
+        )
     sub_runs = [r for r in sub_runs if r.get("created_at", "") >= created_at]
 
     sub_jobs_raw = []
     for sr in sub_runs:
         sr_id = sr["id"]
         sr_name = sr.get("name", "")
-        sr_jobs = api_get(f"/repos/{owner}/{repo_name}/actions/runs/{sr_id}/jobs",
-                          token, list_key="jobs")
+        try:
+            sr_jobs = api_get(
+                f"/repos/{owner}/{repo_name}/actions/runs/{sr_id}/jobs",
+                token,
+                list_key="jobs",
+            )
+        except urllib.error.HTTPError as err:
+            if not _allow_partial_jobs(err):
+                raise
+            warnings.append(
+                _format_http_warning(
+                    label=f"sub-workflow jobs for {sr_name or 'workflow_call'}",
+                    resource_id=f"run {sr_id}",
+                    err=err,
+                )
+            )
+            continue
         for j in sr_jobs:
             j["_workflow_name"] = sr_name
             j["_workflow_run_id"] = sr_id
@@ -177,6 +236,7 @@ def collect_timings(token: str, repo: str, run_id: str, head_sha: str) -> dict:
         "head_sha": head_sha,
         "created_at": created_at,
         "jobs": all_jobs,
+        "warnings": warnings,
     }
 
 
@@ -643,6 +703,7 @@ def generate_html(timings: dict, baseline: dict | None = None) -> str:
     sha_short = (timings.get("head_sha") or "")[:7]
     run_id = timings.get("run_id", "?")
     created = timings.get("created_at", "")
+    warnings = timings.get("warnings") or []
 
     bl_info = ""
     if baseline:
@@ -660,6 +721,11 @@ def generate_html(timings: dict, baseline: dict | None = None) -> str:
         f'<div class="meta">Run <code>{escape(run_id)}</code> | SHA <code>{sha_short}</code>'
         f' | Generated {escape(created)}{bl_info}</div>\n'
     )
+
+    if warnings:
+        html += '<div class="meta"><strong>Warnings:</strong><ul>'
+        html += "".join(f"<li>{escape(warning)}</li>" for warning in warnings)
+        html += '</ul></div>\n'
 
     html += '<h2>Global Stats</h2>\n'
     html += _stats_cards(stats)
@@ -688,8 +754,15 @@ def generate_html(timings: dict, baseline: dict | None = None) -> str:
 def generate_summary(timings: dict, baseline: dict | None = None) -> str:
     stats = compute_stats(timings, baseline)
     bl_map = {j["name"]: j for j in (baseline or {}).get("jobs", [])}
+    warnings = timings.get("warnings") or []
 
     lines = ["## CI Timing Summary\n"]
+
+    if warnings:
+        lines.append("### Warnings")
+        for warning in warnings:
+            lines.append(f"- {warning}")
+        lines.append("")
 
     # Global stats table
     lines.append("| Metric | Current | Baseline | Delta |")
@@ -748,8 +821,7 @@ def main():
         repo = expect_env("GITHUB_REPOSITORY")
         run_id = expect_env("GITHUB_RUN_ID")
         head_sha = expect_env("GITHUB_SHA")
-
-    timings = collect_timings(token, repo, run_id, head_sha)
+        timings = collect_timings(token, repo, run_id, head_sha)
 
     # Save JSON
     with open(args.json_out, "w", encoding="utf-8") as f:

--- a/tests/scripts/test_timings_report.py
+++ b/tests/scripts/test_timings_report.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import importlib.util
+from email.message import Message
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+import urllib.error
+
+import pytest
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "timings_report.py"
+_SPEC = importlib.util.spec_from_file_location("timings_report", SCRIPT_PATH)
+assert _SPEC and _SPEC.loader
+TIMINGS_REPORT = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(TIMINGS_REPORT)
+
+
+def _http_403(url: str) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(url, 403, "Forbidden", hdrs=Message(), fp=None)
+
+
+def test_collect_timings_returns_warning_instead_of_raising_for_orchestrator_jobs_403(monkeypatch: pytest.MonkeyPatch):
+    def fake_api_get(path: str, token: str, params=None, list_key=None):
+        if path == "/repos/acme/hermes/actions/runs/123":
+            return {"created_at": "2026-07-04T00:00:00Z"}
+        if path == "/repos/acme/hermes/actions/runs/123/jobs":
+            raise _http_403(f"https://api.github.com{path}")
+        if path == "/repos/acme/hermes/actions/runs":
+            return []
+        raise AssertionError(f"unexpected path {path}")
+
+    monkeypatch.setattr(TIMINGS_REPORT, "api_get", fake_api_get)
+
+    timings = TIMINGS_REPORT.collect_timings(
+        token="token",
+        repo="acme/hermes",
+        run_id="123",
+        head_sha="deadbeef",
+    )
+
+    assert timings["run_id"] == "123"
+    assert timings["jobs"] == []
+    assert timings["warnings"] == [
+        "Could not list orchestrator jobs for run 123 (HTTP 403 Forbidden); generated a partial report without those jobs."
+    ]
+
+
+def test_collect_timings_skips_only_the_forbidden_subworkflow_runs_listing(monkeypatch: pytest.MonkeyPatch):
+    direct_job = {
+        "id": 1,
+        "name": "direct",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-07-04T00:00:00Z",
+        "completed_at": "2026-07-04T00:01:00Z",
+        "steps": [],
+    }
+
+    def fake_api_get(path: str, token: str, params=None, list_key=None):
+        if path == "/repos/acme/hermes/actions/runs/123":
+            return {"created_at": "2026-07-04T00:00:00Z"}
+        if path == "/repos/acme/hermes/actions/runs/123/jobs":
+            return [direct_job]
+        if path == "/repos/acme/hermes/actions/runs":
+            raise _http_403(f"https://api.github.com{path}")
+        raise AssertionError(f"unexpected path {path}")
+
+    monkeypatch.setattr(TIMINGS_REPORT, "api_get", fake_api_get)
+
+    timings = TIMINGS_REPORT.collect_timings(
+        token="token",
+        repo="acme/hermes",
+        run_id="123",
+        head_sha="deadbeef",
+    )
+
+    assert [job["name"] for job in timings["jobs"]] == ["direct"]
+    assert timings["warnings"] == [
+        "Could not list sub-workflow runs for head deadbeef (HTTP 403 Forbidden); generated a partial report without those jobs."
+    ]
+
+
+def test_collect_timings_skips_only_the_forbidden_subworkflow_jobs(monkeypatch: pytest.MonkeyPatch):
+    direct_job = {
+        "id": 1,
+        "name": "direct",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-07-04T00:00:00Z",
+        "completed_at": "2026-07-04T00:01:00Z",
+        "steps": [],
+    }
+
+    def fake_api_get(path: str, token: str, params=None, list_key=None):
+        if path == "/repos/acme/hermes/actions/runs/123":
+            return {"created_at": "2026-07-04T00:00:00Z"}
+        if path == "/repos/acme/hermes/actions/runs/123/jobs":
+            return [direct_job]
+        if path == "/repos/acme/hermes/actions/runs":
+            return [{"id": 456, "name": "Collect timings", "created_at": "2026-07-04T00:00:01Z"}]
+        if path == "/repos/acme/hermes/actions/runs/456/jobs":
+            raise _http_403(f"https://api.github.com{path}")
+        raise AssertionError(f"unexpected path {path}")
+
+    monkeypatch.setattr(TIMINGS_REPORT, "api_get", fake_api_get)
+
+    timings = TIMINGS_REPORT.collect_timings(
+        token="token",
+        repo="acme/hermes",
+        run_id="123",
+        head_sha="deadbeef",
+    )
+
+    assert [job["name"] for job in timings["jobs"]] == ["direct"]
+    assert timings["warnings"] == [
+        "Could not list sub-workflow jobs for Collect timings for run 456 (HTTP 403 Forbidden); generated a partial report without those jobs."
+    ]
+
+
+def test_collect_timings_reraises_non_403_http_errors(monkeypatch: pytest.MonkeyPatch):
+    def fake_api_get(path: str, token: str, params=None, list_key=None):
+        if path == "/repos/acme/hermes/actions/runs/123":
+            return {"created_at": "2026-07-04T00:00:00Z"}
+        if path == "/repos/acme/hermes/actions/runs/123/jobs":
+            raise urllib.error.HTTPError(
+                f"https://api.github.com{path}",
+                500,
+                "Internal Server Error",
+                hdrs=Message(),
+                fp=None,
+            )
+        raise AssertionError(f"unexpected path {path}")
+
+    monkeypatch.setattr(TIMINGS_REPORT, "api_get", fake_api_get)
+
+    with pytest.raises(urllib.error.HTTPError):
+        TIMINGS_REPORT.collect_timings(
+            token="token",
+            repo="acme/hermes",
+            run_id="123",
+            head_sha="deadbeef",
+        )
+
+
+def test_generate_summary_includes_warnings_section():
+    summary = TIMINGS_REPORT.generate_summary(
+        {
+            "run_id": "123",
+            "head_sha": "deadbeef",
+            "created_at": "2026-07-04T00:00:00Z",
+            "jobs": [],
+            "warnings": [
+                "Could not list orchestrator jobs for run 123 (HTTP 403 Forbidden); generated a partial report without those jobs."
+            ],
+        }
+    )
+
+    assert "### Warnings" in summary
+    assert "HTTP 403 Forbidden" in summary
+
+
+def test_generate_html_includes_warning_banner():
+    html = TIMINGS_REPORT.generate_html(
+        {
+            "run_id": "123",
+            "head_sha": "deadbeef",
+            "created_at": "2026-07-04T00:00:00Z",
+            "jobs": [],
+            "warnings": ["partial report"],
+        }
+    )
+
+    assert "Warnings:" in html
+    assert "partial report" in html
+
+
+def test_format_http_warning_omits_missing_reason():
+    warning = TIMINGS_REPORT._format_http_warning(
+        label="orchestrator jobs",
+        resource_id="run 123",
+        err=cast(urllib.error.HTTPError, SimpleNamespace(code=403, reason=None)),
+    )
+
+    assert warning == (
+        "Could not list orchestrator jobs for run 123 "
+        "(HTTP 403); generated a partial report without those jobs."
+    )
+
+
+def test_main_honors_from_json_without_calling_collect_timings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    input_json = tmp_path / "input.json"
+    baseline_json = tmp_path / "baseline.json"
+    html_out = tmp_path / "report.html"
+    json_out = tmp_path / "out.json"
+    summary_out = tmp_path / "summary.md"
+
+    payload = {
+        "run_id": "123",
+        "head_sha": "deadbeef",
+        "created_at": "2026-07-04T00:00:00Z",
+        "jobs": [],
+        "warnings": ["partial"],
+    }
+    input_json.write_text(__import__("json").dumps(payload), encoding="utf-8")
+    baseline_json.write_text(__import__("json").dumps({"jobs": []}), encoding="utf-8")
+
+    def fail_collect(*args, **kwargs):
+        raise AssertionError("collect_timings should not be called for --from-json")
+
+    monkeypatch.setattr(TIMINGS_REPORT, "collect_timings", fail_collect)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "timings_report.py",
+            "--from-json",
+            str(input_json),
+            "--baseline",
+            str(baseline_json),
+            "--output",
+            str(html_out),
+            "--json-out",
+            str(json_out),
+            "--summary-out",
+            str(summary_out),
+        ],
+    )
+
+    TIMINGS_REPORT.main()
+
+    assert json_out.exists()
+    assert html_out.exists()
+    assert summary_out.exists()
+    assert "### Warnings" in summary_out.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Make `scripts/ci/timings_report.py` non-fatal when a fork PR token receives
`HTTP 403` on GitHub Actions job-listing endpoints.

- All three job-listing API calls (orchestrator jobs, sub-workflow run
  discovery, sub-workflow job lists) now degrade gracefully on 403,
  emitting a warning instead of crashing.
- Warnings appear in both the HTML artifact and the markdown step summary.
- Non-403 HTTP errors remain fatal.
- Fixes a pre-existing bug where `collect_timings` was dedented outside the
  `if args.from_json` else-branch, causing it to run unconditionally and
  overwrite data loaded via `--from-json`.

## Why

Fork PRs were showing a failing `CI timing report` check even when all
product code was fine, because the script crashed on permission-denied
GitHub API responses instead of producing a partial report.

## Related work

No open PR or issue found covering this script path. Scoped entirely to
`scripts/ci/timings_report.py`.

## Testing

```bash
scripts/run_tests.sh tests/scripts/test_timings_report.py -- -q
```

New tests cover 403 degradation on each of the three API call sites,
warning propagation into HTML and step-summary output, and the
`--from-json` fallthrough fix.
