### PR TITLE
fix(gateway): accept unpadded attach base64

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7764,6 +7764,25 @@ def test_image_attach_bytes_accepts_data_url_prefix(monkeypatch, tmp_path):
     assert resp["result"]["attached"] is True
 
 
+def test_image_attach_bytes_accepts_unpadded_data_url(monkeypatch, tmp_path):
+    _attach_bytes_cli(monkeypatch)
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    server._sessions["abx2u"] = _session()
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "image.attach_bytes",
+            "params": {
+                "session_id": "abx2u",
+                "content_base64": f"data:image/png;base64,{_PNG_1X1_B64.rstrip('=')}",
+            },
+        }
+    )
+    assert resp["result"]["attached"] is True
+    assert Path(resp["result"]["path"]).read_bytes().startswith(b"\x89PNG")
+
+
 def test_image_attach_bytes_data_alias_and_magic_sniff(monkeypatch, tmp_path):
     """Older desktop builds send `data` (not content_base64); ext sniffed from bytes."""
     _attach_bytes_cli(monkeypatch)
@@ -7895,13 +7914,19 @@ def test_decode_attach_base64_helper():
 
     raw = _b64.b64encode(b"hello").decode("ascii")
     assert server._decode_attach_base64(raw, mime_prefix="image/") == b"hello"
+    assert server._decode_attach_base64(raw.rstrip("="), mime_prefix="image/") == b"hello"
     assert (
         server._decode_attach_base64(f"data:image/png;base64,{raw}", mime_prefix="image/")
+        == b"hello"
+    )
+    assert (
+        server._decode_attach_base64(f"data:image/png;base64,{raw.rstrip('=')}", mime_prefix="image/")
         == b"hello"
     )
     # whitespace inside payload is tolerated
     assert server._decode_attach_base64(raw[:4] + "\n" + raw[4:], mime_prefix="image/") == b"hello"
     assert server._decode_attach_base64("@@@", mime_prefix="image/") is None
+    assert server._decode_attach_base64("S", mime_prefix="image/") is None
 
 
 def test_sniff_image_ext_magic_and_filename():

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9075,6 +9075,11 @@ def _decode_attach_base64(raw: str, *, mime_prefix: str) -> bytes | None:
     if m:
         cleaned = m.group(1)
     cleaned = _re.sub(r"\s+", "", cleaned)
+    remainder = len(cleaned) % 4
+    if remainder == 1:
+        return None
+    if remainder:
+        cleaned += "=" * (4 - remainder)
     try:
         return _base64.b64decode(cleaned, validate=True)
     except Exception:


### PR DESCRIPTION
## What does this PR do?

Allows the TUI gateway `image.attach_bytes` upload path to accept valid unpadded base64 payloads while keeping malformed base64 rejected.

The current helper strips a `data:image/...;base64,` prefix and whitespace, then passes the payload directly to `base64.b64decode(..., validate=True)`. That rejects remote-client uploads that omit trailing `=` padding even when the payload is otherwise canonical.

This patch pads only valid base64 length remainders (`2` or `3`) before decode. Remainder `1` still fails closed, and `validate=True` continues to reject non-base64 characters or malformed padding.

## Related Issue

Fixes #58791

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py`: normalize missing canonical base64 padding in `_decode_attach_base64()` before strict validation.
- `tests/test_tui_gateway_server.py`: add coverage for unpadded `data:image/...;base64,` uploads and direct helper decoding.

## How to Test

1. On `main`, `_decode_attach_base64("SGVsbG8", mime_prefix="image/")` returns `None`, so the upload path reports invalid base64.
2. On this branch, run:

```text
TMP=F:\openclaw\tmp\pytest TEMP=F:\openclaw\tmp\pytest uv run --locked --extra dev python -m pytest tests/test_tui_gateway_server.py::test_image_attach_bytes_accepts_data_url_prefix tests/test_tui_gateway_server.py::test_image_attach_bytes_accepts_unpadded_data_url tests/test_tui_gateway_server.py::test_decode_attach_base64_helper -q
```

Result:

```text
3 passed in 2.30s
```

3. Additional checks:

```text
python -m py_compile tui_gateway\server.py tests\test_tui_gateway_server.py
git diff --check
```

Both passed; `git diff --check` only printed existing LF/CRLF working-copy warnings.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / PowerShell

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - pure Python base64 handling
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## For New Skills

N/A

## Screenshots / Logs

```text
...                                                                      [100%]
3 passed in 2.30s
```
