### PR TITLE
fix(mcp): close shared stderr log file handle at process exit

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -81,6 +81,7 @@ Thread safety:
     free-threading).
 """
 
+import atexit
 import asyncio
 import contextvars
 import concurrent.futures
@@ -131,6 +132,22 @@ _OSV_MALWARE_CHECK_TIMEOUT_S = 12.0
 
 _mcp_stderr_log_fh: Optional[Any] = None
 _mcp_stderr_log_lock = threading.Lock()
+
+
+def _close_mcp_stderr_log() -> None:
+    """Close the shared MCP stderr log handle at process exit (fd leak fix)."""
+    global _mcp_stderr_log_fh
+    with _mcp_stderr_log_lock:
+        fh = _mcp_stderr_log_fh
+        _mcp_stderr_log_fh = None
+    if fh is not None and not getattr(fh, "closed", True):
+        try:
+            fh.close()
+        except Exception:
+            pass
+
+
+atexit.register(_close_mcp_stderr_log)
 
 
 def _get_mcp_stderr_log() -> Any:


### PR DESCRIPTION
## Summary

Add an atexit handler to close the shared MCP stderr log file handle, preventing a minor fd leak at process shutdown.

## Problem

The shared MCP stderr log file handle () is opened once per process and reused for every stdio server, but was never explicitly closed. While the OS reclaims it at exit, explicit closure is cleaner and prevents edge cases with shutdown order.

## Fix

- Import  module
- Add  function that atomically swaps the global to None and closes the handle
- Register with 
- The fallback path uses  (not ), so no risk of suppressing later shutdown output

## Testing

- Verified syntax: 
- Single-file change, minimal diff (+17 lines)
