### PR TITLE
feat: alias upgrade to update command

### DIFF
--- a/hermes_cli/subcommands/update.py
+++ b/hermes_cli/subcommands/update.py
@@ -16,6 +16,7 @@ def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
     # =========================================================================
     update_parser = subparsers.add_parser(
         "update",
+        aliases=["upgrade"],
         help="Update Hermes Agent to the latest version",
         description="Pull the latest changes from git and reinstall dependencies",
     )

--- a/tests/hermes_cli/test_update_parser.py
+++ b/tests/hermes_cli/test_update_parser.py
@@ -1,0 +1,34 @@
+"""Unit tests for the extracted ``hermes update`` parser builder."""
+
+from __future__ import annotations
+
+import argparse
+
+from hermes_cli.subcommands.update import build_update_parser
+
+
+def _sentinel_handler(args):  # pragma: no cover - only identity is asserted
+    return "update-handler"
+
+
+def _build():
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+    build_update_parser(subparsers, cmd_update=_sentinel_handler)
+    return parser
+
+
+def test_upgrade_alias_routes_to_update_handler():
+    parser = _build()
+    ns = parser.parse_args(["upgrade", "--check"])
+    assert ns.command == "upgrade"
+    assert ns.check is True
+    assert ns.func is _sentinel_handler
+
+
+def test_update_still_routes_to_update_handler():
+    parser = _build()
+    ns = parser.parse_args(["update", "--check"])
+    assert ns.command == "update"
+    assert ns.check is True
+    assert ns.func is _sentinel_handler


### PR DESCRIPTION
## Summary
- Add `hermes upgrade` as an argparse alias for `hermes update`
- Cover both `update` and `upgrade` parser routing with a focused unit test

## Testing
- `python -m pytest tests/hermes_cli/test_update_parser.py -q -o 'addopts='`
- `python -m hermes_cli.main --help`