### PR TITLE
ci(lint): correct stale setup-python version comment (v5 -> v6.2.0)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -152,7 +152,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
﻿## What does this PR do?

Corrects a stale version comment next to a SHA-pinned GitHub Action in `.github/workflows/lint.yml`.

The pinned SHA `a309ff8b426b58ec0e2a45f0f869d46889d02405` for `actions/setup-python` is labeled `# v5`, but that exact SHA is `v6.2.0` — as it is correctly commented in **four** other workflows in this repo:

- `.github/workflows/skills-index.yml`
- `.github/workflows/docs-site-checks.yml`
- `.github/workflows/upload_to_pypi.yml`
- `.github/workflows/deploy-site.yml`

Only `lint.yml` mislabels it as `# v5` — a comment left over from a previous pin bump.

```diff
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
```

## Type of Change

- [x] CI / documentation — comment-only, no behavior change

## Why

The version comment beside a SHA pin is the human-readable reference used when auditing or bumping actions. A stale `# v5` on a `v6.2.0` SHA misleads a maintainer into thinking `lint.yml` lags a major version behind, and could prompt an erroneous "update" that churns or downgrades the pin. This aligns the comment with the other four identical pins.

## Validation

Provable by direct in-repo comparison: the same SHA is commented `# v6.2.0` in `skills-index.yml`, `docs-site-checks.yml`, `upload_to_pypi.yml`, and `deploy-site.yml`. The SHA is unchanged, so CI behavior is identical.

## Notes

- 1 file, 1 line. Comment-only — the executed action (the SHA) is unchanged.
