### PR TITLE
fix(matrix): preserve controls during command batching

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 _skill_commands: Dict[str, Dict[str, Any]] = {}
 _skill_commands_platform: Optional[str] = None
+_skill_commands_home: Optional[str] = None
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
@@ -323,20 +324,22 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     Returns:
         Dict mapping "/skill-name" to {name, description, skill_md_path, skill_dir}.
     """
-    global _skill_commands, _skill_commands_platform
+    global _skill_commands, _skill_commands_platform, _skill_commands_home
     _skill_commands_platform = _resolve_skill_commands_platform()
     _skill_commands = {}
     try:
-        from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
+        from tools.skills_tool import _skills_dir, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
         from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
         from hermes_cli.commands import resolve_command
+        skills_dir = _skills_dir()
+        _skill_commands_home = str(skills_dir)
         disabled = _get_disabled_skill_names()
         seen_names: set = set()
 
         # Scan local dir first, then external dirs
         dirs_to_scan = []
-        if SKILLS_DIR.exists():
-            dirs_to_scan.append(SKILLS_DIR)
+        if skills_dir.exists():
+            dirs_to_scan.append(skills_dir)
         dirs_to_scan.extend(get_external_skills_dirs())
 
         for scan_dir in dirs_to_scan:
@@ -420,9 +423,12 @@ def get_skill_commands() -> Dict[str, Dict[str, Any]]:
     process serving Telegram and Discord concurrently) so each platform
     sees its own ``skills.platform_disabled`` view (#14536).
     """
+    from tools.skills_tool import _skills_dir
+
     if (
         not _skill_commands
         or _skill_commands_platform != _resolve_skill_commands_platform()
+        or _skill_commands_home != str(_skills_dir())
     ):
         scan_skill_commands()
     return _skill_commands
@@ -493,7 +499,9 @@ def reload_skills() -> Dict[str, Any]:
     }
 
 
-def resolve_skill_command_key(command: str) -> Optional[str]:
+def resolve_skill_command_key(
+    command: str, *, profile: str | None = None
+) -> Optional[str]:
     """Resolve a user-typed /command to its canonical skill_cmds key.
 
     Skills are always stored with hyphens — ``scan_skill_commands`` normalizes
@@ -506,10 +514,26 @@ def resolve_skill_command_key(command: str) -> Optional[str]:
     Returns the matching ``/slug`` key from ``get_skill_commands()`` or
     ``None`` if no match.
     """
-    if not command:
-        return None
-    cmd_key = f"/{command.replace('_', '-')}"
-    return cmd_key if cmd_key in get_skill_commands() else None
+    def _resolve() -> Optional[str]:
+        if not command:
+            return None
+        cmd_key = f"/{command.replace('_', '-')}"
+        return cmd_key if cmd_key in get_skill_commands() else None
+
+    if not profile:
+        return _resolve()
+
+    try:
+        from hermes_cli.profiles import get_profile_dir
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+        token = set_hermes_home_override(str(get_profile_dir(profile)))
+        try:
+            return _resolve()
+        finally:
+            reset_hermes_home_override(token)
+    except Exception:
+        return _resolve()
 
 
 def build_skill_invocation_message(

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4807,7 +4807,7 @@ class BasePlatformAdapter(ABC):
             cmd = event.get_command()
             from hermes_cli.commands import should_bypass_active_session
 
-            if should_bypass_active_session(cmd):
+            if should_bypass_active_session(cmd, profile=event.source.profile):
                 # /stop, /new, /reset must cancel the in-flight adapter task
                 # and preserve ordering of queued follow-ups.  Route those
                 # through the dedicated handoff path that serializes

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10119,10 +10119,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Resolve the command once for all early-intercept checks below.
             from hermes_cli.commands import (
                 ACTIVE_SESSION_BYPASS_COMMANDS as _DEDICATED_HANDLERS,
+                is_gateway_known_command as _is_gateway_known_command_inner,
                 resolve_command as _resolve_cmd_inner,
             )
             _evt_cmd = event.get_command()
             _cmd_def_inner = _resolve_cmd_inner(_evt_cmd) if _evt_cmd else None
+            _skill_cmd_key_inner = None
+            _plugin_cmd_inner = None
+            if _evt_cmd and _cmd_def_inner is None:
+                try:
+                    from agent.skill_commands import resolve_skill_command_key
+
+                    _skill_cmd_key_inner = resolve_skill_command_key(
+                        _evt_cmd, profile=source.profile
+                    )
+                except Exception:
+                    _skill_cmd_key_inner = None
+                if _skill_cmd_key_inner is None:
+                    for _plugin_candidate in (
+                        _evt_cmd,
+                        _evt_cmd.replace("_", "-"),
+                    ):
+                        if _is_gateway_known_command_inner(_plugin_candidate):
+                            _plugin_cmd_inner = _plugin_candidate
+                            break
 
             # Slash command access control on the running-agent fast-path.
             # Mirrors the cold-path gate further below so non-admin users
@@ -10132,6 +10152,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # floor inside _check_slash_access.
             if _evt_cmd and _cmd_def_inner is not None:
                 _denied = self._check_slash_access(source, _cmd_def_inner.name)
+                if _denied is not None:
+                    return _denied
+            if _plugin_cmd_inner:
+                _denied = self._check_slash_access(source, _plugin_cmd_inner)
                 if _denied is not None:
                     return _denied
 
@@ -10372,6 +10396,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _cmd_def_inner:
                 return (
                     f"⏳ Agent is running — `/{_cmd_def_inner.name}` can't run "
+                    f"mid-turn. Wait for the current response or `/stop` first."
+                )
+            if _skill_cmd_key_inner or _plugin_cmd_inner:
+                _busy_cmd_name = (
+                    str(_skill_cmd_key_inner).lstrip("/")
+                    if _skill_cmd_key_inner
+                    else str(_plugin_cmd_inner).lstrip("/")
+                )
+                return (
+                    f"⏳ Agent is running — `/{_busy_cmd_name}` can't run "
                     f"mid-turn. Wait for the current response or `/stop` first."
                 )
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -386,7 +386,9 @@ ACTIVE_SESSION_BYPASS_COMMANDS: frozenset[str] = frozenset(
 )
 
 
-def should_bypass_active_session(command_name: str | None) -> bool:
+def should_bypass_active_session(
+    command_name: str | None, *, profile: str | None = None
+) -> bool:
     """Return True for any resolvable slash command.
 
     Rationale: every gateway-registered slash command either has a
@@ -408,17 +410,21 @@ def should_bypass_active_session(command_name: str | None) -> bool:
     """
     if not command_name:
         return False
-    if resolve_command(command_name) is not None:
-        return True
-    # Skill commands (e.g. /arxiv) are resolved through a separate registry
-    # and must also bypass the active-session queue, matching how
-    # _resolve_matrix_bang_command already checks both registries.
-    try:
-        from agent.skill_commands import get_skill_commands
 
-        return f"/{command_name.lstrip('/')}" in (get_skill_commands() or {})
-    except Exception:  # pragma: no cover — defensive
-        return False
+    name = command_name.lower().lstrip("/")
+    candidates = {name, name.replace("_", "-")}
+    if any(is_gateway_known_command(candidate) for candidate in candidates):
+        return True
+
+    def _is_skill_command() -> bool:
+        try:
+            from agent.skill_commands import resolve_skill_command_key
+
+            return resolve_skill_command_key(name, profile=profile) is not None
+        except Exception:
+            return False
+
+    return _is_skill_command()
 
 
 def _resolve_config_gates() -> set[str]:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -406,7 +406,19 @@ def should_bypass_active_session(command_name: str | None) -> bool:
     ACTIVE_SESSION_BYPASS_COMMANDS remains the subset of commands with
     explicit Level-2 handlers; the rest fall through to the catch-all.
     """
-    return resolve_command(command_name) is not None if command_name else False
+    if not command_name:
+        return False
+    if resolve_command(command_name) is not None:
+        return True
+    # Skill commands (e.g. /arxiv) are resolved through a separate registry
+    # and must also bypass the active-session queue, matching how
+    # _resolve_matrix_bang_command already checks both registries.
+    try:
+        from agent.skill_commands import get_skill_commands
+
+        return f"/{command_name.lstrip('/')}" in (get_skill_commands() or {})
+    except Exception:  # pragma: no cover — defensive
+        return False
 
 
 def _resolve_config_gates() -> set[str]:

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2866,7 +2866,11 @@ class MatrixAdapter(BasePlatformAdapter):
             reply_to_message_id=reply_to,
         )
 
-        if msg_type == MessageType.TEXT and self._text_batch_delay_seconds > 0:
+        should_batch = self._text_batch_delay_seconds > 0 and (
+            msg_type == MessageType.TEXT
+            or (msg_type == MessageType.COMMAND and len(body) >= self._SPLIT_THRESHOLD)
+        )
+        if should_batch:
             self._enqueue_text_event(msg_event)
         else:
             await self.handle_message(msg_event)

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2866,12 +2866,37 @@ class MatrixAdapter(BasePlatformAdapter):
             reply_to_message_id=reply_to,
         )
 
-        should_batch = self._text_batch_delay_seconds > 0 and (
-            msg_type == MessageType.TEXT
-            or (msg_type == MessageType.COMMAND and len(body) >= self._SPLIT_THRESHOLD)
-        )
-        if should_batch:
-            self._enqueue_text_event(msg_event)
+        should_batch = msg_type == MessageType.TEXT
+        batch_key = self._text_batch_key(msg_event)
+        pending = self._pending_text_batches.get(batch_key)
+        if not pending and len(body) < self._SPLIT_THRESHOLD:
+            auto_thread_batch = self._pending_auto_thread_command_batch(msg_event)
+            if auto_thread_batch:
+                batch_key, pending = auto_thread_batch
+
+        if msg_type == MessageType.COMMAND and self._text_batch_delay_seconds > 0:
+            if len(body) >= self._SPLIT_THRESHOLD:
+                if pending and pending.message_type != MessageType.COMMAND:
+                    prior_task = self._pending_text_batch_tasks.pop(batch_key, None)
+                    if prior_task and not prior_task.done():
+                        prior_task.cancel()
+                    pending_event = self._pending_text_batches.pop(batch_key, None)
+                    if pending_event:
+                        await self.handle_message(pending_event)
+                should_batch = True
+            elif (
+                pending
+                and pending.message_type == MessageType.COMMAND
+                and len(pending.text or "") >= self._SPLIT_THRESHOLD
+            ):
+                from hermes_cli.commands import should_bypass_active_session
+
+                should_batch = not should_bypass_active_session(
+                    msg_event.get_command(), profile=source.profile
+                )
+
+        if should_batch and self._text_batch_delay_seconds > 0:
+            self._enqueue_text_event(msg_event, key=batch_key)
         else:
             await self.handle_message(msg_event)
 
@@ -3580,9 +3605,33 @@ class MatrixAdapter(BasePlatformAdapter):
             profile=event.source.profile,
         )
 
-    def _enqueue_text_event(self, event: MessageEvent) -> None:
+    def _pending_auto_thread_command_batch(
+        self, event: MessageEvent
+    ) -> tuple[str, MessageEvent] | None:
+        """Find a split-command batch across synthetic Matrix thread roots."""
+        source = event.source
+        if source.thread_id != event.message_id:
+            return None
+        for key, pending in self._pending_text_batches.items():
+            pending_source = pending.source
+            if (
+                pending.message_type == MessageType.COMMAND
+                and len(pending.text or "") >= self._SPLIT_THRESHOLD
+                and pending_source.thread_id == pending.message_id
+                and pending_source.platform == source.platform
+                and pending_source.chat_id == source.chat_id
+                and pending_source.chat_type == source.chat_type
+                and (pending_source.user_id_alt or pending_source.user_id)
+                == (source.user_id_alt or source.user_id)
+                and pending_source.scope_id == source.scope_id
+                and pending_source.profile == source.profile
+            ):
+                return key, pending
+        return None
+
+    def _enqueue_text_event(self, event: MessageEvent, *, key: str | None = None) -> None:
         """Buffer a text event and reset the flush timer."""
-        key = self._text_batch_key(event)
+        key = key or self._text_batch_key(event)
         existing = self._pending_text_batches.get(key)
         chunk_len = len(event.text or "")
         if existing is None:

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -203,6 +203,37 @@ class TestScanSkillCommands:
             assert "/telegram-only" not in telegram_again
             assert "/discord-only" in telegram_again
 
+    def test_get_skill_commands_rescans_when_profile_home_changes(self, tmp_path):
+        """A multiplexed profile must not reuse another profile's skills."""
+        import agent.skill_commands as sc_mod
+        from agent.skill_commands import get_skill_commands
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+        primary = tmp_path / "primary"
+        secondary = tmp_path / "secondary"
+        _make_skill(primary / "skills", "primary-only")
+        _make_skill(secondary / "skills", "secondary-only")
+
+        with (
+            patch.object(sc_mod, "_skill_commands", {}),
+            patch.object(sc_mod, "_skill_commands_platform", None),
+            patch.object(sc_mod, "_skill_commands_home", None),
+        ):
+            token = set_hermes_home_override(str(primary))
+            try:
+                assert "/primary-only" in get_skill_commands()
+            finally:
+                reset_hermes_home_override(token)
+
+            token = set_hermes_home_override(str(secondary))
+            try:
+                commands = get_skill_commands()
+            finally:
+                reset_hermes_home_override(token)
+
+        assert "/secondary-only" in commands
+        assert "/primary-only" not in commands
+
     def test_get_skill_commands_rescans_when_session_platform_changes(self, tmp_path):
         """``HERMES_SESSION_PLATFORM`` from the gateway session context must
         also trigger a rescan, not just ``HERMES_PLATFORM`` (#14536).

--- a/tests/gateway/test_command_bypass_active_session.py
+++ b/tests/gateway/test_command_bypass_active_session.py
@@ -493,3 +493,38 @@ class TestBypassWithBotnameSuffix:
 
         assert sk not in adapter._pending_messages
         assert any("handled:new" in r for r in adapter.sent_responses)
+
+
+# ---------------------------------------------------------------------------
+# Regression: skill commands must also bypass active-session guard (#58559)
+# ---------------------------------------------------------------------------
+
+
+class TestSkillCommandBypass:
+    """Registered skill commands (e.g. /arxiv) must bypass the active-session
+    queue, matching how built-in slash commands are dispatched directly."""
+
+    def test_should_bypass_returns_true_for_skill_command(self):
+        """A registered skill command bypasses the active-session guard."""
+        from unittest.mock import patch as _patch
+
+        from hermes_cli.commands import should_bypass_active_session
+
+        with _patch(
+            "agent.skill_commands.get_skill_commands",
+            return_value={"/arxiv": {"description": "search arXiv papers"}},
+        ):
+            assert should_bypass_active_session("arxiv") is True
+
+    def test_should_bypass_returns_false_for_unregistered_skill(self):
+        """An unknown name that is neither a built-in nor a skill command
+        does NOT bypass."""
+        from unittest.mock import patch as _patch
+
+        from hermes_cli.commands import should_bypass_active_session
+
+        with _patch(
+            "agent.skill_commands.get_skill_commands",
+            return_value={"/arxiv": {"description": "search arXiv papers"}},
+        ):
+            assert should_bypass_active_session("not-a-skill") is False

--- a/tests/gateway/test_command_bypass_active_session.py
+++ b/tests/gateway/test_command_bypass_active_session.py
@@ -495,36 +495,44 @@ class TestBypassWithBotnameSuffix:
         assert any("handled:new" in r for r in adapter.sent_responses)
 
 
-# ---------------------------------------------------------------------------
-# Regression: skill commands must also bypass active-session guard (#58559)
-# ---------------------------------------------------------------------------
+class TestDynamicCommandBypass:
+    """Resolvable plugin and skill commands bypass the Level-1 guard."""
 
-
-class TestSkillCommandBypass:
-    """Registered skill commands (e.g. /arxiv) must bypass the active-session
-    queue, matching how built-in slash commands are dispatched directly."""
-
-    def test_should_bypass_returns_true_for_skill_command(self):
-        """A registered skill command bypasses the active-session guard."""
-        from unittest.mock import patch as _patch
-
+    def test_skill_command_bypasses(self, monkeypatch):
         from hermes_cli.commands import should_bypass_active_session
 
-        with _patch(
+        monkeypatch.setattr(
             "agent.skill_commands.get_skill_commands",
-            return_value={"/arxiv": {"description": "search arXiv papers"}},
-        ):
-            assert should_bypass_active_session("arxiv") is True
+            lambda: {"/claude-code": {"name": "claude-code"}},
+        )
 
-    def test_should_bypass_returns_false_for_unregistered_skill(self):
-        """An unknown name that is neither a built-in nor a skill command
-        does NOT bypass."""
-        from unittest.mock import patch as _patch
+        assert should_bypass_active_session("claude_code") is True
 
+    def test_skill_command_uses_the_routed_profile(self, tmp_path, monkeypatch):
+        import agent.skill_commands as sc_mod
         from hermes_cli.commands import should_bypass_active_session
 
-        with _patch(
-            "agent.skill_commands.get_skill_commands",
-            return_value={"/arxiv": {"description": "search arXiv papers"}},
-        ):
-            assert should_bypass_active_session("not-a-skill") is False
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill = tmp_path / "profiles" / "worker" / "skills" / "worker-only"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(
+            "---\nname: worker-only\ndescription: worker skill.\n---\n# Worker\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(sc_mod, "_skill_commands", {})
+        monkeypatch.setattr(sc_mod, "_skill_commands_platform", None)
+        monkeypatch.setattr(sc_mod, "_skill_commands_home", None)
+
+        assert should_bypass_active_session("worker-only", profile="worker") is True
+
+    def test_plugin_command_bypasses(self, monkeypatch):
+        from hermes_cli import commands
+
+        monkeypatch.setattr(
+            commands,
+            "_iter_plugin_command_entries",
+            lambda: [("plugin-command", "test plugin", "")],
+        )
+
+        assert commands.should_bypass_active_session("plugin_command") is True
+        assert commands.should_bypass_active_session("unknown-command") is False

--- a/tests/gateway/test_matrix_command_batching.py
+++ b/tests/gateway/test_matrix_command_batching.py
@@ -1,13 +1,4 @@
-"""Regression tests: Matrix long commands must be batched, not dispatched immediately.
-
-Matrix uses ``!command`` aliases that normalize to ``/command``.  Before the
-fix, any normalized command (MessageType.COMMAND) was dispatched immediately,
-bypassing the text-batching buffer.  Long commands near the client split
-threshold should still be batched so that continuation chunks from the Matrix
-client's own split arrive as a single aggregated message.
-
-Issue #58559.
-"""
+"""Regression tests for Matrix command batching and command routing."""
 
 import asyncio
 from types import SimpleNamespace
@@ -16,7 +7,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from gateway.config import Platform
-from gateway.platforms.base import MessageEvent, MessageType
+from gateway.platforms.base import MessageType
 from gateway.session import SessionSource
 
 
@@ -24,97 +15,133 @@ ROOM_ID = "!room:example"
 USER_ID = "@user:example"
 
 
-def _source(message_id: str) -> SessionSource:
-    return SessionSource(
-        platform=Platform.MATRIX,
-        chat_id=ROOM_ID,
-        chat_name="Element X DM",
-        chat_type="dm",
-        user_id=USER_ID,
-        user_name="User",
-        message_id=message_id,
-        scope_id="matrix.example",
-    )
-
-
-def _make_adapter(*, split_threshold: int = 3900, batch_delay: float = 0.02):
-    """Create a minimal MatrixAdapter for testing command batching."""
+def _make_adapter(*, synthetic_thread: bool = False):
     from plugins.platforms.matrix.adapter import MatrixAdapter
 
     adapter = object.__new__(MatrixAdapter)
     adapter.config = SimpleNamespace(
-        extra={
-            "group_sessions_per_user": True,
-            "thread_sessions_per_user": False,
-        }
+        extra={"group_sessions_per_user": True, "thread_sessions_per_user": False}
     )
-    adapter._text_batch_delay_seconds = batch_delay
-    adapter._text_batch_split_delay_seconds = batch_delay
+    adapter._text_batch_delay_seconds = 0.02
+    adapter._text_batch_split_delay_seconds = 0.02
     adapter._pending_text_batches = {}
     adapter._pending_text_batch_tasks = {}
-    adapter._SPLIT_THRESHOLD = split_threshold
+
+    async def resolve_context(room_id, sender, event_id, body, source_content, relates_to):
+        return body, not synthetic_thread, "group" if synthetic_thread else "dm", (
+            event_id if synthetic_thread else None
+        ), "User", SessionSource(
+            platform=Platform.MATRIX,
+            chat_id=ROOM_ID,
+            chat_type="group" if synthetic_thread else "dm",
+            user_id=USER_ID,
+            thread_id=event_id if synthetic_thread else None,
+            parent_chat_id=ROOM_ID if synthetic_thread else None,
+            message_id=event_id,
+        )
+
+    adapter._resolve_message_context = resolve_context
+    adapter.handle_message = AsyncMock()
     return adapter
 
 
+async def _send(adapter, event_id: str, body: str) -> None:
+    await adapter._handle_text_message(
+        ROOM_ID, USER_ID, event_id, 0, {"body": body}, {}
+    )
+
+
 @pytest.mark.asyncio
-async def test_long_matrix_command_is_batched():
-    """A Matrix ``!command`` whose normalized body exceeds ``_SPLIT_THRESHOLD``
-    must be held in the text batch, not dispatched immediately."""
+async def test_unknown_command_like_continuation_joins_long_command_batch():
     adapter = _make_adapter()
 
-    async def resolve_context(room_id, sender, event_id, body, source_content, relates_to):
-        return body, True, "dm", None, "User", _source(event_id)
-
-    captured: list[MessageEvent] = []
-
-    async def capture(message: MessageEvent):
-        captured.append(message)
-
-    adapter._resolve_message_context = resolve_context
-    adapter.handle_message = capture
-
-    # First chunk: long command (>= _SPLIT_THRESHOLD)
-    await adapter._handle_text_message(
-        ROOM_ID, USER_ID, "$long-1", 0,
-        {"body": "!queue " + ("x" * 3900)}, {},
-    )
-    # Second chunk: continuation from client split
-    await adapter._handle_text_message(
-        ROOM_ID, USER_ID, "$long-2", 0,
-        {"body": "tail from client split"}, {},
-    )
+    await _send(adapter, "$long", "!queue " + ("x" * 3900))
+    await _send(adapter, "$tail", "/not-a-command client split")
     await asyncio.sleep(0.08)
 
-    assert len(captured) == 1, (
-        f"Expected 1 batched message, got {len(captured)}: "
-        f"{[m.text[:60] for m in captured]}"
-    )
-    assert "tail from client split" in captured[0].text
+    adapter.handle_message.assert_awaited_once()
+    dispatched = adapter.handle_message.await_args.args[0]
+    assert dispatched.message_type == MessageType.COMMAND
+    assert dispatched.get_command() == "queue"
+    assert "/not-a-command client split" in dispatched.text
 
 
 @pytest.mark.asyncio
-async def test_short_matrix_command_dispatches_immediately():
-    """A short Matrix ``!command`` (well below ``_SPLIT_THRESHOLD``) must
-    dispatch immediately, not be held in the text batch."""
+async def test_auto_threaded_continuation_joins_long_command_batch():
+    adapter = _make_adapter(synthetic_thread=True)
+
+    await _send(adapter, "$long", "!queue " + ("x" * 3900))
+    await _send(adapter, "$tail", "client split continuation")
+    await asyncio.sleep(0.08)
+
+    adapter.handle_message.assert_awaited_once()
+    dispatched = adapter.handle_message.await_args.args[0]
+    assert dispatched.message_type == MessageType.COMMAND
+    assert dispatched.get_command() == "queue"
+    assert "client split continuation" in dispatched.text
+
+
+@pytest.mark.parametrize("command", ["/stop", "/new"])
+@pytest.mark.asyncio
+async def test_recognized_control_bypasses_pending_long_command_batch(command):
     adapter = _make_adapter()
 
-    async def resolve_context(room_id, sender, event_id, body, source_content, relates_to):
-        return body, True, "dm", None, "User", _source(event_id)
+    await _send(adapter, "$long", "!queue " + ("x" * 3900))
+    await _send(adapter, "$control", command)
 
-    captured: list[MessageEvent] = []
+    assert adapter.handle_message.await_count == 1
+    assert adapter.handle_message.await_args.args[0].text == command
 
-    async def capture(message: MessageEvent):
-        captured.append(message)
+    await asyncio.sleep(0.08)
+    assert adapter.handle_message.await_count == 2
+    assert adapter.handle_message.await_args_list[1].args[0].get_command() == "queue"
 
-    adapter._resolve_message_context = resolve_context
-    adapter.handle_message = capture
 
-    # Short command
-    await adapter._handle_text_message(
-        ROOM_ID, USER_ID, "$short-1", 0,
-        {"body": "!stop"}, {},
+@pytest.mark.asyncio
+async def test_recognized_skill_bypasses_pending_long_command_batch(monkeypatch):
+    adapter = _make_adapter()
+    monkeypatch.setattr(
+        "agent.skill_commands.get_skill_commands",
+        lambda: {"/arxiv": {"name": "arxiv"}},
     )
-    # Should dispatch immediately without waiting for batch flush
-    assert len(captured) == 1
-    assert captured[0].text == "/stop"
-    assert captured[0].message_type == MessageType.COMMAND
+
+    await _send(adapter, "$long", "!queue " + ("x" * 3900))
+    await _send(adapter, "$skill", "/arxiv matrix routing")
+
+    adapter.handle_message.assert_awaited_once()
+    assert adapter.handle_message.await_args.args[0].get_command() == "arxiv"
+    await asyncio.sleep(0.08)
+
+
+@pytest.mark.asyncio
+async def test_recognized_plugin_bypasses_pending_long_command_batch(monkeypatch):
+    adapter = _make_adapter()
+    monkeypatch.setattr(
+        "hermes_cli.commands._iter_plugin_command_entries",
+        lambda: [("plugin-command", "test plugin", "")],
+    )
+
+    await _send(adapter, "$long", "!queue " + ("x" * 3900))
+    await _send(adapter, "$plugin", "/plugin-command now")
+
+    adapter.handle_message.assert_awaited_once()
+    assert adapter.handle_message.await_args.args[0].get_command() == "plugin-command"
+    await asyncio.sleep(0.08)
+
+
+@pytest.mark.asyncio
+async def test_long_command_flushes_pending_text_before_its_own_batch():
+    adapter = _make_adapter()
+
+    await _send(adapter, "$text", "pending text")
+    await _send(adapter, "$long", "!queue " + ("x" * 3900))
+    await _send(adapter, "$tail", "client split continuation")
+    await asyncio.sleep(0.08)
+
+    assert adapter.handle_message.await_count == 2
+    text_event, command_event = [call.args[0] for call in adapter.handle_message.await_args_list]
+    assert text_event.message_type == MessageType.TEXT
+    assert text_event.text == "pending text"
+    assert command_event.message_type == MessageType.COMMAND
+    assert command_event.get_command() == "queue"
+    assert "client split continuation" in command_event.text

--- a/tests/gateway/test_matrix_command_batching.py
+++ b/tests/gateway/test_matrix_command_batching.py
@@ -1,0 +1,120 @@
+"""Regression tests: Matrix long commands must be batched, not dispatched immediately.
+
+Matrix uses ``!command`` aliases that normalize to ``/command``.  Before the
+fix, any normalized command (MessageType.COMMAND) was dispatched immediately,
+bypassing the text-batching buffer.  Long commands near the client split
+threshold should still be batched so that continuation chunks from the Matrix
+client's own split arrive as a single aggregated message.
+
+Issue #58559.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+
+
+ROOM_ID = "!room:example"
+USER_ID = "@user:example"
+
+
+def _source(message_id: str) -> SessionSource:
+    return SessionSource(
+        platform=Platform.MATRIX,
+        chat_id=ROOM_ID,
+        chat_name="Element X DM",
+        chat_type="dm",
+        user_id=USER_ID,
+        user_name="User",
+        message_id=message_id,
+        scope_id="matrix.example",
+    )
+
+
+def _make_adapter(*, split_threshold: int = 3900, batch_delay: float = 0.02):
+    """Create a minimal MatrixAdapter for testing command batching."""
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    adapter = object.__new__(MatrixAdapter)
+    adapter.config = SimpleNamespace(
+        extra={
+            "group_sessions_per_user": True,
+            "thread_sessions_per_user": False,
+        }
+    )
+    adapter._text_batch_delay_seconds = batch_delay
+    adapter._text_batch_split_delay_seconds = batch_delay
+    adapter._pending_text_batches = {}
+    adapter._pending_text_batch_tasks = {}
+    adapter._SPLIT_THRESHOLD = split_threshold
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_long_matrix_command_is_batched():
+    """A Matrix ``!command`` whose normalized body exceeds ``_SPLIT_THRESHOLD``
+    must be held in the text batch, not dispatched immediately."""
+    adapter = _make_adapter()
+
+    async def resolve_context(room_id, sender, event_id, body, source_content, relates_to):
+        return body, True, "dm", None, "User", _source(event_id)
+
+    captured: list[MessageEvent] = []
+
+    async def capture(message: MessageEvent):
+        captured.append(message)
+
+    adapter._resolve_message_context = resolve_context
+    adapter.handle_message = capture
+
+    # First chunk: long command (>= _SPLIT_THRESHOLD)
+    await adapter._handle_text_message(
+        ROOM_ID, USER_ID, "$long-1", 0,
+        {"body": "!queue " + ("x" * 3900)}, {},
+    )
+    # Second chunk: continuation from client split
+    await adapter._handle_text_message(
+        ROOM_ID, USER_ID, "$long-2", 0,
+        {"body": "tail from client split"}, {},
+    )
+    await asyncio.sleep(0.08)
+
+    assert len(captured) == 1, (
+        f"Expected 1 batched message, got {len(captured)}: "
+        f"{[m.text[:60] for m in captured]}"
+    )
+    assert "tail from client split" in captured[0].text
+
+
+@pytest.mark.asyncio
+async def test_short_matrix_command_dispatches_immediately():
+    """A short Matrix ``!command`` (well below ``_SPLIT_THRESHOLD``) must
+    dispatch immediately, not be held in the text batch."""
+    adapter = _make_adapter()
+
+    async def resolve_context(room_id, sender, event_id, body, source_content, relates_to):
+        return body, True, "dm", None, "User", _source(event_id)
+
+    captured: list[MessageEvent] = []
+
+    async def capture(message: MessageEvent):
+        captured.append(message)
+
+    adapter._resolve_message_context = resolve_context
+    adapter.handle_message = capture
+
+    # Short command
+    await adapter._handle_text_message(
+        ROOM_ID, USER_ID, "$short-1", 0,
+        {"body": "!stop"}, {},
+    )
+    # Should dispatch immediately without waiting for batch flush
+    assert len(captured) == 1
+    assert captured[0].text == "/stop"
+    assert captured[0].message_type == MessageType.COMMAND

--- a/tests/gateway/test_max_concurrent_sessions.py
+++ b/tests/gateway/test_max_concurrent_sessions.py
@@ -31,6 +31,23 @@ class _FakeAdapter:
             event.set()
 
 
+class _FakeRunningAgent:
+    def __init__(self):
+        self.interrupt_args: list[str] = []
+        self._active_children = {}
+
+    def interrupt(self, text: str):
+        self.interrupt_args.append(text)
+
+    def get_activity_summary(self):
+        return {
+            "seconds_since_activity": 0,
+            "last_activity_desc": "test",
+            "api_call_count": 1,
+            "max_iterations": 10,
+        }
+
+
 def _make_source(chat_id: str = "chat-1") -> SessionSource:
     return SessionSource(
         platform=Platform.TELEGRAM,
@@ -206,3 +223,97 @@ def test_skill_command_that_would_start_agent_is_blocked_at_limit(monkeypatch):
         "Hermes is at the active session limit (1/1). "
         "Try again when another session finishes."
     )
+
+
+def test_skill_command_in_active_session_returns_busy_without_interrupt(monkeypatch):
+    _silence_global_gateway_hooks(monkeypatch)
+    runner = _make_runner()
+    event = _make_event("/arxiv mushroom taxonomy")
+    session_key = build_session_key(event.source)
+    running_agent = _FakeRunningAgent()
+    runner._running_agents[session_key] = running_agent
+    runner._running_agents_ts[session_key] = time.time()
+
+    monkeypatch.setattr(
+        "agent.skill_commands.get_skill_commands",
+        lambda: {"/arxiv": {"name": "arxiv"}},
+    )
+
+    result = asyncio.run(runner._handle_message(event))
+
+    assert "Agent is running" in result
+    assert "`/arxiv`" in result
+    assert session_key not in runner.adapters[Platform.TELEGRAM]._pending_messages
+    assert running_agent.interrupt_args == []
+
+
+def test_underscored_skill_command_in_active_session_is_recognized(monkeypatch):
+    _silence_global_gateway_hooks(monkeypatch)
+    runner = _make_runner()
+    event = _make_event("/claude_code inspect this")
+    session_key = build_session_key(event.source)
+    running_agent = _FakeRunningAgent()
+    runner._running_agents[session_key] = running_agent
+    runner._running_agents_ts[session_key] = time.time()
+
+    monkeypatch.setattr(
+        "agent.skill_commands.get_skill_commands",
+        lambda: {"/claude-code": {"name": "claude-code"}},
+    )
+
+    result = asyncio.run(runner._handle_message(event))
+
+    assert "Agent is running" in result
+    assert "`/claude-code`" in result
+    assert session_key not in runner.adapters[Platform.TELEGRAM]._pending_messages
+    assert running_agent.interrupt_args == []
+
+
+def test_profile_skill_command_in_active_session_returns_busy(tmp_path, monkeypatch):
+    _silence_global_gateway_hooks(monkeypatch)
+    runner = _make_runner()
+    event = _make_event("/worker-only inspect")
+    event.source.profile = "worker"
+    skill = tmp_path / ".hermes" / "profiles" / "worker" / "skills" / "worker-only"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text(
+        "---\nname: worker-only\ndescription: worker skill.\n---\n# Worker\n",
+        encoding="utf-8",
+    )
+    session_key = build_session_key(event.source)
+    running_agent = _FakeRunningAgent()
+    runner._running_agents[session_key] = running_agent
+    runner._running_agents_ts[session_key] = time.time()
+
+    result = asyncio.run(runner._handle_message(event))
+
+    assert "Agent is running" in result
+    assert "`/worker-only`" in result
+    assert session_key not in runner.adapters[Platform.TELEGRAM]._pending_messages
+    assert running_agent.interrupt_args == []
+
+
+def test_plugin_command_in_active_session_uses_slash_access_gate(monkeypatch):
+    _silence_global_gateway_hooks(monkeypatch)
+    runner = _make_runner()
+    event = _make_event("/plugin_command run")
+    session_key = build_session_key(event.source)
+    running_agent = _FakeRunningAgent()
+    runner._running_agents[session_key] = running_agent
+    runner._running_agents_ts[session_key] = time.time()
+    runner._check_slash_access = MagicMock(return_value="denied")
+
+    from hermes_cli import commands
+
+    monkeypatch.setattr(
+        commands,
+        "_iter_plugin_command_entries",
+        lambda: [("plugin-command", "test plugin", "")],
+    )
+
+    result = asyncio.run(runner._handle_message(event))
+
+    assert result == "denied"
+    runner._check_slash_access.assert_called_once_with(event.source, "plugin-command")
+    assert session_key not in runner.adapters[Platform.TELEGRAM]._pending_messages
+    assert running_agent.interrupt_args == []


### PR DESCRIPTION
## What does this PR do?

Fixes Matrix long-command batching without allowing a following recognized command to be swallowed into the pending batch.

This draft:

- batches a long Matrix command with its client-split continuation chunks;
- dispatches recognized built-in, plugin, and skill commands immediately while a long command is pending;
- keeps unknown command-like continuation text in the pending command batch;
- preserves command semantics when a long command arrives behind an existing text batch;
- recognizes routed-profile skills in both active-session guards; and
- keeps synthetic auto-thread continuation chunks on the same Matrix batch key.

The first commit preserves the original authorship and patch from @liuhao1024's #58565. The second commit contains the additional runner, continuation-ordering, profile-safety, and auto-thread corrections required by the end-to-end regressions and review.

Fixes #58559.

## Why?

Matrix clients can split long `!command` messages near their message-size limit. The initial command must wait briefly for continuation text, but real control/plugin/skill commands arriving during that window must retain their normal immediate routing. Recognition also has to use the routed profile and the same thread identity that the adapter assigns to the synthetic continuation.

## Validation

- `scripts/run_tests.sh` focused and sibling suites: 407 passed
- relevant Ruff checks: passed
- `python3 scripts/check-windows-footguns.py ...`: passed
- `git diff --check`: passed
- two fresh GPT-5.6 Sol xhigh pre-draft reviews at `f3babd2f6735e5e6d5eebe79f2b78573cd7b4ed6`: PASS

The required full-suite wrapper was attempted once on an earlier candidate and reached about 640 passing tests with no observed failure before its detached process tree was stopped. That incomplete run is not claimed as a full-suite pass. The final simplified tree was validated with the focused and sibling suites above and will be validated by live CI.

## Scope and compatibility

No new public API, dependency, configuration, or general command framework is introduced. The change preserves both gateway active-message guards, Matrix mention/auto-thread behavior, profile boundaries, and cross-platform Python behavior.

This PR remains a draft pending live CI and post-draft review.
