### PR TITLE
feat: add free LLM provider profiles

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1278,7 +1278,49 @@ def get_auth_provider_display_name(provider_id: str) -> str:
     return SERVICE_PROVIDER_NAMES.get(normalized, provider_id)
 
 
-def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
+def _credential_pool_lookup_ids_for(provider_id: str) -> Tuple[str, ...]:
+    """Return canonical+legacy alias pool keys for a provider or alias."""
+    normalized = (provider_id or "").strip().lower()
+    if not normalized:
+        return ()
+    ordered: List[str] = [normalized]
+    try:
+        import importlib
+
+        profile = getattr(importlib.import_module("providers"), "get_provider_profile")(
+            normalized
+        )
+    except Exception:
+        profile = None
+    if profile is not None:
+        ordered = [getattr(profile, "name", normalized), normalized]
+        ordered.extend(getattr(profile, "aliases", ()))
+    seen = set()
+    result = []
+    for candidate in ordered:
+        if not isinstance(candidate, str):
+            continue
+        candidate = candidate.strip().lower()
+        if not candidate or candidate in seen:
+            continue
+        seen.add(candidate)
+        result.append(candidate)
+    return tuple(result)
+
+
+def _first_credential_pool_entries(
+    pool: Dict[str, Any], provider_ids: Iterable[str]
+) -> List[Dict[str, Any]]:
+    for provider_id in provider_ids:
+        entries = pool.get(provider_id)
+        if isinstance(entries, list) and entries:
+            return list(entries)
+    return []
+
+
+def read_credential_pool(
+    provider_id: Optional[str] = None,
+) -> Dict[str, Any] | List[Dict[str, Any]]:
     """Return the persisted credential pool, or one provider slice.
 
     In profile mode, the profile's credential pool is authoritative. If a
@@ -1317,12 +1359,18 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
             merged[gp_key] = list(gp_entries)
         return merged
 
-    provider_entries = pool.get(provider_id)
-    if isinstance(provider_entries, list) and provider_entries:
-        return list(provider_entries)
-    # Profile has no entries for this provider — fall back to global.
-    global_entries = global_pool.get(provider_id)
-    return list(global_entries) if isinstance(global_entries, list) else []
+    provider_entries = _first_credential_pool_entries(
+        pool, _credential_pool_lookup_ids_for(provider_id)
+    )
+    if provider_entries:
+        return provider_entries
+
+    # Profile has no entries for this provider — fall back to global.  Include
+    # legacy alias pools so credentials written before alias canonicalization do
+    # not become stranded when runtime/auth commands resolve to the canonical id.
+    return _first_credential_pool_entries(
+        global_pool, _credential_pool_lookup_ids_for(provider_id)
+    )
 
 
 def write_credential_pool(
@@ -1373,6 +1421,37 @@ def write_credential_pool(
                 continue
             merged.append(sanitize_borrowed_credential_payload(disk_entry, provider_id))
         pool[provider_id] = merged
+
+        # If credentials were previously stored under a provider-profile alias,
+        # remove migrated/removed entries from those legacy buckets.  Canonical
+        # pool reads still fall back to aliases, but any write should gradually
+        # converge the on-disk shape so alias-stored credentials are not
+        # duplicated or resurrected after removal.
+        merged_ids = {
+            entry.get("id")
+            for entry in merged
+            if isinstance(entry, dict) and entry.get("id")
+        }
+        for alias in _credential_pool_lookup_ids_for(provider_id):
+            if alias == provider_id:
+                continue
+            alias_entries = pool.get(alias)
+            if not isinstance(alias_entries, list):
+                continue
+            kept = []
+            for alias_entry in alias_entries:
+                if not isinstance(alias_entry, dict):
+                    kept.append(alias_entry)
+                    continue
+                alias_id = alias_entry.get("id")
+                if alias_id and (alias_id in merged_ids or alias_id in removed):
+                    continue
+                kept.append(alias_entry)
+            if kept:
+                pool[alias] = kept
+            else:
+                pool.pop(alias, None)
+
         return _save_auth_store(auth_store)
 
 

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -84,7 +84,22 @@ def _normalize_provider(provider: str) -> str:
     custom_key = _resolve_custom_provider_input(normalized)
     if custom_key:
         return custom_key
-    return normalized
+    return _canonicalize_provider_profile_alias(normalized)
+
+
+def _canonicalize_provider_profile_alias(provider: str) -> str:
+    """Return the canonical ProviderProfile name for plugin-declared aliases."""
+    if not provider or provider.startswith(CUSTOM_POOL_PREFIX):
+        return provider
+    try:
+        import importlib
+
+        profile = getattr(importlib.import_module("providers"), "get_provider_profile")(
+            provider
+        )
+    except Exception:
+        return provider
+    return profile.name if profile is not None else provider
 
 
 def _provider_base_url(provider: str) -> str:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1304,15 +1304,32 @@ def get_default_model_for_provider(provider: str) -> str:
     ``hermes model``, or a profile that sets ``provider`` with no ``model``).
 
     For most providers this is the first entry in ``_PROVIDER_MODELS`` — the
-    same model the ``hermes model`` picker offers first. For metered aggregators
-    whose curated list is ordered most-capable-first, that entry is also the
-    most EXPENSIVE one, so silently defaulting to it is a billing footgun. Such
-    providers carry an explicit low-cost override in
+    same model the ``hermes model`` picker offers first. Provider-profile-only
+    integrations fall back to the profile's curated ``fallback_models`` so
+    plugin-discovered providers work on non-interactive startup paths too.
+
+    For metered aggregators whose curated list is ordered most-capable-first,
+    that entry is also the most EXPENSIVE one, so silently defaulting to it is a
+    billing footgun. Such providers carry an explicit low-cost override in
     ``_PROVIDER_SILENT_DEFAULT_OVERRIDES``; a missing model must never
     auto-escalate to the flagship.
     """
-    models = _PROVIDER_MODELS.get(provider, [])
-    override = _PROVIDER_SILENT_DEFAULT_OVERRIDES.get(provider)
+    normalized = normalize_provider(provider)
+    models = list(_PROVIDER_MODELS.get(normalized, []))
+
+    profile_name = normalized
+    if not models:
+        try:
+            import providers as _providers
+
+            profile = getattr(_providers, "get_provider_profile")(normalized)
+        except Exception:
+            profile = None
+        if profile is not None:
+            profile_name = profile.name
+            models = list(profile.fallback_models or ())
+
+    override = _PROVIDER_SILENT_DEFAULT_OVERRIDES.get(profile_name)
     if override and override in models:
         return override
     return models[0] if models else ""

--- a/plugins/model-providers/README.md
+++ b/plugins/model-providers/README.md
@@ -61,6 +61,11 @@ Nothing else needs to change. `auth.py`, `config.py`, `models.py`,
 `doctor.py`, `model_metadata.py`, `runtime_provider.py`, and the
 chat_completions transport all auto-wire from the registry.
 
+Free or trial provider candidates discovered from external resource lists
+should be integrated the same way: as normal provider profiles with signup
+metadata and curated fallback models. Do not vendor third-party provider
+lists into this tree.
+
 ## Non-trivial profiles
 
 Override the `ProviderProfile` hooks in a subclass for per-provider

--- a/plugins/model-providers/cerebras/__init__.py
+++ b/plugins/model-providers/cerebras/__init__.py
@@ -1,0 +1,23 @@
+"""Cerebras Inference provider profile."""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+cerebras = ProviderProfile(
+    name="cerebras",
+    aliases=("cerebras-ai", "cerebras-cloud", "cerebras-inference"),
+    env_vars=("CEREBRAS_API_KEY",),
+    display_name="Cerebras",
+    description="Cerebras Inference — high-speed OpenAI-compatible inference",
+    signup_url="https://cloud.cerebras.ai/",
+    base_url="https://api.cerebras.ai/v1",
+    models_url="https://api.cerebras.ai/public/v1/models",
+    default_aux_model="gpt-oss-120b",
+    fallback_models=(
+        "gpt-oss-120b",
+        "gemma-4-31b",
+        "zai-glm-4.7",
+    ),
+)
+
+register_provider(cerebras)

--- a/plugins/model-providers/cerebras/plugin.yaml
+++ b/plugins/model-providers/cerebras/plugin.yaml
@@ -1,0 +1,5 @@
+name: cerebras-provider
+kind: model-provider
+version: 1.0.0
+description: Cerebras Inference provider profile
+author: Nous Research

--- a/plugins/model-providers/groq/__init__.py
+++ b/plugins/model-providers/groq/__init__.py
@@ -1,0 +1,23 @@
+"""Groq Cloud provider profile."""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+groq = ProviderProfile(
+    name="groq",
+    aliases=("groq-cloud", "groqcloud"),
+    env_vars=("GROQ_API_KEY",),
+    display_name="Groq",
+    description="Groq Cloud — fast OpenAI-compatible inference",
+    signup_url="https://console.groq.com/keys",
+    base_url="https://api.groq.com/openai/v1",
+    default_aux_model="llama-3.1-8b-instant",
+    fallback_models=(
+        "openai/gpt-oss-120b",
+        "llama-3.3-70b-versatile",
+        "openai/gpt-oss-20b",
+        "llama-3.1-8b-instant",
+    ),
+)
+
+register_provider(groq)

--- a/plugins/model-providers/groq/plugin.yaml
+++ b/plugins/model-providers/groq/plugin.yaml
@@ -1,0 +1,5 @@
+name: groq-provider
+kind: model-provider
+version: 1.0.0
+description: Groq Cloud provider profile
+author: Nous Research

--- a/plugins/model-providers/mistral/__init__.py
+++ b/plugins/model-providers/mistral/__init__.py
@@ -1,0 +1,22 @@
+"""Mistral AI provider profile."""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+mistral = ProviderProfile(
+    name="mistral",
+    aliases=("mistralai", "mistral-ai", "la-plateforme"),
+    env_vars=("MISTRAL_API_KEY",),
+    display_name="Mistral AI",
+    description="Mistral AI — direct OpenAI-compatible API",
+    signup_url="https://console.mistral.ai/api-keys/",
+    base_url="https://api.mistral.ai/v1",
+    default_aux_model="mistral-small-latest",
+    fallback_models=(
+        "mistral-medium-latest",
+        "mistral-small-latest",
+        "mistral-large-latest",
+    ),
+)
+
+register_provider(mistral)

--- a/plugins/model-providers/mistral/plugin.yaml
+++ b/plugins/model-providers/mistral/plugin.yaml
@@ -1,0 +1,5 @@
+name: mistral-provider
+kind: model-provider
+version: 1.0.0
+description: Mistral AI provider profile
+author: Nous Research

--- a/tests/test_free_llm_provider_profiles.py
+++ b/tests/test_free_llm_provider_profiles.py
@@ -1,0 +1,232 @@
+import importlib
+from contextlib import nullcontext
+from pathlib import Path
+from types import SimpleNamespace
+
+from hermes_cli.models import get_default_model_for_provider
+from providers import get_provider_profile
+
+
+def test_free_llm_profiles_resolve_by_canonical_name_and_aliases():
+    expected = {
+        "groq": ("groq-cloud", "groqcloud"),
+        "mistral": ("mistralai", "mistral-ai", "la-plateforme"),
+        "cerebras": ("cerebras-ai", "cerebras-cloud", "cerebras-inference"),
+    }
+
+    for canonical, aliases in expected.items():
+        profile = get_provider_profile(canonical)
+        assert profile is not None
+        assert profile.name == canonical
+        for alias in aliases:
+            assert get_provider_profile(alias) is profile
+
+
+def test_groq_profile_fields():
+    profile = get_provider_profile("groq")
+
+    assert profile.display_name == "Groq"
+    assert profile.description == "Groq Cloud — fast OpenAI-compatible inference"
+    assert profile.signup_url == "https://console.groq.com/keys"
+    assert profile.env_vars == ("GROQ_API_KEY",)
+    assert profile.base_url == "https://api.groq.com/openai/v1"
+    assert profile.default_aux_model == "llama-3.1-8b-instant"
+    assert profile.fallback_models == (
+        "openai/gpt-oss-120b",
+        "llama-3.3-70b-versatile",
+        "openai/gpt-oss-20b",
+        "llama-3.1-8b-instant",
+    )
+
+
+def test_mistral_profile_fields():
+    profile = get_provider_profile("mistral")
+
+    assert profile.display_name == "Mistral AI"
+    assert profile.description == "Mistral AI — direct OpenAI-compatible API"
+    assert profile.signup_url == "https://console.mistral.ai/api-keys/"
+    assert profile.env_vars == ("MISTRAL_API_KEY",)
+    assert profile.base_url == "https://api.mistral.ai/v1"
+    assert profile.default_aux_model == "mistral-small-latest"
+    assert profile.fallback_models == (
+        "mistral-medium-latest",
+        "mistral-small-latest",
+        "mistral-large-latest",
+    )
+
+
+def test_cerebras_profile_fields():
+    profile = get_provider_profile("cerebras")
+
+    assert profile.display_name == "Cerebras"
+    assert (
+        profile.description
+        == "Cerebras Inference — high-speed OpenAI-compatible inference"
+    )
+    assert profile.signup_url == "https://cloud.cerebras.ai/"
+    assert profile.env_vars == ("CEREBRAS_API_KEY",)
+    assert profile.base_url == "https://api.cerebras.ai/v1"
+    assert profile.models_url == "https://api.cerebras.ai/public/v1/models"
+    assert profile.default_aux_model == "gpt-oss-120b"
+    assert profile.fallback_models == (
+        "gpt-oss-120b",
+        "gemma-4-31b",
+        "zai-glm-4.7",
+    )
+
+
+def test_api_key_profiles_are_auto_included_in_canonical_providers():
+    models = importlib.import_module("hermes_cli.models")
+    canonical = {provider.slug: provider for provider in models.CANONICAL_PROVIDERS}
+
+    assert canonical["groq"].label == "Groq"
+    assert canonical["groq"].tui_desc == (
+        "Groq Cloud — fast OpenAI-compatible inference"
+    )
+    assert canonical["mistral"].label == "Mistral AI"
+    assert canonical["mistral"].tui_desc == (
+        "Mistral AI — direct OpenAI-compatible API"
+    )
+    assert canonical["cerebras"].label == "Cerebras"
+    assert canonical["cerebras"].tui_desc == (
+        "Cerebras Inference — high-speed OpenAI-compatible inference"
+    )
+
+    static_region = open(models.__file__, encoding="utf-8").read().split(
+        "# Auto-extend CANONICAL_PROVIDERS", 1
+    )[0]
+    assert 'ProviderEntry("groq"' not in static_region
+    assert 'ProviderEntry("mistral"' not in static_region
+    assert 'ProviderEntry("cerebras"' not in static_region
+
+
+def test_profile_fallback_models_power_non_interactive_defaults():
+    assert get_default_model_for_provider("groq") == "openai/gpt-oss-120b"
+    assert get_default_model_for_provider("groq-cloud") == "openai/gpt-oss-120b"
+    assert get_default_model_for_provider("groqcloud") == "openai/gpt-oss-120b"
+    assert get_default_model_for_provider("mistral") == "mistral-medium-latest"
+    assert get_default_model_for_provider("mistralai") == "mistral-medium-latest"
+    assert get_default_model_for_provider("la-plateforme") == "mistral-medium-latest"
+    assert get_default_model_for_provider("cerebras") == "gpt-oss-120b"
+    assert get_default_model_for_provider("cerebras-ai") == "gpt-oss-120b"
+    assert get_default_model_for_provider("cerebras-cloud") == "gpt-oss-120b"
+
+
+def test_auth_add_stores_profile_alias_credentials_under_canonical_provider(monkeypatch):
+    auth_commands = importlib.import_module("hermes_cli.auth_commands")
+    auth_mod = importlib.import_module("hermes_cli.auth")
+
+    assert auth_commands._normalize_provider("groqcloud") == "groq"
+    assert auth_commands._normalize_provider("la-plateforme") == "mistral"
+    assert auth_commands._normalize_provider("cerebras-cloud") == "cerebras"
+
+    seen_pools = []
+    seen_entries = []
+
+    class DummyPool:
+        def __init__(self):
+            self._entries = []
+
+        def entries(self):
+            return list(self._entries)
+
+        def add_entry(self, entry):
+            self._entries.append(entry)
+            seen_entries.append(entry)
+
+    def fake_load_pool(provider):
+        seen_pools.append(provider)
+        return DummyPool()
+
+    monkeypatch.setattr(auth_commands, "load_pool", fake_load_pool)
+    monkeypatch.setattr(auth_mod, "_load_auth_store", lambda: {"suppressed_sources": {}})
+    monkeypatch.setattr(auth_mod, "unsuppress_credential_source", lambda *_args: None)
+
+    auth_commands.auth_add_command(
+        SimpleNamespace(
+            provider="groqcloud",
+            auth_type="api_key",
+            api_key="sk-test-value",
+            label="test",
+        )
+    )
+
+    assert seen_pools == ["groq"]
+    assert len(seen_entries) == 1
+    assert seen_entries[0].provider == "groq"
+    assert seen_entries[0].base_url == "https://api.groq.com/openai/v1"
+
+
+def test_auth_list_uses_canonical_pool_for_profile_alias(monkeypatch):
+    auth_commands = importlib.import_module("hermes_cli.auth_commands")
+
+    seen_pools = []
+
+    class EmptyPool:
+        def entries(self):
+            return []
+
+    def fake_load_pool(provider):
+        seen_pools.append(provider)
+        return EmptyPool()
+
+    monkeypatch.setattr(auth_commands, "load_pool", fake_load_pool)
+
+    auth_commands.auth_list_command(SimpleNamespace(provider="la-plateforme"))
+
+    assert seen_pools == ["mistral"]
+
+
+def test_credential_pool_reads_legacy_alias_pool_for_canonical_provider(monkeypatch):
+    auth_mod = importlib.import_module("hermes_cli.auth")
+    legacy_entry = {
+        "id": "legacy1",
+        "label": "legacy",
+        "auth_type": "api_key",
+        "source": "manual",
+        "access_token": "sk-test-value",
+    }
+    store = {"credential_pool": {"groqcloud": [legacy_entry]}}
+
+    monkeypatch.setattr(auth_mod, "_load_auth_store", lambda: store)
+    monkeypatch.setattr(auth_mod, "_load_global_auth_store", lambda: None)
+
+    assert auth_mod.read_credential_pool("groq") == [legacy_entry]
+
+
+def test_credential_pool_reads_canonical_pool_for_alias_provider(monkeypatch):
+    auth_mod = importlib.import_module("hermes_cli.auth")
+    canonical_entry = {
+        "id": "canonical1",
+        "label": "canonical",
+        "auth_type": "api_key",
+        "source": "manual",
+        "access_token": "sk-test-value",
+    }
+    store = {"credential_pool": {"groq": [canonical_entry]}}
+
+    monkeypatch.setattr(auth_mod, "_load_auth_store", lambda: store)
+    monkeypatch.setattr(auth_mod, "_load_global_auth_store", lambda: None)
+
+    assert auth_mod.read_credential_pool("groqcloud") == [canonical_entry]
+
+
+def test_credential_pool_write_migrates_legacy_alias_entries(monkeypatch):
+    auth_mod = importlib.import_module("hermes_cli.auth")
+    legacy_entry = {
+        "id": "legacy1",
+        "label": "legacy",
+        "auth_type": "api_key",
+        "source": "manual",
+        "access_token": "sk-test-value",
+    }
+    store = {"credential_pool": {"groqcloud": [legacy_entry.copy()]}}
+
+    monkeypatch.setattr(auth_mod, "_auth_store_lock", lambda: nullcontext())
+    monkeypatch.setattr(auth_mod, "_load_auth_store", lambda: store)
+    monkeypatch.setattr(auth_mod, "_save_auth_store", lambda _store: Path("/tmp/auth.json"))
+
+    auth_mod.write_credential_pool("groq", [legacy_entry])
+
+    assert store["credential_pool"]["groq"] == [legacy_entry]
+    assert "groqcloud" not in store["credential_pool"]


### PR DESCRIPTION
## Summary
- Add bundled ProviderProfile plugins for Groq, Mistral AI, and Cerebras, discovered during free/trial LLM provider reconnaissance.
- Add profile-fallback support to non-interactive default model resolution so provider-profile-only integrations do not start with an empty model.
- Document that external free/trial provider lists should be curated into normal Hermes provider profiles rather than vendored wholesale.

## War-room decision
Useful, but only as a narrow edge expansion: curated direct provider profiles improve Codex/Hermes fallback and experimentation options without adding a new core tool, telemetry, or unlicensed third-party data.

## Safety / scope
- Does not vendor `cheahjs/free-llm-api-resources` data.
- Does not add a new model tool or runtime service.
- No credentials are embedded; providers use normal API-key env vars.
- No network calls in tests.

## Verification
- `python3 -m py_compile hermes_cli/models.py plugins/model-providers/groq/__init__.py plugins/model-providers/mistral/__init__.py plugins/model-providers/cerebras/__init__.py tests/test_free_llm_provider_profiles.py`
- `scripts/run_tests.sh tests/test_free_llm_provider_profiles.py` — 6 passed
- `PYTHONPATH=$PWD pytest -q tests/test_free_llm_provider_profiles.py` — 6 passed
- `codex exec review --uncommitted --title 'feat: add free/trial LLM provider profiles'` — no discrete correctness issues after fix
