### PR TITLE
fix(anthropic): reorder tool_result blocks to lead user messages, preventing HTTP 400

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2099,10 +2099,22 @@ def _convert_user_message(content: Any) -> Dict[str, Any]:
     """Validate and convert a user message to anthropic format."""
     if isinstance(content, list):
         converted_blocks = _convert_content_to_anthropic(content)
-        if not converted_blocks or all(
-            b.get("text", "").strip() == ""
+        # Consider the message empty ONLY when there are no non-text blocks
+        # AND every text block is blank.  Note: ``all()`` over an empty
+        # generator is True, so without the non-text guard a user message
+        # carrying only tool_result/image blocks (no text at all) would be
+        # destructively replaced by the placeholder.
+        has_non_text = any(
+            isinstance(b, dict) and b.get("type") != "text"
             for b in converted_blocks
-            if isinstance(b, dict) and b.get("type") == "text"
+        )
+        if not converted_blocks or (
+            not has_non_text
+            and all(
+                b.get("text", "").strip() == ""
+                for b in converted_blocks
+                if isinstance(b, dict) and b.get("type") == "text"
+            )
         ):
             converted_blocks = [{"type": "text", "text": "(empty message)"}]
         return {"role": "user", "content": converted_blocks}
@@ -2191,6 +2203,38 @@ def _strip_orphaned_tool_blocks(result: List[Dict[str, Any]]) -> None:
         ]
         if len(new_content) != len(m["content"]):
             m["content"] = new_content if new_content else [{"type": "text", "text": "(tool result removed)"}]
+
+
+def _reorder_tool_results_first(result: List[Dict[str, Any]]) -> None:
+    """Move tool_result blocks to the FRONT of each user message's content.
+
+    Anthropic requires that when an assistant turn ends with tool_use, the
+    immediately following user message present the matching tool_result
+    blocks at the start of its content array.  Context compression and
+    session restore can inject text blocks (e.g. a system-reminder) BEFORE
+    the tool_result inside the same user message, which Anthropic rejects
+    with HTTP 400 "`tool_use` ids were found without `tool_result` blocks
+    immediately after" — even though the tool_result IS present.
+
+    Reordering is a structural invariant: all tool_result blocks first
+    (preserving their relative order), then everything else (preserving
+    relative order).  Mutates ``result`` in place.
+    """
+    for m in result:
+        if m.get("role") != "user" or not isinstance(m.get("content"), list):
+            continue
+        blocks = m["content"]
+        tool_results = [
+            b for b in blocks
+            if isinstance(b, dict) and b.get("type") == "tool_result"
+        ]
+        if not tool_results or blocks[: len(tool_results)] == tool_results:
+            continue  # none present, or already leading — nothing to do
+        others = [
+            b for b in blocks
+            if not (isinstance(b, dict) and b.get("type") == "tool_result")
+        ]
+        m["content"] = tool_results + others
 
 
 def _merge_consecutive_roles(result: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -2442,8 +2486,14 @@ def convert_messages_to_anthropic(
         # Regular user message
         result.append(_convert_user_message(content))
 
-    _strip_orphaned_tool_blocks(result)
+    # Merge BEFORE stripping: a stray user message injected between a
+    # tool_use turn and its tool_result message gets merged into one user
+    # message first, so the adjacency check in _strip_orphaned_tool_blocks
+    # sees the true post-merge shape and doesn't strip a pair that is in
+    # fact adjacent after merging.
     result = _merge_consecutive_roles(result)
+    _strip_orphaned_tool_blocks(result)
+    _reorder_tool_results_first(result)
     _manage_thinking_signatures(result, base_url, model)
     _evict_old_screenshots(result)
 

--- a/tests/agent/test_anthropic_tool_result_block_order.py
+++ b/tests/agent/test_anthropic_tool_result_block_order.py
@@ -1,0 +1,137 @@
+"""Regression: tool_result blocks must come FIRST in a user message's content.
+
+Anthropic rejects requests where a user message carries a tool_result block
+that is not at the front of the content array, when the preceding assistant
+message ends with tool_use — the API reports:
+
+    messages.N: `tool_use` ids were found without `tool_result` blocks
+    immediately after
+
+This happens in practice when context compression / session restore merges a
+system-reminder text block IN FRONT of the tool_result inside the same user
+message (observed 2026-07-05, session 20260705_124405_1849e5: the user msg had
+content [text(system-reminder), tool_result] and Anthropic returned HTTP 400,
+triggering an unnecessary fallback to gpt-5.5).
+
+The adapter must reorder every user message so all tool_result blocks precede
+non-tool_result blocks, preserving relative order within each group.
+"""
+
+from agent.anthropic_adapter import convert_messages_to_anthropic
+
+
+def _mk_tool_use(tid):
+    return {
+        "type": "tool_use",
+        "id": tid,
+        "name": "mcp__hermes___patch",
+        "input": {},
+    }
+
+
+def _mk_tool_result(tid, text="ok"):
+    return {"type": "tool_result", "tool_use_id": tid, "content": text}
+
+
+class TestToolResultBlockOrder:
+    def test_text_before_tool_result_is_reordered(self):
+        """The exact 2026-07-05 failure shape: [text, tool_result] user msg."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "[PRIOR CONTEXT] ..."},
+                    _mk_tool_use("toolu_01Mg8mqq"),
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "<system-reminder>persona...</system-reminder>"},
+                    _mk_tool_result("toolu_01Mg8mqq"),
+                ],
+            },
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+
+        user_msg = result[1]
+        assert user_msg["role"] == "user"
+        types = [b["type"] for b in user_msg["content"]]
+        # tool_result must be first; the tool_use must NOT have been stripped
+        assert types[0] == "tool_result", types
+        asst_types = [b["type"] for b in result[0]["content"]]
+        assert "tool_use" in asst_types, (
+            "tool_use was stripped instead of reordering the tool_result"
+        )
+        # the text block must survive, after the tool_result
+        assert "text" in types[1:]
+
+    def test_multiple_tool_results_keep_relative_order(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": [_mk_tool_use("t1"), _mk_tool_use("t2")],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "reminder"},
+                    _mk_tool_result("t1", "r1"),
+                    {"type": "text", "text": "middle note"},
+                    _mk_tool_result("t2", "r2"),
+                ],
+            },
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        user_msg = result[1]
+        blocks = user_msg["content"]
+        assert [b["type"] for b in blocks[:2]] == ["tool_result", "tool_result"]
+        assert blocks[0]["tool_use_id"] == "t1"
+        assert blocks[1]["tool_use_id"] == "t2"
+        texts = [b["text"] for b in blocks if b["type"] == "text"]
+        assert texts == ["reminder", "middle note"]
+
+    def test_already_ordered_message_untouched(self):
+        messages = [
+            {"role": "assistant", "content": [_mk_tool_use("t1")]},
+            {
+                "role": "user",
+                "content": [
+                    _mk_tool_result("t1"),
+                    {"type": "text", "text": "follow-up"},
+                ],
+            },
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        blocks = result[1]["content"]
+        assert [b["type"] for b in blocks] == ["tool_result", "text"]
+
+    def test_plain_user_text_message_unaffected(self):
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+            {"role": "user", "content": [{"type": "text", "text": "plain"}]},
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        assert result[0]["content"] == "hello"
+        assert result[2]["content"][0]["text"] == "plain"
+
+    def test_merged_consecutive_user_messages_reordered(self):
+        """Merge path: user text msg + user tool_result msg merged into one —
+        the merged content [text, tool_result] must also be reordered."""
+        messages = [
+            {"role": "assistant", "content": [_mk_tool_use("t1")]},
+            # a stray plain user message injected before the tool result
+            {"role": "user", "content": [{"type": "text", "text": "injected"}]},
+            {"role": "user", "content": [_mk_tool_result("t1")]},
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        # after merge there is one user message; tool_result must lead
+        user_msgs = [m for m in result if m["role"] == "user"]
+        assert len(user_msgs) == 1
+        types = [b["type"] for b in user_msgs[0]["content"]]
+        assert types[0] == "tool_result", types
+        # and the assistant tool_use must survive
+        assert any(
+            b.get("type") == "tool_use" for b in result[0]["content"]
+        )


### PR DESCRIPTION
## Symptom

Long-running sessions with context compression intermittently die on a **non-retryable HTTP 400** from Anthropic:

```
messages.N: `tool_use` ids were found without `tool_result` blocks immediately after: toolu_01Mg8mqq...
```

...even though the tool_result **is present** in the immediately following user message. With `fallback_providers` configured, the session silently switches to the fallback model and stays there for the rest of the turn.

## Root cause

Context compression / session restore can inject a text block (e.g. a system-reminder) **in front of** the tool_result inside the same user message:

```
msg[0] assistant: [text('[PRIOR CONTEXT]...'), tool_use(toolu_01Mg8mqq)]
msg[1] user:      [text('<system-reminder>...'), tool_result(toolu_01Mg8mqq)]   # <- 400
```

Anthropic requires tool_result blocks to **lead** the user message that follows a tool_use turn. `_strip_orphaned_tool_blocks` only checks *presence* in the next user message, not *position*, so the request sails through local validation and is rejected by the API.

Reproduced from a captured request dump of a real 166K-token session (2026-07-05).

## Fix — three related defects in the same conversion path

1. **`_reorder_tool_results_first()` (new):** structural invariant in `convert_messages_to_anthropic` — all tool_result blocks are moved to the front of every user message, preserving relative order within both groups. Any injection order becomes safe by construction, at any scale (single linear pass).

2. **Pipeline order: merge before strip.** Previously `_strip_orphaned_tool_blocks` ran before `_merge_consecutive_roles`, so a stray user message injected between a tool_use turn and its tool_result message made the adjacency check see a non-adjacent pair and **destructively strip** a tool_use/tool_result pair that becomes adjacent after merging.

3. **`_convert_user_message` empty check was vacuously true.** `all()` over a generator filtered to text blocks returns True when there are **no text blocks at all**, so a user message carrying only tool_result (or image) blocks was replaced by `(empty message)` — destroying the tool_result.

## Testing

- New regression test `tests/agent/test_anthropic_tool_result_block_order.py` (5 cases), including the exact observed failure shape. Failed before the fix, passes after.
- `tests/agent/test_anthropic_adapter.py` + thinking-block-order + kwargs-sanitize + deepseek/kimi thinking suites: **222 passed**, no regressions.
- E2E: replayed the real captured 400-triggering payload through the fixed converter — 1 ordering violation before → 0 after; per-turn adjacency invariant (every tool_use id covered by leading tool_results of the next user message) holds.

---
Single self-contained commit (code + regression test) based on latest `upstream/main` — cherry-pick friendly. Happy to rebase.