### PR TITLE
fix(context): count fullwidth chars in estimates

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -10,6 +10,7 @@ import logging
 import os
 import re
 import time
+import unicodedata
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
@@ -2320,10 +2321,20 @@ def estimate_tokens_rough(text: str) -> int:
     Uses ceiling division so short texts (1-3 chars) never estimate as
     0 tokens, which would cause the compressor and pre-flight checks to
     systematically undercount when many short tool results are present.
+    East Asian wide/fullwidth glyphs count more conservatively because they
+    often tokenize closer to one token per visible character than ASCII.
     """
     if not text:
         return 0
-    return (len(text) + 3) // 4
+    return (_estimate_token_chars(str(text)) + 3) // 4
+
+
+def _estimate_token_chars(text: str) -> int:
+    """Return weighted chars for rough token estimates."""
+    total = 0
+    for ch in text:
+        total += 4 if unicodedata.east_asian_width(ch) in {"F", "W"} else 1
+    return total
 
 
 def estimate_messages_tokens_rough(messages: List[Dict[str, Any]]) -> int:
@@ -2376,7 +2387,7 @@ def _estimate_message_chars(msg: Dict[str, Any]) -> int:
     their raw chars here would massively overestimate token usage.
     """
     if not isinstance(msg, dict):
-        return len(str(msg))
+        return _estimate_token_chars(str(msg))
     shadow: Dict[str, Any] = {}
     for k, v in msg.items():
         if k == "_anthropic_content_blocks":
@@ -2399,7 +2410,7 @@ def _estimate_message_chars(msg: Dict[str, Any]) -> int:
                 shadow[k] = v
         else:
             shadow[k] = v
-    return len(str(shadow))
+    return _estimate_token_chars(str(shadow))
 
 
 def estimate_request_tokens_rough(
@@ -2418,9 +2429,9 @@ def estimate_request_tokens_rough(
     """
     total = 0
     if system_prompt:
-        total += (len(system_prompt) + 3) // 4
+        total += estimate_tokens_rough(system_prompt)
     if messages:
         total += estimate_messages_tokens_rough(messages)
     if tools:
-        total += (len(str(tools)) + 3) // 4
+        total += estimate_tokens_rough(str(tools))
     return total

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -3031,6 +3031,14 @@ _CJK_DENSE_RE = re.compile(
 )
 
 
+def _estimate_token_chars(text: str) -> int:
+    """Weight token-dense CJK chars as four ASCII estimate chars."""
+    if text.isascii():
+        return len(text)
+    dense = len(text) - len(_CJK_DENSE_RE.sub("", text))
+    return len(text) + (3 * dense)
+
+
 def estimate_tokens_rough(text: str) -> int:
     """Rough token estimate for pre-flight checks.
 
@@ -3345,14 +3353,16 @@ def _estimate_tools_tokens_rough(tools: List[Dict[str, Any]]) -> int:
             params = tool.get("parameters") or {}
 
         if isinstance(name, str):
-            total_chars += len(name)
+            total_chars += _estimate_token_chars(name)
         if isinstance(desc, str):
-            total_chars += len(desc)
+            total_chars += _estimate_token_chars(desc)
         # Parameters can be nested; JSON is closer to over-the-wire size than repr().
         try:
-            total_chars += len(json.dumps(params, ensure_ascii=False, separators=(",", ":")))
+            total_chars += _estimate_token_chars(
+                json.dumps(params, ensure_ascii=False, separators=(",", ":"))
+            )
         except Exception:
-            total_chars += len(str(params))
+            total_chars += _estimate_token_chars(str(params))
 
     tokens = (total_chars + 3) // 4
     # Bound the cache: drop the oldest entry when the cap is exceeded so a

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -56,10 +56,10 @@ class TestEstimateTokensRough:
         long = estimate_tokens_rough("hello world " * 100)
         assert long > short
 
-    def test_unicode_multibyte(self):
-        """Unicode chars are still 1 Python char each — 4 chars/token holds."""
-        text = "你好世界"  # 4 CJK characters
-        assert estimate_tokens_rough(text) == 1
+    def test_east_asian_wide_and_fullwidth_are_conservative(self):
+        assert estimate_tokens_rough("ABC123") == 2
+        assert estimate_tokens_rough("ＡＢＣ１２３") == 6
+        assert estimate_tokens_rough("你好世界") == 4
 
 
 class TestEstimateMessagesTokensRough:
@@ -83,6 +83,12 @@ class TestEstimateMessagesTokensRough:
         n = sum(len(str(m)) for m in msgs)
         expected = (n + 3) // 4
         assert result == expected
+
+    def test_fullwidth_message_content_counts_more_than_ascii(self):
+        ascii_msg = [{"role": "user", "content": "ABC123"}]
+        fullwidth_msg = [{"role": "user", "content": "ＡＢＣ１２３"}]
+
+        assert estimate_messages_tokens_rough(fullwidth_msg) > estimate_messages_tokens_rough(ascii_msg)
 
     def test_tool_call_message(self):
         """Tool call messages with no 'content' key still contribute tokens."""

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -147,6 +147,23 @@ class TestEstimateMessagesTokensRough:
 
 
 class TestEstimateRequestTokensRough:
+    def test_fullwidth_tool_schema_counts_more_than_ascii(self):
+        import agent.model_metadata as mm
+
+        def make_tools(description):
+            return [{"function": {"name": "lookup", "description": description,
+                                   "parameters": {"description": description}}}]
+
+        mm._TOOLS_TOKENS_CACHE.clear()
+        ascii_tools = make_tools("ABC123")
+        fullwidth_tools = make_tools("\uff21\uff22\uff23\uff11\uff12\uff13")
+        ascii_estimate = estimate_request_tokens_rough([], tools=ascii_tools)
+        fullwidth_estimate = estimate_request_tokens_rough(
+            [], tools=fullwidth_tools
+        )
+
+        assert (ascii_estimate, fullwidth_estimate) == (9, 18)
+
     def test_caches_tools_estimate(self):
         messages = [{"role": "user", "content": "hello"}]
         tools = [


### PR DESCRIPTION
## What does this PR do?

Makes Hermes rough token estimation count East Asian wide/fullwidth glyphs more conservatively while preserving existing ASCII behavior.

## Related Issue

Fixes #58784

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Added a weighted character helper for rough token estimates.
- Count East Asian wide/fullwidth characters as four estimate-chars before the existing `/ 4` token conversion.
- Routed plain text, message, system prompt, and tool-schema rough estimates through the same helper.
- Added regression coverage for fullwidth and CJK text while keeping ASCII assertions unchanged.

## How to Test

Focused proof from this branch:

```text
TMP=F:\openclaw\tmp\pytest TEMP=F:\openclaw\tmp\pytest uv run --locked --extra dev python -m pytest tests/agent/test_model_metadata.py::TestEstimateTokensRough tests/agent/test_model_metadata.py::TestEstimateMessagesTokensRough -q
.............                                                            [100%]
13 passed in 1.58s

python -m py_compile agent\model_metadata.py tests\agent\test_model_metadata.py
git diff --check
```

Behavior covered:

```text
estimate_tokens_rough("ABC123") == 2
estimate_tokens_rough("ＡＢＣ１２３") == 6
estimate_tokens_rough("你好世界") == 4
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A

## Screenshots / Logs

Focused regression proof is included above.
