### PR TITLE
feat(proxy): Anthropic Claude OAuth upstream adapter

### DIFF
--- a/hermes_cli/proxy/adapters/__init__.py
+++ b/hermes_cli/proxy/adapters/__init__.py
@@ -8,6 +8,7 @@ token. See :class:`UpstreamAdapter` for the contract.
 from typing import Dict, Type
 
 from hermes_cli.proxy.adapters.base import UpstreamAdapter
+from hermes_cli.proxy.adapters.anthropic import AnthropicOAuthAdapter
 from hermes_cli.proxy.adapters.nous_portal import NousPortalAdapter
 from hermes_cli.proxy.adapters.xai import XAIGrokAdapter
 
@@ -16,6 +17,7 @@ from hermes_cli.proxy.adapters.xai import XAIGrokAdapter
 ADAPTERS: Dict[str, Type[UpstreamAdapter]] = {
     "nous": NousPortalAdapter,
     "xai": XAIGrokAdapter,
+    "anthropic": AnthropicOAuthAdapter,
 }
 
 

--- a/hermes_cli/proxy/adapters/anthropic.py
+++ b/hermes_cli/proxy/adapters/anthropic.py
@@ -1,0 +1,213 @@
+"""Anthropic Claude OAuth upstream adapter.
+
+Forwards Anthropic Messages API requests using Hermes-managed Anthropic OAuth
+credentials (Claude Pro/Max subscription), so external apps can hit Claude
+through the local proxy with any bearer token.
+
+Unlike the OpenAI-compatible providers (nous, xai), Anthropic's OAuth endpoint
+requires more than a bearer swap:
+  - specific beta + version + user-agent headers (see `extra_headers`)
+  - the request body's system prompt must lead with the Claude Code identity
+    block, or OAuth traffic is intermittently rejected/misrouted
+    (see `transform_body`). This mirrors agent/anthropic_adapter.py.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from typing import Dict, FrozenSet, Optional
+
+from agent.credential_pool import CredentialPool, PooledCredential, load_pool
+from hermes_cli.proxy.adapters.base import UpstreamAdapter, UpstreamCredential
+
+logger = logging.getLogger(__name__)
+
+_POOL_PROVIDER = "anthropic"
+_DEFAULT_BASE_URL = "https://api.anthropic.com/v1"
+
+# Only the Messages API is forwarded. (Anthropic OAuth does not serve the
+# OpenAI-compatible /chat/completions surface.)
+_ALLOWED_PATHS: FrozenSet[str] = frozenset({"/messages"})
+
+# Beta headers required for OAuth/subscription auth. Matches what Claude Code
+# sends and what agent/anthropic_adapter.py uses for OAuth traffic.
+_OAUTH_BETAS = "claude-code-20250219,oauth-2025-04-20"
+_ANTHROPIC_VERSION = "2023-06-01"
+_CLAUDE_CODE_VERSION_FALLBACK = "2.1.74"
+
+# The Claude Code system identity block. Anthropic's OAuth infra expects the
+# system prompt to lead with this or it misbehaves on subscription tokens.
+_CLAUDE_CODE_SYSTEM_PREFIX = "You are Claude Code, Anthropic's official CLI for Claude."
+
+_cc_version_cache: Optional[str] = None
+
+
+def _claude_code_version() -> str:
+    global _cc_version_cache
+    if _cc_version_cache is None:
+        import subprocess as _sp
+
+        _cc_version_cache = _CLAUDE_CODE_VERSION_FALLBACK
+        for cmd in ("claude", "claude-code"):
+            try:
+                r = _sp.run([cmd, "--version"], capture_output=True, text=True, timeout=5)
+                if r.returncode == 0 and r.stdout.strip():
+                    v = r.stdout.strip().split()[0]
+                    if v and v[0].isdigit():
+                        _cc_version_cache = v
+                        break
+            except Exception:
+                pass
+    return _cc_version_cache
+
+
+class AnthropicOAuthAdapter(UpstreamAdapter):
+    """Proxy upstream for Anthropic Claude via Hermes-managed OAuth credentials."""
+
+    auth_hint = "hermes auth add anthropic --type oauth"
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._pool: Optional[CredentialPool] = None
+
+    @property
+    def name(self) -> str:
+        return "anthropic"
+
+    @property
+    def display_name(self) -> str:
+        return "Anthropic Claude OAuth"
+
+    @property
+    def allowed_paths(self) -> FrozenSet[str]:
+        return _ALLOWED_PATHS
+
+    def is_authenticated(self) -> bool:
+        pool = self._load_pool()
+        return bool(pool and pool.has_available())
+
+    def get_credential(self) -> UpstreamCredential:
+        with self._lock:
+            pool = self._load_pool()
+            if pool is None or not pool.has_credentials():
+                raise RuntimeError(
+                    "No Anthropic OAuth credentials found. Run "
+                    "`hermes auth add anthropic --type oauth` first."
+                )
+            entry = pool.select()
+            if entry is None:
+                raise RuntimeError(
+                    "No available Anthropic OAuth credentials found. Run "
+                    "`hermes auth reset anthropic` or re-authenticate with "
+                    "`hermes auth add anthropic --type oauth`."
+                )
+            self._pool = pool
+            return self._credential_from_entry(entry)
+
+    def get_retry_credential(
+        self,
+        *,
+        failed_credential: UpstreamCredential,
+        status_code: int,
+    ) -> Optional[UpstreamCredential]:
+        if status_code not in {401, 429}:
+            return None
+        with self._lock:
+            pool = self._pool or self._load_pool()
+            if pool is None:
+                return None
+            if status_code == 429:
+                refreshed = pool.mark_exhausted_and_rotate(status_code=status_code)
+            else:
+                refreshed = pool.try_refresh_current()
+                if refreshed is None:
+                    refreshed = pool.mark_exhausted_and_rotate(status_code=status_code)
+            if refreshed is None:
+                return None
+            retry_cred = self._credential_from_entry(refreshed)
+            if retry_cred.bearer == failed_credential.bearer:
+                return None
+            logger.info(
+                "proxy: Anthropic upstream returned %s; retrying with rotated pool credential",
+                status_code,
+            )
+            return retry_cred
+
+    # --- optional server hooks (see server.py) ---
+
+    def extra_headers(self, cred: UpstreamCredential) -> Dict[str, str]:
+        """Headers Anthropic OAuth requires on every Messages request."""
+        return {
+            "anthropic-version": _ANTHROPIC_VERSION,
+            "anthropic-beta": _OAUTH_BETAS,
+            "user-agent": f"claude-cli/{_claude_code_version()} (external, cli)",
+        }
+
+    def transform_body(self, rel_path: str, body: bytes) -> bytes:
+        """Prepend the Claude Code system identity block to the request body.
+
+        Anthropic's OAuth endpoint expects the system prompt to lead with the
+        Claude Code identity; without it, subscription tokens intermittently
+        get rejected. Non-JSON or unexpected shapes pass through unchanged.
+        """
+        if rel_path != "/messages" or not body:
+            return body
+        try:
+            payload = json.loads(body)
+        except Exception:
+            return body
+        if not isinstance(payload, dict):
+            return body
+
+        cc_block = {"type": "text", "text": _CLAUDE_CODE_SYSTEM_PREFIX}
+        system = payload.get("system")
+        if isinstance(system, list):
+            # Already-prefixed requests must not double-prefix.
+            if not (system and isinstance(system[0], dict)
+                    and system[0].get("text") == _CLAUDE_CODE_SYSTEM_PREFIX):
+                payload["system"] = [cc_block] + system
+        elif isinstance(system, str) and system:
+            if system != _CLAUDE_CODE_SYSTEM_PREFIX:
+                payload["system"] = [cc_block, {"type": "text", "text": system}]
+        else:
+            payload["system"] = [cc_block]
+
+        return json.dumps(payload).encode("utf-8")
+
+    # --- internals (mirror xai adapter) ---
+
+    def _load_pool(self) -> Optional[CredentialPool]:
+        try:
+            return load_pool(_POOL_PROVIDER)
+        except Exception as exc:
+            logger.warning("proxy: failed to load Anthropic OAuth credential pool: %s", exc)
+            return None
+
+    def _credential_from_entry(self, entry: PooledCredential) -> UpstreamCredential:
+        bearer = (
+            getattr(entry, "runtime_api_key", None)
+            or getattr(entry, "access_token", "")
+            or ""
+        )
+        bearer = str(bearer).strip()
+        if not bearer:
+            raise RuntimeError(
+                "Anthropic OAuth credential pool entry did not contain an access token. "
+                "Re-authenticate with `hermes auth add anthropic --type oauth`."
+            )
+        base_url = (
+            getattr(entry, "runtime_base_url", None)
+            or getattr(entry, "base_url", None)
+            or _DEFAULT_BASE_URL
+        )
+        base_url = str(base_url or _DEFAULT_BASE_URL).strip().rstrip("/")
+        return UpstreamCredential(
+            bearer=bearer,
+            base_url=base_url or _DEFAULT_BASE_URL,
+            expires_at=getattr(entry, "expires_at", None),
+        )
+
+
+__all__ = ["AnthropicOAuthAdapter"]

--- a/hermes_cli/proxy/server.py
+++ b/hermes_cli/proxy/server.py
@@ -45,6 +45,7 @@ _HOP_BY_HOP_HEADERS = frozenset(
         "transfer-encoding",
         "upgrade",
         "authorization",  # we replace this one
+        "x-api-key",  # provider-native auth; proxy supplies its own credential
     }
 )
 
@@ -130,6 +131,15 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
         # the request body too.
         body = await request.read()
 
+        # Optional adapter body-rewrite hook (e.g. Anthropic OAuth prepends the
+        # Claude Code system block). Default: identity — other adapters unaffected.
+        _transform = getattr(adapter, "transform_body", None)
+        if callable(_transform):
+            try:
+                body = _transform(rel_path, body)
+            except Exception as exc:
+                logger.warning("proxy: adapter transform_body failed, forwarding verbatim: %s", exc)
+
         timeout = aiohttp.ClientTimeout(total=None, sock_connect=15, sock_read=300)
 
         async def _send_upstream(active_cred: UpstreamCredential):
@@ -140,6 +150,15 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
 
             fwd_headers = _filter_request_headers(request.headers)
             fwd_headers["Authorization"] = f"{active_cred.token_type} {active_cred.bearer}"
+
+            # Optional adapter header hook (e.g. Anthropic OAuth beta/version/UA).
+            _extra = getattr(adapter, "extra_headers", None)
+            if callable(_extra):
+                try:
+                    for k, v in (_extra(active_cred) or {}).items():
+                        fwd_headers[k] = v
+                except Exception as exc:
+                    logger.warning("proxy: adapter extra_headers failed: %s", exc)
 
             logger.debug(
                 "proxy: forwarding %s %s -> %s (body=%d bytes)",


### PR DESCRIPTION
## What

Adds `--provider anthropic` to `hermes proxy`, forwarding Anthropic **Messages API** requests using Hermes-managed Anthropic OAuth credentials (Claude Pro/Max). Local apps can then hit Claude through the proxy with any bearer token — the same "attach real credentials to a dummy-auth request" pattern the existing `nous` and `xai` upstreams already provide.

## Why it needs more than a bearer swap

Unlike the OpenAI-compatible providers, Anthropic's OAuth endpoint rejects/misroutes subscription tokens unless the request also carries:

1. the OAuth **beta/version/user-agent** headers, and
2. a **system prompt that leads with the Claude Code identity block**.

To support that without touching the other adapters, this adds two small **opt-in** hooks to the proxy server, both defaulting to no-op via `getattr` (nous/xai are byte-for-byte unaffected):

- `extra_headers(cred) -> dict` — merged into the forwarded headers.
- `transform_body(rel_path, body) -> bytes` — rewrite the request body (here: prepend the Claude Code system block, idempotently — already-prefixed requests are not double-prefixed).

## `x-api-key` strip

The forward path already strips/replaces inbound `authorization`. This also strips inbound `x-api-key`, because the proxy always supplies its own credential — and a stale client `x-api-key` otherwise takes precedence at Anthropic and 401s the OAuth call. No-op for nous/xai (they never receive one).

## Adapter

`AnthropicOAuthAdapter` reuses the existing `agent.credential_pool` (`load_pool` / `select` / `try_refresh_current` / `mark_exhausted_and_rotate` on 401|429), mirroring the xai adapter's shape. Only `/messages` is in `allowed_paths` (Anthropic OAuth does not serve the `/chat/completions` surface).

## Files

- `hermes_cli/proxy/adapters/anthropic.py` (new)
- `hermes_cli/proxy/server.py` — two opt-in hooks + `x-api-key` strip
- `hermes_cli/proxy/adapters/__init__.py` — register in `ADAPTERS`

## Testing

- `py_compile` clean on all three files.
- `ADAPTERS` resolves `['anthropic', 'nous', 'xai']`.
- End-to-end verified against live Anthropic OAuth: external client with a dummy bearer → real `claude-haiku-4-5` / `claude-sonnet-4-5` 200s (`service_tier: standard`), headers injected and system block prepended by the hooks.
- No credentials in the diff; everything is resolved from the pool at runtime.