### PR TITLE
fix(gateway): clear last-resolved-model cache on daily/idle/suspended auto-reset

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10489,8 +10489,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # compaction summaries. Mirrors /reset and the compression-exhausted
             # path (#9893). Covers daily/idle/suspended auto-reset.
             self._evict_cached_agent(session_key)
+            # Clear per-session model cache so the post-reset turn resolves
+            # from current config, not a stale fallback. Mirrors the /new and
+            # compression-exhausted reset sites (11b4a21a5); covers the
+            # daily/idle/suspended auto-reset boundary those two missed.
+            _lrm = getattr(self, "_last_resolved_model", None)
+            if _lrm is not None:
+                _lrm.pop(session_key, None)
             session_entry.was_auto_reset = False
-        
+
         # Emit session:start for new or auto-reset sessions
         _is_new_session = (
             session_entry.created_at == session_entry.updated_at

--- a/tests/gateway/test_48031_model_switch_after_auto_reset.py
+++ b/tests/gateway/test_48031_model_switch_after_auto_reset.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import ast
 import inspect
+import threading
 
 from gateway import run as gateway_run
 from gateway import slash_commands as gateway_slash
@@ -89,3 +90,120 @@ def test_slash_command_model_path_consumes_was_auto_reset():
         "gateway/slash_commands.py model path must set "
         "`was_auto_reset = False` before storing the model override (#48031)."
     )
+
+
+def _pops_last_resolved_model(node: ast.AST) -> bool:
+    """True if `node` contains a `<something>.pop(session_key, ...)` where the
+    receiver was bound from `getattr(self, "_last_resolved_model", ...)`.
+
+    Fingerprints the sibling clear used at the /new and compression-exhausted
+    reset sites:
+        _lrm = getattr(self, "_last_resolved_model", None)
+        if _lrm is not None:
+            _lrm.pop(session_key, None)
+    """
+    # Collect local names bound from getattr(self, "_last_resolved_model", ...).
+    lrm_names = set()
+    for sub in ast.walk(node):
+        if (
+            isinstance(sub, ast.Assign)
+            and isinstance(sub.value, ast.Call)
+            and isinstance(sub.value.func, ast.Name)
+            and sub.value.func.id == "getattr"
+            and len(sub.value.args) >= 2
+            and isinstance(sub.value.args[1], ast.Constant)
+            and sub.value.args[1].value == "_last_resolved_model"
+        ):
+            for tgt in sub.targets:
+                if isinstance(tgt, ast.Name):
+                    lrm_names.add(tgt.id)
+    if not lrm_names:
+        return False
+    # Look for `<lrm_name>.pop(session_key, ...)`.
+    for sub in ast.walk(node):
+        if (
+            isinstance(sub, ast.Call)
+            and isinstance(sub.func, ast.Attribute)
+            and sub.func.attr == "pop"
+            and isinstance(sub.func.value, ast.Name)
+            and sub.func.value.id in lrm_names
+            and sub.args
+            and isinstance(sub.args[0], ast.Name)
+            and sub.args[0].id == "session_key"
+        ):
+            return True
+    return False
+
+
+def test_run_clears_last_resolved_model_in_auto_reset_cleanup_block():
+    """The `_was_auto_reset` cleanup block in gateway/run.py must clear the
+    per-session `_last_resolved_model` entry, so the first post-reset turn
+    resolves from current config instead of recovering the stale pre-reset
+    model on a transient empty-config read (#35314).
+
+    `11b4a21a5` added this clear to the /new and compression-exhausted reset
+    sites but missed the daily/idle/suspended auto-reset boundary — this pins
+    it into that third site. AST-invariant to match this file's existing style.
+    """
+    tree = ast.parse(inspect.getsource(gateway_run))
+
+    found = False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        calls = {
+            n.func.attr
+            for n in ast.walk(node)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+        }
+        # Uniquely identify the auto-reset cleanup block: it calls the
+        # reasoning-override setter AND consumes was_auto_reset (only that
+        # block does both — the compression-exhausted site does not clear
+        # the flag).
+        if (
+            "_set_session_reasoning_override" in calls
+            and _assigns_false(node, "was_auto_reset")
+        ):
+            assert _pops_last_resolved_model(node), (
+                "gateway/run.py auto-reset cleanup block must clear the "
+                "per-session `_last_resolved_model` entry (pop session_key) so "
+                "the post-reset turn resolves from current config, mirroring the "
+                "/new and compression-exhausted reset sites (11b4a21a5)."
+            )
+            found = True
+            break
+    assert found, (
+        "Could not locate the auto-reset cleanup block in gateway/run.py."
+    )
+
+
+def _make_runner():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._session_model_overrides = {}
+    runner._last_resolved_model = {}
+    runner._service_tier = None
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    return runner
+
+
+def test_auto_reset_cleanup_pops_per_session_last_resolved_model():
+    """Behavioral mirror of test_new_clears_last_resolved_model: exercise the
+    exact clear the cleanup block performs and assert the per-session entry is
+    gone while the process-wide "*" slot survives (#48031 / #35314)."""
+    runner = _make_runner()
+    sk = "agent:main:qqbot:dm:123"
+
+    # Seed a stale pre-reset resolution: per-session AND process-wide.
+    runner._last_resolved_model[sk] = "old-model"
+    runner._last_resolved_model["*"] = "old-model"
+
+    # Run the exact clear the `_was_auto_reset` cleanup block performs.
+    runner._session_model_overrides.pop(sk, None)
+    _lrm = getattr(runner, "_last_resolved_model", None)
+    if _lrm is not None:
+        _lrm.pop(sk, None)
+
+    # Per-session cache cleared; the process-wide "*" safety net survives.
+    assert sk not in runner._last_resolved_model
+    assert runner._last_resolved_model.get("*") == "old-model"


### PR DESCRIPTION
## What does this PR do?

`11b4a21a5` ("fix(gateway): clear last-resolved-model cache on /new and compression auto-reset") cleared the per-session `_last_resolved_model` cache at two of the three session-reset sites: the `/new` handler and the compression-exhausted auto-reset. The third reset site — the daily/idle/suspended auto-reset boundary (the `_was_auto_reset` cleanup block in `_handle_message_with_agent`, added for #48031) — resets the same per-session model state (`_session_model_overrides`, reasoning override, `_pending_model_notes`, cached agent) but was **not** updated to also clear `_last_resolved_model[session_key]`.

Consequence: after a daily/idle/suspended auto-reset, if the first post-reset turn hits the transient empty-config read guarded against in #35314, `_resolve_session_agent_runtime`'s recovery net reads the stale pre-reset value out of `_last_resolved_model` (keyed on the same `session_key`) and serves the old model instead of resolving from current config — the exact symptom `11b4a21a5` fixed for `/new` and compression, still live on the far more frequent auto-reset boundary.

This PR mirrors the identical three-line clear the sibling compression-exhausted block already uses into the auto-reset cleanup block, completing `11b4a21a5`'s coverage across all three reset sites. The process-wide `"*"` fallback slot is intentionally left intact (matching the `11b4a21a5` behavior).

## Related Issue

Follow-up completing the coverage of `11b4a21a5` (context: #48031 auto-reset boundary, #35314 transient empty-config recovery). No issue is closed by this change.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: in the `if _was_auto_reset:` cleanup block, after `_evict_cached_agent(session_key)` and before consuming the flag, clear the per-session `_last_resolved_model` entry (`_lrm.pop(session_key, None)`), mirroring the compression-exhausted reset site verbatim.
- `tests/gateway/test_48031_model_switch_after_auto_reset.py`: adds an AST-invariant regression test pinning the `_last_resolved_model` clear into the auto-reset cleanup block, plus a behavioral test asserting the per-session entry is dropped while the process-wide `"*"` slot survives.

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/gateway/test_48031_model_switch_after_auto_reset.py -v` — 4 passed.
2. Fail-before/pass-after: reverting only the `gateway/run.py` hunk makes `test_run_clears_last_resolved_model_in_auto_reset_cleanup_block` fail (`_last_resolved_model` clear absent from the auto-reset block); restoring it passes.
3. Adjacent auto-reset / model-cache cluster stays green: `pytest tests/gateway/test_10710_auto_reset_evicts_cached_agent.py tests/gateway/test_35809_auto_reset_clean_context.py tests/gateway/test_new_clears_last_resolved_model.py tests/gateway/test_model_switch_persistence.py tests/gateway/test_session_model_reset.py -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4.0), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A