### PR TITLE
context-health: add auto context governance phases 1-9

### DIFF
--- a/agent/context_health_compact.py
+++ b/agent/context_health_compact.py
@@ -1,0 +1,106 @@
+"""Safe compact-fallback helpers for Context Health Phase 7.
+
+This module intentionally does not implement Phase 8 rehydrate.  It builds a
+sanitized continuity packet and user-facing HOLD payload for compact/compression
+exhaustion paths so Hermes stops instead of asking the user to manage `/new` or
+retry `/compress` as the primary recovery path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Any, Dict, Optional
+
+
+_SAFETY_BOUNDARY = (
+    "raw transcript excluded; unrelated A/B task material excluded; "
+    "secret, token, password, and private body content excluded"
+)
+
+
+@dataclass(frozen=True)
+class CompactFallbackHold:
+    """Sanitized continuity metadata for a compact-exhaustion HOLD."""
+
+    reason: str
+    session_id: str
+    task_id: str
+    message_count: int
+    approx_tokens: Optional[int]
+    rehydrate_status: str
+    safety_boundary: str = _SAFETY_BOUNDARY
+
+    def as_packet(self) -> Dict[str, Any]:
+        packet = asdict(self)
+        packet["type"] = "context_health_compact.continuity_packet"
+        packet["raw_transcript_included"] = False
+        packet["unrelated_context_included"] = False
+        packet["secret_token_password_private_body_included"] = False
+        return packet
+
+
+def build_safe_compact_hold_result(
+    hold_result: Dict[str, Any],
+    *,
+    api_calls: int = 0,
+) -> Dict[str, Any]:
+    """Assemble a run_conversation-safe compact HOLD result.
+
+    Some Hermes surfaces expect a `messages` key in run_conversation results,
+    but compact fallback HOLD must not return the raw transcript.  Use a
+    sanitized assistant-only message containing the safe HOLD response.
+    """
+
+    final_response = str(hold_result.get("final_response") or "Context Health compact fallback HOLD")
+    return {
+        **hold_result,
+        "messages": [{"role": "assistant", "content": final_response}],
+        "api_calls": max(0, int(api_calls or 0)),
+    }
+
+
+def build_compact_exhaustion_hold(
+    *,
+    reason: str,
+    session_id: str = "",
+    task_id: str = "default",
+    message_count: int = 0,
+    approx_tokens: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Return a safe HOLD result for compact fallback exhaustion.
+
+    The returned payload is deliberately metadata-only.  It never copies the raw
+    transcript, unrelated A/B needles, or token/password/secret/private body
+    material into the HOLD response or continuity packet.  Actual same-window
+    rehydrate remains a Phase 8 responsibility; Phase 7 only creates a safe
+    re-entry packet and stops the unsafe retry path.
+    """
+
+    hold = CompactFallbackHold(
+        reason=reason,
+        session_id=session_id or "unknown",
+        task_id=task_id or "default",
+        message_count=max(0, int(message_count or 0)),
+        approx_tokens=approx_tokens if isinstance(approx_tokens, int) else None,
+        rehydrate_status="phase8_not_executed_requires_user_approval",
+    )
+    packet = hold.as_packet()
+    response = (
+        "Context Health compact fallback HOLD: compression is exhausted and "
+        "Hermes created a sanitized continuity_packet for approved re-entry. "
+        "The packet excludes raw transcript content, unrelated A/B task context, "
+        "and secret/token/password/private body material. Actual rehydrate is "
+        "not executed in Phase 7 and requires a separate approval."
+    )
+    return {
+        "final_response": response,
+        "error": response,
+        "completed": False,
+        "partial": True,
+        "failed": True,
+        "compression_exhausted": True,
+        "context_health_compact": True,
+        "safe_hold": True,
+        "continuity_packet": packet,
+        "rehydrate": "hold_for_phase8_approval",
+    }

--- a/agent/context_health_intake.py
+++ b/agent/context_health_intake.py
@@ -1,0 +1,268 @@
+"""Phase 2 pre-turn Context Health intake adapter.
+
+This module is intentionally small and deterministic: it does not call a model,
+provider, plugin, retriever, gateway, or task-boundary authority.  It only
+classifies the current inbound user prompt with the Phase 1 policy model and,
+when explicitly enabled for runtime behavior, replaces a long prompt with a
+safe summary/path pointer before the raw prompt enters active history.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from pathlib import Path
+import re
+from typing import Any, Mapping
+from uuid import uuid4
+
+from agent.context_health_policy import (
+    ContextHealthPolicy,
+    classify_prompt_for_intake,
+    default_context_health_policy,
+    normalize_context_health_policy,
+)
+
+
+@dataclass(frozen=True)
+class PreTurnIntakeResult:
+    """Adapter result consumed by ``agent.turn_context``."""
+
+    action: str
+    user_message: str
+    persist_user_message: str | None
+    packet_dir: str | None = None
+    summary_path: str | None = None
+    intake_path: str | None = None
+    task_state_path: str | None = None
+    reason: str = ""
+    signals: tuple[str, ...] = ()
+
+    @property
+    def replaced(self) -> bool:
+        return self.action == "replace"
+
+
+class PreTurnIntakeHold(RuntimeError):
+    """Fail-closed HOLD raised before raw prompt append/persist/provider flow."""
+
+    def __init__(self, user_response: str, *, reason: str = "", signals: tuple[str, ...] = ()):
+        super().__init__(user_response)
+        self.user_response = user_response
+        self.reason = reason
+        self.signals = signals
+
+
+def run_pre_turn_intake(
+    *,
+    agent: Any,
+    user_message: str,
+    persist_user_message: str | None,
+    session_id: str | None,
+    task_id: str,
+    turn_id: str,
+) -> PreTurnIntakeResult:
+    """Apply Phase 2 pre-turn intake or return exact pass-through.
+
+    Runtime behavior is gated by all three policy switches:
+    ``context_health.enabled``, ``runtime_behavior_enabled``, and
+    ``pre_model_intake.enabled``.  Disabled mode returns without writing files
+    or mutating messages, even if later adapter logic would fail.
+    """
+
+    policy = _resolve_policy(agent)
+    if not _runtime_intake_enabled(policy):
+        return PreTurnIntakeResult(
+            action="pass",
+            user_message=user_message,
+            persist_user_message=persist_user_message,
+            reason="context_health_disabled",
+        )
+
+    try:
+        decision = classify_prompt_for_intake(user_message, policy)
+        if decision.action == "pass":
+            return PreTurnIntakeResult(
+                action="pass",
+                user_message=user_message,
+                persist_user_message=persist_user_message,
+                reason=decision.reason,
+                signals=decision.signals,
+            )
+
+        if decision.action == "hold":
+            raise PreTurnIntakeHold(
+                _hold_response(decision.reason),
+                reason=decision.reason,
+                signals=decision.signals,
+            )
+
+        if decision.action != "force_md_intake":
+            raise PreTurnIntakeHold(
+                _hold_response("unsupported_intake_decision"),
+                reason="unsupported_intake_decision",
+                signals=decision.signals,
+            )
+
+        packet = _write_intake_packet(
+            agent=agent,
+            user_message=user_message,
+            session_id=session_id,
+            task_id=task_id,
+            turn_id=turn_id,
+            reason=decision.reason,
+            signals=decision.signals,
+        )
+        replacement = _replacement_message(packet, reason=decision.reason, signals=decision.signals)
+        return PreTurnIntakeResult(
+            action="replace",
+            user_message=replacement,
+            persist_user_message=replacement,
+            packet_dir=str(packet["packet_dir"]),
+            summary_path=str(packet["summary_path"]),
+            intake_path=str(packet["intake_path"]),
+            task_state_path=str(packet["task_state_path"]),
+            reason=decision.reason,
+            signals=decision.signals,
+        )
+    except PreTurnIntakeHold:
+        raise
+    except Exception:
+        # Enabled runtime mode is fail-closed by decision record: do not let an
+        # adapter exception fall through to raw append/persist/provider context.
+        raise PreTurnIntakeHold(
+            _hold_response("intake_adapter_failed"),
+            reason="intake_adapter_failed",
+            signals=(),
+        )
+
+
+def _resolve_policy(agent: Any) -> ContextHealthPolicy:
+    explicit = getattr(agent, "_context_health_policy", None)
+    if isinstance(explicit, ContextHealthPolicy):
+        return explicit
+    explicit = getattr(agent, "context_health_policy", None)
+    if isinstance(explicit, ContextHealthPolicy):
+        return explicit
+    raw = getattr(agent, "context_health", None)
+    if isinstance(raw, Mapping):
+        return _normalize_runtime_policy(raw)
+    cfg = getattr(agent, "config", None)
+    if isinstance(cfg, Mapping):
+        return _normalize_runtime_policy(cfg.get("context_health"))
+    return default_context_health_policy()
+
+
+def _normalize_runtime_policy(raw: Any) -> ContextHealthPolicy:
+    policy = normalize_context_health_policy(raw if isinstance(raw, Mapping) else None)
+    if isinstance(raw, Mapping) and isinstance(raw.get("runtime_behavior_enabled"), bool):
+        return replace(policy, runtime_behavior_enabled=raw["runtime_behavior_enabled"])
+    return policy
+
+
+def _runtime_intake_enabled(policy: ContextHealthPolicy) -> bool:
+    return bool(
+        policy.enabled
+        and policy.runtime_behavior_enabled
+        and policy.pre_model_intake.enabled
+    )
+
+
+def _write_intake_packet(
+    *,
+    agent: Any,
+    user_message: str,
+    session_id: str | None,
+    task_id: str,
+    turn_id: str,
+    reason: str,
+    signals: tuple[str, ...],
+) -> dict[str, Path]:
+    root = Path(
+        getattr(agent, "_context_health_intake_dir", None)
+        or Path.home() / ".hermes" / "context-health" / "intake"
+    )
+    packet_dir = root / _safe_slug(session_id or "session") / _safe_slug(task_id) / _safe_slug(turn_id, suffix=uuid4().hex[:8])
+    packet_dir.mkdir(parents=True, exist_ok=False)
+
+    intake_path = packet_dir / "intake.md"
+    summary_path = packet_dir / "summary.md"
+    task_state_path = packet_dir / "task-state.md"
+
+    line_count = user_message.count("\n") + 1
+    char_count = len(user_message)
+    signal_text = ", ".join(signals) if signals else "none"
+
+    intake_path.write_text(
+        "# Context Health Intake\n\n"
+        "## Metadata\n\n"
+        f"- session_id: `{session_id or 'none'}`\n"
+        f"- task_id: `{task_id}`\n"
+        f"- turn_id: `{turn_id}`\n"
+        f"- reason: `{reason}`\n"
+        f"- signals: `{signal_text}`\n"
+        f"- char_count: `{char_count}`\n"
+        f"- line_count: `{line_count}`\n\n"
+        "## Original Prompt\n\n"
+        "```text\n"
+        f"{user_message}\n"
+        "```\n",
+        encoding="utf-8",
+    )
+    summary_path.write_text(
+        "# Context Health Intake Summary\n\n"
+        "A long inbound user prompt was moved to an intake packet before it "
+        "entered active conversation history. Provider-visible context should "
+        "use this summary and the packet path, not the raw prompt body.\n\n"
+        f"- reason: `{reason}`\n"
+        f"- signals: `{signal_text}`\n"
+        f"- char_count: `{char_count}`\n"
+        f"- line_count: `{line_count}`\n"
+        f"- intake_path: `{intake_path}`\n",
+        encoding="utf-8",
+    )
+    task_state_path.write_text(
+        "# Context Health Task State\n\n"
+        "- phase: Phase 2 pre-turn intake\n"
+        "- state: raw prompt externalized before append/persist\n"
+        "- provider_payload_contract: summary/path pointer only\n"
+        "- full_task_boundary_firewall: not implemented in Phase 2\n"
+        f"- summary_path: `{summary_path}`\n",
+        encoding="utf-8",
+    )
+    return {
+        "packet_dir": packet_dir,
+        "intake_path": intake_path,
+        "summary_path": summary_path,
+        "task_state_path": task_state_path,
+    }
+
+
+def _replacement_message(packet: dict[str, Path], *, reason: str, signals: tuple[str, ...]) -> str:
+    signal_text = ", ".join(signals) if signals else "none"
+    return (
+        "[Context Health Intake]\n"
+        "The current inbound prompt was long enough to require Phase 2 pre-turn intake.\n"
+        "The raw prompt body was moved to an MD intake packet before active history append/persist.\n"
+        f"Reason: {reason}; signals: {signal_text}.\n"
+        f"Summary: {packet['summary_path']}\n"
+        f"Intake packet: {packet['packet_dir']}\n"
+        "Use the summary/path pointer for this turn; do not reconstruct the raw prompt in provider context."
+    )
+
+
+def _hold_response(reason: str) -> str:
+    return (
+        "Context Health HOLD: pre-turn intake could not safely continue. "
+        "The raw prompt was not added to active history, provider context, or the current-turn persisted message. "
+        f"Reason: {reason}."
+    )
+
+
+def _safe_slug(value: str, *, suffix: str | None = None) -> str:
+    slug = re.sub(r"[^A-Za-z0-9_.:-]+", "-", value).strip("-._")[:96] or "item"
+    if suffix:
+        return f"{slug}-{suffix}"
+    return slug
+
+
+__all__ = ["PreTurnIntakeHold", "PreTurnIntakeResult", "run_pre_turn_intake"]

--- a/agent/context_health_policy.py
+++ b/agent/context_health_policy.py
@@ -1,0 +1,360 @@
+"""Pure policy model for future Context Health governance.
+
+Phase 1 intentionally has no runtime integration.  The functions in this
+module only normalize policy data and make deterministic policy decisions that
+future pre-turn intake, task-boundary, and provider-payload hooks can consume.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+
+DEFAULT_LONG_PROMPT_CHAR_THRESHOLD = 8_000
+DEFAULT_LONG_PROMPT_LINE_THRESHOLD = 80
+DEFAULT_MAX_PROVIDER_CONTEXT_RATIO = 0.75
+DEFAULT_BLOCK_PROVIDER_CALL_RATIO = 0.85
+
+
+@dataclass(frozen=True)
+class PreModelIntakePolicy:
+    enabled: bool = False
+    long_prompt_char_threshold: int = DEFAULT_LONG_PROMPT_CHAR_THRESHOLD
+    long_prompt_line_threshold: int = DEFAULT_LONG_PROMPT_LINE_THRESHOLD
+    pre_history_required: bool = True
+    high_risk_keywords: tuple[str, ...] = (
+        "credential",
+        "credentials",
+        "secret",
+        "token",
+        "api key",
+        "password",
+        "private key",
+        "connection string",
+    )
+    sensitive_prompt_action: str = "hold"
+
+
+@dataclass(frozen=True)
+class TaskBoundaryPolicy:
+    enabled: bool = False
+    default_without_clear_continuation: str = "new_task"
+    ambiguous_action: str = "hold"
+
+
+@dataclass(frozen=True)
+class ContextThresholdPolicy:
+    max_provider_context_ratio: float = DEFAULT_MAX_PROVIDER_CONTEXT_RATIO
+    block_provider_call_ratio: float = DEFAULT_BLOCK_PROVIDER_CALL_RATIO
+    allow_model_specific_raise: bool = False
+
+
+@dataclass(frozen=True)
+class ContextHealthPolicy:
+    enabled: bool = False
+    pre_model_intake: PreModelIntakePolicy = field(default_factory=PreModelIntakePolicy)
+    task_boundary: TaskBoundaryPolicy = field(default_factory=TaskBoundaryPolicy)
+    thresholds: ContextThresholdPolicy = field(default_factory=ContextThresholdPolicy)
+    runtime_behavior_enabled: bool = False
+
+
+@dataclass(frozen=True)
+class PromptIntakeDecision:
+    action: str
+    reason: str
+    pre_history_required: bool = False
+    signals: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class TaskBoundaryDecision:
+    action: str
+    reason: str
+    defaulted: bool = False
+    linked_task_id: str | None = None
+
+
+@dataclass(frozen=True)
+class ThresholdDecision:
+    ratio: float
+    reason: str
+    clamped_model_suggestion: bool = False
+
+
+def default_context_health_policy() -> ContextHealthPolicy:
+    """Return the inert default policy.
+
+    Phase 1 must not alter runtime behavior, so the default policy is disabled
+    and `runtime_behavior_enabled` is always false unless a caller explicitly
+    opts in through normalized policy data in a future phase.
+    """
+
+    return ContextHealthPolicy()
+
+
+def normalize_context_health_policy(data: Mapping[str, Any] | None) -> ContextHealthPolicy:
+    """Normalize a mapping into a typed context health policy.
+
+    Unknown keys are ignored deliberately so future config files can be more
+    expressive without breaking this pure Phase 1 model.
+    """
+
+    if not data:
+        return default_context_health_policy()
+
+    pre_model_raw = _mapping(data.get("pre_model_intake"))
+    task_boundary_raw = _mapping(data.get("task_boundary"))
+    thresholds_raw = _mapping(data.get("thresholds"))
+
+    enabled = _bool(data.get("enabled"), False)
+
+    pre_model = PreModelIntakePolicy(
+        enabled=_bool(pre_model_raw.get("enabled"), False),
+        long_prompt_char_threshold=_positive_int(
+            pre_model_raw.get("long_prompt_char_threshold"),
+            DEFAULT_LONG_PROMPT_CHAR_THRESHOLD,
+        ),
+        long_prompt_line_threshold=_positive_int(
+            pre_model_raw.get("long_prompt_line_threshold"),
+            DEFAULT_LONG_PROMPT_LINE_THRESHOLD,
+        ),
+        pre_history_required=_bool(pre_model_raw.get("pre_history_required"), True),
+        high_risk_keywords=_string_tuple(
+            pre_model_raw.get("high_risk_keywords"),
+            PreModelIntakePolicy().high_risk_keywords,
+        ),
+        sensitive_prompt_action=_choice(
+            pre_model_raw.get("sensitive_prompt_action"),
+            {"hold", "force_md_intake"},
+            "hold",
+        ),
+    )
+
+    task_boundary = TaskBoundaryPolicy(
+        enabled=_bool(task_boundary_raw.get("enabled"), False),
+        default_without_clear_continuation=_choice(
+            task_boundary_raw.get("default_without_clear_continuation"),
+            {"new_task", "continue_task", "hold"},
+            "new_task",
+        ),
+        ambiguous_action=_choice(
+            task_boundary_raw.get("ambiguous_action"),
+            {"hold", "new_task"},
+            "hold",
+        ),
+    )
+
+    thresholds = ContextThresholdPolicy(
+        max_provider_context_ratio=_ratio(
+            thresholds_raw.get("max_provider_context_ratio"),
+            DEFAULT_MAX_PROVIDER_CONTEXT_RATIO,
+        ),
+        block_provider_call_ratio=_ratio(
+            thresholds_raw.get("block_provider_call_ratio"),
+            DEFAULT_BLOCK_PROVIDER_CALL_RATIO,
+        ),
+        allow_model_specific_raise=_bool(
+            thresholds_raw.get("allow_model_specific_raise"),
+            False,
+        ),
+    )
+
+    return ContextHealthPolicy(
+        enabled=enabled,
+        pre_model_intake=pre_model,
+        task_boundary=task_boundary,
+        thresholds=thresholds,
+        runtime_behavior_enabled=False,
+    )
+
+
+def classify_prompt_for_intake(
+    user_message: str,
+    policy: ContextHealthPolicy | None = None,
+) -> PromptIntakeDecision:
+    """Classify whether a prompt should be handled by future pre-history intake."""
+
+    policy = policy or default_context_health_policy()
+    if not policy.enabled or not policy.pre_model_intake.enabled:
+        return PromptIntakeDecision(
+            action="pass",
+            reason="context_health_disabled",
+            pre_history_required=False,
+        )
+
+    prompt = user_message or ""
+    signals = _prompt_signals(prompt, policy.pre_model_intake)
+    if "high_risk_keyword" in signals:
+        if policy.pre_model_intake.sensitive_prompt_action == "hold":
+            return PromptIntakeDecision(
+                action="hold",
+                reason="sensitive_prompt_requires_review",
+                pre_history_required=policy.pre_model_intake.pre_history_required,
+                signals=signals,
+            )
+
+    if signals:
+        return PromptIntakeDecision(
+            action="force_md_intake",
+            reason="long_prompt" if _has_long_prompt_signal(signals) else "policy_signal",
+            pre_history_required=policy.pre_model_intake.pre_history_required,
+            signals=signals,
+        )
+
+    return PromptIntakeDecision(
+        action="pass",
+        reason="below_intake_threshold",
+        pre_history_required=policy.pre_model_intake.pre_history_required,
+    )
+
+
+def classify_task_boundary(
+    *,
+    user_message: str,
+    active_task_id: str | None,
+    closed_task_ids: Sequence[str] = (),
+    explicit_continuation_refs: Sequence[str] = (),
+    ambiguous_relation: bool = False,
+    policy: ContextHealthPolicy | None = None,
+) -> TaskBoundaryDecision:
+    """Classify task boundary using policy-only deterministic evidence."""
+
+    policy = policy or default_context_health_policy()
+    if not policy.enabled or not policy.task_boundary.enabled:
+        return TaskBoundaryDecision(action="continue_task", reason="task_boundary_disabled")
+
+    if ambiguous_relation:
+        action = policy.task_boundary.ambiguous_action
+        return TaskBoundaryDecision(
+            action=action,
+            reason="ambiguous_task_relation",
+            defaulted=False,
+        )
+
+    refs = [ref for ref in explicit_continuation_refs if ref]
+    if refs:
+        return TaskBoundaryDecision(
+            action="continue_task",
+            reason="explicit_continuation_reference",
+            linked_task_id=refs[0],
+        )
+
+    lowered = (user_message or "").lower()
+    candidate_ids = [task_id for task_id in [active_task_id, *closed_task_ids] if task_id]
+    for task_id in candidate_ids:
+        if task_id.lower() in lowered and _contains_continuation_language(lowered):
+            return TaskBoundaryDecision(
+                action="continue_task",
+                reason="explicit_continuation_reference",
+                linked_task_id=task_id,
+            )
+
+    default = policy.task_boundary.default_without_clear_continuation
+    if default == "hold":
+        return TaskBoundaryDecision(action="hold", reason="no_clear_continuation_evidence", defaulted=True)
+    if default == "continue_task":
+        return TaskBoundaryDecision(
+            action="continue_task",
+            reason="no_clear_continuation_evidence",
+            defaulted=True,
+            linked_task_id=active_task_id,
+        )
+    return TaskBoundaryDecision(action="new_task", reason="no_clear_continuation_evidence", defaulted=True)
+
+
+def resolve_effective_threshold(
+    *,
+    configured_ratio: float,
+    model_suggested_ratio: float | None,
+    policy: ContextHealthPolicy | None = None,
+) -> ThresholdDecision:
+    """Resolve a safe threshold under the policy model.
+
+    This is only a pure decision helper in Phase 1. Runtime threshold paths are
+    not wired to it yet.
+    """
+
+    policy = policy or default_context_health_policy()
+    configured = _ratio(configured_ratio, DEFAULT_MAX_PROVIDER_CONTEXT_RATIO)
+    model_suggestion = _ratio(model_suggested_ratio, configured) if model_suggested_ratio is not None else None
+
+    if not policy.enabled:
+        return ThresholdDecision(ratio=configured, reason="context_health_disabled")
+
+    max_allowed = policy.thresholds.max_provider_context_ratio
+    if not policy.thresholds.allow_model_specific_raise:
+        safe_ratio = min(configured, max_allowed)
+        return ThresholdDecision(
+            ratio=safe_ratio,
+            reason="model_raise_disallowed" if model_suggestion is not None and model_suggestion > safe_ratio else "configured_threshold_preserved",
+            clamped_model_suggestion=model_suggestion is not None and model_suggestion > safe_ratio,
+        )
+
+    candidate = model_suggestion if model_suggestion is not None else configured
+    if candidate > max_allowed:
+        return ThresholdDecision(
+            ratio=max_allowed,
+            reason="policy_max_provider_context_ratio",
+            clamped_model_suggestion=True,
+        )
+    return ThresholdDecision(ratio=candidate, reason="configured_or_model_threshold")
+
+
+def _prompt_signals(prompt: str, policy: PreModelIntakePolicy) -> tuple[str, ...]:
+    signals: list[str] = []
+    if len(prompt) >= policy.long_prompt_char_threshold:
+        signals.append("char_count")
+    if prompt.count("\n") + 1 >= policy.long_prompt_line_threshold:
+        signals.append("line_count")
+    if "```" in prompt:
+        signals.append("code_block")
+    if any(marker in prompt for marker in ("/", "\\")) and any(
+        suffix in prompt for suffix in (".py", ".md", ".json", ".yaml", ".yml", ".txt", ".log")
+    ):
+        signals.append("file_path")
+    lowered = prompt.lower()
+    if any(keyword.lower() in lowered for keyword in policy.high_risk_keywords):
+        signals.append("high_risk_keyword")
+    return tuple(dict.fromkeys(signals))
+
+
+def _has_long_prompt_signal(signals: Sequence[str]) -> bool:
+    return any(signal in {"char_count", "line_count", "code_block", "file_path"} for signal in signals)
+
+
+def _contains_continuation_language(lowered: str) -> bool:
+    return any(token in lowered for token in ("continue", "계속", "resume", "이어", "이어서"))
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _bool(value: Any, default: bool) -> bool:
+    return value if isinstance(value, bool) else default
+
+
+def _positive_int(value: Any, default: int) -> int:
+    if isinstance(value, int) and value > 0:
+        return value
+    return default
+
+
+def _ratio(value: Any, default: float) -> float:
+    if isinstance(value, (int, float)) and 0 < float(value) <= 1:
+        return float(value)
+    return float(default)
+
+
+def _choice(value: Any, allowed: set[str], default: str) -> str:
+    return value if isinstance(value, str) and value in allowed else default
+
+
+def _string_tuple(value: Any, default: tuple[str, ...]) -> tuple[str, ...]:
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, Sequence):
+        items = tuple(item for item in value if isinstance(item, str) and item)
+        return items or default
+    return default

--- a/agent/context_health_rehydrate.py
+++ b/agent/context_health_rehydrate.py
@@ -1,0 +1,368 @@
+"""Phase 8 same-window rehydrate planner/consumer helpers.
+
+This module is intentionally narrow.  It does not add a CLI command, does not
+activate runtime configuration, and does not touch gateway/update-survival
+paths.  It provides a deterministic planner/consumer API for same-window
+re-entry from a Phase 7 compact fallback continuity packet.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional
+
+_CONTINUITY_PACKET_TYPE = "context_health_compact.continuity_packet"
+_PHASE = "phase8_same_window_rehydrate"
+_ALLOWED_FILES = ["tests/agent/test_same_window_rehydrate.py"]
+_SAFE_HOLD_RESPONSE = (
+    "Context Health same-window rehydrate HOLD: continuity packet is invalid "
+    "or unsafe. Re-entry is blocked before provider calls or state mutation."
+)
+
+_UNSAFE_KEY_PARTS = (
+    "raw",
+    "transcript",
+    "private",
+    "secret",
+    "token",
+    "password",
+    "credential",
+    "exception",
+    "debug",
+)
+
+
+def _safe_str(value: Any) -> str:
+    """Return a sanitized printable value for safe metadata fields only."""
+
+    if value is None:
+        return ""
+    text = str(value)
+    # Metadata identifiers should remain compact and single-line.  Do not carry
+    # arbitrary bodies through planner/consumer outputs.
+    return text.replace("\n", " ").replace("\r", " ")[:200]
+
+
+def _safe_int(value: Any, default: int = 0) -> int:
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return default
+
+
+def _normalized_text(value: Any) -> str:
+    return str(value).lower().replace("_", " ").replace("-", " ")
+
+
+def _value_contains_unsafe_material(value: Any) -> bool:
+    """Detect unsafe body-like material in metadata values without echoing it."""
+
+    if value is None or isinstance(value, (bool, int, float)):
+        return False
+    if isinstance(value, Mapping):
+        return any(
+            _value_contains_unsafe_material(key)
+            or _value_contains_unsafe_material(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return any(_value_contains_unsafe_material(item) for item in value)
+
+    text = _normalized_text(value)
+    if not text:
+        return False
+
+    # Synthetic sentinel values used by safety tests and review packets are never
+    # legitimate metadata.  This catches families of needles without binding the
+    # implementation to one exact test string.
+    if "needle" in text or "do not leak" in text or "do not reinject" in text:
+        return True
+
+    # Safe boundary prose is allowed when it explicitly says sensitive classes
+    # are excluded, not carried as payload.  Do not classify such constants as
+    # leaks merely because they name the forbidden classes.
+    excluded_boundary = "excluded" in text or "not included" in text
+
+    unsafe_markers = (
+        "raw transcript",
+        "unrelated ab",
+        "unrelated a/b",
+        "private body",
+    )
+    if any(marker in text for marker in unsafe_markers) and not excluded_boundary:
+        return True
+
+    credential_markers = (
+        "token=",
+        "token:",
+        "password=",
+        "password:",
+        "secret=",
+        "secret:",
+        "credential=",
+        "credential:",
+        "api key",
+        "apikey",
+        "bearer ",
+        "private key",
+    )
+    return any(marker in text for marker in credential_markers)
+
+
+def _packet_has_unsafe_shape(packet: Mapping[str, Any]) -> bool:
+    """Detect raw/debug/private material without copying it into outputs."""
+
+    if packet.get("raw_transcript_included") is True:
+        return True
+    if packet.get("unrelated_context_included") is True:
+        return True
+    if packet.get("secret_token_password_private_body_included") is True:
+        return True
+
+    safe_metadata_keys = {
+        "type",
+        "reason",
+        "session_id",
+        "task_id",
+        "message_count",
+        "approx_tokens",
+        "rehydrate_status",
+        "safety_boundary",
+        "raw_transcript_included",
+        "unrelated_context_included",
+        "secret_token_password_private_body_included",
+    }
+    for key, value in packet.items():
+        key_l = str(key).lower()
+        if key_l in safe_metadata_keys:
+            # Safety booleans explicitly set to False and known metadata fields
+            # are allowed only when their values are also safe.  `approx_tokens`
+            # contains the substring `token` but is only a count, not credential
+            # material.
+            if key_l in {
+                "raw_transcript_included",
+                "unrelated_context_included",
+                "secret_token_password_private_body_included",
+            } and value is not False:
+                return True
+            if key_l in {"message_count", "approx_tokens"}:
+                continue
+            if _value_contains_unsafe_material(value):
+                return True
+            continue
+        if any(part in key_l for part in _UNSAFE_KEY_PARTS):
+            return True
+        if _value_contains_unsafe_material(value):
+            return True
+    return False
+
+
+def _safe_packet_metadata(packet: Mapping[str, Any]) -> Dict[str, Any]:
+    """Extract only non-body metadata from a continuity packet."""
+
+    return {
+        "type": _safe_str(packet.get("type")) or _CONTINUITY_PACKET_TYPE,
+        "reason": _safe_str(packet.get("reason")) or "unknown",
+        "session_id": _safe_str(packet.get("session_id")) or "unknown",
+        "task_id": _safe_str(packet.get("task_id")) or "default",
+        "message_count": _safe_int(packet.get("message_count")),
+        "approx_tokens": packet.get("approx_tokens") if isinstance(packet.get("approx_tokens"), int) else None,
+        "rehydrate_status": _safe_str(packet.get("rehydrate_status")) or "phase8_planner_ready",
+        "raw_transcript_included": False,
+        "unrelated_context_included": False,
+        "secret_token_password_private_body_included": False,
+    }
+
+
+def _safe_hold(reason: str = "invalid_continuity_packet") -> Dict[str, Any]:
+    return {
+        "status": "hold",
+        "phase": _PHASE,
+        "reason": reason,
+        "safe_hold": True,
+        "provider_call_allowed": False,
+        "state_mutation_allowed": False,
+        "raw_transcript_reinjected": False,
+        "unrelated_context_reinjected": False,
+        "secret_token_password_private_body_reinjected": False,
+        "final_response": _SAFE_HOLD_RESPONSE,
+    }
+
+
+def validate_continuity_packet(continuity_packet: Mapping[str, Any]) -> Dict[str, Any]:
+    """Validate a Phase 7 continuity packet for Phase 8 re-entry.
+
+    Invalid or unsafe packets fail closed before provider calls or state
+    mutation.  The result never reflects raw/debug/private packet values.
+    """
+
+    if not isinstance(continuity_packet, Mapping):
+        return _safe_hold("invalid_continuity_packet")
+    if continuity_packet.get("type") != _CONTINUITY_PACKET_TYPE:
+        return _safe_hold("invalid_continuity_packet")
+    if _packet_has_unsafe_shape(continuity_packet):
+        return _safe_hold("unsafe_continuity_packet")
+
+    metadata = _safe_packet_metadata(continuity_packet)
+    return {
+        "status": "ready",
+        "phase": _PHASE,
+        "safe_hold": False,
+        "provider_call_allowed": False,
+        "state_mutation_allowed": False,
+        "raw_transcript_reinjected": False,
+        "unrelated_context_reinjected": False,
+        "secret_token_password_private_body_reinjected": False,
+        "continuity_packet_metadata": metadata,
+    }
+
+
+def build_same_window_rehydrate_plan(
+    *,
+    continuity_packet: Mapping[str, Any],
+    session_id: str,
+    current_task_id: str,
+    dry_run: bool = True,
+) -> Dict[str, Any]:
+    """Build a same-window rehydrate plan from safe continuity metadata."""
+
+    decision = validate_continuity_packet(continuity_packet)
+    if decision.get("status") != "ready":
+        return {
+            **decision,
+            "same_window": True,
+            "requires_new_process": False,
+            "requires_new_window": False,
+            "requires_new_session": False,
+            "requires_clear": False,
+            "adds_cli_command": False,
+            "touches_gateway_update_survival": False,
+            "runtime_activation_required": False,
+            "scope": "planner_contract_only",
+            "allowed_files": list(_ALLOWED_FILES),
+        }
+
+    metadata = dict(decision["continuity_packet_metadata"])
+    safe_session_id = _safe_str(session_id) or metadata.get("session_id", "unknown")
+    safe_task_id = _safe_str(current_task_id) or metadata.get("task_id", "default")
+    metadata["session_id"] = safe_session_id
+    metadata["task_id"] = safe_task_id
+
+    return {
+        "status": "ready",
+        "phase": _PHASE,
+        "continuity_packet_type": _CONTINUITY_PACKET_TYPE,
+        "dry_run": bool(dry_run),
+        "mutates_state": False,
+        "same_window": True,
+        "same_session_id": safe_session_id,
+        "current_task_id": safe_task_id,
+        "requires_new_process": False,
+        "requires_new_window": False,
+        "requires_new_session": False,
+        "requires_clear": False,
+        "provider_call_allowed": False,
+        "state_mutation_allowed": not bool(dry_run),
+        "raw_transcript_reinjected": False,
+        "unrelated_context_reinjected": False,
+        "secret_token_password_private_body_reinjected": False,
+        "uses_working_context_packet": True,
+        "uses_reentry_metadata": True,
+        "scope": "planner_contract_only",
+        "adds_cli_command": False,
+        "touches_gateway_update_survival": False,
+        "runtime_activation_required": False,
+        "allowed_files": list(_ALLOWED_FILES),
+        "continuity_packet_metadata": metadata,
+    }
+
+
+def _reentry_message_from_plan(plan: Mapping[str, Any]) -> Dict[str, Any]:
+    metadata = plan.get("continuity_packet_metadata") if isinstance(plan, Mapping) else {}
+    if not isinstance(metadata, Mapping):
+        metadata = {}
+    safe_packet = {
+        "type": "phase8.same_window_reentry_metadata",
+        "continuity_packet": {
+            "type": _CONTINUITY_PACKET_TYPE,
+            "reason": _safe_str(metadata.get("reason")) or "unknown",
+            "session_id": _safe_str(plan.get("same_session_id")) or _safe_str(metadata.get("session_id")),
+            "task_id": _safe_str(plan.get("current_task_id")) or _safe_str(metadata.get("task_id")),
+            "message_count": _safe_int(metadata.get("message_count")),
+            "approx_tokens": metadata.get("approx_tokens") if isinstance(metadata.get("approx_tokens"), int) else None,
+            "raw_transcript_included": False,
+            "unrelated_context_included": False,
+            "secret_token_password_private_body_included": False,
+        },
+        "provider_visible_state": "wcp_reentry_safe_metadata_only",
+    }
+    return {
+        "role": "assistant",
+        "content": "continuity_packet reentry metadata: " + json.dumps(safe_packet, sort_keys=True),
+    }
+
+
+def build_reentry_provider_payload(
+    *,
+    plan: Mapping[str, Any],
+    previous_conversation_history: Iterable[Mapping[str, Any]] | None = None,
+) -> Dict[str, Any]:
+    """Build provider-visible re-entry payload without old raw history."""
+
+    if not isinstance(plan, Mapping) or plan.get("status") != "ready":
+        return _safe_hold("invalid_rehydrate_plan")
+
+    message = _reentry_message_from_plan(plan)
+    return {
+        "provider_visible": True,
+        "phase": _PHASE,
+        "same_window": True,
+        "raw_previous_history_included": False,
+        "uses_working_context_packet": True,
+        "uses_reentry_metadata": True,
+        "messages": [message],
+        "raw_transcript_reinjected": False,
+        "unrelated_context_reinjected": False,
+        "secret_token_password_private_body_reinjected": False,
+    }
+
+
+def apply_same_window_rehydrate_plan(
+    plan: Mapping[str, Any],
+    *,
+    session_db: Any,
+) -> Dict[str, Any]:
+    """Apply a same-window rebaseline to the supplied temp SessionDB.
+
+    The caller owns the database boundary.  This function never opens a default
+    or real Hermes state DB; it only uses the injected `session_db` object.
+    """
+
+    if not isinstance(plan, Mapping) or plan.get("status") != "ready":
+        return _safe_hold("invalid_rehydrate_plan")
+    if session_db is None or not hasattr(session_db, "archive_and_compact"):
+        return _safe_hold("invalid_session_db")
+
+    session_id = _safe_str(plan.get("same_session_id")) or _safe_str(plan.get("session_id"))
+    if not session_id:
+        return _safe_hold("invalid_rehydrate_plan")
+
+    message = _reentry_message_from_plan(plan)
+    active_count = session_db.archive_and_compact(session_id, [message])
+    return {
+        "status": "applied",
+        "phase": _PHASE,
+        "same_window": True,
+        "same_session_id": session_id,
+        "active_count": active_count,
+        "deleted_rows": 0,
+        "used_soft_archive": True,
+        "old_rows_recoverable": True,
+        "active_state": "continuity_packet_metadata_only",
+        "raw_transcript_reinjected": False,
+        "unrelated_context_reinjected": False,
+        "secret_token_password_private_body_reinjected": False,
+        "adds_cli_command": False,
+        "touches_gateway_update_survival": False,
+        "runtime_activation_required": False,
+    }

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -28,10 +28,15 @@ import uuid
 from typing import Any, Dict, List, Optional
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
+from agent.context_health_compact import (
+    build_compact_exhaustion_hold,
+    build_safe_compact_hold_result,
+)
 from agent.conversation_compression import conversation_history_after_compression
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.iteration_budget import IterationBudget
+from agent.context_health_intake import PreTurnIntakeHold
 from agent.turn_context import build_turn_context
 from agent.turn_retry_state import TurnRetryState
 from agent.memory_manager import build_memory_context_block
@@ -568,23 +573,35 @@ def run_conversation(
     # ``build_turn_context``.  It mutates ``agent`` exactly as the inline code
     # did and returns the locals the loop below reads back.  See
     # ``agent/turn_context.py``.
-    _ctx = build_turn_context(
-        agent,
-        user_message,
-        system_message,
-        conversation_history,
-        task_id,
-        stream_callback,
-        persist_user_message,
-        persist_user_timestamp,
-        restore_or_build_system_prompt=_restore_or_build_system_prompt,
-        install_safe_stdio=_install_safe_stdio,
-        sanitize_surrogates=_sanitize_surrogates,
-        summarize_user_message_for_log=_summarize_user_message_for_log,
-        set_session_context=set_session_context,
-        set_current_write_origin=set_current_write_origin,
-        ra=_ra,
-    )
+    try:
+        _ctx = build_turn_context(
+            agent,
+            user_message,
+            system_message,
+            conversation_history,
+            task_id,
+            stream_callback,
+            persist_user_message,
+            persist_user_timestamp,
+            restore_or_build_system_prompt=_restore_or_build_system_prompt,
+            install_safe_stdio=_install_safe_stdio,
+            sanitize_surrogates=_sanitize_surrogates,
+            summarize_user_message_for_log=_summarize_user_message_for_log,
+            set_session_context=set_session_context,
+            set_current_write_origin=set_current_write_origin,
+            ra=_ra,
+        )
+    except PreTurnIntakeHold as hold:
+        final_response = getattr(hold, "user_response", str(hold))
+        reason = getattr(hold, "reason", "") or "pre_turn_intake_hold"
+        return {
+            "final_response": final_response,
+            "messages": [{"role": "assistant", "content": final_response}],
+            "api_calls": 0,
+            "completed": False,
+            "failed": True,
+            "error": f"context_health_hold: {reason}",
+        }
     user_message = _ctx.user_message
     original_user_message = _ctx.original_user_message
     messages = _ctx.messages
@@ -844,6 +861,43 @@ def run_conversation(
             effective_system = (effective_system + "\n\n" + agent.ephemeral_system_prompt).strip()
         if effective_system:
             api_messages = [{"role": "system", "content": effective_system}] + api_messages
+
+        # Phase 3 Context Health WCP hook: constrain provider-visible
+        # api_messages only. The persisted/internal messages list remains
+        # untouched, and disabled mode is exact pass-through.
+        from agent.working_context_packet import enforce_working_context_packet
+
+        _wcp_decision = enforce_working_context_packet(
+            agent=agent,
+            policy=getattr(agent, "_context_health_policy", None),
+            api_messages=api_messages,
+            messages=messages,
+            original_user_message=original_user_message,
+            current_turn_user_idx=current_turn_user_idx,
+            effective_task_id=effective_task_id,
+            turn_id=turn_id,
+            session_id=agent.session_id or "",
+            context_health_intake=getattr(_ctx, "context_health_intake", None),
+        )
+        if _wcp_decision.action == "hold":
+            final_response = _wcp_decision.hold_response or "Context Health HOLD: Working Context Packet provider payload could not be built safely."
+            failed = True
+            _turn_exit_reason = "context_health_wcp_hold"
+            try:
+                agent.iteration_budget.refund()
+            except Exception:
+                pass
+            agent._api_call_count = 0
+            return {
+                "final_response": final_response,
+                "messages": [{"role": "assistant", "content": final_response}],
+                "api_calls": 0,
+                "completed": False,
+                "failed": True,
+                "error": f"context_health_wcp_hold: {_wcp_decision.reason}",
+            }
+        if _wcp_decision.action == "replace_api_messages" and _wcp_decision.api_messages is not None:
+            api_messages = _wcp_decision.api_messages
 
         if moa_config:
             try:
@@ -3325,23 +3379,27 @@ def run_conversation(
                 if is_payload_too_large:
                     compression_attempts += 1
                     if compression_attempts > max_compression_attempts:
-                        # Terminal — surface the buffered retry trace.
+                        # Terminal — surface the buffered retry trace, then
+                        # route compression_exhausted to context_health_compact
+                        # safe HOLD with a sanitized continuity_packet. Phase 7
+                        # excludes raw transcript content, unrelated A/B task
+                        # material, and secret/token/password/private body text
+                        # from this packet; actual rehydrate remains Phase 8
+                        # and is not executed here.
                         agent._flush_status_buffer()
-                        agent._vprint(f"{agent.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached for payload-too-large error.", force=True)
-                        agent._vprint(f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                         logger.error(f"{agent.log_prefix}413 compression failed after {max_compression_attempts} attempts.")
                         agent._persist_session(messages, conversation_history)
-                        _final_response = f"Request payload too large: max compression attempts ({max_compression_attempts}) reached."
-                        return {
-                            "final_response": _final_response,
-                            "messages": messages,
-                            "completed": False,
-                            "api_calls": api_call_count,
-                            "error": _final_response,
-                            "partial": True,
-                            "failed": True,
-                            "compression_exhausted": True,
-                        }
+                        hold_result = build_compact_exhaustion_hold(
+                            reason="payload_too_large_max_compression_attempts",
+                            session_id=getattr(agent, "session_id", "") or "",
+                            task_id=effective_task_id,
+                            message_count=len(messages),
+                            approx_tokens=approx_tokens,
+                        )
+                        return build_safe_compact_hold_result(
+                            hold_result,
+                            api_calls=api_call_count,
+                        )
                     agent._buffer_status(f"⚠️  Request payload too large (413) — compression attempt {compression_attempts}/{max_compression_attempts}...")
 
                     original_len = len(messages)
@@ -3380,24 +3438,27 @@ def run_conversation(
                             )
                             continue
 
-                        # Terminal — surface buffered context so the user
-                        # sees what compression attempts were made.
+                        # Terminal — compact failure fallback: switch
+                        # compression_exhausted to context_health_compact safe
+                        # HOLD with sanitized continuity_packet metadata only.
+                        # Do not expose raw transcript text, unrelated A/B task
+                        # material, or secret/token/password/private body
+                        # content; do not execute Phase 8 rehydrate here.
                         agent._flush_status_buffer()
                         agent._vprint(f"{agent.log_prefix}❌ Payload too large and cannot compress further.", force=True)
-                        agent._vprint(f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                         logger.error(f"{agent.log_prefix}413 payload too large. Cannot compress further.")
                         agent._persist_session(messages, conversation_history)
-                        _final_response = "Request payload too large (413). Cannot compress further."
-                        return {
-                            "final_response": _final_response,
-                            "messages": messages,
-                            "completed": False,
-                            "api_calls": api_call_count,
-                            "error": _final_response,
-                            "partial": True,
-                            "failed": True,
-                            "compression_exhausted": True,
-                        }
+                        hold_result = build_compact_exhaustion_hold(
+                            reason="payload_too_large_cannot_compress_further",
+                            session_id=getattr(agent, "session_id", "") or "",
+                            task_id=effective_task_id,
+                            message_count=len(messages),
+                            approx_tokens=approx_tokens,
+                        )
+                        return build_safe_compact_hold_result(
+                            hold_result,
+                            api_calls=api_call_count,
+                        )
 
                 # Check for context-length errors BEFORE generic 4xx handler.
                 # The classifier detects context overflow from: explicit error
@@ -3437,22 +3498,24 @@ def run_conversation(
                         # loop forever if the error keeps recurring.
                         compression_attempts += 1
                         if compression_attempts > max_compression_attempts:
+                            # Context-overflow compression_exhausted path: safe HOLD
+                            # with sanitized continuity_packet; no raw transcript,
+                            # unrelated A/B task material, or secret/token/password/private body.
+                            # Actual rehydrate remains Phase 8 and is not executed here.
                             agent._flush_status_buffer()
-                            agent._vprint(f"{agent.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached.", force=True)
-                            agent._vprint(f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                             logger.error(f"{agent.log_prefix}Context compression failed after {max_compression_attempts} attempts.")
                             agent._persist_session(messages, conversation_history)
-                            _final_response = f"Context length exceeded: max compression attempts ({max_compression_attempts}) reached."
-                            return {
-                                "final_response": _final_response,
-                                "messages": messages,
-                                "completed": False,
-                                "api_calls": api_call_count,
-                                "error": _final_response,
-                                "partial": True,
-                                "failed": True,
-                                "compression_exhausted": True,
-                            }
+                            hold_result = build_compact_exhaustion_hold(
+                                reason="context_overflow_output_cap_max_compression_attempts",
+                                session_id=getattr(agent, "session_id", "") or "",
+                                task_id=effective_task_id,
+                                message_count=len(messages),
+                                approx_tokens=approx_tokens,
+                            )
+                            return build_safe_compact_hold_result(
+                                hold_result,
+                                api_calls=api_call_count,
+                            )
                         _retry.restart_with_compressed_messages = True
                         break
 
@@ -3549,22 +3612,24 @@ def run_conversation(
 
                     compression_attempts += 1
                     if compression_attempts > max_compression_attempts:
+                        # Context-overflow compression_exhausted path: safe HOLD with
+                        # sanitized continuity_packet; no raw transcript,
+                        # unrelated A/B task material, or secret/token/password/private body.
+                        # Actual rehydrate remains Phase 8 and is not executed here.
                         agent._flush_status_buffer()
-                        agent._vprint(f"{agent.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached.", force=True)
-                        agent._vprint(f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                         logger.error(f"{agent.log_prefix}Context compression failed after {max_compression_attempts} attempts.")
                         agent._persist_session(messages, conversation_history)
-                        _final_response = f"Context length exceeded: max compression attempts ({max_compression_attempts}) reached."
-                        return {
-                            "final_response": _final_response,
-                            "messages": messages,
-                            "completed": False,
-                            "api_calls": api_call_count,
-                            "error": _final_response,
-                            "partial": True,
-                            "failed": True,
-                            "compression_exhausted": True,
-                        }
+                        hold_result = build_compact_exhaustion_hold(
+                            reason="context_overflow_max_compression_attempts",
+                            session_id=getattr(agent, "session_id", "") or "",
+                            task_id=effective_task_id,
+                            message_count=len(messages),
+                            approx_tokens=approx_tokens,
+                        )
+                        return build_safe_compact_hold_result(
+                            hold_result,
+                            api_calls=api_call_count,
+                        )
                     agent._buffer_status(f"🗜️ Context too large (~{approx_tokens:,} tokens) — compressing ({compression_attempts}/{max_compression_attempts})...")
 
                     original_len = len(messages)
@@ -3593,23 +3658,26 @@ def run_conversation(
                         _retry.restart_with_compressed_messages = True
                         break
                     else:
-                        # Can't compress further and already at minimum tier
+                        # Can't compress further and already at minimum tier.
+                        # Context-overflow compression_exhausted path: safe HOLD with
+                        # sanitized continuity_packet; no raw transcript,
+                        # unrelated A/B task material, or secret/token/password/private body.
+                        # Actual rehydrate remains Phase 8 and is not executed here.
                         agent._flush_status_buffer()
                         agent._vprint(f"{agent.log_prefix}❌ Context length exceeded and cannot compress further.", force=True)
-                        agent._vprint(f"{agent.log_prefix}   💡 The conversation has accumulated too much content. Try /new to start fresh, or /compress to manually trigger compression.", force=True)
                         logger.error(f"{agent.log_prefix}Context length exceeded: {new_tokens:,} tokens. Cannot compress further.")
                         agent._persist_session(messages, conversation_history)
-                        _final_response = f"Context length exceeded ({new_tokens:,} tokens). Cannot compress further."
-                        return {
-                            "final_response": _final_response,
-                            "messages": messages,
-                            "completed": False,
-                            "api_calls": api_call_count,
-                            "error": _final_response,
-                            "partial": True,
-                            "failed": True,
-                            "compression_exhausted": True,
-                        }
+                        hold_result = build_compact_exhaustion_hold(
+                            reason="context_overflow_cannot_compress_further",
+                            session_id=getattr(agent, "session_id", "") or "",
+                            task_id=effective_task_id,
+                            message_count=len(messages),
+                            approx_tokens=new_tokens,
+                        )
+                        return build_safe_compact_hold_result(
+                            hold_result,
+                            api_calls=api_call_count,
+                        )
 
                 # Check for non-retryable client errors.  The classifier
                 # already accounts for 413, 429, 529 (transient), context

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -351,6 +351,7 @@ def build_memory_context_block(raw_context: str) -> str:
 
 
 class MemoryManager:
+    supports_retrieval_scope = True
     """Orchestrates the built-in provider plus at most one external provider.
 
     The builtin provider is always first. Only one non-builtin (external)
@@ -492,28 +493,55 @@ class MemoryManager:
         """
         return extract_user_instruction_from_skill_message(text)
 
-    def prefetch_all(self, query: str, *, session_id: str = "") -> str:
+    def prefetch_all(
+        self,
+        query: str,
+        *,
+        session_id: str = "",
+        current_task_id: str = "",
+        allowed_task_ids: Optional[list[str]] = None,
+        excluded_task_ids: Optional[list[str]] = None,
+        allowed_session_ids: Optional[list[str]] = None,
+        excluded_session_ids: Optional[list[str]] = None,
+        retrieval_scope: Optional[dict] = None,
+    ) -> str:
         """Collect prefetch context from all providers.
 
-        Returns merged context text labeled by provider. Empty providers
-        are skipped. Failures in one provider don't block others.
+        When Phase 6 retrieval scope is enabled, scope-capable providers receive
+        the task/session allow/exclude metadata. Providers that do not declare
+        scope support are skipped rather than queried unscoped.
         """
         clean_query = self._strip_skill_scaffolding(query)
         if not clean_query:
             return ""
+        scope_enabled = bool(isinstance(retrieval_scope, dict) and retrieval_scope.get("enabled"))
         parts = []
         for provider in self._providers:
             try:
-                result = provider.prefetch(clean_query, session_id=session_id)
+                if scope_enabled and not getattr(provider, "supports_retrieval_scope", False):
+                    continue
+                if scope_enabled:
+                    result = provider.prefetch(
+                        clean_query,
+                        session_id=session_id,
+                        current_task_id=current_task_id,
+                        allowed_task_ids=list(allowed_task_ids or []),
+                        excluded_task_ids=list(excluded_task_ids or []),
+                        allowed_session_ids=list(allowed_session_ids or []),
+                        excluded_session_ids=list(excluded_session_ids or []),
+                        retrieval_scope=retrieval_scope,
+                    )
+                else:
+                    result = provider.prefetch(clean_query, session_id=session_id)
                 if result and result.strip():
                     parts.append(result)
             except Exception as e:
                 logger.debug(
                     "Memory provider '%s' prefetch failed (non-fatal): %s",
                     provider.name, e,
+                    exc_info=True,
                 )
         return "\n\n".join(parts)
-
     def queue_prefetch_all(self, query: str, *, session_id: str = "") -> None:
         """Queue background prefetch on all providers for the next turn.
 

--- a/agent/retrieval_scope.py
+++ b/agent/retrieval_scope.py
@@ -1,0 +1,239 @@
+"""Phase 6 retrieval-scope enforcement helpers.
+
+This module is intentionally deterministic and side-effect free: it does not
+call models, providers, retrievers, or mutate the session DB/transcripts. It
+only derives a small allow/exclude scope from policy + task registry state and
+returns decisions for callers that are about to retrieve context.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+
+_SAFE_HOLD_RESPONSE = (
+    "Context Health HOLD: retrieval scope could not be verified safely; "
+    "no unscoped retrieval was executed."
+)
+
+
+@dataclass
+class RetrievalScopeDecision:
+    action: str
+    reason: str = ""
+    allowed_task_ids: list[str] = field(default_factory=list)
+    excluded_task_ids: list[str] = field(default_factory=list)
+    linked_task_ids: list[str] = field(default_factory=list)
+    allowed_session_ids: list[str] = field(default_factory=list)
+    excluded_session_ids: list[str] = field(default_factory=list)
+    rewritten_args: dict[str, Any] | None = None
+    hold_response: str | None = None
+    fail_closed: bool = False
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, Mapping):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, (str, bytes)):
+        return [str(value)] if str(value) else []
+    try:
+        return [str(v) for v in value if v is not None and str(v)]
+    except TypeError:
+        return [str(value)] if str(value) else []
+
+
+def retrieval_scope_enabled(policy: Any) -> bool:
+    cfg = _as_dict(policy)
+    if cfg.get("enabled") is False or cfg.get("runtime_behavior_enabled") is False:
+        return False
+    scope_cfg = _as_dict(cfg.get("retrieval_scope"))
+    return bool(scope_cfg.get("enabled", False))
+
+
+def _registry_tasks(registry_snapshot: Any) -> dict[str, Any]:
+    snap = _as_dict(registry_snapshot)
+    tasks = snap.get("tasks")
+    return tasks if isinstance(tasks, dict) else {}
+
+
+def _task_session_id(task_record: Any) -> str:
+    value = _get(task_record, "session_id", "")
+    return str(value or "")
+
+
+def _derive_scope(
+    *,
+    current_task_id: str = "",
+    registry_snapshot: Any = None,
+    registry_decision: Any = None,
+    explicit_continuation_refs: Any = None,
+) -> tuple[list[str], list[str], list[str], list[str], list[str]]:
+    tasks = _registry_tasks(registry_snapshot)
+    linked_task_ids = _list(explicit_continuation_refs)
+    linked = _get(registry_decision, "linked_task_id", None)
+    if linked:
+        linked_task_ids.append(str(linked))
+    linked_task_ids = list(dict.fromkeys(linked_task_ids))
+
+    allowed_task_ids: list[str] = []
+    if current_task_id:
+        allowed_task_ids.append(str(current_task_id))
+    allowed_task_ids.extend(linked_task_ids)
+    allowed_task_ids = list(dict.fromkeys(allowed_task_ids))
+
+    excluded_task_ids: list[str] = []
+    allowed_set = set(allowed_task_ids)
+    for task_id, record in tasks.items():
+        status = str(_get(record, "status", "")).lower()
+        if status == "closed" and str(task_id) not in allowed_set:
+            excluded_task_ids.append(str(task_id))
+
+    allowed_session_ids: list[str] = []
+    excluded_session_ids: list[str] = []
+    for task_id in allowed_task_ids:
+        sid = _task_session_id(tasks.get(task_id, {}))
+        if sid:
+            allowed_session_ids.append(sid)
+    for task_id in excluded_task_ids:
+        sid = _task_session_id(tasks.get(task_id, {}))
+        if sid:
+            excluded_session_ids.append(sid)
+
+    return (
+        list(dict.fromkeys(allowed_task_ids)),
+        list(dict.fromkeys(excluded_task_ids)),
+        list(dict.fromkeys(linked_task_ids)),
+        list(dict.fromkeys(allowed_session_ids)),
+        list(dict.fromkeys(excluded_session_ids)),
+    )
+
+
+def build_retrieval_scope(
+    *,
+    policy: Any,
+    current_task_id: str = "",
+    registry_snapshot: Any = None,
+    registry_decision: Any = None,
+    explicit_continuation_refs: Any = None,
+) -> dict[str, Any]:
+    enabled = retrieval_scope_enabled(policy)
+    if not enabled:
+        return {"enabled": False}
+    allowed, excluded, linked, allowed_sessions, excluded_sessions = _derive_scope(
+        current_task_id=current_task_id,
+        registry_snapshot=registry_snapshot,
+        registry_decision=registry_decision,
+        explicit_continuation_refs=explicit_continuation_refs,
+    )
+    return {
+        "enabled": True,
+        "mode": "explicit_link" if linked else "current_task_only",
+        "current_task_id": str(current_task_id or ""),
+        "allowed_task_ids": allowed,
+        "excluded_task_ids": excluded,
+        "linked_task_ids": linked,
+        "allowed_session_ids": allowed_sessions,
+        "excluded_session_ids": excluded_sessions,
+    }
+
+
+def decision_from_scope(scope: Mapping[str, Any], *, action: str, reason: str = "") -> RetrievalScopeDecision:
+    return RetrievalScopeDecision(
+        action=action,
+        reason=reason,
+        allowed_task_ids=_list(scope.get("allowed_task_ids")),
+        excluded_task_ids=_list(scope.get("excluded_task_ids")),
+        linked_task_ids=_list(scope.get("linked_task_ids")),
+        allowed_session_ids=_list(scope.get("allowed_session_ids")),
+        excluded_session_ids=_list(scope.get("excluded_session_ids")),
+    )
+
+
+def enforce_retrieval_scope(
+    *,
+    policy: Any,
+    tool_name: str,
+    tool_args: dict[str, Any] | None = None,
+    current_task_id: str = "",
+    registry_snapshot: Any = None,
+    registry_decision: Any = None,
+    explicit_continuation_refs: Any = None,
+    user_message: str = "",
+) -> RetrievalScopeDecision:
+    if not retrieval_scope_enabled(policy):
+        return RetrievalScopeDecision(action="use_original")
+
+    scope = build_retrieval_scope(
+        policy=policy,
+        current_task_id=current_task_id,
+        registry_snapshot=registry_snapshot,
+        registry_decision=registry_decision,
+        explicit_continuation_refs=explicit_continuation_refs,
+    )
+    relation = str(_get(registry_decision, "action", "") or "").lower()
+    text = f"{user_message or ''} {(_as_dict(tool_args).get('query') or '')}".lower()
+    ambiguous = relation == "hold" or "previous one" in text or "previous" == text.strip()
+    if ambiguous:
+        d = decision_from_scope(scope, action="hold", reason="ambiguous_prior_task_retrieval")
+        d.hold_response = _SAFE_HOLD_RESPONSE
+        return d
+
+    session_id = str((_as_dict(tool_args).get("session_id") or "")).strip()
+    excluded_sessions = set(_list(scope.get("excluded_session_ids")))
+    allowed_sessions = set(_list(scope.get("allowed_session_ids")))
+    if session_id and session_id in excluded_sessions and session_id not in allowed_sessions:
+        d = decision_from_scope(scope, action="block", reason="closed_unlinked_session_excluded")
+        d.hold_response = _SAFE_HOLD_RESPONSE
+        return d
+
+    action = "allow" if _list(scope.get("linked_task_ids")) else "rewrite_args"
+    d = decision_from_scope(scope, action=action, reason="retrieval_scope_applied")
+    d.rewritten_args = {}
+    return d
+
+
+def safe_retrieval_scope_failure(
+    *,
+    policy: Any,
+    reason: str = "",
+    current_task_id: str = "",
+    registry_snapshot: Any = None,
+    registry_decision: Any = None,
+) -> RetrievalScopeDecision:
+    scope = build_retrieval_scope(
+        policy=policy,
+        current_task_id=current_task_id,
+        registry_snapshot=registry_snapshot,
+        registry_decision=registry_decision,
+    ) if retrieval_scope_enabled(policy) else {"enabled": False}
+    d = decision_from_scope(scope, action="hold", reason="retrieval_scope_failure")
+    d.fail_closed = True
+    d.hold_response = _SAFE_HOLD_RESPONSE
+    return d
+
+
+def filter_text_by_scope(text: str, retrieval_scope: Mapping[str, Any] | None) -> str:
+    """Conservative provider-payload quarantine for untrusted retrieval text.
+
+    Phase 6 prevents/ scopes retrieval before execution where possible. For
+    already-returned memory/plugin context we use a safe first implementation:
+    when scope is enabled and there are excluded tasks/sessions, quarantine the
+    untrusted retrieval text rather than trying to redact arbitrary raw content.
+    """
+    scope = _as_dict(retrieval_scope)
+    if not scope.get("enabled"):
+        return text or ""
+    if _list(scope.get("excluded_task_ids")) or _list(scope.get("excluded_session_ids")):
+        return ""
+    return text or ""

--- a/agent/task_boundary_firewall.py
+++ b/agent/task_boundary_firewall.py
@@ -1,0 +1,315 @@
+"""Phase 5 Task Boundary Firewall provider-payload enforcement.
+
+This adapter is deliberately narrow. It classifies the current turn against the
+Phase 4 task-registry snapshot and returns a provider-payload filtering decision.
+It does not call models, providers, retrievers, session_search, memory prefetch,
+or compact fallback code. It does not mutate transcripts or session DB rows.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class TaskBoundaryFirewallDecision:
+    action: str
+    reason: str
+    allowed_task_ids: tuple[str, ...] = ()
+    excluded_task_ids: tuple[str, ...] = ()
+    linked_task_ids: tuple[str, ...] = ()
+    filtered_registry_snapshot: Mapping[str, Any] | None = None
+    safe_linked_task_pointers: tuple[Mapping[str, str], ...] = ()
+    hold_response: str | None = None
+    evidence: Mapping[str, Any] = field(default_factory=dict)
+
+
+_SENSITIVE_MARKERS = (
+    "token",
+    "password",
+    "secret",
+    "credential",
+    "credentials",
+    "api key",
+    "private key",
+    "connection string",
+)
+
+_SAFE_TASK_FIELDS = (
+    "task_id",
+    "status",
+    "session_id",
+    "latest_turn_id",
+    "task_state_path",
+    "workspec_path",
+    "current_pin_path",
+)
+
+_EXPLICIT_CONTINUE_WORDS = (
+    "continue",
+    "continuation",
+    "resume",
+    "reopen",
+    "link",
+    "linked",
+    "same task",
+    "previous task",
+    "prior task",
+)
+
+_AMBIGUOUS_REFERENCE_PHRASES = (
+    "previous one",
+    "the previous",
+    "that one",
+    "same one",
+    "above task",
+    "earlier task",
+    "old task",
+    "last task",
+)
+
+
+def enforce_task_boundary_firewall(
+    *,
+    policy: Any = None,
+    registry_snapshot: Any = None,
+    current_task_id: str | None = None,
+    user_message: Any = None,
+    explicit_continuation_refs: Sequence[Any] | None = None,
+    registry_decision: Any = None,
+    **_kwargs: Any,
+) -> TaskBoundaryFirewallDecision:
+    """Return a Phase 5 provider-payload firewall decision.
+
+    Disabled mode is complete pass-through. Enabled mode narrows registry facts
+    to the current task plus explicitly continued/linked task ids only. Ambiguous
+    prior-task references HOLD before provider/model calls.
+    """
+
+    if not _firewall_enabled(policy):
+        return TaskBoundaryFirewallDecision(
+            action="use_original",
+            reason="task_boundary_firewall_disabled",
+            evidence={"phase": "phase5_provider_payload_firewall"},
+        )
+
+    snapshot = _safe_snapshot(registry_snapshot)
+    current = _safe_text(current_task_id or snapshot.get("active_task_id"))
+    explicit_refs = _normalize_task_ids(explicit_continuation_refs)
+    explicit_refs = explicit_refs or _explicit_refs_from_registry_decision(registry_decision)
+    user_text = _content_to_text(user_message)
+
+    tasks = snapshot.get("tasks") if isinstance(snapshot.get("tasks"), Mapping) else {}
+    closed_task_ids = tuple(
+        _safe_text(task_id)
+        for task_id, record in tasks.items()
+        if isinstance(record, Mapping) and _safe_text(record.get("status")).lower() == "closed"
+    )
+
+    if _should_hold_for_ambiguous_reference(user_text, closed_task_ids, current, explicit_refs):
+        return TaskBoundaryFirewallDecision(
+            action="hold",
+            reason="ambiguous_task_boundary_reference",
+            allowed_task_ids=(),
+            excluded_task_ids=tuple(task_id for task_id in closed_task_ids if task_id),
+            linked_task_ids=(),
+            filtered_registry_snapshot=_filter_snapshot(snapshot, allowed_task_ids=()),
+            hold_response=_safe_hold_response("ambiguous_task_boundary_reference"),
+            evidence={"phase": "phase5_provider_payload_firewall"},
+        )
+
+    allowed = _ordered_unique([current, *explicit_refs])
+    filtered = _filter_snapshot(snapshot, allowed_task_ids=allowed)
+    excluded = tuple(
+        task_id for task_id in tasks.keys()
+        if _safe_text(task_id) and _safe_text(task_id) not in set(allowed)
+    )
+
+    linked_pointers = _safe_linked_pointers(snapshot, explicit_refs)
+    if explicit_refs:
+        action = "allow_continue_task" if current in explicit_refs else "allow_linked_task_context"
+        reason = "explicit_continuation_reference"
+    else:
+        action = "allow_new_task"
+        reason = "default_new_task_without_clear_continuation"
+
+    return TaskBoundaryFirewallDecision(
+        action=action,
+        reason=reason,
+        allowed_task_ids=tuple(allowed),
+        excluded_task_ids=excluded,
+        linked_task_ids=tuple(explicit_refs),
+        filtered_registry_snapshot=filtered,
+        safe_linked_task_pointers=linked_pointers,
+        evidence={"phase": "phase5_provider_payload_firewall"},
+    )
+
+
+def _firewall_enabled(policy: Any) -> bool:
+    raw = _raw_context_health(policy)
+    if not isinstance(raw, Mapping):
+        return False
+    if not raw.get("enabled") or not raw.get("runtime_behavior_enabled"):
+        return False
+    tbf = raw.get("task_boundary_firewall")
+    if isinstance(tbf, Mapping):
+        return bool(tbf.get("enabled"))
+    return False
+
+
+def _raw_context_health(policy: Any) -> Any:
+    if isinstance(policy, Mapping):
+        if "context_health" in policy and isinstance(policy.get("context_health"), Mapping):
+            return policy.get("context_health")
+        return policy
+    return None
+
+
+def _safe_snapshot(snapshot: Any) -> dict[str, Any]:
+    if not isinstance(snapshot, Mapping):
+        return {"schema": "context_health_task_registry_v1", "active_task_id": None, "tasks": {}}
+    tasks_raw = snapshot.get("tasks")
+    tasks: dict[str, dict[str, Any]] = {}
+    if isinstance(tasks_raw, Mapping):
+        for task_id, record in tasks_raw.items():
+            task_id_text = _safe_text(task_id)
+            if not task_id_text or not isinstance(record, Mapping):
+                continue
+            safe_record: dict[str, Any] = {}
+            for key in _SAFE_TASK_FIELDS:
+                value = _safe_text(record.get(key))
+                if value:
+                    safe_record[key] = value
+            linked = record.get("linked_task_ids")
+            if isinstance(linked, Sequence) and not isinstance(linked, (str, bytes)):
+                safe_links = [_safe_text(item) for item in linked]
+                safe_record["linked_task_ids"] = [item for item in safe_links if item]
+            tasks[task_id_text] = safe_record
+    return {
+        "schema": "context_health_task_registry_v1",
+        "active_task_id": _safe_text(snapshot.get("active_task_id")) or None,
+        "tasks": tasks,
+    }
+
+
+def _filter_snapshot(snapshot: Mapping[str, Any], *, allowed_task_ids: Sequence[str]) -> dict[str, Any]:
+    allowed = set(_normalize_task_ids(allowed_task_ids))
+    tasks_raw = snapshot.get("tasks")
+    tasks: dict[str, Any] = {}
+    if isinstance(tasks_raw, Mapping):
+        for task_id, record in tasks_raw.items():
+            task_id_text = _safe_text(task_id)
+            if task_id_text in allowed and isinstance(record, Mapping):
+                tasks[task_id_text] = dict(record)
+    active = _safe_text(snapshot.get("active_task_id"))
+    return {
+        "schema": "context_health_task_registry_v1",
+        "active_task_id": active if active in allowed else None,
+        "tasks": tasks,
+    }
+
+
+def _explicit_refs_from_registry_decision(registry_decision: Any) -> tuple[str, ...]:
+    if registry_decision is None:
+        return ()
+    action = _safe_text(getattr(registry_decision, "action", "")).lower()
+    if action not in {"continue_task", "reopen_task", "link_task", "allow_continue_task", "allow_linked_task_context"}:
+        return ()
+    refs = [
+        getattr(registry_decision, "effective_task_id", None),
+        getattr(registry_decision, "linked_task_id", None),
+    ]
+    linked = getattr(registry_decision, "linked_task_ids", None)
+    if isinstance(linked, Sequence) and not isinstance(linked, (str, bytes)):
+        refs.extend(linked)
+    return _normalize_task_ids(refs)
+
+
+def _normalize_task_ids(values: Sequence[Any] | None) -> tuple[str, ...]:
+    if values is None:
+        return ()
+    return tuple(_ordered_unique(_safe_text(value) for value in values if _safe_text(value)))
+
+
+def _ordered_unique(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _safe_text(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _safe_linked_pointers(snapshot: Mapping[str, Any], refs: Sequence[str]) -> tuple[Mapping[str, str], ...]:
+    tasks = snapshot.get("tasks")
+    if not isinstance(tasks, Mapping):
+        return ()
+    pointers: list[Mapping[str, str]] = []
+    for task_id in refs:
+        record = tasks.get(task_id)
+        if not isinstance(record, Mapping):
+            continue
+        item: dict[str, str] = {"task_id": task_id}
+        for key in ("task_state_path", "workspec_path", "current_pin_path"):
+            value = _safe_text(record.get(key))
+            if value:
+                item[key] = value
+        pointers.append(item)
+    return tuple(pointers)
+
+
+def _should_hold_for_ambiguous_reference(
+    user_text: str,
+    closed_task_ids: Sequence[str],
+    current_task_id: str,
+    explicit_refs: Sequence[str],
+) -> bool:
+    lowered = user_text.lower()
+    if explicit_refs:
+        return False
+    if any(phrase in lowered for phrase in _AMBIGUOUS_REFERENCE_PHRASES):
+        return True
+    closed = [task_id for task_id in closed_task_ids if task_id and task_id != current_task_id]
+    if not closed:
+        return False
+    mentions_closed = any(task_id.lower() in lowered for task_id in closed)
+    if not mentions_closed:
+        return False
+    has_clear_continue = any(word in lowered for word in _EXPLICIT_CONTINUE_WORDS)
+    return not has_clear_continue
+
+
+def _safe_hold_response(reason: str) -> str:
+    return (
+        "Context Health HOLD: task boundary relation is ambiguous, so Hermes "
+        "did not send prior-task context to the provider. Reason: "
+        f"{_safe_text(reason) or 'ambiguous_task_boundary_reference'}"
+    )
+
+
+def _content_to_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, Mapping):
+                if item.get("type") == "text":
+                    parts.append(str(item.get("text", "")))
+                elif "text" in item:
+                    parts.append(str(item.get("text", "")))
+            elif item is not None:
+                parts.append(str(item))
+        return "\n".join(p for p in parts if p)
+    return str(content or "")
+
+
+def _safe_text(value: Any) -> str:
+    text = str(value or "")
+    lowered = text.lower()
+    if any(marker in lowered for marker in _SENSITIVE_MARKERS):
+        return "[REDACTED]"
+    return text[:240]

--- a/agent/task_registry.py
+++ b/agent/task_registry.py
@@ -1,0 +1,492 @@
+"""Phase 4 durable active/closed task registry.
+
+This module is intentionally narrow. It records durable task lifecycle state for
+Context Health, but it does not implement Phase 5 Task Boundary Firewall,
+retrieval scoping, compact fallback changes, or transcript mutation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import uuid
+from typing import Any, Mapping, Sequence
+
+from hermes_constants import get_hermes_home
+from agent.context_health_policy import classify_task_boundary, normalize_context_health_policy
+
+
+SCHEMA = "context_health_task_registry_v1"
+SCHEMA_VERSION = 1
+SENSITIVE_MARKERS = (
+    "token",
+    "password",
+    "secret",
+    "credential",
+    "credentials",
+    "api key",
+    "private key",
+    "connection string",
+)
+
+
+@dataclass(frozen=True)
+class TaskRegistryDecision:
+    action: str
+    effective_task_id: str | None
+    reason: str
+    registry_snapshot: Mapping[str, Any] | None = None
+    linked_task_id: str | None = None
+    hold_response: str | None = None
+    event: Mapping[str, Any] | None = None
+    safe_snapshot: Mapping[str, Any] = field(default_factory=dict)
+
+
+class TaskRegistryFailure(Exception):
+    """Typed failure for enabled registry paths that must fail closed."""
+
+    def __init__(self, reason: str, user_response: str | None = None):
+        super().__init__(reason)
+        self.reason = reason
+        self.user_response = user_response or _safe_failure_response(reason)
+
+
+def default_registry_root() -> Path:
+    return get_hermes_home() / "context-health" / "task-registry"
+
+
+def resolve_task_for_turn(
+    *,
+    policy: Any = None,
+    registry_root: str | Path | None = None,
+    session_id: str | None = None,
+    incoming_task_id: str | None = None,
+    user_message: str = "",
+    explicit_continuation_refs: Sequence[str] = (),
+    ambiguous_relation: bool = False,
+    turn_id: str | None = None,
+) -> TaskRegistryDecision:
+    """Resolve the durable task id for the current turn.
+
+    Disabled mode is complete pass-through: no file read/write and no registry
+    mutation. Enabled mode records only safe metadata and pointer fields.
+    """
+
+    if not _registry_enabled(policy):
+        return TaskRegistryDecision(
+            action="use_original",
+            effective_task_id=incoming_task_id,
+            reason="task_registry_disabled",
+            registry_snapshot=None,
+        )
+
+    root = Path(registry_root) if registry_root is not None else default_registry_root()
+    snapshot = _load_registry(root)
+    active_task_id = _safe_str(snapshot.get("active_task_id"))
+    tasks = _tasks(snapshot)
+    closed_task_ids = [
+        task_id
+        for task_id, rec in tasks.items()
+        if isinstance(rec, Mapping) and str(rec.get("status") or "") in {"closed", "archived"}
+    ]
+
+    boundary_policy = normalize_context_health_policy(_raw_context_health(policy))
+    boundary_decision = classify_task_boundary(
+        user_message=user_message,
+        active_task_id=active_task_id,
+        closed_task_ids=closed_task_ids,
+        explicit_continuation_refs=explicit_continuation_refs,
+        ambiguous_relation=ambiguous_relation,
+        policy=boundary_policy,
+    )
+
+    if boundary_decision.action == "hold":
+        return TaskRegistryDecision(
+            action="hold",
+            effective_task_id=None,
+            reason=boundary_decision.reason,
+            registry_snapshot=_safe_snapshot(snapshot),
+            hold_response=_safe_hold_response(boundary_decision.reason),
+            safe_snapshot=_safe_snapshot(snapshot),
+        )
+
+    if boundary_decision.action == "continue_task":
+        target = boundary_decision.linked_task_id or incoming_task_id or active_task_id or _new_task_id()
+        event_name = "task_continued"
+        updated = _upsert_task(
+            snapshot,
+            task_id=target,
+            status="active",
+            session_id=session_id,
+            turn_id=turn_id,
+            reason=boundary_decision.reason,
+            linked_task_id=boundary_decision.linked_task_id,
+        )
+        try:
+            event = _append_event(
+                root,
+                event=event_name,
+                task_id=target,
+                session_id=session_id,
+                turn_id=turn_id,
+                status="active",
+                reason=boundary_decision.reason,
+                linked_task_id=boundary_decision.linked_task_id,
+            )
+            _write_registry(root, updated)
+        except TaskRegistryFailure:
+            raise
+        except Exception as exc:
+            raise TaskRegistryFailure("task_registry_write_failure") from exc
+        return TaskRegistryDecision(
+            action="continue_task",
+            effective_task_id=target,
+            reason=boundary_decision.reason,
+            registry_snapshot=_safe_snapshot(updated),
+            linked_task_id=boundary_decision.linked_task_id,
+            event=event,
+            safe_snapshot=_safe_snapshot(updated),
+        )
+
+    # Default/new task path. If the caller supplied a task id, preserve it;
+    # otherwise create a durable id here before Phase 2 intake runs.
+    new_task_id = incoming_task_id or _new_task_id()
+    updated = _close_prior_active_if_different(snapshot, new_task_id, session_id=session_id, turn_id=turn_id)
+    updated = _upsert_task(
+        updated,
+        task_id=new_task_id,
+        status="active",
+        session_id=session_id,
+        turn_id=turn_id,
+        reason=boundary_decision.reason,
+    )
+    try:
+        event = _append_event(
+            root,
+            event="task_created",
+            task_id=new_task_id,
+            session_id=session_id,
+            turn_id=turn_id,
+            status="active",
+            reason=boundary_decision.reason,
+        )
+        _write_registry(root, updated)
+    except TaskRegistryFailure:
+        raise
+    except Exception as exc:
+        raise TaskRegistryFailure("task_registry_write_failure") from exc
+    return TaskRegistryDecision(
+        action="new_task",
+        effective_task_id=new_task_id,
+        reason=boundary_decision.reason,
+        registry_snapshot=_safe_snapshot(updated),
+        event=event,
+        safe_snapshot=_safe_snapshot(updated),
+    )
+
+
+def record_task_event(
+    *,
+    registry_root: str | Path | None = None,
+    event: str,
+    task_id: str,
+    session_id: str | None = None,
+    status: str | None = None,
+    reason: str | None = None,
+    turn_id: str | None = None,
+    **extra: Any,
+) -> dict[str, Any]:
+    root = Path(registry_root) if registry_root is not None else default_registry_root()
+    snapshot = _load_registry(root)
+    updated = _upsert_task(
+        snapshot,
+        task_id=task_id,
+        status=status or _status_from_event(event),
+        session_id=session_id,
+        turn_id=turn_id,
+        reason=reason or event,
+        **_safe_extra(extra),
+    )
+    event_record = _append_event(
+        root,
+        event=event,
+        task_id=task_id,
+        session_id=session_id,
+        turn_id=turn_id,
+        status=status or _status_from_event(event),
+        reason=reason,
+        **_safe_extra(extra),
+    )
+    _write_registry(root, updated)
+    return event_record
+
+
+def import_workspec_task_state(
+    *,
+    registry_root: str | Path | None = None,
+    task_id: str,
+    session_id: str | None = None,
+    task_state_path: str | Path,
+    turn_id: str | None = None,
+) -> dict[str, Any]:
+    path = Path(task_state_path)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        data = {}
+    status = str(data.get("status") or "").lower()
+    closed = status in {"completed", "verified", "closed"}
+    event = "task_closed" if closed else "task_state_observed"
+    record = record_task_event(
+        registry_root=registry_root,
+        event=event,
+        task_id=task_id,
+        session_id=session_id,
+        turn_id=turn_id,
+        status="closed" if closed else "active",
+        reason="completed_task_state" if closed else "task_state_observed",
+        task_state_path=str(path),
+    )
+    record["task_state_path"] = str(path)
+    return record
+
+
+def record_completed_workspec_state(
+    *,
+    registry_root: str | Path | None = None,
+    task_id: str,
+    session_id: str | None = None,
+    task_state_path: str | Path,
+    turn_id: str | None = None,
+) -> dict[str, Any]:
+    return import_workspec_task_state(
+        registry_root=registry_root,
+        task_id=task_id,
+        session_id=session_id,
+        task_state_path=task_state_path,
+        turn_id=turn_id,
+    )
+
+
+def registry_enabled(policy: Any = None) -> bool:
+    return _registry_enabled(policy)
+
+
+def _registry_enabled(policy: Any) -> bool:
+    raw = _raw_context_health(policy)
+    if not isinstance(raw, Mapping):
+        return False
+    if not raw.get("enabled") or not raw.get("runtime_behavior_enabled"):
+        return False
+    task_boundary = raw.get("task_boundary")
+    task_registry = raw.get("task_registry")
+    return bool(
+        isinstance(task_boundary, Mapping)
+        and task_boundary.get("enabled")
+        and isinstance(task_registry, Mapping)
+        and task_registry.get("enabled")
+    )
+
+
+def _raw_context_health(policy: Any) -> Mapping[str, Any]:
+    if isinstance(policy, Mapping):
+        if "context_health" in policy and isinstance(policy.get("context_health"), Mapping):
+            return policy.get("context_health") or {}
+        return policy
+    return {}
+
+
+def _load_registry(root: Path) -> dict[str, Any]:
+    path = root / "registry.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            data.setdefault("schema", SCHEMA)
+            data.setdefault("schema_version", SCHEMA_VERSION)
+            data.setdefault("active_task_id", None)
+            data.setdefault("tasks", {})
+            return data
+    except FileNotFoundError:
+        pass
+    except json.JSONDecodeError as exc:
+        raise TaskRegistryFailure("task_registry_corrupt_snapshot") from exc
+    except Exception as exc:
+        raise TaskRegistryFailure("task_registry_read_failure") from exc
+    return _empty_registry()
+
+
+def _empty_registry() -> dict[str, Any]:
+    now = _now()
+    return {
+        "schema": SCHEMA,
+        "schema_version": SCHEMA_VERSION,
+        "created_at": now,
+        "updated_at": now,
+        "active_task_id": None,
+        "tasks": {},
+    }
+
+
+def _write_registry(root: Path, snapshot: Mapping[str, Any]) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    data = dict(snapshot)
+    data["schema"] = SCHEMA
+    data["schema_version"] = SCHEMA_VERSION
+    data["updated_at"] = _now()
+    tmp = root / "registry.json.tmp"
+    dst = root / "registry.json"
+    tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
+    tmp.replace(dst)
+
+
+def _append_event(root: Path, **event: Any) -> dict[str, Any]:
+    root.mkdir(parents=True, exist_ok=True)
+    record = {"ts": _now(), **_safe_extra(event)}
+    with (root / "events.jsonl").open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
+    return record
+
+
+def _upsert_task(
+    snapshot: Mapping[str, Any],
+    *,
+    task_id: str,
+    status: str,
+    session_id: str | None = None,
+    turn_id: str | None = None,
+    reason: str | None = None,
+    linked_task_id: str | None = None,
+    **extra: Any,
+) -> dict[str, Any]:
+    updated = dict(snapshot)
+    updated.setdefault("schema", SCHEMA)
+    updated.setdefault("schema_version", SCHEMA_VERSION)
+    updated.setdefault("created_at", _now())
+    tasks = dict(_tasks(updated))
+    existing = dict(tasks.get(task_id) or {})
+    existing.setdefault("task_id", task_id)
+    existing.setdefault("created_at", _now())
+    existing["status"] = status
+    existing["updated_at"] = _now()
+    if session_id:
+        existing["session_id"] = session_id
+    if turn_id:
+        existing["latest_turn_id"] = turn_id
+    if reason:
+        existing["last_reason"] = _safe_str(reason)
+    if linked_task_id:
+        links = list(existing.get("linked_task_ids") or [])
+        if linked_task_id not in links:
+            links.append(linked_task_id)
+        existing["linked_task_ids"] = links
+    for key, value in _safe_extra(extra).items():
+        existing[key] = value
+    tasks[task_id] = existing
+    updated["tasks"] = tasks
+    if status == "active":
+        updated["active_task_id"] = task_id
+    elif updated.get("active_task_id") == task_id:
+        updated["active_task_id"] = None
+    updated["updated_at"] = _now()
+    return updated
+
+
+def _close_prior_active_if_different(
+    snapshot: Mapping[str, Any],
+    new_task_id: str,
+    *,
+    session_id: str | None,
+    turn_id: str | None,
+) -> dict[str, Any]:
+    active = _safe_str(snapshot.get("active_task_id"))
+    if not active or active == new_task_id:
+        return dict(snapshot)
+    return _upsert_task(
+        snapshot,
+        task_id=active,
+        status="closed",
+        session_id=session_id,
+        turn_id=turn_id,
+        reason="superseded_by_new_independent_task",
+    )
+
+
+def _safe_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    tasks: dict[str, Any] = {}
+    for task_id, rec in _tasks(snapshot).items():
+        if not isinstance(rec, Mapping):
+            continue
+        safe = {
+            "task_id": _safe_str(rec.get("task_id") or task_id),
+            "status": _safe_str(rec.get("status")),
+            "session_id": _safe_str(rec.get("session_id")),
+            "latest_turn_id": _safe_str(rec.get("latest_turn_id")),
+            "task_state_path": _safe_str(rec.get("task_state_path")),
+            "workspec_path": _safe_str(rec.get("workspec_path")),
+            "current_pin_path": _safe_str(rec.get("current_pin_path")),
+            "linked_task_ids": [
+                _safe_str(v) for v in rec.get("linked_task_ids", []) if _safe_str(v)
+            ],
+        }
+        tasks[task_id] = {k: v for k, v in safe.items() if v not in ("", None, [])}
+    return {
+        "schema": SCHEMA,
+        "schema_version": SCHEMA_VERSION,
+        "active_task_id": _safe_str(snapshot.get("active_task_id")) or None,
+        "tasks": tasks,
+    }
+
+
+def _tasks(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    tasks = snapshot.get("tasks")
+    return dict(tasks) if isinstance(tasks, Mapping) else {}
+
+
+def _safe_failure_response(reason: str) -> str:
+    return (
+        "Context Health HOLD: durable task registry could not be resolved "
+        "safely, so Hermes did not fall back to unregistered task-id flow. "
+        f"Reason: {_safe_str(reason)[:120]}"
+    )
+
+
+def _safe_hold_response(reason: str) -> str:
+    return f"Context Health HOLD: task relation is ambiguous. Reason: {_safe_str(reason)[:120]}"
+
+
+def _safe_extra(values: Mapping[str, Any]) -> dict[str, Any]:
+    safe: dict[str, Any] = {}
+    for key, value in values.items():
+        if value is None:
+            continue
+        if isinstance(value, (str, int, float, bool)):
+            safe[key] = _safe_str(value) if isinstance(value, str) else value
+        elif isinstance(value, (list, tuple)):
+            safe[key] = [_safe_str(v) for v in value if isinstance(v, str)]
+    return safe
+
+
+def _safe_str(value: Any) -> str:
+    text = str(value or "")
+    lowered = text.lower()
+    if any(marker in lowered for marker in SENSITIVE_MARKERS):
+        return "[REDACTED]"
+    return text[:500]
+
+
+def _status_from_event(event: str) -> str:
+    if event in {"task_closed", "task_archived"}:
+        return "closed" if event == "task_closed" else "archived"
+    if event in {"task_created", "task_continued", "task_reopened"}:
+        return "active"
+    return "active"
+
+
+def _new_task_id() -> str:
+    return f"task-{uuid.uuid4().hex[:12]}"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -38,6 +38,75 @@ from agent.model_metadata import (
 logger = logging.getLogger(__name__)
 
 
+def _task_registry_enabled_for_policy(policy: Any) -> bool:
+    if not isinstance(policy, dict):
+        return False
+    if "context_health" in policy and isinstance(policy.get("context_health"), dict):
+        policy = policy.get("context_health") or {}
+    task_boundary = policy.get("task_boundary")
+    task_registry = policy.get("task_registry")
+    return bool(
+        policy.get("enabled")
+        and policy.get("runtime_behavior_enabled")
+        and isinstance(task_boundary, dict)
+        and task_boundary.get("enabled")
+        and isinstance(task_registry, dict)
+        and task_registry.get("enabled")
+    )
+
+
+def _task_boundary_firewall_enabled_for_policy(policy: Any) -> bool:
+    if not isinstance(policy, dict):
+        return False
+    if "context_health" in policy and isinstance(policy.get("context_health"), dict):
+        policy = policy.get("context_health") or {}
+    tbf = policy.get("task_boundary_firewall")
+    return bool(
+        policy.get("enabled")
+        and policy.get("runtime_behavior_enabled")
+        and isinstance(tbf, dict)
+        and tbf.get("enabled")
+    )
+
+
+def _retrieval_scope_enabled_for_policy(policy: Any) -> bool:
+    if not isinstance(policy, dict):
+        return False
+    if "context_health" in policy and isinstance(policy.get("context_health"), dict):
+        policy = policy.get("context_health") or {}
+    retrieval_scope = policy.get("retrieval_scope")
+    return bool(
+        policy.get("enabled")
+        and policy.get("runtime_behavior_enabled")
+        and isinstance(retrieval_scope, dict)
+        and retrieval_scope.get("enabled")
+    )
+
+
+def _safe_task_boundary_firewall_hold_response() -> str:
+    return (
+        "Context Health HOLD: Task Boundary Firewall failed closed before "
+        "the current turn was appended or sent to the provider."
+    )
+
+
+def _safe_retrieval_scope_hold_response() -> str:
+    return (
+        "Context Health HOLD: retrieval scope could not be verified safely; "
+        "no unscoped retrieval was executed."
+    )
+
+
+def _safe_task_registry_hold_response(exc: BaseException) -> str:
+    response = getattr(exc, "user_response", None)
+    if isinstance(response, str) and response:
+        return response
+    return (
+        "Context Health HOLD: durable task registry could not be resolved "
+        "safely, so Hermes did not fall back to unregistered task-id flow."
+    )
+
+
 def _compression_made_progress(
     orig_len: int, new_len: int, orig_tokens: int, new_tokens: int
 ) -> bool:
@@ -114,6 +183,10 @@ class TurnContext:
     plugin_user_context: str = ""
     # External-memory prefetch result, reused across loop iterations.
     ext_prefetch_cache: str = ""
+    # Phase 2 Context Health pre-turn intake metadata when a long inbound
+    # prompt was replaced before append/persist. None in disabled/pass-through
+    # mode and for below-threshold prompts.
+    context_health_intake: Any = None
 
 
 def build_turn_context(
@@ -203,11 +276,101 @@ def build_turn_context(
     agent._persist_user_message_override = persist_user_message
     agent._persist_user_message_timestamp = persist_user_timestamp
     # Generate unique task_id if not provided to isolate VMs between tasks.
-    effective_task_id = task_id or str(uuid.uuid4())
+    # Phase 4 task registry, when explicitly enabled, must resolve the durable
+    # task id before Phase 2 intake writes any task-keyed intake packet.
+    task_registry_decision = None
+    task_registry_policy = getattr(agent, "context_health", None) or getattr(agent, "config", {}).get("context_health", {})
+    try:
+        from agent.task_registry import resolve_task_for_turn
+        _registry_decision = resolve_task_for_turn(
+            policy=task_registry_policy,
+            registry_root=getattr(agent, "_context_health_task_registry_dir", None),
+            session_id=agent.session_id,
+            incoming_task_id=task_id,
+            user_message=user_message if isinstance(user_message, str) else str(user_message or ""),
+        )
+        task_registry_decision = _registry_decision
+    except Exception as _registry_err:
+        if _task_registry_enabled_for_policy(task_registry_policy):
+            logger.warning(
+                "context health task registry resolution failed; fail-closed HOLD",
+                exc_info=True,
+            )
+            from agent.context_health_intake import PreTurnIntakeHold
+            raise PreTurnIntakeHold(
+                reason=getattr(_registry_err, "reason", "task_registry_resolution_error"),
+                user_response=_safe_task_registry_hold_response(_registry_err),
+            ) from _registry_err
+        logger.debug("context health task registry resolution skipped", exc_info=True)
+        task_registry_decision = None
+
+    if task_registry_decision is not None and getattr(task_registry_decision, "action", None) == "hold":
+        from agent.context_health_intake import PreTurnIntakeHold
+        raise PreTurnIntakeHold(
+            reason=getattr(task_registry_decision, "reason", "task_registry_hold"),
+            user_response=getattr(task_registry_decision, "hold_response", None)
+            or "Context Health HOLD: task relation is ambiguous; no provider call was made.",
+        )
+
+    resolved_task_id = getattr(task_registry_decision, "effective_task_id", None) if task_registry_decision is not None else None
+    effective_task_id = resolved_task_id or task_id or str(uuid.uuid4())
     agent._current_task_id = effective_task_id
     turn_id = f"{agent.session_id or 'session'}:{effective_task_id}:{uuid.uuid4().hex[:8]}"
     agent._current_turn_id = turn_id
     agent._current_api_request_id = ""
+    agent._context_health_task_registry_decision = task_registry_decision
+    agent._context_health_task_registry_snapshot = getattr(task_registry_decision, "registry_snapshot", None) if task_registry_decision is not None else None
+
+    # Phase 5 Task Boundary Firewall pre-append HOLD path. This is intentionally
+    # narrow: it only blocks ambiguous prior-task references before raw prompt
+    # append/persist/provider call. Provider-payload filtering remains in WCP.
+    try:
+        from agent.task_boundary_firewall import enforce_task_boundary_firewall
+        task_boundary_firewall_decision = enforce_task_boundary_firewall(
+            policy=task_registry_policy,
+            registry_snapshot=agent._context_health_task_registry_snapshot,
+            current_task_id=effective_task_id,
+            user_message=user_message if isinstance(user_message, str) else str(user_message or ""),
+            registry_decision=task_registry_decision,
+        )
+    except Exception:
+        if _task_boundary_firewall_enabled_for_policy(task_registry_policy):
+            task_boundary_firewall_decision = {
+                "action": "hold",
+                "reason": "task_boundary_firewall_failure",
+                "fail_closed": True,
+            }
+            agent._context_health_task_boundary_firewall_decision = task_boundary_firewall_decision
+            from agent.context_health_intake import PreTurnIntakeHold
+            raise PreTurnIntakeHold(
+                reason="task_boundary_firewall_failure",
+                user_response=_safe_task_boundary_firewall_hold_response(),
+            )
+        task_boundary_firewall_decision = None
+    agent._context_health_task_boundary_firewall_decision = task_boundary_firewall_decision
+    if task_boundary_firewall_decision is not None and getattr(task_boundary_firewall_decision, "action", None) == "hold":
+        from agent.context_health_intake import PreTurnIntakeHold
+        raise PreTurnIntakeHold(
+            reason=getattr(task_boundary_firewall_decision, "reason", "task_boundary_firewall_hold"),
+            user_response=getattr(task_boundary_firewall_decision, "hold_response", None)
+            or "Context Health HOLD: task relation is ambiguous; no provider call was made.",
+        )
+
+    # Phase 2 pre-turn intake hook: runs before raw prompt logging, append, or
+    # crash-resilience persistence. The adapter is fully pass-through unless
+    # context_health runtime behavior is explicitly enabled by policy.
+    from agent.context_health_intake import run_pre_turn_intake
+    context_health_intake = run_pre_turn_intake(
+        agent=agent,
+        user_message=user_message,
+        persist_user_message=persist_user_message,
+        session_id=agent.session_id,
+        task_id=effective_task_id,
+        turn_id=turn_id,
+    )
+    user_message = context_health_intake.user_message
+    persist_user_message = context_health_intake.persist_user_message
+    agent._persist_user_message_override = persist_user_message
 
     # Reset retry counters and iteration budget at the start of each turn.
     agent._invalid_tool_retries = 0
@@ -428,6 +591,41 @@ def build_turn_context(
                 if not _compressor.should_compress(_preflight_tokens):
                     break
 
+    retrieval_scope = {"enabled": False}
+    try:
+        from agent.retrieval_scope import build_retrieval_scope
+        retrieval_scope = build_retrieval_scope(
+            policy=task_registry_policy,
+            current_task_id=effective_task_id,
+            registry_snapshot=agent._context_health_task_registry_snapshot,
+            registry_decision=task_registry_decision,
+        )
+    except Exception:
+        if _retrieval_scope_enabled_for_policy(task_registry_policy):
+            retrieval_scope = {
+                "enabled": True,
+                "mode": "retrieval_scope_failure",
+                "reason": "retrieval_scope_failure",
+                "fail_closed": True,
+                "current_task_id": effective_task_id,
+                "allowed_task_ids": [],
+                "excluded_task_ids": [],
+                "allowed_session_ids": [],
+                "excluded_session_ids": [],
+            }
+            agent._context_health_retrieval_scope = retrieval_scope
+            logger.warning(
+                "context health retrieval scope build failed; fail-closed HOLD",
+                exc_info=True,
+            )
+            from agent.context_health_intake import PreTurnIntakeHold
+            raise PreTurnIntakeHold(
+                reason="retrieval_scope_failure",
+                user_response=_safe_retrieval_scope_hold_response(),
+            )
+        retrieval_scope = {"enabled": False}
+    agent._context_health_retrieval_scope = retrieval_scope
+
     # Plugin hook: pre_llm_call (context injected into user message, not system prompt).
     plugin_user_context = ""
     try:
@@ -443,6 +641,7 @@ def build_turn_context(
             model=agent.model,
             platform=getattr(agent, "platform", None) or "",
             sender_id=getattr(agent, "_user_id", None) or "",
+            retrieval_scope=retrieval_scope,
         )
         _ctx_parts: list[str] = []
         for r in _pre_results:
@@ -452,6 +651,12 @@ def build_turn_context(
                 _ctx_parts.append(r)
         if _ctx_parts:
             plugin_user_context = "\n\n".join(_ctx_parts)
+            try:
+                from agent.retrieval_scope import filter_text_by_scope
+                plugin_user_context = filter_text_by_scope(plugin_user_context, retrieval_scope)
+            except Exception:
+                if retrieval_scope.get("enabled"):
+                    plugin_user_context = ""
     except Exception as exc:
         logger.warning("pre_llm_call hook failed: %s", exc)
 
@@ -487,7 +692,26 @@ def build_turn_context(
     if agent._memory_manager:
         try:
             _query = original_user_message if isinstance(original_user_message, str) else ""
-            ext_prefetch_cache = agent._memory_manager.prefetch_all(_query) or ""
+            if retrieval_scope.get("enabled") and not getattr(agent._memory_manager, "supports_retrieval_scope", False):
+                ext_prefetch_cache = ""
+            elif retrieval_scope.get("enabled"):
+                ext_prefetch_cache = agent._memory_manager.prefetch_all(
+                    _query,
+                    session_id=agent.session_id or "",
+                    current_task_id=effective_task_id,
+                    allowed_task_ids=list(retrieval_scope.get("allowed_task_ids") or []),
+                    excluded_task_ids=list(retrieval_scope.get("excluded_task_ids") or []),
+                    allowed_session_ids=list(retrieval_scope.get("allowed_session_ids") or []),
+                    excluded_session_ids=list(retrieval_scope.get("excluded_session_ids") or []),
+                    retrieval_scope=retrieval_scope,
+                ) or ""
+                try:
+                    from agent.retrieval_scope import filter_text_by_scope
+                    ext_prefetch_cache = filter_text_by_scope(ext_prefetch_cache, retrieval_scope)
+                except Exception:
+                    ext_prefetch_cache = ""
+            else:
+                ext_prefetch_cache = agent._memory_manager.prefetch_all(_query) or ""
         except Exception:
             pass
 
@@ -503,4 +727,7 @@ def build_turn_context(
         should_review_memory=should_review_memory,
         plugin_user_context=plugin_user_context,
         ext_prefetch_cache=ext_prefetch_cache,
+        context_health_intake=(
+            context_health_intake if context_health_intake.replaced else None
+        ),
     )

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -27,6 +27,23 @@ import os
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 
 
+def _task_registry_enabled(policy):
+    if not isinstance(policy, dict):
+        return False
+    if "context_health" in policy and isinstance(policy.get("context_health"), dict):
+        policy = policy.get("context_health") or {}
+    task_boundary = policy.get("task_boundary")
+    task_registry = policy.get("task_registry")
+    return bool(
+        policy.get("enabled")
+        and policy.get("runtime_behavior_enabled")
+        and isinstance(task_boundary, dict)
+        and task_boundary.get("enabled")
+        and isinstance(task_registry, dict)
+        and task_registry.get("enabled")
+    )
+
+
 def finalize_turn(
     agent,
     *,
@@ -144,6 +161,24 @@ def finalize_turn(
     # are surfaced on the result dict via ``cleanup_errors`` rather than
     # killing the turn.
     _cleanup_errors = []
+
+    # Phase 4 task registry close-event hook. This is intentionally narrow:
+    # it only records a closed event when an already-known task-state path says
+    # completed, and it never mutates transcripts or session DB schema.
+    try:
+        _task_state_path = getattr(agent, "_context_health_active_task_state_path", None)
+        if completed and _task_state_path and _task_registry_enabled(getattr(agent, "context_health", None) or getattr(agent, "config", {}).get("context_health", {})):
+            from agent.task_registry import record_completed_workspec_state
+            record_completed_workspec_state(
+                registry_root=getattr(agent, "_context_health_task_registry_dir", None),
+                task_id=effective_task_id,
+                session_id=agent.session_id,
+                turn_id=turn_id,
+                task_state_path=_task_state_path,
+            )
+    except Exception as _registry_err:
+        _cleanup_errors.append(f"task_registry_close_event: {_registry_err}")
+        logger.error("finalize_turn: task registry close-event failed: %s", _registry_err, exc_info=True)
 
     # Save trajectory if enabled.  ``user_message`` may be a multimodal
     # list of parts; the trajectory format wants a plain string.

--- a/agent/working_context_packet.py
+++ b/agent/working_context_packet.py
@@ -1,0 +1,447 @@
+"""Phase 3 Working Context Packet provider-payload enforcement.
+
+This module is deliberately narrow: it constrains provider-visible
+``api_messages`` only. It does not mutate persisted transcript messages, does
+not implement active/closed task registry authority, and does not perform Task
+Boundary Firewall or retrieval-scope enforcement.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class WorkingContextPacketDecision:
+    action: str
+    api_messages: list[dict[str, Any]] | None
+    reason: str
+    active_task_id: str | None = None
+    included_sources: tuple[str, ...] = ()
+    excluded_sources: tuple[str, ...] = ()
+    evidence: Mapping[str, Any] = field(default_factory=dict)
+    hold_response: str | None = None
+
+
+class WorkingContextPacketHold(Exception):
+    """Raised by callers that choose exception-style WCP HOLD handling."""
+
+    def __init__(self, reason: str, user_response: str):
+        super().__init__(reason)
+        self.reason = reason
+        self.user_response = user_response
+
+
+_SENSITIVE_MARKERS = (
+    "token",
+    "password",
+    "secret",
+    "credential",
+    "credentials",
+    "api key",
+    "private key",
+    "connection string",
+)
+
+
+def enforce_working_context_packet(
+    *,
+    policy: Any = None,
+    agent: Any = None,
+    api_messages: Sequence[Mapping[str, Any]],
+    messages: Sequence[Mapping[str, Any]] | None = None,
+    original_user_message: Any = None,
+    current_turn_user_idx: int | None = None,
+    effective_task_id: str | None = None,
+    turn_id: str | None = None,
+    session_id: str | None = None,
+    context_health_intake: Any = None,
+    **_kwargs: Any,
+) -> WorkingContextPacketDecision:
+    """Return a provider-payload decision for Phase 3 WCP enforcement.
+
+    Disabled mode is a pass-through. Enabled mode emits a default
+    system-plus-one-user-message WCP, using only current-turn/safe intake
+    pointers and never broad historical transcript content. If the current WCP
+    source is unsafe, return a safe HOLD decision instead of falling back to full
+    history.
+    """
+
+    original_api_messages = [dict(m) for m in api_messages]
+    if not _wcp_enabled(policy, agent):
+        return WorkingContextPacketDecision(
+            action="use_original",
+            api_messages=original_api_messages,
+            reason="working_context_packet_disabled",
+            evidence={"phase": "phase3_provider_payload"},
+        )
+
+    system_message = _first_system_message(original_api_messages)
+    current_user_content = _current_user_content(
+        original_api_messages,
+        messages=messages,
+        current_turn_user_idx=current_turn_user_idx,
+        original_user_message=original_user_message,
+    )
+
+    intake_map = _mapping_from_obj(context_health_intake)
+    registry_snapshot = _safe_registry_snapshot(getattr(agent, "_context_health_task_registry_snapshot", None))
+    try:
+        from agent.task_boundary_firewall import enforce_task_boundary_firewall
+        firewall_decision = enforce_task_boundary_firewall(
+            policy=policy if policy is not None else getattr(agent, "context_health", None),
+            registry_snapshot=registry_snapshot,
+            current_task_id=effective_task_id,
+            user_message=current_user_content,
+            registry_decision=getattr(agent, "_context_health_task_registry_decision", None),
+        )
+    except Exception:
+        if _task_boundary_firewall_enabled(policy, agent):
+            reason = "task_boundary_firewall_failure"
+            return WorkingContextPacketDecision(
+                action="hold",
+                api_messages=None,
+                reason=reason,
+                active_task_id=effective_task_id,
+                included_sources=(),
+                excluded_sources=("full_conversation_history", "unfiltered_task_registry_snapshot"),
+                evidence={
+                    "phase": "phase5_provider_payload_firewall",
+                    "session_id": session_id or "",
+                    "turn_id": turn_id or "",
+                    "fail_closed": True,
+                },
+                hold_response=_safe_task_boundary_firewall_failure_response(),
+            )
+        firewall_decision = None
+    if firewall_decision is not None and getattr(firewall_decision, "action", None) == "hold":
+        reason = str(getattr(firewall_decision, "reason", None) or "task_boundary_firewall_hold")
+        return WorkingContextPacketDecision(
+            action="hold",
+            api_messages=None,
+            reason=reason,
+            active_task_id=effective_task_id,
+            included_sources=(),
+            excluded_sources=("full_conversation_history", "quarantined_closed_task_context"),
+            evidence={
+                "phase": "phase5_provider_payload_firewall",
+                "session_id": session_id or "",
+                "turn_id": turn_id or "",
+            },
+            hold_response=getattr(firewall_decision, "hold_response", None) or _safe_hold_response(reason),
+        )
+    filtered_registry = getattr(firewall_decision, "filtered_registry_snapshot", None) if firewall_decision is not None else None
+    if isinstance(filtered_registry, Mapping):
+        registry_snapshot = _safe_registry_snapshot(filtered_registry)
+    if _intake_explicitly_unsafe(intake_map) or _current_content_unsafe(current_user_content):
+        reason = str(intake_map.get("reason") or "working_context_packet_unsafe")
+        return WorkingContextPacketDecision(
+            action="hold",
+            api_messages=None,
+            reason=reason,
+            active_task_id=effective_task_id,
+            included_sources=(),
+            excluded_sources=("full_conversation_history",),
+            evidence={
+                "phase": "phase3_provider_payload",
+                "session_id": session_id or "",
+                "turn_id": turn_id or "",
+                "unsafe_current_content": True,
+            },
+            hold_response=_safe_hold_response(reason),
+        )
+
+    wcp_text = _build_wcp_text(
+        current_user_content=current_user_content,
+        effective_task_id=effective_task_id,
+        turn_id=turn_id,
+        session_id=session_id,
+        intake=intake_map,
+        registry_snapshot=registry_snapshot,
+    )
+    wcp_messages: list[dict[str, Any]] = []
+    if system_message is not None:
+        wcp_messages.append(system_message)
+    wcp_messages.append({"role": "user", "content": wcp_text})
+
+    return WorkingContextPacketDecision(
+        action="replace_api_messages",
+        api_messages=wcp_messages,
+        reason="working_context_packet_applied",
+        active_task_id=effective_task_id,
+        included_sources=("system_prompt", "current_user_intent", "phase2_intake_pointer"),
+        excluded_sources=("full_conversation_history", "unrelated_prior_tool_chains"),
+        evidence={
+            "phase": "phase3_provider_payload",
+            "original_api_message_count": len(original_api_messages),
+            "wcp_message_count": len(wcp_messages),
+            "session_id": session_id or "",
+            "turn_id": turn_id or "",
+        },
+    )
+
+
+def _wcp_enabled(policy: Any, agent: Any) -> bool:
+    raw = _raw_context_health(policy, agent)
+    if isinstance(raw, Mapping):
+        if not raw.get("enabled"):
+            return False
+        wcp = raw.get("working_context_packet")
+        if isinstance(wcp, Mapping):
+            return bool(raw.get("runtime_behavior_enabled") and wcp.get("enabled"))
+        # Adapter unit tests may pass a minimal {'enabled': True} contract.
+        return True
+
+    # Fallback for tests or callers that provide the Phase 1 typed policy only.
+    return bool(
+        getattr(policy, "enabled", False)
+        and getattr(policy, "runtime_behavior_enabled", False)
+    )
+
+
+def _raw_context_health(policy: Any, agent: Any) -> Any:
+    if isinstance(policy, Mapping):
+        if "context_health" in policy and isinstance(policy.get("context_health"), Mapping):
+            return policy.get("context_health")
+        return policy
+    if agent is not None:
+        raw = getattr(agent, "context_health", None)
+        if isinstance(raw, Mapping):
+            return raw
+        cfg = getattr(agent, "config", None)
+        if isinstance(cfg, Mapping):
+            raw = cfg.get("context_health")
+            if isinstance(raw, Mapping):
+                return raw
+    return None
+
+
+def _task_boundary_firewall_enabled(policy: Any, agent: Any) -> bool:
+    raw = _raw_context_health(policy, agent)
+    if not isinstance(raw, Mapping):
+        return False
+    tbf = raw.get("task_boundary_firewall")
+    return bool(
+        raw.get("enabled")
+        and raw.get("runtime_behavior_enabled")
+        and isinstance(tbf, Mapping)
+        and tbf.get("enabled")
+    )
+
+
+def _safe_task_boundary_firewall_failure_response() -> str:
+    return (
+        "Context Health HOLD: Task Boundary Firewall failed closed before "
+        "provider call. Hermes did not send prior-task context to the provider."
+    )
+
+
+def _first_system_message(api_messages: Sequence[Mapping[str, Any]]) -> dict[str, Any] | None:
+    for msg in api_messages:
+        if msg.get("role") == "system":
+            return dict(msg)
+    return None
+
+
+def _current_user_content(
+    api_messages: Sequence[Mapping[str, Any]],
+    *,
+    messages: Sequence[Mapping[str, Any]] | None,
+    current_turn_user_idx: int | None,
+    original_user_message: Any,
+) -> str:
+    if messages is not None and current_turn_user_idx is not None:
+        try:
+            msg = messages[current_turn_user_idx]
+            if isinstance(msg, Mapping) and msg.get("role") == "user":
+                return _content_to_text(msg.get("content", ""))
+        except Exception:
+            pass
+    if original_user_message is not None:
+        return _content_to_text(original_user_message)
+    for msg in reversed(api_messages):
+        if msg.get("role") == "user":
+            return _content_to_text(msg.get("content", ""))
+    return ""
+
+
+def _content_to_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, Mapping):
+                if item.get("type") == "text":
+                    parts.append(str(item.get("text", "")))
+                elif "text" in item:
+                    parts.append(str(item.get("text", "")))
+            elif item is not None:
+                parts.append(str(item))
+        return "\n".join(p for p in parts if p)
+    return str(content or "")
+
+
+def _mapping_from_obj(obj: Any) -> dict[str, Any]:
+    if obj is None:
+        return {}
+    if isinstance(obj, Mapping):
+        return dict(obj)
+    data: dict[str, Any] = {}
+    for key in (
+        "action",
+        "reason",
+        "packet_dir",
+        "summary_path",
+        "intake_path",
+        "task_state_path",
+        "replaced",
+        "safe",
+    ):
+        if hasattr(obj, key):
+            data[key] = getattr(obj, key)
+    return data
+
+
+def _intake_explicitly_unsafe(intake: Mapping[str, Any]) -> bool:
+    if not intake:
+        return False
+    if intake.get("safe") is False:
+        return True
+    action = str(intake.get("action") or "").lower()
+    return action in {"hold", "unsafe", "block"}
+
+
+def _current_content_unsafe(content: str) -> bool:
+    lowered = content.lower()
+    return any(marker in lowered for marker in _SENSITIVE_MARKERS)
+
+
+def _safe_hold_response(reason: str) -> str:
+    return (
+        "Context Health HOLD: Working Context Packet provider payload could not "
+        "be built safely, so Hermes did not fall back to full conversation "
+        f"history. Reason: {_safe_reason(reason)}"
+    )
+
+
+def _safe_reason(reason: str) -> str:
+    text = str(reason or "unsafe_working_context_packet")
+    for marker in _SENSITIVE_MARKERS:
+        text = text.replace(marker, "[redacted-marker]")
+        text = text.replace(marker.upper(), "[REDACTED-MARKER]")
+    return text[:160]
+
+
+def _safe_registry_snapshot(snapshot: Any) -> dict[str, Any]:
+    if not isinstance(snapshot, Mapping):
+        return {}
+    tasks_raw = snapshot.get("tasks")
+    tasks: dict[str, Any] = {}
+    if isinstance(tasks_raw, Mapping):
+        for task_id, record in tasks_raw.items():
+            if not isinstance(record, Mapping):
+                continue
+            safe: dict[str, Any] = {}
+            for key in (
+                "task_id",
+                "status",
+                "session_id",
+                "latest_turn_id",
+                "task_state_path",
+                "workspec_path",
+                "current_pin_path",
+            ):
+                value = _safe_metadata_text(record.get(key))
+                if value:
+                    safe[key] = value
+            linked = record.get("linked_task_ids")
+            if isinstance(linked, Sequence) and not isinstance(linked, (str, bytes)):
+                safe_links = [_safe_metadata_text(item) for item in linked]
+                safe["linked_task_ids"] = [item for item in safe_links if item]
+            tasks[_safe_metadata_text(task_id)] = safe
+    active = _safe_metadata_text(snapshot.get("active_task_id"))
+    return {
+        "schema": "context_health_task_registry_v1",
+        "active_task_id": active or None,
+        "tasks": tasks,
+    }
+
+
+def _registry_lines(snapshot: Mapping[str, Any] | None) -> list[str]:
+    if not snapshot:
+        return []
+    lines: list[str] = []
+    active_task_id = _safe_metadata_text(snapshot.get("active_task_id"))
+    if active_task_id:
+        lines.append(f"- active_task_id: `{active_task_id}`")
+    tasks = snapshot.get("tasks")
+    if isinstance(tasks, Mapping):
+        for task_id, record in tasks.items():
+            if not isinstance(record, Mapping):
+                continue
+            status = _safe_metadata_text(record.get("status")) or "unknown"
+            task_id_text = _safe_metadata_text(task_id)
+            if task_id_text:
+                lines.append(f"- task `{task_id_text}` status: `{status}`")
+            for key in ("task_state_path", "workspec_path", "current_pin_path"):
+                value = _safe_metadata_text(record.get(key))
+                if value:
+                    lines.append(f"  - {key}: `{value}`")
+    return lines
+
+
+def _safe_metadata_text(value: Any) -> str:
+    text = str(value or "")
+    lowered = text.lower()
+    if any(marker in lowered for marker in _SENSITIVE_MARKERS):
+        return "[REDACTED]"
+    return text[:240]
+
+
+def _build_wcp_text(
+    *,
+    current_user_content: str,
+    effective_task_id: str | None,
+    turn_id: str | None,
+    session_id: str | None,
+    intake: Mapping[str, Any],
+    registry_snapshot: Mapping[str, Any] | None = None,
+) -> str:
+    lines = [
+        "# Working Context Packet",
+        "",
+        "## Scope",
+        "- phase: Phase 3 provider payload enforcement",
+        "- boundary: provider-visible api_messages only",
+        "- non-claim: not full A/B classification; Phase 4/5 remain separate",
+        "",
+        "## Coordinates",
+        f"- session_id: `{session_id or 'none'}`",
+        f"- task_id: `{effective_task_id or 'none'}`",
+        f"- turn_id: `{turn_id or 'none'}`",
+        "",
+        "## Current User Intent",
+        current_user_content,
+    ]
+    safe_paths = []
+    for key in ("summary_path", "task_state_path", "packet_dir"):
+        value = intake.get(key)
+        if value:
+            safe_paths.append(f"- {key}: `{value}`")
+    if safe_paths:
+        lines.extend(["", "## Phase 2 Safe Intake Pointers", *safe_paths])
+    registry_lines = _registry_lines(registry_snapshot)
+    if registry_lines:
+        lines.extend(["", "## Phase 4 Task Registry", *registry_lines])
+    lines.extend(
+        [
+            "",
+            "## Provider Payload Exclusions",
+            "- full conversation history",
+            "- unrelated prior user/assistant/tool messages",
+            "- raw intake.md body",
+        ]
+    )
+    return "\n".join(lines).strip()

--- a/references/context-health-update-survival.md
+++ b/references/context-health-update-survival.md
@@ -1,0 +1,94 @@
+# Context Health Update Survival Aftercare
+
+Phase 9: Update survival smoke/regression tests.
+
+Objective: Ensure Hermes update cannot silently bypass context governance.
+
+This document is the post-update aftercare checklist for Context Health governance. It is a smoke/regression detection artifact, not gateway runtime implementation, not command activation, and not runtime config/profile activation.
+
+## Smoke command
+
+Run the smoke command after a Hermes update from the repository root:
+
+```bash
+python3 scripts/context_health_smoke.py --json
+```
+
+Expected output is a machine-readable summary or a clear PASS/FAIL report. The expected PASS/FAIL output must be reviewed before any deploy/restart or activation decision. A missing hook, missing file, or regression must produce FAIL / nonzero and HOLD.
+
+## Post-update aftercare checklist
+
+1. Run the smoke command immediately after a Hermes update.
+2. Confirm policy loading is still detectable.
+3. Confirm pre-turn intake hook presence is still detectable before raw append/persist/provider flow.
+4. Confirm WCP provider payload enforcement is still detectable.
+5. Confirm Task Boundary Firewall default-new behavior is still detectable.
+6. Confirm closed task exclusion is still detectable.
+7. Confirm retrieval scope enforcement is still detectable.
+8. Confirm compact failure fallback still routes to safe HOLD behavior.
+9. Confirm threshold does not revert to 85%-only path.
+10. Confirm same-window rehydrate path or HOLD if not enabled is still detectable.
+11. Confirm this update-aftercare checklist remains present and referenced.
+
+If any check is missing after update, HOLD. Do not silently continue as if Context Health governance is intact.
+
+## Safety contract
+
+The smoke command is dry-run/default safe mode. It is temp HERMES_HOME/tmp_path based by contract and must use synthetic sentinel only inputs. It exits nonzero on missing hooks/regressions. Its report must contain no raw/private/secret/token/password material. It must provide a machine-readable summary or clear PASS/FAIL report.
+
+The smoke/checklist must not touch live runtime surfaces:
+
+```text
+real ~/.hermes/state.db
+live provider
+network
+secrets
+tmux/session
+profile/systemd/cron/wrapper/env/credential
+gateway restart/deploy/activation
+CLI slash command activation
+runtime config/profile activation
+```
+
+Additional explicit boundaries:
+
+```text
+no real state DB read or mutation
+no live provider call
+no network dependency
+no secret or credential inspection
+no tmux/session control
+no profile/systemd/cron/wrapper/env/credential mutation
+no gateway restart/deploy/activation
+no CLI slash command activation
+no runtime config/profile activation
+```
+
+## Phase 9 scope boundary
+
+Gateway/update survival is Phase 9 smoke/regression detection scope. It is not gateway runtime implementation. It is not a gateway restart, deploy, activation, or runtime behavior change.
+
+Command activation is out of scope. Do not edit `hermes_cli/commands.py`, do not edit `cli.py`, do not add a CLI slash command, and do not execute `/rehydrate` or `/clear` as part of update-survival smoke.
+
+Runtime config/profile activation is out of scope. Do not change config defaults, profiles, env, cron, systemd, wrappers, credentials, symlinks, or live session state from this smoke/checklist.
+
+## HOLD criteria
+
+HOLD if:
+
+- the smoke command is missing;
+- the smoke command cannot detect core hook loss;
+- policy loading is not detectable;
+- pre-turn intake hook presence is not detectable;
+- WCP provider payload enforcement is not detectable;
+- Task Boundary Firewall default-new behavior is not detectable;
+- closed task exclusion is not detectable;
+- retrieval scope enforcement is not detectable;
+- compact failure fallback is not detectable;
+- threshold has reverted to 85%-only path;
+- same-window rehydrate path or HOLD if not enabled is not detectable;
+- the smoke command requires live provider, network, secrets, real state DB, tmux/session, profile/systemd/cron/wrapper/env/credential, gateway restart/deploy/activation, CLI slash command activation, or runtime config/profile activation.
+
+## Non-claims
+
+This checklist does not prove full A/B contamination fix completion. It only defines the aftercare contract for update survival smoke/regression detection.

--- a/scripts/context_health_smoke.py
+++ b/scripts/context_health_smoke.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Context Health update-survival smoke/regression runner.
+
+Phase 9: Update survival smoke/regression tests.
+
+Purpose:
+    Ensure Hermes update cannot silently bypass context governance.
+
+Scope:
+    This script is detection/smoke/regression scope only. It is not gateway
+    runtime implementation, not command activation, and not runtime
+    config/profile activation.
+
+Default mode:
+    Dry-run / safe mode. The smoke runner is designed to be safe to execute
+    after a Hermes update because it uses repository-local inspection only,
+    a temp HERMES_HOME / tmp_path contract, and synthetic sentinel only
+    expectations. It must exit nonzero on missing hook regressions or other
+    missing hook signals, and it must avoid raw/private/secret/token/password
+    material in report output.
+
+Forbidden live/runtime surfaces:
+    real ~/.hermes/state.db; live provider; network; secrets; tmux/session;
+    profile/systemd/cron/wrapper/env/credential; gateway restart/deploy/activation;
+    CLI slash command activation; runtime config/profile activation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+PHASE = "Phase 9: Update survival smoke/regression tests"
+OBJECTIVE = "Ensure Hermes update cannot silently bypass context governance."
+SCOPE_STATEMENT = (
+    "Phase 9 is update survival smoke/regression detection scope, not "
+    "gateway runtime implementation, command activation, or runtime config/profile activation."
+)
+
+REQUIRED_COVERAGE = (
+    "policy loading",
+    "pre-turn intake hook presence",
+    "WCP provider payload enforcement",
+    "Task Boundary Firewall default-new behavior",
+    "closed task exclusion",
+    "retrieval scope enforcement",
+    "compact failure fallback",
+    "threshold does not revert to 85%-only path",
+    "same-window rehydrate path or HOLD if not enabled",
+    "update-aftercare checklist",
+)
+
+SAFE_EXECUTION_CONTRACT = (
+    "dry-run/default safe mode",
+    "temp HERMES_HOME/tmp_path based",
+    "synthetic sentinel only",
+    "nonzero on missing hooks/regressions",
+    "no raw/private/secret/token/password material in report",
+    "machine-readable summary or clear PASS/FAIL report",
+)
+
+FORBIDDEN_RUNTIME_SURFACES = (
+    "real ~/.hermes/state.db",
+    "live provider",
+    "network",
+    "secrets",
+    "tmux/session",
+    "profile/systemd/cron/wrapper/env/credential",
+    "gateway restart/deploy/activation",
+    "CLI slash command activation",
+    "runtime config/profile activation",
+    "no profile activation",
+    "not runtime config",
+)
+
+# This runner intentionally checks local file/hook indicators only. It must not
+# import provider clients, open ~/.hermes/state.db, restart gateway processes,
+# mutate profiles/config, touch cron/systemd/wrappers/env/credentials, open tmux
+# or sessions, call network, or inspect secrets.
+SMOKE_CHECKS = {
+    "policy loading": ("agent/context_health_policy.py", "context_health"),
+    "pre-turn intake hook presence": ("agent/context_health_intake.py", "intake"),
+    "WCP provider payload enforcement": ("agent/working_context_packet.py", "provider payload"),
+    "Task Boundary Firewall default-new behavior": ("agent/task_boundary_firewall.py", "default"),
+    "closed task exclusion": ("agent/task_boundary_firewall.py", "closed"),
+    "retrieval scope enforcement": ("agent/retrieval_scope.py", "session_search"),
+    "compact failure fallback": ("agent/context_health_compact.py", "safe hold"),
+    "threshold does not revert to 85%-only path": ("agent/context_health_policy.py", "85"),
+    "same-window rehydrate path or HOLD if not enabled": ("agent/context_health_rehydrate.py", "hold"),
+    "update-aftercare checklist": ("references/context-health-update-survival.md", "post-update"),
+}
+
+
+@dataclass(frozen=True)
+class SmokeResult:
+    name: str
+    status: str
+    path: str
+    detail: str
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return ""
+
+
+def run_smoke(repo_root: Path = REPO_ROOT) -> tuple[int, dict[str, object]]:
+    """Run dry-run smoke checks and return (exit_code, machine-readable summary)."""
+    results: list[SmokeResult] = []
+    for name, (relative_path, required_text) in SMOKE_CHECKS.items():
+        path = repo_root / relative_path
+        text = _read_text(path).lower()
+        if not path.is_file():
+            results.append(
+                SmokeResult(name=name, status="FAIL", path=relative_path, detail="missing file or hook indicator")
+            )
+        elif required_text.lower() not in text:
+            results.append(
+                SmokeResult(name=name, status="FAIL", path=relative_path, detail="missing hook indicator")
+            )
+        else:
+            results.append(SmokeResult(name=name, status="PASS", path=relative_path, detail="local dry-run indicator present"))
+
+    failures = [result for result in results if result.status != "PASS"]
+    summary = {
+        "phase": PHASE,
+        "objective": OBJECTIVE,
+        "scope": SCOPE_STATEMENT,
+        "mode": "dry-run/default safe mode",
+        "state_isolation": "temp HERMES_HOME/tmp_path based contract; no real ~/.hermes/state.db",
+        "input_policy": "synthetic sentinel only",
+        "report_policy": "no raw/private/secret/token/password material in report",
+        "output_contract": "machine-readable summary or clear PASS/FAIL report",
+        "missing_hook_policy": "exit nonzero on missing hooks/regressions",
+        "forbidden_runtime_surfaces": list(FORBIDDEN_RUNTIME_SURFACES),
+        "coverage": list(REQUIRED_COVERAGE),
+        "results": [asdict(result) for result in results],
+        "status": "PASS" if not failures else "FAIL",
+        "failure_count": len(failures),
+    }
+    return (0 if not failures else 1), summary
+
+
+def _redacted_json(data: dict[str, object]) -> str:
+    # Summary data is deterministic metadata. It must not include user raw/private
+    # bodies, secrets, tokens, passwords, credentials, network results, provider
+    # responses, tmux/session output, real state DB rows, or environment values.
+    return json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=OBJECTIVE)
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON summary")
+    parser.add_argument("--dry-run", action="store_true", default=True, help="default safe dry-run mode")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    exit_code, summary = run_smoke(REPO_ROOT)
+    if args.json:
+        print(_redacted_json(summary))
+    else:
+        print(f"{PHASE}: {summary['status']}")
+        print(SCOPE_STATEMENT)
+        print("Mode: dry-run/default safe mode; temp HERMES_HOME/tmp_path based; synthetic sentinel only")
+        print("Safety: no real ~/.hermes/state.db, live provider, network, secrets, tmux/session, profile/systemd/cron/wrapper/env/credential")
+        print("Activation boundary: no gateway restart/deploy/activation; no CLI slash command activation; no runtime config/profile activation")
+        for result in summary["results"]:  # type: ignore[index]
+            print(f"{result['status']} {result['name']} [{result['path']}]: {result['detail']}")
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent/test_compact_failure_fallback.py
+++ b/tests/agent/test_compact_failure_fallback.py
@@ -1,0 +1,226 @@
+import json
+from pathlib import Path
+
+from agent.context_health_compact import build_compact_exhaustion_hold
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONVERSATION_LOOP = REPO_ROOT / "agent" / "conversation_loop.py"
+
+
+def _source() -> str:
+    return CONVERSATION_LOOP.read_text(encoding="utf-8")
+
+
+def _between(source: str, start: str, end: str) -> str:
+    start_index = source.index(start)
+    end_index = source.index(end, start_index)
+    return source[start_index:end_index]
+
+
+def test_payload_too_large_cannot_compress_further_routes_to_safe_hold_not_new_or_compress_advice():
+    """Phase 7: exhausted compact fallback must become continuity/HOLD, not manual reset advice."""
+    branch = _between(
+        _source(),
+        "if is_payload_too_large:",
+        "# Check for context-length errors BEFORE generic 4xx handler.",
+    )
+
+    assert "Cannot compress further" in branch, "test must target the legacy exhausted compact path"
+    assert "compression_exhausted" in branch, "test must target compact exhaustion behavior"
+
+    assert any(
+        marker in branch
+        for marker in (
+            "context_health_compact",
+            "continuity_packet",
+            "safe HOLD",
+            "safe_hold",
+            "rehydrate",
+        )
+    ), "Phase 7 should route exhausted compact failure to a continuity packet + HOLD/rehydrate path"
+    assert "Try /new" not in branch
+    assert "start a fresh conversation" not in branch
+    assert "Try /compress" not in branch
+
+
+def test_payload_too_large_safe_hold_contract_excludes_raw_cross_task_and_secret_material():
+    """Phase 7 HOLD/continuity output must encode redaction boundaries, not raw transcript leakage."""
+    branch = _between(
+        _source(),
+        "if is_payload_too_large:",
+        "# Check for context-length errors BEFORE generic 4xx handler.",
+    )
+
+    required_safety_terms = (
+        "raw transcript",
+        "unrelated",
+        "secret",
+        "token",
+        "password",
+        "private",
+    )
+    missing_terms = [term for term in required_safety_terms if term not in branch.lower()]
+    assert not missing_terms, (
+        "Phase 7 compact fallback must make the safe HOLD/continuity contract explicit; "
+        f"missing safety terms: {missing_terms}"
+    )
+
+    forbidden_needles = (
+        "CLOSED_TASK_A_NEEDLE_DO_NOT_LEAK",
+        "UNRELATED_TASK_B_NEEDLE_DO_NOT_MIX",
+        "SYNTHETIC_TOKEN_NEEDLE_SHOULD_NOT_APPEAR",
+        "SYNTHETIC_PASSWORD_NEEDLE_SHOULD_NOT_APPEAR",
+        "PRIVATE_RAW_BODY_DO_NOT_STORE",
+    )
+    for needle in forbidden_needles:
+        assert needle not in branch
+
+
+def test_disabled_auto_compaction_preserves_existing_manual_pass_through_guidance():
+    """Disabled Phase 7 compact fallback must not break compression.enabled:false legacy behavior."""
+    branch = _between(
+        _source(),
+        "# ── Respect disabled auto-compaction on overflow",
+        "# ── Anthropic Sonnet long-context tier gate",
+    )
+
+    assert "compression.enabled: false" in branch
+    assert "compaction_disabled" in branch
+    assert "Run /compress" in branch
+    assert "/new to start fresh" in branch
+
+
+def _payload_too_large_branch() -> str:
+    return _between(
+        _source(),
+        "if is_payload_too_large:",
+        "# Check for context-length errors BEFORE generic 4xx handler.",
+    )
+
+
+def _context_overflow_branch() -> str:
+    return _between(
+        _source(),
+        "if is_context_length_error:",
+        "# Check for non-retryable client errors.",
+    )
+
+
+def test_payload_too_large_hold_result_does_not_return_raw_messages_transcript():
+    """Safe HOLD result assembly must not reattach the raw live transcript list."""
+    branch = _payload_too_large_branch()
+
+    assert "build_compact_exhaustion_hold" in branch
+    assert "continuity_packet" in branch
+    assert '"messages": messages' not in branch, (
+        "Phase 7 compact HOLD currently reattaches raw messages; expected "
+        "sanitized assistant-only messages or another safe non-transcript shape."
+    )
+
+
+def test_context_overflow_max_attempts_routes_to_compact_safe_hold_not_legacy_guidance():
+    """Context-overflow max attempts must use compact HOLD, not /new or /compress advice."""
+    branch = _between(
+        _context_overflow_branch(),
+        "if available_out is not None:",
+        "# The error is output-cap-shaped",
+    )
+
+    assert "compression_exhausted" in branch
+    assert any(
+        marker in branch
+        for marker in (
+            "build_compact_exhaustion_hold",
+            "context_health_compact",
+            "continuity_packet",
+            "safe_hold",
+        )
+    ), "context-overflow max-attempts must route to compact safe HOLD"
+    assert "Try /new" not in branch
+    assert "/compress" not in branch
+    assert '"messages": messages' not in branch
+
+
+def test_context_overflow_cannot_compress_further_routes_to_compact_safe_hold():
+    """Context-overflow cannot-compress-further path must not keep legacy fallback result."""
+    overflow_branch = _context_overflow_branch()
+    start_index = overflow_branch.index("# Can't compress further and already at minimum tier")
+    branch = overflow_branch[start_index:]
+
+    assert "Cannot compress further" in branch
+    assert "compression_exhausted" in branch
+    assert any(
+        marker in branch
+        for marker in (
+            "build_compact_exhaustion_hold",
+            "context_health_compact",
+            "continuity_packet",
+            "safe_hold",
+        )
+    ), "context-overflow cannot-compress-further must route to compact safe HOLD"
+    assert "Try /new" not in branch
+    assert "/compress" not in branch
+    assert '"messages": messages' not in branch
+
+
+def test_compact_hold_result_repr_excludes_raw_needles_and_uses_safe_message_shape():
+    """A complete compact HOLD result shape must be safe across repr(result), not final_response only."""
+    hold = build_compact_exhaustion_hold(
+        reason="test_constant_reason",
+        session_id="session-for-red-contract",
+        task_id="task-for-red-contract",
+        message_count=5,
+        approx_tokens=12345,
+    )
+    safe_result = {
+        **hold,
+        "messages": [{"role": "assistant", "content": hold["final_response"]}],
+        "api_calls": 1,
+    }
+
+    assert safe_result["messages"] == [
+        {"role": "assistant", "content": hold["final_response"]}
+    ]
+    result_repr = json.dumps(safe_result, sort_keys=True)
+    forbidden_needles = (
+        "CLOSED_TASK_A_NEEDLE_DO_NOT_LEAK",
+        "UNRELATED_TASK_B_NEEDLE_DO_NOT_MIX",
+        "SYNTHETIC_TOKEN_NEEDLE_SHOULD_NOT_APPEAR",
+        "SYNTHETIC_PASSWORD_NEEDLE_SHOULD_NOT_APPEAR",
+        "PRIVATE_RAW_BODY_DO_NOT_STORE",
+    )
+    for needle in forbidden_needles:
+        assert needle not in result_repr
+
+
+def test_payload_too_large_current_callsite_would_leak_raw_messages_in_result_repr():
+    """RED guard: current payload-too-large callsite must stop assembling raw transcript results."""
+    branch = _payload_too_large_branch()
+    raw_messages = [
+        {"role": "user", "content": "CLOSED_TASK_A_NEEDLE_DO_NOT_LEAK"},
+        {"role": "tool", "content": "SYNTHETIC_TOKEN_NEEDLE_SHOULD_NOT_APPEAR"},
+        {"role": "assistant", "content": "PRIVATE_RAW_BODY_DO_NOT_STORE"},
+    ]
+    hold = build_compact_exhaustion_hold(
+        reason="payload_too_large_cannot_compress_further",
+        session_id="session-for-red-contract",
+        task_id="task-for-red-contract",
+        message_count=len(raw_messages),
+        approx_tokens=999999,
+    )
+
+    if '"messages": messages' in branch:
+        current_shape = {**hold, "messages": raw_messages, "api_calls": 2}
+        result_repr = repr(current_shape)
+    else:
+        current_shape = {
+            **hold,
+            "messages": [{"role": "assistant", "content": hold["final_response"]}],
+            "api_calls": 2,
+        }
+        result_repr = repr(current_shape)
+
+    assert "CLOSED_TASK_A_NEEDLE_DO_NOT_LEAK" not in result_repr
+    assert "SYNTHETIC_TOKEN_NEEDLE_SHOULD_NOT_APPEAR" not in result_repr
+    assert "PRIVATE_RAW_BODY_DO_NOT_STORE" not in result_repr

--- a/tests/agent/test_context_health_policy.py
+++ b/tests/agent/test_context_health_policy.py
@@ -1,0 +1,261 @@
+from agent.context_health_policy import (
+    ContextHealthPolicy,
+    PromptIntakeDecision,
+    TaskBoundaryDecision,
+    default_context_health_policy,
+    normalize_context_health_policy,
+    classify_prompt_for_intake,
+    classify_task_boundary,
+    resolve_effective_threshold,
+)
+
+
+def test_default_policy_is_disabled_and_runtime_neutral():
+    policy = default_context_health_policy()
+
+    assert policy.enabled is False
+    assert policy.pre_model_intake.enabled is False
+    assert policy.task_boundary.enabled is False
+    assert policy.runtime_behavior_enabled is False
+
+    decision = classify_prompt_for_intake("short normal prompt", policy)
+    assert decision.action == "pass"
+    assert decision.reason == "context_health_disabled"
+    assert decision.pre_history_required is False
+
+
+def test_explicit_enabled_policy_expresses_phase1_controls():
+    policy = normalize_context_health_policy(
+        {
+            "enabled": True,
+            "pre_model_intake": {
+                "enabled": True,
+                "long_prompt_char_threshold": 120,
+                "long_prompt_line_threshold": 4,
+                "pre_history_required": True,
+                "high_risk_keywords": ["credential", "token"],
+            },
+            "task_boundary": {
+                "enabled": True,
+                "default_without_clear_continuation": "new_task",
+                "ambiguous_action": "hold",
+            },
+            "thresholds": {
+                "max_provider_context_ratio": 0.72,
+                "block_provider_call_ratio": 0.85,
+                "allow_model_specific_raise": False,
+            },
+        }
+    )
+
+    assert policy.enabled is True
+    assert policy.pre_model_intake.enabled is True
+    assert policy.pre_model_intake.long_prompt_char_threshold == 120
+    assert policy.pre_model_intake.pre_history_required is True
+    assert policy.task_boundary.default_without_clear_continuation == "new_task"
+    assert policy.task_boundary.ambiguous_action == "hold"
+    assert policy.thresholds.max_provider_context_ratio == 0.72
+    assert policy.thresholds.allow_model_specific_raise is False
+
+
+def test_threshold_resolution_preserves_configured_ratio_when_model_raise_disallowed():
+    policy = normalize_context_health_policy(
+        {
+            "enabled": True,
+            "thresholds": {
+                "max_provider_context_ratio": 0.70,
+                "block_provider_call_ratio": 0.85,
+                "allow_model_specific_raise": False,
+            },
+        }
+    )
+
+    result = resolve_effective_threshold(
+        configured_ratio=0.45,
+        model_suggested_ratio=0.85,
+        policy=policy,
+    )
+
+    assert result.ratio == 0.45
+    assert result.clamped_model_suggestion is True
+    assert result.reason == "model_raise_disallowed"
+
+
+def test_threshold_resolution_allows_explicit_raise_only_up_to_policy_max():
+    policy = normalize_context_health_policy(
+        {
+            "enabled": True,
+            "thresholds": {
+                "max_provider_context_ratio": 0.70,
+                "block_provider_call_ratio": 0.85,
+                "allow_model_specific_raise": True,
+            },
+        }
+    )
+
+    result = resolve_effective_threshold(
+        configured_ratio=0.45,
+        model_suggested_ratio=0.85,
+        policy=policy,
+    )
+
+    assert result.ratio == 0.70
+    assert result.clamped_model_suggestion is True
+    assert result.reason == "policy_max_provider_context_ratio"
+
+
+def test_task_boundary_defaults_to_new_task_without_clear_continuation():
+    policy = normalize_context_health_policy(
+        {
+            "enabled": True,
+            "task_boundary": {
+                "enabled": True,
+                "default_without_clear_continuation": "new_task",
+                "ambiguous_action": "hold",
+            },
+        }
+    )
+
+    decision = classify_task_boundary(
+        user_message="새 리서치 주제로 넘어가자",
+        active_task_id="task-a",
+        closed_task_ids=["task-a"],
+        explicit_continuation_refs=[],
+        policy=policy,
+    )
+
+    assert decision.action == "new_task"
+    assert decision.reason == "no_clear_continuation_evidence"
+    assert decision.defaulted is True
+
+
+def test_task_boundary_holds_ambiguous_relation_when_policy_requires_hold():
+    policy = normalize_context_health_policy(
+        {
+            "enabled": True,
+            "task_boundary": {
+                "enabled": True,
+                "default_without_clear_continuation": "new_task",
+                "ambiguous_action": "hold",
+            },
+        }
+    )
+
+    decision = classify_task_boundary(
+        user_message="이거 이어서 하면 되는지 새로 봐야 하는지 애매해",
+        active_task_id="task-a",
+        closed_task_ids=["task-a"],
+        explicit_continuation_refs=[],
+        ambiguous_relation=True,
+        policy=policy,
+    )
+
+    assert decision.action == "hold"
+    assert decision.reason == "ambiguous_task_relation"
+    assert decision.defaulted is False
+
+
+def test_closed_task_does_not_continue_without_explicit_continuation():
+    policy = normalize_context_health_policy(
+        {
+            "enabled": True,
+            "task_boundary": {
+                "enabled": True,
+                "default_without_clear_continuation": "new_task",
+                "ambiguous_action": "hold",
+            },
+        }
+    )
+
+    decision = classify_task_boundary(
+        user_message="task-a와 별개로 새 검토를 시작하자",
+        active_task_id=None,
+        closed_task_ids=["task-a"],
+        explicit_continuation_refs=[],
+        policy=policy,
+    )
+
+    assert decision.action == "new_task"
+    assert decision.reason == "no_clear_continuation_evidence"
+    assert decision.linked_task_id is None
+
+
+def test_task_boundary_can_express_explicit_continuation():
+    policy = normalize_context_health_policy(
+        {
+            "enabled": True,
+            "task_boundary": {"enabled": True},
+        }
+    )
+
+    decision = classify_task_boundary(
+        user_message="task-a 계속 진행해줘",
+        active_task_id=None,
+        closed_task_ids=["task-a"],
+        explicit_continuation_refs=["task-a"],
+        policy=policy,
+    )
+
+    assert decision.action == "continue_task"
+    assert decision.reason == "explicit_continuation_reference"
+    assert decision.linked_task_id == "task-a"
+
+
+def test_long_prompt_pre_history_intake_policy_is_expressible():
+    policy = normalize_context_health_policy(
+        {
+            "enabled": True,
+            "pre_model_intake": {
+                "enabled": True,
+                "long_prompt_char_threshold": 80,
+                "long_prompt_line_threshold": 3,
+                "pre_history_required": True,
+            },
+        }
+    )
+    prompt = "\n".join(
+        [
+            "이번 작업은 긴 요구사항이다.",
+            "1. WorkSpec으로 분리해야 한다.",
+            "2. checklist를 만들어야 한다.",
+            "3. task-state를 만들어야 한다.",
+        ]
+    )
+
+    decision = classify_prompt_for_intake(prompt, policy)
+
+    assert decision.action == "force_md_intake"
+    assert decision.reason == "long_prompt"
+    assert decision.pre_history_required is True
+    assert "line_count" in decision.signals
+
+
+def test_sensitive_long_prompt_holds_without_safe_raw_storage():
+    policy = normalize_context_health_policy(
+        {
+            "enabled": True,
+            "pre_model_intake": {
+                "enabled": True,
+                "long_prompt_char_threshold": 20,
+                "pre_history_required": True,
+                "high_risk_keywords": ["token", "password"],
+                "sensitive_prompt_action": "hold",
+            },
+        }
+    )
+
+    decision = classify_prompt_for_intake(
+        "token value appears in a long prompt that should not enter raw history",
+        policy,
+    )
+
+    assert decision.action == "hold"
+    assert decision.reason == "sensitive_prompt_requires_review"
+    assert decision.pre_history_required is True
+    assert "high_risk_keyword" in decision.signals
+
+
+def test_public_decision_types_are_stable_dataclasses():
+    assert PromptIntakeDecision(action="pass", reason="x").action == "pass"
+    assert TaskBoundaryDecision(action="new_task", reason="x").action == "new_task"
+    assert isinstance(default_context_health_policy(), ContextHealthPolicy)

--- a/tests/agent/test_context_health_update_survival.py
+++ b/tests/agent/test_context_health_update_survival.py
@@ -1,0 +1,144 @@
+"""Phase 9 RED contracts for Context Health update survival.
+
+These tests intentionally describe the expected update-survival smoke/regression
+surface before implementing it. They must fail RED while the smoke script and
+post-update checklist are absent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SMOKE_SCRIPT = REPO_ROOT / "scripts" / "context_health_smoke.py"
+UPDATE_SURVIVAL_CHECKLIST = REPO_ROOT / "references" / "context-health-update-survival.md"
+
+REQUIRED_SMOKE_COVERAGE = {
+    "policy loading": ("policy loading", "context_health_policy"),
+    "pre-turn intake hook presence": ("pre-turn intake", "intake hook"),
+    "WCP provider payload enforcement": ("working context packet", "provider payload"),
+    "Task Boundary Firewall default-new behavior": ("task boundary firewall", "default-new"),
+    "closed task exclusion": ("closed task", "exclusion"),
+    "retrieval scope enforcement": ("retrieval scope", "session_search"),
+    "compact failure fallback": ("compact failure", "safe hold"),
+    "threshold does not revert to 85%-only path": ("85", "threshold"),
+    "same-window rehydrate path or HOLD if not enabled": ("same-window rehydrate", "hold"),
+    "update-aftercare checklist": ("aftercare", "post-update"),
+}
+
+SAFE_EXECUTION_CONTRACT = {
+    "dry-run/default safe mode": ("dry-run", "safe mode"),
+    "temp HERMES_HOME/tmp_path based": ("tmp_path", "HERMES_HOME"),
+    "synthetic sentinel only": ("synthetic", "sentinel"),
+    "nonzero on missing hooks/regressions": ("nonzero", "missing hook"),
+    "no raw/private/secret/token/password material in report": (
+        "raw/private/secret/token/password",
+        "report",
+    ),
+    "machine-readable summary or clear PASS/FAIL report": (
+        "machine-readable",
+        "PASS/FAIL",
+    ),
+}
+
+FORBIDDEN_RUNTIME_SURFACES = {
+    "real ~/.hermes/state.db",
+    "live provider",
+    "network",
+    "secrets",
+    "tmux/session",
+    "profile/systemd/cron/wrapper/env/credential",
+    "gateway restart/deploy/activation",
+    "CLI slash command activation",
+    "runtime config/profile activation",
+}
+
+PHASE9_SCOPE_STATEMENT = (
+    "Phase 9 is update survival smoke/regression detection scope, not "
+    "gateway runtime implementation, command activation, or runtime config/profile activation."
+)
+
+
+def _read_lower(path: Path) -> str:
+    return path.read_text(encoding="utf-8").lower()
+
+
+def _assert_terms_present(text: str, contract: dict[str, tuple[str, ...]]) -> None:
+    missing = []
+    for behavior, terms in contract.items():
+        if not any(term.lower() in text for term in terms):
+            missing.append(f"{behavior}: expected one of {terms!r}")
+    assert not missing, "Missing smoke contract coverage:\n" + "\n".join(missing)
+
+
+def test_update_survival_smoke_script_exists_and_declares_required_coverage() -> None:
+    """Phase 9 smoke script must enumerate every governance invariant it protects."""
+    assert SMOKE_SCRIPT.is_file(), (
+        "Phase 9 RED: expected scripts/context_health_smoke.py to exist and declare "
+        "smoke coverage for policy loading, pre-turn intake, WCP provider payload, "
+        "Task Boundary Firewall default-new behavior, closed task exclusion, retrieval "
+        "scope enforcement, compact fallback, 85%-threshold regression, same-window "
+        "rehydrate/HOLD, and update-aftercare checklist."
+    )
+
+    text = _read_lower(SMOKE_SCRIPT)
+    _assert_terms_present(text, REQUIRED_SMOKE_COVERAGE)
+
+
+def test_update_survival_checklist_document_exists_for_post_update_aftercare() -> None:
+    """Phase 9 must document the post-update aftercare command and HOLD boundary."""
+    assert UPDATE_SURVIVAL_CHECKLIST.is_file(), (
+        "Phase 9 RED: expected references/context-health-update-survival.md to exist "
+        "with a post-update aftercare checklist, smoke command, expected output, and "
+        "HOLD guidance when governance hooks are missing after update."
+    )
+
+    text = _read_lower(UPDATE_SURVIVAL_CHECKLIST)
+    required_doc_terms = {
+        "post-update aftercare checklist": ("post-update", "aftercare"),
+        "smoke command": ("context_health_smoke.py", "smoke command"),
+        "expected PASS/FAIL output": ("pass/fail", "expected output"),
+        "HOLD on missing hooks": ("hold", "missing hook"),
+        "no live side effects": ("no live", "no real state"),
+    }
+    _assert_terms_present(text, required_doc_terms)
+
+
+def test_smoke_script_contract_requires_dry_run_safe_mode_and_no_live_side_effects() -> None:
+    """The smoke runner must be safe even if executed after an update."""
+    assert SMOKE_SCRIPT.is_file(), (
+        "Phase 9 RED: expected scripts/context_health_smoke.py before validating its "
+        "dry-run/default-safe-mode, temp HERMES_HOME/tmp_path, synthetic-sentinel, "
+        "nonzero-on-regression, no-secret-report, and machine-readable summary contracts."
+    )
+
+    text = _read_lower(SMOKE_SCRIPT)
+    _assert_terms_present(text, SAFE_EXECUTION_CONTRACT)
+    for forbidden_surface in FORBIDDEN_RUNTIME_SURFACES:
+        assert forbidden_surface.lower() in text, (
+            "Smoke script contract must explicitly forbid or guard this live/runtime "
+            f"surface: {forbidden_surface}"
+        )
+
+
+def test_phase9_scope_is_detection_not_gateway_or_command_runtime_activation() -> None:
+    """Phase 9 can detect gateway/update drift without implementing runtime activation."""
+    assert SMOKE_SCRIPT.is_file(), (
+        "Phase 9 RED: expected scripts/context_health_smoke.py to encode detection-only "
+        "scope for gateway/update survival, while excluding gateway restart/deploy, "
+        "CLI slash command activation, and runtime config/profile activation. "
+        f"Contract: {PHASE9_SCOPE_STATEMENT}"
+    )
+
+    text = _read_lower(SMOKE_SCRIPT)
+    expected_scope_terms = {
+        "gateway/update detection scope": ("gateway", "detection"),
+        "not gateway runtime implementation": ("not gateway runtime", "no gateway restart"),
+        "not command activation": ("not command activation", "no slash command"),
+        "not runtime config/profile activation": (
+            "not runtime config",
+            "no profile activation",
+        ),
+    }
+    _assert_terms_present(text, expected_scope_terms)

--- a/tests/agent/test_pre_turn_intake_guard.py
+++ b/tests/agent/test_pre_turn_intake_guard.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent.context_health_policy import (
+    ContextHealthPolicy,
+    PreModelIntakePolicy,
+)
+from agent.conversation_loop import run_conversation
+from agent.turn_context import build_turn_context
+
+
+class _FakeGuardrails:
+    def reset_for_turn(self):
+        pass
+
+
+class _FakeTodoStore:
+    def has_items(self):
+        return True
+
+
+class _FakeAgent:
+    def __init__(self, tmp_path: Path):
+        self.session_id = "sess-intake"
+        self.model = "test/model"
+        self.provider = "test-provider"
+        self.base_url = ""
+        self.api_key = ""
+        self.api_mode = "chat_completions"
+        self.platform = "cli"
+        self.quiet_mode = True
+        self.max_iterations = 8
+        self.tools = []
+        self.valid_tool_names = set()
+        self.enabled_toolsets = None
+        self.disabled_toolsets = None
+        self._skip_mcp_refresh = True
+        self.compression_enabled = False
+        self.context_compressor = type("Compressor", (), {"protect_first_n": 2, "protect_last_n": 2})()
+        self._cached_system_prompt = "SYSTEM"
+        self._memory_store = None
+        self._memory_manager = None
+        self._memory_nudge_interval = 0
+        self._turns_since_memory = 0
+        self._user_turn_count = 0
+        self._todo_store = _FakeTodoStore()
+        self._tool_guardrails = _FakeGuardrails()
+        self._compression_warning = None
+        self._interrupt_requested = False
+        self._memory_write_origin = "assistant_tool"
+        self._stream_context_scrubber = None
+        self._stream_think_scrubber = None
+        self._context_health_intake_dir = tmp_path / "intake"
+        self._persisted_messages = None
+        self._persist_calls = 0
+        self._ensure_calls = 0
+
+    def _ensure_db_session(self):
+        self._ensure_calls += 1
+
+    def _restore_primary_runtime(self):
+        pass
+
+    def _cleanup_dead_connections(self):
+        return False
+
+    def _emit_status(self, _msg):
+        pass
+
+    def _replay_compression_warning(self):
+        pass
+
+    def _hydrate_todo_store(self, *_a, **_k):
+        pass
+
+    def _safe_print(self, *_a, **_k):
+        pass
+
+    def _persist_session(self, messages, *_a, **_k):
+        self._persist_calls += 1
+        self._persisted_messages = [dict(m) for m in messages]
+
+
+def _runtime_policy(*, threshold: int = 40, sensitive_action: str = "hold") -> ContextHealthPolicy:
+    return ContextHealthPolicy(
+        enabled=True,
+        runtime_behavior_enabled=True,
+        pre_model_intake=PreModelIntakePolicy(
+            enabled=True,
+            long_prompt_char_threshold=threshold,
+            long_prompt_line_threshold=3,
+            pre_history_required=True,
+            high_risk_keywords=("token", "password", "secret"),
+            sensitive_prompt_action=sensitive_action,
+        ),
+    )
+
+
+def _build(agent, user_message: str, *, persist_user_message=None):
+    return build_turn_context(
+        agent=agent,
+        user_message=user_message,
+        system_message=None,
+        conversation_history=[{"role": "assistant", "content": "previous ok"}],
+        task_id="task-1",
+        stream_callback=None,
+        persist_user_message=persist_user_message,
+        restore_or_build_system_prompt=lambda *a, **k: None,
+        install_safe_stdio=lambda: None,
+        sanitize_surrogates=lambda s: s,
+        summarize_user_message_for_log=lambda s: s,
+        set_session_context=lambda _sid: None,
+        set_current_write_origin=lambda _o: None,
+        ra=lambda: type("RA", (), {"_set_interrupt": lambda self, *a, **k: None})(),
+    )
+
+
+def test_disabled_policy_pass_through_without_file_writes(tmp_path):
+    agent = _FakeAgent(tmp_path)
+    agent._context_health_policy = ContextHealthPolicy(enabled=False)
+    raw = "RAW_NEEDLE_" + ("x" * 200)
+
+    ctx = _build(agent, raw)
+
+    assert ctx.messages[-1] == {"role": "user", "content": raw}
+    assert agent._persist_user_message_override is None
+    assert agent._persisted_messages[-1]["content"] == raw
+    assert not agent._context_health_intake_dir.exists()
+
+
+def test_long_prompt_replaced_before_append_and_persist(tmp_path):
+    agent = _FakeAgent(tmp_path)
+    agent._context_health_policy = _runtime_policy(threshold=40)
+    raw = "LONG_RAW_NEEDLE_" + ("alpha\n" * 20)
+
+    ctx = _build(agent, raw)
+
+    replacement = ctx.messages[-1]["content"]
+    assert "LONG_RAW_NEEDLE_" not in replacement
+    assert "Context Health Intake" in replacement
+    assert str(agent._context_health_intake_dir) in replacement
+    assert "LONG_RAW_NEEDLE_" not in repr(agent._persisted_messages)
+    assert agent._persist_user_message_override == replacement
+
+
+def test_raw_long_prompt_needle_absent_from_ctx_and_persisted_messages(tmp_path):
+    agent = _FakeAgent(tmp_path)
+    agent._context_health_policy = _runtime_policy(threshold=40)
+    raw = "ABSENT_NEEDLE_" + ("body line\n" * 20)
+
+    ctx = _build(agent, raw)
+
+    assert "ABSENT_NEEDLE_" not in repr(ctx.messages)
+    assert "ABSENT_NEEDLE_" not in repr(agent._persisted_messages)
+
+
+def test_intake_packet_contains_required_phase2_artifacts(tmp_path):
+    agent = _FakeAgent(tmp_path)
+    agent._context_health_policy = _runtime_policy(threshold=40)
+
+    ctx = _build(agent, "PACKET_NEEDLE_" + ("work item\n" * 20))
+
+    assert ctx.context_health_intake is not None
+    packet_dir = Path(ctx.context_health_intake.packet_dir)
+    assert (packet_dir / "intake.md").exists()
+    assert (packet_dir / "summary.md").exists()
+    assert (packet_dir / "task-state.md").exists()
+    assert "PACKET_NEEDLE_" not in (packet_dir / "summary.md").read_text()
+    assert "PACKET_NEEDLE_" not in (packet_dir / "task-state.md").read_text()
+
+
+def test_sensitive_long_prompt_holds_before_append(tmp_path):
+    from agent.context_health_intake import PreTurnIntakeHold
+
+    agent = _FakeAgent(tmp_path)
+    agent._context_health_policy = _runtime_policy(threshold=40, sensitive_action="hold")
+    raw = "SECRET_HOLD_NEEDLE token=abc123 " + ("private\n" * 20)
+
+    with pytest.raises(PreTurnIntakeHold) as excinfo:
+        _build(agent, raw)
+
+    assert "SECRET_HOLD_NEEDLE" not in excinfo.value.user_response
+    assert agent._persist_calls == 0
+    assert agent._persisted_messages is None
+    assert getattr(agent, "_persist_user_message_idx", None) is None
+
+
+def test_run_conversation_returns_safe_hold_result_without_provider_or_raw_persist(tmp_path):
+    agent = _FakeAgent(tmp_path)
+    agent._context_health_policy = _runtime_policy(threshold=40, sensitive_action="hold")
+    provider_called = False
+
+    def fail_provider_call(*_args, **_kwargs):
+        nonlocal provider_called
+        provider_called = True
+        raise AssertionError("provider/model call should not happen on intake HOLD")
+
+    agent._get_response = fail_provider_call
+    raw = "RUNTIME_HOLD_NEEDLE token=abc123 password=private " + ("body\n" * 20)
+
+    result = run_conversation(
+        agent,
+        raw,
+        conversation_history=[{"role": "assistant", "content": "previous ok"}],
+        task_id="task-1",
+    )
+
+    assert result["failed"] is True
+    assert result["completed"] is False
+    assert result["api_calls"] == 0
+    assert result["error"].startswith("context_health_hold:")
+    assert "Context Health HOLD" in result["final_response"]
+    assert "RUNTIME_HOLD_NEEDLE" not in repr(result)
+    assert "abc123" not in repr(result)
+    assert provider_called is False
+    assert agent._persist_calls == 0
+    assert agent._persisted_messages is None
+
+
+def test_disabled_short_prompt_pass_through_without_file_writes(tmp_path):
+    agent = _FakeAgent(tmp_path)
+    agent._context_health_policy = ContextHealthPolicy(enabled=False)
+
+    ctx = _build(agent, "short prompt")
+
+    assert ctx.messages[-1] == {"role": "user", "content": "short prompt"}
+    assert agent._persisted_messages[-1]["content"] == "short prompt"
+    assert not agent._context_health_intake_dir.exists()
+
+
+def test_persist_user_message_override_updates_consistently_after_replacement(tmp_path):
+    agent = _FakeAgent(tmp_path)
+    agent._context_health_policy = _runtime_policy(threshold=40)
+    raw = "OVERRIDE_NEEDLE_" + ("line\n" * 20)
+
+    ctx = _build(agent, raw, persist_user_message="clean original")
+
+    assert agent._persist_user_message_override == ctx.user_message
+    assert ctx.original_user_message == ctx.user_message
+    assert "OVERRIDE_NEEDLE_" not in repr(agent._persisted_messages)
+
+
+def test_role_alternation_preserved_after_replacement(tmp_path):
+    agent = _FakeAgent(tmp_path)
+    agent._context_health_policy = _runtime_policy(threshold=40)
+
+    ctx = _build(agent, "ROLE_NEEDLE_" + ("line\n" * 20))
+
+    assert [m["role"] for m in ctx.messages] == ["assistant", "user"]
+
+
+def test_pre_llm_call_receives_safe_replacement_not_raw_long_prompt(tmp_path):
+    agent = _FakeAgent(tmp_path)
+    agent._context_health_policy = _runtime_policy(threshold=40)
+    raw = "PLUGIN_NEEDLE_" + ("line\n" * 20)
+    captured = {}
+
+    def fake_invoke_hook(_name, **kwargs):
+        captured.update(kwargs)
+        return []
+
+    with patch("hermes_cli.plugins.invoke_hook", fake_invoke_hook):
+        _build(agent, raw)
+
+    assert "PLUGIN_NEEDLE_" not in repr(captured["conversation_history"])
+    assert "PLUGIN_NEEDLE_" not in captured["user_message"]
+    assert "Context Health Intake" in captured["user_message"]
+
+
+def test_no_provider_or_model_call_during_intake_classification(tmp_path):
+    agent = _FakeAgent(tmp_path)
+    agent._context_health_policy = _runtime_policy(threshold=40)
+    agent._get_response = lambda *a, **k: (_ for _ in ()).throw(AssertionError("provider called"))
+
+    ctx = _build(agent, "NO_PROVIDER_NEEDLE_" + ("line\n" * 20))
+
+    assert ctx.context_health_intake is not None

--- a/tests/agent/test_retrieval_scope.py
+++ b/tests/agent/test_retrieval_scope.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import importlib
+
+
+TASK_A_ID = "phase6-task-a"
+TASK_B_ID = "phase6-task-b"
+TASK_A_SESSION_ID = "session-phase6-a"
+TASK_B_SESSION_ID = "session-phase6-b"
+TASK_A_NEEDLE = "PHASE6_CLOSED_TASK_A_RETRIEVAL_NEEDLE"
+
+
+def _load_retrieval_scope_module():
+    return importlib.import_module("agent.retrieval_scope")
+
+
+def _policy(*, enabled: bool = True):
+    return {
+        "enabled": enabled,
+        "runtime_behavior_enabled": enabled,
+        "retrieval_scope": {"enabled": enabled},
+        "task_registry": {"enabled": enabled},
+        "task_boundary_firewall": {"enabled": enabled},
+    }
+
+
+def _registry_snapshot_with_closed_a_and_active_b():
+    return {
+        "schema": "context_health_task_registry_v1",
+        "active_task_id": TASK_B_ID,
+        "tasks": {
+            TASK_A_ID: {
+                "task_id": TASK_A_ID,
+                "status": "closed",
+                "session_id": TASK_A_SESSION_ID,
+                "latest_turn_id": "turn-a",
+                "workspec_path": "/tmp/phase6/task-a/WorkSpec.md",
+                "task_state_path": "/tmp/phase6/task-a/task-state.json",
+                "current_pin_path": "/tmp/phase6/task-a/current-pin.md",
+                "raw_transcript_excerpt": TASK_A_NEEDLE,
+            },
+            TASK_B_ID: {
+                "task_id": TASK_B_ID,
+                "status": "active",
+                "session_id": TASK_B_SESSION_ID,
+                "latest_turn_id": "turn-b",
+                "workspec_path": "/tmp/phase6/task-b/WorkSpec.md",
+            },
+        },
+    }
+
+
+def _new_task_decision():
+    return type("Decision", (), {"action": "new_task", "effective_task_id": TASK_B_ID})()
+
+
+def _linked_task_decision():
+    return type(
+        "Decision",
+        (),
+        {"action": "link_task", "effective_task_id": TASK_B_ID, "linked_task_id": TASK_A_ID},
+    )()
+
+
+def test_retrieval_scope_disabled_returns_use_original_pass_through():
+    module = _load_retrieval_scope_module()
+
+    decision = module.enforce_retrieval_scope(
+        policy=_policy(enabled=False),
+        tool_name="session_search",
+        tool_args={"query": TASK_A_NEEDLE},
+        current_task_id=TASK_B_ID,
+        registry_snapshot=_registry_snapshot_with_closed_a_and_active_b(),
+        registry_decision=_new_task_decision(),
+    )
+
+    assert decision.action == "use_original"
+    assert decision.rewritten_args in ({}, None)
+    assert decision.hold_response in ("", None)
+    assert decision.allowed_task_ids in ([], (), None)
+    assert decision.excluded_task_ids in ([], (), None)
+
+
+def test_new_independent_b_excludes_closed_task_a_retrieval():
+    module = _load_retrieval_scope_module()
+
+    decision = module.enforce_retrieval_scope(
+        policy=_policy(enabled=True),
+        tool_name="session_search",
+        tool_args={"query": TASK_A_NEEDLE},
+        current_task_id=TASK_B_ID,
+        registry_snapshot=_registry_snapshot_with_closed_a_and_active_b(),
+        registry_decision=_new_task_decision(),
+    )
+
+    assert decision.action in {"rewrite_args", "hold", "block"}
+    assert decision.reason
+    assert TASK_B_ID in decision.allowed_task_ids
+    assert TASK_A_ID in decision.excluded_task_ids
+    assert TASK_B_SESSION_ID in decision.allowed_session_ids
+    assert TASK_A_SESSION_ID in decision.excluded_session_ids
+    assert TASK_A_NEEDLE not in repr(decision)
+
+
+def test_explicit_continuation_allows_only_current_and_linked_task_ids():
+    module = _load_retrieval_scope_module()
+
+    decision = module.enforce_retrieval_scope(
+        policy=_policy(enabled=True),
+        tool_name="session_search",
+        tool_args={"session_id": TASK_A_SESSION_ID},
+        current_task_id=TASK_B_ID,
+        registry_snapshot=_registry_snapshot_with_closed_a_and_active_b(),
+        explicit_continuation_refs=[TASK_A_ID],
+        registry_decision=_linked_task_decision(),
+    )
+
+    assert decision.action in {"allow", "rewrite_args"}
+    assert set(decision.allowed_task_ids) == {TASK_B_ID, TASK_A_ID}
+    assert set(decision.allowed_session_ids) == {TASK_B_SESSION_ID, TASK_A_SESSION_ID}
+    assert TASK_A_ID not in decision.excluded_task_ids
+    assert TASK_A_SESSION_ID not in decision.excluded_session_ids
+    assert TASK_A_NEEDLE not in repr(decision)
+
+
+def test_ambiguous_prior_task_retrieval_holds_before_search():
+    module = _load_retrieval_scope_module()
+
+    decision = module.enforce_retrieval_scope(
+        policy=_policy(enabled=True),
+        tool_name="session_search",
+        tool_args={"query": "use the previous one"},
+        current_task_id=TASK_B_ID,
+        registry_snapshot=_registry_snapshot_with_closed_a_and_active_b(),
+        registry_decision=type("Decision", (), {"action": "hold", "effective_task_id": TASK_B_ID})(),
+        user_message="use the previous one",
+    )
+
+    assert decision.action in {"hold", "block"}
+    assert decision.hold_response
+    assert TASK_A_ID in decision.excluded_task_ids
+    assert TASK_A_NEEDLE not in decision.hold_response
+    assert TASK_A_NEEDLE not in repr(decision)
+
+
+def test_enabled_adapter_failure_returns_fail_closed_decision_without_raw_leak():
+    module = _load_retrieval_scope_module()
+
+    decision = module.safe_retrieval_scope_failure(
+        policy=_policy(enabled=True),
+        reason="synthetic adapter failure with token password secret",
+        current_task_id=TASK_B_ID,
+        registry_snapshot=_registry_snapshot_with_closed_a_and_active_b(),
+        registry_decision=_new_task_decision(),
+    )
+
+    assert decision.action in {"hold", "block"}
+    assert decision.hold_response
+    rendered = repr(decision)
+    assert TASK_A_NEEDLE not in rendered
+    assert "synthetic adapter failure" not in rendered
+    assert "password" not in rendered.lower()
+    assert "secret" not in rendered.lower()

--- a/tests/agent/test_same_window_rehydrate.py
+++ b/tests/agent/test_same_window_rehydrate.py
@@ -1,0 +1,378 @@
+"""Phase 8 RED contracts for same-window rehydrate.
+
+These tests intentionally define the wished-for Phase 8 API and behavior before
+implementation.  They must use only tmp_path/temp SessionDB state and must not
+open or mutate the real user ~/.hermes/state.db.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+
+RAW_CLOSED_TASK_NEEDLE = "CLOSED_TASK_A_RAW_TRANSCRIPT_NEEDLE_DO_NOT_REINJECT"
+UNRELATED_TASK_NEEDLE = "UNRELATED_TASK_B_NEEDLE_DO_NOT_REINJECT"
+SYNTHETIC_SECRET_NEEDLE = "SYNTHETIC_SECRET_TOKEN_PASSWORD_PRIVATE_BODY_NEEDLE"
+METADATA_RAW_TRANSCRIPT_NEEDLE = "METADATA_ALLOWED_FIELD_RAW_TRANSCRIPT_NEEDLE_DO_NOT_LEAK"
+METADATA_UNRELATED_AB_NEEDLE = "METADATA_ALLOWED_FIELD_UNRELATED_AB_NEEDLE_DO_NOT_LEAK"
+METADATA_TOKEN_NEEDLE = "METADATA_ALLOWED_FIELD_TOKEN_NEEDLE_DO_NOT_LEAK"
+METADATA_PASSWORD_NEEDLE = "METADATA_ALLOWED_FIELD_PASSWORD_NEEDLE_DO_NOT_LEAK"
+METADATA_SECRET_NEEDLE = "METADATA_ALLOWED_FIELD_SECRET_NEEDLE_DO_NOT_LEAK"
+METADATA_PRIVATE_BODY_NEEDLE = "METADATA_ALLOWED_FIELD_PRIVATE_BODY_NEEDLE_DO_NOT_LEAK"
+SAFE_TASK_ID = "task-phase8-current"
+SAFE_SESSION_ID = "phase8-temp-session"
+
+
+def _isolated_hermes_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    hermes_home = tmp_path / "isolated_hermes_home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    return hermes_home
+
+
+def _phase7_continuity_packet(**overrides: Any) -> Dict[str, Any]:
+    packet: Dict[str, Any] = {
+        "type": "context_health_compact.continuity_packet",
+        "reason": "context_overflow_cannot_compress_further",
+        "session_id": SAFE_SESSION_ID,
+        "task_id": SAFE_TASK_ID,
+        "message_count": 42,
+        "approx_tokens": 199999,
+        "rehydrate_status": "phase8_not_executed_requires_user_approval",
+        "safety_boundary": (
+            "raw transcript excluded; unrelated A/B task material excluded; "
+            "secret, token, password, and private body content excluded"
+        ),
+        "raw_transcript_included": False,
+        "unrelated_context_included": False,
+        "secret_token_password_private_body_included": False,
+    }
+    packet.update(overrides)
+    return packet
+
+
+def _load_phase8_module():
+    """Load the expected Phase 8 module and fail with the full contract.
+
+    This should fail RED before implementation because production source
+    `agent/context_health_rehydrate.py` has not been created yet.  The failure
+    message documents the expected API so this is not a bare missing-import
+    smoke test.
+    """
+
+    try:
+        module = importlib.import_module("agent.context_health_rehydrate")
+    except ModuleNotFoundError as exc:
+        pytest.fail(
+            "Phase 8 same-window rehydrate module is missing. Expected "
+            "agent.context_health_rehydrate to expose planner/consumer APIs: "
+            "build_same_window_rehydrate_plan(...), "
+            "validate_continuity_packet(...), "
+            "build_reentry_provider_payload(...), and "
+            "apply_same_window_rehydrate_plan(...). This is the expected RED "
+            "failure before Phase 8 implementation.",
+            pytrace=False,
+        )
+    return module
+
+
+def _assert_no_raw_needles(value: Any) -> None:
+    serialized = json.dumps(value, sort_keys=True, default=str)
+    assert RAW_CLOSED_TASK_NEEDLE not in serialized
+    assert UNRELATED_TASK_NEEDLE not in serialized
+    assert SYNTHETIC_SECRET_NEEDLE not in serialized
+    assert "raw exception" not in serialized.lower()
+
+
+def _unsafe_metadata_value_packet() -> Dict[str, Any]:
+    return _phase7_continuity_packet(
+        reason=METADATA_RAW_TRANSCRIPT_NEEDLE,
+        session_id=METADATA_SECRET_NEEDLE,
+        task_id=METADATA_PRIVATE_BODY_NEEDLE,
+        rehydrate_status=METADATA_TOKEN_NEEDLE,
+        safety_boundary=(
+            f"{METADATA_PASSWORD_NEEDLE} {METADATA_UNRELATED_AB_NEEDLE}"
+        ),
+    )
+
+
+def _assert_no_metadata_value_needles(value: Any) -> None:
+    serialized = json.dumps(value, sort_keys=True, default=str)
+    for needle in (
+        METADATA_RAW_TRANSCRIPT_NEEDLE,
+        METADATA_UNRELATED_AB_NEEDLE,
+        METADATA_TOKEN_NEEDLE,
+        METADATA_PASSWORD_NEEDLE,
+        METADATA_SECRET_NEEDLE,
+        METADATA_PRIVATE_BODY_NEEDLE,
+    ):
+        assert needle not in serialized
+
+
+def test_phase7_continuity_packet_contract_builds_same_window_rehydrate_plan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Phase 8 should consume Phase 7 continuity_packet into a dry-run plan."""
+
+    _isolated_hermes_home(tmp_path, monkeypatch)
+    module = _load_phase8_module()
+
+    packet = _phase7_continuity_packet()
+    plan = module.build_same_window_rehydrate_plan(
+        continuity_packet=packet,
+        session_id=SAFE_SESSION_ID,
+        current_task_id=SAFE_TASK_ID,
+        dry_run=True,
+    )
+
+    assert plan["status"] == "ready"
+    assert plan["phase"] == "phase8_same_window_rehydrate"
+    assert plan["continuity_packet_type"] == "context_health_compact.continuity_packet"
+    assert plan["dry_run"] is True
+    assert plan["mutates_state"] is False
+    _assert_no_raw_needles(plan)
+
+
+def test_same_window_rehydrate_plan_requires_no_new_process_and_no_clear(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same-window rehydrate must not ask 병준 for new window/process or /clear."""
+
+    _isolated_hermes_home(tmp_path, monkeypatch)
+    module = _load_phase8_module()
+
+    plan = module.build_same_window_rehydrate_plan(
+        continuity_packet=_phase7_continuity_packet(),
+        session_id=SAFE_SESSION_ID,
+        current_task_id=SAFE_TASK_ID,
+        dry_run=True,
+    )
+
+    assert plan["same_window"] is True
+    assert plan["requires_new_process"] is False
+    assert plan["requires_new_window"] is False
+    assert plan["requires_new_session"] is False
+    assert plan["requires_clear"] is False
+    assert "/clear" not in json.dumps(plan, default=str)
+    assert "/rehydrate" not in json.dumps(plan, default=str)
+
+
+def test_continuity_packet_consumer_does_not_reinject_raw_transcript_or_private_body(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Continuity consumer must keep raw transcript/unrelated/private data out."""
+
+    _isolated_hermes_home(tmp_path, monkeypatch)
+    module = _load_phase8_module()
+
+    packet = _phase7_continuity_packet(
+        unsafe_debug_payload=(
+            f"{RAW_CLOSED_TASK_NEEDLE} {UNRELATED_TASK_NEEDLE} "
+            f"{SYNTHETIC_SECRET_NEEDLE}"
+        )
+    )
+    decision = module.validate_continuity_packet(packet)
+
+    assert decision["status"] == "hold"
+    assert decision["safe_hold"] is True
+    assert decision["provider_call_allowed"] is False
+    assert decision["raw_transcript_reinjected"] is False
+    assert decision["unrelated_context_reinjected"] is False
+    _assert_no_raw_needles(decision)
+
+
+def test_temp_sessiondb_soft_archive_rehydrate_strategy_preserves_no_data_loss(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Phase 8 executor should use temp SessionDB only and preserve old rows."""
+
+    hermes_home = _isolated_hermes_home(tmp_path, monkeypatch)
+    temp_db_path = hermes_home / "temp_phase8_state.db"
+    assert temp_db_path != Path.home() / ".hermes" / "state.db"
+
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=temp_db_path)
+    db.create_session(session_id=SAFE_SESSION_ID, source="cli", model="phase8-red")
+    db.append_message(SAFE_SESSION_ID, role="user", content=RAW_CLOSED_TASK_NEEDLE)
+    db.append_message(SAFE_SESSION_ID, role="assistant", content="old assistant answer")
+
+    module = _load_phase8_module()
+    plan = module.build_same_window_rehydrate_plan(
+        continuity_packet=_phase7_continuity_packet(),
+        session_id=SAFE_SESSION_ID,
+        current_task_id=SAFE_TASK_ID,
+        dry_run=False,
+    )
+    result = module.apply_same_window_rehydrate_plan(plan, session_db=db)
+
+    active_messages = db.get_messages(SAFE_SESSION_ID)
+    all_messages = db.get_messages(SAFE_SESSION_ID, include_inactive=True)
+
+    assert result["same_session_id"] == SAFE_SESSION_ID
+    assert result["deleted_rows"] == 0
+    assert len(all_messages) >= 2
+    assert any(RAW_CLOSED_TASK_NEEDLE in str(m.get("content")) for m in all_messages)
+    assert not any(RAW_CLOSED_TASK_NEEDLE in str(m.get("content")) for m in active_messages)
+    assert all("continuity_packet" in str(m.get("content")) for m in active_messages)
+    _assert_no_raw_needles(result)
+
+
+def test_rehydrate_provider_payload_uses_reentry_metadata_not_old_conversation_history(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """In-memory conversation_history must not resurrect old transcript."""
+
+    _isolated_hermes_home(tmp_path, monkeypatch)
+    module = _load_phase8_module()
+
+    old_conversation_history = [
+        {"role": "user", "content": RAW_CLOSED_TASK_NEEDLE},
+        {"role": "assistant", "content": UNRELATED_TASK_NEEDLE},
+        {"role": "tool", "content": SYNTHETIC_SECRET_NEEDLE},
+    ]
+    plan = module.build_same_window_rehydrate_plan(
+        continuity_packet=_phase7_continuity_packet(),
+        session_id=SAFE_SESSION_ID,
+        current_task_id=SAFE_TASK_ID,
+        dry_run=True,
+    )
+    payload = module.build_reentry_provider_payload(
+        plan=plan,
+        previous_conversation_history=old_conversation_history,
+    )
+
+    assert payload["provider_visible"] is True
+    assert payload["raw_previous_history_included"] is False
+    assert payload["uses_working_context_packet"] is True
+    assert payload["uses_reentry_metadata"] is True
+    _assert_no_raw_needles(payload)
+
+
+def test_invalid_or_unsafe_continuity_packet_fails_closed_without_leaking_exception_or_secret(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unsafe packet must HOLD before provider call and without raw leakage."""
+
+    _isolated_hermes_home(tmp_path, monkeypatch)
+    module = _load_phase8_module()
+
+    unsafe_packet = {
+        "type": "context_health_compact.continuity_packet",
+        "session_id": SAFE_SESSION_ID,
+        "task_id": SAFE_TASK_ID,
+        "raw_transcript_included": True,
+        "debug_exception": f"raw exception: {SYNTHETIC_SECRET_NEEDLE}",
+        "raw_transcript": RAW_CLOSED_TASK_NEEDLE,
+    }
+    decision = module.validate_continuity_packet(unsafe_packet)
+
+    assert decision["status"] == "hold"
+    assert decision["safe_hold"] is True
+    assert decision["provider_call_allowed"] is False
+    assert decision["state_mutation_allowed"] is False
+    assert decision["reason"] in {
+        "unsafe_continuity_packet",
+        "invalid_continuity_packet",
+    }
+    _assert_no_raw_needles(decision)
+
+
+def test_allowed_metadata_field_values_with_raw_secret_private_material_fail_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Allowed metadata keys must still reject unsafe raw/private values."""
+
+    _isolated_hermes_home(tmp_path, monkeypatch)
+    module = _load_phase8_module()
+
+    decision = module.validate_continuity_packet(_unsafe_metadata_value_packet())
+
+    assert decision["status"] == "hold"
+    assert decision["safe_hold"] is True
+    assert decision["provider_call_allowed"] is False
+    assert decision["state_mutation_allowed"] is False
+    _assert_no_metadata_value_needles(decision)
+    _assert_no_metadata_value_needles(repr(decision))
+
+
+def test_unsafe_metadata_values_do_not_promote_to_same_window_plan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unsafe metadata values must not be promoted into a ready plan."""
+
+    _isolated_hermes_home(tmp_path, monkeypatch)
+    module = _load_phase8_module()
+
+    plan = module.build_same_window_rehydrate_plan(
+        continuity_packet=_unsafe_metadata_value_packet(),
+        session_id=SAFE_SESSION_ID,
+        current_task_id=SAFE_TASK_ID,
+        dry_run=True,
+    )
+
+    assert plan["status"] == "hold"
+    assert plan["safe_hold"] is True
+    assert plan["provider_call_allowed"] is False
+    assert plan["state_mutation_allowed"] is False
+    assert plan.get("same_window") is True
+    assert plan.get("requires_new_process") is False
+    assert plan.get("requires_clear") is False
+    _assert_no_metadata_value_needles(plan)
+    _assert_no_metadata_value_needles(repr(plan))
+
+
+def test_reentry_payload_does_not_reinject_unsafe_metadata_values(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Provider payload must not expose unsafe metadata-field values."""
+
+    _isolated_hermes_home(tmp_path, monkeypatch)
+    module = _load_phase8_module()
+
+    plan = module.build_same_window_rehydrate_plan(
+        continuity_packet=_unsafe_metadata_value_packet(),
+        session_id=SAFE_SESSION_ID,
+        current_task_id=SAFE_TASK_ID,
+        dry_run=True,
+    )
+    payload = module.build_reentry_provider_payload(
+        plan=plan,
+        previous_conversation_history=[
+            {"role": "user", "content": METADATA_RAW_TRANSCRIPT_NEEDLE},
+            {"role": "assistant", "content": METADATA_UNRELATED_AB_NEEDLE},
+        ],
+    )
+
+    assert payload.get("status") == "hold"
+    assert payload.get("safe_hold") is True
+    assert payload.get("provider_call_allowed") is False
+    _assert_no_metadata_value_needles(payload)
+    _assert_no_metadata_value_needles(repr(payload))
+
+
+def test_phase8_red_contract_does_not_include_gateway_update_survival_or_command_activation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Phase 8 RED is planner/contract only, not command/gateway/update survival."""
+
+    _isolated_hermes_home(tmp_path, monkeypatch)
+    module = _load_phase8_module()
+
+    plan = module.build_same_window_rehydrate_plan(
+        continuity_packet=_phase7_continuity_packet(),
+        session_id=SAFE_SESSION_ID,
+        current_task_id=SAFE_TASK_ID,
+        dry_run=True,
+    )
+
+    assert plan["scope"] == "planner_contract_only"
+    assert plan["adds_cli_command"] is False
+    assert plan["touches_gateway_update_survival"] is False
+    assert plan["runtime_activation_required"] is False
+    assert plan["allowed_files"] == ["tests/agent/test_same_window_rehydrate.py"]

--- a/tests/agent/test_task_boundary_firewall.py
+++ b/tests/agent/test_task_boundary_firewall.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import importlib
+
+
+TASK_A_ID = "phase5-task-a"
+TASK_B_ID = "phase5-task-b"
+TASK_A_CURRENT_PIN = "/tmp/phase5/task-a/current-pin.md"
+TASK_A_WORKSPEC = "/tmp/phase5/task-a/WorkSpec.md"
+TASK_A_TASK_STATE = "/tmp/phase5/task-a/task-state.json"
+RAW_A_NEEDLE = "RAW_CLOSED_TASK_A_PHASE5_NEEDLE"
+
+
+def _load_firewall_module():
+    return importlib.import_module("agent.task_boundary_firewall")
+
+
+def _registry_snapshot_with_closed_a_and_active_b():
+    return {
+        "schema": "context_health_task_registry_v1",
+        "active_task_id": TASK_B_ID,
+        "tasks": {
+            TASK_A_ID: {
+                "task_id": TASK_A_ID,
+                "status": "closed",
+                "workspec_path": TASK_A_WORKSPEC,
+                "task_state_path": TASK_A_TASK_STATE,
+                "current_pin_path": TASK_A_CURRENT_PIN,
+                "raw_transcript_excerpt": RAW_A_NEEDLE,
+            },
+            TASK_B_ID: {
+                "task_id": TASK_B_ID,
+                "status": "active",
+                "workspec_path": "/tmp/phase5/task-b/WorkSpec.md",
+            },
+        },
+    }
+
+
+def test_firewall_disabled_returns_use_original_pass_through():
+    module = _load_firewall_module()
+
+    decision = module.enforce_task_boundary_firewall(
+        policy={"enabled": False},
+        registry_snapshot=_registry_snapshot_with_closed_a_and_active_b(),
+        current_task_id=TASK_B_ID,
+        user_message="simple message while firewall disabled",
+    )
+
+    assert decision.action == "use_original"
+    assert decision.allowed_task_ids in ((), [], None)
+    assert decision.excluded_task_ids in ((), [], None)
+
+
+def test_new_independent_b_excludes_closed_task_a_by_default():
+    module = _load_firewall_module()
+
+    decision = module.enforce_task_boundary_firewall(
+        policy={
+            "enabled": True,
+            "runtime_behavior_enabled": True,
+            "task_boundary": {"enabled": True, "default_without_clear_continuation": "new_task"},
+            "task_boundary_firewall": {"enabled": True},
+        },
+        registry_snapshot=_registry_snapshot_with_closed_a_and_active_b(),
+        current_task_id=TASK_B_ID,
+        user_message="start unrelated B task",
+    )
+
+    assert decision.action == "allow_new_task"
+    assert TASK_B_ID in decision.allowed_task_ids
+    assert TASK_A_ID in decision.excluded_task_ids
+    assert TASK_A_CURRENT_PIN not in repr(decision)
+    assert RAW_A_NEEDLE not in repr(decision)
+
+
+def test_explicit_continuation_allows_only_safe_a_pointer():
+    module = _load_firewall_module()
+
+    decision = module.enforce_task_boundary_firewall(
+        policy={"enabled": True, "runtime_behavior_enabled": True, "task_boundary_firewall": {"enabled": True}},
+        registry_snapshot=_registry_snapshot_with_closed_a_and_active_b(),
+        current_task_id=TASK_A_ID,
+        user_message=f"continue {TASK_A_ID} using its WorkSpec",
+        explicit_continuation_refs=[TASK_A_ID],
+    )
+
+    assert decision.action in {"allow_continue_task", "allow_linked_task_context"}
+    assert TASK_A_ID in decision.allowed_task_ids
+    assert TASK_A_ID not in decision.excluded_task_ids
+    assert TASK_A_CURRENT_PIN in repr(decision.safe_linked_task_pointers)
+    assert RAW_A_NEEDLE not in repr(decision)
+
+
+def test_ambiguous_previous_reference_holds():
+    module = _load_firewall_module()
+
+    decision = module.enforce_task_boundary_firewall(
+        policy={"enabled": True, "runtime_behavior_enabled": True, "task_boundary_firewall": {"enabled": True}},
+        registry_snapshot=_registry_snapshot_with_closed_a_and_active_b(),
+        current_task_id=TASK_B_ID,
+        user_message="continue the previous one",
+    )
+
+    assert decision.action == "hold"
+    assert decision.hold_response
+    assert RAW_A_NEEDLE not in decision.hold_response
+
+
+def test_closed_a_paths_quarantined_for_independent_b():
+    module = _load_firewall_module()
+
+    decision = module.enforce_task_boundary_firewall(
+        policy={"enabled": True, "runtime_behavior_enabled": True, "task_boundary_firewall": {"enabled": True}},
+        registry_snapshot=_registry_snapshot_with_closed_a_and_active_b(),
+        current_task_id=TASK_B_ID,
+        user_message="new unrelated B task",
+    )
+
+    rendered = repr(decision.filtered_registry_snapshot)
+    assert TASK_A_CURRENT_PIN not in rendered
+    assert TASK_A_WORKSPEC not in rendered
+    assert TASK_A_TASK_STATE not in rendered
+    assert TASK_B_ID in rendered
+
+
+def test_user_pasted_old_task_marker_without_clear_continuation_holds():
+    module = _load_firewall_module()
+
+    decision = module.enforce_task_boundary_firewall(
+        policy={"enabled": True, "runtime_behavior_enabled": True, "task_boundary_firewall": {"enabled": True}},
+        registry_snapshot=_registry_snapshot_with_closed_a_and_active_b(),
+        current_task_id=TASK_B_ID,
+        user_message=f"Here is {TASK_A_ID}: {RAW_A_NEEDLE}\nNow do something different",
+    )
+
+    assert decision.action == "hold"
+    assert RAW_A_NEEDLE not in repr(decision)

--- a/tests/agent/test_task_registry.py
+++ b/tests/agent/test_task_registry.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+
+
+OLD_TASK_A_ID = "phase4-task-a"
+NEW_TASK_B_ID = "phase4-task-b"
+
+
+def _load_registry_module():
+    return importlib.import_module("agent.task_registry")
+
+
+def test_registry_disabled_returns_use_original_contract(tmp_path):
+    module = _load_registry_module()
+
+    decision = module.resolve_task_for_turn(
+        policy={"enabled": False},
+        registry_root=tmp_path,
+        session_id="phase4-session",
+        incoming_task_id="caller-task-id",
+        user_message="new request while registry disabled",
+    )
+
+    assert decision.action in {"use_original", "pass"}
+    assert decision.effective_task_id == "caller-task-id"
+    assert decision.registry_snapshot is None or decision.registry_snapshot == {}
+    assert not (tmp_path / "registry.json").exists()
+    assert not (tmp_path / "events.jsonl").exists()
+
+
+def test_no_clear_continuation_defaults_to_new_task(tmp_path):
+    module = _load_registry_module()
+    registry = {
+        "schema": "context_health_task_registry_v1",
+        "schema_version": 1,
+        "active_task_id": OLD_TASK_A_ID,
+        "tasks": {
+            OLD_TASK_A_ID: {
+                "task_id": OLD_TASK_A_ID,
+                "status": "active",
+                "title": "old task A",
+                "linked_task_ids": [],
+            }
+        },
+    }
+    (tmp_path / "registry.json").write_text(json.dumps(registry), encoding="utf-8")
+
+    decision = module.resolve_task_for_turn(
+        policy={
+            "enabled": True,
+            "runtime_behavior_enabled": True,
+            "task_boundary": {"enabled": True, "default_without_clear_continuation": "new_task"},
+            "task_registry": {"enabled": True},
+        },
+        registry_root=tmp_path,
+        session_id="phase4-session",
+        incoming_task_id=None,
+        user_message="Start an unrelated task B with no continuation reference.",
+    )
+
+    assert decision.action == "new_task"
+    assert decision.effective_task_id != OLD_TASK_A_ID
+    assert decision.effective_task_id
+    assert decision.reason == "no_clear_continuation_evidence"
+    updated = json.loads((tmp_path / "registry.json").read_text(encoding="utf-8"))
+    assert updated["active_task_id"] == decision.effective_task_id
+    assert updated["tasks"][OLD_TASK_A_ID]["status"] in {"closed", "archived"}
+    assert "task_created" in (tmp_path / "events.jsonl").read_text(encoding="utf-8")
+
+
+def test_explicit_continuation_reuses_or_reopens_task_a(tmp_path):
+    module = _load_registry_module()
+    registry = {
+        "schema": "context_health_task_registry_v1",
+        "schema_version": 1,
+        "active_task_id": None,
+        "tasks": {
+            OLD_TASK_A_ID: {
+                "task_id": OLD_TASK_A_ID,
+                "status": "closed",
+                "title": "old task A",
+                "linked_task_ids": [],
+            }
+        },
+    }
+    (tmp_path / "registry.json").write_text(json.dumps(registry), encoding="utf-8")
+
+    decision = module.resolve_task_for_turn(
+        policy={
+            "enabled": True,
+            "runtime_behavior_enabled": True,
+            "task_boundary": {"enabled": True, "default_without_clear_continuation": "new_task"},
+            "task_registry": {"enabled": True},
+        },
+        registry_root=tmp_path,
+        session_id="phase4-session",
+        incoming_task_id=None,
+        user_message=f"{OLD_TASK_A_ID} 계속 진행해줘",
+        explicit_continuation_refs=[OLD_TASK_A_ID],
+    )
+
+    assert decision.action == "continue_task"
+    assert decision.effective_task_id == OLD_TASK_A_ID
+    assert decision.linked_task_id == OLD_TASK_A_ID
+    assert decision.reason == "explicit_continuation_reference"
+
+
+def test_ambiguous_relation_holds_when_policy_says_hold(tmp_path):
+    module = _load_registry_module()
+    registry = {
+        "schema": "context_health_task_registry_v1",
+        "schema_version": 1,
+        "active_task_id": OLD_TASK_A_ID,
+        "tasks": {OLD_TASK_A_ID: {"task_id": OLD_TASK_A_ID, "status": "active"}},
+    }
+    (tmp_path / "registry.json").write_text(json.dumps(registry), encoding="utf-8")
+
+    decision = module.resolve_task_for_turn(
+        policy={
+            "enabled": True,
+            "runtime_behavior_enabled": True,
+            "task_boundary": {"enabled": True, "ambiguous_action": "hold"},
+            "task_registry": {"enabled": True},
+        },
+        registry_root=tmp_path,
+        session_id="phase4-session",
+        incoming_task_id=None,
+        user_message="이거 아까 그거랑 이어지는지 새로 하는 건지 애매해 token=abc123",
+        ambiguous_relation=True,
+    )
+
+    assert decision.action == "hold"
+    assert decision.effective_task_id is None
+    assert "abc123" not in repr(decision)
+    assert "token=abc123" not in repr(decision)
+
+
+def test_registry_json_snapshot_and_events_jsonl_are_atomic_and_append_only(tmp_path):
+    module = _load_registry_module()
+
+    first = module.record_task_event(
+        registry_root=tmp_path,
+        event="task_created",
+        task_id=OLD_TASK_A_ID,
+        session_id="phase4-session",
+        status="active",
+    )
+    second = module.record_task_event(
+        registry_root=tmp_path,
+        event="task_closed",
+        task_id=OLD_TASK_A_ID,
+        session_id="phase4-session",
+        status="closed",
+        reason="completed_task_state",
+    )
+
+    snapshot = json.loads((tmp_path / "registry.json").read_text(encoding="utf-8"))
+    events = (tmp_path / "events.jsonl").read_text(encoding="utf-8").strip().splitlines()
+    assert first["task_id"] == OLD_TASK_A_ID
+    assert second["task_id"] == OLD_TASK_A_ID
+    assert snapshot["tasks"][OLD_TASK_A_ID]["status"] == "closed"
+    assert len(events) == 2
+    assert "task_created" in events[0]
+    assert "task_closed" in events[1]
+
+
+def test_completed_workspec_task_state_can_seed_closed_registry_record(tmp_path):
+    module = _load_registry_module()
+    task_state = tmp_path / "task-state.json"
+    task_state.write_text(
+        json.dumps(
+            {
+                "schema": "workspec_task_state_v1",
+                "packet_dir": str(tmp_path),
+                "active_goal": "old task A",
+                "status": "completed",
+                "tasks": [{"id": "t1", "status": "completed", "text": "done"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    record = module.import_workspec_task_state(
+        registry_root=tmp_path / "registry",
+        task_id=OLD_TASK_A_ID,
+        session_id="phase4-session",
+        task_state_path=task_state,
+    )
+
+    assert record["task_id"] == OLD_TASK_A_ID
+    assert record["status"] == "closed"
+    assert record["task_state_path"] == str(task_state)
+    assert "task_closed" in (tmp_path / "registry" / "events.jsonl").read_text(encoding="utf-8")
+
+
+def test_enabled_corrupt_registry_json_raises_typed_failure(tmp_path):
+    module = _load_registry_module()
+    (tmp_path / "registry.json").write_text("{not valid json", encoding="utf-8")
+
+    with pytest.raises(module.TaskRegistryFailure) as exc:
+        module.resolve_task_for_turn(
+            policy={
+                "enabled": True,
+                "runtime_behavior_enabled": True,
+                "task_boundary": {"enabled": True},
+                "task_registry": {"enabled": True},
+            },
+            registry_root=tmp_path,
+            session_id="phase4-session",
+            incoming_task_id=None,
+            user_message="new task B",
+        )
+
+    assert exc.value.reason == "task_registry_corrupt_snapshot"
+    assert "not valid" not in exc.value.user_response
+
+
+def test_enabled_event_append_failure_raises_typed_failure(tmp_path, monkeypatch):
+    module = _load_registry_module()
+
+    def fail_append(*_args, **_kwargs):
+        raise OSError("permission denied token=raw-secret")
+
+    monkeypatch.setattr(module, "_append_event", fail_append)
+
+    with pytest.raises(module.TaskRegistryFailure) as exc:
+        module.resolve_task_for_turn(
+            policy={
+                "enabled": True,
+                "runtime_behavior_enabled": True,
+                "task_boundary": {"enabled": True},
+                "task_registry": {"enabled": True},
+            },
+            registry_root=tmp_path,
+            session_id="phase4-session",
+            incoming_task_id=None,
+            user_message="new task B",
+        )
+
+    assert exc.value.reason == "task_registry_write_failure"
+    assert "raw-secret" not in exc.value.user_response
+    assert "token" not in exc.value.user_response.lower()

--- a/tests/agent/test_working_context_packet.py
+++ b/tests/agent/test_working_context_packet.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import importlib
+
+
+OLD_TASK_A_CONTRACT_NEEDLE = "OLD_TASK_A_CONTRACT_NEEDLE_PHASE3_RED"
+CURRENT_TASK_B_CONTRACT_WCP = "CURRENT_TASK_B_CONTRACT_WCP_PHASE3_RED"
+UNSAFE_CONTRACT_SECRET = "UNSAFE_CONTRACT_SECRET_PHASE3_RED token=abc123"
+
+
+def _load_wcp_module():
+    # Phase 3 RED contract: this module must not exist yet in the current
+    # approved scope. These tests document the future adapter API and are
+    # expected to fail with ModuleNotFoundError until implementation is approved.
+    return importlib.import_module("agent.working_context_packet")
+
+
+def test_wcp_adapter_disabled_returns_use_original_contract():
+    module = _load_wcp_module()
+    decision = module.enforce_working_context_packet(
+        policy={"enabled": False},
+        api_messages=[{"role": "user", "content": OLD_TASK_A_CONTRACT_NEEDLE}],
+        messages=[{"role": "user", "content": OLD_TASK_A_CONTRACT_NEEDLE}],
+        context_health_intake=None,
+    )
+
+    assert decision.action == "use_original"
+    assert decision.api_messages[0]["content"] == OLD_TASK_A_CONTRACT_NEEDLE
+
+
+def test_wcp_adapter_enabled_replaces_provider_messages_without_old_task_a_needle():
+    module = _load_wcp_module()
+    decision = module.enforce_working_context_packet(
+        policy={"enabled": True},
+        api_messages=[
+            {"role": "system", "content": "SYSTEM"},
+            {"role": "user", "content": OLD_TASK_A_CONTRACT_NEEDLE},
+            {"role": "user", "content": CURRENT_TASK_B_CONTRACT_WCP},
+        ],
+        messages=[{"role": "user", "content": OLD_TASK_A_CONTRACT_NEEDLE}],
+        context_health_intake={"summary_path": "/tmp/summary.md"},
+    )
+
+    assert decision.action == "replace_api_messages"
+    payload = repr(decision.api_messages)
+    assert CURRENT_TASK_B_CONTRACT_WCP in payload
+    assert OLD_TASK_A_CONTRACT_NEEDLE not in payload
+
+
+def test_wcp_adapter_enabled_unsafe_returns_hold_without_secret_body():
+    module = _load_wcp_module()
+    decision = module.enforce_working_context_packet(
+        policy={"enabled": True},
+        api_messages=[{"role": "user", "content": UNSAFE_CONTRACT_SECRET}],
+        messages=[{"role": "user", "content": UNSAFE_CONTRACT_SECRET}],
+        context_health_intake={"safe": False, "reason": "unsafe"},
+    )
+
+    assert decision.action == "hold"
+    assert decision.api_messages is None
+    assert UNSAFE_CONTRACT_SECRET not in repr(decision)
+    assert "abc123" not in repr(decision)

--- a/tests/run_agent/test_context_health_provider_payload.py
+++ b/tests/run_agent/test_context_health_provider_payload.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+OLD_TASK_A_RAW_NEEDLE = "OLD_TASK_A_RAW_NEEDLE_PHASE3_RED"
+OLD_TASK_A_ASSISTANT_NEEDLE = "OLD_TASK_A_ASSISTANT_NEEDLE_PHASE3_RED"
+OLD_TASK_A_TOOL_RESULT_NEEDLE = "OLD_TASK_A_TOOL_RESULT_NEEDLE_PHASE3_RED"
+PRIOR_PHASE2_RAW_LONG_PROMPT_NEEDLE = "PRIOR_PHASE2_RAW_LONG_PROMPT_NEEDLE_PHASE3_RED"
+CURRENT_TASK_B_WCP_MARKER = "CURRENT_TASK_B_WCP_MARKER_PHASE3_RED"
+CURRENT_TASK_B_NEEDLE = "CURRENT_TASK_B_NEEDLE_PHASE3_RED"
+PRE_API_OLD_TASK_A_NEEDLE = "PRE_API_OLD_TASK_A_NEEDLE_PHASE3_RED"
+PRE_API_CURRENT_WCP_MARKER = "PRE_API_CURRENT_WCP_MARKER_PHASE3_RED"
+DISABLED_PASS_THROUGH_NEEDLE = "DISABLED_WCP_PASS_THROUGH_NEEDLE_PHASE3_RED"
+UNSAFE_WCP_SECRET_NEEDLE = "UNSAFE_WCP_SECRET_NEEDLE_PHASE3_RED"
+
+
+def _response(content: str = "ok"):
+    message = SimpleNamespace(content=content, reasoning=None, tool_calls=[])
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], usage=None, model="fake-model")
+
+
+def _make_agent(*, wcp_enabled: bool) -> AIAgent:
+    cfg = {
+        "context_health": {
+            "enabled": bool(wcp_enabled),
+            "runtime_behavior_enabled": bool(wcp_enabled),
+            "pre_model_intake": {"enabled": False},
+            "working_context_packet": {"enabled": bool(wcp_enabled)},
+        },
+        "agent": {"api_max_retries": 1},
+    }
+    with (
+        patch("run_agent.OpenAI"),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value=cfg),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    setattr(agent, "context_health", cfg["context_health"])
+    agent.client.chat.completions.create.return_value = _response()
+    agent._persist_session = lambda *a, **k: None
+    agent._save_trajectory = lambda *a, **k: None
+    agent._cleanup_task_resources = lambda *a, **k: None
+    return agent
+
+
+def _run_and_capture_provider_kwargs(agent: AIAgent, user_message: str, conversation_history: list[dict]):
+    captured: dict[str, object] = {"provider_called": False}
+    real_build = agent._build_api_kwargs
+
+    def capture_build(api_messages):
+        captured["api_messages_input_to_build_kwargs"] = [dict(m) for m in api_messages]
+        api_kwargs = real_build(api_messages)
+        captured["api_kwargs_after_build"] = dict(api_kwargs)
+        return api_kwargs
+
+    def fake_create(**kwargs):
+        captured["provider_called"] = True
+        captured["provider_kwargs_at_call"] = dict(kwargs)
+        return _response()
+
+    agent._build_api_kwargs = capture_build
+    agent.client.chat.completions.create.side_effect = fake_create
+
+    result = agent.run_conversation(
+        user_message,
+        conversation_history=conversation_history,
+        task_id="phase3-red-test-task",
+    )
+    captured["result"] = result
+    return captured
+
+
+def _payload_text(captured: dict[str, object]) -> str:
+    return repr(
+        {
+            "api_messages": captured.get("api_messages_input_to_build_kwargs"),
+            "api_kwargs_after_build": captured.get("api_kwargs_after_build"),
+            "provider_kwargs_at_call": captured.get("provider_kwargs_at_call"),
+        }
+    )
+
+
+def test_wcp_enabled_excludes_old_task_a_needle_from_provider_kwargs():
+    agent = _make_agent(wcp_enabled=True)
+    history = [
+        {"role": "user", "content": f"old task A body {OLD_TASK_A_RAW_NEEDLE}"},
+        {"role": "assistant", "content": f"old task A plan {OLD_TASK_A_ASSISTANT_NEEDLE}"},
+    ]
+
+    captured = _run_and_capture_provider_kwargs(
+        agent,
+        f"new task B request {CURRENT_TASK_B_NEEDLE} {CURRENT_TASK_B_WCP_MARKER}",
+        history,
+    )
+
+    payload = _payload_text(captured)
+    assert CURRENT_TASK_B_NEEDLE in payload
+    assert OLD_TASK_A_RAW_NEEDLE not in payload
+    assert OLD_TASK_A_ASSISTANT_NEEDLE not in payload
+
+
+def test_wcp_enabled_phase2_bridge_excludes_prior_raw_long_history_needle_from_provider_kwargs():
+    agent = _make_agent(wcp_enabled=True)
+    history = [
+        {
+            "role": "user",
+            "content": "prior raw long prompt that should be excluded "
+            f"{PRIOR_PHASE2_RAW_LONG_PROMPT_NEEDLE} "
+            + ("line " * 80),
+        },
+        {"role": "assistant", "content": "old task A completed"},
+    ]
+    safe_current_pointer = (
+        "Context Health Intake safe summary/path pointer "
+        f"{CURRENT_TASK_B_WCP_MARKER} summary.md task-state.md"
+    )
+
+    captured = _run_and_capture_provider_kwargs(agent, safe_current_pointer, history)
+
+    payload = _payload_text(captured)
+    assert "Context Health Intake" in payload
+    assert CURRENT_TASK_B_WCP_MARKER in payload
+    assert PRIOR_PHASE2_RAW_LONG_PROMPT_NEEDLE not in payload
+
+
+def test_wcp_enabled_unsafe_build_returns_safe_hold_without_provider_call():
+    agent = _make_agent(wcp_enabled=True)
+    provider_called = False
+
+    def fail_if_called(**_kwargs):
+        nonlocal provider_called
+        provider_called = True
+        raise AssertionError("provider/model call should not happen when WCP build is unsafe")
+
+    agent.client.chat.completions.create.side_effect = fail_if_called
+    unsafe_prompt = f"unsafe ambiguous task boundary {UNSAFE_WCP_SECRET_NEEDLE} token=abc123"
+
+    result = agent.run_conversation(
+        unsafe_prompt,
+        conversation_history=[{"role": "assistant", "content": "old task context"}],
+        task_id="phase3-red-unsafe",
+    )
+
+    assert result["failed"] is True
+    assert result["completed"] is False
+    assert result["api_calls"] == 0
+    assert provider_called is False
+    assert UNSAFE_WCP_SECRET_NEEDLE not in repr(result)
+    assert "abc123" not in repr(result)
+
+
+def test_pre_api_request_observes_wcp_limited_request_messages():
+    agent = _make_agent(wcp_enabled=True)
+    captured_hook: dict[str, object] = {}
+
+    def fake_has_hook(name):
+        return name == "pre_api_request"
+
+    def fake_invoke_hook(name, **kwargs):
+        if name == "pre_api_request":
+            captured_hook.update(kwargs)
+        return []
+
+    history = [
+        {"role": "user", "content": f"old task A pre-api text {PRE_API_OLD_TASK_A_NEEDLE}"},
+        {"role": "assistant", "content": "old answer"},
+    ]
+
+    with (
+        patch("hermes_cli.plugins.has_hook", fake_has_hook),
+        patch("hermes_cli.plugins.invoke_hook", fake_invoke_hook),
+    ):
+        _run_and_capture_provider_kwargs(
+            agent,
+            f"current B {PRE_API_CURRENT_WCP_MARKER}",
+            history,
+        )
+
+    request_messages = captured_hook.get("request_messages")
+    assert request_messages, "pre_api_request hook was not invoked with request_messages"
+    request_payload = repr(
+        {
+            "request_messages": request_messages,
+            "request": captured_hook.get("request"),
+        }
+    )
+    assert PRE_API_CURRENT_WCP_MARKER in request_payload
+    assert PRE_API_OLD_TASK_A_NEEDLE not in request_payload
+
+
+def test_wcp_disabled_provider_payload_passes_through_full_history():
+    agent = _make_agent(wcp_enabled=False)
+    history = [
+        {"role": "user", "content": f"old task text {DISABLED_PASS_THROUGH_NEEDLE}"},
+        {"role": "assistant", "content": "old task answer"},
+    ]
+
+    captured = _run_and_capture_provider_kwargs(agent, "new task while disabled", history)
+
+    payload = _payload_text(captured)
+    assert captured["provider_called"] is True
+    assert DISABLED_PASS_THROUGH_NEEDLE in payload
+
+
+def test_wcp_excludes_old_task_tool_chain_without_orphaning_tool_messages():
+    agent = _make_agent(wcp_enabled=True)
+    history = [
+        {"role": "user", "content": "old task A uses a tool"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_old_a",
+                    "type": "function",
+                    "function": {"name": "read_file", "arguments": "{\"path\":\"old.txt\"}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_old_a", "content": OLD_TASK_A_TOOL_RESULT_NEEDLE},
+        {"role": "assistant", "content": "old task A final"},
+    ]
+
+    captured = _run_and_capture_provider_kwargs(
+        agent,
+        f"current B independent task {CURRENT_TASK_B_WCP_MARKER}",
+        history,
+    )
+
+    payload = _payload_text(captured)
+    assert CURRENT_TASK_B_WCP_MARKER in payload
+    assert OLD_TASK_A_TOOL_RESULT_NEEDLE not in payload
+    api_messages = captured.get("api_messages_input_to_build_kwargs") or []
+    tool_messages = [m for m in api_messages if isinstance(m, dict) and m.get("role") == "tool"]
+    assert tool_messages == []

--- a/tests/run_agent/test_context_health_retrieval_scope.py
+++ b/tests/run_agent/test_context_health_retrieval_scope.py
@@ -1,0 +1,479 @@
+from __future__ import annotations
+
+import json
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from run_agent import AIAgent
+from tools.session_search_tool import session_search
+
+
+TASK_A_ID = "phase6-task-a"
+TASK_B_ID = "phase6-task-b"
+TASK_A_SESSION_ID = "session-phase6-a"
+TASK_B_SESSION_ID = "session-phase6-b"
+TASK_A_ANCHOR_ID = 61001
+TASK_A_NEEDLE = "PHASE6_CLOSED_TASK_A_RETRIEVAL_NEEDLE"
+MEMORY_A_NEEDLE = "PHASE6_MEMORY_PREFETCH_CLOSED_A_NEEDLE"
+PLUGIN_A_NEEDLE = "PHASE6_PLUGIN_CONTEXT_CLOSED_A_NEEDLE"
+
+
+class FakeSessionDB:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, object]] = []
+        self.schema_fingerprint = "messages(id,session_id,role,content,timestamp)"
+        self.sessions = {
+            TASK_A_SESSION_ID: {
+                "id": TASK_A_SESSION_ID,
+                "title": "closed task A",
+                "source": "cli",
+                "started_at": 1,
+                "model": "test-model",
+            },
+            TASK_B_SESSION_ID: {
+                "id": TASK_B_SESSION_ID,
+                "title": "active task B",
+                "source": "cli",
+                "started_at": 2,
+                "model": "test-model",
+            },
+        }
+        self.messages = {
+            TASK_A_SESSION_ID: [
+                {"id": TASK_A_ANCHOR_ID, "session_id": TASK_A_SESSION_ID, "role": "user", "content": TASK_A_NEEDLE, "timestamp": 1},
+                {"id": TASK_A_ANCHOR_ID + 1, "session_id": TASK_A_SESSION_ID, "role": "assistant", "content": "closed A answer", "timestamp": 2},
+            ],
+            TASK_B_SESSION_ID: [
+                {"id": 62001, "session_id": TASK_B_SESSION_ID, "role": "user", "content": "active B", "timestamp": 3},
+            ],
+        }
+
+    def get_session(self, session_id: str):
+        self.calls.append(("get_session", session_id))
+        return self.sessions.get(session_id)
+
+    def search_messages(self, **kwargs):
+        self.calls.append(("search_messages", dict(kwargs)))
+        return [
+            {
+                "id": TASK_A_ANCHOR_ID,
+                "session_id": TASK_A_SESSION_ID,
+                "role": "user",
+                "snippet": TASK_A_NEEDLE,
+                "source": "cli",
+                "model": "test-model",
+                "session_started": 1,
+            }
+        ]
+
+    def get_anchored_view(self, session_id: str, msg_id: int, window: int = 5, bookend: int = 3):
+        self.calls.append(("get_anchored_view", {"session_id": session_id, "msg_id": msg_id}))
+        rows = self.messages.get(session_id, [])
+        return {
+            "window": rows,
+            "bookend_start": rows[:bookend],
+            "bookend_end": rows[-bookend:],
+            "messages_before": 0,
+            "messages_after": 0,
+        }
+
+    def get_messages(self, session_id: str):
+        self.calls.append(("get_messages", session_id))
+        return list(self.messages.get(session_id, []))
+
+    def get_messages_around(self, session_id: str, around_message_id: int, window: int = 5):
+        self.calls.append(("get_messages_around", {"session_id": session_id, "around_message_id": around_message_id}))
+        return {
+            "window": list(self.messages.get(session_id, [])),
+            "messages_before": 0,
+            "messages_after": 0,
+        }
+
+    def list_sessions_rich(self, **kwargs):
+        self.calls.append(("list_sessions_rich", dict(kwargs)))
+        return list(self.sessions.values())
+
+
+def _json(text: str):
+    return json.loads(text)
+
+
+def _closed_a_registry_snapshot():
+    return {
+        "schema": "context_health_task_registry_v1",
+        "active_task_id": TASK_B_ID,
+        "tasks": {
+            TASK_A_ID: {"task_id": TASK_A_ID, "status": "closed", "session_id": TASK_A_SESSION_ID, "latest_turn_id": str(TASK_A_ANCHOR_ID)},
+            TASK_B_ID: {"task_id": TASK_B_ID, "status": "active", "session_id": TASK_B_SESSION_ID},
+        },
+    }
+
+
+def _enabled_retrieval_scope(*, linked: bool = False, ambiguous: bool = False):
+    allowed_task_ids = [TASK_B_ID, TASK_A_ID] if linked else [TASK_B_ID]
+    allowed_session_ids = [TASK_B_SESSION_ID, TASK_A_SESSION_ID] if linked else [TASK_B_SESSION_ID]
+    excluded_task_ids = [] if linked else [TASK_A_ID]
+    excluded_session_ids = [] if linked else [TASK_A_SESSION_ID]
+    return {
+        "enabled": True,
+        "mode": "explicit_link" if linked else "current_task_only",
+        "relation": "ambiguous" if ambiguous else ("explicit_link" if linked else "new_independent_task"),
+        "current_task_id": TASK_B_ID,
+        "allowed_task_ids": allowed_task_ids,
+        "excluded_task_ids": excluded_task_ids,
+        "allowed_session_ids": allowed_session_ids,
+        "excluded_session_ids": excluded_session_ids,
+        "linked_task_ids": [TASK_A_ID] if linked else [],
+        "registry_snapshot": _closed_a_registry_snapshot(),
+    }
+
+
+def test_session_search_discovery_with_enabled_scope_excludes_closed_a_for_independent_b():
+    db = FakeSessionDB()
+
+    result = _json(
+        session_search(
+            query=TASK_A_NEEDLE,
+            db=db,
+            current_session_id=TASK_B_SESSION_ID,
+            retrieval_scope=_enabled_retrieval_scope(),
+        )
+    )
+
+    assert result.get("success") is True or result.get("mode") in {"hold", "blocked"}
+    assert TASK_A_NEEDLE not in repr(result)
+    assert result.get("results") in ([], None) or result.get("mode") in {"hold", "blocked"}
+    assert not any(call[0] == "search_messages" for call in db.calls)
+    assert not any(call[0] == "get_anchored_view" for call in db.calls)
+
+
+def test_session_search_read_with_enabled_scope_blocks_closed_a_when_b_is_independent():
+    db = FakeSessionDB()
+
+    result = _json(
+        session_search(
+            session_id=TASK_A_SESSION_ID,
+            db=db,
+            current_session_id=TASK_B_SESSION_ID,
+            retrieval_scope=_enabled_retrieval_scope(),
+        )
+    )
+
+    assert result.get("success") is False or result.get("mode") in {"hold", "blocked"}
+    assert TASK_A_NEEDLE not in repr(result)
+
+
+def test_session_search_scroll_with_enabled_scope_blocks_closed_a_when_b_is_independent():
+    db = FakeSessionDB()
+
+    result = _json(
+        session_search(
+            session_id=TASK_A_SESSION_ID,
+            around_message_id=TASK_A_ANCHOR_ID,
+            db=db,
+            current_session_id=TASK_B_SESSION_ID,
+            retrieval_scope=_enabled_retrieval_scope(),
+        )
+    )
+
+    assert result.get("success") is False or result.get("mode") in {"hold", "blocked"}
+    assert TASK_A_NEEDLE not in repr(result)
+
+
+def test_explicit_continuation_reads_linked_a_only_when_scope_allows_it():
+    db = FakeSessionDB()
+    scope = _enabled_retrieval_scope(linked=True)
+
+    result = _json(
+        session_search(
+            session_id=TASK_A_SESSION_ID,
+            db=db,
+            current_session_id=TASK_B_SESSION_ID,
+            retrieval_scope=scope,
+        )
+    )
+
+    assert TASK_A_ID in scope["linked_task_ids"]
+    assert TASK_A_SESSION_ID in scope["allowed_session_ids"]
+    assert result.get("success") is True
+    assert result.get("mode") == "read"
+    assert result.get("session_id") == TASK_A_SESSION_ID
+    assert len(result.get("messages", [])) <= 30
+
+
+def test_ambiguous_previous_reference_with_enabled_scope_blocks_before_search():
+    db = FakeSessionDB()
+
+    result = _json(
+        session_search(
+            query="use the previous one",
+            db=db,
+            current_session_id=TASK_B_SESSION_ID,
+            retrieval_scope=_enabled_retrieval_scope(ambiguous=True),
+        )
+    )
+
+    assert result.get("success") is False or result.get("mode") in {"hold", "blocked"}
+    assert not any(call[0] == "search_messages" for call in db.calls)
+    assert TASK_A_NEEDLE not in repr(result)
+
+
+def test_disabled_retrieval_scope_preserves_existing_session_search_pass_through():
+    db = FakeSessionDB()
+
+    result = _json(session_search(query=TASK_A_NEEDLE, db=db, current_session_id=TASK_B_SESSION_ID))
+
+    assert result.get("success") is True
+    assert TASK_A_NEEDLE in repr(result)
+    assert any(call[0] == "search_messages" for call in db.calls)
+
+
+def _response(content: str = "ok"):
+    message = SimpleNamespace(content=content, reasoning=None, tool_calls=[])
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], usage=None, model="fake-model")
+
+
+def _make_agent(tmp_path, *, retrieval_scope_enabled: bool = True) -> AIAgent:
+    cfg = {
+        "context_health": {
+            "enabled": True,
+            "runtime_behavior_enabled": True,
+            "pre_model_intake": {"enabled": False},
+            "task_boundary": {"enabled": True, "default_without_clear_continuation": "new_task", "ambiguous_action": "hold"},
+            "task_registry": {"enabled": True},
+            "working_context_packet": {"enabled": True},
+            "task_boundary_firewall": {"enabled": True},
+            "retrieval_scope": {"enabled": retrieval_scope_enabled},
+        },
+        "agent": {"api_max_retries": 1},
+    }
+    with (
+        patch("run_agent.OpenAI"),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value=cfg),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    setattr(agent, "context_health", cfg["context_health"])
+    setattr(agent, "_context_health_intake_dir", tmp_path / "intake")
+    agent.client.chat.completions.create.return_value = _response()
+    agent._persist_session = lambda *a, **k: None
+    agent._save_trajectory = lambda *a, **k: None
+    agent._cleanup_task_resources = lambda *a, **k: None
+    return agent
+
+
+def _install_registry(monkeypatch, *, linked: bool = False):
+    module = types.ModuleType("agent.task_registry")
+
+    def resolve_task_for_turn(**_kwargs):
+        return SimpleNamespace(
+            action="link_task" if linked else "new_task",
+            effective_task_id=TASK_B_ID,
+            reason="explicit_link" if linked else "no_clear_continuation_evidence",
+            registry_snapshot=_closed_a_registry_snapshot(),
+            linked_task_id=TASK_A_ID if linked else None,
+            hold_response=None,
+        )
+
+    setattr(module, "resolve_task_for_turn", resolve_task_for_turn)
+    setattr(module, "record_completed_workspec_state", lambda **kwargs: {"task_id": kwargs.get("task_id")})
+    monkeypatch.setitem(sys.modules, "agent.task_registry", module)
+
+
+def _capture_provider_kwargs(agent: AIAgent):
+    captured: dict[str, object] = {"provider_called": False}
+    real_build = agent._build_api_kwargs
+
+    def capture_build(api_messages):
+        captured["api_messages_input_to_build_kwargs"] = [dict(m) for m in api_messages]
+        api_kwargs = real_build(api_messages)
+        captured["api_kwargs_after_build"] = dict(api_kwargs)
+        return api_kwargs
+
+    def fake_create(**kwargs):
+        captured["provider_called"] = True
+        captured["provider_kwargs_at_call"] = dict(kwargs)
+        return _response()
+
+    agent._build_api_kwargs = capture_build
+    agent.client.chat.completions.create.side_effect = fake_create
+    return captured
+
+
+def _payload_text(captured: dict[str, object]) -> str:
+    return repr(captured)
+
+
+class ScopeCapableMemoryManager:
+    supports_retrieval_scope = True
+
+    def __init__(self) -> None:
+        self.prefetch_calls: list[dict[str, object]] = []
+        self.turn_start_calls: list[str] = []
+
+    def on_turn_start(self, _turn_number, message, **_kwargs):
+        self.turn_start_calls.append(str(message))
+
+    def prefetch_all(self, query: str, **kwargs):
+        self.prefetch_calls.append({"query": query, **kwargs})
+        return f"memory returned closed A despite scope {MEMORY_A_NEEDLE}"
+
+
+class ScopeUnsupportedMemoryManager:
+    supports_retrieval_scope = False
+
+    def __init__(self) -> None:
+        self.prefetch_calls: list[str] = []
+        self.turn_start_calls: list[str] = []
+
+    def on_turn_start(self, _turn_number, message, **_kwargs):
+        self.turn_start_calls.append(str(message))
+
+    def prefetch_all(self, query: str):
+        self.prefetch_calls.append(query)
+        return f"unsupported memory returned closed A {MEMORY_A_NEEDLE}"
+
+
+def test_scope_capable_memory_prefetch_receives_scope_and_excludes_closed_a_from_provider_payload(tmp_path, monkeypatch):
+    _install_registry(monkeypatch)
+    agent = _make_agent(tmp_path, retrieval_scope_enabled=True)
+    fake_memory = ScopeCapableMemoryManager()
+    agent._memory_manager = fake_memory
+    captured = _capture_provider_kwargs(agent)
+
+    agent.run_conversation("start unrelated B task", conversation_history=[])
+
+    assert len(fake_memory.prefetch_calls) == 1
+    call = fake_memory.prefetch_calls[0]
+    assert call["query"] == "start unrelated B task"
+    assert call["current_task_id"] == TASK_B_ID
+    assert TASK_B_ID in call["allowed_task_ids"]
+    assert TASK_A_ID in call["excluded_task_ids"]
+    assert TASK_A_SESSION_ID in call["excluded_session_ids"]
+    assert MEMORY_A_NEEDLE not in _payload_text(captured)
+
+
+def test_scope_unsupported_memory_prefetch_is_skipped_or_holds_in_enabled_mode(tmp_path, monkeypatch):
+    _install_registry(monkeypatch)
+    agent = _make_agent(tmp_path, retrieval_scope_enabled=True)
+    fake_memory = ScopeUnsupportedMemoryManager()
+    agent._memory_manager = fake_memory
+    captured = _capture_provider_kwargs(agent)
+
+    agent.run_conversation("start unrelated B task", conversation_history=[])
+
+    assert fake_memory.prefetch_calls == [] or captured.get("provider_called") is False
+    assert MEMORY_A_NEEDLE not in _payload_text(captured)
+
+
+def test_plugin_pre_llm_call_receives_scope_and_closed_a_result_is_quarantined(tmp_path, monkeypatch):
+    _install_registry(monkeypatch)
+    agent = _make_agent(tmp_path, retrieval_scope_enabled=True)
+    captured = _capture_provider_kwargs(agent)
+    hook_calls: list[dict[str, object]] = []
+
+    def fake_invoke_hook(name, **kwargs):
+        if name == "pre_llm_call":
+            hook_calls.append({"name": name, **kwargs})
+            return [{"context": f"plugin returned closed A {PLUGIN_A_NEEDLE}"}]
+        return []
+
+    with patch("hermes_cli.plugins.invoke_hook", side_effect=fake_invoke_hook):
+        agent.run_conversation("start unrelated B task", conversation_history=[])
+
+    assert len(hook_calls) == 1
+    scope = hook_calls[0]["retrieval_scope"]
+    assert scope["enabled"] is True
+    assert scope["current_task_id"] == TASK_B_ID
+    assert TASK_B_ID in scope["allowed_task_ids"]
+    assert TASK_A_ID in scope["excluded_task_ids"]
+    assert PLUGIN_A_NEEDLE not in _payload_text(captured)
+
+
+def test_enabled_retrieval_scope_build_failure_fails_closed_before_unscoped_memory_plugin_or_provider(tmp_path, monkeypatch):
+    _install_registry(monkeypatch)
+    agent = _make_agent(tmp_path, retrieval_scope_enabled=True)
+    fake_memory = ScopeUnsupportedMemoryManager()
+    agent._memory_manager = fake_memory
+    captured = _capture_provider_kwargs(agent)
+    hook_calls: list[dict[str, object]] = []
+
+    def fake_invoke_hook(name, **kwargs):
+        if name == "pre_llm_call":
+            hook_calls.append({"name": name, **kwargs})
+            return [{"context": f"plugin returned closed A {PLUGIN_A_NEEDLE}"}]
+        return []
+
+    with (
+        patch(
+            "agent.retrieval_scope.build_retrieval_scope",
+            side_effect=RuntimeError("synthetic retrieval scope failure with token password secret"),
+        ),
+        patch("hermes_cli.plugins.invoke_hook", side_effect=fake_invoke_hook),
+    ):
+        result = agent.run_conversation("start unrelated B task", conversation_history=[])
+
+    assert captured.get("provider_called") is False
+    assert fake_memory.prefetch_calls == []
+    assert hook_calls == []
+    assert getattr(agent, "_context_health_retrieval_scope", {}) != {"enabled": False}
+    rendered = repr(result) + _payload_text(captured)
+    assert MEMORY_A_NEEDLE not in rendered
+    assert PLUGIN_A_NEEDLE not in rendered
+    assert TASK_A_NEEDLE not in rendered
+    assert "synthetic retrieval scope failure" not in rendered
+    assert "token" not in rendered.lower()
+    assert "password" not in rendered.lower()
+    assert "secret" not in rendered.lower()
+
+
+def test_disabled_retrieval_scope_build_failure_preserves_pass_through(tmp_path, monkeypatch):
+    _install_registry(monkeypatch)
+    agent = _make_agent(tmp_path, retrieval_scope_enabled=False)
+    fake_memory = ScopeUnsupportedMemoryManager()
+    agent._memory_manager = fake_memory
+    captured = _capture_provider_kwargs(agent)
+    hook_calls: list[dict[str, object]] = []
+
+    def fake_invoke_hook(name, **kwargs):
+        if name == "pre_llm_call":
+            hook_calls.append({"name": name, **kwargs})
+        return []
+
+    with (
+        patch(
+            "agent.retrieval_scope.build_retrieval_scope",
+            side_effect=RuntimeError("disabled synthetic retrieval scope failure"),
+        ),
+        patch("hermes_cli.plugins.invoke_hook", side_effect=fake_invoke_hook),
+    ):
+        agent.run_conversation("disabled scope legacy pass-through", conversation_history=[])
+
+    assert captured.get("provider_called") is True
+    assert fake_memory.prefetch_calls == ["disabled scope legacy pass-through"]
+    assert len(hook_calls) == 1
+    assert hook_calls[0]["retrieval_scope"] == {"enabled": False}
+    assert getattr(agent, "_context_health_retrieval_scope", {}) == {"enabled": False}
+
+
+def test_no_db_schema_or_transcript_mutation_during_phase6_scope_checks():
+    db = FakeSessionDB()
+    schema_before = db.schema_fingerprint
+    messages_before = {sid: [dict(row) for row in rows] for sid, rows in db.messages.items()}
+
+    session_search(query=TASK_A_NEEDLE, db=db, current_session_id=TASK_B_SESSION_ID)
+
+    assert db.schema_fingerprint == schema_before
+    assert db.messages == messages_before
+    assert not any(call[0].startswith("write") or call[0].startswith("delete") for call in db.calls)

--- a/tests/run_agent/test_context_health_task_boundary_firewall.py
+++ b/tests/run_agent/test_context_health_task_boundary_firewall.py
@@ -1,0 +1,418 @@
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from run_agent import AIAgent
+from agent.working_context_packet import enforce_working_context_packet
+
+
+TASK_A_ID = "phase5-task-a"
+TASK_B_ID = "phase5-task-b"
+RAW_A_NEEDLE = "RAW_CLOSED_TASK_A_PHASE5_PROVIDER_NEEDLE"
+A_ASSISTANT_NEEDLE = "ASSISTANT_CLOSED_TASK_A_PHASE5_NEEDLE"
+A_TOOL_NEEDLE = "TOOL_RESULT_CLOSED_TASK_A_PHASE5_NEEDLE"
+A_COMPACT_NEEDLE = "COMPACT_SUMMARY_CLOSED_TASK_A_PHASE5_NEEDLE"
+A_PLUGIN_NEEDLE = "PLUGIN_CONTEXT_CLOSED_TASK_A_PHASE5_NEEDLE"
+A_MEMORY_NEEDLE = "MEMORY_PREFETCH_CLOSED_TASK_A_PHASE5_NEEDLE"
+A_SESSION_SEARCH_NEEDLE = "SESSION_SEARCH_RESULT_CLOSED_TASK_A_PHASE5_NEEDLE"
+TASK_A_CURRENT_PIN = "/tmp/phase5/task-a/current-pin.md"
+TASK_A_WORKSPEC = "/tmp/phase5/task-a/WorkSpec.md"
+TASK_A_TASK_STATE = "/tmp/phase5/task-a/task-state.json"
+TASK_B_WORKSPEC = "/tmp/phase5/task-b/WorkSpec.md"
+
+
+def _response(content: str = "ok"):
+    message = SimpleNamespace(content=content, reasoning=None, tool_calls=[])
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], usage=None, model="fake-model")
+
+
+def _make_agent(tmp_path, *, registry_enabled: bool = True, wcp_enabled: bool = True, intake_enabled: bool = False) -> AIAgent:
+    cfg = {
+        "context_health": {
+            "enabled": bool(registry_enabled or wcp_enabled or intake_enabled),
+            "runtime_behavior_enabled": bool(registry_enabled or wcp_enabled or intake_enabled),
+            "pre_model_intake": {
+                "enabled": bool(intake_enabled),
+                "long_prompt_char_threshold": 40,
+                "long_prompt_line_threshold": 3,
+            },
+            "task_boundary": {
+                "enabled": bool(registry_enabled),
+                "default_without_clear_continuation": "new_task",
+                "ambiguous_action": "hold",
+            },
+            "task_registry": {"enabled": bool(registry_enabled)},
+            "working_context_packet": {"enabled": bool(wcp_enabled)},
+            "task_boundary_firewall": {"enabled": True},
+        },
+        "agent": {"api_max_retries": 1},
+    }
+    with (
+        patch("run_agent.OpenAI"),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value=cfg),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    setattr(agent, "context_health", cfg["context_health"])
+    setattr(agent, "_context_health_intake_dir", tmp_path / "intake")
+    agent.client.chat.completions.create.return_value = _response()
+    agent._persist_session = lambda *a, **k: None
+    agent._save_trajectory = lambda *a, **k: None
+    agent._cleanup_task_resources = lambda *a, **k: None
+    return agent
+
+
+def _capture_provider_kwargs(agent: AIAgent):
+    captured: dict[str, object] = {"provider_called": False}
+    real_build = agent._build_api_kwargs
+
+    def capture_build(api_messages):
+        captured["api_messages_input_to_build_kwargs"] = [dict(m) for m in api_messages]
+        api_kwargs = real_build(api_messages)
+        captured["api_kwargs_after_build"] = dict(api_kwargs)
+        return api_kwargs
+
+    def fake_create(**kwargs):
+        captured["provider_called"] = True
+        captured["provider_kwargs_at_call"] = dict(kwargs)
+        return _response()
+
+    agent._build_api_kwargs = capture_build
+    agent.client.chat.completions.create.side_effect = fake_create
+    return captured
+
+
+def _payload_text(captured: dict[str, object]) -> str:
+    return repr(
+        {
+            "api_messages": captured.get("api_messages_input_to_build_kwargs"),
+            "api_kwargs_after_build": captured.get("api_kwargs_after_build"),
+            "provider_kwargs_at_call": captured.get("provider_kwargs_at_call"),
+        }
+    )
+
+
+def _registry_snapshot(*, active_task_id: str = TASK_B_ID):
+    return {
+        "schema": "context_health_task_registry_v1",
+        "active_task_id": active_task_id,
+        "tasks": {
+            TASK_A_ID: {
+                "task_id": TASK_A_ID,
+                "status": "closed" if active_task_id != TASK_A_ID else "active",
+                "workspec_path": TASK_A_WORKSPEC,
+                "task_state_path": TASK_A_TASK_STATE,
+                "current_pin_path": TASK_A_CURRENT_PIN,
+                "latest_turn_id": "session:phase5-task-a:aaaa1111",
+                "raw_transcript_excerpt": RAW_A_NEEDLE,
+                "compact_summary": A_COMPACT_NEEDLE,
+            },
+            TASK_B_ID: {
+                "task_id": TASK_B_ID,
+                "status": "active" if active_task_id == TASK_B_ID else "linked",
+                "workspec_path": TASK_B_WORKSPEC,
+                "latest_turn_id": "session:phase5-task-b:bbbb2222",
+                "linked_task_ids": [TASK_A_ID] if active_task_id == TASK_A_ID else [],
+            },
+        },
+    }
+
+
+def _install_registry(monkeypatch, *, action: str = "new_task", active_task_id: str = TASK_B_ID, hold: bool = False):
+    calls: list[dict[str, object]] = []
+    module = types.ModuleType("agent.task_registry")
+
+    def resolve_task_for_turn(**kwargs):
+        calls.append(kwargs)
+        if hold:
+            return SimpleNamespace(
+                action="hold",
+                effective_task_id=None,
+                reason="ambiguous_task_relation",
+                registry_snapshot=_registry_snapshot(active_task_id=active_task_id),
+                linked_task_id=None,
+                hold_response="Context Health HOLD: ambiguous task relation; no provider call was made.",
+            )
+        return SimpleNamespace(
+            action=action,
+            effective_task_id=active_task_id,
+            reason="explicit_continuation_reference" if active_task_id == TASK_A_ID else "no_clear_continuation_evidence",
+            registry_snapshot=_registry_snapshot(active_task_id=active_task_id),
+            linked_task_id=TASK_A_ID if active_task_id == TASK_A_ID else None,
+            hold_response=None,
+        )
+
+    setattr(module, "resolve_task_for_turn", resolve_task_for_turn)
+    setattr(module, "record_completed_workspec_state", lambda **kwargs: {"task_id": kwargs.get("task_id")})
+    monkeypatch.setitem(sys.modules, "agent.task_registry", module)
+    return calls
+
+
+def _install_firewall_exception(monkeypatch):
+    module = types.ModuleType("agent.task_boundary_firewall")
+
+    def enforce_task_boundary_firewall(**_kwargs):
+        raise RuntimeError("synthetic_firewall_failure")
+
+    setattr(module, "enforce_task_boundary_firewall", enforce_task_boundary_firewall)
+    monkeypatch.setitem(sys.modules, "agent.task_boundary_firewall", module)
+
+
+def _history_with_closed_a(*, include_tool: bool = True, include_compact: bool = True):
+    history = [
+        {"role": "user", "content": f"task A raw context {RAW_A_NEEDLE}"},
+        {"role": "assistant", "content": f"task A assistant context {A_ASSISTANT_NEEDLE}"},
+    ]
+    if include_tool:
+        history.extend(
+            [
+                {"role": "assistant", "content": "tool call holder", "tool_calls": [{"id": "call-a", "type": "function", "function": {"name": "session_search", "arguments": "{}"}}]},
+                {"role": "tool", "tool_call_id": "call-a", "name": "session_search", "content": f"session search found A {A_TOOL_NEEDLE} {A_SESSION_SEARCH_NEEDLE}"},
+            ]
+        )
+    if include_compact:
+        history.append({"role": "assistant", "content": f"compacted A summary {A_COMPACT_NEEDLE}"})
+    return history
+
+
+def test_firewall_disabled_preserves_existing_provider_payload_pass_through(tmp_path):
+    agent = _make_agent(tmp_path, registry_enabled=False, wcp_enabled=False, intake_enabled=False)
+    captured = _capture_provider_kwargs(agent)
+
+    result = agent.run_conversation(
+        "short B while firewall disabled",
+        conversation_history=_history_with_closed_a(include_tool=False, include_compact=False),
+        task_id="explicit-disabled-task",
+    )
+
+    payload = _payload_text(captured)
+    assert result["completed"] is True
+    assert captured["provider_called"] is True
+    assert RAW_A_NEEDLE in payload
+    assert getattr(agent, "_current_task_id") == "explicit-disabled-task"
+
+
+def test_closed_a_raw_text_not_in_b_provider_payload(tmp_path, monkeypatch):
+    _install_registry(monkeypatch, action="new_task", active_task_id=TASK_B_ID)
+    agent = _make_agent(tmp_path)
+    captured = _capture_provider_kwargs(agent)
+
+    agent.run_conversation(
+        "start unrelated B task",
+        conversation_history=_history_with_closed_a(),
+    )
+
+    payload = _payload_text(captured)
+    assert TASK_B_ID in payload
+    assert RAW_A_NEEDLE not in payload
+    assert A_ASSISTANT_NEEDLE not in payload
+    assert A_TOOL_NEEDLE not in payload
+
+
+def test_closed_a_safe_paths_not_in_independent_b_wcp(tmp_path, monkeypatch):
+    _install_registry(monkeypatch, action="new_task", active_task_id=TASK_B_ID)
+    agent = _make_agent(tmp_path)
+    captured = _capture_provider_kwargs(agent)
+
+    agent.run_conversation(
+        "start unrelated B task without using A",
+        conversation_history=_history_with_closed_a(include_tool=False, include_compact=False),
+    )
+
+    payload = _payload_text(captured)
+    assert TASK_B_ID in payload
+    assert TASK_A_CURRENT_PIN not in payload
+    assert TASK_A_WORKSPEC not in payload
+    assert TASK_A_TASK_STATE not in payload
+
+
+def test_explicit_continue_a_includes_only_safe_a_pointer(tmp_path, monkeypatch):
+    _install_registry(monkeypatch, action="continue_task", active_task_id=TASK_A_ID)
+    agent = _make_agent(tmp_path)
+    captured = _capture_provider_kwargs(agent)
+
+    agent.run_conversation(
+        f"continue {TASK_A_ID} using its WorkSpec",
+        conversation_history=_history_with_closed_a(),
+    )
+
+    payload = _payload_text(captured)
+    assert TASK_A_ID in payload
+    assert TASK_A_WORKSPEC in payload or TASK_A_TASK_STATE in payload or TASK_A_CURRENT_PIN in payload
+    assert RAW_A_NEEDLE not in payload
+    assert A_TOOL_NEEDLE not in payload
+    assert A_COMPACT_NEEDLE not in payload
+
+
+def test_ambiguous_relation_returns_hold_without_provider_call(tmp_path, monkeypatch):
+    _install_registry(monkeypatch, action="new_task", active_task_id=TASK_B_ID)
+    agent = _make_agent(tmp_path)
+    captured = _capture_provider_kwargs(agent)
+    persisted: list[object] = []
+    agent._persist_session = lambda *a, **k: persisted.append((a, k))
+    raw_prompt = f"continue the previous one {RAW_A_NEEDLE}"
+
+    result = agent.run_conversation(
+        raw_prompt,
+        conversation_history=_history_with_closed_a(include_tool=False, include_compact=False),
+    )
+
+    assert result["completed"] is False
+    assert result["failed"] is True
+    assert result["api_calls"] == 0
+    assert captured["provider_called"] is False
+    assert "hold" in result.get("error", "").lower()
+    assert raw_prompt not in repr(persisted)
+    assert RAW_A_NEEDLE not in repr(result)
+
+
+def test_enabled_wcp_firewall_exception_returns_safe_hold_without_unfiltered_registry(tmp_path, monkeypatch):
+    _install_firewall_exception(monkeypatch)
+    agent = _make_agent(tmp_path)
+    setattr(agent, "_context_health_task_registry_snapshot", _registry_snapshot(active_task_id=TASK_B_ID))
+    setattr(agent, "_context_health_task_registry_decision", SimpleNamespace(action="new_task", effective_task_id=TASK_B_ID))
+
+    decision = enforce_working_context_packet(
+        policy=getattr(agent, "context_health"),
+        agent=agent,
+        api_messages=[{"role": "system", "content": "sys"}, {"role": "user", "content": "start unrelated B"}],
+        messages=[{"role": "user", "content": "start unrelated B"}],
+        original_user_message="start unrelated B",
+        current_turn_user_idx=0,
+        effective_task_id=TASK_B_ID,
+        turn_id="turn-b",
+        session_id="session-b",
+    )
+
+    assert decision.action == "hold"
+    assert decision.api_messages is None
+    rendered = repr(decision)
+    assert TASK_A_CURRENT_PIN not in rendered
+    assert TASK_A_WORKSPEC not in rendered
+    assert TASK_A_TASK_STATE not in rendered
+    assert RAW_A_NEEDLE not in rendered
+    assert "synthetic_firewall_failure" not in rendered
+
+
+def test_enabled_pre_append_firewall_exception_holds_without_provider_or_raw_persist(tmp_path, monkeypatch):
+    _install_registry(monkeypatch, action="new_task", active_task_id=TASK_B_ID)
+    _install_firewall_exception(monkeypatch)
+    agent = _make_agent(tmp_path)
+    captured = _capture_provider_kwargs(agent)
+    persisted: list[object] = []
+    agent._persist_session = lambda *a, **k: persisted.append((a, k))
+    raw_prompt = f"start unrelated B with raw private body {RAW_A_NEEDLE}"
+
+    result = agent.run_conversation(
+        raw_prompt,
+        conversation_history=_history_with_closed_a(include_tool=False, include_compact=False),
+    )
+
+    assert result["completed"] is False
+    assert result["failed"] is True
+    assert result["api_calls"] == 0
+    assert captured["provider_called"] is False
+    assert "hold" in result.get("error", "").lower()
+    assert "task_boundary_firewall" in result.get("error", "")
+    assert getattr(agent, "_context_health_task_boundary_firewall_decision") is not None
+    assert raw_prompt not in repr(persisted)
+    assert RAW_A_NEEDLE not in repr(result)
+    assert "synthetic_firewall_failure" not in repr(result)
+
+
+def test_firewall_disabled_with_exception_preserves_pass_through(tmp_path, monkeypatch):
+    _install_firewall_exception(monkeypatch)
+    agent = _make_agent(tmp_path, registry_enabled=False, wcp_enabled=False, intake_enabled=False)
+    captured = _capture_provider_kwargs(agent)
+
+    result = agent.run_conversation(
+        "short B while firewall disabled",
+        conversation_history=_history_with_closed_a(include_tool=False, include_compact=False),
+        task_id="explicit-disabled-task",
+    )
+
+    assert result["completed"] is True
+    assert captured["provider_called"] is True
+    assert RAW_A_NEEDLE in _payload_text(captured)
+    assert getattr(agent, "_current_task_id") == "explicit-disabled-task"
+
+
+def test_fake_pre_llm_call_plugin_a_context_not_in_b_provider_payload(tmp_path, monkeypatch):
+    _install_registry(monkeypatch, action="new_task", active_task_id=TASK_B_ID)
+    agent = _make_agent(tmp_path)
+    captured = _capture_provider_kwargs(agent)
+
+    with patch("hermes_cli.plugins.invoke_hook", return_value=[{"context": f"plugin returns closed A {A_PLUGIN_NEEDLE}"}]):
+        agent.run_conversation(
+            "start unrelated B task",
+            conversation_history=_history_with_closed_a(include_tool=False, include_compact=False),
+        )
+
+    assert A_PLUGIN_NEEDLE not in _payload_text(captured)
+
+
+class _FakeMemoryManager:
+    def on_turn_start(self, *_args, **_kwargs):
+        return None
+
+    def prefetch_all(self, _query):
+        return f"memory returns closed A {A_MEMORY_NEEDLE}"
+
+
+def test_fake_memory_prefetch_a_context_not_in_b_provider_payload(tmp_path, monkeypatch):
+    _install_registry(monkeypatch, action="new_task", active_task_id=TASK_B_ID)
+    agent = _make_agent(tmp_path)
+    agent._memory_manager = _FakeMemoryManager()
+    captured = _capture_provider_kwargs(agent)
+
+    agent.run_conversation(
+        "start unrelated B task",
+        conversation_history=_history_with_closed_a(include_tool=False, include_compact=False),
+    )
+
+    assert A_MEMORY_NEEDLE not in _payload_text(captured)
+
+
+def test_prior_session_search_tool_result_a_not_in_b_provider_payload(tmp_path, monkeypatch):
+    _install_registry(monkeypatch, action="new_task", active_task_id=TASK_B_ID)
+    agent = _make_agent(tmp_path)
+    captured = _capture_provider_kwargs(agent)
+
+    agent.run_conversation(
+        "start unrelated B task",
+        conversation_history=_history_with_closed_a(include_tool=True, include_compact=False),
+    )
+
+    payload = _payload_text(captured)
+    assert A_SESSION_SEARCH_NEEDLE not in payload
+    assert A_TOOL_NEEDLE not in payload
+
+
+def test_firewall_filters_provider_payload_without_db_schema_or_transcript_deletion(tmp_path, monkeypatch):
+    _install_registry(monkeypatch, action="new_task", active_task_id=TASK_B_ID)
+    agent = _make_agent(tmp_path)
+    captured = _capture_provider_kwargs(agent)
+    original_history = _history_with_closed_a(include_tool=False, include_compact=False)
+    history_copy = [dict(m) for m in original_history]
+
+    result = agent.run_conversation(
+        "start unrelated B task",
+        conversation_history=original_history,
+    )
+
+    assert result["completed"] is True
+    assert original_history == history_copy
+    assert RAW_A_NEEDLE in repr(original_history)
+    assert RAW_A_NEEDLE not in _payload_text(captured)

--- a/tests/run_agent/test_context_health_task_registry.py
+++ b/tests/run_agent/test_context_health_task_registry.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from run_agent import AIAgent
+
+
+OLD_TASK_A_ID = "phase4-task-a"
+NEW_TASK_B_ID = "phase4-task-b"
+OLD_TASK_A_NEEDLE = "OLD_TASK_A_PHASE4_REGISTRY_NEEDLE"
+CURRENT_TASK_B_MARKER = "CURRENT_TASK_B_PHASE4_REGISTRY_MARKER"
+COMPLETED_TASK_STATE_ID = "phase4-completed-task"
+
+
+def _response(content: str = "ok"):
+    message = SimpleNamespace(content=content, reasoning=None, tool_calls=[])
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], usage=None, model="fake-model")
+
+
+def _make_agent(
+    tmp_path,
+    *,
+    registry_enabled: bool,
+    wcp_enabled: bool = True,
+    intake_enabled: bool = False,
+) -> AIAgent:
+    cfg = {
+        "context_health": {
+            "enabled": bool(registry_enabled or wcp_enabled or intake_enabled),
+            "runtime_behavior_enabled": bool(registry_enabled or wcp_enabled or intake_enabled),
+            "pre_model_intake": {
+                "enabled": bool(intake_enabled),
+                "long_prompt_char_threshold": 40,
+                "long_prompt_line_threshold": 3,
+            },
+            "task_boundary": {
+                "enabled": bool(registry_enabled),
+                "default_without_clear_continuation": "new_task",
+                "ambiguous_action": "hold",
+            },
+            "task_registry": {"enabled": bool(registry_enabled)},
+            "working_context_packet": {"enabled": bool(wcp_enabled)},
+        },
+        "agent": {"api_max_retries": 1},
+    }
+    with (
+        patch("run_agent.OpenAI"),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value=cfg),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    setattr(agent, "context_health", cfg["context_health"])
+    setattr(agent, "_context_health_intake_dir", tmp_path / "intake")
+    assert agent.client is not None
+    agent.client.chat.completions.create.return_value = _response()
+    agent._persist_session = lambda *a, **k: None
+    agent._save_trajectory = lambda *a, **k: None
+    agent._cleanup_task_resources = lambda *a, **k: None
+    return agent
+
+
+def _capture_provider_kwargs(agent: AIAgent):
+    captured: dict[str, object] = {"provider_called": False}
+    real_build = agent._build_api_kwargs
+
+    def capture_build(api_messages):
+        captured["api_messages_input_to_build_kwargs"] = [dict(m) for m in api_messages]
+        api_kwargs = real_build(api_messages)
+        captured["api_kwargs_after_build"] = dict(api_kwargs)
+        return api_kwargs
+
+    def fake_create(**kwargs):
+        captured["provider_called"] = True
+        captured["provider_kwargs_at_call"] = dict(kwargs)
+        return _response()
+
+    assert agent.client is not None
+    agent._build_api_kwargs = capture_build
+    agent.client.chat.completions.create.side_effect = fake_create
+    return captured
+
+
+def _payload_text(captured: dict[str, object]) -> str:
+    return repr(
+        {
+            "api_messages": captured.get("api_messages_input_to_build_kwargs"),
+            "api_kwargs_after_build": captured.get("api_kwargs_after_build"),
+            "provider_kwargs_at_call": captured.get("provider_kwargs_at_call"),
+        }
+    )
+
+
+def _install_fake_registry(monkeypatch, *, task_id: str = NEW_TASK_B_ID, closed: bool = False):
+    calls: list[dict[str, object]] = []
+    close_events: list[dict[str, object]] = []
+    module = types.ModuleType("agent.task_registry")
+
+    def resolve_task_for_turn(**kwargs):
+        calls.append(kwargs)
+        return SimpleNamespace(
+            action="new_task",
+            effective_task_id=task_id,
+            reason="no_clear_continuation_evidence",
+            registry_snapshot={
+                "active_task_id": task_id,
+                "tasks": {
+                    task_id: {"task_id": task_id, "status": "active"},
+                    OLD_TASK_A_ID: {"task_id": OLD_TASK_A_ID, "status": "closed" if closed else "active"},
+                },
+            },
+            linked_task_id=None,
+            hold_response=None,
+        )
+
+    def record_completed_workspec_state(**kwargs):
+        close_events.append(kwargs)
+        return {"task_id": kwargs.get("task_id"), "status": "closed"}
+
+    setattr(module, "resolve_task_for_turn", resolve_task_for_turn)
+    setattr(module, "record_completed_workspec_state", record_completed_workspec_state)
+    monkeypatch.setitem(sys.modules, "agent.task_registry", module)
+    return calls, close_events
+
+
+def _install_failing_registry(monkeypatch, reason: str = "resolver failed token=raw-secret"):
+    calls: list[dict[str, object]] = []
+    module = types.ModuleType("agent.task_registry")
+
+    def resolve_task_for_turn(**kwargs):
+        calls.append(kwargs)
+        raise RuntimeError(reason)
+
+    setattr(module, "resolve_task_for_turn", resolve_task_for_turn)
+    monkeypatch.setitem(sys.modules, "agent.task_registry", module)
+    return calls
+
+
+def test_registry_disabled_preserves_existing_task_id_pass_through(tmp_path):
+    agent = _make_agent(tmp_path, registry_enabled=False, wcp_enabled=False, intake_enabled=False)
+    captured = _capture_provider_kwargs(agent)
+
+    result = agent.run_conversation(
+        "short task while registry disabled",
+        conversation_history=[{"role": "user", "content": OLD_TASK_A_NEEDLE}],
+        task_id="explicit-existing-task",
+    )
+
+    payload = _payload_text(captured)
+    assert result["completed"] is True
+    assert captured["provider_called"] is True
+    assert getattr(agent, "_current_task_id") == "explicit-existing-task"
+    assert OLD_TASK_A_NEEDLE in payload
+    assert not (tmp_path / "intake").exists()
+
+
+def test_registry_enabled_resolves_b_task_id_before_phase2_intake(tmp_path, monkeypatch):
+    calls, _close_events = _install_fake_registry(monkeypatch, task_id=NEW_TASK_B_ID)
+    agent = _make_agent(tmp_path, registry_enabled=True, wcp_enabled=True, intake_enabled=True)
+    _capture_provider_kwargs(agent)
+    long_task_b_prompt = (
+        f"{CURRENT_TASK_B_MARKER} start independent B work\n"
+        "line two with requirements\n"
+        "line three with checklist\n"
+        "line four with enough text to trigger pre-model intake"
+    )
+
+    agent.run_conversation(
+        long_task_b_prompt,
+        conversation_history=[{"role": "assistant", "content": f"old task A {OLD_TASK_A_NEEDLE}"}],
+    )
+
+    assert calls, "Phase 4 registry hook was not called before Phase 2 intake"
+    intake_paths = [str(path) for path in (tmp_path / "intake").rglob("summary.md")]
+    assert intake_paths, "Phase 2 intake did not create a summary path"
+    assert any(NEW_TASK_B_ID in path for path in intake_paths), intake_paths
+    assert getattr(agent, "_current_task_id") == NEW_TASK_B_ID
+
+
+def test_closed_a_then_b_provider_payload_uses_registry_task_b(tmp_path, monkeypatch):
+    calls, _close_events = _install_fake_registry(monkeypatch, task_id=NEW_TASK_B_ID, closed=True)
+    agent = _make_agent(tmp_path, registry_enabled=True, wcp_enabled=True, intake_enabled=False)
+    captured = _capture_provider_kwargs(agent)
+
+    agent.run_conversation(
+        f"new independent B request {CURRENT_TASK_B_MARKER}",
+        conversation_history=[
+            {"role": "user", "content": f"old task A raw {OLD_TASK_A_NEEDLE}"},
+            {"role": "assistant", "content": "old task A done"},
+        ],
+    )
+
+    payload = _payload_text(captured)
+    assert calls, "Phase 4 registry hook was not called, so WCP cannot receive registry task B"
+    assert NEW_TASK_B_ID in payload
+    assert OLD_TASK_A_NEEDLE not in payload
+
+
+def test_completed_workspec_task_state_records_registry_close_event(tmp_path, monkeypatch):
+    _calls, close_events = _install_fake_registry(monkeypatch, task_id=COMPLETED_TASK_STATE_ID)
+    task_state = tmp_path / "task-state.json"
+    task_state.write_text(
+        '{"schema":"workspec_task_state_v1","status":"completed","tasks":[{"id":"t1","status":"completed"}]}',
+        encoding="utf-8",
+    )
+    agent = _make_agent(tmp_path, registry_enabled=True, wcp_enabled=False, intake_enabled=False)
+    setattr(agent, "_context_health_active_task_state_path", str(task_state))
+    _capture_provider_kwargs(agent)
+
+    agent.run_conversation(
+        "finalize completed WorkSpec task",
+        conversation_history=[],
+        task_id=COMPLETED_TASK_STATE_ID,
+    )
+
+    assert close_events, "completed task-state was not reflected into the durable task registry"
+    assert close_events[-1]["task_id"] == COMPLETED_TASK_STATE_ID
+    assert close_events[-1]["task_state_path"] == str(task_state)
+
+
+def test_registry_enabled_resolver_exception_returns_safe_hold_without_provider_or_persist(tmp_path, monkeypatch):
+    calls = _install_failing_registry(monkeypatch)
+    agent = _make_agent(tmp_path, registry_enabled=True, wcp_enabled=False, intake_enabled=False)
+    captured = _capture_provider_kwargs(agent)
+    persisted: list[object] = []
+    agent._persist_session = lambda *a, **k: persisted.append((a, k))
+    raw_prompt = "new B request with token=RAW_PHASE4_SECRET and password=RAW_PHASE4_PASSWORD"
+
+    result = agent.run_conversation(
+        raw_prompt,
+        conversation_history=[{"role": "user", "content": OLD_TASK_A_NEEDLE}],
+    )
+
+    result_text = repr(result)
+    assert calls, "registry resolver should be reached when registry is enabled"
+    assert result["completed"] is False
+    assert result["failed"] is True
+    assert result["api_calls"] == 0
+    assert captured["provider_called"] is False
+    assert "context_health_hold" in result.get("error", "")
+    assert "RAW_PHASE4_SECRET" not in result_text
+    assert "RAW_PHASE4_PASSWORD" not in result_text
+    assert "token=" not in result_text.lower()
+    assert "password=" not in result_text.lower()
+    assert raw_prompt not in repr(persisted)
+    assert getattr(agent, "_current_task_id", None) in {None, ""}
+
+
+def test_registry_enabled_corrupt_registry_json_returns_safe_hold_without_provider(tmp_path):
+    registry_root = tmp_path / "registry"
+    registry_root.mkdir()
+    (registry_root / "registry.json").write_text("{not valid json", encoding="utf-8")
+    agent = _make_agent(tmp_path, registry_enabled=True, wcp_enabled=False, intake_enabled=False)
+    setattr(agent, "_context_health_task_registry_dir", registry_root)
+    captured = _capture_provider_kwargs(agent)
+
+    result = agent.run_conversation(
+        "new B request after corrupt registry",
+        conversation_history=[{"role": "assistant", "content": OLD_TASK_A_NEEDLE}],
+    )
+
+    assert result["completed"] is False
+    assert result["failed"] is True
+    assert result["api_calls"] == 0
+    assert captured["provider_called"] is False
+    assert "context_health_hold" in result.get("error", "")
+    assert getattr(agent, "_context_health_task_registry_decision", None) is None

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -616,12 +616,65 @@ def _discover(
     }, ensure_ascii=False)
 
 
+def _retrieval_scope_dict(retrieval_scope) -> Dict[str, Any]:
+    return retrieval_scope if isinstance(retrieval_scope, dict) else {}
+
+
+def _retrieval_scope_enabled(retrieval_scope) -> bool:
+    return bool(_retrieval_scope_dict(retrieval_scope).get("enabled"))
+
+
+def _retrieval_scope_blocked_response(reason: str) -> str:
+    return json.dumps({
+        "success": False,
+        "mode": "blocked",
+        "reason": reason,
+        "message": "Context Health HOLD: retrieval scope blocked unscoped or closed-task retrieval.",
+    }, ensure_ascii=False)
+
+
+def _retrieval_scope_allows_session(retrieval_scope, session_id: str) -> bool:
+    scope = _retrieval_scope_dict(retrieval_scope)
+    if not scope.get("enabled"):
+        return True
+    sid = str(session_id or "")
+    allowed = {str(v) for v in scope.get("allowed_session_ids") or []}
+    excluded = {str(v) for v in scope.get("excluded_session_ids") or []}
+    if sid in excluded and sid not in allowed:
+        return False
+    if allowed and sid not in allowed:
+        return False
+    return True
+
+
+def _retrieval_scope_filter_discovery_payload(payload: Dict[str, Any], retrieval_scope) -> Dict[str, Any]:
+    scope = _retrieval_scope_dict(retrieval_scope)
+    if not scope.get("enabled") or not isinstance(payload.get("results"), list):
+        return payload
+    allowed = {str(v) for v in scope.get("allowed_session_ids") or []}
+    excluded = {str(v) for v in scope.get("excluded_session_ids") or []}
+    filtered = []
+    for item in payload.get("results") or []:
+        sid = str(item.get("session_id") or "")
+        if sid in excluded and sid not in allowed:
+            continue
+        if allowed and sid not in allowed:
+            continue
+        filtered.append(item)
+    payload = dict(payload)
+    payload["query"] = "[scoped]"
+    payload["results"] = filtered
+    payload["count"] = len(filtered)
+    return payload
+
+
 def session_search(
     query: str = "",
     role_filter: str = None,
     limit: int = 3,
     db=None,
     current_session_id: str = None,
+    retrieval_scope: Dict[str, Any] = None,
     # Scroll shape
     session_id: str = None,
     around_message_id: int = None,
@@ -651,6 +704,10 @@ def session_search(
             from hermes_state import format_session_db_unavailable
             return tool_error(format_session_db_unavailable(), success=False)
 
+    scope = _retrieval_scope_dict(retrieval_scope)
+    if scope.get("enabled") and str(scope.get("relation") or "").lower() == "ambiguous":
+        return _retrieval_scope_blocked_response("ambiguous_prior_task_retrieval")
+
     # Normalise a raw `@session:<profile>/<id>` link value passed as session_id.
     # Session ids never contain "/", so a slash unambiguously means profile/id —
     # always strip the prefix off the id, and adopt the embedded profile only
@@ -677,6 +734,8 @@ def session_search(
 
     # Scroll shape takes precedence — explicit anchor beats any query.
     if (isinstance(session_id, str) and session_id.strip()) and around_message_id is not None:
+        if not _retrieval_scope_allows_session(retrieval_scope, session_id.strip()):
+            return _retrieval_scope_blocked_response("session_excluded_by_retrieval_scope")
         return _scroll(
             db=db,
             session_id=session_id,
@@ -688,6 +747,8 @@ def session_search(
     # Read shape: a session_id with no anchor → dump the whole session.
     if isinstance(session_id, str) and session_id.strip():
         sid = session_id.strip()
+        if not _retrieval_scope_allows_session(retrieval_scope, sid):
+            return _retrieval_scope_blocked_response("session_excluded_by_retrieval_scope")
         result = _read_session(db, sid)
         if json.loads(result).get("success"):
             return result
@@ -718,6 +779,13 @@ def session_search(
     if not query or not isinstance(query, str) or not query.strip():
         return _list_recent_sessions(db, limit, current_session_id)
 
+    # Enabled discovery cannot safely execute broad FTS unless the DB layer can
+    # prove session-id-scoped search before retrieval.  Phase 6 forbids falling
+    # back to unscoped _discover(...) and then post-filtering, because closed
+    # task rows would already have been searched/materialized.
+    if _retrieval_scope_enabled(retrieval_scope):
+        return _retrieval_scope_blocked_response("discovery_requires_pre_retrieval_scope")
+
     # Parse role_filter
     role_list: Optional[List[str]] = None
     if isinstance(role_filter, str) and role_filter.strip():
@@ -730,7 +798,7 @@ def session_search(
         if candidate in ("newest", "oldest"):
             sort_norm = candidate
 
-    return _discover(
+    discover_result = _discover(
         db=db,
         query=query.strip(),
         role_filter=role_list,
@@ -738,6 +806,14 @@ def session_search(
         sort=sort_norm,
         current_session_id=current_session_id,
     )
+    if _retrieval_scope_enabled(retrieval_scope):
+        try:
+            payload = json.loads(discover_result)
+            payload = _retrieval_scope_filter_discovery_payload(payload, retrieval_scope)
+            return json.dumps(payload, ensure_ascii=False)
+        except Exception:
+            return _retrieval_scope_blocked_response("retrieval_scope_filter_failure")
+    return discover_result
 
 
 def check_session_search_requirements() -> bool:


### PR DESCRIPTION
## Summary

Adds Phase 1~9 Context Health / Auto Context Governance support:

- Phase 1: policy model and tests
- Phase 2: pre-turn intake guard
- Phase 3: Working Context Packet provider-payload enforcement
- Phase 4: durable active/closed task registry
- Phase 5: provider-payload Task Boundary Firewall
- Phase 6: retrieval scope enforcement for reviewed session_search/memory/plugin surfaces
- Phase 7: compact fallback safe HOLD upgrade
- Phase 8: same-window rehydrate planner/consumer with metadata-value safety
- Phase 9: update-survival smoke/checklist

## Verification

- Targeted Phase 1~9 regression: 116 passed
- Final acceptance: PHASE1_9_FINAL_ACCEPTANCE_PASS_READY_FOR_USER_DECISION
- Fork topic branch post-push review: PHASE1_9_FORK_TOPIC_BRANCH_POST_PUSH_REVIEW_PASS_READY_FOR_PR_OR_HOLD_DECISION
- Final checkpoint:
  /srv/harness-lab/Harness-OS-Vault/SecondBrain/ContextContinuity/Backups/20260705_090837_phase1_9_context_health_final_checkpoint

## Scope

This PR is scoped to the accepted Phase 1~9 28-file set only. The topic branch commit is:

```text
ae6946c1fcc0a2b4b22ff8c961abccf6b1f2ffcc context-health: add auto context governance phases 1-9
```

Accepted 28-file set:

```text
agent/context_health_policy.py
tests/agent/test_context_health_policy.py
agent/context_health_intake.py
agent/turn_context.py
tests/agent/test_pre_turn_intake_guard.py
agent/working_context_packet.py
agent/conversation_loop.py
tests/agent/test_working_context_packet.py
tests/run_agent/test_context_health_provider_payload.py
agent/task_registry.py
agent/turn_finalizer.py
tests/agent/test_task_registry.py
tests/run_agent/test_context_health_task_registry.py
agent/task_boundary_firewall.py
tests/agent/test_task_boundary_firewall.py
tests/run_agent/test_context_health_task_boundary_firewall.py
agent/retrieval_scope.py
agent/memory_manager.py
tools/session_search_tool.py
tests/agent/test_retrieval_scope.py
tests/run_agent/test_context_health_retrieval_scope.py
agent/context_health_compact.py
tests/agent/test_compact_failure_fallback.py
agent/context_health_rehydrate.py
tests/agent/test_same_window_rehydrate.py
scripts/context_health_smoke.py
references/context-health-update-survival.md
tests/agent/test_context_health_update_survival.py
```

## Excluded / Not Accepted In This PR

The following adjacent/unaccepted files are intentionally excluded from PR scope:

```text
agent/context_integrity_guard.py
agent/workflow_lane_runtime.py
agent/workspec_state_machine.py
tests/agent/test_auto_workspec_runtime_validation.py
tests/agent/test_context_integrity_guard.py
tests/agent/test_workflow_lane_runtime.py
tests/agent/test_workspec_state_machine.py
```

## Non-claims

This PR does not claim:

- full A/B contamination fix completion
- gateway/update survival runtime implementation
- CLI command activation
- runtime config/profile activation
- real state.db migration or mutation
- deploy/restart
- adjacent/unaccepted 7-file acceptance

## Checklist

- [ ] Phase 1 policy model and tests reviewed
- [ ] Phase 2 pre-turn intake guard reviewed
- [ ] Phase 3 WCP provider-payload enforcement reviewed
- [ ] Phase 4 durable task registry reviewed
- [ ] Phase 5 Task Boundary Firewall reviewed
- [ ] Phase 6 retrieval scope enforcement reviewed within scoped surfaces
- [ ] Phase 7 compact fallback safe HOLD behavior reviewed
- [ ] Phase 8 same-window rehydrate planner/consumer reviewed
- [ ] Phase 9 update-survival smoke/checklist reviewed
- [ ] Targeted Phase 1~9 regression: 116 passed
- [ ] Final acceptance verdict bound: PHASE1_9_FINAL_ACCEPTANCE_PASS_READY_FOR_USER_DECISION
- [ ] Fork post-push verdict bound: PHASE1_9_FORK_TOPIC_BRANCH_POST_PUSH_REVIEW_PASS_READY_FOR_PR_OR_HOLD_DECISION
- [ ] Accepted 28-file set only
- [ ] Adjacent/unaccepted 7 files excluded from PR scope
- [ ] No deploy/restart/runtime activation implied by PR creation
- [ ] No CLI command activation implied by PR creation
- [ ] No real state.db migration/mutation implied by PR creation
- [ ] Non-claims are explicit in PR body
