### PR TITLE
fix(unbroker): require TLS before SMTP login in programmatic send

### DIFF
--- a/optional-skills/security/unbroker/scripts/emailer.py
+++ b/optional-skills/security/unbroker/scripts/emailer.py
@@ -25,6 +25,7 @@ import json
 import os
 import re
 import smtplib
+import ssl
 import time
 from email.message import EmailMessage
 from pathlib import Path
@@ -163,8 +164,22 @@ def _respect_rate_limit(min_interval: float, sleep, now, state_path=None) -> Non
 
 
 # SMTP errors that are permanent (don't retry) vs transient (retry with backoff).
+# SMTPNotSupportedError is permanent: a server that will not STARTTLS (or refuses
+# AUTH) will not change its mind on the next attempt, and in the STARTTLS case a
+# retry would just re-offer the credentials to the same downgraded connection.
 _SMTP_PERMANENT = (smtplib.SMTPAuthenticationError, smtplib.SMTPRecipientsRefused,
-                   smtplib.SMTPSenderRefused, smtplib.SMTPDataError)
+                   smtplib.SMTPSenderRefused, smtplib.SMTPDataError,
+                   smtplib.SMTPNotSupportedError)
+
+
+def _connection_is_tls(smtp) -> bool:
+    """True when the SMTP conversation is already running over TLS.
+
+    Covers implicit-TLS connections (`SMTP_SSL` on port 465, and the injected
+    implicit-TLS test factories): those never advertise STARTTLS and don't need
+    it, so the STARTTLS step is skipped for them.
+    """
+    return isinstance(getattr(smtp, "sock", None), ssl.SSLSocket)
 
 
 def send(broker: dict, body_text: str, to: str | None = None,
@@ -176,7 +191,14 @@ def send(broker: dict, body_text: str, to: str | None = None,
     Recipient is locked to an address the broker record declares (PermissionError
     otherwise). `min_interval` paces sends across invocations (deliverability /
     account-safety); transient SMTP/socket failures retry with exponential backoff,
-    permanent ones (auth, recipient refused) raise immediately. NOTE: a successful
+    permanent ones (auth, recipient refused) raise immediately. TLS is required
+    before login: port 465 connects with implicit TLS (`SMTP_SSL`), any other
+    port must complete STARTTLS, and a server that will not STARTTLS (and is not
+    already on a TLS connection) fails permanently instead of sending the
+    password and the request over cleartext. The TLS context is verified
+    (`create_default_context`), so an internal relay with a self-signed or
+    private-CA certificate is rejected: point `EMAIL_SMTP_HOST` at a host with a
+    publicly trusted certificate. NOTE: a successful
     SMTP handoff is NOT proof of delivery - real bounces arrive later as inbound mail;
     in programmatic mode `poll-verification`/inbox review surfaces them, and the
     due-queue re-scan is the true confirmation. Returns send metadata.
@@ -208,18 +230,34 @@ def send(broker: dict, body_text: str, to: str | None = None,
 
     _respect_rate_limit(min_interval, _sleep, _now, _rate_state)
 
-    factory = _smtp_factory or smtplib.SMTP
+    def _open():
+        # An injected factory owns its own transport (the hermetic tests). With
+        # no factory, port 465 is the implicit-TLS submission port, so connect
+        # with SMTP_SSL and a verified context (TLS from the first byte, no
+        # STARTTLS). Every other port connects plaintext and must STARTTLS below.
+        if _smtp_factory is not None:
+            return _smtp_factory(settings["host"], settings["port"], timeout=30)
+        if settings["port"] == 465:
+            return smtplib.SMTP_SSL(settings["host"], settings["port"], timeout=30,
+                                    context=ssl.create_default_context())
+        return smtplib.SMTP(settings["host"], settings["port"], timeout=30)
+
     attempts = 0
     while True:
         attempts += 1
         try:
-            with factory(settings["host"], settings["port"], timeout=30) as smtp:
+            with _open() as smtp:
                 smtp.ehlo()
-                try:
-                    smtp.starttls()
+                if not _connection_is_tls(smtp):
+                    try:
+                        smtp.starttls(context=ssl.create_default_context())
+                    except smtplib.SMTPNotSupportedError as exc:
+                        raise smtplib.SMTPNotSupportedError(
+                            "server did not offer STARTTLS on a plaintext "
+                            "connection. Refusing to log in: the account "
+                            "password and the request would go out unencrypted."
+                        ) from exc
                     smtp.ehlo()
-                except smtplib.SMTPNotSupportedError:
-                    pass  # already-TLS ports / test doubles
                 smtp.login(settings["address"], settings["password"])
                 smtp.send_message(msg)
             break

--- a/tests/skills/test_unbroker_skill.py
+++ b/tests/skills/test_unbroker_skill.py
@@ -32,6 +32,8 @@ import contextlib as _ctx  # noqa: E402
 import io as _io          # noqa: E402
 import json as _json      # noqa: E402
 import smtplib as _smtplib  # noqa: E402
+import socket as _socket  # noqa: E402
+import ssl as _ssl        # noqa: E402
 import time as _time      # noqa: E402
 
 import badbool          # noqa: E402
@@ -750,7 +752,7 @@ class _FakeSMTP:
     def ehlo(self):
         pass
 
-    def starttls(self):
+    def starttls(self, context=None):
         pass
 
     def login(self, user, password):
@@ -1293,7 +1295,7 @@ class _FlakySMTP:
     def ehlo(self):
         pass
 
-    def starttls(self):
+    def starttls(self, context=None):
         pass
 
     def login(self, u, p):
@@ -1330,6 +1332,134 @@ def test_email_send_does_not_retry_permanent_error():
         pass
     else:
         raise AssertionError("auth failure must raise immediately, not retry")
+
+
+class _StripSMTP:
+    """Plaintext server whose EHLO does not offer STARTTLS (downgrade or bad relay)."""
+    constructed = 0
+    logins: list = []
+
+    def __init__(self, host, port, timeout=None):
+        _StripSMTP.constructed += 1
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def ehlo(self):
+        pass
+
+    def starttls(self, context=None):
+        raise _smtplib.SMTPNotSupportedError("STARTTLS extension not supported by server.")
+
+    def login(self, u, p):
+        _StripSMTP.logins.append((u, p))
+
+    def send_message(self, m):
+        raise AssertionError("must never hand the message to a cleartext connection")
+
+
+class _ImplicitTLSSMTP:
+    """Already-TLS connection (an injected implicit-TLS factory): no STARTTLS needed."""
+    sent: list = []
+
+    def __init__(self, host, port, timeout=None):
+        self.sock = _ssl.create_default_context().wrap_socket(
+            _socket.socket(), do_handshake_on_connect=False,
+            server_hostname="mail.example")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        self.sock.close()
+        return False
+
+    def ehlo(self):
+        pass
+
+    def starttls(self, context=None):
+        raise _smtplib.SMTPNotSupportedError("already using TLS")
+
+    def login(self, u, p):
+        pass
+
+    def send_message(self, m):
+        _ImplicitTLSSMTP.sent.append(m)
+
+
+def test_email_send_refuses_login_when_starttls_is_stripped():
+    _StripSMTP.constructed, _StripSMTP.logins = 0, []
+    env = {"EMAIL_ADDRESS": "agent@gmail.com", "EMAIL_PASSWORD": "hunter2"}
+    broker = {"id": "x", "optout": {"email": "privacy@x.example"}}
+    try:
+        emailer.send(broker, "Subject: s\n\nb", env=env, _smtp_factory=_StripSMTP,
+                     _sleep=lambda *_: None)
+    except _smtplib.SMTPNotSupportedError:
+        pass
+    else:
+        raise AssertionError("send must raise when the server will not STARTTLS")
+    assert _StripSMTP.logins == []       # the password never touched the socket
+    assert _StripSMTP.constructed == 1   # a downgrade is permanent, never retried
+
+
+def test_email_send_accepts_already_tls_connection():
+    _ImplicitTLSSMTP.sent = []
+    env = {"EMAIL_ADDRESS": "agent@gmail.com", "EMAIL_PASSWORD": "p"}
+    broker = {"id": "x", "optout": {"email": "privacy@x.example"}}
+    out = emailer.send(broker, "Subject: s\n\nb", env=env,
+                       _smtp_factory=_ImplicitTLSSMTP, _sleep=lambda *_: None)
+    assert out["attempts"] == 1 and _ImplicitTLSSMTP.sent
+
+
+class _FakeSMTPSSL:
+    """Stand-in for smtplib.SMTP_SSL: implicit TLS from construction, no STARTTLS."""
+    sent: list = []
+    context = None
+
+    def __init__(self, host, port, timeout=None, context=None):
+        _FakeSMTPSSL.context = context
+        self.sock = _ssl.create_default_context().wrap_socket(
+            _socket.socket(), do_handshake_on_connect=False,
+            server_hostname="mail.example")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        self.sock.close()
+        return False
+
+    def ehlo(self):
+        pass
+
+    def starttls(self, context=None):
+        raise AssertionError("port 465 is already TLS, STARTTLS must not run")
+
+    def login(self, u, p):
+        pass
+
+    def send_message(self, m):
+        _FakeSMTPSSL.sent.append(m)
+
+
+def test_email_send_uses_implicit_tls_on_port_465(monkeypatch):
+    _FakeSMTPSSL.sent, _FakeSMTPSSL.context = [], None
+
+    def _forbidden_plaintext(*a, **k):
+        raise AssertionError("port 465 must connect with SMTP_SSL, not plaintext SMTP")
+
+    monkeypatch.setattr(emailer.smtplib, "SMTP_SSL", _FakeSMTPSSL)
+    monkeypatch.setattr(emailer.smtplib, "SMTP", _forbidden_plaintext)
+    env = {"EMAIL_ADDRESS": "agent@corp.example", "EMAIL_PASSWORD": "p",
+           "EMAIL_SMTP_HOST": "mail.corp.example", "EMAIL_SMTP_PORT": "465"}
+    broker = {"id": "x", "optout": {"email": "privacy@x.example"}}
+    out = emailer.send(broker, "Subject: s\n\nb", env=env, _sleep=lambda *_: None)
+    assert out["attempts"] == 1 and _FakeSMTPSSL.sent
+    # The implicit-TLS connection is verified, matching the gateway adapter.
+    assert isinstance(_FakeSMTPSSL.context, _ssl.SSLContext)
 
 
 def _run(argv) -> dict:


### PR DESCRIPTION
## What does this PR do?

Stops the unbroker skill's programmatic email lane from authenticating over cleartext SMTP.

`send()` in `optional-skills/security/unbroker/scripts/emailer.py` called `starttls()` inside a `try` that swallowed `SMTPNotSupportedError` and then ran `login()` and `send_message()` on the same socket. `smtplib` raises that error exactly when the server's EHLO does not advertise STARTTLS, which is what a STARTTLS downgrade (an on-path attacker stripping the capability) or a no-TLS relay looks like. The result was the operator's real `EMAIL_PASSWORD` plus the full opt-out email (name, contact address, listing URLs) transmitted unencrypted, with the send still reported as a success. For a skill whose purpose is reducing the operator's data exposure, that is the worst payload to leak.

The fix requires TLS before login. If the connection is not already TLS (checked by socket type, which covers an implicit-TLS connection), `starttls()` must succeed or `send()` raises with a clear message. The raise is classified permanent in the retry loop, so the credentials are never re-offered to the same downgraded connection. `starttls()` also gets an explicit verified `ssl.create_default_context()`, which is exactly how the repo's own email gateway adapter already connects at both of its call sites (`plugins/platforms/email/adapter.py`). The IMAP side already used implicit-TLS `IMAP4_SSL` and needed no change.

The verified context matters beyond the strip case: the old `starttls()` passed no context, so stdlib used an unverified one (no certificate or hostname check), which means even a successful STARTTLS was readable by an active on-path attacker. `create_default_context()` closes that too, so the change fixes both the downgrade-to-cleartext leak and the silent passive-MITM path.

Port 465 is the implicit-TLS submission port, so with no injected factory the send now connects with `SMTP_SSL` and the same verified context (TLS from the first byte, no STARTTLS), matching the adapter. One tradeoff worth calling out for custom hosts: the verified context rejects an internal relay with a self-signed or private-CA certificate that an unverified context would have accepted. That is the right default for a privacy skill, and it is documented in the `send()` docstring so anyone running such a relay knows to point `EMAIL_SMTP_HOST` at a host with a publicly trusted certificate.

This approach keeps the hermetic `_smtp_factory` test seam fully working. The existing test doubles implement `starttls()` as a successful no-op and are unaffected. The old swallow's stated reasons no longer apply anywhere: an implicit-TLS connection is now detected by socket type instead of by exception, and port 465 is handled explicitly rather than relying on the swallow.

## Related Issue

Fixes #58711

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `optional-skills/security/unbroker/scripts/emailer.py`
  - `send()` only calls `login()` after TLS is established. On a plaintext connection a missing STARTTLS offer raises `SMTPNotSupportedError` with a message saying why, instead of falling through.
  - New `_connection_is_tls()` helper detects an already-TLS connection by socket type, so an injected implicit-TLS factory skips STARTTLS cleanly rather than relying on exception swallowing.
  - `starttls()` now passes `context=ssl.create_default_context()`, matching the email gateway adapter.
  - `SMTPNotSupportedError` added to `_SMTP_PERMANENT` so a downgrade fails immediately and is never retried.
  - Port 465 connects with `SMTP_SSL` and a verified context when no factory is injected, so the implicit-TLS branch is reachable in production instead of only by test factories.
  - `send()` docstring documents the TLS requirement, the port-465 behavior, and the self-signed/private-CA relay tradeoff.
- `tests/skills/test_unbroker_skill.py`
  - `test_email_send_refuses_login_when_starttls_is_stripped`: a server whose EHLO offers no STARTTLS never sees `login()` or `send_message()`, and the connection is attempted exactly once. Fails on the previous code (the fake recorded the password and received the message).
  - `test_email_send_accepts_already_tls_connection`: a factory whose socket is already TLS sends successfully without STARTTLS.
  - `test_email_send_uses_implicit_tls_on_port_465`: a port-465 send connects with `SMTP_SSL` (never plaintext `SMTP`), never runs STARTTLS, sends over the implicit-TLS socket, and is handed a verified context.
  - The two existing SMTP fakes' `starttls()` signatures accept the new context argument.

## How to Test

1. `pytest tests/skills/test_unbroker_skill.py -q` (98 pass here, plus 2 pre-existing local browser-detection failures unrelated to this change, see notes).
2. Proof the fix works: `pytest tests/skills/test_unbroker_skill.py -q -k "starttls_is_stripped or already_tls"` passes on this branch. Check out `main`'s `emailer.py` with this branch's test file and the stripped-STARTTLS test fails at the exact point where the password reaches the socket.
3. No-regression check on the neighboring lane: `pytest tests/gateway/test_email.py -q` is unchanged from `main` (one pre-existing local env failure on both).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Stripped-STARTTLS test against the previous code (the fail-without proof):

```
FAILED tests/skills/test_unbroker_skill.py::test_email_send_refuses_login_when_starttls_is_stripped
E       AssertionError: must never hand the message to a cleartext connection
```

Same test on this branch, plus the already-TLS and existing send/retry tests:

```
pytest tests/skills/test_unbroker_skill.py -q -k "email or smtp or starttls or tls"
18 passed, 81 deselected
```

Note on the full-suite runs above: `test_cdp_launch_command_has_debug_flags` and `test_cdp_find_browser_override` fail identically on a clean `main` checkout on this machine (they probe local browser install paths). Not related to this change.
