### PR TITLE
fix: /goal turn counter stuck at 0 when streaming is enabled

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13767,6 +13767,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return await self._handle_goal_command(event)
         return "Agent is running — use /goal status / pause / clear / wait mid-run, or /stop before setting a new goal."
 
+    def _resolve_goal_final_text(
+        self, agent_result, quick_key: str
+    ) -> str:
+        """Resolve the final response text for the /goal continuation hook.
+
+        Handles every return shape of _handle_message_with_agent:
+
+        - dict: extract ``final_response`` (non-streaming structured result)
+        - str: the response text itself (non-streaming plain result)
+        - None: streaming already delivered the body and the handler
+          returned None to avoid double-delivery — recover the one-shot
+          stashed text keyed by session (consumed via pop, so a later turn
+          with no new streamed text gets "" and the judge is skipped).
+
+        Extracted as a method so the streamed return-None recovery path can
+        be unit-tested directly (driving the real production pop, not a
+        manual simulation of the stash handoff).
+        """
+        if isinstance(agent_result, dict):
+            return str(agent_result.get("final_response") or "")
+        if isinstance(agent_result, str):
+            return agent_result
+        if agent_result is None:
+            return self._last_streamed_response.pop(quick_key, "")
+        return ""
+
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
         """
         Handle an incoming message from any platform.
@@ -15133,20 +15159,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # next turn makes more progress. Wrapped in try/except so a
             # broken judge never breaks normal message handling.
             try:
-                _final_text = ""
-                if isinstance(_agent_result, dict):
-                    _final_text = str(_agent_result.get("final_response") or "")
-                elif isinstance(_agent_result, str):
-                    _final_text = _agent_result
-                elif _agent_result is None:
-                    # Streaming path: the response text was already delivered
-                    # and _handle_message_with_agent returned None to avoid
-                    # double-delivery.  Retrieve and consume the stashed text
-                    # (one-shot, session-scoped via session_key) so the goal
-                    # judge runs even when streaming is enabled.
-                    _final_text = self._last_streamed_response.pop(
-                        _quick_key, ""
-                    )
+                _final_text = self._resolve_goal_final_text(
+                    _agent_result, _quick_key
+                )
                 # Skip for empty responses (interrupted / errored) — the
                 # judge would almost always say "continue" and we'd loop
                 # on error. Let the user drive the next turn.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5835,6 +5835,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # SessionState.persistent.pending_command_text (NOTE: distinct from
         # the adapter-level _pending_messages Dict[str, MessageEvent] in
         # gateway/platforms/base.py, which shares the legacy name).
+        # One-shot streaming response stash, keyed by session_key. Populated
+        # by _handle_message_with_agent on streamed turns and consumed (popped)
+        # by _handle_message's goal-continuation hook, so /goal tracking
+        # works even when the handler returns None to avoid double-delivery.
+        self._last_streamed_response: Dict[str, str] = {}
         # Last successfully-resolved (non-empty) model, keyed by session. Used
         # as a fallback when a fresh config read transiently returns an empty
         # model (e.g. an mtime-keyed config-cache miss during a post-interrupt
@@ -15133,6 +15138,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _final_text = str(_agent_result.get("final_response") or "")
                 elif isinstance(_agent_result, str):
                     _final_text = _agent_result
+                elif _agent_result is None:
+                    # Streaming path: the response text was already delivered
+                    # and _handle_message_with_agent returned None to avoid
+                    # double-delivery.  Retrieve and consume the stashed text
+                    # (one-shot, session-scoped via session_key) so the goal
+                    # judge runs even when streaming is enabled.
+                    _final_text = self._last_streamed_response.pop(
+                        _quick_key, ""
+                    )
                 # Skip for empty responses (interrupted / errored) — the
                 # judge would almost always say "continue" and we'd loop
                 # on error. Let the user drive the next turn.
@@ -17497,6 +17511,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             )
                     except Exception as _e:
                         logger.debug("trailing footer send failed: %s", _e)
+                # Stash the streamed response so the /goal continuation hook
+                # (in _handle_message) can extract the text even when we return
+                # None to avoid double-delivery. Without this, the goal judge
+                # is never called when streaming is enabled, and /goal status
+                # always shows 0/n turns.
+                self._last_streamed_response[session_key] = response
                 return None
 
             return response

--- a/tests/gateway/test_goal_verdict_send.py
+++ b/tests/gateway/test_goal_verdict_send.py
@@ -98,6 +98,33 @@ def _make_runner_with_adapter(session_id: str = None):
 
 
 @pytest.mark.asyncio
+async def test_goal_verdict_done_sent_via_adapter_send(hermes_home):
+    """When the judge says done, the '✓ Goal achieved' message must reach
+    the user through the adapter's ``send()`` method."""
+    runner, adapter, session_entry, src = _make_runner_with_adapter()
+
+    from hermes_cli.goals import GoalManager
+
+    mgr = GoalManager(session_entry.session_id)
+    mgr.set("ship the feature")
+
+    with patch("hermes_cli.goals.judge_goal", return_value=("done", "the feature shipped", False, None, False)):
+        await runner._post_turn_goal_continuation(
+            session_entry=session_entry,
+            source=src,
+            final_response="I shipped the feature.",
+        )
+        # fire-and-forget create_task — give the loop a tick
+        await asyncio.sleep(0.05)
+
+    assert len(adapter.sends) == 1, f"expected 1 send, got {len(adapter.sends)}: {adapter.sends}"
+    msg = adapter.sends[0]
+    assert msg["chat_id"] == "c1"
+    assert "Goal achieved" in msg["content"]
+    assert "the feature shipped" in msg["content"]
+
+
+@pytest.mark.asyncio
 async def test_goal_verdict_continue_enqueues_continuation(hermes_home):
     """When the judge says continue, both the 'continuing' status and the
     continuation-prompt event must be delivered. The continuation prompt is
@@ -199,7 +226,12 @@ async def test_goal_verdict_survives_adapter_without_send(hermes_home):
 async def test_goal_continuation_recovers_stashed_streamed_response(hermes_home):
     """When a turn was streamed (_agent_result is None), the goal hook must
     recover the final response from the one-shot stash so the judge runs and
-    turns_used increments. After recovery the stash is consumed (popped)."""
+    turns_used increments. After recovery the stash is consumed (popped).
+
+    This drives the *production* resolver (_resolve_goal_final_text) — the
+    exact method the streamed return-None path calls in _handle_message —
+    instead of manually performing the stash handoff, so a regression in
+    the pop wiring itself fails this test."""
     runner, adapter, session_entry, src = _make_runner_with_adapter()
 
     from hermes_cli.goals import GoalManager
@@ -214,14 +246,19 @@ async def test_goal_continuation_recovers_stashed_streamed_response(hermes_home)
     # Stash the response (as the streaming path does)
     runner._last_streamed_response[session_key] = stashed_text
 
-    # Goal hook recovers via pop (one-shot)
-    recovered = runner._last_streamed_response.pop(session_key, "")
+    # Goal hook resolves via the production method: agent returned None
+    # (streaming already delivered) -> real pop from the stash
+    recovered = runner._resolve_goal_final_text(None, session_key)
     assert recovered == stashed_text, "stashed text must be recoverable"
 
-    # After pop, the entry is consumed
+    # After pop, the entry is consumed (one-shot)
     assert session_key not in runner._last_streamed_response, (
         "stash must be consumed (one-shot)"
     )
+
+    # A second recovery (e.g. an errored retry turn with no new streamed
+    # text) yields "" so the judge is skipped instead of looping
+    assert runner._resolve_goal_final_text(None, session_key) == ""
 
     # Now simulate the goal hook: call _post_turn_goal_continuation with
     # the recovered text and verify the judge fires and turns_used advances
@@ -247,6 +284,28 @@ async def test_goal_continuation_recovers_stashed_streamed_response(hermes_home)
 
 
 @pytest.mark.asyncio
+async def test_goal_final_text_resolver_passthrough_shapes(hermes_home):
+    """Non-streamed return shapes pass through _resolve_goal_final_text
+    unchanged: dict extracts final_response, str is used verbatim, and an
+    empty/None final_response yields '' (judge skipped)."""
+    runner, _, _, _ = _make_runner_with_adapter()
+
+    # dict shape (structured result)
+    assert runner._resolve_goal_final_text({"final_response": "hello"}, "k") == "hello"
+    assert runner._resolve_goal_final_text({"final_response": None}, "k") == ""
+    assert runner._resolve_goal_final_text({"final_response": ""}, "k") == ""
+
+    # str shape (plain result)
+    assert runner._resolve_goal_final_text("plain text reply", "k") == "plain text reply"
+
+    # Unknown shape -> "" (never crashes the hook)
+    assert runner._resolve_goal_final_text(12345, "k") == ""
+
+    # Stash untouched by non-None shapes
+    assert runner._last_streamed_response == {}
+
+
+@pytest.mark.asyncio
 async def test_goal_continuation_empty_stash_skips_judge(hermes_home):
     """When no streamed text was stashed (empty stash), the goal hook
     must not crash and must not call the judge."""
@@ -258,8 +317,8 @@ async def test_goal_continuation_empty_stash_skips_judge(hermes_home):
 
     session_key = runner._session_key_for_source(src)
 
-    # Empty / missing stash
-    recovered = runner._last_streamed_response.pop(session_key, "")
+    # Empty / missing stash — the production resolver pops with a default
+    recovered = runner._resolve_goal_final_text(None, session_key)
     assert recovered == ""
 
     # Judge must be mocked because _post_turn_goal_continuation always

--- a/tests/gateway/test_goal_verdict_send.py
+++ b/tests/gateway/test_goal_verdict_send.py
@@ -73,6 +73,7 @@ def _make_runner_with_adapter(session_id: str = None):
     runner._running_agents = {}
     runner._running_agents_ts = {}
     runner._queued_events = {}
+    runner._last_streamed_response = {}
 
     src = _make_source()
     # Default to a unique session_id so xdist parallel runs on the same worker
@@ -153,3 +154,124 @@ async def test_goal_verdict_budget_exhausted_sends_pause(hermes_home):
     assert not adapter._pending_messages
 
 
+@pytest.mark.asyncio
+async def test_goal_verdict_skipped_when_no_active_goal(hermes_home):
+    """No goal set → the hook is a no-op. Nothing is sent, nothing enqueued."""
+    runner, adapter, session_entry, src = _make_runner_with_adapter()
+
+    await runner._post_turn_goal_continuation(
+        session_entry=session_entry,
+        source=src,
+        final_response="anything",
+    )
+    await asyncio.sleep(0.05)
+
+    assert adapter.sends == []
+    assert adapter._pending_messages == {}
+
+
+@pytest.mark.asyncio
+async def test_goal_verdict_survives_adapter_without_send(hermes_home):
+    """Bad adapter (no ``send`` attribute) must not crash the judge hook."""
+    runner, _adapter, session_entry, src = _make_runner_with_adapter()
+
+    from hermes_cli.goals import GoalManager
+
+    GoalManager(session_entry.session_id).set("survive missing send")
+
+    class _NoSendAdapter:
+        def __init__(self):
+            self._pending_messages: dict = {}
+
+    runner.adapters[Platform.TELEGRAM] = _NoSendAdapter()
+
+    with patch("hermes_cli.goals.judge_goal", return_value=("done", "ok", False, None, False)):
+        # must not raise
+        await runner._post_turn_goal_continuation(
+            session_entry=session_entry,
+            source=src,
+            final_response="whatever",
+        )
+        await asyncio.sleep(0.05)
+
+
+@pytest.mark.asyncio
+async def test_goal_continuation_recovers_stashed_streamed_response(hermes_home):
+    """When a turn was streamed (_agent_result is None), the goal hook must
+    recover the final response from the one-shot stash so the judge runs and
+    turns_used increments. After recovery the stash is consumed (popped)."""
+    runner, adapter, session_entry, src = _make_runner_with_adapter()
+
+    from hermes_cli.goals import GoalManager
+
+    mgr = GoalManager(session_entry.session_id)
+    state = mgr.set("complete this task")
+    assert state.turns_used == 0
+
+    session_key = runner._session_key_for_source(src)
+    stashed_text = "I have completed the task. Here is the final result."
+
+    # Stash the response (as the streaming path does)
+    runner._last_streamed_response[session_key] = stashed_text
+
+    # Goal hook recovers via pop (one-shot)
+    recovered = runner._last_streamed_response.pop(session_key, "")
+    assert recovered == stashed_text, "stashed text must be recoverable"
+
+    # After pop, the entry is consumed
+    assert session_key not in runner._last_streamed_response, (
+        "stash must be consumed (one-shot)"
+    )
+
+    # Now simulate the goal hook: call _post_turn_goal_continuation with
+    # the recovered text and verify the judge fires and turns_used advances
+    with patch("hermes_cli.goals.judge_goal", return_value=("done", "all done", False, None, False)):
+        await runner._post_turn_goal_continuation(
+            session_entry=session_entry,
+            source=src,
+            final_response=recovered,
+        )
+        await asyncio.sleep(0.05)
+
+    # Judge was called → verdict delivered
+    assert len(adapter.sends) == 1, f"expected 1 send, got {len(adapter.sends)}"
+    assert "Goal achieved" in adapter.sends[0]["content"]
+
+    # turns_used must increment — this proves the streaming bug is fixed
+    from hermes_cli.goals import load_goal
+    updated = load_goal(session_entry.session_id)
+    assert updated.turns_used == 1, (
+        f"turns_used must advance from 0 to 1 after a streamed turn, "
+        f"got {updated.turns_used}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_goal_continuation_empty_stash_skips_judge(hermes_home):
+    """When no streamed text was stashed (empty stash), the goal hook
+    must not crash and must not call the judge."""
+    runner, adapter, session_entry, src = _make_runner_with_adapter()
+
+    from hermes_cli.goals import GoalManager
+
+    GoalManager(session_entry.session_id).set("whatever")
+
+    session_key = runner._session_key_for_source(src)
+
+    # Empty / missing stash
+    recovered = runner._last_streamed_response.pop(session_key, "")
+    assert recovered == ""
+
+    # Judge must be mocked because _post_turn_goal_continuation always
+    # calls evaluate_after_turn, which unpacks judge_goal(). The real code
+    # path guards empty text before reaching this method, but the method
+    # itself must still handle an empty response gracefully.
+    with patch("hermes_cli.goals.judge_goal", return_value=("continue", "empty response", False, None, False)):
+        await runner._post_turn_goal_continuation(
+            session_entry=session_entry,
+            source=src,
+            final_response=recovered,
+        )
+        await asyncio.sleep(0.05)
+
+    assert "Continuing toward goal" in str(adapter.sends)


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where `/goal` turn counter stays at `0` forever when streaming is enabled (the default).

When `streaming.enabled=true`, `_handle_message_with_agent()` delivers the response via streaming chunks and returns `None`. The goal continuation hook in `_handle_message()` then tries to extract `_final_text` — but `None` is neither `dict` nor `str`, so `_final_text` stays empty and the entire goal evaluation block is skipped:

- `evaluate_after_turn()` is **never called**
- `turns_used` stays **0 forever**
- `/goal status` always shows `0/N turns`
- Goal judge never runs → goal never completes

## Root Cause

`gateway/run.py` — streaming path `return None` discards the response text that the goal hook needs. The goal continuation hook only handles `dict` and `str` return types, missing the `None` case.

## Fix

Three changes in `gateway/run.py`:

1. **`__init__`** (~L5654): Initialize `self._last_streamed_response: Dict[str, str]` — a one-shot, session-scoped stash.
2. **`_handle_message_with_agent` streaming exit** (~L17299): Before `return None`, stash `response` text keyed by `session_key`.
3. **`_handle_message` goal hook** (~L14937): When `_agent_result is None`, recover text via `pop(_quick_key, "")` — one-shot consumption ensures no stale entries.

This preserves the existing behavior (return `None` to avoid double-delivery) while making the response text available to the goal continuation hook.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## How to Test

1. Enable streaming (`streaming.enabled=true`)
2. Set a goal: `/goal complete this task`
3. Send a message to the agent
4. Check `/goal status` — before fix: `0/N turns`, after fix: `1/N turns`
5. Goal judge now runs and can reach `done` verdict

## Verification

Tested on live instance + unit tests:
- Before fix: `turns_used=0`, `last_turn_at=0.0`, no goal judge calls in logs
- After fix + gateway restart: `turns_used` increments normally, goal can reach `done` verdict
- 6 tests pass (including 2 new regression tests for the streaming `None` path)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] N/A — no config keys, tool schemas, or architecture changes