### PR TITLE
feat(feishu): parse location messages with coordinates and address

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -265,6 +265,7 @@ FALLBACK_SHARE_CHAT_TEXT = "[Shared chat]"
 FALLBACK_INTERACTIVE_TEXT = "[Interactive message]"
 FALLBACK_IMAGE_TEXT = "[Image]"
 FALLBACK_ATTACHMENT_TEXT = "[Attachment]"
+FALLBACK_LOCATION_TEXT = "[Location]"
 # ---------------------------------------------------------------------------
 # Post/card parsing helpers
 # ---------------------------------------------------------------------------
@@ -872,6 +873,27 @@ def normalize_feishu_message(
         return _normalize_share_chat_message(payload)
     if normalized_type in {"interactive", "card"}:
         return _normalize_interactive_message(normalized_type, payload)
+
+    if normalized_type == "location":
+        address = str(payload.get("address", "") or "")
+        name = str(payload.get("name", "") or payload.get("title", "") or "")
+        latitude = payload.get("latitude")
+        longitude = payload.get("longitude")
+        lines = []
+        if name:
+            lines.append(f"📍 {name}")
+        if address:
+            lines.append(f"   {address}")
+        if latitude is not None and longitude is not None:
+            lines.append(f"   坐标: {latitude}, {longitude}")
+        text_content = "\n".join(lines) if lines else FALLBACK_LOCATION_TEXT
+        return FeishuNormalizedMessage(
+            raw_type=normalized_type,
+            text_content=text_content,
+            preferred_message_type="location",
+            metadata={"latitude": latitude, "longitude": longitude, "address": address, "name": name},
+            mentions=mention_refs,
+        )
 
     return FeishuNormalizedMessage(raw_type=normalized_type, text_content="")
 
@@ -3768,6 +3790,8 @@ class FeishuAdapter(BasePlatformAdapter):
             return self._resolve_media_message_type(media_types[0] if media_types else "", default=MessageType.AUDIO)
         if preferred == "document":
             return self._resolve_media_message_type(media_types[0] if media_types else "", default=MessageType.DOCUMENT)
+        if preferred == "location":
+            return MessageType.LOCATION
         return MessageType.TEXT
 
     async def _maybe_extract_text_document(self, cached_path: str, media_type: str) -> str:


### PR DESCRIPTION
## Summary

Location messages (`msg_type=location`) in Feishu were falling through to the fallback return in `normalize_feishu_message()` and arriving as empty text to the agent.

## Changes

- **`normalize_feishu_message()`**: Added `location` type handler that extracts `latitude`, `longitude`, `name`, and `address` from the location JSON payload
- **`_resolve_normalized_message_type()`**: Added `location` branch to map preferred message type to `MessageType.LOCATION`
- Added `FALLBACK_LOCATION_TEXT = "[Location]"` constant for empty payloads

## Before/After

**Before:** :round_pushpin: Feishu location message → Agent sees `""`
**After:** :round_pushpin: Feishu location message → Agent sees `"碧桂园·剑桥郡  广西桂林临桂区  坐标:25.233,110.198"`

## Testing

- [x] Basic location (name + address + coordinates)
- [x] Minimal location (coordinates only)
- [x] Empty payload (falls back to `[Location]`)
- [x] Name-only location

Fixes: location messages showing up as empty text in Feishu DMs