### PR TITLE
fix(stream_consumer): apply secret redaction to streaming finalize path (#56039)

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -78,6 +78,7 @@ class StreamConsumerConfig:
     # "group", "supergroup", "forum").  Used to gate native draft streaming,
     # which is platform-specific (Telegram drafts are DM-only).
     chat_type: str = ""
+from agent.redact import redact_sensitive_text
 
 
 class GatewayStreamConsumer:
@@ -890,7 +891,7 @@ class GatewayStreamConsumer:
 
     @staticmethod
     def _clean_for_display(text: str) -> str:
-        """Strip MEDIA: directives and internal markers from text before display.
+        """Strip MEDIA: directives and internal markers, then redact secrets.
 
         The streaming path delivers raw text chunks that may include
         ``MEDIA:<path>`` tags and ``[[audio_as_voice]]`` directives meant for
@@ -898,8 +899,14 @@ class GatewayStreamConsumer:
         delivered separately via ``_deliver_media_from_response()`` after the
         stream finishes — we just need to hide the raw directives from the
         user.
+
+        We also apply secret redaction here so that intermediate finalized
+        chunks (which are permanent on platforms like Telegram) do not leak
+        secrets.  See #56039.
         """
-        return _BasePlatformAdapter.strip_media_directives_for_display(text)
+        return _BasePlatformAdapter.strip_media_directives_for_display(
+            redact_sensitive_text(text)
+        )
 
     async def _send_new_chunk(
         self,


### PR DESCRIPTION
## Summary

Issue #56039: Streaming split-message path delivers finalized chunks **without secret redaction**.

## Bug

When a streaming response exceeds the platform message limit (e.g. Telegram 4096 chars), `GatewayStreamConsumer` splits the text and sends intermediate chunks with `finalize=True`. The comment explicitly states:

> "This sealed chunk will never be edited again"

These permanent chunks call `_clean_for_display` which **only strips `MEDIA:` directives** — it does NOT call `redact_sensitive_text`. Any API key, token, or secret appearing in the accumulated text would be permanently exposed.

## Fix

1. Import `agent.redact.redact_sensitive_text` in `gateway/stream_consumer.py`
2. Update `_clean_for_display` to chain `redact_sensitive_text` before `strip_media_directives_for_display`

Since `_send_or_edit` (which handles all finalize=True sends) calls `_clean_for_display`, all permanent streaming chunks now have secrets redacted.

## Testing

```python
# Before fix: SG.xxxxx.yyyyy leaked in finalized Telegram message
# After fix: SG.xxxxx.yyyyy -> *** in all streaming chunks
result = GatewayStreamConsumer._clean_for_display("API key SG.aaa.bbb.ccc here")
assert "***" in result
assert "SG." not in result
```

Fixes #56039