### PR TITLE
Native CloakBrowser integration.

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1752,7 +1752,17 @@ def cleanup_task_resources(agent, task_id: str) -> None:
         if agent.verbose_logging:
             logger.warning(f"Failed to cleanup VM for task {task_id}: {e}")
     try:
-        _ra().cleanup_browser(task_id)
+        from tools.browser_tool import _is_cloakbrowser_mode
+
+        if _is_cloakbrowser_mode():
+            if agent.verbose_logging:
+                logger.debug(
+                    "Skipping per-turn cleanup_browser for native CloakBrowser session %s; "
+                    "session shutdown or inactivity timeout will reap it.",
+                    task_id,
+                )
+        else:
+            _ra().cleanup_browser(task_id)
     except Exception as e:
         if agent.verbose_logging:
             logger.warning(f"Failed to cleanup browser for task {task_id}: {e}")

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -361,9 +361,39 @@ terminal:
 # Browser Tool Configuration
 # =============================================================================
 browser:
+  # Browser provider selection:
+  #   "local"         - Default local Chromium via the agent-browser CLI
+  #   "browserbase"   - Browserbase cloud browser (requires BROWSERBASE_API_KEY + BROWSERBASE_PROJECT_ID)
+  #   "browser-use"   - Browser Use cloud browser (requires BROWSER_USE_API_KEY)
+  #   "firecrawl"     - Firecrawl cloud browser (requires FIRECRAWL_API_KEY)
+  #   "cloakbrowser"  - Native CloakBrowser backend (requires: python -m pip install cloakbrowser)
+  cloud_provider: "local"
   # Inactivity timeout in seconds - browser sessions are automatically closed
   # after this period of no activity between agent loops (default: 120 = 2 minutes)
   inactivity_timeout: 120
+  # Optional CDP override. When set, Hermes attaches directly to this Chromium-family
+  # browser endpoint instead of launching native CloakBrowser or the default local browser.
+  cdp_url: ""
+  # Auto-spawn a local browser for localhost/LAN URLs even when a cloud provider is selected.
+  auto_local_for_private_urls: true
+  # Native JS dialog handling for CDP-capable backends.
+  dialog_policy: "must_respond"  # must_respond | auto_dismiss | auto_accept
+  dialog_timeout_s: 300
+  # CloakBrowser-specific launch settings. These only matter when cloud_provider: "cloakbrowser".
+  cloakbrowser:
+    enabled: false                # Auto-managed; true only while cloud_provider is "cloakbrowser"
+    inactivity_timeout: 3600      # Native CloakBrowser session idle timeout in seconds
+    headless: false               # Run with a visible browser window when false
+    humanize: true                # Enable CloakBrowser humanized behavior
+    proxy: ""                     # Optional proxy URL
+    geoip: false                  # Resolve proxy geolocation automatically when supported
+    stealth_args: true            # Add default stealth Chromium arguments
+    locale: ""                    # Optional locale override, e.g. en-US
+    timezone: ""                  # Optional timezone override, e.g. America/New_York
+    color_scheme: ""              # Optional prefers-color-scheme override: light | dark
+    user_agent: ""                # Optional user-agent override
+    extra_args: []                # Extra Chromium args passed to CloakBrowser
+    user_data_dir: "${HERMES_HOME}/cloakbrowser_profile"
 
 # =============================================================================
 # Tool Loop Guardrails

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6218,6 +6218,10 @@ def _strip_default_values(
         if value == default:
             return None
 
+        if isinstance(value, str) and isinstance(default, str) and re.search(r"\${[^}]+}", default):
+            if value == _expand_env_vars(default):
+                return None
+
         return copy.deepcopy(value)
 
     result: Dict[str, Any] = {}

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1201,6 +1201,21 @@ DEFAULT_CONFIG = {
         # website/docs/developer-guide/browser-supervisor.md.
         "dialog_policy": "must_respond",  # must_respond | auto_dismiss | auto_accept
         "dialog_timeout_s": 300,  # Safety auto-dismiss after N seconds under must_respond
+        "cloakbrowser": {
+            "enabled": False,
+            "inactivity_timeout": 3600,
+            "headless": False,
+            "humanize": True,
+            "proxy": "",
+            "geoip": False,
+            "stealth_args": True,
+            "locale": "",
+            "timezone": "",
+            "color_scheme": "",
+            "user_agent": "",
+            "extra_args": [],
+            "user_data_dir": "${HERMES_HOME}/cloakbrowser_profile",
+        },
         "camofox": {
             # When true, Hermes sends a stable profile-scoped userId to Camofox
             # so the server maps it to a persistent Firefox profile automatically.

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -22,6 +22,7 @@ from tools.tool_backend_helpers import (
     normalize_modal_mode,
     resolve_modal_backend_state,
     resolve_openai_audio_api_key,
+    sync_cloakbrowser_enabled_flag,
 )
 
 
@@ -54,6 +55,23 @@ def _uses_gateway(section: object) -> bool:
     return is_truthy_value(section.get("use_gateway"), default=False)
 
 
+def get_effective_browser_cdp_override(browser_cfg: object) -> tuple[str, str]:
+    """Return the active explicit CDP override and its source label.
+
+    Precedence matches runtime:
+    1. ``BROWSER_CDP_URL``
+    2. ``browser.cdp_url``
+    """
+    env_override = str(get_env_value("BROWSER_CDP_URL") or "").strip()
+    if env_override:
+        return env_override, "BROWSER_CDP_URL"
+    if isinstance(browser_cfg, dict):
+        cfg_override = str(browser_cfg.get("cdp_url") or "").strip()
+        if cfg_override:
+            return cfg_override, "browser.cdp_url"
+    return "", ""
+
+
 @dataclass(frozen=True)
 class NousFeatureState:
     key: str
@@ -66,6 +84,7 @@ class NousFeatureState:
     toolset_enabled: bool
     current_provider: str = ""
     explicit_configured: bool = False
+    blocked_reason: str = ""
 
 
 @dataclass(frozen=True)
@@ -199,12 +218,23 @@ def _local_browser_runnable() -> bool:
     return _chromium_installed()
 
 
+def _cloakbrowser_available() -> bool:
+    """Return True when the CloakBrowser Python package is importable."""
+    try:
+        from tools.browser_cloakbrowser import check_cloakbrowser_available
+
+        return bool(check_cloakbrowser_available())
+    except Exception:
+        return False
+
+
 def _browser_label(current_provider: str) -> str:
     mapping = {
         "browserbase": "Browserbase",
         "browser-use": "Browser Use",
         "firecrawl": "Firecrawl",
         "camofox": "Camofox",
+        "cloakbrowser": "CloakBrowser",
         "local": "Local browser",
     }
     return mapping.get(current_provider or "local", current_provider or "Local browser")
@@ -262,7 +292,8 @@ def _resolve_browser_feature_state(
     direct_browser_use: bool,
     direct_firecrawl: bool,
     managed_browser_available: bool,
-) -> tuple[str, bool, bool, bool]:
+    cdp_override_source: str,
+) -> tuple[str, bool, bool, bool, str]:
     """Resolve browser availability using the same precedence as runtime.
 
     ``browser_local_available`` means "the agent-browser CLI is present" — the
@@ -273,15 +304,12 @@ def _resolve_browser_feature_state(
     on the latter, or setup/status advertise a browser that fails on first use
     when Chromium is missing.
     """
-    if direct_camofox:
-        return "camofox", True, bool(browser_tool_enabled), False
-
     if browser_provider_explicit:
         current_provider = browser_provider or "local"
         if current_provider == "browserbase":
             available = bool(browser_local_available and direct_browserbase)
             active = bool(browser_tool_enabled and available)
-            return current_provider, available, active, False
+            return current_provider, available, active, False, ""
         if current_provider == "browser-use":
             provider_available = managed_browser_available or direct_browser_use
             available = bool(browser_local_available and provider_available)
@@ -292,18 +320,36 @@ def _resolve_browser_feature_state(
                 and not direct_browser_use
             )
             active = bool(browser_tool_enabled and available)
-            return current_provider, available, active, managed
+            return current_provider, available, active, managed, ""
         if current_provider == "firecrawl":
             available = bool(browser_local_available and direct_firecrawl)
             active = bool(browser_tool_enabled and available)
-            return current_provider, available, active, False
+            return current_provider, available, active, False, ""
         if current_provider == "camofox":
-            return current_provider, False, False, False
+            return current_provider, False, False, False, ""
+        if current_provider == "cloakbrowser":
+            if cdp_override_source:
+                return (
+                    current_provider,
+                    False,
+                    False,
+                    False,
+                    f"{cdp_override_source} overrides native CloakBrowser launch",
+                )
+            # CloakBrowser runtime selection is gated by the Python package/path,
+            # not the local agent-browser/Chromium stack used by the default
+            # local backend. Keep setup/status aligned with that contract.
+            available = bool(_cloakbrowser_available())
+            active = bool(browser_tool_enabled and available)
+            return current_provider, available, active, False, ""
 
         current_provider = "local"
         available = bool(browser_local_runnable)
         active = bool(browser_tool_enabled and available)
-        return current_provider, available, active, False
+        return current_provider, available, active, False, ""
+
+    if direct_camofox:
+        return "camofox", True, bool(browser_tool_enabled), False, ""
 
     if managed_browser_available or direct_browser_use:
         available = bool(browser_local_available)
@@ -314,16 +360,16 @@ def _resolve_browser_feature_state(
             and not direct_browser_use
         )
         active = bool(browser_tool_enabled and available)
-        return "browser-use", available, active, managed
+        return "browser-use", available, active, managed, ""
 
     if direct_browserbase:
         available = bool(browser_local_available)
         active = bool(browser_tool_enabled and available)
-        return "browserbase", available, active, False
+        return "browserbase", available, active, False, ""
 
     available = bool(browser_local_runnable)
     active = bool(browser_tool_enabled and available)
-    return "local", available, active, False
+    return "local", available, active, False, ""
 
 
 def get_nous_subscription_features(
@@ -386,6 +432,9 @@ def get_nous_subscription_features(
     browser_provider_explicit = "cloud_provider" in browser_cfg
     browser_provider = normalize_browser_cloud_provider(
         browser_cfg.get("cloud_provider") if browser_provider_explicit else None
+    )
+    _, browser_cdp_override_source = get_effective_browser_cdp_override(
+        browser_cfg
     )
     terminal_backend = (
         str(terminal_cfg.get("backend") or "local").strip().lower()
@@ -579,6 +628,7 @@ def get_nous_subscription_features(
         browser_available,
         browser_active,
         browser_managed,
+        browser_blocked_reason,
     ) = _resolve_browser_feature_state(
         browser_tool_enabled=browser_tool_enabled,
         browser_provider=browser_provider,
@@ -590,6 +640,7 @@ def get_nous_subscription_features(
         direct_browser_use=direct_browser_use,
         direct_firecrawl=direct_firecrawl,
         managed_browser_available=managed_browser_available,
+        cdp_override_source=browser_cdp_override_source,
     )
 
     if terminal_backend != "modal":
@@ -710,6 +761,7 @@ def get_nous_subscription_features(
             toolset_enabled=browser_tool_enabled,
             current_provider=_browser_label(browser_current_provider),
             explicit_configured=browser_provider_explicit,
+            blocked_reason=browser_blocked_reason,
         ),
         "modal": NousFeatureState(
             key="modal",
@@ -821,6 +873,7 @@ def apply_nous_managed_defaults(
         or get_env_value("BROWSERBASE_API_KEY")
     ):
         browser_cfg["cloud_provider"] = "browser-use"
+        sync_cloakbrowser_enabled_flag(browser_cfg)
         changed.add("browser")
 
     if "image_gen" in selected_toolsets and not fal_key_is_configured():
@@ -1026,6 +1079,7 @@ def apply_gateway_defaults(
     if "browser" in tool_keys:
         browser_cfg["cloud_provider"] = "browser-use"
         browser_cfg["use_gateway"] = True
+        sync_cloakbrowser_enabled_flag(browser_cfg)
         changed.add("browser")
 
     if "image_gen" in tool_keys:

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -426,10 +426,11 @@ def _print_setup_summary(config: dict, hermes_home):
         tool_status.append(("Web Search & Extract", False, "EXA_API_KEY, PARALLEL_API_KEY, FIRECRAWL_API_KEY/FIRECRAWL_API_URL, TAVILY_API_KEY, or SEARXNG_URL"))
 
     # Browser tools (local Chromium, Camofox, Browserbase, Browser Use, or Firecrawl)
-    browser_provider = subscription_features.browser.current_provider
-    if subscription_features.browser.managed_by_nous:
+    browser_feature = subscription_features.browser
+    browser_provider = browser_feature.current_provider
+    if browser_feature.managed_by_nous:
         tool_status.append(("Browser Automation (Nous Browser Use)", True, None))
-    elif subscription_features.browser.available:
+    elif browser_feature.available:
         label = "Browser Automation"
         if browser_provider:
             label = f"Browser Automation ({browser_provider})"
@@ -447,13 +448,27 @@ def _print_setup_summary(config: dict, hermes_home):
             )
         elif browser_provider == "Camofox":
             missing_browser_hint = "CAMOFOX_URL"
+        elif browser_provider == "CloakBrowser":
+            if browser_feature.blocked_reason:
+                override_hint = "clear browser.cdp_url to use native CloakBrowser or keep direct CDP attach"
+                if "BROWSER_CDP_URL" in browser_feature.blocked_reason:
+                    override_hint = (
+                        "unset BROWSER_CDP_URL or clear browser.cdp_url to use native CloakBrowser, "
+                        "or keep direct CDP attach"
+                    )
+                missing_browser_hint = (
+                    f"{browser_feature.blocked_reason}; {override_hint}"
+                )
+            else:
+                missing_browser_hint = "pip install cloakbrowser"
         elif browser_provider == "Local browser":
             missing_browser_hint = (
                 "npm install -g agent-browser && agent-browser install --with-deps"
             )
-        tool_status.append(
-            ("Browser Automation", False, missing_browser_hint)
-        )
+        label = "Browser Automation"
+        if browser_provider:
+            label = f"Browser Automation ({browser_provider})"
+        tool_status.append((label, False, missing_browser_hint))
 
     # Image generation — FAL (direct or via Nous), or any plugin-registered
     # provider (OpenAI, etc.)

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -337,7 +337,13 @@ def show_status(args):
         else:
             print("  Nous Portal   ✓ managed tools available")
         for feature in features.items():
-            if feature.managed_by_nous:
+            if feature.blocked_reason:
+                provider = feature.current_provider or "configured provider"
+                if feature.explicit_configured:
+                    state = f"selected {provider}, blocked: {feature.blocked_reason}"
+                else:
+                    state = f"blocked: {feature.blocked_reason}"
+            elif feature.managed_by_nous:
                 state = "active via Nous subscription"
             elif feature.active:
                 current = feature.current_provider or "configured provider"

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -9,6 +9,8 @@ Saves per-platform tool configuration to ~/.hermes/config.yaml under
 the `platform_toolsets` key.
 """
 
+import copy
+import importlib
 import json as _json
 import logging
 import os
@@ -20,16 +22,22 @@ from typing import Dict, List, Optional, Set
 
 
 from hermes_cli.config import (
+    DEFAULT_CONFIG,
     cfg_get,
     load_config, save_config, get_env_value, save_env_value,
 )
 from hermes_cli.colors import Colors, color
 from hermes_cli.nous_subscription import (
     apply_nous_managed_defaults,
+    get_effective_browser_cdp_override,
     get_nous_subscription_features,
 )
 from hermes_cli.nous_account import format_nous_portal_entitlement_message
-from tools.tool_backend_helpers import fal_key_is_configured
+from tools.tool_backend_helpers import (
+    fal_key_is_configured,
+    normalize_browser_cloud_provider,
+    sync_cloakbrowser_enabled_flag,
+)
 from utils import base_url_hostname, is_truthy_value
 
 logger = logging.getLogger(__name__)
@@ -40,6 +48,34 @@ logger = logging.getLogger(__name__)
 _warned_invalid_platform_toolsets: Set[str] = set()
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
+
+
+def _tool_config_preserve_keys(config: dict) -> Set[tuple[str, ...]]:
+    """Return config paths that tool setup should persist even at defaults."""
+    browser_cfg = config.get("browser")
+    if not isinstance(browser_cfg, dict):
+        return set()
+    cloak_cfg = browser_cfg.get("cloakbrowser")
+    if not isinstance(cloak_cfg, dict):
+        return set()
+
+    defaults = DEFAULT_CONFIG.get("browser", {}).get("cloakbrowser", {})
+    preserve = {
+        ("browser", "cloakbrowser", key)
+        for key, value in defaults.items()
+        if not isinstance(value, dict)
+    }
+    preserve.update(
+        ("browser", "cloakbrowser", key)
+        for key, value in cloak_cfg.items()
+        if not isinstance(value, dict)
+    )
+    return preserve
+
+
+def _save_tools_config(config: dict) -> None:
+    """Save tool config while preserving explicit CloakBrowser setup defaults."""
+    save_config(config, preserve_keys=_tool_config_preserve_keys(config))
 
 
 # ─── UI Helpers (shared with setup.py) ────────────────────────────────────────
@@ -490,6 +526,14 @@ TOOL_CATEGORIES = {
                 ],
                 "browser_provider": "camofox",
                 "post_setup": "camofox",
+            },
+            {
+                "name": "CloakBrowser",
+                "badge": "free · local",
+                "tag": "Anti-detection browser (Chromium)",
+                "env_vars": [],
+                "browser_provider": "cloakbrowser",
+                "post_setup": "cloakbrowser",
             },
         ],
     },
@@ -1052,6 +1096,33 @@ def _run_post_setup(post_setup_key: str):
         except Exception as exc:
             _print_warning(f"    Chromium install failed: {exc}")
             _print_info("    Run manually: npx agent-browser install --with-deps")
+
+    elif post_setup_key == "cloakbrowser":
+        try:
+            import importlib.util
+
+            if importlib.util.find_spec("cloakbrowser") is not None:
+                _print_success("    cloakbrowser is already installed")
+                return
+        except Exception:
+            pass
+
+        _print_info("    Installing CloakBrowser Python package...")
+        import subprocess
+
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "install", "cloakbrowser"],
+            capture_output=True,
+            text=True,
+            cwd=str(PROJECT_ROOT),
+        )
+        if result.returncode == 0:
+            _print_success("    CloakBrowser installed")
+        else:
+            _print_warning("    CloakBrowser install failed")
+            if result.stderr:
+                _print_info(f"    {result.stderr.strip().splitlines()[-1]}")
+            _print_info("    Run manually: python -m pip install cloakbrowser")
 
     elif post_setup_key == "camofox":
         camofox_dir = PROJECT_ROOT / "node_modules" / "@askjo" / "camofox-browser"
@@ -1774,7 +1845,7 @@ def _save_platform_tools(config: dict, platform: str, enabled_toolset_keys: Set[
                 if remaining != disabled_toolsets:
                     agent_cfg["disabled_toolsets"] = remaining
 
-    save_config(config)
+    _save_tools_config(config)
 
 
 def _toolset_has_keys(
@@ -2324,6 +2395,7 @@ _POST_SETUP_INSTALLED: dict = {
     # a no-key provider, and (b) an installed-state check is cheap and
     # doesn't trigger a heavy import.
     "cua_driver": lambda: bool(shutil.which(_cua_driver_cmd())),
+    "cloakbrowser": lambda: importlib.util.find_spec("cloakbrowser") is not None,
 }
 
 
@@ -2351,15 +2423,10 @@ def _toolset_needs_configuration_prompt(
     if not cat:
         return not _toolset_has_keys(ts_key, config, force_fresh=force_fresh)
 
-    # If any visible provider has a registered post_setup install-state
-    # check that hasn't been satisfied (e.g. cua-driver binary not on
-    # PATH yet), force the configuration flow so `_configure_provider`
-    # invokes `_run_post_setup` and the install actually runs.
-    for provider in _visible_providers(cat, config, force_fresh=force_fresh):
-        post_setup = provider.get("post_setup")
-        if post_setup and not _post_setup_already_installed(post_setup):
-            return True
-
+    # Toolset-specific checks — run BEFORE the post_setup loop so that a
+    # properly-configured toolset (e.g. browser with Local Browser) is not
+    # forced back into setup just because an unrelated provider (e.g.
+    # CloakBrowser) has an unsatisfied install side-effect (#43284).
     if ts_key == "tts":
         tts_cfg = config.get("tts", {})
         return not isinstance(tts_cfg, dict) or "provider" not in tts_cfg
@@ -2368,7 +2435,14 @@ def _toolset_needs_configuration_prompt(
         return not isinstance(web_cfg, dict) or "backend" not in web_cfg
     if ts_key == "browser":
         browser_cfg = config.get("browser", {})
-        return not isinstance(browser_cfg, dict) or "cloud_provider" not in browser_cfg
+        if not isinstance(browser_cfg, dict) or "cloud_provider" not in browser_cfg:
+            return True
+        if (
+            normalize_browser_cloud_provider(browser_cfg.get("cloud_provider"))
+            == "cloakbrowser"
+        ):
+            return not _post_setup_already_installed("cloakbrowser")
+        return False
     if ts_key == "image_gen":
         # Satisfied when the in-tree FAL backend is configured OR any
         # plugin-registered image gen provider is available.
@@ -2405,6 +2479,14 @@ def _toolset_needs_configuration_prompt(
         except Exception:
             pass
         return True
+
+    # Generic post_setup check: for toolsets without toolset-specific checks
+    # (e.g. computer_use), check if any visible provider has a registered
+    # post_setup install-state check that hasn't been satisfied.
+    for provider in _visible_providers(cat, config, force_fresh=force_fresh):
+        post_setup = provider.get("post_setup")
+        if post_setup and not _post_setup_already_installed(post_setup):
+            return True
 
     return not _toolset_has_keys(ts_key, config, force_fresh=force_fresh)
 
@@ -2979,6 +3061,7 @@ def _write_provider_config(provider: dict, config: dict, *, managed_feature) -> 
         if bp:
             browser_cfg["cloud_provider"] = bp
         browser_cfg["use_gateway"] = bool(managed_feature)
+        sync_cloakbrowser_enabled_flag(browser_cfg)
 
     # Set web search backend in config if applicable
     if provider.get("web_backend"):
@@ -3057,6 +3140,118 @@ def apply_provider_selection(ts_key: str, provider_name: str, config: dict) -> N
             img_cfg["provider"] = "fal"
 
 
+def _configure_cloakbrowser_settings(config: dict) -> None:
+    """Prompt for the CloakBrowser settings still exposed in setup UX."""
+    cloak_defaults = DEFAULT_CONFIG.get("browser", {}).get("cloakbrowser", {})
+    browser_cfg = config.setdefault("browser", {})
+    if not isinstance(browser_cfg, dict):
+        browser_cfg = {}
+        config["browser"] = browser_cfg
+    cloak_cfg = browser_cfg.setdefault("cloakbrowser", {})
+    if not isinstance(cloak_cfg, dict):
+        cloak_cfg = {}
+        browser_cfg["cloakbrowser"] = cloak_cfg
+
+    cloak_cfg.setdefault("proxy", str(cloak_cfg.get("proxy") or ""))
+    cloak_cfg.setdefault(
+        "user_data_dir",
+        str(cloak_cfg.get("user_data_dir") or cloak_defaults.get("user_data_dir") or ""),
+    )
+    cloak_cfg.setdefault(
+        "inactivity_timeout",
+        cloak_defaults.get("inactivity_timeout", 3600),
+    )
+
+    headless_default = 1 if is_truthy_value(cloak_cfg.get("headless"), default=False) else 0
+    headless_choice = _prompt_choice(
+        "  Run CloakBrowser headed or headless?",
+        ["headed", "headless"],
+        default=headless_default,
+    )
+    cloak_cfg["headless"] = headless_choice == 1
+
+    humanize_default = 0 if is_truthy_value(cloak_cfg.get("humanize"), default=True) else 1
+    humanize_choice = _prompt_choice(
+        "  Enable humanized behavior?",
+        ["yes", "no"],
+        default=humanize_default,
+    )
+    cloak_cfg["humanize"] = humanize_choice == 0
+
+    stealth_default = 0 if is_truthy_value(cloak_cfg.get("stealth_args"), default=True) else 1
+    stealth_choice = _prompt_choice(
+        "  Enable default stealth arguments?",
+        ["yes", "no"],
+        default=stealth_default,
+    )
+    cloak_cfg["stealth_args"] = stealth_choice == 0
+
+
+
+def _handle_cloakbrowser_cdp_conflict(config: dict) -> str:
+    """Resolve an explicit CDP override before native CloakBrowser setup.
+
+    Returns one of: ``"clear"`` (continue with native CloakBrowser setup),
+    ``"keep"`` (preserve direct CDP attach and skip native setup), or
+    ``"cancel"`` (restore prior browser config and abort).
+    """
+    browser_cfg = config.setdefault("browser", {})
+    if not isinstance(browser_cfg, dict):
+        browser_cfg = {}
+        config["browser"] = browser_cfg
+
+    cdp_url, cdp_source = get_effective_browser_cdp_override(browser_cfg)
+    if not cdp_url:
+        return "clear"
+
+    if cdp_source == "BROWSER_CDP_URL":
+        _print_warning("  BROWSER_CDP_URL is set and overrides native CloakBrowser launch.")
+        _print_info(f"  Current BROWSER_CDP_URL: {cdp_url}")
+        _print_info(
+            "  Unset BROWSER_CDP_URL before rerunning setup if you want native CloakBrowser to launch."
+        )
+        conflict_choice = _prompt_choice(
+            "  Resolve the BROWSER_CDP_URL conflict:",
+            [
+                "Keep BROWSER_CDP_URL and keep using direct CDP attach",
+                "Cancel and go back",
+            ],
+            default=0,
+        )
+        if conflict_choice == 0:
+            _print_info(
+                "  Keeping BROWSER_CDP_URL. Runtime will continue using direct CDP attach."
+            )
+            return "keep"
+        _print_info("  Cancelled")
+        return "cancel"
+
+    _print_warning("  browser.cdp_url is configured and overrides native CloakBrowser launch.")
+    _print_info(f"  Current browser.cdp_url: {cdp_url}")
+    _print_info("  Keep it to continue using direct CDP attach, or clear it to use native CloakBrowser.")
+
+    conflict_choice = _prompt_choice(
+        "  Resolve the browser.cdp_url conflict:",
+        [
+            "Clear browser.cdp_url and use native CloakBrowser",
+            "Keep browser.cdp_url and keep using direct CDP attach",
+            "Cancel and go back",
+        ],
+        default=0,
+    )
+    if conflict_choice == 0:
+        browser_cfg["cdp_url"] = ""
+        _print_success("  Cleared browser.cdp_url; native CloakBrowser can launch.")
+        return "clear"
+    if conflict_choice == 1:
+        _print_info("  Keeping browser.cdp_url. Runtime will continue using direct CDP attach.")
+        return "keep"
+
+    _print_info("  Cancelled")
+    return "cancel"
+
+
+
 def _configure_provider(
     provider: dict,
     config: dict,
@@ -3126,7 +3321,20 @@ def _configure_provider(
     # Persist the provider/backend config keys + use_gateway flags. Shared
     # with the GUI provider-select endpoint via apply_provider_selection so
     # there is a single source of truth for these writes.
+    original_browser_cfg = copy.deepcopy(config.get("browser")) if "browser_provider" in provider else None
+    conflict_action = None
     _write_provider_config(provider, config, managed_feature=managed_feature)
+
+    if provider.get("browser_provider") == "cloakbrowser":
+        conflict_action = _handle_cloakbrowser_cdp_conflict(config)
+        if conflict_action == "cancel":
+            if original_browser_cfg is None:
+                config.pop("browser", None)
+            else:
+                config["browser"] = original_browser_cfg
+            return
+        if conflict_action == "clear":
+            _configure_cloakbrowser_settings(config)
 
     if not env_vars:
         if provider.get("post_setup"):
@@ -3274,7 +3482,7 @@ def _configure_vision_backend() -> None:
         # Auto: clear any pinned override so the resolver auto-detects.
         for key in ("provider", "model", "base_url", "api_key", "api_mode"):
             vision_cfg.pop(key, None)
-        save_config(config)
+        _save_tools_config(config)
         _print_success("  Vision set to auto (main model / aggregator fallback)")
         return
 
@@ -3306,7 +3514,7 @@ def _configure_vision_backend() -> None:
             vision_cfg["model"] = model
         else:
             vision_cfg.pop("model", None)
-        save_config(config)
+        _save_tools_config(config)
         _print_success(f"  Vision set to custom endpoint{f' ({model})' if model else ''}")
         return
 
@@ -3375,7 +3583,7 @@ def _configure_vision_provider_model(config: dict, vision_cfg: dict) -> None:
     # A provider selection supersedes any prior custom endpoint override.
     vision_cfg.pop("base_url", None)
     vision_cfg.pop("api_key", None)
-    save_config(config)
+    _save_tools_config(config)
     _print_success(f"  Vision set to {slug} / {model}")
 
 
@@ -3453,7 +3661,7 @@ def _reconfigure_tool(
     else:
         _reconfigure_simple_requirements(ts_key)
 
-    save_config(config)
+    _save_tools_config(config)
 
 
 def _toolset_enabled_for_reconfigure(ts_key: str, config: dict) -> bool:
@@ -3550,6 +3758,8 @@ def _reconfigure_provider(
     """Reconfigure a provider - update API keys."""
     env_vars = provider.get("env_vars", [])
     managed_feature = provider.get("managed_nous_feature")
+    original_browser_cfg = None
+    conflict_action = None
 
     # Same inline Nous Portal login + entitlement gate as _configure_provider:
     # managed Tool Gateway backends only activate with paid Portal access.
@@ -3592,6 +3802,7 @@ def _reconfigure_provider(
         _print_success(f"  TTS provider set to: {provider['tts_provider']}")
 
     if "browser_provider" in provider:
+        original_browser_cfg = copy.deepcopy(config.get("browser"))
         bp = provider["browser_provider"]
         browser_cfg = config.setdefault("browser", {})
         if bp == "local":
@@ -3601,6 +3812,18 @@ def _reconfigure_provider(
             browser_cfg["cloud_provider"] = bp
             _print_success(f"  Browser cloud provider set to: {bp}")
         browser_cfg["use_gateway"] = bool(managed_feature)
+        sync_cloakbrowser_enabled_flag(browser_cfg)
+
+    if provider.get("browser_provider") == "cloakbrowser":
+        conflict_action = _handle_cloakbrowser_cdp_conflict(config)
+        if conflict_action == "cancel":
+            if original_browser_cfg is None:
+                config.pop("browser", None)
+            else:
+                config["browser"] = original_browser_cfg
+            return
+        if conflict_action == "clear":
+            _configure_cloakbrowser_settings(config)
 
     # Set web search backend in config if applicable
     if provider.get("web_backend"):
@@ -3825,7 +4048,7 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
                     _configure_toolset(ts_key, config)
 
             _save_platform_tools(config, pkey, new_enabled)
-            save_config(config)
+            _save_tools_config(config)
             print(color(f"  ✓ Saved {pinfo['label']} tool configuration", Colors.GREEN))
             print()
 
@@ -3917,8 +4140,24 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
                                 force_fresh=True,
                             ):
                                 _configure_toolset(ts_key, config)
+
+                    # Configure already-enabled toolsets with unsatisfied
+                    # post_setup (e.g. CloakBrowser configured but the
+                    # package failed to install during setup).
+                    for ts_key in sorted(new_enabled & _diff_universe):
+                        if ts_key in added:
+                            continue
+                        cat = TOOL_CATEGORIES.get(ts_key)
+                        if not cat:
+                            continue
+                        if _toolset_needs_configuration_prompt(
+                            ts_key,
+                            config,
+                            force_fresh=True,
+                        ):
+                            _configure_toolset(ts_key, config)
                     _save_platform_tools(config, pk, new_enabled)
-                save_config(config)
+                _save_tools_config(config)
                 print(color("  ✓ Saved configuration for all platforms", Colors.GREEN))
                 # Update choice labels
                 for ci, pk in enumerate(platform_keys):
@@ -3970,8 +4209,24 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
                     ):
                         _configure_toolset(ts_key, config)
 
+            # Configure already-enabled toolsets whose post_setup install
+            # side-effect is unsatisfied (e.g. CloakBrowser configured but
+            # the package failed to install during first-time setup).
+            for ts_key in sorted(new_enabled):
+                if ts_key in added:
+                    continue
+                cat = TOOL_CATEGORIES.get(ts_key)
+                if not cat:
+                    continue
+                if _toolset_needs_configuration_prompt(
+                    ts_key,
+                    config,
+                    force_fresh=True,
+                ):
+                    _configure_toolset(ts_key, config)
+
             _save_platform_tools(config, pkey, new_enabled)
-            save_config(config)
+            _save_tools_config(config)
             print(color(f"  ✓ Saved {pinfo['label']} configuration", Colors.GREEN))
         else:
             print(color(f"  No changes to {pinfo['label']}", Colors.DIM))
@@ -4119,7 +4374,7 @@ def _configure_mcp_tools_interactive(config: dict):
         any_changes = True
 
     if any_changes:
-        save_config(config)
+        _save_tools_config(config)
         print()
         print(color("  ✓ MCP tool configuration saved", Colors.GREEN))
     else:
@@ -4259,7 +4514,7 @@ def tools_disable_enable_command(args):
         for srv in failed_servers:
             _print_error(f"MCP server '{srv}' not found in config")
 
-    save_config(config)
+    _save_tools_config(config)
 
     successful = [
         t for t in targets

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -100,6 +100,71 @@ class TestLoadConfigDefaults:
             assert "terminal" in config
             assert config["terminal"]["backend"] == "local"
             assert config["display"]["interim_assistant_messages"] is True
+            assert config["browser"]["cloakbrowser"] == {
+                "enabled": False,
+                "headless": False,
+                "humanize": True,
+                "proxy": "",
+                "geoip": False,
+                "stealth_args": True,
+                "locale": "",
+                "timezone": "",
+                "color_scheme": "",
+                "user_agent": "",
+                "extra_args": [],
+                "user_data_dir": "",
+            }
+
+    def test_partial_browser_config_gets_cloakbrowser_defaults(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config_path = tmp_path / "config.yaml"
+            config_path.write_text("browser:\n  allow_private_urls: true\n")
+
+            config = load_config()
+            assert config["browser"]["allow_private_urls"] is True
+            assert config["browser"]["cloakbrowser"] == {
+                "enabled": False,
+                "headless": False,
+                "humanize": True,
+                "proxy": "",
+                "geoip": False,
+                "stealth_args": True,
+                "locale": "",
+                "timezone": "",
+                "color_scheme": "",
+                "user_agent": "",
+                "extra_args": [],
+                "user_data_dir": "",
+            }
+
+    def test_partial_cloakbrowser_config_keeps_user_values_and_fills_supported_defaults(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config_path = tmp_path / "config.yaml"
+            config_path.write_text(
+                "browser:\n"
+                "  cloakbrowser:\n"
+                "    headless: true\n"
+                "    proxy: http://proxy.example:8080\n"
+                "    extra_args:\n"
+                "      - --disable-blink-features=AutomationControlled\n"
+            )
+
+            config = load_config()
+
+            assert config["browser"]["cloakbrowser"] == {
+                "enabled": False,
+                "headless": True,
+                "humanize": True,
+                "proxy": "http://proxy.example:8080",
+                "geoip": False,
+                "stealth_args": True,
+                "locale": "",
+                "timezone": "",
+                "color_scheme": "",
+                "user_agent": "",
+                "extra_args": ["--disable-blink-features=AutomationControlled"],
+                "user_data_dir": "",
+            }
 
     def test_legacy_root_level_max_turns_migrates_to_agent_config(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
@@ -1700,3 +1765,9 @@ class TestConfigNormalizationDoesNotOverwriteUserValues:
 
     def test_explicit_config_paths_ignore_empty_sections(self):
         assert _explicit_config_paths({"memory": {}, "display": {}}) == set()
+
+    def test_default_cloakbrowser_config_contains_hidden_setup_defaults(self):
+        cloak_cfg = DEFAULT_CONFIG["browser"]["cloakbrowser"]
+
+        assert cloak_cfg["inactivity_timeout"] == 3600
+        assert cloak_cfg["user_data_dir"] == "${HERMES_HOME}/cloakbrowser_profile"

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -102,6 +102,7 @@ class TestLoadConfigDefaults:
             assert config["display"]["interim_assistant_messages"] is True
             assert config["browser"]["cloakbrowser"] == {
                 "enabled": False,
+                "inactivity_timeout": 3600,
                 "headless": False,
                 "humanize": True,
                 "proxy": "",
@@ -112,7 +113,7 @@ class TestLoadConfigDefaults:
                 "color_scheme": "",
                 "user_agent": "",
                 "extra_args": [],
-                "user_data_dir": "",
+                "user_data_dir": str(tmp_path / "cloakbrowser_profile"),
             }
 
     def test_partial_browser_config_gets_cloakbrowser_defaults(self, tmp_path):
@@ -124,6 +125,7 @@ class TestLoadConfigDefaults:
             assert config["browser"]["allow_private_urls"] is True
             assert config["browser"]["cloakbrowser"] == {
                 "enabled": False,
+                "inactivity_timeout": 3600,
                 "headless": False,
                 "humanize": True,
                 "proxy": "",
@@ -134,7 +136,7 @@ class TestLoadConfigDefaults:
                 "color_scheme": "",
                 "user_agent": "",
                 "extra_args": [],
-                "user_data_dir": "",
+                "user_data_dir": str(tmp_path / "cloakbrowser_profile"),
             }
 
     def test_partial_cloakbrowser_config_keeps_user_values_and_fills_supported_defaults(self, tmp_path):
@@ -153,6 +155,7 @@ class TestLoadConfigDefaults:
 
             assert config["browser"]["cloakbrowser"] == {
                 "enabled": False,
+                "inactivity_timeout": 3600,
                 "headless": True,
                 "humanize": True,
                 "proxy": "http://proxy.example:8080",
@@ -163,7 +166,7 @@ class TestLoadConfigDefaults:
                 "color_scheme": "",
                 "user_agent": "",
                 "extra_args": ["--disable-blink-features=AutomationControlled"],
-                "user_data_dir": "",
+                "user_data_dir": str(tmp_path / "cloakbrowser_profile"),
             }
 
     def test_legacy_root_level_max_turns_migrates_to_agent_config(self, tmp_path):
@@ -338,6 +341,15 @@ class TestSaveAndLoadRoundtrip:
             saved = yaml.safe_load((tmp_path / "config.yaml").read_text())
             assert saved["agent"]["max_turns"] == 37
             assert "max_turns" not in saved
+
+    def test_save_config_does_not_materialize_default_cloakbrowser_user_data_dir(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config = load_config()
+
+            save_config(config)
+
+            saved = yaml.safe_load((tmp_path / "config.yaml").read_text())
+            assert "browser" not in saved or "cloakbrowser" not in saved.get("browser", {})
 
     def test_nested_values_preserved(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):

--- a/tests/hermes_cli/test_nous_subscription.py
+++ b/tests/hermes_cli/test_nous_subscription.py
@@ -1,5 +1,7 @@
 """Tests for Nous subscription feature detection."""
 
+from typing import cast
+
 from hermes_cli.nous_account import NousPortalAccountInfo, NousToolAccessInfo
 from hermes_cli import nous_subscription as ns
 
@@ -156,7 +158,37 @@ def test_get_nous_subscription_features_uses_direct_browserbase_when_no_managed_
     assert features.browser.current_provider == "Browserbase"
 
 
-def test_get_nous_subscription_features_prefers_camofox_over_managed_browser_use(monkeypatch):
+def test_get_nous_subscription_features_respects_explicit_browser_use_over_camofox(
+    monkeypatch,
+):
+    env = {"CAMOFOX_URL": "http://localhost:9377"}
+
+    monkeypatch.setattr(ns, "get_env_value", lambda name: env.get(name, ""))
+    monkeypatch.setattr(
+        ns, "get_nous_portal_account_info", lambda: _account(logged_in=True, paid=True)
+    )
+    monkeypatch.setattr(ns, "_toolset_enabled", lambda config, key: key == "browser")
+    monkeypatch.setattr(ns, "_has_agent_browser", lambda: True)
+    monkeypatch.setattr(ns, "resolve_openai_audio_api_key", lambda: "")
+    monkeypatch.setattr(ns, "has_direct_modal_credentials", lambda: False)
+    monkeypatch.setattr(
+        ns,
+        "is_managed_tool_gateway_ready",
+        lambda vendor: vendor == "browser-use",
+    )
+
+    features = ns.get_nous_subscription_features(
+        {"browser": {"cloud_provider": "browser-use"}}
+    )
+
+    assert features.browser.available is True
+    assert features.browser.active is True
+    assert features.browser.managed_by_nous is True
+    assert features.browser.direct_override is False
+    assert features.browser.current_provider == "Browser Use"
+
+
+def test_get_nous_subscription_features_legacy_camofox_still_wins_when_unconfigured(monkeypatch):
     env = {"CAMOFOX_URL": "http://localhost:9377"}
 
     monkeypatch.setattr(ns, "get_env_value", lambda name: env.get(name, ""))
@@ -173,15 +205,128 @@ def test_get_nous_subscription_features_prefers_camofox_over_managed_browser_use
         lambda vendor: vendor == "browser-use",
     )
 
-    features = ns.get_nous_subscription_features(
-        {"browser": {"cloud_provider": "browser-use"}}
-    )
+    features = ns.get_nous_subscription_features({})
 
     assert features.browser.available is True
     assert features.browser.active is True
     assert features.browser.managed_by_nous is False
     assert features.browser.direct_override is True
     assert features.browser.current_provider == "Camofox"
+
+
+def test_get_nous_subscription_features_reports_selected_cloakbrowser_when_available(
+    monkeypatch,
+):
+    monkeypatch.setattr(ns, "get_env_value", lambda name: "http://localhost:9377" if name == "CAMOFOX_URL" else "")
+    monkeypatch.setattr(
+        ns, "get_nous_portal_account_info", lambda: _account(logged_in=False)
+    )
+    monkeypatch.setattr(ns, "_toolset_enabled", lambda config, key: key == "browser")
+    monkeypatch.setattr(ns, "_has_agent_browser", lambda: False)
+    monkeypatch.setattr(ns, "_local_browser_runnable", lambda: False)
+    monkeypatch.setattr(ns, "_cloakbrowser_available", lambda: True)
+    monkeypatch.setattr(ns, "resolve_openai_audio_api_key", lambda: "")
+    monkeypatch.setattr(ns, "has_direct_modal_credentials", lambda: False)
+    monkeypatch.setattr(ns, "is_managed_tool_gateway_ready", lambda vendor: False)
+
+    features = ns.get_nous_subscription_features(
+        {"browser": {"cloud_provider": "cloakbrowser", "cloakbrowser": {"enabled": True}}}
+    )
+
+    assert features.browser.available is True
+    assert features.browser.active is True
+    assert features.browser.current_provider == "CloakBrowser"
+
+
+def test_get_nous_subscription_features_selected_cloakbrowser_without_package_is_unavailable(
+    monkeypatch,
+):
+    monkeypatch.setattr(ns, "get_env_value", lambda name: "")
+    monkeypatch.setattr(
+        ns, "get_nous_portal_account_info", lambda: _account(logged_in=False)
+    )
+    monkeypatch.setattr(ns, "_toolset_enabled", lambda config, key: key == "browser")
+    monkeypatch.setattr(ns, "_has_agent_browser", lambda: False)
+    monkeypatch.setattr(ns, "_local_browser_runnable", lambda: False)
+    monkeypatch.setattr(ns, "_cloakbrowser_available", lambda: False)
+    monkeypatch.setattr(ns, "resolve_openai_audio_api_key", lambda: "")
+    monkeypatch.setattr(ns, "has_direct_modal_credentials", lambda: False)
+    monkeypatch.setattr(ns, "is_managed_tool_gateway_ready", lambda vendor: False)
+
+    features = ns.get_nous_subscription_features(
+        {"browser": {"cloud_provider": "cloakbrowser", "cloakbrowser": {"enabled": True}}}
+    )
+
+    assert features.browser.available is False
+    assert features.browser.active is False
+    assert features.browser.current_provider == "CloakBrowser"
+
+
+def test_get_nous_subscription_features_marks_cloakbrowser_blocked_by_cdp_url(
+    monkeypatch,
+):
+    monkeypatch.setattr(ns, "get_env_value", lambda name: "")
+    monkeypatch.setattr(
+        ns, "get_nous_portal_account_info", lambda: _account(logged_in=False)
+    )
+    monkeypatch.setattr(ns, "_toolset_enabled", lambda config, key: key == "browser")
+    monkeypatch.setattr(ns, "_has_agent_browser", lambda: False)
+    monkeypatch.setattr(ns, "_local_browser_runnable", lambda: False)
+    monkeypatch.setattr(ns, "_cloakbrowser_available", lambda: True)
+    monkeypatch.setattr(ns, "resolve_openai_audio_api_key", lambda: "")
+    monkeypatch.setattr(ns, "has_direct_modal_credentials", lambda: False)
+    monkeypatch.setattr(ns, "is_managed_tool_gateway_ready", lambda vendor: False)
+
+    features = ns.get_nous_subscription_features(
+        {
+            "browser": {
+                "cloud_provider": "cloakbrowser",
+                "cdp_url": "http://localhost:9222",
+                "cloakbrowser": {"enabled": True},
+            }
+        }
+    )
+
+    assert features.browser.available is False
+    assert features.browser.active is False
+    assert features.browser.current_provider == "CloakBrowser"
+    assert features.browser.blocked_reason == "browser.cdp_url overrides native CloakBrowser launch"
+
+
+def test_get_nous_subscription_features_marks_cloakbrowser_blocked_by_browser_cdp_url_env(
+    monkeypatch,
+):
+    env = {"BROWSER_CDP_URL": "http://localhost:9333"}
+
+    monkeypatch.setattr(ns, "get_env_value", lambda name: env.get(name, ""))
+    monkeypatch.setattr(
+        ns, "get_nous_portal_account_info", lambda: _account(logged_in=False)
+    )
+    monkeypatch.setattr(ns, "_toolset_enabled", lambda config, key: key == "browser")
+    monkeypatch.setattr(ns, "_has_agent_browser", lambda: False)
+    monkeypatch.setattr(ns, "_local_browser_runnable", lambda: False)
+    monkeypatch.setattr(ns, "_cloakbrowser_available", lambda: True)
+    monkeypatch.setattr(ns, "resolve_openai_audio_api_key", lambda: "")
+    monkeypatch.setattr(ns, "has_direct_modal_credentials", lambda: False)
+    monkeypatch.setattr(ns, "is_managed_tool_gateway_ready", lambda vendor: False)
+
+    features = ns.get_nous_subscription_features(
+        {
+            "browser": {
+                "cloud_provider": "cloakbrowser",
+                "cdp_url": "http://localhost:9222",
+                "cloakbrowser": {"enabled": True},
+            }
+        }
+    )
+
+    assert features.browser.available is False
+    assert features.browser.active is False
+    assert features.browser.current_provider == "CloakBrowser"
+    assert (
+        features.browser.blocked_reason
+        == "BROWSER_CDP_URL overrides native CloakBrowser launch"
+    )
 
 
 def test_get_nous_subscription_features_requires_agent_browser_for_browserbase(monkeypatch):
@@ -525,6 +670,33 @@ def test_apply_nous_managed_defaults_writes_image_gen_config(monkeypatch):
     assert config["image_gen"]["use_gateway"] is True
 
 
+def test_apply_nous_managed_defaults_clears_stale_cloakbrowser_flag(monkeypatch):
+    monkeypatch.setattr(ns, "managed_nous_tools_enabled", lambda **kw: True)
+    monkeypatch.setattr(
+        ns,
+        "get_nous_portal_account_info",
+        lambda **kw: _account(logged_in=True, paid=True),
+    )
+    monkeypatch.setattr(ns, "get_env_value", lambda name: "")
+    monkeypatch.setattr(ns, "_toolset_enabled", lambda config, key: key == "browser")
+    monkeypatch.setattr(ns, "_has_agent_browser", lambda: True)
+    monkeypatch.setattr(ns, "_local_browser_runnable", lambda: True)
+    monkeypatch.setattr(ns, "resolve_openai_audio_api_key", lambda: "")
+    monkeypatch.setattr(ns, "has_direct_modal_credentials", lambda: False)
+    monkeypatch.setattr(ns, "is_managed_tool_gateway_ready", lambda vendor: vendor == "browser-use")
+
+    config = {
+        "model": {"provider": "nous"},
+        "browser": {"cloakbrowser": {"enabled": True}},
+    }
+
+    changed = ns.apply_nous_managed_defaults(config, enabled_toolsets=["browser"])
+
+    assert "browser" in changed
+    assert config["browser"]["cloud_provider"] == "browser-use"
+    assert config["browser"]["cloakbrowser"]["enabled"] is False
+
+
 def test_apply_nous_managed_defaults_skips_fal_tools_when_key_present(monkeypatch):
     """When FAL_KEY is set, apply_nous_managed_defaults should not touch
     image_gen or video_gen config — the user's direct key takes precedence."""
@@ -854,3 +1026,20 @@ def test_apply_gateway_defaults_sets_stt_use_gateway(monkeypatch):
     assert "stt" in changed
     assert config["stt"]["provider"] == "openai"
     assert config["stt"]["use_gateway"] is True
+
+
+def test_apply_gateway_defaults_clears_stale_cloakbrowser_enabled():
+    config = {
+        "browser": {
+            "cloud_provider": "cloakbrowser",
+            "use_gateway": False,
+            "cloakbrowser": {"enabled": True},
+        }
+    }
+
+    changed = ns.apply_gateway_defaults(cast(dict[str, object], config), ["browser"])
+
+    assert "browser" in changed
+    assert config["browser"]["cloud_provider"] == "browser-use"
+    assert config["browser"]["use_gateway"] is True
+    assert config["browser"]["cloakbrowser"]["enabled"] is False

--- a/tests/hermes_cli/test_setup_model_provider.py
+++ b/tests/hermes_cli/test_setup_model_provider.py
@@ -341,8 +341,7 @@ def test_setup_summary_does_not_mark_incomplete_browserbase_as_available(tmp_pat
     _print_setup_summary(load_config(), tmp_path)
     output = capsys.readouterr().out
 
-    assert "Browser Automation (Browserbase)" not in output
-    assert "Browser Automation" in output
+    assert "Browser Automation (Browserbase)" in output
     assert "BROWSERBASE_API_KEY/BROWSERBASE_PROJECT_ID" in output
 
 
@@ -382,5 +381,124 @@ def test_setup_summary_local_browser_unavailable_without_chromium(
     _print_setup_summary(load_config(), tmp_path)
     output = capsys.readouterr().out
 
-    assert "Browser Automation (Local browser)" not in output
+    assert "Browser Automation (Local browser)" in output
     assert "agent-browser install --with-deps" in output
+
+
+def test_setup_summary_selected_cloakbrowser_without_package_shows_install_hint(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setattr(
+        "hermes_cli.setup.get_nous_subscription_features",
+        lambda config: NousSubscriptionFeatures(
+            subscribed=False,
+            nous_auth_present=False,
+            provider_is_nous=False,
+            features={
+                "web": NousFeatureState("web", "Web tools", True, False, False, False, False, True, ""),
+                "image_gen": NousFeatureState("image_gen", "Image generation", True, False, False, False, False, True, ""),
+                "video_gen": NousFeatureState("video_gen", "Video generation", False, False, False, False, False, False, ""),
+                "tts": NousFeatureState("tts", "OpenAI TTS", True, False, False, False, False, True, ""),
+                "browser": NousFeatureState("browser", "Browser automation", True, False, False, False, False, True, "CloakBrowser"),
+                "modal": NousFeatureState("modal", "Modal execution", False, False, False, False, False, True, "local"),
+            },
+        ),
+    )
+    monkeypatch.setattr("agent.auxiliary_client.get_available_vision_backends", lambda: [])
+
+    _print_setup_summary(load_config(), tmp_path)
+    output = capsys.readouterr().out
+
+    assert "Browser Automation (CloakBrowser)" in output
+    assert "pip install cloakbrowser" in output
+
+
+
+def test_setup_summary_cloakbrowser_cdp_conflict_shows_selected_provider_and_conflict_hint(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setattr(
+        "hermes_cli.setup.get_nous_subscription_features",
+        lambda config: NousSubscriptionFeatures(
+            subscribed=False,
+            nous_auth_present=False,
+            provider_is_nous=False,
+            features={
+                "web": NousFeatureState("web", "Web tools", True, False, False, False, False, True, ""),
+                "image_gen": NousFeatureState("image_gen", "Image generation", True, False, False, False, False, True, ""),
+                "video_gen": NousFeatureState("video_gen", "Video generation", False, False, False, False, False, False, ""),
+                "tts": NousFeatureState("tts", "OpenAI TTS", True, False, False, False, False, True, ""),
+                "browser": NousFeatureState(
+                    "browser",
+                    "Browser automation",
+                    True,
+                    False,
+                    False,
+                    False,
+                    False,
+                    True,
+                    "CloakBrowser",
+                    False,
+                    blocked_reason="browser.cdp_url overrides native CloakBrowser launch",
+                ),
+                "modal": NousFeatureState("modal", "Modal execution", False, False, False, False, False, True, "local"),
+            },
+        ),
+    )
+    monkeypatch.setattr("agent.auxiliary_client.get_available_vision_backends", lambda: [])
+
+    _print_setup_summary(load_config(), tmp_path)
+    output = capsys.readouterr().out
+
+    assert "Browser Automation (CloakBrowser)" in output
+    assert "browser.cdp_url overrides native CloakBrowser launch" in output
+    assert "clear browser.cdp_url" in output
+
+
+
+def test_setup_summary_cloakbrowser_env_cdp_conflict_mentions_env_override(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setattr(
+        "hermes_cli.setup.get_nous_subscription_features",
+        lambda config: NousSubscriptionFeatures(
+            subscribed=False,
+            nous_auth_present=False,
+            provider_is_nous=False,
+            features={
+                "web": NousFeatureState("web", "Web tools", True, False, False, False, False, True, ""),
+                "image_gen": NousFeatureState("image_gen", "Image generation", True, False, False, False, False, True, ""),
+                "video_gen": NousFeatureState("video_gen", "Video generation", False, False, False, False, False, False, ""),
+                "tts": NousFeatureState("tts", "OpenAI TTS", True, False, False, False, False, True, ""),
+                "browser": NousFeatureState(
+                    "browser",
+                    "Browser automation",
+                    True,
+                    False,
+                    False,
+                    False,
+                    False,
+                    True,
+                    "CloakBrowser",
+                    False,
+                    blocked_reason="BROWSER_CDP_URL overrides native CloakBrowser launch",
+                ),
+                "modal": NousFeatureState("modal", "Modal execution", False, False, False, False, False, True, "local"),
+            },
+        ),
+    )
+    monkeypatch.setattr("agent.auxiliary_client.get_available_vision_backends", lambda: [])
+
+    _print_setup_summary(load_config(), tmp_path)
+    output = capsys.readouterr().out
+
+    assert "Browser Automation (CloakBrowser)" in output
+    assert "BROWSER_CDP_URL overrides native CloakBrowser launch" in output
+    assert "unset BROWSER_CDP_URL" in output
+    assert "clear browser.cdp_url" in output

--- a/tests/hermes_cli/test_status_model_provider.py
+++ b/tests/hermes_cli/test_status_model_provider.py
@@ -106,6 +106,116 @@ def test_show_status_reports_managed_nous_features(monkeypatch, capsys, tmp_path
     assert "active via Nous subscription" in out
 
 
+def test_show_status_surfaces_explicit_cloakbrowser_cdp_block_reason(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr("hermes_cli.status.managed_nous_tools_enabled", lambda: True)
+    from hermes_cli import status as status_mod
+
+    _patch_common_status_deps(monkeypatch, status_mod, tmp_path)
+    monkeypatch.setattr(
+        status_mod,
+        "load_config",
+        lambda: {"model": {"default": "claude-opus-4-6", "provider": "nous"}},
+        raising=False,
+    )
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "nous", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "nous", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "Nous Portal", raising=False)
+    monkeypatch.setattr(
+        status_mod,
+        "get_nous_subscription_features",
+        lambda config: NousSubscriptionFeatures(
+            subscribed=True,
+            nous_auth_present=True,
+            provider_is_nous=True,
+            features={
+                "web": NousFeatureState("web", "Web tools", True, True, True, True, False, True, "firecrawl"),
+                "image_gen": NousFeatureState("image_gen", "Image generation", True, True, True, True, False, True, "Nous Subscription"),
+                "video_gen": NousFeatureState("video_gen", "Video generation", False, False, False, False, False, False, ""),
+                "tts": NousFeatureState("tts", "OpenAI TTS", True, True, True, True, False, True, "OpenAI TTS"),
+                "stt": NousFeatureState("stt", "Speech-to-text", True, True, True, True, False, True, "OpenAI Whisper"),
+                "browser": NousFeatureState(
+                    "browser",
+                    "Browser automation",
+                    True,
+                    False,
+                    False,
+                    False,
+                    False,
+                    True,
+                    "CloakBrowser",
+                    True,
+                    "browser.cdp_url overrides native CloakBrowser launch",
+                ),
+                "modal": NousFeatureState("modal", "Modal execution", False, True, False, False, False, True, "local"),
+            },
+        ),
+        raising=False,
+    )
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+
+    out = capsys.readouterr().out
+    assert "Browser automation" in out
+    assert "CloakBrowser" in out
+    assert "browser.cdp_url overrides native CloakBrowser launch" in out
+    assert "included by subscription, not currently selected" not in out
+
+
+def test_show_status_surfaces_env_specific_cloakbrowser_cdp_block_reason(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr("hermes_cli.status.managed_nous_tools_enabled", lambda: True)
+    from hermes_cli import status as status_mod
+
+    _patch_common_status_deps(monkeypatch, status_mod, tmp_path)
+    monkeypatch.setattr(
+        status_mod,
+        "load_config",
+        lambda: {"model": {"default": "claude-opus-4-6", "provider": "nous"}},
+        raising=False,
+    )
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "nous", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "nous", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "Nous Portal", raising=False)
+    monkeypatch.setattr(
+        status_mod,
+        "get_nous_subscription_features",
+        lambda config: NousSubscriptionFeatures(
+            subscribed=True,
+            nous_auth_present=True,
+            provider_is_nous=True,
+            features={
+                "web": NousFeatureState("web", "Web tools", True, True, True, True, False, True, "firecrawl"),
+                "image_gen": NousFeatureState("image_gen", "Image generation", True, True, True, True, False, True, "Nous Subscription"),
+                "video_gen": NousFeatureState("video_gen", "Video generation", False, False, False, False, False, False, ""),
+                "tts": NousFeatureState("tts", "OpenAI TTS", True, True, True, True, False, True, "OpenAI TTS"),
+                "stt": NousFeatureState("stt", "Speech-to-text", True, True, True, True, False, True, "OpenAI Whisper"),
+                "browser": NousFeatureState(
+                    "browser",
+                    "Browser automation",
+                    True,
+                    False,
+                    False,
+                    False,
+                    False,
+                    True,
+                    "CloakBrowser",
+                    True,
+                    "BROWSER_CDP_URL overrides native CloakBrowser launch",
+                ),
+                "modal": NousFeatureState("modal", "Modal execution", False, True, False, False, False, True, "local"),
+            },
+        ),
+        raising=False,
+    )
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+
+    out = capsys.readouterr().out
+    assert "Browser automation" in out
+    assert "CloakBrowser" in out
+    assert "BROWSER_CDP_URL overrides native CloakBrowser launch" in out
+    assert "included by subscription, not currently selected" not in out
+
+
 def test_show_status_hides_nous_subscription_section_when_feature_flag_is_off(monkeypatch, capsys, tmp_path):
     monkeypatch.setattr("hermes_cli.status.managed_nous_tools_enabled", lambda: False)
     from hermes_cli import status as status_mod

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -1,11 +1,13 @@
 """Tests for hermes_cli.tools_config platform tool persistence."""
 
 import logging
+import os
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
+from hermes_cli.config import load_config, read_raw_config
 from hermes_cli.nous_account import NousPortalAccountInfo
 from hermes_cli.tools_config import (
     _DEFAULT_OFF_TOOLSETS,
@@ -18,6 +20,7 @@ from hermes_cli.tools_config import (
     _reconfigure_tool,
     _run_post_setup,
     _save_platform_tools,
+    _save_tools_config,
     _toolset_has_keys,
     _toolset_needs_configuration_prompt,
     CONFIGURABLE_TOOLSETS,
@@ -764,6 +767,439 @@ def test_local_browser_provider_is_saved_explicitly(monkeypatch):
     assert config["browser"]["cloud_provider"] == "local"
 
 
+
+def test_browser_picker_includes_cloakbrowser_row():
+    cloak_provider = next(
+        provider
+        for provider in TOOL_CATEGORIES["browser"]["providers"]
+        if provider.get("browser_provider") == "cloakbrowser"
+    )
+
+    assert cloak_provider["name"] == "CloakBrowser"
+    assert cloak_provider["badge"] == "free · local"
+    assert "Anti-detection" in cloak_provider["tag"]
+    assert cloak_provider["env_vars"] == []
+    assert cloak_provider["post_setup"] == "cloakbrowser"
+
+
+
+def test_cloakbrowser_provider_writes_browser_config(monkeypatch):
+    config = {
+        "browser": {
+            "cloakbrowser": {
+                "proxy": "http://proxy.example:8080",
+                "user_data_dir": "/tmp/cloak-profile",
+            }
+        }
+    }
+    cloak_provider = next(
+        provider
+        for provider in TOOL_CATEGORIES["browser"]["providers"]
+        if provider.get("browser_provider") == "cloakbrowser"
+    )
+
+    prompt_choices = iter([1, 1, 1])
+
+    monkeypatch.setattr("hermes_cli.tools_config._run_post_setup", lambda key: None)
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._prompt_choice",
+        lambda question, choices, default=0: next(prompt_choices),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._prompt",
+        lambda *args, **kwargs: pytest.fail("removed CloakBrowser prompts should not run"),
+    )
+    _configure_provider(cloak_provider, config)
+
+    assert config["browser"]["cloud_provider"] == "cloakbrowser"
+    assert config["browser"]["use_gateway"] is False
+    assert config["browser"]["cloakbrowser"] == {
+        "enabled": True,
+        "headless": True,
+        "humanize": False,
+        "proxy": "http://proxy.example:8080",
+        "stealth_args": False,
+        "user_data_dir": "/tmp/cloak-profile",
+    }
+
+
+
+def test_cloakbrowser_provider_default_prompts_write_defaults(monkeypatch):
+    config = {}
+    cloak_provider = next(
+        provider
+        for provider in TOOL_CATEGORIES["browser"]["providers"]
+        if provider.get("browser_provider") == "cloakbrowser"
+    )
+
+    prompt_choices = iter([0, 0, 0])
+
+    monkeypatch.setattr("hermes_cli.tools_config._run_post_setup", lambda key: None)
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._prompt_choice",
+        lambda question, choices, default=0: next(prompt_choices),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._prompt",
+        lambda *args, **kwargs: pytest.fail("removed CloakBrowser prompts should not run"),
+    )
+    _configure_provider(cloak_provider, config)
+
+    assert config["browser"]["cloakbrowser"] == {
+        "enabled": True,
+        "inactivity_timeout": 3600,
+        "headless": False,
+        "humanize": True,
+        "proxy": "",
+        "stealth_args": True,
+        "user_data_dir": "${HERMES_HOME}/cloakbrowser_profile",
+    }
+
+
+
+def test_cloakbrowser_default_keys_persist_on_save(tmp_path):
+    cloakbrowser_defaults = {
+        "enabled": True,
+        "inactivity_timeout": 3600,
+        "headless": False,
+        "humanize": True,
+        "proxy": "",
+        "geoip": False,
+        "stealth_args": True,
+        "locale": "",
+        "timezone": "",
+        "color_scheme": "",
+        "user_agent": "",
+        "extra_args": [],
+        "user_data_dir": "${HERMES_HOME}/cloakbrowser_profile",
+    }
+    config = {
+        "browser": {
+            "cloud_provider": "cloakbrowser",
+            "cloakbrowser": dict(cloakbrowser_defaults),
+        }
+    }
+
+    with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+        _save_tools_config(config)
+        raw = read_raw_config()
+
+    assert raw["browser"]["cloud_provider"] == "cloakbrowser"
+    assert raw["browser"]["cloakbrowser"] == cloakbrowser_defaults
+
+
+def test_cloakbrowser_default_keys_survive_provider_switch_and_later_save(tmp_path):
+    cloakbrowser_defaults = {
+        "enabled": True,
+        "inactivity_timeout": 3600,
+        "headless": False,
+        "humanize": True,
+        "proxy": "",
+        "geoip": False,
+        "stealth_args": True,
+        "locale": "",
+        "timezone": "",
+        "color_scheme": "",
+        "user_agent": "",
+        "extra_args": [],
+        "user_data_dir": "${HERMES_HOME}/cloakbrowser_profile",
+    }
+    config = {
+        "browser": {
+            "cloud_provider": "cloakbrowser",
+            "cloakbrowser": dict(cloakbrowser_defaults),
+        }
+    }
+
+    with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+        _save_tools_config(config)
+        config["browser"]["cloud_provider"] = "browserbase"
+        _save_tools_config(config)
+        raw = read_raw_config()
+
+    assert raw["browser"]["cloud_provider"] == "browserbase"
+    assert raw["browser"]["cloakbrowser"] == cloakbrowser_defaults
+
+
+def test_cloakbrowser_default_user_data_dir_expands_from_hermes_home(tmp_path):
+    with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+        loaded = load_config()
+
+    assert loaded["browser"]["cloakbrowser"]["user_data_dir"] == str(
+        tmp_path / "cloakbrowser_profile"
+    )
+
+
+
+def test_cloakbrowser_provider_conflict_clear_cdp_url(monkeypatch):
+    config = {"browser": {"cdp_url": "http://localhost:9222"}}
+    cloak_provider = next(
+        provider
+        for provider in TOOL_CATEGORIES["browser"]["providers"]
+        if provider.get("browser_provider") == "cloakbrowser"
+    )
+
+    prompt_choices = iter([0, 1, 0, 1, 0])
+    prompt_values = iter(["", "", "", ""])
+
+    monkeypatch.setattr("hermes_cli.tools_config._run_post_setup", lambda key: None)
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._prompt_choice",
+        lambda question, choices, default=0: next(prompt_choices),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._prompt",
+        lambda question, **kwargs: next(prompt_values),
+    )
+
+    _configure_provider(cloak_provider, config)
+
+    assert config["browser"]["cloud_provider"] == "cloakbrowser"
+    assert config["browser"]["cdp_url"] == ""
+    assert config["browser"]["cloakbrowser"]["headless"] is True
+
+
+
+def test_cloakbrowser_provider_conflict_keep_cdp_url(monkeypatch):
+    config = {"browser": {"cdp_url": "http://localhost:9222"}}
+    cloak_provider = next(
+        provider
+        for provider in TOOL_CATEGORIES["browser"]["providers"]
+        if provider.get("browser_provider") == "cloakbrowser"
+    )
+
+    called = []
+    monkeypatch.setattr("hermes_cli.tools_config._run_post_setup", lambda key: called.append(key))
+
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._prompt_choice",
+        lambda question, choices, default=0: 1 if "Resolve the browser.cdp_url conflict" in question else pytest.fail("settings prompts should not run after keeping browser.cdp_url"),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._prompt",
+        lambda question, **kwargs: pytest.fail("settings prompts should not run after keeping browser.cdp_url"),
+    )
+
+    _configure_provider(cloak_provider, config)
+
+    assert config["browser"]["cloud_provider"] == "cloakbrowser"
+    assert config["browser"]["cdp_url"] == "http://localhost:9222"
+    assert config["browser"]["cloakbrowser"] == {"enabled": True}
+    assert called == ["cloakbrowser"]
+
+
+
+def test_reconfigure_cloakbrowser_conflict_keep_cdp_url_skips_native_setup(monkeypatch):
+    config = {
+        "browser": {
+            "cloud_provider": "local",
+            "use_gateway": False,
+            "cdp_url": "http://localhost:9222",
+        }
+    }
+    cloak_provider = next(
+        provider
+        for provider in TOOL_CATEGORIES["browser"]["providers"]
+        if provider.get("browser_provider") == "cloakbrowser"
+    )
+
+    called = []
+    monkeypatch.setattr("hermes_cli.tools_config._run_post_setup", lambda key: called.append(key))
+
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._prompt_choice",
+        lambda question, choices, default=0: 1 if "Resolve the browser.cdp_url conflict" in question else pytest.fail("settings prompts should not run after keeping browser.cdp_url"),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._prompt",
+        lambda question, **kwargs: pytest.fail("settings prompts should not run after keeping browser.cdp_url"),
+    )
+
+    _reconfigure_provider(cloak_provider, config)
+
+    assert config["browser"]["cloud_provider"] == "cloakbrowser"
+    assert config["browser"]["cdp_url"] == "http://localhost:9222"
+    assert config["browser"]["cloakbrowser"] == {"enabled": True}
+    assert called == ["cloakbrowser"]
+
+
+
+
+
+
+def test_cloakbrowser_provider_conflict_keep_browser_cdp_url_env(monkeypatch):
+    config = {"browser": {"cdp_url": "http://localhost:9222"}}
+    cloak_provider = next(
+        provider
+        for provider in TOOL_CATEGORIES["browser"]["providers"]
+        if provider.get("browser_provider") == "cloakbrowser"
+    )
+    called = []
+    prompts = []
+
+    def fake_prompt_choice(question, choices, default=0):
+        prompts.append((question, choices, default))
+        if "Resolve the BROWSER_CDP_URL conflict" in question:
+            return 0
+        pytest.fail("settings prompts should not run after keeping BROWSER_CDP_URL")
+
+    monkeypatch.setenv("BROWSER_CDP_URL", "http://localhost:9333")
+    monkeypatch.setattr("hermes_cli.tools_config._run_post_setup", lambda key: called.append(key))
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._prompt_choice",
+        fake_prompt_choice,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._prompt",
+        lambda question, **kwargs: pytest.fail("settings prompts should not run after keeping BROWSER_CDP_URL"),
+    )
+
+    _configure_provider(cloak_provider, config)
+
+    assert config["browser"]["cloud_provider"] == "cloakbrowser"
+    assert config["browser"]["cdp_url"] == "http://localhost:9222"
+    assert config["browser"]["cloakbrowser"] == {"enabled": True}
+    assert called == ["cloakbrowser"]
+    question, choices, default = prompts[0]
+    assert "Resolve the BROWSER_CDP_URL conflict" in question
+    assert choices == [
+        "Keep BROWSER_CDP_URL and keep using direct CDP attach",
+        "Cancel and go back",
+    ]
+    assert default == 0
+
+
+def test_reconfigure_cloakbrowser_conflict_cancel_keeps_existing_config(monkeypatch):
+    config = {
+        "browser": {
+            "cloud_provider": "cloakbrowser",
+            "use_gateway": False,
+            "cdp_url": "http://localhost:9222",
+            "cloakbrowser": {
+                "enabled": True,
+                "headless": True,
+                "humanize": False,
+                "proxy": "http://proxy.example:8080",
+                "geoip": True,
+                "locale": "en-US",
+                "timezone": "America/New_York",
+                "stealth_args": False,
+                "user_data_dir": "/tmp/cloak-profile",
+            },
+        }
+    }
+    original = {
+        "browser": {
+            "cloud_provider": config["browser"]["cloud_provider"],
+            "use_gateway": config["browser"]["use_gateway"],
+            "cdp_url": config["browser"]["cdp_url"],
+            "cloakbrowser": dict(config["browser"]["cloakbrowser"]),
+        }
+    }
+    cloak_provider = next(
+        provider
+        for provider in TOOL_CATEGORIES["browser"]["providers"]
+        if provider.get("browser_provider") == "cloakbrowser"
+    )
+
+    monkeypatch.setattr("hermes_cli.tools_config._run_post_setup", lambda key: pytest.fail("post-setup should not run on cancel"))
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._prompt_choice",
+        lambda question, choices, default=0: 2,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._prompt",
+        lambda question, **kwargs: pytest.fail("settings prompts should not run on cancel"),
+    )
+
+    _reconfigure_provider(cloak_provider, config)
+
+    assert config == original
+
+
+
+def test_reconfigure_cloakbrowser_uses_existing_values_as_prompt_defaults(monkeypatch):
+    config = {
+        "browser": {
+            "cloud_provider": "cloakbrowser",
+            "use_gateway": False,
+            "cloakbrowser": {
+                "enabled": True,
+                "headless": True,
+                "humanize": False,
+                "proxy": "http://proxy.example:8080",
+                "geoip": True,
+                "locale": "en-US",
+                "timezone": "America/New_York",
+                "stealth_args": False,
+                "user_data_dir": "/tmp/cloak-profile",
+            },
+        }
+    }
+    cloak_provider = next(
+        provider
+        for provider in TOOL_CATEGORIES["browser"]["providers"]
+        if provider.get("browser_provider") == "cloakbrowser"
+    )
+
+    seen_defaults = []
+    seen_prompts = []
+    seen_prompt_defaults = {}
+
+    monkeypatch.setattr("hermes_cli.tools_config._run_post_setup", lambda key: None)
+
+    def fake_prompt_choice(question, choices, default=0):
+        seen_defaults.append(default)
+        return default
+
+    def fake_prompt(question, **kwargs):
+        seen_prompts.append(question)
+        seen_prompt_defaults[question] = kwargs.get("default")
+        return kwargs.get("default", "")
+
+    monkeypatch.setattr("hermes_cli.tools_config._prompt_choice", fake_prompt_choice)
+    monkeypatch.setattr("hermes_cli.tools_config._prompt", fake_prompt)
+    _reconfigure_provider(cloak_provider, config)
+
+    assert seen_defaults == [1, 1, 1]
+    assert seen_prompt_defaults == {}
+    assert seen_prompts == []
+    assert config["browser"]["cloakbrowser"] == {
+        "enabled": True,
+        "headless": True,
+        "humanize": False,
+        "proxy": "http://proxy.example:8080",
+        "geoip": True,
+        "locale": "en-US",
+        "timezone": "America/New_York",
+        "stealth_args": False,
+        "user_data_dir": "/tmp/cloak-profile",
+    }
+
+
+
+def test_switching_away_from_cloakbrowser_disables_cloakbrowser_flag(monkeypatch):
+    config = {
+        "browser": {
+            "cloud_provider": "cloakbrowser",
+            "use_gateway": False,
+            "cloakbrowser": {"enabled": True},
+        }
+    }
+    local_provider = next(
+        provider
+        for provider in TOOL_CATEGORIES["browser"]["providers"]
+        if provider.get("browser_provider") == "local"
+    )
+
+    monkeypatch.setattr("hermes_cli.tools_config._run_post_setup", lambda key: None)
+    _configure_provider(local_provider, config)
+
+    assert config["browser"]["cloud_provider"] == "local"
+    assert config["browser"]["use_gateway"] is False
+    assert config["browser"]["cloakbrowser"]["enabled"] is False
+
+
 def test_fresh_install_browser_default_is_free_local_not_paid_nous():
     """On a fresh install the browser picker must default to the free local
     backend, never the paid Nous Subscription gateway.
@@ -810,7 +1246,7 @@ def test_reconfigure_lists_enabled_web_without_existing_provider_config(monkeypa
         "hermes_cli.tools_config._configure_tool_category_for_reconfig",
         lambda ts_key, cat, config, **kwargs: configured.append(ts_key),
     )
-    monkeypatch.setattr("hermes_cli.tools_config.save_config", lambda config: None)
+    monkeypatch.setattr("hermes_cli.tools_config.save_config", lambda config, **kwargs: None)
 
     _reconfigure_tool(config)
 
@@ -843,7 +1279,7 @@ def test_first_install_nous_auto_configures_managed_defaults(monkeypatch):
         "hermes_cli.tools_config._prompt_toolset_checklist",
         lambda *args, **kwargs: {"web", "image_gen", "tts", "browser"},
     )
-    monkeypatch.setattr("hermes_cli.tools_config.save_config", lambda config: None)
+    monkeypatch.setattr("hermes_cli.tools_config.save_config", lambda config, **kwargs: None)
     # Prevent leaked platform tokens (e.g. DISCORD_BOT_TOKEN from gateway.run
     # import) from adding extra platforms. The loop in tools_command runs
     # apply_nous_managed_defaults per platform; a second iteration sees values
@@ -907,7 +1343,7 @@ def test_first_install_nous_auto_configures_video_gen(monkeypatch):
         "hermes_cli.tools_config._prompt_toolset_checklist",
         lambda *args, **kwargs: {"video_gen"},
     )
-    monkeypatch.setattr("hermes_cli.tools_config.save_config", lambda config: None)
+    monkeypatch.setattr("hermes_cli.tools_config.save_config", lambda config, **kwargs: None)
     monkeypatch.setattr(
         "hermes_cli.tools_config._get_enabled_platforms",
         lambda: ["cli"],
@@ -1098,6 +1534,197 @@ def test_computer_use_post_setup_missing_override_does_not_accept_default_binary
     run.assert_not_called()
     assert "custom-cua" in seen
     assert "curl" in seen
+
+
+class TestCloakBrowserSetupGate:
+    """_toolset_needs_configuration_prompt must gate on cloakbrowser install state.
+
+    A returning user whose config selects CloakBrowser but whose Python
+    environment lacks the ``cloakbrowser`` package should be re-prompted so the
+    post-setup install hook can run.  Existing non-CloakBrowser providers should
+    not be affected.
+    """
+
+    def test_cloakbrowser_not_installed_forces_prompt(self):
+        """When cloakbrowser is not importable and no cloud_provider exists → prompt."""
+        with patch("hermes_cli.tools_config.importlib.util.find_spec", return_value=None):
+            assert _toolset_needs_configuration_prompt("browser", {}) is True
+
+    def test_cloakbrowser_installed_with_cloud_provider_skips_prompt(self):
+        """Installed package + existing cloud_provider → no prompt needed."""
+        config = {"browser": {"cloud_provider": "cloakbrowser"}}
+        with patch("hermes_cli.tools_config.importlib.util.find_spec") as find_spec:
+            find_spec.return_value = object()  # importlib found it
+            assert _toolset_needs_configuration_prompt("browser", config) is False
+
+    def test_cloakbrowser_not_installed_with_cloud_provider_forces_prompt(self):
+        """cloud_provider is set but package is missing → re-prompt so post_setup runs."""
+        config = {"browser": {"cloud_provider": "cloakbrowser"}}
+        with patch("hermes_cli.tools_config.importlib.util.find_spec", return_value=None):
+            assert _toolset_needs_configuration_prompt("browser", config) is True
+
+    def test_non_cloakbrowser_provider_does_not_trigger_on_missing_cloakbrowser(self):
+        """User with a non-CloakBrowser provider should not be forced back into
+        the browser setup picker just because the CloakBrowser package is absent."""
+        config = {"browser": {"cloud_provider": "local"}}
+        with patch("hermes_cli.tools_config.importlib.util.find_spec", return_value=None):
+            assert _toolset_needs_configuration_prompt("browser", config) is False
+
+    def test_cloakbrowser_missing_package_inline_check(self):
+        """Direct inline check: find_spec(None) forces re-prompt when CloakBrowser active."""
+        from hermes_cli.tools_config import importlib as tc_importlib
+        with patch.object(tc_importlib.util, "find_spec", return_value=None):
+            config = {"browser": {"cloud_provider": "cloakbrowser"}}
+            assert _toolset_needs_configuration_prompt("browser", config) is True
+
+    def test_cloakbrowser_present_package_inline_check(self):
+        """Direct inline check: find_spec(spec) skips prompt when CloakBrowser active."""
+        from hermes_cli.tools_config import importlib as tc_importlib
+        with patch.object(tc_importlib.util, "find_spec", return_value=object()):
+            config = {"browser": {"cloud_provider": "cloakbrowser"}}
+            assert _toolset_needs_configuration_prompt("browser", config) is False
+
+    def test_cloakbrowser_provider_normalized_before_install_gate(self):
+        """Legacy mixed-case provider strings should still trigger the CloakBrowser gate."""
+        config = {"browser": {"cloud_provider": " CloakBrowser "}}
+        with patch("hermes_cli.tools_config.importlib.util.find_spec", return_value=None):
+            assert _toolset_needs_configuration_prompt("browser", config) is True
+
+
+def test_returning_user_tools_command_reconfigures_browser_post_setup(monkeypatch):
+    """Returning-user flow re-enters the browser provider/post_setup path
+    when browser is already enabled with CloakBrowser but the package is
+    not installed (e.g., a first-time install that failed).
+
+    The fix adds a post_setup check for already-enabled category toolsets
+    after the usual ``added``-toolset config loop, so toggling a *different*
+    toolset still triggers the CloakBrowser re-install prompt.
+    """
+    config = {
+        "browser": {"cloud_provider": "cloakbrowser"},
+        "platform_toolsets": {"cli": ["browser"]},
+    }
+
+    # Clear env vars that would add extra platforms.
+    for env_var in (
+        "DISCORD_BOT_TOKEN",
+        "TELEGRAM_BOT_TOKEN",
+        "SLACK_BOT_TOKEN",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_enabled_platforms",
+        lambda: ["cli"],
+    )
+    monkeypatch.setattr("hermes_cli.tools_config.save_config", lambda config, **kwargs: None)
+
+    # Return to the platform menu, then hit "Done".
+    prompt_choice_calls = iter([0, 2])
+
+    def fake_prompt_choice(question, choices, default=0):
+        return next(prompt_choice_calls)
+
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._prompt_choice",
+        fake_prompt_choice,
+    )
+    # User toggles "web" on; browser stays enabled.
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._prompt_toolset_checklist",
+        lambda *args, **kwargs: {"browser", "web"},
+    )
+    # Simulate CloakBrowser package missing.
+    monkeypatch.setattr(
+        "hermes_cli.tools_config.importlib.util.find_spec",
+        lambda *args: None,
+    )
+    # Record which toolsets _configure_toolset is called for.
+    configured = []
+
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._configure_toolset",
+        lambda ts_key, config: configured.append(ts_key),
+    )
+    # Prevent calls to Nous subscription internals from _visible_providers.
+    monkeypatch.setattr(
+        "hermes_cli.tools_config.get_nous_subscription_features",
+        lambda *args, **kwargs: type("MockFeatures", (), {
+            "nous_auth_present": False,
+            "account_info": None,
+            "features": {},
+        })(),
+    )
+
+    tools_command(first_install=False, config=config)
+
+    assert "browser" in configured, (
+        "Expected browser to be reconfigured when CloakBrowser package is missing, "
+        f"got configured={configured}"
+    )
+
+
+def test_returning_user_tools_command_skips_browser_when_installed(monkeypatch):
+    """Returning-user flow should NOT re-enter browser setup when
+    CloakBrowser is already installed — no false-positive re-prompt.
+    """
+    config = {
+        "browser": {"cloud_provider": "cloakbrowser"},
+        "platform_toolsets": {"cli": ["browser"]},
+    }
+
+    for env_var in (
+        "DISCORD_BOT_TOKEN",
+        "TELEGRAM_BOT_TOKEN",
+        "SLACK_BOT_TOKEN",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_enabled_platforms",
+        lambda: ["cli"],
+    )
+    monkeypatch.setattr("hermes_cli.tools_config.save_config", lambda config, **kwargs: None)
+
+    prompt_choice_calls = iter([0, 2])
+
+    def fake_prompt_choice(question, choices, default=0):
+        return next(prompt_choice_calls)
+
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._prompt_choice",
+        fake_prompt_choice,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._prompt_toolset_checklist",
+        lambda *args, **kwargs: {"browser", "web"},
+    )
+    # Simulate CloakBrowser package IS installed.
+    monkeypatch.setattr(
+        "hermes_cli.tools_config.importlib.util.find_spec",
+        lambda *args: object(),
+    )
+    configured = []
+
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._configure_toolset",
+        lambda ts_key, config: configured.append(ts_key),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.tools_config.get_nous_subscription_features",
+        lambda *args, **kwargs: type("MockFeatures", (), {
+            "nous_auth_present": False,
+            "account_info": None,
+            "features": {},
+        })(),
+    )
+
+    tools_command(first_install=False, config=config)
+
+    assert "browser" not in configured, (
+        "Expected browser NOT to be reconfigured when CloakBrowser is installed, "
+        f"got configured={configured}"
+    )
 
 
 class TestImagegenBackendRegistry:
@@ -1401,6 +2028,23 @@ def test_reconfigure_browser_provider_overwrites_stale_use_gateway():
     assert config["browser"]["use_gateway"] is False
 
 
+def test_reconfigure_browser_provider_clears_stale_cloakbrowser_enabled():
+    config = {
+        "browser": {
+            "cloud_provider": "cloakbrowser",
+            "use_gateway": False,
+            "cloakbrowser": {"enabled": True},
+        }
+    }
+    provider = {"name": "Browserbase", "browser_provider": "browserbase", "env_vars": []}
+
+    _reconfigure_provider(provider, config)
+
+    assert config["browser"]["cloud_provider"] == "browserbase"
+    assert config["browser"]["use_gateway"] is False
+    assert config["browser"]["cloakbrowser"]["enabled"] is False
+
+
 @pytest.mark.parametrize("provider_name,post_setup_key", [
     ("Camofox", "camofox"),
 ])
@@ -1511,6 +2155,24 @@ def test_apply_provider_selection_tts_sets_provider():
 
     assert config["tts"]["provider"] == "edge"
     assert config["tts"]["use_gateway"] is False
+
+
+
+def test_apply_provider_selection_browser_cloakbrowser_switches_and_cleans_up():
+    from hermes_cli.tools_config import apply_provider_selection
+
+    config = {}
+    apply_provider_selection("browser", "CloakBrowser", config)
+
+    assert config["browser"]["cloud_provider"] == "cloakbrowser"
+    assert config["browser"]["use_gateway"] is False
+    assert config["browser"]["cloakbrowser"]["enabled"] is True
+
+    apply_provider_selection("browser", "Nous Subscription (Browser Use cloud)", config)
+
+    assert config["browser"]["cloud_provider"] == "browser-use"
+    assert config["browser"]["use_gateway"] is True
+    assert config["browser"]["cloakbrowser"]["enabled"] is False
 
 
 def test_apply_provider_selection_unknown_provider_raises_keyerror():

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -815,6 +815,7 @@ def test_cloakbrowser_provider_writes_browser_config(monkeypatch):
     assert config["browser"]["use_gateway"] is False
     assert config["browser"]["cloakbrowser"] == {
         "enabled": True,
+        "inactivity_timeout": 3600,
         "headless": True,
         "humanize": False,
         "proxy": "http://proxy.example:8080",
@@ -1166,6 +1167,7 @@ def test_reconfigure_cloakbrowser_uses_existing_values_as_prompt_defaults(monkey
     assert seen_prompts == []
     assert config["browser"]["cloakbrowser"] == {
         "enabled": True,
+        "inactivity_timeout": 3600,
         "headless": True,
         "humanize": False,
         "proxy": "http://proxy.example:8080",

--- a/tests/tools/test_browser_cdp_override.py
+++ b/tests/tools/test_browser_cdp_override.py
@@ -182,6 +182,20 @@ class TestGetCdpOverride:
                    return_value={"browser": {"cdp_url": HTTP_URL}}):
             assert bc.is_camofox_mode() is False
 
+        # An explicit conflicting browser.cloud_provider also suppresses camofox.
+        with patch(
+            "hermes_cli.config.read_raw_config",
+            return_value={"browser": {"cloud_provider": "cloakbrowser"}},
+        ):
+            assert bc.is_camofox_mode() is False
+
+        # Explicit camofox keeps the legacy CAMOFOX_URL path enabled.
+        with patch(
+            "hermes_cli.config.read_raw_config",
+            return_value={"browser": {"cloud_provider": "camofox"}},
+        ):
+            assert bc.is_camofox_mode() is True
+
         # The env override still suppresses camofox.
         monkeypatch.setenv("BROWSER_CDP_URL", HTTP_URL)
         with patch("hermes_cli.config.read_raw_config", return_value={}):

--- a/tests/tools/test_browser_cloakbrowser.py
+++ b/tests/tools/test_browser_cloakbrowser.py
@@ -1,0 +1,595 @@
+"""Focused tests for the minimal CloakBrowser runtime wrapper."""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+async def _async_noop(*args, **kwargs):
+    return None
+
+
+def _awaitable(value):
+    async def _inner(*args, **kwargs):
+        return value
+
+    return _inner
+
+
+class TestCloakBrowserMode:
+    def test_enabled_when_config_selects_cloakbrowser(self):
+        from tools.browser_cloakbrowser import is_cloakbrowser_mode
+
+        cfg = {
+            "browser": {
+                "cloud_provider": "cloakbrowser",
+                "use_gateway": False,
+                "cloakbrowser": {"enabled": True},
+            }
+        }
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            assert is_cloakbrowser_mode() is True
+
+    def test_enabled_when_selector_chooses_cloakbrowser_without_enabled_flag(self):
+        from tools.browser_cloakbrowser import is_cloakbrowser_mode
+
+        cfg = {"browser": {"cloud_provider": "cloakbrowser", "use_gateway": False}}
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            assert is_cloakbrowser_mode() is True
+
+    def test_enabled_when_selector_uses_legacy_mixed_case_provider(self):
+        from tools.browser_cloakbrowser import is_cloakbrowser_mode
+
+        cfg = {"browser": {"cloud_provider": " CloakBrowser ", "use_gateway": False}}
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            assert is_cloakbrowser_mode() is True
+
+    def test_disabled_for_other_provider(self):
+        from tools.browser_cloakbrowser import is_cloakbrowser_mode
+
+        cfg = {"browser": {"cloud_provider": "browserbase", "use_gateway": False}}
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            assert is_cloakbrowser_mode() is False
+
+    def test_disabled_for_other_provider_even_with_stale_enabled_flag(self):
+        from tools.browser_cloakbrowser import is_cloakbrowser_mode
+
+        cfg = {
+            "browser": {
+                "cloud_provider": "browser-use",
+                "use_gateway": True,
+                "cloakbrowser": {"enabled": True},
+            }
+        }
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            assert is_cloakbrowser_mode() is False
+
+    def test_disabled_when_gateway_mode_enabled(self):
+        from tools.browser_cloakbrowser import is_cloakbrowser_mode
+
+        cfg = {
+            "browser": {
+                "cloud_provider": "cloakbrowser",
+                "use_gateway": True,
+                "cloakbrowser": {"enabled": True},
+            }
+        }
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            assert is_cloakbrowser_mode() is False
+
+    def test_cdp_override_takes_priority(self, monkeypatch):
+        from tools.browser_cloakbrowser import is_cloakbrowser_mode
+
+        monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+        cfg = {
+            "browser": {
+                "cloud_provider": "cloakbrowser",
+                "use_gateway": False,
+                "cloakbrowser": {"enabled": True},
+            }
+        }
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            assert is_cloakbrowser_mode() is True
+
+        with patch(
+            "hermes_cli.config.read_raw_config",
+            return_value={
+                "browser": {
+                    "cloud_provider": "cloakbrowser",
+                    "use_gateway": False,
+                    "cdp_url": "http://example-host:9222",
+                    "cloakbrowser": {"enabled": True},
+                }
+            },
+        ):
+            assert is_cloakbrowser_mode() is False
+
+        monkeypatch.setenv("BROWSER_CDP_URL", "http://example-host:9223")
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            assert is_cloakbrowser_mode() is False
+
+
+class TestCloakBrowserAvailability:
+    def test_missing_package_returns_false_without_importing_browser(self):
+        from tools.browser_cloakbrowser import check_cloakbrowser_available
+
+        with patch("importlib.util.find_spec", return_value=None) as mock_find_spec:
+            assert check_cloakbrowser_available() is False
+
+        mock_find_spec.assert_called_once_with("cloakbrowser")
+
+
+class TestBuildLaunchOptions:
+    def test_missing_config_uses_defaults(self, tmp_path):
+        from tools import browser_cloakbrowser as bc
+
+        with patch.object(bc, "get_hermes_home", return_value=tmp_path), patch(
+            "tools.browser_cloakbrowser.hermes_config.load_config", return_value={}
+        ):
+            assert bc.build_cloakbrowser_launch_options() == {
+                "headless": False,
+                "humanize": True,
+                "stealth_args": True,
+                "user_data_dir": str(tmp_path / "cloakbrowser_profile"),
+            }
+
+    def test_empty_user_data_dir_resolves_to_profile_scoped_default(self, tmp_path):
+        from tools import browser_cloakbrowser as bc
+
+        cfg = {"browser": {"cloakbrowser": {"headless": True, "user_data_dir": ""}}}
+        with patch.object(bc, "get_hermes_home", return_value=tmp_path), patch(
+            "tools.browser_cloakbrowser.hermes_config.load_config", return_value=cfg
+        ):
+            options = bc.build_cloakbrowser_launch_options()
+
+        assert options["headless"] is True
+        assert options["user_data_dir"] == str(tmp_path / "cloakbrowser_profile")
+
+    def test_explicit_user_data_dir_is_respected(self, tmp_path):
+        from tools import browser_cloakbrowser as bc
+
+        explicit_dir = tmp_path / "custom-profile"
+        cfg = {
+            "browser": {
+                "cloakbrowser": {
+                    "headless": True,
+                    "user_data_dir": str(explicit_dir),
+                    "timezone": "UTC",
+                    "locale": "en-US",
+                }
+            }
+        }
+        with patch.object(bc, "get_hermes_home", return_value=tmp_path), patch(
+            "tools.browser_cloakbrowser.hermes_config.load_config", return_value=cfg
+        ):
+            options = bc.build_cloakbrowser_launch_options()
+
+        assert options["user_data_dir"] == str(explicit_dir)
+        assert options["headless"] is True
+        assert options["timezone"] == "UTC"
+        assert options["locale"] == "en-US"
+        assert Path(options["user_data_dir"]) == explicit_dir
+
+    def test_supported_schema_keys_are_forwarded_and_unsupported_keys_are_ignored(self, tmp_path):
+        from tools import browser_cloakbrowser as bc
+
+        cfg = {
+            "browser": {
+                "cloakbrowser": {
+                    "headless": True,
+                    "humanize": False,
+                    "proxy": "http://proxy.example:8080",
+                    "geoip": True,
+                    "locale": "en-US",
+                    "timezone": "America/New_York",
+                    "stealth_args": False,
+                    "user_agent": "Slice4Agent/1.0",
+                    "color_scheme": "dark",
+                    "extra_args": ["--disable-gpu"],
+                    "user_data_dir": str(tmp_path / "profile"),
+                    "fingerprint_seed": "stale-unsupported-setting",
+                }
+            }
+        }
+
+        with patch.object(bc, "get_hermes_home", return_value=tmp_path), patch(
+            "tools.browser_cloakbrowser.hermes_config.load_config", return_value=cfg
+        ):
+            options = bc.build_cloakbrowser_launch_options()
+
+        assert options == {
+            "headless": True,
+            "humanize": False,
+            "proxy": "http://proxy.example:8080",
+            "geoip": True,
+            "locale": "en-US",
+            "timezone": "America/New_York",
+            "stealth_args": False,
+            "user_agent": "Slice4Agent/1.0",
+            "color_scheme": "dark",
+            "extra_args": ["--disable-gpu"],
+            "user_data_dir": str(tmp_path / "profile"),
+        }
+
+
+class TestWrapperEntrypoints:
+    def test_launch_session_strips_duplicate_user_data_dir_for_persistent_launch(self, monkeypatch, tmp_path):
+        from tools import browser_cloakbrowser as bc
+
+        captured = {}
+        page = SimpleNamespace()
+        context = SimpleNamespace(pages=[page])
+
+        async def fake_launch_persistent_context_async(*, user_data_dir, **kwargs):
+            captured["user_data_dir"] = user_data_dir
+            captured["kwargs"] = kwargs
+            return context
+
+        monkeypatch.setattr(
+            bc,
+            "_import_cloakbrowser_api",
+            lambda: (None, fake_launch_persistent_context_async),
+        )
+        monkeypatch.setattr(
+            bc,
+            "build_cloakbrowser_launch_options",
+            lambda: {
+                "user_data_dir": str(tmp_path / "profile"),
+                "headless": True,
+                "humanize": True,
+            },
+        )
+
+        session = bc._run_async(bc._launch_session())
+
+        assert captured == {
+            "user_data_dir": str(tmp_path / "profile"),
+            "kwargs": {"headless": True, "humanize": True},
+        }
+        assert session["context"] is context
+        assert session["page"] is page
+        assert session["persistent"] is True
+
+    def test_snapshot_click_type_scroll_back_press_use_runtime_state(self, monkeypatch):
+        from tools import browser_cloakbrowser as bc
+
+        page = SimpleNamespace(
+            url="https://example.com/after",
+            title=_awaitable("Example Page"),
+            go_back=_awaitable(None),
+        )
+        page.keyboard = SimpleNamespace(press=_async_noop)
+        page.mouse = SimpleNamespace(wheel=_async_noop)
+
+        session = {
+            "page": page,
+            "refs": {
+                "e1": {"selector": "#submit"},
+                "e2": {"selector": "#name"},
+            },
+        }
+
+        clicked = []
+        filled = []
+        monkeypatch.setattr(bc, "_ensure_session", lambda task_id=None: session)
+        monkeypatch.setattr(
+            bc,
+            "_snapshot_page",
+            _awaitable({
+                "snapshot": "- button \"Submit\" [@e1]",
+                "element_count": 1,
+                "refs": {"e1": {"selector": "#submit"}, "e2": {"selector": "#name"}},
+            }),
+        )
+        monkeypatch.setattr(bc, "_click_selector", lambda page, selector: clicked.append((page, selector)) or _awaitable(None)())
+        monkeypatch.setattr(bc, "_type_into_selector", lambda page, selector, text: filled.append((page, selector, text)) or _awaitable(None)())
+
+        snap = json.loads(bc.cloakbrowser_snapshot(task_id="task-1"))
+        assert snap == {"success": True, "snapshot": "- button \"Submit\" [@e1]", "element_count": 1}
+
+        click = json.loads(bc.cloakbrowser_click("@e1", task_id="task-1"))
+        assert click == {"success": True, "clicked": "@e1", "url": "https://example.com/after"}
+        assert clicked == [(page, "#submit")]
+
+        typed = json.loads(bc.cloakbrowser_type("e2", "hello", task_id="task-1"))
+        assert typed == {"success": True, "typed": "hello", "element": "@e2"}
+        assert filled == [(page, "#name", "hello")]
+
+        scroll = json.loads(bc.cloakbrowser_scroll("down", task_id="task-1"))
+        assert scroll == {"success": True, "scrolled": "down"}
+
+        back = json.loads(bc.cloakbrowser_back(task_id="task-1"))
+        assert back == {"success": True, "url": "https://example.com/after"}
+
+        press = json.loads(bc.cloakbrowser_press("Enter", task_id="task-1"))
+        assert press == {"success": True, "pressed": "Enter"}
+
+    def test_navigate_uses_launch_session_and_auto_snapshot(self, monkeypatch):
+        from tools import browser_cloakbrowser as bc
+
+        page = SimpleNamespace(url="https://example.com/final", title=_awaitable("Example Title"))
+        session = {"page": page, "refs": {"e1": {"selector": "#link"}}}
+        navigated = []
+
+        monkeypatch.setattr(bc, "_ensure_session", lambda task_id=None: session)
+        monkeypatch.setattr(bc, "_navigate_page", lambda page, url, **kw: navigated.append((page, url)) or _awaitable(None)())
+        monkeypatch.setattr(bc, "_snapshot_page", _awaitable({"snapshot": "- link \"Docs\" [@e1]", "element_count": 1}))
+
+        result = json.loads(bc.cloakbrowser_navigate("https://example.com/start", task_id="task-nav"))
+
+        assert result == {
+            "success": True,
+            "url": "https://example.com/final",
+            "title": "Example Title",
+            "snapshot": "- link \"Docs\" [@e1]",
+            "element_count": 1,
+        }
+        assert navigated == [(page, "https://example.com/start")]
+
+    def test_navigate_returns_clear_error_when_snapshot_fails_after_successful_nav(self, monkeypatch):
+        from tools import browser_cloakbrowser as bc
+
+        page = SimpleNamespace(url="https://example.com/final", title=_awaitable("Example Title"))
+        monkeypatch.setattr(bc, "_ensure_session", lambda task_id=None: {"page": page, "refs": {}})
+        monkeypatch.setattr(bc, "_navigate_page", _awaitable(None))
+        monkeypatch.setattr(bc, "_snapshot_page", lambda page, full=False, user_task=None: (_ for _ in ()).throw(RuntimeError("snap broke")))
+
+        result = json.loads(bc.cloakbrowser_navigate("https://example.com/start", task_id="task-nav"))
+
+        assert result["success"] is True
+        assert result["snapshot_warning"] == "snap broke"
+
+    def test_get_images_uses_runtime_page_and_matches_browser_tool_shape(self, monkeypatch):
+        from tools import browser_cloakbrowser as bc
+
+        page = SimpleNamespace()
+        session = {"page": page, "refs": {}}
+        captured = {}
+        images = [
+            {"src": "https://example.com/logo.png", "alt": "Logo", "width": 640, "height": 480},
+            {"src": "https://example.com/banner.jpg", "alt": "", "width": 1200, "height": 300},
+        ]
+
+        async def fake_evaluate(script):
+            captured["script"] = script
+            return images
+
+        page.evaluate = fake_evaluate
+        monkeypatch.setattr(bc, "_ensure_session", lambda task_id=None: session)
+
+        result = json.loads(bc.cloakbrowser_get_images(task_id="task-images"))
+
+        assert result == {"success": True, "images": images, "count": 2}
+        assert "document.images" in captured["script"]
+        assert "startsWith('data:')" in captured["script"]
+
+    def test_get_images_falls_back_to_empty_list_when_page_returns_non_list(self, monkeypatch):
+        from tools import browser_cloakbrowser as bc
+
+        page = SimpleNamespace(evaluate=_awaitable({"unexpected": True}))
+        monkeypatch.setattr(bc, "_ensure_session", lambda task_id=None: {"page": page, "refs": {}})
+
+        result = json.loads(bc.cloakbrowser_get_images(task_id="task-images"))
+
+        assert result == {"success": True, "images": [], "count": 0}
+
+
+class TestBrowserToolRouting:
+    def test_check_requirements_requires_cloakbrowser_package(self, monkeypatch):
+        from tools.browser_tool import check_browser_requirements
+
+        monkeypatch.setattr("tools.browser_tool._is_cloakbrowser_mode", lambda: True)
+        monkeypatch.setattr("tools.browser_tool.check_cloakbrowser_available", lambda: False)
+        assert check_browser_requirements() is False
+
+        monkeypatch.setattr("tools.browser_tool.check_cloakbrowser_available", lambda: True)
+        assert check_browser_requirements() is True
+
+    def test_is_local_backend_treats_cloakbrowser_as_local(self, monkeypatch):
+        from tools.browser_tool import _is_local_backend
+
+        monkeypatch.setattr("tools.browser_tool._get_cdp_override", lambda: "")
+        monkeypatch.setattr("tools.browser_tool._is_camofox_mode", lambda: False)
+        monkeypatch.setattr("tools.browser_tool._is_cloakbrowser_mode", lambda: True)
+        monkeypatch.setattr("tools.browser_tool._get_cloud_provider", lambda: "cloakbrowser")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        assert _is_local_backend() is True
+
+    def test_is_local_backend_keeps_containerized_cloakbrowser_non_local(self, monkeypatch):
+        from tools.browser_tool import _is_local_backend
+
+        monkeypatch.setattr("tools.browser_tool._get_cdp_override", lambda: "")
+        monkeypatch.setattr("tools.browser_tool._is_camofox_mode", lambda: False)
+        monkeypatch.setattr("tools.browser_tool._is_cloakbrowser_mode", lambda: True)
+        monkeypatch.setattr("tools.browser_tool._get_cloud_provider", lambda: "cloakbrowser")
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+        assert _is_local_backend() is False
+
+    def test_browser_navigate_routes_to_cloakbrowser(self, monkeypatch):
+        from tools.browser_tool import browser_navigate
+
+        monkeypatch.setattr("tools.browser_tool._is_cloakbrowser_mode", lambda: True)
+        monkeypatch.setattr("tools.browser_tool._sensitive_query_param_name", lambda url: None)
+        monkeypatch.setattr("tools.browser_tool._is_always_blocked_url", lambda url: False)
+        monkeypatch.setattr("tools.browser_tool._is_safe_url", lambda url: True)
+        monkeypatch.setattr("tools.browser_tool.check_website_access", lambda url: None)
+        monkeypatch.setattr(
+            "tools.browser_tool.cloakbrowser_navigate",
+            lambda url, task_id=None: json.dumps(
+                {
+                    "success": True,
+                    "url": url,
+                    "task_id": task_id,
+                    "backend": "cloakbrowser",
+                }
+            ),
+        )
+
+        result = json.loads(browser_navigate("https://example.com", task_id="t-route"))
+        assert result == {
+            "success": True,
+            "url": "https://example.com",
+            "task_id": "t-route",
+            "backend": "cloakbrowser",
+        }
+
+    def test_cloud_blocks_redirect_to_private_in_cloakbrowser_mode(self, monkeypatch):
+        from tools.browser_tool import browser_navigate
+
+        calls = []
+
+        monkeypatch.setattr("tools.browser_tool._is_cloakbrowser_mode", lambda: True)
+        monkeypatch.setattr("tools.browser_tool._is_camofox_mode", lambda: False)
+        monkeypatch.setattr("tools.browser_tool._is_local_backend", lambda: False)
+        monkeypatch.setattr("tools.browser_tool._allow_private_urls", lambda: False)
+        monkeypatch.setattr("tools.browser_tool._sensitive_query_param_name", lambda url: None)
+        monkeypatch.setattr("tools.browser_tool._is_always_blocked_url", lambda url: False)
+        monkeypatch.setattr("tools.browser_tool._is_safe_url", lambda url: "192.168" not in url)
+        monkeypatch.setattr("tools.browser_tool.check_website_access", lambda url: None)
+        monkeypatch.setattr(
+            "tools.browser_tool.cloakbrowser_navigate",
+            lambda url, task_id=None: calls.append((url, task_id)) or json.dumps(
+                {
+                    "success": True,
+                    "url": "http://192.168.1.1/internal",
+                    "title": "Internal",
+                    "snapshot": "secret",
+                }
+            ),
+        )
+
+        result = json.loads(browser_navigate("https://example.com/start", task_id="t-ssrf"))
+
+        assert result == {
+            "success": False,
+            "error": "Blocked: redirect landed on a private/internal address",
+        }
+        assert calls == [
+            ("https://example.com/start", "t-ssrf"),
+            ("about:blank", "t-ssrf"),
+        ]
+
+    def test_containerized_cloakbrowser_blocks_redirect_to_imds(self, monkeypatch):
+        from tools.browser_tool import browser_navigate
+
+        calls = []
+
+        monkeypatch.setattr("tools.browser_tool._is_cloakbrowser_mode", lambda: True)
+        monkeypatch.setattr("tools.browser_tool._is_camofox_mode", lambda: False)
+        monkeypatch.setattr("tools.browser_tool._is_local_backend", lambda: False)
+        monkeypatch.setattr("tools.browser_tool._allow_private_urls", lambda: False)
+        monkeypatch.setattr("tools.browser_tool._sensitive_query_param_name", lambda url: None)
+        monkeypatch.setattr(
+            "tools.browser_tool._is_always_blocked_url",
+            lambda url: "169.254.169.254" in url,
+        )
+        monkeypatch.setattr("tools.browser_tool._is_safe_url", lambda url: True)
+        monkeypatch.setattr("tools.browser_tool.check_website_access", lambda url: None)
+        monkeypatch.setattr(
+            "tools.browser_tool.cloakbrowser_navigate",
+            lambda url, task_id=None: calls.append((url, task_id)) or json.dumps(
+                {
+                    "success": True,
+                    "url": "http://169.254.169.254/latest/meta-data/",
+                    "title": "IMDS",
+                }
+            ),
+        )
+
+        result = json.loads(browser_navigate("https://example.com/start", task_id="t-imds"))
+
+        assert result == {
+            "success": False,
+            "error": "Blocked: redirect landed on a cloud metadata endpoint",
+        }
+        assert calls == [
+            ("https://example.com/start", "t-imds"),
+            ("about:blank", "t-imds"),
+        ]
+
+    def test_browser_snapshot_routes_to_cloakbrowser(self, monkeypatch):
+        from tools.browser_tool import browser_snapshot
+
+        monkeypatch.setattr("tools.browser_tool._is_cloakbrowser_mode", lambda: True)
+        monkeypatch.setattr(
+            "tools.browser_tool.cloakbrowser_snapshot",
+            lambda full=False, task_id=None, user_task=None: json.dumps(
+                {
+                    "success": True,
+                    "full": full,
+                    "task_id": task_id,
+                    "user_task": user_task,
+                    "backend": "cloakbrowser",
+                }
+            ),
+        )
+
+        result = json.loads(browser_snapshot(full=True, task_id="t-snap", user_task="inspect"))
+        assert result == {
+            "success": True,
+            "full": True,
+            "task_id": "t-snap",
+            "user_task": "inspect",
+            "backend": "cloakbrowser",
+        }
+
+    def test_browser_actions_route_to_cloakbrowser(self, monkeypatch):
+        from tools import browser_tool as bt
+
+        monkeypatch.setattr(bt, "_is_cloakbrowser_mode", lambda: True)
+        monkeypatch.setattr(bt, "cloakbrowser_click", lambda ref, task_id=None: json.dumps({"tool": "click", "ref": ref, "task_id": task_id}))
+        monkeypatch.setattr(bt, "cloakbrowser_type", lambda ref, text, task_id=None: json.dumps({"tool": "type", "ref": ref, "text": text, "task_id": task_id}))
+        monkeypatch.setattr(bt, "cloakbrowser_scroll", lambda direction, task_id=None: json.dumps({"tool": "scroll", "direction": direction, "task_id": task_id}))
+        monkeypatch.setattr(bt, "cloakbrowser_back", lambda task_id=None: json.dumps({"tool": "back", "task_id": task_id}))
+        monkeypatch.setattr(bt, "cloakbrowser_press", lambda key, task_id=None: json.dumps({"tool": "press", "key": key, "task_id": task_id}))
+        monkeypatch.setattr(bt, "cloakbrowser_get_images", lambda task_id=None: json.dumps({"tool": "get_images", "task_id": task_id}))
+        monkeypatch.setattr(bt, "cloakbrowser_console", lambda clear=False, task_id=None: json.dumps({"tool": "console", "clear": clear, "task_id": task_id}))
+
+        assert json.loads(bt.browser_click("@e1", task_id="t1")) == {"tool": "click", "ref": "@e1", "task_id": "t1"}
+        assert json.loads(bt.browser_type("@e2", "hello", task_id="t2")) == {"tool": "type", "ref": "@e2", "text": "hello", "task_id": "t2"}
+        assert json.loads(bt.browser_scroll("down", task_id="t3")) == {"tool": "scroll", "direction": "down", "task_id": "t3"}
+        assert json.loads(bt.browser_back(task_id="t4")) == {"tool": "back", "task_id": "t4"}
+        assert json.loads(bt.browser_press("Enter", task_id="t5")) == {"tool": "press", "key": "Enter", "task_id": "t5"}
+        assert json.loads(bt.browser_get_images(task_id="t6")) == {"tool": "get_images", "task_id": "t6"}
+        assert json.loads(bt.browser_console(clear=True, task_id="t7")) == {"tool": "console", "clear": True, "task_id": "t7"}
+
+    def test_cloakbrowser_activity_updates_for_headed_and_headless_sessions(self, monkeypatch):
+        from tools import browser_tool as bt
+
+        monkeypatch.setattr(bt, "_is_cloakbrowser_mode", lambda: True)
+        monkeypatch.setattr(bt, "_last_session_key", lambda task_id: task_id)
+        monkeypatch.setattr(bt, "_blocked_private_page_snapshot", lambda task_id: None)
+        monkeypatch.setattr(bt, "_blocked_private_page_action", lambda task_id, action: None)
+
+        started = []
+        touched = []
+        monkeypatch.setattr(bt, "_start_browser_cleanup_thread", lambda: started.append(True))
+        monkeypatch.setattr(bt, "_update_session_activity", lambda task_id: touched.append(task_id))
+        monkeypatch.setattr(bt, "cloakbrowser_snapshot", lambda full=False, task_id=None, user_task=None: json.dumps({"success": True, "task_id": task_id, "full": full}))
+        monkeypatch.setattr(bt, "cloakbrowser_click", lambda ref, task_id=None: json.dumps({"success": True, "task_id": task_id, "ref": ref}))
+
+        headed = json.loads(bt.browser_snapshot(task_id="headed-task"))
+        headless = json.loads(bt.browser_click("@e1", task_id="headless-task"))
+
+        assert headed == {"success": True, "task_id": "headed-task", "full": False}
+        assert headless == {"success": True, "task_id": "headless-task", "ref": "@e1"}
+        assert started == [True, True]
+        assert touched == ["headed-task", "headless-task"]
+
+
+class TestPerTurnCleanup:
+    def test_native_cloakbrowser_survives_per_turn_cleanup(self, monkeypatch):
+        from agent.chat_completion_helpers import cleanup_task_resources
+
+        calls = []
+        monkeypatch.setattr("tools.browser_tool._is_cloakbrowser_mode", lambda: True)
+        monkeypatch.setattr("run_agent.cleanup_vm", lambda task_id: calls.append(("vm", task_id)))
+        monkeypatch.setattr("run_agent.cleanup_browser", lambda task_id: calls.append(("browser", task_id)))
+
+        agent = SimpleNamespace(verbose_logging=True)
+        cleanup_task_resources(agent, "cloak-task")
+
+        assert calls == [("vm", "cloak-task")]

--- a/tests/tools/test_browser_cloakbrowser.py
+++ b/tests/tools/test_browser_cloakbrowser.py
@@ -214,6 +214,55 @@ class TestBuildLaunchOptions:
 
 
 class TestWrapperEntrypoints:
+    def test_screenshot_returns_standard_data_path_shape(self, monkeypatch, tmp_path):
+        from tools import browser_cloakbrowser as bc
+
+        screenshot_bytes = b"\x89PNG\r\n\x1a\ncloakbrowser"
+        page = SimpleNamespace(screenshot=_awaitable(screenshot_bytes))
+        session = {"page": page, "refs": {}}
+        shots_dir = tmp_path / "cache" / "screenshots"
+
+        monkeypatch.setattr(bc, "_ensure_session", lambda task_id=None: session)
+        monkeypatch.setattr(bc, "_run_on_session_loop", lambda session, coro, timeout=None: bc._run_async(coro))
+        monkeypatch.setattr("hermes_constants.get_hermes_dir", lambda *parts: shots_dir)
+
+        result = json.loads(bc.cloakbrowser_screenshot(task_id="task-shot"))
+
+        assert result["success"] is True
+        assert result["data"]["path"].endswith(".png")
+        assert Path(result["data"]["path"]).read_bytes() == screenshot_bytes
+
+    def test_screenshot_annotate_true_includes_snapshot_annotations(self, monkeypatch, tmp_path):
+        from tools import browser_cloakbrowser as bc
+
+        screenshot_bytes = b"\x89PNG\r\n\x1a\ncloakbrowser"
+        page = SimpleNamespace(screenshot=_awaitable(screenshot_bytes))
+        session = {"page": page, "refs": {}}
+        snapshot = {
+            "snapshot": '- button "Submit" [@e1]',
+            "refs": {"e1": {"selector": "[data-hermes-ref=\"e1\"]", "tag": "button", "text": "Submit"}},
+            "element_count": 1,
+        }
+        shots_dir = tmp_path / "cache" / "screenshots"
+
+        monkeypatch.setattr(bc, "_ensure_session", lambda task_id=None: session)
+        monkeypatch.setattr(bc, "_ensure_live_page", _awaitable(page))
+        monkeypatch.setattr(bc, "_snapshot_page", _awaitable(snapshot))
+        monkeypatch.setattr(bc, "_run_on_session_loop", lambda session, coro, timeout=None: bc._run_async(coro))
+        monkeypatch.setattr("hermes_constants.get_hermes_dir", lambda *parts: shots_dir)
+
+        result = json.loads(bc.cloakbrowser_screenshot(task_id="task-shot", annotate=True))
+
+        assert result["success"] is True
+        assert result["data"]["annotations"] == [{
+            "ref": "@e1",
+            "label": 'button "Submit"',
+            "tag": "button",
+            "text": "Submit",
+            "selector": '[data-hermes-ref="e1"]',
+        }]
+        assert session["refs"] == snapshot["refs"]
+
     def test_launch_session_strips_duplicate_user_data_dir_for_persistent_launch(self, monkeypatch, tmp_path):
         from tools import browser_cloakbrowser as bc
 
@@ -373,6 +422,144 @@ class TestWrapperEntrypoints:
         result = json.loads(bc.cloakbrowser_get_images(task_id="task-images"))
 
         assert result == {"success": True, "images": [], "count": 0}
+
+    def test_ensure_session_runs_listener_registration_on_session_loop(self, monkeypatch):
+        from tools import browser_cloakbrowser as bc
+
+        class LoopBoundPage:
+            def __init__(self):
+                self.listeners = {}
+                self.loop_ids = []
+
+            def on(self, event, handler):
+                self.loop_ids.append(id(__import__("asyncio").get_running_loop()))
+                self.listeners[event] = handler
+
+        loop, thread = bc._start_loop_thread("cloakbrowser-test-loop")
+        session = {"page": LoopBoundPage(), "refs": {}, "_loop": loop, "_thread": thread}
+        monkeypatch.setitem(bc._sessions, "loop-test", session)
+        try:
+            ready = bc._ensure_session("loop-test")
+        finally:
+            bc._sessions.pop("loop-test", None)
+            bc._shutdown_loop_thread(loop, thread)
+
+        assert ready is session
+        assert len(session["page"].loop_ids) == 2
+        assert session["_console_listeners_page"] is session["page"]
+
+    def test_console_returns_buffered_messages_and_errors_and_clear_empties_buffers(self, monkeypatch):
+        from tools import browser_cloakbrowser as bc
+
+        session = {
+            "page": SimpleNamespace(url="https://example.com"),
+            "refs": {},
+            "console_messages": [
+                {"type": "log", "text": "hello", "source": "console"},
+                {"type": "error", "text": "oops", "source": "console"},
+            ],
+            "page_errors": [
+                {"message": "Uncaught TypeError", "source": "exception"},
+            ],
+        }
+        monkeypatch.setattr(bc, "_ensure_session", lambda task_id=None: session)
+
+        result = json.loads(bc.cloakbrowser_console(task_id="task-console"))
+
+        assert result == {
+            "success": True,
+            "console_messages": [
+                {"type": "log", "text": "hello", "source": "console"},
+                {"type": "error", "text": "oops", "source": "console"},
+            ],
+            "js_errors": [
+                {"message": "Uncaught TypeError", "source": "exception"},
+            ],
+            "total_messages": 2,
+            "total_errors": 1,
+        }
+
+        cleared = json.loads(bc.cloakbrowser_console(clear=True, task_id="task-console"))
+        assert cleared["success"] is True
+        assert cleared["total_messages"] == 2
+        assert cleared["total_errors"] == 1
+        assert session["console_messages"] == []
+        assert session["page_errors"] == []
+
+    def test_eval_returns_structured_serializable_result(self, monkeypatch):
+        from tools import browser_cloakbrowser as bc
+
+        page = SimpleNamespace(url="https://example.com", evaluate=_awaitable('{"title":"Example"}'))
+        monkeypatch.setattr(bc, "_ensure_session", lambda task_id=None: {"page": page, "refs": {}})
+
+        result = json.loads(bc.cloakbrowser_eval("document.title", task_id="task-eval"))
+
+        assert result == {
+            "success": True,
+            "result": {"title": "Example"},
+            "result_type": "dict",
+            "method": "cloakbrowser_native",
+        }
+
+    def test_session_listener_registration_buffers_console_and_pageerror_events(self):
+        from tools import browser_cloakbrowser as bc
+
+        class FakePage:
+            def __init__(self):
+                self.listeners = {}
+                self.loop_ids = []
+
+            def on(self, event, handler):
+                self.loop_ids.append(id(__import__("asyncio").get_running_loop()))
+                self.listeners[event] = handler
+
+        page = FakePage()
+        session = {"page": page, "refs": {}}
+
+        bc._run_async(bc._ensure_session_ready(session))
+
+        page.listeners["console"](SimpleNamespace(type="warning", text="watch out"))
+        page.listeners["pageerror"](RuntimeError("boom"))
+
+        assert len(page.loop_ids) == 2
+        assert len(set(page.loop_ids)) == 1
+        assert session["console_messages"] == [
+            {"type": "warning", "text": "watch out", "source": "console"},
+        ]
+        assert session["page_errors"] == [
+            {"message": "boom", "source": "exception"},
+        ]
+
+    def test_session_listener_registration_reregisters_after_page_recreation(self):
+        from tools import browser_cloakbrowser as bc
+
+        class FakePage:
+            def __init__(self, closed=False):
+                self.closed = closed
+                self.listeners = {}
+
+            def is_closed(self):
+                return self.closed
+
+            def on(self, event, handler):
+                __import__("asyncio").get_running_loop()
+                self.listeners[event] = handler
+
+        first_page = FakePage(closed=True)
+        replacement_page = FakePage()
+        context = SimpleNamespace(new_page=_awaitable(replacement_page))
+        session = {"page": first_page, "context": context, "refs": {"e1": {"selector": "#x"}}}
+
+        page = bc._run_async(bc._ensure_session_ready(session))
+        assert page is replacement_page
+        assert session["page"] is replacement_page
+        assert session["refs"] == {}
+        assert session["_console_listeners_page"] is replacement_page
+        replacement_page.listeners["console"](SimpleNamespace(type="info", text="fresh page"))
+
+        assert session["console_messages"] == [
+            {"type": "info", "text": "fresh page", "source": "console"},
+        ]
 
 
 class TestBrowserToolRouting:

--- a/tests/tools/test_browser_cloakbrowser_private_page_guards.py
+++ b/tests/tools/test_browser_cloakbrowser_private_page_guards.py
@@ -135,3 +135,50 @@ def test_cloakbrowser_guard_inactive_does_not_probe(monkeypatch):
     out = json.loads(browser_tool.browser_click("@e1", task_id="task-1"))
 
     assert out == {"success": True, "clicked": "@e1"}
+
+
+def test_cloakbrowser_navigate_redacts_snapshot_payload(monkeypatch):
+    secret = "super-secret-999"
+    monkeypatch.setattr(
+        browser_tool,
+        "cloakbrowser_navigate",
+        lambda url, task_id=None: json.dumps(
+            {
+                "success": True,
+                "url": url,
+                "title": "Example",
+                "snapshot": f'token: {secret}',
+                "element_count": 1,
+            }
+        ),
+    )
+
+    out = json.loads(browser_tool.browser_navigate("https://example.com", task_id="task-1"))
+
+    assert out["success"] is True
+    assert out["url"] == "https://example.com"
+    assert out["title"] == "Example"
+    assert secret not in out["snapshot"]
+    assert out["snapshot"] == "token: ***"
+
+
+def test_cloakbrowser_snapshot_redacts_snapshot_payload(monkeypatch):
+    secret = "super-secret-999"
+    monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", lambda task_id: False)
+    monkeypatch.setattr(
+        browser_tool,
+        "cloakbrowser_snapshot",
+        lambda full=False, task_id=None, user_task=None: json.dumps(
+            {
+                "success": True,
+                "snapshot": f'token: {secret}',
+                "element_count": 1,
+            }
+        ),
+    )
+
+    out = json.loads(browser_tool.browser_snapshot(task_id="task-1"))
+
+    assert out["success"] is True
+    assert secret not in out["snapshot"]
+    assert out["snapshot"] == "token: ***"

--- a/tests/tools/test_browser_cloakbrowser_private_page_guards.py
+++ b/tests/tools/test_browser_cloakbrowser_private_page_guards.py
@@ -55,6 +55,42 @@ def test_cloakbrowser_get_images_blocks_private_pages(monkeypatch, url):
     assert url in out["error"]
 
 
+@pytest.mark.parametrize("url", BLOCKED_URLS)
+def test_cloakbrowser_vision_blocks_private_pages_before_screenshot(monkeypatch, url):
+    monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(browser_tool, "cloakbrowser_current_url", lambda task_id: url)
+    monkeypatch.setattr(
+        browser_tool,
+        "cloakbrowser_screenshot",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("vision screenshot backend should not run")),
+    )
+
+    out = json.loads(browser_tool.browser_vision("what is on page?", task_id="task-1"))
+
+    assert out["success"] is False
+    assert "private or internal address" in out["error"]
+    assert url in out["error"]
+
+
+def test_cloakbrowser_vision_allows_public_page(monkeypatch):
+    screenshot_calls = []
+
+    monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(browser_tool, "cloakbrowser_current_url", lambda task_id: "https://example.com/")
+
+    def fake_screenshot(*args, **kwargs):
+        screenshot_calls.append((args, kwargs))
+        return json.dumps({"success": False, "error": "expected test stop"})
+
+    monkeypatch.setattr(browser_tool, "cloakbrowser_screenshot", fake_screenshot)
+
+    out = json.loads(browser_tool.browser_vision("what is on page?", task_id="task-1"))
+
+    assert screenshot_calls == [((), {"task_id": "task-1", "annotate": False, "full": True})]
+    assert out["success"] is False
+    assert out["error"] == "Failed to take screenshot (local mode): expected test stop"
+
+
 @pytest.mark.parametrize(
     ("tool_call", "args"),
     [

--- a/tests/tools/test_browser_cloakbrowser_private_page_guards.py
+++ b/tests/tools/test_browser_cloakbrowser_private_page_guards.py
@@ -1,0 +1,137 @@
+"""Regression tests for CloakBrowser private-page guards on snapshot/action paths."""
+
+import json
+
+import pytest
+
+from tools import browser_tool
+
+
+BLOCKED_URLS = [
+    "http://127.0.0.1:8080/internal",
+    "http://10.0.0.8/admin",
+    "http://169.254.169.254/latest/meta-data/",
+]
+
+
+@pytest.fixture(autouse=True)
+def _cloakbrowser_mode(monkeypatch):
+    monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+    monkeypatch.setattr(browser_tool, "_is_cloakbrowser_mode", lambda: True)
+    monkeypatch.setattr(browser_tool, "_last_session_key", lambda task_id: task_id)
+
+
+@pytest.mark.parametrize("url", BLOCKED_URLS)
+def test_cloakbrowser_snapshot_blocks_private_pages(monkeypatch, url):
+    monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(browser_tool, "cloakbrowser_current_url", lambda task_id: url)
+    monkeypatch.setattr(
+        browser_tool,
+        "cloakbrowser_snapshot",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("snapshot backend should not run")),
+    )
+
+    out = json.loads(browser_tool.browser_snapshot(task_id="task-1"))
+
+    assert out["success"] is False
+    assert "private or internal address" in out["error"]
+    assert url in out["error"]
+
+
+@pytest.mark.parametrize("url", BLOCKED_URLS)
+def test_cloakbrowser_get_images_blocks_private_pages(monkeypatch, url):
+    monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(browser_tool, "cloakbrowser_current_url", lambda task_id: url)
+    monkeypatch.setattr(
+        browser_tool,
+        "cloakbrowser_get_images",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("get_images backend should not run")),
+    )
+
+    out = json.loads(browser_tool.browser_get_images(task_id="task-1"))
+
+    assert out["success"] is False
+    assert "private or internal address" in out["error"]
+    assert url in out["error"]
+
+
+@pytest.mark.parametrize(
+    ("tool_call", "args"),
+    [
+        (browser_tool.browser_click, ("@e1",)),
+        (browser_tool.browser_type, ("@e1", "secret-text")),
+        (browser_tool.browser_press, ("Enter",)),
+    ],
+)
+@pytest.mark.parametrize("url", BLOCKED_URLS)
+def test_cloakbrowser_actions_block_private_pages(monkeypatch, tool_call, args, url):
+    monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(browser_tool, "cloakbrowser_current_url", lambda task_id: url)
+
+    backend_name = {
+        browser_tool.browser_click: "cloakbrowser_click",
+        browser_tool.browser_type: "cloakbrowser_type",
+        browser_tool.browser_press: "cloakbrowser_press",
+    }[tool_call]
+    monkeypatch.setattr(
+        browser_tool,
+        backend_name,
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("action backend should not run")),
+    )
+
+    out = json.loads(tool_call(*args, task_id="task-1"))
+
+    assert out["success"] is False
+    assert "private or internal address" in out["error"]
+    assert url in out["error"]
+    assert "secret-text" not in json.dumps(out)
+
+
+@pytest.mark.parametrize("url", BLOCKED_URLS)
+def test_cloakbrowser_back_blocks_when_history_lands_on_private_page(monkeypatch, url):
+    monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(browser_tool, "cloakbrowser_current_url", lambda task_id: url)
+    monkeypatch.setattr(
+        browser_tool,
+        "cloakbrowser_back",
+        lambda task_id=None: json.dumps({"success": True, "url": url}),
+    )
+
+    out = json.loads(browser_tool.browser_back(task_id="task-1"))
+
+    assert out["success"] is False
+    assert "private or internal address" in out["error"]
+    assert url in out["error"]
+    assert "url" not in out
+
+
+def test_cloakbrowser_snapshot_allows_public_page(monkeypatch):
+    monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(browser_tool, "cloakbrowser_current_url", lambda task_id: "https://example.com/")
+    monkeypatch.setattr(
+        browser_tool,
+        "cloakbrowser_snapshot",
+        lambda full=False, task_id=None, user_task=None: json.dumps({"success": True, "snapshot": "ok", "element_count": 1}),
+    )
+
+    out = json.loads(browser_tool.browser_snapshot(task_id="task-1"))
+
+    assert out == {"success": True, "snapshot": "ok", "element_count": 1}
+
+
+def test_cloakbrowser_guard_inactive_does_not_probe(monkeypatch):
+    monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", lambda task_id: False)
+
+    def fail_probe(task_id):
+        raise AssertionError("cloakbrowser_current_url must not be probed when guard inactive")
+
+    monkeypatch.setattr(browser_tool, "cloakbrowser_current_url", fail_probe)
+    monkeypatch.setattr(
+        browser_tool,
+        "cloakbrowser_click",
+        lambda ref, task_id=None: json.dumps({"success": True, "clicked": ref}),
+    )
+
+    out = json.loads(browser_tool.browser_click("@e1", task_id="task-1"))
+
+    assert out == {"success": True, "clicked": "@e1"}

--- a/tests/tools/test_browser_cloakbrowser_timeout.py
+++ b/tests/tools/test_browser_cloakbrowser_timeout.py
@@ -369,6 +369,61 @@ class TestNormalBehaviorPreserved:
 
 
 class TestCloakBrowserPersistencePolicy:
+    @pytest.mark.parametrize(
+        ("headless", "task_id"),
+        [
+            (False, "headed-persist"),
+            (True, "headless-persist"),
+        ],
+    )
+    def test_native_session_stays_open_across_turns_for_headed_and_headless(
+        self,
+        monkeypatch,
+        headless,
+        task_id,
+    ):
+        launch_calls = []
+
+        async def fake_launch_session():
+            launch_calls.append(headless)
+            page = SimpleNamespace(
+                url="about:blank",
+                title=_awaitable("Persisted Page"),
+            )
+            return {
+                "page": page,
+                "context": SimpleNamespace(),
+                "refs": {},
+            }
+
+        def fake_navigate(page, url, timeout=None):
+            page.url = url
+            return _awaitable(None)()
+
+        monkeypatch.setattr(bc, "_launch_session", fake_launch_session)
+        monkeypatch.setattr(bc, "build_cloakbrowser_launch_options", lambda: {"headless": headless})
+        monkeypatch.setattr(bc, "_navigate_page", fake_navigate)
+        monkeypatch.setattr(
+            bc,
+            "_snapshot_page",
+            _awaitable({
+                "snapshot": '- link "Docs" [@e1]',
+                "element_count": 1,
+                "refs": {"e1": {"selector": "#docs"}},
+            }),
+        )
+
+        first = json.loads(bc.cloakbrowser_navigate("https://example.com/one", task_id=task_id))
+        second = json.loads(bc.cloakbrowser_snapshot(task_id=task_id))
+
+        assert first["success"] is True
+        assert second["success"] is True
+        assert launch_calls == [headless]
+        session = bc._sessions[task_id]
+        assert getattr(session["page"], "url", None) == "https://example.com/one"
+        assert bc.cloakbrowser_close(task_id) is True
+        _wait_for_thread_stop(session["_thread"])
+
     def test_inactivity_cleanup_closes_native_cloakbrowser_session(self, monkeypatch):
         from tools import browser_tool as bt
 
@@ -378,7 +433,8 @@ class TestCloakBrowserPersistencePolicy:
         monkeypatch.setattr(bt, "_active_sessions", {})
         monkeypatch.setattr(bt, "_last_active_session_key", {})
         monkeypatch.setattr(bt, "_session_last_activity", {"idle-task": 0.0})
-        monkeypatch.setattr(bt, "BROWSER_SESSION_INACTIVITY_TIMEOUT", 30)
+        monkeypatch.setattr(bt, "_get_cloakbrowser_session_inactivity_timeout", lambda: 30)
+        monkeypatch.setattr(bt, "BROWSER_SESSION_INACTIVITY_TIMEOUT", 3600)
         monkeypatch.setattr(bt.time, "time", lambda: 100.0)
 
         bt._cleanup_inactive_browser_sessions()
@@ -400,3 +456,42 @@ class TestCloakBrowserPersistencePolicy:
 
         assert closed == ["cleanup-task"]
         assert "cleanup-task" not in bt._session_last_activity
+
+    def test_timeout_poison_teardown_closes_resources_immediately(self):
+        events = []
+
+        async def fake_launch_session():
+            page = _LoopBoundClosable("page", events)
+            context = _LoopBoundClosable("context", events)
+            browser = _LoopBoundClosable("browser", events)
+            return {
+                "page": page,
+                "context": context,
+                "browser": browser,
+                "refs": {},
+                "persistent": False,
+            }
+
+        with patch.object(bc, "_launch_session", fake_launch_session):
+            session = bc._ensure_session("poisoned-timeout")
+
+        with patch.object(bc, "_CLOAKBROWSER_NAV_TIMEOUT", 0.05), patch.object(
+            bc,
+            "_navigate_page",
+            _never_completes,
+        ):
+            result = json.loads(
+                bc.cloakbrowser_navigate(
+                    "https://example.com/hang",
+                    task_id="poisoned-timeout",
+                )
+            )
+
+        assert result["success"] is False
+        assert "timed out" in result["error"]
+        assert events == [("page", "close"), ("context", "close"), ("browser", "close")]
+        assert session["page"].close_calls == 1
+        assert session["context"].close_calls == 1
+        assert session["browser"].close_calls == 1
+        assert "poisoned-timeout" not in bc._sessions
+        _wait_for_thread_stop(session["_thread"])

--- a/tests/tools/test_browser_cloakbrowser_timeout.py
+++ b/tests/tools/test_browser_cloakbrowser_timeout.py
@@ -1,0 +1,402 @@
+"""Focused tests for CloakBrowser runtime timeout/error handling.
+
+Verifies that _run_async, _ensure_session, and cloakbrowser_navigate
+fail fast with a clear JSON error instead of hanging forever when
+launch, navigation, or other async operations stall.
+"""
+
+import asyncio
+import json
+import time
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from tools import browser_cloakbrowser as bc
+
+
+@pytest.fixture(autouse=True)
+def _reset_sessions():
+    for task_id in list(bc._sessions):
+        bc.cloakbrowser_close(task_id)
+    yield
+    for task_id in list(bc._sessions):
+        bc.cloakbrowser_close(task_id)
+
+
+async def _never_completes(*args, **kwargs):
+    await asyncio.sleep(9999)
+
+
+def _awaitable(value):
+    async def _inner(*args, **kwargs):
+        return value
+
+    return _inner
+
+
+def _wait_for_thread_stop(thread, timeout=2.0):
+    deadline = time.time() + timeout
+    while thread.is_alive() and time.time() < deadline:
+        time.sleep(0.01)
+    assert not thread.is_alive()
+
+
+class _LoopBoundPage:
+    def __init__(self):
+        self.loop = asyncio.get_running_loop()
+        self.url = "about:blank"
+        self.titles = []
+        self.snapshots = []
+
+    def _check_loop(self):
+        current = asyncio.get_running_loop()
+        if current is not self.loop:
+            raise RuntimeError("page used from different event loop")
+
+    async def goto(self, url, **kwargs):
+        self._check_loop()
+        self.url = url
+        return None
+
+    async def title(self):
+        self._check_loop()
+        self.titles.append(self.url)
+        return "Loop Bound"
+
+    async def evaluate(self, script, payload=None):
+        self._check_loop()
+        self.snapshots.append((script, payload))
+        return {"snapshot": f"snapshot for {self.url}", "refs": {"e1": {"selector": "#ok"}}, "element_count": 1}
+
+
+class _LoopBoundClosable:
+    def __init__(self, name, events, fail=False):
+        self.name = name
+        self.events = events
+        self.fail = fail
+        self.loop = asyncio.get_running_loop()
+        self.close_calls = 0
+
+    async def close(self):
+        current = asyncio.get_running_loop()
+        if current is not self.loop:
+            raise RuntimeError(f"{self.name} closed from different event loop")
+        self.close_calls += 1
+        self.events.append((self.name, "close"))
+        if self.fail:
+            raise RuntimeError(f"{self.name} close failed")
+        return None
+
+
+class TestRunAsyncTimeout:
+    """_run_async must surface a clear RuntimeError when a coroutine stalls."""
+
+    def test_timeout_raises_clear_runtime_error(self):
+        with pytest.raises(RuntimeError, match="timed out"):
+            bc._run_async(_never_completes(), timeout=0.001)
+
+    def test_fast_coro_completes_normally_with_timeout(self):
+        async def fast():
+            return 42
+
+        assert bc._run_async(fast(), timeout=5) == 42
+
+    def test_fast_coro_completes_normally_without_explicit_timeout(self):
+        async def fast():
+            return "ok"
+
+        assert bc._run_async(fast()) == "ok"
+
+
+class TestEnsureSessionTimeout:
+    """_ensure_session must surface timeout when launch stalls."""
+
+    def test_hanging_launch_returns_clear_error(self):
+        with patch.object(bc, "_launch_session", _never_completes), \
+             patch.object(bc, "_CLOAKBROWSER_LAUNCH_TIMEOUT", 0.05):
+            with pytest.raises(RuntimeError, match="timed out"):
+                bc._ensure_session("test-launch-hang")
+
+    def test_hanging_operation_cancels_session_and_stops_loop_thread(self):
+        async def fake_launch_session():
+            page = _LoopBoundPage()
+            return {"page": page, "context": SimpleNamespace(), "refs": {}}
+
+        with patch.object(bc, "_launch_session", fake_launch_session):
+            session = bc._ensure_session("timeout-poison")
+
+        thread = session["_thread"]
+        with patch.object(bc, "_CLOAKBROWSER_NAV_TIMEOUT", 0.05), \
+             patch.object(bc, "_navigate_page", _never_completes):
+            result = json.loads(bc.cloakbrowser_navigate("https://example.com/hang", task_id="timeout-poison"))
+
+        assert result["success"] is False
+        assert "timed out" in result["error"]
+        assert "timeout-poison" not in bc._sessions
+        _wait_for_thread_stop(thread)
+
+    def test_session_bound_page_stays_on_launch_loop_for_navigate_and_snapshot(self):
+        async def fake_launch_session():
+            page = _LoopBoundPage()
+            return {"page": page, "context": SimpleNamespace(), "refs": {}}
+
+        with patch.object(bc, "_launch_session", fake_launch_session):
+            navigate = json.loads(bc.cloakbrowser_navigate("https://example.com/loop", task_id="loop-bound"))
+            snapshot = json.loads(bc.cloakbrowser_snapshot(task_id="loop-bound"))
+
+        assert navigate == {
+            "success": True,
+            "url": "https://example.com/loop",
+            "title": "Loop Bound",
+            "snapshot": "snapshot for https://example.com/loop",
+            "element_count": 1,
+        }
+        assert snapshot == {
+            "success": True,
+            "snapshot": "snapshot for https://example.com/loop",
+            "element_count": 1,
+        }
+        session = bc._sessions["loop-bound"]
+        assert session["page"].loop is session["_loop"]
+        assert bc.cloakbrowser_close("loop-bound") is True
+        _wait_for_thread_stop(session["_thread"])
+        assert "loop-bound" not in bc._sessions
+
+    def test_close_teardown_closes_persistent_page_and_context_before_thread_stop(self):
+        events = []
+
+        async def fake_launch_session():
+            page = _LoopBoundClosable("page", events)
+            context = _LoopBoundClosable("context", events)
+            return {
+                "page": page,
+                "context": context,
+                "browser": None,
+                "refs": {},
+                "persistent": True,
+            }
+
+        with patch.object(bc, "_launch_session", fake_launch_session):
+            session = bc._ensure_session("persistent-close")
+
+        assert bc.cloakbrowser_close("persistent-close") is True
+        _wait_for_thread_stop(session["_thread"])
+        assert events == [("page", "close"), ("context", "close")]
+        assert session["page"].close_calls == 1
+        assert session["context"].close_calls == 1
+        assert "persistent-close" not in bc._sessions
+
+    def test_teardown_best_effort_closes_browser_even_if_page_and_context_close_fail(self):
+        events = []
+
+        async def fake_launch_session():
+            page = _LoopBoundClosable("page", events, fail=True)
+            context = _LoopBoundClosable("context", events, fail=True)
+            browser = _LoopBoundClosable("browser", events)
+            return {
+                "page": page,
+                "context": context,
+                "browser": browser,
+                "refs": {},
+                "persistent": False,
+            }
+
+        with patch.object(bc, "_launch_session", fake_launch_session):
+            session = bc._ensure_session("best-effort-close")
+
+        assert bc.cloakbrowser_close("best-effort-close") is True
+        _wait_for_thread_stop(session["_thread"])
+        assert events == [("page", "close"), ("context", "close"), ("browser", "close")]
+        assert session["browser"].close_calls == 1
+        assert "best-effort-close" not in bc._sessions
+
+    def test_close_all_tears_down_every_live_session(self):
+        events = []
+
+        async def fake_launch_session():
+            page = _LoopBoundClosable("page", events)
+            context = _LoopBoundClosable("context", events)
+            return {
+                "page": page,
+                "context": context,
+                "browser": None,
+                "refs": {},
+                "persistent": True,
+            }
+
+        with patch.object(bc, "_launch_session", fake_launch_session):
+            headed = bc._ensure_session("headed-session")
+            headless = bc._ensure_session("headless-session")
+
+        assert bc.cloakbrowser_close_all() == 2
+        _wait_for_thread_stop(headed["_thread"])
+        _wait_for_thread_stop(headless["_thread"])
+        assert "headed-session" not in bc._sessions
+        assert "headless-session" not in bc._sessions
+
+
+class TestNavigateTimeout:
+    """cloakbrowser_navigate must return JSON error instead of hanging."""
+
+    def test_hanging_launch_returns_json_error(self):
+        with patch.object(bc, "_launch_session", _never_completes), \
+             patch.object(bc, "_CLOAKBROWSER_LAUNCH_TIMEOUT", 0.05):
+            result = json.loads(bc.cloakbrowser_navigate("https://example.com", task_id="test-nav-launch-hang"))
+            assert result["success"] is False
+            assert "timed out" in result["error"]
+
+    def test_hanging_navigate_returns_json_error(self, monkeypatch):
+        page = SimpleNamespace(url="https://example.com", title=_awaitable("Test"))
+        session = {"page": page, "refs": {}}
+        monkeypatch.setattr(bc, "_ensure_session", lambda task_id=None: session)
+        monkeypatch.setattr(bc, "_CLOAKBROWSER_NAV_TIMEOUT", 0.05)
+        monkeypatch.setattr(bc, "_navigate_page", _never_completes)
+
+        result = json.loads(bc.cloakbrowser_navigate("https://example.com/hang", task_id="test-nav-hang"))
+        assert result["success"] is False
+        assert "timed out" in result["error"]
+
+    def test_hanging_title_returns_json_error(self, monkeypatch):
+        page = SimpleNamespace(url="https://example.com", title=_never_completes)
+        session = {"page": page, "refs": {}}
+        monkeypatch.setattr(bc, "_ensure_session", lambda task_id=None: session)
+        monkeypatch.setattr(bc, "_navigate_page", lambda page, url, timeout=None: _awaitable(None)())
+        monkeypatch.setattr(bc, "_CLOAKBROWSER_DEFAULT_TIMEOUT", 0.05)
+
+        result = json.loads(bc.cloakbrowser_navigate("https://example.com", task_id="test-title-hang"))
+        assert result["success"] is False
+        assert "timed out" in result["error"]
+
+
+class TestNormalBehaviorPreserved:
+    """Existing non-hanging paths must still work correctly."""
+
+    def test_navigate_succeeds_with_mocked_session(self, monkeypatch):
+        page = SimpleNamespace(url="https://example.com/final", title=_awaitable("Example Title"))
+        session = {"page": page, "refs": {}}
+        navigated = []
+
+        monkeypatch.setattr(bc, "_ensure_session", lambda task_id=None: session)
+        monkeypatch.setattr(
+            bc, "_navigate_page",
+            lambda page, url, timeout=None: navigated.append((page, url)) or _awaitable(None)(),
+        )
+        monkeypatch.setattr(
+            bc, "_snapshot_page",
+            _awaitable({"snapshot": "- link \"Docs\" [@e1]", "element_count": 1}),
+        )
+
+        result = json.loads(bc.cloakbrowser_navigate("https://example.com/start", task_id="test-normal-nav"))
+        assert result == {
+            "success": True,
+            "url": "https://example.com/final",
+            "title": "Example Title",
+            "snapshot": "- link \"Docs\" [@e1]",
+            "element_count": 1,
+        }
+        assert navigated == [(page, "https://example.com/start")]
+
+    def test_navigate_passes_timeout_to_page_goto(self, monkeypatch):
+        page = SimpleNamespace(url="https://example.com", title=_awaitable("T"))
+        session = {"page": page, "refs": {}}
+        captured = {}
+
+        async def tracking_navigate(p, url, timeout=None):
+            captured["timeout"] = timeout
+            return None
+
+        monkeypatch.setattr(bc, "_ensure_session", lambda task_id=None: session)
+        monkeypatch.setattr(bc, "_navigate_page", tracking_navigate)
+        monkeypatch.setattr(bc, "_snapshot_page", _awaitable({"snapshot": "", "element_count": 0}))
+
+        bc.cloakbrowser_navigate("https://example.com", task_id="test-timeout-prop")
+        assert captured["timeout"] == bc._CLOAKBROWSER_NAV_TIMEOUT
+
+    def test_click_type_scroll_back_press_succeed(self, monkeypatch):
+        page = SimpleNamespace(
+            url="https://example.com/after",
+            title=_awaitable("After"),
+            go_back=_awaitable(None),
+        )
+        page.keyboard = SimpleNamespace(press=_awaitable(None))
+        page.mouse = SimpleNamespace(wheel=_awaitable(None))
+
+        session = {
+            "page": page,
+            "refs": {
+                "e1": {"selector": "#submit"},
+                "e2": {"selector": "#name"},
+            },
+        }
+
+        monkeypatch.setattr(bc, "_ensure_session", lambda task_id=None: session)
+        monkeypatch.setattr(
+            bc, "_snapshot_page",
+            _awaitable({
+                "snapshot": "- button \"Submit\" [@e1]",
+                "element_count": 2,
+                "refs": {"e1": {"selector": "#submit"}, "e2": {"selector": "#name"}},
+            }),
+        )
+        monkeypatch.setattr(
+            bc, "_click_selector",
+            _awaitable(None),
+        )
+        monkeypatch.setattr(
+            bc, "_type_into_selector",
+            _awaitable(None),
+        )
+
+        snap = json.loads(bc.cloakbrowser_snapshot(task_id="test-ops"))
+        assert snap["success"] is True, f"snapshot failed: {snap}"
+
+        click = json.loads(bc.cloakbrowser_click("@e1", task_id="test-ops"))
+        assert click["success"] is True, f"click failed: {click}"
+
+        typed = json.loads(bc.cloakbrowser_type("e2", "hello", task_id="test-ops"))
+        assert typed["success"] is True, f"type failed: {typed}"
+
+        scroll = json.loads(bc.cloakbrowser_scroll("down", task_id="test-ops"))
+        assert scroll["success"] is True, f"scroll failed: {scroll}"
+
+        back = json.loads(bc.cloakbrowser_back(task_id="test-ops"))
+        assert back["success"] is True, f"back failed: {back}"
+
+        press = json.loads(bc.cloakbrowser_press("Enter", task_id="test-ops"))
+        assert press["success"] is True, f"press failed: {press}"
+
+
+class TestCloakBrowserPersistencePolicy:
+    def test_inactivity_cleanup_closes_native_cloakbrowser_session(self, monkeypatch):
+        from tools import browser_tool as bt
+
+        closed = []
+        monkeypatch.setattr(bt, "_is_cloakbrowser_mode", lambda: True)
+        monkeypatch.setattr(bt, "cloakbrowser_close", lambda task_id=None: closed.append(task_id) or True)
+        monkeypatch.setattr(bt, "_active_sessions", {})
+        monkeypatch.setattr(bt, "_last_active_session_key", {})
+        monkeypatch.setattr(bt, "_session_last_activity", {"idle-task": 0.0})
+        monkeypatch.setattr(bt, "BROWSER_SESSION_INACTIVITY_TIMEOUT", 30)
+        monkeypatch.setattr(bt.time, "time", lambda: 100.0)
+
+        bt._cleanup_inactive_browser_sessions()
+
+        assert closed == ["idle-task"]
+        assert "idle-task" not in bt._session_last_activity
+
+    def test_explicit_cleanup_closes_native_cloakbrowser_session(self, monkeypatch):
+        from tools import browser_tool as bt
+
+        closed = []
+        monkeypatch.setattr(bt, "_is_cloakbrowser_mode", lambda: True)
+        monkeypatch.setattr(bt, "cloakbrowser_close", lambda task_id=None: closed.append(task_id) or True)
+        monkeypatch.setattr(bt, "_active_sessions", {})
+        monkeypatch.setattr(bt, "_last_active_session_key", {})
+        monkeypatch.setattr(bt, "_session_last_activity", {"cleanup-task": 50.0})
+
+        bt.cleanup_browser("cleanup-task")
+
+        assert closed == ["cleanup-task"]
+        assert "cleanup-task" not in bt._session_last_activity

--- a/tests/tools/test_browser_cloud_provider_cache.py
+++ b/tests/tools/test_browser_cloud_provider_cache.py
@@ -61,6 +61,34 @@ class TestCloudProviderCachePolicy:
         assert browser_tool._get_cloud_provider() is fake_provider
         assert factory.call_count == 1
 
+    def test_explicit_cloakbrowser_caches_local_mode_without_plugin_lookup(
+        self, monkeypatch, caplog
+    ):
+        """CloakBrowser selection is native local backend, not plugin cloud mode."""
+        browser_use_factory = Mock(side_effect=AssertionError("auto-detect should not run"))
+        browserbase_factory = Mock(side_effect=AssertionError("auto-detect should not run"))
+        registry_lookup = Mock(side_effect=AssertionError("plugin lookup should not run"))
+        plugin_loader = Mock(side_effect=AssertionError("plugin discovery should not run"))
+
+        monkeypatch.setattr(browser_tool, "BrowserUseProvider", browser_use_factory)
+        monkeypatch.setattr(browser_tool, "BrowserbaseProvider", browserbase_factory)
+        monkeypatch.setattr(browser_tool, "_registry_get_browser_provider", registry_lookup)
+        monkeypatch.setattr(browser_tool, "_ensure_browser_plugins_loaded", plugin_loader)
+        monkeypatch.setattr(
+            "hermes_cli.config.read_raw_config",
+            lambda: {"browser": {"cloud_provider": "cloakbrowser"}},
+        )
+
+        with caplog.at_level(logging.WARNING, logger="tools.browser_tool"):
+            assert browser_tool._get_cloud_provider() is None
+
+        assert browser_tool._cloud_provider_resolved is True
+        assert not [r for r in caplog.records if "registered browser plugin" in r.message]
+        assert browser_use_factory.call_count == 0
+        assert browserbase_factory.call_count == 0
+        assert registry_lookup.call_count == 0
+        assert plugin_loader.call_count == 0
+
     def test_no_credentials_yet_does_not_cache_none(self, monkeypatch):
         """Auto-detect path with no creds: must NOT poison the cache."""
         monkeypatch.setattr(

--- a/tests/tools/test_browser_console.py
+++ b/tests/tools/test_browser_console.py
@@ -160,6 +160,20 @@ class TestBrowserConsole:
         assert result == {"success": True, "result": "Example"}
         mock_eval.assert_called_once_with("document.title", "test")
 
+    def test_expression_reports_cloakbrowser_backend_limitation_without_eval(self):
+        from tools.browser_tool import browser_console
+
+        with patch("tools.browser_tool._allow_unsafe_browser_evaluate", return_value=False), \
+             patch("tools.browser_tool._is_cloakbrowser_mode", return_value=True), \
+             patch("tools.browser_tool._browser_eval") as mock_eval:
+            result = json.loads(browser_console(expression="document.title", task_id="test"))
+
+        assert result["success"] is False
+        assert "browser_console(expression=...)" in result["error"]
+        assert "CloakBrowser backend" in result["error"]
+        assert "browser_snapshot or browser_vision" in result["error"]
+        mock_eval.assert_not_called()
+
     def test_expression_blocks_cookie_access_before_eval(self):
         from tools.browser_tool import browser_console
 

--- a/tests/tools/test_browser_console.py
+++ b/tests/tools/test_browser_console.py
@@ -160,19 +160,67 @@ class TestBrowserConsole:
         assert result == {"success": True, "result": "Example"}
         mock_eval.assert_called_once_with("document.title", "test")
 
-    def test_expression_reports_cloakbrowser_backend_limitation_without_eval(self):
+    def test_expression_routes_cloakbrowser_through_shared_eval_policy(self):
         from tools.browser_tool import browser_console
 
         with patch("tools.browser_tool._allow_unsafe_browser_evaluate", return_value=False), \
              patch("tools.browser_tool._is_cloakbrowser_mode", return_value=True), \
-             patch("tools.browser_tool._browser_eval") as mock_eval:
+             patch("tools.browser_tool._browser_eval", return_value=json.dumps({"success": True, "result": "Example"})) as mock_eval:
             result = json.loads(browser_console(expression="document.title", task_id="test"))
 
-        assert result["success"] is False
-        assert "browser_console(expression=...)" in result["error"]
-        assert "CloakBrowser backend" in result["error"]
-        assert "browser_snapshot or browser_vision" in result["error"]
-        mock_eval.assert_not_called()
+        assert result == {"success": True, "result": "Example"}
+        mock_eval.assert_called_once_with("document.title", "test")
+
+    def test_expression_redacts_cloakbrowser_eval_result_with_shared_output_path(self):
+        from tools.browser_tool import browser_console
+
+        fake_key = "ghp_" + "CLOAKBROWSEREVALSECRET1234567890"
+        with patch("tools.browser_tool._allow_unsafe_browser_evaluate", return_value=False), \
+             patch("tools.browser_tool._is_cloakbrowser_mode", return_value=True), \
+             patch("tools.browser_tool._last_session_key", return_value="test"), \
+             patch("tools.browser_tool._eval_ssrf_guard_active", return_value=False), \
+             patch(
+                 "tools.browser_tool.cloakbrowser_eval",
+                 return_value=json.dumps({
+                     "success": True,
+                     "result": fake_key,
+                     "result_type": "str",
+                     "method": "cloakbrowser_native",
+                     "fallback_warning": "warn",
+                 }),
+             ):
+            result = json.loads(browser_console(expression="document.title", task_id="test"))
+
+        assert result["success"] is True
+        assert result["fallback_warning"] == "warn"
+        assert "CLOAKBROWSEREVALSECRET" not in json.dumps(result)
+        assert result["result"].startswith("ghp_")
+
+    def test_redacts_cloakbrowser_console_output_with_shared_output_path(self):
+        from tools.browser_tool import browser_console
+
+        fake_key = "sk-" + "CLOAKBROWSERCONSOLESECRET1234567890"
+        with patch("tools.browser_tool._is_cloakbrowser_mode", return_value=True), \
+             patch(
+                 "tools.browser_tool.cloakbrowser_console",
+                 return_value=json.dumps(
+                     {
+                         "success": True,
+                         "console_messages": [{"text": f"token={fake_key}", "type": "log", "source": "console"}],
+                         "js_errors": [{"message": f"boom {fake_key}", "source": "exception"}],
+                         "total_messages": 1,
+                         "total_errors": 1,
+                         "fallback_warning": "warn",
+                     }
+                 ),
+             ):
+            result = json.loads(browser_console(task_id="test"))
+
+        assert result["success"] is True
+        assert result["fallback_warning"] == "warn"
+        assert "CLOAKBROWSERCONSOLESECRET" not in json.dumps(result)
+        assert fake_key not in result["console_messages"][0]["text"]
+        assert fake_key not in result["js_errors"][0]["message"]
 
     def test_expression_blocks_cookie_access_before_eval(self):
         from tools.browser_tool import browser_console
@@ -450,6 +498,173 @@ class TestBrowserVisionConfig:
         assert result["meta"]["annotations"] == annotations
         assert any(p.get("type") == "image_url" for p in result["content"])
         assert f"Screenshot path: {screenshot}" in result["text_summary"]
+        mock_get_vision_model.assert_not_called()
+        mock_llm.assert_not_called()
+
+    def test_browser_vision_routes_cloakbrowser_capture_through_shared_pipeline(self, tmp_path):
+        from tools.browser_tool import browser_vision
+
+        shots_dir = tmp_path / "cache" / "screenshots"
+        shots_dir.mkdir(parents=True, exist_ok=True)
+        screenshot = shots_dir / "cloakbrowser.png"
+        screenshot.write_bytes(b"\x89PNG\r\n\x1a\ncloakbrowser")
+
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "CloakBrowser screenshot analysis"
+        mock_response.choices = [mock_choice]
+
+        with (
+            patch("hermes_constants.get_hermes_dir", return_value=shots_dir),
+            patch("tools.browser_tool._cleanup_old_screenshots"),
+            patch("tools.browser_tool._is_camofox_mode", return_value=False),
+            patch("tools.browser_tool._is_cloakbrowser_mode", return_value=True),
+            patch(
+                "tools.browser_tool.cloakbrowser_screenshot",
+                return_value=json.dumps({"success": True, "data": {"path": str(screenshot)}}),
+            ) as mock_cb_screenshot,
+            patch(
+                "tools.browser_tool._run_browser_command",
+                side_effect=AssertionError("generic screenshot path should not run for CloakBrowser"),
+            ),
+            patch("tools.browser_tool._get_vision_model", return_value="test-model"),
+            patch("hermes_cli.config.load_config", return_value={"auxiliary": {"vision": {}}}),
+            patch("tools.browser_tool.call_llm", return_value=mock_response) as mock_llm,
+        ):
+            result = json.loads(browser_vision("what is on the page?", task_id="test"))
+
+        assert result["success"] is True
+        assert result["analysis"] == "CloakBrowser screenshot analysis"
+        assert result["screenshot_path"] == str(screenshot)
+        mock_cb_screenshot.assert_called_once_with(task_id="test", annotate=False, full=True)
+        image_url = mock_llm.call_args.kwargs["messages"][0]["content"][1]["image_url"]["url"]
+        assert image_url.startswith("data:image/png;base64,")
+
+    def test_browser_vision_cloakbrowser_native_fast_path_preserves_screenshot_path(self, tmp_path):
+        from agent.auxiliary_client import clear_runtime_main, set_runtime_main
+        from tools.browser_tool import browser_vision
+
+        shots_dir = tmp_path / "cache" / "screenshots"
+        shots_dir.mkdir(parents=True, exist_ok=True)
+        screenshot = shots_dir / "cloakbrowser-native.png"
+        screenshot.write_bytes(b"\x89PNG\r\n\x1a\ncloakbrowser-native")
+
+        set_runtime_main("brand-new-provider", "llava-v1.6")
+        try:
+            with (
+                patch("hermes_constants.get_hermes_dir", return_value=shots_dir),
+                patch("tools.browser_tool._cleanup_old_screenshots"),
+                patch("tools.browser_tool._is_camofox_mode", return_value=False),
+                patch("tools.browser_tool._is_cloakbrowser_mode", return_value=True),
+                patch(
+                    "tools.browser_tool.cloakbrowser_screenshot",
+                    return_value=json.dumps({"success": True, "data": {"path": str(screenshot)}}),
+                ),
+                patch(
+                    "tools.browser_tool._run_browser_command",
+                    side_effect=AssertionError("generic screenshot path should not run for CloakBrowser"),
+                ),
+                patch("hermes_cli.config.load_config", return_value={"model": {"supports_vision": True}}),
+                patch("tools.browser_tool._get_vision_model") as mock_get_vision_model,
+                patch("tools.browser_tool.call_llm") as mock_llm,
+            ):
+                result = browser_vision("what is on the page?", task_id="test")
+        finally:
+            clear_runtime_main()
+
+        assert isinstance(result, dict)
+        assert result["_multimodal"] is True
+        assert result["meta"]["screenshot_path"] == str(screenshot)
+        assert f"Screenshot path: {screenshot}" in result["text_summary"]
+        mock_get_vision_model.assert_not_called()
+        mock_llm.assert_not_called()
+
+    def test_browser_vision_cloakbrowser_annotate_true_preserves_annotations(self, tmp_path):
+        from tools.browser_tool import browser_vision
+
+        shots_dir = tmp_path / "cache" / "screenshots"
+        shots_dir.mkdir(parents=True, exist_ok=True)
+        screenshot = shots_dir / "cloakbrowser-annotated.png"
+        screenshot.write_bytes(b"\x89PNG\r\n\x1a\ncloakbrowser-annotated")
+        annotations = [{"ref": "@e1", "label": 'button "Submit"'}]
+
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Annotated CloakBrowser screenshot analysis"
+        mock_response.choices = [mock_choice]
+
+        with (
+            patch("hermes_constants.get_hermes_dir", return_value=shots_dir),
+            patch("tools.browser_tool._cleanup_old_screenshots"),
+            patch("tools.browser_tool._is_camofox_mode", return_value=False),
+            patch("tools.browser_tool._is_cloakbrowser_mode", return_value=True),
+            patch("tools.browser_tool._mark_cloakbrowser_activity") as mock_mark_activity,
+            patch(
+                "tools.browser_tool.cloakbrowser_screenshot",
+                return_value=json.dumps({"success": True, "data": {"path": str(screenshot), "annotations": annotations}}),
+            ) as mock_cb_screenshot,
+            patch(
+                "tools.browser_tool._run_browser_command",
+                side_effect=AssertionError("generic screenshot path should not run for CloakBrowser"),
+            ),
+            patch("tools.browser_tool._get_vision_model", return_value="test-model"),
+            patch("hermes_cli.config.load_config", return_value={"auxiliary": {"vision": {}}}),
+            patch("tools.browser_tool.call_llm", return_value=mock_response),
+        ):
+            raw_result = browser_vision("what is on the page?", annotate=True, task_id="test")
+
+        assert isinstance(raw_result, str)
+        result = json.loads(raw_result)
+        assert result["success"] is True
+        assert result["annotations"] == annotations
+        mock_mark_activity.assert_called_once_with("test")
+        mock_cb_screenshot.assert_called_once_with(task_id="test", annotate=True, full=True)
+
+    def test_browser_vision_cloakbrowser_native_fast_path_marks_activity_before_capture(self, tmp_path):
+        from agent.auxiliary_client import clear_runtime_main, set_runtime_main
+        from tools.browser_tool import browser_vision
+
+        shots_dir = tmp_path / "cache" / "screenshots"
+        shots_dir.mkdir(parents=True, exist_ok=True)
+        screenshot = shots_dir / "cloakbrowser-native-order.png"
+        screenshot.write_bytes(b"\x89PNG\r\n\x1a\ncloakbrowser-native-order")
+
+        call_order = []
+
+        def mark_activity(task_id):
+            call_order.append(("mark", task_id))
+
+        def take_screenshot(*, task_id=None, annotate=False, full=True):
+            call_order.append(("screenshot", task_id, annotate, full))
+            return json.dumps({"success": True, "data": {"path": str(screenshot)}})
+
+        set_runtime_main("brand-new-provider", "llava-v1.6")
+        try:
+            with (
+                patch("hermes_constants.get_hermes_dir", return_value=shots_dir),
+                patch("tools.browser_tool._cleanup_old_screenshots"),
+                patch("tools.browser_tool._is_camofox_mode", return_value=False),
+                patch("tools.browser_tool._is_cloakbrowser_mode", return_value=True),
+                patch("tools.browser_tool._mark_cloakbrowser_activity", side_effect=mark_activity),
+                patch("tools.browser_tool.cloakbrowser_screenshot", side_effect=take_screenshot),
+                patch(
+                    "tools.browser_tool._run_browser_command",
+                    side_effect=AssertionError("generic screenshot path should not run for CloakBrowser"),
+                ),
+                patch("hermes_cli.config.load_config", return_value={"model": {"supports_vision": True}}),
+                patch("tools.browser_tool._get_vision_model") as mock_get_vision_model,
+                patch("tools.browser_tool.call_llm") as mock_llm,
+            ):
+                result = browser_vision("what is on the page?", task_id="test")
+        finally:
+            clear_runtime_main()
+
+        assert isinstance(result, dict)
+        assert result["_multimodal"] is True
+        assert call_order == [
+            ("mark", "test"),
+            ("screenshot", "test", False, True),
+        ]
         mock_get_vision_model.assert_not_called()
         mock_llm.assert_not_called()
 

--- a/tests/tools/test_browser_hardening.py
+++ b/tests/tools/test_browser_hardening.py
@@ -17,6 +17,7 @@ def _reset_caches():
     bt._agent_browser_resolved = False
     bt._cached_command_timeout = None
     bt._command_timeout_resolved = False
+    bt._session_last_activity.clear()
     # lru_cache for _discover_homebrew_node_dirs
     if hasattr(bt._discover_homebrew_node_dirs, "cache_clear"):
         bt._discover_homebrew_node_dirs.cache_clear()
@@ -145,6 +146,36 @@ class TestSessionInactivityTimeout:
         cfg = {"browser": {"inactivity_timeout": "not-an-int"}}
         with patch("hermes_cli.config.read_raw_config", return_value=cfg):
             assert _get_session_inactivity_timeout() == 240
+
+    def test_cloakbrowser_cleanup_uses_nested_timeout(self):
+        import tools.browser_tool as bt
+
+        with patch.object(bt, "_is_cloakbrowser_mode", return_value=True), \
+             patch.object(bt, "_get_cloakbrowser_session_inactivity_timeout", return_value=600), \
+             patch.object(bt, "BROWSER_SESSION_INACTIVITY_TIMEOUT", 120), \
+             patch.object(bt, "cleanup_browser") as mock_cleanup, \
+             patch("tools.browser_tool.time.time", return_value=1000):
+            bt._session_last_activity.clear()
+            bt._session_last_activity["cloak-task"] = 700
+            bt._cleanup_inactive_browser_sessions()
+
+        assert "cloak-task" in bt._session_last_activity
+        mock_cleanup.assert_not_called()
+
+    def test_generic_cleanup_keeps_using_generic_timeout(self):
+        import tools.browser_tool as bt
+
+        with patch.object(bt, "_is_cloakbrowser_mode", return_value=False), \
+             patch.object(bt, "_get_cloakbrowser_session_inactivity_timeout", return_value=600), \
+             patch.object(bt, "BROWSER_SESSION_INACTIVITY_TIMEOUT", 120), \
+             patch.object(bt, "cleanup_browser") as mock_cleanup, \
+             patch("tools.browser_tool.time.time", return_value=1000):
+            bt._session_last_activity.clear()
+            bt._session_last_activity["generic-task"] = 700
+            bt._cleanup_inactive_browser_sessions()
+
+        assert "generic-task" not in bt._session_last_activity
+        mock_cleanup.assert_called_once_with("generic-task")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_browser_ssrf_local.py
+++ b/tests/tools/test_browser_ssrf_local.py
@@ -184,17 +184,38 @@ class TestIsLocalBackend:
         assert browser_tool._is_local_backend() is True
 
     def test_cloud_provider_is_not_local(self, monkeypatch):
-        """Cloud provider configured and not Camofox → NOT local."""
+        """Cloud provider configured and not Camofox/CloakBrowser → NOT local."""
         monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+        monkeypatch.setattr(browser_tool, "_is_cloakbrowser_mode", lambda: False)
         monkeypatch.setattr(browser_tool, "_get_cloud_provider", lambda: "bb")
 
         assert browser_tool._is_local_backend() is False
+
+    def test_truly_local_cloakbrowser_is_local(self, monkeypatch):
+        """CloakBrowser preserves local behavior only on a truly local terminal."""
+        monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+        monkeypatch.setattr(browser_tool, "_is_cloakbrowser_mode", lambda: True)
+        monkeypatch.setattr(browser_tool, "_get_cloud_provider", lambda: "cloakbrowser")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        assert browser_tool._is_local_backend() is True
 
     @pytest.mark.parametrize("backend", ["docker", "modal", "daytona", "ssh", "singularity"])
     def test_container_terminal_backend_is_not_local(self, monkeypatch, backend):
         """Terminal running in a container → NOT local (browser on host can access internal networks)."""
         monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+        monkeypatch.setattr(browser_tool, "_is_cloakbrowser_mode", lambda: False)
         monkeypatch.setattr(browser_tool, "_get_cloud_provider", lambda: None)
+        monkeypatch.setenv("TERMINAL_ENV", backend)
+
+        assert browser_tool._is_local_backend() is False
+
+    @pytest.mark.parametrize("backend", ["docker", "modal", "daytona", "ssh", "singularity"])
+    def test_container_terminal_backend_keeps_cloakbrowser_non_local(self, monkeypatch, backend):
+        """CloakBrowser must not widen trust in remote/container terminal deployments."""
+        monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+        monkeypatch.setattr(browser_tool, "_is_cloakbrowser_mode", lambda: True)
+        monkeypatch.setattr(browser_tool, "_get_cloud_provider", lambda: "cloakbrowser")
         monkeypatch.setenv("TERMINAL_ENV", backend)
 
         assert browser_tool._is_local_backend() is False

--- a/tests/tools/test_tool_backend_helpers.py
+++ b/tests/tools/test_tool_backend_helpers.py
@@ -27,6 +27,7 @@ from tools.tool_backend_helpers import (
     prefers_gateway,
     resolve_modal_backend_state,
     resolve_openai_audio_api_key,
+    sync_cloakbrowser_enabled_flag,
 )
 
 
@@ -154,6 +155,23 @@ class TestNormalizeBrowserCloudProvider:
         result = normalize_browser_cloud_provider(42)
         assert isinstance(result, str)
         assert result == "42"
+
+
+class TestSyncCloakBrowserEnabledFlag:
+    def test_enables_only_for_cloakbrowser_provider(self):
+        cfg = {"cloud_provider": "cloakbrowser", "cloakbrowser": {"enabled": False}}
+
+        result = sync_cloakbrowser_enabled_flag(cfg)
+
+        assert result is cfg
+        assert cfg["cloakbrowser"]["enabled"] is True
+
+    def test_clears_stale_enabled_flag_for_other_provider(self):
+        cfg = {"cloud_provider": "browser-use", "cloakbrowser": {"enabled": True}}
+
+        sync_cloakbrowser_enabled_flag(cfg)
+
+        assert cfg["cloakbrowser"]["enabled"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -111,6 +111,20 @@ def _config_cdp_url() -> str:
     return ""
 
 
+def _configured_browser_provider() -> tuple[str, bool]:
+    """Return (normalized provider key, was_explicitly_configured)."""
+    try:
+        from hermes_cli.config import read_raw_config
+
+        browser_cfg = read_raw_config().get("browser", {})
+    except Exception:
+        return "", False
+    if not isinstance(browser_cfg, dict) or "cloud_provider" not in browser_cfg:
+        return "", False
+    provider = str(browser_cfg.get("cloud_provider", "") or "").strip().lower()
+    return provider, True
+
+
 def is_camofox_mode() -> bool:
     """True when Camofox backend is configured and no CDP override is active.
 
@@ -126,6 +140,9 @@ def is_camofox_mode() -> bool:
     if os.getenv("BROWSER_CDP_URL", "").strip():
         return False
     if _config_cdp_url():
+        return False
+    configured_provider, explicit = _configured_browser_provider()
+    if explicit and configured_provider != "camofox":
         return False
     return bool(get_camofox_url())
 

--- a/tools/browser_cloakbrowser.py
+++ b/tools/browser_cloakbrowser.py
@@ -14,11 +14,12 @@ import inspect
 import json
 import os
 import threading
+import uuid
 from pathlib import Path
 from typing import Any
 
 from hermes_cli import config as hermes_config
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, get_hermes_dir
 from tools.tool_backend_helpers import normalize_browser_cloud_provider
 from tools.registry import tool_error
 
@@ -373,6 +374,12 @@ async def _ensure_live_page(session: dict[str, Any]) -> Any:
     return page
 
 
+async def _ensure_session_ready(session: dict[str, Any]) -> Any:
+    page = await _ensure_live_page(session)
+    _register_console_listeners(session)
+    return page
+
+
 def _ensure_session(task_id: str | None = None) -> dict[str, Any]:
     key = _task_key(task_id)
     with _sessions_lock:
@@ -381,11 +388,81 @@ def _ensure_session(task_id: str | None = None) -> dict[str, Any]:
             session = _launch_session_on_dedicated_loop(timeout=_CLOAKBROWSER_LAUNCH_TIMEOUT)
             _sessions[key] = session
     try:
-        _run_on_session_loop(session, _ensure_live_page(session), timeout=_CLOAKBROWSER_DEFAULT_TIMEOUT)
+        _run_on_session_loop(session, _ensure_session_ready(session), timeout=_CLOAKBROWSER_DEFAULT_TIMEOUT)
         return session
     except Exception:
         _teardown_session(session, task_id=task_id)
         raise
+
+
+def _console_buffer(session: dict[str, Any]) -> list[dict[str, Any]]:
+    messages = session.get("console_messages")
+    if not isinstance(messages, list):
+        messages = []
+        session["console_messages"] = messages
+    return messages
+
+
+def _page_error_buffer(session: dict[str, Any]) -> list[dict[str, Any]]:
+    errors = session.get("page_errors")
+    if not isinstance(errors, list):
+        errors = []
+        session["page_errors"] = errors
+    return errors
+
+
+def _listener_text(value: Any) -> str:
+    text_attr = getattr(value, "text", None)
+    if callable(text_attr):
+        try:
+            text_attr = text_attr()
+        except Exception:
+            text_attr = None
+    if text_attr not in (None, ""):
+        return str(text_attr)
+    return str(value or "")
+
+
+def _listener_type(value: Any) -> str:
+    type_attr = getattr(value, "type", None)
+    if callable(type_attr):
+        try:
+            type_attr = type_attr()
+        except Exception:
+            type_attr = None
+    return str(type_attr or "log")
+
+
+def _register_console_listeners(session: dict[str, Any]) -> None:
+    page = session.get("page")
+    _console_buffer(session)
+    _page_error_buffer(session)
+    if session.get("_console_listeners_page") is page:
+        return
+    if page is None or not callable(getattr(page, "on", None)):
+        session["_console_listeners_page"] = page
+        return
+
+    def _on_console(message: Any) -> None:
+        _console_buffer(session).append(
+            {
+                "type": _listener_type(message),
+                "text": _listener_text(message),
+                "source": "console",
+            }
+        )
+
+    def _on_pageerror(error: Any) -> None:
+        _page_error_buffer(session).append(
+            {
+                "message": _listener_text(error),
+                "source": "exception",
+            }
+        )
+
+    page.on("console", _on_console)
+    page.on("pageerror", _on_pageerror)
+    session["_console_listeners_page"] = page
 
 
 async def _navigate_page(page: Any, url: str, timeout: float | None = None) -> None:
@@ -461,6 +538,67 @@ def _resolve_ref(session: dict[str, Any], ref: str) -> tuple[str, str]:
     if not info or not info.get("selector"):
         raise RuntimeError(f"Unknown element ref '@{clean_ref}'. Call browser_snapshot first.")
     return clean_ref, str(info["selector"])
+
+
+async def _capture_screenshot(page: Any, *, full: bool = True) -> bytes:
+    screenshot = getattr(page, "screenshot", None)
+    if not callable(screenshot):
+        raise RuntimeError("Browser page does not support screenshots")
+    payload = await screenshot(full_page=full)
+    if isinstance(payload, (bytes, bytearray)):
+        return bytes(payload)
+    if isinstance(payload, str):
+        candidate = Path(payload)
+        if candidate.exists():
+            return candidate.read_bytes()
+    raise RuntimeError("CloakBrowser screenshot capture returned no image bytes")
+
+
+def _annotation_payload_from_snapshot(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
+    refs = snapshot.get("refs", {}) or {}
+    annotations: list[dict[str, Any]] = []
+    for ref, info in refs.items():
+        clean_ref = str(ref).lstrip("@")
+        tag = str(info.get("tag") or "element").strip() or "element"
+        text = str(info.get("text") or "").strip()
+        label = f"{tag} {json.dumps(text)}" if text else tag
+        annotations.append({
+            "ref": f"@{clean_ref}",
+            "label": label,
+            "tag": tag,
+            "text": text,
+            "selector": str(info.get("selector") or ""),
+        })
+    return annotations
+
+
+def cloakbrowser_screenshot(
+    task_id: str | None = None,
+    *,
+    annotate: bool = False,
+    full: bool = True,
+) -> str:
+    try:
+        session = _ensure_session(task_id)
+        page = _run_on_session_loop(session, _ensure_live_page(session))
+        annotation_data = None
+        if annotate:
+            snapshot = _run_on_session_loop(session, _snapshot_page(page, full=False))
+            session["refs"] = snapshot.get("refs", {}) or {}
+            annotation_data = _annotation_payload_from_snapshot(snapshot)
+        screenshot_bytes = _run_on_session_loop(session, _capture_screenshot(page, full=full))
+        screenshots_dir = get_hermes_dir("cache/screenshots", "browser_screenshots")
+        screenshots_dir.mkdir(parents=True, exist_ok=True)
+        screenshot_path = screenshots_dir / f"browser_screenshot_{uuid.uuid4().hex}.png"
+        screenshot_path.write_bytes(screenshot_bytes)
+        data: dict[str, Any] = {"path": str(screenshot_path)}
+        if annotation_data is not None:
+            data["annotations"] = annotation_data
+        return json.dumps({"success": True, "data": data}, ensure_ascii=False)
+    except ModuleNotFoundError:
+        return tool_error("CloakBrowser Python package is not installed", success=False)
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
 
 
 def cloakbrowser_navigate(url: str, task_id: str | None = None) -> str:
@@ -617,12 +755,55 @@ def cloakbrowser_get_images(task_id: str | None = None) -> str:
         return tool_error(str(exc), success=False)
 
 
+def cloakbrowser_eval(expression: str, task_id: str | None = None) -> str:
+    try:
+        session = _ensure_session(task_id)
+        page = _run_on_session_loop(session, _ensure_live_page(session))
+        raw_result = _run_on_session_loop(session, page.evaluate(expression))
+        parsed = raw_result
+        if isinstance(raw_result, str):
+            try:
+                parsed = json.loads(raw_result)
+            except (json.JSONDecodeError, ValueError):
+                pass
+        return json.dumps(
+            {
+                "success": True,
+                "result": parsed,
+                "result_type": type(parsed).__name__,
+                "method": "cloakbrowser_native",
+            },
+            ensure_ascii=False,
+            default=str,
+        )
+    except ModuleNotFoundError:
+        return tool_error("CloakBrowser Python package is not installed", success=False)
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
 def cloakbrowser_console(clear: bool = False, task_id: str | None = None) -> str:
-    del clear, task_id
-    return tool_error(
-        "CloakBrowser console is not implemented in this minimal slice yet.",
-        success=False,
-    )
+    try:
+        session = _ensure_session(task_id)
+        messages = list(_console_buffer(session))
+        errors = list(_page_error_buffer(session))
+        if clear:
+            session["console_messages"] = []
+            session["page_errors"] = []
+        return json.dumps(
+            {
+                "success": True,
+                "console_messages": messages,
+                "js_errors": errors,
+                "total_messages": len(messages),
+                "total_errors": len(errors),
+            },
+            ensure_ascii=False,
+        )
+    except ModuleNotFoundError:
+        return tool_error("CloakBrowser Python package is not installed", success=False)
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
 
 
 def cloakbrowser_close(task_id: str | None = None) -> bool:

--- a/tools/browser_cloakbrowser.py
+++ b/tools/browser_cloakbrowser.py
@@ -1,0 +1,645 @@
+"""Minimal CloakBrowser runtime wrapper.
+
+This slice keeps the runtime narrowly scoped to the already-wired browser tool
+surface: navigate, snapshot, click, type, scroll, back, and press.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import importlib
+import importlib.util
+import inspect
+import json
+import os
+import threading
+from pathlib import Path
+from typing import Any
+
+from hermes_cli import config as hermes_config
+from hermes_constants import get_hermes_home
+from tools.tool_backend_helpers import normalize_browser_cloud_provider
+from tools.registry import tool_error
+
+# Timeouts in seconds for CloakBrowser async operations.
+_CLOAKBROWSER_DEFAULT_TIMEOUT: float = 60.0
+_CLOAKBROWSER_NAV_TIMEOUT: float = 90.0
+_CLOAKBROWSER_LAUNCH_TIMEOUT: float = 30.0
+
+
+def _config_cdp_url() -> str:
+    """Return persistent ``browser.cdp_url`` from config, if any."""
+    try:
+        browser_cfg = hermes_config.read_raw_config().get("browser", {})
+    except Exception:
+        return ""
+    if not isinstance(browser_cfg, dict):
+        return ""
+    return str(browser_cfg.get("cdp_url", "") or "").strip()
+
+
+def _get_browser_config() -> dict[str, Any]:
+    try:
+        browser_cfg = hermes_config.load_config().get("browser", {})
+    except Exception:
+        return {}
+    return browser_cfg if isinstance(browser_cfg, dict) else {}
+
+
+def _get_cloakbrowser_config() -> dict[str, Any]:
+    browser_cfg = _get_browser_config()
+    cloak_cfg = browser_cfg.get("cloakbrowser", {})
+    return cloak_cfg if isinstance(cloak_cfg, dict) else {}
+
+
+def get_cloakbrowser_profile_dir() -> Path:
+    """Return the profile-scoped default user-data directory."""
+    return get_hermes_home() / "cloakbrowser_profile"
+
+
+def is_cloakbrowser_mode() -> bool:
+    """True when config selects CloakBrowser and no CDP override is active."""
+    if os.environ.get("BROWSER_CDP_URL", "").strip():
+        return False
+    if _config_cdp_url():
+        return False
+
+    try:
+        browser_cfg = hermes_config.read_raw_config().get("browser", {})
+    except Exception:
+        return False
+    if not isinstance(browser_cfg, dict):
+        return False
+
+    return (
+        normalize_browser_cloud_provider(browser_cfg.get("cloud_provider"))
+        == "cloakbrowser"
+        and not bool(browser_cfg.get("use_gateway"))
+    )
+
+
+def check_cloakbrowser_available() -> bool:
+    """Return whether the Python package is importable.
+
+    Deliberately avoids launching or probing the network in this minimal slice.
+    """
+    return importlib.util.find_spec("cloakbrowser") is not None
+
+
+def build_cloakbrowser_launch_options() -> dict[str, Any]:
+    """Normalize config into a minimal launch-options dict."""
+    cloak_cfg = _get_cloakbrowser_config()
+    user_data_dir = str(cloak_cfg.get("user_data_dir", "") or "").strip()
+    if not user_data_dir:
+        user_data_dir = str(get_cloakbrowser_profile_dir())
+
+    options: dict[str, Any] = {
+        "headless": bool(cloak_cfg.get("headless", False)),
+        "humanize": bool(cloak_cfg.get("humanize", True)),
+        "stealth_args": bool(cloak_cfg.get("stealth_args", True)),
+        "user_data_dir": user_data_dir,
+    }
+
+    for key in (
+        "proxy",
+        "geoip",
+        "locale",
+        "timezone",
+        "viewport_width",
+        "viewport_height",
+        "color_scheme",
+        "user_agent",
+    ):
+        value = cloak_cfg.get(key)
+        if value not in (None, ""):
+            options[key] = value
+
+    extra_args = cloak_cfg.get("extra_args")
+    if isinstance(extra_args, list) and extra_args:
+        options["extra_args"] = extra_args
+
+    return options
+
+
+_sessions: dict[str, dict[str, Any]] = {}
+_sessions_lock = threading.Lock()
+_loop: asyncio.AbstractEventLoop | None = None
+_loop_thread: threading.Thread | None = None
+
+
+def _start_loop_thread(name: str) -> tuple[asyncio.AbstractEventLoop, threading.Thread]:
+    loop = asyncio.new_event_loop()
+    ready = threading.Event()
+
+    def _runner() -> None:
+        asyncio.set_event_loop(loop)
+        ready.set()
+        try:
+            loop.run_forever()
+        finally:
+            pending = [task for task in asyncio.all_tasks(loop) if not task.done()]
+            for task in pending:
+                task.cancel()
+            if pending:
+                loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+            loop.run_until_complete(loop.shutdown_asyncgens())
+            loop.close()
+
+    thread = threading.Thread(target=_runner, name=name, daemon=True)
+    thread.start()
+    ready.wait()
+    return loop, thread
+
+
+def _task_key(task_id: str | None) -> str:
+    return task_id or "default"
+
+
+def _get_loop() -> asyncio.AbstractEventLoop:
+    global _loop, _loop_thread
+    if _loop is not None and _loop.is_running():
+        return _loop
+
+    with _sessions_lock:
+        if _loop is not None and _loop.is_running():
+            return _loop
+
+        loop, thread = _start_loop_thread("cloakbrowser-loop")
+        _loop = loop
+        _loop_thread = thread
+        return loop
+
+
+def _run_async(coro: Any, timeout: float | None = None) -> Any:
+    loop = _get_loop()
+    future = asyncio.run_coroutine_threadsafe(coro, loop)
+    effective = timeout if timeout is not None else _CLOAKBROWSER_DEFAULT_TIMEOUT
+    try:
+        return future.result(timeout=effective)
+    except concurrent.futures.TimeoutError:
+        future.cancel()
+        try:
+            future.result(timeout=1)
+        except (concurrent.futures.CancelledError, concurrent.futures.TimeoutError):
+            pass
+        raise RuntimeError(
+            f"CloakBrowser operation timed out after {effective}s"
+        )
+
+
+def _run_coro_in_thread(coro_factory: Any, timeout: float) -> Any:
+    """Run a coroutine to completion in a worker thread with a hard timeout.
+
+    Some CloakBrowser launch paths call synchronous helpers inside their async
+    wrappers. If those helpers block, they can stall the shared event-loop
+    thread before asyncio timeouts get a chance to fire. Running the whole
+    launch coroutine in a dedicated worker thread preserves a hard timeout at
+    the caller boundary.
+    """
+
+    def _runner() -> Any:
+        return asyncio.run(coro_factory())
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(_runner)
+        try:
+            return future.result(timeout=timeout)
+        except concurrent.futures.TimeoutError:
+            raise RuntimeError(
+                f"CloakBrowser operation timed out after {timeout}s"
+            )
+
+
+def _run_on_session_loop(
+    session: dict[str, Any],
+    coro: Any,
+    timeout: float | None = None,
+) -> Any:
+    loop = session.get("_loop")
+    if loop is None:
+        return _run_async(coro, timeout=timeout)
+
+    future = asyncio.run_coroutine_threadsafe(coro, loop)
+    effective = timeout if timeout is not None else _CLOAKBROWSER_DEFAULT_TIMEOUT
+    try:
+        return future.result(timeout=effective)
+    except concurrent.futures.TimeoutError:
+        future.cancel()
+        try:
+            future.result(timeout=1)
+        except (concurrent.futures.CancelledError, concurrent.futures.TimeoutError):
+            pass
+        _teardown_session(session)
+        raise RuntimeError(
+            f"CloakBrowser operation timed out after {effective}s"
+        )
+
+
+def _launch_session_on_dedicated_loop(timeout: float) -> dict[str, Any]:
+    loop, thread = _start_loop_thread("cloakbrowser-session-loop")
+    future = asyncio.run_coroutine_threadsafe(_launch_session(), loop)
+    try:
+        session = future.result(timeout=timeout)
+    except concurrent.futures.TimeoutError:
+        future.cancel()
+        _shutdown_loop_thread(loop, thread)
+        raise RuntimeError(
+            f"CloakBrowser operation timed out after {timeout}s"
+        )
+    except Exception:
+        _shutdown_loop_thread(loop, thread)
+        raise
+
+    if isinstance(session, dict):
+        session["_loop"] = loop
+        session["_thread"] = thread
+    return session
+
+
+def _shutdown_loop_thread(
+    loop: asyncio.AbstractEventLoop | None,
+    thread: threading.Thread | None,
+    join_timeout: float = 2.0,
+) -> None:
+    if loop is not None and not loop.is_closed() and loop.is_running():
+        loop.call_soon_threadsafe(loop.stop)
+    if thread is not None and thread.is_alive() and thread is not threading.current_thread():
+        thread.join(timeout=join_timeout)
+
+
+async def _close_session_resources(session: dict[str, Any]) -> None:
+    for name in ("page", "context", "browser"):
+        resource = session.get(name)
+        close = getattr(resource, "close", None)
+        if not callable(close):
+            continue
+        try:
+            result = close()
+            if inspect.isawaitable(result):
+                await result
+        except Exception:
+            continue
+
+
+def _teardown_session(session: dict[str, Any], task_id: str | None = None) -> None:
+    with _sessions_lock:
+        if task_id is not None:
+            key = _task_key(task_id)
+            if _sessions.get(key) is session:
+                _sessions.pop(key, None)
+        else:
+            for key, candidate in list(_sessions.items()):
+                if candidate is session:
+                    _sessions.pop(key, None)
+                    break
+
+    loop = session.get("_loop")
+    if loop is not None and not loop.is_closed() and loop.is_running():
+        try:
+            future = asyncio.run_coroutine_threadsafe(_close_session_resources(session), loop)
+            future.result(timeout=_CLOAKBROWSER_DEFAULT_TIMEOUT)
+        except Exception:
+            pass
+
+    _shutdown_loop_thread(loop, session.get("_thread"))
+
+
+def _import_cloakbrowser_api() -> tuple[Any, Any]:
+    module = importlib.import_module("cloakbrowser")
+    launch_async = getattr(module, "launch_async", None)
+    launch_persistent_context_async = getattr(module, "launch_persistent_context_async", None)
+    if launch_async is None and launch_persistent_context_async is None:
+        raise RuntimeError("cloakbrowser package is missing launch_async/launch_persistent_context_async")
+    return launch_async, launch_persistent_context_async
+
+
+def _normalized_viewport(options: dict[str, Any]) -> dict[str, int] | None:
+    width = options.get("viewport_width")
+    height = options.get("viewport_height")
+    if width in (None, "") or height in (None, ""):
+        return None
+    try:
+        return {"width": int(width), "height": int(height)}
+    except Exception:
+        return None
+
+
+async def _launch_session() -> dict[str, Any]:
+    launch_async, launch_persistent_context_async = _import_cloakbrowser_api()
+    options = build_cloakbrowser_launch_options()
+    user_data_dir = str(options.get("user_data_dir") or "")
+    viewport = _normalized_viewport(options)
+    launch_kwargs = dict(options)
+    launch_kwargs.pop("viewport_width", None)
+    launch_kwargs.pop("viewport_height", None)
+    if viewport is not None:
+        launch_kwargs["viewport"] = viewport
+
+    if user_data_dir:
+        Path(user_data_dir).mkdir(parents=True, exist_ok=True)
+
+    if launch_persistent_context_async is not None and user_data_dir:
+        launch_kwargs.pop("user_data_dir", None)
+        context = await launch_persistent_context_async(user_data_dir=user_data_dir, **launch_kwargs)
+        page = None
+        pages = getattr(context, "pages", None)
+        if isinstance(pages, list) and pages:
+            page = pages[0]
+        if page is None:
+            page = await context.new_page()
+        return {"browser": None, "context": context, "page": page, "refs": {}, "persistent": True}
+
+    if launch_async is None:
+        raise RuntimeError("cloakbrowser launch_async unavailable")
+    browser = await launch_async(**launch_kwargs)
+    context = await browser.new_context(viewport=viewport) if viewport is not None else await browser.new_context()
+    page = await context.new_page()
+    return {"browser": browser, "context": context, "page": page, "refs": {}, "persistent": False}
+
+
+async def _ensure_live_page(session: dict[str, Any]) -> Any:
+    page = session.get("page")
+    if page is None:
+        raise RuntimeError("No browser page available")
+    is_closed = getattr(page, "is_closed", None)
+    if callable(is_closed) and is_closed():
+        context = session.get("context")
+        if context is None:
+            raise RuntimeError("Browser context disappeared; navigate again to recreate it")
+        page = await context.new_page()
+        session["page"] = page
+        session["refs"] = {}
+    return page
+
+
+def _ensure_session(task_id: str | None = None) -> dict[str, Any]:
+    key = _task_key(task_id)
+    with _sessions_lock:
+        session = _sessions.get(key)
+        if session is None:
+            session = _launch_session_on_dedicated_loop(timeout=_CLOAKBROWSER_LAUNCH_TIMEOUT)
+            _sessions[key] = session
+    try:
+        _run_on_session_loop(session, _ensure_live_page(session), timeout=_CLOAKBROWSER_DEFAULT_TIMEOUT)
+        return session
+    except Exception:
+        _teardown_session(session, task_id=task_id)
+        raise
+
+
+async def _navigate_page(page: Any, url: str, timeout: float | None = None) -> None:
+    goto_kwargs = {}
+    if timeout is not None:
+        goto_kwargs["timeout"] = int(timeout * 1000)
+    await page.goto(url, **goto_kwargs)
+
+
+async def _click_selector(page: Any, selector: str) -> None:
+    await page.click(selector)
+
+
+async def _type_into_selector(page: Any, selector: str, text: str) -> None:
+    await page.fill(selector, text)
+
+
+async def _snapshot_page(page: Any, full: bool = False, user_task: str | None = None) -> dict[str, Any]:
+    del user_task
+    payload = await page.evaluate(
+        r"""
+        ({ full }) => {
+          const isVisible = (el) => {
+            if (!el || !el.getBoundingClientRect) return false;
+            const style = window.getComputedStyle(el);
+            if (style.display === 'none' || style.visibility === 'hidden') return false;
+            const rect = el.getBoundingClientRect();
+            return rect.width > 0 && rect.height > 0;
+          };
+
+          const quote = (value) => JSON.stringify((value || '').replace(/\s+/g, ' ').trim());
+          const refs = {};
+          const lines = [];
+          let counter = 1;
+
+          const interactiveSelector = [
+            'a[href]', 'button', 'input', 'textarea', 'select',
+            '[role="button"]', '[role="link"]', '[role="textbox"]',
+            '[contenteditable="true"]'
+          ].join(',');
+
+          const elements = Array.from(document.querySelectorAll(interactiveSelector));
+          for (const el of elements) {
+            if (!isVisible(el)) continue;
+            const tag = (el.tagName || '').toLowerCase();
+            const text = el.innerText || el.textContent || el.getAttribute('aria-label') || el.value || '';
+            const ref = `e${counter++}`;
+            el.setAttribute('data-hermes-ref', ref);
+            refs[ref] = {
+              selector: `[data-hermes-ref="${ref}"]`,
+              tag,
+              text: (text || '').trim(),
+            };
+            lines.push(`- ${tag || 'element'} ${quote(text)} [@${ref}]`);
+          }
+
+          if (full) {
+            const bodyText = (document.body?.innerText || '').replace(/\s+/g, ' ').trim();
+            if (bodyText) lines.unshift(bodyText);
+          }
+
+          return { snapshot: lines.join('\n'), refs, element_count: Object.keys(refs).length };
+        }
+        """,
+        {"full": full},
+    )
+    return payload if isinstance(payload, dict) else {"snapshot": "", "refs": {}, "element_count": 0}
+
+
+def _resolve_ref(session: dict[str, Any], ref: str) -> tuple[str, str]:
+    clean_ref = ref.lstrip("@")
+    info = session.get("refs", {}).get(clean_ref)
+    if not info or not info.get("selector"):
+        raise RuntimeError(f"Unknown element ref '@{clean_ref}'. Call browser_snapshot first.")
+    return clean_ref, str(info["selector"])
+
+
+def cloakbrowser_navigate(url: str, task_id: str | None = None) -> str:
+    try:
+        session = _ensure_session(task_id)
+        page = _run_on_session_loop(session, _ensure_live_page(session), timeout=_CLOAKBROWSER_DEFAULT_TIMEOUT)
+        _run_on_session_loop(
+            session,
+            _navigate_page(page, url, timeout=_CLOAKBROWSER_NAV_TIMEOUT),
+            timeout=_CLOAKBROWSER_NAV_TIMEOUT,
+        )
+        title = _run_on_session_loop(session, page.title())
+        response = {"success": True, "url": getattr(page, "url", url), "title": title}
+        try:
+            snap = _run_on_session_loop(session, _snapshot_page(page, full=False))
+            session["refs"] = snap.get("refs", {}) or {}
+            response["snapshot"] = snap.get("snapshot", "")
+            response["element_count"] = int(snap.get("element_count", len(session["refs"])))
+        except Exception as exc:
+            response["snapshot_warning"] = str(exc)
+        return json.dumps(response, ensure_ascii=False)
+    except ModuleNotFoundError:
+        return tool_error("CloakBrowser Python package is not installed", success=False)
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def cloakbrowser_snapshot(full: bool = False, task_id: str | None = None, user_task: str | None = None) -> str:
+    try:
+        session = _ensure_session(task_id)
+        page = _run_on_session_loop(session, _ensure_live_page(session))
+        snap = _run_on_session_loop(session, _snapshot_page(page, full=full, user_task=user_task))
+        session["refs"] = snap.get("refs", {}) or {}
+        return json.dumps(
+            {
+                "success": True,
+                "snapshot": snap.get("snapshot", ""),
+                "element_count": int(snap.get("element_count", len(session["refs"]))),
+            },
+            ensure_ascii=False,
+        )
+    except ModuleNotFoundError:
+        return tool_error("CloakBrowser Python package is not installed", success=False)
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def cloakbrowser_click(ref: str, task_id: str | None = None) -> str:
+    try:
+        session = _ensure_session(task_id)
+        page = _run_on_session_loop(session, _ensure_live_page(session))
+        clean_ref, selector = _resolve_ref(session, ref)
+        _run_on_session_loop(session, _click_selector(page, selector))
+        return json.dumps({"success": True, "clicked": f"@{clean_ref}", "url": getattr(page, "url", "")}, ensure_ascii=False)
+    except ModuleNotFoundError:
+        return tool_error("CloakBrowser Python package is not installed", success=False)
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def cloakbrowser_type(ref: str, text: str, task_id: str | None = None) -> str:
+    try:
+        from agent.display import redact_browser_typed_text_for_display, redact_tool_args_for_display
+
+        session = _ensure_session(task_id)
+        page = _run_on_session_loop(session, _ensure_live_page(session))
+        clean_ref, selector = _resolve_ref(session, ref)
+        _run_on_session_loop(session, _type_into_selector(page, selector, text))
+        display_text = (redact_tool_args_for_display("browser_type", {"text": text}) or {"text": text})["text"]
+        response = {"success": True, "typed": display_text, "element": f"@{clean_ref}"}
+        response = redact_browser_typed_text_for_display(response, text)
+        return json.dumps(response, ensure_ascii=False)
+    except ModuleNotFoundError:
+        return tool_error("CloakBrowser Python package is not installed", success=False)
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def cloakbrowser_scroll(direction: str, task_id: str | None = None) -> str:
+    try:
+        session = _ensure_session(task_id)
+        page = _run_on_session_loop(session, _ensure_live_page(session))
+        delta_y = 500 if direction == "down" else -500
+        _run_on_session_loop(session, page.mouse.wheel(0, delta_y))
+        return json.dumps({"success": True, "scrolled": direction}, ensure_ascii=False)
+    except ModuleNotFoundError:
+        return tool_error("CloakBrowser Python package is not installed", success=False)
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def cloakbrowser_back(task_id: str | None = None) -> str:
+    try:
+        session = _ensure_session(task_id)
+        page = _run_on_session_loop(session, _ensure_live_page(session))
+        _run_on_session_loop(session, page.go_back())
+        return json.dumps({"success": True, "url": getattr(page, "url", "")}, ensure_ascii=False)
+    except ModuleNotFoundError:
+        return tool_error("CloakBrowser Python package is not installed", success=False)
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def cloakbrowser_press(key: str, task_id: str | None = None) -> str:
+    try:
+        session = _ensure_session(task_id)
+        page = _run_on_session_loop(session, _ensure_live_page(session))
+        _run_on_session_loop(session, page.keyboard.press(key))
+        return json.dumps({"success": True, "pressed": key}, ensure_ascii=False)
+    except ModuleNotFoundError:
+        return tool_error("CloakBrowser Python package is not installed", success=False)
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def cloakbrowser_current_url(task_id: str | None = None) -> str | None:
+    """Return the current page URL for the task's live CloakBrowser session."""
+    try:
+        session = _ensure_session(task_id)
+        page = _run_on_session_loop(session, _ensure_live_page(session))
+        return getattr(page, "url", None)
+    except Exception:
+        return None
+
+
+def cloakbrowser_get_images(task_id: str | None = None) -> str:
+    try:
+        session = _ensure_session(task_id)
+        page = _run_on_session_loop(session, _ensure_live_page(session))
+        images = _run_on_session_loop(
+            session,
+            page.evaluate(
+                r"""
+                () => [...document.images]
+                  .map((img) => ({
+                    src: img.src,
+                    alt: img.alt || '',
+                    width: img.naturalWidth,
+                    height: img.naturalHeight,
+                  }))
+                  .filter((img) => img.src && !img.src.startsWith('data:'))
+                """
+            ),
+        )
+        if not isinstance(images, list):
+            images = []
+        return json.dumps(
+            {"success": True, "images": images, "count": len(images)},
+            ensure_ascii=False,
+        )
+    except ModuleNotFoundError:
+        return tool_error("CloakBrowser Python package is not installed", success=False)
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def cloakbrowser_console(clear: bool = False, task_id: str | None = None) -> str:
+    del clear, task_id
+    return tool_error(
+        "CloakBrowser console is not implemented in this minimal slice yet.",
+        success=False,
+    )
+
+
+def cloakbrowser_close(task_id: str | None = None) -> bool:
+    key = _task_key(task_id)
+    with _sessions_lock:
+        session = _sessions.pop(key, None)
+    if session is None:
+        return False
+    _teardown_session(session)
+    return True
+
+
+def cloakbrowser_close_all() -> int:
+    """Close all live CloakBrowser sessions and return the count closed."""
+    with _sessions_lock:
+        items = list(_sessions.items())
+        _sessions.clear()
+    for _, session in items:
+        _teardown_session(session)
+    return len(items)

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -3532,6 +3532,23 @@ def _blocked_private_page_images(effective_task_id: str) -> Optional[str]:
     }, ensure_ascii=False)
 
 
+def _blocked_private_page_vision(effective_task_id: str) -> Optional[str]:
+    """Return a blocked payload when vision capture would expose a private page."""
+    if not _eval_ssrf_guard_active(effective_task_id):
+        return None
+    blocked_url = _current_page_private_url(effective_task_id)
+    if not blocked_url:
+        return None
+    return json.dumps({
+        "success": False,
+        "error": (
+            "Blocked: page URL targets a private or internal address "
+            f"({blocked_url}). This may have been caused by a "
+            "JavaScript navigation via browser_console."
+        ),
+    }, ensure_ascii=False)
+
+
 def browser_console(clear: bool = False, expression: Optional[str] = None, task_id: Optional[str] = None) -> str:
     """Get browser console messages and JavaScript errors, or evaluate JS in the page.
 
@@ -4232,6 +4249,10 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
         result = {}
         try:
             _mark_cloakbrowser_activity(task_id)
+            effective_task_id = _last_session_key(task_id or "default")
+            blocked = _blocked_private_page_vision(effective_task_id)
+            if blocked is not None:
+                return blocked
             raw_result = cloakbrowser_screenshot(task_id=task_id, annotate=annotate, full=True)
             result = json.loads(raw_result) if isinstance(raw_result, str) else raw_result
         except json.JSONDecodeError:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -162,7 +162,9 @@ try:
         cloakbrowser_press,
         cloakbrowser_current_url,
         cloakbrowser_get_images,
+        cloakbrowser_eval,
         cloakbrowser_console,
+        cloakbrowser_screenshot,
         cloakbrowser_close,
         cloakbrowser_close_all,
     )
@@ -197,7 +199,13 @@ except ImportError:
     def cloakbrowser_get_images(task_id: Optional[str] = None) -> str:
         raise RuntimeError("CloakBrowser wrapper unavailable")
 
+    def cloakbrowser_eval(expression: str, task_id: Optional[str] = None) -> str:
+        raise RuntimeError("CloakBrowser wrapper unavailable")
+
     def cloakbrowser_console(clear: bool = False, task_id: Optional[str] = None) -> str:
+        raise RuntimeError("CloakBrowser wrapper unavailable")
+
+    def cloakbrowser_screenshot(task_id: Optional[str] = None, *, annotate: bool = False, full: bool = True) -> str:
         raise RuntimeError("CloakBrowser wrapper unavailable")
 
     def cloakbrowser_close(task_id: Optional[str] = None) -> bool:
@@ -740,7 +748,12 @@ def _get_cloud_provider() -> Optional[CloudBrowserProvider]:
             provider_key = normalize_browser_cloud_provider(
                 browser_cfg.get("cloud_provider")
             )
-            if provider_key == "local":
+            if provider_key in {"local", "cloakbrowser"}:
+                # ``browser.cloud_provider`` is still the persisted selector for
+                # both real cloud plugins and native local backends wired in-core.
+                # CloakBrowser is the latter: keep its explicit selection sticky
+                # like ``local`` and do NOT fall through to plugin lookup or
+                # Browser Use / Browserbase auto-detect.
                 _cached_cloud_provider = None
                 _cloud_provider_resolved = True
                 return None
@@ -3524,17 +3537,6 @@ def browser_console(clear: bool = False, expression: Optional[str] = None, task_
         policy_error = _enforce_browser_eval_policy(expression)
         if policy_error:
             return json.dumps({"success": False, "error": policy_error}, ensure_ascii=False)
-        if _is_cloakbrowser_mode():
-            return json.dumps({
-                "success": False,
-                "error": (
-                    "JavaScript evaluation via browser_console(expression=...) is "
-                    "not yet supported with the CloakBrowser backend in this "
-                    "minimal slice. CloakBrowser console capture is also not "
-                    "available yet; use browser_snapshot or browser_vision to "
-                    "inspect page state instead."
-                ),
-            }, ensure_ascii=False)
         return _browser_eval(expression, task_id)
 
     # --- Console output mode (original behaviour) ---
@@ -3543,7 +3545,21 @@ def browser_console(clear: bool = False, expression: Optional[str] = None, task_
         return camofox_console(clear, task_id)
     if _is_cloakbrowser_mode():
         _mark_cloakbrowser_activity(task_id)
-        return cloakbrowser_console(clear, task_id)
+        raw_result = cloakbrowser_console(clear, task_id)
+        try:
+            result = json.loads(raw_result)
+        except Exception:
+            return raw_result
+        if result.get("success"):
+            response = {
+                "success": True,
+                "console_messages": _redact_browser_output(result.get("console_messages", [])),
+                "js_errors": _redact_browser_output(result.get("js_errors", [])),
+                "total_messages": int(result.get("total_messages", 0)),
+                "total_errors": int(result.get("total_errors", 0)),
+            }
+            return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
+        return json.dumps(_copy_fallback_warning(result, result), ensure_ascii=False)
 
     effective_task_id = _last_session_key(task_id or "default")
 
@@ -3805,6 +3821,29 @@ def _browser_eval(expression: str, task_id: Optional[str] = None) -> str:
                     "browser mode."
                 ),
             }, ensure_ascii=False)
+
+    if _is_cloakbrowser_mode():
+        raw_result = cloakbrowser_eval(expression, task_id)
+        try:
+            result = json.loads(raw_result)
+        except Exception:
+            return raw_result
+        if _eval_ssrf_guard_active(effective_task_id):
+            _blocked_url = _current_page_private_url(effective_task_id)
+            if _blocked_url:
+                return json.dumps({
+                    "success": False,
+                    "error": (
+                        "Blocked: page URL targets a private or internal address "
+                        f"({_blocked_url}). This may have been caused by a "
+                        "JavaScript navigation via browser_console."
+                    ),
+                }, ensure_ascii=False)
+        if result.get("success"):
+            if "result" in result:
+                result["result"] = _redact_browser_output(result.get("result"))
+            return json.dumps(_copy_fallback_warning(result, result), ensure_ascii=False, default=str)
+        return json.dumps(_copy_fallback_warning(result, result), ensure_ascii=False)
 
     # Camofox keeps its own raw-``task_id``-keyed session map, so pass the raw
     # id (matching every other Camofox tool) rather than the resolved
@@ -4174,6 +4213,25 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
         from tools.browser_camofox import camofox_vision
         return camofox_vision(question, annotate, task_id)
 
+    if _is_cloakbrowser_mode():
+        result = {}
+        try:
+            _mark_cloakbrowser_activity(task_id)
+            raw_result = cloakbrowser_screenshot(task_id=task_id, annotate=annotate, full=True)
+            result = json.loads(raw_result) if isinstance(raw_result, str) else raw_result
+        except json.JSONDecodeError:
+            return json.dumps({
+                "success": False,
+                "error": "Failed to parse CloakBrowser screenshot response",
+            }, ensure_ascii=False)
+        except Exception as e:
+            return json.dumps({
+                "success": False,
+                "error": f"Failed to take screenshot (native CloakBrowser mode): {e}",
+            }, ensure_ascii=False)
+    else:
+        result = None
+
     import base64
     import uuid as uuid_mod
     from hermes_constants import get_hermes_dir
@@ -4254,7 +4312,9 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
         # Prune old screenshots (older than 24 hours) to prevent unbounded disk growth
         _cleanup_old_screenshots(screenshots_dir, max_age_hours=24)
 
-        if _lp_prerouted and screenshot_path.exists():
+        if result is not None:
+            pass
+        elif _lp_prerouted and screenshot_path.exists():
             result = {
                 "success": True,
                 "data": {

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -62,7 +62,7 @@ import tempfile
 import threading
 import time
 import requests
-from typing import Dict, Any, Optional, List, Tuple, Union
+from typing import Callable, Dict, Any, Optional, List, Tuple, Union
 from pathlib import Path
 from agent.auxiliary_client import call_llm
 from agent.redact import redact_cdp_url
@@ -70,6 +70,8 @@ from hermes_constants import agent_browser_runnable, get_hermes_home
 from utils import env_int, is_truthy_value
 from hermes_cli.config import DEFAULT_CONFIG, cfg_get
 from hermes_cli._subprocess_compat import windows_hide_flags
+
+logger = logging.getLogger(__name__)
 
 # Browser-specific tool keys passed through to the agent-browser subprocess
 # AFTER credential stripping.  agent-browser is a Node process loading npm
@@ -147,8 +149,62 @@ try:
     from tools.browser_camofox import is_camofox_mode as _is_camofox_mode
 except ImportError:
     _is_camofox_mode = lambda: False  # noqa: E731
+try:
+    from tools.browser_cloakbrowser import (
+        is_cloakbrowser_mode as _is_cloakbrowser_mode,
+        check_cloakbrowser_available,
+        cloakbrowser_navigate,
+        cloakbrowser_snapshot,
+        cloakbrowser_click,
+        cloakbrowser_type,
+        cloakbrowser_scroll,
+        cloakbrowser_back,
+        cloakbrowser_press,
+        cloakbrowser_current_url,
+        cloakbrowser_get_images,
+        cloakbrowser_console,
+        cloakbrowser_close,
+        cloakbrowser_close_all,
+    )
+except ImportError:
+    _is_cloakbrowser_mode = lambda: False  # noqa: E731
+    check_cloakbrowser_available = lambda: False  # noqa: E731
 
-logger = logging.getLogger(__name__)
+    def cloakbrowser_navigate(url: str, task_id: Optional[str] = None) -> str:
+        raise RuntimeError("CloakBrowser wrapper unavailable")
+
+    def cloakbrowser_snapshot(full: bool = False, task_id: Optional[str] = None, user_task: Optional[str] = None) -> str:
+        raise RuntimeError("CloakBrowser wrapper unavailable")
+
+    def cloakbrowser_click(ref: str, task_id: Optional[str] = None) -> str:
+        raise RuntimeError("CloakBrowser wrapper unavailable")
+
+    def cloakbrowser_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
+        raise RuntimeError("CloakBrowser wrapper unavailable")
+
+    def cloakbrowser_scroll(direction: str, task_id: Optional[str] = None) -> str:
+        raise RuntimeError("CloakBrowser wrapper unavailable")
+
+    def cloakbrowser_back(task_id: Optional[str] = None) -> str:
+        raise RuntimeError("CloakBrowser wrapper unavailable")
+
+    def cloakbrowser_press(key: str, task_id: Optional[str] = None) -> str:
+        raise RuntimeError("CloakBrowser wrapper unavailable")
+
+    def cloakbrowser_current_url(task_id: Optional[str] = None) -> Optional[str]:
+        raise RuntimeError("CloakBrowser wrapper unavailable")
+
+    def cloakbrowser_get_images(task_id: Optional[str] = None) -> str:
+        raise RuntimeError("CloakBrowser wrapper unavailable")
+
+    def cloakbrowser_console(clear: bool = False, task_id: Optional[str] = None) -> str:
+        raise RuntimeError("CloakBrowser wrapper unavailable")
+
+    def cloakbrowser_close(task_id: Optional[str] = None) -> bool:
+        raise RuntimeError("CloakBrowser wrapper unavailable")
+
+    def cloakbrowser_close_all() -> int:
+        raise RuntimeError("CloakBrowser wrapper unavailable")
 
 # Standard PATH entries for environments with minimal PATH (e.g. systemd services).
 # Includes Android/Termux and macOS Homebrew locations needed for agent-browser,
@@ -782,6 +838,8 @@ def _is_local_mode() -> bool:
     """Return True when the browser tool will use a local browser backend."""
     if _get_cdp_override():
         return False
+    if _is_cloakbrowser_mode():
+        return True
     return _get_cloud_provider() is None
 
 
@@ -816,10 +874,13 @@ def _is_local_backend() -> bool:
         return False
     if _is_camofox_mode():
         return True
-    if _get_cloud_provider() is not None:
+    if _get_cloud_provider() is not None and not _is_cloakbrowser_mode():
         return False
     # When terminal runs in a container, browser on host can access
     # internal networks the terminal can't → treat as non-local.
+    # CloakBrowser is a local browser backend only when that terminal/browser
+    # trust boundary is actually shared; remote/container terminal deployments
+    # must keep SSRF protection enabled.
     terminal_backend = os.getenv("TERMINAL_ENV", "local").strip().lower()
     return terminal_backend in ("local", "")
 
@@ -885,6 +946,8 @@ def _should_inject_engine(engine: str) -> bool:
     if engine == "auto":
         return False
     if _is_camofox_mode():
+        return False
+    if _is_cloakbrowser_mode():
         return False
     return _is_local_mode()
 
@@ -1274,6 +1337,8 @@ def _navigation_session_key(task_id: str, url: str) -> str:
         return task_id
     if _is_camofox_mode():
         return task_id
+    if _is_cloakbrowser_mode():
+        return task_id
     if _get_cloud_provider() is None:
         return task_id
     if not _auto_local_for_private_urls():
@@ -1416,6 +1481,12 @@ DEFAULT_SESSION_INACTIVITY_TIMEOUT = int(
     DEFAULT_CONFIG.get("browser", {}).get("inactivity_timeout", 120)
 )
 
+DEFAULT_CLOAKBROWSER_SESSION_INACTIVITY_TIMEOUT = int(
+    DEFAULT_CONFIG.get("browser", {}).get("cloakbrowser", {}).get(
+        "inactivity_timeout", DEFAULT_SESSION_INACTIVITY_TIMEOUT
+    )
+)
+
 
 def _get_session_inactivity_timeout() -> int:
     result = env_int("BROWSER_INACTIVITY_TIMEOUT", DEFAULT_SESSION_INACTIVITY_TIMEOUT)
@@ -1428,6 +1499,25 @@ def _get_session_inactivity_timeout() -> int:
     except Exception as e:
         logger.debug("Could not read inactivity_timeout from config: %s", e)
     return result
+
+
+def _get_cloakbrowser_session_inactivity_timeout() -> int:
+    result = DEFAULT_CLOAKBROWSER_SESSION_INACTIVITY_TIMEOUT
+    try:
+        from hermes_cli.config import read_raw_config
+        cfg = read_raw_config()
+        val = cfg_get(cfg, "browser", "cloakbrowser", "inactivity_timeout")
+        if val is not None:
+            result = max(int(val), 30)  # Floor at 30s to avoid instant reaping
+    except Exception as e:
+        logger.debug("Could not read cloakbrowser inactivity_timeout from config: %s", e)
+    return result
+
+
+def _get_active_session_inactivity_timeout() -> int:
+    if _is_cloakbrowser_mode():
+        return _get_cloakbrowser_session_inactivity_timeout()
+    return BROWSER_SESSION_INACTIVITY_TIMEOUT
 
 
 BROWSER_SESSION_INACTIVITY_TIMEOUT = _get_session_inactivity_timeout()
@@ -1503,11 +1593,12 @@ def _cleanup_inactive_browser_sessions():
     orphaned sessions (local or Browserbase) from accumulating.
     """
     current_time = time.time()
+    inactivity_timeout = _get_active_session_inactivity_timeout()
     sessions_to_cleanup = []
 
     with _cleanup_lock:
         for task_id, last_time in list(_session_last_activity.items()):
-            if current_time - last_time > BROWSER_SESSION_INACTIVITY_TIMEOUT:
+            if current_time - last_time > inactivity_timeout:
                 sessions_to_cleanup.append(task_id)
 
     for task_id in sessions_to_cleanup:
@@ -1806,6 +1897,14 @@ def _update_session_activity(task_id: str):
     """Update the last activity timestamp for a session."""
     with _cleanup_lock:
         _session_last_activity[task_id] = time.time()
+
+
+def _mark_cloakbrowser_activity(task_id: Optional[str] = None) -> str:
+    """Track native CloakBrowser activity for inactivity cleanup."""
+    effective_task_id = task_id or "default"
+    _start_browser_cleanup_thread()
+    _update_session_activity(effective_task_id)
+    return effective_task_id
 
 
 # Register cleanup thread stop on exit
@@ -2346,7 +2445,7 @@ def _run_browser_command(
     # hybrid private-URL routing can create a local sidecar while a cloud
     # provider remains configured for public URLs.
     engine = _engine_override or _get_browser_engine()
-    if engine != "auto" and not _is_camofox_mode() and not session_info.get("cdp_url"):
+    if engine != "auto" and not _is_camofox_mode() and not _is_cloakbrowser_mode() and not session_info.get("cdp_url"):
         backend_args += ["--engine", engine]
 
     # Keep concrete executable paths intact, even when they contain spaces.
@@ -2691,6 +2790,47 @@ def _redact_browser_output(value: Any) -> Any:
 # Browser Tool Functions
 # ============================================================================
 
+def _post_redirect_ssrf_response(
+    *,
+    requested_url: str,
+    result: Dict[str, Any],
+    is_local_backend: bool,
+    auto_local_this_nav: bool,
+    clear_session: Callable[[], Any],
+) -> Optional[str]:
+    """Return a blocked response if navigation redirected across the SSRF boundary."""
+    if not result.get("success"):
+        return None
+
+    data = result.get("data")
+    if not isinstance(data, dict):
+        data = result
+    final_url = data.get("url", requested_url)
+    if not final_url or final_url == requested_url:
+        return None
+
+    if _is_always_blocked_url(final_url):
+        clear_session()
+        return json.dumps({
+            "success": False,
+            "error": "Blocked: redirect landed on a cloud metadata endpoint",
+        })
+
+    if (
+        not is_local_backend
+        and not auto_local_this_nav
+        and not _allow_private_urls()
+        and not _is_safe_url(final_url)
+    ):
+        clear_session()
+        return json.dumps({
+            "success": False,
+            "error": "Blocked: redirect landed on a private/internal address",
+        })
+
+    return None
+
+
 def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
     """
     Navigate to a URL in the browser.
@@ -2787,6 +2927,22 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_navigate
         return camofox_navigate(url, task_id)
+    if _is_cloakbrowser_mode():
+        _mark_cloakbrowser_activity(task_id)
+        raw_result = cloakbrowser_navigate(url, task_id)
+        try:
+            parsed_result = json.loads(raw_result)
+        except Exception:
+            return raw_result
+
+        blocked_response = _post_redirect_ssrf_response(
+            requested_url=url,
+            result=parsed_result,
+            is_local_backend=_is_local_backend(),
+            auto_local_this_nav=auto_local_this_nav,
+            clear_session=lambda: cloakbrowser_navigate("about:blank", task_id),
+        )
+        return blocked_response or raw_result
 
     if auto_local_this_nav:
         logger.info(
@@ -2828,29 +2984,15 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
         # Always-blocked floor (cloud metadata / IMDS) is enforced for every
         # backend and even when auto_local_this_nav is true — see pre-nav
         # check for rationale (#16234).
-        if (
-            final_url
-            and final_url != url
-            and _is_always_blocked_url(final_url)
-        ):
-            _run_browser_command(nav_session_key, "open", ["about:blank"], timeout=10)
-            return json.dumps({
-                "success": False,
-                "error": "Blocked: redirect landed on a cloud metadata endpoint",
-            })
-
-        if (
-            not _is_local_backend()
-            and not auto_local_this_nav
-            and not _allow_private_urls()
-            and final_url and final_url != url and not _is_safe_url(final_url)
-        ):
-            # Navigate away to a blank page to prevent snapshot leaks
-            _run_browser_command(nav_session_key, "open", ["about:blank"], timeout=10)
-            return json.dumps({
-                "success": False,
-                "error": "Blocked: redirect landed on a private/internal address",
-            })
+        blocked_response = _post_redirect_ssrf_response(
+            requested_url=url,
+            result=result,
+            is_local_backend=_is_local_backend(),
+            auto_local_this_nav=auto_local_this_nav,
+            clear_session=lambda: _run_browser_command(nav_session_key, "open", ["about:blank"], timeout=10),
+        )
+        if blocked_response:
+            return blocked_response
 
         response = {
             "success": True,
@@ -2936,6 +3078,13 @@ def browser_snapshot(
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_snapshot
         return camofox_snapshot(full, task_id, user_task)
+    if _is_cloakbrowser_mode():
+        _mark_cloakbrowser_activity(task_id)
+        effective_task_id = _last_session_key(task_id or "default")
+        blocked = _blocked_private_page_snapshot(effective_task_id)
+        if blocked is not None:
+            return blocked
+        return cloakbrowser_snapshot(full, task_id, user_task)
 
     effective_task_id = _last_session_key(task_id or "default")
 
@@ -3031,6 +3180,13 @@ def browser_click(ref: str, task_id: Optional[str] = None) -> str:
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_click
         return camofox_click(ref, task_id)
+    if _is_cloakbrowser_mode():
+        _mark_cloakbrowser_activity(task_id)
+        effective_task_id = _last_session_key(task_id or "default")
+        blocked = _blocked_private_page_action(effective_task_id, "click")
+        if blocked is not None:
+            return blocked
+        return cloakbrowser_click(ref, task_id)
 
     effective_task_id = _last_session_key(task_id or "default")
     blocked = _blocked_private_page_action(effective_task_id, "click")
@@ -3072,6 +3228,13 @@ def browser_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_type
         return camofox_type(ref, text, task_id)
+    if _is_cloakbrowser_mode():
+        _mark_cloakbrowser_activity(task_id)
+        effective_task_id = _last_session_key(task_id or "default")
+        blocked = _blocked_private_page_action(effective_task_id, "type")
+        if blocked is not None:
+            return blocked
+        return cloakbrowser_type(ref, text, task_id)
 
     effective_task_id = _last_session_key(task_id or "default")
     blocked = _blocked_private_page_action(effective_task_id, "type")
@@ -3146,6 +3309,9 @@ def browser_scroll(direction: str, task_id: Optional[str] = None) -> str:
         for _ in range(_SCROLL_REPEATS):
             result = camofox_scroll(direction, task_id)
         return result
+    if _is_cloakbrowser_mode():
+        _mark_cloakbrowser_activity(task_id)
+        return cloakbrowser_scroll(direction, task_id)
 
     effective_task_id = _last_session_key(task_id or "default")
 
@@ -3177,6 +3343,19 @@ def browser_back(task_id: Optional[str] = None) -> str:
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_back
         return camofox_back(task_id)
+    if _is_cloakbrowser_mode():
+        _mark_cloakbrowser_activity(task_id)
+        effective_task_id = _last_session_key(task_id or "default")
+        raw_result = cloakbrowser_back(task_id)
+        try:
+            result = json.loads(raw_result)
+        except Exception:
+            return raw_result
+        if result.get("success"):
+            blocked = _blocked_private_page_history(effective_task_id, "back")
+            if blocked is not None:
+                return blocked
+        return raw_result
 
     effective_task_id = _last_session_key(task_id or "default")
     result = _run_browser_command(effective_task_id, "back", [])
@@ -3229,6 +3408,13 @@ def browser_press(key: str, task_id: Optional[str] = None) -> str:
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_press
         return camofox_press(key, task_id)
+    if _is_cloakbrowser_mode():
+        _mark_cloakbrowser_activity(task_id)
+        effective_task_id = _last_session_key(task_id or "default")
+        blocked = _blocked_private_page_action(effective_task_id, "press")
+        if blocked is not None:
+            return blocked
+        return cloakbrowser_press(key, task_id)
 
     effective_task_id = _last_session_key(task_id or "default")
     blocked = _blocked_private_page_action(effective_task_id, "press")
@@ -3267,6 +3453,57 @@ def _blocked_private_page_action(effective_task_id: str, action: str) -> Optiona
     }, ensure_ascii=False)
 
 
+def _blocked_private_page_snapshot(effective_task_id: str) -> Optional[str]:
+    """Return a blocked payload when a snapshot would expose a private page."""
+    if not _eval_ssrf_guard_active(effective_task_id):
+        return None
+    blocked_url = _current_page_private_url(effective_task_id)
+    if not blocked_url:
+        return None
+    return json.dumps({
+        "success": False,
+        "error": (
+            "Blocked: page URL targets a private or internal address "
+            f"({blocked_url}). This may have been caused by a JavaScript "
+            "navigation via browser_console."
+        ),
+    }, ensure_ascii=False)
+
+
+def _blocked_private_page_history(effective_task_id: str, action: str) -> Optional[str]:
+    """Return a blocked payload when history navigation lands on a private page."""
+    if not _eval_ssrf_guard_active(effective_task_id):
+        return None
+    blocked_url = _current_page_private_url(effective_task_id)
+    if not blocked_url:
+        return None
+    return json.dumps({
+        "success": False,
+        "error": (
+            "Blocked: page URL targets a private or internal address "
+            f"({blocked_url}). Browser history navigation ({action}) landed "
+            "on this address."
+        ),
+    }, ensure_ascii=False)
+
+
+def _blocked_private_page_images(effective_task_id: str) -> Optional[str]:
+    """Return a blocked payload when image extraction would expose a private page."""
+    if not _eval_ssrf_guard_active(effective_task_id):
+        return None
+    blocked_url = _current_page_private_url(effective_task_id)
+    if not blocked_url:
+        return None
+    return json.dumps({
+        "success": False,
+        "error": (
+            "Blocked: page URL targets a private or internal address "
+            f"({blocked_url}). This may have been caused by a "
+            "JavaScript navigation via browser_console."
+        ),
+    }, ensure_ascii=False)
+
+
 def browser_console(clear: bool = False, expression: Optional[str] = None, task_id: Optional[str] = None) -> str:
     """Get browser console messages and JavaScript errors, or evaluate JS in the page.
 
@@ -3287,12 +3524,26 @@ def browser_console(clear: bool = False, expression: Optional[str] = None, task_
         policy_error = _enforce_browser_eval_policy(expression)
         if policy_error:
             return json.dumps({"success": False, "error": policy_error}, ensure_ascii=False)
+        if _is_cloakbrowser_mode():
+            return json.dumps({
+                "success": False,
+                "error": (
+                    "JavaScript evaluation via browser_console(expression=...) is "
+                    "not yet supported with the CloakBrowser backend in this "
+                    "minimal slice. CloakBrowser console capture is also not "
+                    "available yet; use browser_snapshot or browser_vision to "
+                    "inspect page state instead."
+                ),
+            }, ensure_ascii=False)
         return _browser_eval(expression, task_id)
 
     # --- Console output mode (original behaviour) ---
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_console
         return camofox_console(clear, task_id)
+    if _is_cloakbrowser_mode():
+        _mark_cloakbrowser_activity(task_id)
+        return cloakbrowser_console(clear, task_id)
 
     effective_task_id = _last_session_key(task_id or "default")
 
@@ -3387,26 +3638,30 @@ def _expression_targets_private_url(expression: str) -> Optional[str]:
 def _current_page_private_url(effective_task_id: str) -> Optional[str]:
     """Return the current page URL when it targets a private/internal address.
 
-    Reads ``window.location.href`` via a low-cost eval and returns it when the
-    page has been navigated (e.g. via ``location.href = '...'`` in a prior
-    eval) to an address the SSRF guard would reject.  Returns ``None`` when the
-    page is public, the URL can't be determined, or the check errors (fail-open
-    on probe failure, matching the snapshot/vision guards).
+    Reads the current page URL and returns it when the page has been navigated
+    (e.g. via ``location.href = '...'`` in a prior eval) to an address the SSRF
+    guard would reject. Returns ``None`` when the page is public, the URL can't
+    be determined, or the check errors (fail-open on probe failure, matching the
+    snapshot/vision guards).
     """
     try:
-        url_result = _run_browser_command(
-            effective_task_id, "eval", ["window.location.href"],
-            timeout=5, _engine_override="auto",
-        )
-        if url_result.get("success"):
+        if _is_cloakbrowser_mode():
+            current_url = (cloakbrowser_current_url(_bare_task_id_for_session_key(effective_task_id)) or "").strip()
+        else:
+            url_result = _run_browser_command(
+                effective_task_id, "eval", ["window.location.href"],
+                timeout=5, _engine_override="auto",
+            )
+            if not url_result.get("success"):
+                return None
             current_url = (
                 url_result.get("data", {}).get("result", "")
                 .strip().strip('"').strip("'")
             )
-            if current_url and (
-                _is_always_blocked_url(current_url) or not _is_safe_url(current_url)
-            ):
-                return current_url
+        if current_url and (
+            _is_always_blocked_url(current_url) or not _is_safe_url(current_url)
+        ):
+            return current_url
     except Exception as exc:
         logger.debug("_current_page_private_url: probe failed (%s)", exc)
     return None
@@ -3824,6 +4079,13 @@ def browser_get_images(task_id: Optional[str] = None) -> str:
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_get_images
         return camofox_get_images(task_id)
+    if _is_cloakbrowser_mode():
+        _mark_cloakbrowser_activity(task_id)
+        effective_task_id = _last_session_key(task_id or "default")
+        blocked = _blocked_private_page_images(effective_task_id)
+        if blocked is not None:
+            return blocked
+        return cloakbrowser_get_images(task_id)
 
     effective_task_id = _last_session_key(task_id or "default")
 
@@ -4271,6 +4533,10 @@ def cleanup_browser(task_id: Optional[str] = None) -> None:
     for session_key in session_keys:
         _cleanup_single_browser_session(session_key)
 
+    with _cleanup_lock:
+        for session_key in session_keys:
+            _session_last_activity.pop(session_key, None)
+
     # Drop stale last-active ownership. Cleaning a bare task drops its binding;
     # cleaning a sidecar drops the binding only if that sidecar was still the
     # recorded owner. This prevents a later click/snapshot from resurrecting a
@@ -4299,6 +4565,12 @@ def _cleanup_single_browser_session(task_id: str) -> None:
                 camofox_close(task_id)
         except Exception as e:
             logger.debug("Camofox cleanup for task %s: %s", task_id, e)
+
+    if _is_cloakbrowser_mode():
+        try:
+            cloakbrowser_close(task_id)
+        except Exception as e:
+            logger.debug("CloakBrowser cleanup for task %s: %s", task_id, e)
 
     logger.debug("cleanup_browser called for task_id: %s", task_id)
     logger.debug("Active sessions: %s", list(_active_sessions.keys()))
@@ -4369,6 +4641,12 @@ def cleanup_all_browsers() -> None:
         task_ids = list(_active_sessions.keys())
     for task_id in task_ids:
         cleanup_browser(task_id)
+
+    if _is_cloakbrowser_mode():
+        try:
+            cloakbrowser_close_all()
+        except Exception:
+            pass
 
     # Tear down CDP supervisors for all tasks so background threads exit.
     try:
@@ -4595,6 +4873,8 @@ def check_browser_requirements() -> bool:
     # Camofox backend — only needs the server URL, no agent-browser CLI
     if _is_camofox_mode():
         return True
+    if _is_cloakbrowser_mode():
+        return check_cloakbrowser_available()
 
     # CDP override mode can connect to an existing remote/local browser endpoint
     # without requiring the local agent-browser binary on PATH.

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2955,7 +2955,13 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
             auto_local_this_nav=auto_local_this_nav,
             clear_session=lambda: cloakbrowser_navigate("about:blank", task_id),
         )
-        return blocked_response or raw_result
+        if blocked_response:
+            return blocked_response
+
+        if parsed_result.get("success") and "snapshot" in parsed_result:
+            parsed_result["snapshot"] = _redact_browser_output(parsed_result.get("snapshot", ""))
+
+        return json.dumps(parsed_result, ensure_ascii=False)
 
     if auto_local_this_nav:
         logger.info(
@@ -3097,7 +3103,16 @@ def browser_snapshot(
         blocked = _blocked_private_page_snapshot(effective_task_id)
         if blocked is not None:
             return blocked
-        return cloakbrowser_snapshot(full, task_id, user_task)
+        raw_result = cloakbrowser_snapshot(full, task_id, user_task)
+        try:
+            parsed_result = json.loads(raw_result)
+        except Exception:
+            return raw_result
+
+        if parsed_result.get("success") and "snapshot" in parsed_result:
+            parsed_result["snapshot"] = _redact_browser_output(parsed_result.get("snapshot", ""))
+
+        return json.dumps(parsed_result, ensure_ascii=False)
 
     effective_task_id = _last_session_key(task_id or "default")
 

--- a/tools/tool_backend_helpers.py
+++ b/tools/tool_backend_helpers.py
@@ -74,6 +74,28 @@ def normalize_browser_cloud_provider(value: object | None) -> str:
     return provider or _DEFAULT_BROWSER_PROVIDER
 
 
+def sync_cloakbrowser_enabled_flag(browser_cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Keep ``browser.cloakbrowser.enabled`` aligned with ``cloud_provider``.
+
+    The flag is only meaningful when CloakBrowser is the selected browser
+    provider. Persisting a stale ``enabled: true`` while another provider is
+    selected should not change runtime behavior, but it can mislead setup/status
+    surfaces that inspect config. Normalize the flag in-place wherever provider
+    selection is persisted.
+    """
+    if not isinstance(browser_cfg, dict):
+        return browser_cfg
+
+    cloak_cfg = browser_cfg.get("cloakbrowser")
+    if not isinstance(cloak_cfg, dict):
+        cloak_cfg = {}
+        browser_cfg["cloakbrowser"] = cloak_cfg
+
+    provider = normalize_browser_cloud_provider(browser_cfg.get("cloud_provider"))
+    cloak_cfg["enabled"] = provider == "cloakbrowser"
+    return browser_cfg
+
+
 def coerce_modal_mode(value: object | None) -> str:
     """Return the requested modal mode when valid, else the default."""
     mode = str(value or _DEFAULT_MODAL_MODE).strip().lower()

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1769,23 +1769,44 @@ Configure browser automation behavior:
 
 ```yaml
 browser:
+  cloud_provider: local          # local | browserbase | browser-use | firecrawl | cloakbrowser
   inactivity_timeout: 120        # Seconds before auto-closing idle sessions
-  command_timeout: 30             # Timeout in seconds for browser commands (screenshot, navigate, etc.)
+  command_timeout: 30            # Timeout in seconds for browser commands (screenshot, navigate, etc.)
   record_sessions: false         # Auto-record browser sessions as WebM videos to ~/.hermes/browser_recordings/
+  auto_local_for_private_urls: true  # Use local Chromium for localhost/LAN even when a cloud provider is selected
   # Optional CDP override — when set, Hermes attaches directly to your own
-  # Chromium-family browser (via /browser connect) rather than starting a headless browser.
+  # Chromium-family browser (via /browser connect) rather than starting native
+  # CloakBrowser or the default local browser.
   cdp_url: ""
   # Dialog supervisor — controls how native JS dialogs (alert / confirm / prompt)
   # are handled when a CDP backend is attached (Browserbase, local Chromium-family
   # browser via /browser connect). Ignored on Camofox and default local agent-browser mode.
   dialog_policy: must_respond    # must_respond | auto_dismiss | auto_accept
   dialog_timeout_s: 300          # Safety auto-dismiss under must_respond (seconds)
+  cloakbrowser:
+    enabled: false               # Auto-managed; true only while cloud_provider is "cloakbrowser"
+    inactivity_timeout: 3600     # Native CloakBrowser session idle timeout in seconds
+    headless: false              # Run with a visible browser window when false
+    humanize: true               # Enable CloakBrowser humanized behavior
+    proxy: ""                    # Optional proxy URL
+    geoip: false                 # Resolve proxy geolocation automatically when supported
+    stealth_args: true           # Add default stealth Chromium arguments
+    locale: ""                   # Optional locale override, e.g. en-US
+    timezone: ""                 # Optional timezone override, e.g. America/New_York
+    color_scheme: ""             # Optional prefers-color-scheme override: light | dark
+    user_agent: ""               # Optional user-agent override
+    extra_args: []               # Extra Chromium args passed to CloakBrowser
+    user_data_dir: "${HERMES_HOME}/cloakbrowser_profile"
   camofox:
     managed_persistence: false   # When true, Camofox sessions persist cookies/logins across restarts
     user_id: ""                  # Optional externally managed Camofox userId
     session_key: ""              # Optional session key sent when Hermes creates a tab
     adopt_existing_tab: false    # Reuse an existing tab for this identity before creating one
 ```
+
+**Provider selection:** set `browser.cloud_provider` to choose Browserbase, Browser Use, Firecrawl, native CloakBrowser, or the default local browser path.
+
+**CloakBrowser:** Hermes only uses the nested `browser.cloakbrowser.*` settings when `browser.cloud_provider: cloakbrowser`. If `browser.cdp_url` or `BROWSER_CDP_URL` is set, that direct CDP attach path wins and native CloakBrowser launch is skipped until you clear the override.
 
 **Dialog policies:**
 

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -13,6 +13,7 @@ Hermes Agent includes a full browser automation toolset with multiple backend op
 - **Browser Use cloud mode** via [Browser Use](https://browser-use.com) as an alternative cloud browser provider
 - **Firecrawl cloud mode** via [Firecrawl](https://firecrawl.dev) for cloud browsers with built-in scraping
 - **Camofox local mode** via [Camofox](https://github.com/jo-inc/camofox-browser) for local anti-detection browsing (Firefox-based fingerprint spoofing)
+- **CloakBrowser local mode** via the native Python CloakBrowser backend for local stealth Chromium sessions
 - **Local Chromium-family CDP** — connect browser tools to your own Chrome, Brave, Chromium, or Edge instance using `/browser connect`
 - **Local browser mode** via the `agent-browser` CLI and a local Chromium installation
 
@@ -303,6 +304,51 @@ Adoption only fires until `tab_id` is populated for the session. If the external
 #### VNC live view
 
 When Camofox runs in headed mode (with a visible browser window), it exposes a VNC port in its health check response. Hermes automatically discovers this and includes the VNC URL in navigation responses, so the agent can share a link for you to watch the browser live.
+
+### CloakBrowser local mode
+
+[CloakBrowser](https://pypi.org/project/cloakbrowser/) is a native Python browser backend for local stealth Chromium sessions. Select it when you want Hermes to launch CloakBrowser directly instead of using Browserbase, Camofox, or the default `agent-browser` path.
+
+1. Install the package:
+
+```bash
+python -m pip install cloakbrowser
+```
+
+2. Select it as the browser provider:
+
+```yaml
+# ~/.hermes/config.yaml
+browser:
+  cloud_provider: cloakbrowser
+  cloakbrowser:
+    headless: false
+    humanize: true
+    stealth_args: true
+```
+
+Or configure it via `hermes tools` → Browser Automation → CloakBrowser.
+
+Common settings:
+
+```yaml
+browser:
+  cloakbrowser:
+    proxy: "http://proxy.example:8080"
+    geoip: true
+    locale: "en-US"
+    timezone: "America/New_York"
+    color_scheme: "dark"
+    user_agent: ""
+    extra_args: []
+    user_data_dir: "${HERMES_HOME}/cloakbrowser_profile"
+```
+
+`browser.cloakbrowser.enabled` is auto-managed from `browser.cloud_provider` and normally should not be edited by hand.
+
+:::warning CDP overrides win
+If `browser.cdp_url` or `BROWSER_CDP_URL` is set, Hermes attaches to that existing Chromium-family browser instead of launching native CloakBrowser. Clear the override to return to native CloakBrowser launch.
+:::
 
 ### Local Chromium-family browser via CDP (`/browser connect`)
 


### PR DESCRIPTION
## Summary
- wire native CloakBrowser backend support with parity-focused browser tool handling
- preserve redaction parity and add private-page guard before vision screenshot capture
- update example config and user docs for configuration and browser features

## Verification
- targeted changed-area verification passed
- full test suite not run; not claiming full-suite green
