### PR TITLE
fix(delegate): prefer current delegation config

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -11,9 +11,11 @@ Run with:  python -m pytest tests/test_delegate.py -v
 
 import json
 import os
+import sys
 import threading
 import time
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from tools.delegate_tool import (
@@ -33,6 +35,7 @@ from tools.delegate_tool import (
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
     _inherit_parent_base_url,
+    _load_config,
 )
 
 
@@ -134,6 +137,27 @@ class TestDelegateRequirements(unittest.TestCase):
         )
         self.assertIn(f"up to {_get_max_concurrent_children()}", fn["description"])
         self.assertIn(f"max_spawn_depth={_get_max_spawn_depth()}", fn["description"])
+
+
+class TestDelegationConfigLoading(unittest.TestCase):
+    def test_file_config_wins_over_stale_cli_snapshot(self):
+        fake_cli = SimpleNamespace(
+            CLI_CONFIG={
+                "delegation": {
+                    "child_timeout_seconds": 600,
+                    "max_spawn_depth": 4,
+                }
+            }
+        )
+
+        with patch.dict(sys.modules, {"cli": fake_cli}), patch(
+            "hermes_cli.config.load_config",
+            return_value={"delegation": {"child_timeout_seconds": 900}},
+        ):
+            cfg = _load_config()
+
+        self.assertEqual(cfg["child_timeout_seconds"], 900)
+        self.assertEqual(cfg["max_spawn_depth"], 4)
 
 
 class TestChildSystemPrompt(unittest.TestCase):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3098,28 +3098,33 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 
 
 def _load_config() -> dict:
-    """Load delegation config from CLI_CONFIG or persistent config.
+    """Load delegation config from persistent config, then CLI_CONFIG fallback.
 
-    Checks the runtime config (cli.py CLI_CONFIG) first, then falls back
-    to the persistent config (hermes_cli/config.py load_config()) so that
-    ``delegation.model`` / ``delegation.provider`` are picked up regardless
-    of the entry point (CLI, gateway, cron).
+    ``cli.CLI_CONFIG`` is a startup snapshot and can go stale in long-lived
+    gateways after ``hermes config set delegation.*`` writes to disk. Treat the
+    current file config as authoritative, while preserving CLI_CONFIG values
+    for entry points that have not materialized the section on disk.
     """
-    try:
-        from cli import CLI_CONFIG
-
-        cfg = CLI_CONFIG.get("delegation") or {}
-        if cfg:
-            return cfg
-    except Exception:
-        pass
+    delegation_config: dict = {}
     try:
         from hermes_cli.config import load_config
 
         full = load_config()
-        return full.get("delegation") or {}
+        cfg = full.get("delegation") or {}
+        if isinstance(cfg, dict):
+            delegation_config.update(cfg)
     except Exception:
-        return {}
+        pass
+    try:
+        from cli import CLI_CONFIG
+
+        cfg = CLI_CONFIG.get("delegation") or {}
+        if isinstance(cfg, dict):
+            for key, value in cfg.items():
+                delegation_config.setdefault(key, value)
+    except Exception:
+        pass
+    return delegation_config
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- load delegation settings from the current persistent config before falling back to cli.CLI_CONFIG
- keep CLI_CONFIG values as fallback defaults when the file config lacks a key
- add regression coverage for a stale CLI snapshot being overridden by current disk config

Fixes #57930.

## Tests
- .venv/bin/python -m pytest tests/tools/test_delegate.py -q
- .venv/bin/python -m ruff check tools/delegate_tool.py tests/tools/test_delegate.py