### PR TITLE
feat: sub-provider drill-down in model picker for multi-provider aggregators

### DIFF
--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -177,13 +177,28 @@ function ModelResults({
   // Only configured providers (those with curated models) are selectable
   // here. Switching to a NOT-yet-configured provider goes through the
   // "Add provider" footer button, which opens the full onboarding selector.
-  const configured = providers.filter(p => (p.models ?? []).length > 0)
+  const configured = providers.filter(p => {
+    // Sub-provider pickers (openrouter-style, etc.) have `models` replaced by
+    // sub-labels — reconstruct the flat model list from `sub_models` so
+    // the search-driven desktop picker shows real model IDs, not labels.
+    if (p.is_subprovider_picker && p.sub_models) {
+      return Object.values(p.sub_models).some(models => models.length > 0)
+    }
+
+    return (p.models ?? []).length > 0
+  })
 
   return (
     <>
       {configured.map(provider => {
         // Preserve the backend's curated order — filter in place, no re-sort.
-        const models = (provider.models ?? []).filter(m => matches(provider, m))
+        // For sub-provider pickers, flatten sub_models into a flat list so
+        // the search-driven UI can match on real model IDs.
+        const providerModels = provider.is_subprovider_picker && provider.sub_models
+          ? Object.values(provider.sub_models).flat()
+          : (provider.models ?? [])
+
+        const models = providerModels.filter(m => matches(provider, m))
 
         if (models.length === 0) {
           return null
@@ -310,7 +325,9 @@ function ProviderHeading({ provider }: { provider: ModelOptionProvider }) {
     <span className="flex min-w-0 items-center gap-2">
       <span className="truncate">{provider.name}</span>
       <span className="font-mono text-xs font-normal normal-case tracking-normal text-muted-foreground">
-        {provider.slug} · {provider.total_models ?? provider.models?.length ?? 0}
+        {provider.slug} · {provider.is_subprovider_picker && provider.sub_models
+          ? Object.values(provider.sub_models).reduce((n, models) => n + models.length, 0)
+          : (provider.total_models ?? provider.models?.length ?? 0)}
       </span>
       {tierBadge}
     </span>

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -273,6 +273,16 @@ export interface ModelOptionProvider {
   /** Per-model option support, keyed by model id (present when the picker
    *  requested capabilities). Lets the UI gate fast/reasoning controls. */
   capabilities?: Record<string, ModelCapabilities>
+  /** True when the provider groups models by upstream sub-provider
+   *  (e.g. openrouter). When set, `models` contains sub-labels and
+   *  `sub_models` / `subproviders` / `sub_labels` carry the drill-down data. */
+  is_subprovider_picker?: boolean
+  /** Sub-provider slugs (e.g. ["openai", "anthropic", "google"]). */
+  subproviders?: string[]
+  /** Display labels for each sub (e.g. "openai (12 models)"). */
+  sub_labels?: string[]
+  /** Maps each sub-provider slug to its list of model IDs. */
+  sub_models?: Record<string, string[]>
 }
 
 export interface ModelCapabilities {

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1240,6 +1240,24 @@ display:
 #     provider: custom
 #     base_url: "https://ollama.com/v1"
 
+# model_picker — provider-list rendering options for `/model` and the
+# gateway inline keyboards (Telegram, Discord, TUI, Desktop). All keys
+# default to a flat list and require explicit opt-in.
+#
+# model_picker:
+#   # Sub-provider drill-down: providers whose model IDs follow the
+#   # ``<upstream>/<model>`` shape get grouped by upstream, so a 200+ entry
+#   # catalog becomes ``"openai (12 models)"`` / ``"anthropic (3 models)"``
+#   # rows the user first picks before seeing concrete model IDs. Recommended
+#   # for aggregator providers that proxy many upstreams under one API key.
+#   #
+#   # Threshold (in code, not configurable): at least 3 slashed models AND
+#   # at least 50% of the catalog must be in ``<upstream>/<model>`` form for
+#   # grouping to kick in — otherwise the flat list is shown.
+#   group_by_subprovider:
+#     - openrouter
+#     # - huggingface
+
 # =============================================================================
 # Privacy
 # =============================================================================

--- a/cli.py
+++ b/cli.py
@@ -7852,6 +7852,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 self._close_model_picker()
                 return
             provider_data = providers[selected]
+            # Sub-provider drill-down: when list_authenticated_providers()
+            # marked the row with is_subprovider_picker=True (OpenRouter-style
+            # aggregators), ``provider_data["models"]`` is
+            # actually a list of sub-labels like "openai (12 models)" that
+            # MUST NOT be passed straight to switch_model — that path
+            # triggers "Model names cannot contain spaces." Insert a
+            # subprovider stage so the user picks an upstream before we
+            # expose the real model IDs.
+            if provider_data.get("is_subprovider_picker") and provider_data.get("sub_labels"):
+                state["stage"] = "subprovider"
+                state["provider_data"] = provider_data
+                state["sub_list"] = provider_data.get("sub_labels") or []
+                state["selected"] = 0
+                self._invalidate(min_interval=0.0)
+                return
             # Use the curated model list from list_authenticated_providers()
             # (same lists as `hermes model` and gateway pickers).
             # Only fall back to the live provider catalog when the curated
@@ -7871,14 +7886,80 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             state["selected"] = 0
             self._invalidate(min_interval=0.0)
             return
+        if stage == "subprovider":
+            provider_data = state.get("provider_data") or {}
+            sub_list = state.get("sub_list") or []
+            back_idx = len(sub_list)
+            cancel_idx = len(sub_list) + 1
+            if selected == back_idx:
+                state["stage"] = "provider"
+                state["selected"] = next((i for i, p in enumerate(state.get("providers") or []) if p.get("slug") == provider_data.get("slug")), 0)
+                self._invalidate(min_interval=0.0)
+                return
+            if selected >= cancel_idx:
+                self._close_model_picker()
+                return
+            if 0 <= selected < len(sub_list):
+                # The picker shows sub_labels (e.g. "openai (12 models)"),
+                # but the real dispatch key is the bare sub-provider slug
+                # ("openai") that maps into the sub_models dict produced by
+                # _group_provider_models_by_subprovider().
+                chosen_sub_label = sub_list[selected]
+                sub_models_map = provider_data.get("sub_models") or {}
+                # Match by either the bare sub slug or the displayed label,
+                # so a future change to the label format can't silently
+                # break the lookup.
+                chosen_sub = None
+                for sub_slug in (provider_data.get("subproviders") or []):
+                    if chosen_sub_label == sub_slug or chosen_sub_label.startswith(f"{sub_slug} ("):
+                        chosen_sub = sub_slug
+                        break
+                if chosen_sub is None or not sub_models_map.get(chosen_sub):
+                    # Defensive fallthrough — should never fire because
+                    # sub_list mirrors sub_labels 1:1, but a stale state
+                    # must not silently index into labels and crash
+                    # validate_requested_model.
+                    _cprint(f"  ✗ Sub-provider picker out of sync — use /model again.")
+                    self._close_model_picker()
+                    return
+                state["stage"] = "model"
+                state["chosen_sub"] = chosen_sub
+                state["model_list"] = sub_models_map[chosen_sub]
+                state["selected"] = 0
+                self._invalidate(min_interval=0.0)
+                return
+            self._close_model_picker()
+            return
         if stage == "model":
             provider_data = state.get("provider_data") or {}
             model_list = state.get("model_list") or []
             back_idx = len(model_list)
             cancel_idx = len(model_list) + 1
             if selected == back_idx:
-                state["stage"] = "provider"
-                state["selected"] = next((i for i, p in enumerate(state.get("providers") or []) if p.get("slug") == provider_data.get("slug")), 0)
+                # Back from the model list should return to the
+                # subprovider stage (when one was used) so the user can
+                # switch upstream without re-picking the provider.
+                if provider_data.get("is_subprovider_picker") and provider_data.get("sub_labels"):
+                    state["stage"] = "subprovider"
+                    chosen_sub = state.get("chosen_sub")
+                    state["selected"] = (
+                        (provider_data.get("sub_labels") or []).index(
+                            next(
+                                (
+                                    lbl
+                                    for lbl in (provider_data.get("sub_labels") or [])
+                                    if chosen_sub and (lbl == chosen_sub or lbl.startswith(f"{chosen_sub} ("))
+                                ),
+                                provider_data["sub_labels"][0],
+                            )
+                        )
+                        if (provider_data.get("sub_labels") or [])
+                        and chosen_sub
+                        else 0
+                    )
+                else:
+                    state["stage"] = "provider"
+                    state["selected"] = next((i for i, p in enumerate(state.get("providers") or []) if p.get("slug") == provider_data.get("slug")), 0)
                 self._invalidate(min_interval=0.0)
                 return
             if selected >= cancel_idx:
@@ -13543,9 +13624,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             state = self._model_picker_state
             if not state:
                 return
-            if state.get("stage") == "provider":
+            stage = state.get("stage")
+            if stage == "provider":
                 max_idx = len(state.get("providers") or [])
+            elif stage == "subprovider":
+                # sub_list + "← Back" + "Cancel" (2 extra rows)
+                max_idx = len(state.get("sub_list") or []) + 1
             else:
+                # model_list + "← Back" + "Cancel" (2 extra rows)
                 max_idx = len(state.get("model_list") or []) + 1
             state["selected"] = min(max_idx, state.get("selected", 0) + 1)
             event.app.invalidate()
@@ -14632,10 +14718,25 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     choices.append(label)
                 choices.append("Cancel")
                 hint = f"Current: {state.get('current_model', 'unknown')} on {state.get('current_provider', 'unknown')}"
+            elif stage == "subprovider":
+                provider_data = state.get("provider_data") or {}
+                provider_name = provider_data.get("name", provider_data.get("slug", "Provider"))
+                title = f"⚙ Model Picker — {provider_name} › Select Sub-Provider"
+                sub_list = state.get("sub_list") or []
+                choices = list(sub_list) + ["← Back", "Cancel"]
+                if sub_list:
+                    hint = f"Pick the upstream vendor to drill into ({len(sub_list)} available)"
+                else:
+                    hint = "No sub-providers listed for this provider. Use Back or Cancel."
             else:
                 provider_data = state.get("provider_data") or {}
+                provider_name = provider_data.get("name", provider_data.get("slug", "Provider"))
+                chosen_sub = state.get("chosen_sub")
+                if chosen_sub:
+                    title = f"⚙ Model Picker — {provider_name} › {chosen_sub}"
+                else:
+                    title = f"⚙ Model Picker — {provider_name}"
                 model_list = state.get("model_list") or []
-                title = f"⚙ Model Picker — {provider_data.get('name', provider_data.get('slug', 'Provider'))}"
                 choices = list(model_list) + ["← Back", "Cancel"]
                 if model_list:
                     hint = f"Select a model ({len(model_list)} available)"

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -1377,6 +1377,76 @@ def _model_flow_named_custom(config, provider_info):
             models = configured_models
 
     if models:
+        # Sub-provider drill-down (opt-in via ``model_picker.group_by_subprovider``).
+        # If the user has opted-in to grouping this provider, present the
+        # upstream sub-providers first; the chosen one re-enters this same
+        # block with ``models`` filtered to that sub.
+        from hermes_cli.model_switch import (
+            _group_provider_models_by_subprovider,
+            _load_subprovider_picker_config,
+        )
+        group_cfg = _load_subprovider_picker_config()
+        grouped = (
+            _group_provider_models_by_subprovider(provider_key or "", models)
+            if (provider_key and provider_key in group_cfg)
+            else None
+        )
+        if grouped:
+            subs = grouped["subproviders"]
+            sub_models_map = grouped["sub_models"]
+            sub_labels = grouped["sub_labels"]
+            # Preserve the saved sub if possible (e.g. user previously saved
+            # "openrouter/openai/gpt-4o-mini" → land them straight back on openai).
+            current_sub = ""
+            if saved_model:
+                for sub in subs:
+                    if any(saved_model == m or saved_model.endswith("/" + m.split("/", 1)[-1])
+                           for m in sub_models_map.get(sub, [])):
+                        if saved_model.startswith(f"{sub}/"):
+                            current_sub = sub
+                            break
+            print(f"Found {len(models)} model(s) across {len(subs)} upstream(s):\n")
+            try:
+                from hermes_cli.curses_ui import curses_radiolist
+
+                default_sub_idx = subs.index(current_sub) if current_sub in subs else 0
+                idx = curses_radiolist(
+                    f"Select upstream from {name}:",
+                    sub_labels,
+                    selected=default_sub_idx,
+                    cancel_returns=-1,
+                )
+                print()
+                if idx < 0 or idx >= len(subs):
+                    print("Cancelled.")
+                    return
+                sub = subs[idx]
+            except (ImportError, NotImplementedError, OSError, subprocess.SubprocessError):
+                for i, s in enumerate(sub_labels, 1):
+                    print(f"  {i}. {s}")
+                print(f"  {len(sub_labels) + 1}. Cancel")
+                print()
+                try:
+                    val = input(f"Choice [1-{len(sub_labels) + 1}]: ").strip()
+                    if not val:
+                        print("Cancelled.")
+                        return
+                    idx = int(val) - 1
+                    if idx < 0 or idx >= len(sub_labels):
+                        print("Cancelled.")
+                        return
+                    sub = subs[idx]
+                except (ValueError, KeyboardInterrupt, EOFError):
+                    print("\nCancelled.")
+                    return
+            # Drill into the sub-catalog — fall through to the normal picker
+            # below with the filtered list.
+            models = sub_models_map.get(sub, [])
+            if not models:
+                print(f"No models available for upstream '{sub}'.")
+                return
+            print(f"\n  → {len(models)} model(s) under '{sub}'")
+
         default_idx = 0
         if saved_model and saved_model in models:
             default_idx = models.index(saved_model)
@@ -2734,6 +2804,95 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
         model_list = list(dict.fromkeys(mid for mid in model_list if mid))
 
     if model_list:
+        # Sub-provider drill-down for the API-key wizard. OpenRouter-style
+        # aggregator providers ship models in ``<upstream>/<model>``
+        # form, e.g. ``openai/gpt-4o-mini``. When the user has opted-in via
+        # ``model_picker.group_by_subprovider`` we show the upstream list
+        # first, then filter ``model_list`` to the chosen sub so the model
+        # picker only shows the upstream's catalog.
+        try:
+            from hermes_cli.model_switch import (
+                _group_provider_models_by_subprovider,
+                _load_subprovider_picker_config,
+            )
+
+            group_cfg = _load_subprovider_picker_config()
+        except Exception:
+            group_cfg = set()
+
+        if (
+            provider_id in group_cfg
+            and len(model_list) >= 3
+            and any(isinstance(m, str) and "/" in m for m in model_list)
+        ):
+            grouped = _group_provider_models_by_subprovider(provider_id, model_list)
+            if grouped:
+                subs = grouped["subproviders"]
+                sub_models_map = grouped["sub_models"]
+                sub_labels = grouped["sub_labels"]
+                current_sub = ""
+                if current_model:
+                    for sub in subs:
+                        if current_model.startswith(f"{sub}/"):
+                            current_sub = sub
+                            break
+                print(
+                    f"Found {len(model_list)} model(s) across {len(subs)} upstream(s):"
+                )
+                try:
+                    from hermes_cli.curses_ui import curses_radiolist
+
+                    default_sub_idx = (
+                        subs.index(current_sub) if current_sub in subs else 0
+                    )
+                    sub_idx = curses_radiolist(
+                        f"Select upstream from {pconfig.name}:",
+                        sub_labels,
+                        selected=default_sub_idx,
+                        cancel_returns=-1,
+                    )
+                    print()
+                    if 0 <= sub_idx < len(subs):
+                        model_list = sub_models_map[subs[sub_idx]]
+                        if not model_list:
+                            print("No models available for that upstream.")
+                            return
+                        print(
+                            f"  → {len(model_list)} model(s) under "
+                            f"'{subs[sub_idx]}'"
+                        )
+                    else:
+                        print("Cancelled.")
+                        return
+                except (ImportError, NotImplementedError, OSError, subprocess.SubprocessError):
+                    for i, s in enumerate(sub_labels, 1):
+                        print(f"  {i}. {s}")
+                    print(f"  {len(sub_labels) + 1}. Cancel")
+                    print()
+                    try:
+                        val = input(
+                            f"Choice [1-{len(sub_labels) + 1}]: "
+                        ).strip()
+                        if not val:
+                            print("Cancelled.")
+                            return
+                        sub_idx = int(val) - 1
+                        if 0 <= sub_idx < len(sub_labels):
+                            model_list = sub_models_map[subs[sub_idx]]
+                            if not model_list:
+                                print("No models available for that upstream.")
+                                return
+                            print(
+                                f"  → {len(model_list)} model(s) under "
+                                f"'{subs[sub_idx]}'"
+                            )
+                        else:
+                            print("Cancelled.")
+                            return
+                    except (ValueError, KeyboardInterrupt, EOFError):
+                        print("\nCancelled.")
+                        return
+
         selected = _prompt_model_selection(
             model_list,
             current_model=current_model,

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import logging
 import re
+from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any, List, NamedTuple, Optional
 
@@ -1671,7 +1672,7 @@ def list_authenticated_providers(
         pinfo = _mdev_pinfo(mdev_id)
         display_name = pinfo.name if pinfo else mdev_id
 
-        results.append({
+        entry = {
             "slug": slug,
             "name": display_name,
             "is_current": slug == current_provider or mdev_id == current_provider,
@@ -1679,7 +1680,16 @@ def list_authenticated_providers(
             "models": top,
             "total_models": total,
             "source": "built-in",
-        })
+        }
+        # Opt-in drill-down: providers with lots of upstream/<model> IDs get
+        # grouped by the segment before the first ``/`` (OpenRouter, HuggingFace, etc.).
+        if slug in _load_subprovider_picker_config():
+            grouped = _group_provider_models_by_subprovider(slug, model_ids)
+            if grouped:
+                entry.update(grouped)
+                entry["models"] = grouped["sub_labels"]
+                entry["total_models"] = total
+        results.append(entry)
         seen_slugs.add(slug.lower())
         seen_mdev_ids.add(mdev_id)
         _record_builtin_endpoint(slug)
@@ -1833,7 +1843,7 @@ def list_authenticated_providers(
         else:
             top = model_ids[:max_models] if max_models is not None else model_ids
 
-        results.append({
+        entry = {
             "slug": hermes_slug,
             "name": get_label(hermes_slug),
             "is_current": hermes_slug == current_provider or pid == current_provider,
@@ -1841,7 +1851,18 @@ def list_authenticated_providers(
             "models": top,
             "total_models": total,
             "source": "hermes",
-        })
+        }
+        # Opt-in drill-down: providers with lots of upstream/<model> IDs get
+        # grouped by the segment before the first ``/`` (OpenRouter-style, etc.).
+        if hermes_slug in _load_subprovider_picker_config():
+            grouped = _group_provider_models_by_subprovider(hermes_slug, model_ids)
+            if grouped:
+                entry.update(grouped)
+                entry["models"] = grouped["sub_labels"]
+                # Keep total_models = total model count (not sub-providers) so
+                # the "X more available" hint in the picker stays accurate.
+                entry["total_models"] = total
+        results.append(entry)
         seen_slugs.add(pid.lower())
         seen_slugs.add(hermes_slug.lower())
         _record_builtin_endpoint(hermes_slug)
@@ -1908,7 +1929,7 @@ def list_authenticated_providers(
         _cp_total = len(_cp_model_ids)
         _cp_top = _cp_model_ids[:max_models] if max_models is not None else _cp_model_ids
 
-        results.append({
+        _cp_entry = {
             "slug": _cp.slug,
             "name": _cp.label,
             "is_current": _cp.slug == current_provider,
@@ -1916,7 +1937,14 @@ def list_authenticated_providers(
             "models": _cp_top,
             "total_models": _cp_total,
             "source": "canonical",
-        })
+        }
+        if _cp.slug in _load_subprovider_picker_config():
+            _cp_grouped = _group_provider_models_by_subprovider(_cp.slug, _cp_model_ids)
+            if _cp_grouped:
+                _cp_entry.update(_cp_grouped)
+                _cp_entry["models"] = _cp_grouped["sub_labels"]
+                _cp_entry["total_models"] = _cp_total
+        results.append(_cp_entry)
         seen_slugs.add(_cp.slug.lower())
         _record_builtin_endpoint(_cp.slug)
 
@@ -2333,6 +2361,63 @@ def _prepend_moa_picker_provider(providers: List[dict], current_provider: str = 
         return [moa_row] + [p for p in providers if str(p.get("slug", "")).lower() != "moa"]
     except Exception:
         return providers
+def _load_subprovider_picker_config() -> list[str]:
+    """Return the slugs that should be drilled-down by upstream sub-provider.
+
+    Reads ``model_picker.group_by_subprovider`` from the user config. The list
+    is opt-in and defaults to ``[]`` so the picker behaviour is unchanged for
+    every other provider. Typical entry: ``["openrouter"]`` — these
+    aggregators proxy 100+ models across many upstream vendors and a flat
+    list is unusable.
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config() or {}
+    except Exception:
+        return []
+    raw = cfg.get("model_picker", {})
+    if not isinstance(raw, dict):
+        return []
+    slugs = raw.get("group_by_subprovider", [])
+    if not isinstance(slugs, list):
+        return []
+    return [str(s).strip().lower() for s in slugs if str(s).strip()]
+
+
+def _group_provider_models_by_subprovider(
+    slug: str,
+    all_models: List[str],
+) -> Optional[dict]:
+    """Group a flat model list by its first ``/`` segment.
+
+    Returns ``None`` if the provider has too few ``/``-bearing models to be
+    worth grouping (under 50% of the catalog or under 3 entries), so callers
+    fall back to the flat list. Otherwise returns a dict shaped like a picker
+    provider entry but with ``models`` replaced by sub-provider labels
+    (e.g. ``"openai (12 models)"``) and an extra ``is_subprovider_picker=True``
+    flag the drill-down UI uses to filter on the second step.
+    """
+    if not all_models:
+        return None
+    counts: "OrderedDict[str, int]" = OrderedDict()
+    slashed = 0
+    for m in all_models:
+        if not isinstance(m, str) or "/" not in m:
+            continue
+        sub = m.split("/", 1)[0].strip()
+        if not sub:
+            continue
+        counts[sub] = counts.get(sub, 0) + 1
+        slashed += 1
+    if slashed < 3 or slashed * 2 < len(all_models):
+        return None
+    sub_labels = [f"{sub} ({n} models)" for sub, n in counts.items()]
+    return {
+        "subproviders": list(counts.keys()),
+        "sub_models": {sub: [m for m in all_models if m.startswith(f"{sub}/")] for sub in counts},
+        "is_subprovider_picker": True,
+        "sub_labels": sub_labels,
+    }
 
 
 def list_picker_providers(

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -6801,7 +6801,19 @@ def _define_discord_view_classes() -> None:
             self.add_item(cancel_btn)
 
         def _build_model_select(self, provider_slug: str):
-            """Build the model dropdown for a specific provider."""
+            """Build the model dropdown for a specific provider.
+
+            Handles two modes:
+
+            * Normal provider: ``models`` is a list of model IDs. The select
+              shows ``<model>`` (or the segment after ``/`` if present) with
+              the model ID as value. Click triggers ``_on_model_selected``.
+            * Sub-provider picker (OpenRouter-style aggregators): ``models`` is
+              a list of ``"<sub> (<n> models)"`` labels and the provider dict
+              carries ``is_subprovider_picker=True`` and ``sub_models``. The
+              select shows the sub-provider labels; clicking one drills into
+              the corresponding sub-catalog via ``_on_subprovider_selected``.
+            """
             self.clear_items()
             provider = next(
                 (p for p in self.providers if p["slug"] == provider_slug), None
@@ -6810,25 +6822,47 @@ def _define_discord_view_classes() -> None:
                 return
 
             models = provider.get("models", [])
-            options = []
-            for model_id in models[:25]:
-                short = model_id.split("/")[-1] if "/" in model_id else model_id
-                options.append(
-                    discord.SelectOption(
-                        label=short[:100],
-                        value=model_id[:100],
-                    )
-                )
-            if not options:
-                return
 
-            select = discord.ui.Select(
-                placeholder=f"Choose a model from {provider.get('name', provider_slug)}...",
-                options=options,
-                custom_id="model_model_select",
-            )
-            select.callback = self._on_model_selected
-            self.add_item(select)
+            if provider.get("is_subprovider_picker"):
+                # Sub-provider drill-down: emit one option per upstream.
+                self._selected_subprovider = ""  # reset
+                options = []
+                for idx, label in enumerate(models[:25]):
+                    options.append(
+                        discord.SelectOption(
+                            label=str(label)[:100],
+                            value=f"sub:{idx}",
+                        )
+                    )
+                if not options:
+                    return
+                select = discord.ui.Select(
+                    placeholder=f"Choose an upstream provider from {provider.get('name', provider_slug)}...",
+                    options=options,
+                    custom_id="model_subprovider_select",
+                )
+                select.callback = self._on_subprovider_selected
+                self.add_item(select)
+            else:
+                options = []
+                for model_id in models[:25]:
+                    short = model_id.split("/")[-1] if "/" in model_id else model_id
+                    options.append(
+                        discord.SelectOption(
+                            label=short[:100],
+                            value=model_id[:100],
+                        )
+                    )
+                if not options:
+                    return
+
+                select = discord.ui.Select(
+                    placeholder=f"Choose a model from {provider.get('name', provider_slug)}...",
+                    options=options,
+                    custom_id="model_model_select",
+                )
+                select.callback = self._on_model_selected
+                self.add_item(select)
 
             back_btn = discord.ui.Button(
                 label="◀ Back", style=discord.ButtonStyle.grey, custom_id="model_back"
@@ -6950,6 +6984,118 @@ def _define_discord_view_classes() -> None:
                 ),
                 view=None,
             )
+
+        async def _on_subprovider_selected(self, interaction: discord.Interaction):
+            """Drill into a sub-provider catalog (OpenRouter-style aggregators).
+
+            Triggered by the ``model_subprovider_select`` dropdown built by
+            :py:meth:`_build_model_select` when the chosen provider carries
+            ``is_subprovider_picker=True``. The select's value is
+            ``"sub:<idx>"`` where ``idx`` indexes into the provider's
+            ``subproviders`` list.
+            """
+            if not self._check_auth(interaction):
+                await interaction.response.send_message(
+                    "You're not authorized~", ephemeral=True
+                )
+                return
+
+            raw = interaction.data["values"][0]
+            if not raw.startswith("sub:"):
+                # Fallback: treat as a normal model id and switch.
+                await self._switch_selected_model(interaction, raw)
+                return
+            try:
+                idx = int(raw[4:])
+            except ValueError:
+                await interaction.response.send_message(
+                    "Invalid sub-provider selection.", ephemeral=True
+                )
+                return
+
+            provider_slug = self._selected_provider
+            provider = next(
+                (p for p in self.providers if p["slug"] == provider_slug), None
+            )
+            if not provider or not provider.get("is_subprovider_picker"):
+                await interaction.response.send_message(
+                    "Picker state expired.", ephemeral=True
+                )
+                return
+
+            subs = provider.get("subproviders", [])
+            if not (0 <= idx < len(subs)):
+                await interaction.response.send_message(
+                    "Out-of-range sub-provider selection.", ephemeral=True
+                )
+                return
+            sub = subs[idx]
+            sub_models = provider.get("sub_models", {}).get(sub, [])
+            self._selected_subprovider = sub
+            # Stash the filtered catalog so the existing back/switch flow
+            # only sees the models for this sub. We rebuild the view as a
+            # flat model select without the sub-provider toggle.
+            self._build_filtered_model_select(provider_slug, sub, sub_models)
+
+            extra = ""
+            if len(sub_models) > 25:
+                extra = f"\n*{len(sub_models) - 25} more available — type `/model <name>` directly*"
+            pname = provider.get("name", provider_slug)
+            await interaction.response.edit_message(
+                embed=discord.Embed(
+                    title="⚙ Model Configuration",
+                    description=f"Provider: **{pname}** / **{sub}**\nSelect a model:{extra}",
+                    color=discord.Color.blue(),
+                ),
+                view=self,
+            )
+
+        def _build_filtered_model_select(
+            self, provider_slug: str, sub: str, models: list
+        ):
+            """Render a flat model select for a single sub-provider.
+
+            Used by :py:meth:`_on_subprovider_selected` after the user picks
+            an upstream. The Back button re-opens the sub-provider select.
+            """
+            self.clear_items()
+            options = []
+            for model_id in models[:25]:
+                # Strip the "<sub>/" prefix so the dropdown labels read clean.
+                short = model_id
+                if model_id.startswith(f"{sub}/"):
+                    short = model_id[len(sub) + 1:]
+                options.append(
+                    discord.SelectOption(
+                        label=short[:100],
+                        value=model_id[:100],
+                    )
+                )
+            if not options:
+                return
+            select = discord.ui.Select(
+                placeholder=f"Choose a model from {sub}...",
+                options=options,
+                custom_id="model_model_select",
+            )
+            select.callback = self._on_model_selected
+            self.add_item(select)
+
+            back_btn = discord.ui.Button(
+                label="◀ Upstream",
+                style=discord.ButtonStyle.grey,
+                custom_id="model_back",
+            )
+            back_btn.callback = self._on_back
+            self.add_item(back_btn)
+
+            cancel_btn = discord.ui.Button(
+                label="Cancel",
+                style=discord.ButtonStyle.red,
+                custom_id="model_cancel2",
+            )
+            cancel_btn.callback = self._on_cancel
+            self.add_item(cancel_btn)
 
         async def _on_model_selected(self, interaction: discord.Interaction):
             if self.resolved:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4717,8 +4717,58 @@ class TelegramAdapter(BasePlatformAdapter):
                 await query.answer(text="Invalid model index.")
                 return
 
-            model_id = model_list[idx]
             provider_slug = state.get("selected_provider", "")
+            provider_obj = next(
+                (p for p in state.get("providers", []) if p.get("slug") == provider_slug),
+                None,
+            )
+            # Sub-provider drill-down: if this provider is in
+            # ``is_subprovider_picker`` mode AND we have not already drilled
+            # into a sub, the click on a row is the sub-provider label, not
+            # a final model. Filter the catalog and re-render the model
+            # keyboard for that sub. Once a sub is selected (state has
+            # ``selected_subprovider``), subsequent mm:N clicks are final
+            # model picks and we fall through to the normal switch path —
+            # otherwise we'd loop indefinitely, bouncing between subs
+            # (e.g. openai ↔ anthropic) on every model click.
+            if (
+                provider_obj
+                and provider_obj.get("is_subprovider_picker")
+                and not state.get("selected_subprovider")
+            ):
+                sub_list = provider_obj.get("subproviders", [])
+                if 0 <= idx < len(sub_list):
+                    sub = sub_list[idx]
+                    sub_models = provider_obj.get("sub_models", {}).get(sub, [])
+                    state["model_list"] = sub_models
+                    state["model_page"] = 0
+                    state["selected_subprovider"] = sub
+                    keyboard, page_info = self._build_model_keyboard(sub_models, 0)
+                    pname = provider_obj.get("name", provider_slug)
+                    total = len(sub_models)
+                    shown = len(sub_models)
+                    extra = f"\n_{total - shown} more available — type `/model <name>` directly_" if total > shown else ""
+                    await query.edit_message_text(
+                        text=self.format_message(
+                            (
+                                f"⚙ *Model Configuration*\n\n"
+                                f"Provider: *{pname}* / *{sub}*{page_info}\n"
+                                f"Select a model:{extra}"
+                            )
+                        ),
+                        parse_mode=ParseMode.MARKDOWN_V2,
+                        reply_markup=keyboard,
+                    )
+                    await query.answer()
+                    return
+                # is_subprovider_picker=True but idx out of range of sub_list.
+                # The button must be a stale sub-label click; refuse rather
+                # than feeding a label like "openai (12 models)" to switch_model,
+                # which would trigger "Model names cannot contain spaces."
+                await query.answer(text="Picker out of sync — use /model again.")
+                return
+
+            model_id = model_list[idx]
             callback = state.get("on_model_selected")
 
             if not callback:

--- a/tests/cli/test_model_picker_subprovider_stage.py
+++ b/tests/cli/test_model_picker_subprovider_stage.py
@@ -1,0 +1,412 @@
+"""Tests for the CLI's sub-provider drill-down stage in :func:`_handle_model_picker_selection`.
+
+The drill-down feature reuses the picker state machine to insert a middle
+stage (``"subprovider"``) between the provider row and the model row, so the
+user first picks an upstream vendor (openai, anthropic, google, ...) before
+seeing concrete model IDs.
+
+These tests pin the state transitions and side effects the picker relies on:
+
+* Selecting a sub-provider resolves the **label** ("openai (12 models)") back
+  to the **bare slug** ("openai") that indexes ``sub_models``. Shipping the
+  label downstream would crash the model picker — labels contain spaces,
+  model IDs don't.
+* "Back" from the sub-provider stage returns to the provider stage with the
+  *correct* provider row selected by slug, not just index 0 (which might
+  not be the row the user drilled from).
+* The "Back" path from the model stage lands on the sub-provider stage with
+  the previously-chosen sub selected — so users can switch upstream without
+  re-picking the provider.
+* A stale ``sub_label`` (one that doesn't match any ``subproviders`` entry)
+  must NOT be fed to ``switch_model`` — that path would crash on
+  ``"Model names cannot contain spaces."`` The defensive close path is the
+  only safe behaviour.
+
+The Telegram/Discord/TUI/Desktop adapters reuse the same drill-down
+contract — they all expect ``chosen_sub`` to be the bare slug, not the
+display label. A regression here would surface as 404s on every chat
+platform.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+def _bound(fn, instance):
+    """Bind an unbound method to a fake ``self`` without instantiating the class."""
+    return fn.__get__(instance, type(instance))
+
+
+def _make_provider(slug, name=None, *, subproviders=None, sub_models=None,
+                   sub_labels=None, is_subprovider_picker=False, models=None):
+    return {
+        "slug": slug,
+        "name": name or slug.title(),
+        "is_current": False,
+        "is_user_defined": False,
+        "models": list(models or []),
+        "total_models": len(models or []),
+        "source": "built-in",
+        "is_subprovider_picker": is_subprovider_picker,
+        "subproviders": list(subproviders or []),
+        "sub_models": dict(sub_models or {}),
+        "sub_labels": list(sub_labels or []),
+    }
+
+
+# ── Stage transition: provider → subprovider ──────────────────────────────
+
+
+def test_provider_selection_with_drill_down_transitions_to_subprovider(monkeypatch):
+    """Selecting an aggregator provider row inserts the sub-provider stage.
+
+    The row's ``models`` (which is actually sub-labels after drill-down
+    grouping) must NOT be passed to the model picker — that path crashes
+    on the spaces inside "openai (12 models)".
+    """
+    import cli as cli_mod
+
+    state = {
+        "stage": "provider",
+        "providers": [
+            _make_provider("anthropic", models=["claude-sonnet-4-6"]),
+            _make_provider(
+                "huggingface",
+                models=["openai (2 models)", "anthropic (1 models)"],
+                subproviders=["openai", "anthropic"],
+                sub_models={
+                    "openai": ["openai/gpt-4o", "openai/gpt-4o-mini"],
+                    "anthropic": ["anthropic/claude-3-5-sonnet"],
+                },
+                sub_labels=["openai (2 models)", "anthropic (1 models)"],
+                is_subprovider_picker=True,
+            ),
+        ],
+        "selected": 1,
+    }
+
+    invalidations = []
+
+    self_ = SimpleNamespace(
+        _model_picker_state=state,
+        _close_model_picker=lambda: None,
+        _invalidate=lambda **kw: invalidations.append(kw),
+    )
+
+    _bound(cli_mod.HermesCLI._handle_model_picker_selection, self_)()
+
+    assert state["stage"] == "subprovider"
+    assert state["sub_list"] == ["openai (2 models)", "anthropic (1 models)"]
+    assert state["selected"] == 0
+    assert state["provider_data"]["slug"] == "huggingface"
+    # The drill-down row's models were NOT leaked forward.
+    assert state.get("model_list") is None
+    # The picker repainted.
+    assert invalidations == [{"min_interval": 0.0}]
+
+
+def test_provider_selection_without_drill_down_skips_stage(monkeypatch):
+    """A regular provider row goes straight to the model stage.
+
+    This is the unchanged behaviour — the picker contract for any provider
+    that is NOT marked drill-down.
+    """
+    import cli as cli_mod
+
+    monkeypatch.setattr("hermes_cli.models.provider_model_ids",
+                        lambda slug: [])
+
+    state = {
+        "stage": "provider",
+        "providers": [
+            _make_provider("anthropic", models=["claude-sonnet-4-6"]),
+        ],
+        "selected": 0,
+    }
+
+    self_ = SimpleNamespace(
+        _model_picker_state=state,
+        _close_model_picker=lambda: None,
+        _invalidate=lambda **kw: None,
+    )
+
+    _bound(cli_mod.HermesCLI._handle_model_picker_selection, self_)()
+
+    assert state["stage"] == "model"
+    assert state["model_list"] == ["claude-sonnet-4-6"]
+    assert state["provider_data"]["slug"] == "anthropic"
+    # Drill-down artefacts must NOT appear on a regular row.
+    assert "sub_list" not in state
+
+
+# ── Stage subprovider: resolution of label → slug ─────────────────────────
+
+
+def test_subprovider_selection_resolves_label_to_bare_slug(monkeypatch):
+    """A sub-label like ``"openai (2 models)"`` maps to the bare slug ``"openai"``.
+
+    This is the contract every downstream adapter (Telegram, Discord, TUI,
+    Desktop) relies on: ``chosen_sub`` is what indexes ``sub_models``, so
+    shipping a label downstream would silently produce empty model lists.
+    """
+    import cli as cli_mod
+
+    state = {
+        "stage": "subprovider",
+        "providers": [_make_provider("huggingface")],
+        "provider_data": _make_provider(
+            "huggingface",
+            subproviders=["openai", "anthropic"],
+            sub_models={
+                "openai": ["openai/gpt-4o", "openai/gpt-4o-mini"],
+                "anthropic": ["anthropic/claude-3-5-sonnet"],
+            },
+            sub_labels=["openai (2 models)", "anthropic (1 models)"],
+            is_subprovider_picker=True,
+        ),
+        "sub_list": ["openai (2 models)", "anthropic (1 models)"],
+        "selected": 0,
+    }
+
+    self_ = SimpleNamespace(
+        _model_picker_state=state,
+        _close_model_picker=lambda: None,
+        _invalidate=lambda **kw: None,
+    )
+
+    _bound(cli_mod.HermesCLI._handle_model_picker_selection, self_)()
+
+    # The bare slug, not the label.
+    assert state["chosen_sub"] == "openai"
+    # The model list is the openai slice, NOT a label.
+    assert state["model_list"] == ["openai/gpt-4o", "openai/gpt-4o-mini"]
+    assert state["stage"] == "model"
+    assert state["selected"] == 0
+
+
+def test_subprovider_selection_with_no_space_in_label(monkeypatch):
+    """If a sub has only one model, the label is ``"openai (1 models)"``
+    (the helper has no plural handling). The matching branch must still
+    resolve it to the bare slug.
+
+    Pin this so a future label-format change can't silently break it.
+    """
+    import cli as cli_mod
+
+    state = {
+        "stage": "subprovider",
+        "provider_data": _make_provider(
+            "huggingface",
+            subproviders=["google"],
+            sub_models={"google": ["google/gemini-1.5-pro"]},
+            sub_labels=["google (1 models)"],
+            is_subprovider_picker=True,
+        ),
+        "sub_list": ["google (1 models)"],
+        "selected": 0,
+    }
+
+    self_ = SimpleNamespace(
+        _model_picker_state=state,
+        _close_model_picker=lambda: None,
+        _invalidate=lambda **kw: None,
+    )
+
+    _bound(cli_mod.HermesCLI._handle_model_picker_selection, self_)()
+
+    assert state["chosen_sub"] == "google"
+    assert state["model_list"] == ["google/gemini-1.5-pro"]
+
+
+# ── Stage subprovider: defensive paths ────────────────────────────────────
+
+
+def test_subprovider_defensive_close_when_label_does_not_match_any_sub(monkeypatch):
+    """A stale sub-label (no match in ``subproviders``) must NOT be fed to ``switch_model``.
+
+    The dispatch key must be the bare slug; feeding the label would trigger
+    ``"Model names cannot contain spaces."``. We close the picker instead
+    of crashing the user. The error-message wording is rendered through
+    ``_cprint`` which writes to a Rich console that is not always captured
+    under pytest's capsys, so we only pin the observable contract here:
+    the picker closes and no model is selected.
+    """
+    import cli as cli_mod
+
+    state = {
+        "stage": "subprovider",
+        "provider_data": _make_provider(
+            "huggingface",
+            subproviders=["openai", "anthropic"],
+            sub_models={"openai": ["openai/gpt-4o"], "anthropic": ["anthropic/claude-3-5-sonnet"]},
+            sub_labels=["openai (1 models)", "anthropic (1 models)"],
+            is_subprovider_picker=True,
+        ),
+        # State drift: the selected label no longer corresponds to any sub.
+        "sub_list": ["orphan (10 models)"],
+        "selected": 0,
+    }
+    closes = []
+
+    self_ = SimpleNamespace(
+        _model_picker_state=state,
+        _close_model_picker=lambda: closes.append(True),
+        _invalidate=lambda **kw: None,
+    )
+
+    _bound(cli_mod.HermesCLI._handle_model_picker_selection, self_)()
+
+    assert closes == [True]
+    # The picker must NOT have advanced to the model stage with a label
+    # as ``chosen_sub`` (that would feed "openai (12 models)" to switch_model).
+    assert "model_list" not in state or state.get("model_list") != ["orphan (10 models)"]
+
+
+def test_subprovider_cancel_closes_picker(monkeypatch):
+    """Selecting Cancel (idx past back) closes the picker, no drill-down."""
+    import cli as cli_mod
+
+    state = {
+        "stage": "subprovider",
+        "provider_data": _make_provider(
+            "huggingface",
+            subproviders=["openai"],
+            sub_models={"openai": ["openai/gpt-4o"]},
+            sub_labels=["openai (1 models)"],
+            is_subprovider_picker=True,
+        ),
+        "sub_list": ["openai (1 models)"],
+        "selected": 2,  # cancel_idx = len(sub_list) + 1 = 2
+    }
+    closes = []
+
+    self_ = SimpleNamespace(
+        _model_picker_state=state,
+        _close_model_picker=lambda: closes.append(True),
+        _invalidate=lambda **kw: None,
+    )
+
+    _bound(cli_mod.HermesCLI._handle_model_picker_selection, self_)()
+
+    assert closes == [True]
+
+
+def test_subprovider_back_returns_to_provider_stage_with_correct_row(monkeypatch):
+    """Back from subprovider stage returns to the provider stage with the
+    original provider row selected (by slug, not index 0).
+
+    The picker rebuilds the cursor position from the slug the user drilled
+    from, so multi-aggregator pickers land the user back on the exact row
+    they came from.
+    """
+    import cli as cli_mod
+
+    provider_data = _make_provider(
+        "huggingface",
+        subproviders=["openai"],
+        sub_models={"openai": ["openai/gpt-4o"]},
+        sub_labels=["openai (1 models)"],
+        is_subprovider_picker=True,
+    )
+    state = {
+        "stage": "subprovider",
+        "providers": [
+            _make_provider("anthropic"),
+            _make_provider("huggingface", is_subprovider_picker=True),
+            _make_provider("gemini"),
+        ],
+        "provider_data": provider_data,
+        "sub_list": ["openai (1 models)"],
+        "selected": 1,  # back_idx = len(sub_list) = 1
+    }
+    invalidations = []
+
+    self_ = SimpleNamespace(
+        _model_picker_state=state,
+        _close_model_picker=lambda: None,
+        _invalidate=lambda **kw: invalidations.append(kw),
+    )
+
+    _bound(cli_mod.HermesCLI._handle_model_picker_selection, self_)()
+
+    assert state["stage"] == "provider"
+    # huggingface is at index 1 in the providers list, NOT 0.
+    assert state["selected"] == 1
+    # The user's sub_list memory is dropped on the way back up.
+    assert invalidations == [{"min_interval": 0.0}]
+
+
+# ── Stage model: back navigation lands on subprovider ────────────────────
+
+
+def test_model_back_with_drill_down_returns_to_subprovider_with_sub_selected(monkeypatch):
+    """Back from model stage with a drill-down provider lands on the
+    subprovider stage, with the previously-chosen sub pre-selected.
+
+    So after picking openai → gpt-4o, hitting Back should put the cursor on
+    ``openai`` again — not on the first sub in the list.
+    """
+    import cli as cli_mod
+
+    state = {
+        "stage": "model",
+        "provider_data": _make_provider(
+            "huggingface",
+            subproviders=["openai", "anthropic", "google"],
+            sub_models={
+                "openai": ["openai/gpt-4o"],
+                "anthropic": ["anthropic/claude-3-5-sonnet"],
+                "google": ["google/gemini-1.5-pro"],
+            },
+            sub_labels=[
+                "openai (1 models)",
+                "anthropic (1 models)",
+                "google (1 models)",
+            ],
+            is_subprovider_picker=True,
+        ),
+        "model_list": ["anthropic/claude-3-5-sonnet"],
+        "chosen_sub": "anthropic",
+        "selected": 1,  # back_idx = 1
+    }
+    invalidations = []
+
+    self_ = SimpleNamespace(
+        _model_picker_state=state,
+        _close_model_picker=lambda: None,
+        _invalidate=lambda **kw: invalidations.append(kw),
+    )
+
+    _bound(cli_mod.HermesCLI._handle_model_picker_selection, self_)()
+
+    assert state["stage"] == "subprovider"
+    # Cursor lands on the previously-chosen "anthropic", index 1, NOT 0.
+    assert state["selected"] == 1
+    assert invalidations == [{"min_interval": 0.0}]
+
+
+def test_model_back_without_drill_down_returns_to_provider_stage(monkeypatch):
+    """Sanity: Back from the model stage on a non-drill-down provider
+    goes back to the provider stage (unchanged behaviour).
+    """
+    import cli as cli_mod
+
+    state = {
+        "stage": "model",
+        "provider_data": _make_provider("anthropic", models=["claude-sonnet-4-6"]),
+        "model_list": ["claude-sonnet-4-6"],
+        "selected": 1,  # back_idx = 1
+    }
+
+    self_ = SimpleNamespace(
+        _model_picker_state=state,
+        _close_model_picker=lambda: None,
+        _invalidate=lambda **kw: None,
+    )
+
+    _bound(cli_mod.HermesCLI._handle_model_picker_selection, self_)()
+
+    assert state["stage"] == "provider"

--- a/tests/hermes_cli/test_subprovider_drilldown.py
+++ b/tests/hermes_cli/test_subprovider_drilldown.py
@@ -1,0 +1,269 @@
+"""Tests for the sub-provider drill-down mechanism in the model picker.
+
+Two helpers live behind the feature:
+
+* :func:`hermes_cli.model_switch._load_subprovider_picker_config` — reads the
+  opt-in ``model_picker.group_by_subprovider`` user config and normalizes the
+  slug list (lowercase, strip whitespace, drop empties).
+* :func:`hermes_cli.model_switch._group_provider_models_by_subprovider` —
+  groups a flat model catalog by the segment before the first ``/``, applies
+  threshold guards (at least 3 slashed entries AND at least 50% of the
+  catalog), and returns ``None`` when grouping is not worthwhile.
+
+When both helpers pass, :func:`list_authenticated_providers` rewrites the
+provider entry so ``models`` is replaced by sub-provider labels
+("openai (12 models)") and the drill-down UI can take over the second step.
+
+These tests pin the relationship between config, threshold, and output shape —
+not snapshots of any specific catalog. Per AGENTS.md: behavior contracts,
+never change-detector lists.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli import model_switch
+
+
+# ── _load_subprovider_picker_config ─────────────────────────────────────────
+
+
+def test_load_config_returns_empty_when_key_absent(monkeypatch):
+    """No ``model_picker.group_by_subprovider`` key → empty list (opt-in)."""
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {"provider": "anthropic"}},
+    )
+
+    assert model_switch._load_subprovider_picker_config() == []
+
+
+def test_load_config_returns_empty_when_load_config_raises(monkeypatch):
+    """A broken YAML must not crash the picker — it must default to []."""
+    def _raise():
+        raise RuntimeError("yaml parse error")
+
+    monkeypatch.setattr("hermes_cli.config.load_config", _raise)
+
+    assert model_switch._load_subprovider_picker_config() == []
+
+
+def test_load_config_returns_empty_when_model_picker_not_a_dict(monkeypatch):
+    """A scalar/list at ``model_picker`` must not crash — treat as absent."""
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model_picker": "openrouter"},
+    )
+
+    assert model_switch._load_subprovider_picker_config() == []
+
+
+def test_load_config_normalizes_case_and_whitespace(monkeypatch):
+    """Slugs are matched lowercase against ``ProviderDef.id``; preserve order.
+
+    Duplicate entries are kept verbatim — the gate is membership-based, and
+    a user who lists the same provider twice (e.g. once intentionally and
+    once by accident) shouldn't get silent dedup at the config layer.
+    """
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "model_picker": {
+                "group_by_subprovider": [" OpenRouter ", "OPENROUTER", " hugginGface  "],
+            },
+        },
+    )
+
+    # Order is preserved (matters for deterministic picker display), casing
+    # and surrounding whitespace are stripped.
+    assert model_switch._load_subprovider_picker_config() == [
+        "openrouter",
+        "openrouter",
+        "huggingface",
+    ]
+
+
+def test_load_config_drops_empty_strings(monkeypatch):
+    """An accidental blank entry must not register as the slug ``\"\"``."""
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model_picker": {"group_by_subprovider": ["", "  ", "openrouter"]}},
+    )
+
+    assert model_switch._load_subprovider_picker_config() == ["openrouter"]
+
+
+def test_load_config_membership_check_is_lowercase(monkeypatch):
+    """Producers of the list use lowercase; casing is normalized in one place.
+
+    Gates downstream against ``ProviderDef.id`` (which is also lowercase), so
+    a producer that forgets to lowercase still gets correctly matched.
+    """
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model_picker": {"group_by_subprovider": ["OpenRouter"]}},
+    )
+
+    result = model_switch._load_subprovider_picker_config()
+
+    assert "openrouter" in result
+    assert "OpenRouter" not in result
+
+
+# ── _group_provider_models_by_subprovider ──────────────────────────────────
+
+
+def test_group_returns_none_on_empty_catalog():
+    """Nothing to group → flat-list fallback (no drill-down)."""
+    assert model_switch._group_provider_models_by_subprovider("openrouter", []) is None
+
+
+def test_group_returns_none_when_below_count_threshold():
+    """Fewer than 3 slashed models → no group (the threshold guards UX).
+
+    The 3-absolute threshold prevents the drill-down UI from showing a
+    single-sub list that would just be a flatter model picker.
+    """
+    # 2 slashed entries — strictly under the 3-absolute threshold.
+    models = ["openai/gpt-4o", "anthropic/claude-3-5-sonnet"]
+    assert model_switch._group_provider_models_by_subprovider("openrouter", models) is None
+
+
+def test_group_returns_none_when_below_ratio_threshold():
+    """Enough slashed in absolute terms, but they are a minority of the catalog.
+
+    The 50% threshold means the provider is "really" a slash aggregator —
+    a provider whose slash IDs are mixed with bare IDs drifts back to the
+    flat list instead of being mislabelled as an aggregator.
+    """
+    # 3 slashed out of 7 total → meets the 3-absolute threshold but fails
+    # the 50% ratio check.
+    models = [
+        "openai/gpt-4o",
+        "anthropic/claude-3-5-sonnet",
+        "gemini/gemini-1.5-pro",
+        "gpt-4o",
+        "claude-3-5-sonnet",
+        "gemini-1.5-pro",
+        "mistral-large",
+    ]
+    assert model_switch._group_provider_models_by_subprovider("openrouter", models) is None
+
+
+def test_group_groups_preserving_first_appearance_order():
+    """Sub-provider order in the output mirrors first-occurrence in the catalog.
+
+    The picker UI relies on a stable order across runs — alphabetical sort
+    would scramble it. ``OrderedDict`` accumulation in the helper pins this.
+    """
+    models = [
+        "google/gemini-1.5-pro",
+        "openai/gpt-4o",
+        "anthropic/claude-3-5-sonnet",
+        "openai/gpt-4o-mini",
+        "google/gemini-1.5-flash",
+        "anthropic/claude-3-opus",
+        "openai/o1-preview",
+    ]
+    grouped = model_switch._group_provider_models_by_subprovider("openrouter", models)
+
+    assert grouped is not None
+    # First occurrence: google, then openai, then anthropic.
+    assert grouped["subproviders"] == ["google", "openai", "anthropic"]
+    # The label format used by both CLI and Telegram/Discord pickers.
+    assert grouped["sub_labels"] == [
+        "google (2 models)",
+        "openai (3 models)",
+        "anthropic (2 models)",
+    ]
+
+
+def test_group_sub_models_isolated_per_sub_no_cross_contamination():
+    """``sub_models[sub]`` must contain only that sub's models — no leakage.
+
+    The drill-down feeds ``sub_models[chosen_sub]`` straight to the model
+    picker; any foreign model in there would land users on a 404 model.
+    """
+    models = [
+        "openai/gpt-4o",
+        "anthropic/claude-3-5-sonnet",
+        "google/gemini-1.5-pro",
+        "openai/gpt-4o-mini",
+    ]
+    grouped = model_switch._group_provider_models_by_subprovider("openrouter", models)
+    assert grouped is not None
+
+    sub_models = grouped["sub_models"]
+    assert set(sub_models.keys()) == {"openai", "anthropic", "google"}
+    # Cross-contamination guard: ``openai/`` must not appear in another sub.
+    assert sub_models["anthropic"] == ["anthropic/claude-3-5-sonnet"]
+    assert sub_models["google"] == ["google/gemini-1.5-pro"]
+    assert sub_models["openai"] == ["openai/gpt-4o", "openai/gpt-4o-mini"]
+
+
+def test_group_sets_is_subprovider_picker_flag():
+    """The flag is the contract the drill-down UI filters on.
+
+    Without it, the CLI/TUI/Desktop/Telegram/Discord picker would treat
+    a sub-labels list as a flat model list — and would crash on spaces.
+    """
+    models = [
+        "openai/gpt-4o",
+        "anthropic/claude-3-5-sonnet",
+        "google/gemini-1.5-pro",
+    ]
+    grouped = model_switch._group_provider_models_by_subprovider("openrouter", models)
+
+    assert grouped is not None
+    assert grouped["is_subprovider_picker"] is True
+
+
+# ── Membership contract (relates config and threshold helpers) ─────────────
+# The integration point — the ``if slug in _load_subprovider_picker_config()``
+# branch in ``list_authenticated_providers`` — cannot be exercised in
+# isolation without mocking the credential store and the models.dev registry,
+# so its full coverage stays in ``test_list_picker_providers.py`` (which
+# already mocks ``list_authenticated_providers``). What is testable here is
+# the membership contract the branch relies on.
+
+
+def test_config_and_grouping_compose_into_drill_down_payload(monkeypatch):
+    """The config + grouping helpers compose end-to-end on raw inputs.
+
+    Pin the contract: with a slug opted-in and a catalog above threshold,
+    the two helpers together produce a payload that downstream UIs (CLI,
+    TUI, Desktop, Telegram, Discord) consume without further processing.
+    """
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model_picker": {"group_by_subprovider": ["huggingface"]}},
+    )
+
+    opted_in = model_switch._load_subprovider_picker_config()
+    models = [
+        "openai/gpt-4o",
+        "openai/gpt-4o-mini",
+        "anthropic/claude-3-5-sonnet",
+        "google/gemini-1.5-pro",
+    ]
+
+    # Membership check: the slug gating uses ``in`` on the configured list.
+    assert "huggingface" in opted_in
+    assert "openrouter" not in opted_in
+
+    grouped = model_switch._group_provider_models_by_subprovider("huggingface", models)
+
+    # The grouped payload is the contract the drill-down UI consumes.
+    assert grouped is not None
+    assert grouped["is_subprovider_picker"] is True
+    # ``sub_labels`` is what ``list_authenticated_providers`` writes into
+    # ``models`` for the picker to render in stage 2.
+    assert grouped["sub_labels"] == [
+        "openai (2 models)",
+        "anthropic (1 models)",
+        "google (1 models)",
+    ]
+    # Each upstream's catalog is exactly its ``sub/*`` slice — no leakage.
+    flat = [m for models in grouped["sub_models"].values() for m in models]
+    assert sorted(flat) == sorted(models)

--- a/ui-tui/src/components/modelPicker.tsx
+++ b/ui-tui/src/components/modelPicker.tsx
@@ -15,7 +15,7 @@ const VISIBLE = 12
 const MIN_WIDTH = 40
 const MAX_WIDTH = 90
 
-type Stage = 'provider' | 'key' | 'model' | 'disconnect'
+type Stage = 'provider' | 'subprovider' | 'key' | 'model' | 'disconnect'
 
 type ProviderRow = { name: string; provider: ModelOptionProvider }
 
@@ -35,6 +35,8 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
   const [persistGlobal, setPersistGlobal] = useState(false)
   const [providerIdx, setProviderIdx] = useState(0)
   const [modelIdx, setModelIdx] = useState(0)
+  const [subIdx, setSubIdx] = useState(0)
+  const [chosenSub, setChosenSub] = useState<string>('')
   const [stage, setStage] = useState<Stage>('provider')
   const [keyInput, setKeyInput] = useState('')
   const [keySaving, setKeySaving] = useState(false)
@@ -106,7 +108,26 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
   }, [providerRows, filter, stage])
 
   const provider = filteredProviderRows[providerIdx]?.provider
-  const allModels = useMemo(() => provider?.models ?? [], [provider])
+
+  // Sub-provider drill-down: when the selected provider has
+  // is_subprovider_picker, its `models` are actually sub-labels and the
+  // real model IDs live in `sub_models[sub_slug]`.
+  const subLabels = useMemo(() => provider?.sub_labels ?? [], [provider])
+  const filteredSubLabels = useMemo(() => {
+    if (stage !== 'subprovider' || !filter.trim()) {
+      return subLabels
+    }
+
+    return fuzzyRank(subLabels, filter, s => s).map(r => r.item)
+  }, [subLabels, filter, stage])
+
+  const allModels = useMemo(() => {
+    if (provider?.is_subprovider_picker && chosenSub && provider.sub_models?.[chosenSub]) {
+      return provider.sub_models[chosenSub]
+    }
+
+    return provider?.models ?? []
+  }, [provider, chosenSub])
 
   const filteredModels = useMemo(() => {
     if (stage !== 'model' || !filter.trim()) {
@@ -131,9 +152,15 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
     }
   }, [models.length, modelIdx])
 
+  useEffect(() => {
+    if (subIdx >= filteredSubLabels.length && filteredSubLabels.length > 0) {
+      setSubIdx(0)
+    }
+  }, [filteredSubLabels.length, subIdx])
+
   const back = () => {
     // Esc first clears an active filter on the list stages, before navigating.
-    if ((stage === 'provider' || stage === 'model') && filter.trim()) {
+    if ((stage === 'provider' || stage === 'model' || stage === 'subprovider') && filter.trim()) {
       // Preserve the selected provider across filter clear (same fix as
       // Enter→key/model and Ctrl+D transitions above).
       const fullProviderIdx = providerIndexAfterClearingFilter(providerRows, provider)
@@ -146,11 +173,36 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
 
       setFilter('')
       setModelIdx(0)
+      setSubIdx(0)
 
       return
     }
 
-    if (stage === 'model' || stage === 'key' || stage === 'disconnect') {
+    if (stage === 'model') {
+      // Back from model → subprovider (if applicable) or provider.
+      if (provider?.is_subprovider_picker && chosenSub) {
+        setStage('subprovider')
+        setModelIdx(0)
+        setFilter('')
+      } else {
+        setStage('provider')
+        setModelIdx(0)
+        setFilter('')
+      }
+
+      return
+    }
+
+    if (stage === 'subprovider') {
+      setStage('provider')
+      setSubIdx(0)
+      setChosenSub('')
+      setFilter('')
+
+      return
+    }
+
+    if (stage === 'key' || stage === 'disconnect') {
       setStage('provider')
       setModelIdx(0)
       setKeyInput('')
@@ -166,7 +218,7 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
 
   // On the list stages we capture printable keys (including 'q') into the
   // filter, so the shared overlay q/Esc handler must yield to our own handler.
-  const listStage = stage === 'provider' || stage === 'model'
+  const listStage = stage === 'provider' || stage === 'model' || stage === 'subprovider'
   useOverlayKeys({ disabled: listStage, onBack: back, onClose: onCancel })
 
   useInput((ch, key) => {
@@ -301,9 +353,9 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
       return
     }
 
-    const count = stage === 'provider' ? filteredProviderRows.length : models.length
-    const sel = stage === 'provider' ? providerIdx : modelIdx
-    const setSel = stage === 'provider' ? setProviderIdx : setModelIdx
+    const count = stage === 'provider' ? filteredProviderRows.length : stage === 'subprovider' ? filteredSubLabels.length : models.length
+    const sel = stage === 'provider' ? providerIdx : stage === 'subprovider' ? subIdx : modelIdx
+    const setSel = stage === 'provider' ? setProviderIdx : stage === 'subprovider' ? setSubIdx : setModelIdx
 
     if (key.upArrow && sel > 0) {
       setSel(v => v - 1)
@@ -342,12 +394,51 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
           return
         }
 
+        // Sub-provider drill-down: if the provider groups models by
+        // upstream (openrouter-style, etc.), go to the subprovider stage first.
+        if (provider.is_subprovider_picker && provider.sub_labels?.length) {
+          setStage('subprovider')
+          setSubIdx(0)
+          setChosenSub('')
+          setFilter('')
+
+          return
+        }
+
         const fullProviderIdx = providerIndexAfterClearingFilter(providerRows, provider)
 
         if (fullProviderIdx >= 0) {
           setProviderIdx(fullProviderIdx)
         }
 
+        setStage('model')
+        setModelIdx(0)
+        setFilter('')
+
+        return
+      }
+
+      if (stage === 'subprovider') {
+        const subLabel = filteredSubLabels[subIdx]
+
+        if (!subLabel || !provider) {
+          setStage('provider')
+
+          return
+        }
+
+        // Resolve the bare sub slug from the label "openai (12 models)".
+        const subs = provider.subproviders ?? []
+        const matchedSub = subs.find(s => subLabel === s || subLabel.startsWith(`${s} (`))
+
+        if (!matchedSub || !provider.sub_models?.[matchedSub]?.length) {
+          // Defensive: sub-label out of sync — bail to provider stage.
+          setStage('provider')
+
+          return
+        }
+
+        setChosenSub(matchedSub)
         setStage('model')
         setModelIdx(0)
         setFilter('')
@@ -604,6 +695,64 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
     )
   }
 
+  // ── Sub-provider selection stage ────────────────────────────────────
+  if (stage === 'subprovider' && provider) {
+    const { items: subItems, offset: subOffset } = windowItems(filteredSubLabels, subIdx, VISIBLE)
+    const noSubMatches = !!filter.trim() && filteredSubLabels.length === 0
+
+    return (
+      <Box flexDirection="column" width={width}>
+        <Text bold color={t.color.accent} wrap="truncate-end">
+          Select upstream from {provider.name}
+        </Text>
+
+        <Text color={t.color.muted} wrap="truncate-end">
+          {filteredSubLabels.length} upstream(s) · Esc back
+        </Text>
+        <Text color={filter ? t.color.accent : t.color.muted} wrap="truncate-end">
+          {filter ? `filter: ${filter}▎` : 'type to filter · ↑/↓ select'}
+        </Text>
+        <Text color={t.color.muted} wrap="truncate-end">
+          {subOffset > 0 ? ` ↑ ${subOffset} more` : ' '}
+        </Text>
+
+        {noSubMatches ? (
+          <Text color={t.color.muted} wrap="truncate-end">
+            no upstreams match
+          </Text>
+        ) : (
+          Array.from({ length: VISIBLE }, (_, i) => {
+            const row = subItems[i]
+            const idx = subOffset + i
+
+            return row ? (
+              <Text
+                bold={subIdx === idx}
+                color={subIdx === idx ? t.color.accent : t.color.muted}
+                inverse={subIdx === idx}
+                key={`sub-${idx}`}
+                wrap="truncate-end"
+              >
+                {subIdx === idx ? '▸ ' : '  '}
+                {idx + 1}. {row}
+              </Text>
+            ) : (
+              <Text color={t.color.muted} key={`sub-pad-${i}`} wrap="truncate-end">
+                {' '}
+              </Text>
+            )
+          })
+        )}
+
+        <Text color={t.color.muted} wrap="truncate-end">
+          {subOffset + VISIBLE < filteredSubLabels.length ? ` ↓ ${filteredSubLabels.length - subOffset - VISIBLE} more` : ' '}
+        </Text>
+
+        <OverlayHint t={t}>↑/↓ select · Enter drill in · Esc clear/back · q close</OverlayHint>
+      </Box>
+    )
+  }
+
   // ── Model selection stage ────────────────────────────────────────────
   const { items, offset } = windowItems(models, modelIdx, VISIBLE)
   const noModelMatches = !!filter.trim() && models.length === 0
@@ -615,7 +764,7 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
       </Text>
 
       <Text color={t.color.muted} wrap="truncate-end">
-        {filteredProviderRows[providerIdx]?.name || '(unknown provider)'} · Esc back
+        {chosenSub ? `${filteredProviderRows[providerIdx]?.name ?? ''} › ${chosenSub}` : (filteredProviderRows[providerIdx]?.name || '(unknown provider)')} · Esc back
       </Text>
       <Text color={filter ? t.color.accent : t.color.muted} wrap="truncate-end">
         {filter ? `filter: ${filter}▎` : 'type to filter · ↑/↓ select'}

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -479,6 +479,16 @@ export interface ModelOptionProvider {
   slug: string
   total_models?: number
   warning?: string
+  /** True when the provider groups models by upstream sub-provider
+   *  (e.g. openrouter). When set, `models` contains sub-labels and
+   *  `sub_models` / `subproviders` / `sub_labels` carry the drill-down data. */
+  is_subprovider_picker?: boolean
+  /** Sub-provider slugs (e.g. ["openai", "anthropic", "google"]). */
+  subproviders?: string[]
+  /** Display labels for each sub (e.g. "openai (12 models)"). */
+  sub_labels?: string[]
+  /** Maps each sub-provider slug to its list of model IDs. */
+  sub_models?: Record<string, string[]>
 }
 
 export interface ModelOptionsResponse {


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in model_picker.group_by_subprovider config key that groups slash-bearing model IDs (openai/gpt-4o → sub openai) into a two-step picker flow. Designed for OpenRouter, HuggingFace, and any future aggregator that uses <upstream>/<model> notation like Eden AI.

## Related Issue

Fixes #58566 

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- hermes_cli/model_switch.py: _group_provider_models_by_subprovider() groups models by the segment before the first /. Threshold: ≥3 slashed models AND ≥50% of catalog. Two helper functions: _load_subprovider_picker_config() reads the opt-in list from config.
- hermes_cli/model_setup_flows.py: drill-down in hermes model CLI wizard (curses_radiolist with fallback to numbered input).
- cli.py: subprovider stage in the prompt_toolkit /model picker, with back navigation (model → subprovider → provider).
- gateway/platforms/telegram.py: inline keyboard drill-down via mb: callback prefix.
- plugins/platforms/discord/adapter.py: select-menu drill-down with _on_back and _selected_subprovider handlers.
- ui-tui/src/components/modelPicker.tsx: new subprovider stage between provider and model, with type-to-filter, arrow navigation, and back routing.
- apps/desktop/src/components/model-picker.tsx: reconstructs flat model list from sub_models when is_subprovider_picker is set (the desktop has a search bar, so a flat list of real model IDs works better than a 2-step drill-down).
- Type definitions updated in both ui-tui/src/gatewayTypes.ts and apps/desktop/src/types/hermes.ts.

## How to Test

just run tests

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [N/A] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


