### PR TITLE
fix(telegram): forward keepalive limits into fallback transport

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3054,17 +3054,28 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
                 # Keep request/update pools separate to reduce contention during
                 # polling reconnect + bot API bootstrap/delete_webhook calls.
+                # httpx ignores the client-level `limits` kwarg when a custom
+                # `transport` is supplied (#58790).  Pass the tuned limits
+                # directly into TelegramFallbackTransport so its inner
+                # AsyncHTTPTransport instances honour keepalive_expiry.
+                _transport_kwargs: dict = {}
+                if _pool_limits is not None:
+                    _transport_kwargs["limits"] = _pool_limits
                 request = HTTPXRequest(
                     **request_kwargs,
-                    httpx_kwargs=_with_limits(
-                        {"transport": TelegramFallbackTransport(fallback_ips)}
-                    ),
+                    httpx_kwargs={
+                        "transport": TelegramFallbackTransport(
+                            fallback_ips, **_transport_kwargs
+                        )
+                    },
                 )
                 get_updates_request = HTTPXRequest(
                     **request_kwargs,
-                    httpx_kwargs=_with_limits(
-                        {"transport": TelegramFallbackTransport(fallback_ips)}
-                    ),
+                    httpx_kwargs={
+                        "transport": TelegramFallbackTransport(
+                            fallback_ips, **_transport_kwargs
+                        )
+                    },
                 )
             elif proxy_url:
                 logger.info("[%s] Proxy detected; passing explicitly to HTTPXRequest: %s", self.name, proxy_url)

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -20,7 +20,6 @@ import pytest
 
 import plugins.platforms.telegram.telegram_network as tnet
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -54,7 +53,6 @@ class FakeTransport(httpx.AsyncBaseTransport):
     async def aclose(self) -> None:
         self.closed = True
 
-
 def _fake_transport_factory(calls, behavior):
     """Returns a factory that creates FakeTransport instances."""
     instances = []
@@ -67,10 +65,8 @@ def _fake_transport_factory(calls, behavior):
     factory.instances = instances
     return factory
 
-
 def _telegram_request(path="/botTOKEN/getMe"):
     return httpx.Request("GET", f"https://api.telegram.org{path}")
-
 
 # ═══════════════════════════════════════════════════════════════════════════
 # IP parsing & validation
@@ -105,7 +101,6 @@ class TestParseFallbackIpEnv:
         assert ips == []
         assert "Ignoring invalid" in caplog.text
 
-
 class TestNormalizeFallbackIps:
     def test_deduplication_happens_at_transport_level(self):
         """_normalize does not dedup; TelegramFallbackTransport.__init__ does."""
@@ -114,7 +109,6 @@ class TestNormalizeFallbackIps:
 
     def test_empty_strings_skipped(self):
         assert tnet._normalize_fallback_ips(["", "  ", "149.154.167.220"]) == ["149.154.167.220"]
-
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Request rewriting
@@ -136,7 +130,6 @@ class TestRewriteRequestForIp:
 
         assert rewritten.method == "POST"
         assert rewritten.url.path == "/botTOKEN/sendMessage"
-
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Fallback transport – core behavior
@@ -258,7 +251,6 @@ class TestFallbackTransport:
         assert [c["url_host"] for c in calls] == ["149.154.167.220", "api.telegram.org", "149.154.167.221"]
         assert transport._sticky_ip == "149.154.167.221"
 
-
 class TestFallbackTransportPassthrough:
     """Requests that don't need fallback behavior."""
 
@@ -300,7 +292,6 @@ class TestFallbackTransportPassthrough:
         assert resp.status_code == 200
         assert transport._sticky_ip is None
         assert len(calls) == 1
-
 
 class TestFallbackTransportInit:
     def test_deduplicates_fallback_ips(self, monkeypatch):
@@ -354,6 +345,38 @@ class TestFallbackTransportInit:
         assert len(seen_kwargs) == 2
         assert all("proxy" not in kwargs for kwargs in seen_kwargs)
 
+    def test_forwards_limits_to_inner_transports(self, monkeypatch):
+        """Verify that caller-supplied limits reach the inner
+        AsyncHTTPTransport instances (#58790).  httpx ignores the
+        client-level limits kwarg when a custom transport is
+        supplied, so the limits must be forwarded via transport_kwargs.
+        """
+        seen_kwargs = []
+
+        def factory(**kwargs):
+            seen_kwargs.append(kwargs.copy())
+            return FakeTransport([], {})
+
+        for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY", "https_proxy",
+                    "http_proxy", "all_proxy", "TELEGRAM_PROXY", "NO_PROXY",
+                    "no_proxy"):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", factory)
+
+        custom_limits = httpx.Limits(
+            max_connections=42,
+            max_keepalive_connections=10,
+            keepalive_expiry=30.0,
+        )
+        transport = tnet.TelegramFallbackTransport(
+            ["149.154.167.220"], limits=custom_limits
+        )
+
+        # 1 primary + 1 fallback = 2 AsyncHTTPTransport instances
+        assert len(seen_kwargs) == 2
+        for kw in seen_kwargs:
+            assert "limits" in kw
+            assert kw["limits"] is custom_limits
 
 class TestFallbackTransportClose:
     @pytest.mark.asyncio
@@ -367,7 +390,6 @@ class TestFallbackTransportClose:
         # 1 primary + 2 fallback transports
         assert len(factory.instances) == 3
         assert all(t.closed for t in factory.instances)
-
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Config layer – TELEGRAM_FALLBACK_IPS env → config.extra
@@ -414,7 +436,6 @@ class TestConfigFallbackIps:
         _apply_env_overrides(config)
 
         assert "fallback_ips" not in config.platforms[Platform.TELEGRAM].extra
-
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Adapter layer – _fallback_ips() reads config correctly
@@ -466,7 +487,6 @@ class TestAdapterFallbackIps:
         adapter = self._make_adapter(extra={"fallback_ips": ["149.154.167.220", "not-valid"]})
         assert adapter._fallback_ips() == ["149.154.167.220"]
 
-
 # ═══════════════════════════════════════════════════════════════════════════
 # DoH auto-discovery
 # ═══════════════════════════════════════════════════════════════════════════
@@ -474,7 +494,6 @@ class TestAdapterFallbackIps:
 def _doh_answer(*ips: str) -> dict:
     """Build a minimal DoH JSON response with A records."""
     return {"Answer": [{"type": 1, "data": ip} for ip in ips]}
-
 
 class FakeDoHClient:
     """Mock httpx.AsyncClient for DoH queries."""
@@ -505,7 +524,6 @@ class FakeDoHClient:
 
     async def __aexit__(self, *args):
         pass
-
 
 class TestDiscoverFallbackIps:
     """Tests for discover_fallback_ips() — DoH-based auto-discovery."""


### PR DESCRIPTION
## What does this PR do?

Fixes a CLOSE_WAIT fd leak in the Telegram fallback-IP transport path.  When `api.telegram.org` is only reachable via `TelegramFallbackTransport` (no proxy, fallback IPs active), the general-request pool accumulates half-closed sockets because httpx silently ignores the client-level `limits` kwarg when a custom `transport` is supplied.  The #31599 keepalive fix injected limits via `httpx_kwargs["limits"]`, but the fallback branch also passes a custom transport — so the tuned `keepalive_expiry` was never applied to the inner `AsyncHTTPTransport` instances.

The fix passes the tuned limits directly into `TelegramFallbackTransport` via `transport_kwargs` so its inner transports honour `keepalive_expiry`.  Only the fallback-IP branch is affected; proxy and direct-DNS branches continue to use `_with_limits()` as before.

## Related Issue

Fixes #58790

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/telegram/adapter.py`: Pass `_pool_limits` to `TelegramFallbackTransport` via `transport_kwargs` instead of putting `limits` in `httpx_kwargs` (where httpx ignores it when `transport` is present).  Build `_transport_kwargs` dict with `limits` key when `_pool_limits` is not None.
- `tests/gateway/test_telegram_network.py`: Add `test_forwards_limits_to_inner_transports` to verify that caller-supplied `limits` reach the inner `AsyncHTTPTransport` instances.

## How to Test

1. Run `pytest tests/gateway/test_telegram_network.py::TestFallbackTransportInit::test_forwards_limits_to_inner_transports -v` — should pass.
2. Run `pytest tests/gateway/test_telegram_network.py -v` — all 47 tests should pass.
3. On a host where `api.telegram.org` requires fallback IPs, run a long-lived gateway and monitor fd count with `lsof -p PID | grep -c CLOSE_WAIT` (replace PID with the gateway process ID).  Before this fix, CLOSE_WAIT sockets accumulate; after, they drain per `keepalive_expiry`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_telegram_network.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
