### PR TITLE
fix(compression): preserve flush baseline after abort

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -392,7 +392,11 @@ def replay_compression_warning(agent: Any) -> None:
             pass
 
 
-def conversation_history_after_compression(agent: Any, messages: list) -> Optional[list]:
+def conversation_history_after_compression(
+    agent: Any,
+    messages: list,
+    previous_history: Optional[list] = None,
+) -> Optional[list]:
     """Return the correct flush baseline after a compression boundary.
 
     Legacy compression rotates to a fresh child session. That child has not
@@ -409,7 +413,19 @@ def conversation_history_after_compression(agent: Any, messages: list) -> Option
 
     A shallow copy is intentional: it captures the current compacted dict
     identities as history while allowing later same-turn appends to remain new.
+
+    An aborted or no-op attempt after an earlier in-place compaction must retain
+    the pre-attempt baseline.  Treating all current messages as persisted would
+    drop any later, unflushed turns on restart; clearing the baseline would
+    append the already-persisted compacted rows a second time.
     """
+    if bool(getattr(agent, "_last_compression_attempt_recorded", False)):
+        attempt_in_place = getattr(agent, "_last_compression_attempt_in_place", None)
+        if attempt_in_place is True:
+            return list(messages)
+        if attempt_in_place is False:
+            return None
+        return previous_history
     if bool(getattr(agent, "_last_compaction_in_place", False)):
         return list(messages)
     return None
@@ -593,6 +609,13 @@ def compress_context(
         prompt — the session is NOT rotated.  Callers should detect the
         no-op via ``len(returned) == len(input)`` and stop the retry loop.
     """
+    # ``conversation_history_after_compression()`` needs the latest attempt's
+    # outcome, while ``_last_compaction_in_place`` remains the run-level signal
+    # read by gateway callers. ``None`` means this attempt aborted or made no
+    # boundary, so the previous flush baseline remains authoritative.
+    agent._last_compression_attempt_recorded = True
+    agent._last_compression_attempt_in_place = None
+
     # Codex app-server sessions: the codex agent owns the real thread context;
     # Hermes' summarizer would only rewrite a local mirror without shrinking
     # the actual thread (#36801). Route compaction to the app server's own
@@ -1194,6 +1217,7 @@ def compress_context(
         # via a rotation-independent flag. The gateway uses this — NOT an
         # id-change diff — to re-baseline transcript handling (history_offset=0 +
         # rewrite on the same id) when compaction happened in place. See #38763.
+        agent._last_compression_attempt_in_place = compacted_in_place
         agent._last_compaction_in_place = compacted_in_place
 
         # Keep the post-compression rough estimate for diagnostics, but do not

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -629,6 +629,13 @@ def run_conversation(
         except Exception:
             pass
 
+    # The gateway caches agents across user turns.  Compression state is
+    # per-turn: carrying a prior in-place boundary forward would make a later
+    # uncompressed result look like a compacted transcript to gateway writers.
+    agent._last_compaction_in_place = False
+    agent._last_compression_attempt_recorded = False
+    agent._last_compression_attempt_in_place = None
+
     # ── Per-turn setup (the prologue) ──
     # All once-per-turn setup — stdio guarding, retry-counter resets, user
     # message sanitization, todo/nudge hydration, system-prompt restore-or-
@@ -1171,7 +1178,7 @@ def run_conversation(
             # and preflight compaction sites; see
             # conversation_history_after_compression().
             conversation_history = conversation_history_after_compression(
-                agent, messages
+                agent, messages, conversation_history
             )
             api_call_count -= 1
             agent._api_call_count = api_call_count
@@ -3303,7 +3310,7 @@ def run_conversation(
                             task_id=effective_task_id,
                         )
                         conversation_history = conversation_history_after_compression(
-                            agent, messages
+                            agent, messages, conversation_history
                         )
                         if len(messages) < original_len or old_ctx > _reduced_ctx:
                             agent._buffer_status(
@@ -3557,7 +3564,7 @@ def run_conversation(
                         task_id=effective_task_id,
                     )
                     conversation_history = conversation_history_after_compression(
-                        agent, messages
+                        agent, messages, conversation_history
                     )
 
                     # Re-estimate tokens after compression.  Same-message-count
@@ -3798,7 +3805,7 @@ def run_conversation(
                         task_id=effective_task_id,
                     )
                     conversation_history = conversation_history_after_compression(
-                        agent, messages
+                        agent, messages, conversation_history
                     )
 
                     # Re-estimate tokens after compression.  Same-message-count
@@ -5141,7 +5148,7 @@ def run_conversation(
                         task_id=effective_task_id,
                     )
                     conversation_history = conversation_history_after_compression(
-                        agent, messages
+                        agent, messages, conversation_history
                     )
                 
                 # Save session log incrementally (so progress is visible even if interrupted)

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -626,7 +626,7 @@ def build_turn_context(
                 ):
                     break  # Cannot compress further: neither rows nor tokens moved
                 conversation_history = conversation_history_after_compression(
-                    agent, messages
+                    agent, messages, conversation_history
                 )
                 agent._empty_content_retries = 0
                 agent._thinking_prefill_retries = 0

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -19,7 +19,6 @@ Bug scenario (pre-fix):
 import os
 import tempfile
 from pathlib import Path
-from types import SimpleNamespace
 from unittest.mock import patch
 
 
@@ -271,45 +270,6 @@ class TestFlushAfterCompression:
                 "new request",
                 "new answer",
             ]
-
-    def test_new_run_clears_stale_in_place_compaction_state(self, monkeypatch):
-        """A cached agent must not report a prior turn's compaction boundary."""
-        import agent.conversation_loop as loop
-
-        observed = {}
-
-        def fake_build_turn_context(agent, *_args, **_kwargs):
-            observed["in_place"] = agent._last_compaction_in_place
-            observed["attempt_recorded"] = agent._last_compression_attempt_recorded
-            observed["attempt_in_place"] = agent._last_compression_attempt_in_place
-            return SimpleNamespace(
-                user_message="hello",
-                original_user_message="hello",
-                messages=[],
-                conversation_history=[],
-                active_system_prompt="system",
-                effective_task_id="default",
-                turn_id="turn-1",
-                current_turn_user_idx=0,
-                should_review_memory=False,
-                plugin_user_context={},
-                ext_prefetch_cache=None,
-            )
-
-        agent = SimpleNamespace(
-            api_mode="codex_app_server",
-            _last_compaction_in_place=True,
-            _last_compression_attempt_recorded=True,
-            _last_compression_attempt_in_place=True,
-        )
-        agent._run_codex_app_server_turn = lambda **_kwargs: dict(observed)
-        monkeypatch.setattr(loop, "build_turn_context", fake_build_turn_context)
-
-        assert loop.run_conversation(agent, "hello") == {
-            "in_place": False,
-            "attempt_recorded": False,
-            "attempt_in_place": None,
-        }
 
     def test_rotation_child_session_flushes_full_compressed_transcript_with_markers(self):
         """Regression for #57491: live cached-agent markers must not block child flush."""

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -192,7 +192,7 @@ class TestFlushAfterCompression:
             ]
 
     def test_abort_after_in_place_compaction_preserves_flush_baseline(self):
-        """An aborted retry must retain both compacted rows and new turns."""
+        """An aborted retry must survive flush, restart, and resume."""
         from agent.conversation_compression import (
             compress_context,
             conversation_history_after_compression,
@@ -232,7 +232,8 @@ class TestFlushAfterCompression:
                 return messages
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            db_path = Path(tmpdir) / "test.db"
+            db = SessionDB(db_path=db_path)
             agent = self._make_agent(db)
             agent.compression_in_place = True
             original = [
@@ -262,7 +263,9 @@ class TestFlushAfterCompression:
             )
             agent._flush_messages_to_session_db(returned, history)
 
-            assert [message["content"] for message in db.get_messages_as_conversation(
+            db.close()
+            resumed_db = SessionDB(db_path=db_path)
+            assert [message["content"] for message in resumed_db.get_messages_as_conversation(
                 agent.session_id
             )] == [
                 "[summary] earlier state",
@@ -270,6 +273,7 @@ class TestFlushAfterCompression:
                 "new request",
                 "new answer",
             ]
+            resumed_db.close()
 
     def test_rotation_child_session_flushes_full_compressed_transcript_with_markers(self):
         """Regression for #57491: live cached-agent markers must not block child flush."""

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -19,6 +19,7 @@ Bug scenario (pre-fix):
 import os
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 
@@ -190,6 +191,125 @@ class TestFlushAfterCompression:
                 "tool result",
                 "final answer",
             ]
+
+    def test_abort_after_in_place_compaction_preserves_flush_baseline(self):
+        """An aborted retry must retain both compacted rows and new turns."""
+        from agent.conversation_compression import (
+            compress_context,
+            conversation_history_after_compression,
+        )
+        from hermes_state import SessionDB
+
+        class SuccessCompressor:
+            _last_compress_aborted = False
+            _last_summary_error = None
+            compression_count = 1
+            _last_compression_made_progress = True
+            _last_summary_fallback_used = False
+            last_compression_rough_tokens = 0
+            last_prompt_tokens = 0
+            last_completion_tokens = 0
+            awaiting_real_usage_after_compression = False
+
+            def compress(self, _messages, **_kwargs):
+                return [
+                    {"role": "user", "content": "[summary] earlier state"},
+                    {"role": "assistant", "content": "retained tail"},
+                ]
+
+        class AbortCompressor:
+            _last_compress_aborted = False
+            _last_summary_error = "simulated auxiliary timeout"
+            compression_count = 2
+            _last_compression_made_progress = False
+            _last_summary_fallback_used = False
+            last_compression_rough_tokens = 0
+            last_prompt_tokens = 0
+            last_completion_tokens = 0
+            awaiting_real_usage_after_compression = False
+
+            def compress(self, messages, **_kwargs):
+                self._last_compress_aborted = True
+                return messages
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(db)
+            agent.compression_in_place = True
+            original = [
+                {"role": "user", "content": "old question"},
+                {"role": "assistant", "content": "old answer"},
+            ]
+            agent._flush_messages_to_session_db(original, [])
+
+            agent.context_compressor = SuccessCompressor()
+            compacted, _ = compress_context(
+                agent, original, "system", approx_tokens=100_000
+            )
+            history = conversation_history_after_compression(
+                agent, compacted, None
+            )
+
+            messages = compacted + [
+                {"role": "user", "content": "new request"},
+                {"role": "assistant", "content": "new answer"},
+            ]
+            agent.context_compressor = AbortCompressor()
+            returned, _ = compress_context(
+                agent, messages, "system", approx_tokens=100_000
+            )
+            history = conversation_history_after_compression(
+                agent, returned, history
+            )
+            agent._flush_messages_to_session_db(returned, history)
+
+            assert [message["content"] for message in db.get_messages_as_conversation(
+                agent.session_id
+            )] == [
+                "[summary] earlier state",
+                "retained tail",
+                "new request",
+                "new answer",
+            ]
+
+    def test_new_run_clears_stale_in_place_compaction_state(self, monkeypatch):
+        """A cached agent must not report a prior turn's compaction boundary."""
+        import agent.conversation_loop as loop
+
+        observed = {}
+
+        def fake_build_turn_context(agent, *_args, **_kwargs):
+            observed["in_place"] = agent._last_compaction_in_place
+            observed["attempt_recorded"] = agent._last_compression_attempt_recorded
+            observed["attempt_in_place"] = agent._last_compression_attempt_in_place
+            return SimpleNamespace(
+                user_message="hello",
+                original_user_message="hello",
+                messages=[],
+                conversation_history=[],
+                active_system_prompt="system",
+                effective_task_id="default",
+                turn_id="turn-1",
+                current_turn_user_idx=0,
+                should_review_memory=False,
+                plugin_user_context={},
+                ext_prefetch_cache=None,
+            )
+
+        agent = SimpleNamespace(
+            api_mode="codex_app_server",
+            _last_compaction_in_place=True,
+            _last_compression_attempt_recorded=True,
+            _last_compression_attempt_in_place=True,
+        )
+        agent._run_codex_app_server_turn = lambda **_kwargs: dict(observed)
+        monkeypatch.setattr(loop, "build_turn_context", fake_build_turn_context)
+
+        assert loop.run_conversation(agent, "hello") == {
+            "in_place": False,
+            "attempt_recorded": False,
+            "attempt_in_place": None,
+        }
 
     def test_rotation_child_session_flushes_full_compressed_transcript_with_markers(self):
         """Regression for #57491: live cached-agent markers must not block child flush."""


### PR DESCRIPTION
## What does this PR do?

Fixes a verified compression-persistence state lifetime: after a successful in-place compaction, a later aborted or no-op attempt could reuse the old in-place flag and treat later unflushed turns as already persisted. A `SessionDB` restart then lost those turns.

`conversation_history_after_compression()` now distinguishes a completed in-place/rotating boundary from an aborted/no-op attempt. Callers retain the preceding flush baseline for the latter. Each `run_conversation()` also resets run-scoped compression signals before its prologue.

## Related Issue

Fixes #58630

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Reproduction

On current upstream main (`e598cef87465981fcea1c0339edfcf5d9716c917`), with a temporary `HERMES_HOME` and a real `SessionDB`:

1. Persist an initial transcript.
2. Perform successful in-place compaction, which archives old active rows and inserts the compacted live set.
3. Append a new user/assistant pair in the same turn.
4. Abort a second compression attempt and flush.
5. Close the database, open a fresh `SessionDB` on the same path, and resume the session.

Before this change, the stale in-place flag caused the flush baseline to cover all current messages, so the new pair was not written. The reopened database contained only the compacted rows. After this change, the fresh consumer returns the compacted rows plus the new pair exactly once.

The cached-agent next-turn state was also exercised during diagnosis. That private-state probe is recorded as PR evidence rather than retained as permanent test code because it asserted implementation shape instead of an observable persistence contract.

## Changes Made

- `agent/conversation_compression.py`: track the latest compression outcome separately from the run-level gateway signal and retain the prior flush baseline after abort/no-op.
- `agent/conversation_loop.py` and `agent/turn_context.py`: pass that baseline through all compression callers and reset per-turn state before prologue compression.
- `tests/run_agent/test_compression_persistence.py`: real `SessionDB` success → append → abort → flush → close → reopen/resume coverage.

## Regression-test retention

A dedicated permanent-suite audit retained the single end-to-end `SessionDB` persistence regression and removed the synthetic cached-agent private-flag probe. Fresh live review then verified that restart/resume must use a fresh database consumer; the retained test now explicitly closes and reopens the same SQLite path before asserting the exact resumed transcript. The test diff remains substantially smaller than the earlier draft, and production behavior is unchanged.

## Validation

At final head `0ed256a48d31b8f8a40938bb48f115bd173517e1`:

```bash
scripts/run_tests.sh   tests/run_agent/test_compression_persistence.py   tests/run_agent/test_in_place_compaction.py   tests/agent/test_compression_rotation_state.py   tests/gateway/test_session_hygiene.py -q
```

Result: `49 passed`.

Relevant Ruff, Windows-footgun, and `git diff --check` checks passed. Two fresh GPT-5.6 Sol xhigh exact-SHA restart/maintainability reviews passed. The rebased production commit was range-diffed against the prior draft and is unchanged in intent; subsequent commits are test-only.

## Full-suite note

The full wrapper was attempted on the superseded pre-rebase candidate. It ran for approximately 17 minutes without a surfaced failure but was terminated as an orphaned incomplete run. It is not claimed as a final-head full-suite pass. The final head is being validated by live CI.

## Checklist

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs and inspected the existing PR/review state.
- [x] My PR contains only this compression-persistence fix and its durable regression.
- [x] I've added behavioral regression coverage.
- [x] I've considered cross-platform impact.

This PR remains a draft pending live CI and post-draft review.
