### PR TITLE
fix(security): guard native image routing with file-safety policy

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -633,6 +633,17 @@ def _file_to_data_url(path: Path) -> Optional[str]:
     proceeds.
     """
     try:
+        from agent.file_safety import raise_if_read_blocked
+
+        raise_if_read_blocked(str(path))
+    except ValueError as exc:
+        logger.warning("image_routing: blocked local image attachment %s -- %s", path, exc)
+        return None
+    except Exception:
+        # Keep attachment routing best-effort if the guard itself is unavailable.
+        pass
+
+    try:
         raw = path.read_bytes()
     except Exception as exc:
         logger.warning("image_routing: failed to read %s — %s", path, exc)

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -780,6 +780,44 @@ class TestFormatCompatibility:
         b64 = url.split(",", 1)[1]
         assert base64.b64decode(b64) == _png_bytes()
 
+    def test_file_to_data_url_blocks_read_denied_image_path(self, tmp_path: Path):
+        """Native image routing must honor the shared credential read guard."""
+        from agent.image_routing import _file_to_data_url
+
+        img_path = tmp_path / ".env"
+        img_path.write_bytes(_png_bytes())
+
+        assert _file_to_data_url(img_path) is None
+
+    def test_native_content_parts_skip_read_denied_local_image(self, tmp_path: Path):
+        from agent.image_routing import build_native_content_parts
+
+        img_path = tmp_path / ".env.local"
+        img_path.write_bytes(_png_bytes())
+
+        parts, skipped = build_native_content_parts("inspect this", [str(img_path)])
+
+        assert skipped == [str(img_path)]
+        assert all(part.get("type") != "image_url" for part in parts)
+
+    def test_native_content_parts_blocks_image_symlink_to_read_denied_file(self, tmp_path: Path):
+        from agent.image_routing import build_native_content_parts
+        import os
+        import pytest
+
+        secret = tmp_path / ".env"
+        secret.write_bytes(_png_bytes())
+        img_link = tmp_path / "secret.png"
+        try:
+            os.symlink(secret, img_link)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"symlinks unavailable: {exc}")
+
+        parts, skipped = build_native_content_parts("inspect this", [str(img_link)])
+
+        assert skipped == [str(img_link)]
+        assert all(part.get("type") != "image_url" for part in parts)
+
     def test_jpeg_passes_through_no_transcode(self, tmp_path: Path):
         from agent.image_routing import _file_to_data_url
 


### PR DESCRIPTION
## Summary
Salvage of #58517 by @necoweb3 (cherry-picked onto current main, authorship preserved). Native image routing (`agent/image_routing.py::_file_to_data_url`) now honors the shared file-safety read guard before embedding local image bytes into outbound model requests — closing the path where a read-denied file (including an image-named symlink pointing at `.env`/`auth.json`) could be base64-embedded into a provider request.

## Changes
- `agent/image_routing.py`: `_file_to_data_url()` calls `raise_if_read_blocked()` before `read_bytes()`. Blocked files are treated like unreadable attachments — logged, returned as `skipped`, turn continues. Guard failure itself no-ops (best-effort, consistent with the defense-in-depth framing).
- Regression tests: direct read-denied path, skipped native content parts, and the symlink-disguise case.

## Validation
| Check | Result |
|---|---|
| `tests/agent/test_image_routing.py` | 97 passed, 0 failed |
| E2E (real imports, temp HERMES_HOME): `.env` with real PNG bytes, `secret.png` symlink → `.env`, direct `auth.json` | all blocked/skipped |
| E2E positive control: legit PNG | embeds, base64 round-trip byte-identical |

11-line guard at the single byte-loading chokepoint used by `build_native_content_parts` (gateway native multimodal path). Same policy chokepoint as #57698 / #58709.

Closes #58517.

## Infographic

![image-routing-read-guard](https://v3b.fal.media/files/b/0aa1036a/NRp_eE2mR4VGk1WQBdvbE_o7L6lfZf.png)
