### PR TITLE
fix(slack): bridge rich_blocks opt-in from a top-level slack: block to extra

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3421,8 +3421,11 @@ class SlackAdapter(BasePlatformAdapter):
     def _rich_blocks_enabled(self) -> bool:
         """Whether to render outbound agent messages as Slack Block Kit blocks.
 
-        Opt-in via ``platforms.slack.extra.rich_blocks`` (config.yaml). Default
-        off: messages continue to go out as flat mrkdwn ``text``. Enabling it
+        Opt-in via ``rich_blocks`` in config.yaml — under a top-level ``slack:``
+        block (``slack.rich_blocks`` or ``slack.extra.rich_blocks``) or under
+        ``platforms.slack.extra.rich_blocks``; all are bridged into
+        ``config.extra`` by ``_apply_yaml_config``. Default off: messages
+        continue to go out as flat mrkdwn ``text``. Enabling it
         renders the *final* agent message with real structural primitives
         (headers, dividers, true nested lists via ``rich_text``, and native
         Block Kit ``table`` blocks with per-column alignment); over-limit
@@ -8969,8 +8972,13 @@ def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
     existing env-driven model and owns the YAML→env translation here, next to
     the adapter that consumes it. Env vars take precedence over YAML — every
     assignment is guarded by ``not os.getenv(...)`` so explicit env vars
-    survive a config.yaml update. Returns ``None`` because no extras are
-    seeded into ``PlatformConfig.extra`` directly (everything flows through env).
+    survive a config.yaml update. Most keys flow through env, but
+    ``rich_blocks`` is consumed from ``PlatformConfig.extra`` (by
+    ``_rich_blocks_enabled()``), so it is returned here for the gateway to
+    merge into ``extra`` rather than exported as an env var. Both the flat
+    ``slack.rich_blocks`` and the nested ``slack.extra.rich_blocks`` forms are
+    accepted; the flat form wins when both are set, matching the discord and
+    telegram hooks' flat-over-nested precedence.
     """
     if "require_mention" in slack_cfg and not os.getenv("SLACK_REQUIRE_MENTION"):
         os.environ["SLACK_REQUIRE_MENTION"] = str(slack_cfg["require_mention"]).lower()
@@ -9022,7 +9030,23 @@ def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
         if isinstance(ic, list):
             ic = ",".join(str(v) for v in ic)
         os.environ["SLACK_IGNORED_CHANNELS"] = str(ic)
-    return None  # all settings flow through env; nothing to merge into extras
+    # ``rich_blocks`` is consumed from PlatformConfig.extra, not env. Under a
+    # top-level ``slack:`` block it was never populated — it is not a shared
+    # key, not env-bridged, and ``_merge_platform_map`` only deep-merges the
+    # nested ``extra`` sub-dict for ``platforms:``-nested blocks — so the
+    # documented opt-in was inert there. Bridge it here; the flat
+    # ``slack.rich_blocks`` wins over the nested ``slack.extra.rich_blocks``
+    # (same flat-over-nested precedence as the discord/telegram hooks). Value
+    # coercion is the reader's job.
+    _extra_in = slack_cfg.get("extra")
+    if not isinstance(_extra_in, dict):
+        _extra_in = {}
+    seeded: dict = {}
+    if "rich_blocks" in slack_cfg:
+        seeded["rich_blocks"] = slack_cfg["rich_blocks"]
+    elif "rich_blocks" in _extra_in:
+        seeded["rich_blocks"] = _extra_in["rich_blocks"]
+    return seeded or None
 
 
 def _is_connected(config) -> bool:
@@ -9056,12 +9080,12 @@ def register(ctx) -> None:
         # Interactive setup wizard — replaces hermes_cli/setup.py::_setup_slack
         # and the static _PLATFORMS["slack"] dict in hermes_cli/gateway.py.
         setup_fn=interactive_setup,
-        # YAML→env config bridge — owns the translation of config.yaml slack:
+        # YAML→config bridge — owns the translation of config.yaml slack:
         # keys (require_mention, strict_mention, ignore_other_user_mentions,
         # thread_require_mention, allow_bots, free_response_channels,
         # reactions, disable_dms, allowed_channels, ignored_channels) into
-        # SLACK_* env vars that
-        # the adapter reads via os.getenv(). Replaces the
+        # SLACK_* env vars that the adapter reads via os.getenv(), and seeds
+        # ``rich_blocks`` into PlatformConfig.extra. Replaces the
         # hardcoded block in gateway/config.py. Hook contract: #24849.
         apply_yaml_config_fn=_apply_yaml_config,
         # Auth env vars for _is_user_authorized() integration

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3432,8 +3432,11 @@ class SlackAdapter(BasePlatformAdapter):
     def _rich_blocks_enabled(self) -> bool:
         """Whether to render outbound agent messages as Slack Block Kit blocks.
 
-        Opt-in via ``platforms.slack.extra.rich_blocks`` (config.yaml). Default
-        off: messages continue to go out as flat mrkdwn ``text``. Enabling it
+        Opt-in via ``rich_blocks`` in config.yaml — under a top-level ``slack:``
+        block (``slack.rich_blocks`` or ``slack.extra.rich_blocks``) or under
+        ``platforms.slack.extra.rich_blocks``; all are bridged into
+        ``config.extra`` by ``_apply_yaml_config``. Default off: messages
+        continue to go out as flat mrkdwn ``text``. Enabling it
         renders the *final* agent message with real structural primitives
         (headers, dividers, true nested lists via ``rich_text``, and native
         Block Kit ``table`` blocks with per-column alignment); over-limit
@@ -8996,8 +8999,13 @@ def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
     existing env-driven model and owns the YAML→env translation here, next to
     the adapter that consumes it. Env vars take precedence over YAML — every
     assignment is guarded by ``not os.getenv(...)`` so explicit env vars
-    survive a config.yaml update. Returns ``None`` because no extras are
-    seeded into ``PlatformConfig.extra`` directly (everything flows through env).
+    survive a config.yaml update. Most keys flow through env, but
+    ``rich_blocks`` is consumed from ``PlatformConfig.extra`` (by
+    ``_rich_blocks_enabled()``), so it is returned here for the gateway to
+    merge into ``extra`` rather than exported as an env var. Both the flat
+    ``slack.rich_blocks`` and the nested ``slack.extra.rich_blocks`` forms are
+    accepted; the flat form wins when both are set, matching the discord and
+    telegram hooks' flat-over-nested precedence.
     """
     if "require_mention" in slack_cfg and not os.getenv("SLACK_REQUIRE_MENTION"):
         os.environ["SLACK_REQUIRE_MENTION"] = str(slack_cfg["require_mention"]).lower()
@@ -9049,7 +9057,23 @@ def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
         if isinstance(ic, list):
             ic = ",".join(str(v) for v in ic)
         os.environ["SLACK_IGNORED_CHANNELS"] = str(ic)
-    return None  # all settings flow through env; nothing to merge into extras
+    # ``rich_blocks`` is consumed from PlatformConfig.extra, not env. Under a
+    # top-level ``slack:`` block it was never populated — it is not a shared
+    # key, not env-bridged, and ``_merge_platform_map`` only deep-merges the
+    # nested ``extra`` sub-dict for ``platforms:``-nested blocks — so the
+    # documented opt-in was inert there. Bridge it here; the flat
+    # ``slack.rich_blocks`` wins over the nested ``slack.extra.rich_blocks``
+    # (same flat-over-nested precedence as the discord/telegram hooks). Value
+    # coercion is the reader's job.
+    _extra_in = slack_cfg.get("extra")
+    if not isinstance(_extra_in, dict):
+        _extra_in = {}
+    seeded: dict = {}
+    if "rich_blocks" in slack_cfg:
+        seeded["rich_blocks"] = slack_cfg["rich_blocks"]
+    elif "rich_blocks" in _extra_in:
+        seeded["rich_blocks"] = _extra_in["rich_blocks"]
+    return seeded or None
 
 
 def _is_connected(config) -> bool:
@@ -9084,12 +9108,12 @@ def register(ctx) -> None:
         # Interactive setup wizard — replaces hermes_cli/setup.py::_setup_slack
         # and the static _PLATFORMS["slack"] dict in hermes_cli/gateway.py.
         setup_fn=interactive_setup,
-        # YAML→env config bridge — owns the translation of config.yaml slack:
+        # YAML→config bridge — owns the translation of config.yaml slack:
         # keys (require_mention, strict_mention, ignore_other_user_mentions,
         # thread_require_mention, allow_bots, free_response_channels,
         # reactions, disable_dms, allowed_channels, ignored_channels) into
-        # SLACK_* env vars that
-        # the adapter reads via os.getenv(). Replaces the
+        # SLACK_* env vars that the adapter reads via os.getenv(), and seeds
+        # ``rich_blocks`` into PlatformConfig.extra. Replaces the
         # hardcoded block in gateway/config.py. Hook contract: #24849.
         apply_yaml_config_fn=_apply_yaml_config,
         # Auth env vars for _is_user_authorized() integration

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1821,6 +1821,41 @@ class TestLoadGatewayConfig:
             "C01ABC": "Code review mode",
         }
 
+    def test_bridges_slack_rich_blocks_nested_extra_from_config_yaml(
+        self, tmp_path, monkeypatch
+    ):
+        # rich_blocks under a top-level ``slack:`` block reaches extra only via
+        # the slack apply_yaml_config hook (it is not a shared key and
+        # _merge_platform_map only deep-merges the nested extra sub-dict for
+        # ``platforms:`` blocks). Guards the bridge fix against a revert to the
+        # old ``return None`` that would silently re-disable native rendering.
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "slack:\n  extra:\n    rich_blocks: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.SLACK].extra["rich_blocks"] is True
+
+    def test_bridges_slack_rich_blocks_flat_from_config_yaml(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "slack:\n  rich_blocks: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.SLACK].extra["rich_blocks"] is True
+
     def test_bridges_feishu_allow_bots_from_config_yaml_to_env(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -909,6 +909,42 @@ class TestLoadGatewayConfig:
         assert config.platforms[Platform.DISCORD].token == "worker-token"
         assert Platform.API_SERVER not in config.platforms
 
+    def test_bridges_slack_rich_blocks_nested_extra_from_config_yaml(
+        self, tmp_path, monkeypatch
+    ):
+        # rich_blocks under a top-level ``slack:`` block reaches extra only via
+        # the slack apply_yaml_config hook (it is not a shared key and
+        # _merge_platform_map only deep-merges the nested extra sub-dict for
+        # ``platforms:`` blocks). Guards the bridge fix against a revert to the
+        # old ``return None`` that would silently re-disable native rendering.
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "slack:\n  extra:\n    rich_blocks: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.SLACK].extra["rich_blocks"] is True
+
+    def test_bridges_slack_rich_blocks_flat_from_config_yaml(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "slack:\n  rich_blocks: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.SLACK].extra["rich_blocks"] is True
+
+
 
 class TestWebhookPortBridging:
     """Top-level port/host in the YAML platform section must be bridged into

--- a/tests/gateway/test_slack_block_kit_adapter.py
+++ b/tests/gateway/test_slack_block_kit_adapter.py
@@ -13,7 +13,7 @@ import pytest
 
 from gateway.config import PlatformConfig
 from plugins.platforms.slack import adapter as slack_module
-from plugins.platforms.slack.adapter import SlackAdapter
+from plugins.platforms.slack.adapter import SlackAdapter, _apply_yaml_config
 
 
 def _make_adapter(extra=None):
@@ -429,3 +429,67 @@ class TestMarkdownBlockMode:
         adapter, _ = _make_adapter({"markdown_blocks": True})
         assert adapter._markdown_block_payload("") is None
         assert adapter._markdown_block_payload("   ") is None
+
+
+class TestApplyYamlConfigRichBlocksBridge:
+    """``_apply_yaml_config`` must seed ``rich_blocks`` into PlatformConfig.extra.
+
+    Regression guard for the config bridge: ``_rich_blocks_enabled()`` reads
+    ``self.config.extra["rich_blocks"]``, but the YAML→config hook previously
+    returned ``None`` and only ever set ``SLACK_*`` env vars, so the documented
+    ``slack.rich_blocks`` opt-in never reached ``extra`` and was silently inert.
+    The gateway merges this hook's returned dict into ``extra`` (see
+    ``TestApplyYamlConfigFnDispatch`` for the dispatch contract), so returning
+    ``{"rich_blocks": ...}`` here is what actually enables the feature.
+    """
+
+    def test_nested_extra_form_is_bridged(self):
+        seeded = _apply_yaml_config({}, {"extra": {"rich_blocks": True}})
+        assert seeded == {"rich_blocks": True}
+
+    def test_flat_form_is_bridged(self):
+        seeded = _apply_yaml_config({}, {"rich_blocks": True})
+        assert seeded == {"rich_blocks": True}
+
+    def test_string_value_is_bridged_verbatim(self):
+        # Coercion is the reader's job (_rich_blocks_enabled); the bridge just
+        # forwards the raw value so "true"/"1"/"on" all survive to the reader.
+        seeded = _apply_yaml_config({}, {"rich_blocks": "true"})
+        assert seeded == {"rich_blocks": "true"}
+
+    def test_flat_form_wins_over_nested_when_both_present(self):
+        # Matches the discord/telegram precedence idiom: the flat top-level key
+        # takes precedence over the nested ``extra`` form.
+        seeded = _apply_yaml_config(
+            {}, {"rich_blocks": True, "extra": {"rich_blocks": False}}
+        )
+        assert seeded == {"rich_blocks": True}
+
+    def test_false_value_is_bridged_and_stays_disabled(self):
+        # ``rich_blocks: false`` is a non-empty dict, so it is NOT dropped by
+        # ``seeded or None``; it is forwarded and the reader stays disabled.
+        seeded = _apply_yaml_config({}, {"rich_blocks": False})
+        assert seeded == {"rich_blocks": False}
+        adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake", extra=seeded))
+        assert adapter._rich_blocks_enabled() is False
+
+    def test_absent_returns_none(self):
+        # No rich_blocks anywhere -> nothing to merge; other keys still flow
+        # through env, so the hook returns None (unchanged contract).
+        assert _apply_yaml_config({}, {"require_mention": True}) is None
+
+    def test_non_dict_extra_is_ignored(self):
+        # A malformed ``extra:`` (not a mapping) must not raise; it degrades to
+        # "no nested form present". ``None``/``int`` raise on the
+        # ``"rich_blocks" in _extra_in`` membership test and a list raises on
+        # the subsequent subscript, so these exercise the ``isinstance`` guard
+        # directly (a plain string would pass even without it).
+        for bad in (None, 123, ["rich_blocks"], "oops"):
+            assert _apply_yaml_config({}, {"extra": bad}) is None
+
+    def test_bridged_value_enables_reader(self):
+        # End-to-end within the adapter: what the hook seeds must be what
+        # _rich_blocks_enabled() reads back as truthy.
+        seeded = _apply_yaml_config({}, {"extra": {"rich_blocks": True}})
+        adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake", extra=seeded))
+        assert adapter._rich_blocks_enabled() is True

--- a/tests/gateway/test_slack_block_kit_adapter.py
+++ b/tests/gateway/test_slack_block_kit_adapter.py
@@ -13,7 +13,7 @@ import pytest
 
 from gateway.config import PlatformConfig
 from plugins.platforms.slack import adapter as slack_module
-from plugins.platforms.slack.adapter import SlackAdapter
+from plugins.platforms.slack.adapter import SlackAdapter, _apply_yaml_config
 
 
 def _make_adapter(extra=None):
@@ -185,3 +185,65 @@ class TestMarkdownBlockMode:
         assert kwargs["blocks"][0]["text"] == RICH_TABLE_MD
 
 
+class TestApplyYamlConfigRichBlocksBridge:
+    """``_apply_yaml_config`` must seed ``rich_blocks`` into PlatformConfig.extra.
+
+    Regression guard for the config bridge: ``_rich_blocks_enabled()`` reads
+    ``self.config.extra["rich_blocks"]``, but the YAML→config hook previously
+    returned ``None`` and only ever set ``SLACK_*`` env vars, so the documented
+    ``slack.rich_blocks`` opt-in never reached ``extra`` and was silently inert.
+    The gateway merges this hook's returned dict into ``extra`` (see
+    ``TestApplyYamlConfigFnDispatch`` for the dispatch contract), so returning
+    ``{"rich_blocks": ...}`` here is what actually enables the feature.
+    """
+
+    def test_nested_extra_form_is_bridged(self):
+        seeded = _apply_yaml_config({}, {"extra": {"rich_blocks": True}})
+        assert seeded == {"rich_blocks": True}
+
+    def test_flat_form_is_bridged(self):
+        seeded = _apply_yaml_config({}, {"rich_blocks": True})
+        assert seeded == {"rich_blocks": True}
+
+    def test_string_value_is_bridged_verbatim(self):
+        # Coercion is the reader's job (_rich_blocks_enabled); the bridge just
+        # forwards the raw value so "true"/"1"/"on" all survive to the reader.
+        seeded = _apply_yaml_config({}, {"rich_blocks": "true"})
+        assert seeded == {"rich_blocks": "true"}
+
+    def test_flat_form_wins_over_nested_when_both_present(self):
+        # Matches the discord/telegram precedence idiom: the flat top-level key
+        # takes precedence over the nested ``extra`` form.
+        seeded = _apply_yaml_config(
+            {}, {"rich_blocks": True, "extra": {"rich_blocks": False}}
+        )
+        assert seeded == {"rich_blocks": True}
+
+    def test_false_value_is_bridged_and_stays_disabled(self):
+        # ``rich_blocks: false`` is a non-empty dict, so it is NOT dropped by
+        # ``seeded or None``; it is forwarded and the reader stays disabled.
+        seeded = _apply_yaml_config({}, {"rich_blocks": False})
+        assert seeded == {"rich_blocks": False}
+        adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake", extra=seeded))
+        assert adapter._rich_blocks_enabled() is False
+
+    def test_absent_returns_none(self):
+        # No rich_blocks anywhere -> nothing to merge; other keys still flow
+        # through env, so the hook returns None (unchanged contract).
+        assert _apply_yaml_config({}, {"require_mention": True}) is None
+
+    def test_non_dict_extra_is_ignored(self):
+        # A malformed ``extra:`` (not a mapping) must not raise; it degrades to
+        # "no nested form present". ``None``/``int`` raise on the
+        # ``"rich_blocks" in _extra_in`` membership test and a list raises on
+        # the subsequent subscript, so these exercise the ``isinstance`` guard
+        # directly (a plain string would pass even without it).
+        for bad in (None, 123, ["rich_blocks"], "oops"):
+            assert _apply_yaml_config({}, {"extra": bad}) is None
+
+    def test_bridged_value_enables_reader(self):
+        # End-to-end within the adapter: what the hook seeds must be what
+        # _rich_blocks_enabled() reads back as truthy.
+        seeded = _apply_yaml_config({}, {"extra": {"rich_blocks": True}})
+        adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake", extra=seeded))
+        assert adapter._rich_blocks_enabled() is True


### PR DESCRIPTION
## What does this PR do?

`SlackAdapter._rich_blocks_enabled()` reads the Block Kit opt-in from
`self.config.extra["rich_blocks"]`. But under a **top-level `slack:` block** —
the surface where every sibling key lives (`require_mention`, `allow_bots`,
`free_response_channels`, …) — that key never reached `extra`:

- it is not one of the shared keys the loader bridges,
- it is not env-bridged (unlike `require_mention` et al., which
  `_apply_yaml_config` translates into `SLACK_*` env vars), and
- `_merge_platform_map` only deep-merges the nested `extra` sub-dict for blocks
  under `platforms:` / `gateway.platforms:`, not for a top-level `slack:` block.

So `slack.rich_blocks` / `slack.extra.rich_blocks` under a top-level `slack:`
block was silently inert: `_rich_blocks_enabled()` stayed `False`,
`_maybe_blocks()` returned `None`, and outbound agent messages went out as flat
mrkdwn `text` regardless of config. The Block Kit rendering that already exists
in the adapter (headers, dividers, `rich_text` lists, and native `table`
blocks) was unreachable from the top-level block — most visibly with markdown
tables, since Slack has no table syntax and `| ... |` renders as raw pipes.

**Fix:** have the slack `_apply_yaml_config` hook **return** the `rich_blocks`
value so the gateway merges it into `PlatformConfig.extra` via the returned-dict
dispatch the hook contract already provides (`extra.update(seeded)`). This
mirrors telegram's hook, which returns `extras or None` for the same reason.
Keeping the bridge in the slack plugin — rather than adding a `gateway/config.py`
whitelist entry — is the point of the plugin `apply_yaml_config_fn` migration
(#24849).

- Both the flat `slack.rich_blocks` and the nested `slack.extra.rich_blocks`
  forms are accepted; the **flat form wins** when both are set, matching the
  discord/telegram hooks' flat-over-nested precedence.
- Value coercion stays the reader's job (`_rich_blocks_enabled()` already
  handles `true`/`1`/`on`/…).
- Env-only keys are untouched, and the hook still returns `None` when no
  `rich_blocks` is present — no behaviour change for existing configs.

(`platforms.slack.extra.rich_blocks` already worked, because `_merge_platform_map`
deep-merges the nested `extra` sub-dict for `platforms:`-nested blocks. This
change makes the top-level `slack:` forms behave the same as that documented
path.)

## Related Issue

No existing issue — self-contained bug fix; root cause and repro are described
above. (Searched open issues/PRs for the config-bridge gap; none found.)

Complementary to the open rendering-side PR #56618 (*harden rich table block
fallback*), which hardens `block_kit.py` / the fallback path against
`invalid_blocks`. This PR is orthogonal: it fixes the config→`extra` wiring so
the opt-in is reachable in the first place, and does not touch
`_apply_yaml_config` in #56618 (no overlap there).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/slack/adapter.py` — `_apply_yaml_config` now returns
  `{"rich_blocks": <value>}` (was `return None`) so the gateway merges it into
  `PlatformConfig.extra`; accepts flat `slack.rich_blocks` and nested
  `slack.extra.rich_blocks`, flat wins. Updated the `_rich_blocks_enabled` and
  `_apply_yaml_config` docstrings and the `register()` comment to reflect the
  bridged surface.
- `tests/gateway/test_slack_block_kit_adapter.py` — new
  `TestApplyYamlConfigRichBlocksBridge` (flat, nested, string, `false`,
  flat-wins-over-nested precedence, non-dict `extra`, absent, hook→reader
  roundtrip).
- `tests/gateway/test_config.py` — end-to-end `load_gateway_config()` dispatch
  tests for both top-level forms reaching
  `config.platforms[Platform.SLACK].extra["rich_blocks"]`.

## How to Test

**Repro (before this change):** in `config.yaml`, under a top-level `slack:`
block, set `extra: { rich_blocks: true }`; ask the agent to reply with a
markdown table. It posts as raw `| ... |` pipes (no `table` block), because
`extra["rich_blocks"]` is never populated.

**With this change:** the same config posts a native Block Kit `table` block.

1. `pytest tests/gateway/test_slack_block_kit_adapter.py tests/gateway/test_config.py -q`
2. New unit + e2e tests fail against the pre-fix `return None` (slack isn't even
   seeded into `config.platforms`, so the e2e assertions raise `KeyError`),
   confirming they're real regression guards.
3. Verified live against a running gateway: with `slack.extra.rich_blocks: true`
   under a top-level `slack:` block, a 5-column markdown table posts as a native
   `table` block, no `invalid_blocks` errors.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(slack): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected suites — `test_slack_block_kit_adapter.py`,
  `test_config.py`, `test_platform_registry.py`: 146/146 pass. (The full
  `tests/gateway/` run has ~10 unrelated timing/environment-flaky failures that
  also fail on the base commit; none are in files this PR touches.)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin 25.4.0)

### Documentation & Housekeeping

- [x] I've updated relevant docstrings — updated `_rich_blocks_enabled` /
  `_apply_yaml_config` docstrings and the `register()` comment
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys —
  N/A (`rich_blocks` is a pre-existing documented key; no new key introduced)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture — N/A
- [x] I've considered cross-platform impact — N/A (pure config/dict handling, no
  file/process/terminal I/O)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
