### PR TITLE
fix(stt): read Groq model from stt.groq.model config before env fallback

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -919,6 +919,17 @@ class TestTranscribeAudioDispatch:
 
         assert mock_groq.call_args[0][1] == DEFAULT_GROQ_STT_MODEL
 
+    def test_config_groq_model_used(self, sample_ogg):
+        config = {"groq": {"model": "whisper-large-v3"}}
+        with patch("tools.transcription_tools._load_stt_config", return_value=config), \
+             patch("tools.transcription_tools._get_provider", return_value="groq"), \
+             patch("tools.transcription_tools._transcribe_groq",
+                   return_value={"success": True, "transcript": "hi"}) as mock_groq:
+            from tools.transcription_tools import transcribe_audio
+            transcribe_audio(sample_ogg, model=None)
+
+        assert mock_groq.call_args[0][1] == "whisper-large-v3"
+
     def test_config_local_model_used(self, sample_ogg):
         config = {"local": {"model": "small"}}
         with patch("tools.transcription_tools._load_stt_config", return_value=config), \

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1671,7 +1671,8 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         return _transcribe_local_command(file_path, model_name)
 
     if provider == "groq":
-        model_name = model or DEFAULT_GROQ_STT_MODEL
+        groq_cfg = stt_config.get("groq", {})
+        model_name = model or groq_cfg.get("model", DEFAULT_GROQ_STT_MODEL)
         return _transcribe_groq(file_path, model_name)
 
     if provider == "openai":


### PR DESCRIPTION
## What does this PR do?

Fixes the Groq STT provider's model resolution to read from `stt.groq.model` in config.yaml before falling back to the `STT_GROQ_MODEL` env var / default. Every other STT provider (OpenAI, Mistral, ElevenLabs, local) already follows this pattern, but the Groq branch skipped the config lookup entirely.

## Related Issue

Fixes #58734

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/transcription_tools.py` — Add `stt_config.get("groq", {})` lookup before `DEFAULT_GROQ_STT_MODEL` fallback, matching the pattern used by OpenAI/Mistral/ElevenLabs/local providers
- `tests/tools/test_transcription_tools.py` — Add `test_config_groq_model_used` regression test verifying `stt.groq.model` is read from config

## How to Test

1. Run `python -m pytest tests/tools/test_transcription_tools.py -k groq -xvs` — all 24 Groq-related tests should pass
2. Run `python -m pytest tests/tools/test_transcription_tools.py -x` — full suite (108 tests) should pass
3. Verify the new test specifically: `python -m pytest tests/tools/test_transcription_tools.py::TestTranscribeAudioDispatch::test_config_groq_model_used -xvs` should pass
4. Manual: set `stt.groq.model: whisper-large-v3` in config.yaml (without setting `STT_GROQ_MODEL` env), trigger voice transcription, and confirm Groq uses `whisper-large-v3` instead of the default `whisper-large-v3-turbo`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (this is a config resolution fix with no platform-specific behavior)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
