### PR TITLE
fix(desktop): roll relativeTime to the coarser unit at bucket edges

### DIFF
--- a/apps/desktop/src/lib/time.test.ts
+++ b/apps/desktop/src/lib/time.test.ts
@@ -43,6 +43,11 @@ describe('formatAgo', () => {
   })
 })
 
+// Mirror the production formatter's locale/options so expectations assert the
+// unit/value without hardcoding English output — otherwise the suite breaks on
+// a non-English CI/dev runtime, since `relativeTime` uses the runtime locale.
+const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto', style: 'short' })
+
 describe('relativeTime', () => {
   it('rolls to the coarser unit at the top edge of a bucket', () => {
     // 59.5 min rounds to 60 minutes → should read "in 1 hr", not "in 60 min".
@@ -54,9 +59,9 @@ describe('relativeTime', () => {
   })
 
   it('keeps non-boundary values in their own bucket', () => {
-    expect(relativeTime(2 * HOUR, 0)).toBe('in 2 hr.')
-    expect(relativeTime(5 * MINUTE, 0)).toBe('in 5 min.')
-    expect(relativeTime(30 * SECOND, 0)).toBe('in 30 sec.')
+    expect(relativeTime(2 * HOUR, 0)).toBe(rtf.format(2, 'hour'))
+    expect(relativeTime(5 * MINUTE, 0)).toBe(rtf.format(5, 'minute'))
+    expect(relativeTime(30 * SECOND, 0)).toBe(rtf.format(30, 'second'))
   })
 
   it('preserves the past direction when a value carries to the coarser unit', () => {

--- a/apps/desktop/src/lib/time.test.ts
+++ b/apps/desktop/src/lib/time.test.ts
@@ -9,6 +9,7 @@ import {
   HOUR,
   MINUTE,
   nominalDayStart,
+  relativeTime,
   SECOND,
   sessionBucketLabel
 } from './time'
@@ -39,6 +40,28 @@ describe('formatAgo', () => {
 
   it('clamps future timestamps to "now"', () => {
     expect(ago(-HOUR)).toBe('now')
+  })
+})
+
+describe('relativeTime', () => {
+  it('rolls to the coarser unit at the top edge of a bucket', () => {
+    // 59.5 min rounds to 60 minutes → should read "in 1 hr", not "in 60 min".
+    expect(relativeTime(3_570_000, 0)).toBe(relativeTime(HOUR, 0))
+    // 59.7 s rounds to 60 seconds → should read "in 1 min", not "in 60 sec".
+    expect(relativeTime(59_700, 0)).toBe(relativeTime(MINUTE, 0))
+    // 23.5 h rounds to 24 hours → should read the coarser day form, not "in 24 hr".
+    expect(relativeTime(84_600_000, 0)).toBe(relativeTime(DAY, 0))
+  })
+
+  it('keeps non-boundary values in their own bucket', () => {
+    expect(relativeTime(2 * HOUR, 0)).toBe('in 2 hr.')
+    expect(relativeTime(5 * MINUTE, 0)).toBe('in 5 min.')
+    expect(relativeTime(30 * SECOND, 0)).toBe('in 30 sec.')
+  })
+
+  it('preserves the past direction when a value carries to the coarser unit', () => {
+    // 59.5 min in the past → "1 hr ago", not "60 min ago".
+    expect(relativeTime(0, 3_570_000)).toBe(relativeTime(0, HOUR))
   })
 })
 

--- a/apps/desktop/src/lib/time.ts
+++ b/apps/desktop/src/lib/time.ts
@@ -40,16 +40,31 @@ export function relativeTime(targetMs: number, nowMs = Date.now()): string {
   const abs = Math.abs(diff)
   const sign = diff < 0 ? -1 : 1
 
+  // Round within the bucket first, then carry up to the coarser unit when the
+  // rounded count saturates its divisor — otherwise a value in the top half of a
+  // bucket reads "in 60 min" / "in 24 hr" instead of rolling to "in 1 hr" / "1 day".
   if (abs < MINUTE) {
-    return rtf.format(sign * Math.round(abs / SECOND), 'second')
+    const seconds = Math.round(abs / SECOND)
+
+    if (seconds < 60) {
+      return rtf.format(sign * seconds, 'second')
+    }
   }
 
   if (abs < HOUR) {
-    return rtf.format(sign * Math.round(abs / MINUTE), 'minute')
+    const minutes = Math.round(abs / MINUTE)
+
+    if (minutes < 60) {
+      return rtf.format(sign * minutes, 'minute')
+    }
   }
 
   if (abs < DAY) {
-    return rtf.format(sign * Math.round(abs / HOUR), 'hour')
+    const hours = Math.round(abs / HOUR)
+
+    if (hours < 24) {
+      return rtf.format(sign * hours, 'hour')
+    }
   }
 
   return rtf.format(sign * Math.round(abs / DAY), 'day')


### PR DESCRIPTION
## What does this PR do?

`relativeTime` (`apps/desktop/src/lib/time.ts`) picks a display bucket by the raw magnitude of the delta (`abs < MINUTE` / `abs < HOUR` / `abs < DAY`) but then rounds the count independently inside that bucket. When `abs` sits in the top ~half-unit of a bucket, `Math.round` carries the count up to the next unit's threshold, so the string shows the awkward saturated form instead of rolling to the coarser unit its own docstring promises ("coarsest sensible unit so a daily job reads 'in 14 hr', not 'in 840 min'").

Reproduced against current `main`:

- `relativeTime(3_570_000, 0)` (59.5 min) → `"in 60 min."`   (want "in 1 hr")
- `relativeTime(59_700, 0)` (59.7 s)     → `"in 60 sec."`   (want "in 1 min")
- `relativeTime(84_600_000, 0)` (23.5 h) → `"in 24 hr."`    (want "in 1 day")

This surfaces on the cron-job next-run label (`cron-jobs-section.tsx:195`), which is the only caller of this helper. (An earlier version of this description also credited the "last checked" line in `about-settings.tsx` — that was wrong: it defines its own local `relativeTime` with a different signature and does not import this one. Thanks to @AmirF194 for the correction.)

The fix rounds within each bucket first, then falls through to the coarser branch when the rounded count reaches its divisor (a saturated minute count renders as 1 hour, a saturated hour count as 1 day). Behavior is identical for all non-boundary inputs, and both the `sign` (in/ago) direction and the `numeric:'auto'` phrasing are preserved. The sibling `coarseElapsed` already handles this correctly (via `>=` bucket tests + `Math.floor`) and is left untouched.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/time.ts`: in `relativeTime`, round the count within a bucket, then carry to the coarser unit on saturation rather than emitting the saturated form.
- `apps/desktop/src/lib/time.test.ts` (new): boundary-roll, non-boundary, and past-direction coverage.

## How to Test

1. `cd apps/desktop && npx vitest run src/lib/time.test.ts --environment jsdom` — 3 passing.
2. Fail-before/pass-after verified: with the production hunk reverted to `main`, the boundary and past-direction assertions fail (`"60 min. ago"` vs `"1 hr. ago"`); with the fix they pass. The non-boundary assertion passes in both states.
3. `npx tsc -p . --noEmit` and `npx eslint src/lib/time.ts src/lib/time.test.ts` are clean for the touched files.

CI coverage: `src/lib/time.test.ts` is picked up by the `ui` project in `apps/desktop/vitest.config.ts` (`include: ['src/**/*.test.{ts,tsx}']`), which `npm run --prefix apps/desktop check` runs via `vitest run`. That is invoked by `.github/workflows/js-tests.yml`, called from `ci.yml` on `frontend == 'true'` and required by `all-checks-pass`. Note this wiring landed on `main` in 7b3f3047a on 2026-07-13, after this PR was opened — the checks currently shown on this PR predate it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected suite (`vitest run` for the desktop app) and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (desktop renderer vitest / jsdom)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure TS logic, no platform-specific paths)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
