### PR TITLE
fix: replace bare asserts with explicit exceptions (P0 — python -O survival)

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1335,7 +1335,8 @@ class WeixinAdapter(BasePlatformAdapter):
         logger.info("[%s] Disconnected", self.name)
 
     async def _poll_loop(self) -> None:
-        assert self._poll_session is not None
+        if self._poll_session is None:
+            raise RuntimeError("poll session not initialized")
         sync_buf = _load_sync_buf(self._hermes_home, self._account_id)
         timeout_ms = LONG_POLL_TIMEOUT_MS
         consecutive_failures = 0
@@ -1401,7 +1402,8 @@ class WeixinAdapter(BasePlatformAdapter):
             logger.error("[%s] unhandled inbound error from=%s: %s", self.name, _safe_id(message.get("from_user_id")), exc, exc_info=True)
 
     async def _process_message(self, message: Dict[str, Any]) -> None:
-        assert self._poll_session is not None
+        if self._poll_session is None:
+            raise RuntimeError("poll session not initialized")
         sender_id = str(message.get("from_user_id") or "").strip()
         if not sender_id:
             return
@@ -2088,7 +2090,8 @@ class WeixinAdapter(BasePlatformAdapter):
         if not is_safe_url(url):
             raise ValueError(f"Blocked unsafe URL (SSRF protection): {url}")
 
-        assert self._send_session is not None
+        if self._send_session is None:
+            raise RuntimeError("send session not initialized")
         # Use asyncio.wait_for() instead of aiohttp ClientTimeout to avoid
         # "Timeout context manager should be used inside a task" errors.
         async def _do_fetch():
@@ -2108,7 +2111,8 @@ class WeixinAdapter(BasePlatformAdapter):
         caption: str,
         force_file_attachment: bool = False,
     ) -> str:
-        assert self._send_session is not None and self._token is not None
+        if self._send_session is None or self._token is None:
+            raise RuntimeError("send session or token not initialized")
         plaintext = Path(path).read_bytes()
         media_type, item_builder = self._outbound_media_builder(path, force_file_attachment=force_file_attachment)
         filekey = secrets.token_hex(16)

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -548,7 +548,8 @@ class WebSocketRelayTransport:
         await self._ws.send(json.dumps(frame) + "\n")
 
     async def _read_loop(self) -> None:
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("WebSocket not connected — _read_loop called before connect()")
         buf = ""
         try:
             async for chunk in self._ws:

--- a/plugins/google_meet/realtime/openai_client.py
+++ b/plugins/google_meet/realtime/openai_client.py
@@ -221,12 +221,14 @@ class RealtimeSession:
             return False
 
     def _send_json(self, payload: dict) -> None:
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("WebSocket not connected")
         with self._send_lock:
             self._ws.send(json.dumps(payload))
 
     def _recv(self, timeout: Optional[float] = None):
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("WebSocket not connected")
         try:
             if timeout is None:
                 return self._ws.recv()

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -848,7 +848,8 @@ class CDPSupervisor:
 
     async def _read_loop(self) -> None:
         """Continuously dispatch incoming CDP frames."""
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("WebSocket not connected — _read_loop called before connect()")
         try:
             async for raw in self._ws:
                 if self._stop_requested:

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -1019,7 +1019,8 @@ class DockerEnvironment(BaseEnvironment):
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
         """Spawn a bash process inside the Docker container."""
-        assert self._container_id, "Container not started"
+        if not self._container_id:
+            raise RuntimeError("Container not started — call start() first")
         cmd = [self._docker_exe, "exec"]
         if stdin_data is not None:
             cmd.append("-i")

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -928,7 +928,8 @@ def _patch_skill(
         target, err = _resolve_skill_target(skill_dir, file_path)
         if err:
             return {"success": False, "error": err}
-        assert target is not None
+        if target is None:
+            return {"success": False, "error": "Failed to resolve skill target"}
     else:
         # Patching SKILL.md
         target = skill_dir / "SKILL.md"
@@ -1146,7 +1147,8 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     target, err = _resolve_skill_target(existing["path"], file_path)
     if err:
         return {"success": False, "error": err}
-    assert target is not None
+    if target is None:
+            return {"success": False, "error": "Failed to resolve skill target"}
     if target.exists():
         read_guard = _background_review_read_before_write_guard(
             name, target, "write_file", file_path
@@ -1192,7 +1194,8 @@ def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
     target, err = _resolve_skill_target(skill_dir, file_path)
     if err:
         return {"success": False, "error": err}
-    assert target is not None
+    if target is None:
+            return {"success": False, "error": "Failed to resolve skill target"}
     if not target.exists():
         # List what's actually there for the model to see
         available = []


### PR DESCRIPTION
## Summary

Replace bare `assert` statements with explicit exceptions that survive `python -O` (optimized mode).

## Problem

Bare `assert` statements are **stripped silently** when Python runs with `-O` flag. This means critical runtime guards (WebSocket connections, session initialization, container state) simply disappear in production, leading to confusing `AttributeError` or `NoneType` crashes with no useful error message.

## Changes

| File | Guard | Fix |
|------|-------|-----|
| `tools/browser_supervisor.py` | `assert self._ws is not None` in `_read_loop` | `if ... raise RuntimeError` |
| `plugins/google_meet/realtime/openai_client.py` | `assert self._ws` in `_send_json` and `_recv` | `if ... raise RuntimeError` |
| `gateway/relay/ws_transport.py` | `assert self._ws` in `_read_loop` | `if ... raise RuntimeError` |
| `tools/environments/docker.py` | `assert self._container_id` in `exec_bash` | `if not ... raise RuntimeError` |
| `gateway/platforms/weixin.py` | 4 session/tensor asserts in poll/send methods | `if ... raise RuntimeError` |
| `tools/skill_manager_tool.py` | 3 target asserts in write/patch/remove ops | `if ... return error dict` |

## Impact

- **P0**: All 12 fixed asserts were in critical runtime paths (WebSocket I/O, container execution, message polling)
- All checks already existed but would vanish under `-O`, creating false confidence
- Explicit exceptions provide clear error messages and always execute regardless of optimization level

## Testing

All 6 files pass `python3 -m py_compile` verification.
