### PR TITLE
fix(cli): remove keep=1 from pre-update snapshot to preserve prior snapshots

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9707,7 +9707,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         try:
             from hermes_cli.backup import create_quick_snapshot
 
-            pre_update_snapshot_id = create_quick_snapshot(label="pre-update", keep=1)
+            pre_update_snapshot_id = create_quick_snapshot(label="pre-update")
             if pre_update_snapshot_id:
                 print(f"  ✓ Pre-update snapshot: {pre_update_snapshot_id}")
         except Exception as exc:

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1666,6 +1666,32 @@ class TestQuickSnapshot:
         # Cleanup the seeded escape source so the test is hermetic.
         escape_src.unlink()
 
+    def test_pre_update_snapshot_preserves_prior_snapshots(self, hermes_home):
+        """Pre-update snapshots must NOT use keep=1, which silently prunes ALL
+        previously retained quick snapshots (issue #58672)."""
+        from hermes_cli.backup import (
+            _QUICK_DEFAULT_KEEP,
+            create_quick_snapshot,
+            list_quick_snapshots,
+        )
+
+        # Create several snapshots before the pre-update one.
+        for i in range(5):
+            create_quick_snapshot(label=f"manual-{i}", hermes_home=hermes_home)
+
+        pre_count = len(list_quick_snapshots(limit=100, hermes_home=hermes_home))
+        assert pre_count == 5
+
+        # The pre-update snapshot (no keep override) should use default keep.
+        create_quick_snapshot(label="pre-update", hermes_home=hermes_home)
+
+        post = list_quick_snapshots(limit=100, hermes_home=hermes_home)
+        # All 5 prior + the new pre-update = 6 total (well under default keep=20).
+        assert len(post) == 6, (
+            f"pre-update snapshot pruned prior snapshots; "
+            f"expected 6, got {len(post)}"
+        )
+
 
 class TestQuickSnapshotProjectsKanban:
     """Regression for #52889: projects.db / kanban.db must survive an upgrade.


### PR DESCRIPTION
## What does this PR do?

Remove the explicit `keep=1` argument from the pre-update safety snapshot call in `hermes_cli/main.py`.  This one-liner was causing `hermes update` to delete ALL previously retained quick snapshots (state.db, config.yaml, pairing JSONs, etc.) on every update, defeating the purpose of the snapshot retention policy.

The default `keep=20` (via `_QUICK_DEFAULT_KEEP`) is the correct limit for all callers — the comment on line 882-884 of `backup.py` documents that callers with "known high-churn safety snapshots" can pass a smaller value, but `keep=1` was an over-aggressive choice that wiped the entire snapshot history.

## Related Issue

Fixes #58672

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py:9710` — Remove `keep=1` from `create_quick_snapshot(label="pre-update")` so it uses the default `_QUICK_DEFAULT_KEEP = 20`.
- `tests/hermes_cli/test_backup.py` — Add `test_pre_update_snapshot_preserves_prior_snapshots` regression test verifying that a pre-update snapshot coexists with 5 prior snapshots instead of pruning them.

## How to Test

1. Create 5 quick snapshots: `hermes snapshot create --label test-{1..5}`
2. Run `hermes update` (which triggers a pre-update snapshot)
3. Run `hermes snapshot list` — should show 6 snapshots (5 manual + 1 pre-update), not just 1
4. `pytest tests/hermes_cli/test_backup.py::TestQuickSnapshot -xvs` — all 20 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_backup.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (snapshot logic is cross-platform; no OS-specific code touched)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
