### PR TITLE
fix(desktop): reap dying pool backends before spawning replacements

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -781,6 +781,11 @@ let connectionPromise = null
 // with no named profiles never populates this map, so their experience is
 // byte-for-byte the single-backend behavior.
 const backendPool = new Map() // profile -> { process, port, token, connectionPromise, lastActiveAt }
+// Track pool backend children that have been sent SIGTERM but haven't exited yet.
+// Without this, stopPoolBackend() deletes the pool entry before the child dies,
+// so the next ensureBackend() call for the same profile spawns a new serve process
+// while the old one is still alive — causing unbounded process accumulation (#58619).
+const dyingPoolChildren = new Map() // profile -> { child, killTimer }
 // Keep the pool light: cap concurrent profile backends (LRU eviction) and reap
 // idle ones. A user idles at exactly the primary backend; pool backends only
 // exist while a non-primary profile is actively being chatted through.
@@ -5297,6 +5302,19 @@ function startPoolIdleReaper() {
 // local-spawn portion of startHermes() but without the boot-progress UI,
 // bootstrap, or remote handling (those belong to the primary backend only).
 async function spawnPoolBackend(profile, entry) {
+  // Wait for any dying child for this profile to fully exit before spawning
+  // a replacement.  stopPoolBackend() sends SIGTERM and schedules SIGKILL,
+  // but the child may still be alive when ensureBackend() calls us (#58619).
+  const dying = dyingPoolChildren.get(profile)
+  if (dying) {
+    clearTimeout(dying.killTimer)
+    try {
+      if (dying.child.exitCode === null) dying.child.kill('SIGKILL')
+    } catch {}
+    await waitForBackendExit(dying.child)
+    dyingPoolChildren.delete(profile)
+  }
+
   // A profile may point at its OWN remote backend (connection.json
   // `profiles[name]`), or inherit the app-wide remote (env / global settings).
   // In either case there is no local child to spawn — we just verify the
@@ -5412,7 +5430,24 @@ function stopPoolBackend(profile) {
   const entry = backendPool.get(profile)
   if (!entry) return
   backendPool.delete(profile)
-  stopBackendChild(entry.process)
+  const child = entry.process
+  stopBackendChild(child)
+  // Track the dying child so spawnPoolBackend() waits for it before creating
+  // a replacement.  Without this, the pool entry is gone but the child is
+  // still alive (SIGTERM pending), and the next ensureBackend() for the same
+  // profile spawns a duplicate serve process (#58619).
+  if (child && !child.killed && child.exitCode === null) {
+    const killTimer = setTimeout(() => {
+      try {
+        if (child.exitCode === null) child.kill('SIGKILL')
+      } catch {}
+    }, 5000)
+    dyingPoolChildren.set(profile, { child, killTimer })
+    child.once('exit', () => {
+      clearTimeout(killTimer)
+      dyingPoolChildren.delete(profile)
+    })
+  }
 }
 
 async function teardownPoolBackendAndWait(profile) {


### PR DESCRIPTION
## What does this PR do?

Fixes unbounded `hermes serve` process accumulation in the Desktop app. When pool backends (non-primary profiles) are reaped by the idle reaper or LRU eviction, `stopPoolBackend()` sends SIGTERM and immediately deletes the pool entry — but never waits for the child to actually exit and never sends SIGKILL. The next `ensureBackend()` call for the same profile sees no pool entry and spawns a fresh serve process while the old one is still alive (SIGTERM pending or ignored). Over time this leaks one process per reaper cycle per profile.

## Related Issue

Fixes #58619

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/main.cjs`: Added `dyingPoolChildren` Map to track pool backend children that have been sent SIGTERM but haven't exited yet. Modified `stopPoolBackend()` to schedule SIGKILL after 5s timeout and register the dying child in the tracking map. Modified `spawnPoolBackend()` to wait for any dying child for the same profile to fully exit before spawning a replacement.

## How to Test

1. Run the existing desktop electron tests: `cd apps/desktop && node --test electron/*.test.cjs` — all existing tests should pass (309/311 pass, 1 pre-existing failure in `git-review-ops.test.cjs`, 1 skip).
2. Verify the code path: `grep -n 'dyingPoolChildren' apps/desktop/electron/main.cjs` should show the tracking map declaration and references in `spawnPoolBackend` and `stopPoolBackend`.
3. The fix is structural (process lifecycle management) and is best verified by code review of the `stopPoolBackend` → `spawnPoolBackend` coordination logic.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `node --test electron/*.test.cjs` and all tests pass (pre-existing failure excluded)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — SIGKILL fallback is POSIX; Windows uses `forceKillProcessTree` in `stopBackendChild`, which already handles process tree cleanup
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
