### PR TITLE
fix(plugins): warn on missing required env vars and zero-registration (salvage #2768)

### DIFF
--- a/contributors/emails/seraphine@Seraphines-Mac-Studio.local
+++ b/contributors/emails/seraphine@Seraphines-Mac-Studio.local
@@ -1,0 +1,2 @@
+Bartok9
+# Seraphine Mac Studio local email on Bartok9 PR tips (per-PR attribution; Teknium/Daniel 2026-08-01)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -541,6 +541,9 @@ class PluginContext:
             "handler_fn": handler_fn,
             "plugin": self.manifest.name,
         }
+        # Counted by the zero-registration check (and the DEBUG summary) so a
+        # CLI-only plugin is not treated as an empty register().
+        self._extra_registrations += 1
         logger.debug("Plugin %s registered CLI command: %s", self.manifest.name, name)
 
     # -- slash command registration -------------------------------------------
@@ -657,6 +660,7 @@ class PluginContext:
             )
             return
         self._manager._context_engine = engine
+        self._extra_registrations += 1
         logger.info(
             "Plugin '%s' registered context engine: %s",
             self.manifest.name, engine.name,
@@ -684,6 +688,7 @@ class PluginContext:
             )
             return
         register_provider(provider)
+        self._extra_registrations += 1
         logger.info(
             "Plugin '%s' registered image_gen provider: %s",
             self.manifest.name, provider.name,
@@ -724,6 +729,7 @@ class PluginContext:
                 self.manifest.name, getattr(provider, "name", "?"), e,
             )
             return
+        self._extra_registrations += 1
         logger.info(
             "Plugin '%s' registered dashboard-auth provider: %s (%s)",
             self.manifest.name, provider.name, provider.display_name,
@@ -751,6 +757,7 @@ class PluginContext:
             )
             return
         _register_video_provider(provider)
+        self._extra_registrations += 1
         logger.info(
             "Plugin '%s' registered video_gen provider: %s",
             self.manifest.name, provider.name,
@@ -779,6 +786,7 @@ class PluginContext:
             )
             return
         _register_web_provider(provider)
+        self._extra_registrations += 1
         logger.info(
             "Plugin '%s' registered web provider: %s",
             self.manifest.name, provider.name,
@@ -811,6 +819,7 @@ class PluginContext:
             )
             return
         _register_browser_provider(provider)
+        self._extra_registrations += 1
         logger.info(
             "Plugin '%s' registered browser provider: %s",
             self.manifest.name, provider.name,
@@ -858,6 +867,10 @@ class PluginContext:
             )
             return
         if register_source(source):
+            # Secret-source-only plugins are a legitimate registration surface
+            # (not tracked on LoadedPlugin), so count them for the
+            # zero-registration warning. (#58692 review)
+            self._extra_registrations += 1
             logger.info(
                 "Plugin '%s' registered secret source: %s",
                 self.manifest.name, source.name,
@@ -896,6 +909,7 @@ class PluginContext:
             )
             return
         _register_tts_provider(provider)
+        self._extra_registrations += 1
         logger.info(
             "Plugin '%s' registered TTS provider: %s",
             self.manifest.name, provider.name,
@@ -940,6 +954,7 @@ class PluginContext:
             )
             return
         _register_stt_provider(provider)
+        self._extra_registrations += 1
         logger.info(
             "Plugin '%s' registered transcription provider: %s",
             self.manifest.name, provider.name,
@@ -995,6 +1010,7 @@ class PluginContext:
         )
         platform_registry.register(entry)
         self._manager._plugin_platform_names.add(name)
+        self._extra_registrations += 1
         logger.debug(
             "Plugin %s registered platform: %s",
             self.manifest.name,
@@ -1053,6 +1069,7 @@ class PluginContext:
         self._manager._slack_action_handlers.append(
             (action_id, callback, self.manifest.name)
         )
+        self._extra_registrations += 1
         logger.debug(
             "Plugin %s registered Slack action handler: %s",
             self.manifest.name,
@@ -1167,6 +1184,7 @@ class PluginContext:
             "defaults": merged_defaults,
             "plugin": self.manifest.name,
         }
+        self._extra_registrations += 1
         logger.debug(
             "Plugin %s registered auxiliary task: %s (%s)",
             self.manifest.name,
@@ -1254,6 +1272,7 @@ class PluginContext:
             "bare_name": name,
             "description": description,
         }
+        self._extra_registrations += 1
         logger.debug(
             "Plugin %s registered skill: %s",
             self.manifest.name, qualified,
@@ -1787,6 +1806,29 @@ class PluginManager:
 
             loaded.module = module
 
+            # Warn early when declared required env vars are absent, so the
+            # user gets a clear message instead of a silent no-op from the
+            # plugin's own register() (issue #2765). ``requires_env`` entries
+            # may be bare strings or dicts with a ``name`` key.
+            _missing_env: list[str] = []
+            for _entry in manifest.requires_env or []:
+                if isinstance(_entry, str):
+                    _var = _entry
+                elif isinstance(_entry, dict):
+                    _var = _entry.get("name") or ""
+                else:
+                    _var = ""
+                if _var and not os.environ.get(_var):
+                    _missing_env.append(_var)
+            if _missing_env:
+                logger.warning(
+                    "Plugin '%s' is missing required environment variable(s): %s. "
+                    "Tools or other surfaces may not be registered — ensure these "
+                    "are set in the process environment that loads plugins.",
+                    manifest.name,
+                    ", ".join(_missing_env),
+                )
+
             # Call register()
             register_fn = getattr(module, "register", None)
             if register_fn is None:
@@ -1828,6 +1870,40 @@ class PluginManager:
                     if self._plugin_commands[c].get("plugin") == manifest.name
                 ]
                 loaded.enabled = True
+
+                # Warn when register() completed but added nothing at all —
+                # the silent-skip pattern reported in #2765 (e.g. a plugin
+                # returns early when a required env var is absent, emitting no
+                # log of its own). Deferred platform loaders legitimately
+                # register nothing here, so exempt them. Also exempt plugins
+                # that registered any "other" surface not tracked on
+                # LoadedPlugin — providers (image/video/web/browser/tts/stt/
+                # dashboard-auth), context engines, platforms, slack action
+                # handlers, auxiliary tasks, skills, CLI commands, or secret
+                # sources — counted via ctx._extra_registrations. Without this,
+                # a legitimately provider-only / CLI-only / secret-source-only
+                # plugin would trigger a false zero-registration warning
+                # (#2768 / #58692 review).
+                _cli_commands_registered = any(
+                    c.get("plugin") == manifest.name
+                    for c in self._cli_commands.values()
+                )
+                if (
+                    not loaded.deferred
+                    and not loaded.tools_registered
+                    and not loaded.hooks_registered
+                    and not loaded.middleware_registered
+                    and not loaded.commands_registered
+                    and not _cli_commands_registered
+                    and not ctx._extra_registrations
+                ):
+                    logger.warning(
+                        "Plugin '%s' registered zero tools, hooks, middleware, "
+                        "commands, CLI commands, and other surfaces. If it "
+                        "requires environment variables, ensure they are set "
+                        "in the process environment that loads plugins.",
+                        manifest.name,
+                    )
                 logger.debug(
                     "  registered: %d tool(s), %d hook(s), %d middleware, %d slash command(s), %d CLI command(s)",
                     len(loaded.tools_registered),

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -86,6 +86,195 @@ def _make_plugin_dir(base: Path, name: str, *, register_body: str = "pass",
     return plugin_dir
 
 
+# ── TestPluginMissingEnvWarnings ───────────────────────────────────────────
+
+
+class TestPluginMissingEnvWarnings:
+    """Warnings when required env vars are absent or nothing is registered (#2765)."""
+
+    def test_missing_requires_env_logs_warning(self, tmp_path, monkeypatch, caplog):
+        """A warning names the absent required env var declared in plugin.yaml."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "needs_env_plugin",
+            manifest_extra={"requires_env": ["MY_PLUGIN_API_URL"]},
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+        monkeypatch.delenv("MY_PLUGIN_API_URL", raising=False)
+
+        mgr = PluginManager()
+        with caplog.at_level(logging.WARNING):
+            mgr.discover_and_load()
+
+        assert any(
+            "needs_env_plugin" in r.getMessage()
+            and "MY_PLUGIN_API_URL" in r.getMessage()
+            for r in caplog.records
+        ), caplog.text
+
+    def test_requires_env_dict_form_logs_warning(self, tmp_path, monkeypatch, caplog):
+        """``requires_env`` dict entries (name/description) are handled too."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "dict_env_plugin",
+            manifest_extra={"requires_env": [{"name": "HINDSIGHT_API_URL",
+                                              "description": "Hindsight endpoint"}]},
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+        monkeypatch.delenv("HINDSIGHT_API_URL", raising=False)
+
+        mgr = PluginManager()
+        with caplog.at_level(logging.WARNING):
+            mgr.discover_and_load()
+
+        assert any(
+            "HINDSIGHT_API_URL" in r.getMessage() for r in caplog.records
+        ), caplog.text
+
+    def test_present_requires_env_no_warning(self, tmp_path, monkeypatch, caplog):
+        """No missing-env warning when the required var is set."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "has_env_plugin",
+            register_body="ctx.register_tool('has_env_tool', lambda **kw: 'ok')",
+            manifest_extra={"requires_env": ["PRESENT_VAR"]},
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+        monkeypatch.setenv("PRESENT_VAR", "1")
+
+        mgr = PluginManager()
+        with caplog.at_level(logging.WARNING):
+            mgr.discover_and_load()
+
+        assert not any(
+            "missing required environment" in r.getMessage()
+            and "has_env_plugin" in r.getMessage()
+            for r in caplog.records
+        ), caplog.text
+
+    def test_zero_registration_logs_warning(self, tmp_path, monkeypatch, caplog):
+        """A plugin whose register() adds nothing triggers a zero-registration warning."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(plugins_dir, "empty_plugin", register_body="pass")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        with caplog.at_level(logging.WARNING):
+            mgr.discover_and_load()
+
+        assert any(
+            "empty_plugin" in r.getMessage() and "zero tools" in r.getMessage()
+            for r in caplog.records
+        ), caplog.text
+
+    def test_registering_plugin_no_zero_warning(self, tmp_path, monkeypatch, caplog):
+        """A plugin that registers a tool does not get the zero-registration warning."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "busy_plugin",
+            register_body="ctx.register_tool('busy_tool', lambda **kw: 'ok')",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        with caplog.at_level(logging.WARNING):
+            mgr.discover_and_load()
+
+        assert not any(
+            "busy_plugin" in r.getMessage() and "zero tools" in r.getMessage()
+            for r in caplog.records
+        ), caplog.text
+
+    def test_extra_registration_no_zero_warning(self, tmp_path, monkeypatch, caplog):
+        """A plugin that registers only a non-tool/hook surface (here a skill,
+        standing in for provider-only plugins like plugins/image_gen/fal) must
+        NOT get the zero-registration warning (#2768 review)."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        skill_md = plugins_dir / "provider_plugin" / "MY_SKILL.md"
+        _make_plugin_dir(
+            plugins_dir,
+            "provider_plugin",
+            register_body=(
+                "from pathlib import Path\n"
+                "    ctx.register_skill('extra', "
+                "Path(__file__).parent / 'MY_SKILL.md')"
+            ),
+        )
+        skill_md.write_text("# skill\nbody\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        with caplog.at_level(logging.WARNING):
+            mgr.discover_and_load()
+
+        assert not any(
+            "provider_plugin" in r.getMessage() and "zero tools" in r.getMessage()
+            for r in caplog.records
+        ), caplog.text
+
+    def test_cli_only_plugin_no_zero_warning(self, tmp_path, monkeypatch, caplog):
+        """CLI-only plugins must not trigger the zero-registration warning (#58692)."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "cli_only_plugin",
+            register_body=(
+                "ctx.register_cli_command(\n"
+                "        'cli_only_cmd',\n"
+                "        help='CLI-only test command',\n"
+                "        setup_fn=lambda p: None,\n"
+                "        handler_fn=lambda args: None,\n"
+                "    )"
+            ),
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        with caplog.at_level(logging.WARNING):
+            mgr.discover_and_load()
+
+        assert "cli_only_cmd" in mgr._cli_commands
+        assert not any(
+            "cli_only_plugin" in r.getMessage() and "zero tools" in r.getMessage()
+            for r in caplog.records
+        ), caplog.text
+
+    def test_secret_source_only_plugin_no_zero_warning(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """Secret-source-only plugins must not trigger zero-registration (#58692)."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "secret_only_plugin",
+            register_body=(
+                "from pathlib import Path\n"
+                "    from agent.secret_sources.base import FetchResult, SecretSource\n"
+                "    class _Src(SecretSource):\n"
+                "        name = 'test_secret_src'\n"
+                "        label = 'Test Secret Source'\n"
+                "        shape = 'mapped'\n"
+                "        def fetch(self, cfg, home_path):\n"
+                "            return FetchResult()\n"
+                "    ctx.register_secret_source(_Src())"
+            ),
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        with caplog.at_level(logging.WARNING):
+            mgr.discover_and_load()
+
+        assert not any(
+            "secret_only_plugin" in r.getMessage() and "zero tools" in r.getMessage()
+            for r in caplog.records
+        ), caplog.text
+
+
 # ── TestPluginDiscovery ────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- When a plugin declares `requires_env` but those vars are absent — or when its `register()` completes without adding any tools/hooks/middleware/commands/CLI commands/other surfaces — the loader now emits a `WARNING`.
- Turns a silent no-op into an actionable diagnostic for general plugins.

## Motivation

Closes #2765.

Some plugins return early from `register()` when a required environment variable is unset (or otherwise complete without registering anything), emitting no log of their own. The user sees a plugin that "loaded" but registered zero surfaces, with no clue why. Two warnings cover both angles: declared-but-missing env vars, and completed-but-empty registration.

This is a **generic plugin-loader diagnostic**, not a Hindsight/memory-provider-specific path. Memory providers are exclusive and skipped by `_load_plugin()`; Hindsight currently declares `requires_env: []`. A Hindsight-specific diagnostic would belong in memory-provider discovery if still desired.

## Salvage of #2768 by @ygd58

Re-applied to current `main`. Changes from the original:

- Env-name extraction handles **both** `requires_env` shapes — bare strings **and** dicts with a `name` key — because current main allows the rich dict form (`{name, description, url, secret}`). The original only handled strings.
- The zero-registration check also considers **middleware**, **slash commands**, **CLI commands**, and **secret sources** (plus other `_extra_registrations` surfaces: providers, context engines, platforms, skills, etc.) and **exempts deferred platform loaders**, which legitimately register nothing at load time.
- Rebased cleanly onto current `main`; tests updated to the current `tests/hermes_cli/test_plugins.py` harness (`_make_plugin_dir`, `PluginManager.discover_and_load`).

## Review follow-ups (#58692 hermes-sweeper / @teknium1)

Addressed:

1. **CLI-only false positive** — `register_cli_command()` now counts toward registration; predicate also inspects `_cli_commands`. Regression: `test_cli_only_plugin_no_zero_warning`.
2. **Secret-source-only false positive** — successful `register_secret_source()` bumps `_extra_registrations`. Regression: `test_secret_source_only_plugin_no_zero_warning`.
3. **Motivation narrowed** — dropped Hindsight/systemd-dotenv claims that don't match current load paths (memory providers skip `_load_plugin()`; gateway already loads Hermes dotenv; #18606 closed).

## Verification

```
python3 -m pytest tests/hermes_cli/test_plugins.py::TestPluginMissingEnvWarnings -q
8 passed

python3 -m pytest tests/hermes_cli/test_plugins.py -q
124 passed
```

- `test_missing_requires_env_logs_warning` — string-form `requires_env`
- `test_requires_env_dict_form_logs_warning` — dict-form `requires_env`
- `test_zero_registration_logs_warning` — empty `register()`
- `test_present_requires_env_no_warning` / `test_registering_plugin_no_zero_warning` — negative controls
- `test_extra_registration_no_zero_warning` — skill/provider-style surface
- `test_cli_only_plugin_no_zero_warning` — CLI command surface
- `test_secret_source_only_plugin_no_zero_warning` — secret source surface