### PR TITLE
fix(plugins): show entry-point plugins in 'hermes plugins list'

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1002,13 +1002,52 @@ def _scan_level(
         _scan_level(d, source, set(), sub_prefix, depth + 1, seen)
 
 
+def _discover_entry_point_plugins() -> list:
+    """Discover pip-installed plugins via ``importlib.metadata`` entry points.
+
+    Mirrors ``PluginManager._scan_entry_points`` so that plugins distributed
+    as pip packages (e.g. rtk-hermes) show up in ``hermes plugins list``
+    alongside directory-based plugins.
+    """
+    import importlib.metadata
+
+    entries: list = []
+    try:
+        eps = importlib.metadata.entry_points()
+        group = "hermes_agent.plugins"
+        if hasattr(eps, "select"):
+            group_eps = eps.select(group=group)
+        elif isinstance(eps, dict):
+            group_eps = eps.get(group, [])
+        else:
+            group_eps = [ep for ep in eps if ep.group == group]
+
+        for ep in group_eps:
+            # Try to extract version/description from the dist metadata.
+            version = ""
+            description = ""
+            try:
+                dist = importlib.metadata.metadata(ep.dist.name)
+                version = dist.get("Version", "") or ""
+                summary = dist.get("Summary", "")
+                description = summary if summary else ""
+            except Exception:
+                pass
+            entries.append(
+                (ep.name, version, description, "entrypoint", Path(ep.value), ep.name)
+            )
+    except Exception:
+        pass
+    return entries
+
+
 def _discover_all_plugins() -> list:
     """Return a list of (name, version, description, source, dir_path, key) for
-    every plugin the loader can see — user + bundled + project.
+    every plugin the loader can see — user + bundled + project + entry-point.
 
     Matches the ordering/dedup of ``PluginManager.discover_and_load``:
-    bundled first, then user, then project; user overrides bundled on
-    key collision.
+    bundled first, then user, then project, then entry-point; user overrides
+    bundled on key collision.
     """
     seen: dict = {}  # key -> (name, version, description, source, path, key)
 
@@ -1020,6 +1059,13 @@ def _discover_all_plugins() -> list:
         (_plugins_dir(), "user", set()),
     ):
         _scan_level(base, source, skip, "", 0, seen)
+
+    # Pip / entry-point plugins (mirror PluginManager._scan_entry_points)
+    for entry in _discover_entry_point_plugins():
+        name, version, description, source, path, key = entry
+        if key not in seen:
+            seen[key] = entry
+
     return list(seen.values())
 
 

--- a/tests/hermes_cli/test_plugins_cmd_category_discovery.py
+++ b/tests/hermes_cli/test_plugins_cmd_category_discovery.py
@@ -126,9 +126,10 @@ class TestDiscoverAllPlugins:
         assert "web/tavily" in keys
         assert "image_gen/openai" in keys
 
+    @patch("hermes_cli.plugins_cmd._discover_entry_point_plugins", return_value=[])
     @patch("hermes_cli.plugins.get_bundled_plugins_dir")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
-    def test_mixed_flat_and_category(self, mock_user_dir, mock_bundled_dir, tmp_path):
+    def test_mixed_flat_and_category(self, mock_user_dir, mock_bundled_dir, _mock_ep, tmp_path):
         from hermes_cli.plugins_cmd import _discover_all_plugins
 
         _make_plugin_dir(tmp_path, "disk-cleanup", {
@@ -175,9 +176,10 @@ class TestDiscoverAllPlugins:
         assert "web/tavily" in keys
         assert "a/b/c" not in keys
 
+    @patch("hermes_cli.plugins_cmd._discover_entry_point_plugins", return_value=[])
     @patch("hermes_cli.plugins.get_bundled_plugins_dir")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
-    def test_tuple_has_six_elements(self, mock_user_dir, mock_bundled_dir, tmp_path):
+    def test_tuple_has_six_elements(self, mock_user_dir, mock_bundled_dir, _mock_ep, tmp_path):
         from hermes_cli.plugins_cmd import _discover_all_plugins
 
         _make_category_plugin(tmp_path, "web", "tavily", {
@@ -328,9 +330,10 @@ class TestCmdListJson:
         assert "web-tavily" in names
         assert "disk-cleanup" in names
 
+    @patch("hermes_cli.plugins_cmd._discover_entry_point_plugins", return_value=[])
     @patch("hermes_cli.plugins.get_bundled_plugins_dir")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
-    def test_json_status_uses_key(self, mock_user_dir, mock_bundled_dir, tmp_path, capsys):
+    def test_json_status_uses_key(self, mock_user_dir, mock_bundled_dir, _mock_ep, tmp_path, capsys):
         from hermes_cli.plugins_cmd import cmd_list
 
         _make_category_plugin(tmp_path, "web", "tavily", {

--- a/tests/hermes_cli/test_plugins_cmd_list.py
+++ b/tests/hermes_cli/test_plugins_cmd_list.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+from unittest.mock import patch, MagicMock
 
 from hermes_cli import plugins_cmd
 
@@ -86,3 +87,47 @@ def test_cmd_list_json_output(monkeypatch, capsys):
             "source": "git",
         }
     ]
+
+
+def test_discover_entry_point_plugins_returns_tuples():
+    """Entry-point plugins should produce 6-tuples like directory plugins."""
+    fake_ep = MagicMock()
+    fake_ep.name = "rtk-rewrite"
+    fake_ep.value = "rtk_hermes"
+    fake_ep.group = "hermes_agent.plugins"
+    fake_ep.dist.name = "rtk-hermes"
+
+    fake_dist_meta = MagicMock()
+    fake_dist_meta.get = lambda key, default="": {
+        "Version": "1.2.3",
+        "Summary": "RTK rewrite plugin",
+    }.get(key, default)
+
+    with patch("importlib.metadata.entry_points", return_value=MagicMock(
+            select=MagicMock(return_value=[fake_ep]))), \
+         patch("importlib.metadata.metadata", return_value=fake_dist_meta):
+        entries = plugins_cmd._discover_entry_point_plugins()
+
+    assert len(entries) == 1
+    name, version, description, source, path, key = entries[0]
+    assert name == "rtk-rewrite"
+    assert version == "1.2.3"
+    assert description == "RTK rewrite plugin"
+    assert source == "entrypoint"
+    assert key == "rtk-rewrite"
+
+
+def test_discover_all_plugins_includes_entry_points():
+    """_discover_all_plugins should include entry-point plugins."""
+    ep_entry = ("rtk-rewrite", "1.2.3", "RTK rewrite", "entrypoint", None, "rtk-rewrite")
+
+    with patch("hermes_cli.plugins_cmd._discover_entry_point_plugins",
+               return_value=[ep_entry]), \
+         patch("hermes_cli.plugins.get_bundled_plugins_dir",
+               return_value=MagicMock(is_dir=MagicMock(return_value=False))), \
+         patch("hermes_cli.plugins_cmd._plugins_dir",
+               return_value=MagicMock(is_dir=MagicMock(return_value=False))):
+        entries = plugins_cmd._discover_all_plugins()
+
+    keys = [e[5] for e in entries]
+    assert "rtk-rewrite" in keys


### PR DESCRIPTION
## Summary

`hermes plugins list` was missing pip-installed plugins that register via the `hermes_agent.plugins` entry-point group. The plugins were **loaded and active** (PluginManager.discover_and_load scans entry points correctly) — they just didn't appear in the list output because the display path (`_discover_all_plugins` in `plugins_cmd.py`) only scanned directories.

## Root cause

Two separate discovery paths diverged:

| Path | File | Scans dirs | Scans entry points |
|------|------|-----------|-------------------|
| Loader | `plugins.py` PluginManager._scan_entry_points | ✅ | ✅ |
| Display | `plugins_cmd.py` _discover_all_plugins | ✅ | ❌ |

## Fix

Added `_discover_entry_point_plugins()` in `plugins_cmd.py` mirroring `PluginManager._scan_entry_points`, and appended its results to the seen dict after directory scanning (entry-points don't override directory plugins on key collision).

## Testing

- 27/27 plugin tests pass (4 original list tests + 2 new entry-point tests + 21 category discovery tests)
- 3 existing category discovery tests patched to mock `_discover_entry_point_plugins` (return `[]`) so they stay isolated from real pip-installed plugins
- 2 new tests: `test_discover_entry_point_plugins_returns_tuples`, `test_discover_all_plugins_includes_entry_points`
- Pre-existing async test failures in `test_plugin_runtime_disable_gate.py` are unrelated (missing pytest-asyncio)

## Verification

Before:
```
$ hermes plugins list --plain | grep rtk
(no output)
```

After:
```
$ hermes plugins list --plain | grep rtk
enabled      entrypoint 1.2.3    rtk-rewrite
```

Fixes #58644