### PR TITLE
refactor: replace len(x) == 0 / len(x) > 0 with idiomatic Python (P2)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1198,7 +1198,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # _fallback_index=0 and re-marshaling the whole context across every
         # provider again.  Guards the cross-turn replay storm in #24996.
         if (
-            len(agent._fallback_chain) > 0
+            agent._fallback_chain
             and reason not in {FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit}
         ):
             _existing_cooldown = getattr(agent, "_rate_limited_until", 0) or 0

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -1762,7 +1762,7 @@ class ExtractContentMiddleware(InboundMiddleware):
                 # Prefer medium image (index 1), fallback to index 0
                 if len(image_info_array) > 1 and isinstance(image_info_array[1], dict):
                     image_info = image_info_array[1]
-                elif len(image_info_array) > 0 and isinstance(image_info_array[0], dict):
+                elif image_info_array and isinstance(image_info_array[0], dict):
                     image_info = image_info_array[0]
                 image_url = str((image_info or {}).get("url") or "").strip()
                 rid = cls._parse_resource_id(image_url)
@@ -1862,7 +1862,7 @@ class ExtractContentMiddleware(InboundMiddleware):
                 image_info = None
                 if len(image_info_array) > 1 and isinstance(image_info_array[1], dict):
                     image_info = image_info_array[1]
-                elif len(image_info_array) > 0 and isinstance(image_info_array[0], dict):
+                elif image_info_array and isinstance(image_info_array[0], dict):
                     image_info = image_info_array[0]
                 image_url = str((image_info or {}).get("url") or "").strip()
                 if image_url:
@@ -4846,7 +4846,7 @@ class MessageSender:
         Returns:
             Error description (str) if validation fails, otherwise None.
         """
-        if file_bytes is None or len(file_bytes) == 0:
+        if file_bytes is None or not file_bytes:
             return f"Empty file: {filename}"
         max_bytes = max_size_mb * 1024 * 1024
         if len(file_bytes) > max_bytes:

--- a/gateway/relay/auth.py
+++ b/gateway/relay/auth.py
@@ -67,7 +67,7 @@ def verify_signature(payload: str, sig_hex: str, secrets: Sequence[str]) -> bool
         sig_buf = bytes.fromhex(sig_hex)
     except (ValueError, TypeError):
         return False
-    if len(sig_buf) == 0:
+    if not sig_buf:
         return False
     for secret in secrets:
         if not secret:

--- a/gateway/scale_to_zero.py
+++ b/gateway/scale_to_zero.py
@@ -80,7 +80,7 @@ def messaging_is_relay_only_or_absent(platforms: Iterable[Any]) -> bool:
     """
     names = {_platform_name(p) for p in platforms}
     names.discard("relay")
-    return len(names) == 0
+    return not names
 
 
 def _platform_name(platform: Any) -> str:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1797,7 +1797,7 @@ class SlashCommandCompleter(Completer):
         trailing_space = sub_text.endswith(" ")
 
         # Subcommand stage: zero words typed, or completing the first word.
-        if len(parts) == 0 or (len(parts) == 1 and not trailing_space):
+        if not parts or (len(parts) == 1 and not trailing_space):
             partial = sub_text if not trailing_space else ""
             for sub in SUBS:
                 if sub.startswith(partial.lower()) and sub != partial.lower():

--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -17,7 +17,7 @@ def _has_configured_mcp_servers() -> bool:
         from hermes_cli.config import read_raw_config
 
         mcp_servers = (read_raw_config() or {}).get("mcp_servers")
-        return isinstance(mcp_servers, dict) and len(mcp_servers) > 0
+        return isinstance(mcp_servers, dict) and mcp_servers
     except Exception:
         # Be conservative: if config probing fails, try discovery in the
         # background so startup still can't block.

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1013,7 +1013,7 @@ class HonchoMemoryProvider(MemoryProvider):
             # pass 2: reconciliation
             return (
                 f"Prior passes produced:\n\n"
-                f"Pass 1:\n{prior_results[0] if len(prior_results) > 0 else '(empty)'}\n\n"
+                f"Pass 1:\n{prior_results[0] if prior_results else '(empty)'}\n\n"
                 f"Pass 2:\n{prior_results[1] if len(prior_results) > 1 else '(empty)'}\n\n"
                 "Do these assessments cohere? Reconcile any contradictions "
                 "and produce a final, concise synthesis of what matters most "

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1218,7 +1218,7 @@ class MatrixAdapter(BasePlatformAdapter):
                         )
                         if len(all_devices) == 1:
                             client.device_id = next(iter(all_devices))
-                        elif len(all_devices) == 0:
+                        elif not all_devices:
                             logger.warning(
                                 "Matrix: no devices found for %s — "
                                 "key verification will be skipped",

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -316,7 +316,7 @@ def main():
     try:
         from hermes_cli.config import read_raw_config
         _mcp_servers = (read_raw_config() or {}).get("mcp_servers")
-        _has_mcp_servers = isinstance(_mcp_servers, dict) and len(_mcp_servers) > 0
+        _has_mcp_servers = isinstance(_mcp_servers, dict) and _mcp_servers
     except Exception:
         # Be conservative: if we can't decide, fall back to attempting
         # discovery (still backgrounded, so it can't block startup).

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12150,7 +12150,7 @@ def _details_completions(text: str) -> list[dict] | None:
     sections = ("thinking", "tools", "subagents", "activity")
     modes = ("hidden", "collapsed", "expanded")
 
-    if not body or (len(parts) == 0 and has_trailing_space):
+    if not body or (not parts and has_trailing_space):
         return [
             *[
                 _details_root_completion_item(


### PR DESCRIPTION
## Summary

Replace explicit `len()` comparisons with idiomatic Python truthiness checks.

## Problem

`len(x) == 0` and `len(x) > 0` are non-Pythonic — Python's truthiness protocol handles empty-checks natively and more readably:

```python
# BAD:
if len(items) == 0:
if len(items) > 0:

# GOOD:
if not items:
if items:
```

## Changes

12 instances fixed across 10 files:

| File | Pattern |
|------|---------|
| `agent/chat_completion_helpers.py` | `len(x) == 0` |
| `plugins/platforms/matrix/adapter.py` | `len(x) > 0` |
| `plugins/memory/honcho/__init__.py` | `len(x) == 0` |
| `hermes_cli/commands.py` | `len(x) == 0` |
| `hermes_cli/mcp_startup.py` | `len(x) == 0` |
| `gateway/scale_to_zero.py` | `len(x) == 0` |
| `gateway/platforms/yuanbao.py` | `len(x) > 0` |
| `gateway/relay/auth.py` | `len(x) == 0` |
| `tui_gateway/entry.py` | `len(x) == 0` |
| `tui_gateway/server.py` | `len(x) > 0` |

## Testing

All 10 files pass `python3 -m py_compile` verification.
