### PR TITLE
feat: preserve model ID dots for custom providers + extra_models config

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2269,7 +2269,27 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
     (opencode-go/zen, xiaomi, deepseek, smaller inference providers, etc.),
     models.dev entries are merged on top of curated so new models released
     on the platform appear in ``/model`` without a Hermes release.
+
+    User-defined ``model.extra_models.<provider>`` entries in config.yaml
+    are prepended to the result so custom model IDs appear at the top of
+    the picker without touching source code.
     """
+    normalized = normalize_provider(provider)
+    result = _provider_model_ids_core(provider, force_refresh=force_refresh)
+    try:
+        extra = _get_model_config_dict().get("extra_models", {})
+        extra_list = extra.get(normalized, [])
+        if isinstance(extra_list, list) and extra_list:
+            result_lower = {m.lower() for m in result}
+            prepend = [m for m in extra_list if isinstance(m, str) and m.lower() not in result_lower]
+            if prepend:
+                result = prepend + result
+    except Exception:
+        pass
+    return result
+
+
+def _provider_model_ids_core(provider: Optional[str], *, force_refresh: bool = False) -> list[str]:
     normalized = normalize_provider(provider)
     if normalized == "openrouter":
         return model_ids(force_refresh=force_refresh)

--- a/run_agent.py
+++ b/run_agent.py
@@ -5178,6 +5178,7 @@ class AIAgent:
             "opencode-go", "opencode-zen",
             "zai", "bedrock",
             "xiaomi", "vertex",
+            "custom",
         }:
             return True
         base = (getattr(self, "base_url", "") or "").lower()


### PR DESCRIPTION
## Summary
- **Preserve dots in custom provider model names** — `_anthropic_preserve_dots()` now includes `"custom"` in its allowlist, so user-defined `providers:` entries with model IDs containing dots (e.g. `Claude-Opus-4.6-hq`) are sent as-is instead of being normalized to `Claude-Opus-4-6-hq`. Third-party Anthropic-compatible endpoints often use non-standard IDs that break when dots are replaced with hyphens.
- **`model.extra_models` config support** — New config key `model.extra_models.<provider>` lets users prepend custom model IDs to any provider's `/model` picker list. When `base_url` points to a custom endpoint, `provider_model_ids()` fetches the live `/v1/models` catalog and ignores the static list — users with proprietary IDs not in the live response had no way to surface them. The wrapper reads from config and prepends (with dedup) before returning.

## Test plan
- [ ] Configure a custom `providers:` entry with model IDs containing dots, verify they are sent verbatim in API requests
- [ ] Add `model.extra_models.anthropic: [MyModel]` to config.yaml, verify it appears in the `/model` picker
- [ ] Verify existing provider behavior (anthropic, openai-api, etc.) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)