### PR TITLE
fix(mcp): gate probe prompts/resources on config + advertised capabilities

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -267,6 +267,7 @@ def _probe_single_server(
         _run_on_mcp_loop,
         _connect_server,
         _stop_mcp_loop_if_idle,
+        _parse_boolish,
     )
 
     config = _resolve_mcp_server_config(config)
@@ -287,18 +288,49 @@ def _probe_single_server(
                     desc = desc[:77] + "..."
                 tools_found.append((t.name, desc))
             if details is not None:
+                # Gate the capability probes exactly like runtime utility-tool
+                # registration (tools.mcp_tool._select_utility_schemas):
+                #   1. honour the user's tools.prompts / tools.resources config
+                #   2. only call a family the server actually advertises.
+                # Without this the "Test server" probe fired prompts/list and
+                # resources/list at every server unconditionally — so a server
+                # that rejects those methods (e.g. Unreal's MCP server, which
+                # answers "Call to unknown method 'prompts/list'") logged a hard
+                # error, and setting tools.prompts: false did NOT suppress it.
+                tools_filter = config.get("tools") or {}
+                prompts_enabled = _parse_boolish(
+                    tools_filter.get("prompts"), default=True
+                )
+                resources_enabled = _parse_boolish(
+                    tools_filter.get("resources"), default=True
+                )
+                advertised_caps = getattr(
+                    getattr(server, "initialize_result", None),
+                    "capabilities",
+                    None,
+                )
+
+                def _advertises(cap_attr: str) -> bool:
+                    # When no capability info was captured (legacy fixtures /
+                    # older servers) preserve the old always-try behaviour.
+                    if advertised_caps is None:
+                        return True
+                    return getattr(advertised_caps, cap_attr, None) is not None
+
                 # Capability probes are best-effort: servers without the
                 # capability raise, which just means "0".
-                try:
-                    result = await server.session.list_prompts()
-                    details["prompts"] = len(result.prompts)
-                except Exception:
-                    pass
-                try:
-                    result = await server.session.list_resources()
-                    details["resources"] = len(result.resources)
-                except Exception:
-                    pass
+                if prompts_enabled and _advertises("prompts"):
+                    try:
+                        result = await server.session.list_prompts()
+                        details["prompts"] = len(result.prompts)
+                    except Exception:
+                        pass
+                if resources_enabled and _advertises("resources"):
+                    try:
+                        result = await server.session.list_resources()
+                        details["resources"] = len(result.resources)
+                    except Exception:
+                        pass
         finally:
             await server.shutdown()
 

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -576,6 +576,99 @@ class TestProbeEnvResolution:
         assert seen["config"]["headers"]["Authorization"] == "Bearer jwt-token-xyz"
 
 
+class TestProbeCapabilityGating:
+    """The ``details`` probe must not fire prompts/list or resources/list at
+    servers that either disabled them in config or never advertised them.
+
+    Regression for the Unreal MCP server case: it answers
+    ``Call to unknown method "prompts/list"``, so an unconditional probe logged
+    a hard error and ``tools.prompts: false`` (the documented workaround) had no
+    effect because the probe never consulted config or capabilities.
+    """
+
+    class _FakeTool:
+        name = "do_thing"
+        description = "a tool"
+
+    class _Caps:
+        def __init__(self, prompts=None, resources=None):
+            self.prompts = prompts
+            self.resources = resources
+
+    class _InitResult:
+        def __init__(self, caps):
+            self.capabilities = caps
+
+    def _make_server(self, called, caps):
+        outer = self
+
+        class _Result(list):
+            @property
+            def prompts(self):
+                return self
+
+            @property
+            def resources(self):
+                return self
+
+        class _Session:
+            async def list_prompts(self_inner):
+                called.append("prompts")
+                return _Result()
+
+            async def list_resources(self_inner):
+                called.append("resources")
+                return _Result()
+
+        class _FakeServer:
+            _tools = [outer._FakeTool()]
+            session = _Session()
+            initialize_result = outer._InitResult(caps)
+
+            async def shutdown(self_inner):
+                return None
+
+        return _FakeServer()
+
+    def _run_probe(self, monkeypatch, config, caps):
+        import hermes_cli.mcp_config as mc
+
+        called: list[str] = []
+
+        async def _fake_connect(name, cfg):
+            return self._make_server(called, caps)
+
+        monkeypatch.setattr("tools.mcp_tool._connect_server", _fake_connect)
+        details: dict = {}
+        mc._probe_single_server("srv", config, details=details)
+        return called, details
+
+    def test_config_disables_prompts_probe(self, monkeypatch):
+        # Server advertises both, but user turned prompts off.
+        caps = self._Caps(prompts=object(), resources=object())
+        called, details = self._run_probe(
+            monkeypatch, {"url": "http://x/mcp", "tools": {"prompts": False}}, caps
+        )
+        assert "prompts" not in called
+        assert "resources" in called
+
+    def test_unadvertised_capability_not_probed(self, monkeypatch):
+        # Unreal case: no prompts capability advertised → never call it.
+        caps = self._Caps(prompts=None, resources=None)
+        called, _ = self._run_probe(monkeypatch, {"url": "http://x/mcp"}, caps)
+        assert called == []
+
+    def test_advertised_and_enabled_is_probed(self, monkeypatch):
+        caps = self._Caps(prompts=object(), resources=object())
+        called, details = self._run_probe(monkeypatch, {"url": "http://x/mcp"}, caps)
+        assert set(called) == {"prompts", "resources"}
+
+    def test_missing_capability_info_falls_back_to_probe(self, monkeypatch):
+        # No initialize_result captured → preserve legacy always-try behaviour.
+        called, _ = self._run_probe(monkeypatch, {"url": "http://x/mcp"}, None)
+        assert set(called) == {"prompts", "resources"}
+
+
 class TestStripBearerPrefix:
     """Pasted tokens that already include ``Bearer `` would otherwise produce
     ``Bearer Bearer <jwt>`` once the header template adds its own prefix."""


### PR DESCRIPTION
## Summary

The MCP "Test server" probe (`_probe_single_server` in `hermes_cli/mcp_config.py`) — used by the Desktop/dashboard MCP tab, `hermes mcp add`, and `hermes mcp test` — called `prompts/list` and `resources/list` on **every** server unconditionally whenever capability `details` were requested. It ignored:

1. the user's `tools.prompts` / `tools.resources` config, and
2. the server's own advertised `initialize` capabilities.

Servers that don't implement those optional families (e.g. **Unreal Engine's MCP server**, which answers `Call to unknown method "prompts/list"`) logged a hard error during discovery. Worse, `tools.prompts: false` — the documented workaround — had no effect, because the probe never consulted config or capabilities. The runtime utility-tool path (`tools.mcp_tool._select_utility_schemas`) already gates on both; the probe drifted from it.

This mirrors that runtime gating: only probe a family when it is enabled in config **and** advertised in the server's `initialize` capabilities, falling back to the previous always-try behaviour when no capability info was captured.

## Changes

- `hermes_cli/mcp_config.py` — gate the `list_prompts()` / `list_resources()` probe calls on `tools.prompts` / `tools.resources` config and advertised capabilities (reusing `_parse_boolish`).
- `tests/hermes_cli/test_mcp_config.py` — `TestProbeCapabilityGating` covers: prompts disabled by config, neither capability advertised (Unreal case), both advertised+enabled, and the no-capability-info fallback.

## Test plan

- [x] `scripts/run_tests.sh tests/hermes_cli/test_mcp_config.py -q` (55 passed)

## Infographic

![mcp-probe-capability-gating](https://v3b.fal.media/files/b/0aa11503/ImWHNlh7U9WsdtQZWvKcu_oI7Nqmtg.png)
