### PR TITLE
fix(qqbot): add missing is_reconnect param to QQAdapter.connect()

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,7 +278,7 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"


### PR DESCRIPTION
## Summary
- `QQAdapter.connect()` was missing the `is_reconnect` keyword-only parameter that `gateway/run.py` passes on reconnection attempts
- This caused a `TypeError` on every reconnect, preventing the QQ bot from recovering after a dropped WebSocket
- All other platform adapters already accept this parameter — this aligns QQAdapter with the `BasePlatformAdapter.connect()` interface

## Test plan
- [ ] Verify QQ bot connects normally on first launch
- [ ] Simulate a WebSocket disconnect and confirm reconnection succeeds without TypeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)