### PR TITLE
test(hermes_cli): add unit tests for resolve_rename_path

### DIFF
--- a/tests/hermes_cli/test_web_git.py
+++ b/tests/hermes_cli/test_web_git.py
@@ -1,0 +1,37 @@
+"""Unit tests for resolve_rename_path (hermes_cli/web_git.py).
+
+Pure, I/O-free parser that turns git's rename notation into the NEW path:
+- no " => "            -> path returned unchanged (stripped)
+- "old => new"         -> "new"
+- "dir/{old => new}/f" -> "dir/new/f" (brace form), collapsing "//"
+"""
+
+import pytest
+
+from hermes_cli.web_git import resolve_rename_path
+
+
+class TestResolveRenamePath:
+    @pytest.mark.parametrize("raw,expected", [
+        ("src/foo.py", "src/foo.py"),   # no rename token
+        ("", ""),
+        ("  a/b.py  ", "a/b.py"),        # stripped
+    ])
+    def test_non_rename_paths_pass_through(self, raw, expected):
+        assert resolve_rename_path(raw) == expected
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("old.py => new.py", "new.py"),
+        ("a/old.py => a/new.py", "a/new.py"),
+        ("  x => y  ", "y"),
+    ])
+    def test_simple_rename_returns_new_path(self, raw, expected):
+        assert resolve_rename_path(raw) == expected
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("src/{old => new}/f.py", "src/new/f.py"),
+        ("{a => b}/f", "b/f"),
+        ("dir/{old => }/f", "dir/f"),   # empty new collapses "//"
+    ])
+    def test_brace_rename_reconstructs_new_path(self, raw, expected):
+        assert resolve_rename_path(raw) == expected


### PR DESCRIPTION
﻿## What does this PR do?

Adds unit test coverage for `resolve_rename_path` in `hermes_cli/web_git.py` — a pure, I/O-free parser that converts git's rename notation into the NEW path so a dashboard diff/stage row addresses the real file. It had no direct tests.

The tests pin the contract:
- No `" => "` token → path returned unchanged (stripped): `src/foo.py` → `src/foo.py`
- Simple rename → new path: `old.py => new.py` → `new.py`
- Brace form → reconstructed new path: `src/{old => new}/f.py` → `src/new/f.py`, `{a => b}/f` → `b/f`
- Empty new segment collapses `//`: `dir/{old => }/f` → `dir/f`

## Type of Change

- [x] Test coverage (no production code changed)

## How to Test

```bash
scripts/run_tests.sh tests/hermes_cli/test_web_git.py -v
```

## Notes

- 1 new file, no production code touched. Pure input→output assertions — no mocks, no network, no filesystem.
- Follows the existing `tests/tools/test_binary_extensions.py` style.
