### PR TITLE
fix(telegram): redact bot tokens from transport error logs

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1600,7 +1600,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     self._rich_send_disabled = True
                 logger.debug(
                     "[%s] sendRichMessage rejected (%s) — falling back to MarkdownV2",
-                    self.name, exc,
+                    self.name, _redact_telegram_error_text(exc),
                 )
                 return None
             # Transient / network / unknown: the request may have reached
@@ -1706,7 +1706,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     return SendResult(success=True, message_id=message_id)
                 logger.debug(
                     "[%s] rich editMessageText rejected (%s) — falling back to MarkdownV2 edit",
-                    self.name, exc,
+                    self.name, _redact_telegram_error_text(exc),
                 )
                 return None
             if "not modified" in str(exc).lower():
@@ -1899,7 +1899,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self._send_path_degraded = True
         logger.warning(
             "[%s] Telegram polling degraded (%s); gateway stays alive and will retry. Error: %s",
-            self.name, reason, error,
+            self.name, reason, _redact_telegram_error_text(error),
         )
         loop = asyncio.get_running_loop()
         self._polling_error_task = loop.create_task(self._handle_polling_network_error(error))


### PR DESCRIPTION
## Summary

Telegram Bot API URLs carry credentials in the path as `/bot<TOKEN>/<method>`. Three error-handling paths logged raw exception text that could include these URLs, leaking bot tokens to gateway logs.

## Affected Paths

| Location | Function | Issue |
|----------|----------|-------|
| adapter.py:1603 | sendRichMessage fallback | `logger.debug(... exc)` |
| adapter.py:1709 | editMessageText fallback | `logger.debug(... exc)` |
| adapter.py:1902 | polling reconnect warning | `logger.warning(... error)` |

## Fix

Replace raw `exc`/`error` with `_redact_telegram_error_text()` in all three locations. This function already exists and uses `redact_sensitive_text(force=True)` from the shared redaction pipeline.

This matches the pattern already used by:
- Transient sendRichMessage failures (line 1625)
- Rich editMessageText failures (line 1721)
- Legacy send/edit retry errors (lines 3649, 3659, 3699, 3710)
- Polling error callback (line 1996)

## Testing

The redaction function is already tested via `agent.redact` test suite. The fix ensures transport-level errors are treated consistently with all other Telegram error paths.

Fixes #58376
