### PR TITLE
fix: route memory provider tools discovered after init

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -73,6 +73,11 @@ def normalize_tool_schema(schema: Any) -> Optional[Dict[str, Any]]:
         schema = schema["function"]
         if not isinstance(schema, dict):
             return None
+    schema = dict(schema)
+    if "parameters" not in schema and isinstance(schema.get("inputSchema"), dict):
+        schema["parameters"] = schema["inputSchema"]
+    schema.pop("inputSchema", None)
+
     name = schema.get("name", "")
     if not name or not isinstance(name, str):
         return None
@@ -396,7 +401,16 @@ class MemoryManager:
             self._has_external = True
 
         self._providers.append(provider)
+        self._index_provider_tools(provider)
 
+        logger.info(
+            "Memory provider '%s' registered (%d tools)",
+            provider.name,
+            len(provider.get_tool_schemas()),
+        )
+
+    def _index_provider_tools(self, provider: MemoryProvider) -> None:
+        """Index provider tools for routing after schema discovery."""
         # Core tool names are reserved — a memory provider must never register
         # a tool that shadows a built-in (e.g. ``clarify``, ``delegate_task``).
         # Built-ins always win, so such a tool is dropped at agent init and
@@ -432,12 +446,6 @@ class MemoryManager:
                     self._tool_to_provider[tool_name].name,
                     provider.name,
                 )
-
-        logger.info(
-            "Memory provider '%s' registered (%d tools)",
-            provider.name,
-            len(provider.get_tool_schemas()),
-        )
 
     @property
     def providers(self) -> List[MemoryProvider]:
@@ -1079,6 +1087,7 @@ class MemoryManager:
         for provider in self._providers:
             try:
                 provider.initialize(session_id=session_id, **kwargs)
+                self._index_provider_tools(provider)
             except Exception as e:
                 logger.warning(
                     "Memory provider '%s' initialize failed: %s",

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -92,6 +92,19 @@ class MessagesMemoryProvider(FakeMemoryProvider):
         self.synced_turns.append((user_content, assistant_content, session_id, messages))
 
 
+class InitDiscoveredToolsProvider(FakeMemoryProvider):
+    """Provider that only discovers tools during initialize()."""
+
+    def __init__(self, name="external"):
+        super().__init__(name, tools=[])
+
+    def initialize(self, session_id, **kwargs):
+        super().initialize(session_id, **kwargs)
+        self._tools = [
+            {"name": "late_tool", "description": "Late", "parameters": {"type": "object"}}
+        ]
+
+
 # ---------------------------------------------------------------------------
 # MemoryProvider ABC tests
 # ---------------------------------------------------------------------------
@@ -335,6 +348,38 @@ class TestMemoryManager:
         assert r1["handled"] == "builtin_tool"
         r2 = json.loads(mgr.handle_tool_call("ext_tool", {"b": 2}))
         assert r2["handled"] == "ext_tool"
+
+    def test_tools_discovered_during_initialize_are_routed(self):
+        mgr = MemoryManager()
+        p = InitDiscoveredToolsProvider()
+        mgr.add_provider(p)
+        assert not mgr.has_tool("late_tool")
+
+        mgr.initialize_all("sess-1")
+
+        assert mgr.has_tool("late_tool")
+        result = json.loads(mgr.handle_tool_call("late_tool", {"ok": True}))
+        assert result == {"handled": "late_tool", "args": {"ok": True}}
+
+    def test_mcp_input_schema_normalized_to_parameters(self):
+        mgr = MemoryManager()
+        p = FakeMemoryProvider("external", tools=[
+            {
+                "name": "mcp_tool",
+                "description": "MCP style",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"text": {"type": "string"}},
+                    "required": ["text"],
+                },
+            }
+        ])
+        mgr.add_provider(p)
+
+        schema = mgr.get_all_tool_schemas()[0]
+        assert "inputSchema" not in schema
+        assert schema["parameters"]["required"] == ["text"]
+        assert schema["parameters"]["properties"]["text"]["type"] == "string"
 
     # -- Lifecycle hooks -----------------------------------------------------
 


### PR DESCRIPTION
## Summary
- re-index memory provider tools after provider initialization so tools discovered during init route correctly
- normalize MCP-style inputSchema to OpenAI/Hermes parameters for model-facing schemas
- add regression coverage for init-discovered tools and inputSchema normalization

## Test
- scripts/run_tests.sh tests/agent/test_memory_provider.py -q
