### PR TITLE
feat(kanban): add coder qa pm workflow template

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -26,6 +26,7 @@ from typing import Any, Optional
 
 from hermes_cli import kanban_db as kb
 from hermes_cli import kanban_swarm as ks
+from hermes_cli import kanban_workflows as kw
 from hermes_cli.profiles import get_active_profile_name
 
 
@@ -388,6 +389,35 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_swarm.add_argument("--created-by", default=None, help="Creator/anchor profile")
     p_swarm.add_argument("--idempotency-key", default=None, help="Dedup key for the root card")
     p_swarm.add_argument("--json", action="store_true", help="Emit JSON output")
+
+    # --- workflow templates ---
+    p_workflow = sub.add_parser(
+        "workflow",
+        aliases=["wf"],
+        help="Create a standard Kanban workflow template graph",
+    )
+    workflow_sub = p_workflow.add_subparsers(dest="workflow_action")
+    p_coder_qa_pm = workflow_sub.add_parser(
+        "coder-qa-pm",
+        aliases=["coder-qa-pm-review"],
+        help="Create coder -> QA -> PM review tasks with dependency handoff",
+    )
+    p_coder_qa_pm.add_argument("title", help="Workflow title / request")
+    p_coder_qa_pm.add_argument("--body", default=None, help="Optional full request body")
+    p_coder_qa_pm.add_argument("--coder", default="coder-codex", help="Coder profile")
+    p_coder_qa_pm.add_argument("--qa", default="qa-minimax", help="QA profile")
+    p_coder_qa_pm.add_argument("--pm", default="pm-deepseek", help="PM review profile")
+    p_coder_qa_pm.add_argument("--tenant", default=None, help="Tenant namespace")
+    p_coder_qa_pm.add_argument("--priority", type=int, default=0, help="Priority tiebreaker")
+    p_coder_qa_pm.add_argument("--created-by", default=None, help="Creator/anchor profile")
+    p_coder_qa_pm.add_argument("--workspace", default="scratch",
+                               help="scratch | worktree | worktree:<path> | dir:<path> "
+                                    "(default: scratch)")
+    p_coder_qa_pm.add_argument("--project", default=None,
+                               help="Link tasks to a project (id or slug)")
+    p_coder_qa_pm.add_argument("--idempotency-key", default=None,
+                               help="Dedup key for the root card")
+    p_coder_qa_pm.add_argument("--json", action="store_true", help="Emit JSON output")
 
     # --- list ---
     p_list = sub.add_parser("list", aliases=["ls"], help="List tasks")
@@ -939,6 +969,8 @@ def kanban_command(args: argparse.Namespace) -> int:
             "init":     _cmd_init,
             "create":   _cmd_create,
             "swarm":    _cmd_swarm,
+            "workflow": _cmd_workflow,
+            "wf":       _cmd_workflow,
             "list":     _cmd_list,
             "ls":       _cmd_list,
             "show":     _cmd_show,
@@ -1396,6 +1428,45 @@ def _cmd_swarm(args: argparse.Namespace) -> int:
         print("Workers: " + ", ".join(created.worker_ids))
         print(f"Verifier: {created.verifier_id}")
         print(f"Synthesizer: {created.synthesizer_id}")
+    return 0
+
+
+def _cmd_workflow(args: argparse.Namespace) -> int:
+    action = getattr(args, "workflow_action", None)
+    if action not in {"coder-qa-pm", "coder-qa-pm-review"}:
+        print(
+            "kanban workflow: choose a template, e.g. coder-qa-pm",
+            file=sys.stderr,
+        )
+        return 2
+    try:
+        ws_kind, ws_path = _parse_workspace_flag(getattr(args, "workspace", "scratch"))
+    except argparse.ArgumentTypeError as exc:
+        print(f"kanban workflow: {exc}", file=sys.stderr)
+        return 2
+    with kb.connect_closing() as conn:
+        created = kw.create_coder_qa_pm_review_workflow(
+            conn,
+            title=args.title,
+            body=args.body,
+            coder_assignee=args.coder,
+            qa_assignee=args.qa,
+            pm_assignee=args.pm,
+            tenant=args.tenant,
+            created_by=args.created_by or _profile_author(),
+            workspace_kind=ws_kind,
+            workspace_path=ws_path,
+            project_id=getattr(args, "project", None),
+            priority=args.priority,
+            idempotency_key=getattr(args, "idempotency_key", None),
+        )
+    if getattr(args, "json", False):
+        print(json.dumps(created.as_dict(), indent=2, ensure_ascii=False))
+    else:
+        print(f"Workflow root: {created.root_id}")
+        print(f"Coder: {created.coder_task_id}")
+        print(f"QA: {created.qa_task_id}")
+        print(f"PM review: {created.pm_review_task_id}")
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2405,6 +2405,8 @@ def create_task(
     goal_max_turns: Optional[int] = None,
     initial_status: str = "running",
     session_id: Optional[str] = None,
+    workflow_template_id: Optional[str] = None,
+    current_step_key: Optional[str] = None,
     board: Optional[str] = None,
     project_id: Optional[str] = None,
 ) -> str:
@@ -2635,8 +2637,9 @@ def create_task(
                         created_by, created_at, workspace_kind, workspace_path,
                         branch_name, project_id, tenant, idempotency_key,
                         max_runtime_seconds,
-                        skills, max_retries, goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        skills, max_retries, goal_mode, goal_max_turns, session_id,
+                        workflow_template_id, current_step_key
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -2659,6 +2662,8 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        workflow_template_id,
+                        current_step_key,
                     ),
                 )
                 for pid in parents:
@@ -2678,6 +2683,8 @@ def create_task(
                         "branch_name": branch_name,
                         "skills": list(skills_list) if skills_list else None,
                         "goal_mode": bool(goal_mode) or None,
+                        "workflow_template_id": workflow_template_id,
+                        "current_step_key": current_step_key,
                     },
                 )
             return task_id

--- a/hermes_cli/kanban_workflows.py
+++ b/hermes_cli/kanban_workflows.py
@@ -1,0 +1,262 @@
+"""Standard Kanban workflow templates.
+
+These helpers write durable task graphs into the existing Kanban kernel. They
+do not introduce a second scheduler: parent/child links keep downstream steps in
+``todo`` until the dispatcher promotes them to ``ready`` after upstream
+completion.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+import json
+import sqlite3
+from typing import Any, Optional
+
+from hermes_cli import kanban_db as kb
+
+TEMPLATE_CODER_QA_PM_REVIEW = "coder_qa_pm_review"
+WORKFLOW_COMMENT_PREFIX = "[workflow:coder_qa_pm_review] "
+
+
+@dataclass(frozen=True)
+class CoderQaPmWorkflowCreated:
+    """IDs produced by :func:`create_coder_qa_pm_review_workflow`."""
+
+    root_id: str
+    coder_task_id: str
+    qa_task_id: str
+    pm_review_task_id: str
+    template_id: str = TEMPLATE_CODER_QA_PM_REVIEW
+    subscriptions: dict[str, bool] = field(default_factory=dict)
+
+    @property
+    def task_ids(self) -> list[str]:
+        return [self.coder_task_id, self.qa_task_id, self.pm_review_task_id]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "template_id": self.template_id,
+            "root_id": self.root_id,
+            "coder_task_id": self.coder_task_id,
+            "qa_task_id": self.qa_task_id,
+            "pm_review_task_id": self.pm_review_task_id,
+            "task_ids": self.task_ids,
+            "subscriptions": dict(self.subscriptions),
+        }
+
+
+def _require_text(value: Optional[str], field_name: str) -> str:
+    text = (value or "").strip()
+    if not text:
+        raise ValueError(f"{field_name} is required")
+    return text
+
+
+def _workflow_context(root_id: str, title: str, body: Optional[str]) -> str:
+    spec = body.strip() if body else "(no extra body provided)"
+    return (
+        "\n\n## Standard workflow\n"
+        f"- Template: {TEMPLATE_CODER_QA_PM_REVIEW}\n"
+        f"- Workflow root: `{root_id}`.\n"
+        "- Handoff through Kanban completion summaries and metadata.\n"
+        "- Do not skip downstream gates; Coder completes for QA, QA completes for PM review.\n"
+        "- Keep releases, pushes, deploys, and irreversible external actions "
+        "behind PM review unless the task explicitly authorizes them.\n"
+        f"\n## Original request\nTitle: {title}\n\n{spec}\n"
+    )
+
+
+def _latest_topology(conn: sqlite3.Connection, root_id: str) -> dict[str, Any]:
+    rows = kb.list_comments(conn, root_id)
+    for comment in reversed(rows):
+        body = comment.body or ""
+        if not body.startswith(WORKFLOW_COMMENT_PREFIX):
+            continue
+        try:
+            payload = json.loads(body[len(WORKFLOW_COMMENT_PREFIX):])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            return payload
+    return {}
+
+
+def _subscribe_all(
+    task_ids: list[str],
+    subscribe_task: Optional[Callable[[str], bool]],
+) -> dict[str, bool]:
+    if subscribe_task is None:
+        return {task_id: False for task_id in task_ids}
+    subscribed: dict[str, bool] = {}
+    for task_id in task_ids:
+        try:
+            subscribed[task_id] = bool(subscribe_task(task_id))
+        except Exception:
+            subscribed[task_id] = False
+    return subscribed
+
+
+def create_coder_qa_pm_review_workflow(
+    conn: sqlite3.Connection,
+    *,
+    title: str,
+    body: Optional[str] = None,
+    coder_assignee: str = "coder-codex",
+    qa_assignee: str = "qa-minimax",
+    pm_assignee: str = "pm-deepseek",
+    tenant: Optional[str] = None,
+    created_by: str = "workflow-orchestrator",
+    workspace_kind: str = "scratch",
+    workspace_path: Optional[str] = None,
+    project_id: Optional[str] = None,
+    priority: int = 0,
+    idempotency_key: Optional[str] = None,
+    session_id: Optional[str] = None,
+    subscribe_task: Optional[Callable[[str], bool]] = None,
+) -> CoderQaPmWorkflowCreated:
+    """Create the standard ``coder -> qa -> pm review`` Kanban workflow.
+
+    The returned graph is immediately dispatchable. The root card is completed
+    as an audit anchor, the coder card is ``ready``, QA waits on coder, and PM
+    review waits on QA. If ``subscribe_task`` is provided, it is called for all
+    three executable cards so the creating PM gets completion notifications for
+    each handoff.
+    """
+
+    title = _require_text(title, "title")
+    coder_assignee = _require_text(coder_assignee, "coder_assignee")
+    qa_assignee = _require_text(qa_assignee, "qa_assignee")
+    pm_assignee = _require_text(pm_assignee, "pm_assignee")
+    created_by = _require_text(created_by, "created_by")
+
+    root = kb.create_task(
+        conn,
+        title=f"Workflow: {title[:80]}",
+        body=(
+            "Standard coder -> qa -> pm review workflow root. This card is "
+            "completed immediately so the first executable step can dispatch, "
+            "while the card remains the audit anchor for the pipeline.\n\n"
+            f"Original request:\n{body or title}"
+        ),
+        assignee=created_by,
+        created_by=created_by,
+        tenant=tenant,
+        priority=priority,
+        idempotency_key=idempotency_key,
+        workspace_kind=workspace_kind,
+        workspace_path=workspace_path,
+        project_id=project_id,
+        session_id=session_id,
+        workflow_template_id=TEMPLATE_CODER_QA_PM_REVIEW,
+        current_step_key="root",
+    )
+
+    existing = _latest_topology(conn, root)
+    if existing:
+        coder_id = existing.get("coder_task_id")
+        qa_id = existing.get("qa_task_id")
+        pm_review_id = existing.get("pm_review_task_id")
+        if coder_id and qa_id and pm_review_id:
+            task_ids = [str(coder_id), str(qa_id), str(pm_review_id)]
+            return CoderQaPmWorkflowCreated(
+                root_id=root,
+                coder_task_id=str(coder_id),
+                qa_task_id=str(qa_id),
+                pm_review_task_id=str(pm_review_id),
+                subscriptions=_subscribe_all(task_ids, subscribe_task),
+            )
+
+    kb.complete_task(
+        conn,
+        root,
+        summary="Workflow topology planned; executable steps are linked by dependencies.",
+        metadata={"template_id": TEMPLATE_CODER_QA_PM_REVIEW, "title": title},
+    )
+
+    context = _workflow_context(root, title, body)
+    coder = kb.create_task(
+        conn,
+        title=f"Coder: {title}",
+        body=(
+            "Implement the requested work and complete this card with a concise "
+            "handoff for QA: changed files, verification commands, and residual "
+            "risks."
+            + context
+        ),
+        assignee=coder_assignee,
+        created_by=created_by,
+        parents=[root],
+        tenant=tenant,
+        priority=priority,
+        workspace_kind=workspace_kind,
+        workspace_path=workspace_path,
+        project_id=project_id,
+        session_id=session_id,
+        workflow_template_id=TEMPLATE_CODER_QA_PM_REVIEW,
+        current_step_key="coder",
+    )
+
+    qa = kb.create_task(
+        conn,
+        title=f"QA: {title}",
+        body=(
+            "Review the coder handoff and verify the acceptance criteria. "
+            "Complete this card only when QA evidence is ready for PM review; "
+            "otherwise block with the exact missing input or failing evidence."
+            + context
+        ),
+        assignee=qa_assignee,
+        created_by=created_by,
+        parents=[coder],
+        tenant=tenant,
+        priority=priority,
+        workspace_kind=workspace_kind,
+        workspace_path=workspace_path,
+        project_id=project_id,
+        session_id=session_id,
+        skills=["requesting-code-review"],
+        workflow_template_id=TEMPLATE_CODER_QA_PM_REVIEW,
+        current_step_key="qa",
+    )
+
+    pm_review = kb.create_task(
+        conn,
+        title=f"PM review: {title}",
+        body=(
+            "Review the coder and QA handoffs, decide whether the workflow is "
+            "accepted, and perform or explicitly authorize any final human-gated "
+            "action."
+            + context
+        ),
+        assignee=pm_assignee,
+        created_by=created_by,
+        parents=[qa],
+        tenant=tenant,
+        priority=priority,
+        workspace_kind=workspace_kind,
+        workspace_path=workspace_path,
+        project_id=project_id,
+        session_id=session_id,
+        workflow_template_id=TEMPLATE_CODER_QA_PM_REVIEW,
+        current_step_key="pm_review",
+    )
+
+    task_ids = [coder, qa, pm_review]
+    subscriptions = _subscribe_all(task_ids, subscribe_task)
+    created = CoderQaPmWorkflowCreated(
+        root_id=root,
+        coder_task_id=coder,
+        qa_task_id=qa,
+        pm_review_task_id=pm_review,
+        subscriptions=subscriptions,
+    )
+    kb.add_comment(
+        conn,
+        root,
+        author=created_by,
+        body=WORKFLOW_COMMENT_PREFIX
+        + json.dumps(created.as_dict() | {"title": title}, sort_keys=True),
+    )
+    return created

--- a/tests/hermes_cli/test_kanban_workflows.py
+++ b/tests/hermes_cli/test_kanban_workflows.py
@@ -1,0 +1,128 @@
+import argparse
+import json
+
+from hermes_cli import kanban as kanban_cli
+from hermes_cli import kanban_db as kb
+from hermes_cli.kanban_workflows import (
+    TEMPLATE_CODER_QA_PM_REVIEW,
+    create_coder_qa_pm_review_workflow,
+)
+
+
+def test_coder_qa_pm_workflow_builds_dependency_gated_pipeline(tmp_path):
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        subscribed: list[str] = []
+
+        created = create_coder_qa_pm_review_workflow(
+            conn,
+            title="Ship the notification fix",
+            body="Implement the code path and verify it end to end.",
+            coder_assignee="coder-codex",
+            qa_assignee="qa-minimax",
+            pm_assignee="pm-deepseek",
+            tenant="hermes",
+            created_by="pm-deepseek",
+            subscribe_task=lambda task_id: subscribed.append(task_id) is None,
+        )
+
+        root = kb.get_task(conn, created.root_id)
+        coder = kb.get_task(conn, created.coder_task_id)
+        qa = kb.get_task(conn, created.qa_task_id)
+        pm_review = kb.get_task(conn, created.pm_review_task_id)
+
+        assert root.status == "done"
+        assert root.workflow_template_id == TEMPLATE_CODER_QA_PM_REVIEW
+        assert root.current_step_key == "root"
+
+        assert coder.status == "ready"
+        assert coder.assignee == "coder-codex"
+        assert coder.workflow_template_id == TEMPLATE_CODER_QA_PM_REVIEW
+        assert coder.current_step_key == "coder"
+        assert kb.parent_ids(conn, created.coder_task_id) == [created.root_id]
+
+        assert qa.status == "todo"
+        assert qa.assignee == "qa-minimax"
+        assert qa.workflow_template_id == TEMPLATE_CODER_QA_PM_REVIEW
+        assert qa.current_step_key == "qa"
+        assert kb.parent_ids(conn, created.qa_task_id) == [created.coder_task_id]
+
+        assert pm_review.status == "todo"
+        assert pm_review.assignee == "pm-deepseek"
+        assert pm_review.workflow_template_id == TEMPLATE_CODER_QA_PM_REVIEW
+        assert pm_review.current_step_key == "pm_review"
+        assert kb.parent_ids(conn, created.pm_review_task_id) == [created.qa_task_id]
+
+        assert subscribed == [
+            created.coder_task_id,
+            created.qa_task_id,
+            created.pm_review_task_id,
+        ]
+        assert created.subscriptions == {
+            created.coder_task_id: True,
+            created.qa_task_id: True,
+            created.pm_review_task_id: True,
+        }
+    finally:
+        conn.close()
+
+
+def test_coder_qa_pm_workflow_dispatcher_handoff_promotes_next_step(tmp_path):
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        created = create_coder_qa_pm_review_workflow(
+            conn,
+            title="Verify dispatcher handoff",
+            coder_assignee="coder",
+            qa_assignee="qa",
+            pm_assignee="pm",
+        )
+
+        kb.complete_task(conn, created.coder_task_id, summary="Coder done")
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, created.qa_task_id).status == "ready"
+        assert kb.get_task(conn, created.pm_review_task_id).status == "todo"
+
+        kb.complete_task(conn, created.qa_task_id, summary="QA passed")
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, created.pm_review_task_id).status == "ready"
+    finally:
+        conn.close()
+
+
+def test_coder_qa_pm_workflow_cli_creates_template_graph(
+    monkeypatch, tmp_path, capsys
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    kb._INITIALIZED_PATHS.clear()
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    kanban_cli.build_parser(sub)
+    args = parser.parse_args([
+        "kanban",
+        "workflow",
+        "coder-qa-pm",
+        "CLI flow",
+        "--coder",
+        "coder",
+        "--qa",
+        "qa",
+        "--pm",
+        "pm",
+        "--json",
+    ])
+
+    assert kanban_cli.kanban_command(args) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["template_id"] == TEMPLATE_CODER_QA_PM_REVIEW
+
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, payload["coder_task_id"]).status == "ready"
+        assert kb.get_task(conn, payload["qa_task_id"]).status == "todo"
+        assert kb.get_task(conn, payload["pm_review_task_id"]).status == "todo"
+    finally:
+        conn.close()

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -138,6 +138,7 @@ def test_kanban_tools_visible_with_toolset_config(monkeypatch, tmp_path):
         "kanban_show", "kanban_complete", "kanban_block", "kanban_heartbeat",
         "kanban_comment", "kanban_create", "kanban_link",
         "kanban_unblock",
+        "kanban_workflow_create",
     }
     assert kanban == expected, f"expected {expected}, got {kanban}"
 
@@ -1123,6 +1124,55 @@ def test_create_session_id_absent_when_env_unset(monkeypatch, worker_env):
         assert new_task.session_id is None
     finally:
         conn.close()
+
+
+def test_workflow_create_builds_standard_pipeline_and_subscribes(
+    monkeypatch, worker_env
+):
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    subscribed: list[str] = []
+    monkeypatch.setattr(
+        kt,
+        "_maybe_auto_subscribe",
+        lambda conn, task_id: subscribed.append(task_id) is None,
+    )
+
+    out = kt._handle_workflow_create({
+        "title": "workflow tool",
+        "body": "prove the tool creates a durable handoff",
+        "coder": "coder",
+        "qa": "qa",
+        "pm": "pm",
+        "tenant": "hermes",
+    })
+    payload = json.loads(out)
+    assert payload["ok"] is True
+    workflow = payload["workflow"]
+    assert subscribed == workflow["task_ids"]
+    assert all(workflow["subscriptions"].values())
+
+    conn = kb.connect()
+    try:
+        coder = kb.get_task(conn, workflow["coder_task_id"])
+        qa = kb.get_task(conn, workflow["qa_task_id"])
+        pm_review = kb.get_task(conn, workflow["pm_review_task_id"])
+        assert coder.status == "ready"
+        assert qa.status == "todo"
+        assert pm_review.status == "todo"
+        assert kb.parent_ids(conn, qa.id) == [coder.id]
+        assert kb.parent_ids(conn, pm_review.id) == [qa.id]
+    finally:
+        conn.close()
+
+
+def test_workflow_create_is_orchestrator_only(worker_env):
+    from tools import kanban_tools as kt
+
+    out = kt._handle_workflow_create({"title": "worker should not fan out"})
+    assert "orchestrator-only" in json.loads(out).get("error", "")
 
 
 def test_create_rejects_no_title(worker_env):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -950,6 +950,60 @@ def _handle_create(args: dict, **kw) -> str:
         return tool_error(f"kanban_create: {e}")
 
 
+def _handle_workflow_create(args: dict, **kw) -> str:
+    """Create a standard multi-step Kanban workflow graph."""
+    guard = _require_orchestrator_tool("kanban_workflow_create")
+    if guard:
+        return guard
+    template = args.get("template") or "coder_qa_pm_review"
+    if template not in {"coder_qa_pm_review", "coder-qa-pm-review", "coder-qa-pm"}:
+        return tool_error(
+            "template must be coder_qa_pm_review (coder -> qa -> pm review)"
+        )
+    title = args.get("title")
+    if not title or not str(title).strip():
+        return tool_error("title is required")
+    priority = args.get("priority")
+    workspace_kind = args.get("workspace_kind") or "scratch"
+    workspace_path = args.get("workspace_path")
+    session_id = args.get("session_id") or os.environ.get("HERMES_SESSION_ID")
+    board = args.get("board")
+    try:
+        kb, conn = _connect(board=board)
+        try:
+            from hermes_cli import kanban_workflows as kwf
+
+            created = kwf.create_coder_qa_pm_review_workflow(
+                conn,
+                title=str(title).strip(),
+                body=args.get("body"),
+                coder_assignee=args.get("coder") or "coder-codex",
+                qa_assignee=args.get("qa") or "qa-minimax",
+                pm_assignee=args.get("pm") or "pm-deepseek",
+                tenant=args.get("tenant") or os.environ.get("HERMES_TENANT"),
+                created_by=(
+                    args.get("created_by")
+                    or os.environ.get("HERMES_PROFILE")
+                    or "workflow-orchestrator"
+                ),
+                workspace_kind=str(workspace_kind),
+                workspace_path=workspace_path,
+                project_id=args.get("project") or args.get("project_id"),
+                priority=int(priority) if priority is not None else 0,
+                idempotency_key=args.get("idempotency_key"),
+                session_id=session_id,
+                subscribe_task=lambda task_id: _maybe_auto_subscribe(conn, task_id),
+            )
+            return _ok(workflow=created.as_dict())
+        finally:
+            conn.close()
+    except ValueError as e:
+        return tool_error(f"kanban_workflow_create: {e}")
+    except Exception as e:
+        logger.exception("kanban_workflow_create failed")
+        return tool_error(f"kanban_workflow_create: {e}")
+
+
 def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
     """Auto-subscribe the calling session to task completion / block events.
 
@@ -1547,6 +1601,81 @@ KANBAN_CREATE_SCHEMA = {
     },
 }
 
+KANBAN_WORKFLOW_CREATE_SCHEMA = {
+    "name": "kanban_workflow_create",
+    "description": (
+        "Create a standard Kanban workflow graph. The supported template "
+        "creates coder -> QA -> PM review tasks, automatically subscribes "
+        "the creating PM/session to all executable child tasks, and uses "
+        "parent/child dependencies so the dispatcher promotes each next "
+        "step when the previous one completes. Orchestrator-only."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "template": {
+                "type": "string",
+                "enum": ["coder_qa_pm_review"],
+                "description": (
+                    "Workflow template to create. Defaults to "
+                    "coder_qa_pm_review."
+                ),
+            },
+            "title": {
+                "type": "string",
+                "description": "Short workflow title / request (required).",
+            },
+            "body": {
+                "type": "string",
+                "description": "Full request, acceptance criteria, links, and context.",
+            },
+            "coder": {
+                "type": "string",
+                "description": "Coder profile. Defaults to coder-codex.",
+            },
+            "qa": {
+                "type": "string",
+                "description": "QA profile. Defaults to qa-minimax.",
+            },
+            "pm": {
+                "type": "string",
+                "description": "PM review profile. Defaults to pm-deepseek.",
+            },
+            "tenant": {
+                "type": "string",
+                "description": "Optional tenant/project namespace.",
+            },
+            "priority": {
+                "type": "integer",
+                "description": "Priority tiebreaker for every executable step.",
+            },
+            "workspace_kind": {
+                "type": "string",
+                "enum": ["scratch", "dir", "worktree"],
+                "description": "Workspace flavor for the workflow tasks.",
+            },
+            "workspace_path": {
+                "type": "string",
+                "description": "Absolute path for dir/worktree workflow tasks.",
+            },
+            "project": {
+                "type": "string",
+                "description": "Optional project id or slug to link all tasks to.",
+            },
+            "idempotency_key": {
+                "type": "string",
+                "description": "Dedup key for the workflow root card.",
+            },
+            "session_id": {
+                "type": "string",
+                "description": "Optional originating session id override.",
+            },
+            "board": _board_schema_prop(),
+        },
+        "required": ["title"],
+    },
+}
+
 KANBAN_UNBLOCK_SCHEMA = {
     "name": "kanban_unblock",
     "description": (
@@ -1651,6 +1780,15 @@ registry.register(
     handler=_handle_create,
     check_fn=_check_kanban_mode,
     emoji="➕",
+)
+
+registry.register(
+    name="kanban_workflow_create",
+    toolset="kanban",
+    schema=KANBAN_WORKFLOW_CREATE_SCHEMA,
+    handler=_handle_workflow_create,
+    check_fn=_check_kanban_orchestrator_mode,
+    emoji="🧭",
 )
 
 registry.register(

--- a/toolsets.py
+++ b/toolsets.py
@@ -74,6 +74,7 @@ _HERMES_CORE_TOOLS = [
     "kanban_show", "kanban_list",
     "kanban_complete", "kanban_block", "kanban_heartbeat",
     "kanban_comment", "kanban_create", "kanban_link",
+    "kanban_workflow_create",
     "kanban_unblock",
     # Computer use (macOS, gated on cua-driver being installed via check_fn)
     "computer_use",
@@ -265,12 +266,14 @@ TOOLSETS = {
             "`kanban.dispatch_in_gateway` in config.yaml. Lets workers mark "
             "tasks done with structured handoffs, block for human input, "
             "heartbeat during long ops, comment on threads, and (for "
-            "orchestrators) list, unblock, and fan out tasks."
+            "orchestrators) list, unblock, fan out tasks, and create "
+            "standard workflow templates."
         ),
         "tools": [
             "kanban_show", "kanban_list", "kanban_complete", "kanban_block",
             "kanban_heartbeat", "kanban_comment",
             "kanban_create", "kanban_link",
+            "kanban_workflow_create",
             "kanban_unblock",
         ],
         "includes": [],


### PR DESCRIPTION
Summary: add a standard coder_qa_pm_review Kanban workflow helper, CLI command, and kanban_workflow_create tool; automatically subscribes the creating PM/session to coder, QA, and PM-review child tasks; stores workflow_template_id/current_step_key through create_task so dispatcher handoff is auditable.

Tests: pytest tests/hermes_cli/test_kanban_workflows.py tests/tools/test_kanban_tools.py -q; py_compile changed Python files.