### PR TITLE
fix(lazy-deps): detect active features by primary package

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -304,7 +304,7 @@ class TestActiveFeatures:
         monkeypatch.setattr(ld, "_is_present", lambda spec: False)
         assert ld.active_features() == []
 
-    def test_finds_features_with_at_least_one_package_installed(self, monkeypatch):
+    def test_finds_features_with_primary_package_installed(self, monkeypatch):
         # Pretend only honcho-ai is installed; nothing else.
         monkeypatch.setattr(
             ld, "_is_present",
@@ -316,15 +316,29 @@ class TestActiveFeatures:
         assert "memory.hindsight" not in active
         assert "platform.slack" not in active
 
-    def test_multi_package_feature_active_if_any_present(self, monkeypatch):
-        # platform.slack has 3 packages; only one needs to be present
-        # for the feature to count as active (user activated it before,
-        # one transitive may have been uninstalled separately).
+    def test_multi_package_feature_active_if_primary_present(self, monkeypatch):
+        # platform.slack has 3 packages; the first one identifies that Slack
+        # was enabled, while later entries may be shared transitive pins.
         monkeypatch.setattr(
             ld, "_is_present",
             lambda spec: ld._pkg_name_from_spec(spec) == "slack-bolt",
         )
         assert "platform.slack" in ld.active_features()
+
+    def test_shared_transitive_pin_does_not_mark_backends_active(self, monkeypatch):
+        """Shared pins like aiohttp are not evidence a platform was enabled."""
+        monkeypatch.setattr(
+            ld,
+            "_is_present",
+            lambda spec: ld._pkg_name_from_spec(spec) == "aiohttp",
+        )
+
+        active = ld.active_features()
+
+        assert "platform.discord" not in active
+        assert "platform.slack" not in active
+        assert "platform.matrix" not in active
+        assert "platform.teams" not in active
 
 
 class TestRefreshActiveFeatures:

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -856,16 +856,18 @@ def feature_install_command(feature: str) -> Optional[str]:
 def active_features() -> list[str]:
     """Return the list of features the user has ever lazy-installed.
 
-    A feature counts as "active" if at least one of its declared packages
-    is currently installed in the venv (presence check, ignoring version).
-    Features the user has never enabled stay quiet.
+    A feature counts as "active" if its primary package is currently installed
+    in the venv (presence check, ignoring version).  The first spec in each
+    LAZY_DEPS entry is the backend-identifying package; later specs may be
+    shared security-floor pins such as aiohttp that should not make unrelated
+    backends look enabled.
 
     Used by ``hermes update`` to figure out which lazy backends need a
     refresh pass when pins move in :data:`LAZY_DEPS`.
     """
     active = []
     for feature, specs in LAZY_DEPS.items():
-        if any(_is_present(s) for s in specs):
+        if specs and _is_present(specs[0]):
             active.append(feature)
     return active
 


### PR DESCRIPTION
## Summary
- treat a lazy feature as active only when its first, backend-identifying package is installed
- prevent shared transitive pins such as aiohttp from marking Slack, Matrix, Discord, or Teams active
- update active feature regression coverage for the primary-package contract

Fixes #58458.

## Tests
- .venv/bin/python -m pytest tests/tools/test_lazy_deps.py -q
- .venv/bin/python -m ruff check tools/lazy_deps.py tests/tools/test_lazy_deps.py