### PR TITLE
fix(kanban): enforce review change loop before completion

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4648,8 +4648,17 @@ def block_task(
         # An un-typed (None) block compares as "same" to a prior un-typed block.
         same_cause = prev_kind == kind
         recurrences = prev_recurrences + 1 if same_cause else 1
+        # The single-card code-review convention intentionally does
+        # block(review-required) -> unblock -> block(review-required) while a
+        # reviewer requests changes. That is not the cron-unblock loop this
+        # breaker protects against, so keep review handoffs in the normal
+        # blocked bucket even after multiple rounds. The explicit review
+        # comments remain the human-in-the-loop control plane.
+        is_review_required = bool(
+            reason and reason.strip().lower().startswith("review-required:")
+        )
 
-        if recurrences >= BLOCK_RECURRENCE_LIMIT:
+        if recurrences >= BLOCK_RECURRENCE_LIMIT and not is_review_required:
             # Loop detected — stop letting the unblocker spin this task. Route
             # to triage for a human-in-the-loop decision instead of blocked.
             cur = conn.execute(

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -91,6 +91,23 @@ def test_same_cause_reblock_routes_to_triage(kanban_home: Path) -> None:
         assert t.block_recurrences == 2
 
 
+def test_review_required_reblocks_stay_blocked_for_review_loop(kanban_home: Path) -> None:
+    """Single-card code review can legitimately block for review more than once."""
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        kb.block_task(conn, tid, reason="review-required: initial", kind="needs_input")
+        assert kb.unblock_task(conn, tid)
+        _make_running_again(conn, tid)
+        kb.block_task(conn, tid, reason="review-required: after changes", kind="needs_input")
+        t = kb.get_task(conn, tid)
+        assert t is not None
+        assert t.status == "blocked"
+        assert t.block_kind == "needs_input"
+        assert t.block_recurrences == 2
+        events = [e.kind for e in kb.list_events(conn, tid)]
+        assert "block_loop_detected" not in events
+
+
 def test_untyped_block_loop_also_protected(kanban_home: Path) -> None:
     """Legacy un-typed blocks (kind=None) still trip the breaker."""
     with kb.connect_closing() as conn:

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -311,6 +311,45 @@ def test_complete_happy_path(worker_env):
         conn.close()
 
 
+def test_complete_rejects_unresolved_changes_requested(worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        kb.add_comment(conn, worker_env, "reviewer", "CHANGES REQUESTED: fix edge case")
+    finally:
+        conn.close()
+
+    out = kt._handle_complete({"summary": "fixed it without re-review"})
+    err = json.loads(out).get("error", "")
+    assert "CHANGES REQUESTED" in err
+    assert "kanban_block" in err
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, worker_env)
+        assert task is not None
+        assert task.status == "running"
+    finally:
+        conn.close()
+
+
+def test_complete_allows_later_approve_after_changes_requested(worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        kb.add_comment(conn, worker_env, "reviewer", "CHANGES REQUESTED: fix edge case")
+        kb.add_comment(conn, worker_env, "reviewer", "APPROVE: fixed in follow-up")
+    finally:
+        conn.close()
+
+    out = kt._handle_complete({"summary": "fixed after approval"})
+    assert json.loads(out).get("ok") is True
+
+
 def test_complete_metadata_round_trips_through_show(worker_env):
     """Structured completion metadata should be visible to downstream agents."""
     from tools import kanban_tools as kt

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -598,6 +598,24 @@ def _handle_complete(args: dict, **kw) -> str:
             # Only enforce when a judge is actually reachable — see
             # _goal_judge_available for why an unavailable judge fails open.
             task = kb.get_task(conn, tid)
+            if task and os.environ.get("HERMES_KANBAN_TASK") == tid:
+                comments = kb.list_comments(conn, tid)
+                last_changes = -1
+                last_approve = -1
+                for idx, comment in enumerate(comments):
+                    body = (comment.body or "").upper()
+                    if "CHANGES REQUESTED" in body:
+                        last_changes = idx
+                    if "APPROVE" in body:
+                        last_approve = idx
+                if last_changes >= 0 and last_changes > last_approve:
+                    return tool_error(
+                        "kanban_complete rejected: latest review verdict is "
+                        "CHANGES REQUESTED and no later APPROVE comment exists. "
+                        "Fix the findings, commit, post kanban_comment with "
+                        "evidence, then call kanban_block(reason='review-required: ...') "
+                        "for re-review instead of completing."
+                    )
             if task and task.goal_mode and _goal_judge_available():
                 verdict = "done"
                 reason = ""


### PR DESCRIPTION
## Problem

Kanban reviewer handoffs can be accidentally finalized or re-triaged after a reviewer returns `CHANGES REQUESTED`.

Two bad outcomes follow:
- a `review-required:` re-block can hit the generic unblock-loop breaker and route to triage instead of preserving the normal reviewer → coder change loop;
- a scoped `kanban_complete` can complete a task even though the latest reviewer verdict requested changes and no later approval exists.

## Root cause

The Kanban lifecycle already treats review blocks specially in several places, but the generic blocked-loop guard and completion path did not enforce the review verdict invariant.

## Fix

- Keep repeated `review-required:` blocks out of the generic unblock-loop breaker so the normal change loop can continue.
- Reject scoped `kanban_complete` when the latest reviewer verdict is `CHANGES REQUESTED` and no later `APPROVE` comment exists.
- Add focused regression coverage for both paths.

## Tests

```bash
python -m pytest \
  tests/hermes_cli/test_kanban_db.py \
  tests/hermes_cli/test_kanban_block_kinds.py \
  tests/hermes_cli/test_kanban_blocked_sticky.py \
  tests/tools/test_kanban_tools.py \
  -q
```

Result: `340 passed in 7.68s`.
