### PR TITLE
fix(tts): convert Piper WAV-in-OGG to real Opus on Telegram

### DIFF
--- a/tests/tools/test_tts_opus_routing.py
+++ b/tests/tools/test_tts_opus_routing.py
@@ -68,3 +68,57 @@ def test_edge_telegram_converts_to_opus_voice(tmp_path, monkeypatch):
     assert result["voice_compatible"] is True
     assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{opus}"
     convert.assert_called_once_with(str(out))
+
+
+def _write_piper_wav_output(_text: str, output_path: str, _tts_config: dict) -> str:
+    """Simulate Piper: always writes raw WAV bytes regardless of extension."""
+    Path(output_path).write_bytes(b"RIFF" + b"\x00" * 100)
+    return output_path
+
+
+def test_piper_telegram_converts_wav_in_ogg_to_opus(tmp_path, monkeypatch):
+    """When the caller passes an .ogg path (e.g. _send_voice_reply),
+    Piper writes WAV bytes into that .ogg file.  The conversion logic must
+    rename to .wav first so ffmpeg treats the input correctly."""
+    out = tmp_path / "tts_reply.ogg"
+    opus = tmp_path / "tts_reply_opus.ogg"
+
+    def fake_convert(path: str) -> str:
+        # After the rename, the input should be .wav
+        assert path.endswith(".wav"), f"expected .wav input, got {path}"
+        opus.write_bytes(b"opus")
+        return str(opus)
+
+    convert = Mock(side_effect=fake_convert)
+
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "piper"})
+    monkeypatch.setattr(tts_tool, "_import_piper", lambda: object())
+    monkeypatch.setattr(tts_tool, "_generate_piper_tts", _write_piper_wav_output)
+    monkeypatch.setattr(tts_tool, "_convert_to_opus", convert)
+
+    result = json.loads(tts_tool.text_to_speech_tool("hello", output_path=str(out)))
+
+    assert result["success"] is True
+    assert result["file_path"] == str(opus)
+    assert result["voice_compatible"] is True
+    assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{opus}"
+    convert.assert_called_once()
+
+
+def test_piper_cli_preserves_wav_when_not_telegram(tmp_path, monkeypatch):
+    """On non-Telegram platforms, Piper's WAV output is left as-is."""
+    out = tmp_path / "speech.wav"
+    convert = Mock()
+
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "piper"})
+    monkeypatch.setattr(tts_tool, "_import_piper", lambda: object())
+    monkeypatch.setattr(tts_tool, "_generate_piper_tts", _write_piper_wav_output)
+    monkeypatch.setattr(tts_tool, "_convert_to_opus", convert)
+
+    result = json.loads(tts_tool.text_to_speech_tool("hello", output_path=str(out)))
+
+    assert result["success"] is True
+    assert result["file_path"] == str(out)
+    assert result["voice_compatible"] is False
+    convert.assert_not_called()

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2417,9 +2417,24 @@ def text_to_speech_tool(
                     if opus_path:
                         file_str = opus_path
                 voice_compatible = file_str.endswith(".ogg")
+        elif want_opus and provider == "piper":
+            # Piper always writes raw WAV bytes regardless of the output
+            # path extension (see _generate_piper_tts docstring).  When
+            # the caller supplies an .ogg path (e.g. _send_voice_reply in
+            # gateway/run.py), the file contains WAV data in an .ogg
+            # container — ffmpeg needs a .wav input to handle it correctly.
+            if file_str.endswith(".ogg"):
+                wav_path = file_str[:-4] + ".wav"
+                os.rename(file_str, wav_path)
+                opus_path = _convert_to_opus(wav_path)
+            else:
+                opus_path = _convert_to_opus(file_str)
+            if opus_path:
+                file_str = opus_path
+                voice_compatible = True
         elif (
             want_opus
-            and provider in {"edge", "neutts", "minimax", "xai", "kittentts", "piper"}
+            and provider in {"edge", "neutts", "minimax", "xai", "kittentts"}
             and not file_str.endswith(".ogg")
         ):
             opus_path = _convert_to_opus(file_str)


### PR DESCRIPTION
## What does this PR do?

Fixes Piper TTS producing 0-second voice bubbles on Telegram. Piper always writes raw WAV bytes regardless of the output path extension. When the gateway's `_send_voice_reply` passes an `.ogg` path, the file ends up containing WAV data in an `.ogg` container — Telegram accepts it but cannot derive a duration, showing 0:00.

## Related Issue

Fixes #58845

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/tts_tool.py`: Add a Piper-specific conversion branch that detects when Piper has written WAV bytes to an `.ogg` path, renames to `.wav` so ffmpeg handles the input format correctly, then converts to real Opus. Removes `"piper"` from the generic `not file_str.endswith(".ogg")` guard.
- `tests/tools/test_tts_opus_routing.py`: Add 2 regression tests — one verifying the Telegram path converts WAV-in-OGG to Opus, one verifying non-Telegram platforms leave WAV as-is.

## How to Test

1. Configure `tts.provider: piper` with a valid voice model.
2. Set `voice_only` mode on Telegram.
3. Send a voice message — the reply should show correct duration (not 0:00).
4. `pytest tests/tools/test_tts_opus_routing.py -v` — should pass all 4 tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (ffmpeg conversion is cross-platform)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — the fix is a code-path change in the TTS conversion logic. Regression tests verify the behavior.
