### PR TITLE
fix(toolsets): recover nested/malformed platform_toolsets instead of silently dropping tools

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1410,6 +1410,80 @@ def enabled_mcp_server_names(config: dict) -> Set[str]:
     }
 
 
+def _flatten_toolset_names(raw_entries: list, platform: str) -> List[str]:
+    """Normalise a ``platform_toolsets.<platform>`` list into flat str names.
+
+    A well-formed entry is a flat list of strings. But a stray indentation
+    in ``config.yaml`` nests names under a mapping — the single most common
+    hand-edit mistake:
+
+        discord:
+          - hermes-discord:
+              - browser
+              - terminal
+
+    YAML parses that as ``[{'hermes-discord': ['browser', 'terminal']}]``.
+    The old normalisation (``[str(ts) for ts in toolset_names]``) turned the
+    mapping into the literal string ``"{'hermes-discord': [...]}"`` — a name
+    that matches no toolset, so ``has_explicit_config`` stayed False for the
+    real toolsets and every nested toolset was silently dropped. The platform
+    then loaded almost no tools while ``config.yaml`` *looked* correct, with
+    zero warning anywhere. Recover the intended names (both mapping keys and
+    their nested values) so the platform still works, and log loudly so the
+    malformed config is visible and fixable.
+
+    Well-formed configs pass through unchanged (no warning, same order).
+    """
+    flat: List[str] = []
+    malformed = False
+
+    def _extract(node) -> None:
+        if isinstance(node, bool):
+            flat.append(str(node))
+        elif isinstance(node, str):
+            flat.append(node)
+        elif isinstance(node, (int, float)):
+            flat.append(str(node))
+        elif isinstance(node, dict):
+            for key, value in node.items():
+                _extract(key)
+                _extract(value)
+        elif isinstance(node, (list, tuple, set)):
+            for item in node:
+                _extract(item)
+        elif node is not None:
+            flat.append(str(node))
+
+    for entry in raw_entries:
+        if isinstance(entry, (str, int, float, bool)):
+            # YAML may parse bare numeric names (e.g. ``12306:``) as int.
+            flat.append(str(entry))
+        else:
+            malformed = True
+            _extract(entry)
+
+    # De-duplicate while preserving first-seen order.
+    seen: Set[str] = set()
+    result: List[str] = []
+    for name in flat:
+        if name not in seen:
+            seen.add(name)
+            result.append(name)
+
+    if malformed:
+        logger.warning(
+            "platform_toolsets.%s in config.yaml is malformed: it contains a "
+            "nested list/mapping instead of a flat list of toolset names "
+            "(usually a YAML indentation error). Recovered toolset names: %s. "
+            "Fix the indentation so each toolset is its own top-level "
+            "'- <name>' entry.",
+            platform,
+            ", ".join(result) if result else "(none)",
+        )
+
+    return result
+
+
 def _get_platform_tools(
     config: dict,
     platform: str,
@@ -1431,9 +1505,11 @@ def _get_platform_tools(
             default_ts = f"hermes-{platform}"
         toolset_names = [default_ts]
 
-    # YAML may parse bare numeric names (e.g. ``12306:``) as int.
-    # Normalise to str so downstream sorted() never mixes types.
-    toolset_names = [str(ts) for ts in toolset_names]
+    # Normalise to a flat list of str names. Handles the bare-numeric YAML
+    # case (``12306:`` → int) and, critically, recovers from nested/malformed
+    # entries instead of stringifying a mapping into an unmatchable name that
+    # silently drops every real toolset. See _flatten_toolset_names.
+    toolset_names = _flatten_toolset_names(toolset_names, platform)
 
     configurable_keys = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
     plugin_ts_keys = _get_plugin_toolset_keys()

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -114,6 +114,53 @@ def test_partially_valid_platform_toolsets_no_runtime_warning(caplog):
     assert not any("#38798" in r.getMessage() for r in caplog.records)
 
 
+def test_malformed_nested_platform_toolsets_recovers_intended_toolsets(caplog):
+    """A YAML indentation error that nests toolset names under a mapping
+    (``[{'hermes-discord': ['browser', 'terminal', ...]}]``) must not silently
+    collapse the platform's toolset. The old code stringified the mapping into
+    an unmatchable name and dropped every nested toolset, leaving the platform
+    with almost no tools while config.yaml looked correct. The intended
+    toolsets must be recovered and a warning emitted."""
+    malformed = {
+        "platform_toolsets": {
+            "discord": [
+                {"hermes-discord": ["browser", "terminal", "file", "web", "cronjob"]}
+            ]
+        }
+    }
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.tools_config"):
+        enabled = _get_platform_tools(malformed, "discord")
+
+    # Core interactive toolsets must survive the malformed nesting.
+    for ts in ("browser", "terminal", "file", "web", "cronjob"):
+        assert ts in enabled, ts
+
+    # The malformed structure must be surfaced, not swallowed silently.
+    assert any("malformed" in r.getMessage() for r in caplog.records)
+
+
+def test_malformed_nested_matches_well_formed_equivalent():
+    """Recovering a nested/malformed entry must yield the same toolset as the
+    equivalent flat list — the indentation error should be fully transparent
+    once recovered."""
+    names = ["hermes-discord", "browser", "terminal", "file", "web", "cronjob", "tts"]
+    flat = {"platform_toolsets": {"discord": names}}
+    nested = {"platform_toolsets": {"discord": [{names[0]: names[1:]}]}}
+
+    assert _get_platform_tools(nested, "discord") == _get_platform_tools(flat, "discord")
+
+
+def test_well_formed_platform_toolsets_emit_no_malformed_warning(caplog):
+    """Well-formed flat lists must pass through without the malformed warning."""
+    config = {"platform_toolsets": {"cli": ["web", "terminal", "file"]}}
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.tools_config"):
+        _get_platform_tools(config, "cli")
+
+    assert not any("malformed" in r.getMessage() for r in caplog.records)
+
+
 def test_agent_disabled_toolsets_empty_list_is_noop():
     """Empty or missing disabled_toolsets should not change behavior."""
     config_empty = {"agent": {"disabled_toolsets": []}}


### PR DESCRIPTION
## Summary
A gateway/CLI/TUI platform can silently run with almost no tools while `config.yaml` *looks* correctly configured — the agent reaches `cronjob`/`text_to_speech` but not `terminal`/`file`/`web`/`browser`, and `hermes tools` + reconfigure never fixes it. Root cause: a **nested/malformed `platform_toolsets` entry** is stringified into an unmatchable name and every real toolset is dropped, with no warning anywhere.

## Root cause
A common YAML indentation slip nests toolset names under a mapping:

```yaml
platform_toolsets:
  discord:
    - hermes-discord:
        - browser
        - terminal
        - file
        - web
```

YAML parses that as `[{'hermes-discord': ['browser', 'terminal', ...]}]`. In `_get_platform_tools`:

```python
toolset_names = [str(ts) for ts in toolset_names]
```

turns the mapping into the literal string `"{'hermes-discord': [...]}"` — a name that matches no toolset. `has_explicit_config` then stays `False` for the real toolsets, and the nested toolsets are silently discarded. The platform loads only a handful of default/plugin toolsets. Confirmed against a real `hermes debug` bundle: `in=15510` tokens (full toolset) before, `in=3718` after, from the same-looking config; only `text_to_speech`/`cronjob` reachable.

Because CLI, messaging gateway and TUI all resolve through `_get_platform_tools`, every surface is affected.

## Why existing fixes don't cover this
This belongs to the "silent toolset failure" family (#38798/#52920, #55801, #56731, #57063, #56735) but is a distinct hole:
- #52920 warns only when **every** name is invalid and the platform ends with **zero** tools.
- #57063 covers missing plugin bundles and `config set` storing a list literal as a plain **string** (fails `isinstance(..., list)` → falls back to default).

Here the value **is** a list and the result is **non-empty-but-wrong**, so none of those guards fire and no recovery happens.

## Fix
Add `_flatten_toolset_names`, which:
- recovers the intended names from nested mappings/lists (mapping keys **and** their nested values) so the platform keeps working, and
- logs a loud warning so the malformed config is visible and fixable.

Well-formed flat lists pass through unchanged (same order, no warning), so there is no behavior change for correct configs.

## Tests
`tests/hermes_cli/test_tools_config.py` (new invariant-style cases):
- a nested-mapping entry recovers `browser/terminal/file/web/cronjob`,
- a nested entry resolves identically to the equivalent flat list,
- the malformed structure is warned about,
- well-formed flat lists emit no warning.

`scripts/run_tests.sh tests/hermes_cli/test_tools_config.py tests/hermes_cli/test_toolset_validation.py` — 124 passed.

Made with [Cursor](https://cursor.com)