### PR TITLE
fix(doctor): recognise 'moa' as a valid internal provider

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -749,7 +749,7 @@ def run_doctor(args):
                     PROVIDER_REGISTRY,
                     resolve_provider as _resolve_auth_provider,
                 )
-                known_providers = set(PROVIDER_REGISTRY.keys()) | {"openrouter", "custom", "auto"}
+                known_providers = set(PROVIDER_REGISTRY.keys()) | {"openrouter", "custom", "auto", "moa"}
             except Exception:
                 _resolve_auth_provider = None
                 pass

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -517,6 +517,7 @@ def test_run_doctor_flags_missing_credentials_for_active_openrouter_provider(mon
         ("kilocode", "anthropic/claude-sonnet-4.6"),
         ("kimi-coding", "kimi-k2"),
         ("nvidia", "qwen/qwen3.5-122b-a10b"),
+        ("moa", "anthropic/claude-sonnet-4.6"),
     ],
 )
 def test_run_doctor_accepts_hermes_provider_ids_that_catalog_aliases(


### PR DESCRIPTION
## What does this PR do?

Fixes `hermes doctor` reporting `model.provider 'moa' is not a recognised provider` when a MoA/Diagnosis preset sets `model.provider` to `moa`. MoA (Mixture of Agents) is a legitimate internal provider used by Diagnosis presets and multi-model aggregation — doctor should not flag it as a broken config requiring user intervention.

## Related Issue

Fixes #58759

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/doctor.py`: Added `"moa"` to the `known_providers` set alongside `"openrouter"`, `"custom"`, and `"auto"` so doctor recognises it as a valid internal provider
- `tests/hermes_cli/test_doctor.py`: Added `("moa", "anthropic/claude-sonnet-4.6")` to the parametrized `test_run_doctor_accepts_hermes_provider_ids_that_catalog_aliases` test

## How to Test

1. Configure Hermes with a MoA preset that sets `model.provider` to `moa`
2. Run `hermes doctor`
3. Observed result: doctor no longer reports `model.provider 'moa' is not a recognised provider`
4. Run `python -m pytest tests/hermes_cli/test_doctor.py::test_run_doctor_accepts_hermes_provider_ids_that_catalog_aliases -q` — should pass all 5 parametrized cases

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
Before fix:
$ hermes doctor
model.provider 'moa' is not a recognised provider (known: alibaba, ...)
Fix: run 'hermes config set model.provider <valid_provider>'

After fix:
$ hermes doctor
(no false-positive warning about moa)
```
