### PR TITLE
fix(gateway): cap proxy SSE buffer to prevent unbounded memory growth

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16177,6 +16177,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         }
 
                     # Parse SSE stream
+                    _SSE_BUFFER_CAP = 1 << 20  # 1 MiB — reject boundary-less lines
                     buffer = ""
                     async for chunk in resp.content.iter_any():
                         if not _run_still_current():
@@ -16196,6 +16197,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             }
                         text = chunk.decode("utf-8", errors="replace")
                         buffer += text
+
+                        if len(buffer) > _SSE_BUFFER_CAP:
+                            raise RuntimeError(
+                                f"Proxy SSE buffer exceeded {_SSE_BUFFER_CAP} bytes "
+                                "without a line boundary — aborting"
+                            )
 
                         # Process complete SSE lines
                         while "\n" in buffer:


### PR DESCRIPTION
## Summary

Gateway proxy mode parses SSE streams by appending chunks to a buffer and splitting on newlines. A malformed or boundary-less upstream can grow the buffer without limit, eventually OOMing the process.

## Root Cause

In `gateway/run.py::_run_agent_via_proxy`, the successful SSE path:
```python
buffer = ""
async for chunk in resp.content.iter_any():
    text = chunk.decode("utf-8", errors="replace")
    buffer += text
    while "\n" in buffer:
        line, buffer = buffer.split("\n", 1)
```

If the remote proxy sends a long malformed SSE line without a newline boundary, the residual `buffer` has no cap.

## Fix

Add a 1 MiB cap on the residual buffer. If the buffer exceeds this without seeing a line boundary, raise `RuntimeError` to abort the proxy connection instead of continuing to accumulate.

Fixes #58471
