### PR TITLE
fix(skills): normalize CRLF to LF in content_hash for Windows parity

### DIFF
--- a/tests/tools/test_skills_guard.py
+++ b/tests/tools/test_skills_guard.py
@@ -500,6 +500,35 @@ class TestContentHash:
         h2 = content_hash(tmp_path)
         assert h1 != h2
 
+    def test_crlf_normalized_to_lf(self, tmp_path):
+        """CRLF and LF line endings must produce the same hash.
+
+        On Windows, files on disk use CRLF while the upstream GitHub bundle
+        uses LF. Without normalization the hashes diverge and
+        ``hermes skills check`` always reports ``update_available``.
+        """
+        lf_content = "line one\nline two\n"
+        crlf_content = lf_content.replace("\n", "\r\n")
+
+        lf_dir = tmp_path / "lf"
+        lf_dir.mkdir()
+        (lf_dir / "a.txt").write_text(lf_content, newline="")
+
+        crlf_dir = tmp_path / "crlf"
+        crlf_dir.mkdir()
+        (crlf_dir / "a.txt").write_bytes(crlf_content.encode("utf-8"))
+
+        assert content_hash(lf_dir) == content_hash(crlf_dir)
+
+    def test_crlf_normalized_single_file(self, tmp_path):
+        lf_file = tmp_path / "lf.txt"
+        lf_file.write_text("line one\nline two\n", newline="")
+
+        crlf_file = tmp_path / "crlf.txt"
+        crlf_file.write_bytes(b"line one\r\nline two\r\n")
+
+        assert content_hash(lf_file) == content_hash(crlf_file)
+
 
 # ---------------------------------------------------------------------------
 # _unicode_char_name

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -782,11 +782,13 @@ def content_hash(skill_path: Path) -> str:
                     rel = f.relative_to(skill_path).as_posix()
                     h.update(rel.encode("utf-8"))
                     h.update(b"\x00")
-                    h.update(f.read_bytes())
+                    # Normalize CRLF → LF so Windows disk reads match
+                    # the LF-only upstream bundle hash (see bundle_content_hash).
+                    h.update(f.read_bytes().replace(b"\r\n", b"\n"))
                 except OSError:
                     continue
     elif skill_path.is_file():
-        h.update(skill_path.read_bytes())
+        h.update(skill_path.read_bytes().replace(b"\r\n", b"\n"))
     return f"sha256:{h.hexdigest()[:16]}"
 
 


### PR DESCRIPTION
## What does this PR do?

Normalizes CRLF line endings to LF in `content_hash()` before computing the SHA-256 digest. On Windows, skill files on disk use CRLF while the upstream GitHub bundle (fetched via the Trees API) uses LF. Without normalization, the two hashes never match, causing `hermes skills check` to always report `update_available` for every hub-installed skill.

The docstring in `content_hash()` explicitly states: *"This must stay symmetric with `bundle_content_hash`"* — on Windows this invariant was always violated.

## Related Issue

Fixes #58825

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skills_guard.py`: Add `.replace(b"\r\n", b"\n")` to both the directory and single-file code paths in `content_hash()` so CRLF and LF produce identical hashes
- `tests/tools/test_skills_guard.py`: Add two regression tests (`test_crlf_normalized_to_lf`, `test_crlf_normalized_single_file`) verifying CRLF and LF content produce the same hash

## How to Test

1. Run `python -m pytest tests/tools/test_skills_guard.py::TestContentHash -xvs` — all 6 tests should pass, including the two new CRLF normalization tests
2. On Windows: install any hub skill via `hermes skills install skills-sh/obra/superpowers/brainstorming`, then run `hermes skills check` — should report `up_to_date` instead of `update_available`
3. On macOS/Linux: no behavior change (files already use LF), existing tests continue to pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
