### PR TITLE
fix: preserve explicitly-enabled tools when disabling overlapping composite toolset

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -421,7 +421,23 @@ def _compute_tool_definitions(
                         )
                 else:
                     resolved = resolve_toolset(toolset_name)
-                    tools_to_include.difference_update(resolved)
+                    if enabled_toolsets is not None:
+                        # When the user has explicitly enabled certain toolsets,
+                        # only subtract tools from the disabled composite that
+                        # are NOT also provided by an enabled toolset.  Without
+                        # this guard, disabling an overlapping composite like
+                        # ``coding`` silently strips tools from explicitly
+                        # enabled toolsets such as ``terminal`` and ``file``,
+                        # resulting in zero tools (#58281).
+                        enabled_tools: set = set()
+                        for ename in enabled_toolsets:
+                            if validate_toolset(ename):
+                                enabled_tools.update(resolve_toolset(ename))
+                        to_remove = set(resolved) - enabled_tools
+                        tools_to_include.difference_update(to_remove)
+                        resolved = sorted(to_remove)
+                    else:
+                        tools_to_include.difference_update(resolved)
                 if not quiet_mode:
                     print(f"🚫 Disabled toolset '{toolset_name}': {', '.join(resolved) if resolved else 'no tools'}")
             elif toolset_name in _LEGACY_TOOLSET_MAP:


### PR DESCRIPTION
## Problem

When `agent.disabled_toolsets` contains a composite toolset like `coding` that overlaps with explicitly enabled toolsets like `terminal` and `file`, the subtraction step removes ALL tools from the disabled toolset — including tools that belong to enabled toolsets. This results in zero tools sent to the model with no warning.

**Reproduction** (from #58281):
```yaml
agent:
  disabled_toolsets:
    - coding
```
With `terminal` + `file` enabled, disabling `coding` strips all their tools → model gets 0 tools.

## Root Cause

In `model_tools.py::_compute_tool_definitions`, the non-core-delta subtraction (#33924) only applies to `hermes-*` platform bundles. All other composite toolsets subtract fully, even when the user has explicitly enabled overlapping toolsets.

## Fix

When `enabled_toolsets` is set and a disabled composite toolset overlaps, only subtract tools that are NOT also provided by an enabled toolset. This extends the same protection from #33924 to all composite toolsets.

- `enabled_toolsets=None` (default): behavior unchanged — full subtraction
- `enabled_toolsets=[...] + disabled_toolsets=[...]`: subtract only non-overlapping tools

Fixes #58281
