### PR TITLE
fix(approval): scan commands carried by sh -c and env --split-string

### DIFF
--- a/tests/tools/test_execution_flag_detection.py
+++ b/tests/tools/test_execution_flag_detection.py
@@ -296,6 +296,21 @@ def test_execution_detection_handles_wrappers_and_compound_commands():
     assert dangerous is True
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "sudo -C 3 sh -c 'echo ok'",
+        "env -C /tmp sh -c 'echo ok'",
+        "env -iC /tmp sh -c 'echo ok'",
+        "env -a custom -S 'sh -c echo ok'",
+        "env --argv0 custom -S 'sh -c echo ok'",
+    ],
+)
+def test_case_sensitive_wrapper_option_operands_reach_carried_command(command):
+    dangerous, _, _ = detect_dangerous_command(command)
+    assert dangerous is True
+
+
 def test_hardline_payload_after_wrapper_still_reaches_floor():
     hardline, _ = detect_hardline_command(
         "sudo -u nobody sort --compress-program='rm -rf --no-preserve-root /' names"

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -118,6 +118,11 @@ _HARDLINE_BLOCK = [
     "exec shutdown",
     "nohup reboot",
     "setsid poweroff",
+    "${UNSET:-reboot}",
+    '"${UNSET:-reboot}"',
+    "${SET/x/reboot}",
+    "$(printf reboot)",
+    "`printf reboot`",
     # Bare subshell `(cmd)` and brace-group `{ cmd; }` openers put the trigger
     # at a real command position, so they must hit the floor just like `$(…)`.
     # These slipped through before the quote-aware command-start tokenizer
@@ -178,6 +183,10 @@ _HARDLINE_ALLOW = [
     # Unrelated commands that happen to contain the trigger word
     "grep 'shutdown' logs.txt",
     "echo reboot",
+    "echo '${UNSET:-reboot}'",
+    "'${UNSET:-reboot}'",
+    "echo '$(printf reboot)'",
+    "'$(printf reboot)'",
     "echo '# init 0 in comment'",
     "cat rebooting.log",
     "echo 'halt and catch fire'",
@@ -302,6 +311,313 @@ def test_root_wipe_at_command_position_is_hardline(command):
     is_hl, desc = detect_hardline_command(command)
     assert is_hl, f"real root wipe leaked past the floor: {command!r}"
     assert desc
+
+
+# -------------------------------------------------------------------------
+# Command-carrying wrappers
+# -------------------------------------------------------------------------
+#
+# A wrapper that runs a command string it is handed (`sh -c <string>`, GNU
+# `env -S` / `--split-string`) or the `su`/`runuser` `-c` form puts the real
+# verb inside an argument, not at a shell command position, so the anchored
+# patterns cannot see it. The detector re-scans the carried string as its own
+# command. Only literal strings are reachable: a value computed at runtime
+# (`sh -c "$(...)"`, a pipe into a shell, a variable) is arbitrary execution no
+# static scan can resolve, and stays out of scope (see issue for the ceiling).
+_LONG_CARRIER_PREFIX = "env " + " ".join(f"A{i}=x" for i in range(21))
+
+_CARRIED_HARDLINE_BYPASS = [
+    "sh -c 'reboot'",
+    "bash -c 'reboot'",
+    "dash -c 'reboot'",
+    "zsh -c 'reboot'",
+    "ksh -c 'reboot'",
+    "sh -c 'systemctl poweroff'",
+    "bash -c 'shutdown -h now'",
+    "sh -c 'rm -rf /'",
+    "bash -c 'rm -rf ~'",
+    "su -c 'reboot'",
+    "runuser -c 'reboot'",
+    "su root -c 'reboot'",
+    "su --command 'reboot' root",
+    "su --command='reboot' root",
+    "su --session-command 'reboot' root",
+    "su --session-command='reboot' root",
+    "runuser --command 'reboot' root",
+    "runuser --command='reboot' root",
+    "runuser --session-command 'reboot' root",
+    "runuser --session-command='reboot' root",
+    "su --command=re'boot' root",
+    "runuser --session-command re'boot' root",
+    "su --command 'echo safe' --command reboot root",
+    "runuser --session-command 'echo safe' --session-command reboot root",
+    "su -c 'echo safe' --command reboot root",
+    "runuser --command 'echo safe' -c reboot root",
+    "su -c reboot -w --command root",
+    "runuser -c reboot --whitelist-environment --command root",
+    "su -c reboot -g --command root",
+    "runuser -c reboot --shell --command root",
+    "su -c reboot root # --command 'echo safe'",
+    "runuser -c reboot root # --session-command 'echo safe'",
+    "su -c reboot root\nprintf safe",
+    "runuser -c reboot root\nrunuser --command 'echo safe' root",
+    "su --comm reboot root",
+    "runuser --sess reboot root",
+    'env --split-string="reboot"',
+    "env --split-string='rm -rf /'",
+    "env --split-string reboot",
+    "env --s='sh -c reboot'",
+    "env --split 'sh -c reboot'",
+    "env --split-strin='sh -c reboot'",
+    "env --s''='sh -c reboot'",
+    "env --sp''lit='sh -c reboot'",
+    "env --s$''='sh -c reboot'",
+    "env --$'split'='sh -c reboot'",
+    r"env --$'\x73'='sh -c reboot'",
+    r"env --s$'\0'='sh -c reboot'",
+    r"env --s$'\c@'='sh -c reboot'",
+    r"su --command re$'\0'boot root",
+    r"env --s=sh\ -c\ reboot",
+    r'''env -S "sh\_-c\_reboot"''',
+    r'''env --s="sh\_-c\_reboot"''',
+    "env --u sh -- sh -c reboot",
+    "env --c /tmp -- sh -c reboot",
+    "env --a sh -- sh -c reboot",
+    "env --u FOO --s reboot",
+    "env --c /tmp --s reboot",
+    "env --a custom --s reboot",
+    "env --b --s reboot",
+    "env -Sreboot",
+    "/bin/sh -c 'reboot'",
+    "sudo sh -c 'reboot'",
+    "env FOO=1 sh -c 'reboot'",
+    "env FOO=1 BAR=2 bash -c 'rm -rf /'",
+    "env A-B=1 sh -c reboot",
+    "env -S 'A-B=1 sh -c reboot'",
+    "sh -c 'sh -c reboot'",           # carrier nested in carrier
+    "ls; sh -c 'reboot'",             # after a separator
+    "sh -ec 'reboot'",                # clustered short options, -c is last
+    "bash -ec 'reboot'",
+    "dash -ec 'reboot'",
+    "sh -xc 'rm -rf /'",
+    "bash -exc 'rm -rf /'",
+    "sh -lc 'reboot'",
+    "sh -cx 'reboot'",                # letters after c are still shell options
+    "sh -ce 'reboot'",
+    "bash -cx 'reboot'",
+    "bash -ce 'reboot'",
+    # Shells keep parsing invocation options after seeing c; the first word
+    # after the complete option prefix is still the command string.
+    "sh -c -x 'reboot'",
+    "bash -c -e 'rm -rf /'",
+    "sh -ce -- 'reboot'",
+    "bash -c -o nounset 'reboot'",
+    "su -lc 'reboot'",
+    # GNU env permits S after no-argument options in a short-option bundle and
+    # appends operands after the split string to the resulting argv.
+    "env -iS 'reboot'",
+    "env -viS 'reboot'",
+    "env -iS 'rm -rf /'",
+    "env -iSreboot",
+    "env -viS/bin/sh -c reboot",
+    "env -vS/bin/sh -c 'rm -rf /'",
+    r"env -S '/bin/sh\_-c\_reboot'",
+    "env -S '-i sh -c reboot'",
+    "env -iC /tmp sh -c reboot",
+    "env -a custom -S 'sh -c reboot'",
+    "env --argv0 custom -S 'sh -c reboot'",
+    # A carrier reached behind wrapper OPTIONS, not just wrapper words and
+    # NAME=VALUE assignments. The whole option prefix must be skipped.
+    "env -i sh -c 'reboot'",
+    "env --ignore-environment sh -c 'reboot'",
+    "env -u FOO sh -c 'reboot'",
+    "env --unset=FOO sh -c 'reboot'",
+    "sudo -u root sh -c 'reboot'",
+    "sudo --user root sh -c 'reboot'",
+    "sudo -E sh -c 'reboot'",
+    "sudo -n sh -c 'reboot'",
+    "sudo -u root -E sh -c 'reboot'",
+    "sudo -u root sh -c 'rm -rf /'",
+    # Wrappers that carry no command of their own but still hide a carrier.
+    "nice sh -c 'reboot'",
+    "nice -n 10 sh -c 'reboot'",
+    "ionice sh -c 'reboot'",
+    "stdbuf -oL sh -c 'reboot'",
+    "timeout 5 sh -c 'reboot'",
+    "timeout -s KILL 5 sh -c 'reboot'",
+    "timeout 1.5s sh -c 'reboot'",
+    "timeout 5 bash -ec 'reboot'",
+    "doas sh -c 'reboot'",
+    "doas -u root sh -c 'reboot'",
+    # Wrappers nested and path-prefixed with options in between.
+    "sudo -u root env -i sh -c 'reboot'",
+    "env -i sudo sh -c 'reboot'",
+    "/usr/bin/env -i /bin/sh -c 'reboot'",
+    "/bin/sudo -u root sh -c 'reboot'",
+    # Options that really do take an operand still reach the carrier after it.
+    "ionice -c 2 sh -c 'reboot'",
+    "ionice -c best-effort sh -c 'reboot'",
+    "stdbuf -o L sh -c 'reboot'",
+    "timeout -s KILL 5 sh -c 'reboot'",
+]
+
+
+@pytest.mark.parametrize("command", _CARRIED_HARDLINE_BYPASS)
+def test_command_carrying_wrappers_are_hardline_blocked(command):
+    """A hardline verb inside a carried command string still hits the floor."""
+    is_hl, desc = detect_hardline_command(command)
+    assert is_hl, f"command-carrying wrapper leaked past the floor: {command!r}"
+    assert desc
+
+
+def test_carrier_scan_reaches_payload_beyond_former_token_boundary():
+    """Legal wrapper prefixes cannot push a carried payload out of the scan."""
+    for payload in ("reboot", "'rm -rf /'"):
+        command = f"{_LONG_CARRIER_PREFIX} sh -c {payload}"
+        is_hl, desc = detect_hardline_command(command)
+        assert is_hl, f"long carrier prefix leaked past the floor: {command!r}"
+        assert desc
+
+    benign = f"{_LONG_CARRIER_PREFIX} sh -c 'echo reboot'"
+    assert detect_hardline_command(benign) == (False, None)
+    is_dangerous, pattern, description = detect_dangerous_command(benign)
+    assert is_dangerous, f"long carrier prefix hid shell execution: {benign!r}"
+    assert pattern
+    assert description
+
+    too_long_prefix = "env " + " ".join(f"A{i}=x" for i in range(61))
+    truncated = f"{too_long_prefix} sh -c 'echo reboot'"
+    is_hl, hl_description = detect_hardline_command(truncated)
+    assert is_hl
+    assert hl_description == "command parser limit exceeded"
+    assert detect_dangerous_command(truncated) == (
+        True,
+        "command parser limit exceeded",
+        "command parser limit exceeded",
+    )
+
+    ordinary = "echo " + " ".join(f"arg{i}" for i in range(100))
+    assert detect_hardline_command(ordinary) == (False, None)
+    assert detect_dangerous_command(ordinary) == (False, None, None)
+
+
+# The verb sits at an ARGUMENT position inside the carried string (an echo/grep
+# argument, a filename, a non-destructive subcommand), so re-scanning the string
+# must keep the command-position anchor and leave these runnable. Same guard the
+# top-level anchor gives, carried one level down.
+_CARRIED_NOT_A_COMMAND = [
+    "sh -c 'echo reboot'",
+    "bash -c 'git commit -m reboot'",
+    "sh -c 'systemctl status nginx'",
+    "sh -c 'grep -r reboot /etc'",
+    "bash -c 'ls -la'",
+    "env --split-string='echo reboot'",
+    "env --s='/bin/echo reboot'",
+    "env --split '/bin/echo reboot'",
+    "env --n --s reboot",
+    "env --nu --s reboot",
+    "env --nul --s reboot",
+    "env FOO=1 --s reboot",
+    "env FOO=1 --debug sh -c reboot",
+    '''env --s='$(printf "reboot")' ''',
+    '''env --s=A=1 '$(printf sh)' -c reboot''',
+    r"env --unset=$'\U00110000' printf OK",
+    "su --command 'echo reboot' root",
+    "su --session-command='printf reboot' root",
+    "runuser --command 'echo reboot' root",
+    "runuser --session-command='printf reboot' root",
+    "su --command reboot --command 'echo safe' root",
+    "runuser --session-command reboot -c 'echo safe' root",
+    "su -- root --command reboot",
+    "runuser -- root --session-command reboot",
+    "su --command 'echo safe' --command",
+    "runuser --session-command 'echo safe' -c",
+    "su -wFOO,creboot root",
+    "runuser --whitelist-environment=FOO,creboot root",
+    "su -s/bin/sh root",
+    "runuser -u root --command reboot",
+    "su -m -w FOO --command reboot root",
+    "su --preserve-environment --whitelist-environment FOO --command reboot root",
+    "runuser -p -w FOO --session-command reboot root",
+    # Non-carrier programs whose own `-c` means something else entirely.
+    "gcc -c main.c",
+    "grep -c reboot access.log",
+    "env EDITOR=vim git commit",
+    "find . -name reboot.service",
+    "sh -ec 'echo reboot'",           # clustered options, benign payload
+    "sh -cx 'echo reboot'",           # options after c do not become its payload
+    "sh -- -c reboot",                # option parsing already ended
+    "sh /dev/null -c reboot",         # script path already selected
+    "bash -lc 'ls -la'",
+    "env -iS 'echo reboot'",
+    "env -Svi reboot",                # vi is the split-string program
+    "env -uS /bin/echo reboot",       # S is the operand of -u, not an option
+    "env -S/bin/echo reboot",
+    r"env -S '/bin/echo\_reboot'",
+    "env -- /bin/echo -iS reboot",
+    "env /bin/echo -viS reboot",
+    "env -0S reboot",                 # --null is incompatible with a command
+    # Wrapped commands with options, but no carrier or a benign payload, must
+    # not be swept up by the option-skipping prefix walk.
+    "sudo -u root ls",
+    "sudo -u root sh",                # interactive shell, no -c payload
+    "timeout 5 curl https://example.com",
+    "nice -n 10 make -j4",
+    "env -i printenv",
+    "env -u FOO make",
+    "stdbuf -oL grep reboot app.log",
+    "sudo -E git push",
+    "doas -u root ls",
+    "timeout 5 sh -c 'echo reboot'",
+    "sudo -u root sh -c 'echo reboot'",
+    # Interpreter carriers run another language rather than a shell command
+    # string, so they are the runtime-computed / arbitrary-code class and are
+    # deliberately left to the softer guards, not the shell-carrier extractor.
+    "python3 -c 'import os; os.system(\"reboot\")'",
+    "perl -e 'system(\"reboot\")'",
+    # A no-operand wrapper flag must not consume the wrapper's real program, so
+    # its arguments (which merely look like a carrier) are not rescanned. Here
+    # `echo` is the program and `sh -c reboot` are the words it prints.
+    "sudo -E echo sh -c reboot",
+    "sudo -n echo sh -c reboot",
+    "timeout --foreground echo sh -c reboot",
+    "timeout --preserve-status echo sh -c reboot",
+    "sudo -H echo sh -c reboot",
+    "env -v echo sh -c reboot",
+    "stdbuf -oL echo sh -c reboot",
+    # `nice -n` takes a numeric operand, so a non-numeric next token is the
+    # program, not the niceness value.
+    "nice -n echo sh -c reboot",
+    # `env` must only parse its own option/assignment prefix for `-S` /
+    # `--split-string`. After `--` or after the program word, later tokens are
+    # data for that program, not an env-carried command string.
+    "env -- echo --split-string reboot",
+    "env echo --split-string reboot",
+    "env -i echo --split-string reboot",
+    "env FOO=1 echo --split-string reboot",
+]
+
+
+@pytest.mark.parametrize("command", _CARRIED_NOT_A_COMMAND)
+def test_carried_arg_position_verb_is_not_hardline(command):
+    """A verb used as data inside a carried string is not a command."""
+    is_hl, desc = detect_hardline_command(command)
+    assert not is_hl, f"false positive: carried arg-position verb blocked: {command!r} ({desc})"
+
+
+def test_command_carrying_wrapper_blocked_under_yolo(clean_session, monkeypatch):
+    """The carried root wipe cannot be waived by yolo, the floor runs first."""
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+    for cmd in ("sh -c 'rm -rf /'", "env --split-string='rm -rf /'"):
+        result = check_all_command_guards(cmd, "local")
+        assert result["approved"] is False, f"yolo leaked carried hardline on {cmd!r}"
+
+
+def test_command_carrying_wrapper_blocked_in_default_mode(clean_session):
+    """The carried reboot (no dangerous backstop) is blocked in default mode."""
+    for cmd in ("dash -c 'reboot'", "env --split-string='reboot'", "su -c 'reboot'"):
+        result = check_all_command_guards(cmd, "local")
+        assert result["approved"] is False, f"carried reboot approved with no prompt: {cmd!r}"
 
 
 # -------------------------------------------------------------------------

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -511,14 +511,17 @@ def detect_hardline_command(command: str) -> tuple:
     if _command_parser_limit_exceeded(command):
         return (True, _PARSER_LIMIT_DESCRIPTION)
     normalized = _normalize_command_for_detection(command)
-    _, malformed_grep = _grep_safe_detection_variant(normalized)
-    if malformed_grep:
-        return (True, _MALFORMED_EXEC_DESCRIPTION)
-    for command_variant in _command_detection_variants(command):
-        variant_lower = command_variant.lower()
-        for pattern_re, description in HARDLINE_PATTERNS_COMPILED:
-            if pattern_re.search(variant_lower):
-                return (True, description)
+    try:
+        _, malformed_grep = _grep_safe_detection_variant(normalized)
+        if malformed_grep:
+            return (True, _MALFORMED_EXEC_DESCRIPTION)
+        for command_variant in _command_detection_variants(command):
+            variant_lower = command_variant.lower()
+            for pattern_re, description in HARDLINE_PATTERNS_COMPILED:
+                if pattern_re.search(variant_lower):
+                    return (True, description)
+    except _CommandScanLimitExceeded:
+        return (True, _PARSER_LIMIT_DESCRIPTION)
     return (False, None)
 
 
@@ -1046,12 +1049,15 @@ _COMMAND_WRAPPER_WORDS = {
     "command",
     "builtin",
 }
-_SUDO_OPTIONS_WITH_ARG = {
-    "-c", "--close-from",
-    "-g", "--group",
-    "-h", "--host",
-    "-p", "--prompt",
-    "-u", "--user",
+_WRAPPER_OPTIONS_WITH_ARG = {
+    "sudo": {
+        "-C", "--close-from",
+        "-g", "--group",
+        "-h", "--host",
+        "-p", "--prompt",
+        "-u", "--user",
+    },
+    "env": {"-a", "--argv0", "-C", "--chdir", "-u", "--unset"},
 }
 
 _INTERPRETER_EXEC_FLAGS = {
@@ -1118,9 +1124,14 @@ _SHELL_PUNCTUATION = {";", "&", "&&", "|", "||", "(", ")", "{", "}"}
 _MAX_DETECTION_COMMAND_CHARS = 128_000
 _MAX_SEPARATOR_FREE_COMMAND_CHARS = 4_096
 _MAX_DETECTION_SEGMENTS = 25_000
+_MAX_COMMAND_PREFIX_WORDS = 64
+_MAX_COMMAND_PREFIX_WORK = 8_192
 _PARSER_LIMIT_DESCRIPTION = "command parser limit exceeded"
 _MALFORMED_EXEC_DESCRIPTION = "command parser limit or malformed executable payload"
 
+
+class _CommandScanLimitExceeded(Exception):
+    """Structured command scanning exceeded its bounded work budget."""
 
 
 def _command_parser_limit_exceeded(command: str) -> bool:
@@ -1428,15 +1439,20 @@ _BASH_SHORT_OPTION_LETTERS = frozenset("ilrsDcabefhkmnptuvxBCEHPTOo")
 def _bash_exec_payload(args: list[str]) -> tuple[bool, str | None]:
     """Return whether Bash ``-c`` occurs and the command string it owns.
 
-    Bash's O/o invocation options consume the following argument even when
-    they precede a later ``-c`` or occur in the same short-option bundle.
-    Likewise, the two startup-file long options own their next token. Parsing
-    those operands first prevents both missed payloads and false ``-c`` hits.
+    ``-c`` is an invocation flag, not an option that immediately consumes the
+    next word. Shells keep parsing invocation options after it: in
+    ``sh -c -x cmd`` and ``bash -c -o nounset cmd``, ``cmd`` is the command
+    string. Parse the complete option prefix, including option operands and
+    ``--``, before selecting the first non-option word as the payload.
     """
     index = 0
+    found_c = False
     while index < len(args):
         token = args[index]
-        if token == "--" or not token.startswith(("-", "+")):
+        if token == "--":
+            index += 1
+            break
+        if not token.startswith(("-", "+")):
             break
         if token in _BASH_OPTIONS_WITH_ARG:
             index += 2
@@ -1451,14 +1467,12 @@ def _bash_exec_payload(args: list[str]) -> tuple[bool, str | None]:
         if not set(chars) <= _BASH_SHORT_OPTION_LETTERS:
             index += 1
             continue
+        found_c = found_c or (token.startswith("-") and "c" in chars)
         consumed_option_arg = "O" in chars or "o" in chars
-        if "c" not in chars:
-            index += 1 + int(consumed_option_arg)
-            continue
-        payload_index = index + 1 + int(consumed_option_arg)
-        payload = args[payload_index] if payload_index < len(args) else None
-        return True, payload
-    return False, None
+        index += 1 + int(consumed_option_arg)
+
+    payload = args[index] if found_c and index < len(args) else None
+    return found_c, payload
 
 
 def _read_tool_exec_flag(tool: str, args: list[str]) -> tuple[str, str] | None:
@@ -1682,35 +1696,135 @@ def _literal_command_substitution_output(script: str) -> str | None:
     return None
 
 
-def _replace_simple_command_substitutions(word: str) -> str:
+def _replace_command_word_expansions(word: str) -> str:
+    """Resolve supported literal expansions unless single-quote protected."""
     chars: list[str] = []
+    quote: str | None = None
     i = 0
     while i < len(word):
-        if word.startswith("$(", i):
+        char = word[i]
+        if char == "\\" and quote != "'" and i + 1 < len(word):
+            chars.extend((char, word[i + 1]))
+            i += 2
+            continue
+        if char == "'" and quote != '"':
+            quote = None if quote == "'" else "'"
+            chars.append(char)
+            i += 1
+            continue
+        if char == '"' and quote != "'":
+            quote = None if quote == '"' else '"'
+            chars.append(char)
+            i += 1
+            continue
+        if quote != "'" and word.startswith("$(", i):
             end = _scan_dollar_paren_end(word, i)
             if end is not None:
-                replacement = _literal_command_substitution_output(word[i + 2:end - 1])
+                replacement = _literal_command_substitution_output(
+                    word[i + 2:end - 1]
+                )
                 if replacement is not None:
                     chars.append(replacement)
                     i = end
                     continue
-        if word[i] == "`":
+        if quote != "'" and char == "`":
             end = _scan_backtick_end(word, i)
             if end is not None:
-                replacement = _literal_command_substitution_output(word[i + 1:end - 1])
+                replacement = _literal_command_substitution_output(
+                    word[i + 1:end - 1]
+                )
                 if replacement is not None:
                     chars.append(replacement)
                     i = end
                     continue
-        chars.append(word[i])
+        if quote != "'" and word.startswith("${", i):
+            end = word.find("}", i + 2)
+            if end != -1:
+                token = word[i:end + 1]
+                replacement = _PARAM_REPLACEMENT_RE.fullmatch(token)
+                if replacement is not None:
+                    chars.append(replacement.group("replacement"))
+                    i = end + 1
+                    continue
+                default = _PARAM_DEFAULT_RE.fullmatch(token)
+                if default is not None:
+                    chars.append(default.group("default"))
+                    i = end + 1
+                    continue
+        chars.append(char)
         i += 1
     return "".join(chars)
 
 
-def _replace_simple_shell_expansions(word: str) -> str:
-    word = _replace_simple_command_substitutions(word)
-    word = _PARAM_REPLACEMENT_RE.sub(lambda match: match.group("replacement"), word)
-    return _PARAM_DEFAULT_RE.sub(lambda match: match.group("default"), word)
+def _decode_ansi_c_shell_quote(word: str, start: int) -> tuple[int, str] | None:
+    """Decode a literal Bash ``$'...'`` word fragment without executing it."""
+    chars: list[str] = []
+    escapes = {
+        "a": "\a", "b": "\b", "e": "\x1b", "E": "\x1b", "f": "\f",
+        "n": "\n", "r": "\r", "t": "\t", "v": "\v", "\\": "\\",
+        "'": "'", '"': '"',
+    }
+    i = start + 2
+    while i < len(word):
+        char = word[i]
+        if char == "'":
+            return i + 1, "".join(chars)
+        if char != "\\" or i + 1 >= len(word):
+            chars.append(char)
+            i += 1
+            continue
+        escaped = word[i + 1]
+        if escaped == "\n":
+            i += 2
+            continue
+        if escaped in escapes:
+            chars.append(escapes[escaped])
+            i += 2
+            continue
+        if escaped in "01234567":
+            end = i + 2
+            while end < len(word) and end < i + 4 and word[end] in "01234567":
+                end += 1
+            value = int(word[i + 1:end], 8)
+            if value:
+                chars.append(chr(value))
+            i = end
+            continue
+        if escaped == "c" and i + 2 < len(word):
+            control = word[i + 2]
+            value = 127 if control == "?" else ord(control.upper()) & 31
+            if value:
+                chars.append(chr(value))
+            i += 3
+            continue
+        if escaped in {"x", "u", "U"}:
+            limit = {"x": 2, "u": 4, "U": 8}[escaped]
+            end = i + 2
+            while (
+                end < len(word)
+                and end < i + 2 + limit
+                and word[end] in "0123456789abcdefABCDEF"
+            ):
+                end += 1
+            if end > i + 2:
+                value = int(word[i + 2:end], 16)
+                if value == 0:
+                    i = end
+                    continue
+                if value <= 0x10FFFF:
+                    chars.append(chr(value))
+                    i = end
+                    continue
+                # Bash accepts extended values that Python cannot represent as
+                # Unicode. Preserve the source escape; it cannot form an ASCII
+                # option name and must never crash approval detection.
+                chars.append(word[i:end])
+                i = end
+                continue
+        # Bash preserves the backslash for an unrecognized ANSI-C escape.
+        chars.extend(("\\", escaped))
+        i += 2
+    return None
 
 
 def _strip_shell_word_syntax(word: str) -> str:
@@ -1721,8 +1835,19 @@ def _strip_shell_word_syntax(word: str) -> str:
         ch = word[i]
         if quote:
             if ch == "\\" and quote == '"' and i + 1 < len(word):
-                chars.append(word[i + 1])
-                i += 2
+                escaped = word[i + 1]
+                if escaped in {'$', '`', '"', "\\"}:
+                    chars.append(escaped)
+                    i += 2
+                    continue
+                if escaped == "\n":
+                    i += 2
+                    continue
+                # Inside double quotes, backslash is literal before every
+                # other character. GNU env must receive `\_` intact for its
+                # split-string separator grammar.
+                chars.append(ch)
+                i += 1
                 continue
             if ch == quote:
                 quote = None
@@ -1731,6 +1856,12 @@ def _strip_shell_word_syntax(word: str) -> str:
             chars.append(ch)
             i += 1
             continue
+        if word.startswith("$'", i):
+            decoded = _decode_ansi_c_shell_quote(word, i)
+            if decoded is not None:
+                i, value = decoded
+                chars.append(value)
+                continue
         if ch in ("'", '"'):
             quote = ch
             i += 1
@@ -1744,6 +1875,15 @@ def _strip_shell_word_syntax(word: str) -> str:
     return "".join(chars)
 
 
+def _shell_argv_word_for_detection(word: str) -> str:
+    """Decode literal shell quoting and escapes into an approximate argv word.
+
+    Runtime expansions stay opaque here. Expanding before quote parsing would
+    incorrectly activate `$()` and parameter syntax protected by single quotes.
+    """
+    return _strip_shell_word_syntax(word)
+
+
 def _deobfuscate_shell_word_for_detection(word: str) -> str:
     """Approximate how shell syntax can spell a command word.
 
@@ -1754,8 +1894,12 @@ def _deobfuscate_shell_word_for_detection(word: str) -> str:
     deobfuscated = word
     for _ in range(2):
         previous = deobfuscated
-        deobfuscated = _replace_simple_shell_expansions(deobfuscated)
-        deobfuscated = _strip_shell_word_syntax(deobfuscated)
+        deobfuscated = _replace_command_word_expansions(deobfuscated)
+        if deobfuscated == previous:
+            break
+    for _ in range(2):
+        previous = deobfuscated
+        deobfuscated = _shell_argv_word_for_detection(deobfuscated)
         if deobfuscated == previous:
             break
     return deobfuscated
@@ -1870,12 +2014,16 @@ def _mark_command_starts(command: str) -> str:
 
 def _iter_shell_command_word_spans(command: str):
     """Yield command-position words that may be executable names."""
+    work = 0
     for command_start in _iter_shell_command_starts(command):
         pos = command_start
         prefix_words = 0
-        skip_wrapper_options = False
+        option_wrapper: str | None = None
         skip_next_wrapper_arg = False
-        while prefix_words < 12:
+        while prefix_words < _MAX_COMMAND_PREFIX_WORDS:
+            work += 1
+            if work > _MAX_COMMAND_PREFIX_WORK:
+                raise _CommandScanLimitExceeded
             word_start, word_end, word = _read_shell_word(command, pos)
             if word_start == word_end:
                 break
@@ -1886,12 +2034,27 @@ def _iter_shell_command_word_spans(command: str):
                 pos = word_end
                 prefix_words += 1
                 continue
-            if skip_wrapper_options and lower_word.startswith("-"):
-                option_name = lower_word.split("=", 1)[0]
-                skip_next_wrapper_arg = (
-                    "=" not in lower_word
-                    and option_name in _SUDO_OPTIONS_WITH_ARG
+            if option_wrapper and deobfuscated.startswith("-"):
+                option_name = deobfuscated.split("=", 1)[0]
+                comparable_option = (
+                    option_name.lower() if option_name.startswith("--") else option_name
                 )
+                env_bundle = (
+                    _env_short_option_bundle(deobfuscated)
+                    if option_wrapper == "env"
+                    else None
+                )
+                if env_bundle and env_bundle[0]:
+                    _, value_option, attached, _ = env_bundle
+                    skip_next_wrapper_arg = (
+                        value_option in {"a", "u", "C"} and attached is None
+                    )
+                else:
+                    skip_next_wrapper_arg = (
+                        "=" not in deobfuscated
+                        and comparable_option
+                        in _WRAPPER_OPTIONS_WITH_ARG[option_wrapper]
+                    )
                 pos = word_end
                 prefix_words += 1
                 continue
@@ -1900,14 +2063,652 @@ def _iter_shell_command_word_spans(command: str):
             prefix_words += 1
 
             if lower_word in _COMMAND_WRAPPER_WORDS:
-                skip_wrapper_options = lower_word in {"sudo", "env"}
+                option_wrapper = lower_word if lower_word in {"sudo", "env"} else None
                 pos = word_end
                 continue
             if _ENV_ASSIGNMENT_RE.fullmatch(deobfuscated):
-                skip_wrapper_options = False
+                option_wrapper = None
                 pos = word_end
                 continue
             break
+
+
+# Programs whose `-c <string>` argument is a shell command line, so the real
+# verb lives inside that string rather than at a shell command position. The
+# hardline / dangerous patterns are command-position anchored and cannot see a
+# verb carried inside an argument, so we extract the string and re-scan it as
+# its own command (see `_iter_embedded_commands`). `su`/`runuser` take the same
+# `-c <string>` and are included. `env` is handled separately for its
+# `-S` / `--split-string` form.
+_SHELL_C_CARRIERS = frozenset({
+    "sh", "bash", "dash", "zsh", "ksh", "ash", "mksh", "sash",
+    "su", "runuser",
+})
+# How deep to follow carriers nested inside carriers (`sh -c 'sh -c reboot'`).
+# A small bound keeps a crafted deeply-nested string from spinning.
+_EMBEDDED_COMMAND_MAX_DEPTH = 4
+
+# Standard command wrappers a carrier can hide behind. A carrier reached
+# through any composition of these, with their options, option operands, bare
+# numeric or duration arguments, and NAME=VALUE assignments, is still the same
+# carried-command class (`sudo -u root sh -c 'reboot'`, `env -i sh -c 'reboot'`,
+# `timeout 5 sh -c 'reboot'`), so the whole prefix is skipped before looking for
+# the carrier program. This is the wrapper set the command-position rules treat
+# the same way, kept here so carrier detection does not fall behind it.
+_CARRIER_WRAPPER_WORDS = frozenset({
+    "sudo", "doas", "env", "exec", "nohup", "setsid", "time",
+    "command", "builtin", "nice", "ionice", "stdbuf", "timeout",
+})
+# A bare numeric or duration argument (`5`, `1.5s`, `30m`). `timeout` takes one
+# as its leading positional, so it is part of the prefix there.
+_WRAPPER_NUMERIC_ARG_RE = re.compile(r"\d+(?:\.\d+)?[A-Za-z]*")
+
+# Wrapper options that consume a following STRING operand (a username, host,
+# signal name, variable, chdir path). Skipping the operand is what lets the real
+# program after it be reached. A `--opt=value` form carries its own operand and
+# needs no entry. Any option NOT listed for its wrapper is treated as taking no
+# operand, so a no-operand flag (`sudo -E`, `sudo -n`, `timeout --foreground`)
+# can never swallow the wrapper's actual program word.
+_WRAPPER_OPTIONS_STR_ARG = {
+    "sudo": {
+        "-u", "--user", "-g", "--group", "-h", "--host", "-p", "--prompt",
+        "-r", "--role", "-t", "--type", "-R", "--chroot", "-D", "--chdir",
+        "-T", "--command-timeout", "-U", "--other-user",
+    },
+    "doas": {"-u", "-C", "-a"},
+    "env": {"-a", "--argv0", "-u", "--unset", "-C", "--chdir"},
+    "timeout": {"-s", "--signal", "-k", "--kill-after"},
+    "stdbuf": {"-i", "--input", "-o", "--output", "-e", "--error"},
+    "exec": {"-a"},
+}
+# Wrapper options whose operand is numeric (a priority, class, pid, fd), so a
+# non-numeric following token is the program, not the operand (`nice -n echo` is
+# `echo` run at default niceness, not niceness `echo`).
+_WRAPPER_OPTIONS_NUM_ARG = {
+    "nice": {"-n", "--adjustment"},
+    "ionice": {"-n", "--classdata", "-p", "--pid", "-P", "--pgid", "-u", "--uid"},
+    "sudo": {"-C", "--close-from"},
+}
+# `ionice -c` takes either a numeric class or a class name.
+_IONICE_CLASS_OPTIONS = {"-c", "--class"}
+_IONICE_CLASS_NAMES = {"none", "realtime", "best-effort", "idle"}
+
+
+def _carrier_prefix_word(token: str) -> str:
+    """Normalise a token to its lowercase basename for carrier matching."""
+    word = _strip_optional_shell_quotes(
+        _deobfuscate_shell_word_for_detection(token)
+    )
+    return word.lower().rsplit("/", 1)[-1]
+
+
+def _wrapper_option_takes_operand(wrapper: str, option: str, operand: str) -> bool:
+    """Whether ``option`` of ``wrapper`` consumes ``operand`` as its value."""
+    if wrapper == "env" and option.startswith("--"):
+        resolved = _env_long_option(option[2:])
+        if resolved in _ENV_LONG_OPTIONS_REQUIRED_ARG:
+            return True
+    if option in _WRAPPER_OPTIONS_STR_ARG.get(wrapper, ()):
+        return True
+    if option in _WRAPPER_OPTIONS_NUM_ARG.get(wrapper, ()):
+        return bool(_WRAPPER_NUMERIC_ARG_RE.fullmatch(operand))
+    if wrapper == "ionice" and option in _IONICE_CLASS_OPTIONS:
+        return bool(_WRAPPER_NUMERIC_ARG_RE.fullmatch(operand)) or (
+            operand.lower() in _IONICE_CLASS_NAMES
+        )
+    return False
+
+
+def _skip_wrapper_arguments(tokens: list, idx: int, wrapper: str) -> int:
+    """Advance past a wrapper's options, option operands, leading duration, and
+    assignments, stopping at the next program candidate.
+
+    Option parsing is arity-aware: a flag consumes one operand only when that
+    wrapper's option is known to take one, so `sudo -u root sh -c` skips the
+    `root` operand and reaches `sh`, while a no-operand flag (`sudo -E sh -c`,
+    `timeout --foreground echo ...`) leaves the following word as the program.
+    A carrier or another wrapper is never consumed as an operand either, so a
+    carrier is always reached rather than skipped.
+    """
+    env_options_ended = False
+    while idx < len(tokens):
+        word = _strip_optional_shell_quotes(
+            _deobfuscate_shell_word_for_detection(tokens[idx])
+        )
+        is_assignment = (
+            "=" in word if wrapper == "env" else bool(_ENV_ASSIGNMENT_RE.fullmatch(word))
+        )
+        if is_assignment:
+            idx += 1
+            env_options_ended = env_options_ended or wrapper == "env"
+            continue
+        if wrapper == "env" and not env_options_ended and word in {"-", "--"}:
+            idx += 1
+            env_options_ended = True
+            continue
+        if word.startswith("-") and word != "-" and not env_options_ended:
+            option = word.split("=", 1)[0]
+            env_bundle = (
+                _env_short_option_bundle(word) if wrapper == "env" else None
+            )
+            idx += 1
+            if env_bundle and env_bundle[0]:
+                _, value_option, attached, _ = env_bundle
+                if (
+                    value_option in {"a", "u", "C"}
+                    and attached is None
+                    and idx < len(tokens)
+                ):
+                    idx += 1
+                continue
+            if "=" not in word and idx < len(tokens):
+                nxt = tokens[idx]
+                nbase = _carrier_prefix_word(nxt)
+                stripped_nxt = _strip_optional_shell_quotes(
+                    _deobfuscate_shell_word_for_detection(nxt)
+                )
+                takes_operand = _wrapper_option_takes_operand(
+                    wrapper, option, stripped_nxt
+                )
+                if takes_operand and (
+                    wrapper == "env"
+                    or (
+                        not stripped_nxt.startswith("-")
+                        and not _ENV_ASSIGNMENT_RE.fullmatch(stripped_nxt)
+                        and nbase not in _SHELL_C_CARRIERS
+                        and nbase not in _CARRIER_WRAPPER_WORDS
+                    )
+                ):
+                    idx += 1
+            continue
+        # `timeout DURATION command` carries a bare duration positional before
+        # the command it runs.
+        if wrapper == "timeout" and _WRAPPER_NUMERIC_ARG_RE.fullmatch(word):
+            idx += 1
+            continue
+        break
+    return idx
+
+
+def _read_same_command_word(command: str, pos: int) -> tuple[int, int, str]:
+    """Read a word without crossing a comment or command-line boundary."""
+    while pos < len(command) and command[pos].isspace() and command[pos] not in "\r\n":
+        pos += 1
+    if pos >= len(command) or command[pos] in "\r\n#":
+        return (pos, pos, "")
+    return _read_shell_word(command, pos)
+
+
+def _read_command_tokens(
+    command: str,
+    start: int,
+    work: list[int],
+) -> tuple[list, bool]:
+    """Read a bounded command prefix and report whether more words remain."""
+    tokens: list = []
+    pos = start
+    carrier: str | None = None
+    carrier_rest = 0
+    while len(tokens) < _MAX_COMMAND_PREFIX_WORDS:
+        work[0] += 1
+        if work[0] > _MAX_COMMAND_PREFIX_WORK:
+            raise _CommandScanLimitExceeded
+        word_start, word_end, word = _read_same_command_word(command, pos)
+        if word_start == word_end:
+            return tokens, False
+        tokens.append(word)
+        pos = word_end
+
+        if carrier is None:
+            program, rest, prefix_incomplete = _carrier_program(tokens)
+            if program is None and not prefix_incomplete:
+                return tokens, False
+            if program is not None:
+                carrier = program
+                carrier_rest = rest
+
+        if carrier is not None and carrier not in {"env", "su", "runuser"}:
+            if _dash_c_payload(carrier, tokens[carrier_rest:]) is not None:
+                return tokens, False
+
+    work[0] += 1
+    if work[0] > _MAX_COMMAND_PREFIX_WORK:
+        raise _CommandScanLimitExceeded
+    word_start, word_end, _ = _read_same_command_word(command, pos)
+    return tokens, word_start != word_end
+
+
+def _carrier_program(tokens: list) -> tuple:
+    """Return ``(program, rest_index, prefix_incomplete)`` for a carrier.
+
+    Skips any composition of the leading exec wrappers in
+    ``_CARRIER_WRAPPER_WORDS`` together with their options, option operands,
+    numeric or duration arguments, and ``NAME=VALUE`` assignments (the same
+    prefix a command-position verb is read through), so a carrier reached
+    behind `sudo -u root ...`, `env -i ...`, `nice ...`, or `timeout 5 ...`
+    still resolves. Bails on any other leading token so a payload is only ever
+    extracted when the program really is a carrier.
+    """
+    idx = 0
+    while idx < len(tokens):
+        base = _carrier_prefix_word(tokens[idx])
+        if _ENV_ASSIGNMENT_RE.fullmatch(
+            _strip_optional_shell_quotes(
+                _deobfuscate_shell_word_for_detection(tokens[idx])
+            )
+        ):
+            idx += 1
+            continue
+        if base == "env":
+            # `env` is a carrier only when it carries `-S` / `--split-string`.
+            # Otherwise it is a pass-through wrapper (`env FOO=1 sh -c ...`,
+            # `env -i sh -c ...`), so skip its options and assignments and keep
+            # looking for the real program.
+            if _env_split_string_payload(tokens[idx + 1:]) is not None:
+                return ("env", idx + 1, False)
+            idx = _skip_wrapper_arguments(tokens, idx + 1, "env")
+            continue
+        if base in _SHELL_C_CARRIERS:
+            return (base, idx + 1, False)
+        if base in _CARRIER_WRAPPER_WORDS:
+            idx = _skip_wrapper_arguments(tokens, idx + 1, base)
+            continue
+        return (None, 0, False)
+    return (None, 0, True)
+
+
+_SU_LONG_OPTIONS_WITH_ARG = frozenset({
+    "command", "session-command", "shell", "group", "supp-group", "user",
+    "whitelist-environment",
+})
+_SU_LONG_OPTIONS_NO_ARG = frozenset({
+    "fast", "login", "preserve-environment", "pty", "no-pty", "help",
+    "version",
+})
+_SU_SHORT_OPTIONS_WITH_ARG = frozenset("cgGsuw")
+_SU_SHORT_OPTIONS_NO_ARG = frozenset("flmpPThV")
+_SU_COMMAND_LONG_OPTIONS = frozenset({"command", "session-command"})
+
+
+def _su_long_option(name: str) -> str | None:
+    """Resolve an exact or uniquely abbreviated util-linux su/runuser option."""
+    options = _SU_LONG_OPTIONS_WITH_ARG | _SU_LONG_OPTIONS_NO_ARG
+    if name in options:
+        return name
+    matches = [option for option in options if option.startswith(name)]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _su_command_payload(program: str, args: list) -> str | None:
+    """Parse util-linux su/runuser options and return the effective command."""
+    payload: str | None = None
+    runuser_user = False
+    preserve_environment = False
+    whitelist_environment = False
+    i = 0
+    while i < len(args):
+        token = _deobfuscate_shell_word_for_detection(args[i])
+        if token == "--":
+            break
+        if token == "-" or not token.startswith("-"):
+            # GNU getopt permutes options past positional words by default.
+            i += 1
+            continue
+        if token.startswith("--"):
+            option_token, attached = _split_option(token[2:])
+            option = _su_long_option(option_token)
+            if option is None:
+                return None
+            if option in _SU_LONG_OPTIONS_NO_ARG:
+                if attached is not None or option in {"help", "version"}:
+                    return None
+                preserve_environment = preserve_environment or option == "preserve-environment"
+                i += 1
+                continue
+            if attached is None:
+                if i + 1 >= len(args):
+                    return None
+                value = _deobfuscate_shell_word_for_detection(args[i + 1])
+                i += 2
+            else:
+                value = attached
+                i += 1
+            if option == "user":
+                if program != "runuser":
+                    return None
+                runuser_user = True
+            elif option in _SU_COMMAND_LONG_OPTIONS:
+                payload = value or None
+            elif option == "whitelist-environment":
+                whitelist_environment = True
+            continue
+
+        letters = token[1:]
+        pos = 0
+        while pos < len(letters):
+            option = letters[pos]
+            if option in _SU_SHORT_OPTIONS_NO_ARG:
+                if option in {"h", "V"}:
+                    return None
+                preserve_environment = preserve_environment or option in {"m", "p"}
+                pos += 1
+                continue
+            if option not in _SU_SHORT_OPTIONS_WITH_ARG:
+                return None
+            if pos + 1 < len(letters):
+                value = letters[pos + 1:]
+                i += 1
+            elif i + 1 < len(args):
+                value = _deobfuscate_shell_word_for_detection(args[i + 1])
+                i += 2
+            else:
+                return None
+            if option == "u":
+                if program != "runuser":
+                    return None
+                runuser_user = True
+            elif option == "c":
+                payload = value or None
+            elif option == "w":
+                whitelist_environment = True
+            break
+        else:
+            i += 1
+            continue
+        continue
+
+    # In runuser's -u mode, command-string options are mutually exclusive and
+    # the remaining argv is executed directly rather than passed to a shell.
+    # util-linux also rejects preserve-environment combined with a whitelist.
+    if runuser_user or (preserve_environment and whitelist_environment):
+        return None
+    return payload
+
+
+def _dash_c_payload(program: str, args: list) -> str | None:
+    """The command string a shell or account-switching carrier runs via `-c`.
+
+    Shell invocation options are flags: in `sh -cx cmd`, both `c` and `x` are
+    options and the next word is the command string. `su` and `runuser` use
+    getopt-style options, parsed by `_su_command_payload`. Only programs in
+    `_SHELL_C_CARRIERS` reach this helper.
+    """
+    if program in {"su", "runuser"}:
+        return _su_command_payload(program, args)
+    found, payload = _bash_exec_payload(args)
+    return _strip_optional_shell_quotes(payload) if found and payload else None
+
+
+_ENV_SHORT_OPTIONS_NO_ARG = frozenset("i0v")
+_ENV_SHORT_OPTIONS_WITH_ARG = frozenset("auCS")
+_ENV_LONG_OPTIONS_REQUIRED_ARG = frozenset({
+    "argv0", "unset", "chdir", "split-string",
+})
+_ENV_LONG_OPTIONS_OPTIONAL_ARG = frozenset({
+    "default-signal", "ignore-signal", "block-signal",
+})
+_ENV_LONG_OPTIONS_NO_ARG = frozenset({
+    "ignore-environment", "null", "list-signal-handling", "debug", "help",
+    "version",
+})
+
+
+def _env_long_option(name: str) -> str | None:
+    """Resolve an exact or uniquely abbreviated GNU env long option."""
+    options = (
+        _ENV_LONG_OPTIONS_REQUIRED_ARG
+        | _ENV_LONG_OPTIONS_OPTIONAL_ARG
+        | _ENV_LONG_OPTIONS_NO_ARG
+    )
+    if name in options:
+        return name
+    matches = [option for option in options if option.startswith(name)]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _env_short_option_bundle(
+    token: str,
+) -> tuple[bool, str | None, str | None, bool]:
+    """Parse a GNU env short-option bundle.
+
+    Returns ``(valid, value_option, attached_value, has_null)``. The first
+    option that takes a value owns the rest of the token, matching getopt
+    semantics; later letters are therefore data, not more options.
+    """
+    if not token.startswith("-") or token.startswith("--") or len(token) < 2:
+        return False, None, None, False
+    letters = token[1:]
+    has_null = False
+    for index, letter in enumerate(letters):
+        if letter in _ENV_SHORT_OPTIONS_NO_ARG:
+            has_null = has_null or letter == "0"
+            continue
+        if letter in _ENV_SHORT_OPTIONS_WITH_ARG:
+            attached = letters[index + 1:] or None
+            return True, letter, attached, has_null
+        return False, None, None, False
+    return True, None, None, has_null
+
+
+_ENV_SPLIT_ESCAPES = {
+    "f": "\f",
+    "n": "\n",
+    "r": "\r",
+    "t": "\t",
+    "v": "\v",
+    "#": "#",
+    "$": "$",
+    '"': '"',
+    "'": "'",
+    "\\": "\\",
+}
+
+
+def _split_gnu_env_string(value: str) -> list[str] | None:
+    """Split a GNU ``env -S`` value without applying shell semantics."""
+    words: list[str] = []
+    current: list[str] = []
+    quote: str | None = None
+    word_started = False
+    index = 0
+
+    def finish_word() -> None:
+        nonlocal current, word_started
+        if word_started:
+            words.append("".join(current))
+            current = []
+            word_started = False
+
+    while index < len(value):
+        char = value[index]
+        if quote is None:
+            if char.isspace():
+                finish_word()
+                index += 1
+                continue
+            if char in {"'", '"'}:
+                quote = char
+                word_started = True
+                index += 1
+                continue
+            if char == "#" and not word_started:
+                break
+            if char == "$":
+                # ${NAME} expands from env's runtime environment, so it is
+                # outside this literal carrier scanner's ceiling.
+                return None
+            if char == "\\":
+                if index + 1 >= len(value):
+                    return None
+                escaped = value[index + 1]
+                if escaped == "c":
+                    break
+                if escaped == "_":
+                    finish_word()
+                elif escaped in _ENV_SPLIT_ESCAPES:
+                    current.append(_ENV_SPLIT_ESCAPES[escaped])
+                    word_started = True
+                else:
+                    return None
+                index += 2
+                continue
+            current.append(char)
+            word_started = True
+            index += 1
+            continue
+
+        if char == quote:
+            quote = None
+            index += 1
+            continue
+        if char == "$" and quote == '"':
+            return None
+        if char == "\\":
+            if index + 1 >= len(value):
+                return None
+            escaped = value[index + 1]
+            if quote == "'" and escaped not in {"'", "\\"}:
+                current.append("\\")
+                word_started = True
+                index += 1
+                continue
+            if escaped == "c" and quote == '"':
+                return None
+            if escaped == "_" and quote == '"':
+                current.append(" ")
+            elif escaped in _ENV_SPLIT_ESCAPES:
+                current.append(_ENV_SPLIT_ESCAPES[escaped])
+            else:
+                return None
+            word_started = True
+            index += 2
+            continue
+        current.append(char)
+        word_started = True
+        index += 1
+
+    if quote is not None:
+        return None
+    finish_word()
+    return words
+
+
+def _env_split_effective_command(payload: str, trailing_args: list) -> str | None:
+    """Build env's effective argv from a split string and later operands."""
+    split_args = _split_gnu_env_string(payload)
+    if split_args is None:
+        return None
+    effective_argv = split_args + [
+        _shell_argv_word_for_detection(arg) for arg in trailing_args
+    ]
+    # GNU env inserts the split words back into its own argv and reprocesses
+    # them as options, assignments, and finally the command to execute.
+    return f"env {shlex.join(effective_argv)}" if effective_argv else None
+
+
+def _env_split_string_payload(args: list) -> str | None:
+    """The command string GNU `env` would run for `-S` / `--split-string`.
+
+    Only env's own option prefix is scanned. GNU env uses leading ``+`` getopt
+    mode, so parsing stops at ``--`` and at the first non-option word, including
+    a ``NAME=VALUE`` assignment. Searching every remaining token would
+    treat data for that program as env options, so
+    ``env -- echo --split-string reboot`` and ``env echo --split-string reboot``
+    would hardline-block on a carried ``reboot`` even though ``echo`` runs with
+    those words as arguments.
+    """
+    i = 0
+    null_output = False
+    while i < len(args):
+        stripped = _shell_argv_word_for_detection(args[i])
+        if stripped in {"--", "-"}:
+            return None
+        if not stripped.startswith("-"):
+            # GNU env's leading '+' getopt mode stops at the first assignment
+            # or program word. Later option-looking words are program data.
+            return None
+        if stripped.startswith("--"):
+            option_token, attached = _split_option(stripped[2:])
+            option = _env_long_option(option_token)
+            if option is None:
+                return None
+            if option in _ENV_LONG_OPTIONS_NO_ARG:
+                if attached is not None or option in {"help", "version"}:
+                    return None
+                null_output = null_output or option == "null"
+                i += 1
+                continue
+            if option in _ENV_LONG_OPTIONS_OPTIONAL_ARG:
+                # getopt_long accepts an optional long-option operand only in
+                # the attached `=VALUE` form, so no following argv is consumed.
+                i += 1
+                continue
+            if attached is None:
+                if i + 1 >= len(args):
+                    return None
+                value = _shell_argv_word_for_detection(args[i + 1])
+                i += 2
+            else:
+                value = attached
+                i += 1
+            if option == "split-string":
+                if null_output:
+                    return None
+                return _env_split_effective_command(value, args[i:])
+            continue
+
+        valid_bundle, value_option, attached, bundle_null = (
+            _env_short_option_bundle(stripped)
+        )
+        if not valid_bundle:
+            return None
+        if value_option == "S":
+            if null_output or bundle_null:
+                return None
+            if attached is not None:
+                return _env_split_effective_command(attached, args[i + 1:])
+            if i + 1 < len(args):
+                return _env_split_effective_command(
+                    _shell_argv_word_for_detection(args[i + 1]),
+                    args[i + 2:],
+                )
+            return None
+        null_output = null_output or bundle_null
+        i += 2 if value_option in {"a", "u", "C"} and attached is None else 1
+    return None
+
+
+def _direct_embedded_commands(command: str):
+    """Yield the literal command strings command-carrying wrappers would run."""
+    work = [0]
+    for start in _iter_shell_command_starts(command):
+        tokens, truncated = _read_command_tokens(command, start, work)
+        if not tokens:
+            continue
+        program, rest, prefix_incomplete = _carrier_program(tokens)
+        if program is None:
+            if truncated and prefix_incomplete:
+                raise _CommandScanLimitExceeded
+            continue
+        args = tokens[rest:]
+        payload = (
+            _env_split_string_payload(args)
+            if program == "env"
+            else _dash_c_payload(program, args)
+        )
+        if truncated and (program in {"env", "su", "runuser"} or payload is None):
+            raise _CommandScanLimitExceeded
+        if payload:
+            yield payload
+
+
+def _iter_embedded_commands(command: str, _depth: int = 0):
+    """Yield carried command strings, following carriers nested in carriers."""
+    if _depth >= _EMBEDDED_COMMAND_MAX_DEPTH:
+        return
+    for payload in _direct_embedded_commands(command):
+        yield payload
+        yield from _iter_embedded_commands(payload, _depth + 1)
 
 
 def _command_detection_variants(command: str):
@@ -1962,6 +2763,22 @@ def _command_detection_variants(command: str):
             continue
         seen.add(variant)
         yield variant
+    # A command-carrying wrapper (`sh -c 'reboot'`, `env --split-string='reboot'`)
+    # runs a command string that never sits at a shell command position, so the
+    # anchored patterns above miss the verb inside it. Re-scan each carried
+    # string as its own command. Because the re-scan keeps command-position
+    # anchoring, an arg-position verb (`sh -c 'echo reboot'`) stays runnable
+    # while a real one (`sh -c 'reboot'`) is caught. Only literal strings are
+    # reachable here: a value built at runtime (`sh -c "$(...)"`, a pipe into a
+    # shell, a variable) is arbitrary execution no static scan can resolve.
+    # Parse carriers from the original source so GNU env escape sequences such
+    # as ``\_`` survive until its split-string grammar interprets them.
+    for embedded in _iter_embedded_commands(command):
+        variant = _normalize_command_for_detection(embedded)
+        if not variant or variant in seen:
+            continue
+        seen.add(variant)
+        yield variant
 
 
 def _is_verification_artifact_cleanup(command: str) -> bool:
@@ -1996,15 +2813,23 @@ def detect_dangerous_command(command: str) -> tuple:
     if _is_verification_artifact_cleanup(command):
         return (False, None, None)
 
-    for command_variant in _command_detection_variants(command):
-        command_lower = command_variant.lower()
-        for pattern_re, description in DANGEROUS_PATTERNS_COMPILED:
-            if pattern_re.search(command_lower):
-                pattern_key = description
-                return (True, pattern_key, description)
+    try:
+        for command_variant in _command_detection_variants(command):
+            command_lower = command_variant.lower()
+            for pattern_re, description in DANGEROUS_PATTERNS_COMPILED:
+                if pattern_re.search(command_lower):
+                    pattern_key = description
+                    return (True, pattern_key, description)
+    except _CommandScanLimitExceeded:
+        return (True, _PARSER_LIMIT_DESCRIPTION, _PARSER_LIMIT_DESCRIPTION)
     normalized = _normalize_command_for_detection(command)
     for description, _ in _execution_flag_findings(normalized):
         return (True, description, description)
+    # env -S inserts its split words back into env's argv. Inspect those
+    # effective commands for execution-bearing flags as well as hardline verbs.
+    for embedded in _iter_embedded_commands(command):
+        for description, _ in _execution_flag_findings(embedded):
+            return (True, description, description)
     return (False, None, None)
 
 


### PR DESCRIPTION
Scan literal commands carried by shell -c, su/runuser command options, and GNU env split strings. Keep current main's quote-aware detection and isolate carrier parsing in a dedicated module. Preserve benign argument text, consume wrapper operands by arity, and bound parser work. Addresses the command-string subset of #58736; runtime-computed commands remain outside this static scanner's scope.



Validation: The updated portable sweep passed 520 cases, followed by 262 carrier/guard/denylist cases after the final operand correction and execution-flag check. The existing scaling benchmark passed. Four real-binary tests fail identically on unmodified main on Windows; three platform cases skip. The new carrier tests reproduce 75 failures on base main.

Updated on the refactored main at 1ab32b212b, with the repair folded into one commit.
