### PR TITLE
fix(agent): add return_exceptions=True to asyncio.gather in context_references

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -167,9 +167,15 @@ async def preprocess_context_references_async(
                 allowed_root=allowed_root_path,
             )
             for ref in refs
-        )
+        ),
+        return_exceptions=True,
     )
-    for warning, block in expanded:
+    for item in expanded:
+        # Filter out exceptions from return_exceptions=True
+        if isinstance(item, BaseException):
+            warnings.append(f"@ context expansion failed: {item}")
+            continue
+        warning, block = item
         if warning:
             warnings.append(warning)
         if block:


### PR DESCRIPTION
## Summary

Add  to the  call in  so that a single failing reference expansion doesn't cancel all sibling coroutines.

## Problem

Without , if one  call raises (e.g., network timeout on a remote URL, permission error on a local file), the exception propagates immediately and cancels all other in-flight expansions. The agent loses all successfully expanded references.

## Fix

- Add  to the gather call
- After gathering, iterate results and filter out exceptions, adding them to the warnings list
- Successful expansions still render normally

## Testing

- Verified syntax: 
- Single-file change (+8/-2 lines)
- Follows the pattern already used in other gather calls in the codebase (e.g. )
