### PR TITLE
fix: preserve context after compression exhaustion

### DIFF
--- a/agent/compression_handoff.py
+++ b/agent/compression_handoff.py
@@ -1,0 +1,215 @@
+"""Deterministic handoff seeding for compression-exhausted sessions.
+
+This module is intentionally model-free. It is called after the agent has already
+failed with ``compression_exhausted=True``; calling another LLM to summarize at
+that point would risk the same context overflow loop. Instead we extract bounded,
+high-signal snippets from the failed result and seed the fresh session with a
+small reference message plus an assistant acknowledgement. The next real user
+message can then continue in a clean session without replaying the bloated
+transcript.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable
+
+_HANDOFF_MAX_CHARS = 10_000
+_SECTION_MAX_CHARS = 2_400
+_PATH_MAX = 24
+_TODO_MAX = 18
+
+_REPEATED_CHAR_RE = re.compile(r"([^\s])\1{80,}")
+_PATH_RE = re.compile(
+    r"(?<![\w@])(?:~|/(?:Users|home|private|tmp|var|Volumes|opt|etc))"
+    r"[^\s\"'`<>)]*"
+)
+_TODO_RE = re.compile(r"^\s*[-*]\s*\[[ xX>\-]?\]\s+.+")
+_HEADING_RE = re.compile(r"^\s{0,3}#{1,4}\s+.+")
+
+
+def _plain_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, dict):
+                text = part.get("text") or part.get("content")
+                if isinstance(text, str):
+                    parts.append(text)
+            elif isinstance(part, str):
+                parts.append(part)
+        return "\n".join(parts)
+    if content is None:
+        return ""
+    return str(content)
+
+
+def _squash(text: str, *, limit: int = _SECTION_MAX_CHARS) -> str:
+    text = _REPEATED_CHAR_RE.sub(lambda m: f"{m.group(1)}…[repeated]", text)
+    lines = [line.rstrip() for line in text.replace("\r\n", "\n").split("\n")]
+    collapsed: list[str] = []
+    blank = False
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            if not blank:
+                collapsed.append("")
+            blank = True
+            continue
+        blank = False
+        collapsed.append(stripped)
+    text = "\n".join(collapsed).strip()
+    if len(text) <= limit:
+        return text
+    head = text[: int(limit * 0.65)].rstrip()
+    tail = text[-int(limit * 0.25) :].lstrip()
+    return f"{head}\n…[gekürzt: {len(text) - len(head) - len(tail)} Zeichen ausgelassen]…\n{tail}".strip()
+
+
+def _dedupe_keep_order(items: Iterable[str], *, limit: int) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in items:
+        item = item.strip().rstrip(".,;:")
+        if not item or item in seen:
+            continue
+        seen.add(item)
+        out.append(item)
+        if len(out) >= limit:
+            break
+    return out
+
+
+def _iter_message_texts(agent_result: dict[str, Any]) -> Iterable[tuple[dict[str, Any], str]]:
+    for msg in agent_result.get("messages") or []:
+        if not isinstance(msg, dict):
+            continue
+        text = _plain_text(msg.get("content"))
+        if text.strip():
+            yield msg, text
+
+
+def _extract_paths(agent_result: dict[str, Any]) -> list[str]:
+    paths: list[str] = []
+    for _msg, text in _iter_message_texts(agent_result):
+        for match in _PATH_RE.findall(text):
+            cleaned = match.strip().rstrip(".,;:]")
+            if cleaned:
+                paths.append(cleaned)
+    return _dedupe_keep_order(paths, limit=_PATH_MAX)
+
+
+def _extract_todos(agent_result: dict[str, Any]) -> list[str]:
+    todos: list[str] = []
+    for _msg, text in _iter_message_texts(agent_result):
+        for line in text.splitlines():
+            if _TODO_RE.match(line):
+                todos.append(_squash(line, limit=400))
+    return _dedupe_keep_order(todos, limit=_TODO_MAX)
+
+
+def _extract_compressed_summary(agent_result: dict[str, Any]) -> str:
+    candidates: list[str] = []
+    for msg, text in _iter_message_texts(agent_result):
+        if msg.get("_compressed_summary") or "CONTEXT COMPACTION" in text:
+            keep: list[str] = []
+            for line in text.splitlines():
+                stripped = line.strip()
+                if not stripped:
+                    if keep and keep[-1] != "":
+                        keep.append("")
+                    continue
+                # Keep headings and concise content; drop long raw blocks.
+                if _HEADING_RE.match(stripped) or len(stripped) <= 260:
+                    keep.append(stripped)
+            if keep:
+                candidates.append("\n".join(keep))
+    return _squash("\n\n".join(candidates), limit=_SECTION_MAX_CHARS)
+
+
+def _extract_recent_user_intent(agent_result: dict[str, Any]) -> str:
+    for msg, text in reversed(list(_iter_message_texts(agent_result))):
+        if msg.get("role") == "user":
+            return _squash(text, limit=1_800)
+    return ""
+
+
+def _format_bullets(items: list[str]) -> str:
+    return "\n".join(f"- {item}" for item in items)
+
+
+def build_compression_handoff_messages(
+    agent_result: dict[str, Any],
+    *,
+    old_session_id: str,
+    new_session_id: str,
+    profile: str | None = None,
+    max_chars: int = _HANDOFF_MAX_CHARS,
+) -> list[dict[str, str]]:
+    """Return a bounded user/assistant handoff pair for a fresh session.
+
+    The first message is a *reference* user message seeded into the new
+    transcript. The second is an assistant acknowledgement. This yields a clean
+    prior-history sequence before the next real user turn: user → assistant →
+    user, avoiding provider role-order errors.
+    """
+    profile_name = (profile or "default").strip() or "default"
+    old_link = f"@session:{profile_name}/{old_session_id}" if old_session_id else "unknown"
+    error = _squash(str(agent_result.get("error") or "Compression exhausted"), limit=700)
+    summary = _extract_compressed_summary(agent_result)
+    recent = _extract_recent_user_intent(agent_result)
+    todos = _extract_todos(agent_result)
+    paths = _extract_paths(agent_result)
+
+    sections: list[str] = [
+        "[AUTOMATIC CONTEXT HANDOFF — REFERENCE ONLY]",
+        "The previous session exceeded the model context window after repeated compression attempts. Hermes started a fresh visible handoff session instead of sending another oversized model request.",
+        "",
+        "## Session links",
+        f"- Previous session: {old_link}",
+        f"- New session: {new_session_id or 'unknown'}",
+        "",
+        "## What carried over",
+        "- Compact working state extracted deterministically from the failed turn",
+        "- Open todo/path references found in the surviving context",
+        "- The old full transcript remains searchable via the previous-session link",
+        "",
+        "## Not carried over automatically",
+        "- Live terminal/process/UI state",
+        "- Huge raw tool outputs or media payloads that caused the overflow",
+        "- Any unsaved external side effects",
+        "",
+        "## Failure reason",
+        error,
+    ]
+
+    if summary:
+        sections.extend(["", "## Compact prior summary", summary])
+    if todos:
+        sections.extend(["", "## Open todos / active work", _format_bullets(todos)])
+    if paths:
+        sections.extend(["", "## Relevant file/path references", _format_bullets(paths)])
+    if recent:
+        sections.extend(["", "## Last visible user intent", recent])
+
+    sections.extend(
+        [
+            "",
+            "## Instruction for the assistant reading this history",
+            "Treat this as background context only. Do not answer this handoff message directly; wait for the next real user message and continue from the compact state above.",
+        ]
+    )
+
+    handoff_text = _squash("\n".join(sections), limit=max_chars)
+    return [
+        {"role": "user", "content": handoff_text},
+        {
+            "role": "assistant",
+            "content": (
+                "Handoff übernommen. Ich habe eine neue Session mit kompaktem "
+                "Arbeitsstand gestartet und warte auf die nächste Nutzeranweisung."
+            ),
+        },
+    ]

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -33,6 +33,10 @@ from typing import Any
 _GLOBAL_DEFAULTS: dict[str, Any] = {
     "tool_progress": "all",
     "tool_progress_grouping": "accumulate",  # "accumulate" = edit one bubble; "separate" = one msg per tool
+    # When true, terminal tool progress on markdown-capable platforms is shown
+    # as fenced code blocks. Set false for mobile/chat surfaces that should
+    # keep tool progress visible but compact/plain.
+    "tool_progress_code_blocks": True,
     "show_reasoning": False,
     # How a reasoning/thinking summary is rendered when show_reasoning is on.
     #   "code"      -> 💭 **Reasoning:** + fenced code block (legacy default)
@@ -240,6 +244,7 @@ def _normalise(setting: str, value: Any) -> Any:
         "interim_assistant_messages",
         "long_running_notifications",
         "busy_ack_detail",
+        "tool_progress_code_blocks",
     }:
         if isinstance(value, str):
             return value.lower() in {"true", "1", "yes", "on"}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -54,6 +54,7 @@ from typing import Callable, Dict, Optional, Any, List, Union
 # preserving the established test-patch surface.
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.async_utils import safe_schedule_threadsafe
+from agent.compression_handoff import build_compression_handoff_messages
 from agent.i18n import t
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
@@ -11365,9 +11366,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # fresh instead of replaying the same oversized context in an
             # infinite fail loop.  (#9893)
             if agent_result.get("compression_exhausted") and session_entry and session_key:
+                _compression_old_session_id = session_entry.session_id
                 logger.info(
                     "Auto-resetting session %s after compression exhaustion.",
-                    session_entry.session_id,
+                    _compression_old_session_id,
                 )
                 new_entry = self.session_store.reset_session(session_key)
                 self._evict_cached_agent(session_key)
@@ -11393,10 +11395,53 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         self._sync_telegram_topic_binding,
                         source, session_entry, reason="compression-exhausted-reset",
                     )
+
+                    # Seed the fresh session with a bounded, deterministic
+                    # handoff so the next user message has actionable context
+                    # instead of an empty reset.  This deliberately does NOT
+                    # call a model: compression is already exhausted, so any
+                    # extra summarisation LLM call risks repeating the same
+                    # context-length failure.  The old full transcript stays
+                    # searchable via the @session link embedded in the handoff.
+                    try:
+                        try:
+                            from hermes_cli.profiles import get_active_profile_name
+                            _handoff_profile = get_active_profile_name()
+                        except Exception:
+                            _handoff_profile = "default"
+                        _handoff_messages = build_compression_handoff_messages(
+                            agent_result,
+                            old_session_id=_compression_old_session_id,
+                            new_session_id=session_entry.session_id,
+                            profile=_handoff_profile,
+                        )
+                        for _handoff_msg in _handoff_messages:
+                            self.session_store.append_to_transcript(
+                                session_entry.session_id,
+                                _handoff_msg,
+                            )
+                        logger.info(
+                            "Seeded compression handoff %s -> %s (%d messages).",
+                            _compression_old_session_id,
+                            session_entry.session_id,
+                            len(_handoff_messages),
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            "Failed to seed compression handoff for %s -> %s: %s",
+                            _compression_old_session_id,
+                            session_entry.session_id,
+                            e,
+                        )
                 response = (response or "") + (
-                    "\n\n🔄 Session auto-reset — the conversation exceeded the "
-                    "maximum context size and could not be compressed further. "
-                    "Your next message will start a fresh session."
+                    "\n\n🔄 Automatischer Handoff — diese Unterhaltung war nach "
+                    "mehreren Kompressionsversuchen weiterhin zu groß für das "
+                    "Modell. Ich habe deshalb sichtbar eine neue Session mit "
+                    "kompaktem Arbeitsstand gestartet, statt noch einen "
+                    "übergroßen Modellaufruf zu versuchen. Terminal-/UI-Zustand "
+                    "kann dabei nicht vollständig übertragen werden; Dateien, "
+                    "Pfade, To-dos und der alte Session-Verweis wurden als "
+                    "Handoff in die neue Session übernommen."
                 )
 
             ts = time.time()  # Unix epoch float — consistent with DB storage
@@ -16437,6 +16482,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # at ``tool_preview_length`` (default 40) so a long or multi-line
             # command doesn't render as a huge block — matching the budget the
             # non-terminal preview path already applies (#42634).
+            try:
+                _terminal_progress_code_blocks = bool(
+                    resolve_display_setting(
+                        user_config,
+                        platform_key,
+                        "tool_progress_code_blocks",
+                        True,
+                    )
+                )
+            except Exception:
+                _terminal_progress_code_blocks = True
             _code_block_full = None
             _code_block_short = None
             try:
@@ -16444,7 +16500,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 _progress_adapter = None
             if (
-                getattr(_progress_adapter, "supports_code_blocks", False)
+                _terminal_progress_code_blocks
+                and getattr(_progress_adapter, "supports_code_blocks", False)
                 and tool_name == "terminal"
                 and isinstance(args, dict)
                 and isinstance(args.get("command"), str)

--- a/tests/gateway/test_compression_exhaustion_handoff.py
+++ b/tests/gateway/test_compression_exhaustion_handoff.py
@@ -1,0 +1,145 @@
+"""Compression exhaustion should hand off usable context into the fresh session.
+
+When the agent gives up after repeated compression attempts, the gateway must not
+just say "try /new" or reset to an empty transcript. It should reset visibly and
+seed the new session with a bounded, deterministic handoff: old-session pointer,
+compact working state, todos/path references, and an assistant acknowledgement so
+the next real user message has a clean role sequence.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+
+from agent.compression_handoff import build_compression_handoff_messages
+from gateway import run as gateway_run
+from gateway.config import GatewayConfig, Platform
+from gateway.session import SessionSource, SessionStore
+from hermes_state import SessionDB
+
+
+def _find_compression_exhausted_reset_block() -> ast.If:
+    tree = ast.parse(inspect.getsource(gateway_run))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        consts = [
+            n.value
+            for n in ast.walk(node.test)
+            if isinstance(n, ast.Constant) and isinstance(n.value, str)
+        ]
+        if "compression_exhausted" not in consts:
+            continue
+        calls = {
+            sub.func.attr
+            for sub in ast.walk(node)
+            if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Attribute)
+        }
+        if "reset_session" in calls:
+            return node
+    raise AssertionError("Could not locate compression-exhausted reset block")
+
+
+def _make_agent_result() -> dict:
+    huge_noise = "x" * 20_000
+    return {
+        "failed": True,
+        "compression_exhausted": True,
+        "error": "Context length exceeded (260,000 tokens). Cannot compress further.",
+        "messages": [
+            {
+                "role": "user",
+                "content": (
+                    "Bitte die Makler-Mail prüfen und nicht senden. "
+                    "Arbeitsdatei: /Users/semih/Documents/Immobilien/Hoelderlinstrasse_28/"
+                    "00_Arbeitsstand/Makler_Vrakas_Emailentwurf.txt\n" + huge_noise
+                ),
+            },
+            {
+                "role": "assistant",
+                "content": (
+                    "[CONTEXT COMPACTION — REFERENCE ONLY]\n"
+                    "## Historical Task Snapshot\n"
+                    "Semih wollte automatische Session-Handoffs bei vollem Kontext.\n"
+                    "## Historical Remaining Work\n"
+                    "Tests ergänzen, Core implementieren, nicht committen."
+                ),
+                "_compressed_summary": True,
+            },
+            {
+                "role": "user",
+                "content": (
+                    "[Your active task list was preserved across context compression]\n"
+                    "- [>] 1. Auto-Handoff implementieren\n"
+                    "- [ ] 2. Tests ausführen"
+                ),
+            },
+        ],
+    }
+
+
+class TestCompressionExhaustionHandoffBuilder:
+    def test_builds_bounded_role_safe_handoff_with_old_session_pointer(self):
+        handoff = build_compression_handoff_messages(
+            _make_agent_result(),
+            old_session_id="old-session-123",
+            new_session_id="new-session-456",
+            profile="default",
+        )
+
+        assert [m["role"] for m in handoff] == ["user", "assistant"]
+        assert "@session:default/old-session-123" in handoff[0]["content"]
+        assert "new-session-456" in handoff[0]["content"]
+        assert "Makler_Vrakas_Emailentwurf.txt" in handoff[0]["content"]
+        assert "Auto-Handoff implementieren" in handoff[0]["content"]
+        assert "x" * 1000 not in handoff[0]["content"]
+        assert len(handoff[0]["content"]) < 12_000
+        assert "Handoff übernommen" in handoff[1]["content"]
+
+
+class TestGatewayAutoResetSeedsHandoff:
+    def test_gateway_reset_block_builds_and_persists_handoff(self):
+        block = _find_compression_exhausted_reset_block()
+        name_calls = {
+            sub.func.id
+            for sub in ast.walk(block)
+            if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Name)
+        }
+        attr_calls = {
+            sub.func.attr
+            for sub in ast.walk(block)
+            if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Attribute)
+        }
+
+        assert "build_compression_handoff_messages" in name_calls
+        assert "append_to_transcript" in attr_calls
+
+    def test_seeded_handoff_is_loaded_by_fresh_session_without_old_bloat(self, tmp_path):
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        store._db = SessionDB(db_path=tmp_path / "state.db")
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="123", user_id="u1")
+        entry = store.get_or_create_session(source)
+        old_sid = entry.session_id
+        store._db.create_session(session_id=old_sid, source="telegram", user_id="u1")
+        store._db.replace_messages(
+            old_sid,
+            [{"role": "user", "content": "bloated" * 2000} for _ in range(80)],
+        )
+
+        new_entry = store.reset_session(entry.session_key)
+        assert new_entry is not None
+        handoff = build_compression_handoff_messages(
+            _make_agent_result(),
+            old_session_id=old_sid,
+            new_session_id=new_entry.session_id,
+            profile="default",
+        )
+        for msg in handoff:
+            store.append_to_transcript(new_entry.session_id, msg)
+
+        loaded = store.load_transcript(new_entry.session_id)
+        assert [m["role"] for m in loaded] == ["user", "assistant"]
+        assert "@session:default/" in loaded[0]["content"]
+        assert "bloated" not in loaded[0]["content"]
+        assert len(store.load_transcript(old_sid)) == 80

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1,3 +1,5 @@
+import ast
+import inspect
 import json
 import os
 import subprocess
@@ -3880,6 +3882,96 @@ def test_session_compress_syncs_session_key_after_rotation(monkeypatch):
         server._sessions.pop("sid", None)
 
 
+def test_tui_compression_exhausted_handoff_rotates_to_fresh_session(monkeypatch):
+    old_agent = types.SimpleNamespace(session_id="old-key", model="old-model")
+    new_agent = types.SimpleNamespace(session_id="new-key", model="new-model")
+    session = _session(
+        agent=old_agent,
+        history=[{"role": "user", "content": "bloated" * 1000}],
+        attached_images=["/tmp/image.png"],
+        image_counter=1,
+    )
+    server._sessions["sid"] = session
+
+    persisted = {}
+    emitted = []
+
+    class _DB:
+        def replace_messages(self, key, messages):
+            persisted["key"] = key
+            persisted["messages"] = messages
+
+    @server.contextlib.contextmanager
+    def _fake_session_db(_session):
+        yield _DB()
+
+    monkeypatch.setattr(server, "_new_session_key", lambda: "new-key")
+    monkeypatch.setattr(server, "_current_profile_name", lambda: "default")
+    monkeypatch.setattr(server, "_set_session_context", lambda key: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
+    monkeypatch.setattr(server, "_session_db", _fake_session_db)
+    monkeypatch.setattr(server, "_restart_slash_worker", lambda sid, s: None)
+    monkeypatch.setattr(server, "_session_info", lambda agent, session: {"model": agent.model})
+    monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
+    monkeypatch.setattr(server, "_make_agent", lambda sid, key, **kwargs: new_agent)
+
+    try:
+        notice = server._seed_compression_exhausted_handoff(
+            "sid",
+            session,
+            {
+                "compression_exhausted": True,
+                "error": "Context length exceeded",
+                "messages": [
+                    {"role": "user", "content": "Bitte weiterarbeiten"},
+                    {
+                        "role": "assistant",
+                        "content": "[CONTEXT COMPACTION]\n## Summary\nWichtig",
+                        "_compressed_summary": True,
+                    },
+                ],
+            },
+        )
+
+        assert session["session_key"] == "new-key"
+        assert session["agent"] is new_agent
+        assert [m["role"] for m in session["history"]] == ["user", "assistant"]
+        assert "@session:default/session-key" in session["history"][0]["content"]
+        assert session["attached_images"] == []
+        assert session["image_counter"] == 0
+        assert persisted["key"] == "new-key"
+        assert persisted["messages"] == session["history"]
+        assert "@session:default/session-key" in notice
+        assert ("session.info", "sid", {"model": "new-model"}) in emitted
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_prompt_submit_wires_tui_handoff_when_compression_exhausted():
+    tree = ast.parse(inspect.getsource(server._run_prompt_submit))
+    compression_branch = None
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        constants = [
+            sub.value
+            for sub in ast.walk(node.test)
+            if isinstance(sub, ast.Constant) and isinstance(sub.value, str)
+        ]
+        if "compression_exhausted" in constants:
+            compression_branch = node
+            break
+
+    assert compression_branch is not None
+    calls = {
+        sub.func.id
+        for sub in ast.walk(compression_branch)
+        if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Name)
+    }
+    assert "_seed_compression_exhausted_handoff" in calls
+
+
 def test_prompt_submit_sets_approval_session_key(monkeypatch):
     from tools.approval import get_current_session_key
 
@@ -6605,6 +6697,7 @@ def test_browser_manage_connect_default_local_reports_launch_hint(monkeypatch):
                 "hermes_cli.browser_connect.get_chrome_debug_candidates",
                 return_value=[],
             ),
+            patch("platform.system", return_value="Linux"),
         ):
             resp = server.handle_request(
                 {

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2959,6 +2959,94 @@ def _sync_session_key_after_compress(
             pass
 
 
+def _seed_compression_exhausted_handoff(
+    sid: str,
+    session: dict,
+    agent_result: dict,
+) -> str:
+    """Rotate a Desktop/TUI session to a fresh handoff after compression exhausts.
+
+    Gateway platforms had this guard first; Desktop/TUI runs through
+    ``prompt.submit`` in this module, so it needs the same deterministic handoff
+    instead of surfacing the context-length error against the bloated history.
+    """
+    old_key = str(
+        session.get("session_key")
+        or getattr(session.get("agent"), "session_id", "")
+        or ""
+    )
+    new_key = _new_session_key()
+    profile_name = _current_profile_name()
+
+    from agent.compression_handoff import build_compression_handoff_messages
+
+    handoff_messages = build_compression_handoff_messages(
+        agent_result,
+        old_session_id=old_key,
+        new_session_id=new_key,
+        profile=profile_name,
+    )
+
+    # Build a fresh agent anchored on the fresh DB session. Keep the same live
+    # UI session id (sid), model override, cwd/profile, approval wiring, and
+    # active-session lease; only the persisted conversation id + history rotate.
+    tokens = _set_session_context(new_key)
+    home_token = None
+    session_db = None
+    profile_home = session.get("profile_home")
+    if profile_home:
+        home_token = set_hermes_home_override(profile_home)
+        try:
+            from hermes_state import SessionDB
+
+            session_db = SessionDB(db_path=Path(profile_home) / "state.db")
+        except Exception:
+            session_db = None
+    try:
+        new_agent = _make_agent(
+            sid,
+            new_key,
+            session_id=new_key,
+            session_db=session_db,
+            model_override=session.get("model_override"),
+            reasoning_config_override=session.get("create_reasoning_override"),
+            service_tier_override=session.get("create_service_tier_override"),
+        )
+    finally:
+        if home_token is not None:
+            reset_hermes_home_override(home_token)
+        _clear_session_context(tokens)
+
+    session["agent"] = new_agent
+    _sync_session_key_after_compress(
+        sid,
+        session,
+        clear_pending_title=False,
+        restart_slash_worker=True,
+    )
+    with session["history_lock"]:
+        session["history"] = [dict(msg) for msg in handoff_messages]
+        session["history_version"] = int(session.get("history_version", 0)) + 1
+        session["attached_images"] = []
+        session["image_counter"] = 0
+
+    _ensure_session_db_row(session)
+    with _session_db(session) as db:
+        if db is not None:
+            try:
+                db.replace_messages(new_key, handoff_messages)
+            except Exception:
+                logger.debug("failed to persist TUI compression handoff", exc_info=True)
+
+    _emit("session.info", sid, _session_info(new_agent, session))
+    return (
+        "🔄 Automatischer Handoff — diese Desktop/TUI-Unterhaltung war nach "
+        "mehreren Kompressionsversuchen weiterhin zu groß für das Modell. "
+        "Ich habe eine neue interne Session mit kompaktem Arbeitsstand gestartet. "
+        f"Alte Session: @session:{profile_name}/{old_key}"
+    )
+
+
 def _get_usage(agent) -> dict:
     g = lambda k, fb=None: getattr(agent, k, 0) or (getattr(agent, fb, 0) if fb else 0)
     usage = {
@@ -8466,6 +8554,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
     _emit("message.start", sid)
 
     def run():
+        nonlocal agent
         approval_token = None
         session_tokens = []
         home_token = None  # per-turn HERMES_HOME override for a resumed remote profile
@@ -8642,8 +8731,16 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
 
             last_reasoning = None
             status_note = None
+            handoff_done = False
+            raw = ""
+            status = "complete"
             if isinstance(result, dict):
-                if isinstance(result.get("messages"), list):
+                if result.get("compression_exhausted"):
+                    raw = _seed_compression_exhausted_handoff(sid, session, result)
+                    agent = session["agent"]
+                    status = "complete"
+                    handoff_done = True
+                elif isinstance(result.get("messages"), list):
                     with session["history_lock"]:
                         current_version = int(session.get("history_version", 0))
                         if current_version == history_version:
@@ -8679,27 +8776,28 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     sid, session, clear_pending_title=False, restart_slash_worker=True,
                 )
 
-                raw = result.get("final_response", "")
-                status = (
-                    "interrupted"
-                    if result.get("interrupted")
-                    else "error" if result.get("error") else "complete"
-                )
-                # When the backend produced no visible response AND reported a
-                # real error (e.g. invalid model slug → provider 4xx), surface
-                # that error as the visible text instead of shipping an empty
-                # turn to Ink. Mirrors classic CLI behavior at cli.py where
-                # (failed|partial) + no final_response → "Error: <detail>".
-                # Leaves the None-with-no-error path untouched: an empty
-                # successful turn still renders as empty, and the existing
-                # "(empty)" sentinel handling stays in its own lane.
-                if (not raw) and result.get("error") and (
-                    result.get("failed") or result.get("partial")
-                ):
-                    raw = f"Error: {result.get('error')}"
-                lr = result.get("last_reasoning")
-                if isinstance(lr, str) and lr.strip():
-                    last_reasoning = lr.strip()
+                if not handoff_done:
+                    raw = result.get("final_response", "")
+                    status = (
+                        "interrupted"
+                        if result.get("interrupted")
+                        else "error" if result.get("error") else "complete"
+                    )
+                    # When the backend produced no visible response AND reported a
+                    # real error (e.g. invalid model slug → provider 4xx), surface
+                    # that error as the visible text instead of shipping an empty
+                    # turn to Ink. Mirrors classic CLI behavior at cli.py where
+                    # (failed|partial) + no final_response → "Error: <detail>".
+                    # Leaves the None-with-no-error path untouched: an empty
+                    # successful turn still renders as empty, and the existing
+                    # "(empty)" sentinel handling stays in its own lane.
+                    if (not raw) and result.get("error") and (
+                        result.get("failed") or result.get("partial")
+                    ):
+                        raw = f"Error: {result.get('error')}"
+                    lr = result.get("last_reasoning")
+                    if isinstance(lr, str) and lr.strip():
+                        last_reasoning = lr.strip()
             else:
                 raw = str(result)
                 status = "complete"
@@ -8724,7 +8822,12 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             # ("✓ Goal achieved" / "⏸ budget exhausted") is surfaced as
             # a system line so the user sees progress regardless of
             # outcome. Mirrors gateway/run._post_turn_goal_continuation.
-            if status == "complete" and isinstance(raw, str) and raw.strip():
+            if (
+                not handoff_done
+                and status == "complete"
+                and isinstance(raw, str)
+                and raw.strip()
+            ):
                 try:
                     from hermes_cli.goals import GoalManager
 
@@ -8770,7 +8873,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
 
             # Apply pending_title now that the DB row exists.
             _pending = session.get("pending_title")
-            if _pending and status == "complete":
+            if _pending and status == "complete" and not handoff_done:
                 _pdb = _get_db()
                 if _pdb:
                     _session_key = session.get("session_key") or sid
@@ -8790,7 +8893,8 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                         pass
 
             if (
-                status == "complete"
+                not handoff_done
+                and status == "complete"
                 and isinstance(raw, str)
                 and raw.strip()
                 and isinstance(text, str)
@@ -8821,7 +8925,8 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             # calls / reasoning already stream separately and would be
             # noisy to read aloud.
             if (
-                status == "complete"
+                not handoff_done
+                and status == "complete"
                 and isinstance(raw, str)
                 and raw.strip()
                 and _voice_tts_enabled()


### PR DESCRIPTION
## Summary
- Add deterministic compression-exhaustion handoff messages so a fresh session keeps a compact old-session pointer, prior summary, todos, and paths.
- Seed the fresh handoff in both gateway and Desktop/TUI paths when compression is exhausted.
- Keep Telegram tool progress visible without forcing fenced code blocks on markdown-capable platforms.

## Test Plan
- `./venv/bin/python -m py_compile agent/compression_handoff.py gateway/display_config.py gateway/run.py tui_gateway/server.py tests/gateway/test_compression_exhaustion_handoff.py tests/test_tui_gateway_server.py`
- `./scripts/run_tests.sh tests/test_tui_gateway_queue_on_busy.py tests/gateway/test_busy_session_ack.py tests/gateway/test_queue_consumption.py tests/gateway/test_compression_interrupt_demotion_56391.py tests/gateway/test_internal_event_never_interrupts_busy_session.py tests/test_tui_gateway_server.py tests/gateway/test_compression_exhaustion_handoff.py tests/gateway/test_35809_auto_reset_clean_context.py tests/run_agent/test_1630_context_overflow_loop.py`