### PR TITLE
fix(setup): blank slate stops disabling the tools it means to keep

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -3036,12 +3036,20 @@ def _blank_slate_minimal_toolsets(config: dict):
        keep, guaranteeing a true blank slate regardless of platform/recovery
        quirks. The user re-enables any of them later via ``hermes tools`` (which
        rewrites ``platform_toolsets``) or by editing ``agent.disabled_toolsets``.
+
+    ``disabled_toolsets`` is applied at *tool* granularity, and a single tool can
+    belong to several toolsets. Aggregate bundles like ``coding`` are defined via
+    ``tools`` (not ``includes``) and re-list core tools such as ``terminal`` and
+    ``read_file``. Disabling such a bundle therefore strips those tools even
+    though ``file``/``terminal`` are the toolsets we mean to keep — leaving the
+    agent with ZERO tools despite ``platform_toolsets`` keeping them. So we never
+    disable a toolset whose tools overlap the ones we keep.
     """
     keep = {"file", "terminal"}
     config.setdefault("platform_toolsets", {})["cli"] = sorted(keep)
 
     try:
-        from toolsets import TOOLSETS
+        from toolsets import TOOLSETS, resolve_toolset
         from hermes_cli.tools_config import CONFIGURABLE_TOOLSETS, _get_plugin_toolset_keys
 
         all_keys = set()
@@ -3056,7 +3064,18 @@ def _blank_slate_minimal_toolsets(config: dict):
                 continue  # composite groupings, not leaf toolsets
             all_keys.add(k)
 
-        disabled = sorted(all_keys - keep)
+        # Tools the kept toolsets provide. Any toolset we disable that shares one
+        # of these would silently strip it back out (disabled_toolsets wins), so
+        # exclude every overlapping bundle from the suppression list.
+        kept_tools = set()
+        for k in keep:
+            kept_tools.update(resolve_toolset(k))
+
+        disabled = sorted(
+            k
+            for k in (all_keys - keep)
+            if not (set(resolve_toolset(k)) & kept_tools)
+        )
         if disabled:
             config.setdefault("agent", {})["disabled_toolsets"] = disabled
     except Exception as exc:

--- a/tests/hermes_cli/test_setup_blank_slate.py
+++ b/tests/hermes_cli/test_setup_blank_slate.py
@@ -59,6 +59,52 @@ class TestBlankSlateMinimalToolsets:
         assert names == ["patch", "process", "read_file", "search_files",
                          "terminal", "write_file"]
 
+    def test_no_disabled_bundle_overlaps_kept_tools(self):
+        # Regression: ``coding`` is a bundle (defined via ``tools``, with an
+        # empty ``includes``) that re-lists ``terminal``/``read_file``/… .
+        # Listing it in disabled_toolsets strips those tools even though we mean
+        # to keep file+terminal, because get_tool_definitions() subtracts a
+        # disabled toolset at TOOL granularity. No disabled entry may share a
+        # tool with a kept toolset.
+        from toolsets import resolve_toolset
+        cfg = {}
+        _blank_slate_minimal_toolsets(cfg)
+        kept_tools = set()
+        for ts in cfg["platform_toolsets"]["cli"]:
+            kept_tools.update(resolve_toolset(ts))
+        for ts in cfg["agent"]["disabled_toolsets"]:
+            overlap = set(resolve_toolset(ts)) & kept_tools
+            assert not overlap, (
+                f"disabled toolset '{ts}' overlaps kept tools {sorted(overlap)}; "
+                "it would silently strip them from the blank-slate agent"
+            )
+
+    def test_real_agent_path_keeps_core_tools_with_disabled_applied(self):
+        # The bug this fixes: the live agent path (agent/agent_init.py) calls
+        # get_tool_definitions(enabled=<platform tools>, disabled=<agent
+        # .disabled_toolsets>). The earlier schema test passed disabled=None and
+        # so never exercised the subtraction that actually broke installs. Here
+        # we feed BOTH — as the runtime does — and assert file/terminal tools
+        # survive rather than being zeroed out by a disabled bundle.
+        import model_tools
+        from hermes_cli.tools_config import _get_platform_tools
+        cfg = {}
+        _blank_slate_minimal_toolsets(cfg)
+        _blank_slate_minimize_config(cfg)
+        enabled = sorted(_get_platform_tools(cfg, "cli"))
+        disabled = cfg["agent"]["disabled_toolsets"]
+        defs = model_tools.get_tool_definitions(
+            enabled_toolsets=enabled, disabled_toolsets=disabled, quiet_mode=True
+        )
+        names = {
+            (d.get("function") or {}).get("name") or d.get("name") for d in defs
+        }
+        for core in ("terminal", "read_file", "write_file", "patch", "search_files"):
+            assert core in names, (
+                f"core tool '{core}' was stripped by disabled_toolsets "
+                f"{disabled}; agent left with {sorted(names)}"
+            )
+
 
 class TestBlankSlateMinimizeConfig:
     def test_optional_features_turned_off(self):


### PR DESCRIPTION
## Summary

The **Blank Slate** installer (`_blank_slate_minimal_toolsets` in `hermes_cli/setup.py`) writes `agent.disabled_toolsets` as a hard suppression list of "every known toolset except `file` and `terminal`". That list is applied by `get_tool_definitions()` at **tool granularity** — a disabled toolset's tools are subtracted from the final set — and a single tool can belong to several toolsets.

`coding` is an aggregate bundle defined via `tools` (with an *empty* `includes`, so the existing `includes` filter never skipped it). It re-lists the core tools `terminal`, `read_file`, `write_file`, `patch`, `search_files`, `web_search`, `web_extract`, `todo`, `clarify`, `delegate_task`, `skills_*`. Because `coding` landed in `disabled_toolsets`, all of those were stripped even though `file`+`terminal` were kept via `platform_toolsets` — leaving the agent with essentially no usable tools (only unrelated plugin tools survived).

This is silent (no error/warning) and affects **every interactive surface** (CLI, gateway/Discord/Telegram, TUI) because they all resolve tools through the same path. Re-running `hermes tools` does not fix it: the reconcile step only drops *newly-enabled configurable* keys from `disabled_toolsets`, never a posture bundle like `coding`.

## Fix

Never put a toolset in the blank-slate disabled list if its tools overlap the tools of the kept toolsets (`file`, `terminal`). In practice this excludes only `coding`; every genuinely off-by-default leaf/niche toolset (kanban, image_gen, memory, …) stays disabled.

## Repro (before fix)

With `coding` in `agent.disabled_toolsets`, `get_tool_definitions(enabled=<platform tools>, disabled=<disabled_toolsets>)` returns a set with `terminal`/`read_file`/`web_search`/… removed. After the fix, the core tools survive.

## Test plan

- [x] `test_no_disabled_bundle_overlaps_kept_tools` — no disabled toolset shares a tool with a kept toolset.
- [x] `test_real_agent_path_keeps_core_tools_with_disabled_applied` — the real agent path (both `enabled_toolsets` **and** `disabled_toolsets`, as `agent/agent_init.py` does) keeps the core file/terminal tools. The pre-existing schema test passed `disabled_toolsets=None`, so it never exercised the subtraction that actually broke installs.
- [x] Both new tests fail on the prior `setup.py`, pass with the fix.
- [x] `scripts/run_tests.sh tests/hermes_cli/test_setup_blank_slate.py tests/hermes_cli/test_tools_config.py tests/hermes_cli/test_setup.py` → 139 passed.