### PR TITLE
fix(models): route Responses-only Copilot models to the Responses API

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3301,7 +3301,12 @@ def copilot_model_api_mode(
     if _should_use_copilot_responses_api(normalized):
         return "codex_responses"
 
-    # Secondary: check catalog for non-GPT-5 models (Claude via /v1/messages, etc.)
+    # Catalog-driven fallback for models the pattern check doesn't cover.
+    # Honor the catalog's supported_endpoints, but only OVERRIDE chat_completions
+    # when the model does NOT advertise /chat/completions at all: some Copilot
+    # models are Responses-only (e.g. mai-code-1-flash-picker -> /responses) or
+    # Messages-only (Claude via /v1/messages). Models that DO advertise
+    # /chat/completions (Claude, Gemini on Copilot) keep using it.
     if catalog:
         catalog_entry = next((item for item in catalog if item.get("id") == normalized), None)
         if isinstance(catalog_entry, dict):
@@ -3310,9 +3315,11 @@ def copilot_model_api_mode(
                 for endpoint in (catalog_entry.get("supported_endpoints") or [])
                 if str(endpoint).strip()
             }
-            # For non-GPT-5 models, check if they only support messages API
-            if "/v1/messages" in supported_endpoints and "/chat/completions" not in supported_endpoints:
-                return "anthropic_messages"
+            if supported_endpoints and "/chat/completions" not in supported_endpoints:
+                if "/responses" in supported_endpoints:
+                    return "codex_responses"
+                if "/v1/messages" in supported_endpoints:
+                    return "anthropic_messages"
 
     return "chat_completions"
 

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -411,6 +411,44 @@ class TestCopilotNormalization:
         }]
         assert copilot_model_api_mode("gpt-5.4", catalog=catalog) == "codex_responses"
 
+    def test_copilot_api_mode_non_gpt_responses_only_uses_responses(self):
+        """A non-GPT Responses-only model (e.g. mai-code) must use codex_responses.
+
+        The ID regex only recognises GPT-5+ models, so without the catalog
+        fallback mai-code-1-flash-picker falls through to chat_completions and
+        the request fails with HTTP 400 'not accessible via /chat/completions'.
+        """
+        catalog = [{
+            "id": "mai-code-1-flash-picker",
+            "supported_endpoints": ["/responses"],
+        }]
+        assert (
+            copilot_model_api_mode("mai-code-1-flash-picker", catalog=catalog)
+            == "codex_responses"
+        )
+
+    def test_copilot_api_mode_non_gpt_messages_only_uses_anthropic(self):
+        """A non-GPT Messages-only model keeps routing to anthropic_messages."""
+        catalog = [{
+            "id": "claude-opus-4.6",
+            "supported_endpoints": ["/v1/messages"],
+        }]
+        assert (
+            copilot_model_api_mode("claude-opus-4.6", catalog=catalog)
+            == "anthropic_messages"
+        )
+
+    def test_copilot_api_mode_non_gpt_chat_capable_stays_chat(self):
+        """Non-GPT models that advertise /chat/completions keep using it."""
+        catalog = [{
+            "id": "claude-opus-4.6",
+            "supported_endpoints": ["/chat/completions", "/v1/messages"],
+        }]
+        assert (
+            copilot_model_api_mode("claude-opus-4.6", catalog=catalog)
+            == "chat_completions"
+        )
+
     def test_normalize_opencode_model_id_strips_provider_prefix(self):
         assert normalize_opencode_model_id("opencode-go", "opencode-go/kimi-k2.5") == "kimi-k2.5"
         assert normalize_opencode_model_id("opencode-zen", "opencode-zen/claude-sonnet-4-6") == "claude-sonnet-4-6"


### PR DESCRIPTION
## What does this PR do?

Routes **Responses-only** Copilot models to the Responses API so they stop failing with `HTTP 400 "model … is not accessible via the /chat/completions endpoint"`.

`copilot_model_api_mode()` picks the Copilot API mode primarily from a model-id regex (`_should_use_copilot_responses_api`) that only recognises **GPT-5+** models as Responses-API models. A non-GPT model that is Responses-only — e.g. `mai-code-1-flash-picker` — falls through to `chat_completions` and the request fails.

This PR keeps the opencode-parity regex **first** (so GPT-5+ reasoning models stay on their native Responses endpoint even when the catalog also advertises `/chat/completions`), then consults the catalog's `supported_endpoints` to rescue models the regex doesn't cover: when a model does **not** advertise `/chat/completions` at all, it is routed by its declared endpoint — `/responses` → `codex_responses`, `/v1/messages` → `anthropic_messages`. Models that **do** advertise `/chat/completions` (Claude, Gemini on Copilot) keep using it, so their behaviour is unchanged.

| Model | supported_endpoints | before | after |
| --- | --- | --- | --- |
| `mai-code-1-flash-picker` | `/responses` | chat_completions → **400** | **codex_responses** ✅ |
| `claude-*` / `gemini-*` (Copilot) | `/chat/completions`, … | chat_completions | chat_completions (unchanged) |
| Messages-only model | `/v1/messages` | anthropic_messages | anthropic_messages (unchanged) |

> Follow-up to #58830 (raw-token exchange). #58830 is required first — without it every Copilot model fails with the integrator error, so this change is only observable once tokens are exchanged correctly. Together they make every model advertised by a Copilot seat usable.

## Related Issue

Relates to #45813

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/models.py`: in `copilot_model_api_mode`, replace the "messages-only" catalog check with a general "no `/chat/completions`" fallback that honours `/responses` (→ codex_responses) and `/v1/messages` (→ anthropic_messages).
- `tests/hermes_cli/test_model_validation.py`: add 3 unit tests — Responses-only non-GPT model → codex_responses, Messages-only → anthropic_messages, chat-capable non-GPT stays chat_completions.

## How to Test

1. On top of #58830, configure the Copilot provider and select `mai-code-1-flash-picker`.
2. On `main`: `HTTP 400 … not accessible via the /chat/completions endpoint`.
3. With this patch: returns 200 via the Responses API and the model answers. All other Copilot models keep their previous api_mode.
4. `pytest tests/hermes_cli/test_model_validation.py -q` → 90 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(models):`)
- [x] I searched for existing PRs (no duplicate; follow-up to #58830)
- [x] My PR contains **only** changes related to this fix
- [x] I've run the tests and they pass (`tests/hermes_cli/test_model_validation.py`: 90 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] No user-facing docs/config keys changed — N/A for README / `cli-config.yaml.example`
- [x] No architecture/workflow change — N/A for `CONTRIBUTING.md` / `AGENTS.md`
- [x] Cross-platform safe (pure-Python catalog/string handling)
