### PR TITLE
fix(slack): bound Socket Mode close during reconnect

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -63,6 +63,8 @@ except ImportError:  # pragma: no cover - plugin loaded outside package context
 
 logger = logging.getLogger(__name__)
 
+_SOCKET_MODE_CLOSE_TIMEOUT = 15.0
+
 # ContextVar carrying the user_id of the slash-command invoker.
 # Set in _handle_slash_command, read in send() to match the correct
 # stashed response_url when multiple users issue commands on the same
@@ -500,6 +502,8 @@ class SlackAdapter(BasePlatformAdapter):
         self._app_token: Optional[str] = None
         self._proxy_url: Optional[str] = None
         self._socket_watchdog_task: Optional[asyncio.Task] = None
+        self._socket_mode_close_task: Optional[asyncio.Task] = None
+        self._socket_mode_teardown_incomplete = False
         self._socket_reconnect_lock = asyncio.Lock()
         self._socket_watchdog_interval_s = 15.0
 
@@ -517,33 +521,96 @@ class SlackAdapter(BasePlatformAdapter):
         self._socket_mode_task = task
         task.add_done_callback(self._on_socket_mode_task_done)
 
-    async def _stop_socket_mode_handler(self) -> None:
+    @staticmethod
+    def _consume_socket_mode_close_result(task: asyncio.Task) -> None:
+        try:
+            task.result()
+        except (asyncio.CancelledError, Exception):
+            pass
+
+    async def _stop_socket_mode_handler(
+        self, timeout: Optional[float] = None
+    ) -> bool:
         """Stop Socket Mode handler and task."""
         handler = self._handler
         task = self._socket_mode_task
-        self._handler = None
-        self._socket_mode_task = None
+        deadline = (
+            asyncio.get_running_loop().time() + timeout
+            if timeout is not None
+            else None
+        )
 
         if handler is not None:
+            close_task = self._socket_mode_close_task
+            if close_task is None:
+                close_task = asyncio.get_running_loop().create_task(handler.close_async())
+                close_task.add_done_callback(self._consume_socket_mode_close_result)
+                self._socket_mode_close_task = close_task
+
             try:
-                await handler.close_async()
-            except Exception as e:  # pragma: no cover - defensive logging
+                if deadline is None:
+                    await asyncio.shield(close_task)
+                else:
+                    done, _ = await asyncio.wait(
+                        {close_task}, timeout=max(0.0, deadline - asyncio.get_running_loop().time())
+                    )
+                    if not done:
+                        self._socket_mode_teardown_incomplete = True
+                        logger.warning(
+                            "[Slack] Timed out closing Socket Mode handler"
+                        )
+                        return False
+                close_task.result()
+            except asyncio.CancelledError:
+                if close_task.cancelled():
+                    if self._socket_mode_close_task is close_task:
+                        self._socket_mode_close_task = None
+                    self._socket_mode_teardown_incomplete = True
+                    return False
+                raise
+            except Exception as e:
+                if self._socket_mode_close_task is close_task:
+                    self._socket_mode_close_task = None
+                self._socket_mode_teardown_incomplete = True
                 logger.warning(
                     "[Slack] Error while closing Socket Mode handler: %s",
                     e,
                     exc_info=True,
                 )
+                return False
 
         if task is not None and not task.done():
             task.cancel()
+            if deadline is None:
+                await asyncio.gather(task, return_exceptions=True)
+            else:
+                done, _ = await asyncio.wait(
+                    {task}, timeout=max(0.0, deadline - asyncio.get_running_loop().time())
+                )
+                if not done:
+                    self._socket_mode_teardown_incomplete = True
+                    logger.warning("[Slack] Timed out stopping Socket Mode task")
+                    return False
+
+        if task is not None and task.done():
             try:
-                await task
+                task.result()
             except asyncio.CancelledError:
                 pass
             except Exception:  # pragma: no cover - defensive logging
                 logger.debug(
                     "[Slack] Socket Mode task failed while stopping", exc_info=True
                 )
+
+        if self._handler is handler:
+            self._handler = None
+        if self._socket_mode_task is task:
+            self._socket_mode_task = None
+        close_task = self._socket_mode_close_task
+        if close_task is not None and close_task.done():
+            self._socket_mode_close_task = None
+        self._socket_mode_teardown_incomplete = False
+        return True
 
     async def _socket_transport_connected(self) -> Optional[bool]:
         """Best-effort check of current Socket Mode transport state."""
@@ -576,7 +643,11 @@ class SlackAdapter(BasePlatformAdapter):
                 return
 
             logger.warning("[Slack] Socket Mode unhealthy (%s); reconnecting", reason)
-            await self._stop_socket_mode_handler()
+            stopped = await self._stop_socket_mode_handler(
+                timeout=_SOCKET_MODE_CLOSE_TIMEOUT
+            )
+            if not stopped or not self._running or not self._app or not self._app_token:
+                return
 
             try:
                 self._start_socket_mode_handler()
@@ -647,6 +718,8 @@ class SlackAdapter(BasePlatformAdapter):
     def _on_socket_mode_task_done(self, task: asyncio.Task) -> None:
         # Ignore stale tasks from intentional reconnect/shutdown.
         if task is not self._socket_mode_task:
+            return
+        if self._socket_mode_close_task is not None or self._socket_mode_teardown_incomplete:
             return
         if task.cancelled():
             return
@@ -1061,7 +1134,9 @@ class SlackAdapter(BasePlatformAdapter):
             # connection alive.  Both the old and new connections would otherwise
             # receive every Slack event and dispatch it twice, producing double
             # responses — the same bug that affected DiscordAdapter (#18187).
-            await self._stop_socket_mode_handler()
+            if not await self._stop_socket_mode_handler():
+                self._socket_mode_teardown_incomplete = True
+                return False
             self._app = None
             self._app_token = app_token
             self._proxy_url = proxy_url
@@ -1286,7 +1361,8 @@ class SlackAdapter(BasePlatformAdapter):
             except Exception:
                 self._running = False
                 try:
-                    await self._stop_socket_mode_handler()
+                    if not await self._stop_socket_mode_handler():
+                        self._socket_mode_teardown_incomplete = True
                 except Exception:  # pragma: no cover - defensive logging
                     logger.debug(
                         "[Slack] Cleanup after failed start raised", exc_info=True
@@ -1303,7 +1379,11 @@ class SlackAdapter(BasePlatformAdapter):
             logger.error("[Slack] Connection failed: %s", e, exc_info=True)
             return False
         finally:
-            if lock_acquired and not self._running:
+            if (
+                lock_acquired
+                and not self._running
+                and not self._socket_mode_teardown_incomplete
+            ):
                 self._release_platform_lock()
 
     async def create_handoff_thread(
@@ -1369,7 +1449,9 @@ class SlackAdapter(BasePlatformAdapter):
                     "[Slack] Watchdog task raised during disconnect", exc_info=True
                 )
 
-        await self._stop_socket_mode_handler()
+        if not await self._stop_socket_mode_handler():
+            self._socket_mode_teardown_incomplete = True
+            return
         self._app = None
         self._app_token = None
         self._proxy_url = None

--- a/tests/gateway/test_slack_socket_mode_reconnect.py
+++ b/tests/gateway/test_slack_socket_mode_reconnect.py
@@ -1,0 +1,228 @@
+import asyncio
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_slack_mock():
+    if "slack_bolt" in sys.modules and hasattr(sys.modules["slack_bolt"], "__file__"):
+        return
+
+    slack_bolt = MagicMock()
+    slack_bolt.async_app.AsyncApp = MagicMock
+    slack_bolt.adapter.socket_mode.async_handler.AsyncSocketModeHandler = MagicMock
+
+    slack_sdk = MagicMock()
+    slack_sdk.web.async_client.AsyncWebClient = MagicMock
+
+    for name, mod in [
+        ("slack_bolt", slack_bolt),
+        ("slack_bolt.async_app", slack_bolt.async_app),
+        ("slack_bolt.adapter", slack_bolt.adapter),
+        ("slack_bolt.adapter.socket_mode", slack_bolt.adapter.socket_mode),
+        ("slack_bolt.adapter.socket_mode.async_handler", slack_bolt.adapter.socket_mode.async_handler),
+        ("slack_sdk", slack_sdk),
+        ("slack_sdk.web", slack_sdk.web),
+        ("slack_sdk.web.async_client", slack_sdk.web.async_client),
+    ]:
+        sys.modules.setdefault(name, mod)
+
+
+_ensure_slack_mock()
+
+import plugins.platforms.slack.adapter as _slack_mod  # noqa: E402
+
+_slack_mod.SLACK_AVAILABLE = True
+
+from plugins.platforms.slack.adapter import SlackAdapter  # noqa: E402
+
+
+async def _never_finishes():
+    await asyncio.Event().wait()
+
+
+@pytest.mark.asyncio
+async def test_restart_waits_for_cancellation_resistant_close_before_replacing(monkeypatch):
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-test"))
+    adapter._running = True
+    adapter._app = MagicMock()
+    adapter._app_token = "xapp-test"
+    handler = MagicMock()
+    release_close = asyncio.Event()
+
+    async def close_async():
+        try:
+            await release_close.wait()
+        except asyncio.CancelledError:
+            await release_close.wait()
+
+    handler.close_async = AsyncMock(side_effect=close_async)
+    socket_task = asyncio.create_task(_never_finishes())
+    adapter._handler = handler
+    adapter._socket_mode_task = socket_task
+    start_socket_mode_handler = MagicMock()
+    monkeypatch.setattr(adapter, "_start_socket_mode_handler", start_socket_mode_handler)
+    monkeypatch.setattr(_slack_mod, "_SOCKET_MODE_CLOSE_TIMEOUT", 0.01, raising=False)
+
+    restart_task = asyncio.create_task(adapter._restart_socket_mode("transport disconnected"))
+    try:
+        await asyncio.sleep(0.05)
+
+        assert restart_task.done()
+        start_socket_mode_handler.assert_not_called()
+        assert adapter._handler is handler
+        assert adapter._socket_mode_task is socket_task
+        close_task = adapter._socket_mode_close_task
+        assert close_task is not None and not close_task.done()
+
+        release_close.set()
+        await close_task
+        await asyncio.wait_for(
+            adapter._restart_socket_mode("transport disconnected"), timeout=0.2
+        )
+
+        start_socket_mode_handler.assert_called_once_with()
+        handler.close_async.assert_awaited_once_with()
+        assert socket_task.done()
+        assert adapter._socket_mode_close_task is None
+    finally:
+        release_close.set()
+        if not restart_task.done():
+            await asyncio.wait_for(restart_task, timeout=0.2)
+        if not socket_task.done():
+            socket_task.cancel()
+            await asyncio.gather(socket_task, return_exceptions=True)
+        close_task = getattr(adapter, "_socket_mode_close_task", None)
+        if close_task is not None and not close_task.done():
+            await asyncio.wait_for(close_task, timeout=0.2)
+
+
+@pytest.mark.asyncio
+async def test_connect_preserves_prior_handler_when_teardown_fails(monkeypatch):
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-test"))
+    old_app = MagicMock()
+    old_handler = MagicMock()
+    adapter._app = old_app
+    adapter._handler = old_handler
+    monkeypatch.setattr(
+        adapter, "_stop_socket_mode_handler", AsyncMock(return_value=False)
+    )
+
+    with (
+        patch.dict(os.environ, {"SLACK_APP_TOKEN": "xapp-test"}),
+        patch("gateway.status.acquire_scoped_lock", return_value=(True, None)),
+        patch("gateway.status.release_scoped_lock") as release_lock,
+        patch.object(_slack_mod, "AsyncApp") as async_app,
+    ):
+        assert await adapter.connect() is False
+
+    async_app.assert_not_called()
+    release_lock.assert_not_called()
+    assert adapter._app is old_app
+    assert adapter._handler is old_handler
+
+
+@pytest.mark.asyncio
+async def test_disconnect_preserves_state_and_lock_when_teardown_fails(monkeypatch):
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-test"))
+    old_app = MagicMock()
+    old_handler = MagicMock()
+    adapter._app = old_app
+    adapter._app_token = "xapp-test"
+    adapter._proxy_url = "http://proxy.test"
+    adapter._handler = old_handler
+    release_lock = MagicMock()
+    monkeypatch.setattr(
+        adapter, "_stop_socket_mode_handler", AsyncMock(return_value=False)
+    )
+    monkeypatch.setattr(adapter, "_release_platform_lock", release_lock)
+
+    await adapter.disconnect()
+
+    assert adapter._app is old_app
+    assert adapter._app_token == "xapp-test"
+    assert adapter._proxy_url == "http://proxy.test"
+    assert adapter._handler is old_handler
+    release_lock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_restart_retries_failed_close_before_replacing(monkeypatch):
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-test"))
+    adapter._running = True
+    adapter._app = MagicMock()
+    adapter._app_token = "xapp-test"
+    handler = MagicMock()
+    handler.close_async = AsyncMock(side_effect=[RuntimeError("close failed"), None])
+    socket_task = asyncio.create_task(_never_finishes())
+    adapter._handler = handler
+    adapter._socket_mode_task = socket_task
+    start_socket_mode_handler = MagicMock()
+    monkeypatch.setattr(adapter, "_start_socket_mode_handler", start_socket_mode_handler)
+
+    await adapter._restart_socket_mode("transport disconnected")
+
+    start_socket_mode_handler.assert_not_called()
+    assert adapter._handler is handler
+    assert adapter._socket_mode_close_task is None
+
+    await adapter._restart_socket_mode("transport disconnected")
+
+    start_socket_mode_handler.assert_called_once_with()
+    assert handler.close_async.await_count == 2
+    assert socket_task.done()
+    assert adapter._socket_mode_close_task is None
+
+
+@pytest.mark.asyncio
+async def test_restart_waits_for_cancellation_resistant_socket_task(monkeypatch):
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-test"))
+    adapter._running = True
+    adapter._app = MagicMock()
+    adapter._app_token = "xapp-test"
+    handler = MagicMock()
+    handler.close_async = AsyncMock(return_value=None)
+    release_task = asyncio.Event()
+
+    async def resistant_socket_task():
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            await release_task.wait()
+
+    socket_task = asyncio.create_task(resistant_socket_task())
+    adapter._handler = handler
+    adapter._socket_mode_task = socket_task
+    start_socket_mode_handler = MagicMock()
+    monkeypatch.setattr(adapter, "_start_socket_mode_handler", start_socket_mode_handler)
+    monkeypatch.setattr(_slack_mod, "_SOCKET_MODE_CLOSE_TIMEOUT", 0.01, raising=False)
+
+    try:
+        await asyncio.wait_for(
+            adapter._restart_socket_mode("transport disconnected"), timeout=0.2
+        )
+
+        start_socket_mode_handler.assert_not_called()
+        assert adapter._handler is handler
+        assert adapter._socket_mode_task is socket_task
+        assert adapter._socket_mode_close_task is not None
+
+        release_task.set()
+        await asyncio.sleep(0)
+        await asyncio.wait_for(
+            adapter._restart_socket_mode("transport disconnected"), timeout=0.2
+        )
+
+        start_socket_mode_handler.assert_called_once_with()
+        handler.close_async.assert_awaited_once_with()
+        assert socket_task.done()
+        assert adapter._socket_mode_close_task is None
+    finally:
+        release_task.set()
+        if not socket_task.done():
+            socket_task.cancel()
+            await asyncio.gather(socket_task, return_exceptions=True)


### PR DESCRIPTION
## What does this PR do?

Makes Slack Socket Mode reconnect fail closed when the previous handler cannot be proven stopped.

The watchdog still bounds reconnect teardown to 15 seconds, but a timeout or close failure now preserves the old handler/task state and skips replacement startup. A later watchdog pass reuses or retries the teardown. This prevents two live Socket Mode handlers from dispatching the same Slack event.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Track an in-flight Socket Mode close attempt explicitly and reuse it across retries.
- Apply one reconnect deadline to both handler close and old `start_async()` task cleanup using `asyncio.wait()`.
- Start a replacement only after both old resources reach terminal state.
- Preserve handler, app, proxy, and platform-lock state when teardown is incomplete.
- Suppress socket-task restart callbacks during intentional or failed teardown.
- Add regressions for cancellation-resistant close/start tasks, close retry, and connect/disconnect failure state.

## How to Test

```bash
scripts/run_tests.sh tests/gateway/test_slack_socket_mode_reconnect.py tests/gateway/test_slack.py -q
uv run ruff check plugins/platforms/slack/adapter.py tests/gateway/test_slack_socket_mode_reconnect.py
git diff --check
```

Result after rebasing current upstream:

```text
252 passed
All checks passed!
```

A targeted `ty` check reports the same 18 pre-existing diagnostics in `plugins/platforms/slack/adapter.py`; the changed test file introduces no diagnostics.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
