### PR TITLE
feat(agent): pre_persist_user_message hook — agent-path ingress seam

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -303,6 +303,33 @@ def build_turn_context(
             should_review_memory = True
             agent._turns_since_memory = 0
 
+    # Plugin hook: pre_persist_user_message — agent-path ingress. Fragments
+    # returned here are appended to user_message BEFORE it is persisted (:329),
+    # so they land on the wire (the agent-path analogue of gateway's
+    # pre_gateway_dispatch event.text mutation).
+    try:
+        from hermes_cli.plugins import invoke_hook as _invoke_hook
+        _pp = _invoke_hook(
+            "pre_persist_user_message",
+            session_id=agent.session_id or "",
+            task_id=effective_task_id,
+            turn_id=turn_id,
+            user_message=user_message,
+            conversation_history=list(messages),
+            platform=getattr(agent, "platform", None) or "",
+            sender_id=getattr(agent, "_user_id", None) or "",
+        )
+        _pp_parts = []
+        for r in _pp:
+            if isinstance(r, dict) and r.get("context"):
+                _pp_parts.append(str(r["context"]))
+            elif isinstance(r, str) and r.strip():
+                _pp_parts.append(r)
+        if _pp_parts:
+            user_message = user_message + "\n\n" + "\n\n".join(_pp_parts)
+    except Exception as exc:
+        logger.warning("pre_persist_user_message hook failed: %s", exc)
+
     # Add user message.
     user_msg = {"role": "user", "content": user_message}
     messages.append(user_msg)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -171,6 +171,14 @@ VALID_HOOKS: Set[str] = {
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
+    # Agent-path ingress hook. Fired once per user turn in build_turn_context,
+    # BEFORE the inbound user message is appended and persisted (unlike
+    # pre_llm_call, which fires after the crash-resilience persist and whose
+    # context is ephemeral). Plugins return {"context": "..."} or a str; the
+    # host joins all non-None returns and appends them to user_message so they
+    # persist to the session DB (and thus onto the wire). Kwargs: session_id,
+    # task_id, turn_id, user_message, conversation_history, platform, sender_id.
+    "pre_persist_user_message",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs user approval -- fires BOTH for CLI-interactive prompts
     # and for gateway/ACP approvals (Telegram, Discord, Slack, TUI, etc.).

--- a/tests/agent/test_pre_persist_user_message.py
+++ b/tests/agent/test_pre_persist_user_message.py
@@ -1,0 +1,21 @@
+"""pre_persist_user_message: a returned {"context"} is appended to the user
+message before it is baked into `messages` (and thus before the :329 persist)."""
+from hermes_cli import plugins as P
+
+
+def test_hook_registered():
+    assert "pre_persist_user_message" in P.VALID_HOOKS
+
+
+def test_join_semantics():
+    # invoke_hook is pure fan-out; the host joins non-None returns. Mirror the
+    # host's join+append logic to lock the contract without spinning a full agent.
+    results = [{"context": "A"}, None, "B", {"nope": 1}]
+    parts = []
+    for r in results:
+        if isinstance(r, dict) and r.get("context"):
+            parts.append(str(r["context"]))
+        elif isinstance(r, str) and r.strip():
+            parts.append(r)
+    user_message = "hi" + ("\n\n" + "\n\n".join(parts) if parts else "")
+    assert user_message == "hi\n\nA\n\nB"


### PR DESCRIPTION
## Problem

Plugins can rewrite the user's turn on the **gateway** path via `pre_gateway_dispatch` (it mutates `event.text` before dispatch, so the change is persisted and lands on the wire). But agents invoked **directly** through `run_conversation` — `platform="cli"`, subagents, any non-gateway caller — never fire that hook. There is no seam to inject persisted context before the user turn is written.

`pre_llm_call` is not a substitute: it fires *after* the crash-resilience persist in `build_turn_context`, and its `{"context"}` is ephemeral (added to the API payload only, never persisted). Anything a plugin needs on the wire across turns therefore has no home on the agent path.

This is a missing symmetry:

| direction | hook |
|-----------|------|
| egress | `transform_llm_output` |
| gateway-ingress | `pre_gateway_dispatch` |
| **agent-ingress (persisted)** | **— (nothing) ← this PR** |

## Fix

A generic hook `pre_persist_user_message`, fired once per turn in `build_turn_context` *before* the inbound message is appended and persisted. Plugins return `{"context": "..."}` or a `str`; the host joins all non-`None` returns (pure fan-out, same convention as every other hook) and appends them to `user_message`. Because it runs before the persist, fragments land in the session DB and on the wire — the durable analogue of the gateway path.

56 insertions, no behavior change when no plugin registers the hook. The invoke is wrapped so a misbehaving plugin can't break turn construction.

```python
# agent/turn_context.py, before the user message is appended + persisted
_pp = invoke_hook("pre_persist_user_message", session_id=..., turn_id=...,
                  user_message=user_message, conversation_history=list(messages),
                  platform=..., sender_id=...)
# join non-None {"context"} / str returns, append to user_message
```

## Beneficiaries

- **#25061** — asks for exactly a pre-turn hook in `run_conversation`; this is the generic seam that request needs.
- **#16661** — context-resume hits the same ephemeral ceiling (`pre_llm_call` context does not persist).

## Test

`tests/agent/test_pre_persist_user_message.py` locks the hook registration and the join/append contract (fan-out of `{"context"}`/`str`/`None`).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)