### PR TITLE
fix(dashboard): route single password-only provider to /login, not OAuth (500 on basic-auth login)

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -185,6 +185,13 @@ def _auto_sso_response(request: Request) -> Response | None:
     from hermes_cli.dashboard_auth.prefix import prefix_from_request
 
     provider = providers[0]
+    if getattr(provider, "supports_password", False):
+        # Fork patch: a single password-only provider (BasicAuthProvider)
+        # has no OAuth redirect — start_login() raises NotImplementedError,
+        # so the auto-SSO bounce to /auth/login 500s. Fall through to the
+        # /login form instead. Upstream _auto_sso_response guards only on
+        # provider COUNT, not capability. Carry: report upstream.
+        return None
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -193,6 +193,20 @@ async def auth_login(request: Request, provider: str, next: str = ""):
             detail=f"Provider does not support interactive login: {provider!r}",
         )
 
+    if getattr(p, "supports_password", False):
+        # Fork patch: password-only providers have no OAuth redirect
+        # (start_login raises NotImplementedError -> 500). Send direct or
+        # bookmarked /auth/login hits to the /login form instead. Carry:
+        # report upstream alongside the _auto_sso_response guard.
+        from urllib.parse import quote as _quote
+        from hermes_cli.dashboard_auth.prefix import prefix_from_request
+        _prefix = prefix_from_request(request)
+        _loc = (
+            f"{_prefix}/login?next={_quote(next, safe='')}" if next
+            else f"{_prefix}/login"
+        )
+        return RedirectResponse(url=_loc, status_code=302)
+
     try:
         ls = p.start_login(redirect_uri=_redirect_uri(request))
     except ProviderError as e:


### PR DESCRIPTION
## Problem

With a **single password-only auth provider** (`BasicAuthProvider`) configured, the dashboard returns **HTTP 500** on any unauthenticated navigation.

The June-2026 hardening requires an auth provider to bind the dashboard to a non-loopback host. Configuring `dashboard.basic_auth` satisfies the bind gate, but logging in fails: two code paths bounce the browser to the **OAuth-initiation** route `GET /auth/login?provider=<name>`, which calls `provider.start_login()` — and `BasicAuthProvider.start_login()` raises `NotImplementedError` ("password-only; there is no OAuth redirect flow").

```
NotImplementedError: BasicAuthProvider is password-only; there is no OAuth
redirect flow. The login page POSTs to /auth/password-login instead.
```

### Root cause

Two spots dispatch to the OAuth flow without checking whether the provider actually supports it:

1. `hermes_cli/dashboard_auth/middleware.py::_auto_sso_response` — auto-redirects to `/auth/login?provider=<name>` whenever exactly **one** session provider is registered. It guards on provider **count**, not capability, so a lone password provider is treated like a lone OAuth IDP.
2. `hermes_cli/dashboard_auth/routes.py::auth_login` — calls `start_login()` unconditionally after the `supports_session` check.

The correct server-rendered form at `GET /login` (which POSTs to `/auth/password-login`) works fine — the gate just never routes password providers there. This only manifests with a single-provider **password** setup; single-provider OAuth (the common self-hosted path) is unaffected, which is presumably why it went unnoticed.

## Fix

Guard both paths on `supports_password`:

- `_auto_sso_response` returns `None` (falls through to the `/login` chooser) when the single provider is password-only.
- `auth_login` redirects to `/login?next=...` instead of calling `start_login()` for password-only providers (handles direct/bookmarked hits gracefully).

No behavior change for OAuth providers.

## Testing

Single `BasicAuthProvider`, dashboard bound to `0.0.0.0`:

| Request | Before | After |
| --- | --- | --- |
| `GET /` (unauth) | 302 → `/auth/login?provider=basic` → **500** | 302 → `/login` |
| `GET /auth/login?provider=basic` | **500** | 302 → `/login` |
| `GET /login` | 200 | 200 |
| `POST /auth/password-login` (valid) | 200 `{"ok":true}` | 200 `{"ok":true}` |
| `POST /auth/password-login` (wrong pw) | 401 | 401 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
