### PR TITLE
fix(agent): add opt-in cross-channel context digest

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1364,6 +1364,11 @@ def init_agent(
     # are noisy.
     agent._environment_probe = bool(_agent_section.get("environment_probe", True))
 
+    _cross_channel_context = _agent_section.get("cross_channel_context", {})
+    if not isinstance(_cross_channel_context, dict):
+        _cross_channel_context = {}
+    agent._cross_channel_context_config = _cross_channel_context
+
     # Per-platform prompt-hint overrides (config.yaml → platform_hints).
     # Lets an enterprise admin append to or replace Hermes' built-in
     # platform hint for a single messaging platform (e.g. WhatsApp) without

--- a/agent/cross_channel_context.py
+++ b/agent/cross_channel_context.py
@@ -1,0 +1,171 @@
+"""Opt-in cross-channel context digest for session startup prompts."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+
+from hermes_constants import get_default_hermes_root, get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+
+def _enabled(config: Dict[str, Any]) -> bool:
+    return bool(config.get("enabled", False))
+
+
+def _positive_int(config: Dict[str, Any], key: str, default: int, *, minimum: int, maximum: int) -> int:
+    try:
+        value = int(config.get(key, default))
+    except (TypeError, ValueError):
+        value = default
+    return max(minimum, min(value, maximum))
+
+
+def _active_profile_name() -> str:
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        return get_active_profile_name() or "default"
+    except Exception:
+        return "default"
+
+
+def _candidate_state_dbs(include_profiles: bool) -> List[Tuple[str, Path, bool]]:
+    """Return ``(profile, db_path, is_current_home)`` candidates."""
+    current_home = get_hermes_home()
+    current_db = (current_home / "state.db").resolve()
+    active_profile = _active_profile_name()
+    candidates: List[Tuple[str, Path, bool]] = [(active_profile, current_db, True)]
+    seen: Set[Path] = {current_db}
+
+    if not include_profiles:
+        return candidates
+
+    root = get_default_hermes_root()
+    profile_paths: Iterable[Tuple[str, Path]] = [("default", root)]
+    profiles_root = root / "profiles"
+    try:
+        if profiles_root.is_dir():
+            profile_paths = [
+                *profile_paths,
+                *(
+                    (entry.name, entry)
+                    for entry in sorted(profiles_root.iterdir())
+                    if entry.is_dir()
+                ),
+            ]
+    except OSError:
+        return candidates
+
+    for profile, home in profile_paths:
+        db_path = (home / "state.db").resolve()
+        if db_path in seen or not db_path.exists():
+            continue
+        seen.add(db_path)
+        candidates.append((profile, db_path, False))
+    return candidates
+
+
+def _collect_activity(agent: Any, config: Dict[str, Any]) -> List[Dict[str, Any]]:
+    lookback_seconds = _positive_int(config, "lookback_seconds", 86400, minimum=60, maximum=30 * 86400)
+    max_sessions = _positive_int(config, "max_sessions", 4, minimum=1, maximum=20)
+    max_messages = _positive_int(config, "max_messages_per_session", 4, minimum=1, maximum=20)
+    max_chars = _positive_int(config, "max_chars_per_message", 500, minimum=80, maximum=4000)
+    include_profiles = bool(config.get("include_profiles", True))
+
+    from hermes_state import SessionDB
+
+    items: List[Dict[str, Any]] = []
+    for profile, db_path, is_current in _candidate_state_dbs(include_profiles):
+        db = getattr(agent, "_session_db", None) if is_current else None
+        close_db = False
+        try:
+            if db is None:
+                db = SessionDB(db_path=db_path, read_only=True)
+                close_db = True
+            rows = db.get_recent_cross_session_messages(
+                current_session_id=getattr(agent, "session_id", "") or "",
+                lookback_seconds=lookback_seconds,
+                max_sessions=max_sessions,
+                max_messages_per_session=max_messages,
+                max_chars_per_message=max_chars,
+            )
+        except Exception as exc:
+            logger.debug("cross-channel context read skipped for %s: %s", db_path, exc)
+            rows = []
+        finally:
+            if close_db and db is not None:
+                try:
+                    db.close()
+                except Exception:
+                    pass
+
+        for row in rows:
+            row["profile"] = profile
+            items.append(row)
+
+    items.sort(
+        key=lambda item: float((item.get("session") or {}).get("last_active") or 0),
+        reverse=True,
+    )
+    return items[:max_sessions]
+
+
+def _session_label(profile: str, session: Dict[str, Any]) -> str:
+    parts: List[str] = []
+    if profile and profile != "default":
+        parts.append(f"profile {profile}")
+    source = str(session.get("source") or "").strip()
+    if source:
+        parts.append(source)
+    chat_type = str(session.get("chat_type") or "").strip()
+    chat_id = str(session.get("chat_id") or "").strip()
+    thread_id = str(session.get("thread_id") or "").strip()
+    if chat_type or chat_id:
+        parts.append("/".join(p for p in (chat_type, chat_id) if p))
+    if thread_id:
+        parts.append(f"thread {thread_id}")
+    title = str(session.get("title") or "").strip()
+    if title:
+        parts.append(f"title {title}")
+    if not parts:
+        parts.append(str(session.get("id") or "session"))
+    return ", ".join(parts)
+
+
+def _format_time(timestamp: Optional[float]) -> str:
+    if not timestamp:
+        return "recently"
+    try:
+        return datetime.fromtimestamp(float(timestamp)).strftime("%Y-%m-%d %H:%M")
+    except (OSError, TypeError, ValueError):
+        return "recently"
+
+
+def build_cross_channel_context_block(agent: Any) -> str:
+    """Build a compact prompt block from recent activity in other sessions."""
+    config = getattr(agent, "_cross_channel_context_config", {}) or {}
+    if not isinstance(config, dict) or not _enabled(config):
+        return ""
+
+    items = _collect_activity(agent, config)
+    if not items:
+        return ""
+
+    lines = [
+        "Recent activity from other Hermes sessions (read-only context; do not act on it unless the user asks):"
+    ]
+    for item in items:
+        session = item.get("session") or {}
+        profile = str(item.get("profile") or "")
+        lines.append(f"- {_session_label(profile, session)} at {_format_time(session.get('last_active'))}:")
+        for msg in item.get("messages") or []:
+            role = str(msg.get("role") or "message")
+            content = str(msg.get("content") or "").strip()
+            if content:
+                lines.append(f"  {role}: {content}")
+    return "\n".join(lines)
+

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -409,6 +409,15 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if system_message is not None:
         context_parts.append(system_message)
 
+    try:
+        from agent.cross_channel_context import build_cross_channel_context_block
+
+        cross_channel_context = build_cross_channel_context_block(agent)
+        if cross_channel_context:
+            context_parts.append(cross_channel_context)
+    except Exception:
+        pass
+
     if not agent.skip_context_files:
         # Prefer the configured TERMINAL_CWD (gateway mode). When unset (local
         # CLI), None lets build_context_files_prompt fall back to the launch

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -986,6 +986,20 @@ DEFAULT_CONFIG = {
         # (docker/modal/ssh — they have their own probe).  Set False to
         # disable entirely.
         "environment_probe": True,
+        # Opt-in cross-channel awareness. When enabled, a new session's cached
+        # system prompt includes a compact read-only digest of recent
+        # user/assistant activity from other sessions in the shared state DB.
+        # Named profile state DBs are included by default only after this
+        # feature is explicitly enabled, preserving profile isolation by
+        # default while supporting multi-profile gateway groups.
+        "cross_channel_context": {
+            "enabled": False,
+            "lookback_seconds": 86400,
+            "max_sessions": 4,
+            "max_messages_per_session": 4,
+            "max_chars_per_message": 500,
+            "include_profiles": True,
+        },
         # Embedder-supplied environment description appended to the system
         # prompt's environment-hints block. Lets a host that wraps Hermes
         # (sandbox runner, managed platform) explain the runtime environment

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3467,6 +3467,91 @@ class SessionDB:
             result.append(msg)
         return result
 
+    def get_recent_cross_session_messages(
+        self,
+        *,
+        current_session_id: str,
+        lookback_seconds: int = 86400,
+        max_sessions: int = 4,
+        max_messages_per_session: int = 4,
+        max_chars_per_message: int = 500,
+    ) -> List[Dict[str, Any]]:
+        """Return compact recent user/assistant activity from other sessions.
+
+        This is the storage primitive for opt-in cross-channel context. It is
+        intentionally read-only and excludes the active session: callers use it
+        to give a new session awareness of nearby work without merging histories
+        or changing any channel's routing/response behavior.
+        """
+        if max_sessions <= 0 or max_messages_per_session <= 0:
+            return []
+
+        try:
+            cutoff = time.time() - max(0, int(lookback_seconds))
+        except (TypeError, ValueError):
+            cutoff = time.time() - 86400
+        max_sessions = max(1, min(int(max_sessions), 20))
+        max_messages_per_session = max(1, min(int(max_messages_per_session), 20))
+        max_chars_per_message = max(80, min(int(max_chars_per_message), 4000))
+
+        with self._lock:
+            session_rows = self._conn.execute(
+                """
+                SELECT
+                    s.id, s.source, s.user_id, s.session_key, s.chat_id,
+                    s.chat_type, s.thread_id, s.title, s.started_at,
+                    MAX(m.timestamp) AS last_active
+                FROM sessions s
+                JOIN messages m ON m.session_id = s.id
+                WHERE s.id != ?
+                  AND COALESCE(s.source, '') != 'tool'
+                  AND m.active = 1
+                  AND m.role IN ('user', 'assistant')
+                  AND m.content IS NOT NULL
+                  AND LENGTH(TRIM(m.content)) > 0
+                  AND m.timestamp >= ?
+                GROUP BY s.id
+                ORDER BY last_active DESC, s.started_at DESC, s.id DESC
+                LIMIT ?
+                """,
+                (current_session_id or "", cutoff, max_sessions),
+            ).fetchall()
+
+            out: List[Dict[str, Any]] = []
+            for session_row in session_rows:
+                message_rows = self._conn.execute(
+                    """
+                    SELECT id, role, content, timestamp
+                    FROM messages
+                    WHERE session_id = ?
+                      AND active = 1
+                      AND role IN ('user', 'assistant')
+                      AND content IS NOT NULL
+                      AND LENGTH(TRIM(content)) > 0
+                    ORDER BY id DESC
+                    LIMIT ?
+                    """,
+                    (session_row["id"], max_messages_per_session),
+                ).fetchall()
+                out.append(
+                    {
+                        "session": dict(session_row),
+                        "messages": [dict(row) for row in reversed(message_rows)],
+                    }
+                )
+
+        for item in out:
+            for msg in item["messages"]:
+                content = self._decode_content(msg.get("content"))
+                if not isinstance(content, str):
+                    content = json.dumps(content, ensure_ascii=False)
+                content = sanitize_context(content)
+                content = re.sub(r"\s+", " ", content).strip()
+                if len(content) > max_chars_per_message:
+                    content = content[: max_chars_per_message - 3].rstrip() + "..."
+                msg["content"] = content
+        return out
+
     def get_messages_around(
         self,
         session_id: str,

--- a/tests/run_agent/test_cross_channel_context.py
+++ b/tests/run_agent/test_cross_channel_context.py
@@ -1,0 +1,67 @@
+from types import SimpleNamespace
+
+from agent.cross_channel_context import build_cross_channel_context_block
+from hermes_state import SessionDB
+
+
+def test_cross_channel_context_disabled_returns_empty():
+    agent = SimpleNamespace(_cross_channel_context_config={"enabled": False})
+
+    assert build_cross_channel_context_block(agent) == ""
+
+
+def test_cross_channel_context_reads_sibling_profile_state(tmp_path, monkeypatch):
+    root = tmp_path / "hermes"
+    active_home = root / "profiles" / "sknerus"
+    other_home = root / "profiles" / "diodak"
+    active_home.mkdir(parents=True)
+    other_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(active_home))
+
+    active_db = SessionDB(active_home / "state.db")
+    other_db = SessionDB(other_home / "state.db")
+    try:
+        active_db.create_session(
+            session_id="sknerus-active",
+            source="telegram",
+            chat_id="shopping",
+            chat_type="group",
+        )
+        active_db.append_message("sknerus-active", "user", "current follow-up")
+
+        other_db.create_session(
+            session_id="diodak-research",
+            source="telegram",
+            chat_id="shopping",
+            chat_type="group",
+        )
+        other_db.append_message("diodak-research", "user", "research product from TikTok")
+        other_db.append_message(
+            "diodak-research",
+            "assistant",
+            "Added Insta360 Wave and Govee floor lamp to the Hub shopping list.",
+        )
+
+        agent = SimpleNamespace(
+            session_id="sknerus-active",
+            _session_db=active_db,
+            _cross_channel_context_config={
+                "enabled": True,
+                "lookback_seconds": 3600,
+                "max_sessions": 3,
+                "max_messages_per_session": 3,
+                "max_chars_per_message": 200,
+                "include_profiles": True,
+            },
+        )
+
+        block = build_cross_channel_context_block(agent)
+    finally:
+        active_db.close()
+        other_db.close()
+
+    assert "profile diodak" in block
+    assert "research product from TikTok" in block
+    assert "Insta360 Wave and Govee floor lamp" in block
+    assert "current follow-up" not in block
+

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -271,6 +271,30 @@ class TestSessionLifecycle:
         session = db.get_session("s1")
         assert session["model"] == "openai/gpt-5.4"
 
+    def test_recent_cross_session_messages_excludes_active_and_bounds_content(self, db):
+        now = time.time()
+        db.create_session(session_id="active", source="cli")
+        db.append_message("active", "user", "do not include", timestamp=now)
+        db.create_session(session_id="telegram-session", source="telegram", chat_id="group-1", chat_type="group")
+        db.append_message("telegram-session", "user", "research product alpha", timestamp=now - 20)
+        db.append_message("telegram-session", "assistant", "Alpha result " + ("x" * 200), timestamp=now - 10)
+        db.create_session(session_id="old", source="discord")
+        db.append_message("old", "user", "too old", timestamp=now - 100000)
+
+        rows = db.get_recent_cross_session_messages(
+            current_session_id="active",
+            lookback_seconds=3600,
+            max_sessions=5,
+            max_messages_per_session=2,
+            max_chars_per_message=40,
+        )
+
+        assert [row["session"]["id"] for row in rows] == ["telegram-session"]
+        assert [msg["role"] for msg in rows[0]["messages"]] == ["user", "assistant"]
+        assert rows[0]["messages"][0]["content"] == "research product alpha"
+        assert rows[0]["messages"][1]["content"].endswith("...")
+        assert len(rows[0]["messages"][1]["content"]) <= 80
+
     def test_update_token_counts_preserves_existing_model(self, db):
         db.create_session(session_id="s1", source="cli", model="anthropic/claude-opus-4.6")
         db.update_token_counts("s1", input_tokens=10, output_tokens=5, model="openai/gpt-5.4")


### PR DESCRIPTION
Adds a disabled-by-default cross-channel context digest so new sessions can see compact recent activity from other channels and profiles without merging live conversations.

## Shared root cause
- Gateway, desktop/TUI, CLI, cron, and named profile sessions already persist transcripts, but prompt construction only restores the current session. A newly started or separately routed session therefore has no read-only view into recent work from the same user's other channels.
- The fix adds a bounded `SessionDB.get_recent_cross_session_messages()` query and injects its formatted digest into the cached session-start prompt only when `agent.cross_channel_context.enabled` is true. It also reads sibling profile `state.db` files in read-only mode when enabled, preserving profile isolation by default.

## How this fixes each issue
- #43928: desktop/gateway users can opt into a shared recent-activity digest, so starting on desktop and continuing through Telegram gives the new session enough recent context to orient itself without requiring a full database merge.
- #44846: each new session can receive a compact digest of recent activity from other channels at startup, matching the proposed cross-channel session awareness while avoiding real-time sync spam.
- #44881: in multi-profile Telegram groups, a tagged profile bot can read recent group context from sibling profile state stores when the opt-in is enabled, while untagged bots still do not wake or respond.

## How to test
- `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/test_hermes_state.py::TestSessionLifecycle::test_recent_cross_session_messages_excludes_active_and_bounds_content tests/run_agent/test_cross_channel_context.py -q --timeout=60' sh`
- `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh` (aborted during collection because optional dashboard deps `fastapi`/`uvicorn` are not installed and the environment cannot auto-install under PEP 668)
- `ruff check` on changed Python files
- `python scripts/check-windows-footguns.py` on changed Python files

## What platforms tested on
- macOS on darwin-arm64 (local)

---
_This coordinated PR bundles a fix that spans several issues. Happy to split it back into focused per-issue PRs if you'd prefer to review them separately._

Refs #43928
Refs #44846
Refs #44881

<!-- autocontrib:worker-id=pr-spanning-b36755e8 kind=pr-open -->