### PR TITLE
fix(discord): restore allow-all default when no allowlists configured

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3163,6 +3163,12 @@ class DiscordAdapter(BasePlatformAdapter):
                 and self._discord_channel_ids_allowed(channel_ids)
             ):
                 return True
+            # When no allowlists are configured at all (no users, no roles,
+            # and no DISCORD_ALLOWED_CHANNELS), default to allowing everyone.
+            # This preserves the pre-v0.18.0 backwards-compatible behavior
+            # where empty allowlists = open access.
+            if not os.getenv("DISCORD_ALLOWED_CHANNELS", "").strip():
+                return True
             return False
         # Check user ID allowlist (works for both DMs and guild messages).
         # ``"*"`` is honored as an open-mode wildcard, mirroring

--- a/tests/gateway/test_discord_roles_dm_scope.py
+++ b/tests/gateway/test_discord_roles_dm_scope.py
@@ -256,11 +256,11 @@ def test_user_id_allowlist_works_in_guild():
     )
 
 
-def test_empty_allowlists_deny_without_opt_in():
+def test_empty_allowlists_allow_without_opt_in():
     adapter = _make_adapter()
     assert (
         adapter._is_allowed_user("42", author=None, guild=None, is_dm=True)
-        is False
+        is True
     )
 
 

--- a/tests/gateway/test_discord_slash_auth.py
+++ b/tests/gateway/test_discord_slash_auth.py
@@ -185,18 +185,18 @@ def _make_interaction(
 
 @pytest.mark.asyncio
 async def test_no_allowlist_denies_without_opt_in(adapter):
-    """Without allowlists or allow-all flags, Discord traffic is denied."""
+    """Without any allowlists configured, Discord traffic is allowed (open default)."""
     interaction = _make_interaction("999999999")
-    assert await adapter._check_slash_authorization(interaction, "/help") is False
-    interaction.response.send_message.assert_awaited()
+    assert await adapter._check_slash_authorization(interaction, "/help") is True
+    interaction.response.send_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_no_allowlist_dm_denied_without_opt_in(adapter):
-    """DM slash commands follow the same fail-closed default."""
+    """DM slash commands follow the same open default when no allowlists configured."""
     interaction = _make_interaction("999999999", in_dm=True)
-    assert await adapter._check_slash_authorization(interaction, "/help") is False
-    interaction.response.send_message.assert_awaited()
+    assert await adapter._check_slash_authorization(interaction, "/help") is True
+    interaction.response.send_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -475,10 +475,19 @@ async def test_missing_channel_id_rejected_when_channel_policy_configured(
 
 
 @pytest.mark.asyncio
-async def test_missing_channel_id_denied_without_allowlists(adapter):
-    """No channel or user policy configured: fail closed by default."""
+async def test_missing_channel_id_allows_without_allowlists(adapter):
+    """No channel or user policy configured: open by default."""
+    interaction = _make_interaction("100200300", channel_id=None)
+    assert await adapter._check_slash_authorization(interaction, "/help") is True
+
+
+@pytest.mark.asyncio
+async def test_channel_policy_fail_closed_when_channels_configured(adapter, monkeypatch):
+    """DISCORD_ALLOWED_CHANNELS set but interaction has no channel id: fail closed."""
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "111222333")
     interaction = _make_interaction("100200300", channel_id=None)
     assert await adapter._check_slash_authorization(interaction, "/help") is False
+    interaction.response.send_message.assert_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -1211,7 +1211,7 @@ class TestDiscordVoiceChannelMethods:
 
     def test_is_allowed_user_empty_list(self):
         adapter = self._make_adapter()
-        assert adapter._is_allowed_user("42") is False
+        assert adapter._is_allowed_user("42") is True
 
     def test_is_allowed_user_in_list(self):
         adapter = self._make_adapter()


### PR DESCRIPTION
## Summary

v0.18.0 regression: `_is_allowed_user()` returns `False` when both user and role allowlists are empty, even without `DISCORD_ALLOWED_CHANNELS` set. This silently blocks ALL Discord messages for users who haven't configured any allowlists — the default install state.

## Root Cause

In `_is_allowed_user()`, when `has_users=False` and `has_roles=False`:
1. Checks `DISCORD_ALLOW_ALL_USERS` env → not set
2. Checks `GATEWAY_ALLOW_ALL_USERS` env → not set  
3. Checks `DISCORD_ALLOWED_CHANNELS` → not set → returns False
4. **Falls through to `return False`** — blocks everyone

Previous behavior (pre-v0.18.0): empty allowlists = everyone allowed.

## Fix

When no allowlists are configured at all (no users, no roles, AND no `DISCORD_ALLOWED_CHANNELS`), default to allowing everyone. This preserves backwards compatibility.

The explicit `DISCORD_ALLOW_ALL_USERS=true` override still works for users who want to be explicit.

## Testing

- No allowlists configured → messages pass through (backwards compatible)
- `DISCORD_ALLOWED_CHANNELS` set → channel-scoped access still works
- `DISCORD_ALLOW_ALL_USERS=true` → explicit override still works
- User/role allowlists configured → existing behavior unchanged

Fixes #58568