### PR TITLE
fix(cron): skip delivery/dispatch when the interpreter is shutting down (#58720)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -407,6 +407,31 @@ def _shutdown_parallel_pool() -> None:
 atexit.register(_shutdown_parallel_pool)
 
 
+def _interpreter_shutting_down(exc: Optional[BaseException] = None) -> bool:
+    """True when the Python interpreter is finalizing.
+
+    A cron tick can fire while the gateway is tearing down — SIGTERM from
+    ``hermes update`` / ``hermes gateway stop`` / systemd restart, or an
+    OOM-kill. Once finalization starts, ``concurrent.futures`` refuses new
+    work with ``RuntimeError: cannot schedule new futures after interpreter
+    shutdown`` and asyncio's default executor is gone, so *any* attempt to
+    schedule delivery (live-adapter, ``asyncio.run``, or a fresh pool) is
+    doomed and only pollutes ``errors.log`` with a traceback. Callers use
+    this to skip gracefully with a warning instead of crashing (#58720,
+    #55924).
+
+    ``exc`` lets a caller also treat an already-raised scheduling error as a
+    shutdown signal: the ``concurrent.futures`` module-global flag can be set
+    a hair before ``sys.is_finalizing()`` flips, so matching the error text is
+    a safe fallback for that race.
+    """
+    if sys.is_finalizing():
+        return True
+    if exc is not None:
+        return "cannot schedule new futures" in str(exc).lower()
+    return False
+
+
 # Backward-compatible module override used by tests and emergency monkeypatches.
 _hermes_home: Path | None = None
 
@@ -1758,16 +1783,37 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 )
 
         if not delivered:
+            # If the interpreter is finalizing (gateway SIGTERM / restart /
+            # OOM), scheduling any new delivery is futile — asyncio.run and a
+            # fresh ThreadPoolExecutor both raise "cannot schedule new futures
+            # after interpreter shutdown". Skip gracefully with a warning
+            # rather than emitting an ERROR traceback on every restart-race
+            # (#58720, #55924).
+            if _interpreter_shutting_down():
+                msg = f"delivery to {platform_name}:{chat_id} skipped — interpreter is shutting down"
+                logger.warning("Job '%s': %s", job["id"], msg)
+                target_errors.append(msg)
+                delivery_errors.extend(target_errors)
+                continue
             # Standalone path: run the async send in a fresh event loop (safe from any thread)
             coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
             try:
                 result = asyncio.run(coro)
-            except RuntimeError:
+            except RuntimeError as run_err:
                 # asyncio.run() checks for a running loop before awaiting the coroutine;
                 # when it raises, the original coro was never started — close it to
                 # prevent "coroutine was never awaited" RuntimeWarning, then retry in a
                 # fresh thread that has no running loop.
                 coro.close()
+                # If the RuntimeError is the interpreter-finalization signal,
+                # the fresh-thread fallback would fail identically — skip
+                # gracefully instead of logging a shutdown-race traceback.
+                if _interpreter_shutting_down(run_err):
+                    msg = f"delivery to {platform_name}:{chat_id} skipped — interpreter is shutting down"
+                    logger.warning("Job '%s': %s", job["id"], msg)
+                    target_errors.append(msg)
+                    delivery_errors.extend(target_errors)
+                    continue
                 # The thread-pool fallback can itself raise (SMTP ConnectionError,
                 # future.result timeout, etc.). An exception raised inside this
                 # `except RuntimeError` block is NOT caught by the sibling
@@ -1784,6 +1830,14 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     finally:
                         pool.shutdown(wait=False)
                 except Exception as e:
+                    # A shutdown-race here is expected during teardown; downgrade
+                    # to a warning so it doesn't read as a genuine failure.
+                    if _interpreter_shutting_down(e):
+                        msg = f"delivery to {platform_name}:{chat_id} skipped — interpreter is shutting down"
+                        logger.warning("Job '%s': %s", job["id"], msg)
+                        target_errors.append(msg)
+                        delivery_errors.extend(target_errors)
+                        continue
                     msg = f"delivery to {platform_name}:{chat_id} failed: {e}"
                     logger.error("Job '%s': %s", job["id"], msg, exc_info=True)
                     target_errors.extend([msg])
@@ -3375,6 +3429,17 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
             membership is released in the worker's finally block.
             """
             job_id = job["id"]
+            # A tick can race gateway teardown: once the interpreter is
+            # finalizing, ``pool.submit`` raises "cannot schedule new futures
+            # after interpreter shutdown" and crashes the tick. Skip cleanly —
+            # the job stays due and will fire on the next healthy tick
+            # (#58720, #55924).
+            if _interpreter_shutting_down():
+                logger.warning(
+                    "Job '%s' not dispatched — interpreter is shutting down",
+                    job.get("name", job_id),
+                )
+                return None
             with _running_lock:
                 if job_id in _running_job_ids:
                     logger.info("Job '%s' already running — skipping", job.get("name", job_id))
@@ -3389,7 +3454,20 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
                     with _running_lock:
                         _running_job_ids.discard(j["id"])
 
-            return pool.submit(_run_and_release)
+            try:
+                return pool.submit(_run_and_release)
+            except RuntimeError as submit_err:
+                # Interpreter began finalizing between the guard above and the
+                # submit — release the in-flight claim we just took and skip.
+                if _interpreter_shutting_down(submit_err):
+                    with _running_lock:
+                        _running_job_ids.discard(job_id)
+                    logger.warning(
+                        "Job '%s' not dispatched — interpreter is shutting down",
+                        job.get("name", job_id),
+                    )
+                    return None
+                raise
 
         # Sequential pass for env-mutating (workdir) jobs.
         # Queued to a persistent single-thread pool so they run one at a time

--- a/tests/cron/test_scheduler_shutdown_guard.py
+++ b/tests/cron/test_scheduler_shutdown_guard.py
@@ -1,0 +1,137 @@
+"""Regression coverage for #58720 / #55924 — cron scheduling races
+interpreter finalization.
+
+When the gateway tears down (SIGTERM from ``hermes update`` /
+``hermes gateway stop`` / systemd restart, or an OOM-kill), a cron tick can
+still fire. Once the Python interpreter is finalizing, ``concurrent.futures``
+refuses new work with ``RuntimeError: cannot schedule new futures after
+interpreter shutdown`` and asyncio's default executor is gone. The cron
+delivery + dispatch paths used to hit that unguarded, crashing the tick and
+spraying a traceback into ``errors.log`` on every restart-race.
+
+The fix adds ``_interpreter_shutting_down()`` and guards the scheduling
+sites so they skip gracefully with a warning instead of raising.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestInterpreterShuttingDownHelper:
+    def test_true_when_finalizing(self):
+        from cron.scheduler import _interpreter_shutting_down
+
+        with patch("sys.is_finalizing", return_value=True):
+            assert _interpreter_shutting_down() is True
+
+    def test_false_when_not_finalizing_and_no_exc(self):
+        from cron.scheduler import _interpreter_shutting_down
+
+        with patch("sys.is_finalizing", return_value=False):
+            assert _interpreter_shutting_down() is False
+
+    def test_matches_shutdown_error_text_as_fallback(self):
+        """The concurrent.futures module-global flag can be set a hair before
+        ``sys.is_finalizing()`` flips — matching the error text catches that
+        race so a shutdown RuntimeError isn't misread as a real failure."""
+        from cron.scheduler import _interpreter_shutting_down
+
+        exc = RuntimeError("cannot schedule new futures after interpreter shutdown")
+        with patch("sys.is_finalizing", return_value=False):
+            assert _interpreter_shutting_down(exc) is True
+
+    def test_unrelated_error_is_not_shutdown(self):
+        from cron.scheduler import _interpreter_shutting_down
+
+        exc = RuntimeError("some other problem")
+        with patch("sys.is_finalizing", return_value=False):
+            assert _interpreter_shutting_down(exc) is False
+
+
+class TestStandaloneDeliverySkipsDuringShutdown:
+    def _telegram_cfg(self):
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+        return mock_cfg
+
+    def test_standalone_path_skips_without_scheduling(self):
+        """With the interpreter finalizing, the standalone delivery path must
+        skip BEFORE attempting to schedule the send — no ``_send_to_platform``
+        call, a graceful warning-level skip, and an error string returned
+        (not a raised exception)."""
+        from cron.scheduler import _deliver_result
+
+        job = {
+            "id": "gov-job",
+            "name": "model-governor",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "123"},
+        }
+        send_mock = AsyncMock(return_value={"success": True})
+        with patch("gateway.config.load_gateway_config", return_value=self._telegram_cfg()), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("sys.is_finalizing", return_value=True):
+            result = _deliver_result(job, "daily report body")
+
+        send_mock.assert_not_called()
+        assert result is not None
+        assert "shutting down" in result
+
+    def test_normal_delivery_still_works_when_not_finalizing(self):
+        """Guard must not regress the happy path: a normal (non-finalizing)
+        run still delivers via the standalone send."""
+        from cron.scheduler import _deliver_result
+
+        job = {
+            "id": "gov-job",
+            "name": "model-governor",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "123"},
+        }
+        send_mock = AsyncMock(return_value={"success": True})
+        with patch("gateway.config.load_gateway_config", return_value=self._telegram_cfg()), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("sys.is_finalizing", return_value=False):
+            result = _deliver_result(job, "daily report body")
+
+        send_mock.assert_called_once()
+        assert result is None
+
+
+class TestSourceGuardrail:
+    @pytest.fixture
+    def source(self) -> str:
+        from pathlib import Path
+
+        return (
+            Path(__file__).resolve().parents[2] / "cron" / "scheduler.py"
+        ).read_text(encoding="utf-8")
+
+    def test_helper_defined(self, source):
+        assert "def _interpreter_shutting_down(" in source
+        assert "#58720" in source
+
+    def test_helper_guards_dispatch_submit(self, source):
+        """The tick dispatch (``_submit_with_guard``) must consult the guard so
+        a tick that races teardown skips instead of crashing."""
+        idx_submit = source.find("def _submit_with_guard(")
+        assert idx_submit >= 0
+        tail = source[idx_submit:idx_submit + 1600]
+        assert "_interpreter_shutting_down(" in tail
+
+    def test_helper_guards_standalone_delivery(self, source):
+        """The standalone delivery path must consult the guard before
+        scheduling ``asyncio.run`` / a fresh pool."""
+        idx = source.find("Standalone path: run the async send")
+        assert idx >= 0
+        # The guard appears shortly before the standalone send comment.
+        window = source[max(0, idx - 600):idx]
+        assert "_interpreter_shutting_down()" in window


### PR DESCRIPTION
## Summary

Fixes #58720 (also covers the cron paths in #55924). A cron tick can fire while the gateway is tearing down — SIGTERM from `hermes update` / `hermes gateway stop` / systemd restart, or an OOM-kill. Once the interpreter is finalizing, `concurrent.futures` refuses new work with `RuntimeError: cannot schedule new futures after interpreter shutdown` and asyncio's default executor is gone, so the cron **delivery** and **dispatch** paths crash the tick and spray a traceback into `errors.log` on every restart-race. Telegram/live-adapter deliveries surface it as:

```
delivery error: Telegram send failed: Unknown error in HTTP implementation: RuntimeError('cannot schedule new futures after interpreter shutdown')
```

## Root cause

The error is the `concurrent.futures.thread` module-global shutdown flag (set only at interpreter finalization), not the cron agent's `agent.close()` teardown — `agent.close()` / `cleanup_stale_async_clients()` never touch the gateway loop or its executor. Every scheduling site in the cron path (`asyncio.run`, a fresh `ThreadPoolExecutor`, `pool.submit`) is therefore doomed once finalization starts. The delivery paths were unguarded and raised into `errors.log`.

## Fix

Add `_interpreter_shutting_down()` and consult it at the scheduling sites in `cron/scheduler.py`:

- **standalone delivery** — before `asyncio.run(coro)` and its fresh-pool fallback,
- **tick dispatch** — `_submit_with_guard`'s `pool.submit`.

When finalizing, skip gracefully with a **warning** instead of crashing; the job stays due and fires on the next healthy tick. The helper also matches the RuntimeError text as a fallback, since the `concurrent.futures` global flag can be set a hair before `sys.is_finalizing()` flips.

## Test plan

- [x] New suite `tests/cron/test_scheduler_shutdown_guard.py` (9 tests): helper contract (finalizing flag + error-text fallback), standalone delivery skips without scheduling a send during finalization, normal path still delivers, plus source guardrails for both scheduling sites.
- [x] Existing cron suites still green (`tests/cron/test_scheduler.py`, `tests/cron/test_run_one_job.py` — 219 tests).

## Note

The reporter hypothesised an `agent.close()` ordering cause; the actual trigger is interpreter finalization (a shutdown-race), so this guards the scheduling sites rather than reordering delivery — reordering would not help, because delivery itself schedules futures and would fail identically during finalization. If deliveries fail on *every* run, the gateway is being restarted/killed around cron fire time (worth investigating separately), but the scheduler should still degrade cleanly rather than crash-log.