### PR TITLE
fix(telegram): default fallback transport to platform keepalive limits (stop CLOSE_WAIT fd leak)

### DIFF
--- a/plugins/platforms/telegram/telegram_network.py
+++ b/plugins/platforms/telegram/telegram_network.py
@@ -63,6 +63,20 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
         proxy_url = _resolve_proxy_url(target_hosts=[_TELEGRAM_API_HOST, *self._fallback_ips])
         if proxy_url and "proxy" not in transport_kwargs:
             transport_kwargs["proxy"] = proxy_url
+        # httpx discards a client-level ``limits`` whenever a custom transport is
+        # supplied (adapter.py passes this transport into HTTPXRequest), so the
+        # CLOSE_WAIT-safe keepalive tuning would be lost on the fallback path
+        # unless the transport applies it itself. Default to the shared platform
+        # limits so peer-FIN'd keepalive sockets are reaped before the process
+        # walks into the fd limit (#31599 / #58790). An explicit ``limits=`` wins.
+        if "limits" not in transport_kwargs:
+            try:
+                from gateway.platforms._http_client_limits import platform_httpx_limits
+                _fallback_limits = platform_httpx_limits()
+            except Exception:
+                _fallback_limits = None
+            if _fallback_limits is not None:
+                transport_kwargs["limits"] = _fallback_limits
         self._primary = httpx.AsyncHTTPTransport(**transport_kwargs)
         self._fallbacks = {
             ip: httpx.AsyncHTTPTransport(**transport_kwargs) for ip in self._fallback_ips


### PR DESCRIPTION
## Summary

When Telegram is reached via the **fallback-IP transport** (`api.telegram.org` not directly reachable, so `TelegramFallbackTransport` is active), the CLOSE_WAIT-safe keepalive tuning added in #31599 is **silently dropped**, and the general request pool leaks `CLOSE_WAIT` sockets until the process hits its file-descriptor limit and wedges.

## Root cause

`platform_httpx_limits()` (keepalive_expiry=2.0, max_keepalive=10) is injected into the PTB client via `httpx_kwargs["limits"]`. But at the fallback-IP construction site a **custom `transport`** is also supplied:

```python
# plugins/platforms/telegram/adapter.py  (fallback branch)
request = HTTPXRequest(
    **request_kwargs,
    httpx_kwargs=_with_limits(
        {"transport": TelegramFallbackTransport(fallback_ips)}   # <-- limits + transport together
    ),
)
```

**httpx ignores the client-level `limits` argument whenever a custom `transport` is passed** — `limits` only ever configures the default transport that httpx builds internally. So the inner transports created in `TelegramFallbackTransport.__init__` run with httpx's **defaults** (`keepalive_expiry=5.0`, `max_keepalive=20`), not the tuned values:

```python
# plugins/platforms/telegram/telegram_network.py
self._primary   = httpx.AsyncHTTPTransport(**transport_kwargs)          # no limits
self._fallbacks = {ip: httpx.AsyncHTTPTransport(**transport_kwargs) ...} # no limits
```

The polling pool is periodically reset by `_drain_polling_connections()`, but the **general request pool** (`send_message` / `editMessageText` — heavy during streaming status edits) is not, and its keepalive tuning is bypassed. Peer-initiated FINs pile up as `CLOSE_WAIT` and are never reaped.

The in-code comment at the injection site already notes "`limits` here wins" — that reasoning holds against *other* `limits` kwargs, but not against a custom `transport`, which is the blind spot this PR closes.

## Observed impact (production)

On a long-lived gateway (10 days, no restart) behind a network that forces the fallback path:

```
pid 87694 (ai.hermes.gateway):  289 open fds — 224 CLOSE_WAIT to sticky fallback IP :443
pid 87774 (ai.hermes.gateway-macro): 289 open fds — 227 CLOSE_WAIT
```

macOS per-process soft limit is 256, so both wedged with `OSError: [Errno 24] Too many open files`: kanban sqlite opens fail, channel-directory writes fail, and — user-visibly — new Telegram send/stream sockets can't be created, so the bot hangs forever on "receiving stream response". Restarting the gateway clears it (fds 289 → ~54) but it recurs on the same ~10-day cadence.

Fixes #58790.

## Fix

Have `TelegramFallbackTransport` **default its inner `AsyncHTTPTransport`s to the shared `platform_httpx_limits()`** when the caller doesn't pass an explicit `limits`. Since httpx drops the client-level `limits` whenever a custom transport is supplied, the tuning has to live on the transport itself — so the fallback path now gets the same CLOSE_WAIT-safe keepalive (`keepalive_expiry=2.0`, `max_keepalive=10`) the proxy/direct branches already receive via `_with_limits()`.

Single-file change (`plugins/platforms/telegram/telegram_network.py`), fully contained in the fallback path:
- No change to `adapter.py`; the call site keeps `TelegramFallbackTransport(fallback_ips)`.
- An explicit `limits=` is still honored if ever passed.
- Proxy / direct-DNS branches unchanged.

```python
# telegram_network.py — TelegramFallbackTransport.__init__
if "limits" not in transport_kwargs:
    try:
        from gateway.platforms._http_client_limits import platform_httpx_limits
        _lim = platform_httpx_limits()
    except Exception:
        _lim = None
    if _lim is not None:
        transport_kwargs["limits"] = _lim
self._primary = httpx.AsyncHTTPTransport(**transport_kwargs)
self._fallbacks = {ip: httpx.AsyncHTTPTransport(**transport_kwargs) for ip in self._fallback_ips}
```

## Testing

- Verified `httpx.AsyncHTTPTransport(limits=platform_httpx_limits())` carries `keepalive_expiry=2.0` / `max_keepalive_connections=10`, and that `httpx.AsyncClient(transport=..., limits=...)` ignores the client-level `limits` (the root gotcha).
- With the default applied, steady-state `send_message`/`editMessageText` over the fallback path no longer accumulates `CLOSE_WAIT` beyond `max_keepalive`.
- Proxy / direct-DNS branches unchanged (they never construct a custom transport, so `_with_limits()` still applies).
