### PR TITLE
fix(compression): handle dict/list content in write_file summarizer

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -574,7 +574,13 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
 
     if tool_name == "write_file":
         path = args.get("path", "?")
-        written_lines = args.get("content", "").count("\n") + 1 if args.get("content") else "?"
+        raw_content = args.get("content")
+        if isinstance(raw_content, str):
+            written_lines = raw_content.count("\n") + 1 if raw_content else "?"
+        elif isinstance(raw_content, (dict, list)):
+            written_lines = f"{type(raw_content).__name__}"
+        else:
+            written_lines = "?"
         return f"[write_file] wrote to {path} ({written_lines} lines)"
 
     if tool_name == "search_files":


### PR DESCRIPTION
## Summary

`_summarize_tool_result()` crashes with `AttributeError: 'dict' object has no attribute 'count'` when a `write_file` tool call's `content` argument is parsed as a `dict` instead of a `str`.

## Traceback

```
File "agent/context_compressor.py", line 577, in _summarize_tool_result
    written_lines = args.get("content", "").count("\n") + 1 if args.get("content") else "?"
AttributeError: 'dict' object has no attribute 'count'
```

## Impact

This blocks context compression entirely. The session grows past the threshold and every subsequent compression attempt hits the same crash, so the context window eventually overflows.

## Root Cause

Line 577 assumes `args.get("content")` is always a `str`. But tool call arguments can be parsed with `content` as a `dict` (e.g. structured write_file output from certain providers).

## Fix

Add `isinstance` checks:
- `str` → `.count("\n")` (original behavior)
- `dict`/`list` → report type name
- Everything else → `"?"`

Fixes #58317
