### PR TITLE
fix(tests): isolate anthropic adapter tests from macOS Keychain

### DIFF
--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -29,6 +29,21 @@ from agent.anthropic_adapter import (
 from agent.transports import get_transport
 
 
+@pytest.fixture(autouse=True)
+def _isolate_from_keychain(monkeypatch):
+    """Prevent all tests from reading real macOS Keychain credentials.
+
+    The Claude Code keychain read is outside ``Path.home()`` control, so
+    tests that only monkeypatch ``Path.home()`` still hit the real
+    Keychain on macOS.  This module-level autouse fixture stubs the
+    keychain function so every test starts with a clean slate.
+    """
+    monkeypatch.setattr(
+        "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+        lambda: None,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Auth helpers
 # ---------------------------------------------------------------------------
@@ -225,13 +240,6 @@ class TestBuildAnthropicClient:
 
 
 class TestReadClaudeCodeCredentials:
-    @pytest.fixture(autouse=True)
-    def no_keychain(self, monkeypatch):
-        monkeypatch.setattr(
-            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
-            lambda: None,
-        )
-
     def test_reads_valid_credentials(self, tmp_path, monkeypatch):
         cred_file = tmp_path / ".claude" / ".credentials.json"
         cred_file.parent.mkdir(parents=True)


### PR DESCRIPTION
## What does this PR do?

Isolates all tests in `tests/agent/test_anthropic_adapter.py` from real macOS Keychain credentials. Previously, only the `TestReadClaudeCodeCredentials` class stubbed the Keychain read; tests in `TestResolveAnthropicToken` that call `resolve_anthropic_token()` without explicitly mocking `read_claude_code_credentials` would hit the real Keychain on macOS, causing 14 test failures when Claude Code credentials are present.

## Related Issue

Fixes #58609

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/agent/test_anthropic_adapter.py`: Added a module-level `autouse` fixture `_isolate_from_keychain` that mocks `_read_claude_code_credentials_from_keychain` to return `None` for every test in the file. Removed the now-redundant class-level `no_keychain` fixture from `TestReadClaudeCodeCredentials`.

## How to Test

1. On a macOS machine with Claude Code credentials stored in Keychain, verify the entry exists: `security find-generic-password -s "Claude Code-credentials" -w >/dev/null && echo "present"`
2. Run the full test file: `python -m pytest tests/agent/test_anthropic_adapter.py -q`
3. All 173 tests should pass (previously 14 failed with `AssertionError` comparing real Keychain tokens to test fixtures).
4. Should pass on systems without Keychain credentials as well — the fixture is a no-op when the real function already returns `None`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (macOS Keychain isolation only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

**Before (macOS with Claude Code credentials in Keychain):**
```
14 failed, 159 passed
TestResolveAnthropicToken.test_prefers_oauth_token_over_api_key
E   AssertionError: assert '<real keychain token>' == 'sk-ant...oken'
```

**After:**
```
173 passed in 3.82s
```
