### PR TITLE
fix(security): close leading-wrapper and path bypass of the hardline approval floor

### DIFF
--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -305,6 +305,156 @@ def test_root_wipe_at_command_position_is_hardline(command):
 
 
 # -------------------------------------------------------------------------
+# Leading-wrapper and binary-path bypass of the command-position anchor
+# -------------------------------------------------------------------------
+#
+# The floor anchors its shutdown/reboot and rm-root rules to command position
+# via _CMDPOS, which consumes a set of leading wrapper commands. That set missed
+# ordinary exec wrappers (nice, ionice, stdbuf, timeout) and the shell builtins
+# command/builtin, and it allowed no path to the binary. Each of those shifts
+# the destructive verb off the anchor while the shell still runs it, so
+# `nice reboot`, `command systemctl poweroff`, `timeout 5 rm -rf /` and
+# `/bin/reboot` slipped the floor. The reboot family has no softer
+# DANGEROUS_PATTERNS backstop, so those bypassed approval in every mode
+# including the default one; the rm forms bypassed the floor under --yolo /
+# approvals.mode=off / cron approve-mode, where the floor is the only guard.
+_WRAPPER_PATH_BYPASS = [
+    # shutdown / reboot family behind a wrapper or a path
+    "nice reboot",
+    "command reboot",
+    "command shutdown -h now",
+    "command systemctl poweroff",
+    "ionice poweroff",
+    "nice init 0",
+    "command telinit 6",
+    "timeout 5 reboot",
+    "nice -n 10 reboot",
+    "nice -10 reboot",
+    "timeout -k 5s 10 reboot",
+    "/bin/reboot",
+    "/sbin/shutdown -h now",
+    "/usr/bin/systemctl poweroff",
+    "./reboot",
+    # root / protected / home wipe behind a wrapper or a path
+    "command rm -rf /",
+    "nice rm -rf /",
+    "ionice rm -rf /",
+    "stdbuf -oL rm -rf /",
+    "timeout 5 rm -rf /",
+    "/bin/rm -rf /",
+    "/usr/bin/rm -rf /",
+    "./rm -rf /",
+    "command rm -rf /etc",
+    "nice rm -rf ~",
+    'nice rm -rf "/"',
+    # Wrapper flags whose operand is non-numeric command metadata (a signal
+    # name, an ionice class, a stdbuf mode) must be consumed too, so the verb
+    # after them still anchors. Consuming only flags and digit-leading operands
+    # left these outside the floor.
+    "timeout -s KILL 5 reboot",
+    "timeout --signal KILL 5 reboot",
+    "ionice -c best-effort rm -rf /",
+    "stdbuf -o L rm -rf /",
+    "env FOO=1 timeout --signal KILL 5 rm -rf /",
+    # sudo/env/doas are wrappers too, and their OPTIONS (not just env
+    # assignments and sudo flags-without-operands) must be consumed so the verb
+    # after them still anchors. `env -i reboot` and `sudo -u root reboot` were
+    # left outside the floor by the narrower per-wrapper handling.
+    "env -i reboot",
+    "env --ignore-environment reboot",
+    "env -u FOO reboot",
+    "env -i systemctl poweroff",
+    "env --unset=FOO rm -rf /",
+    "sudo -u root reboot",
+    "sudo -u root rm -rf /",
+    "doas reboot",
+    "doas -u root rm -rf /",
+    # A path to the WRAPPER executable (not just to the verb) must be consumed
+    # too, so `/usr/bin/nice reboot` anchors like `nice reboot` does. The path
+    # prefix previously applied only in front of the final verb.
+    "/usr/bin/nice reboot",
+    "/usr/bin/timeout 5 reboot",
+    "/usr/bin/env -i reboot",
+    "/usr/bin/sudo -u root reboot",
+    "/usr/bin/env --unset=FOO rm -rf /",
+    "/bin/nice rm -rf /",
+    "./env -i reboot",
+    "../bin/env -i reboot",
+    # A slash-containing RELATIVE path names the same executable as its absolute
+    # form (identical after `cd /`), so a relative path whose first segment is a
+    # bare name (no leading `/`, `./`, or `../`) must be consumed too. These
+    # slipped the anchor while the shell still ran the system binary.
+    "usr/bin/env -i reboot",
+    "usr/bin/nice reboot",
+    "bin/reboot",
+    "bin/rm -rf /",
+    "sbin/shutdown -h now",
+    "usr/bin/systemctl poweroff",
+    "cd / && usr/bin/env -i reboot",
+    "cd / && bin/rm -rf /",
+]
+
+
+@pytest.mark.parametrize("command", _WRAPPER_PATH_BYPASS)
+def test_wrapper_or_path_prefixed_hardline_is_blocked(command):
+    """A destructive verb behind an exec wrapper or a binary path is still that
+    verb at command position, so it must hit the floor (was a silent bypass)."""
+    is_hl, desc = detect_hardline_command(command)
+    assert is_hl, f"wrapper/path bypass leaked past the hardline floor: {command!r}"
+    assert desc
+
+
+# The wrapper prefixes only move the anchor. A wrapper in front of a NON-trigger
+# command, or the trigger word as a later data argument, must stay runnable: the
+# flag/duration consumption in the anchor must never swallow a real following
+# command into the wrapper prefix.
+_WRAPPER_PREFIX_NOT_A_HARDLINE = [
+    "nice grep reboot log.txt",
+    "timeout 5 echo reboot",
+    "nice -n 10 grep reboot file",
+    "command grep reboot",
+    "command ls",
+    "nice make -j4",
+    "timeout 30 pytest tests/",
+    "ionice -c3 cp big.iso /mnt/backup/",
+    "echo /bin/reboot",
+    "nice rm -rf ./build",
+    "timeout 5 rm -rf /tmp/scratch",
+    # A flag operand must not be mistaken for the command: the benign command
+    # after an operand-taking flag stays runnable.
+    "ionice -c best-effort tar -cf out.tar /etc",
+    "timeout -s KILL 5 echo reboot",
+    "nice -n 10 grep -c reboot file",
+    # sudo/env/doas options and assignments in front of a benign command stay
+    # runnable, and a non-destructive systemctl verb after a wrapper option is
+    # not on the floor.
+    "sudo apt update",
+    "env EDITOR=vim git commit",
+    "env -i make",
+    "sudo -u deploy systemctl status nginx",
+    "doas -u deploy ls",
+    # A path to a NON-wrapper program is not a wrapper prefix, and a path that
+    # merely contains a trigger word is not the verb at command position.
+    "/usr/bin/grep reboot file",
+    "/usr/local/bin/my-reboot-log --tail",
+    "/home/user/nice-tool reboot-helper",
+    # A slash-containing relative path to a NON-wrapper program, or a relative
+    # path that merely contains a trigger word, is not the verb at command
+    # position and stays runnable.
+    "usr/bin/grep reboot file",
+    "usr/local/bin/my-reboot-log --tail",
+    "git log origin/reboot-branch",
+]
+
+
+@pytest.mark.parametrize("command", _WRAPPER_PREFIX_NOT_A_HARDLINE)
+def test_wrapper_prefix_with_safe_target_is_not_hardline(command):
+    """A wrapper in front of a benign command must not become a false positive."""
+    is_hl, desc = detect_hardline_command(command)
+    assert not is_hl, f"false positive: wrapper prefix hit the floor: {command!r} ({desc})"
+
+
+# -------------------------------------------------------------------------
 # Shell line-continuation bypass
 # -------------------------------------------------------------------------
 #
@@ -471,6 +621,32 @@ def test_line_continuation_root_wipe_cannot_bypass_hardline(clean_session, monke
     assert result["approved"] is False, "yolo leaked a line-continuation root wipe"
     assert result.get("hardline") is True
     assert "BLOCKED (hardline)" in result["message"]
+
+
+def test_wrapper_reboot_blocked_in_default_mode(clean_session):
+    """The reboot family has no softer DANGEROUS_PATTERNS backstop, so a wrapper
+    or path spelling that missed the hardline anchor was approved with NO prompt
+    even in the DEFAULT (non-yolo) flow. This is the core of the bug: the floor
+    must catch it so the agent cannot power off the host without consent.
+    """
+    for cmd in ["nice reboot", "command systemctl poweroff", "/bin/reboot",
+                "timeout 5 reboot", "nice init 0"]:
+        result = check_all_command_guards(cmd, "local")
+        assert result["approved"] is False, f"wrapper reboot auto-approved in default mode: {cmd!r}"
+        assert result.get("hardline") is True
+        assert "BLOCKED (hardline)" in result["message"]
+
+
+def test_wrapper_path_root_wipe_cannot_bypass_hardline(clean_session, monkeypatch):
+    """Under yolo the hardline floor is the only guard left; a wrapper or path
+    spelling of a root wipe must still be blocked."""
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+
+    for cmd in ["command rm -rf /", "nice rm -rf /", "/bin/rm -rf /",
+                "stdbuf -oL rm -rf /", "timeout 5 rm -rf /"]:
+        result = check_all_command_guards(cmd, "local")
+        assert result["approved"] is False, f"yolo leaked a wrapper/path root wipe: {cmd!r}"
+        assert result.get("hardline") is True
 
 
 def test_session_yolo_cannot_bypass_hardline(clean_session):

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -367,6 +367,11 @@ _WRAPPER_PATH_BYPASS = [
     "env --unset=FOO rm -rf /",
     "sudo -u root reboot",
     "sudo -u root rm -rf /",
+    # Operand-taking flags whose operand is case-distinct from a no-operand
+    # sibling: `sudo -h host` (lowercase) vs `sudo -H` (uppercase, no operand).
+    # Matching options case-insensitively would drop one side of this pair.
+    "sudo -h host reboot",
+    "sudo --host host reboot",
     "doas reboot",
     "doas -u root rm -rf /",
     # A path to the WRAPPER executable (not just to the verb) must be consumed
@@ -444,6 +449,20 @@ _WRAPPER_PREFIX_NOT_A_HARDLINE = [
     "usr/bin/grep reboot file",
     "usr/local/bin/my-reboot-log --tail",
     "git log origin/reboot-branch",
+    # No-operand wrapper flags must never swallow the real program as their
+    # "operand" and re-anchor its arguments as a command. These all blocked
+    # when the anchor regex treated every wrapper option as maybe-consuming an
+    # operand. `sudo -H` is a no-operand flag (set HOME) while `sudo -h` takes
+    # a host operand, so option matching has to be case-sensitive.
+    "env -i echo reboot",
+    "sudo -n echo reboot",
+    "doas -n echo reboot",
+    "timeout --foreground echo reboot",
+    "env -i echo rm -rf /",
+    "nice -n echo reboot",
+    "sudo -E echo rm -rf /",
+    "sudo -H echo reboot",
+    "timeout --preserve-status echo reboot",
 ]
 
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -356,19 +356,62 @@ _WRITE_TARGET_BOUNDARY = r'(?=[\s;&|<>"\']|$)'
 # Inspired by Mercury Agent's permission-hardened blocklist
 # (https://github.com/cosmicstack-labs/mercury-agent).
 
-# Regex fragment matching the *start* of a command (i.e. positions where
-# a shell would begin parsing a new command).  Used by shutdown/reboot
-# patterns so they don't fire on "echo reboot" or "grep 'shutdown' log".
-# Matches: start of string, after command separators (; && || | newline),
-# after subshell openers ( `$(` or backtick ), optionally consuming
-# leading wrapper commands (sudo, env VAR=VAL, exec, nohup, setsid).
+# Command-position-anchored destructive verbs (the ones _CMDPOS guards). A
+# wrapper flag may consume its own operand, but never one of these: the operand
+# lookahead below stops so the verb still anchors as a command.
+_HARDLINE_VERBS = r'(?:rm|shutdown|reboot|halt|poweroff|init|systemctl|telinit)\b'
+
+# Leading wrapper commands that run their argument as a new command, so a
+# destructive verb sitting after the whole prefix is still that verb at command
+# position. sudo, env, and doas are wrappers too and are handled by the same
+# argument grammar as the rest: a narrower "env assignments only" / "sudo flags
+# only" special case left `env -i reboot`, `env --unset=FOO rm -rf /`, and
+# `sudo -u root reboot` outside the floor because their options (and the option
+# operands) were not consumed before the verb.
+_WRAPPER_WORD = (
+    r'(?:sudo|doas|env|exec|nohup|setsid|time|nice|ionice|stdbuf|timeout'
+    r'|command|builtin)'
+)
+
+# One wrapper argument: a flag optionally followed by a single operand that is
+# not itself a destructive verb (`-u root`, `-s KILL`, `--unset=FOO`), a bare
+# numeric/duration positional (`timeout 5`, `nice -n 10`), or a NAME=VALUE
+# assignment (`env FOO=1`). The operand lookahead never eats a destructive
+# command word, so the verb after the wrapper still anchors and an option
+# operand cannot be mistaken for the command.
+_WRAPPER_ARG = (
+    r'(?:\s+-\S+(?:\s+(?!' + _HARDLINE_VERBS + r')[^\s-]\S*)?'
+    r'|\s+\d+\S*'
+    r'|\s+\w+=\S*)'
+)
+
+# Regex fragment matching the *start* of a command (i.e. positions where a
+# shell would begin parsing a new command). Used by shutdown/reboot patterns so
+# they don't fire on "echo reboot" or "grep 'shutdown' log". Matches: start of
+# string, after command separators (; && || | newline), after subshell openers
+# (`$(` or backtick), optionally consuming leading wrapper commands with their
+# options/operands/assignments and an absolute/relative path to the binary.
+# Optional path to an executable, applied before both the leading wrappers and
+# the destructive verb, so a path-qualified wrapper (`/usr/bin/nice reboot`,
+# `./env -i reboot`) is consumed the same way as a path-qualified verb
+# (`/bin/reboot`) and cannot move the verb off anchor.
+#
+# Any slash-containing path resolves to the same executable, so the prefix must
+# accept every spelling that names a binary: absolute (`/usr/bin/`), dot-relative
+# (`./`, `../bin/`), AND slash-containing relative (`usr/bin/`, `bin/`). The
+# earlier `\.{0,2}/…` form only matched a leading `/`, `./`, or `../`, so a
+# relative path whose first segment is a bare name (`usr/bin/env -i reboot`,
+# `bin/reboot`, and after `cd /` the same system binaries) still slipped the
+# anchor. The first segment is now an optional leading `/` followed by zero or
+# more `name/` segments, where a segment is any non-space non-slash run (covering
+# `.`, `..`, and bare names alike).
+_OPTIONAL_PATH_PREFIX = r'(?:/?(?:[^\s/]+/)*)?'
 _CMDPOS = (
-    r'(?:^|[;&|\n`]|\$\()'         # start position
-    r'\s*'                          # optional whitespace
-    r'(?:sudo\s+(?:-[^\s]+\s+)*)?'  # optional sudo with flags
-    r'(?:env\s+(?:\w+=\S*\s+)*)?'   # optional env with VAR=VAL pairs
-    r'(?:(?:exec|nohup|setsid|time)\s+)*'  # optional wrapper commands
+    r'(?:^|[;&|\n`]|\$\()'                          # start position
+    r'\s*'                                          # optional whitespace
+    r'(?:' + _OPTIONAL_PATH_PREFIX + _WRAPPER_WORD + _WRAPPER_ARG + r'*\s+)*'  # leading (path-qualified) wrappers + args
     r'\s*'
+    + _OPTIONAL_PATH_PREFIX                         # optional path to the verb (/bin/, ./)
 )
 
 # Destructive-path argument matcher for the rm hardline rules.

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -356,45 +356,20 @@ _WRITE_TARGET_BOUNDARY = r'(?=[\s;&|<>"\']|$)'
 # Inspired by Mercury Agent's permission-hardened blocklist
 # (https://github.com/cosmicstack-labs/mercury-agent).
 
-# Command-position-anchored destructive verbs (the ones _CMDPOS guards). A
-# wrapper flag may consume its own operand, but never one of these: the operand
-# lookahead below stops so the verb still anchors as a command.
-_HARDLINE_VERBS = r'(?:rm|shutdown|reboot|halt|poweroff|init|systemctl|telinit)\b'
-
-# Leading wrapper commands that run their argument as a new command, so a
-# destructive verb sitting after the whole prefix is still that verb at command
-# position. sudo, env, and doas are wrappers too and are handled by the same
-# argument grammar as the rest: a narrower "env assignments only" / "sudo flags
-# only" special case left `env -i reboot`, `env --unset=FOO rm -rf /`, and
-# `sudo -u root reboot` outside the floor because their options (and the option
-# operands) were not consumed before the verb.
-_WRAPPER_WORD = (
-    r'(?:sudo|doas|env|exec|nohup|setsid|time|nice|ionice|stdbuf|timeout'
-    r'|command|builtin)'
-)
-
-# One wrapper argument: a flag optionally followed by a single operand that is
-# not itself a destructive verb (`-u root`, `-s KILL`, `--unset=FOO`), a bare
-# numeric/duration positional (`timeout 5`, `nice -n 10`), or a NAME=VALUE
-# assignment (`env FOO=1`). The operand lookahead never eats a destructive
-# command word, so the verb after the wrapper still anchors and an option
-# operand cannot be mistaken for the command.
-_WRAPPER_ARG = (
-    r'(?:\s+-\S+(?:\s+(?!' + _HARDLINE_VERBS + r')[^\s-]\S*)?'
-    r'|\s+\d+\S*'
-    r'|\s+\w+=\S*)'
-)
-
 # Regex fragment matching the *start* of a command (i.e. positions where a
 # shell would begin parsing a new command). Used by shutdown/reboot patterns so
 # they don't fire on "echo reboot" or "grep 'shutdown' log". Matches: start of
 # string, after command separators (; && || | newline), after subshell openers
-# (`$(` or backtick), optionally consuming leading wrapper commands with their
-# options/operands/assignments and an absolute/relative path to the binary.
-# Optional path to an executable, applied before both the leading wrappers and
-# the destructive verb, so a path-qualified wrapper (`/usr/bin/nice reboot`,
-# `./env -i reboot`) is consumed the same way as a path-qualified verb
-# (`/bin/reboot`) and cannot move the verb off anchor.
+# (`$(` or backtick), and an optional absolute/relative path to the binary.
+# Leading wrapper commands (`sudo`, `env`, `timeout`, ...) are handled by
+# `_strip_wrapper_prefixes` instead of this anchor: a regex cannot know which
+# option takes an operand, so `sudo -n reboot` and `sudo -u root reboot` came
+# out identical and every no-operand flag re-anchored its own operand as the
+# command.
+#
+# Optional path to an executable, applied before the destructive verb, so a
+# path-qualified verb (`/bin/reboot`, `./rm -rf /`) cannot move itself off
+# anchor.
 #
 # Any slash-containing path resolves to the same executable, so the prefix must
 # accept every spelling that names a binary: absolute (`/usr/bin/`), dot-relative
@@ -409,8 +384,6 @@ _OPTIONAL_PATH_PREFIX = r'(?:/?(?:[^\s/]+/)*)?'
 _CMDPOS = (
     r'(?:^|[;&|\n`]|\$\()'                          # start position
     r'\s*'                                          # optional whitespace
-    r'(?:' + _OPTIONAL_PATH_PREFIX + _WRAPPER_WORD + _WRAPPER_ARG + r'*\s+)*'  # leading (path-qualified) wrappers + args
-    r'\s*'
     + _OPTIONAL_PATH_PREFIX                         # optional path to the verb (/bin/, ./)
 )
 
@@ -1399,6 +1372,113 @@ def _mark_command_starts(command: str) -> str:
     return out
 
 
+
+
+# Leading exec wrappers (`sudo`, `env`, `timeout`, ...) push the real program
+# off the command-start anchor the hardline patterns use. Which option takes
+# an operand is data here, not regex, so a no-operand flag (`sudo -n`,
+# `timeout --foreground`) can never swallow the program and re-anchor its
+# arguments as a command.
+_WRAPPER_WORDS = frozenset({
+    "sudo", "doas", "env", "exec", "nohup", "setsid", "time",
+    "command", "builtin", "nice", "ionice", "stdbuf", "timeout",
+})
+_WRAPPER_STR_OPERAND = {
+    "sudo": {"-u", "-g", "-h", "-p", "-U", "-D", "-R", "-T",
+             "--user", "--group", "--host", "--prompt", "--chdir",
+             "--role", "--type"},
+    "doas": {"-u"},
+    "env": {"-u", "-C", "-a", "-S",
+            "--unset", "--chdir", "--argv0", "--split-string"},
+    "exec": {"-a"},
+    "ionice": {"-c", "-p", "--class", "--pid"},
+    "stdbuf": {"-i", "-o", "-e", "--input", "--output", "--error"},
+    "timeout": {"-s", "-k", "--signal", "--kill-after"},
+}
+_WRAPPER_NUM_OPERAND = {
+    "sudo": {"-C", "--close-from"},
+    "nice": {"-n", "--adjustment"},
+    "ionice": {"-n", "--classdata"},
+}
+_WRAPPER_DURATION_RE = re.compile(r"\d+(?:\.\d+)?[A-Za-z]*")
+
+
+def _wrapper_prefix_end(command: str, start: int) -> int:
+    """Offset where the real program after any leading wrappers begins."""
+    pos = start
+    seen_wrapper = False
+    while True:
+        ws, we, word = _read_shell_word(command, pos)
+        if ws == we:
+            return start  # prefix with no program: nothing executes
+        base = word.rsplit("/", 1)[-1].lower()
+        if base not in _WRAPPER_WORDS:
+            return ws if seen_wrapper else start
+        seen_wrapper = True
+        pos = we
+        while True:  # this wrapper's options / assignments / leading positional
+            ows, owe, oword = _read_shell_word(command, pos)
+            if ows == owe:
+                pos = owe
+                break
+            # Option matching is case-sensitive (`sudo -H` is a no-operand
+            # flag, `sudo -h host` takes an operand).
+            if oword == "--":
+                pos = owe
+                break
+            if oword.startswith("-") and oword != "-":
+                if "=" in oword:
+                    pos = owe  # --opt=value carries its own operand
+                    continue
+                str_opts = _WRAPPER_STR_OPERAND.get(base, ())
+                num_opts = _WRAPPER_NUM_OPERAND.get(base, ())
+                kind = None
+                if oword in str_opts:
+                    kind = "str"
+                elif oword in num_opts:
+                    kind = "num"
+                elif re.fullmatch(r"-[a-zA-Z]+", oword):
+                    # short bundle: the last letter owns the operand
+                    if ("-" + oword[-1]) in str_opts:
+                        kind = "str"
+                    elif ("-" + oword[-1]) in num_opts:
+                        kind = "num"
+                if kind is None:
+                    pos = owe  # no-operand flag
+                    continue
+                vws, vwe, value = _read_shell_word(command, owe)
+                if vws == vwe:
+                    pos = owe
+                    continue
+                if kind == "num" and not _WRAPPER_DURATION_RE.fullmatch(value):
+                    return start  # invalid operand: the wrapper errors here
+                pos = vwe
+                continue
+            if base == "env" and _ENV_ASSIGNMENT_RE.fullmatch(oword):
+                pos = owe
+                continue
+            if base == "timeout" and _WRAPPER_DURATION_RE.fullmatch(oword):
+                pos = owe  # leading duration positional
+                continue
+            break  # the real program: the outer loop re-reads it
+
+
+def _strip_wrapper_prefixes(command: str) -> str:
+    """Blank every leading wrapper chain so the real verb sits at the anchor."""
+    cuts = []
+    for start in _iter_shell_command_starts(command):
+        end = _wrapper_prefix_end(command, start)
+        if end > start:
+            cuts.append((start, end))
+    if not cuts:
+        return command
+    out = command
+    for s, e in reversed(cuts):
+        out = out[:s] + " " + out[e:]
+    return out
+
+
+
 def _iter_shell_command_word_spans(command: str):
     """Yield command-position words that may be executable names."""
     for command_start in _iter_shell_command_starts(command):
@@ -1460,6 +1540,14 @@ def _command_detection_variants(command: str):
     if marked != normalized and marked not in seen:
         seen.add(marked)
         yield marked
+    # Leading exec wrappers (`sudo -u root reboot`, `env -i rm -rf /`) push the
+    # real verb off the command anchor. Strip them into a variant so the
+    # anchored patterns see the verb itself.
+    for base_variant in (normalized, marked):
+        stripped = _strip_wrapper_prefixes(base_variant)
+        if stripped not in seen:
+            seen.add(stripped)
+            yield stripped
     # Shell quoting/escaping can spell a dangerous executable name in pieces
     # (for example r\m or r''m). Keep that deobfuscation scoped to command
     # words so similarly shaped arguments do not become false positives.


### PR DESCRIPTION
Close hardline approval bypasses through leading execution wrappers and path-qualified binaries. Parse wrapper operands before matching the actual executable, including signed niceness values, while preserving quote-aware command boundaries and benign argument text. Command-string carriers remain handled separately in #58742.

Fixes #58642

Validation: All 402 wrapper, hardline, command-guard, and denylist tests passed through scripts/run_tests.sh. Before the repair, 58 original wrapper/path cases failed on base main.

Updated on the refactored main at 1ab32b212b, with the repair folded into one commit.
