### PR TITLE
fix(gateway): systemd timing check false positive when unit not loaded in queried manager

### DIFF
--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -367,12 +367,20 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
     for flag in (["--user"], []):
         try:
             result = subprocess.run(
-                ["systemctl", *flag, "show", unit_name, "--property=TimeoutStopUSec"],
+                ["systemctl", *flag, "show", unit_name,
+                 "--property=TimeoutStopUSec", "--property=LoadState"],
                 capture_output=True, text=True, timeout=2.0,
             )
         except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
             continue
         if result.returncode != 0:
+            continue
+        # ``systemctl show`` exits 0 and prints *default* properties for
+        # units that don't exist in the queried manager (e.g. asking the
+        # root *user* manager about a *system* unit yields the stock
+        # TimeoutStopUSec=90s). Only trust a manager that actually has
+        # the unit loaded, otherwise we report a false mismatch.
+        if "LoadState=loaded" not in result.stdout:
             continue
         # Output: "TimeoutStopUSec=1min 30s" or "TimeoutStopUSec=90000000"
         for line in result.stdout.splitlines():


### PR DESCRIPTION
## Problem

`check_systemd_timing_alignment()` in `gateway/shutdown_forensics.py` queries `systemctl --user show <unit>` before falling back to the system manager.

`systemctl show` **exits 0 and prints default properties for units that don't exist** in the queried manager. So on hosts where a user manager is reachable (e.g. root with lingering enabled, or an active session), asking the *user* manager about the *system* unit `hermes-gateway.service` returns the stock default `TimeoutStopUSec=1min 30s` — and the check never reaches the system manager that actually owns the unit.

Result: a spurious warning on every gateway start, even when the installed unit already has the correct `TimeoutStopSec=210`:

```
WARNING gateway.run: Stale systemd unit detected: hermes-gateway.service has TimeoutStopSec=90s but drain_timeout=180s (expected >=210s)...
```

## Reproduction

```console
# unit exists only in the system manager, with TimeoutStopSec=210
$ systemctl show hermes-gateway.service -p TimeoutStopUSec
TimeoutStopUSec=3min 30s

# user manager happily reports defaults for a unit it doesn't have (rc=0)
$ systemctl --user show hermes-gateway.service -p TimeoutStopUSec; echo rc=$?
TimeoutStopUSec=1min 30s
rc=0
$ systemctl --user list-unit-files | grep -c hermes
0
```

## Fix

Also request `LoadState` and only trust a manager where the unit is actually `loaded`; otherwise continue to the next manager. Verified on a host exhibiting the false positive: with the fix the warning no longer fires and the check correctly reads the system unit's 210s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)