### PR TITLE
fix(yuanbao): normalize image mime parameters

### DIFF
--- a/gateway/platforms/yuanbao_media.py
+++ b/gateway/platforms/yuanbao_media.py
@@ -92,9 +92,14 @@ def guess_mime_type(filename: str) -> str:
     return _EXT_TO_MIME.get(ext, "application/octet-stream")
 
 
+def _normalize_mime_type(mime_type: str) -> str:
+    """Normalize a MIME value for classification."""
+    return (mime_type or "").split(";", 1)[0].strip().lower()
+
+
 def is_image(filename: str, mime_type: str = "") -> bool:
     """判断是否为图片类型。"""
-    if mime_type.startswith("image/"):
+    if _normalize_mime_type(mime_type).startswith("image/"):
         return True
     ext = os.path.splitext(filename)[-1].lower()
     return ext in {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".heic", ".tiff", ".ico"}
@@ -102,7 +107,7 @@ def is_image(filename: str, mime_type: str = "") -> bool:
 
 def get_image_format(mime_type: str) -> int:
     """获取 TIM 图片格式编号。"""
-    return _MIME_TO_IMAGE_FORMAT.get(mime_type.lower(), 255)
+    return _MIME_TO_IMAGE_FORMAT.get(_normalize_mime_type(mime_type), 255)
 
 
 def md5_hex(data: bytes) -> str:

--- a/gateway/platforms/yuanbao_media.py
+++ b/gateway/platforms/yuanbao_media.py
@@ -92,9 +92,14 @@ def guess_mime_type(filename: str) -> str:
     return _EXT_TO_MIME.get(ext, "application/octet-stream")
 
 
+def _normalize_mime_type(mime_type: str) -> str:
+    """Normalize a MIME value for classification."""
+    return (mime_type or "").split(";", 1)[0].strip().lower()
+
+
 def is_image(filename: str, mime_type: str = "") -> bool:
     """判断是否为图片类型。"""
-    if mime_type.startswith("image/"):
+    if _normalize_mime_type(mime_type).startswith("image/"):
         return True
     ext = os.path.splitext(filename)[-1].lower()
     return ext in {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".heic", ".tiff", ".ico"}
@@ -102,7 +107,7 @@ def is_image(filename: str, mime_type: str = "") -> bool:
 
 def get_image_format(mime_type: str) -> int:
     """获取 TIM 图片格式编号。"""
-    return _MIME_TO_IMAGE_FORMAT.get(mime_type.lower(), 255)
+    return _MIME_TO_IMAGE_FORMAT.get(_normalize_mime_type(mime_type), 255)
 
 
 def md5_hex(data: bytes) -> str:
@@ -557,7 +562,7 @@ async def upload_to_cos(
         "size": file_size,
     }
 
-    if content_type.startswith("image/"):
+    if _normalize_mime_type(content_type).startswith("image/"):
         size_info = parse_image_size(file_bytes)
         if size_info:
             result["width"] = size_info["width"]

--- a/tests/test_yuanbao_proto.py
+++ b/tests/test_yuanbao_proto.py
@@ -20,6 +20,11 @@ if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
 import pytest
+from gateway.platforms.yuanbao_media import (
+    build_image_msg_body,
+    get_image_format,
+    is_image,
+)
 from gateway.platforms.yuanbao_proto import (
     # 基础工具
     _encode_varint,
@@ -53,6 +58,25 @@ from gateway.platforms.yuanbao_proto import (
 # ===========================================================
 # 1. varint 编解码
 # ===========================================================
+
+class TestYuanbaoMediaMime:
+    def test_gif_mime_parameters_keep_image_format(self):
+        assert get_image_format(" image/gif; charset=binary ") == 2
+
+        body = build_image_msg_body(
+            "https://example.com/anim.gif",
+            uuid="gif-1",
+            size=123,
+            width=10,
+            height=10,
+            mime_type="IMAGE/GIF; charset=binary",
+        )
+        assert body[0]["msg_content"]["image_format"] == 2
+
+    def test_image_detection_normalizes_mime_parameters(self):
+        assert is_image("upload.bin", " IMAGE/GIF; charset=binary ") is True
+        assert is_image("upload.bin", " text/plain; charset=utf-8 ") is False
+
 
 class TestVarint:
     def test_small_values(self):

--- a/tests/test_yuanbao_proto.py
+++ b/tests/test_yuanbao_proto.py
@@ -20,6 +20,13 @@ if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
 import pytest
+from unittest.mock import patch
+from gateway.platforms.yuanbao_media import (
+    build_image_msg_body,
+    get_image_format,
+    is_image,
+    upload_to_cos,
+)
 from gateway.platforms.yuanbao_proto import (
     # 基础工具
     _encode_varint,
@@ -53,6 +60,54 @@ from gateway.platforms.yuanbao_proto import (
 # ===========================================================
 # 1. varint 编解码
 # ===========================================================
+
+class TestYuanbaoMediaMime:
+    def test_gif_mime_parameters_keep_image_format(self):
+        assert get_image_format(" image/gif; charset=binary ") == 2
+
+        body = build_image_msg_body(
+            "https://example.com/anim.gif",
+            uuid="gif-1",
+            size=123,
+            width=10,
+            height=10,
+            mime_type="IMAGE/GIF; charset=binary",
+        )
+        assert body[0]["msg_content"]["image_format"] == 2
+
+    def test_image_detection_normalizes_mime_parameters(self):
+        assert is_image("upload.bin", " IMAGE/GIF; charset=binary ") is True
+        assert is_image("upload.bin", " text/plain; charset=utf-8 ") is False
+
+    @pytest.mark.asyncio
+    async def test_upload_normalizes_image_mime_for_dimensions(self):
+        class Client:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return None
+
+            async def put(self, *args, **kwargs):
+                return type("Response", (), {"raise_for_status": lambda self: None})()
+
+        credentials = {
+            "encryptTmpSecretId": "id",
+            "encryptTmpSecretKey": "key",
+            "location": "x.gif",
+        }
+        with (
+            patch("gateway.platforms.yuanbao_media.httpx.AsyncClient", return_value=Client()),
+            patch(
+                "gateway.platforms.yuanbao_media.parse_image_size",
+                return_value={"width": 7, "height": 9},
+            ),
+        ):
+            result = await upload_to_cos(
+                b"gif", "x.gif", "IMAGE/GIF", credentials, "bucket", "region"
+            )
+        assert (result["width"], result["height"]) == (7, 9)
+
 
 class TestVarint:
     def test_small_values(self):


### PR DESCRIPTION
## What does this PR do?

Normalizes Yuanbao image MIME values before classification so GIF content types with parameters or casing/whitespace differences still map to TIM image format `2`.

Before this change, `get_image_format("image/gif; charset=binary")` returned `255`, and `build_image_msg_body(..., mime_type=...)` propagated that unknown format into `msg_content.image_format`. The same raw-prefix handling also made `is_image()` miss image MIME values with leading whitespace or uppercase casing.

The fix adds a small MIME classification helper that trims, lowercases, and drops `;...` parameters, then uses it for image detection and image-format lookup.

## Related Issue

Fixes #58797

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `gateway/platforms/yuanbao_media.py`: normalize MIME values for `is_image()` and `get_image_format()`.
- `tests/test_yuanbao_proto.py`: add focused coverage for parameterized GIF MIME values and image detection.

## How to Test

1. On `main`, `get_image_format("image/gif; charset=binary")` returns `255`.
2. On this branch:

```text
from gateway.platforms.yuanbao_media import get_image_format
print(get_image_format("image/gif; charset=binary"))
print(get_image_format(" IMAGE/GIF "))
print(get_image_format("image/png"))
```

Output:

```text
2
2
3
```

3. Focused regression:

```text
TMP=F:\openclaw\tmp\pytest TEMP=F:\openclaw\tmp\pytest uv run --locked --extra dev python -m pytest tests/test_yuanbao_proto.py::TestYuanbaoMediaMime -q
```

Result:

```text
2 passed in 0.39s
```

4. Additional checks:

```text
python -m py_compile gateway\platforms\yuanbao_media.py tests\test_yuanbao_proto.py
git diff --check
```

Both passed; `git diff --check` only printed existing LF/CRLF working-copy warnings.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / PowerShell

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - pure Python string normalization
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## For New Skills

N/A

## Screenshots / Logs

```text
..                                                                       [100%]
2 passed in 0.39s
```
