### PR TITLE
fix(desktop): restore chrome-sandbox SUID permissions after update rebuild

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9942,6 +9942,17 @@ def _cmd_update_impl(args, gateway_mode: bool):
             else:
                 print("  ✓ Desktop app up to date")
 
+            # After a desktop rebuild the chrome-sandbox helper may have
+            # lost its root:root + SUID (4755) permissions — git reset
+            # --hard replaces the file with a user-owned copy and electron-
+            # builder's dir mode doesn't restore the setuid bit.  Fix it
+            # here so the next launch doesn't silently fail on Linux hosts
+            # that require the SUID sandbox helper (Ubuntu 23.10+ with
+            # AppArmor restrict_unprivileged_userns).  (#58593)
+            _pe = _desktop_packaged_executable(desktop_dir)
+            if _pe is not None:
+                _desktop_linux_sandbox_fixup(_pe)
+
         print()
         print("✓ Code updated!")
 


### PR DESCRIPTION
## What does this PR do?

Restores the Electron `chrome-sandbox` helper's SUID (`root:root 4755`) permissions after `hermes update` rebuilds the desktop app. Without this fix, Linux users on hosts with AppArmor `restrict_unprivileged_userns` (Ubuntu 23.10+) find that the desktop app silently fails to launch after every update.

## Related Issue

Fixes #58593

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py`: Added `_desktop_linux_sandbox_fixup()` call after the desktop rebuild completes in `_cmd_update_impl`. The function checks if the `chrome-sandbox` helper has the correct `root:root 4755` permissions and fixes them via `sudo` if needed. It is a no-op on non-Linux platforms.

## How to Test

1. On a Linux host (Ubuntu 23.10+ with AppArmor `restrict_unprivileged_userns` enabled), install Hermes Desktop via `hermes desktop`.
2. Verify `chrome-sandbox` has correct permissions: `ls -la apps/desktop/release/linux-unpacked/chrome-sandbox` should show `-rwsr-xr-x 1 root root`.
3. Run `hermes update` to trigger a desktop rebuild.
4. Verify permissions are still correct after the update.
5. Launch `hermes desktop` — it should start without sandbox errors.
6. On macOS/Windows, `hermes update` should work unchanged (the sandbox fixup is Linux-only).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (27 update tests + 18 venv health tests pass)
- [x] I've added tests for my changes — N/A (the fix calls an existing, already-tested function; the sandbox fixup itself is exercised by the desktop launch path tests)
- [x] I've tested on my platform: macOS (no-op path verified), Linux behavior follows the existing `_desktop_linux_sandbox_fixup` contract

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — the added code is guarded by `sys.platform` checks inside `_desktop_linux_sandbox_fixup` and is a no-op on macOS/Windows
- [x] I've updated tool descriptions/schemas — N/A
