### PR TITLE
fix(agent): prefer _resolve_auto() result over pre-filled model in auxiliary auto branch

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4073,6 +4073,7 @@ def resolve_provider_client(
     # main_model also empty), the branches still hit their own
     # missing-credentials returns and ``_resolve_auto`` falls through to
     # the Step-2 chain as before.
+    _model_was_prefilled = not bool(model)
     if not model:
         model = _get_aux_model_for_provider(provider) or _read_main_model() or model
 
@@ -4139,7 +4140,21 @@ def resolve_provider_client(
                 "Dropping OpenRouter-format model %r for non-OpenRouter "
                 "auxiliary provider (using %r instead)", model, resolved)
             model = None
-        final_model = model or resolved
+        # _resolve_auto() already resolves MoA→aggregator (PR #53827) and
+        # returns the real model ID for every provider it successfully builds
+        # a client for.  When ``model`` was pre-filled from _read_main_model()
+        # (i.e. the caller passed no explicit model), prefer ``resolved`` over
+        # ``model`` — the pre-fill may carry the MoA preset name (e.g.
+        # "default"), a truthy but invalid model ID that would override the
+        # correctly resolved value (issue #58639).  When the caller passed an
+        # explicit model (e.g. auxiliary.<task>.model via
+        # _resolve_task_provider_model), honor it — that is a user config
+        # override, not a stale pre-fill, and resolved is just the main model.
+        # ``model`` remains as a fallback when resolved is None.
+        if _model_was_prefilled:
+            final_model = resolved or model
+        else:
+            final_model = model or resolved
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                 else (client, final_model))
 

--- a/tests/agent/test_auxiliary_moa_auto_override.py
+++ b/tests/agent/test_auxiliary_moa_auto_override.py
@@ -1,0 +1,231 @@
+"""Regression test for issue #58639.
+
+When MoA (Mixture-of-Agents) is the active main provider, auxiliary tasks
+configured with ``provider: auto`` (the default) fail with HTTP 400 because
+the MoA preset name (e.g. ``"default"``) is sent as the model ID instead of
+the real aggregator model.
+
+Root cause: ``resolve_provider_client()`` pre-fills ``model`` from
+``_read_main_model()`` before the ``auto`` branch runs.  When MoA is main,
+``_read_main_model()`` returns the preset name — a truthy but invalid model
+ID.  The ``auto`` branch then does ``final_model = model or resolved``, which
+picks the pre-filled preset name over ``_resolve_auto()``'s correctly resolved
+aggregator model (the fix from PR #53827).
+
+Fix: ``final_model = resolved or model`` — ``_resolve_auto()`` already handles
+MoA→aggregator resolution; its result takes precedence.  ``model`` remains as
+a fallback for the rare case where ``_resolve_auto`` returns a valid client
+with no model.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+class TestAutoBranchMoaPresetOverride:
+    """resolve_provider_client("auto") must not let a pre-filled MoA preset
+    name override _resolve_auto()'s resolved aggregator model."""
+
+    def test_moa_preset_does_not_override_resolved_aggregator(self):
+        """MoA main → _read_main_model() returns preset "default".
+
+        _resolve_auto() resolves MoA→aggregator and returns the real model
+        (e.g. "maas-glm-5.2-aliyun").  The auto branch must use that resolved
+        model, not the pre-filled preset name "default".
+
+        Before fix: final_model = model or resolved  → "default" (preset)
+        After fix:  final_model = resolved or model  → "maas-glm-5.2-aliyun"
+        """
+        mock_client = MagicMock()
+
+        with (
+            patch(
+                "agent.auxiliary_client._read_main_model",
+                return_value="default",  # MoA preset name, not a real model ID
+            ),
+            patch(
+                "agent.auxiliary_client._get_aux_model_for_provider",
+                return_value="",  # no catalog default for "auto"
+            ),
+            patch(
+                "agent.auxiliary_client._resolve_auto",
+                return_value=(mock_client, "maas-glm-5.2-aliyun"),
+            ) as mock_resolve_auto,
+        ):
+            from agent.auxiliary_client import resolve_provider_client
+
+            client, model = resolve_provider_client("auto")
+
+        assert client is mock_client
+        # The resolved aggregator model must win over the pre-filled preset name.
+        assert model == "maas-glm-5.2-aliyun"
+        assert model != "default", (
+            "Preset name leaked as final model — the auto branch is "
+            "overriding _resolve_auto() with the pre-filled model."
+        )
+        mock_resolve_auto.assert_called_once()
+
+    def test_resolved_none_falls_back_to_model(self):
+        """When _resolve_auto() returns a client but no model (resolved=None),
+        the pre-filled model is used as a fallback — no regression for
+        providers that don't report a model.
+        """
+        mock_client = MagicMock()
+
+        with (
+            patch(
+                "agent.auxiliary_client._read_main_model",
+                return_value="fallback-model",
+            ),
+            patch(
+                "agent.auxiliary_client._get_aux_model_for_provider",
+                return_value="",
+            ),
+            patch(
+                "agent.auxiliary_client._resolve_auto",
+                return_value=(mock_client, None),
+            ),
+        ):
+            from agent.auxiliary_client import resolve_provider_client
+
+            client, model = resolve_provider_client("auto")
+
+        assert client is mock_client
+        # resolved was None → fall back to the pre-filled model.
+        assert model == "fallback-model"
+
+    def test_non_moa_resolved_still_preferred_over_prefill(self):
+        """Non-MoA scenario: _resolve_auto() resolves to the main provider's
+        real model.  resolved should still take precedence over a pre-filled
+        model — this is the general behavior change and should not regress
+        existing non-MoA users.
+        """
+        mock_client = MagicMock()
+
+        with (
+            patch(
+                "agent.auxiliary_client._read_main_model",
+                return_value="claude-opus-4-6",
+            ),
+            patch(
+                "agent.auxiliary_client._get_aux_model_for_provider",
+                return_value="",
+            ),
+            patch(
+                "agent.auxiliary_client._resolve_auto",
+                return_value=(mock_client, "claude-opus-4-6"),
+            ),
+        ):
+            from agent.auxiliary_client import resolve_provider_client
+
+            client, model = resolve_provider_client("auto")
+
+        assert client is mock_client
+        assert model == "claude-opus-4-6"
+
+    def test_openrouter_format_model_dropped_for_non_or_provider(self):
+        """The existing OpenRouter-format drop guard must still work.
+
+        When the pre-filled model is in OpenRouter format (contains "/") and
+        _resolve_auto() lands on a non-OpenRouter provider (resolved has no
+        "/"), the pre-filled model is dropped.  After the drop, resolved
+        should be used (it's now the only truthy value).
+        """
+        mock_client = MagicMock()
+
+        with (
+            patch(
+                "agent.auxiliary_client._read_main_model",
+                return_value="google/gemini-3-flash-preview",  # OR format
+            ),
+            patch(
+                "agent.auxiliary_client._get_aux_model_for_provider",
+                return_value="",
+            ),
+            patch(
+                "agent.auxiliary_client._resolve_auto",
+                return_value=(mock_client, "local-llama-3.3"),  # non-OR, no "/"
+            ),
+        ):
+            from agent.auxiliary_client import resolve_provider_client
+
+            client, model = resolve_provider_client("auto")
+
+        assert client is mock_client
+        # The OR-format model was dropped; resolved (local model) is used.
+        assert model == "local-llama-3.3"
+        assert "/" not in model
+
+    def test_explicit_caller_model_not_overridden_by_resolved(self):
+        """When the caller passes an explicit model (e.g. from
+        auxiliary.<task>.model via _resolve_task_provider_model), it must NOT
+        be overridden by _resolve_auto()'s resolved (main) model.
+
+        This is the case AmirF194 raised on PR #58665: a user on OpenRouter
+        who sets a cheaper auxiliary.compression.model but leaves the per-task
+        provider as 'auto' should get their configured cheap model, not the
+        expensive main model.
+
+        Before the _model_was_prefilled guard, `resolved or model` would
+        silently return the main model (e.g. claude-opus) instead of the
+        caller's explicit gpt-4o-mini.
+        """
+        mock_client = MagicMock()
+
+        with (
+            patch(
+                "agent.auxiliary_client._read_main_model",
+                return_value="anthropic/claude-opus-4-6",
+            ),
+            patch(
+                "agent.auxiliary_client._get_aux_model_for_provider",
+                return_value="",
+            ),
+            patch(
+                "agent.auxiliary_client._resolve_auto",
+                return_value=(mock_client, "anthropic/claude-opus-4-6"),
+            ),
+        ):
+            from agent.auxiliary_client import resolve_provider_client
+
+            # Caller explicitly passes a cheaper model (per-task config override)
+            client, model = resolve_provider_client(
+                "auto", "openai/gpt-4o-mini",
+            )
+
+        assert client is mock_client
+        # Explicit caller model wins — resolved (main model) does NOT override it.
+        assert model == "openai/gpt-4o-mini"
+        assert model != "anthropic/claude-opus-4-6"
+
+    def test_explicit_plain_slug_model_not_overridden_by_resolved(self):
+        """Same as above but with plain slug models (no '/').
+
+        The OpenRouter-format drop guard only fires when model has '/' and
+        resolved doesn't.  Plain slugs like 'gpt-4o-mini' bypass that guard,
+        so the _model_was_prefilled check is the only thing protecting the
+        caller's explicit choice.
+        """
+        mock_client = MagicMock()
+
+        with (
+            patch(
+                "agent.auxiliary_client._read_main_model",
+                return_value="claude-opus-4-6",
+            ),
+            patch(
+                "agent.auxiliary_client._get_aux_model_for_provider",
+                return_value="",
+            ),
+            patch(
+                "agent.auxiliary_client._resolve_auto",
+                return_value=(mock_client, "claude-opus-4-6"),
+            ),
+        ):
+            from agent.auxiliary_client import resolve_provider_client
+
+            client, model = resolve_provider_client("auto", "gpt-4o-mini")
+
+        assert client is mock_client
+        assert model == "gpt-4o-mini"


### PR DESCRIPTION
## Bug Description

When MoA (Mixture-of-Agents) is the active main provider, auxiliary tasks (title generation, compression, vision, session search, etc.) configured with `provider: auto` (the default) fail with HTTP 400 — the MoA preset name is sent as the model ID instead of the real aggregator model.

Visible symptom (from `agent.log`):
```
Auxiliary title_generation: using auto (default) at http://172.24.48.1:18089/v1/
WARNING agent.title_generator: Title generation failed: Error code: 400 - {"error":"...用户对该模型无权限...TM.00001005..."}
```

Note `using auto (default)` — `"default"` is the MoA preset name, not a valid model ID.

Fixes #58639

## Root Cause

In `agent/auxiliary_client.py`, `resolve_provider_client()` has a universal model-resolution fallback chain (line ~4073) that pre-fills `model` from `_read_main_model()` before any provider branch runs:

```python
if not model:
    model = _get_aux_model_for_provider(provider) or _read_main_model() or model
```

When MoA is the active main provider, `set_runtime_main(provider="moa", model="default", ...)` sets the process-global `_RUNTIME_MAIN_MODEL = "default"` (the preset name — MoA has no real HTTP endpoint). So `_read_main_model()` returns `"default"` and `model` gets pre-filled with it.

Then in the `auto` branch (line ~4142):

```python
client, resolved = _resolve_auto(main_runtime=main_runtime, task=task)
...
final_model = model or resolved   # ← BUG
```

`_resolve_auto()` **correctly** resolves MoA → aggregator and returns the real model ID (e.g. `"maas-glm-5.2-aliyun"`). This resolution was added by #53827 (merged 2026-06-27) via the `if main_provider == "moa":` block inside `_resolve_auto()`. But `final_model = model or resolved` picks the pre-filled `model="default"` (truthy) over the correct `resolved` value, **overriding** #53827's fix.

The request goes out with `model="default"` → the backend rejects it (400 / TM.00001005 / "not a valid model ID").

### Why PR #53827 Didn't Fully Fix This

#53827 fixed `_resolve_auto()` to return the correct aggregator model. But the bug is one level up: `resolve_provider_client()`'s auto branch overrides `_resolve_auto()`'s return value with the pre-filled `model`. The pre-fill comes from `_read_main_model()`, which returns the MoA preset name — a value that is truthy but not a valid model ID for any real endpoint.

| Layer | Fixed by | Status |
|-------|----------|--------|
| `_resolve_auto()` MoA→aggregator resolution | #53827 | ✅ Merged |
| `resolve_provider_client()` auto branch model override | — | ❌ Not fixed on `main` |

## Fix

Track whether `model` was pre-filled (from `_read_main_model()`) vs. explicitly passed by the caller, then prefer `resolved` only in the pre-filled case:

```python
_model_was_prefilled = not bool(model)
if not model:
    model = _get_aux_model_for_provider(provider) or _read_main_model() or model
```

In the auto branch:

```python
if _model_was_prefilled:
    final_model = resolved or model   # pre-fill may carry MoA preset name → prefer resolved
else:
    final_model = model or resolved   # explicit caller/config model → honor it
```

### Why not a blanket `resolved or model`

An earlier revision of this PR used `final_model = resolved or model` unconditionally. @AmirF194 [pointed out](https://github.com/NousResearch/hermes-agent/pull/58665#issuecomment-) that this is broader than the bug needs: `_resolve_task_provider_model` threads a config-set `auxiliary.<task>.model` through as the `model` arg while keeping provider as `auto`, and `_resolve_auto()` never sees that model, so `resolved` is the main model. A blanket flip would silently override a user's explicit `auxiliary.<task>.model` config. The `_model_was_prefilled` guard fixes MoA (the failing aux task has no per-task model, so pre-fill runs → resolved wins) without dropping that feature.

This is also what distinguishes this PR from the competing #51284, which is a blanket `resolved if resolved else model` flip with no caller-model guard.

## Safety Analysis

- **MoA users (the bug)**: `_model_was_prefilled = True` (no per-task model), `resolved` is the aggregator model (e.g. `"maas-glm-5.2-aliyun"`). Before: `"default"` (wrong, 400). After: `"maas-glm-5.2-aliyun"` (correct). ✅
- **Non-MoA, no per-task model**: `resolved` and pre-filled `model` are the same value (both = main model). `resolved or model` is identical to `model or resolved`. No behavioral change. ✅
- **Explicit `auxiliary.<task>.model` with provider `auto`**: `_model_was_prefilled = False`, so `model or resolved` — caller's config wins. This preserves the documented per-task model override (raised by @AmirF194). ✅
- **`_resolve_auto` returns `(client, None)`**: `resolved or model` falls back to pre-filled `model`. Same as before. ✅
- **OpenRouter-format drop guard** (line ~4137): unchanged. OR-format model dropped to `None` before the `final_model` line for non-OR aux providers. ✅

## How to Verify

1. `hermes chat --provider moa -m default` with an MoA preset whose aggregator is a real provider (e.g. `custom:codeagent` → `maas-glm-5.2-aliyun`)
2. Check `agent.log` for auxiliary task lines — before fix: `using auto (default)`, after fix: `using auto (maas-glm-5.2-aliyun)`
3. Title generation / compression should succeed without HTTP 400

## Test Plan

- [x] Added regression tests: `tests/agent/test_auxiliary_moa_auto_override.py` (6 cases)
  - `test_moa_preset_does_not_override_resolved_aggregator` — the core MoA regression
  - `test_resolved_none_falls_back_to_model` — edge case: resolved=None falls back to model
  - `test_non_moa_resolved_still_preferred_over_prefill` — non-MoA: no regression
  - `test_openrouter_format_model_dropped_for_non_or_provider` — existing OR-format drop guard still works
  - `test_explicit_caller_model_not_overridden_by_resolved` — OR-format explicit model not overridden (regression guard for the blanket-flip concern)
  - `test_explicit_plain_slug_model_not_overridden_by_resolved` — plain slug (bypasses OR-format drop guard) not overridden
- [x] All 309 tests pass (307 existing + 6 new, including the two explicit-model guards added after @AmirF194's review)
- [x] Reproduced in a clean Python 3.11 container matching CI by @AmirF194 — main fails `test_moa_preset_does_not_override_resolved_aggregator` with `assert 'default' == 'maas-glm-5.2-aliyun'`; fix passes

## Risk Assessment

**Low** — The change only affects the `auto` branch of `resolve_provider_client()`. The `_model_was_prefilled` guard scopes the behavioral change to exactly the bug (pre-fill from `_read_main_model()`) without touching the explicit-caller-model path. Reviewed and LGTM'd by @AmirF194 after the narrowing revision.
