### PR TITLE
fix(acp): resolve symlinks in sensitive-path auto-approve guard (#55367)

### DIFF
--- a/acp_adapter/edit_approval.py
+++ b/acp_adapter/edit_approval.py
@@ -190,11 +190,14 @@ def build_edit_proposal(tool_name: str, arguments: dict[str, Any]) -> EditPropos
 
 
 def _is_sensitive_auto_approve_path(path: str) -> bool:
-    parts = Path(path).expanduser().parts
+    # Resolve symlinks so that symlink-to-sensitive-file is also caught.
+    # Without this, `notes.txt -> ~/.ssh/authorized_keys` bypasses the guard.
+    resolved = Path(path).expanduser().resolve(strict=False)
+    parts = resolved.parts
     lowered = {part.lower() for part in parts}
     if ".git" in lowered or ".ssh" in lowered:
         return True
-    return Path(path).name.lower() in SENSITIVE_AUTO_APPROVE_NAMES
+    return resolved.name.lower() in SENSITIVE_AUTO_APPROVE_NAMES
 
 
 def should_auto_approve_edit(proposal: EditProposal, policy: str, cwd: str | None = None) -> bool:


### PR DESCRIPTION
## Summary

Issue #55367: `_is_sensitive_auto_approve_path` only checked the path string as written, without resolving symlinks. An edit targeting `project/notes.txt` where `notes.txt` is a symlink to `~/.ssh/authorized_keys` was auto-approved under the `session` policy with no prompt, because `notes.txt` itself is not a sensitive name.

## Root Cause

```python
# Vulnerable — checks the written path, not the symlink target
def _is_sensitive_auto_approve_path(path: str) -> bool:
    parts = Path(path).expanduser().parts  # ← no .resolve()
    ...
    return Path(path).name.lower() in SENSITIVE_AUTO_APPROVE_NAMES  # ← not resolved
```

## Fix

```python
# Fixed — resolves symlinks before checking
def _is_sensitive_auto_approve_path(path: str) -> bool:
    resolved = Path(path).expanduser().resolve(strict=False)  # ← resolves symlinks
    parts = resolved.parts
    ...
    return resolved.name.lower() in SENSITIVE_AUTO_APPROVE_NAMES  # ← checks resolved name
```

## Testing

```python
# notes.txt -> ~/.ssh/authorized_keys
_is_sensitive_auto_approve_path("tmp/proj/notes.txt")
# Before fix: False (auto-approved) ❌
# After fix: True (prompts) ✅
```

Fixes #55367