### PR TITLE
fix: gate risky hands-free voice commands

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -98,6 +98,43 @@ npm run lint
 npm run test:desktop:all
 ```
 
+For Voice changes, also run the focused automated checks:
+
+```bash
+# Renderer voice safety / composer integration
+npm run test:ui -- --run \
+  src/lib/voice-risk.test.ts \
+  src/app/chat/composer/hooks/use-composer-voice.test.tsx \
+  src/app/chat/composer/hooks/use-voice-conversation.test.tsx
+
+# Backend STT/TTS routes and CLI/gateway voice behavior
+cd ../..
+env -u PYTHONPATH uv run --extra dev pytest -q \
+  tests/hermes_cli/test_web_server.py \
+  tests/tools/test_voice_mode.py \
+  tests/tools/test_voice_cli_integration.py \
+  tests/hermes_cli/test_voice_wrapper.py \
+  tests/hermes_cli/test_tts_picker.py \
+  tests/tools/test_tts_speed.py \
+  tests/tools/test_tts_opus_routing.py \
+  tests/tools/test_tts_plugin_dispatch.py \
+  tests/gateway/test_tts_media_routing.py \
+  tests/gateway/test_voice_command.py \
+  tests/gateway/test_voice_mode_platform_isolation.py \
+  tests/gateway/test_telegram_audio_vs_voice.py \
+  tests/gateway/test_send_voice_reply_notify.py \
+  tests/gateway/test_auto_voice_reply_format.py \
+  -k 'audio or voice or tts or elevenlabs or speak or transcribe'
+```
+
+Manual Voice smoke must be done on a real desktop with a microphone and speakers; containers/headless CI cannot validate OS microphone prompts or actual autoplay behavior:
+
+1. Start the app, open a chat, and enable hands-free voice.
+2. Say a harmless request such as “summarize this session”; it should transcribe and submit automatically.
+3. Say a risky command such as “delete all files in downloads”; it should **not** submit, should place the transcript in the composer draft, should stop hands-free mode, and should show the risky-command warning.
+4. Use push-to-dictate mode; it should insert text without auto-submitting.
+5. After a normal assistant reply, verify TTS playback starts and can be stopped.
+
 ### Troubleshooting
 
 Boot logs land in `HERMES_HOME/logs/desktop.log` (includes backend output and recent Python tracebacks) — check it first if the app reports a boot failure.

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.test.tsx
@@ -8,6 +8,8 @@ import { useComposerVoice } from './use-composer-voice'
 interface CapturedConversationOptions {
   enabled: boolean
   onSubmit: (text: string) => Promise<void> | void
+  shouldHoldTranscript?: (text: string) => boolean
+  onTranscriptHeld?: (text: string) => void
 }
 
 const captured = vi.hoisted(() => ({ options: null as CapturedConversationOptions | null }))
@@ -92,7 +94,8 @@ describe('useComposerVoice hands-free confirmation gate', () => {
     expect(captured.options!.enabled).toBe(true)
 
     const transcript = 'delete all the files in the downloads folder'
-    await act(async () => captured.options!.onSubmit(transcript))
+    expect(captured.options!.shouldHoldTranscript?.(transcript)).toBe(true)
+    act(() => captured.options!.onTranscriptHeld?.(transcript))
 
     expect(props.onSubmit).not.toHaveBeenCalled()
     expect(props.clearDraft).not.toHaveBeenCalled()

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.test.tsx
@@ -1,0 +1,104 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { notify } from '@/store/notifications'
+
+import { useComposerVoice } from './use-composer-voice'
+
+interface CapturedConversationOptions {
+  enabled: boolean
+  onSubmit: (text: string) => Promise<void> | void
+}
+
+const captured = vi.hoisted(() => ({ options: null as CapturedConversationOptions | null }))
+
+vi.mock('@/lib/haptics', () => ({ triggerHaptic: vi.fn() }))
+vi.mock('@/store/composer-input-history', () => ({ resetBrowseState: vi.fn() }))
+vi.mock('@/store/notifications', () => ({ notify: vi.fn(() => 'id'), notifyError: vi.fn(() => 'id') }))
+vi.mock('@/store/session', async () => {
+  const { atom } = await import('nanostores')
+
+  return { $messages: atom([]) }
+})
+vi.mock('@/store/voice-prefs', async () => {
+  const { atom } = await import('nanostores')
+
+  return { $autoSpeakReplies: atom(false), setAutoSpeakReplies: vi.fn(async () => {}) }
+})
+vi.mock('../focus', () => ({ onComposerVoiceToggleRequest: vi.fn(() => () => {}) }))
+vi.mock('./use-auto-speak-replies', () => ({ useAutoSpeakReplies: vi.fn() }))
+vi.mock('./use-voice-recorder', () => ({
+  useVoiceRecorder: vi.fn(() => ({
+    dictate: vi.fn(),
+    voiceActivityState: { elapsedSeconds: 0, level: 0, status: 'idle' },
+    voiceStatus: 'idle'
+  }))
+}))
+vi.mock('./use-voice-conversation', () => ({
+  useVoiceConversation: vi.fn((options: CapturedConversationOptions) => {
+    captured.options = options
+
+    return {
+      end: vi.fn(async () => {}),
+      level: 0,
+      muted: false,
+      start: vi.fn(async () => {}),
+      status: 'idle',
+      stopTurn: vi.fn(),
+      toggleMute: vi.fn()
+    }
+  })
+}))
+
+function renderComposerVoice() {
+  const props = {
+    busy: false,
+    clearDraft: vi.fn(),
+    disabled: false,
+    focusInput: vi.fn(),
+    insertText: vi.fn(),
+    maxRecordingSeconds: 60,
+    onSubmit: vi.fn(async () => true),
+    onTranscribeAudio: vi.fn(async () => ''),
+    sessionId: 'session-1'
+  }
+
+  const view = renderHook(() => useComposerVoice(props))
+
+  return { props, ...view }
+}
+
+describe('useComposerVoice hands-free confirmation gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    captured.options = null
+  })
+
+  it('auto-submits non-risky transcripts as before', async () => {
+    const { props } = renderComposerVoice()
+
+    await act(async () => captured.options!.onSubmit("what's the weather like today"))
+
+    expect(props.onSubmit).toHaveBeenCalledWith("what's the weather like today")
+    expect(props.clearDraft).toHaveBeenCalled()
+    expect(props.insertText).not.toHaveBeenCalled()
+    expect(notify).not.toHaveBeenCalled()
+  })
+
+  it('holds risky transcripts in the draft instead of submitting them', async () => {
+    const { props, result } = renderComposerVoice()
+
+    act(() => result.current.startConversation())
+    expect(captured.options!.enabled).toBe(true)
+
+    const transcript = 'delete all the files in the downloads folder'
+    await act(async () => captured.options!.onSubmit(transcript))
+
+    expect(props.onSubmit).not.toHaveBeenCalled()
+    expect(props.clearDraft).not.toHaveBeenCalled()
+    expect(props.insertText).toHaveBeenCalledWith(transcript)
+    expect(notify).toHaveBeenCalledWith(expect.objectContaining({ kind: 'warning' }))
+    // The hands-free loop deactivates so it cannot keep listening past the warning.
+    expect(captured.options!.enabled).toBe(false)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -86,15 +86,11 @@ export function useComposerVoice({
     }
   }
 
-  const submitVoiceTurn = async (text: string) => {
-    if (busy) {
-      return
-    }
-
-    // Risky spoken commands (delete files, push, deploy, pay, message someone,
-    // touch secrets) never auto-submit: park the transcript in the draft, stop
-    // the hands-free loop, and warn so the user reviews and sends manually.
-    if (isRiskyVoiceTranscript(text)) {
+  const handleRiskyVoiceTranscript = useCallback(
+    (text: string) => {
+      // Risky spoken commands (delete files, push, deploy, pay, message someone,
+      // touch secrets) never auto-submit: park the transcript in the draft, stop
+      // the hands-free loop, and warn so the user reviews and sends manually.
       setVoiceConversationActive(false)
       insertText(text)
       focusInput()
@@ -103,7 +99,12 @@ export function useComposerVoice({
         title: t.notifications.voice.confirmationRequired,
         message: t.notifications.voice.riskyTranscriptHeld
       })
+    },
+    [focusInput, insertText, t.notifications.voice.confirmationRequired, t.notifications.voice.riskyTranscriptHeld]
+  )
 
+  const submitVoiceTurn = async (text: string) => {
+    if (busy) {
       return
     }
 
@@ -119,8 +120,10 @@ export function useComposerVoice({
     enabled: voiceConversationActive,
     onFatalError: () => setVoiceConversationActive(false),
     onSubmit: submitVoiceTurn,
+    onTranscriptHeld: handleRiskyVoiceTranscript,
     onTranscribeAudio,
-    pendingResponse
+    pendingResponse,
+    shouldHoldTranscript: isRiskyVoiceTranscript
   })
 
   // The `composer.voice` hotkey (Ctrl+B) toggles the conversation. Starting

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -3,8 +3,9 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useI18n } from '@/i18n'
 import { chatMessageText } from '@/lib/chat-messages'
 import { triggerHaptic } from '@/lib/haptics'
+import { isRiskyVoiceTranscript } from '@/lib/voice-risk'
 import { resetBrowseState } from '@/store/composer-input-history'
-import { notifyError } from '@/store/notifications'
+import { notify, notifyError } from '@/store/notifications'
 import { $messages } from '@/store/session'
 import { $autoSpeakReplies, setAutoSpeakReplies } from '@/store/voice-prefs'
 
@@ -87,6 +88,22 @@ export function useComposerVoice({
 
   const submitVoiceTurn = async (text: string) => {
     if (busy) {
+      return
+    }
+
+    // Risky spoken commands (delete files, push, deploy, pay, message someone,
+    // touch secrets) never auto-submit: park the transcript in the draft, stop
+    // the hands-free loop, and warn so the user reviews and sends manually.
+    if (isRiskyVoiceTranscript(text)) {
+      setVoiceConversationActive(false)
+      insertText(text)
+      focusInput()
+      notify({
+        kind: 'warning',
+        title: t.notifications.voice.confirmationRequired,
+        message: t.notifications.voice.riskyTranscriptHeld
+      })
+
       return
     }
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
@@ -1,0 +1,60 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useVoiceConversation } from './use-voice-conversation'
+
+interface StartOptions {
+  onSilence: () => void
+}
+
+const mic = vi.hoisted(() => ({
+  startOptions: null as StartOptions | null,
+  handle: {
+    cancel: vi.fn(),
+    start: vi.fn(async (options: StartOptions) => {
+      mic.startOptions = options
+    }),
+    stop: vi.fn(async () => ({ audio: new Blob(['audio']), heardSpeech: true }))
+  }
+}))
+
+vi.mock('@/lib/voice-playback', () => ({ playSpeechText: vi.fn(), stopVoicePlayback: vi.fn() }))
+vi.mock('@/store/notifications', () => ({ notify: vi.fn(), notifyError: vi.fn() }))
+vi.mock('./use-mic-recorder', () => ({
+  useMicRecorder: vi.fn(() => ({ handle: mic.handle, level: 0 }))
+}))
+
+describe('useVoiceConversation transcript hold gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mic.startOptions = null
+  })
+
+  it('holds a risky transcript before it reaches onSubmit', async () => {
+    const onSubmit = vi.fn(async () => {})
+    const onTranscriptHeld = vi.fn()
+
+    const props = {
+      busy: false,
+      consumePendingResponse: vi.fn(),
+      enabled: false,
+      onSubmit,
+      onTranscriptHeld,
+      onTranscribeAudio: vi.fn(async () => 'delete all the files in downloads'),
+      pendingResponse: vi.fn(() => null),
+      shouldHoldTranscript: vi.fn(() => true)
+    }
+
+    const view = renderHook(({ enabled }) => useVoiceConversation({ ...props, enabled }), {
+      initialProps: { enabled: false }
+    })
+
+    view.rerender({ enabled: true })
+
+    await waitFor(() => expect(mic.handle.start).toHaveBeenCalled())
+    await act(async () => mic.startOptions!.onSilence())
+
+    await waitFor(() => expect(onTranscriptHeld).toHaveBeenCalledWith('delete all the files in downloads'))
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -20,6 +20,8 @@ interface VoiceConversationOptions {
   onFatalError?: () => void
   onSubmit: (text: string) => Promise<void> | void
   onTranscribeAudio?: (audio: Blob) => Promise<string>
+  shouldHoldTranscript?: (text: string) => boolean
+  onTranscriptHeld?: (text: string) => void
   pendingResponse: () => PendingVoiceResponse | null
   consumePendingResponse: () => void
 }
@@ -30,6 +32,8 @@ export function useVoiceConversation({
   onFatalError,
   onSubmit,
   onTranscribeAudio,
+  shouldHoldTranscript,
+  onTranscriptHeld,
   pendingResponse,
   consumePendingResponse
 }: VoiceConversationOptions) {
@@ -166,6 +170,15 @@ export function useVoiceConversation({
             return
           }
 
+          if (shouldHoldTranscript?.(transcript)) {
+            awaitingSpokenResponseRef.current = false
+            resetSpeechBuffer()
+            onTranscriptHeld?.(transcript)
+            setStatus('idle')
+
+            return
+          }
+
           awaitingSpokenResponseRef.current = true
           resetSpeechBuffer()
           await onSubmit(transcript)
@@ -183,7 +196,7 @@ export function useVoiceConversation({
         turnClosingRef.current = false
       }
     },
-    [handle, onSubmit, onTranscribeAudio, voiceCopy.transcriptionFailed]
+    [handle, onSubmit, onTranscribeAudio, onTranscriptHeld, shouldHoldTranscript, voiceCopy.transcriptionFailed]
   )
 
   const startListening = useCallback(async () => {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -135,6 +135,7 @@ export const en: Translations = {
     },
     voice: {
       configureSpeechToText: 'Configure speech-to-text to use voice mode.',
+      confirmationRequired: 'Confirm before sending',
       couldNotStartSession: 'Could not start voice session',
       microphoneAccessDenied: 'Microphone access denied.',
       microphoneConstraintsUnsupported: 'Microphone constraints are not supported by this device.',
@@ -147,6 +148,8 @@ export const en: Translations = {
       noSpeechDetected: 'No speech detected',
       playbackFailed: 'Voice playback failed',
       recordingFailed: 'Voice recording failed',
+      riskyTranscriptHeld:
+        'That voice command could perform a risky action, so it was placed in the composer instead of being sent. Review it and send manually.',
       transcriptionFailed: 'Voice transcription failed',
       transcriptionUnavailable: 'Voice transcription is not available yet.',
       tryRecordingAgain: 'Try recording again.',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -176,6 +176,7 @@ export interface Translations {
     }
     voice: {
       configureSpeechToText: string
+      confirmationRequired: string
       couldNotStartSession: string
       microphoneAccessDenied: string
       microphoneConstraintsUnsupported: string
@@ -188,6 +189,7 @@ export interface Translations {
       noSpeechDetected: string
       playbackFailed: string
       recordingFailed: string
+      riskyTranscriptHeld: string
       transcriptionFailed: string
       transcriptionUnavailable: string
       tryRecordingAgain: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -131,6 +131,7 @@ export const zh: Translations = {
     },
     voice: {
       configureSpeechToText: '配置语音转文字后即可使用语音模式。',
+      confirmationRequired: '发送前需确认',
       couldNotStartSession: '无法启动语音会话',
       microphoneAccessDenied: '麦克风访问被拒绝。',
       microphoneConstraintsUnsupported: '此设备不支持当前麦克风约束。',
@@ -143,6 +144,7 @@ export const zh: Translations = {
       noSpeechDetected: '没有检测到语音',
       playbackFailed: '语音播放失败',
       recordingFailed: '语音录制失败',
+      riskyTranscriptHeld: '这条语音指令可能执行高风险操作，已放入输入框而未自动发送。请检查后手动发送。',
       transcriptionFailed: '语音转写失败',
       transcriptionUnavailable: '语音转写暂不可用。',
       tryRecordingAgain: '请再录一次。',

--- a/apps/desktop/src/lib/voice-risk.test.ts
+++ b/apps/desktop/src/lib/voice-risk.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+
+import { isRiskyVoiceTranscript } from './voice-risk'
+
+describe('isRiskyVoiceTranscript', () => {
+  const risky = [
+    // Destructive file operations
+    'delete all the files in the downloads folder',
+    'remove the old backup folder',
+    'wipe everything in the temp directory',
+    'run rm -rf on the build directory',
+    'rm dash rf the build folder',
+    'drop the users table from the database',
+    'empty the trash',
+    'format the drive',
+    'overwrite the config file',
+    '删除所有文件',
+    // Git state changes
+    'git push origin main',
+    'commit the changes and push to main',
+    'push the latest changes to origin',
+    'force push the branch',
+    'git commit everything with a message saying done',
+    '重置 git 分支',
+    '推送到 main 分支',
+    // Publishing / deploying
+    'deploy the site to production',
+    'publish the package to npm',
+    'publish it now',
+    'ship the new version to the app store',
+    '部署到生产环境',
+    '发布这个版本',
+    // Messages to third parties
+    "send an email to the client saying we're done",
+    'send a message to the team on slack',
+    'text him that the demo is ready',
+    '给客户发邮件说我们完成了',
+    '发短信给他说明天见',
+    // Purchases / payments
+    'buy the domain for me',
+    'purchase a license for the pro version',
+    'pay the invoice',
+    'pay the bill',
+    'transfer the money to him',
+    'wire the money to the vendor',
+    'venmo him 50 dollars',
+    'cancel the subscription',
+    'unsubscribe from the paid plan',
+    'subscribe to the pro plan',
+    '购买这个域名',
+    '支付账单',
+    // Secrets / credentials
+    'rotate the api keys',
+    'change the database password',
+    'delete the environment variables from the config',
+    '更新 API 密钥',
+    '删除环境变量'
+  ]
+
+  const safe = [
+    '',
+    '   ',
+    "what's the weather like today",
+    'summarize the last reply for me',
+    'open the readme file and read it aloud',
+    'the push notification design looks great',
+    'explain how commits work in git',
+    'tell me about the deployment process',
+    'i bought a new keyboard yesterday',
+    'did the message from alice mention the schedule',
+    'what does this error message the app shows mean',
+    'check out the PR and tell me what it does',
+    'in order to fix it we should refactor the parser'
+  ]
+
+  it.each(risky)('flags risky transcript: %s', transcript => {
+    expect(isRiskyVoiceTranscript(transcript)).toBe(true)
+  })
+
+  it('flags risky transcripts regardless of casing', () => {
+    expect(isRiskyVoiceTranscript('Delete ALL the files in the Downloads folder')).toBe(true)
+  })
+
+  it.each(safe)('allows harmless transcript: %s', transcript => {
+    expect(isRiskyVoiceTranscript(transcript)).toBe(false)
+  })
+})

--- a/apps/desktop/src/lib/voice-risk.ts
+++ b/apps/desktop/src/lib/voice-risk.ts
@@ -1,0 +1,58 @@
+/**
+ * Best-effort heuristic for hands-free voice transcripts. The voice
+ * conversation loop auto-submits whatever it hears, so obvious commands that
+ * could destroy files, rewrite git state, publish, spend money, message third
+ * parties, or touch secrets are held for manual confirmation instead.
+ *
+ * This is not a complete policy engine. Keep it biased toward holding clear
+ * high-risk intents, but expect the backend approval system to remain the real
+ * enforcement layer for dangerous tool execution.
+ */
+
+// Patterns run against lowercased, whitespace-collapsed text. Most English
+// patterns pair a risky verb with a nearby target so harmless mentions ("the
+// push notification design", "the deployment process") stay below the bar.
+const RISKY_PATTERNS: RegExp[] = [
+  // Shell-destructive removals, including how STT tends to render `rm -rf`.
+  /\brm\s+(?:-|dash |minus )/,
+  /\brimraf\b/,
+  // Deleting or overwriting files, folders, repos, branches, databases, config.
+  /\b(?:delete|remove|erase|wipe|destroy|drop|purge|trash|empty|format|overwrite)\b.{0,60}\b(?:files?|folders?|director(?:y|ies)|drives?|trash|configs?|config files?|repositor(?:y|ies)|repos?|branch(?:es)?|databases?|tables?|backups?|everything|node modules)\b/,
+  // Git commands that rewrite history or remote state.
+  /\bgit\s+(?:commit|push|reset|clean|rebase|merge|revert)\b/,
+  /\b(?:commit|push)\b.{0,50}\b(?:changes?|code|work|files?|branch(?:es)?|repo|origin|remote|main|master|everything)\b/,
+  /\bforce[\s-]?push/,
+  // Publishing / deploying / releasing.
+  /\b(?:deploy|publish|release|ship)\b.{0,60}\b(?:apps?|sites?|websites?|packages?|builds?|versions?|updates?|changes?|prod(?:uction)?|live|npm|store|staging)\b/,
+  /\b(?:deploy|publish|release|ship)\s+(?:it|this|that|now|everything)\b/,
+  /\bgo\s+live\b/,
+  // Outbound messages to third parties. Avoid "error message" noun phrases.
+  /\b(?:send|forward|shoot)\b.{0,50}\b(?:e-?mails?|messages?|dms?|texts?|sms|slack|tweets?|replies|invoices?)\b/,
+  /\b(?:email|text|dm|ping|slack)\s+(?:him|her|them|everyone|the\s+\w+|[\w.]+@)/,
+  /\bmessage\s+(?:him|her|them|everyone|[\w.]+@)/,
+  // Spending money and subscription changes. Carve out everyday phrases.
+  /\b(?:buy|purchase|pay(?!\s+attention)|transfer|wire|venmo|checkout)\b.{0,60}\b(?:licen[cs]es?|domains?|plans?|subscriptions?|credits?|servers?|invoices?|bills?|money|dollars?|vendors?|versions?|it|this|that|one)\b/,
+  /\b(?<!in\s)order\b.{0,60}\b(?:licen[cs]es?|domains?|plans?|subscriptions?|credits?|servers?|invoices?|bills?|it|this|that|one)\b/,
+  /\bplace\s+(?:an?\s+)?order\b/,
+  /\b(?:subscribe\s+to|unsubscribe\s+from|cancel\s+(?:the\s+)?subscription)\b/,
+  // Secrets / credentials / environment configuration.
+  /\b(?:rotate|revoke|regenerate|delete|remove|change|update|set|edit)\b.{0,50}\b(?:secrets?|api ?keys?|tokens?|credentials?|passwords?|environment variables?|env (?:vars?|variables?|files?)|\.env)\b/,
+  // Chinese high-risk transcripts (zh locale support; broad by design).
+  /(?:删除|移除|清空|擦除|格式化|覆盖).{0,20}(?:文件|文件夹|目录|硬盘|驱动器|垃圾箱|数据库|表|备份|环境变量|配置|仓库|分支|所有)/,
+  /(?:git\s*)?(?:提交|推送|重置|强推).{0,20}(?:git|代码|更改|分支|main|master|远程|仓库)?/,
+  /(?:部署|发布|上线|发版).{0,20}(?:生产|线上|网站|应用|版本|npm|商店|这个|现在)?/,
+  /(?:发邮件|发送邮件|发短信|发消息|私信|通知).{0,20}(?:客户|团队|他|她|他们|所有人|用户)/,
+  /(?:客户|团队|他|她|他们|所有人|用户).{0,20}(?:发邮件|发送邮件|发短信|发消息|私信|通知)/,
+  /(?:购买|买|支付|付款|转账|订阅|取消订阅).{0,20}(?:域名|账单|发票|套餐|订阅|许可证|积分|服务器|钱|款)/,
+  /(?:更新|删除|移除|轮换|吊销|重置|修改|设置).{0,20}(?:api\s*密钥|密钥|令牌|凭证|密码|环境变量|\.env)/
+]
+
+export function isRiskyVoiceTranscript(text: string): boolean {
+  const normalized = text.toLowerCase().replace(/\s+/g, ' ').trim()
+
+  if (!normalized) {
+    return false
+  }
+
+  return RISKY_PATTERNS.some(pattern => pattern.test(normalized))
+}

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -134,6 +134,7 @@ class TestDetectAudioEnvironment:
         monkeypatch.delenv("SSH_CLIENT", raising=False)
         monkeypatch.delenv("SSH_TTY", raising=False)
         monkeypatch.delenv("SSH_CONNECTION", raising=False)
+        monkeypatch.setattr("hermes_constants.is_container", lambda: False)
         monkeypatch.setattr("tools.voice_mode._import_audio",
                             lambda: (MagicMock(), MagicMock()))
         monkeypatch.setattr("builtins.open", _non_wsl_proc_version(open))
@@ -424,6 +425,7 @@ class TestDetectAudioEnvironment:
         monkeypatch.delenv("SSH_CLIENT", raising=False)
         monkeypatch.delenv("SSH_TTY", raising=False)
         monkeypatch.delenv("SSH_CONNECTION", raising=False)
+        monkeypatch.setattr("hermes_constants.is_container", lambda: False)
         monkeypatch.setattr("tools.voice_mode.shutil.which", lambda cmd: "/data/data/com.termux/files/usr/bin/termux-microphone-record" if cmd == "termux-microphone-record" else None)
         monkeypatch.setattr("tools.voice_mode._termux_api_app_installed", lambda: True)
         monkeypatch.setattr("tools.voice_mode._import_audio", lambda: (_ for _ in ()).throw(ImportError("no audio libs")))


### PR DESCRIPTION
## Summary
- Add a best-effort risk detector for hands-free VoiceOps transcripts.
- Hold obvious risky voice commands in the composer draft instead of auto-submitting them.
- Add English + Chinese risky-transcript coverage and hook-level tests.

## Test plan
- npm --workspace apps/desktop run test:ui -- --run src/lib/voice-risk.test.ts src/app/chat/composer/hooks/use-composer-voice.test.tsx
- npm --workspace apps/desktop run typecheck
- npm --workspace apps/desktop exec eslint -- src/lib/voice-risk.ts src/lib/voice-risk.test.ts src/app/chat/composer/hooks/use-composer-voice.ts src/app/chat/composer/hooks/use-composer-voice.test.tsx src/i18n/en.ts src/i18n/types.ts src/i18n/zh.ts
- env -u PYTHONPATH uv run --extra dev pytest -q tests/hermes_cli/test_web_server.py -k 'audio or elevenlabs or speak_text'
- npm --workspace apps/desktop run build
- npm --workspace web run build
- git diff --check
