### PR TITLE
fix(logging): null and lock-guard the listener in drain_log_queue

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -676,7 +676,16 @@ def drain_log_queue(timeout: float = 1.0) -> None:
     proceed. Availability beats the last log line when the disk is already
     wedged.
     """
-    listener = _queue_listener
+    global _queue_listener
+    # Drain stops the listener but used to leave _queue_listener pointing at it,
+    # so a later flush_log_queue()/setup_logging(force=True) stopped the same
+    # dead listener a second time — on CPython <3.13 QueueListener.stop() is not
+    # idempotent and a second stop joins a None thread -> AttributeError.
+    # Grab-and-null so the global never outlives the listener it names; the lock
+    # keeps the swap atomic and mirrors every sibling teardown path
+    # (_stop_queue_listener_locked / flush_log_queue / _register_queued_handler).
+    with _queue_state_lock:
+        listener, _queue_listener = _queue_listener, None
     if listener is None:
         return
 

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -668,3 +668,38 @@ class TestAsyncQueueLogging:
         )
 
 
+
+
+class TestDrainLogQueue:
+    """drain_log_queue() must null the listener under the lock so a later
+    teardown never stops the same QueueListener twice (which raises
+    AttributeError on CPython <3.13, whose stop() is not idempotent)."""
+
+    def test_drain_nulls_the_listener(self, hermes_home):
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+        assert hermes_logging._queue_listener is not None
+        hermes_logging.drain_log_queue(timeout=1.0)
+        # After a drain the global must be cleared, so nothing can stop the
+        # already-stopped listener a second time.
+        assert hermes_logging._queue_listener is None
+
+    def test_flush_after_drain_does_not_raise(self, hermes_home):
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+        hermes_logging.drain_log_queue(timeout=1.0)
+        # Before the fix this double-stopped the drained listener:
+        # AttributeError: 'NoneType' object has no attribute 'join'.
+        hermes_logging.flush_log_queue()
+
+    def test_forced_resetup_after_drain_does_not_raise(self, hermes_home):
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+        hermes_logging.drain_log_queue(timeout=1.0)
+        # The re-setup must ADD a handler to exercise the double-stop:
+        # _add_rotating_handler() returns early for agent.log/errors.log
+        # because a handler for the same resolved path is already attached, so
+        # an identical force=True call never reaches _register_queued_handler.
+        # mode="gateway" adds gateway.log — a new path — which does re-register
+        # and, before the fix, stopped the already-drained listener a second
+        # time via the non-idempotent stop() and raised AttributeError.
+        hermes_logging.setup_logging(
+            hermes_home=hermes_home, mode="gateway", force=True
+        )


### PR DESCRIPTION
## What does this PR do?

`drain_log_queue()` in `hermes_logging.py` stops the shared `_queue_listener` but never clears the module global that points at it. Every other teardown path in the file — `_stop_queue_listener_locked`, `flush_log_queue`, `_register_queued_handler` — grabs `_queue_state_lock` and nulls the global atomically. Drain was the only one that didn't, so after a drain the global outlived the listener it named.

Because the global still pointed at the (now stopped) listener, a subsequent `flush_log_queue()` or a `setup_logging(force=True)` that registers a new handler calls `QueueListener.stop()` a **second time** on the already-stopped listener. On the repo's pinned CPython 3.11 (`requires-python ">=3.11,<3.14"`), whose `QueueListener.stop()` predates the gh-114706 idempotency guard, the second stop runs `self._thread.join()` with `_thread is None`:

```
AttributeError: 'NoneType' object has no attribute 'join'
```

To be precise about the root cause: this is **not** a read race. The local capture plus the `is None` check already prevented a None-deref inside `drain` itself. The defect is simply that **drain never cleared the global, so teardown stopped a dead listener twice.** The fix grabs-and-nulls the listener at the top of the function so the global cannot outlive it; the lock keeps that swap atomic and mirrors the sibling paths. The lock scope covers **only** the swap — the bounded throwaway-thread `stop()`/`join(timeout)` drain mechanism (the whole point of the function, so a hard-exit path never re-freezes on the cross-process rotation lock) runs outside the lock and is unchanged.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_logging.py`: `drain_log_queue()` now grabs-and-nulls `_queue_listener` under `_queue_state_lock` before running the bounded drain, so a later teardown cannot stop the same listener a second time.
- `tests/test_hermes_logging.py`: new `TestDrainLogQueue` — drain nulls the global, and both `drain → flush` and `drain → forced re-setup` must not raise.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/test_hermes_logging.py -v` — 71 passing.
2. Fail-before/pass-after: with the production hunk reverted to `main`, all three `TestDrainLogQueue` tests fail; `test_flush_after_drain_does_not_raise` and `test_forced_resetup_after_drain_does_not_raise` fail with the exact `AttributeError: 'NoneType' object has no attribute 'join'`. With the fix restored all three pass and the full existing suite stays green.

Note on the forced-resetup test: an identical `setup_logging(hermes_home=..., force=True)` does **not** exercise the double-stop, because `_add_rotating_handler()` returns early when a handler for the same resolved path is already attached, so `_register_queued_handler` — the only setup-path caller of `stop()` — never runs. The test therefore forces re-setup with `mode="gateway"`, whose `gateway.log` is a new path that does re-register. Thanks to @AmirF194 for catching that the original version of this test passed with and without the fix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/test_hermes_logging.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (CPython 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (the double-stop crash reproduces on any CPython <3.13 regardless of OS)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
