### PR TITLE
fix(memory): ensure char limit config values are cast to int

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1245,8 +1245,8 @@ def init_agent(
             if agent._memory_enabled or agent._user_profile_enabled:
                 from tools.memory_tool import MemoryStore
                 agent._memory_store = MemoryStore(
-                    memory_char_limit=mem_config.get("memory_char_limit", 2200),
-                    user_char_limit=mem_config.get("user_char_limit", 1375),
+                    memory_char_limit=int(mem_config.get("memory_char_limit", 2200)),
+                    user_char_limit=int(mem_config.get("user_char_limit", 1375)),
                 )
                 agent._memory_store.load_from_disk()
         except Exception:

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -895,3 +895,25 @@ class TestLoadTimeSnapshotSanitization:
         # Block marker appears exactly once, not nested
         assert snapshot.count("[BLOCKED:") == 1
         assert "Clean fact" in snapshot
+
+
+class TestMemoryStoreCharLimits:
+    """Verifies that configured char limits are properly cast to int (issue #53834)."""
+
+    def test_char_limits_cast_to_int(self):
+        """MemoryStore should handle string-typed char limits from config."""
+        s = MemoryStore(memory_char_limit="20000", user_char_limit="30000")  # type: ignore[arg-type]
+        assert s.memory_char_limit == 20000
+        assert s.user_char_limit == 30000
+
+    def test_char_limits_int_passthrough(self):
+        """Int-typed char limits should pass through unchanged."""
+        s = MemoryStore(memory_char_limit=20000, user_char_limit=30000)
+        assert s.memory_char_limit == 20000
+        assert s.user_char_limit == 30000
+
+    def test_char_limit_target_resolution(self):
+        """_char_limit should resolve per-target limits correctly."""
+        s = MemoryStore(memory_char_limit=999, user_char_limit=444)
+        assert s._char_limit("memory") == 999
+        assert s._char_limit("user") == 444

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -130,8 +130,8 @@ class MemoryStore:
     def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375):
         self.memory_entries: List[str] = []
         self.user_entries: List[str] = []
-        self.memory_char_limit = memory_char_limit
-        self.user_char_limit = user_char_limit
+        self.memory_char_limit = int(memory_char_limit)
+        self.user_char_limit = int(user_char_limit)
         # Frozen snapshot for system prompt -- set once at load_from_disk()
         self._system_prompt_snapshot: Dict[str, str] = {"memory": "", "user": ""}
         # Per-turn counter of failed at-capacity consolidation attempts; reset


### PR DESCRIPTION
## Summary

Fixes #53834 — memory.user_char_limit / memory_char_limit config changes not taking effect after gateway restart.

## Root Cause

`agent_init.py` was missing `int()` conversion for `memory.user_char_limit` and `memory.memory_char_limit` config values, unlike `load_on_disk_store()` which already did the conversion. When config values are parsed as strings (e.g. from env-var substitution, quoted YAML values, or config migration), the string values were stored directly on MemoryStore, causing silent comparison failures between int limits and string config values.

## Changes

- **agent/agent_init.py**: Add `int()` cast around `mem_config.get()` for memory_char_limit and user_char_limit (matching the pattern already used for nudge_interval on the same code path)
- **tools/memory_tool.py**: Add `int()` cast in `MemoryStore.__init__` for defense-in-depth
- **tests/tools/test_memory_tool.py**: Add `TestMemoryStoreCharLimits` with 3 test cases (string-to-int cast, int passthrough, target resolution)

## Test Results

```
tests/tools/test_memory_tool.py::TestMemoryStoreCharLimits::test_char_limits_cast_to_int PASSED
tests/tools/test_memory_tool.py::TestMemoryStoreCharLimits::test_char_limits_int_passthrough PASSED
tests/tools/test_memory_tool.py::TestMemoryStoreCharLimits::test_char_limit_target_resolution PASSED
```

Diff: 3 files, +26/-4 lines