### PR TITLE
fix(model_tools): preserve explicitly-enabled tools when disabling a composite toolset

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -420,13 +420,38 @@ def _compute_tool_definitions(
                             ", ".join(resolved) if resolved else "none",
                         )
                 else:
-                    resolved = resolve_toolset(toolset_name)
-                    tools_to_include.difference_update(resolved)
+                    resolved = set(resolve_toolset(toolset_name))
+                    if enabled_toolsets is not None:
+                        # When explicitly-enabled toolsets are set, only
+                        # subtract the tools of the disabled composite that
+                        # are NOT also contributed by an enabled toolset.
+                        # Otherwise disabling a composite like "coding"
+                        # strips every terminal + file tool and the model
+                        # receives zero tools with no warning (#58281).
+                        exclusive = resolved - tools_to_include
+                        if exclusive != resolved and not quiet_mode:
+                            preserved = resolved - exclusive
+                            logger.info(
+                                "disabled_toolsets includes '%s' which overlaps "
+                                "with enabled toolsets; %d tools are preserved "
+                                "because they are provided by enabled toolsets: %s",
+                                toolset_name, len(preserved),
+                                ", ".join(sorted(preserved)),
+                            )
+                        tools_to_include.difference_update(exclusive)
+                    else:
+                        tools_to_include.difference_update(resolved)
+                resolved_display = sorted(resolved)
                 if not quiet_mode:
-                    print(f"🚫 Disabled toolset '{toolset_name}': {', '.join(resolved) if resolved else 'no tools'}")
+                    print(f"🚫 Disabled toolset '{toolset_name}': {', '.join(resolved_display) if resolved_display else 'no tools'}")
             elif toolset_name in _LEGACY_TOOLSET_MAP:
                 legacy_tools = _LEGACY_TOOLSET_MAP[toolset_name]
-                tools_to_include.difference_update(legacy_tools)
+                if enabled_toolsets is not None:
+                    legacy_set = set(legacy_tools)
+                    exclusive = legacy_set - tools_to_include
+                    tools_to_include.difference_update(exclusive)
+                else:
+                    tools_to_include.difference_update(legacy_tools)
                 if not quiet_mode:
                     print(f"🚫 Disabled legacy toolset '{toolset_name}': {', '.join(legacy_tools)}")
             elif not quiet_mode:

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -536,3 +536,127 @@ class TestDisabledToolsetsPlatformBundle:
         from toolsets import bundle_non_core_tools
         # A non-existent bundle resolves to an empty set (no tools), not a crash.
         assert bundle_non_core_tools("hermes-does-not-exist") == set()
+
+
+class TestDisabledCompositeToolsetOverlap:
+    """Regression for #58281: disabling a composite toolset like ``coding``
+    must preserve tools belonging to explicitly-enabled subtoolsets."""
+
+    def test_disabling_coding_preserves_terminal_and_file_tools(self):
+        """With terminal + file enabled, disabling coding keeps terminal/file tools."""
+        from model_tools import get_tool_definitions
+
+        tools_before = get_tool_definitions(
+            enabled_toolsets=["terminal", "file"],
+            quiet_mode=True,
+        )
+        tools_after = get_tool_definitions(
+            enabled_toolsets=["terminal", "file"],
+            disabled_toolsets=["coding"],
+            quiet_mode=True,
+        )
+        names_before = {t["function"]["name"] for t in tools_before}
+        names_after = {t["function"]["name"] for t in tools_after}
+
+        # Should not lose any terminal or file tools
+        assert names_before == names_after, (
+            f"Tools lost when disabling coding: {names_before - names_after}"
+        )
+
+    def test_disabling_coding_removes_coding_only_tools(self):
+        """Tools exclusive to 'coding' (not in terminal/file) are still removed."""
+        from model_tools import get_tool_definitions
+
+        tools_all = get_tool_definitions(
+            enabled_toolsets=["terminal", "file", "coding"],
+            quiet_mode=True,
+        )
+        tools_no_coding = get_tool_definitions(
+            enabled_toolsets=["terminal", "file"],
+            disabled_toolsets=["coding"],
+            quiet_mode=True,
+        )
+        names_all = {t["function"]["name"] for t in tools_all}
+        names_no_coding = {t["function"]["name"] for t in tools_no_coding}
+
+        # coding-only tools should NOT appear
+        coding_only = names_all - names_no_coding
+        assert coding_only, "expected coding to contribute exclusive tools"
+        assert not (coding_only & names_no_coding), (
+            f"coding-only tools leaked: {coding_only & names_no_coding}"
+        )
+
+    def test_disabling_safe_preserves_enabled_overlap(self):
+        """Disabling 'safe' preserves tools from explicitly enabled terminal/file."""
+        from model_tools import get_tool_definitions
+
+        tools = get_tool_definitions(
+            enabled_toolsets=["terminal", "file"],
+            disabled_toolsets=["safe"],
+            quiet_mode=True,
+        )
+        names = {t["function"]["name"] for t in tools}
+        assert "terminal" in names
+        assert "read_file" in names
+
+    def test_disabling_debugging_preserves_enabled_overlap(self):
+        """Disabling 'debugging' preserves tools from explicitly enabled terminal/file."""
+        from model_tools import get_tool_definitions
+
+        tools = get_tool_definitions(
+            enabled_toolsets=["terminal", "file"],
+            disabled_toolsets=["debugging"],
+            quiet_mode=True,
+        )
+        names = {t["function"]["name"] for t in tools}
+        assert "terminal" in names
+        assert "read_file" in names
+
+    def test_default_enabled_toolsets_full_subtraction_still_works(self):
+        """When enabled_toolsets is None (default=all), full subtraction still works."""
+        from model_tools import get_tool_definitions
+
+        tools_all = get_tool_definitions(quiet_mode=True)
+        tools_no_coding = get_tool_definitions(
+            disabled_toolsets=["coding"],
+            quiet_mode=True,
+        )
+        names_all = {t["function"]["name"] for t in tools_all}
+        names_no_coding = {t["function"]["name"] for t in tools_no_coding}
+
+        removed = names_all - names_no_coding
+        assert removed, "expected tools to be removed when all toolsets are enabled"
+
+    def test_legacy_toolset_disabled_preserves_enabled_overlap(self):
+        """Disabling legacy 'file_tools' preserves file tools from enabled 'terminal' + 'file'."""
+        from model_tools import get_tool_definitions
+
+        tools = get_tool_definitions(
+            enabled_toolsets=["terminal", "file"],
+            disabled_toolsets=["file_tools"],
+            quiet_mode=True,
+        )
+        names = {t["function"]["name"] for t in tools}
+        # file tools should still be present because "file" toolset is explicitly enabled
+        for file_tool in ("read_file", "write_file", "patch", "search_files"):
+            assert file_tool in names, f"{file_tool} lost when disabling legacy file_tools"
+
+    def test_hermes_bundle_regression_unchanged(self):
+        """hermes-* bundle protection (#33924) is unchanged by the new logic."""
+        from model_tools import get_tool_definitions
+
+        tools_telegram = get_tool_definitions(
+            enabled_toolsets=["hermes-telegram"],
+            quiet_mode=True,
+        )
+        tools_telegram_no_yuanbao = get_tool_definitions(
+            enabled_toolsets=["hermes-telegram"],
+            disabled_toolsets=["hermes-yuanbao"],
+            quiet_mode=True,
+        )
+        names_telegram = {t["function"]["name"] for t in tools_telegram}
+        names_no_yuanbao = {t["function"]["name"] for t in tools_telegram_no_yuanbao}
+
+        assert names_telegram == names_no_yuanbao, (
+            f"Tools lost from telegram bundle: {names_telegram - names_no_yuanbao}"
+        )


### PR DESCRIPTION
## Summary

Fixes #58281. When  is explicitly set and a composite toolset (like ) appears in , the old code removed ALL tools from the disabled composite — including tools that belong to explicitly-enabled subtoolsets. This left the model with zero tools and no warning.

## Changes

### model_tools.py
- In the  subtraction loop, when  is explicitly set, compute the exclusive set of tools (tools the disabled composite contributes that no enabled toolset also contributes) and subtract only those
- Same protection applied to legacy toolset names ()
- Default path () behavior is unchanged — full subtraction

### tests/test_model_tools.py
New  class with 7 tests:
- Disabling  preserves terminal and file tools
- Coding-only tools (web_search, browser, etc.) are still removed
- Disabling other composites (, ) preserves enabled tools
- Default (all toolsets) still does full subtraction
- Legacy toolset names get the same protection
- hermes-* bundle regression pin

## Root Cause

The disabled_toolsets subtraction at line 422 performed  without checking whether any of those tools belonged to explicitly-enabled toolsets. The  bundle special case had this protection for core tools, but it only applied to names starting with .

Type: Bug fix
Closes: #58281