### PR TITLE
fix(tools): scope availability cache by session context

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -29,7 +29,7 @@ import threading
 import time
 from typing import Dict, Any, List, Optional, Tuple
 
-from tools.registry import discover_builtin_tools, registry
+from tools.registry import discover_builtin_tools, get_availability_cache_key, registry
 from toolsets import resolve_toolset, validate_toolset
 
 logger = logging.getLogger(__name__)
@@ -248,7 +248,8 @@ _LEGACY_TOOLSET_MAP = {
 # =============================================================================
 
 # Module-level memoization for get_tool_definitions(). Keyed on
-# (frozenset(enabled_toolsets), frozenset(disabled_toolsets), registry._generation).
+# (frozenset(enabled_toolsets), frozenset(disabled_toolsets), registry._generation,
+# availability cache key).
 # Hot callers (gateway runner, AIAgent.__init__) invoke this on every turn
 # with quiet_mode=True; caching avoids ~7 ms of registry walking + schema
 # filtering + check_fn probing per call. Only active when quiet_mode=True
@@ -259,6 +260,7 @@ _LEGACY_TOOLSET_MAP = {
 # inner check_fn TTL cache in registry.py handles environment drift (Docker
 # daemon start/stop, env var changes, etc.) on a 30 s horizon.
 _tool_defs_cache: Dict[tuple, List[Dict[str, Any]]] = {}
+_tool_defs_cache_expiry: Dict[tuple, float] = {}
 
 # Hard cap on memoized get_tool_definitions() results. A long-lived Gateway
 # process sees many distinct toolset/config fingerprints over its lifetime
@@ -274,6 +276,7 @@ def _clear_tool_defs_cache() -> None:
     schema dependencies change (e.g. discord capability cache reset,
     execute_code sandbox reconfigured)."""
     _tool_defs_cache.clear()
+    _tool_defs_cache_expiry.clear()
 
 
 def get_tool_definitions(
@@ -304,7 +307,9 @@ def get_tool_definitions(
     # The cache key captures every argument-level input; the registry
     # generation captures registry mutations (MCP refresh, plugin load).
     # check_fn results are TTL-cached one level down, inside
-    # registry.get_definitions. The config-mtime fingerprint below captures
+    # registry.get_definitions. The availability cache key separates
+    # session/environment-gated schemas and advances on explicit availability
+    # invalidation. The config-mtime fingerprint below captures
     # user-visible config edits that affect dynamic schemas (execute_code
     # mode, discord action allowlist, etc.) without needing an explicit
     # invalidate hook on every config-writer.
@@ -320,12 +325,13 @@ def get_tool_definitions(
             frozenset(enabled_toolsets) if enabled_toolsets is not None else None,
             frozenset(disabled_toolsets) if disabled_toolsets else None,
             registry._generation,
+            get_availability_cache_key(session_scoped=True),
             cfg_fp,
             bool(os.environ.get("HERMES_KANBAN_TASK")),
             bool(skip_tool_search_assembly),
         )
         cached = _tool_defs_cache.get(cache_key)
-        if cached is not None:
+        if cached is not None and time.monotonic() < _tool_defs_cache_expiry.get(cache_key, float("inf")):
             # Update _last_resolved_tool_names so downstream callers see
             # consistent state even on a cache hit.
             global _last_resolved_tool_names
@@ -334,8 +340,21 @@ def get_tool_definitions(
             # schemas are treated as read-only by all known callers.
             return list(cached)
 
-    result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode,
-                                       skip_tool_search_assembly=skip_tool_search_assembly)
+    if quiet_mode:
+        result, availability_expires_at = _compute_tool_definitions(
+            enabled_toolsets,
+            disabled_toolsets,
+            quiet_mode,
+            skip_tool_search_assembly=skip_tool_search_assembly,
+            return_availability_expiry=True,
+        )
+    else:
+        result = _compute_tool_definitions(
+            enabled_toolsets,
+            disabled_toolsets,
+            quiet_mode,
+            skip_tool_search_assembly=skip_tool_search_assembly,
+        )
     if quiet_mode:
         # Cache the freshly-computed list, but hand callers a shallow copy so
         # downstream mutations (e.g. run_agent appending memory/LCM tool
@@ -348,8 +367,11 @@ def get_tool_definitions(
         # doesn't accumulate entries unboundedly across the many distinct
         # toolset/config fingerprints it sees over its lifetime (#19251).
         if len(_tool_defs_cache) >= _TOOL_DEFS_CACHE_MAX:
-            _tool_defs_cache.pop(next(iter(_tool_defs_cache)))  # evict oldest
+            oldest_key = next(iter(_tool_defs_cache))
+            _tool_defs_cache.pop(oldest_key)
+            _tool_defs_cache_expiry.pop(oldest_key, None)
         _tool_defs_cache[cache_key] = result
+        _tool_defs_cache_expiry[cache_key] = availability_expires_at
         return list(result)
     return result
 
@@ -359,7 +381,8 @@ def _compute_tool_definitions(
     disabled_toolsets: Optional[List[str]] = None,
     quiet_mode: bool = False,
     skip_tool_search_assembly: bool = False,
-) -> List[Dict[str, Any]]:
+    return_availability_expiry: bool = False,
+) -> List[Dict[str, Any]] | tuple[List[Dict[str, Any]], float]:
     """Uncached implementation of :func:`get_tool_definitions`."""
     # Determine which tool names the caller wants
     tools_to_include: set = set()
@@ -442,7 +465,15 @@ def _compute_tool_definitions(
     # other toolset.
 
     # Ask the registry for schemas (only returns tools whose check_fn passes)
-    filtered_tools = registry.get_definitions(tools_to_include, quiet=quiet_mode)
+    registry_result = registry.get_definitions(
+        tools_to_include,
+        quiet=quiet_mode,
+        return_availability_expiry=return_availability_expiry,
+    )
+    if return_availability_expiry:
+        filtered_tools, availability_expires_at = registry_result
+    else:
+        filtered_tools = registry_result
 
     # The set of tool names that actually passed check_fn filtering.
     # Use this (not tools_to_include) for any downstream schema that references
@@ -564,6 +595,8 @@ def _compute_tool_definitions(
     except Exception as e:  # pragma: no cover — never break tool loading
         logger.warning("Tool search assembly skipped: %s", e)
 
+    if return_availability_expiry:
+        return filtered_tools, availability_expires_at
     return filtered_tools
 
 

--- a/tests/test_get_tool_definitions_cache_isolation.py
+++ b/tests/test_get_tool_definitions_cache_isolation.py
@@ -113,3 +113,171 @@ class TestQuietModeCacheIsolation:
         explains why the bug only hit Gateway."""
         model_tools.get_tool_definitions(quiet_mode=False)
         assert len(model_tools._tool_defs_cache) == 0
+
+    def test_availability_invalidation_refreshes_filtered_schema_cache(self):
+        """Explicit invalidation must refresh an already-filtered cache entry."""
+        from tools.registry import invalidate_check_fn_cache, registry
+
+        name = "test_availability_invalidation"
+        available = {"value": False}
+
+        def check():
+            return available["value"]
+
+        registry.register(
+            name=name,
+            toolset=name,
+            schema={"description": "availability probe", "parameters": {"type": "object"}},
+            handler=lambda _args: "{}",
+            check_fn=check,
+        )
+        try:
+            invalidate_check_fn_cache()
+            missing = model_tools.get_tool_definitions(
+                enabled_toolsets=[name], quiet_mode=True,
+            )
+            assert name not in {tool["function"]["name"] for tool in missing}
+
+            available["value"] = True
+            invalidate_check_fn_cache()
+            refreshed = model_tools.get_tool_definitions(
+                enabled_toolsets=[name], quiet_mode=True,
+            )
+            assert name in {tool["function"]["name"] for tool in refreshed}
+        finally:
+            registry.deregister(name)
+            invalidate_check_fn_cache()
+
+    def test_availability_cache_isolated_by_active_profile(self, tmp_path):
+        """A filtered schema from one profile cannot leak into another turn."""
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+        from tools.registry import invalidate_check_fn_cache, registry
+
+        name = "test_profile_availability"
+        first_home = tmp_path / "first"
+        second_home = tmp_path / "second"
+        first_home.mkdir()
+        second_home.mkdir()
+
+        def check():
+            from hermes_constants import get_hermes_home
+
+            return get_hermes_home() == first_home
+
+        registry.register(
+            name=name,
+            toolset=name,
+            schema={"description": "profile availability probe", "parameters": {"type": "object"}},
+            handler=lambda _args: "{}",
+            check_fn=check,
+        )
+        try:
+            invalidate_check_fn_cache()
+            first_token = set_hermes_home_override(first_home)
+            try:
+                visible = model_tools.get_tool_definitions(
+                    enabled_toolsets=[name], quiet_mode=True,
+                )
+                assert name in {tool["function"]["name"] for tool in visible}
+            finally:
+                reset_hermes_home_override(first_token)
+
+            second_token = set_hermes_home_override(second_home)
+            try:
+                hidden = model_tools.get_tool_definitions(
+                    enabled_toolsets=[name], quiet_mode=True,
+                )
+                assert name not in {tool["function"]["name"] for tool in hidden}
+            finally:
+                reset_hermes_home_override(second_token)
+        finally:
+            registry.deregister(name)
+            invalidate_check_fn_cache()
+
+    def test_availability_cache_refreshes_with_check_fn_ttl(self, monkeypatch):
+        """The outer filtered-schema cache cannot outlive check_fn freshness."""
+        import tools.registry as registry_module
+        from tools.registry import invalidate_check_fn_cache, registry
+
+        name = "test_availability_ttl"
+        available = {"value": False}
+        now = {"value": 30.1}
+
+        def check():
+            return available["value"]
+
+        monkeypatch.setattr(registry_module.time, "monotonic", lambda: now["value"])
+        registry.register(
+            name=name,
+            toolset=name,
+            schema={"description": "TTL availability probe", "parameters": {"type": "object"}},
+            handler=lambda _args: "{}",
+            check_fn=check,
+        )
+        try:
+            invalidate_check_fn_cache()
+            missing = model_tools.get_tool_definitions(
+                enabled_toolsets=[name], quiet_mode=True,
+            )
+            assert name not in {tool["function"]["name"] for tool in missing}
+
+            now["value"] = 60.0
+            assert name not in {
+                tool["function"]["name"]
+                for tool in model_tools.get_tool_definitions(
+                    enabled_toolsets=[name], quiet_mode=True,
+                )
+            }
+
+            available["value"] = True
+            now["value"] = 60.2
+            refreshed = model_tools.get_tool_definitions(
+                enabled_toolsets=[name], quiet_mode=True,
+            )
+            assert name in {tool["function"]["name"] for tool in refreshed}
+        finally:
+            registry.deregister(name)
+            invalidate_check_fn_cache()
+
+    def test_availability_cache_expires_last_good_after_grace(self, monkeypatch):
+        """The outer cache cannot advertise a failed check past its grace."""
+        import tools.registry as registry_module
+        from tools.registry import invalidate_check_fn_cache, registry
+
+        name = "test_availability_grace"
+        available = {"value": True}
+        now = {"value": 0.1}
+
+        def check():
+            return available["value"]
+
+        monkeypatch.setattr(registry_module.time, "monotonic", lambda: now["value"])
+        registry.register(
+            name=name,
+            toolset=name,
+            schema={"description": "grace availability probe", "parameters": {"type": "object"}},
+            handler=lambda _args: "{}",
+            check_fn=check,
+        )
+        try:
+            invalidate_check_fn_cache()
+            visible = model_tools.get_tool_definitions(
+                enabled_toolsets=[name], quiet_mode=True,
+            )
+            assert name in {tool["function"]["name"] for tool in visible}
+
+            available["value"] = False
+            now["value"] = 60.0
+            still_visible = model_tools.get_tool_definitions(
+                enabled_toolsets=[name], quiet_mode=True,
+            )
+            assert name in {tool["function"]["name"] for tool in still_visible}
+
+            now["value"] = 60.2
+            hidden = model_tools.get_tool_definitions(
+                enabled_toolsets=[name], quiet_mode=True,
+            )
+            assert name not in {tool["function"]["name"] for tool in hidden}
+        finally:
+            registry.deregister(name)
+            invalidate_check_fn_cache()

--- a/tests/tools/test_cronjob_tool_availability.py
+++ b/tests/tools/test_cronjob_tool_availability.py
@@ -1,0 +1,63 @@
+"""Regression tests for cronjob availability across gateway context changes."""
+
+import pytest
+
+import model_tools
+
+
+_AVAILABILITY_ENV = (
+    "HERMES_INTERACTIVE",
+    "HERMES_GATEWAY_SESSION",
+    "HERMES_EXEC_ASK",
+    "HERMES_SESSION_PLATFORM",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_availability_context(monkeypatch):
+    """Keep each assertion independent of process and ContextVar state."""
+    from gateway.session_context import reset_session_vars
+    from tools.registry import invalidate_check_fn_cache
+
+    for name in _AVAILABILITY_ENV:
+        monkeypatch.delenv(name, raising=False)
+    reset_session_vars()
+    model_tools._clear_tool_defs_cache()
+    invalidate_check_fn_cache()
+    yield
+    reset_session_vars()
+    model_tools._clear_tool_defs_cache()
+    invalidate_check_fn_cache()
+
+
+def _cronjob_names() -> set[str]:
+    return {
+        tool["function"]["name"]
+        for tool in model_tools.get_tool_definitions(
+            enabled_toolsets=["cronjob"],
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        )
+    }
+
+
+def test_cached_missing_cronjob_refreshes_after_gateway_env(monkeypatch):
+    """A pre-gateway lookup cannot hide cronjob after approval mode appears."""
+    assert "cronjob" not in _cronjob_names()
+
+    monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+
+    assert "cronjob" in _cronjob_names()
+
+
+def test_cached_missing_cronjob_refreshes_after_gateway_session():
+    """Task-local gateway identity enables cronjob without a global env flag."""
+    from gateway.session_context import clear_session_vars, set_session_vars
+
+    assert "cronjob" not in _cronjob_names()
+
+    tokens = set_session_vars(platform="matrix", chat_id="!room:example.org")
+    try:
+        assert "cronjob" in _cronjob_names()
+    finally:
+        clear_session_vars(tokens)

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -175,6 +175,116 @@ class TestGetDefinitions:
         assert len(defs) == 2
         assert calls["count"] == 1
 
+    def test_check_fn_cache_isolated_by_gateway_session_context(self):
+        """A cached availability result from one gateway turn cannot leak."""
+        from gateway.session_context import clear_session_vars, reset_session_vars, set_session_vars
+        from tools.registry import invalidate_check_fn_cache
+
+        reg = ToolRegistry()
+
+        def check():
+            from gateway.session_context import get_session_env
+
+            return get_session_env("HERMES_SESSION_PLATFORM") == "matrix"
+
+        reg.register(
+            name="session-gated",
+            toolset="session-gated",
+            schema=_make_schema("session-gated"),
+            handler=_dummy_handler,
+            check_fn=check,
+            check_fn_session_scoped=True,
+        )
+        try:
+            reset_session_vars()
+            invalidate_check_fn_cache()
+            matrix_tokens = set_session_vars(platform="matrix")
+            assert reg.get_definitions({"session-gated"})
+
+            clear_session_vars(matrix_tokens)
+            discord_tokens = set_session_vars(platform="discord")
+            assert reg.get_definitions({"session-gated"}) == []
+            clear_session_vars(discord_tokens)
+        finally:
+            reset_session_vars()
+            invalidate_check_fn_cache()
+
+    def test_check_fn_cache_isolated_by_active_profile(self, tmp_path):
+        """A profile-scoped availability result cannot leak into another turn."""
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+        from tools.registry import invalidate_check_fn_cache
+
+        reg = ToolRegistry()
+        first_home = tmp_path / "first"
+        second_home = tmp_path / "second"
+        first_home.mkdir()
+        second_home.mkdir()
+
+        def check():
+            from hermes_constants import get_hermes_home
+
+            return get_hermes_home() == first_home
+
+        reg.register(
+            name="profile-gated",
+            toolset="profile-gated",
+            schema=_make_schema("profile-gated"),
+            handler=_dummy_handler,
+            check_fn=check,
+        )
+        try:
+            invalidate_check_fn_cache()
+            first_token = set_hermes_home_override(first_home)
+            try:
+                assert reg.get_definitions({"profile-gated"})
+            finally:
+                reset_hermes_home_override(first_token)
+
+            second_token = set_hermes_home_override(second_home)
+            try:
+                assert reg.get_definitions({"profile-gated"}) == []
+            finally:
+                reset_hermes_home_override(second_token)
+        finally:
+            invalidate_check_fn_cache()
+
+    def test_external_check_keeps_last_good_across_sessions(self, monkeypatch):
+        """Session changes do not discard an external probe's failure grace."""
+        import tools.registry as registry_module
+        from gateway.session_context import clear_session_vars, reset_session_vars, set_session_vars
+        from tools.registry import invalidate_check_fn_cache
+
+        reg = ToolRegistry()
+        state = {"available": True}
+        now = {"value": 100.0}
+
+        def check():
+            return state["available"]
+
+        monkeypatch.setattr(registry_module.time, "monotonic", lambda: now["value"])
+        reg.register(
+            name="external-gated",
+            toolset="external-gated",
+            schema=_make_schema("external-gated"),
+            handler=_dummy_handler,
+            check_fn=check,
+        )
+        try:
+            reset_session_vars()
+            invalidate_check_fn_cache()
+            matrix_tokens = set_session_vars(platform="matrix")
+            assert reg.get_definitions({"external-gated"})
+
+            clear_session_vars(matrix_tokens)
+            discord_tokens = set_session_vars(platform="discord")
+            now["value"] += registry_module._CHECK_FN_TTL_SECONDS + 1
+            state["available"] = False
+            assert reg.get_definitions({"external-gated"})
+            clear_session_vars(discord_tokens)
+        finally:
+            reset_session_vars()
+            invalidate_check_fn_cache()
+
 
 class TestUnknownToolDispatch:
     def test_returns_error_json(self):

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1099,18 +1099,25 @@ def check_cronjob_requirements() -> bool:
     The cron system is internal (JSON file-based scheduler ticked by the gateway),
     so no external crontab executable is required.
 
-    Session env vars must hold an explicit truthy string (``1``, ``true``,
-    ``yes``, ``on``) — false-like values (``0``, ``false``, ``no``, ``off``)
-    leave the tool disabled. Uses the shared ``env_var_enabled`` helper so
-    every consumer of these flags agrees on the truthy set.
+    Legacy process env vars must hold an explicit truthy string (``1``,
+    ``true``, ``yes``, ``on``). Gateway turns bind their platform identity in
+    ContextVars, so they must not depend on process-global env flags.
     """
     from utils import env_var_enabled
 
-    return (
+    if (
         env_var_enabled("HERMES_INTERACTIVE")
         or env_var_enabled("HERMES_GATEWAY_SESSION")
         or env_var_enabled("HERMES_EXEC_ASK")
-    )
+    ):
+        return True
+
+    try:
+        from gateway.session_context import get_session_env
+
+        return bool(get_session_env("HERMES_SESSION_PLATFORM", ""))
+    except Exception:
+        return False
 
 
 # --- Registry ---
@@ -1143,5 +1150,6 @@ registry.register(
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,
+    check_fn_session_scoped=True,
     emoji="⏰",
 )

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -18,6 +18,7 @@ import ast
 import importlib
 import json
 import logging
+import os
 import sys
 import threading
 import time
@@ -91,11 +92,13 @@ class ToolEntry:
         "name", "toolset", "schema", "handler", "check_fn",
         "requires_env", "is_async", "description", "emoji",
         "max_result_size_chars", "dynamic_schema_overrides",
+        "check_fn_session_scoped",
     )
 
     def __init__(self, name, toolset, schema, handler, check_fn,
                  requires_env, is_async, description, emoji,
-                 max_result_size_chars=None, dynamic_schema_overrides=None):
+                 max_result_size_chars=None, dynamic_schema_overrides=None,
+                 check_fn_session_scoped=False):
         self.name = name
         self.toolset = toolset
         self.schema = schema
@@ -114,6 +117,7 @@ class ToolEntry:
         # on every get_definitions() call; results are merged shallow on top
         # of the base schema before the {"type": "function", ...} wrap.
         self.dynamic_schema_overrides = dynamic_schema_overrides
+        self.check_fn_session_scoped = check_fn_session_scoped
 
 
 # ---------------------------------------------------------------------------
@@ -148,10 +152,49 @@ _CHECK_FN_FAILURE_GRACE_SECONDS = 60.0
 _check_fn_cache: Dict[Callable, tuple[float, bool]] = {}
 # Monotonic timestamp of the most recent True result per check_fn.
 _check_fn_last_good: Dict[Callable, float] = {}
+_check_fn_cache_generation = 0
 _check_fn_cache_lock = threading.Lock()
 
 
-def _check_fn_cached(fn: Callable) -> bool:
+def get_availability_cache_key(session_scoped: bool = False) -> tuple:
+    """Return the cache inputs that affect built-in tool availability.
+
+    Every availability check is scoped to the active Hermes home because
+    multiplexed gateway turns can resolve different profile credentials. Only
+    cronjob's gate is session-dependent, so external probes keep their
+    cross-platform TTL and last-good behavior.
+    """
+    try:
+        from hermes_constants import get_hermes_home
+
+        hermes_home = str(get_hermes_home())
+    except Exception:
+        hermes_home = ""
+    with _check_fn_cache_lock:
+        generation = _check_fn_cache_generation
+    key = (generation, hermes_home)
+    if not session_scoped:
+        return key
+
+    try:
+        from gateway.session_context import get_session_env
+
+        session_platform = get_session_env("HERMES_SESSION_PLATFORM", "")
+    except Exception:
+        session_platform = ""
+    return key + (
+        os.environ.get("HERMES_INTERACTIVE", ""),
+        os.environ.get("HERMES_GATEWAY_SESSION", ""),
+        os.environ.get("HERMES_EXEC_ASK", ""),
+        session_platform,
+    )
+
+
+def _check_fn_cached(
+    fn: Callable,
+    session_scoped: bool = False,
+    return_expiry: bool = False,
+) -> bool | tuple[bool, float]:
     """Return bool(fn()), TTL-cached across calls.
 
     Exceptions are swallowed as False. A transient False/exception within
@@ -161,12 +204,17 @@ def _check_fn_cached(fn: Callable) -> bool:
     contention, probe timeout) from silently stripping tools mid-session.
     """
     now = time.monotonic()
+
+    def result(value: bool, expires_at: float):
+        return (value, expires_at) if return_expiry else value
+
+    cache_key = (fn, get_availability_cache_key(session_scoped))
     with _check_fn_cache_lock:
-        cached = _check_fn_cache.get(fn)
+        cached = _check_fn_cache.get(cache_key)
         if cached is not None:
             ts, value = cached
             if now - ts < _CHECK_FN_TTL_SECONDS:
-                return value
+                return result(value, ts + _CHECK_FN_TTL_SECONDS)
 
     raised = False
     try:
@@ -177,11 +225,11 @@ def _check_fn_cached(fn: Callable) -> bool:
 
     with _check_fn_cache_lock:
         if value:
-            _check_fn_last_good[fn] = now
-            _check_fn_cache[fn] = (now, True)
-            return True
+            _check_fn_last_good[cache_key] = now
+            _check_fn_cache[cache_key] = (now, True)
+            return result(True, now + _CHECK_FN_TTL_SECONDS)
 
-        last_good = _check_fn_last_good.get(fn)
+        last_good = _check_fn_last_good.get(cache_key)
         if last_good is not None and now - last_good < _CHECK_FN_FAILURE_GRACE_SECONDS:
             # Recent success → treat this failure as a flake. Serve last-good
             # True and do NOT cache the failure, so the next call re-probes
@@ -193,7 +241,9 @@ def _check_fn_cached(fn: Callable) -> bool:
                 "raised" if raised else "returned False",
                 _CHECK_FN_FAILURE_GRACE_SECONDS,
             )
-            return True
+            # Do not let a higher-level cache extend the grace window: this
+            # failure is deliberately re-probed on the next lookup.
+            return result(True, now)
 
         # No recent success (or grace expired) — honor the failure. Log it so
         # silent tool loss in quiet mode (subagents) is diagnosable.
@@ -202,16 +252,18 @@ def _check_fn_cached(fn: Callable) -> bool:
             getattr(fn, "__qualname__", fn),
             "raised" if raised else "returned False",
         )
-        _check_fn_cache[fn] = (now, False)
-        return False
+        _check_fn_cache[cache_key] = (now, False)
+        return result(False, now + _CHECK_FN_TTL_SECONDS)
 
 
 def invalidate_check_fn_cache() -> None:
     """Drop all cached ``check_fn`` results. Call after config changes that
     affect tool availability (e.g. ``hermes tools enable``)."""
+    global _check_fn_cache_generation
     with _check_fn_cache_lock:
         _check_fn_cache.clear()
         _check_fn_last_good.clear()
+        _check_fn_cache_generation += 1
 
 
 class ToolRegistry:
@@ -259,15 +311,16 @@ class ToolRegistry:
         Mixed toolsets (e.g. ``terminal`` plus desktop-only ``read_terminal``)
         must not be gated solely by the first registered ``check_fn``.
         """
-        check_results: Dict[Callable, bool] = {}
+        check_results: Dict[tuple, bool] = {}
         for entry in entries:
             if entry.toolset != toolset:
                 continue
             if not entry.check_fn:
                 return True
-            if entry.check_fn not in check_results:
-                check_results[entry.check_fn] = _check_fn_cached(entry.check_fn)
-            if check_results[entry.check_fn]:
+            check_key = (entry.check_fn, entry.check_fn_session_scoped)
+            if check_key not in check_results:
+                check_results[check_key] = _check_fn_cached(*check_key)
+            if check_results[check_key]:
                 return True
         return False
 
@@ -375,6 +428,7 @@ class ToolRegistry:
         emoji: str = "",
         max_result_size_chars: int | float | None = None,
         dynamic_schema_overrides: Callable = None,
+        check_fn_session_scoped: bool = False,
         override: bool = False,
     ):
         """Register a tool.  Called at module-import time by each tool file.
@@ -445,6 +499,7 @@ class ToolRegistry:
                 emoji=emoji,
                 max_result_size_chars=max_result_size_chars,
                 dynamic_schema_overrides=dynamic_schema_overrides,
+                check_fn_session_scoped=check_fn_session_scoped,
             )
             # Availability is now derived per-tool (_toolset_has_exposable_tools),
             # so this map no longer gates a toolset. It is still consumed by
@@ -527,7 +582,12 @@ class ToolRegistry:
     # Schema retrieval
     # ------------------------------------------------------------------
 
-    def get_definitions(self, tool_names: Set[str], quiet: bool = False) -> List[dict]:
+    def get_definitions(
+        self,
+        tool_names: Set[str],
+        quiet: bool = False,
+        return_availability_expiry: bool = False,
+    ) -> List[dict] | tuple[List[dict], float]:
         """Return OpenAI-format tool schemas for the requested tool names.
 
         Only tools whose ``check_fn()`` returns True (or have no check_fn)
@@ -542,16 +602,23 @@ class ToolRegistry:
         # Per-call cache on top of the 30 s TTL — handles repeat probes of the
         # same check_fn within one definitions pass without re-reading the
         # TTL clock.
-        check_results: Dict[Callable, bool] = {}
+        check_results: Dict[tuple, tuple[bool, float]] = {}
+        availability_expires_at = float("inf")
         entries_by_name = {entry.name: entry for entry in self._snapshot_entries()}
         for name in sorted(tool_names):
             entry = entries_by_name.get(name)
             if not entry:
                 continue
             if entry.check_fn:
-                if entry.check_fn not in check_results:
-                    check_results[entry.check_fn] = _check_fn_cached(entry.check_fn)
-                if not check_results[entry.check_fn]:
+                check_key = (entry.check_fn, entry.check_fn_session_scoped)
+                if check_key not in check_results:
+                    check_results[check_key] = _check_fn_cached(
+                        *check_key,
+                        return_expiry=True,
+                    )
+                available, expires_at = check_results[check_key]
+                availability_expires_at = min(availability_expires_at, expires_at)
+                if not available:
                     if not quiet:
                         logger.debug("Tool %s unavailable (check failed)", name)
                     continue
@@ -574,6 +641,8 @@ class ToolRegistry:
                         name, exc,
                     )
             result.append({"type": "function", "function": schema_with_name})
+        if return_availability_expiry:
+            return result, availability_expires_at
         return result
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes stale tool availability in long-lived gateway processes.

Hermes has two cache layers around tool definitions: the registry caches each availability probe, and `model_tools` caches the already-filtered schema list. A lookup before gateway/session context existed could therefore keep `cronjob` hidden after the environment or ContextVar changed; explicit registry invalidation could also leave the outer filtered list stale.

This rebuild gives both layers the same profile/session availability identity and propagates the registry entry's real expiry to the outer cache. It keeps ordinary external probes' existing TTL/last-good behavior, scopes session identity only to the cron gate that depends on it, and preserves the existing bounded schema cache.

## Related Issue

Fixes #35561

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/registry.py`: key availability results by profile scope, optionally include gateway-session identity for context-dependent checks, advance an epoch on explicit invalidation, and expose each result's actual TTL/grace expiry to callers.
- `model_tools.py`: include the availability identity in quiet-mode schema keys and expire an already-filtered schema at the registry result's real entry-relative boundary.
- `tools/cronjob_tools.py`: recognize the task-local gateway platform ContextVar and mark only the cron availability check as session-scoped.
- Focused regressions cover environment and ContextVar transitions, active-profile and cross-session isolation, explicit invalidation, TTL rollover, last-good grace expiry, and bounded outer-cache eviction.

## How to Test

Before the fix on current main, a direct live-style sequence produced `False → False`: `cronjob` was absent before `HERMES_EXEC_ASK=1` and remained absent after it was set, even after the existing registry invalidation path, because the outer filtered schema list was reused.

On commit `0f5f8fefc5f6ac98799d64018e91c512f4ce6955`:

```text
192 focused and sibling tests passed across registry, filtered-schema caching,
cron availability, terminal requirements, and gateway/session isolation.
```

Static and portability checks also passed:

```bash
python -m ruff check model_tools.py tools/registry.py tools/cronjob_tools.py tests/test_get_tool_definitions_cache_isolation.py tests/tools/test_cronjob_tool_availability.py tests/tools/test_registry.py
python scripts/check-windows-footguns.py model_tools.py tools/registry.py tools/cronjob_tools.py tests/test_get_tool_definitions_cache_isolation.py tests/tools/test_cronjob_tool_availability.py tests/tools/test_registry.py
git diff --check upstream/main...HEAD
```

The full local wrapper was attempted once and stopped after unrelated existing failures in untouched credential-pool/Anthropic tests. It is not claimed as passing; GitHub CI on this draft is the final full-suite gate.

The inherited registry behavior that timestamps a probe before the probe completes is intentionally unchanged. It can cause a conservative early re-probe after an unusually slow check, but cannot retain stale visibility or extend the last-good grace window.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
