### PR TITLE
fix(anthropic): preserve Hermes docs URL in OAuth prompt

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import platform
+import re
 import secrets
 import stat
 import subprocess
@@ -32,8 +33,6 @@ from utils import base_url_host_matches, normalize_proxy_env_vars
 # paths. Access via the `_get_anthropic_sdk()` accessor below, which caches
 # the module after the first call and returns None on ImportError.
 _anthropic_sdk: Any = ...  # sentinel — None means "tried and missing"
-
-
 def _get_anthropic_sdk():
     """Return the ``anthropic`` SDK module, importing lazily. None if not installed."""
     global _anthropic_sdk
@@ -207,6 +206,15 @@ def _resolve_positive_anthropic_max_tokens(value) -> Optional[int]:
         return None
     floored = int(value)  # truncates toward zero for floats
     return floored if floored > 0 else None
+
+
+def _sanitize_oauth_system_prompt_text(text: str) -> str:
+    """Apply Claude Code OAuth identity substitutions without breaking docs URLs."""
+    text = text.replace("Hermes Agent", "Claude Code")
+    text = text.replace("Hermes agent", "Claude Code")
+    text = re.sub(r"\bhermes-agent\b(?!\.nousresearch\.com)", "claude-code", text)
+    text = text.replace("Nous Research", "Anthropic")
+    return text
 
 
 def _resolve_anthropic_messages_max_tokens(
@@ -2543,11 +2551,7 @@ def build_anthropic_kwargs(
         for block in system:
             if isinstance(block, dict) and block.get("type") == "text":
                 text = block.get("text", "")
-                text = text.replace("Hermes Agent", "Claude Code")
-                text = text.replace("Hermes agent", "Claude Code")
-                text = text.replace("hermes-agent", "claude-code")
-                text = text.replace("Nous Research", "Anthropic")
-                block["text"] = text
+                block["text"] = _sanitize_oauth_system_prompt_text(text)
 
         # 3. Normalize tool names so NOTHING goes on the OAuth wire with a
         #    single-underscore ``mcp_`` prefix.  Anthropic's subscription/OAuth

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1388,6 +1388,36 @@ class TestBuildAnthropicKwargs:
         assert "claude-code-20250219" in betas
         assert "interleaved-thinking-2025-05-14" in betas
 
+    def test_oauth_system_prompt_sanitizer_preserves_hermes_docs_url(self):
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-20250514",
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "You are Hermes Agent by Nous Research. "
+                        "Docs: https://hermes-agent.nousresearch.com/docs. "
+                        "Load the hermes-agent skill. "
+                        "Literal marker: __HERMES_DOCS_URL__."
+                    ),
+                },
+                {"role": "user", "content": "Hi"},
+            ],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config=None,
+            is_oauth=True,
+        )
+
+        system_text = "\n".join(
+            block["text"] for block in kwargs["system"] if block.get("type") == "text"
+        )
+        assert "Claude Code by Anthropic" in system_text
+        assert "https://hermes-agent.nousresearch.com/docs" in system_text
+        assert "https://claude-code.nousresearch.com/docs" not in system_text
+        assert "Load the claude-code skill." in system_text
+        assert "Literal marker: __HERMES_DOCS_URL__." in system_text
+
     def test_reasoning_config_maps_to_manual_thinking_for_pre_4_6_models(self):
         kwargs = build_anthropic_kwargs(
             model="claude-sonnet-4-20250514",


### PR DESCRIPTION
## Summary
- protect the official Hermes docs URL before applying Anthropic OAuth Claude Code identity substitutions
- keep existing product-name substitutions everywhere else in the OAuth system prompt
- add regression coverage so the docs URL does not become claude-code.nousresearch.com

Addresses #58025.

## Tests
- .venv/bin/python -m pytest tests/agent/test_anthropic_adapter.py::TestBuildAnthropicKwargs -q
- .venv/bin/python -m pytest tests/agent/test_anthropic_adapter.py -q -k "not TestRunOauthSetupToken"
- .venv/bin/python -m ruff check agent/anthropic_adapter.py tests/agent/test_anthropic_adapter.py

Note: the full tests/agent/test_anthropic_adapter.py run still hits the existing macOS Keychain subprocess mock issue tracked in #58415; the affected TestRunOauthSetupToken cases are excluded above.