### PR TITLE
fix(matrix): remove forced buffer_only streaming to enable progressive m.replace edits

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16115,7 +16115,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _buffer_only = False
                     if source.platform == Platform.MATRIX:
                         _effective_cursor = ""
-                        _buffer_only = True
                     # Fresh-final applies to Telegram only — other
                     # platforms either edit in place cheaply (Discord,
                     # Slack) or don't have the timestamp-on-edit
@@ -17411,7 +17410,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         _buffer_only = False
                         if source.platform == Platform.MATRIX:
                             _effective_cursor = ""
-                            _buffer_only = True
                         # Fresh-final applies to Telegram only — other
                         # platforms either edit in place cheaply or don't
                         # have the edit-timestamp-stays-stale problem.

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -39,12 +39,13 @@ class ProgressCaptureAdapter(BasePlatformAdapter):
         )
         return SendResult(success=True, message_id="progress-1")
 
-    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+    async def edit_message(self, chat_id, message_id, content, finalize: bool = False) -> SendResult:
         self.edits.append(
             {
                 "chat_id": chat_id,
                 "message_id": message_id,
                 "content": content,
+                "finalize": finalize,
             }
         )
         return SendResult(success=True, message_id=message_id)
@@ -87,7 +88,7 @@ class SmallLimitProgressAdapter(ProgressCaptureAdapter):
         )
         return SendResult(success=True, message_id=self._mint_id())
 
-    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+    async def edit_message(self, chat_id, message_id, content, finalize: bool = False) -> SendResult:
         if len(content) > self.MAX_MESSAGE_LENGTH:
             self.oversized_edits.append(content)
         self.edits.append(
@@ -95,6 +96,7 @@ class SmallLimitProgressAdapter(ProgressCaptureAdapter):
                 "chat_id": chat_id,
                 "message_id": message_id,
                 "content": content,
+                "finalize": finalize,
             }
         )
         return SendResult(success=True, message_id=message_id)


### PR DESCRIPTION
## Summary

Matrix gateway was sending only final/split `m.room.message` events — zero `m.replace` (`m.relates_to.rel_type == "m.replace"`) edits, despite streaming being enabled both globally and for the Matrix platform. Long answers arrived as monolithic messages instead of progressive live updates (#58728).

Control tests confirmed the individual pieces worked:
- Direct Matrix API `m.replace` edits work in the test room.
- `GatewayStreamConsumer` with `buffer_only=False` produces edits with a fake adapter.

---

## Root Cause

`gateway/run.py` forced `_buffer_only = True` exclusively for Matrix at both stream consumer instantiation sites:

**1. Proxy/SSE path (~line 16118):**
```python
if source.platform == Platform.MATRIX:
    _effective_cursor = ""
    _buffer_only = True          # kills progressive edits
```

**2. Delta/error consumer path (~line 17414):**
```python
if source.platform == Platform.MATRIX:
    _effective_cursor = ""
    _buffer_only = True          # same
```

`buffer_only = True` makes `GatewayStreamConsumer` skip the interval/threshold flush path (only `got_done` / `segment_break` / commentary trigger edits), effectively making Matrix final/split-only.

This guard was added in #10860 ("make buffered streaming") as a defensive measure during the E2EE/migration fix batch.

---

## Fix

Remove both `_buffer_only = True` lines. The `_buffer_only` default (`False`) already set above remains active, so Matrix now receives progressive `m.replace` edits like other platforms (Discord, Slack, etc.). Cursor suppression (`_effective_cursor = ""`) is preserved — some Matrix clients render the stream cursor as a tofu/white-box artifact.

---

## How to Test

```bash
pytest tests/gateway/test_stream_consumer.py
# ✅ 97 passed

pytest tests/gateway/test_matrix.py::test_edit_payload_uses_m_replace
# ✅ 1 passed — confirms Matrix adapter edit_message produces correct m.replace payloads
```

---

## Checklist

- [x] Tests pass — 97/97 stream consumer, 1/1 targeted matrix test
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cursor suppression preserved (`_effective_cursor = ""`)

---

## Risk & Impact

**Low.** Two-line removal — the `_buffer_only` default (`False`) was already set above both removed lines. No logic is added; the guard suppressing progressive edits is simply removed. All other platforms are unaffected.

**Type:** 🐛 Bug fix
**Related:** #41090 / #37931 / #49815 / #57091 (Matrix streaming delivery family, different mechanisms)
**Fixes:** #58728