### PR TITLE
fix(runtime): exchange raw Copilot OAuth token in runtime resolution

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -311,6 +311,40 @@ def _provider_supports_explicit_api_mode(provider: Optional[str], configured_pro
     return normalized_configured == normalized_provider
 
 
+def _looks_like_raw_github_token(token: str) -> bool:
+    """True when ``token`` is a raw GitHub OAuth/PAT token (needs exchange)."""
+    t = (token or "").strip()
+    return t.startswith(("ghu_", "gho_", "ghp_", "ghs_", "github_pat_"))
+
+
+def _exchange_copilot_api_key(api_key: str, base_url: str) -> tuple[str, str]:
+    """Return ``(api_key, base_url)`` with any raw GitHub token exchanged.
+
+    Copilot chat requests must use the short-lived Copilot API token
+    (``tid=...``) obtained from the token-exchange endpoint. A raw ``ghu_``
+    token makes GitHub ignore ``Copilot-Integration-Id: vscode-chat`` and pin
+    the request to integrator ``copilot-language-server``, whose model
+    allow-list is tiny, so Claude/Gemini/most GPT models fail with HTTP 400
+    ``model_not_available_for_integrator``. Non-raw tokens and exchange
+    failures pass through unchanged, so behaviour is never worse than before.
+    """
+    if not _looks_like_raw_github_token(api_key):
+        return api_key, base_url
+    try:
+        from hermes_cli.copilot_auth import get_copilot_api_token
+
+        exchanged, exchanged_base_url = get_copilot_api_token(api_key)
+        if exchanged:
+            api_key = exchanged
+            if exchanged_base_url:
+                base_url = exchanged_base_url.rstrip("/")
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug(
+            "Copilot token exchange during runtime resolution failed: %s", exc
+        )
+    return api_key, base_url
+
+
 def _copilot_runtime_api_mode(model_cfg: Dict[str, Any], api_key: str) -> str:
     configured_provider = str(model_cfg.get("provider") or "").strip().lower()
     configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
@@ -443,7 +477,8 @@ def _resolve_runtime_from_pool_entry(
         api_mode = "chat_completions"
         base_url = _nous_inference_base_url_override() or base_url
     elif provider == "copilot":
-        api_mode = _copilot_runtime_api_mode(model_cfg, getattr(entry, "runtime_api_key", ""))
+        api_key, base_url = _exchange_copilot_api_key(api_key, base_url)
+        api_mode = _copilot_runtime_api_mode(model_cfg, api_key)
         base_url = base_url or PROVIDER_REGISTRY["copilot"].inference_base_url
     elif provider == "azure-foundry":
         # Azure Foundry: read api_mode and base_url from config
@@ -1480,6 +1515,7 @@ def _resolve_explicit_runtime(
 
         api_mode = "chat_completions"
         if provider == "copilot":
+            api_key, base_url = _exchange_copilot_api_key(api_key, base_url)
             api_mode = _copilot_runtime_api_mode(model_cfg, api_key)
         elif provider == "xai":
             api_mode = "codex_responses"

--- a/tests/hermes_cli/test_copilot_runtime_token_exchange.py
+++ b/tests/hermes_cli/test_copilot_runtime_token_exchange.py
@@ -1,0 +1,76 @@
+"""Regression tests for Copilot raw-token exchange during runtime resolution.
+
+A raw GitHub OAuth token (``ghu_...``) sent as the Bearer to
+``api.githubcopilot.com`` makes GitHub ignore ``Copilot-Integration-Id:
+vscode-chat`` and pin the request to integrator ``copilot-language-server``,
+whose model allow-list is tiny (only a handful of GPT models). Claude, Gemini
+and most GPT models then fail with HTTP 400
+``model_not_available_for_integrator``. The credential pool can end up holding
+the raw token (the env seeder overwrites the exchanged singleton entry under
+the same source key), so runtime resolution must defensively exchange a raw
+token for a short-lived Copilot API token (``tid=...``) before use.
+
+These tests pin that behaviour without any network access.
+"""
+from unittest.mock import patch
+
+from hermes_cli import runtime_provider as rp
+
+
+def test_looks_like_raw_github_token_recognizes_prefixes():
+    for raw in (
+        "ghu_abc123",
+        "gho_abc123",
+        "ghp_abc123",
+        "ghs_abc123",
+        "github_pat_abc123",
+        "  ghu_leading_ws  ",
+    ):
+        assert rp._looks_like_raw_github_token(raw) is True
+
+    # Already-exchanged Copilot API tokens and empty values are not "raw".
+    for other in ("tid=abc;exp=123", "", "sk-proj-abc", "some-random-key"):
+        assert rp._looks_like_raw_github_token(other) is False
+
+
+def test_exchange_copilot_api_key_exchanges_raw_token_and_adopts_base_url():
+    with patch(
+        "hermes_cli.copilot_auth.get_copilot_api_token",
+        return_value=("tid=exchanged;exp=999", "https://api.business.githubcopilot.com/"),
+    ) as mock_exchange:
+        api_key, base_url = rp._exchange_copilot_api_key(
+            "ghu_rawtoken", "https://api.githubcopilot.com"
+        )
+
+    mock_exchange.assert_called_once_with("ghu_rawtoken")
+    assert api_key == "tid=exchanged;exp=999"
+    # Account-specific endpoint advertised by the exchange is adopted (trailing
+    # slash stripped) so Business/Enterprise tenants hit the right host.
+    assert base_url == "https://api.business.githubcopilot.com"
+
+
+def test_exchange_copilot_api_key_passes_through_already_exchanged_token():
+    with patch("hermes_cli.copilot_auth.get_copilot_api_token") as mock_exchange:
+        api_key, base_url = rp._exchange_copilot_api_key(
+            "tid=already;exp=1", "https://api.githubcopilot.com"
+        )
+
+    # No exchange attempted for a non-raw token; values pass through unchanged.
+    mock_exchange.assert_not_called()
+    assert api_key == "tid=already;exp=1"
+    assert base_url == "https://api.githubcopilot.com"
+
+
+def test_exchange_copilot_api_key_keeps_base_url_when_exchange_returns_none():
+    # get_copilot_api_token returns (raw_token, None) on exchange failure; the
+    # original base_url must be preserved rather than clobbered with None.
+    with patch(
+        "hermes_cli.copilot_auth.get_copilot_api_token",
+        return_value=("ghu_rawtoken", None),
+    ):
+        api_key, base_url = rp._exchange_copilot_api_key(
+            "ghu_rawtoken", "https://api.githubcopilot.com"
+        )
+
+    assert api_key == "ghu_rawtoken"
+    assert base_url == "https://api.githubcopilot.com"


### PR DESCRIPTION
## What does this PR do?

Fixes GitHub Copilot models failing with `HTTP 400 "The requested model is not available for integrator"` / `"...is not supported"`.

When Hermes sends a **raw** GitHub OAuth token (`ghu_...`) as the Bearer to `api.githubcopilot.com`, GitHub ignores the `Copilot-Integration-Id: vscode-chat` header and pins the request to integrator `copilot-language-server`, whose model allow-list is tiny. As a result Claude, Gemini and most GPT models fail; only a handful (`gpt-5.5`, `gpt-5-mini`, …) work.

The credential pool can end up holding the **raw** token: `_seed_from_env` writes the raw `COPILOT_GITHUB_TOKEN` under the same source key as the token-exchanging singleton seeder, and `_upsert_entry` (matching by source) overwrites the exchanged `tid=` entry. Runtime resolution then puts the raw token on the wire.

This PR exchanges a raw GitHub token for a short-lived Copilot API token (`tid=…`) at the two `copilot` choke points in runtime resolution, and adopts the account-specific base URL advertised by the exchange (Business/Enterprise tenants). Already-exchanged tokens and exchange failures pass through unchanged, so behaviour is never worse than before.

Empirical matrix on one Business seat (same token):

| Bearer | `Copilot-Integration-Id` | Result |
| --- | --- | --- |
| raw `ghu_…` | `vscode-chat` | 400 — integrator `copilot-language-server`, most models blocked |
| exchanged `tid=…` | `vscode-chat` | 200 — all models |

> **Supersedes #24546**, which attempts the same exchange but assigns the `(token, base_url)` **tuple** returned by `get_copilot_api_token` directly to `api_key`, sending a stringified tuple on the wire — every model then fails with `invalid token: invalid whitespace`. (Verified by applying #24546 on current `main`.) Credit to @lucvan for identifying the same root cause.

## Related Issue

Fixes #45813

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/runtime_provider.py`: add `_looks_like_raw_github_token()` and `_exchange_copilot_api_key()`; call the exchange in `_resolve_runtime_from_pool_entry` and `_resolve_explicit_runtime` for the `copilot` provider, adopting the exchange base URL.
- `tests/hermes_cli/test_copilot_runtime_token_exchange.py`: 4 network-free regression tests — raw-token detection, exchange + base-URL adoption, already-exchanged pass-through, base-URL preserved on exchange failure.

## How to Test

1. Configure the Copilot provider via OAuth (Business/Enterprise seat) and select `claude-opus-4.8`.
2. On `main`: request fails with `HTTP 400 … not available for integrator "copilot-language-server"`.
3. With this patch: the same request returns 200 and the model answers correctly. Verified across all 13 Copilot models advertised by the seat — every model that previously failed with the integrator error now works.
4. `pytest tests/hermes_cli/test_copilot_runtime_token_exchange.py -q` → 4 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(runtime):`)
- [x] I searched for existing PRs (this supersedes #24546)
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests and they pass (`test_copilot_runtime_token_exchange.py`, `test_provider_attribution_headers.py`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] Docstrings added for new helpers — no user-facing docs/config keys changed (N/A for README / `cli-config.yaml.example`)
- [x] No architecture/workflow change (N/A for `CONTRIBUTING.md` / `AGENTS.md`)
- [x] Cross-platform safe (pure-Python string/token handling, no platform primitives)
