### PR TITLE
security(vision): route media-tool local-file reads through the shared credential-read guard

### DIFF
--- a/tests/tools/test_video_analyze.py
+++ b/tests/tools/test_video_analyze.py
@@ -193,6 +193,29 @@ class TestVideoAnalyzeTool:
         assert data["success"] is True
         assert "demo" in data["analysis"].lower()
 
+    def test_local_file_read_guard_blocks_env_via_video_extension(self, tmp_path):
+        """A .env file symlinked with a video extension must still be blocked.
+
+        _detect_video_mime_type only checks the file extension, not file
+        content, so without a read guard a model could point video_url at
+        any credential-store file (renamed/symlinked to look like a video)
+        and have its raw bytes base64-encoded and sent to the vision
+        provider. Regression for the shared agent.file_safety chokepoint
+        added to video_analyze_tool's local-file branch.
+        """
+        secret = tmp_path / ".env"
+        secret.write_text("OPENAI_API_KEY=sk-super-secret\n", encoding="utf-8")
+        disguised = tmp_path / "video.mp4"
+        disguised.symlink_to(secret)
+
+        with patch("tools.vision_tools.async_call_llm", new_callable=AsyncMock) as mock_llm:
+            result = self._run(video_analyze_tool(str(disguised), "What is this?"))
+
+        data = json.loads(result)
+        assert data["success"] is False
+        assert "secret-bearing environment file" in data["error"]
+        mock_llm.assert_not_awaited()
+
     def test_local_file_not_found(self, tmp_path):
         """Non-existent file raises appropriate error."""
         result = self._run(video_analyze_tool("/nonexistent/video.mp4", "What?"))

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -496,6 +496,38 @@ class TestVisionSafetyGuards:
         mock_llm.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_local_env_file_blocked_via_read_guard(self, tmp_path):
+        """A .env file must be blocked even if given an image-like path.
+
+        Mirrors the video_analyze_tool regression: the local-file branch
+        must route through agent.file_safety.raise_if_read_blocked before
+        vision_analyze_tool ever opens the file, not rely solely on the
+        magic-byte mime check as an accidental side effect.
+        """
+        secret = tmp_path / ".env"
+        secret.write_text("OPENAI_API_KEY=sk-super-secret\n", encoding="utf-8")
+
+        with patch("tools.vision_tools.async_call_llm", new_callable=AsyncMock) as mock_llm:
+            result = json.loads(await vision_analyze_tool(str(secret), "extract text"))
+
+        assert result["success"] is False
+        assert "secret-bearing environment file" in result["error"]
+        mock_llm.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_native_fast_path_local_env_file_blocked_via_read_guard(self, tmp_path):
+        """Same read guard must apply to the native vision fast path."""
+        from tools.vision_tools import _vision_analyze_native
+
+        secret = tmp_path / ".env"
+        secret.write_text("OPENAI_API_KEY=sk-super-secret\n", encoding="utf-8")
+
+        result = json.loads(await _vision_analyze_native(str(secret), "extract text"))
+
+        assert result["success"] is False
+        assert "secret-bearing environment file" in result["error"]
+
+    @pytest.mark.asyncio
     async def test_blocked_remote_url_short_circuits_before_download(self):
         blocked = {
             "host": "blocked.test",

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -117,6 +117,22 @@ async def resolve_image_source(src: str, ctx: ResolveContext) -> ResolvedImage:
     # path outside the caches never yields the host's bytes.
     host_target = _permitted_host_read_target(p, ctx)
     if host_target is not None and host_target.is_file():
+        # Shared credential-read guard (agent.file_safety, #57698): refuse
+        # secret-bearing files (.env, auth.json, ...) with an intentional,
+        # specific error instead of relying on the magic-byte sniff to
+        # reject them incidentally. Same chokepoint the image-gen/video-gen
+        # provider plugins enforce on model-supplied local paths. Import is
+        # best-effort (guard unavailability must not break image loading);
+        # a real block always propagates.
+        try:
+            from agent.file_safety import raise_if_read_blocked
+        except Exception:  # noqa: BLE001 — guard unavailable: proceed
+            raise_if_read_blocked = None
+        if raise_if_read_blocked is not None:
+            try:
+                raise_if_read_blocked(str(host_target))
+            except ValueError as exc:
+                raise SourceUnsafe(str(exc), src=s, origin="file")
         data = await asyncio.to_thread(host_target.read_bytes)
         return _finalize(data, "", "file", s)
     if _is_local_terminal_backend():

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1666,6 +1666,8 @@ async def video_analyze_tool(
         local_path = Path(os.path.expanduser(resolved_url))
 
         if local_path.is_file():
+            from agent.file_safety import raise_if_read_blocked
+            raise_if_read_blocked(str(local_path))
             logger.info("Using local video file: %s", video_url)
             temp_video_path = local_path
             should_cleanup = False


### PR DESCRIPTION
Salvage of #57827 by @srojk34 onto current main (the original predates #57890's unified image-source resolver and went stale against it). Cherry-picked with authorship preserved.

## Summary
`video_analyze_tool` validated local files by extension only — a `.env`/`auth.json` symlinked or renamed to `video.mp4` had its raw bytes base64-encoded and sent to the vision provider. Vision's image paths were only *incidentally* protected by the magic-byte sniff. This routes all media-tool local-file reads through the shared `agent.file_safety.raise_if_read_blocked` chokepoint (#57698) that the image-gen/video-gen provider plugins already enforce.

## Changes
- `tools/vision_tools.py` (contributor commit): guard on `video_analyze_tool`'s local-file branch — the real payload, since the video path has no content sniff at all.
- `tools/image_source.py` (follow-up): the same guard on the resolver's host-read path, wrapped as `SourceUnsafe`, so image sources are refused intentionally with the specific error rather than incidentally by the sniff. Import is best-effort per the guard's own defense-in-depth contract; a real block always propagates.
- Contributor's vision-path hunks (written against the pre-resolver `local_path.is_file()` branches that #57890 deleted) were resolved into the resolver call site; his tests pass unmodified against the new error surface.

## Validation
| | Result |
|---|---|
| Targeted suites (image_source, vision_tools, native_fast_path, video_analyze) | 156/156 |
| E2E real imports: `.env` direct + `.env` symlinked as `pic.png` | both blocked with the specific error |
| E2E legit PNG through same path | unaffected |

Defense-in-depth, not a boundary change: local backend keeps full filesystem vision access; the denylist is only secret-bearing credential files, same as every other media provider call site.

## Infographic

![vision-video-read-guard](https://v3b.fal.media/files/b/0aa100f4/Cp_sP2klO3Hz4GoX7YvvP_eckQlUqW.png)
