### PR TITLE
fix(memory/mem0): reuse Memory's Qdrant client for dims check to avoid Windows file-lock conflict

### DIFF
--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -111,9 +111,11 @@ class OSSBackend(Mem0Backend):
             dims = KNOWN_DIMS.get(model)
         if dims:
             vs_config["embedding_model_dims"] = dims
-            self._recreate_collection_if_dims_changed(
-                vector_store.get("provider", "qdrant"), vs_config, dims,
-            )
+
+        provider = vector_store.get("provider", "qdrant")
+        # pgvector: check dims before Memory creation (no file lock issue).
+        if dims and provider == "pgvector":
+            self._recreate_collection_if_dims_changed(provider, vs_config, dims)
 
         vector_store["config"] = vs_config
 
@@ -124,6 +126,15 @@ class OSSBackend(Mem0Backend):
             "version": "v1.1",
         }
         self._memory = Memory.from_config(config)
+
+        # Qdrant: check dims AFTER Memory creation, reusing its own
+        # vector_store client.  The previous approach created a separate
+        # temporary QdrantClient(path=...) which holds an exclusive file
+        # lock; on Windows the lock may not release before Memory's own
+        # QdrantClient opens the same path, causing "Storage folder is
+        # already accessed by another instance".
+        if dims and provider == "qdrant":
+            self._recreate_qdrant_if_dims_changed(dims)
 
     @staticmethod
     def _recreate_collection_if_dims_changed(provider: str, vs_config: dict, expected_dims: int) -> None:
@@ -188,6 +199,32 @@ class OSSBackend(Mem0Backend):
                     conn.close()
             except Exception:
                 pass
+
+    def _recreate_qdrant_if_dims_changed(self, expected_dims: int) -> None:
+        """Recreate Qdrant collection if embedding dimensions changed.
+
+        Uses Memory's own vector_store.client instead of creating a separate
+        QdrantClient — avoids Windows file-lock conflicts (#58705).
+        """
+        try:
+            vs = getattr(self._memory, "vector_store", None)
+            client = getattr(vs, "client", None)
+            if client is None:
+                return
+            collection_name = self._memory.collection_name
+            if not client.collection_exists(collection_name):
+                return
+            info = client.get_collection(collection_name)
+            vectors = info.config.params.vectors
+            if isinstance(vectors, dict):
+                first = next(iter(vectors.values()), None)
+                current_dims = first.size if first else None
+            else:
+                current_dims = getattr(vectors, "size", None)
+            if current_dims is not None and current_dims != expected_dims:
+                client.delete_collection(collection_name)
+        except Exception:
+            pass
 
     def search(self, query: str, *, filters: dict, top_k: int = 10, rerank: bool = True) -> list[dict]:
         response = self._memory.search(query, filters=filters, top_k=top_k)

--- a/tests/plugins/memory/test_mem0_backend.py
+++ b/tests/plugins/memory/test_mem0_backend.py
@@ -207,3 +207,79 @@ class TestOSSBackend:
         backend, _ = self._make()
         result = backend.delete("m1")
         assert result == {"result": "Memory deleted.", "memory_id": "m1"}
+
+
+class _FakeCollectionInfo:
+    """Minimal stand-in for qdrant_client.models.CollectionInfo."""
+    def __init__(self, dims: int):
+        class _Vectors:
+            def __init__(self, size):
+                self.size = size
+        self.config = type("C", (), {"params": type("P", (), {"vectors": _Vectors(dims)})()})()
+
+
+class _FakeQdrantClient:
+    """Fake QdrantClient that tracks calls — no file locks."""
+
+    def __init__(self, *, existing_dims: int | None = 8, collection_name: str = "mem0"):
+        self._existing_dims = existing_dims
+        self._collection_name = collection_name
+        self.deleted = False
+
+    def collection_exists(self, name: str) -> bool:
+        return self._existing_dims is not None and name == self._collection_name
+
+    def get_collection(self, name: str):
+        return _FakeCollectionInfo(self._existing_dims)
+
+    def delete_collection(self, name: str):
+        self.deleted = True
+
+
+class TestOSSBackendRecreateQdrantDims:
+    """Verify _recreate_qdrant_if_dims_changed uses Memory's own client."""
+
+    def _make_backend(self, client: _FakeQdrantClient, collection_name: str = "mem0"):
+        backend = OSSBackend.__new__(OSSBackend)
+        # Wire up a fake Memory with a fake vector_store that has the client.
+        memory = type("M", (), {
+            "vector_store": type("VS", (), {"client": client})(),
+            "collection_name": collection_name,
+        })()
+        backend._memory = memory
+        return backend
+
+    def test_dims_match_no_delete(self):
+        """When collection dims match expected, nothing happens."""
+        client = _FakeQdrantClient(existing_dims=384)
+        backend = self._make_backend(client)
+        backend._recreate_qdrant_if_dims_changed(384)
+        assert not client.deleted
+
+    def test_dims_mismatch_deletes_collection(self):
+        """When collection dims differ, the collection is deleted."""
+        client = _FakeQdrantClient(existing_dims=128)
+        backend = self._make_backend(client)
+        backend._recreate_qdrant_if_dims_changed(384)
+        assert client.deleted
+
+    def test_missing_collection_noop(self):
+        """When collection doesn't exist, nothing happens."""
+        client = _FakeQdrantClient(existing_dims=None)
+        backend = self._make_backend(client)
+        backend._recreate_qdrant_if_dims_changed(384)
+        assert not client.deleted
+
+    def test_no_vector_store_client_noop(self):
+        """When Memory has no vector_store.client, nothing happens."""
+        backend = OSSBackend.__new__(OSSBackend)
+        backend._memory = type("M", (), {"vector_store": None, "collection_name": "mem0"})()
+        backend._recreate_qdrant_if_dims_changed(384)
+        # Should not raise
+
+    def test_uses_memory_own_client(self):
+        """Verify the method accesses Memory's vector_store.client, not a new QdrantClient."""
+        client = _FakeQdrantClient(existing_dims=128)
+        backend = self._make_backend(client)
+        backend._recreate_qdrant_if_dims_changed(384)
+        assert client.deleted  # confirms it used THIS client


### PR DESCRIPTION
## What does this PR do?

Fixes a Qdrant file-lock conflict in mem0 OSS mode on Windows. `OSSBackend.__init__` previously created a **separate temporary `QdrantClient(path=...)`** via `_recreate_collection_if_dims_changed()` to check collection dimensions, then immediately created **another** `QdrantClient` inside `Memory.from_config()`. On Windows, mandatory file locks may not release between the two clients, causing:

```
Storage folder is already accessed by another instance of Qdrant client.
If you require concurrent access, use Qdrant server instead.
```

The fix moves the Qdrant dimension check to **after** `Memory.from_config()`, reusing Memory's own `vector_store.client` instead of creating a separate temporary client. This eliminates the second `QdrantClient` entirely for the Qdrant path. The pgvector path (no file-lock semantics) is unchanged.

## Related Issue

Fixes #58705

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/mem0/_backend.py`: Split `_recreate_collection_if_dims_changed()` call — pgvector still runs before `Memory.from_config()` (no lock issue); Qdrant now runs after via new `_recreate_qdrant_if_dims_changed()` method that reuses Memory's own `vector_store.client`.
- `tests/plugins/memory/test_mem0_backend.py`: Added 5 tests for `_recreate_qdrant_if_dims_changed` — dims match (no delete), dims mismatch (delete), missing collection (noop), no vector_store client (noop), and verification that Memory's own client is used.

## How to Test

1. `pytest tests/plugins/memory/test_mem0_backend.py -q` — all 25 tests should pass (20 existing + 5 new).
2. On Windows with mem0 OSS + Qdrant local: configure `mem0.json` with `"mode": "oss"` and a local Qdrant path, restart Hermes, then call `mem0_search` — should no longer raise "Storage folder is already accessed by another instance".

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (code-only fix)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — Yes (this is a Windows-specific fix; verified code path is safe on all platforms)
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

N/A — structural change in initialization order; no new user-facing output.
