### PR TITLE
fix(computer-use): resolve cua-driver binary from common install paths when not on PATH

### DIFF
--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -73,7 +73,35 @@ logger = logging.getLogger(__name__)
 # only have *looked* like it pinned. For a reproducible version, point
 # `HERMES_CUA_DRIVER_CMD` at a specific binary instead.
 
-_CUA_DRIVER_CMD = os.environ.get("HERMES_CUA_DRIVER_CMD", "cua-driver")
+def _resolve_cua_driver_cmd() -> str:
+    """Resolve the cua-driver binary path.
+
+    Priority order:
+    1. ``HERMES_CUA_DRIVER_CMD`` env var (absolute path or basename).
+    2. ``shutil.which("cua-driver")`` — PATH lookup.
+    3. Common install paths (``~/.local/bin``, ``~/.cargo/bin``) — handles
+       runtimes where the user's local bin directory isn't on PATH (e.g.
+       the Hermes desktop app's bundled Python).
+    """
+    cmd = os.environ.get("HERMES_CUA_DRIVER_CMD")
+    if cmd:
+        return cmd
+
+    resolved = shutil.which("cua-driver")
+    if resolved:
+        return resolved
+
+    for candidate in (
+        os.path.expanduser("~/.local/bin/cua-driver"),
+        os.path.expanduser("~/.cargo/bin/cua-driver"),
+    ):
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+
+    return "cua-driver"  # last resort — will fail with a clear error downstream
+
+
+_CUA_DRIVER_CMD = _resolve_cua_driver_cmd()
 _CUA_DRIVER_ARGS = ["mcp"]  # stdio MCP transport (fallback when the
                             # driver doesn't expose `manifest` — see
                             # `_resolve_mcp_invocation` below)


### PR DESCRIPTION
## Problem

The computer_use tool's `check_computer_use_requirements()` calls `shutil.which("cua-driver")`, which returns `None` when `~/.local/bin` isn't on the runtime's `PATH`. This happens reliably in the Hermes desktop app (Electron-bundled Python) and can also occur in containerized environments, SSH sessions, and any runtime where the user's local bin isn't on `PATH`.

Result: the `computer_use` tool silently never registers, even though `cua-driver` is installed and the daemon is running.

## Fix

Replaced the module-level `_CUA_DRIVER_CMD = os.environ.get("HERMES_CUA_DRIVER_CMD", "cua-driver")` with a `_resolve_cua_driver_cmd()` function that checks three tiers:

1. `HERMES_CUA_DRIVER_CMD` env var (existing override, still works)
2. `shutil.which("cua-driver")` — PATH lookup
3. `~/.local/bin/cua-driver` and `~/.cargo/bin/cua-driver` — checked for existence + executability

Falls back to the bare string `"cua-driver"` as last resort (same behavior as before — will fail with a clear error downstream).

## Testing

- Manual verification: `_CUA_DRIVER_CMD` now resolves to `/Users/adriansoto/.local/bin/cua-driver` and `cua_driver_binary_available()` returns `True` on a system where `~/.local/bin` is not on the runtime PATH
- Existing test suite: 166/167 pass (1 unrelated `pydantic_core` environment mismatch in system pytest vs venv)
- Full capture + list_apps verified functional after the fix