### PR TITLE
feat(telegram): add mobile control panel

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -238,6 +238,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True, aliases=("gateway",)),
     CommandDef("platform", "Pause, resume, or list a failing gateway platform", "Info",
                gateway_only=True, args_hint="<pause|resume|list> [name]"),
+    CommandDef("mobile", "Open the Telegram mobile computer-control panel", "Info",
+               gateway_only=True, aliases=("mac", "panel")),
     CommandDef("copy", "Copy the last assistant response to clipboard", "Info",
                cli_only=True, args_hint="[number]"),
     CommandDef("paste", "Attach clipboard image from your clipboard", "Info",
@@ -509,6 +511,76 @@ def _iter_plugin_command_entries() -> list[tuple[str, str, str]]:
     return entries
 
 
+# Telegram menu descriptions in Simplified Chinese.
+# These override the English description for the Telegram `/` command menu.
+_TG_CMD_DESCRIPTIONS_CN: dict[str, str] = {
+    # Session
+    "start":    "忽略平台启动信号（不回复）",
+    "new":      "开始新会话（清空上下文）",
+    "topic":    "管理 Telegram 主题会话",
+    "retry":    "重试最后一条消息",
+    "undo":     "撤销 N 轮对话（默认1轮）",
+    "title":    "给当前会话取个标题",
+    "branch":   "分支当前会话（探索不同方向）",
+    "compress": "压缩对话上下文",
+    "rollback": "列出或恢复系统检查点",
+    "stop":     "停止所有后台任务",
+    "approve":  "批准待处理的危险操作",
+    "deny":     "拒绝待处理的危险操作",
+    "background": "后台运行提示词",
+    "agents":   "查看活跃 Agent 和任务",
+    "queue":    "将提示词排队（不中断当前任务）",
+    "steer":    "在下次工具调用后注入消息（不中断）",
+    "goal":     "设定 Agent 持续完成的目标",
+    "moa":      "用多 Agent 模式运行一次提示词",
+    "subgoal":  "管理当前目标的附加条件",
+    "status":   "查看会话、模型、Token 状态",
+    "whoami":   "查看你的命令权限（管理员/普通用户）",
+    "profile":  "查看当前配置profile名称和目录",
+    "sethome":  "将本聊天设为主频道",
+    "resume":   "恢复之前的会话",
+    "sessions": "浏览并恢复历史会话",
+    # Configuration
+    "model":         "切换模型（默认永久生效）",
+    "codex_runtime": "切换 Codex 运行时模式",
+    "personality":   "设置预定义人设",
+    "verbose":       "切换工具进度显示：关→新→全部→详细",
+    "footer":        "切换消息尾部运行时信息",
+    "yolo":          "切换 YOLO 模式（跳过危险操作确认）",
+    "reasoning":     "管理推理强度和显示",
+    "fast":          "切换快速模式（优先处理/正常处理）",
+    "voice":         "切换语音模式",
+    # Tools & Skills
+    "memory":       "查看待写入记忆 / 切换审批开关",
+    "bundles":      "查看技能包列表（多技能别名）",
+    "learn":        "从任意内容学习可复用技能",
+    "suggestions":  "查看建议自动化（接受/忽略）",
+    "blueprint":    "从模板设置自动化任务",
+    "curator":      "技能后台维护（状态/运行/置顶/归档）",
+    "kanban":       "多profile协作看板（任务/链接/评论）",
+    "reload_mcp":   "重载 MCP 服务器配置",
+    "reload_skills":"重新扫描技能目录",
+    # Info
+    "commands": "浏览所有命令和技能（分页）",
+    "help":     "查看可用命令",
+    "restart":  "重启网关（排空当前任务后）",
+    "usage":    "查看会话 Token 用量和限流",
+    "credits":  "查看 Nous 积分余额和充值",
+    "insights": "查看使用分析和洞察",
+    "platform": "暂停/恢复/列出网关平台",
+    "mobile":   "打开 Telegram 远程控制面板",
+    "update":   "更新 Hermes 到最新版本",
+    "version":  "查看 Hermes 版本号",
+    "debug":    "上传调试报告并获取分享链接",
+}
+"""Telegram menu descriptions in Simplified Chinese.
+
+These override the English description for the Telegram ``/`` command menu.
+Command names are stored in lowercase (already sanitized by
+``_sanitize_telegram_name``).
+"""
+
+
 def telegram_bot_commands() -> list[tuple[str, str]]:
     """Return (command_name, description) pairs for Telegram setMyCommands.
 
@@ -533,7 +605,8 @@ def telegram_bot_commands() -> list[tuple[str, str]]:
         # the menu hurts discoverability (issue #24312).
         tg_name = _sanitize_telegram_name(cmd.name)
         if tg_name:
-            result.append((tg_name, cmd.description))
+            desc = _TG_CMD_DESCRIPTIONS_CN.get(tg_name, cmd.description)
+            result.append((tg_name, desc))
     for name, description, args_hint in _iter_plugin_command_entries():
         if _requires_argument(args_hint):
             continue
@@ -553,6 +626,7 @@ _TELEGRAM_PRIORITY_MODES = {"prepend", "append", "replace"}
 
 _TELEGRAM_MENU_PRIORITY = (
     # Most-typed everyday commands first.
+    "mobile",
     "help",
     "new",
     "stop",
@@ -1163,7 +1237,8 @@ _SLACK_PRIORITY_ALIASES = ("btw", "bg")
 #   - moa: high-cost slash mode, available through /hermes moa to avoid
 #     displacing existing native Slack slash commands at the 50-command cap.
 #   - debug: the log/report upload surface; reached via /hermes debug on Slack.
-_SLACK_VIA_HERMES_ONLY = frozenset({"credits", "billing", "moa", "debug"})
+#   - mobile: Telegram-specific button panel; not useful as a native Slack slash.
+_SLACK_VIA_HERMES_ONLY = frozenset({"credits", "billing", "moa", "debug", "mobile"})
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -460,8 +460,14 @@ def _moa_provider_row(current_provider: str = "") -> dict | None:
         from hermes_cli.config import load_config
         from hermes_cli.moa_config import normalize_moa_config
 
-        cfg = normalize_moa_config(load_config().get("moa") or {})
+        raw_moa = load_config().get("moa") or {}
+        cfg = normalize_moa_config(raw_moa)
         models = list(cfg.get("presets", {}).keys())
+        models = [
+            name
+            for name in models
+            if cfg.get("presets", {}).get(name, {}).get("enabled", True)
+        ]
         if not models:
             return None
         return {

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1397,6 +1397,42 @@ def _extra_headers_from_config(entry: Any) -> dict[str, str]:
     return normalize_extra_headers(entry.get("extra_headers"))
 
 
+def _model_picker_allowlists() -> tuple[set[str], dict[str, set[str]]]:
+    """Return provider/model allowlists from config.model_picker, if any."""
+    try:
+        from hermes_cli.config import load_config
+
+        picker_cfg = (load_config() or {}).get("model_picker") or {}
+    except Exception:
+        return set(), {}
+    if not isinstance(picker_cfg, dict):
+        return set(), {}
+
+    raw_providers = picker_cfg.get("allowed_providers") or []
+    allowed_providers = {
+        str(item).strip().lower()
+        for item in raw_providers
+        if str(item).strip()
+    }
+
+    allowed_models: dict[str, set[str]] = {}
+    raw_models = picker_cfg.get("allowed_models") or {}
+    if isinstance(raw_models, dict):
+        for provider, models in raw_models.items():
+            if not isinstance(models, list):
+                continue
+            allowed_models[str(provider).strip().lower()] = {
+                str(model).strip()
+                for model in models
+                if str(model).strip()
+            }
+    return allowed_providers, allowed_models
+
+
+def _model_picker_provider_allowed(slug: str, allowed_providers: set[str]) -> bool:
+    return not allowed_providers or str(slug or "").strip().lower() in allowed_providers
+
+
 def prewarm_picker_cache_async() -> Optional["_threading.Thread"]:
     """Warm the provider-models disk cache in a background daemon thread.
 
@@ -1521,6 +1557,13 @@ def list_authenticated_providers(
     # https://coding-intl.dashscope.aliyuncs.com/v1 collides with the built-in
     # alibaba-coding-plan row when DASHSCOPE_API_KEY is present). Fixes #16970.
     _builtin_endpoints: set = set()
+    _picker_allowed_providers, _ = _model_picker_allowlists()
+    _user_provider_keys = {
+        str(key).strip().lower()
+        for key in (user_providers or {})
+        if str(key).strip()
+    } if isinstance(user_providers, dict) else set()
+    _picker_user_only = bool(_picker_allowed_providers) and _picker_allowed_providers <= _user_provider_keys
 
     def _norm_url(url: str) -> str:
         return str(url or "").strip().rstrip("/").lower()
@@ -1586,28 +1629,29 @@ def list_authenticated_providers(
         except Exception:
             return False
 
-    data = fetch_models_dev()
+    data = {} if _picker_user_only else fetch_models_dev()
 
     # Build curated model lists keyed by hermes provider ID
     curated: dict[str, list[str]] = dict(_PROVIDER_MODELS)
-    curated["openrouter"] = [mid for mid, _ in OPENROUTER_MODELS]
-    # "nous" pulls from the remote model-catalog manifest published at
-    # https://hermes-agent.nousresearch.com/docs/api/model-catalog.json so
-    # newly added Portal models surface in the /model picker without
-    # requiring a Hermes release. Falls back to the in-repo
-    # _PROVIDER_MODELS["nous"] snapshot when the manifest is unreachable.
-    curated["nous"] = get_curated_nous_model_ids()
-    # Ollama Cloud uses dynamic discovery (no static curated list)
-    if "ollama-cloud" not in curated:
-        from hermes_cli.models import fetch_ollama_cloud_models
-        curated["ollama-cloud"] = fetch_ollama_cloud_models()
+    if not _picker_user_only:
+        curated["openrouter"] = [mid for mid, _ in OPENROUTER_MODELS]
+        # "nous" pulls from the remote model-catalog manifest published at
+        # https://hermes-agent.nousresearch.com/docs/api/model-catalog.json so
+        # newly added Portal models surface in the /model picker without
+        # requiring a Hermes release. Falls back to the in-repo
+        # _PROVIDER_MODELS["nous"] snapshot when the manifest is unreachable.
+        curated["nous"] = get_curated_nous_model_ids()
+        # Ollama Cloud uses dynamic discovery (no static curated list)
+        if "ollama-cloud" not in curated:
+            from hermes_cli.models import fetch_ollama_cloud_models
+            curated["ollama-cloud"] = fetch_ollama_cloud_models()
     # LM Studio has no static catalog — probe its native /api/v1/models
     # endpoint live so the picker reflects whatever the user has loaded.
     # Base URL precedence: LM_BASE_URL env var > active config's base_url
     # (when current provider is lmstudio) > 127.0.0.1 default.
     # On auth rejection or unreachable server, fall back to the caller-supplied
     # current model so the picker still shows something when offline / mis-keyed.
-    if "lmstudio" not in curated and (
+    if not _picker_user_only and "lmstudio" not in curated and (
         os.environ.get("LM_API_KEY") or os.environ.get("LM_BASE_URL") or current_provider.strip().lower() == "lmstudio"
     ):
         from hermes_cli.models import fetch_lmstudio_models
@@ -1653,6 +1697,8 @@ def list_authenticated_providers(
         # kimi-coding and kimi-coding-cn both → kimi-for-coding).
         # The first one with valid credentials wins (#10526).
         if mdev_id in seen_mdev_ids:
+            continue
+        if not _model_picker_provider_allowed(hermes_id, _picker_allowed_providers):
             continue
         pdata = data.get(mdev_id)
         if not isinstance(pdata, dict):
@@ -1734,6 +1780,8 @@ def list_authenticated_providers(
         # Resolve Hermes slug — e.g. "github-copilot" → "copilot"
         hermes_slug = _mdev_to_hermes.get(pid, pid)
         if hermes_slug.lower() in seen_slugs:
+            continue
+        if not _model_picker_provider_allowed(hermes_slug, _picker_allowed_providers):
             continue
 
         # Check if credentials exist
@@ -1892,6 +1940,8 @@ def list_authenticated_providers(
     for _cp in _canon_provs:
         if _cp.slug.lower() in seen_slugs:
             continue
+        if not _model_picker_provider_allowed(_cp.slug, _picker_allowed_providers):
+            continue
 
         # Check credentials via PROVIDER_REGISTRY (auth.py)
         _cp_config = _auth_registry.get(_cp.slug)
@@ -1965,6 +2015,8 @@ def list_authenticated_providers(
     if user_providers and isinstance(user_providers, dict):
         for ep_name, ep_cfg in user_providers.items():
             if not isinstance(ep_cfg, dict):
+                continue
+            if not _model_picker_provider_allowed(ep_name, _picker_allowed_providers):
                 continue
             # Skip if this slug was already emitted (e.g. canonical provider
             # with the same name) or will be picked up by section 4.
@@ -2067,6 +2119,7 @@ def list_authenticated_providers(
     _current_provider_norm = str(current_provider or "").strip().lower()
     if (
         _current_provider_norm == "custom"
+        and _model_picker_provider_allowed("custom", _picker_allowed_providers)
         and current_base_url
         and "custom" not in seen_slugs
         and not any(
@@ -2124,6 +2177,10 @@ def list_authenticated_providers(
             ).strip().rstrip("/")
             if not raw_name or not api_url:
                 continue
+            if _picker_allowed_providers:
+                custom_slug = custom_provider_slug(raw_name).lower()
+                if custom_slug not in _picker_allowed_providers and raw_name.lower() not in _picker_allowed_providers:
+                    continue
             inline_api_key = (entry.get("api_key") or "").strip()
             key_env = (entry.get("key_env") or "").strip()
             api_key = inline_api_key or (
@@ -2334,7 +2391,58 @@ def list_authenticated_providers(
     # Sort: current provider first, then by model count descending
     results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))
 
-    return results
+    return _apply_model_picker_allowlist(results)
+
+
+def _apply_model_picker_allowlist(results: List[dict]) -> List[dict]:
+    """Restrict picker rows when config.model_picker defines an allowlist."""
+    try:
+        from hermes_cli.config import load_config
+
+        picker_cfg = (load_config() or {}).get("model_picker") or {}
+    except Exception:
+        return results
+    if not isinstance(picker_cfg, dict):
+        return results
+
+    raw_providers = picker_cfg.get("allowed_providers") or []
+    allowed_providers = {
+        str(item).strip().lower()
+        for item in raw_providers
+        if str(item).strip()
+    }
+    raw_models = picker_cfg.get("allowed_models") or {}
+    allowed_models: dict[str, set[str]] = {}
+    if isinstance(raw_models, dict):
+        for provider, models in raw_models.items():
+            if not isinstance(models, list):
+                continue
+            allowed_models[str(provider).strip().lower()] = {
+                str(model).strip()
+                for model in models
+                if str(model).strip()
+            }
+
+    if not allowed_providers and not allowed_models:
+        return results
+
+    filtered: List[dict] = []
+    for row in results:
+        slug = str(row.get("slug") or "").strip().lower()
+        if allowed_providers and slug not in allowed_providers:
+            continue
+        model_allowlist = allowed_models.get(slug)
+        if model_allowlist is not None:
+            row = dict(row)
+            row["models"] = [
+                model
+                for model in (row.get("models") or [])
+                if str(model).strip() in model_allowlist
+            ]
+            row["total_models"] = len(row["models"])
+        if row.get("models"):
+            filtered.append(row)
+    return filtered
 
 
 def _prepend_moa_picker_provider(providers: List[dict], current_provider: str = "") -> List[dict]:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14979,6 +14979,170 @@ _mount_plugin_api_routes()
 from hermes_cli.dashboard_auth.routes import router as _dashboard_auth_router  # noqa: E402
 app.include_router(_dashboard_auth_router)
 
+
+# --- HERMES_ONE_MODEL_LIBRARY_COMPAT_V1 -------------------------------------
+# Compatibility endpoint installed by Hermes One. Upstream Hermes Agent exposes
+# /api/model/options and /api/model/set, but Hermes One also needs a small
+# configured-model shortcut library for remote/SSH model pickers. The library is
+# deliberately stored in this agent's HERMES_HOME so remote shortcuts stay on
+# the remote host and survive desktop restarts without changing upstream model
+# assignment semantics.
+def _hermes_one_model_library_path():
+    return get_hermes_home() / "models.json"
+
+
+def _hermes_one_short_model_label(model):
+    text = str(model or "").strip()
+    return (text.rsplit("/", 1)[-1] if text else "") or text
+
+
+def _hermes_one_model_key(row):
+    return (
+        str(row.get("provider", "")).strip().lower(),
+        str(row.get("model", "")).strip().lower(),
+        str(row.get("baseUrl", row.get("base_url", ""))).strip().rstrip("/").lower(),
+    )
+
+
+def _hermes_one_normalize_model_row(row, index=0):
+    if not isinstance(row, dict):
+        return None
+    provider = str(row.get("provider", "")).strip()
+    model = str(row.get("model", "")).strip()
+    if not provider or not model:
+        return None
+    base_url = str(row.get("baseUrl", row.get("base_url", "")) or "").strip()
+    return {
+        "id": str(row.get("id") or f"remote:library:{provider}:{index}:{model}"),
+        "name": str(row.get("name") or _hermes_one_short_model_label(model) or provider),
+        "provider": provider,
+        "model": model,
+        "baseUrl": base_url,
+        "createdAt": row.get("createdAt") if isinstance(row.get("createdAt"), (int, float)) else 0,
+    }
+
+
+def _hermes_one_read_model_library():
+    path = _hermes_one_model_library_path()
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8")) if path.exists() else []
+    except Exception:
+        raw = []
+    rows = []
+    seen = set()
+    for index, item in enumerate(raw if isinstance(raw, list) else []):
+        row = _hermes_one_normalize_model_row(item, index)
+        if not row:
+            continue
+        key = _hermes_one_model_key(row)
+        if key in seen:
+            continue
+        seen.add(key)
+        rows.append(row)
+    return rows
+
+
+def _hermes_one_write_model_library(rows):
+    path = _hermes_one_model_library_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(rows, indent=2), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _hermes_one_current_model_row():
+    try:
+        cfg = load_config()
+    except Exception:
+        return None
+    model_cfg = cfg.get("model", {})
+    if isinstance(model_cfg, dict):
+        provider = str(model_cfg.get("provider", "") or "").strip()
+        model = str(model_cfg.get("default", model_cfg.get("name", "")) or "").strip()
+        base_url = str(model_cfg.get("base_url", "") or "").strip()
+    else:
+        provider = ""
+        model = str(model_cfg or "").strip()
+        base_url = ""
+    if not provider or not model:
+        return None
+    return {
+        "id": f"remote:active:{provider}:{model}",
+        "name": _hermes_one_short_model_label(model) or provider,
+        "provider": provider,
+        "model": model,
+        "baseUrl": base_url,
+        "createdAt": 0,
+    }
+
+
+@app.get("/api/model/library")
+def hermes_one_get_model_library():
+    rows = _hermes_one_read_model_library()
+    current = _hermes_one_current_model_row()
+    if current:
+        current_key = _hermes_one_model_key(current)
+        rows = [current] + [row for row in rows if _hermes_one_model_key(row) != current_key]
+    return {"models": rows}
+
+
+@app.post("/api/model/library")
+def hermes_one_add_model_library_row(body: Dict[str, Any]):
+    provider = str(body.get("provider", "") or "").strip()
+    model = str(body.get("model", "") or "").strip()
+    if not provider or not model:
+        raise HTTPException(status_code=400, detail="provider and model required")
+    base_url = str(body.get("baseUrl", body.get("base_url", "")) or "").strip()
+    name = str(body.get("name", "") or "").strip() or _hermes_one_short_model_label(model) or provider
+    rows = _hermes_one_read_model_library()
+    key = (provider.lower(), model.lower(), base_url.rstrip("/").lower())
+    for row in rows:
+        if _hermes_one_model_key(row) == key:
+            return row
+    row = {
+        "id": f"remote:library:{secrets.token_hex(8)}",
+        "name": name,
+        "provider": provider,
+        "model": model,
+        "baseUrl": base_url,
+        "createdAt": int(time.time() * 1000),
+    }
+    rows.append(row)
+    _hermes_one_write_model_library(rows)
+    return row
+
+
+@app.patch("/api/model/library/{model_id:path}")
+def hermes_one_update_model_library_row(model_id: str, body: Dict[str, Any]):
+    rows = _hermes_one_read_model_library()
+    for index, row in enumerate(rows):
+        if row.get("id") != model_id:
+            continue
+        next_row = dict(row)
+        for key in ("name", "provider", "model"):
+            if key in body:
+                next_row[key] = str(body.get(key, "") or "").strip()
+        if "baseUrl" in body or "base_url" in body:
+            next_row["baseUrl"] = str(body.get("baseUrl", body.get("base_url", "")) or "").strip()
+        normalized = _hermes_one_normalize_model_row(next_row, index)
+        if not normalized:
+            raise HTTPException(status_code=400, detail="provider and model required")
+        rows[index] = normalized
+        _hermes_one_write_model_library(rows)
+        return {"ok": True, "model": normalized}
+    raise HTTPException(status_code=404, detail="model not found")
+
+
+@app.delete("/api/model/library/{model_id:path}")
+def hermes_one_delete_model_library_row(model_id: str):
+    rows = _hermes_one_read_model_library()
+    filtered = [row for row in rows if row.get("id") != model_id]
+    if len(filtered) == len(rows):
+        raise HTTPException(status_code=404, detail="model not found")
+    _hermes_one_write_model_library(filtered)
+    return {"ok": True}
+# --- /HERMES_ONE_MODEL_LIBRARY_COMPAT_V1 ------------------------------------
+
 mount_spa(app)
 
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -7391,11 +7391,70 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         await self._ensure_forum_commands(update.message)
 
+        handled_quick_button = await self._handle_mobile_quick_text(msg)
+        if handled_quick_button:
+            return
+
         event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
         await self._cache_replied_media(msg, event)
         event = self._apply_telegram_group_observe_attribution(event)
         self._enqueue_text_event(event)
+
+    async def _handle_mobile_quick_text(self, msg: Any) -> bool:
+        """Handle Chinese mobile quick-keyboard labels locally.
+
+        Some mobile Telegram clients show custom keyboard buttons as plain text
+        messages. Treat the known Chinese labels like commands so they do not
+        fall through to the LLM and produce mixed-language guidance.
+        """
+        text = (getattr(msg, "text", "") or "").strip()
+        normalized = re.sub(r"\s+", "", text)
+        if normalized in {"🕹掌上控制", "掌上控制", "手机控制", "控制面板"}:
+            await self._send_mobile_panel_for_message(msg)
+            return True
+        if normalized in {"◷定时", "⏰定时", "定时", "定时任务"}:
+            await self._send_mobile_schedule_help(msg)
+            return True
+        return False
+
+    async def _send_mobile_schedule_help(self, msg: Any) -> None:
+        if not self._bot:
+            return
+        thread_id = getattr(msg, "message_thread_id", None)
+        chat_id = str(getattr(getattr(msg, "chat", None), "id", getattr(msg, "chat_id", "")))
+        reply_to_id = getattr(msg, "message_id", None)
+        metadata = {"thread_id": str(thread_id)} if thread_id is not None else None
+        text = (
+            "◷ <b>定时任务</b>\n"
+            "━━━━━━━━\n"
+            "你可以直接用中文告诉我什么时候提醒或执行任务。\n\n"
+            "常用说法：\n"
+            "• <code>明天上午 9 点提醒我看周报</code>\n"
+            "• <code>每天下午 6 点汇总今天任务</code>\n"
+            "• <code>每周一早上检查 Hermes 状态</code>\n\n"
+            "查看/管理：\n"
+            "• <code>/cron list</code> 查看定时任务\n"
+            "• <code>/cron</code> 打开定时任务帮助\n"
+        )
+        kwargs: Dict[str, Any] = {
+            "chat_id": normalize_telegram_chat_id(chat_id),
+            "text": text,
+            "parse_mode": ParseMode.HTML,
+            "reply_markup": InlineKeyboardMarkup([[InlineKeyboardButton("◀ 返回控制面板", callback_data="mpanel:menu")]]),
+            "reply_to_message_id": reply_to_id,
+            **self._link_preview_kwargs(),
+        }
+        kwargs.update(
+            self._thread_kwargs_for_send(
+                chat_id,
+                str(thread_id) if thread_id is not None else None,
+                metadata,
+                reply_to_message_id=reply_to_id,
+                reply_to_mode=self._reply_to_mode,
+            )
+        )
+        await self._send_message_with_thread_fallback(**kwargs)
 
     def _mobile_panel_keyboard(self) -> InlineKeyboardMarkup:
         return InlineKeyboardMarkup([
@@ -7408,7 +7467,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 InlineKeyboardButton("🔥 高占用进程", callback_data="mpanel:topproc"),
             ],
             [
-                InlineKeyboardButton("⚕ Gateway", callback_data="mpanel:health"),
+                InlineKeyboardButton("⚕ 网关状态", callback_data="mpanel:health"),
                 InlineKeyboardButton("📸 截图命令", callback_data="mpanel:hint:shot"),
             ],
             [InlineKeyboardButton("🔄 刷新菜单", callback_data="mpanel:menu")],

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8,6 +8,7 @@ Uses python-telegram-bot library for:
 """
 
 import asyncio
+import contextlib
 import dataclasses
 import inspect
 import json
@@ -15,6 +16,7 @@ import logging
 import os
 import html as _html
 import re
+import subprocess
 import threading
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Any
@@ -585,6 +587,31 @@ class TelegramAdapter(BasePlatformAdapter):
         self._forum_command_registered: set[int] = set()
         # Lock per la registrazione sicura dei comandi nei forum supergroup
         self._forum_lock = asyncio.Lock()
+        # Lightweight mobile-control panel for Telegram DM/mobile use. This is
+        # intentionally handled inside the adapter so button taps can execute
+        # safe status commands without spending an agent turn.
+        self._mobile_panel_commands: Dict[str, Dict[str, str]] = {
+            "sys": {
+                "label": "🖥 Mac 状态",
+                "command": "python3 - <<'PY2'\nimport subprocess, re\nprint('🖥 Mac 状态')\nprint('━━━━━━━━')\ndef sh(cmd):\n    return subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, timeout=8).stdout.strip()\ncpu=sh(\"top -l 1 -n 0 | grep 'CPU usage' | awk '{print $3}'\") or 'N/A'\nvm=sh('vm_stat')\nm=re.search(r'Pages free:\\s+(\\d+)', vm)\nmem=f'{int(m.group(1))*4096/1024/1024/1024:.1f} GB' if m else 'N/A'\ndisk=sh(\"df -h / | tail -1 | awk '{print $4}'\") or 'N/A'\nbatt=sh(\"pmset -g batt 2>/dev/null | grep -Eo '[0-9]+%' | head -1\") or 'N/A'\nip=sh('curl -s --max-time 5 ifconfig.me') or 'N/A'\nprocs=sh(\"ps aux | wc -l | tr -d ' '\") or 'N/A'\nprint(f'CPU: {cpu}')\nprint(f'内存空闲: {mem}')\nprint(f'磁盘剩余: {disk}')\nprint(f'电池: {batt}')\nprint(f'公网 IP: {ip}')\nprint(f'进程数: {procs}')\nPY2",
+            },
+            "tasks": {
+                "label": "⏳ 任务状态",
+                "command": "p=\"$HOME/Downloads/Hermes输出/状态/Hermes任务状态.md\"; if [ -f \"$p\" ]; then sed -n '1,80p' \"$p\"; else echo '暂无任务状态文件'; fi",
+            },
+            "downloads": {
+                "label": "📁 最近下载",
+                "command": "python3 - <<'PY2'\nfrom pathlib import Path\nfiles=sorted(Path.home().joinpath('Downloads').iterdir(), key=lambda p:p.stat().st_mtime if p.exists() else 0, reverse=True)[:10]\nprint('📁 最近下载\\n━━━━━━━━')\nfor p in files:\n    try:\n        size=p.stat().st_size\n        if size>1024**3: s=f'{size/1024**3:.1f}G'\n        elif size>1024**2: s=f'{size/1024**2:.1f}M'\n        elif size>1024: s=f'{size/1024:.1f}K'\n        else: s=f'{size}B'\n    except Exception: s='?'\n    print(f'- {p.name} ({s})')\nPY2",
+            },
+            "topproc": {
+                "label": "🔥 高占用进程",
+                "command": "ps aux -r | awk 'NR==1{print \"USER PID CPU MEM COMMAND\";next} NR<=8{print $1,$2,$3,$4,$11}'",
+            },
+            "health": {
+                "label": "⚕ Gateway 状态",
+                "command": "hermes gateway status",
+            },
+        }
         # Status indicator: when enabled, the bot's short description (the line
         # shown under its name in the profile) is set to "Online" on connect and
         # "Offline" on clean disconnect, so users can tell whether the gateway is
@@ -5216,6 +5243,11 @@ class TelegramAdapter(BasePlatformAdapter):
         query_thread_id = getattr(query_message, "message_thread_id", None)
         query_user_name = getattr(query.from_user, "first_name", None)
 
+        # --- Mobile control panel callbacks ---
+        if data.startswith("mpanel:"):
+            await self._handle_mobile_panel_callback(query, data)
+            return
+
         # --- Model picker callbacks ---
         if data.startswith(("mp:", "mpg:", "mpv:", "mm:", "mc:", "mb", "mx", "mg:")):
             chat_id = str(query.message.chat_id) if query.message else None
@@ -7365,6 +7397,144 @@ class TelegramAdapter(BasePlatformAdapter):
         event = self._apply_telegram_group_observe_attribution(event)
         self._enqueue_text_event(event)
 
+    def _mobile_panel_keyboard(self) -> InlineKeyboardMarkup:
+        return InlineKeyboardMarkup([
+            [
+                InlineKeyboardButton("🖥 Mac 状态", callback_data="mpanel:sys"),
+                InlineKeyboardButton("⏳ 任务状态", callback_data="mpanel:tasks"),
+            ],
+            [
+                InlineKeyboardButton("📁 最近下载", callback_data="mpanel:downloads"),
+                InlineKeyboardButton("🔥 高占用进程", callback_data="mpanel:topproc"),
+            ],
+            [
+                InlineKeyboardButton("⚕ Gateway", callback_data="mpanel:health"),
+                InlineKeyboardButton("📸 截图命令", callback_data="mpanel:hint:shot"),
+            ],
+            [InlineKeyboardButton("🔄 刷新菜单", callback_data="mpanel:menu")],
+        ])
+
+    def _mobile_panel_text(self) -> str:
+        return (
+            "📱 <b>Hermes 手机控制面板</b>\n"
+            "━━━━━━━━\n"
+            "点按钮即可查看电脑状态，不需要记命令。\n\n"
+            "常用命令：\n"
+            "• <code>/sys</code> 系统状态\n"
+            "• <code>/tasks</code> 长任务状态\n"
+            "• <code>/shot</code> 截图回传\n"
+            "• <code>/downloads</code> 最近下载\n"
+        )
+
+    async def _send_mobile_panel_for_message(self, msg: Message) -> None:
+        if not self._bot:
+            return
+        thread_id = getattr(msg, "message_thread_id", None)
+        chat_id = str(getattr(getattr(msg, "chat", None), "id", getattr(msg, "chat_id", "")))
+        reply_to_id = getattr(msg, "message_id", None)
+        metadata = {"thread_id": str(thread_id)} if thread_id is not None else None
+        kwargs: Dict[str, Any] = {
+            "chat_id": normalize_telegram_chat_id(chat_id),
+            "text": self._mobile_panel_text(),
+            "parse_mode": ParseMode.HTML,
+            "reply_markup": self._mobile_panel_keyboard(),
+            "reply_to_message_id": reply_to_id,
+            **self._link_preview_kwargs(),
+        }
+        kwargs.update(
+            self._thread_kwargs_for_send(
+                chat_id,
+                str(thread_id) if thread_id is not None else None,
+                metadata,
+                reply_to_message_id=reply_to_id,
+                reply_to_mode=self._reply_to_mode,
+            )
+        )
+        await self._send_message_with_thread_fallback(**kwargs)
+
+    async def _run_mobile_panel_command(self, action: str) -> str:
+        entry = self._mobile_panel_commands.get(action)
+        if not entry:
+            return "未知面板操作。"
+        try:
+            from tools.environments.local import _sanitize_subprocess_env
+            env = _sanitize_subprocess_env(os.environ.copy())
+        except Exception:
+            env = os.environ.copy()
+        proc = await asyncio.create_subprocess_shell(
+            entry["command"],
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
+        except asyncio.TimeoutError:
+            with contextlib.suppress(Exception):
+                proc.kill()
+            return "操作超时（30 秒）。"
+        output = (stdout or stderr or b"").decode(errors="replace").strip()
+        if not output:
+            output = "没有输出。"
+        try:
+            from agent.redact import redact_sensitive_text
+            output = redact_sensitive_text(output)
+        except Exception:
+            pass
+        return output[:3500]
+
+    async def _handle_mobile_panel_callback(self, query, data: str) -> None:
+        caller_id = str(getattr(query.from_user, "id", ""))
+        query_message = getattr(query, "message", None)
+        query_chat_id = getattr(query_message, "chat_id", None)
+        query_chat = getattr(query_message, "chat", None)
+        query_chat_type = getattr(query_chat, "type", None)
+        query_thread_id = getattr(query_message, "message_thread_id", None)
+        query_user_name = getattr(query.from_user, "first_name", None)
+        if not self._is_callback_user_authorized(
+            caller_id,
+            chat_id=query_chat_id,
+            chat_type=str(query_chat_type) if query_chat_type is not None else None,
+            thread_id=str(query_thread_id) if query_thread_id is not None else None,
+            user_name=query_user_name,
+        ):
+            await query.answer(text="⛔ 你没有权限使用这个面板。")
+            return
+
+        action = data.split(":", 1)[1] if ":" in data else "menu"
+        if action == "menu":
+            await query.edit_message_text(
+                text=self._mobile_panel_text(),
+                parse_mode=ParseMode.HTML,
+                reply_markup=self._mobile_panel_keyboard(),
+                **self._link_preview_kwargs(),
+            )
+            await query.answer(text="已刷新")
+            return
+        if action == "hint:shot":
+            await query.answer(text="请发送 /shot")
+            await query.edit_message_text(
+                text=(
+                    "📸 <b>截图回传</b>\n━━━━━━━━\n"
+                    "请直接发送 <code>/shot</code>。\n\n"
+                    "说明：截图会保存到 <code>Downloads/Hermes输出/图片</code>，并通过 Telegram 回传。"
+                ),
+                parse_mode=ParseMode.HTML,
+                reply_markup=InlineKeyboardMarkup([[InlineKeyboardButton("◀ 返回菜单", callback_data="mpanel:menu")]]),
+                **self._link_preview_kwargs(),
+            )
+            return
+
+        await query.answer(text="正在执行…")
+        output = await self._run_mobile_panel_command(action)
+        title = self._mobile_panel_commands.get(action, {}).get("label", action)
+        await query.edit_message_text(
+            text=f"{_html.escape(title)}\n━━━━━━━━\n<pre>{_html.escape(output)}</pre>",
+            parse_mode=ParseMode.HTML,
+            reply_markup=InlineKeyboardMarkup([[InlineKeyboardButton("◀ 返回菜单", callback_data="mpanel:menu")]]),
+            **self._link_preview_kwargs(),
+        )
+
     async def _handle_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming command messages."""
         msg = self._effective_update_message(update)
@@ -7380,6 +7550,12 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             return
         await self._ensure_forum_commands(msg)
+
+        raw_command = (msg.text or "").strip().split(maxsplit=1)[0]
+        command_name = raw_command.split("@", 1)[0].lower().lstrip("/")
+        if command_name in {"mobile", "mac", "panel"}:
+            await self._send_mobile_panel_for_message(msg)
+            return
 
         event = self._build_message_event(msg, MessageType.COMMAND, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -591,6 +591,14 @@ class TelegramAdapter(BasePlatformAdapter):
         # intentionally handled inside the adapter so button taps can execute
         # safe status commands without spending an agent turn.
         self._mobile_panel_commands: Dict[str, Dict[str, str]] = {
+            "active": {
+                "label": "👀 正在执行",
+                "command": "python3 - <<'PY2'\nimport subprocess\nfrom pathlib import Path\nprint('👀 Hermes 正在执行')\nprint('━━━━━━━━')\nstatus=Path.home()/'Downloads/Hermes输出/状态/Hermes任务状态.md'\nif status.exists():\n    lines=status.read_text(errors='replace').splitlines()[:60]\n    print('任务状态文件：')\n    print('\\n'.join(lines) or '（空）')\nelse:\n    print('任务状态文件：暂无')\nprint('\\nHermes 相关进程：')\ncmd=\"ps aux | grep -Ei 'hermes|run_agent|gateway' | grep -v grep | awk '{print $2, $3\"%\", $4\"%\", $11, $12, $13}' | head -12\"\nout=subprocess.run(cmd, shell=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=8).stdout.strip()\nprint(out or '未发现活跃 Hermes 进程')\nPY2",
+            },
+            "sessions": {
+                "label": "💬 最近会话",
+                "command": "(hermes sessions list --source telegram --limit 8 2>/dev/null || hermes sessions list --limit 8 2>/dev/null || echo '无法读取会话列表') | sed -n '1,80p'",
+            },
             "sys": {
                 "label": "🖥 Mac 状态",
                 "command": "python3 - <<'PY2'\nimport subprocess, re\nprint('🖥 Mac 状态')\nprint('━━━━━━━━')\ndef sh(cmd):\n    return subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, timeout=8).stdout.strip()\ncpu=sh(\"top -l 1 -n 0 | grep 'CPU usage' | awk '{print $3}'\") or 'N/A'\nvm=sh('vm_stat')\nm=re.search(r'Pages free:\\s+(\\d+)', vm)\nmem=f'{int(m.group(1))*4096/1024/1024/1024:.1f} GB' if m else 'N/A'\ndisk=sh(\"df -h / | tail -1 | awk '{print $4}'\") or 'N/A'\nbatt=sh(\"pmset -g batt 2>/dev/null | grep -Eo '[0-9]+%' | head -1\") or 'N/A'\nip=sh('curl -s --max-time 5 ifconfig.me') or 'N/A'\nprocs=sh(\"ps aux | wc -l | tr -d ' '\") or 'N/A'\nprint(f'CPU: {cpu}')\nprint(f'内存空闲: {mem}')\nprint(f'磁盘剩余: {disk}')\nprint(f'电池: {batt}')\nprint(f'公网 IP: {ip}')\nprint(f'进程数: {procs}')\nPY2",
@@ -7459,6 +7467,10 @@ class TelegramAdapter(BasePlatformAdapter):
     def _mobile_panel_keyboard(self) -> InlineKeyboardMarkup:
         return InlineKeyboardMarkup([
             [
+                InlineKeyboardButton("👀 正在执行", callback_data="mpanel:active"),
+                InlineKeyboardButton("💬 最近会话", callback_data="mpanel:sessions"),
+            ],
+            [
                 InlineKeyboardButton("🖥 Mac 状态", callback_data="mpanel:sys"),
                 InlineKeyboardButton("⏳ 任务状态", callback_data="mpanel:tasks"),
             ],
@@ -7475,14 +7487,19 @@ class TelegramAdapter(BasePlatformAdapter):
 
     def _mobile_panel_text(self) -> str:
         return (
-            "📱 <b>Hermes 手机控制面板</b>\n"
+            "📱 <b>Hermes 手机控制台</b>\n"
             "━━━━━━━━\n"
-            "点按钮即可查看电脑状态，不需要记命令。\n\n"
+            "用手机查看 Hermes 当前在做什么、最近有哪些会话，"
+            "也可以快速检查这台 Mac 的状态。\n\n"
+            "推荐手机操作：\n"
+            "• 点 <b>正在执行</b>：看后台任务 / Agent / Gateway 进程\n"
+            "• 点 <b>最近会话</b>：找到 Telegram 历史会话，之后可用 <code>/resume</code> 继续\n"
+            "• 点 <b>任务状态</b>：查看长任务交付文件\n\n"
             "常用命令：\n"
-            "• <code>/sys</code> 系统状态\n"
-            "• <code>/tasks</code> 长任务状态\n"
+            "• <code>/sessions</code> 浏览历史会话\n"
+            "• <code>/agents</code> 查看活跃 Agent 和任务\n"
+            "• <code>/status</code> 查看当前会话/模型/Token 状态\n"
             "• <code>/shot</code> 截图回传\n"
-            "• <code>/downloads</code> 最近下载\n"
         )
 
     async def _send_mobile_panel_for_message(self, msg: Message) -> None:

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -129,6 +129,20 @@ class TestTelegramMobileQuickLabels:
         assert "明天上午 9 点提醒我看周报" in kwargs["text"]
         assert kwargs["reply_markup"] is not None
 
+    def test_mobile_panel_surfaces_execution_and_sessions(self):
+        adapter = _make_adapter()
+
+        text = adapter._mobile_panel_text()
+
+        assert "Hermes 手机控制台" in text
+        assert "正在执行" in text
+        assert "最近会话" in text
+        assert "/sessions" in text
+        assert "/agents" in text
+        assert "active" in adapter._mobile_panel_commands
+        assert "sessions" in adapter._mobile_panel_commands
+        assert "hermes sessions list --source telegram" in adapter._mobile_panel_commands["sessions"]["command"]
+
 
 # ===========================================================================
 # send_exec_approval — inline keyboard buttons

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -75,6 +75,62 @@ class _AuthRunner:
 
 
 # ===========================================================================
+# Mobile quick-keyboard labels
+# ===========================================================================
+
+class TestTelegramMobileQuickLabels:
+    """Chinese mobile keyboard labels should be handled locally."""
+
+    @pytest.mark.asyncio
+    async def test_chinese_control_label_opens_mobile_panel(self):
+        adapter = _make_adapter()
+        adapter._send_mobile_panel_for_message = AsyncMock()
+        adapter._send_mobile_schedule_help = AsyncMock()
+        msg = SimpleNamespace(text="🕹 掌上控制")
+
+        handled = await adapter._handle_mobile_quick_text(msg)
+
+        assert handled is True
+        adapter._send_mobile_panel_for_message.assert_awaited_once_with(msg)
+        adapter._send_mobile_schedule_help.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_chinese_schedule_label_shows_chinese_schedule_help(self):
+        adapter = _make_adapter()
+        adapter._send_mobile_panel_for_message = AsyncMock()
+        adapter._send_mobile_schedule_help = AsyncMock()
+        msg = SimpleNamespace(text="◷ 定时")
+
+        handled = await adapter._handle_mobile_quick_text(msg)
+
+        assert handled is True
+        adapter._send_mobile_schedule_help.assert_awaited_once_with(msg)
+        adapter._send_mobile_panel_for_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_schedule_help_text_is_chinese_and_local(self):
+        adapter = _make_adapter()
+        adapter._bot = AsyncMock()
+        adapter._send_message_with_thread_fallback = AsyncMock()
+        msg = SimpleNamespace(
+            text="◷ 定时",
+            message_id=77,
+            message_thread_id=None,
+            chat=SimpleNamespace(id="12345"),
+        )
+
+        await adapter._send_mobile_schedule_help(msg)
+
+        adapter._send_message_with_thread_fallback.assert_awaited_once()
+        kwargs = adapter._send_message_with_thread_fallback.call_args.kwargs
+        assert kwargs["chat_id"] == 12345
+        assert "定时任务" in kwargs["text"]
+        assert "你可以直接用中文告诉我" in kwargs["text"]
+        assert "明天上午 9 点提醒我看周报" in kwargs["text"]
+        assert kwargs["reply_markup"] is not None
+
+
+# ===========================================================================
 # send_exec_approval — inline keyboard buttons
 # ===========================================================================
 


### PR DESCRIPTION
## Summary
- add Chinese Telegram menu labels and mobile-friendly control panel shortcuts
- handle Telegram mobile quick-button callbacks locally
- cover mobile quick labels in Telegram approval button tests

## Tests
- `uv run pytest tests/gateway/test_telegram_approval_buttons.py -q`

## Notes
- prepared from a clean branch based on current `origin/main` with only the Telegram mobile changes