### PR TITLE
fix(mcp): populate elicitation content from requested schema on accept

### DIFF
--- a/tests/tools/test_mcp_elicitation.py
+++ b/tests/tools/test_mcp_elicitation.py
@@ -20,6 +20,7 @@ from mcp.types import ElicitResult  # noqa: E402  -- after importorskip
 
 from tools.mcp_tool import (  # noqa: E402
     ElicitationHandler,
+    _build_elicitation_content,
     _format_elicitation_schema_summary,
 )
 
@@ -68,6 +69,77 @@ class TestSchemaSummary:
         assert "recipient (string)" in out
 
 
+class TestBuildElicitationContent:
+    def test_empty_schema_returns_empty_dict(self):
+        assert _build_elicitation_content({}) == {}
+        assert _build_elicitation_content({"properties": {}}) == {}
+
+    def test_required_boolean_field_defaults_to_true(self):
+        schema = {
+            "properties": {"approved": {"type": "boolean"}},
+            "required": ["approved"],
+        }
+        assert _build_elicitation_content(schema) == {"approved": True}
+
+    def test_required_string_field_defaults_to_empty(self):
+        schema = {
+            "properties": {"reason": {"type": "string"}},
+            "required": ["reason"],
+        }
+        assert _build_elicitation_content(schema) == {"reason": ""}
+
+    def test_required_integer_field_defaults_to_zero(self):
+        schema = {
+            "properties": {"count": {"type": "integer"}},
+            "required": ["count"],
+        }
+        assert _build_elicitation_content(schema) == {"count": 0}
+
+    def test_optional_field_without_default_is_omitted(self):
+        schema = {
+            "properties": {
+                "approved": {"type": "boolean"},
+                "note": {"type": "string"},
+            },
+            "required": ["approved"],
+        }
+        assert _build_elicitation_content(schema) == {"approved": True}
+
+    def test_field_with_explicit_default_is_included(self):
+        schema = {
+            "properties": {
+                "level": {"type": "string", "default": "info"},
+            },
+            "required": [],
+        }
+        assert _build_elicitation_content(schema) == {"level": "info"}
+
+    def test_enum_field_picks_first_value(self):
+        schema = {
+            "properties": {
+                "mode": {"type": "string", "enum": ["read", "write"]},
+            },
+            "required": ["mode"],
+        }
+        assert _build_elicitation_content(schema) == {"mode": "read"}
+
+    def test_multiple_required_fields(self):
+        schema = {
+            "properties": {
+                "approved": {"type": "boolean"},
+                "amount": {"type": "number"},
+                "reason": {"type": "string"},
+            },
+            "required": ["approved", "amount"],
+        }
+        result = _build_elicitation_content(schema)
+        assert result == {"approved": True, "amount": 0.0}
+
+    def test_non_dict_schema_returns_empty(self):
+        assert _build_elicitation_content(None) == {}
+        assert _build_elicitation_content("bad") == {}
+
+
 class TestElicitationHandlerFormMode:
     def test_user_accepts_once_returns_accept(self):
         handler = ElicitationHandler("pay", {"timeout": 5})
@@ -81,7 +153,7 @@ class TestElicitationHandlerFormMode:
 
         assert isinstance(result, ElicitResult)
         assert result.action == "accept"
-        assert result.content == {}
+        assert result.content == {"approved": True}
         assert handler.metrics["accepted"] == 1
         assert handler.metrics["declined"] == 0
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1295,6 +1295,53 @@ def _format_elicitation_schema_summary(schema: dict, server_name: str) -> str:
     return "\n".join(lines)
 
 
+# Default values for JSON Schema types used in MCP elicitation schemas.
+_TYPE_DEFAULTS: dict[str, object] = {
+    "boolean": True,
+    "string": "",
+    "integer": 0,
+    "number": 0.0,
+}
+
+
+def _build_elicitation_content(schema: dict) -> dict[str, object]:
+    """Build a default content dict from a ``requested_schema``.
+
+    MCP form-mode elicitations require ``content`` to match the requested
+    schema when the user accepts.  We populate required fields (and any
+    field with an explicit ``default``) so the response is schema-valid.
+
+    Boolean fields default to ``True`` (the user accepted the prompt);
+    other types use conventional empty/zero defaults.  Enum fields pick
+    the first listed value.
+    """
+    props = schema.get("properties") if isinstance(schema, dict) else None
+    if not isinstance(props, dict):
+        return {}
+
+    required = set(schema.get("required") or ())
+    # When no required list is specified, populate all properties so the
+    # response is schema-valid.  With an explicit required list, only
+    # populate required fields plus any field with an explicit default.
+    populate_all = not required
+    content: dict[str, object] = {}
+    for name, spec in props.items():
+        if not isinstance(spec, dict):
+            continue
+        if populate_all or name in required or "default" in spec:
+            if "default" in spec:
+                content[name] = spec["default"]
+            else:
+                field_type = str(spec.get("type", "") or "")
+                if field_type == "boolean":
+                    content[name] = True
+                elif "enum" in spec and spec["enum"]:
+                    content[name] = spec["enum"][0]
+                else:
+                    content[name] = _TYPE_DEFAULTS.get(field_type, "")
+    return content
+
+
 class ElicitationHandler:
     """Handles ``elicitation/create`` requests for a single MCP server.
 
@@ -1444,7 +1491,8 @@ class ElicitationHandler:
 
         if answer == "accept":
             self.metrics["accepted"] += 1
-            return ElicitResult(action="accept", content={})
+            content = _build_elicitation_content(schema)
+            return ElicitResult(action="accept", content=content)
         if answer == "cancel":
             self.metrics["errors"] += 1
             return ElicitResult(action="cancel")


### PR DESCRIPTION
## What does this PR do?

When a user accepts an MCP form-mode elicitation (e.g. a write-approval prompt), Hermes returns `ElicitResult(action="accept", content={})`. The empty `content` dict fails schema validation on servers that check `requestedSchema.required` fields, causing the approval to be silently rejected even though the user explicitly approved.

This fix populates `content` with type-appropriate default values derived from the `requestedSchema`: booleans default to `True` (user accepted), enums to the first value, strings to `""`, numbers to `0`. Fields without a `default` and not listed in `required` are omitted (unless no `required` list exists, in which case all properties are populated to maximize schema-validity).

## Related Issue

Fixes #58778

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py`: Added `_build_elicitation_content()` helper that generates schema-appropriate defaults from `requestedSchema`. Updated `ElicitationHandler.__call__` to use it instead of `content={}` on accept.
- `tests/tools/test_mcp_elicitation.py`: Added 9 tests for `_build_elicitation_content` (empty schema, required boolean/string/integer, optional omission, explicit defaults, enum, multiple required, non-dict schema). Updated existing accept test to expect populated content.

## How to Test

1. `python -m pytest tests/tools/test_mcp_elicitation.py -v` — all 24 tests should pass
2. The key behavioral change: when a server sends `requestedSchema` with `required: ["approved"]` and `approved` is `boolean`, accepting now returns `{"approved": true}` instead of `{}`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
