### PR TITLE
feat(kanban): add due date to task creation

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -78,6 +78,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "skills": list(t.skills) if t.skills else [],
         "max_retries": t.max_retries,
         "session_id": t.session_id,
+        "due_at": t.due_at,
         "workflow_template_id": t.workflow_template_id,
         "current_step_key": t.current_step_key,
     }

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -914,6 +914,9 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # Optional due date/time as a Unix timestamp. Created by dashboard/API for
+    # human prioritisation; dispatch semantics remain priority/status-driven.
+    due_at: Optional[int] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -997,6 +1000,11 @@ class Task:
                 int(row["block_recurrences"])
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
+            ),
+            due_at=(
+                int(row["due_at"])
+                if "due_at" in keys and row["due_at"] is not None
+                else None
             ),
         )
 
@@ -1175,7 +1183,8 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    due_at               INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -1986,6 +1995,11 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
         )
 
+    if "due_at" not in cols:
+        # Optional due date/time for human planning. NULL preserves legacy rows
+        # and keeps dispatcher ordering unchanged unless future code opts in.
+        _add_column_if_missing(conn, "tasks", "due_at", "due_at INTEGER")
+
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
     # parses each statement in ``executescript`` against the live schema, so a
@@ -2407,6 +2421,7 @@ def create_task(
     session_id: Optional[str] = None,
     board: Optional[str] = None,
     project_id: Optional[str] = None,
+    due_at: Optional[int] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -2635,8 +2650,9 @@ def create_task(
                         created_by, created_at, workspace_kind, workspace_path,
                         branch_name, project_id, tenant, idempotency_key,
                         max_runtime_seconds,
-                        skills, max_retries, goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        skills, max_retries, goal_mode, goal_max_turns, session_id,
+                        due_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -2659,6 +2675,7 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        int(due_at) if due_at is not None else None,
                     ),
                 )
                 for pid in parents:
@@ -2678,6 +2695,7 @@ def create_task(
                         "branch_name": branch_name,
                         "skills": list(skills_list) if skills_list else None,
                         "goal_mode": bool(goal_mode) or None,
+                        "due_at": int(due_at) if due_at is not None else None,
                     },
                 )
             return task_id

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -68,6 +68,37 @@
     return str;
   }
 
+  function dueDateLabel(ts) {
+    if (!ts) return "";
+    const d = new Date(Number(ts) * 1000);
+    if (Number.isNaN(d.getTime())) return "";
+    return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  }
+  function dueDateFull(ts) {
+    if (!ts) return "";
+    const d = new Date(Number(ts) * 1000);
+    if (Number.isNaN(d.getTime())) return "";
+    return d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+  }
+  function dueDateInputValue(ts) {
+    if (!ts) return "";
+    const d = new Date(Number(ts) * 1000);
+    if (Number.isNaN(d.getTime())) return "";
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, "0");
+    const day = String(d.getDate()).padStart(2, "0");
+    return `${y}-${m}-${day}`;
+  }
+  function dueDateEndOfDay(value) {
+    if (!value) return null;
+    const d = new Date(value + "T23:59:59");
+    if (Number.isNaN(d.getTime())) return null;
+    return Math.floor(d.getTime() / 1000);
+  }
+  function isOverdue(task) {
+    return task && task.due_at && task.status !== "done" && task.status !== "archived" && Number(task.due_at) < Math.floor(Date.now() / 1000);
+  }
+
   // ``fetchJSON`` throws ``Error("<status>: <raw body>")`` on non-2xx, and
   // FastAPI bodies look like ``{"detail":"<message>"}``.  Pull the
   // human-readable message out so banners/toasts don't have to leak HTTP
@@ -2587,6 +2618,10 @@
               ? h(Badge, { className: "hermes-kanban-priority",
                            title: `Priority ${t.priority}. Higher-priority tasks are claimed first by the dispatcher.` }, `P${t.priority}`)
               : null,
+            t.due_at
+              ? h(Badge, { variant: "outline", className: cn("hermes-kanban-due", isOverdue(t) ? "hermes-kanban-due--overdue" : ""),
+                           title: `Due ${dueDateFull(t.due_at)}` }, "due ", dueDateLabel(t.due_at))
+              : null,
             t.tenant
               ? h(Badge, { variant: "outline", className: "hermes-kanban-tag",
                            title: `Tenant: ${t.tenant}. Free-form tag for grouping tasks (customer, project, team).` }, t.tenant)
@@ -2646,6 +2681,7 @@
     const [title, setTitle] = useState("");
     const [assignee, setAssignee] = useState("");
     const [priority, setPriority] = useState(0);
+    const [dueDate, setDueDate] = useState("");
     const [parent, setParent] = useState("");
     const [skills, setSkills] = useState("");
     // Workspace controls. `scratch` (default) ignores path; `worktree` optionally
@@ -2671,6 +2707,8 @@
         priority: Number(priority) || 0,
         triage: props.columnName === "triage",
       };
+      const dueAt = dueDateEndOfDay(dueDate);
+      if (dueAt) body.due_at = dueAt;
       if (parent) body.parents = [parent];
       // Parse comma-separated skills into a clean list. Blank = no
       // extras (omit key so backend leaves it null). The dispatcher
@@ -2695,7 +2733,7 @@
         if (Number.isFinite(gmt) && gmt > 0) body.goal_max_turns = gmt;
       }
       props.onSubmit(body);
-      setTitle(""); setAssignee(""); setPriority(0); setParent(""); setSkills("");
+      setTitle(""); setAssignee(""); setPriority(0); setDueDate(""); setParent(""); setSkills("");
       setWorkspaceKind("scratch"); setWorkspacePath("");
       setGoalMode(false); setGoalMaxTurns("");
     };
@@ -2744,6 +2782,13 @@
           placeholder: "pri",
           className: "h-7 text-xs w-16",
           title: "Priority. Higher-priority tasks are claimed first by the dispatcher. 0 = default.",
+        }),
+        h(Input, {
+          type: "date",
+          value: dueDate,
+          onChange: function (e) { setDueDate(e.target.value); },
+          className: "h-7 text-xs w-36",
+          title: "Optional due date for planning/triage visibility.",
         }),
       ),
       h(Input, {
@@ -3247,6 +3292,7 @@
         h(MetaRow, { label: tx(i18n, "status", "Status"), value: t.status }),
         h(AssigneeEditor, { task: t, onPatch: props.onPatch }),
         h(PriorityEditor, { task: t, onPatch: props.onPatch }),
+        h(DueDateEditor, { task: t, onPatch: props.onPatch }),
         t.tenant ? h(MetaRow, { label: tx(i18n, "tenant", "Tenant"), value: t.tenant }) : null,
         h(MetaRow, {
           label: tx(i18n, "workspace", "Workspace"),
@@ -3598,6 +3644,45 @@
         },
         className: "h-7 text-xs w-20",
       }),
+    );
+  }
+
+  function DueDateEditor(props) {
+    const { t } = useI18n();
+    const [editing, setEditing] = useState(false);
+    const [v, setV] = useState(dueDateInputValue(props.task.due_at));
+    useEffect(function () { setV(dueDateInputValue(props.task.due_at)); }, [props.task.due_at]);
+    const save = function () {
+      const dueAt = dueDateEndOfDay(v) || 0;
+      props.onPatch({ due_at: dueAt }).then(function () { setEditing(false); });
+    };
+    if (!editing) {
+      return h("div", { className: "hermes-kanban-meta-row" },
+        h("span", { className: "hermes-kanban-meta-label" }, tx(t, "dueDate", "Due date")),
+        h("span", {
+          className: cn("hermes-kanban-meta-value hermes-kanban-editable", isOverdue(props.task) ? "hermes-kanban-due-overdue" : ""),
+          onClick: function () { setEditing(true); },
+          title: tx(t, "clickToEdit", "Click to edit"),
+        }, props.task.due_at ? dueDateFull(props.task.due_at) : "—"),
+      );
+    }
+    return h("div", { className: "hermes-kanban-meta-row" },
+      h("span", { className: "hermes-kanban-meta-label" }, tx(t, "dueDate", "Due date")),
+      h(Input, {
+        type: "date", value: v, autoFocus: true,
+        onChange: function (e) { setV(e.target.value); },
+        onKeyDown: function (e) {
+          if (e.key === "Enter") { e.preventDefault(); save(); }
+          if (e.key === "Escape") setEditing(false);
+        },
+        className: "h-7 text-xs w-36",
+      }),
+      h(Button, { onClick: save, size: "sm", className: "h-7 text-xs" }, tx(t, "save", "Save")),
+      h(Button, {
+        onClick: function () { props.onPatch({ due_at: 0 }).then(function () { setEditing(false); }); },
+        size: "sm",
+        className: "h-7 text-xs",
+      }, tx(t, "clear", "Clear")),
     );
   }
 

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -283,6 +283,19 @@
   padding: 0.05rem 0.3rem !important;
 }
 
+.hermes-kanban-due {
+  font-size: 0.6rem !important;
+  padding: 0.05rem 0.3rem !important;
+  border-color: color-mix(in srgb, var(--color-ring) 45%, var(--color-border));
+}
+
+.hermes-kanban-due--overdue,
+.hermes-kanban-due-overdue {
+  color: var(--color-destructive, #dc2626) !important;
+  border-color: color-mix(in srgb, var(--color-destructive, #dc2626) 55%, var(--color-border)) !important;
+  font-weight: 700;
+}
+
 .hermes-kanban-needs-assignee {
   font-size: 0.6rem !important;
   padding: 0.05rem 0.3rem !important;

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -592,6 +592,7 @@ class CreateTaskBody(BaseModel):
     skills: Optional[list[str]] = None
     goal_mode: bool = False
     goal_max_turns: Optional[int] = None
+    due_at: Optional[int] = None
 
 
 @router.post("/tasks")
@@ -616,6 +617,7 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             skills=payload.skills,
             goal_mode=payload.goal_mode,
             goal_max_turns=payload.goal_max_turns,
+            due_at=payload.due_at,
         )
         task = kanban_db.get_task(conn, task_id)
         body: dict[str, Any] = {"task": _task_dict(task) if task else None}
@@ -816,6 +818,7 @@ class UpdateTaskBody(BaseModel):
     # complete --summary ... --metadata ...``.
     summary: Optional[str] = None
     metadata: Optional[dict] = None
+    due_at: Optional[int] = None
 
 
 @router.patch("/tasks/{task_id}")
@@ -907,6 +910,20 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     "VALUES (?, 'reprioritized', ?, ?)",
                     (task_id, json.dumps({"priority": int(payload.priority)}),
                      int(time.time())),
+                )
+
+        # --- due date -----------------------------------------------------
+        if payload.due_at is not None:
+            with kanban_db.write_txn(conn):
+                due_at = int(payload.due_at)
+                conn.execute(
+                    "UPDATE tasks SET due_at = ? WHERE id = ?",
+                    (due_at if due_at > 0 else None, task_id),
+                )
+                conn.execute(
+                    "INSERT INTO task_events (task_id, kind, payload, created_at) "
+                    "VALUES (?, 'due_date_changed', ?, ?)",
+                    (task_id, json.dumps({"due_at": due_at if due_at > 0 else None}), int(time.time())),
                 )
 
         # --- title / body -------------------------------------------------


### PR DESCRIPTION
## Summary
- add optional due_at storage/migration for kanban tasks
- allow dashboard Add task / AI triage and lane + forms to set a due date
- display and edit due dates on cards and task drawer

## Test plan
- python3 -m py_compile hermes_cli/kanban.py hermes_cli/kanban_db.py plugins/kanban/dashboard/plugin_api.py
- node --check plugins/kanban/dashboard/dist/index.js
- git diff --check
- FastAPI smoke: POST /tasks with due_at and PATCH due_at=0