### PR TITLE
feat(whatsapp): add configurable human cascade delivery

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -507,6 +507,10 @@ async def _send_or_update_status_coro(adapter, chat_id, status_key, content, met
     Telegram) edit the previous bubble for the same status_key instead of
     appending a new one. Adapters without the method fall back to plain send.
     """
+    metadata = dict(metadata or {})
+    # Status/thinking/progress bubbles are gateway chrome, not the final answer.
+    # Keep them single-unit on platforms with rich final-message delivery.
+    metadata["delivery_style"] = "single"
     sender = getattr(adapter, "send_or_update_status", None)
     if callable(sender):
         return await sender(chat_id, status_key, content, metadata=metadata)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17106,8 +17106,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             _chat_id=source.chat_id,
                         ) -> None:
                             _adapter.pause_typing_for_chat(_chat_id)
+                    # Non-editable messaging adapters (WhatsApp, Signal-style
+                    # transports, BlueBubbles, QQ, WeChat, …) must not receive
+                    # progressive preview sends. A first preview cannot be
+                    # edited into the final answer later, so let the normal
+                    # final send path run once instead.
                     _adapter_supports_edit = getattr(_adapter, "SUPPORTS_MESSAGE_EDITING", True)
-                    _effective_cursor = _scfg.cursor if _adapter_supports_edit else ""
+                    if not _adapter_supports_edit:
+                        raise RuntimeError("skip streaming for non-editable platform")
+                    _effective_cursor = _scfg.cursor
                     _buffer_only = False
                     if source.platform == Platform.MATRIX:
                         _effective_cursor = ""

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -242,6 +242,12 @@ class GatewayStreamConsumer:
         meta = dict(self.metadata) if self.metadata else {}
         if expect_edits:
             meta["expect_edits"] = True
+        if not final:
+            # Stream preview/commentary/progress sends are gateway chrome, not
+            # the final assistant reply. Messaging adapters that support rich
+            # final delivery (for example WhatsApp cascade bubbles) must keep
+            # these as one unit instead of fanning scratch/status text out.
+            meta["delivery_style"] = "single"
         if final:
             meta["notify"] = True
         return meta or None

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -19,6 +19,7 @@ import asyncio
 import logging
 import os
 import platform
+import random
 import re
 import signal
 import subprocess
@@ -385,6 +386,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     share it. Only transport-specific code lives here.
     """
 
+    # Baileys exposes message editing, but WhatsApp surfaces each edit/delete as
+    # protocol-message upserts. Treat WhatsApp as non-editable for gateway
+    # streaming so replies are delivered once through the final send path, where
+    # adapter-level media/cascade formatting can run.
+    SUPPORTS_MESSAGE_EDITING = False
+
     # Default bridge location resolved via shared helper
     _DEFAULT_BRIDGE_DIR = None  # resolved in __init__
     splits_long_messages = True  # send() chunks via truncate_message()
@@ -442,6 +449,74 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
 
+        # Outbound "human cascade" mode: split normal assistant replies on
+        # blank-line paragraph boundaries so WhatsApp receives natural text
+        # bubbles instead of one large wall. Gateway/status chrome can opt out
+        # with metadata={"delivery_style": "single"}; normal long/copyable
+        # payloads still fall back to truncate_message(). Config lives in
+        # gateway.platforms.whatsapp.extra.* so no new user-facing env knobs are
+        # required for this adapter-level behavior.
+        self._human_cascade_messages = self._coerce_bool_extra(
+            "human_cascade_messages", True
+        )
+        self._human_cascade_max_bubbles = self._coerce_int_extra(
+            "human_cascade_max_bubbles", 3
+        )
+        self._human_cascade_delay_seconds = self._coerce_float_extra(
+            "human_cascade_delay_seconds", 0.55
+        )
+        self._human_cascade_delay_jitter_seconds = self._coerce_float_extra(
+            "human_cascade_delay_jitter_seconds", 0.25
+        )
+        self._human_cascade_max_total_chars = self._coerce_int_extra(
+            "human_cascade_max_total_chars", 900
+        )
+        self._human_cascade_min_total_chars = self._coerce_int_extra(
+            "human_cascade_min_total_chars", 320
+        )
+        self._human_cascade_min_lead_chars = self._coerce_int_extra(
+            "human_cascade_min_lead_chars", 40
+        )
+        self._human_cascade_max_bubble_chars = self._coerce_int_extra(
+            "human_cascade_max_bubble_chars", 320
+        )
+        self._human_cascade_max_merged_bubble_chars = self._coerce_int_extra(
+            "human_cascade_max_merged_bubble_chars", 640
+        )
+        self._human_cascade_groups = self._coerce_bool_extra(
+            "human_cascade_groups", False
+        )
+        self._chunk_delay_seconds = self._coerce_float_extra(
+            "chunk_delay_seconds", 0.3
+        )
+
+    def _coerce_bool_extra(self, key: str, default: bool) -> bool:
+        """Read a boolean from platform extras, accepting common string forms."""
+        value = self.config.extra.get(key) if getattr(self.config, "extra", None) else None
+        if value is None:
+            return bool(default)
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)):
+            return bool(value)
+        normalized = str(value).strip().lower()
+        if normalized in {"1", "true", "yes", "y", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "n", "off"}:
+            return False
+        return bool(default)
+
+    def _coerce_int_extra(self, key: str, default: int) -> int:
+        """Read a non-negative integer from platform extras."""
+        value = self.config.extra.get(key) if getattr(self.config, "extra", None) else None
+        if value is None:
+            return int(default)
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return int(default)
+        return max(0, parsed)
+
     def _coerce_float_extra(self, key: str, default: float) -> float:
         """Read a float from ``config.extra``, guarding against bad/non-finite values.
 
@@ -460,6 +535,304 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if not math.isfinite(parsed) or parsed < 0:
             return float(default)
         return parsed
+
+    @classmethod
+    def _has_approval_gate(cls, text: str) -> bool:
+        """Return True for explicit approval/control prompts that must stay intact."""
+        command = r"`?/(approve|deny|reject|confirm|cancel|stop|new|reset|always)\b"
+        for line in text.splitlines():
+            stripped = line.strip()
+            if not stripped or cls._looks_list_like_line(stripped):
+                continue
+            if re.search(rf"(^|\b(reply|respond|type|send)\s+){command}", stripped, re.IGNORECASE):
+                return True
+        return False
+
+    @staticmethod
+    def _looks_list_like_line(text: str) -> bool:
+        """Return True for markdown/WhatsApp-style list item lines."""
+        stripped = text.strip().lstrip("\u200b\u200c\u200d\u2060\ufeff")
+        return bool(
+            re.match(
+                r"^(?:[-*+•‣◦]\s|[-*+•‣◦][\u200b\u200c\u200d\u2060\ufeff]+\s*|\d+[.)]\s+)",
+                stripped,
+            )
+        )
+
+    @classmethod
+    def _looks_structured_outbound(cls, text: str) -> bool:
+        """Return True for reports/artifacts that should not be split mid-body."""
+        structured_lines = 0
+        artifact_lines = 0
+        for line in text.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if re.match(r"^(#{1,6}\s+|[*_-]{3,}$|>\s+|\|.*\|$)", stripped) or cls._looks_list_like_line(stripped):
+                structured_lines += 1
+            if re.match(
+                r"^(\{\s*$|\}\s*,?$|\[\s*$|\]\s*,?$|[\"']?[A-Za-z0-9_.-]+[\"']?\s*[:=]\s*.+$|[-+]{3}\s|@@\s|[+!]\s|\$\s+|(?:sudo\s+)?(?:git|gh|npm|pnpm|yarn|python\d*|pip|uv|docker|kubectl|helm|curl|ssh|scp|rsync|systemctl|journalctl)\b|(?:TRACE|DEBUG|INFO|WARN|WARNING|ERROR|CRITICAL)\b|Traceback \(most recent call last\):|File \".+\", line \d+|[A-Za-z_][\w.]*Error:|[-*+•‣◦]\s+\[[ xX]\]\s+)",
+                stripped,
+            ):
+                artifact_lines += 1
+        if structured_lines >= 2:
+            return True
+        return artifact_lines >= 3
+
+    @staticmethod
+    def _has_copy_sensitive_outbound(text: str) -> bool:
+        """Return True when content likely needs to be copied/read as one unit."""
+        return bool(
+            re.search(
+                r"\b(copy|paste|run|send|use)\s+(this|it|the following)\s+(exactly|as-is|as is)\b",
+                text,
+                re.IGNORECASE,
+            )
+        )
+
+    @staticmethod
+    def _word_count(text: str) -> int:
+        return len(re.findall(r"\b[\w'’.-]+\b", text))
+
+    def _is_substantive_cascade_lead(self, paragraph: str) -> bool:
+        """Return True when a paragraph is worth its own WhatsApp bubble."""
+        stripped = paragraph.strip()
+        if self._looks_structured_outbound(stripped):
+            return False
+        min_lead_chars = getattr(self, "_human_cascade_min_lead_chars", 40)
+        if min_lead_chars <= 0:
+            return bool(stripped)
+        if len(stripped) < min_lead_chars:
+            return False
+        return self._word_count(stripped) >= 6
+
+    def _should_human_cascade(self, text: str, paragraphs: list[str], *, force: bool) -> bool:
+        """Gate human cascade on reading value, not just blank-line presence."""
+        if force:
+            return True
+        min_total = getattr(self, "_human_cascade_min_total_chars", 320)
+        if min_total > 0 and len(text) < min_total:
+            return False
+        if len(paragraphs) > 1 and any(self._looks_list_like_line(line) for line in paragraphs[0].splitlines()):
+            return True
+        return self._is_substantive_cascade_lead(paragraphs[0])
+
+    @staticmethod
+    def _contains_outbound_link(text: str) -> bool:
+        """Return True when a bubble contains a URL/markdown link."""
+        return bool(re.search(r"https?://|www\.|\[[^\]]+\]\([^\)]+\)", text, re.IGNORECASE))
+
+    @staticmethod
+    def _contains_active_prompt(text: str) -> bool:
+        """Return True for direct user-response prompts that should stay atomic."""
+        stripped = text.strip()
+        return bool(
+            re.search(
+                r"\b(reply|respond|choose|pick|select|confirm this|approve this|deny this|send me|tell me|want me to|should i|do you want me to)\b",
+                stripped,
+                re.IGNORECASE,
+            )
+        )
+
+    @staticmethod
+    def _split_cascade_paragraphs(text: str) -> list[str]:
+        """Split on blank lines while preserving fenced code blocks."""
+        paragraphs: list[str] = []
+        current: list[str] = []
+        in_fence = False
+        for line in text.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("```"):
+                current.append(line)
+                in_fence = not in_fence
+                continue
+            if not stripped and not in_fence:
+                if current:
+                    paragraphs.append("\n".join(current).strip())
+                    current = []
+                continue
+            current.append(line)
+        if current:
+            paragraphs.append("\n".join(current).strip())
+        return [paragraph for paragraph in paragraphs if paragraph]
+
+    def _is_action_context_paragraph(self, paragraph: str) -> bool:
+        """Return True when a paragraph should travel with an action prompt."""
+        stripped = paragraph.strip()
+        if not stripped:
+            return False
+        if "```" in stripped:
+            return True
+        if self._has_approval_gate(stripped) or self._contains_outbound_link(stripped):
+            return True
+        if re.match(r"^(risk|command|target|branch|commit|diff|verify|verified|tests?|scope)\s*:", stripped, re.IGNORECASE):
+            return True
+        return self._looks_structured_outbound(stripped)
+
+    def _protect_atomic_sections(self, paragraphs: list[str]) -> list[str]:
+        """Keep code/action/link/copy-sensitive sections atomic without disabling cascade globally."""
+        if len(paragraphs) < 2:
+            return paragraphs
+
+        protected: list[str] = []
+        idx = 0
+        while idx < len(paragraphs):
+            paragraph = paragraphs[idx]
+            paragraph_has_own_context = "\n" in paragraph and not paragraph.lstrip().startswith("```")
+            if (
+                ("```" in paragraph or self._contains_outbound_link(paragraph))
+                and protected
+                and not paragraph_has_own_context
+            ):
+                protected[-1] = f"{protected[-1]}\n\n{paragraph}".strip()
+                idx += 1
+                continue
+
+            starts_action = (
+                self._has_approval_gate(paragraph)
+                or self._contains_active_prompt(paragraph)
+                or self._has_copy_sensitive_outbound(paragraph)
+            )
+            if starts_action:
+                block = [paragraph]
+                idx += 1
+                copy_sensitive = self._has_copy_sensitive_outbound(paragraph)
+                if copy_sensitive and idx < len(paragraphs):
+                    block.append(paragraphs[idx])
+                    idx += 1
+                while idx < len(paragraphs) and self._is_action_context_paragraph(paragraphs[idx]):
+                    block.append(paragraphs[idx])
+                    idx += 1
+                protected.append("\n\n".join(block).strip())
+                continue
+
+            protected.append(paragraph)
+            idx += 1
+        return protected
+
+    def _merge_list_paragraphs_with_context(self, paragraphs: list[str]) -> list[str]:
+        """Attach bare list paragraphs to their immediate lead-in without collapsing later prose."""
+        merged: list[str] = []
+        for paragraph in paragraphs:
+            lines = [line for line in paragraph.splitlines() if line.strip()]
+            starts_with_list = bool(lines and self._looks_list_like_line(lines[0]))
+            if starts_with_list and merged:
+                merged[-1] = f"{merged[-1]}\n{paragraph}".strip()
+            else:
+                merged.append(paragraph)
+        return merged
+
+    def _merge_structured_tail(self, paragraphs: list[str], max_bubbles: int | None) -> list[str] | None:
+        """Return lead paragraphs + glued structured tail, or None if not worth cascading."""
+        if max_bubbles is None:
+            max_bubbles = len(paragraphs)
+        lead_limit = max(1, max_bubbles - 1)
+        lead: list[str] = []
+        for paragraph in paragraphs:
+            if len(lead) >= lead_limit or self._looks_structured_outbound(paragraph):
+                break
+            lead.append(paragraph)
+        if not lead or len(lead) >= len(paragraphs):
+            return None
+        if not self._is_substantive_cascade_lead(lead[0]):
+            return None
+        tail = "\n\n".join(paragraphs[len(lead):]).strip()
+        return [*lead, tail]
+
+    def _split_outgoing_text(
+        self,
+        formatted: str,
+        *,
+        chat_id: Optional[str] = None,
+        delivery_style: str = "auto",
+    ) -> tuple[list[str], bool]:
+        """Return outbound WhatsApp bubbles plus whether the split is human-cascade."""
+        limit = self._outgoing_chunk_limit()
+        if not formatted:
+            return [], False
+        text = formatted.strip()
+        style = (delivery_style or "auto").strip().lower()
+        if style in {"single", "off", "none"}:
+            return self.truncate_message(formatted, limit), False
+        if not getattr(self, "_human_cascade_messages", True):
+            return self.truncate_message(formatted, limit), False
+
+        force_cascade = style in {"cascade", "human_cascade", "human-cascade"}
+        is_group = bool(chat_id and str(chat_id).lower().endswith("@g.us"))
+        if not force_cascade and is_group and not getattr(self, "_human_cascade_groups", False):
+            return self.truncate_message(formatted, limit), False
+        if not force_cascade and (
+            self._has_approval_gate(text)
+            or self._has_copy_sensitive_outbound(text)
+            or self._contains_active_prompt(text.split("\n\n", 1)[0])
+        ):
+            return self.truncate_message(formatted, limit), False
+
+        max_total = getattr(self, "_human_cascade_max_total_chars", 900)
+        if not force_cascade and max_total > 0 and len(text) > max_total:
+            return self.truncate_message(formatted, limit), False
+
+        paragraphs = self._split_cascade_paragraphs(text)
+        if len(paragraphs) < 2:
+            return self.truncate_message(formatted, limit), False
+        paragraphs = self._merge_list_paragraphs_with_context(paragraphs)
+        paragraphs = self._protect_atomic_sections(paragraphs)
+        if len(paragraphs) < 2:
+            return self.truncate_message(paragraphs[0], limit), False
+
+        max_bubbles_config = getattr(self, "_human_cascade_max_bubbles", 3)
+        if max_bubbles_config == 0:
+            max_bubbles: int | None = None
+        elif max_bubbles_config <= 1:
+            return self.truncate_message(formatted, limit), False
+        else:
+            max_bubbles = max_bubbles_config
+
+        if not self._should_human_cascade(text, paragraphs, force=force_cascade):
+            return self.truncate_message(formatted, limit), False
+
+        has_list_paragraph = any(
+            any(self._looks_list_like_line(line) for line in paragraph.splitlines())
+            for paragraph in paragraphs
+        )
+        if not force_cascade and not has_list_paragraph and self._looks_structured_outbound(text):
+            merged = self._merge_structured_tail(paragraphs, max_bubbles)
+            if merged is None:
+                return self.truncate_message(formatted, limit), False
+            paragraphs = merged
+
+        if max_bubbles is not None and len(paragraphs) > max_bubbles and not force_cascade:
+            head = paragraphs[: max_bubbles - 1]
+            tail = "\n\n".join(paragraphs[max_bubbles - 1:]).strip()
+            paragraphs = [*head, tail]
+
+        max_merged = getattr(self, "_human_cascade_max_merged_bubble_chars", 640)
+        if not force_cascade and max_merged > 0 and len(paragraphs[-1]) > max_merged:
+            return self.truncate_message(formatted, limit), False
+
+        max_bubble = getattr(self, "_human_cascade_max_bubble_chars", 320)
+        if not force_cascade and max_bubble > 0:
+            normal_bubbles = paragraphs[:-1]
+            if any(len(paragraph) > max_bubble for paragraph in normal_bubbles):
+                return self.truncate_message(formatted, limit), False
+
+        chunks: list[str] = []
+        for idx, paragraph in enumerate(paragraphs):
+            if max_bubbles is not None and len(chunks) >= max_bubbles - 1:
+                remainder = "\n\n".join(paragraphs[idx:])
+                chunks.extend(self.truncate_message(remainder, limit))
+                break
+            chunks.extend(self.truncate_message(paragraph, limit))
+
+        return chunks, len(chunks) > 1
+
+    def _cascade_delay_seconds(self) -> float:
+        """Return a slightly jittered delay for human-cascade bubbles."""
+        delay = getattr(self, "_human_cascade_delay_seconds", 0.55)
+        jitter = getattr(self, "_human_cascade_delay_jitter_seconds", 0.25)
+        if delay <= 0 or jitter <= 0:
+            return max(0.0, delay)
+        return random.uniform(max(0.0, delay - jitter), delay + jitter)
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """
@@ -856,9 +1229,15 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         try:
             import aiohttp
 
-            # Format and chunk the message
             formatted = self.format_message(content)
-            chunks = self.truncate_message(formatted, self._outgoing_chunk_limit())
+            delivery_style = "auto"
+            if isinstance(metadata, dict):
+                delivery_style = str(metadata.get("delivery_style") or "auto")
+            chunks, human_cascade = self._split_outgoing_text(
+                formatted,
+                chat_id=chat_id,
+                delivery_style=delivery_style,
+            )
 
             sent_message_ids: list[str] = []
             last_message_id = None
@@ -879,22 +1258,30 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 ) as resp:
                     if resp.status == 200:
                         data = await resp.json()
-                        last_message_id = data.get("messageId")
-                        if last_message_id:
-                            sent_message_ids.append(str(last_message_id))
+                        response_ids = data.get("messageIds") or data.get("message_ids")
+                        if isinstance(response_ids, list):
+                            for message_id in response_ids:
+                                if message_id:
+                                    sent_message_ids.append(str(message_id))
+                        else:
+                            message_id = data.get("messageId")
+                            if message_id:
+                                sent_message_ids.append(str(message_id))
+                        last_message_id = sent_message_ids[-1] if sent_message_ids else None
                     else:
                         error = await resp.text()
                         return SendResult(success=False, error=error)
 
-                # Small delay between chunks to avoid rate limiting
-                if len(chunks) > 1:
-                    await asyncio.sleep(0.3)
+                if idx < len(chunks) - 1:
+                    delay = self._cascade_delay_seconds() if human_cascade else getattr(self, "_chunk_delay_seconds", 0.3)
+                    if delay > 0:
+                        await asyncio.sleep(delay)
 
             return SendResult(
                 success=True,
                 message_id=last_message_id,
                 continuation_message_ids=tuple(sent_message_ids[:-1]),
-                raw_response={"message_ids": sent_message_ids},
+                raw_response={"message_ids": sent_message_ids, "human_cascade": human_cascade},
             )
         except Exception as e:
             return SendResult(success=False, error=str(e))

--- a/tests/gateway/test_gateway_status_delivery_style.py
+++ b/tests/gateway/test_gateway_status_delivery_style.py
@@ -1,0 +1,52 @@
+"""Gateway status/progress sends stay single-unit on rich delivery platforms."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.run import _send_or_update_status_coro
+
+
+class _SendOnlyAdapter:
+    def __init__(self):
+        self.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+
+class _StatusAdapter(_SendOnlyAdapter):
+    def __init__(self):
+        super().__init__()
+        self.send_or_update_status = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+
+@pytest.mark.asyncio
+async def test_status_fallback_send_forces_single_delivery_style():
+    adapter = _SendOnlyAdapter()
+
+    await _send_or_update_status_coro(
+        adapter,
+        "chat-1",
+        "thinking",
+        "thinking\n\nstill checking",
+        {"thread_id": "thread-1"},
+    )
+
+    metadata = adapter.send.call_args.kwargs["metadata"]
+    assert metadata["thread_id"] == "thread-1"
+    assert metadata["delivery_style"] == "single"
+
+
+@pytest.mark.asyncio
+async def test_status_update_adapter_forces_single_delivery_style():
+    adapter = _StatusAdapter()
+
+    await _send_or_update_status_coro(
+        adapter,
+        "chat-1",
+        "thinking",
+        "thinking\n\nstill checking",
+        None,
+    )
+
+    metadata = adapter.send_or_update_status.call_args.kwargs["metadata"]
+    assert metadata["delivery_style"] == "single"

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -993,6 +993,111 @@ async def test_run_agent_previewed_split_keeps_final_delivery_pending(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_run_agent_non_editable_streaming_uses_final_delivery_only(monkeypatch, tmp_path):
+    """Non-editable platforms must not send a stream preview.
+
+    Messaging adapters without edit support can only deliver the final answer
+    once. If streaming creates a preview first, it cannot be replaced by the
+    final delivery path.
+    """
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        StreamingRefineAgent,
+        session_id="sess-whatsapp-final-only",
+        config_data={
+            "display": {"tool_progress": "off", "interim_assistant_messages": False},
+            "streaming": {"enabled": True, "edit_interval": 0.01, "buffer_threshold": 1},
+        },
+        platform=Platform.WHATSAPP,
+        chat_id="hermes-test@s.whatsapp.net",
+        chat_type="dm",
+        thread_id=None,
+        adapter_cls=NonEditingProgressCaptureAdapter,
+    )
+
+    assert result.get("already_sent") is not True
+    assert adapter.edits == []
+    assert [call["content"] for call in adapter.sent] == []
+
+
+class _FakeProxyContent:
+    async def iter_any(self):
+        yield b'data: {"choices":[{"delta":{"content":"Continuing to refine:"}}]}\n'
+        yield b'data: {"choices":[{"delta":{"content":" Final answer."}}]}\n'
+        yield b'data: [DONE]\n'
+
+
+class _FakeProxyResponse:
+    status = 200
+    content = _FakeProxyContent()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def text(self):
+        return ""
+
+
+class _FakeProxyClientSession:
+    def __init__(self, *args, **kwargs):
+        self.requests = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, url, *, json=None, headers=None):
+        self.requests.append({"url": url, "json": json, "headers": headers})
+        return _FakeProxyResponse()
+
+
+@pytest.mark.asyncio
+async def test_proxy_non_editable_streaming_uses_final_delivery_only(monkeypatch, tmp_path):
+    fake_aiohttp = types.ModuleType("aiohttp")
+    fake_aiohttp.ClientSession = _FakeProxyClientSession
+    fake_aiohttp.ClientTimeout = lambda *args, **kwargs: SimpleNamespace(
+        args=args, kwargs=kwargs
+    )
+    monkeypatch.setitem(sys.modules, "aiohttp", fake_aiohttp)
+    monkeypatch.setenv("GATEWAY_PROXY_URL", "http://proxy.example")
+
+    adapter = NonEditingProgressCaptureAdapter(platform=Platform.WHATSAPP)
+    runner = _make_runner(adapter)
+    runner.config.streaming = StreamingConfig.from_dict(
+        {"enabled": True, "edit_interval": 0.01, "buffer_threshold": 1}
+    )
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    source = SessionSource(
+        platform=Platform.WHATSAPP,
+        chat_id="hermes-test@s.whatsapp.net",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent_via_proxy(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-whatsapp-proxy-final-only",
+        session_key="agent:main:whatsapp:dm:hermes-test@s.whatsapp.net",
+        event_message_id="inbound-1",
+    )
+
+    assert result["final_response"] == "Continuing to refine: Final answer."
+    assert result["response_previewed"] is False
+    assert adapter.edits == []
+    assert adapter.sent == []
+
+
+@pytest.mark.asyncio
 async def test_run_agent_matrix_streaming_omits_cursor(monkeypatch, tmp_path):
     adapter, result = await _run_with_agent(
         monkeypatch,

--- a/tests/gateway/test_stream_consumer_thread_routing.py
+++ b/tests/gateway/test_stream_consumer_thread_routing.py
@@ -103,7 +103,11 @@ class TestInitialReplyToId:
         await consumer._send_or_edit("Test")
 
         call_kwargs = adapter.send.call_args[1]
-        assert call_kwargs["metadata"] == {**metadata, "expect_edits": True}
+        assert call_kwargs["metadata"] == {
+            **metadata,
+            "expect_edits": True,
+            "delivery_style": "single",
+        }
         assert metadata == {"thread_id": "omt_topic789"}
 
     @pytest.mark.asyncio
@@ -140,7 +144,11 @@ class TestInitialReplyToId:
         await consumer._send_or_edit("Preview", finalize=False)
 
         metadata = adapter.send.call_args[1]["metadata"]
-        assert metadata == {"thread_id": "root_post_123", "expect_edits": True}
+        assert metadata == {
+            "thread_id": "root_post_123",
+            "expect_edits": True,
+            "delivery_style": "single",
+        }
 
 
 class TestOverflowFirstMessage:

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gateway.config import Platform
+from gateway.config import Platform, PlatformConfig
 
 
 @pytest.fixture(autouse=True)
@@ -61,6 +61,17 @@ def _make_adapter():
     adapter._allow_from = set()
     adapter._group_policy = "open"
     adapter._group_allow_from = set()
+    adapter._human_cascade_messages = True
+    adapter._human_cascade_max_bubbles = 3
+    adapter._human_cascade_delay_seconds = 0
+    adapter._human_cascade_delay_jitter_seconds = 0
+    adapter._human_cascade_max_total_chars = 900
+    adapter._human_cascade_min_total_chars = 320
+    adapter._human_cascade_min_lead_chars = 40
+    adapter._human_cascade_max_bubble_chars = 320
+    adapter._human_cascade_max_merged_bubble_chars = 640
+    adapter._human_cascade_groups = False
+    adapter._chunk_delay_seconds = 0
     return adapter
 
 
@@ -75,6 +86,27 @@ class _AsyncCM:
 
     async def __aexit__(self, *exc):
         return False
+
+
+def test_human_cascade_knobs_read_platform_extras():
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "human_cascade_messages": "false",
+                "human_cascade_max_bubbles": "5",
+                "human_cascade_delay_seconds": "0.2",
+                "human_cascade_groups": "true",
+            },
+        )
+    )
+
+    assert adapter._human_cascade_messages is False
+    assert adapter._human_cascade_max_bubbles == 5
+    assert adapter._human_cascade_delay_seconds == 0.2
+    assert adapter._human_cascade_groups is True
 
 
 # ---------------------------------------------------------------------------
@@ -202,6 +234,259 @@ class TestSendChunking:
         assert result.success
         # Only one call to bridge /send
         assert adapter._http_session.post.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_substantive_blank_line_paragraphs_send_as_human_cascade(self):
+        adapter = _make_adapter()
+        responses = []
+        for msg_id in ("msg1", "msg2", "msg3"):
+            resp = MagicMock(status=200)
+            resp.json = AsyncMock(return_value={"messageId": msg_id})
+            responses.append(_AsyncCM(resp))
+        adapter._http_session.post = MagicMock(side_effect=responses)
+
+        messages = [
+            "First thought has enough actual content to deserve its own bubble, because it frames the answer before the heavier detail arrives and gives the reader a clean starting point.",
+            "Second thought is also a real sentence with useful substance, so it reads like a natural follow-up instead of a random tiny ack split for no reason.",
+            "Third thought closes the answer with enough context for the reader, proving the cascade is being used for cadence rather than just reacting to blank lines.",
+        ]
+        result = await adapter.send("chat1", "\n\n".join(messages))
+
+        assert result.success
+        assert adapter._http_session.post.call_count == 3
+        payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
+        assert [payload["message"] for payload in payloads] == messages
+        assert result.message_id == "msg3"
+        assert result.continuation_message_ids == ("msg1", "msg2")
+        assert result.raw_response["human_cascade"] is True
+
+    @pytest.mark.asyncio
+    async def test_metadata_delivery_style_single_suppresses_human_cascade(self):
+        adapter = _make_adapter()
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        await adapter.send("chat1", "thinking\n\nstill checking", metadata={"delivery_style": "single"})
+
+        assert adapter._http_session.post.call_count == 1
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert payload["message"] == "thinking\n\nstill checking"
+
+    @pytest.mark.asyncio
+    async def test_extra_paragraphs_merge_into_final_cascade_bubble(self):
+        adapter = _make_adapter()
+        adapter._human_cascade_max_total_chars = 2000
+        adapter._human_cascade_max_merged_bubble_chars = 1200
+        responses = []
+        for msg_id in ("msg1", "msg2", "msg3"):
+            resp = MagicMock(status=200)
+            resp.json = AsyncMock(return_value={"messageId": msg_id})
+            responses.append(_AsyncCM(resp))
+        adapter._http_session.post = MagicMock(side_effect=responses)
+
+        messages = [
+            "First paragraph is substantive enough to be worth a separate WhatsApp bubble.",
+            "Second paragraph keeps the cadence readable before the merged tail arrives.",
+            "Third paragraph is still short enough to fit as a clean lead-in bubble.",
+            ("The fourth paragraph is deliberately longer and should be merged with the final paragraph instead of creating a fifth bubble. " * 3).strip(),
+            ("The fifth paragraph continues the tail so the adapter proves it caps cascade count without collapsing everything into one wall. " * 3).strip(),
+        ]
+        result = await adapter.send("chat1", "\n\n".join(messages))
+
+        assert result.success
+        assert adapter._http_session.post.call_count == 3
+        payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
+        assert [payload["message"] for payload in payloads] == [
+            messages[0],
+            messages[1],
+            messages[2] + "\n\n" + messages[3] + "\n\n" + messages[4],
+        ]
+        assert result.raw_response["human_cascade"] is True
+
+    @pytest.mark.asyncio
+    async def test_code_block_keeps_only_its_section_atomic(self):
+        adapter = _make_adapter()
+        adapter._human_cascade_max_bubbles = 0
+        adapter._human_cascade_max_total_chars = 0
+        adapter._human_cascade_max_bubble_chars = 0
+        adapter._human_cascade_max_merged_bubble_chars = 0
+        adapter._human_cascade_min_total_chars = 0
+        adapter._human_cascade_min_lead_chars = 0
+        responses = []
+        for msg_id in ("msg1", "msg2", "msg3"):
+            resp = MagicMock(status=200)
+            resp.json = AsyncMock(return_value={"messageId": msg_id})
+            responses.append(_AsyncCM(resp))
+        adapter._http_session.post = MagicMock(side_effect=responses)
+
+        intro = "plain intro can still be its own bubble"
+        code = "run this:\n\n```bash\necho hi\n\necho bye\n```"
+        tail = "plain tail can still be its own bubble"
+        await adapter.send("chat1", "\n\n".join([intro, code, tail]))
+
+        assert adapter._http_session.post.call_count == 3
+        payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
+        assert payloads[0]["message"] == intro
+        assert payloads[1]["message"] == code
+        assert payloads[2]["message"] == tail
+
+    @pytest.mark.asyncio
+    async def test_intro_list_then_later_prose_cascades_after_list_block(self):
+        adapter = _make_adapter()
+        adapter._human_cascade_max_bubbles = 0
+        adapter._human_cascade_max_total_chars = 0
+        adapter._human_cascade_max_bubble_chars = 0
+        adapter._human_cascade_max_merged_bubble_chars = 0
+        adapter._human_cascade_min_total_chars = 0
+        adapter._human_cascade_min_lead_chars = 0
+        responses = []
+        for msg_id in ("msg1", "msg2"):
+            resp = MagicMock(status=200)
+            resp.json = AsyncMock(return_value={"messageId": msg_id})
+            responses.append(_AsyncCM(resp))
+        adapter._http_session.post = MagicMock(side_effect=responses)
+
+        first = "settings now are:\n• split prose blank lines\n• keep list sections together"
+        second = "plain later prose can still get its own follow-up bubble"
+        await adapter.send("chat1", "settings now are:\n\n• split prose blank lines\n• keep list sections together\n\n" + second)
+
+        assert adapter._http_session.post.call_count == 2
+        payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
+        assert payloads[0]["message"] == first
+        assert payloads[1]["message"] == second
+
+    @pytest.mark.asyncio
+    async def test_consecutive_list_sections_keep_local_context_only(self):
+        adapter = _make_adapter()
+        adapter._human_cascade_max_bubbles = 0
+        adapter._human_cascade_max_total_chars = 0
+        adapter._human_cascade_max_bubble_chars = 0
+        adapter._human_cascade_max_merged_bubble_chars = 0
+        adapter._human_cascade_min_total_chars = 0
+        adapter._human_cascade_min_lead_chars = 0
+        responses = []
+        for msg_id in ("msg1", "msg2", "msg3", "msg4"):
+            resp = MagicMock(status=200)
+            resp.json = AsyncMock(return_value={"messageId": msg_id})
+            responses.append(_AsyncCM(resp))
+        adapter._http_session.post = MagicMock(side_effect=responses)
+
+        content = (
+            "first section:\n\n"
+            "• one\n"
+            "• two\n\n"
+            "plain bridge paragraph between list sections\n\n"
+            "second section:\n\n"
+            "• three\n"
+            "• four\n\n"
+            "final prose bubble"
+        )
+
+        await adapter.send("chat1", content)
+
+        payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
+        messages = [payload["message"] for payload in payloads]
+        assert messages == [
+            "first section:\n• one\n• two",
+            "plain bridge paragraph between list sections",
+            "second section:\n• three\n• four",
+            "final prose bubble",
+        ]
+        assert all("\n\n•" not in message for message in messages)
+        assert all("\n\n-" not in message for message in messages)
+
+    @pytest.mark.asyncio
+    async def test_group_chats_can_human_cascade_when_configured(self):
+        adapter = _make_adapter()
+        adapter._human_cascade_groups = True
+        adapter._human_cascade_min_total_chars = 0
+        adapter._human_cascade_min_lead_chars = 0
+        responses = []
+        for msg_id in ("msg1", "msg2"):
+            resp = MagicMock(status=200)
+            resp.json = AsyncMock(return_value={"messageId": msg_id})
+            responses.append(_AsyncCM(resp))
+        adapter._http_session.post = MagicMock(side_effect=responses)
+
+        await adapter.send("test-group@g.us", "first\n\nsecond")
+
+        assert adapter._http_session.post.call_count == 2
+
+
+    @pytest.mark.asyncio
+    async def test_bridge_message_ids_array_stays_snake_case(self):
+        adapter = _make_adapter()
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageIds": ["msg1", "msg2"], "messageId": "msg2"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        result = await adapter.send("chat1", "short message")
+
+        assert result.success
+        assert result.message_id == "msg2"
+        assert result.continuation_message_ids == ("msg1",)
+        assert result.raw_response["message_ids"] == ["msg1", "msg2"]
+        assert "messageIds" not in result.raw_response
+
+    @pytest.mark.asyncio
+    async def test_machine_artifacts_do_not_human_cascade(self):
+        adapter = _make_adapter()
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        content = "Here is the config to verify as one unit.\n\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\n\nCopy this exactly into the config file."
+        await adapter.send("chat1", content)
+
+        assert adapter._http_session.post.call_count == 1
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert payload["message"] == content
+
+    @pytest.mark.asyncio
+    async def test_approval_gates_do_not_human_cascade(self):
+        adapter = _make_adapter()
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        content = "I can restart the gateway.\n\nReply `/approve` to restart.\n\nRisk: brief downtime."
+        await adapter.send("chat1", content)
+
+        assert adapter._http_session.post.call_count == 1
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert "Reply `/approve`" in payload["message"]
+
+    @pytest.mark.asyncio
+    async def test_group_chats_do_not_human_cascade_by_default(self):
+        adapter = _make_adapter()
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        await adapter.send("test-group@g.us", "first\n\nsecond")
+
+        assert adapter._http_session.post.call_count == 1
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert payload["message"] == "first\n\nsecond"
+
+    @pytest.mark.asyncio
+    async def test_reply_to_only_on_first_cascade_chunk_even_when_bridge_omits_message_id(self):
+        adapter = _make_adapter()
+        adapter._human_cascade_min_total_chars = 0
+        adapter._human_cascade_min_lead_chars = 0
+        responses = []
+        for _ in range(2):
+            resp = MagicMock(status=200)
+            resp.json = AsyncMock(return_value={})
+            responses.append(_AsyncCM(resp))
+        adapter._http_session.post = MagicMock(side_effect=responses)
+
+        await adapter.send("chat1", "first paragraph\n\nsecond paragraph", reply_to="orig123")
+
+        payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
+        assert payloads[0].get("replyTo") == "orig123"
+        assert "replyTo" not in payloads[1]
 
     @pytest.mark.asyncio
     async def test_long_message_chunked(self):

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -186,11 +186,37 @@ whatsapp:
 
 ## Message Formatting & Delivery
 
-WhatsApp supports **streaming (progressive) responses** — the bot edits its message in real-time as the AI generates text, just like Discord and Telegram. Internally, WhatsApp is classified as a TIER_MEDIUM platform for delivery capabilities.
+WhatsApp uses **final-only response delivery**. Hermes may send separate tool/status progress messages while it works, but the generated answer is sent only after it is complete instead of repeatedly editing a streamed preview. This avoids noisy Baileys protocol-message edit upserts and lets final formatting, media, and cascade handling run exactly once.
+
+### Human Cascade
+
+By default, qualifying prose replies in direct messages can be split at paragraph boundaries into a small number of natural chat bubbles. Group replies remain single-message unless group cascading is explicitly enabled. Approval gates, active prompts, and copy-sensitive or heavily structured content stay together automatically.
+
+Configure the behavior under `gateway.platforms.whatsapp.extra`:
+
+```yaml
+# ~/.hermes/config.yaml
+gateway:
+  platforms:
+    whatsapp:
+      extra:
+        human_cascade_messages: true               # false disables cascade delivery
+        human_cascade_groups: false                # keep group replies single by default
+        human_cascade_max_bubbles: 3               # 0 = unlimited; 1 = effectively disabled
+        human_cascade_delay_seconds: 0.55           # base delay between bubbles
+        human_cascade_delay_jitter_seconds: 0.25    # random variation added to the delay
+        human_cascade_min_total_chars: 320          # shorter replies stay together
+        human_cascade_max_total_chars: 900          # longer replies use normal chunking
+        human_cascade_min_lead_chars: 40            # minimum useful lead paragraph length
+        human_cascade_max_bubble_chars: 320         # maximum non-final bubble length
+        human_cascade_max_merged_bubble_chars: 640  # maximum merged final bubble length
+```
+
+Set `human_cascade_messages: false` to opt out entirely. The defaults apply cascade delivery to eligible direct-message replies only; set `human_cascade_groups: true` to allow the same behavior in groups.
 
 ### Chunking
 
-Long responses are automatically split into multiple messages at **4,096 characters** per chunk (WhatsApp's practical display limit). You don't need to configure anything — the gateway handles splitting and sends chunks sequentially.
+Responses that are too long or unsuitable for human cascade are automatically split into multiple messages at **4,096 characters** per chunk (WhatsApp's practical display limit). The adapter sends those chunks sequentially.
 
 ### WhatsApp-Compatible Markdown
 


### PR DESCRIPTION
## Summary
- add configurable human-style WhatsApp cascade delivery for suitable prose replies
- split readable paragraph-style replies into a small number of natural WhatsApp bubbles
- keep structured output, code blocks, copy-sensitive text, approval gates, links/action context, and group chats atomic by default
- preserve bridge multi-message ID tracking with snake_case `raw_response["message_ids"]`
- keep gateway/status/stream-preview chrome single-unit via `metadata["delivery_style"] = "single"`

## Stack
This PR is stacked on #58929 (`fix(gateway): preserve final delivery on non-editable streams`). Once #58929 lands, this PR can be rebased to show only the WhatsApp adapter cascade layer.

## Why
WhatsApp is a chat UI, not a markdown document viewer. Large prose replies are hard to read as one wall of text, but blindly splitting every blank line is dangerous for approvals, commands, configs, logs, code, and copy/paste content. This keeps the behavior WhatsApp-specific and conservative.

## Behavior
Cascade is gated by:
- platform: WhatsApp only
- chat type: DMs by default; groups require platform-extra opt-in
- response shape: substantive prose with paragraph boundaries
- safety: approval gates, code/copy-sensitive payloads, links/action context, and structured output stay atomic
- platform extras: enable/disable cascade, max bubbles, total/lead/bubble length thresholds, merged-tail cap, group behavior, and inter-bubble delays
- metadata override: `delivery_style="single"` forces atomic delivery; `delivery_style="cascade"` can force cascade for explicit adapter callers

## Test plan
- `python3 -m pytest tests/gateway/test_whatsapp_formatting.py tests/gateway/test_gateway_status_delivery_style.py tests/gateway/test_run_progress_topics.py::test_proxy_non_editable_streaming_uses_final_delivery_only tests/gateway/test_run_progress_topics.py::test_run_agent_non_editable_streaming_uses_final_delivery_only tests/gateway/test_stream_consumer_thread_routing.py::TestInitialReplyToId -q`
- `scripts/run_tests.sh tests/gateway/test_whatsapp_formatting.py tests/gateway/test_gateway_status_delivery_style.py tests/gateway/test_run_progress_topics.py tests/gateway/test_stream_consumer_thread_routing.py -q`
- `python3 -m py_compile plugins/platforms/whatsapp/adapter.py gateway/run.py gateway/stream_consumer.py tests/gateway/test_whatsapp_formatting.py tests/gateway/test_gateway_status_delivery_style.py tests/gateway/test_run_progress_topics.py tests/gateway/test_stream_consumer_thread_routing.py`
- `git diff --check origin/main...HEAD`
- added-lines private/secret pattern scan against the combined diff
