### PR TITLE
fix(cron): wire max_tokens from per-job config into AIAgent constructor

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2891,6 +2891,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             openrouter_min_coding_score=(_cfg.get("openrouter") or {}).get("min_coding_score"),
             enabled_toolsets=_resolve_cron_enabled_toolsets(job, _cfg),
             disabled_toolsets=_resolve_cron_disabled_toolsets(_cfg),
+            max_tokens=job.get("max_tokens"),
             quiet_mode=True,
             # Cron jobs should always inherit the user's SOUL.md identity from
             # HERMES_HOME. When a workdir is configured, also inject project


### PR DESCRIPTION
## Summary

`run_job()` in `cron/scheduler.py` reads several job-config keys (model, reasoning_config, toolsets, etc.) into the `AIAgent(...)` constructor but never reads `max_tokens`. A cron job that sets `max_tokens: 4096` gets it silently ignored.

## Impact

Any cron job whose expected output exceeds the model's default max-output behavior fails with `RuntimeError: Response remained truncated after 3 continuation attempts` — and setting `max_tokens` in that job's config to fix it does nothing, silently.

## Fix

Added `max_tokens=job.get(max_tokens)` to the `AIAgent()` constructor call in `run_job()`.

## Root Cause

`AIAgent.__init__` accepts `max_tokens: int = None` and the plumbing exists everywhere downstream (`agent_init.py` → `build_api_kwargs()`). The only missing link was the constructor call in `cron/scheduler.py`.

Fixes #58423