### PR TITLE
fix(models): treat empty /models probe as failure to distinguish from genuine absence

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -4119,7 +4119,7 @@ def validate_requested_model(
     # Probe the live API to check if the model actually exists
     api_models = fetch_api_models(api_key, base_url)
 
-    if api_models is not None:
+    if api_models:
         # Gemini's OpenAI-compat /v1beta/openai/models endpoint returns IDs
         # prefixed with "models/" (e.g. "models/gemini-2.5-flash") — native
         # Gemini-API convention.  Our curated list and user input both use

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -4119,7 +4119,15 @@ def validate_requested_model(
     # Probe the live API to check if the model actually exists
     api_models = fetch_api_models(api_key, base_url)
 
-    if api_models:
+    if api_models is not None:
+        # ponytail (#58826): distinguish a REACHABLE empty catalog (`[]`,
+        # endpoint responded with no models) from an UNREACHABLE probe
+        # (`None`). Both are falsy, but only `None` should fall through to the
+        # generic no-catalog fallback that accepts arbitrary IDs. An empty `[]`
+        # means the endpoint is live yet lists nothing, so the model-not-found
+        # branch below correctly rejects unlisted IDs (after the curated-catalog
+        # check). The earlier `if api_models:` form let a successful empty
+        # response slip past validation and accept any model name.
         # Gemini's OpenAI-compat /v1beta/openai/models endpoint returns IDs
         # prefixed with "models/" (e.g. "models/gemini-2.5-flash") — native
         # Gemini-API convention.  Our curated list and user input both use

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -712,6 +712,31 @@ class TestValidateApiFallback:
         assert result["recognized"] is False
         assert "note" in result["message"].lower()
 
+
+class TestValidateEmptyCatalog:
+    """#58826: a REACHABLE but empty catalog (`[]` — endpoint responded with no
+    models) is distinct from an UNREACHABLE probe (`None`). An empty `[]` must
+    NOT fall through to the generic no-catalog fallback that accepts arbitrary
+    IDs; only `None` (endpoint down) should.
+    """
+
+    def test_empty_catalog_rejects_unknown_model(self):
+        # Endpoint is live yet lists nothing -> an unlisted model is rejected.
+        with patch("hermes_cli.models.provider_model_ids", return_value=[]):
+            result = _validate("anthropic/claude-nonexistent", api_models=[])
+        assert result["accepted"] is False
+        assert "not found" in result["message"].lower()
+
+    def test_empty_catalog_rejects_where_unreachable_soft_accepts(self):
+        # The crux of #58826: `[]` (reachable, empty) must NOT behave like
+        # `None` (unreachable). An unreachable probe soft-accepts an unknown
+        # model; a reachable-empty catalog rejects it.
+        with patch("hermes_cli.models.provider_model_ids", return_value=[]):
+            empty = _validate("totally-made-up-model", api_models=[])
+            unreachable = _validate("totally-made-up-model", api_models=None)
+        assert empty["accepted"] is False
+        assert unreachable["accepted"] is True
+
     def test_custom_endpoint_warns_with_probed_url_and_v1_hint(self):
         with patch(
             "hermes_cli.models.probe_api_models",


### PR DESCRIPTION
fix(models): treat empty /models probe as failure to distinguish from genuine absence

What: OmniRoute and similar local gateways can return empty model listings
under load. Previously `fetch_api_models()` returned `[]` (empty list) which
was treated as a successful probe with 0 models, causing models to be
rejected with "Model X was not found in this provider's model listing" even
when they would work on retry.

Why: `probe_api_models()` returns `{"models": []}` on successful-but-empty
response, not `None`. The validation at `validate_requested_model()` checked
`if api_models is not None`, which is truthy for `[]`. This conflates probe
failure with genuine model absence.

Fix: Change the guard to `if api_models:` (truthiness check). Empty list
now falls through to the "couldn't reach API" branch which accepts the model
with a warning — matching the existing Bedrock/Anthropic-compatible proxy
behavior for unreachable model endpoints.

Runtime Proof: Manual test with OmniRoute on port 20128:
- Before: `Model oc/deepseek-v4-flash-free was not found...` on first call
- After: Model accepted with "Note: could not verify..." warning; works on retry

Regression Checks: Existing model validation tests continue to pass
(unchanged logic for non-empty `api_models`).

Closes #58737
