### PR TITLE
fix: gate Codex gpt-5.5 autoraise warning

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -68,8 +68,8 @@ def _ra():
     return run_agent
 
 
-def _build_codex_gpt55_autoraise_notice(autoraise: Dict[str, float]) -> str:
-    """Build the one-time notice shown when Codex gpt-5.5 raises compaction.
+def _build_codex_gpt55_autoraise_warning(autoraise: Dict[str, float]) -> str:
+    """Build the one-time warning shown when Codex gpt-5.5 raises compaction.
 
     ``autoraise`` is ``{"from": <old_ratio>, "to": <new_ratio>}``. The same
     text is printed inline for CLI users and replayed via ``status_callback``
@@ -1402,15 +1402,18 @@ def init_agent(
     # 85% (the Codex backend caps the window at 272K, so the default 50% would
     # compact at ~136K — half the usable context). Gated by an opt-out config
     # flag so the user can fall back to the global threshold; when the override
-    # fires we stash a one-time notification (replayed on the first turn) that
-    # tells the user what changed and how to revert. The notice has its own
-    # display gate so users can keep the threshold autoraise without getting
-    # the banner on gateway turns.
+    # fires we stash a one-time warning (replayed on the first turn) that tells
+    # the user what changed and how to revert. The warning has its own display
+    # gate so users can keep the threshold autoraise without getting the banner
+    # on gateway turns.
     _codex_gpt55_autoraise = str(
         _compression_cfg.get("codex_gpt55_autoraise", True)
     ).lower() in {"true", "1", "yes"}
-    _codex_gpt55_autoraise_notice = str(
-        _compression_cfg.get("codex_gpt55_autoraise_notice", True)
+    _codex_gpt55_autoraise_warning = str(
+        _compression_cfg.get(
+            "codex_gpt55_autoraise_warning",
+            _compression_cfg.get("codex_gpt55_autoraise_notice", True),
+        )
     ).lower() in {"true", "1", "yes"}
     agent._compression_threshold_autoraised = None
     try:
@@ -1426,8 +1429,8 @@ def init_agent(
         if _model_cthresh is not None:
             _prev_threshold = compression_threshold
             compression_threshold = _model_cthresh
-            # Notify only for the Codex gpt-5.5 autoraise (the Arcee Trinity
-            # override is a long-standing silent default). Skip the notice when
+            # Warn only for the Codex gpt-5.5 autoraise (the Arcee Trinity
+            # override is a long-standing silent default). Skip the warning when
             # the user's global threshold already meets/exceeds the raised
             # value, since nothing actually changed for them.
             if (
@@ -1891,24 +1894,24 @@ def init_agent(
             print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (compress at {int(compression_threshold*100)}% = {agent.context_compressor.threshold_tokens:,})")
         else:
             print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (auto-compression disabled)")
-        # One-time notice when the Codex gpt-5.5 autoraise kicked in, with the
+        # One-time warning when the Codex gpt-5.5 autoraise kicked in, with the
         # exact opt-back-out command. Printed inline at startup for CLI users;
         # gateway users get the same text replayed via _compression_warning on
         # turn 1 (set below, after the warning slot is initialized).
         _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-        if _autoraise and compression_enabled and _codex_gpt55_autoraise_notice:
-            print(_build_codex_gpt55_autoraise_notice(_autoraise))
+        if _autoraise and compression_enabled and _codex_gpt55_autoraise_warning:
+            print(_build_codex_gpt55_autoraise_warning(_autoraise))
 
     # Check immediately so CLI users see the warning at startup.
     # Gateway status_callback is not yet wired, so any warning is stored
     # in _compression_warning and replayed in the first run_conversation().
     agent._compression_warning = None
-    # Gateway parity for the Codex gpt-5.5 autoraise notice: the startup print
+    # Gateway parity for the Codex gpt-5.5 autoraise warning: the startup print
     # above only reaches the CLI, so stash the same text here to be replayed
     # through status_callback on the first turn (Telegram/Discord/Slack/etc.).
     _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-    if _autoraise and compression_enabled and _codex_gpt55_autoraise_notice:
-        agent._compression_warning = _build_codex_gpt55_autoraise_notice(_autoraise)
+    if _autoraise and compression_enabled and _codex_gpt55_autoraise_warning:
+        agent._compression_warning = _build_codex_gpt55_autoraise_warning(_autoraise)
     # Lazy feasibility check: deferred to the first turn that approaches the
     # compression threshold. Running it eagerly here costs ~400ms cold (network
     # probe of the auxiliary provider chain + /models lookup) on every agent

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1367,10 +1367,10 @@ DEFAULT_CONFIG = {
                                       # exact route is affected — gpt-5.5 on OpenAI's
                                       # direct API, OpenRouter, and Copilot keep the
                                       # global threshold regardless.
-        "codex_gpt55_autoraise_notice": True,  # Display the one-time Codex gpt-5.5
-                                      # autoraise banner. Set False to keep the
+        "codex_gpt55_autoraise_warning": True,  # Display the one-time Codex gpt-5.5
+                                      # autoraise warning. Set False to keep the
                                       # 85% threshold autoraise but suppress the
-                                      # user-facing notice in CLI/gateway output.
+                                      # user-facing warning in CLI/gateway output.
         "in_place": True,             # When True, compaction rewrites the message
                                       # list and rebuilds the system prompt WITHOUT
                                       # rotating the session id — the conversation

--- a/tests/agent/test_codex_gpt55_autoraise_warning.py
+++ b/tests/agent/test_codex_gpt55_autoraise_warning.py
@@ -1,4 +1,4 @@
-"""Regression tests for the Codex gpt-5.5 autoraise notice gate."""
+"""Regression tests for the Codex gpt-5.5 autoraise warning gate."""
 
 from __future__ import annotations
 
@@ -10,7 +10,12 @@ from hermes_state import SessionDB
 from run_agent import AIAgent
 
 
-def _config(*, show_notice: bool) -> dict:
+def _config(*, show_warning: bool, legacy_notice_key: bool = False) -> dict:
+    warning_key = (
+        "codex_gpt55_autoraise_notice"
+        if legacy_notice_key
+        else "codex_gpt55_autoraise_warning"
+    )
     return {
         "compression": {
             "enabled": True,
@@ -19,7 +24,7 @@ def _config(*, show_notice: bool) -> dict:
             "protect_first_n": 3,
             "protect_last_n": 20,
             "codex_gpt55_autoraise": True,
-            "codex_gpt55_autoraise_notice": show_notice,
+            warning_key: show_warning,
         },
         "prompt_caching": {"cache_ttl": "5m"},
         "sessions": {},
@@ -27,11 +32,24 @@ def _config(*, show_notice: bool) -> dict:
     }
 
 
-def _make_codex_agent(monkeypatch, tmp_path: Path, *, show_notice: bool):
+def _make_codex_agent(
+    monkeypatch,
+    tmp_path: Path,
+    *,
+    show_warning: bool,
+    legacy_notice_key: bool = False,
+):
     """Construct a real Codex gpt-5.5 agent under an isolated config."""
     from hermes_cli import config as config_mod
 
-    monkeypatch.setattr(config_mod, "load_config", lambda: _config(show_notice=show_notice))
+    monkeypatch.setattr(
+        config_mod,
+        "load_config",
+        lambda: _config(
+            show_warning=show_warning,
+            legacy_notice_key=legacy_notice_key,
+        ),
+    )
     db = SessionDB(db_path=tmp_path / "state.db")
     stdout = io.StringIO()
 
@@ -46,7 +64,7 @@ def _make_codex_agent(monkeypatch, tmp_path: Path, *, show_notice: bool):
             quiet_mode=False,
             skip_memory=True,
             session_db=db,
-            session_id="codex-notice-test",
+            session_id="codex-warning-test",
         )
 
     return agent, stdout.getvalue()
@@ -57,8 +75,8 @@ def _threshold_ratio(agent: AIAgent) -> float:
     return round(compressor.threshold_tokens / compressor.context_length, 2)
 
 
-def test_codex_gpt55_autoraise_notice_enabled_by_default(monkeypatch, tmp_path):
-    agent, stdout = _make_codex_agent(monkeypatch, tmp_path, show_notice=True)
+def test_codex_gpt55_autoraise_warning_enabled_by_default(monkeypatch, tmp_path):
+    agent, stdout = _make_codex_agent(monkeypatch, tmp_path, show_warning=True)
 
     assert _threshold_ratio(agent) == 0.85
     warning = getattr(agent, "_compression_warning")
@@ -67,10 +85,23 @@ def test_codex_gpt55_autoraise_notice_enabled_by_default(monkeypatch, tmp_path):
     assert "auto-compaction was raised" in stdout
 
 
-def test_codex_gpt55_autoraise_notice_can_be_suppressed_without_disabling_autoraise(
+def test_codex_gpt55_autoraise_warning_can_be_suppressed_without_disabling_autoraise(
     monkeypatch, tmp_path
 ):
-    agent, stdout = _make_codex_agent(monkeypatch, tmp_path, show_notice=False)
+    agent, stdout = _make_codex_agent(monkeypatch, tmp_path, show_warning=False)
+
+    assert _threshold_ratio(agent) == 0.85
+    assert getattr(agent, "_compression_warning") is None
+    assert "auto-compaction was raised" not in stdout
+
+
+def test_legacy_notice_key_still_suppresses_warning(monkeypatch, tmp_path):
+    agent, stdout = _make_codex_agent(
+        monkeypatch,
+        tmp_path,
+        show_warning=False,
+        legacy_notice_key=True,
+    )
 
     assert _threshold_ratio(agent) == 0.85
     assert getattr(agent, "_compression_warning") is None

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -85,7 +85,7 @@ compression:
   target_ratio: 0.20         # How much of threshold to keep as tail (default: 0.20)
   protect_last_n: 20         # Minimum protected tail messages (default: 20)
   codex_gpt55_autoraise: true  # gpt-5.5 on Codex OAuth: raise trigger to 85% (default: true)
-  codex_gpt55_autoraise_notice: true  # Show the one-time autoraise notice (default: true)
+  codex_gpt55_autoraise_warning: true  # Show the one-time autoraise warning (default: true)
 
 # Summarization model/provider configured under auxiliary:
 auxiliary:
@@ -104,7 +104,7 @@ auxiliary:
 | `protect_last_n` | `20` | ≥1 | Minimum number of recent messages always preserved |
 | `protect_first_n` | `3` | (hardcoded) | System prompt + first exchange always preserved |
 | `codex_gpt55_autoraise` | `true` | bool | Raise the trigger to 85% for gpt-5.5 on the ChatGPT Codex OAuth route (see below). Set `false` to keep the global `threshold` |
-| `codex_gpt55_autoraise_notice` | `true` | bool | Show the one-time Codex gpt-5.5 autoraise notice. Set `false` to keep the 85% autoraise but suppress the banner |
+| `codex_gpt55_autoraise_warning` | `true` | bool | Show the one-time Codex gpt-5.5 autoraise warning. Set `false` to keep the 85% autoraise but suppress the banner |
 
 ### Codex gpt-5.5 threshold autoraise
 
@@ -113,7 +113,7 @@ The ChatGPT Codex OAuth backend hard-caps gpt-5.5 at a **272K** context window
 GitHub Copilot). At the default 50% trigger, compaction would fire at ~136K —
 half the window the model can actually use. When the active route is Codex
 OAuth (`provider: openai-codex`) and the model is gpt-5.5, Hermes raises the
-trigger to **85%** (~231K) and prints a one-time notice with the opt-out
+trigger to **85%** (~231K) and prints a one-time warning with the opt-out
 command. Only this exact route is affected; gpt-5.5 on any other provider keeps
 your global `threshold`. To opt back down to the global value:
 
@@ -121,10 +121,10 @@ your global `threshold`. To opt back down to the global value:
 hermes config set compression.codex_gpt55_autoraise false
 ```
 
-To keep the 85% autoraise but hide only the one-time notice:
+To keep the 85% autoraise but hide only the one-time warning:
 
 ```bash
-hermes config set compression.codex_gpt55_autoraise_notice false
+hermes config set compression.codex_gpt55_autoraise_warning false
 ```
 
 ### Computed Values (for a 200K context model at defaults)


### PR DESCRIPTION
## Summary
- adds `compression.codex_gpt55_autoraise_warning` to hide the Codex gpt-5.5 autoraise warning without disabling the 85% threshold override
- keeps `compression.codex_gpt55_autoraise_notice` as a backwards-compatible fallback
- updates the compression docs and regression tests

## Testing
- `python -m pytest tests/agent/test_codex_gpt55_autoraise_warning.py tests/agent/test_arcee_trinity_overrides.py tests/hermes_cli/test_config.py -q -o 'addopts='`
