### PR TITLE
feat(cli): terminal bell on dangerous-command approval prompts

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3706,6 +3706,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self.resume_display = CLI_CONFIG["display"].get("resume_display", "full")
         # bell_on_complete: play terminal bell (\a) when agent finishes a response
         self.bell_on_complete = CLI_CONFIG["display"].get("bell_on_complete", False)
+        # bell_on_approval: play terminal bell when a dangerous-command approval
+        # prompt appears mid-task (default true — the agent blocks silently
+        # otherwise, unlike turn-end where bell_on_complete covers it).
+        self.bell_on_approval = CLI_CONFIG["display"].get("bell_on_approval", True)
         # show_reasoning: display model thinking/reasoning before the response
         self.show_reasoning = CLI_CONFIG["display"].get("show_reasoning", False)
         # reasoning_full: when reasoning display is on, print the post-response
@@ -11592,6 +11596,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 "response_queue": response_queue,
             }
             self._approval_deadline = _time.monotonic() + timeout
+
+            # Play terminal bell when a dangerous-command approval prompt
+            # appears mid-task. Without this, the agent blocks silently while
+            # the user is tabbed away — bell_on_complete only fires at turn end.
+            if getattr(self, "bell_on_approval", True):
+                sys.stdout.write("\a")
+                sys.stdout.flush()
 
             # Modal prompt — paint immediately, bypassing the throttle/resize
             # guard. A throttled paint here can be silently dropped (250ms

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1692,6 +1692,10 @@ DEFAULT_CONFIG = {
         # dashboard. Set false to suppress the hint.
         "tui_agents_nudge": True,
         "bell_on_complete": False,
+        # Play terminal bell (\a) when a dangerous-command approval prompt
+        # appears mid-task. Without this, the agent blocks silently while the
+        # user is tabbed away — bell_on_complete only fires at turn end.
+        "bell_on_approval": True,
         "show_reasoning": False,
         # When reasoning display is on, the post-response "Reasoning" recap box
         # collapses long thinking to the first 10 lines. Set true to print the
@@ -7627,7 +7631,8 @@ def show_config():
     display = config.get('display', {})
     print(f"  Personality:  {display.get('personality') or 'none'}")
     print(f"  Reasoning:    {'on' if display.get('show_reasoning', False) else 'off'}")
-    print(f"  Bell:         {'on' if display.get('bell_on_complete', False) else 'off'}")
+    print(f"  Bell:         {'on' if display.get('bell_on_complete', False) else 'off'} (turn-end), "
+          f"{'on' if display.get('bell_on_approval', True) else 'off'} (approval)")
     ump = display.get('user_message_preview', {}) if isinstance(display.get('user_message_preview', {}), dict) else {}
     ump_first = ump.get('first_lines', 2)
     ump_last = ump.get('last_lines', 2)

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -27,6 +27,7 @@ def _make_cli_stub():
     cli._sudo_deadline = 0
     cli._modal_input_snapshot = None
     cli._invalidate = MagicMock()
+    cli.bell_on_approval = True
     cli._app = SimpleNamespace(invalidate=MagicMock(), current_buffer=_FakeBuffer())
     return cli
 
@@ -62,8 +63,94 @@ def _make_background_cli_stub():
     cli._agent_running = False
     cli._spinner_text = ""
     cli.bell_on_complete = False
+    cli.bell_on_approval = True
     cli.final_response_markdown = "strip"
     return cli
+
+
+class TestApprovalBell:
+    """Terminal bell (\a) fires on dangerous-command approval prompts.
+
+    bell_on_complete covers turn-end notification, but approval prompts
+    block mid-task — without a bell the agent stalls silently while the
+    user is tabbed away.
+    """
+
+    def test_bell_writes_bell_char_when_enabled(self):
+        """When bell_on_approval is True, \\a is written to stdout."""
+        import io
+        cli = _make_cli_stub()
+        cli.bell_on_approval = True
+        result = {}
+
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            def _run():
+                result["value"] = cli._approval_callback("rm -rf /tmp/x", "danger")
+
+            thread = threading.Thread(target=_run, daemon=True)
+            thread.start()
+
+            deadline = time.time() + 2
+            while cli._approval_state is None and time.time() < deadline:
+                time.sleep(0.01)
+
+            assert cli._approval_state is not None
+            assert "\a" in mock_stdout.getvalue()
+
+            cli._approval_state["response_queue"].put("deny")
+            thread.join(timeout=2)
+
+        assert result["value"] == "deny"
+
+    def test_bell_suppressed_when_disabled(self):
+        """When bell_on_approval is False, no \\a is written."""
+        import io
+        cli = _make_cli_stub()
+        cli.bell_on_approval = False
+        result = {}
+
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            def _run():
+                result["value"] = cli._approval_callback("rm -rf /tmp/x", "danger")
+
+            thread = threading.Thread(target=_run, daemon=True)
+            thread.start()
+
+            deadline = time.time() + 2
+            while cli._approval_state is None and time.time() < deadline:
+                time.sleep(0.01)
+
+            assert cli._approval_state is not None
+            assert "\a" not in mock_stdout.getvalue()
+
+            cli._approval_state["response_queue"].put("deny")
+            thread.join(timeout=2)
+
+        assert result["value"] == "deny"
+
+    def test_bell_defaults_to_true_when_attr_missing(self):
+        """If bell_on_approval is not set, bell fires (safe default)."""
+        import io
+        cli = _make_cli_stub()
+        delattr(cli, "bell_on_approval")  # simulate missing attr
+        result = {}
+
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            def _run():
+                result["value"] = cli._approval_callback("rm -rf /tmp/x", "danger")
+
+            thread = threading.Thread(target=_run, daemon=True)
+            thread.start()
+
+            deadline = time.time() + 2
+            while cli._approval_state is None and time.time() < deadline:
+                time.sleep(0.01)
+
+            assert cli._approval_state is not None
+            assert "\a" in mock_stdout.getvalue()
+
+            cli._approval_state["response_queue"].put("deny")
+            thread.join(timeout=2)
 
 
 class TestCliApprovalUi:
@@ -384,6 +471,7 @@ def _make_real_paint_cli_stub():
     cli._clarify_freetext = False
     cli._clarify_deadline = 0
     cli._modal_input_snapshot = None
+    cli.bell_on_approval = False  # suppress bell in paint tests
     # Real methods, not mocks.
     cli._paint_now = HermesCLI._paint_now.__get__(cli, HermesCLI)
     cli._invalidate = HermesCLI._invalidate.__get__(cli, HermesCLI)

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1676,6 +1676,18 @@ def prompt_dangerous_approval(command: str, description: str,
 
     os.environ["HERMES_SPINNER_PAUSE"] = "1"
     try:
+        # Play terminal bell if bell_on_approval is enabled (default true).
+        # This is the non-TUI fallback path (scripts, sshd, tests); the TUI
+        # path fires its own bell in approval_callback.
+        try:
+            from hermes_cli.config import load_config_readonly as _load_cfg
+            _bell_approval = (_load_cfg() or {}).get("display", {}).get("bell_on_approval", True)
+        except Exception:
+            _bell_approval = True
+        if _bell_approval:
+            sys.stdout.write("\a")
+            sys.stdout.flush()
+
         # Resolve the active UI language once per prompt so we don't re-read
         # config/YAML inside the retry loop below.
         from agent.i18n import t


### PR DESCRIPTION
## Problem

When the agent hits a dangerous-command or Tirith security approval prompt mid-task, it blocks silently. The user — often tabbed away during a long-running task — gets no signal that their input is needed. The existing `bell_on_complete` only fires at turn-end, so it never triggers for mid-task approval prompts. This leads to 60s timeout denials on commands the user would have approved.

## Solution

Add `display.bell_on_approval` config option (default: `true`) that plays a terminal bell (`\a`) when an approval prompt appears. This mirrors the existing `bell_on_complete` pattern — same mechanism (write `\a` to stdout), just a different trigger point.

The bell fires in both approval code paths:
- **TUI path**: `HermesCLI._approval_callback` (cli.py) — the prompt_toolkit modal
- **Non-TUI fallback**: `prompt_dangerous_approval` (tools/approval.py) — scripts, sshd, non-interactive contexts

## Changes

| File | Change |
|------|--------|
| `hermes_cli/config.py` | Add `bell_on_approval: True` to display config defaults |
| `cli.py` | Load `self.bell_on_approval` at init; fire bell in `_approval_callback` |
| `tools/approval.py` | Fire bell in non-callback `input()` fallback path |
| `tests/cli/test_cli_approval_ui.py` | 3 new tests: bell-on, bell-off, default-true-when-missing |

## Config

```yaml
display:
  bell_on_complete: false  # existing — fires at turn end
  bell_on_approval: true   # new — fires on approval prompts (default true)
```

Default `true` because the problem it solves (silent blocking) is worse than a harmless terminal bell. Users who don't want it can set `false`.

## Test plan

- [x] `test_bell_writes_bell_char_when_enabled` — `\a` appears in stdout when enabled
- [x] `test_bell_suppressed_when_disabled` — no `\a` when `bell_on_approval: false`
- [x] `test_bell_defaults_to_true_when_attr_missing` — fires even without explicit config
- [x] All 29 existing tests in `test_cli_approval_ui.py` still pass
- [x] `getattr(self, "bell_on_approval", True)` — safe default if attribute is missing