### PR TITLE
fix(gateway): use OGG/Opus for Matrix voice replies

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12623,9 +12623,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not tts_text:
                 return
 
-            # Telegram's adapter only sends native voice bubbles for OGG/Opus.
-            # Other platforms keep the existing MP3 default.
-            audio_ext = "ogg" if event.source.platform == Platform.TELEGRAM else "mp3"
+            # Telegram and Matrix adapters only render native voice bubbles
+            # for OGG/Opus audio.  Other platforms keep the existing MP3
+            # default.
+            _voice_platforms = (Platform.TELEGRAM, Platform.MATRIX)
+            audio_ext = "ogg" if event.source.platform in _voice_platforms else "mp3"
             audio_path = os.path.join(
                 tempfile.gettempdir(), "hermes_voice",
                 f"tts_reply_{_uuid.uuid4().hex[:12]}.{audio_ext}",

--- a/tests/tools/test_tts_opus_routing.py
+++ b/tests/tools/test_tts_opus_routing.py
@@ -68,3 +68,30 @@ def test_edge_telegram_converts_to_opus_voice(tmp_path, monkeypatch):
     assert result["voice_compatible"] is True
     assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{opus}"
     convert.assert_called_once_with(str(out))
+
+
+def test_edge_matrix_converts_to_opus_voice(tmp_path, monkeypatch):
+    """Matrix voice messages also require Opus (MSC3245). Regression for #58715."""
+    out = tmp_path / "speech.mp3"
+    opus = tmp_path / "speech.ogg"
+
+    def fake_convert(path: str) -> str:
+        assert path == str(out)
+        opus.write_bytes(b"ogg")
+        return str(opus)
+
+    convert = Mock(side_effect=fake_convert)
+
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "matrix")
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "edge"})
+    monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: object())
+    monkeypatch.setattr(tts_tool, "_generate_edge_tts", _write_edge_output)
+    monkeypatch.setattr(tts_tool, "_convert_to_opus", convert)
+
+    result = json.loads(tts_tool.text_to_speech_tool("hello", output_path=str(out)))
+
+    assert result["success"] is True
+    assert result["file_path"] == str(opus)
+    assert result["voice_compatible"] is True
+    assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{opus}"
+    convert.assert_called_once_with(str(out))

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2194,12 +2194,12 @@ def text_to_speech_tool(
         text = text[:max_len]
 
     # Detect platform from gateway env var to choose the best output format.
-    # Telegram voice bubbles require Opus (.ogg); OpenAI and ElevenLabs can
-    # produce Opus natively (no ffmpeg needed).  Edge TTS always outputs MP3
-    # and needs ffmpeg for conversion.
+    # Telegram and Matrix voice bubbles require Opus (.ogg); OpenAI and
+    # ElevenLabs can produce Opus natively (no ffmpeg needed).  Edge TTS
+    # always outputs MP3 and needs ffmpeg for conversion.
     from gateway.session_context import get_session_env
     platform = get_session_env("HERMES_SESSION_PLATFORM", "").lower()
-    want_opus = (platform == "telegram")
+    want_opus = platform in ("telegram", "matrix")
 
     # Determine output path
     if output_path:


### PR DESCRIPTION
## What does this PR do?

Matrix MSC3245 voice messages require Opus audio format, but both the `_send_voice_reply` path in `gateway/run.py` and the `want_opus` check in `tools/tts_tool.py` only triggered Opus conversion for Telegram. Matrix voice replies were sent as MP3/WAV, which Element X silently refuses to play in the voice bubble.

## Related Issue

Fixes #58715

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: Add `Platform.MATRIX` to the `_voice_platforms` tuple so `_send_voice_reply` generates `.ogg` files for Matrix sessions
- `tools/tts_tool.py`: Add `"matrix"` to the `want_opus` condition so the TTS tool triggers ffmpeg Opus conversion for Matrix platform sessions
- `tests/tools/test_tts_opus_routing.py`: Add regression test verifying Edge TTS converts to Opus when `HERMES_SESSION_PLATFORM=matrix`

## How to Test

1. Configure a Matrix gateway with any TTS provider (e.g., Edge TTS or piper)
2. In a room, send `/voice tts` to enable voice replies
3. Send a text message and wait for the voice reply
4. The voice bubble should now play correctly in Element X iOS — previously it showed the bubble with correct duration but playback did nothing
5. Run `pytest tests/tools/test_tts_opus_routing.py -v` — all 3 tests should pass, including the new `test_edge_matrix_converts_to_opus_voice`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tools/test_tts_opus_routing.py -v` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
