### PR TITLE
fix(approval): extend hardline floor to cover wrapper bypasses and binary paths (P2 security)

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -318,7 +318,8 @@ _CMDPOS = (
     r'\s*'                          # optional whitespace
     r'(?:sudo\s+(?:-[^\s]+\s+)*)?'  # optional sudo with flags
     r'(?:env\s+(?:\w+=\S*\s+)*)?'   # optional env with VAR=VAL pairs
-    r'(?:(?:exec|nohup|setsid|time)\s+)*'  # optional wrapper commands
+    r'(?:(?:exec|nohup|setsid|time|command|builtin|nice|ionice|stdbuf|timeout)\s+(?:-[^\s]+\s+)*)*'  # optional wrapper commands with flags
+    r'(?:/(?:usr/|s?bin/)*|\./)?'   # optional absolute/relative path prefix
     r'\s*'
 )
 
@@ -925,6 +926,10 @@ _COMMAND_WRAPPER_WORDS = {
     "time",
     "command",
     "builtin",
+    "nice",
+    "ionice",
+    "stdbuf",
+    "timeout",
 }
 _SUDO_OPTIONS_WITH_ARG = {
     "-c", "--close-from",


### PR DESCRIPTION
## Problem

P2 security: hardline approval floor bypassed by command wrappers and binary paths.

The `_CMDPOS` regex in `tools/approval.py` only consumes `sudo`, `env`, `exec`, `nohup`, `setsid`, `time` as wrapper prefixes. Any other exec wrapper (`nice`, `ionice`, `stdbuf`, `timeout`), shell builtins (`command`/`builtin`), or an absolute/relative path to the binary shifts the destructive verb off the anchor, causing the hardline floor to miss it.

**Impact tiers:**
1. `shutdown`/`reboot`/`halt`/`poweroff` exist ONLY in the hardline list with no dangerous-layer backstop. `nice reboot`, `command systemctl poweroff`, `/bin/reboot` are auto-approved with no prompt in every mode, including the default.
2. Under `--yolo` / `approvals.mode: off` / cron approve-mode, destructive `rm` commands with wrapper/path prefixes defeat the hardline floor — the only remaining guard.

## Fix

- Add `command`, `builtin`, `nice`, `ionice`, `stdbuf`, `timeout` to `_CMDPOS` wrapper list (with optional flags)
- Add optional path prefix (`/bin/`, `/usr/sbin/`, `./`, etc.) to `_CMDPOS`
- Add `nice`, `ionice`, `stdbuf`, `timeout` to `_COMMAND_WRAPPER_WORDS`

Fixes #58642
