### PR TITLE
fix(qqbot): add missing is_reconnect parameter to QQAdapter.connect()

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,7 +278,7 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -190,6 +190,18 @@ class TestVoiceAttachmentSSRFProtection:
         assert kwargs.get("follow_redirects") is True
         assert kwargs.get("event_hooks", {}).get("response") == [_ssrf_redirect_guard]
 
+    def test_connect_accepts_is_reconnect_param(self):
+        """connect() must accept is_reconnect for gateway reconnect compat."""
+        from gateway.platforms.qqbot import QQAdapter
+
+        adapter = QQAdapter(_make_config(app_id="a", client_secret="b"))
+        adapter._ensure_token = mock.AsyncMock(side_effect=RuntimeError("stop early"))
+
+        connected_default = asyncio.run(adapter.connect())
+        connected_reconnect = asyncio.run(adapter.connect(is_reconnect=True))
+        assert connected_default is False
+        assert connected_reconnect is False
+
 
 # ---------------------------------------------------------------------------
 # WebSocket proxy handling


### PR DESCRIPTION
## Problem

QQ Bot connection enters an infinite failure loop. Every reconnect attempt crashes:

```
QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'
```

## Root Cause

The Hermes gateway calls `adapter.connect(is_reconnect=True)` during reconnection. All platform adapters (Telegram, Discord, Slack, etc.) accept this parameter — but QQAdapter's `connect()` only accepted `self`, causing reconnection to fail permanently.

## Fix

One line — add `is_reconnect: bool = False` to `QQAdapter.connect()` signature. Default value preserves existing behavior for initial connections.

## Verification

- Gateway logs confirm QQ Bot now connects and reconnects successfully
- Session resume works correctly after server-initiated reconnect (op 7)