### PR TITLE
fix(ntfy): fall back to chat_id for home-channel name when NTFY_HOME_CHANNEL_NAME is empty

### DIFF
--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -482,7 +482,7 @@ def _env_enablement() -> dict | None:
     if home:
         seed["home_channel"] = {
             "chat_id": home,
-            "name": os.getenv("NTFY_HOME_CHANNEL_NAME", home),
+            "name": os.getenv("NTFY_HOME_CHANNEL_NAME", "").strip() or home,
         }
     return seed
 

--- a/tests/gateway/test_ntfy_plugin.py
+++ b/tests/gateway/test_ntfy_plugin.py
@@ -758,6 +758,18 @@ class TestEnvEnablement:
         assert seed["home_channel"]["chat_id"] == "alerts"
         assert seed["home_channel"]["name"] == "Alerts Channel"
 
+    def test_home_channel_empty_name_falls_back_to_id(self, monkeypatch):
+        """A present-but-empty NTFY_HOME_CHANNEL_NAME (e.g. an env-only
+        Docker/compose/systemd config that exports the key blank) must fall
+        back to the chat_id, not yield an empty display name. Mirrors the
+        adjacent NTFY_HOME_CHANNEL `.strip() or topic` guard."""
+        monkeypatch.setenv("NTFY_TOPIC", "hermes-in")
+        monkeypatch.setenv("NTFY_HOME_CHANNEL", "alerts")
+        monkeypatch.setenv("NTFY_HOME_CHANNEL_NAME", "")
+        seed = _env_enablement()
+        assert seed["home_channel"]["chat_id"] == "alerts"
+        assert seed["home_channel"]["name"] == "alerts"
+
 
 # ---------------------------------------------------------------------------
 # 10. _standalone_send() — out-of-process cron delivery

--- a/tests/gateway/test_ntfy_plugin.py
+++ b/tests/gateway/test_ntfy_plugin.py
@@ -788,6 +788,67 @@ class TestEnvEnablement:
         assert seed["home_channel"]["name"] == "alerts"
 
 
+class TestHomeChannelConfigPath:
+    """End-to-end through the production configuration layer.
+
+    The env seed above is only half the path. ``gateway/config.py``'s
+    plugin-platform enable pass (inside ``_apply_env_overrides``) wires
+    ``seed["home_channel"]`` into a :class:`HomeChannel` dataclass with
+    ``name=str(home.get("name") or "Home")``. A blank seed name is falsy
+    there, so *without* the adapter fix the user-visible channel name is the
+    generic ``"Home"`` rather than the channel id — which is exactly the
+    normalization these tests have to disprove.
+    """
+
+    @staticmethod
+    def _resolve_home_channel(monkeypatch, name_value):
+        """Drive the real config loader and return the resulting HomeChannel."""
+        from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+
+        monkeypatch.setenv("NTFY_TOPIC", "hermes-in")
+        monkeypatch.setenv("NTFY_HOME_CHANNEL", "alerts")
+        if name_value is None:
+            monkeypatch.delenv("NTFY_HOME_CHANNEL_NAME", raising=False)
+        else:
+            monkeypatch.setenv("NTFY_HOME_CHANNEL_NAME", name_value)
+
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+
+        platform_config = config.platforms.get(Platform("ntfy"))
+        assert platform_config is not None, "ntfy plugin was not enabled from env"
+        return platform_config.home_channel
+
+    def test_empty_name_resolves_to_channel_id_not_home(self, monkeypatch):
+        home_channel = self._resolve_home_channel(monkeypatch, "")
+        assert home_channel is not None
+        assert home_channel.chat_id == "alerts"
+        # The assertion teknium1 asked for: user-visible name is the channel
+        # id, NOT the "Home" default that `or "Home"` yields for a blank seed.
+        assert home_channel.name == "alerts"
+        assert home_channel.name != "Home"
+
+    @pytest.mark.parametrize("blank", [" ", "   ", "\t", "\n", " \t\n "])
+    def test_whitespace_name_resolves_to_channel_id_not_home(self, monkeypatch, blank):
+        home_channel = self._resolve_home_channel(monkeypatch, blank)
+        assert home_channel is not None
+        assert home_channel.chat_id == "alerts"
+        assert home_channel.name == "alerts"
+        assert home_channel.name != "Home"
+
+    def test_unset_name_resolves_to_channel_id(self, monkeypatch):
+        home_channel = self._resolve_home_channel(monkeypatch, None)
+        assert home_channel is not None
+        assert home_channel.name == "alerts"
+
+    def test_explicit_name_is_preserved(self, monkeypatch):
+        """Anchor: a real name must survive the config layer untouched."""
+        home_channel = self._resolve_home_channel(monkeypatch, "Alerts Channel")
+        assert home_channel is not None
+        assert home_channel.chat_id == "alerts"
+        assert home_channel.name == "Alerts Channel"
+
+
 # ---------------------------------------------------------------------------
 # 10. _standalone_send() — out-of-process cron delivery
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_ntfy_plugin.py
+++ b/tests/gateway/test_ntfy_plugin.py
@@ -770,6 +770,23 @@ class TestEnvEnablement:
         assert seed["home_channel"]["chat_id"] == "alerts"
         assert seed["home_channel"]["name"] == "alerts"
 
+    @pytest.mark.parametrize("blank", [" ", "   ", "\t", "\n", " \t\n "])
+    def test_home_channel_whitespace_name_falls_back_to_id(
+        self, monkeypatch, blank
+    ):
+        """Whitespace-only NTFY_HOME_CHANNEL_NAME must also fall back to the
+        chat_id. This pins the ``.strip()`` half of the guard specifically:
+        the empty-string case above passes under a bare
+        ``os.getenv(..., "") or home``, but a value like ``"   "`` is truthy
+        and only ``.strip()`` collapses it, so this is the case that fails
+        without the production change."""
+        monkeypatch.setenv("NTFY_TOPIC", "hermes-in")
+        monkeypatch.setenv("NTFY_HOME_CHANNEL", "alerts")
+        monkeypatch.setenv("NTFY_HOME_CHANNEL_NAME", blank)
+        seed = _env_enablement()
+        assert seed["home_channel"]["chat_id"] == "alerts"
+        assert seed["home_channel"]["name"] == "alerts"
+
 
 # ---------------------------------------------------------------------------
 # 10. _standalone_send() — out-of-process cron delivery


### PR DESCRIPTION
## What does this PR do?

`_env_enablement()` in the ntfy adapter builds the home-channel display name with a bare 2-arg default:

```python
home = os.getenv("NTFY_HOME_CHANNEL", "").strip() or topic
if home:
    seed["home_channel"] = {
        "chat_id": home,
        "name": os.getenv("NTFY_HOME_CHANNEL_NAME", home),   # <-- 2-arg default only fires when the var is ABSENT
    }
```

The `os.getenv(key, default)` default only fires when the variable is **unset**. An env-only deployment that exports `NTFY_HOME_CHANNEL_NAME=` (present-but-empty — a common Docker/compose/systemd idiom for blanking a key) makes `getenv` return `""`, so the home channel gets an **empty display name** instead of falling back to the chat_id.

Note the `NTFY_HOME_CHANNEL` read one line up already handles exactly this case correctly with `os.getenv("NTFY_HOME_CHANNEL", "").strip() or topic`. This change mirrors that in-file sibling guard for the name field (and matches `simplex/adapter.py`'s home-channel handling).

## Related Issue

No filed issue; author-found consistency bug. Fixes an env-only home-channel misconfiguration path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/ntfy/adapter.py`: home-channel `name` now uses `os.getenv("NTFY_HOME_CHANNEL_NAME", "").strip() or home`, so a present-but-empty value falls back to the chat_id, mirroring the adjacent `NTFY_HOME_CHANNEL` guard.
- `tests/gateway/test_ntfy_plugin.py`: add `test_home_channel_empty_name_falls_back_to_id` to `TestEnvEnablement`.

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/gateway/test_ntfy_plugin.py::TestEnvEnablement -v` — 10 passed.
2. Fail-before/pass-after: reverting only the `plugins/platforms/ntfy/adapter.py` hunk makes `test_home_channel_empty_name_falls_back_to_id` fail (name resolves to `""`); restoring passes (name resolves to `"alerts"`).
3. Full ntfy plugin suite stays green: `pytest tests/gateway/test_ntfy_plugin.py -q` (83 passed). Pure-logic, no network.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4.0), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A