### PR TITLE
fix(credential-pool): attribute failures to the key that failed, not the shared current() pointer

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -922,6 +922,19 @@ def recover_with_credential_pool(
             )
             return False, has_retried_429
 
+    # Attribute the failure to the API key the agent actually dispatched the
+    # request with, not to pool.current(). The current() pointer is shared,
+    # mutable state — round-robin select() advances it on every call, and
+    # concurrent turns or a second process (gateway/dashboard) reloading the
+    # pool reset it to None — so by the time recovery runs it routinely points
+    # at a DIFFERENT, healthy entry. Marking that entry exhausted copies this
+    # request's error/reset time onto it and can take the whole pool offline
+    # from a single rate-limited key. ``_swap_credential`` keeps
+    # ``agent.api_key`` in sync with the entry in use, so it identifies the
+    # failing entry exactly (mirrors ``_recover_provider_pool`` in
+    # auxiliary_client.py, which already passes this hint).
+    failed_api_key = str(getattr(agent, "api_key", "") or "") or None
+
     effective_reason = classified_reason
     if effective_reason is None:
         if status_code == 402:
@@ -958,7 +971,7 @@ def recover_with_credential_pool(
             # Runtime credentials can be resolved by a separate pool instance,
             # leaving this recovery pool without ``current_id``. Match the key
             # that actually failed instead of quarantining a different account.
-            api_key_hint=getattr(agent, "api_key", None),
+            api_key_hint=failed_api_key,
         )
         if next_entry is not None:
             _ra().logger.info(
@@ -975,7 +988,16 @@ def recover_with_credential_pool(
         # rotate immediately. This prevents the "cancel-between-429s" trap
         # where has_retried_429 (a local var) gets reset on each new prompt,
         # causing the pool to retry the same exhausted credential forever.
-        current_entry = pool.current()
+        # Prefer the entry matching the failing key over the shared current()
+        # pointer, for the same attribution reason as above.
+        current_entry = None
+        if failed_api_key:
+            current_entry = next(
+                (e for e in pool.entries() if e.runtime_api_key == failed_api_key),
+                None,
+            )
+        if current_entry is None:
+            current_entry = pool.current()
         current_last_status = getattr(current_entry, "last_status", None) if current_entry else None
         if current_last_status == STATUS_EXHAUSTED:
             _ra().logger.info(
@@ -983,7 +1005,11 @@ def recover_with_credential_pool(
                 current_last_status,
             )
             rotate_status = status_code if status_code is not None else 429
-            next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
+            next_entry = pool.mark_exhausted_and_rotate(
+                status_code=rotate_status,
+                error_context=error_context,
+                api_key_hint=failed_api_key,
+            )
             if next_entry is not None:
                 _ra().logger.info(
                     "Credential %s (rate limit, pre-exhausted) — rotated to pool entry %s",
@@ -1007,7 +1033,11 @@ def recover_with_credential_pool(
         if not has_retried_429 and not usage_limit_reached:
             return False, True
         rotate_status = status_code if status_code is not None else 429
-        next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
+        next_entry = pool.mark_exhausted_and_rotate(
+            status_code=rotate_status,
+            error_context=error_context,
+            api_key_hint=failed_api_key,
+        )
         if next_entry is not None:
             _ra().logger.info(
                 "Credential %s (rate limit) — rotated to pool entry %s",
@@ -1107,7 +1137,11 @@ def recover_with_credential_pool(
         # Refresh failed — rotate to next credential instead of giving up.
         # The failed entry is already marked exhausted by try_refresh_current().
         rotate_status = status_code if status_code is not None else 401
-        next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
+        next_entry = pool.mark_exhausted_and_rotate(
+            status_code=rotate_status,
+            error_context=error_context,
+            api_key_hint=failed_api_key,
+        )
         if next_entry is not None:
             _ra().logger.info(
                 "Credential %s (auth refresh failed) — rotated to pool entry %s",

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1052,7 +1052,7 @@ def recover_with_credential_pool(
         # Subscription/entitlement 403s look like auth failures on the wire
         # but refresh cannot fix them — the OAuth token is already valid,
         # the account simply lacks the entitlement.  Without this guard,
-        # ``try_refresh_current()`` keeps minting fresh tokens against the
+        # the refresh path keeps minting fresh tokens against the
         # same unsubscribed account and the main agent loop spins re-issuing
         # the same 403 until the user Ctrl+C's.
         #
@@ -1105,9 +1105,13 @@ def recover_with_credential_pool(
                 agent.provider or "provider",
             )
             return False, has_retried_429
-        refreshed = pool.try_refresh_current()
+        # Refresh the entry that supplied the failing key, not current():
+        # the shared pointer can reference a different, healthy entry, and
+        # refreshing it would consume that entry's single-use refresh token
+        # (or mark it exhausted on failure) for a failure it never had.
+        refreshed = pool.try_refresh_matching(api_key_hint=failed_api_key)
         if refreshed is not None:
-            # ``try_refresh_current()`` re-mints a fresh OAuth token and reports
+            # ``try_refresh_matching()`` re-mints a fresh OAuth token and reports
             # success even when the upstream keeps rejecting it — a single-entry
             # pool (common for OAuth/Max subscribers) has nothing to rotate to,
             # so a bare "refreshed → retry" loop spins forever on the same dead
@@ -1135,7 +1139,7 @@ def recover_with_credential_pool(
             agent._swap_credential(refreshed)
             return True, has_retried_429
         # Refresh failed — rotate to next credential instead of giving up.
-        # The failed entry is already marked exhausted by try_refresh_current().
+        # The failed entry is already marked exhausted by the refresh attempt.
         rotate_status = status_code if status_code is not None else 401
         next_entry = pool.mark_exhausted_and_rotate(
             status_code=rotate_status,

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -369,3 +369,35 @@ class TestFailureAttribution:
         assert statuses["cred-0"] != "exhausted"
         swapped = agent._swap_credential.call_args[0][0]
         assert swapped.id == "cred-0"
+
+    def test_auth_refresh_targets_failing_key_not_pointer(self, tmp_path, monkeypatch):
+        """The auth path must refresh the entry that supplied the failing key,
+        not current(). With current() pointing at healthy A while key B failed,
+        try_refresh_current() force-refreshes A — for non-OAuth entries a
+        forced refresh marks the entry exhausted outright — so healthy A dies,
+        the hinted rotation then exhausts B, and the pool has nothing left."""
+        pool = self._make_pool(
+            tmp_path, monkeypatch,
+            [self._entry(0, "key-a"), self._entry(1, "key-b")],
+        )
+        # Point the shared cursor at the healthy entry, as a concurrent
+        # turn's select() would.
+        selected = pool.select()
+        assert selected.id == "cred-0"
+        assert pool.current().id == "cred-0"
+
+        agent = self._agent(pool, failing_key="key-b")
+        agent._is_entitlement_failure = MagicMock(return_value=False)
+
+        from agent.agent_runtime_helpers import recover_with_credential_pool
+
+        recovered, _ = recover_with_credential_pool(
+            agent, status_code=401, has_retried_429=False
+        )
+
+        assert recovered is True
+        statuses = self._statuses(pool)
+        assert statuses["cred-1"] == "exhausted"
+        assert statuses["cred-0"] != "exhausted"
+        swapped = agent._swap_credential.call_args[0][0]
+        assert swapped.id == "cred-0"

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -6,8 +6,12 @@ Covers:
 3. Eager fallback deferred when credential pool has credentials
 4. Eager fallback fires when no credential pool exists
 5. Full 429 rotation cycle: retry-same → rotate → exhaust → fallback
+6. Failure attribution: the entry matching the failing API key is marked
+   exhausted, not whatever pool.current() happens to point at
 """
 
+import json
+import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -194,7 +198,9 @@ class TestPoolRotationCycle:
         )
         assert recovered is True
         assert has_retried is False  # reset after rotation
-        pool.mark_exhausted_and_rotate.assert_called_once_with(status_code=429, error_context=None)
+        pool.mark_exhausted_and_rotate.assert_called_once_with(
+            status_code=429, error_context=None, api_key_hint=None
+        )
         agent._swap_credential.assert_called_once_with(entries[1])
 
     def test_pool_exhaustion_returns_false(self):
@@ -239,3 +245,127 @@ class TestPoolRotationCycle:
         )
         assert recovered is False
         assert has_retried is False
+
+
+# ---------------------------------------------------------------------------
+# 6. Failure attribution — mark the key that failed, not pool.current()
+# ---------------------------------------------------------------------------
+
+class TestFailureAttribution:
+    """Regression: recover_with_credential_pool must mark the entry whose API
+    key actually produced the failure.
+
+    pool.current() is shared mutable state: round-robin select() advances it,
+    concurrent turns move it, and a freshly loaded pool (second process) has
+    current() == None — in which case the old code fell through to
+    _select_unlocked() and exhausted the NEXT (healthy) entry, copying the
+    failing key's error/reset time onto it until the whole pool went offline.
+    """
+
+    def _make_pool(self, tmp_path, monkeypatch, entries):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        (hermes_home / "auth.json").write_text(
+            json.dumps({"version": 1, "credential_pool": {"anthropic": entries}})
+        )
+        from agent.credential_pool import load_pool
+
+        return load_pool("anthropic")
+
+    def _entry(self, idx, key, **overrides):
+        entry = {
+            "id": f"cred-{idx}",
+            "label": f"key-{idx}",
+            "auth_type": "api_key",
+            "priority": idx,
+            "source": "manual",
+            "access_token": key,
+        }
+        entry.update(overrides)
+        return entry
+
+    def _agent(self, pool, failing_key):
+        return SimpleNamespace(
+            provider="anthropic",
+            api_key=failing_key,
+            _credential_pool=pool,
+            _swap_credential=MagicMock(),
+        )
+
+    def _statuses(self, pool):
+        return {e.id: e.last_status for e in pool.entries()}
+
+    def test_billing_marks_failing_key_not_pointer(self, tmp_path, monkeypatch):
+        """Freshly loaded pool (current() is None): a 402 on key B must mark
+        entry B exhausted, not entry A (which _select_unlocked would return)."""
+        pool = self._make_pool(
+            tmp_path, monkeypatch,
+            [self._entry(0, "key-a"), self._entry(1, "key-b")],
+        )
+        assert pool.current() is None
+        agent = self._agent(pool, failing_key="key-b")
+
+        from agent.agent_runtime_helpers import recover_with_credential_pool
+
+        recovered, _ = recover_with_credential_pool(
+            agent, status_code=402, has_retried_429=False
+        )
+
+        assert recovered is True
+        statuses = self._statuses(pool)
+        assert statuses["cred-1"] == "exhausted"
+        assert statuses["cred-0"] != "exhausted"
+        swapped = agent._swap_credential.call_args[0][0]
+        assert swapped.id == "cred-0"
+
+    def test_rate_limit_marks_failing_key_not_pointer(self, tmp_path, monkeypatch):
+        """Same attribution for the 429 rotation path (second consecutive 429)."""
+        pool = self._make_pool(
+            tmp_path, monkeypatch,
+            [self._entry(0, "key-a"), self._entry(1, "key-b")],
+        )
+        agent = self._agent(pool, failing_key="key-b")
+
+        from agent.agent_runtime_helpers import recover_with_credential_pool
+
+        recovered, has_retried = recover_with_credential_pool(
+            agent, status_code=429, has_retried_429=True
+        )
+
+        assert recovered is True
+        assert has_retried is False
+        statuses = self._statuses(pool)
+        assert statuses["cred-1"] == "exhausted"
+        assert statuses["cred-0"] != "exhausted"
+
+    def test_pre_exhausted_check_uses_failing_key(self, tmp_path, monkeypatch):
+        """The 'already exhausted → rotate immediately' check must inspect the
+        failing entry, not pool.current(): first 429 on an already-exhausted
+        key rotates without burning a retry."""
+        pool = self._make_pool(
+            tmp_path, monkeypatch,
+            [
+                self._entry(0, "key-a"),
+                self._entry(
+                    1, "key-b",
+                    last_status="exhausted",
+                    last_status_at=time.time(),
+                    last_error_code=429,
+                ),
+            ],
+        )
+        agent = self._agent(pool, failing_key="key-b")
+
+        from agent.agent_runtime_helpers import recover_with_credential_pool
+
+        recovered, has_retried = recover_with_credential_pool(
+            agent, status_code=429, has_retried_429=False
+        )
+
+        assert recovered is True
+        assert has_retried is False
+        statuses = self._statuses(pool)
+        assert statuses["cred-0"] != "exhausted"
+        swapped = agent._swap_credential.call_args[0][0]
+        assert swapped.id == "cred-0"

--- a/tests/run_agent/test_codex_xai_oauth_recovery.py
+++ b/tests/run_agent/test_codex_xai_oauth_recovery.py
@@ -706,7 +706,7 @@ def test_recover_with_credential_pool_skips_refresh_on_entitlement_403():
     refresh_calls = {"n": 0}
 
     class _FakePool:
-        def try_refresh_current(self):
+        def try_refresh_matching(self, api_key_hint=None):
             refresh_calls["n"] += 1
             return MagicMock(id="should_not_be_called")
 
@@ -756,7 +756,7 @@ def test_recover_with_credential_pool_rotates_on_xai_spending_limit_403():
     class _FakePool:
         provider = "xai-oauth"
 
-        def try_refresh_current(self):
+        def try_refresh_matching(self, api_key_hint=None):
             refresh_calls["n"] += 1
             return MagicMock(id="should_not_be_called")
 
@@ -816,7 +816,7 @@ def test_recover_with_credential_pool_skips_refresh_on_bare_403_for_xai_oauth():
     refresh_calls = {"n": 0}
 
     class _FakePool:
-        def try_refresh_current(self):
+        def try_refresh_matching(self, api_key_hint=None):
             refresh_calls["n"] += 1
             return MagicMock(id="should_not_be_called")
 
@@ -857,7 +857,7 @@ def test_recover_with_credential_pool_still_refreshes_genuine_auth_failure():
     refresh_calls = {"n": 0}
 
     class _FakePool:
-        def try_refresh_current(self):
+        def try_refresh_matching(self, api_key_hint=None):
             refresh_calls["n"] += 1
             # Return a fake refreshed entry — semantically "refresh worked"
             entry = MagicMock()
@@ -1038,7 +1038,7 @@ def test_recover_with_credential_pool_refreshes_on_xai_bad_credentials_403():
     refresh_calls = {"n": 0}
 
     class _FakePool:
-        def try_refresh_current(self):
+        def try_refresh_matching(self, api_key_hint=None):
             refresh_calls["n"] += 1
             entry = MagicMock()
             entry.id = "entry_refreshed_after_stale"
@@ -1094,7 +1094,7 @@ def test_recover_with_credential_pool_still_blocks_real_entitlement():
     refresh_calls = {"n": 0}
 
     class _FakePool:
-        def try_refresh_current(self):
+        def try_refresh_matching(self, api_key_hint=None):
             refresh_calls["n"] += 1
             return MagicMock(id="should_not_be_called")
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6313,7 +6313,7 @@ class TestCredentialPoolRecovery:
         refreshed_entry = SimpleNamespace(label="refreshed-primary", id="abc")
 
         class _Pool:
-            def try_refresh_current(self):
+            def try_refresh_matching(self, api_key_hint=None):
                 return refreshed_entry
 
         agent._credential_pool = _Pool()
@@ -6331,7 +6331,7 @@ class TestCredentialPoolRecovery:
         """Repeated same-entry auth refreshes must eventually fall through.
 
         A single-entry OAuth pool re-mints a fresh token on every 401, so
-        ``try_refresh_current()`` reports success forever. The cap (#26080)
+        ``try_refresh_matching()`` reports success forever. The cap (#26080)
         must let the third consecutive same-entry refresh fall through
         (return not-recovered) so the fallback chain can activate instead of
         looping on the same dead credential.
@@ -6339,7 +6339,7 @@ class TestCredentialPoolRecovery:
         refreshed_entry = SimpleNamespace(label="primary", id="abc")
 
         class _Pool:
-            def try_refresh_current(self):
+            def try_refresh_matching(self, api_key_hint=None):
                 return refreshed_entry
 
         agent._credential_pool = _Pool()
@@ -6363,7 +6363,7 @@ class TestCredentialPoolRecovery:
         sequence = [entry_a, entry_a, entry_b, entry_b]
 
         class _Pool:
-            def try_refresh_current(self):
+            def try_refresh_matching(self, api_key_hint=None):
                 return sequence.pop(0)
 
         agent._credential_pool = _Pool()
@@ -6385,7 +6385,7 @@ class TestCredentialPoolRecovery:
         next_entry = SimpleNamespace(label="secondary", id="def")
 
         class _Pool:
-            def try_refresh_current(self):
+            def try_refresh_matching(self, api_key_hint=None):
                 return None  # refresh failed
 
             def mark_exhausted_and_rotate(self, *, status_code, error_context=None, api_key_hint=None):
@@ -6409,7 +6409,7 @@ class TestCredentialPoolRecovery:
         """401 with failed refresh and no other credentials returns not recovered."""
 
         class _Pool:
-            def try_refresh_current(self):
+            def try_refresh_matching(self, api_key_hint=None):
                 return None
 
             def mark_exhausted_and_rotate(self, *, status_code, error_context=None, api_key_hint=None):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6280,7 +6280,10 @@ class TestCredentialPoolRecovery:
             def current(self):
                 return SimpleNamespace(label="primary")
 
-            def mark_exhausted_and_rotate(self, *, status_code, error_context=None):
+            def entries(self):
+                return []
+
+            def mark_exhausted_and_rotate(self, *, status_code, error_context=None, api_key_hint=None):
                 assert status_code == 429
                 assert error_context is None
                 return next_entry
@@ -6385,7 +6388,7 @@ class TestCredentialPoolRecovery:
             def try_refresh_current(self):
                 return None  # refresh failed
 
-            def mark_exhausted_and_rotate(self, *, status_code, error_context=None):
+            def mark_exhausted_and_rotate(self, *, status_code, error_context=None, api_key_hint=None):
                 assert status_code == 401
                 assert error_context is None
                 return next_entry
@@ -6409,7 +6412,7 @@ class TestCredentialPoolRecovery:
             def try_refresh_current(self):
                 return None
 
-            def mark_exhausted_and_rotate(self, *, status_code, error_context=None):
+            def mark_exhausted_and_rotate(self, *, status_code, error_context=None, api_key_hint=None):
                 assert error_context is None
                 return None  # no more credentials
 
@@ -6486,7 +6489,10 @@ class TestCredentialPoolRecovery:
             def current(self):
                 return SimpleNamespace(label="primary")
 
-            def mark_exhausted_and_rotate(self, *, status_code, error_context=None):
+            def entries(self):
+                return []
+
+            def mark_exhausted_and_rotate(self, *, status_code, error_context=None, api_key_hint=None):
                 captured["status_code"] = status_code
                 captured["error_context"] = error_context
                 return next_entry


### PR DESCRIPTION
## Problem

When a request fails with a rate-limit/billing/auth error, the main conversation-loop recovery path (`recover_with_credential_pool` in `agent/agent_runtime_helpers.py`) identifies "which credential failed" by reading the pool's shared, mutable `current()` pointer instead of the API key the failing request actually used.

`current()` is advanced by every `select()` — round-robin rotation, concurrent turns on ThreadPoolExecutor workers, and other processes (gateway/dashboard) each `load_pool()` a fresh pool object with `_current_id = None`. So by the time recovery runs, `current()` routinely points at a **different, healthy** entry (or is `None`, in which case `mark_exhausted_and_rotate` falls through to `_select_unlocked()` and picks the *next* key). The recovery then marks that innocent entry exhausted and copies the failing request's error message and reset time onto it.

**Impact:** with `round_robin` and one hard-capped key (e.g. a zai key returning 429 code 1310 until a weekly reset), the mis-attribution lands on the healthy key with near-certainty over a multi-call run. Both entries end up `status=exhausted` with byte-identical error strings and reset times, `_select_unlocked()` reports "no available entries", and every request fails — a single rate-limited key takes the whole pool offline, the opposite of the pool's purpose. Observed in production: a healthy key marked exhausted with reason 1310 while a direct call with that same key returned HTTP 200.

> **Update (2026-07-20):** `main` has since fixed **one** of the four affected call sites — #66123 (`3483759`) added `api_key_hint=getattr(agent, "api_key", None)` to the **billing** path, with a comment describing this same hazard. The other three sites (both rate-limit rotations and auth-refresh-failed) and the "already exhausted" pre-check still use the shared pointer, so the 429 scenario described above remains reproducible on `main`. This PR (rebased onto current `main`) completes the fix for those remaining sites and adds regression tests for both the billing and rate-limit paths.

## Fix

`mark_exhausted_and_rotate` already supports an `api_key_hint` parameter for exactly this case, and the auxiliary-client path (`_recover_provider_pool` in `agent/auxiliary_client.py`) already passes it — with a comment describing precisely this hazard. The main path (billing aside, see update note) never did.

- Capture the failing key from `agent.api_key` (kept in sync with the entry in use by `_swap_credential`) once, normalized, and pass it as `api_key_hint` on all four `mark_exhausted_and_rotate` call sites (billing — unifying with the fix from #66123 — rate-limit pre-exhausted, rate-limit rotate, auth-refresh-failed).
- Make the "already exhausted → rotate immediately" pre-check look up the failing entry by key too, with the same fallback to `current()`.
- (Review follow-up, `7c23928`) The auth path called `try_refresh_current()` before the hinted rotation, so a stale pointer could force-refresh — and, for non-OAuth entries, exhaust — a healthy entry first. It now uses `try_refresh_matching(api_key_hint=...)` (added by #66123) to refresh the entry that supplied the failing key, resolved under the pool lock.

## Tests

- New `TestFailureAttribution` regression tests (`tests/agent/test_credential_pool_routing.py`) build a real two-entry pool from an on-disk auth store, simulate a failure on key B while `current()` is `None` (fresh pool — the cross-process case), and assert entry B is marked exhausted, never entry A. All three fail on the pre-#66123 code, and the two non-billing ones still fail on current `main`:
  - billing (402) path
  - rate-limit (429) rotation path
  - pre-exhausted immediate-rotation check
  - auth (401) refresh path with `current()` deliberately mismatched (fails on current `main`: the healthy entry gets exhausted by the forced refresh and the pool ends up fully offline)
- Updated existing fakes/mocks for the new kwarg (`tests/run_agent/test_run_agent.py`, `tests/agent/test_credential_pool_routing.py`).
- Affected suites green: `test_credential_pool_routing.py`, `test_credential_pool.py`, `test_credential_pool_interrupt.py`, `test_custom_pool_mismatch_guard.py`, `test_fallback_credential_isolation.py`, `test_restore_primary_pool_reselect.py`, `test_credential_pool_oauth_writethrough.py`, `TestCredentialPoolRecovery` (143 passed). Wider `-k "credential or pool or fallback or recover"` sweep over `tests/agent/` + `tests/run_agent/`: 778 passed; the 5 remaining failures also fail on unmodified `main` in this environment (4× `test_auxiliary_client.py` network-shaped, 1× `test_context_references.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
