### PR TITLE
fix(cron): guard lock_fd unlock+close in tick() finally to prevent fd leak on lock contention

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3471,17 +3471,21 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
 
         return sum(_results)
     finally:
-        if fcntl:
+        if lock_fd is not None:
             try:
-                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                if fcntl:
+                    try:
+                        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                    except (OSError, IOError):
+                        pass
+                elif msvcrt:
+                    try:
+                        msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
+                    except (OSError, IOError):
+                        pass
             except (OSError, IOError):
                 pass
-        elif msvcrt:
-            try:
-                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
-            except (OSError, IOError):
-                pass
-        lock_fd.close()
+            lock_fd.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Guard the  block in  with  to prevent AttributeError when flock acquisition fails due to lock contention.

## Problem

When  or  raises (lock already held by another instance),  is set back to  in the except block. However, the  block unconditionally calls  and , raising . This masks the original contention error and leaves the lock file in an inconsistent state.

## Fix

- Wrap the entire finally unlock/close sequence in 
- This ensures that failed lock acquisition exits cleanly without attempting to unlock or close a None fd
- The outer  already has its own try/finally that closes the fd on acquisition failure

## Testing

- Verified syntax: 
- Single-file change (+12/-8 lines)
