### PR TITLE
fix(tools): adapt DaemonThreadPoolExecutor for Python 3.14 _worker signature

### DIFF
--- a/tests/tools/test_daemon_pool.py
+++ b/tests/tools/test_daemon_pool.py
@@ -83,6 +83,34 @@ def test_wedged_worker_does_not_block_interpreter_exit():
     assert "main-done" in proc.stdout
 
 
+def test_worker_signature_detection_matches_runtime():
+    """_WORKER_USES_CTX must reflect the actual _worker signature."""
+    import inspect
+
+    from concurrent.futures.thread import _worker
+
+    from tools.daemon_pool import _WORKER_USES_CTX
+
+    param_count = len(inspect.signature(_worker).parameters)
+    if sys.version_info >= (3, 14):
+        assert param_count == 3, f"Expected 3 params on 3.14+, got {param_count}"
+        assert _WORKER_USES_CTX is True
+    else:
+        assert param_count == 4, f"Expected 4 params on <3.14, got {param_count}"
+        assert _WORKER_USES_CTX is False
+
+
+def test_concurrent_submit_with_context_path():
+    """Multiple concurrent submits must work under the ctx-based worker path."""
+    pool = DaemonThreadPoolExecutor(max_workers=3)
+    try:
+        futures = [pool.submit(lambda x: x ** 2, i) for i in range(10)]
+        results = sorted(f.result(timeout=10) for f in futures)
+        assert results == [i ** 2 for i in range(10)]
+    finally:
+        pool.shutdown(wait=True)
+
+
 def _repo_root():
     import pathlib
 

--- a/tools/daemon_pool.py
+++ b/tools/daemon_pool.py
@@ -26,6 +26,7 @@ explicit bounded joins.
 
 from __future__ import annotations
 
+import inspect
 import threading
 import weakref
 from concurrent.futures import ThreadPoolExecutor
@@ -33,12 +34,16 @@ from concurrent.futures.thread import _worker
 
 __all__ = ["DaemonThreadPoolExecutor"]
 
+# Python ≥ 3.14 changed _worker from 4 params to 3, replacing
+# (initializer, initargs) with a WorkerContext object.
+_WORKER_USES_CTX = len(inspect.signature(_worker).parameters) == 3
+
 
 class DaemonThreadPoolExecutor(ThreadPoolExecutor):
     """ThreadPoolExecutor variant whose workers do not block process exit."""
 
     def _adjust_thread_count(self) -> None:
-        # Mirrors CPython's implementation (3.8–3.13) with two changes:
+        # Mirrors CPython's implementation with two changes:
         # daemon=True and no _threads_queues registration.
         if self._idle_semaphore.acquire(timeout=0):
             return
@@ -49,15 +54,25 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
         num_threads = len(self._threads)
         if num_threads < self._max_workers:
             thread_name = "%s_%d" % (self._thread_name_prefix or self, num_threads)
-            t = threading.Thread(
-                name=thread_name,
-                target=_worker,
-                args=(
+            if _WORKER_USES_CTX:
+                # Python >= 3.14: _worker(executor_ref, ctx, work_queue)
+                args = (
+                    weakref.ref(self, weakref_cb),
+                    self._create_worker_context(),
+                    self._work_queue,
+                )
+            else:
+                # Python <= 3.13: _worker(executor_ref, work_queue, initializer, initargs)
+                args = (
                     weakref.ref(self, weakref_cb),
                     self._work_queue,
                     self._initializer,
                     self._initargs,
-                ),
+                )
+            t = threading.Thread(
+                name=thread_name,
+                target=_worker,
+                args=args,
                 daemon=True,
             )
             t.start()


### PR DESCRIPTION
## What does this PR do?

Fixes `DaemonThreadPoolExecutor` crash on Python 3.14 where `_adjust_thread_count()` references `self._initializer` and `self._initargs`, which no longer exist. Python 3.14 changed `concurrent.futures.thread._worker` from 4 params to 3, replacing `(initializer, initargs)` with a `WorkerContext` object created via `self._create_worker_context()`.

## Related Issue

Fixes #58596

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/daemon_pool.py`: Detect `_worker` signature at import time (`inspect.signature`, 3 vs 4 params) and branch `_adjust_thread_count` args accordingly. Python ≥3.14 passes `self._create_worker_context()` as the ctx argument; ≤3.13 passes `self._initializer`/`self._initargs`.
- `tests/tools/test_daemon_pool.py`: Added `test_worker_signature_detection_matches_runtime` (verifies `_WORKER_USES_CTX` matches runtime `_worker` param count) and `test_concurrent_submit_with_context_path` (10 concurrent submits under the ctx-based path).

## How to Test

1. Run `python -m pytest tests/tools/test_daemon_pool.py -v` — all 6 tests should pass
2. On Python 3.14: `python -c "from tools.daemon_pool import DaemonThreadPoolExecutor; e = DaemonThreadPoolExecutor(max_workers=1); print(e.submit(lambda: 42).result())"` should print `42` (previously crashed with `AttributeError`)
3. On Python ≤3.13: same tests pass via the legacy 4-param `_worker` path

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tools/test_daemon_pool.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26, Python 3.14.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (stdlib change is cross-platform)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
