### PR TITLE
fix(qqbot): apply configured home channel env

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -2060,29 +2060,29 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         qq_group_allowed = getenv("QQ_GROUP_ALLOWED_USERS", "").strip()
         if qq_group_allowed:
             extra["group_allow_from"] = qq_group_allowed
-        qq_home = getenv("QQBOT_HOME_CHANNEL", "").strip()
-        qq_home_name_env = "QQBOT_HOME_CHANNEL_NAME"
-        if not qq_home:
-            # Back-compat: accept the pre-rename name and log a one-time warning.
-            legacy_home = getenv("QQ_HOME_CHANNEL", "").strip()
-            if legacy_home:
-                qq_home = legacy_home
-                qq_home_name_env = "QQ_HOME_CHANNEL_NAME"
-                logging.getLogger(__name__).warning(
-                    "QQ_HOME_CHANNEL is deprecated; rename to QQBOT_HOME_CHANNEL "
-                    "in your .env for consistency with the platform key."
-                )
-        if qq_home:
-            config.platforms[Platform.QQBOT].home_channel = HomeChannel(
-                platform=Platform.QQBOT,
-                chat_id=qq_home,
-                name=getenv("QQBOT_HOME_CHANNEL_NAME") or getenv(qq_home_name_env, "Home"),
-                thread_id=(
-                    getenv("QQBOT_HOME_CHANNEL_THREAD_ID")
-                    or getenv("QQ_HOME_CHANNEL_THREAD_ID")
-                    or None
-                ),
+    qq_home = getenv("QQBOT_HOME_CHANNEL", "").strip()
+    qq_home_name_env = "QQBOT_HOME_CHANNEL_NAME"
+    if not qq_home:
+        # Back-compat: accept the pre-rename name and log a one-time warning.
+        legacy_home = getenv("QQ_HOME_CHANNEL", "").strip()
+        if legacy_home:
+            qq_home = legacy_home
+            qq_home_name_env = "QQ_HOME_CHANNEL_NAME"
+            logging.getLogger(__name__).warning(
+                "QQ_HOME_CHANNEL is deprecated; rename to QQBOT_HOME_CHANNEL "
+                "in your .env for consistency with the platform key."
             )
+    if qq_home and Platform.QQBOT in config.platforms:
+        config.platforms[Platform.QQBOT].home_channel = HomeChannel(
+            platform=Platform.QQBOT,
+            chat_id=qq_home,
+            name=getenv("QQBOT_HOME_CHANNEL_NAME") or getenv(qq_home_name_env, "Home"),
+            thread_id=(
+                getenv("QQBOT_HOME_CHANNEL_THREAD_ID")
+                or getenv("QQ_HOME_CHANNEL_THREAD_ID")
+                or None
+            ),
+        )
 
     # Yuanbao — YUANBAO_APP_ID preferred
     yuanbao_app_id = getenv("YUANBAO_APP_ID") or getenv("YUANBAO_APP_KEY")

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -451,7 +451,7 @@ def show_status(args):
         "WeCom Callback": ("WECOM_CALLBACK_CORP_ID", None),
         "Weixin": ("WEIXIN_ACCOUNT_ID", "WEIXIN_HOME_CHANNEL"),
         "BlueBubbles": ("BLUEBUBBLES_SERVER_URL", "BLUEBUBBLES_HOME_CHANNEL"),
-        "QQBot": ("QQ_APP_ID", "QQ_HOME_CHANNEL"),
+        "QQBot": ("QQ_APP_ID", "QQBOT_HOME_CHANNEL"),
         "Yuanbao": ("YUANBAO_APP_ID", "YUANBAO_HOME_CHANNEL"),
     }
 

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1364,6 +1364,12 @@ class TestHomeChannelEnvOverrides:
                 {"SMS_HOME_CHANNEL": "+15559876543", "SMS_HOME_CHANNEL_NAME": "My Phone"},
                 ("+15559876543", "My Phone"),
             ),
+            (
+                Platform.QQBOT,
+                PlatformConfig(enabled=True, extra={"app_id": "from-config"}),
+                {"QQBOT_HOME_CHANNEL": "direct:owner", "QQBOT_HOME_CHANNEL_NAME": "Owner QQ"},
+                ("direct:owner", "Owner QQ"),
+            ),
         ]
 
         for platform, platform_config, env, expected in cases:
@@ -1374,6 +1380,38 @@ class TestHomeChannelEnvOverrides:
             home = config.platforms[platform].home_channel
             assert home is not None, f"{platform.value}: home_channel should not be None"
             assert (home.chat_id, home.name) == expected, platform.value
+
+    def test_qqbot_home_channel_prefers_active_profile_secret_scope(self, monkeypatch):
+        config = GatewayConfig(
+            platforms={
+                Platform.QQBOT: PlatformConfig(
+                    enabled=True,
+                    extra={"app_id": "from-config"},
+                )
+            }
+        )
+        monkeypatch.setenv("QQBOT_HOME_CHANNEL", "direct:default")
+        monkeypatch.setenv("QQBOT_HOME_CHANNEL_NAME", "Default QQ")
+        monkeypatch.setenv("QQBOT_HOME_CHANNEL_THREAD_ID", "default-thread")
+
+        secret_token = set_secret_scope(
+            {
+                "QQBOT_HOME_CHANNEL": "direct:profile",
+                "QQBOT_HOME_CHANNEL_NAME": "Profile QQ",
+                "QQBOT_HOME_CHANNEL_THREAD_ID": "profile-thread",
+            }
+        )
+        try:
+            _apply_env_overrides(config)
+        finally:
+            reset_secret_scope(secret_token)
+
+        assert config.platforms[Platform.QQBOT].home_channel == HomeChannel(
+            platform=Platform.QQBOT,
+            chat_id="direct:profile",
+            name="Profile QQ",
+            thread_id="profile-thread",
+        )
 
 
 class TestMultiplexProfilesEnvOverride:

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -15,6 +15,35 @@ def test_show_status_all_does_not_print_tavily_key_value(monkeypatch, capsys, tm
     assert sentinel not in output
 
 
+def _qqbot_status_line(output):
+    return next(line for line in output.splitlines() if "QQBot" in line)
+
+
+def test_show_status_prefers_canonical_qqbot_home_channel(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("QQ_APP_ID", "qq-app")
+    monkeypatch.setenv("QQBOT_HOME_CHANNEL", "direct:canonical")
+    monkeypatch.setenv("QQ_HOME_CHANNEL", "direct:legacy")
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    line = _qqbot_status_line(capsys.readouterr().out)
+    assert "configured (home: direct:canonical)" in line
+    assert "direct:legacy" not in line
+
+
+def test_show_status_falls_back_to_legacy_qqbot_home_channel(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("QQ_APP_ID", "qq-app")
+    monkeypatch.delenv("QQBOT_HOME_CHANNEL", raising=False)
+    monkeypatch.setenv("QQ_HOME_CHANNEL", "direct:legacy")
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    line = _qqbot_status_line(capsys.readouterr().out)
+    assert "configured (home: direct:legacy)" in line
+
+
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):
     from hermes_cli import status as status_mod
     import hermes_cli.auth as auth_mod


### PR DESCRIPTION
## Summary
- apply `QQBOT_HOME_CHANNEL` / legacy `QQ_HOME_CHANNEL` whenever QQBot is already configured via config.yaml, not only when QQ credentials come from env
- make `hermes status` report the renamed `QQBOT_HOME_CHANNEL` first while preserving the existing legacy fallback
- add regression coverage for configured QQBot platforms receiving home-channel env overrides

Fixes #58406.

## Tests
- `.venv/bin/python -m pytest tests/gateway/test_config.py::TestHomeChannelEnvOverrides -q`
- `.venv/bin/python -m pytest tests/gateway/test_config.py -q`
- `.venv/bin/python -m ruff check gateway/config.py hermes_cli/status.py tests/gateway/test_config.py`