### PR TITLE
feat(skill): add tool-audit — agent self-monitoring for tool execution patterns

### DIFF
--- a/skills/autonomous-ai-agents/tool-audit/SKILL.md
+++ b/skills/autonomous-ai-agents/tool-audit/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: tool-audit
+description: "Report per-tool call counts and error rates for a session."
+version: 2.0.0
+author: nankingjing + Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [audit, diagnostics, sessions, tool-usage, self-monitoring]
+    related_skills: [hermes-agent]
+---
+
+# Tool Audit Skill
+
+Generate an operator-facing report of one session's tool usage from the
+canonical SQLite session store (`state.db`): per-tool call counts, results
+correlated back to their calls by `tool_call_id`, orphaned calls, and provable
+tool errors. The audit is strictly read-only and reports only what the store
+can prove — it does not report latency, because per-call `duration_ms` exists
+only inside the in-process `post_tool_call` observer hook and is never
+persisted to the session store.
+
+## When to Use
+
+- The user asks "how are my tools performing?" or "audit your tool usage"
+- After a long session with many tool calls, to spot failing or runaway tools
+- When debugging agent loops, repeated tool failures, or orphaned calls
+- Don't use for: latency profiling (that needs a `post_tool_call` observer
+  plugin), or batch-runner / RL trajectories (not stored in `state.db`)
+
+## Prerequisites
+
+- A readable `state.db` under the active Hermes home. The bundled script
+  resolves it profile-aware: `hermes_constants.get_hermes_home()` when
+  importable, else the `HERMES_HOME` env var, else the platform default.
+- Python 3 available to the `terminal` tool. The script is stdlib-only.
+
+## How to Run
+
+Run the bundled helper with the `terminal` tool (paths relative to this
+skill directory):
+
+```
+python scripts/tool_audit.py                     # audit $HERMES_SESSION_ID, else the latest session
+python scripts/tool_audit.py --session <id>      # audit a specific session (full id or unique prefix)
+python scripts/tool_audit.py --json              # machine-readable output
+python scripts/tool_audit.py --db /path/state.db # explicit store (e.g. another profile's)
+```
+
+## Quick Reference
+
+| Column | Meaning | Source of truth |
+|--------|---------|-----------------|
+| calls | `tool_calls` entries on assistant rows | `messages.tool_calls` JSON |
+| results | tool-role rows matched to a call by `tool_call_id` | `messages.tool_call_id` |
+| orphaned | calls with no matching result row | correlation gap |
+| errors | matched results whose payload is a JSON object with a truthy `error` key | same rule as the runtime observer (`model_tools._tool_result_observer_fields`) |
+
+Uncorrelated tool results (a result row whose `tool_call_id` matches no
+surviving call, e.g. after compaction) are counted separately, never
+attributed to a tool.
+
+## Procedure
+
+1. Resolve the target session. Default is `$HERMES_SESSION_ID` (set by the
+   running agent), falling back to the most recently started session. Pass
+   `--session` when the user names one. Done when the script prints the
+   session header (id, source, started, message count).
+2. Run the audit via `terminal` as shown above. Done when the per-tool table
+   and totals print with exit code 0.
+3. Interpret the numbers — only claims the table supports:
+   - High `errors` on one tool → quote 1-2 of its error payloads (rerun with
+     `--json` and read the `sample_errors` field) and suggest a concrete fix.
+   - `orphaned` calls → usually an interrupted turn or a compaction boundary;
+     say so instead of calling it a failure.
+   - A tool dominating `calls` → look for loops or missed batching.
+4. Deliver a short report to the operator: session header, the table, then
+   at most three recommendations, each tied to a number in the table. Done
+   when every recommendation cites a metric the script actually printed.
+
+## Pitfalls
+
+- Do not invent success rates or latency. The store has no per-call duration;
+  anything beyond calls / results / orphaned / errors is fabrication.
+- `errors` is a lower bound: only JSON-object results with a truthy `error`
+  key are provable. Plain-text failure prose is not counted — say "provable
+  errors", not "all errors".
+- Legacy `~/.hermes/**/*.jsonl` transcripts are dead: no longer written or
+  read. Never grep them; only `state.db` is canonical.
+- The script opens the store with SQLite `mode=ro` — never "fix" it to a
+  writable connection, and do not run schema queries against a live gateway
+  store outside the script.
+- Session id prefixes must be unique; the script exits non-zero on ambiguity
+  instead of guessing.
+
+## Verification
+
+- [ ] Script exited 0 and printed the session header for the intended session
+- [ ] Every number in your report appears in the script output
+- [ ] No latency, duration, or "success rate" claims anywhere in the report
+- [ ] Store untouched: no `state.db-wal` growth from the audit (read-only URI)

--- a/skills/autonomous-ai-agents/tool-audit/scripts/tool_audit.py
+++ b/skills/autonomous-ai-agents/tool-audit/scripts/tool_audit.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Per-tool call/result metrics for one session, from the Hermes session store.
+
+Reads the canonical SQLite session store (``state.db``) strictly READ-ONLY
+(SQLite ``mode=ro`` URI, same pattern as ``hermes_state.SessionDB(read_only=True)``)
+and reports, for a single session, only metrics the store can prove:
+
+* ``calls``    — ``tool_calls`` entries on assistant rows
+* ``results``  — tool-role rows correlated back to a call by ``tool_call_id``
+* ``orphaned`` — calls with no matching result row
+* ``errors``   — correlated results whose payload is a JSON object with a
+  truthy ``"error"`` key. This is deliberately the same classification rule
+  the runtime observer applies (``model_tools._tool_result_observer_fields``),
+  so the audit never claims more than the runtime itself would.
+
+Latency is deliberately NOT reported: per-call ``duration_ms`` is computed in
+``model_tools.handle_function_call`` and exposed only to ``post_tool_call``
+observer hooks — it is never persisted to ``state.db``, so no store-derived
+latency figure would be honest.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+# Sentinel used by hermes_state.SessionDB._encode_content for structured
+# (list/dict) message content. Kept as a literal so this script stays
+# importable outside the Hermes process (system Python, CI).
+CONTENT_JSON_PREFIX = "\x00json:"
+
+# Sample error payloads included per tool in --json output (truncated).
+MAX_SAMPLE_ERRORS = 3
+MAX_SAMPLE_ERROR_CHARS = 200
+
+
+def get_hermes_home() -> Path:
+    """Resolve the active Hermes home, profile-aware when possible.
+
+    Prefers ``hermes_constants.get_hermes_home()`` (honors profile overrides
+    and future resolution changes). Falls back to the same core logic using
+    only the stdlib: ``HERMES_HOME`` env var, else the platform default.
+    """
+    try:
+        from hermes_constants import get_hermes_home as _real
+
+        return _real()
+    except (ModuleNotFoundError, ImportError):
+        pass
+    val = os.environ.get("HERMES_HOME", "").strip()
+    if val:
+        return Path(val)
+    if sys.platform == "win32":
+        local_appdata = os.environ.get("LOCALAPPDATA", "").strip()
+        base = Path(local_appdata) if local_appdata else Path.home() / "AppData" / "Local"
+        return base / "hermes"
+    return Path.home() / ".hermes"
+
+
+def open_db_readonly(db_path: Path) -> sqlite3.Connection:
+    """Open ``state.db`` read-only (no write lock, no schema init)."""
+    conn = sqlite3.connect(
+        f"file:{db_path}?mode=ro",
+        uri=True,
+        timeout=1.0,
+        isolation_level=None,
+    )
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def resolve_session(conn: sqlite3.Connection, session_arg: Optional[str]) -> str:
+    """Resolve the target session id.
+
+    Order: explicit ``session_arg`` (exact id, then unique prefix) →
+    ``HERMES_SESSION_ID`` env (set by the running agent) → most recently
+    started session. Raises ``LookupError`` when nothing matches or a prefix
+    is ambiguous.
+    """
+    candidate = (session_arg or "").strip() or os.environ.get("HERMES_SESSION_ID", "").strip()
+    if candidate:
+        row = conn.execute("SELECT id FROM sessions WHERE id = ?", (candidate,)).fetchone()
+        if row:
+            return row["id"]
+        rows = conn.execute(
+            "SELECT id FROM sessions WHERE id LIKE ? ORDER BY started_at DESC LIMIT 5",
+            (candidate + "%",),
+        ).fetchall()
+        if len(rows) == 1:
+            return rows[0]["id"]
+        if not rows:
+            raise LookupError(f"no session matches '{candidate}'")
+        matches = ", ".join(r["id"] for r in rows)
+        raise LookupError(f"ambiguous session prefix '{candidate}': {matches}")
+    row = conn.execute("SELECT id FROM sessions ORDER BY started_at DESC LIMIT 1").fetchone()
+    if not row:
+        raise LookupError("session store contains no sessions")
+    return row["id"]
+
+
+def fetch_messages(conn: sqlite3.Connection, session_id: str) -> List[Dict[str, Any]]:
+    """Load active messages in insertion order (mirrors SessionDB.get_messages)."""
+    sql = "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages WHERE session_id = ?{} ORDER BY id"
+    try:
+        rows = conn.execute(sql.format(" AND active = 1"), (session_id,)).fetchall()
+    except sqlite3.OperationalError:
+        # Older schema without the soft-delete column.
+        rows = conn.execute(sql.format(""), (session_id,)).fetchall()
+    return [dict(r) for r in rows]
+
+
+def decode_content(content: Any) -> Any:
+    """Reverse SessionDB._encode_content's sentinel-prefixed JSON encoding."""
+    if isinstance(content, str) and content.startswith(CONTENT_JSON_PREFIX):
+        try:
+            return json.loads(content[len(CONTENT_JSON_PREFIX):])
+        except (json.JSONDecodeError, TypeError):
+            return content
+    return content
+
+
+def result_error(content: Any) -> Optional[str]:
+    """Return the error message when a tool result payload is a provable error.
+
+    Same rule as ``model_tools._tool_result_observer_fields``: the payload
+    (JSON-decoded when it is a string) must be a dict with a truthy
+    ``"error"`` key. Anything else — including plain-text failure prose —
+    is NOT counted; the audit reports a lower bound, not a guess.
+    """
+    payload = decode_content(content)
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except (json.JSONDecodeError, TypeError):
+            return None
+    if isinstance(payload, dict) and payload.get("error"):
+        return str(payload.get("error"))
+    return None
+
+
+def audit_messages(messages: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Correlate tool calls with results by ``tool_call_id`` and aggregate."""
+    call_id_to_tool: Dict[str, str] = {}
+    stats: Dict[str, Dict[str, int]] = {}
+    samples: Dict[str, List[str]] = {}
+    uncorrelated_results = 0
+
+    def _tool_stats(name: str) -> Dict[str, int]:
+        return stats.setdefault(name, {"calls": 0, "results": 0, "orphaned": 0, "errors": 0})
+
+    for msg in messages:
+        if msg.get("role") != "assistant" or not msg.get("tool_calls"):
+            continue
+        try:
+            tool_calls = json.loads(msg["tool_calls"])
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(tool_calls, list):
+            continue
+        for entry in tool_calls:
+            if not isinstance(entry, dict):
+                continue
+            name = (entry.get("function") or {}).get("name") or entry.get("name") or "<unknown>"
+            _tool_stats(name)["calls"] += 1
+            call_id = entry.get("id")
+            if call_id:
+                call_id_to_tool[str(call_id)] = name
+
+    matched_ids = set()
+    for msg in messages:
+        if msg.get("role") != "tool":
+            continue
+        call_id = str(msg.get("tool_call_id") or "")
+        name = call_id_to_tool.get(call_id)
+        if name is None:
+            uncorrelated_results += 1
+            continue
+        matched_ids.add(call_id)
+        tool = _tool_stats(name)
+        tool["results"] += 1
+        error = result_error(msg.get("content"))
+        if error is not None:
+            tool["errors"] += 1
+            bucket = samples.setdefault(name, [])
+            if len(bucket) < MAX_SAMPLE_ERRORS:
+                bucket.append(error[:MAX_SAMPLE_ERROR_CHARS])
+
+    for call_id, name in call_id_to_tool.items():
+        if call_id not in matched_ids:
+            _tool_stats(name)["orphaned"] += 1
+
+    tools = [
+        {"name": name, **counts, "sample_errors": samples.get(name, [])}
+        for name, counts in sorted(stats.items(), key=lambda kv: (-kv[1]["calls"], kv[0]))
+    ]
+    totals = {
+        key: sum(t[key] for t in tools) for key in ("calls", "results", "orphaned", "errors")
+    }
+    return {"tools": tools, "totals": totals, "uncorrelated_results": uncorrelated_results}
+
+
+def _session_header(conn: sqlite3.Connection, session_id: str) -> Dict[str, Any]:
+    row = conn.execute(
+        "SELECT id, source, title, started_at, message_count, tool_call_count"
+        " FROM sessions WHERE id = ?",
+        (session_id,),
+    ).fetchone()
+    header = dict(row) if row else {"id": session_id}
+    started = header.get("started_at")
+    if isinstance(started, (int, float)):
+        try:
+            header["started_at"] = datetime.fromtimestamp(started).isoformat(sep=" ", timespec="seconds")
+        except (OSError, OverflowError, ValueError):
+            pass
+    return header
+
+
+def render_text(header: Dict[str, Any], report: Dict[str, Any]) -> str:
+    lines = [
+        f"Tool audit — session {header.get('id')}",
+        "  source: {}  started: {}  messages: {}".format(
+            header.get("source", "?"), header.get("started_at", "?"), header.get("message_count", "?")
+        ),
+        "",
+        f"{'tool':<32} {'calls':>6} {'results':>8} {'orphaned':>9} {'errors':>7}",
+    ]
+    for tool in report["tools"]:
+        lines.append(
+            f"{tool['name']:<32} {tool['calls']:>6} {tool['results']:>8}"
+            f" {tool['orphaned']:>9} {tool['errors']:>7}"
+        )
+    totals = report["totals"]
+    lines.append(
+        f"{'TOTAL':<32} {totals['calls']:>6} {totals['results']:>8}"
+        f" {totals['orphaned']:>9} {totals['errors']:>7}"
+    )
+    if report["uncorrelated_results"]:
+        lines.append(f"uncorrelated tool results (no surviving call): {report['uncorrelated_results']}")
+    lines.append("errors = results whose JSON payload has a truthy 'error' key (lower bound).")
+    lines.append("Latency is not persisted to state.db and is intentionally not reported.")
+    return "\n".join(lines)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Read-only per-tool audit of a Hermes session.")
+    parser.add_argument("--session", help="session id or unique prefix (default: $HERMES_SESSION_ID, else latest)")
+    parser.add_argument("--db", type=Path, help="path to state.db (default: <hermes home>/state.db)")
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    args = parser.parse_args(argv)
+
+    db_path = args.db or (get_hermes_home() / "state.db")
+    if not db_path.exists():
+        print(f"error: session store not found: {db_path}", file=sys.stderr)
+        return 2
+
+    try:
+        conn = open_db_readonly(db_path)
+    except sqlite3.Error as exc:
+        print(f"error: cannot open {db_path} read-only: {exc}", file=sys.stderr)
+        return 2
+    try:
+        try:
+            session_id = resolve_session(conn, args.session)
+        except LookupError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        header = _session_header(conn, session_id)
+        report = audit_messages(fetch_messages(conn, session_id))
+    finally:
+        conn.close()
+
+    if args.json:
+        print(json.dumps({"session": header, **report}, ensure_ascii=False, indent=2))
+    else:
+        print(render_text(header, report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/skills/test_tool_audit_skill.py
+++ b/tests/skills/test_tool_audit_skill.py
@@ -1,0 +1,293 @@
+"""Tests for the bundled tool-audit skill (metadata + workflow).
+
+Metadata: the skill must be discoverable by the real bundled-skill scanner
+(SKILL.md, not DESCRIPTION.md) and honor the skill-authoring hardlines.
+
+Workflow: scripts/tool_audit.py must correlate tool calls with results by
+tool_call_id against a real (fixture) state.db, count only provable errors,
+open the store read-only, and never report latency.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_DIR = REPO_ROOT / "skills" / "autonomous-ai-agents" / "tool-audit"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+SCRIPT_PATH = SKILL_DIR / "scripts" / "tool_audit.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("tool_audit_skill", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _frontmatter() -> dict:
+    text = SKILL_MD.read_text(encoding="utf-8")
+    assert text.startswith("---\n"), "frontmatter must open the file"
+    body = text.split("---", 2)
+    assert len(body) == 3, "frontmatter must be closed"
+    fields = {}
+    for line in body[1].splitlines():
+        m = re.match(r"^(\w[\w-]*):\s*(.*)$", line)
+        if m:
+            fields[m.group(1)] = m.group(2).strip().strip("\"'")
+    return fields
+
+
+# ── Metadata ────────────────────────────────────────────────────────────────
+
+
+def test_skill_md_exists_where_discovery_scans():
+    assert SKILL_MD.is_file(), "skill must ship a SKILL.md (DESCRIPTION.md is not discoverable)"
+    assert not (SKILL_DIR / "DESCRIPTION.md").exists()
+
+
+def test_bundled_discovery_finds_tool_audit():
+    from tools.skills_sync import _discover_bundled_skills
+
+    found = {name: path for name, path in _discover_bundled_skills(REPO_ROOT / "skills")}
+    assert "tool-audit" in found
+    assert found["tool-audit"] == SKILL_DIR
+
+
+def test_frontmatter_hardlines():
+    fields = _frontmatter()
+    assert fields["name"] == "tool-audit"
+    description = fields["description"]
+    assert description, "description is required"
+    assert len(description) <= 60, f"description must be <=60 chars, got {len(description)}"
+    assert description.endswith("."), "description must end with a period"
+    assert "tool-audit" not in description.lower(), "description must not repeat the skill name"
+
+
+def test_body_uses_modern_section_order():
+    text = SKILL_MD.read_text(encoding="utf-8")
+    sections = [
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ]
+    positions = [text.index(section) for section in sections]
+    assert positions == sorted(positions), "sections must appear in the modern order"
+
+
+def test_no_legacy_jsonl_or_latency_promises():
+    text = SKILL_MD.read_text(encoding="utf-8")
+    assert "agents/*/sessions" not in text, "legacy JSONL session path must not be referenced"
+    assert "state.db" in text, "audit must be grounded in the canonical store"
+    assert "Avg Latency" not in text and "average latency" not in text.lower()
+    assert "Success Rate" not in text
+
+
+def test_script_is_referenced_and_stdlib_only():
+    assert SCRIPT_PATH.is_file()
+    assert "scripts/tool_audit.py" in SKILL_MD.read_text(encoding="utf-8")
+    source = SCRIPT_PATH.read_text(encoding="utf-8")
+    for banned in ("requests", "httpx", "aiohttp"):
+        assert f"import {banned}" not in source
+
+
+# ── Workflow fixtures ───────────────────────────────────────────────────────
+
+
+def _make_store(tmp_path: Path) -> Path:
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT NOT NULL,
+            title TEXT,
+            started_at REAL NOT NULL,
+            message_count INTEGER DEFAULT 0,
+            tool_call_count INTEGER DEFAULT 0
+        );
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT,
+            tool_call_id TEXT,
+            tool_calls TEXT,
+            tool_name TEXT,
+            timestamp REAL NOT NULL,
+            active INTEGER NOT NULL DEFAULT 1
+        );
+        """
+    )
+
+    def call(call_id: str, name: str) -> dict:
+        return {"id": call_id, "type": "function", "function": {"name": name, "arguments": "{}"}}
+
+    conn.execute(
+        "INSERT INTO sessions (id, source, title, started_at, message_count, tool_call_count)"
+        " VALUES (?, ?, ?, ?, ?, ?)",
+        ("sess-aaa111", "cli", "audit me", 1000.0, 8, 4),
+    )
+    conn.execute(
+        "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+        ("sess-bbb222", "cli", 2000.0),
+    )
+
+    rows = [
+        # (role, content, tool_call_id, tool_calls, tool_name, ts, active)
+        ("user", "please work", None, None, None, 1001.0, 1),
+        (
+            "assistant",
+            None,
+            None,
+            json.dumps([call("call_1", "terminal"), call("call_2", "read_file"), call("call_3", "terminal")]),
+            None,
+            1002.0,
+            1,
+        ),
+        ("tool", json.dumps({"error": "boom exploded"}), "call_1", None, "terminal", 1003.0, 1),
+        ("tool", "file contents here", "call_2", None, "read_file", 1004.0, 1),
+        # call_3 stays orphaned: no result row.
+        # Uncorrelated result — its call was compacted away.
+        ("tool", "stale", "call_ghost", None, "terminal", 1005.0, 1),
+        # Structured content stored via the SessionDB sentinel encoding.
+        (
+            "assistant",
+            None,
+            None,
+            json.dumps([call("call_4", "web_search")]),
+            None,
+            1006.0,
+            1,
+        ),
+        ("tool", "\x00json:" + json.dumps({"error": "quota"}), "call_4", None, "web_search", 1007.0, 1),
+        # Plain-text failure prose must NOT count as a provable error.
+        (
+            "assistant",
+            None,
+            None,
+            json.dumps([call("call_5", "terminal")]),
+            None,
+            1008.0,
+            1,
+        ),
+        ("tool", "Error: something vague happened", "call_5", None, "terminal", 1009.0, 1),
+        # Soft-deleted (rewound) rows are excluded from the audit.
+        ("assistant", None, None, json.dumps([call("call_6", "terminal")]), None, 1010.0, 0),
+    ]
+    conn.executemany(
+        "INSERT INTO messages (session_id, role, content, tool_call_id, tool_calls, tool_name, timestamp, active)"
+        " VALUES ('sess-aaa111', ?, ?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _by_name(report: dict) -> dict:
+    return {tool["name"]: tool for tool in report["tools"]}
+
+
+# ── Workflow ────────────────────────────────────────────────────────────────
+
+
+def test_audit_correlates_calls_and_results_by_id(tmp_path):
+    mod = load_module()
+    conn = mod.open_db_readonly(_make_store(tmp_path))
+    report = mod.audit_messages(mod.fetch_messages(conn, "sess-aaa111"))
+    conn.close()
+
+    tools = _by_name(report)
+    terminal = tools["terminal"]
+    assert terminal["calls"] == 3  # call_6 is inactive, not counted
+    assert terminal["results"] == 2  # call_1 + call_5; ghost result not attributed
+    assert terminal["orphaned"] == 1  # call_3
+    assert terminal["errors"] == 1  # only the JSON {"error": ...} payload
+    assert terminal["sample_errors"] == ["boom exploded"]
+
+    assert tools["read_file"] == {
+        "name": "read_file", "calls": 1, "results": 1, "orphaned": 0, "errors": 0, "sample_errors": [],
+    }
+    assert tools["web_search"]["errors"] == 1  # sentinel-encoded structured payload
+    assert report["uncorrelated_results"] == 1
+    assert report["totals"] == {"calls": 5, "results": 4, "orphaned": 1, "errors": 2}
+
+
+def test_provable_error_rule_matches_runtime_observer():
+    mod = load_module()
+    assert mod.result_error(json.dumps({"error": "x"})) == "x"
+    assert mod.result_error(json.dumps({"error": ""})) is None  # falsy — same as observer
+    assert mod.result_error(json.dumps({"ok": True})) is None
+    assert mod.result_error("Error: not json") is None
+    assert mod.result_error(None) is None
+
+
+def test_main_json_output_and_no_latency_fields(tmp_path, capsys, monkeypatch):
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    mod = load_module()
+    db_path = _make_store(tmp_path)
+
+    exit_code = mod.main(["--db", str(db_path), "--session", "sess-aaa111", "--json"])
+    assert exit_code == 0
+
+    rendered = json.loads(capsys.readouterr().out)
+    assert rendered["session"]["id"] == "sess-aaa111"
+    assert rendered["session"]["source"] == "cli"
+    assert rendered["totals"]["calls"] == 5
+    flat = json.dumps(rendered).lower()
+    assert "latency" not in flat and "duration_ms" not in flat and "success_rate" not in flat
+
+
+def test_session_resolution_prefix_env_and_latest(tmp_path, monkeypatch):
+    mod = load_module()
+    conn = mod.open_db_readonly(_make_store(tmp_path))
+
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    assert mod.resolve_session(conn, "sess-aaa") == "sess-aaa111"  # unique prefix
+    assert mod.resolve_session(conn, None) == "sess-bbb222"  # latest started_at
+
+    monkeypatch.setenv("HERMES_SESSION_ID", "sess-aaa111")
+    assert mod.resolve_session(conn, None) == "sess-aaa111"  # agent's own session wins
+
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    try:
+        mod.resolve_session(conn, "sess-")  # ambiguous
+        raised = False
+    except LookupError:
+        raised = True
+    assert raised
+    conn.close()
+
+
+def test_store_is_opened_readonly_and_missing_db_fails_cleanly(tmp_path, capsys):
+    mod = load_module()
+    db_path = _make_store(tmp_path)
+
+    real_connect = sqlite3.connect
+    seen = {}
+
+    def spy(dsn, *args, **kwargs):
+        seen["dsn"], seen["uri"] = dsn, kwargs.get("uri")
+        return real_connect(dsn, *args, **kwargs)
+
+    with patch.object(mod.sqlite3, "connect", side_effect=spy):
+        assert mod.main(["--db", str(db_path), "--session", "sess-aaa111"]) == 0
+    assert seen["uri"] is True and "mode=ro" in seen["dsn"]
+    capsys.readouterr()
+
+    assert mod.main(["--db", str(tmp_path / "nope.db")]) == 2
+    assert "not found" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

New bundled skill: **tool-audit** — an operator-facing, read-only audit of one session's tool usage, grounded in the canonical SQLite session store.

Rebuilt per the sweeper review (see review reply for the point-by-point mapping).

## What it reports

`scripts/tool_audit.py` opens `state.db` read-only (SQLite `mode=ro`, the same pattern as `SessionDB(read_only=True)`) and correlates assistant `tool_calls` entries with tool-role rows by `tool_call_id`:

| Metric | Source |
|--------|--------|
| calls | `messages.tool_calls` JSON on assistant rows |
| results | tool-role rows matched by `tool_call_id` |
| orphaned | calls with no matching result row |
| errors | matched results whose JSON payload has a truthy `error` key — the same rule as `model_tools._tool_result_observer_fields` |

Uncorrelated results (call compacted away) are counted separately, never attributed to a tool.

**Deliberately not reported:** latency / success rates. Per-call `duration_ms` only exists in the in-process `post_tool_call` observer hook and is never persisted, so the report claims exactly what the store can prove — nothing more.

## Design

- `skills/autonomous-ai-agents/tool-audit/SKILL.md` with required frontmatter (description 58 chars, modern section order, contributor-first author credit)
- Profile-aware store resolution: `hermes_constants.get_hermes_home()` when importable, stdlib fallback otherwise (same pattern as `google-workspace/scripts/_hermes_home.py`)
- Session resolution: `--session` (id or unique prefix) → `$HERMES_SESSION_ID` → latest session; ambiguous prefixes fail instead of guessing
- Cross-platform, stdlib-only script; `platforms: [linux, macos, windows]`

## Files

```
skills/autonomous-ai-agents/tool-audit/SKILL.md
skills/autonomous-ai-agents/tool-audit/scripts/tool_audit.py
tests/skills/test_tool_audit_skill.py
```

## Testing

`scripts/run_tests.sh tests/skills/test_tool_audit_skill.py -q` — 11 tests: bundled-discovery via the real `_discover_bundled_skills` scanner, frontmatter hardlines, ID-correlated metrics against a fixture `state.db`, error-rule parity with the runtime observer, read-only URI enforcement, and session resolution.
