### PR TITLE
Feat groq cerebras

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1048,22 +1048,29 @@ def recover_with_credential_pool(
         elif status_code in {401, 403}:
             effective_reason = FailoverReason.auth
 
-    if effective_reason == FailoverReason.upstream_rate_limit:
-        # An upstream provider (e.g. DeepSeek behind OpenRouter) is
-        # rate-limiting the aggregator's traffic — the user's credential is
-        # healthy. Do NOT rotate or mark exhausted; let the caller's fallback
-        # path switch to a different model entirely.
+    if effective_reason in {
+        FailoverReason.upstream_rate_limit,
+        FailoverReason.upstream_provider_error,
+    }:
+        # Upstream provider throttling (429) or provider error (403)
+        # happened behind the aggregator — the user's credential is healthy.
+        # Do NOT rotate or mark exhausted; let the caller's fallback path
+        # switch to a different model entirely.
         upstream = (error_context or {}).get("upstream_provider") if error_context else None
         if upstream:
             _ra().logger.info(
-                "Upstream provider %s rate-limited via aggregator — skipping "
+                "Upstream provider %s %s via aggregator — skipping "
                 "credential rotation, deferring to fallback chain",
                 upstream,
+                "rate-limited" if effective_reason == FailoverReason.upstream_rate_limit
+                else "error",
             )
         else:
             _ra().logger.info(
-                "Upstream aggregator 429 (provider unknown) — skipping "
-                "credential rotation, deferring to fallback chain"
+                "Upstream aggregator %s (provider unknown) — skipping "
+                "credential rotation, deferring to fallback chain",
+                "429" if effective_reason == FailoverReason.upstream_rate_limit
+                else "403",
             )
         return False, has_retried_429
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1932,7 +1932,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     auth resolution and client construction — no duplicated provider→key
     mappings.
     """
-    if reason in {FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit}:
+    if reason in {FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit, FailoverReason.upstream_provider_error}:
         # Only start cooldown when leaving the primary provider.  If we're
         # already on a fallback and chain-switching, the primary wasn't the
         # source of the 429 so the cooldown should not be reset/extended.
@@ -1963,7 +1963,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # provider again.  Guards the cross-turn replay storm in #24996.
         if (
             len(agent._fallback_chain) > 0
-            and reason not in {FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit}
+            and reason not in {FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit, FailoverReason.upstream_provider_error}
         ):
             _existing_cooldown = getattr(agent, "_rate_limited_until", 0) or 0
             agent._rate_limited_until = max(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4793,6 +4793,7 @@ def run_conversation(
                     FailoverReason.rate_limit,
                     FailoverReason.billing,
                     FailoverReason.upstream_rate_limit,
+                    FailoverReason.upstream_provider_error,
                 }
                 _is_transport_failure = classified.reason in {
                     FailoverReason.timeout,
@@ -4819,11 +4820,14 @@ def run_conversation(
                     # still recover.  See _pool_may_recover_from_rate_limit
                     # for the single-credential-pool exception.  Fixes #11314.
                     #
-                    # Exception: an upstream-aggregator 429 — the credential
+                    # Exception: an upstream-aggregator 429/403 — the credential
                     # pool can't help when the *upstream* model (DeepSeek,
                     # etc.) is throttling OpenRouter, so always fall back to a
                     # different model regardless of pool state.
-                    _is_upstream = classified.reason == FailoverReason.upstream_rate_limit
+                    _is_upstream = classified.reason in {
+                        FailoverReason.upstream_rate_limit,
+                        FailoverReason.upstream_provider_error,
+                    }
                     pool_may_recover = (
                         False if _is_upstream
                         else _ra()._pool_may_recover_from_rate_limit(

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -34,6 +34,7 @@ class FailoverReason(enum.Enum):
     # Upstream model rate-limited (aggregator 429) — fallback to a different
     # model, NOT credential rotation. The user's key is healthy.
     upstream_rate_limit = "upstream_rate_limit"
+    upstream_provider_error = "upstream_provider_error"  # Aggregator (OpenRouter, Groq, etc.) wrapped upstream provider 403 — fallback to different model, DON'T rotate credential
 
     # Server-side
     overloaded = "overloaded"            # 503/529 — provider overloaded, backoff
@@ -1035,6 +1036,14 @@ def _classify_by_status(
     if status_code == 403:
         # OpenRouter 403 "key limit exceeded" is actually billing. Other
         # providers also use 403 for account-plan or credit exhaustion.
+        # Some providers also reuse 403 for server-wide overload (same
+        # disambiguation as the 429 path) — the credential is valid and the
+        # correct recovery is "back off and retry the same key".
+        if any(p in error_msg for p in _OVERLOADED_PATTERNS):
+            return result_fn(
+                FailoverReason.overloaded,
+                retryable=True,
+            )
         if (
             (
                 provider == "xai-oauth"
@@ -1049,6 +1058,22 @@ def _classify_by_status(
                 retryable=False,
                 should_rotate_credential=True,
                 should_fallback=True,
+            )
+        # Distinguish an aggregator-wrapped upstream 403 (an upstream model like
+        # Sakana or Poolside rejected the request — the aggregator's outer
+        # message is "Provider returned error" and the real error is nested in
+        # metadata.raw) from an account-level 403 (the user's key is actually
+        # exhausted). The user's aggregator key is healthy, so rotating the
+        # credential is wrong — fall back to a different model instead.
+        if _is_openrouter_upstream_error(body, provider):
+            upstream_provider = _extract_upstream_provider_name(body)
+            ctx = {"upstream_provider": upstream_provider} if upstream_provider else {}
+            return result_fn(
+                FailoverReason.upstream_provider_error,
+                retryable=False,
+                should_rotate_credential=False,
+                should_fallback=True,
+                error_context=ctx,
             )
         return result_fn(
             FailoverReason.auth,

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -504,6 +504,22 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("AZURE_FOUNDRY_API_KEY",),
         base_url_env_var="AZURE_FOUNDRY_BASE_URL",
     ),
+    "groq": ProviderConfig(
+        id="groq",
+        name="Groq",
+        auth_type="api_key",
+        inference_base_url="https://api.groq.com/openai/v1",
+        api_key_env_vars=("GROQ_API_KEY",),
+        base_url_env_var="GROQ_BASE_URL",
+    ),
+    "cerebras": ProviderConfig(
+        id="cerebras",
+        name="Cerebras",
+        auth_type="api_key",
+        inference_base_url="https://api.cerebras.ai/v1",
+        api_key_env_vars=("CEREBRAS_API_KEY",),
+        base_url_env_var="CEREBRAS_BASE_URL",
+    ),
 }
 
 # Auto-extend PROVIDER_REGISTRY with any api-key provider registered in

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -65,6 +65,7 @@ class TestFailoverReason:
             "thinking_signature", "long_context_tier",
             "oauth_long_context_beta_forbidden",
             "llama_cpp_grammar_pattern",
+            "upstream_provider_error",
             "unknown",
         }
         actual = {r.value for r in FailoverReason}
@@ -1083,3 +1084,142 @@ class TestExpandedOverflowPatterns:
 
 
 
+
+
+class TestUpstreamProviderError403:
+    """Distinguish upstream-provider 403 from account-level 403 on aggregators.
+
+    When an upstream model (Sakana, Poolside, etc.) returns a 403 through an
+    aggregator (OpenRouter, Groq, Together, Fireworks), the aggregator wraps it
+    with "Provider returned error". The user's aggregator key is healthy — we
+    must fall back to a different model, NOT mark the credential exhausted.
+    """
+
+    def test_openrouter_upstream_403_classified_as_upstream_provider_error(self):
+        """OpenRouter 403 with 'Provider returned error' -> upstream_provider_error."""
+        e = MockAPIError(
+            "Provider returned error",
+            status_code=403,
+            body={
+                "error": {
+                    "message": "Provider returned error",
+                    "code": 403,
+                    "metadata": {
+                        "provider_name": "Sakana AI",
+                        "raw": '{"error":{"message":"Access denied"}}',
+                    },
+                }
+            },
+        )
+        result = classify_api_error(e, provider="openrouter", model="sakana/fugu-ultra")
+        assert result.reason == FailoverReason.upstream_provider_error
+        assert result.should_rotate_credential is False
+        assert result.should_fallback is True
+        assert result.error_context.get("upstream_provider") == "Sakana AI"
+
+    def test_groq_upstream_403_classified_as_upstream_provider_error(self):
+        """Groq 403 with upstream wrapper -> upstream_provider_error."""
+        e = MockAPIError(
+            "Provider returned error",
+            status_code=403,
+            body={
+                "error": {
+                    "message": "Provider returned error",
+                    "metadata": {"provider_name": "Poolside", "raw": '{"error":{}}'},
+                }
+            },
+        )
+        result = classify_api_error(e, provider="groq", model="poolside/malibu")
+        assert result.reason == FailoverReason.upstream_provider_error
+        assert result.should_rotate_credential is False
+        assert result.should_fallback is True
+        assert result.error_context.get("upstream_provider") == "Poolside"
+
+    def test_together_upstream_403_classified_as_upstream_provider_error(self):
+        """Together 403 with upstream wrapper -> upstream_provider_error."""
+        e = MockAPIError(
+            "Provider returned error",
+            status_code=403,
+            body={
+                "error": {
+                    "message": "Provider returned error",
+                    "metadata": {"provider_name": "Together", "raw": '{"error":{}}'},
+                }
+            },
+        )
+        result = classify_api_error(e, provider="together", model="together/model")
+        assert result.reason == FailoverReason.upstream_provider_error
+        assert result.should_rotate_credential is False
+
+    def test_fireworks_upstream_403_classified_as_upstream_provider_error(self):
+        """Fireworks 403 with upstream wrapper -> upstream_provider_error."""
+        e = MockAPIError(
+            "Provider returned error",
+            status_code=403,
+            body={
+                "error": {
+                    "message": "Provider returned error",
+                    "metadata": {"provider_name": "Fireworks", "raw": '{"error":{}}'},
+                }
+            },
+        )
+        result = classify_api_error(e, provider="fireworks", model="fireworks/model")
+        assert result.reason == FailoverReason.upstream_provider_error
+        assert result.should_rotate_credential is False
+
+    def test_account_level_403_still_classified_as_auth_or_billing(self):
+        """A real account-level 403 (no upstream wrapper) -> auth or billing."""
+        # Plain 403 -> auth
+        e = MockAPIError("Forbidden", status_code=403)
+        result = classify_api_error(e, provider="openrouter", model="x")
+        assert result.reason == FailoverReason.auth
+
+        # 403 with billing language -> billing
+        e = MockAPIError("spending limit reached", status_code=403)
+        result = classify_api_error(e, provider="openrouter", model="x")
+        assert result.reason == FailoverReason.billing
+        assert result.should_rotate_credential is True
+
+    def test_upstream_403_without_metadata_on_non_aggregator_not_matched(self):
+        """'Provider returned error' alone on a non-aggregator provider -> plain auth."""
+        e = MockAPIError(
+            "Provider returned error",
+            status_code=403,
+            body={"error": {"message": "Provider returned error", "code": 403}},
+        )
+        result = classify_api_error(e, provider="anthropic", model="claude-sonnet-4")
+        # Not an aggregator, so no upstream detection
+        assert result.reason == FailoverReason.auth
+
+    def test_upstream_provider_name_missing_yields_empty_context(self):
+        """No provider_name in metadata -> upstream_provider_error with empty context."""
+        e = MockAPIError(
+            "Provider returned error",
+            status_code=403,
+            body={
+                "error": {
+                    "message": "Provider returned error",
+                    "metadata": {"raw": '{"error":{"code":403}}'},
+                }
+            },
+        )
+        result = classify_api_error(e, provider="openrouter", model="x")
+        assert result.reason == FailoverReason.upstream_provider_error
+        assert result.error_context.get("upstream_provider") is None
+
+    def test_overload_403_takes_precedence_over_upstream(self):
+        """A 403 carrying overload language stays overloaded (retry same key)."""
+        e = MockAPIError(
+            "Provider returned error",
+            status_code=403,
+            body={
+                "error": {
+                    "message": "service is temporarily overloaded",
+                    "metadata": {"provider_name": "Sakana AI"},
+                }
+            },
+        )
+        result = classify_api_error(e, provider="openrouter", model="x")
+        # Overload disambiguation runs first; the outer message is the overload
+        # phrase, so this is an overload, not an upstream provider error.
+        assert result.reason == FailoverReason.overloaded


### PR DESCRIPTION
## What does this PR do?

This PR adds groq and cerebras as providers, so they are recognized automatically.


## Related Issue

[<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->
](https://github.com/NousResearch/hermes-agent/issues/58603)

Fixes #58603

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

diff --git a/hermes_cli/auth.py b/hermes_cli/auth.py
index a91fbb2fa..c1d706d0d 100644
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -224,6 +224,22 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("SILICONFLOW_API_KEY",),
         base_url_env_var="SILICONFLOW_BASE_URL",
     ),
+    "groq": ProviderConfig(
+        id="groq",
+        name="Groq",
+        auth_type="api_key",
+        inference_base_url="https://api.groq.com/openai/v1",
+        api_key_env_vars=("GROQ_API_KEY",),
+        base_url_env_var="GROQ_BASE_URL",
+    ),
+    "cerebras": ProviderConfig(
+        id="cerebras",
+        name="Cerebras",
+        auth_type="api_key",
+        inference_base_url="https://api.cerebras.ai/openai/v1",
+        api_key_env_vars=("CEREBRAS_API_KEY",),
+        base_url_env_var="CEREBRAS_BASE_URL",
+    ),
     "xai-oauth": ProviderConfig(
- 

## How to Test

1.  Configure matching API keys in .env
2.  Call up hermes auth add and list functions; the providers shall be recognized as such.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [N/A] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

## Screenshots / Logs

