### PR TITLE
fix(moa): preserve save_traces/trace_dir on GUI config save

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4486,7 +4486,10 @@ def set_moa_models(body: MoaConfigPayload, profile: Optional[str] = None):
                     "enabled": body.enabled,
                 }
             normalized = normalize_moa_config(raw)
-            cfg["moa"] = normalized
+            # Merge instead of overwrite so that hand-edited keys not declared
+            # in MoaConfigPayload (e.g. save_traces, trace_dir) survive a GUI
+            # save.  See issue #58819.
+            cfg.setdefault("moa", {}).update(normalized)
             save_config(cfg)
             return {"ok": True, **normalized}
     except HTTPException:

--- a/tests/hermes_cli/test_moa_set_models_preserves_extra_keys.py
+++ b/tests/hermes_cli/test_moa_set_models_preserves_extra_keys.py
@@ -1,0 +1,146 @@
+"""Regression tests for ``set_moa_models`` preserving undeclared config keys.
+
+Issue #58819: ``MoaConfigPayload`` does not declare ``save_traces`` or
+``trace_dir``, so a GUI save via ``PUT /api/model/moa`` silently drops
+these hand-edited keys from ``config.yaml``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from hermes_cli.web_server import MoaConfigPayload, MoaModelSlot, MoaPresetPayload, set_moa_models
+
+
+def _base_payload(**overrides) -> MoaConfigPayload:
+    """Return a minimal valid MoaConfigPayload."""
+    defaults = dict(
+        default_preset="default",
+        active_preset="",
+        presets={
+            "default": MoaPresetPayload(
+                reference_models=[
+                    MoaModelSlot(provider="openai-codex", model="gpt-5.5"),
+                ],
+                aggregator=MoaModelSlot(provider="openrouter", model="anthropic/claude-opus-4.8"),
+                max_tokens=4096,
+                enabled=True,
+            ),
+        },
+    )
+    defaults.update(overrides)
+    return MoaConfigPayload(**defaults)
+
+
+class TestSetMoaModelsPreservesUndeclaredKeys:
+    """save_traces / trace_dir must survive a GUI save."""
+
+    def test_save_traces_preserved(self, tmp_path):
+        """Hand-edited ``moa.save_traces: true`` must not be dropped."""
+        existing_cfg = {
+            "moa": {
+                "save_traces": True,
+                "trace_dir": "/custom/traces",
+                "default_preset": "default",
+                "presets": {
+                    "default": {
+                        "reference_models": [
+                            {"provider": "openai-codex", "model": "gpt-5.5"},
+                        ],
+                        "aggregator": {"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
+                        "max_tokens": 4096,
+                        "enabled": True,
+                    },
+                },
+            },
+        }
+
+        saved_cfg = {}
+
+        def fake_load_config():
+            return dict(existing_cfg)  # shallow copy
+
+        def fake_save_config(cfg):
+            saved_cfg.update(cfg)
+
+        payload = _base_payload()
+
+        with (
+            patch("hermes_cli.web_server.load_config", side_effect=fake_load_config),
+            patch("hermes_cli.web_server.save_config", side_effect=fake_save_config),
+            patch("hermes_cli.web_server._profile_scope"),
+        ):
+            set_moa_models(payload)
+
+        moa = saved_cfg["moa"]
+        assert moa.get("save_traces") is True, (
+            "save_traces was dropped by set_moa_models"
+        )
+        assert moa.get("trace_dir") == "/custom/traces", (
+            "trace_dir was dropped by set_moa_models"
+        )
+
+    def test_trace_dir_empty_string_preserved(self, tmp_path):
+        """Even an empty-string ``trace_dir`` must survive."""
+        existing_cfg = {
+            "moa": {
+                "save_traces": True,
+                "trace_dir": "",
+                "default_preset": "default",
+                "presets": {
+                    "default": {
+                        "reference_models": [
+                            {"provider": "openai-codex", "model": "gpt-5.5"},
+                        ],
+                        "aggregator": {"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
+                        "max_tokens": 4096,
+                        "enabled": True,
+                    },
+                },
+            },
+        }
+
+        saved_cfg = {}
+
+        def fake_load_config():
+            return dict(existing_cfg)
+
+        def fake_save_config(cfg):
+            saved_cfg.update(cfg)
+
+        payload = _base_payload()
+
+        with (
+            patch("hermes_cli.web_server.load_config", side_effect=fake_load_config),
+            patch("hermes_cli.web_server.save_config", side_effect=fake_save_config),
+            patch("hermes_cli.web_server._profile_scope"),
+        ):
+            set_moa_models(payload)
+
+        moa = saved_cfg["moa"]
+        assert moa.get("save_traces") is True
+        assert moa.get("trace_dir") == ""
+
+    def test_no_existing_moa_key_still_works(self, tmp_path):
+        """When ``moa`` key is absent from config, the endpoint must not crash."""
+        existing_cfg: dict = {}
+
+        saved_cfg = {}
+
+        def fake_load_config():
+            return dict(existing_cfg)
+
+        def fake_save_config(cfg):
+            saved_cfg.update(cfg)
+
+        payload = _base_payload()
+
+        with (
+            patch("hermes_cli.web_server.load_config", side_effect=fake_load_config),
+            patch("hermes_cli.web_server.save_config", side_effect=fake_save_config),
+            patch("hermes_cli.web_server._profile_scope"),
+        ):
+            result = set_moa_models(payload)
+
+        assert result["ok"] is True
+        assert "default_preset" in saved_cfg["moa"]


### PR DESCRIPTION
## What does this PR do?

`set_moa_models()` overwrites `cfg["moa"]` with the output of `normalize_moa_config(raw)`, which only contains keys declared in `MoaConfigPayload`. Hand-edited keys like `save_traces` and `trace_dir` are silently dropped, disabling MoA trace persistence without warning.

This PR changes the assignment to a merge (`dict.update()`) so undeclared keys survive a GUI save.

## Related Issue

Fixes #58819

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py`: Replace `cfg["moa"] = normalized` with `cfg.setdefault("moa", {}).update(normalized)` in `set_moa_models()` to preserve config keys not declared in the Pydantic payload (e.g. `save_traces`, `trace_dir`).
- `tests/hermes_cli/test_moa_set_models_preserves_extra_keys.py`: 3 regression tests verifying that `save_traces`, `trace_dir`, and a missing `moa` key all behave correctly after the fix.

## How to Test

1. Hand-edit `~/.hermes/config.yaml` and add under the `moa:` block: `save_traces: true` and `trace_dir: ""`.
2. Open Desktop → Settings → Model → MoA panel. Change any preset parameter and click Save.
3. Re-open `~/.hermes/config.yaml` — `save_traces: true` should still be present. Before this fix, it was silently dropped.
4. Run `pytest tests/hermes_cli/test_moa_set_models_preserves_extra_keys.py -v` — all 3 tests should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (Python dict merge, platform-independent)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
