### PR TITLE
fix(tests): isolate Anthropic keychain credentials

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -902,7 +902,12 @@ def _read_claude_code_credentials_from_keychain() -> Optional[Dict[str, Any]]:
         logger.debug("Keychain: no entry found for 'Claude Code-credentials'")
         return None
 
-    raw = result.stdout.strip()
+    stdout = getattr(result, "stdout", "")
+    if not isinstance(stdout, str):
+        logger.debug("Keychain: credentials payload is not text")
+        return None
+
+    raw = stdout.strip()
     if not raw:
         return None
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -12,6 +12,7 @@ from agent.prompt_caching import apply_anthropic_cache_control
 from agent.anthropic_adapter import (
     _is_azure_anthropic_endpoint,
     _is_oauth_token,
+    _read_claude_code_credentials_from_keychain,
     _refresh_oauth_token,
     _to_plain_data,
     _write_claude_code_credentials,
@@ -278,6 +279,16 @@ class TestReadClaudeCodeCredentials:
         assert read_claude_code_credentials() is None
 
 
+class TestReadClaudeCodeCredentialsFromKeychain:
+    def test_returns_none_for_non_text_security_stdout(self):
+        result = MagicMock(returncode=0)
+
+        with patch("agent.anthropic_adapter.platform.system", return_value="Darwin"), patch(
+            "agent.anthropic_adapter.subprocess.run", return_value=result
+        ):
+            assert _read_claude_code_credentials_from_keychain() is None
+
+
 class TestIsClaudeCodeTokenValid:
     def test_valid_token(self):
         creds = {"accessToken": "tok", "expiresAt": int(time.time() * 1000) + 3600_000}
@@ -293,6 +304,13 @@ class TestIsClaudeCodeTokenValid:
 
 
 class TestResolveAnthropicToken:
+    @pytest.fixture(autouse=True)
+    def no_keychain(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
+
     def test_prefers_oauth_token_over_api_key(self, monkeypatch, tmp_path):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-mykey")
         monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-mytoken")
@@ -611,6 +629,13 @@ class TestWriteClaudeCodeCredentials:
 
 
 class TestResolveWithRefresh:
+    @pytest.fixture(autouse=True)
+    def no_keychain(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
+
     def test_auto_refresh_on_expired_creds(self, monkeypatch, tmp_path):
         """When cred file has expired token + refresh token, auto-refresh is attempted."""
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
@@ -658,6 +683,13 @@ class TestResolveWithRefresh:
 
 
 class TestRunOauthSetupToken:
+    @pytest.fixture(autouse=True)
+    def no_keychain(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
+
     def test_raises_when_claude_not_installed(self, monkeypatch):
         monkeypatch.setattr("shutil.which", lambda _: None)
         with pytest.raises(FileNotFoundError, match="claude.*CLI.*not installed"):


### PR DESCRIPTION
## What does this PR do?

Fixes #58609 by making Anthropic adapter credential tests deterministic on macOS machines that have real Claude Code OAuth credentials in Keychain.

The failure had two related paths:

1. Several tests monkeypatch env vars and `Path.home()`, but `read_claude_code_credentials()` still reads the macOS Keychain path, so a real `Claude Code-credentials` entry could override test fixtures.
2. `TestRunOauthSetupToken` patches `subprocess.run` for the Claude CLI command, but the Keychain helper also uses `subprocess.run`, so the helper could try to parse a `MagicMock` as JSON.

This PR keeps the production Keychain behavior intact while isolating tests that are not explicitly testing Keychain lookup. It also makes the Keychain helper defensive when `security` returns a non-text `stdout`, which avoids leaking a mocked subprocess object into JSON parsing.

## Related Issue

Fixes #58609

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/anthropic_adapter.py`
  - Treat non-string Keychain command stdout as an unreadable payload and return `None` instead of passing it to `json.loads()`.
- `tests/agent/test_anthropic_adapter.py`
  - Add coverage for the non-text Keychain stdout path.
  - Patch `_read_claude_code_credentials_from_keychain()` in `TestResolveAnthropicToken`, `TestResolveWithRefresh`, and `TestRunOauthSetupToken` so machine-local macOS Keychain state cannot affect those tests.

## How to Test

Repro before fix on `origin/main` at `7e8f50a14`, on macOS with a real `Claude Code-credentials` Keychain entry:

```bash
scripts/run_tests.sh tests/agent/test_anthropic_adapter.py -q
```

Result before fix:

```text
14 failed, 159 passed
```

Validation after fix:

```bash
scripts/run_tests.sh \
  tests/agent/test_anthropic_adapter.py \
  tests/agent/test_anthropic_oauth_pkce.py \
  tests/agent/test_anthropic_keychain.py \
  tests/hermes_cli/test_anthropic_oauth_flow.py \
  tests/hermes_cli/test_anthropic_oauth_routes_to_messages_api.py \
  -q
```

Result after fix:

```text
205 tests passed, 0 failed
```

Additional checks:

```bash
git diff --check --cached
python -m ruff check agent/anthropic_adapter.py tests/agent/test_anthropic_adapter.py
python scripts/check-windows-footguns.py
```

Results:

```text
All checks passed!
✓ No Windows footguns found (2 file(s) scanned).
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
