### PR TITLE
feat(kanban): reject empty-diff worktree completions (deterministic, fail-closed)

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1993,13 +1993,32 @@ def _cmd_complete(args: argparse.Namespace) -> int:
     failed: list[str] = []
     with kb.connect_closing() as conn:
         for tid in ids:
-            if not kb.complete_task(
-                conn, tid,
-                result=args.result,
-                summary=summary,
-                metadata=metadata,
-                expected_run_id=_worker_run_id_for(tid),
-            ):
+            try:
+                ok = kb.complete_task(
+                    conn, tid,
+                    result=args.result,
+                    summary=summary,
+                    metadata=metadata,
+                    expected_run_id=_worker_run_id_for(tid),
+                )
+            except kb.EmptyDiffCompletionError as exc:
+                # Deterministic empty-diff rejection — audit event already
+                # landed, task state untouched, retry is safe. Mirror the
+                # kanban_complete tool handler's recovery message and keep
+                # going so a bulk complete still processes the other ids.
+                failed.append(tid)
+                print(
+                    f"cannot complete {tid}: worktree "
+                    f"{exc.workspace_path or '<unknown>'} has no committed or "
+                    "uncommitted changes vs its base branch. The task is "
+                    "still in-flight (no state change). Commit the work in "
+                    "the worktree and retry, or if this task legitimately "
+                    "produced no code changes, retry with "
+                    "--metadata '{\"no_diff_expected\": true}'.",
+                    file=sys.stderr,
+                )
+                continue
+            if not ok:
                 failed.append(tid)
                 print(f"cannot complete {tid} (unknown id or terminal state)", file=sys.stderr)
             else:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4091,6 +4091,28 @@ class ArtifactPreservationError(RuntimeError):
     """Raised when a declared scratch deliverable cannot be preserved."""
 
 
+class EmptyDiffCompletionError(ValueError):
+    """Raised by ``complete_task`` when a worktree task is completed with
+    no committed or uncommitted changes in its worktree.
+
+    Deterministic, fail-closed sibling of ``HallucinatedCardsError``: the
+    rejection is auditable (``completion_blocked_empty_diff`` event) and
+    never mutates task state, so the worker can simply retry.
+    ``metadata["no_diff_expected"]`` skips the check for tasks that
+    legitimately produce no diff (investigation done in a worktree, docs
+    landed elsewhere). Kept as a ``ValueError`` subclass so existing
+    tool-error handlers treat it as a recoverable user error.
+    """
+
+    def __init__(self, completing_task_id: str, workspace_path: str):
+        self.completing_task_id = completing_task_id
+        self.workspace_path = workspace_path
+        super().__init__(
+            f"completion blocked: worktree {workspace_path or '<unknown>'} has "
+            f"no committed or uncommitted changes for task {completing_task_id}"
+        )
+
+
 def complete_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4128,6 +4150,13 @@ def complete_task(
     Any suspected phantom references are recorded as a
     ``suspected_hallucinated_references`` event. This pass is advisory
     and never blocks.
+
+    Worktree tasks are additionally gated on having real work: if the
+    task's worktree provably has neither uncommitted changes nor commits
+    beyond its base, completion is blocked with
+    ``EmptyDiffCompletionError`` and a ``completion_blocked_empty_diff``
+    event. Pass ``metadata={"no_diff_expected": True}`` to skip the check
+    for tasks that legitimately produce no diff.
     """
     now = int(time.time())
 
@@ -4157,6 +4186,43 @@ def complete_task(
             raise HallucinatedCardsError(phantom_cards, task_id)
     else:
         verified_cards = []
+
+    # Gate: deterministic empty-diff check for worktree tasks, same
+    # contract as the card gate above (audit event in a tiny txn, then
+    # raise; task state is never mutated on rejection). Only a provably
+    # clean worktree blocks — an indeterminate answer (missing path, not
+    # a git checkout, no derivable base) must never wedge a legitimate
+    # completion, so it is recorded and allowed through.
+    if not (metadata or {}).get("no_diff_expected"):
+        _task = get_task(conn, task_id)
+        if _task is not None and _task.workspace_kind == "worktree":
+            _wt_path = (_task.workspace_path or "").strip()
+            _has_changes = (
+                _worktree_has_changes(Path(_wt_path).expanduser())
+                if _wt_path
+                else None
+            )
+            if _has_changes is False:
+                with write_txn(conn):
+                    _append_event(
+                        conn, task_id, "completion_blocked_empty_diff",
+                        {
+                            "workspace_path": _wt_path,
+                            "branch_name": _task.branch_name,
+                            "summary_preview": (
+                                (summary or result or "").strip().splitlines()[0][:200]
+                                if (summary or result)
+                                else None
+                            ),
+                        },
+                    )
+                raise EmptyDiffCompletionError(task_id, _wt_path)
+            if _has_changes is None and _wt_path:
+                with write_txn(conn):
+                    _append_event(
+                        conn, task_id, "empty_diff_check_indeterminate",
+                        {"workspace_path": _wt_path},
+                    )
 
     metadata = _merge_completion_prose_artifacts(
         conn, task_id, metadata, summary=summary, result=result,
@@ -5708,6 +5774,83 @@ def _git_current_branch(path: Path) -> Optional[str]:
         return None
     branch = (result.stdout or "").strip()
     return branch or None
+
+
+def _default_branch_ref(path: Path) -> Optional[str]:
+    """Best-effort name of the repo's default branch, for diff bases."""
+    try:
+        head = subprocess.run(
+            ["git", "-C", str(path), "symbolic-ref", "--short",
+             "refs/remotes/origin/HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        if head.returncode == 0 and (head.stdout or "").strip():
+            return (head.stdout or "").strip()
+    except Exception:
+        pass
+    repo_root = _git_toplevel(path)
+    if repo_root is None:
+        return None
+    for candidate in ("main", "master"):
+        if _git_branch_exists(repo_root, candidate):
+            return candidate
+    return None
+
+
+def _worktree_has_changes(path: Path) -> Optional[bool]:
+    """Tri-state work detector for a task worktree.
+
+    Returns ``True`` when the checkout has uncommitted changes (including
+    untracked files) or commits beyond its merge-base with the repo's
+    default branch, ``False`` when it provably has neither, and ``None``
+    when the answer cannot be determined (missing path, not a git
+    checkout, no derivable base). Callers must treat ``None`` as
+    "do not block".
+    """
+    try:
+        if not path.is_dir():
+            return None
+        status = subprocess.run(
+            ["git", "-C", str(path), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        if status.returncode != 0:
+            return None
+        if (status.stdout or "").strip():
+            return True
+        base = _default_branch_ref(path)
+        if base is None:
+            return None
+        merge_base = subprocess.run(
+            ["git", "-C", str(path), "merge-base", "HEAD", base],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        base_sha = (merge_base.stdout or "").strip()
+        if merge_base.returncode != 0 or not base_sha:
+            return None
+        diff = subprocess.run(
+            ["git", "-C", str(path), "diff", "--quiet", base_sha, "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        if diff.returncode == 0:
+            return False
+        if diff.returncode == 1:
+            return True
+        return None
+    except Exception:
+        return None
 
 
 def _is_linked_worktree_checkout(path: Path) -> bool:

--- a/hermes_cli/kanban_swarm.py
+++ b/hermes_cli/kanban_swarm.py
@@ -150,6 +150,10 @@ def create_swarm(
             "kind": "kanban_swarm_v1",
             "goal": goal,
             "worker_count": len(worker_specs),
+            # The planning root is completed by design without producing a
+            # diff; exempt it from the worktree empty-diff completion gate
+            # so an explicit clean worktree root can't abort graph creation.
+            "no_diff_expected": True,
         },
     )
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -2020,6 +2020,7 @@ AUTHOR_MAP = {
     "1torhan@protonmail.com": "uzaylisak",  # PR #29988 salvage (detect_local_server_type process-lifetime cache)
     "zhchl@hermes-agent.local": "8294",  # PR #50572 salvage (honor config context_length on banner)
     "yansh2017@gmail.com": "ya-nsh",  # PR #26790 salvage (normalize local terminal relative cwd; #26783)
+    "s.suzuki784@hotmail.com": "suzu784",  # sandbox egress control / kanban empty-diff guard PRs
 }
 
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -5049,6 +5049,47 @@ def test_complete_scratch_task_skips_diff_gate(kanban_home):
         assert kb.complete_task(conn, tid, result="notes written") is True
 
 
+def test_cli_complete_empty_diff_prints_actionable_error(kanban_home, tmp_path, capsys):
+    """``hermes kanban complete`` must surface the empty-diff rejection as
+    an actionable stderr message (still in-flight + both recovery paths),
+    not a raw traceback — parity with the kanban_complete tool handler."""
+    import argparse
+
+    from hermes_cli.kanban import _cmd_complete
+
+    with kb.connect() as conn:
+        tid, _ = _worktree_task(conn, tmp_path)
+
+    rc = _cmd_complete(argparse.Namespace(task_ids=[tid], result=None))
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "no committed or uncommitted changes" in err
+    assert "still in-flight" in err
+    assert "no_diff_expected" in err
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).status == "running"
+
+
+def test_cli_complete_empty_diff_continues_with_remaining_ids(kanban_home, tmp_path, capsys):
+    """A blocked worktree completion must not abort a bulk complete — the
+    remaining ids in the list still get processed."""
+    import argparse
+
+    from hermes_cli.kanban import _cmd_complete
+
+    with kb.connect() as conn:
+        blocked, _ = _worktree_task(conn, tmp_path)
+        ok_tid = kb.create_task(conn, title="scratch work")
+        kb.claim_task(conn, ok_tid)
+
+    rc = _cmd_complete(argparse.Namespace(task_ids=[blocked, ok_tid], result=None))
+    assert rc == 1
+    assert f"Completed {ok_tid}" in capsys.readouterr().out
+    with kb.connect() as conn:
+        assert kb.get_task(conn, blocked).status == "running"
+        assert kb.get_task(conn, ok_tid).status == "done"
+
+
 def test_worktree_has_changes_tristate(tmp_path):
     repo = tmp_path / "repo"
     _init_git_repo(repo)

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -4959,3 +4959,118 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# Empty-diff completion gate
+# ---------------------------------------------------------------------------
+
+def _worktree_task(conn, tmp_path: Path, *, materialize: bool = True) -> tuple[str, Path]:
+    """Create a claimed worktree task backed by a real git worktree."""
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    worktree = tmp_path / "wt-task"
+    if materialize:
+        subprocess.run(
+            ["git", "-C", str(repo), "worktree", "add", "-b", "wt/task",
+             str(worktree), "HEAD"],
+            check=True, capture_output=True, text=True,
+        )
+    tid = kb.create_task(
+        conn,
+        title="worktree work",
+        workspace_kind="worktree",
+        workspace_path=str(worktree),
+        branch_name="wt/task",
+    )
+    kb.claim_task(conn, tid)
+    return tid, worktree
+
+
+def test_complete_blocks_empty_diff_worktree(kanban_home, tmp_path):
+    """A worktree task with no changes at all must not be completable —
+    the gate raises, records an audit event, and leaves the task
+    in-flight (same contract as the hallucinated-cards gate)."""
+    with kb.connect() as conn:
+        tid, _ = _worktree_task(conn, tmp_path)
+        with pytest.raises(kb.EmptyDiffCompletionError):
+            kb.complete_task(conn, tid, result="claims work happened")
+        assert kb.get_task(conn, tid).status == "running"
+        kinds = [e.kind for e in kb.list_events(conn, tid)]
+        assert "completion_blocked_empty_diff" in kinds
+
+
+def test_complete_allows_uncommitted_worktree_changes(kanban_home, tmp_path):
+    with kb.connect() as conn:
+        tid, worktree = _worktree_task(conn, tmp_path)
+        (worktree / "work.py").write_text("print('x')\n", encoding="utf-8")
+        assert kb.complete_task(conn, tid, result="done") is True
+        assert kb.get_task(conn, tid).status == "done"
+
+
+def test_complete_allows_committed_worktree_changes(kanban_home, tmp_path):
+    with kb.connect() as conn:
+        tid, worktree = _worktree_task(conn, tmp_path)
+        (worktree / "work.py").write_text("print('x')\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(worktree), "add", "work.py"],
+                       check=True, capture_output=True, text=True)
+        subprocess.run(["git", "-C", str(worktree), "commit", "-m", "work"],
+                       check=True, capture_output=True, text=True)
+        assert kb.complete_task(conn, tid, result="done") is True
+
+
+def test_complete_empty_diff_escape_hatch(kanban_home, tmp_path):
+    """metadata.no_diff_expected is the documented opt-out for tasks that
+    legitimately produce no diff (investigation, docs landed elsewhere)."""
+    with kb.connect() as conn:
+        tid, _ = _worktree_task(conn, tmp_path)
+        assert kb.complete_task(
+            conn, tid,
+            result="investigation only",
+            metadata={"no_diff_expected": True},
+        ) is True
+        assert kb.get_task(conn, tid).status == "done"
+
+
+def test_complete_missing_worktree_is_indeterminate_and_allowed(kanban_home, tmp_path):
+    """An unresolvable worktree must never block completion — the check
+    records an indeterminate event and lets the completion through."""
+    with kb.connect() as conn:
+        tid, _ = _worktree_task(conn, tmp_path, materialize=False)
+        assert kb.complete_task(conn, tid, result="done elsewhere") is True
+        kinds = [e.kind for e in kb.list_events(conn, tid)]
+        assert "empty_diff_check_indeterminate" in kinds
+
+
+def test_complete_scratch_task_skips_diff_gate(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="research")
+        kb.claim_task(conn, tid)
+        assert kb.complete_task(conn, tid, result="notes written") is True
+
+
+def test_worktree_has_changes_tristate(tmp_path):
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    worktree = tmp_path / "wt"
+    subprocess.run(
+        ["git", "-C", str(repo), "worktree", "add", "-b", "wt/x",
+         str(worktree), "HEAD"],
+        check=True, capture_output=True, text=True,
+    )
+    # Provably clean.
+    assert kb._worktree_has_changes(worktree) is False
+    # Untracked file counts as work.
+    (worktree / "new.txt").write_text("x\n", encoding="utf-8")
+    assert kb._worktree_has_changes(worktree) is True
+    # Committed-ahead-of-base counts as work.
+    subprocess.run(["git", "-C", str(worktree), "add", "new.txt"],
+                   check=True, capture_output=True, text=True)
+    subprocess.run(["git", "-C", str(worktree), "commit", "-m", "w"],
+                   check=True, capture_output=True, text=True)
+    assert kb._worktree_has_changes(worktree) is True
+    # Indeterminate: missing path / not a git checkout.
+    assert kb._worktree_has_changes(tmp_path / "nope") is None
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    assert kb._worktree_has_changes(plain) is None

--- a/tests/hermes_cli/test_kanban_swarm.py
+++ b/tests/hermes_cli/test_kanban_swarm.py
@@ -115,3 +115,45 @@ def test_swarm_verifier_and_synthesis_are_dependency_gated(tmp_path):
         assert kb.get_task(conn, created.synthesizer_id).status == "ready"
     finally:
         conn.close()
+
+
+def test_create_swarm_completes_clean_worktree_planning_root(tmp_path):
+    """The planning root is completed by design without producing a diff,
+    so a clean explicit worktree root must not trip the empty-diff
+    completion gate (EmptyDiffCompletionError) and abort graph creation."""
+    import subprocess
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for cmd in (
+        ["git", "init", "-b", "main", str(repo)],
+        ["git", "-C", str(repo), "config", "user.email", "swarm@example.com"],
+        ["git", "-C", str(repo), "config", "user.name", "Swarm Test"],
+    ):
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "README.md"],
+                   check=True, capture_output=True, text=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-m", "init"],
+                   check=True, capture_output=True, text=True)
+    worktree = tmp_path / "wt-root"
+    subprocess.run(
+        ["git", "-C", str(repo), "worktree", "add", "-b", "wt/swarm-root",
+         str(worktree), "HEAD"],
+        check=True, capture_output=True, text=True,
+    )
+
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        created = create_swarm(
+            conn,
+            goal="Plan from a clean worktree root.",
+            workers=[SwarmWorkerSpec(profile="researcher", title="Scan", body="Find")],
+            verifier_assignee="reviewer",
+            synthesizer_assignee="writer",
+            workspace_kind="worktree",
+            workspace_path=str(worktree),
+        )
+        assert kb.get_task(conn, created.root_id).status == "done"
+    finally:
+        conn.close()

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -2681,3 +2681,115 @@ def test_attach_url_happy_path_public_host(worker_env, default_url_guard, monkey
         assert Path(atts[0].stored_path).read_bytes() == payload
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Empty-diff completion gate (tool surface)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def worktree_worker_env(monkeypatch, tmp_path):
+    """Like worker_env, but the claimed task owns a real, clean git
+    worktree — the exact state the empty-diff gate exists to reject."""
+    import subprocess
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "test-worker")
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    from pathlib import Path as _Path
+    monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for cmd in (
+        ["git", "init", "-b", "main", str(repo)],
+        ["git", "-C", str(repo), "config", "user.email", "kanban@example.com"],
+        ["git", "-C", str(repo), "config", "user.name", "Kanban Test"],
+    ):
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "README.md"],
+                   check=True, capture_output=True, text=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-m", "init"],
+                   check=True, capture_output=True, text=True)
+    worktree = tmp_path / "wt-task"
+    subprocess.run(
+        ["git", "-C", str(repo), "worktree", "add", "-b", "wt/task",
+         str(worktree), "HEAD"],
+        check=True, capture_output=True, text=True,
+    )
+
+    from hermes_cli import kanban_db as kb
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="worktree-worker-test",
+            assignee="test-worker",
+            workspace_kind="worktree",
+            workspace_path=str(worktree),
+            branch_name="wt/task",
+        )
+        kb.claim_task(conn, tid)
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    return tid, worktree
+
+
+def test_complete_empty_diff_message_advertises_recovery(worktree_worker_env):
+    """The empty-diff rejection must read as retryable — spell out that
+    the task is still in-flight and name both recovery paths (commit the
+    work, or metadata.no_diff_expected). Same doctrine as the phantom-card
+    message (#22923): a tool_error that reads terminal makes workers
+    abandon the run."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    tid, _ = worktree_worker_env
+    out = json.loads(kt._handle_complete({"summary": "claims work happened"}))
+    err = out.get("error", "")
+    assert err, f"expected an error, got {out!r}"
+    assert "no committed or uncommitted changes" in err
+    assert "still in-flight" in err
+    assert "no_diff_expected" in err
+
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, tid).status == "running"
+    finally:
+        conn.close()
+
+
+def test_complete_empty_diff_retry_after_real_work(worktree_worker_env):
+    from tools import kanban_tools as kt
+
+    tid, worktree = worktree_worker_env
+    rejected = json.loads(kt._handle_complete({"summary": "no work yet"}))
+    assert rejected.get("error")
+
+    (worktree / "notes.md").write_text("real work\n", encoding="utf-8")
+    ok = json.loads(kt._handle_complete({"summary": "did work"}))
+    assert ok.get("ok") is True, ok
+
+
+def test_complete_empty_diff_escape_hatch(worktree_worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    tid, _ = worktree_worker_env
+    ok = json.loads(kt._handle_complete({
+        "summary": "investigation only, no code changes by design",
+        "metadata": {"no_diff_expected": True},
+    }))
+    assert ok.get("ok") is True, ok
+
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, tid).status == "done"
+    finally:
+        conn.close()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -657,6 +657,19 @@ def _handle_complete(args: dict, **kw) -> str:
                     f"and either drop these ids from created_cards, or pass "
                     f"created_cards=[] to skip the card-claim check entirely."
                 )
+            except kb.EmptyDiffCompletionError as diff_err:
+                # Deterministic empty-diff rejection — same contract as
+                # the hallucinated-cards gate above: audit event already
+                # landed, task state untouched, retry is safe.
+                return tool_error(
+                    f"kanban_complete blocked: worktree "
+                    f"{diff_err.workspace_path or '<unknown>'} has no "
+                    f"committed or uncommitted changes vs its base branch. "
+                    f"Your task is still in-flight (no state change). "
+                    f"Commit your work in the worktree and retry, or if this "
+                    f"task legitimately produced no code changes, retry with "
+                    f'metadata={{"no_diff_expected": true}}.'
+                )
             if not ok:
                 return tool_error(
                     f"could not complete {tid} (unknown id or already terminal)"


### PR DESCRIPTION
## What does this PR do?

`complete_task()` verifies `created_cards` claims (`HallucinatedCardsError`) but never checks whether any work actually happened: a worker can `kanban_complete` a worktree task having produced **no commits and no working-tree changes at all**. This PR adds a deterministic, fail-closed gate mirroring the hallucinated-cards contract, so empty-diff completions are rejected at the DB layer instead of silently marking phantom work as done.

## Related Issue

No linked issue. The tool-error wording follows the doctrine discussed in #22923.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/kanban_db.py`:
  - `_worktree_has_changes(path)`: tri-state detector — `True` on uncommitted changes (incl. untracked) or commits beyond the merge-base with the repo's default branch; `False` only when provably clean; `None` when indeterminate (missing path, not a git checkout, no derivable base)
  - `complete_task` raises `EmptyDiffCompletionError(ValueError)` for `workspace_kind == "worktree"` tasks whose worktree is provably clean, after recording a `completion_blocked_empty_diff` audit event in its own transaction; task state is never mutated, so retry is safe
  - Indeterminate answers never block (`empty_diff_check_indeterminate` event only) — infrastructure noise must not wedge legitimate completions
  - Escape hatch: `metadata={"no_diff_expected": true}` for tasks that legitimately produce no diff (investigation in a worktree, docs landed elsewhere); analogous to the `created_cards=[]` bypass
- `tools/kanban_tools.py`: `_handle_complete` returns a retryable `tool_error` naming both recovery paths (commit the work, or set the metadata flag)
- `scripts/release.py`: AUTHOR_MAP entry for this contributor (contributor-check; same entry as in the sibling egress PR — whichever merges first, the other rebases clean)

## How to Test

1. `bash scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/tools/test_kanban_tools.py` — 330 tests pass (10 new: clean-worktree block, untracked/committed-work pass, indeterminate pass-through, escape hatch, audit events, retry safety)
2. Manual: create a worktree task, call `kanban_complete` without touching the worktree → blocked with a retryable error naming both recovery paths; commit any change → completes

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (plus the AUTHOR_MAP entry required by contributor-check)
- [x] Affected suites pass via the canonical runner (`scripts/run_tests.sh`, 330 tests); relying on CI for the full matrix — my host lacks some optional deps so a full local run has known env-caused failures unrelated to this change
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26 (Apple Silicon)

### Documentation & Housekeeping

- [x] Documentation — N/A (internal DB-layer guard; behavior documented in docstrings and the tool error message)
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform: git subprocess calls only, no path/OS assumptions beyond existing kanban code
- [x] Tool descriptions/schemas — N/A (error message change only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013n8YAnnTrwfzD5oECy6zdi
