### PR TITLE
feat(telegram): support per-message rich mode metadata

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1377,14 +1377,52 @@ class TelegramAdapter(BasePlatformAdapter):
             return False
         return True
 
-    def _rich_delivery_enabled(self, content: str) -> bool:
+    def _metadata_rich_mode(self, metadata: Optional[Dict[str, Any]]) -> str:
+        """Return the per-message rich-delivery mode from send metadata.
+
+        ``telegram_rich_mode`` lets deterministic jobs opt a single message into
+        the rich path without turning on global Telegram rich delivery.  The
+        boolean ``telegram_rich_message`` alias is kept deliberately narrow for
+        cron/job templates that only need yes/no behavior.
+        """
+        if not metadata:
+            return "auto"
+        raw_mode = metadata.get("telegram_rich_mode")
+        if raw_mode is None and "telegram_rich_message" in metadata:
+            raw_mode = metadata.get("telegram_rich_message")
+        if isinstance(raw_mode, bool):
+            return "force_safe" if raw_mode else "off"
+        if raw_mode is None:
+            return "auto"
+        if isinstance(raw_mode, str):
+            mode = raw_mode.strip().lower().replace("-", "_")
+            if mode in {"", "auto", "default"}:
+                return "auto"
+            if mode in {"off", "false", "0", "no", "legacy", "markdown", "markdownv2"}:
+                return "off"
+            if mode in {"force", "force_safe", "rich", "true", "1", "yes", "on", "safe"}:
+                return "force_safe"
+        return "auto"
+
+    def _rich_delivery_enabled(
+        self, content: str, metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
         """Whether rich delivery is allowed for this payload."""
+        mode = self._metadata_rich_mode(metadata)
+        if mode == "off":
+            return False
+        if mode == "force_safe":
+            # Per-message opt-in still passes through the normal rich safety
+            # guards below (CJK/Desktop, details+math, size, endpoint support).
+            return True
         return bool(
             getattr(self, "_rich_messages_enabled", True)
             or self._content_is_pipe_table_primary(content)
         )
 
-    def _rich_eligible(self, content: str) -> bool:
+    def _rich_eligible(
+        self, content: str, metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
         """Capability/content eligibility for rich, ignoring ``expect_edits``.
 
         Shared core of :meth:`_should_attempt_rich` minus the per-call
@@ -1394,7 +1432,7 @@ class TelegramAdapter(BasePlatformAdapter):
         FINAL edit should still upgrade to rich when the content warrants it.
         """
         return bool(
-            self._rich_delivery_enabled(content)
+            self._rich_delivery_enabled(content, metadata=metadata)
             and not getattr(self, "_rich_send_disabled", False)
             and content
             and content.strip()
@@ -1410,7 +1448,7 @@ class TelegramAdapter(BasePlatformAdapter):
     ) -> bool:
         return bool(
             not (metadata or {}).get("expect_edits")
-            and self._rich_eligible(content)
+            and self._rich_eligible(content, metadata=metadata)
         )
 
     def prefers_fresh_final_streaming(
@@ -3841,7 +3879,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # table that exceeds the MarkdownV2 limit must not be split into legacy
         # chunks.  Falls back to the legacy edit path (overflow split included)
         # on capability/permanent rejection.
-        if finalize and self._rich_eligible(content):
+        if finalize and self._rich_eligible(content, metadata=metadata):
             rich_result = await self._try_edit_rich(
                 chat_id, message_id, content, metadata=metadata,
             )

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -283,6 +283,81 @@ async def test_rich_messages_can_be_opted_out():
 
 
 @pytest.mark.asyncio
+async def test_metadata_rich_mode_force_safe_overrides_global_opt_out():
+    """A deterministic job can opt one safe rich payload in without enabling
+    global rich delivery for every Telegram reply."""
+    adapter = _make_adapter(extra={"rich_messages": False})
+
+    result = await adapter.send(
+        "12345",
+        RICH_CONTENT,
+        metadata={"telegram_rich_mode": "force_safe"},
+    )
+
+    assert result.success is True
+    bot = adapter._bot
+    assert bot is not None
+    bot.do_api_request.assert_awaited_once()
+    bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_metadata_boolean_rich_message_alias_enables_one_message():
+    adapter = _make_adapter(extra={"rich_messages": False})
+
+    result = await adapter.send(
+        "12345",
+        RICH_CONTENT,
+        metadata={"telegram_rich_message": True},
+    )
+
+    assert result.success is True
+    bot = adapter._bot
+    assert bot is not None
+    bot.do_api_request.assert_awaited_once()
+    bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_metadata_rich_mode_off_disables_table_auto_route():
+    """Per-message off is stronger than the default table-only auto route."""
+    config = PlatformConfig(enabled=True, token="fake-token")
+    adapter = TelegramAdapter(config)
+    bot = MagicMock()
+    bot.do_api_request = AsyncMock(return_value=SimpleNamespace(message_id=123))
+    bot.send_message = AsyncMock(return_value=MagicMock(message_id=1))
+    bot.send_chat_action = AsyncMock()
+    adapter._bot = bot
+
+    result = await adapter.send(
+        "12345",
+        TABLE_ONLY_CONTENT,
+        metadata={"telegram_rich_mode": "off"},
+    )
+
+    assert result.success is True
+    bot.do_api_request.assert_not_called()
+    bot.send_message.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_metadata_force_safe_still_honors_cjk_guard():
+    adapter = _make_adapter(extra={"rich_messages": False})
+
+    result = await adapter.send(
+        "12345",
+        CJK_RICH_CONTENT,
+        metadata={"telegram_rich_mode": "force_safe"},
+    )
+
+    assert result.success is True
+    bot = adapter._bot
+    assert bot is not None
+    bot.do_api_request.assert_not_called()
+    bot.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_plain_markdown_stays_on_legacy_path():
     """Ordinary replies (no table/task-list/details/math) stay on the legacy
     MarkdownV2 path for consistent client rendering, even with rich enabled."""


### PR DESCRIPTION
## Summary
- Add per-message Telegram rich delivery metadata gates: `telegram_rich_mode` (`off`, `auto`, `force_safe`) and boolean `telegram_rich_message` alias.
- Keep default/global behavior unchanged: free-form replies stay legacy MarkdownV2, table-only auto-route remains, and `off` can disable rich for a single message.
- Preserve existing rich safety guards for CJK/Desktop garble, details+math crash shapes, size limits, endpoint support, and transient no-resend behavior.

## Verification
- `python3 -m py_compile plugins/platforms/telegram/adapter.py gateway/rich_sent_store.py`
- `uv run --extra dev python -m pytest tests/gateway/test_telegram_rich_messages.py tests/gateway/test_telegram_rich_newlines.py -q` → 86 passed
- `git diff --check`

## Safety / non-actions
- No Gateway restart.
- No Telegram live pilot send.
- No config, cron schedule/model/provider/delivery, OAuth/secrets, Slack scope, production/admin, public/customer-facing, payment/contract/legal/accounting changes.

Linear: L7-636