### PR TITLE
fix(gateway): replace blocking time.sleep with await asyncio.sleep in start_gateway

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19736,7 +19736,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 if not _pid_exists(existing_pid):
                     old_gateway_exited = True
                     break  # Process is gone
-                time.sleep(0.5)
+                await asyncio.sleep(0.5)
             else:
                 # Still alive after 10s — force kill
                 logger.warning(
@@ -19760,7 +19760,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                         if not _pid_exists(existing_pid):
                             old_gateway_exited = True
                             break
-                        time.sleep(0.25)
+                        await asyncio.sleep(0.25)
                 if not old_gateway_exited:
                     logger.error(
                         "Old gateway (PID %d) still appears alive after SIGKILL; "


### PR DESCRIPTION
## Summary

Replace `time.sleep(0.5)` and `time.sleep(0.25)` with `await asyncio.sleep()` in the async `start_gateway()` function.

## Problem

The `start_gateway()` function is async but uses blocking `time.sleep()` calls while waiting for the old gateway process to exit. This blocks the entire event loop, preventing any other async tasks (platform adapters, cron ticks, etc.) from running during the 10-second wait period.

## Fix

- Replace `time.sleep(0.5)` with `await asyncio.sleep(0.5)` (line 19739)
- Replace `time.sleep(0.25)` with `await asyncio.sleep(0.25)` (line 19763)
- Both are in the same async function, within the same PID-wait loop

## Testing

- Verified syntax: `python3 -c "import py_compile; py_compile.compile('gateway/run.py', doraise=True)"`
- 2-line change, minimal risk
- The function is already async and uses `await` elsewhere