### PR TITLE
feat(telegram): per-chat require_mention opt-in (require_mention_chats)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1034,6 +1034,14 @@ def load_gateway_config() -> GatewayConfig:
                     if isinstance(frc, list):
                         frc = ",".join(str(v) for v in frc)
                     os.environ["TELEGRAM_FREE_RESPONSE_CHATS"] = str(frc)
+                # require_mention_chats: opt-in counterpart to free_response_chats —
+                # force @mention gating in these chats even when require_mention is
+                # globally off (e.g. multi-bot rooms).
+                rmc = telegram_cfg.get("require_mention_chats")
+                if rmc is not None and not os.getenv("TELEGRAM_REQUIRE_MENTION_CHATS"):
+                    if isinstance(rmc, list):
+                        rmc = ",".join(str(v) for v in rmc)
+                    os.environ["TELEGRAM_REQUIRE_MENTION_CHATS"] = str(rmc)
                 # allowed_chats: if set, bot ONLY responds in these group chats (whitelist)
                 ac = telegram_cfg.get("allowed_chats")
                 if ac is not None and not os.getenv("TELEGRAM_ALLOWED_CHATS"):

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4507,8 +4507,35 @@ class TelegramAdapter(BasePlatformAdapter):
 
     # ── Group mention gating ──────────────────────────────────────────────
 
-    def _telegram_require_mention(self) -> bool:
-        """Return whether group chats should require an explicit bot trigger."""
+    def _telegram_require_mention_chats(self) -> set[str]:
+        """Return group chat IDs that require an explicit bot trigger even when
+        ``require_mention`` is globally disabled.
+
+        This is the opt-in counterpart to ``free_response_chats``: it lets the
+        bot stay chatty everywhere by default while still requiring an @mention
+        in specific chats — e.g. multi-bot rooms where several agents share a
+        group and should not all answer every unaddressed message.  DMs are
+        never affected.  Empty set means no per-chat override (backward
+        compatible).
+        """
+        raw = self.config.extra.get("require_mention_chats")
+        if raw is None:
+            raw = os.getenv("TELEGRAM_REQUIRE_MENTION_CHATS", "")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        return {part.strip() for part in str(raw).split(",") if part.strip()}
+
+    def _telegram_require_mention(self, chat_id: Optional[str] = None) -> bool:
+        """Return whether group chats should require an explicit bot trigger.
+
+        When *chat_id* is supplied and appears in ``require_mention_chats``, the
+        mention requirement is forced on for that chat regardless of the global
+        setting — the per-chat opt-in counterpart to ``free_response_chats``.
+        (``free_response_chats`` is checked ahead of this at the call sites, so a
+        chat listed in both stays chatty; keep chats in only one list.)
+        """
+        if chat_id is not None and str(chat_id) in self._telegram_require_mention_chats():
+            return True
         configured = self.config.extra.get("require_mention")
         if configured is not None:
             if isinstance(configured, str):
@@ -4884,7 +4911,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # if require_mention is disabled, every group message is a request.
         if chat_id_str in self._telegram_free_response_chats():
             return False
-        if not self._telegram_require_mention():
+        if not self._telegram_require_mention(chat_id_str):
             return False
         if self._is_reply_to_bot(message):
             return False
@@ -5135,7 +5162,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return True
         if chat_id_str in self._telegram_free_response_chats():
             return True
-        if not self._telegram_require_mention():
+        if not self._telegram_require_mention(chat_id_str):
             return True
         if self._is_reply_to_bot(message):
             return True

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -11,6 +11,7 @@ from gateway.session import SessionSource
 def _make_adapter(
     require_mention=None,
     free_response_chats=None,
+    require_mention_chats=None,
     mention_patterns=None,
     exclusive_bot_mentions=None,
     ignored_threads=None,
@@ -30,6 +31,8 @@ def _make_adapter(
         extra["require_mention"] = require_mention
     if free_response_chats is not None:
         extra["free_response_chats"] = free_response_chats
+    if require_mention_chats is not None:
+        extra["require_mention_chats"] = require_mention_chats
     if mention_patterns is not None:
         extra["mention_patterns"] = mention_patterns
     if exclusive_bot_mentions is not None:
@@ -541,6 +544,37 @@ def test_free_response_chats_bypass_mention_requirement():
 
     assert adapter._should_process_message(_group_message("hello everyone", chat_id=-200)) is True
     assert adapter._should_process_message(_group_message("hello everyone", chat_id=-201)) is False
+
+
+def test_require_mention_chats_opt_in_gates_specific_chat():
+    """require_mention_chats forces @mention gating in listed chats even when
+    require_mention is globally off — the opt-in counterpart to
+    free_response_chats (e.g. multi-bot rooms where several agents share a
+    group and should not all answer every unaddressed message)."""
+    adapter = _make_adapter(require_mention=False, require_mention_chats=["-200"])
+
+    # In the opted-in chat a plain message is ignored...
+    assert adapter._should_process_message(_group_message("hello everyone", chat_id=-200)) is False
+    # ...but an explicit @mention still triggers.
+    mentioned = _group_message(
+        "hi @hermes_bot",
+        chat_id=-200,
+        entities=[_mention_entity("hi @hermes_bot")],
+    )
+    assert adapter._should_process_message(mentioned) is True
+    # Every other chat stays chatty because the global default is off.
+    assert adapter._should_process_message(_group_message("hello everyone", chat_id=-201)) is True
+
+
+def test_require_mention_chats_from_env(monkeypatch):
+    """TELEGRAM_REQUIRE_MENTION_CHATS feeds the per-chat opt-in when config is absent."""
+    monkeypatch.setenv("TELEGRAM_REQUIRE_MENTION_CHATS", "-200, -300")
+    adapter = _make_adapter(require_mention=False)
+
+    assert adapter._telegram_require_mention_chats() == {"-200", "-300"}
+    assert adapter._telegram_require_mention("-200") is True   # opted-in chat
+    assert adapter._telegram_require_mention("-999") is False  # falls back to global (off)
+    assert adapter._telegram_require_mention() is False        # no chat_id → global
 
 
 def test_guest_mode_allows_only_direct_mentions_outside_allowed_chats():


### PR DESCRIPTION
## What

Adds `require_mention_chats` — a **per-chat opt-in** counterpart to the existing `free_response_chats`. Chats listed here require an explicit @mention **even when `require_mention` is globally disabled**.

This lets the bot stay chatty everywhere by default while staying quiet-until-addressed in specific rooms — e.g. **multi-bot groups** where several agents share a chat and shouldn't all answer every unaddressed message.

Today the choice is only global:
- `require_mention: false` → responds to everything, everywhere
- `require_mention: true` → needs @mention everywhere (+ `free_response_chats` to exempt specific chats)

There was no way to say "stay chatty everywhere **except** these few multi-bot rooms" without enumerating every other chat in `free_response_chats`. This adds the symmetric knob.

## Usage

```yaml
telegram:
  require_mention: false                 # chatty by default
  require_mention_chats:                 # ...but require @mention in these
    - "-1004409934113"
```

Also honored via `TELEGRAM_REQUIRE_MENTION_CHATS` (comma-separated), mirroring `TELEGRAM_FREE_RESPONSE_CHATS`.

## Changes

- **`gateway/platforms/telegram.py`** — new `_telegram_require_mention_chats()` and an optional `chat_id` arg on `_telegram_require_mention()`, passed at both group-gating call sites. `free_response_chats` still takes precedence (checked first at the call sites).
- **`gateway/config.py`** — bridges `telegram.require_mention_chats` → `TELEGRAM_REQUIRE_MENTION_CHATS`, mirroring the `free_response_chats` bridge.
- **`tests/gateway/test_telegram_group_gating.py`** — per-chat opt-in gating + env-var resolution.

## Testing

`tests/gateway/test_telegram_group_gating.py` — **46 passed** (2 new).

## Compatibility

Fully backward compatible. Unset/empty `require_mention_chats` = no behavior change. Mirrors `free_response_chats` exactly (config key, env var, set semantics). DMs are never affected.
