### PR TITLE
feat(api-server): support approval and stop on session chat stream

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1979,6 +1979,33 @@ class APIServerAdapter(BasePlatformAdapter):
                 event_name = event_type.replace("tool.", "tool.")
                 _enqueue(event_name, {"message_id": message_id, "tool_name": tool_name, "preview": preview, "args": args})
 
+        def _approval_notify(approval_data: Dict[str, Any]) -> None:
+            event = dict(approval_data or {})
+            # Redact credentials before the command reaches the SSE wire.
+            if "command" in event:
+                from gateway.run import _redact_approval_command
+                event["command"] = _redact_approval_command(event.get("command"))
+            event.update({
+                "message_id": message_id,
+                "choices": ["once", "session", "always", "deny"],
+            })
+            # Fires on the agent's executor thread; hop to the loop. Inline
+            # put_nowait (not _enqueue) keeps redaction and sink together.
+            payload = _event_payload("approval.request", event)
+            try:
+                loop.call_soon_threadsafe(queue.put_nowait, payload)
+            except Exception:
+                pass
+
+        # Register this streaming turn in the shared run maps so the runs-API
+        # control endpoints act on it — POST /v1/runs/{run_id}/approval and
+        # /stop (run_id is announced in run.started). See #58853.
+        approval_session_key = gateway_session_key or session_id or run_id
+        self._run_approval_sessions[run_id] = approval_session_key
+        self._set_run_status(
+            run_id, "running", session_id=session_id, model=self._model_name,
+        )
+
         async def _run_and_signal() -> None:
             try:
                 await queue.put(_event_payload("run.started", {"user_message": {"role": "user", "content": user_message}}))
@@ -1992,6 +2019,8 @@ class APIServerAdapter(BasePlatformAdapter):
                     stream_delta_callback=_delta,
                     tool_progress_callback=_tool_progress,
                     gateway_session_key=gateway_session_key,
+                    approval_notify_callback=_approval_notify,
+                    run_id=run_id,
                 )
                 final_response = _resolve_media_to_data_urls(result.get("final_response", "") if isinstance(result, dict) else "")
                 effective_session_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id
@@ -2019,12 +2048,22 @@ class APIServerAdapter(BasePlatformAdapter):
                 await queue.put(None)
 
         task = asyncio.create_task(_run_and_signal())
+        # Expose the run to the stop/approval endpoints; the done callback
+        # below undoes it (_active_run_agents is handled in _run_agent).
+        self._active_run_tasks[run_id] = task
+
+        def _cleanup_run(_fut: "asyncio.Future") -> None:
+            self._active_run_tasks.pop(run_id, None)
+            self._run_approval_sessions.pop(run_id, None)
+            self._run_statuses.pop(run_id, None)
+
         try:
             self._background_tasks.add(task)
         except TypeError:
             pass
         if hasattr(task, "add_done_callback"):
             task.add_done_callback(self._background_tasks.discard)
+            task.add_done_callback(_cleanup_run)
 
         headers = {
             "Content-Type": "text/event-stream",
@@ -4031,6 +4070,8 @@ class APIServerAdapter(BasePlatformAdapter):
         agent_ref: Optional[list] = None,
         gateway_session_key: Optional[str] = None,
         route: Optional[Dict[str, Any]] = None,
+        approval_notify_callback=None,
+        run_id: Optional[str] = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -4046,6 +4087,12 @@ class APIServerAdapter(BasePlatformAdapter):
         at ``agent_ref[0]`` before ``run_conversation`` begins.  This allows
         callers (e.g. the SSE writer) to call ``agent.interrupt()`` from
         another thread to stop in-progress LLM calls.
+
+        *approval_notify_callback* / *run_id* wire the turn like a ``/v1/runs``
+        run: the callback is registered as the gateway approval notifier (so
+        guarded tools surface ``approval.request`` instead of failing closed),
+        and the agent is published to ``_active_run_agents[run_id]`` so
+        ``POST /v1/runs/{run_id}/stop`` can interrupt it.
         """
         loop = asyncio.get_running_loop()
 
@@ -4070,12 +4117,41 @@ class APIServerAdapter(BasePlatformAdapter):
                 )
                 if agent_ref is not None:
                     agent_ref[0] = agent
+                if run_id is not None:
+                    self._active_run_agents[run_id] = agent
                 effective_task_id = session_id or str(uuid.uuid4())
-                result = agent.run_conversation(
-                    user_message=user_message,
-                    conversation_history=conversation_history,
-                    task_id=effective_task_id,
+                approval_token = None
+                approval_session_key = (
+                    gateway_session_key or session_id or effective_task_id
                 )
+                try:
+                    if approval_notify_callback is not None:
+                        from tools.approval import (
+                            register_gateway_notify,
+                            reset_current_session_key,
+                            set_current_session_key,
+                            unregister_gateway_notify,
+                        )
+                        approval_token = set_current_session_key(approval_session_key)
+                        register_gateway_notify(
+                            approval_session_key, approval_notify_callback
+                        )
+                    result = agent.run_conversation(
+                        user_message=user_message,
+                        conversation_history=conversation_history,
+                        task_id=effective_task_id,
+                    )
+                finally:
+                    if approval_notify_callback is not None:
+                        try:
+                            unregister_gateway_notify(approval_session_key)
+                        except Exception:
+                            pass
+                    if approval_token is not None:
+                        try:
+                            reset_current_session_key(approval_token)
+                        except Exception:
+                            pass
                 usage = {
                     "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
                     "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
@@ -4090,6 +4166,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 return result, usage
             finally:
                 clear_session_vars(tokens)
+                if run_id is not None:
+                    self._active_run_agents.pop(run_id, None)
 
         self._inflight_agent_runs += 1
         try:

--- a/tests/gateway/test_approval_prompt_redaction.py
+++ b/tests/gateway/test_approval_prompt_redaction.py
@@ -78,44 +78,48 @@ class TestApprovalCommandWiring:
     call (`_redact(cmd); send(cmd)`) does NOT pass."""
 
     def _assert_redacts_then_uses(self, module, func_name: str, sink_substr: str):
-        """Parse `module`'s full AST, locate the (possibly nested) function
-        `func_name`, and assert it contains an assignment
+        """Parse `module`'s full AST, locate EVERY (possibly nested) function
+        named `func_name`, and assert each one contains an assignment
         `<x> = _redact_approval_command(...)` whose result is then used by a
         statement matching `sink_substr` on a LATER line. Walking the real AST
         (not a source slice) is refactor-robust and rejects discarded-result
-        calls (the call must be an assignment, not a bare expression)."""
+        calls (the call must be an assignment, not a bare expression). All
+        instances are checked (not just the first) so additional approval-notify
+        transports on the same module can't silently skip redaction."""
         import ast
         import inspect
 
         source = inspect.getsource(module)
         tree = ast.parse(source)
-        target_fn = None
-        for node in ast.walk(tree):
-            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == func_name:
-                target_fn = node
-                break
-        assert target_fn is not None, f"function {func_name} not found in {module.__name__}"
+        target_fns = [
+            node for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == func_name
+        ]
+        assert target_fns, f"function {func_name} not found in {module.__name__}"
 
-        redact_line = None
-        for node in ast.walk(target_fn):
-            if isinstance(node, ast.Assign) and isinstance(node.value, ast.Call):
-                fn = node.value.func
-                if isinstance(fn, ast.Name) and fn.id == "_redact_approval_command":
-                    redact_line = node.lineno
-        assert redact_line is not None, (
-            f"{func_name} must assign the result of _redact_approval_command(...) "
-            "(a discarded-result call would still leak the raw command)"
-        )
+        for target_fn in target_fns:
+            where = f"{func_name} (line {target_fn.lineno})"
+            redact_line = None
+            for node in ast.walk(target_fn):
+                if isinstance(node, ast.Assign) and isinstance(node.value, ast.Call):
+                    fn = node.value.func
+                    if isinstance(fn, ast.Name) and fn.id == "_redact_approval_command":
+                        redact_line = node.lineno
+            assert redact_line is not None, (
+                f"{where} must assign the result of _redact_approval_command(...) "
+                "(a discarded-result call would still leak the raw command)"
+            )
 
-        sink_line = None
-        for node in ast.walk(target_fn):
-            seg = ast.get_source_segment(source, node)
-            if seg and sink_substr in seg and getattr(node, "lineno", 0) > redact_line:
-                sink_line = node.lineno
-                break
-        assert sink_line is not None, (
-            f"`{sink_substr}` sink not found after the redaction in {func_name}"
-        )
+            sink_line = None
+            for node in ast.walk(target_fn):
+                seg = ast.get_source_segment(source, node)
+                if seg and sink_substr in seg and getattr(node, "lineno", 0) > redact_line:
+                    sink_line = node.lineno
+                    break
+            assert sink_line is not None, (
+                f"`{sink_substr}` sink not found after the redaction in {where}"
+            )
 
     def test_chat_platform_path_redacts_before_send(self):
         import gateway.run as run

--- a/tests/gateway/test_session_chat_approval_stop.py
+++ b/tests/gateway/test_session_chat_approval_stop.py
@@ -1,0 +1,284 @@
+"""
+Tests for interactive approval + stop on the /api/sessions/{id}/chat/stream path.
+
+The session chat stream reaches the agent through ``_run_agent`` and, before
+this change, registered nothing in the shared run maps — so guarded tools
+failed closed with no ``approval.request`` event, and there was no way to stop
+a turn.  This wires the streaming session turn into the same run maps the
+``/v1/runs`` control endpoints already use, reusing them unchanged:
+
+- ``_run_agent`` gains ``approval_notify_callback`` (register/unregister the
+  gateway approval notifier for the turn) and ``run_id`` (publish the live
+  ``AIAgent`` in ``_active_run_agents[run_id]`` so ``/v1/runs/{id}/stop`` can
+  interrupt it).
+- ``_handle_session_chat_stream`` defines an ``_approval_notify`` closure that
+  emits ``approval.request`` on the SSE stream, registers the run in
+  ``_run_approval_sessions`` / ``_run_statuses`` / ``_active_run_tasks`` so
+  ``POST /v1/runs/{run_id}/approval`` and ``/stop`` resolve, and cleans the
+  registrations up when the turn ends.
+
+Covers:
+- _run_agent publishes / cleans up _active_run_agents[run_id]
+- _run_agent registers / unregisters the approval callback
+- the session _approval_notify closure redacts + shapes approval.request
+- streaming session turn emits approval.request and populates the shared maps
+"""
+
+import asyncio
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gateway.platforms.api_server import APIServerAdapter
+from gateway.config import PlatformConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_adapter(api_key: str = "") -> APIServerAdapter:
+    extra = {}
+    if api_key:
+        extra["key"] = api_key
+    config = PlatformConfig(enabled=True, extra=extra)
+    return APIServerAdapter(config)
+
+
+def _make_mock_agent() -> MagicMock:
+    agent = MagicMock()
+    agent.run_conversation.return_value = {
+        "final_response": "ok",
+        "messages": [],
+        "api_calls": 1,
+    }
+    agent.session_prompt_tokens = 0
+    agent.session_completion_tokens = 0
+    agent.session_total_tokens = 0
+    agent.session_id = "sess-1"
+    return agent
+
+
+# ---------------------------------------------------------------------------
+# _run_agent run_id registration (stop support)
+# ---------------------------------------------------------------------------
+
+class TestRunAgentRunIdRegistration:
+    """run_id makes the live agent reachable by POST /v1/runs/{id}/stop."""
+
+    @pytest.mark.asyncio
+    async def test_agent_registered_during_run_and_cleaned_up_after(self):
+        adapter = _make_adapter()
+        agent = _make_mock_agent()
+        seen_during_run = {}
+
+        def _during_run(*args, **kwargs):
+            # While run_conversation executes, the agent must be reachable by
+            # the stop handler via _active_run_agents[run_id].
+            seen_during_run["agent"] = adapter._active_run_agents.get("run-xyz")
+            return {"final_response": "ok", "messages": [], "api_calls": 1}
+
+        agent.run_conversation.side_effect = _during_run
+
+        with (
+            patch.object(adapter, "_create_agent", return_value=agent),
+            patch.object(adapter, "_bind_api_server_session", return_value=[]),
+            patch("gateway.session_context.clear_session_vars"),
+        ):
+            await adapter._run_agent(
+                user_message="hi",
+                conversation_history=[],
+                session_id="sess-1",
+                run_id="run-xyz",
+            )
+
+        assert seen_during_run["agent"] is agent
+        # Cleaned up once the turn ends so the map does not leak.
+        assert "run-xyz" not in adapter._active_run_agents
+
+    @pytest.mark.asyncio
+    async def test_no_registration_without_run_id(self):
+        adapter = _make_adapter()
+        agent = _make_mock_agent()
+        with (
+            patch.object(adapter, "_create_agent", return_value=agent),
+            patch.object(adapter, "_bind_api_server_session", return_value=[]),
+            patch("gateway.session_context.clear_session_vars"),
+        ):
+            await adapter._run_agent(
+                user_message="hi", conversation_history=[], session_id="sess-1",
+            )
+        assert adapter._active_run_agents == {}
+
+
+# ---------------------------------------------------------------------------
+# _run_agent approval callback registration
+# ---------------------------------------------------------------------------
+
+class TestRunAgentApprovalCallback:
+    """approval_notify_callback is registered for the turn and torn down."""
+
+    @pytest.mark.asyncio
+    async def test_registers_and_unregisters_with_session_key(self):
+        adapter = _make_adapter()
+        registered, unregistered = {}, {}
+        agent = _make_mock_agent()
+
+        with (
+            patch.object(adapter, "_create_agent", return_value=agent),
+            patch.object(adapter, "_bind_api_server_session", return_value=[]),
+            patch("gateway.session_context.clear_session_vars"),
+            patch("tools.approval.register_gateway_notify",
+                  side_effect=lambda k, cb: registered.update(key=k, cb=cb)),
+            patch("tools.approval.unregister_gateway_notify",
+                  side_effect=lambda k: unregistered.update(key=k)),
+            patch("tools.approval.set_current_session_key", return_value=MagicMock()),
+            patch("tools.approval.reset_current_session_key"),
+        ):
+            notify_cb = MagicMock()
+            await adapter._run_agent(
+                user_message="t",
+                conversation_history=[],
+                session_id="sess-1",
+                gateway_session_key="gkey-1",
+                approval_notify_callback=notify_cb,
+            )
+
+        # Prefers the gateway session key, then session_id, then task id.
+        assert registered["key"] == "gkey-1"
+        assert registered["cb"] is notify_cb
+        assert unregistered["key"] == "gkey-1"
+
+    @pytest.mark.asyncio
+    async def test_no_registration_when_callback_is_none(self):
+        adapter = _make_adapter()
+        registered = {}
+        agent = _make_mock_agent()
+        with (
+            patch.object(adapter, "_create_agent", return_value=agent),
+            patch.object(adapter, "_bind_api_server_session", return_value=[]),
+            patch("gateway.session_context.clear_session_vars"),
+            patch("tools.approval.register_gateway_notify",
+                  side_effect=lambda k, cb: registered.update(key=k)),
+        ):
+            await adapter._run_agent(
+                user_message="t", conversation_history=[], session_id="sess-1",
+            )
+        assert registered == {}
+
+
+# ---------------------------------------------------------------------------
+# The session _approval_notify closure shape
+# ---------------------------------------------------------------------------
+
+class TestSessionApprovalNotifyClosure:
+    """Reproduces the closure defined in _handle_session_chat_stream."""
+
+    def _make_closure(self, enqueue, message_id="msg-1"):
+        def _approval_notify(approval_data):
+            event = dict(approval_data or {})
+            if "command" in event:
+                from gateway.run import _redact_approval_command
+                event["command"] = _redact_approval_command(event.get("command"))
+            event.update({
+                "message_id": message_id,
+                "choices": ["once", "session", "always", "deny"],
+            })
+            enqueue("approval.request", event)
+        return _approval_notify
+
+    def test_emits_approval_request_with_choices(self):
+        captured = []
+        cb = self._make_closure(lambda name, ev: captured.append((name, ev)))
+        cb({"command": "rm -rf /tmp/x", "description": "delete dir"})
+        assert len(captured) == 1
+        name, event = captured[0]
+        assert name == "approval.request"
+        assert event["choices"] == ["once", "session", "always", "deny"]
+        assert event["description"] == "delete dir"
+        assert event["message_id"] == "msg-1"
+
+    def test_routes_command_through_redaction(self):
+        captured = []
+        cb = self._make_closure(lambda name, ev: captured.append((name, ev)))
+        with patch("gateway.run._redact_approval_command",
+                   return_value="<redacted>") as red:
+            cb({"command": "curl -H 'Authorization: Bearer sk-secret' x"})
+        red.assert_called_once()
+        assert captured[0][1]["command"] == "<redacted>"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end streaming session turn
+# ---------------------------------------------------------------------------
+
+class TestSessionChatStreamControl:
+    """A streaming session turn emits approval.request and registers the run
+    in the shared maps the runs-API control endpoints read."""
+
+    @pytest.mark.asyncio
+    async def test_stream_emits_approval_and_registers_run(self):
+        from aiohttp import web
+        from aiohttp.test_utils import TestClient, TestServer
+
+        adapter = _make_adapter()
+        app = web.Application()
+        app.router.add_post(
+            "/api/sessions/{session_id}/chat/stream",
+            adapter._handle_session_chat_stream,
+        )
+
+        captured = {}
+
+        async def _mock_run_agent(**kwargs):
+            # The handler must hand us the approval notifier and the run_id,
+            # and must have populated the shared maps the control endpoints
+            # read *before* the turn runs.
+            captured["has_notify"] = kwargs.get("approval_notify_callback") is not None
+            captured["run_id"] = kwargs.get("run_id")
+            captured["approval_sessions"] = dict(adapter._run_approval_sessions)
+            captured["statuses"] = dict(adapter._run_statuses)
+            captured["active_tasks"] = dict(adapter._active_run_tasks)
+            cb = kwargs.get("approval_notify_callback")
+            if cb:
+                cb({"command": "echo hi", "description": "run echo"})
+                await asyncio.sleep(0.05)
+            return (
+                {"final_response": "done", "messages": [], "api_calls": 1},
+                {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+            )
+
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_run_agent", side_effect=_mock_run_agent),
+                patch.object(adapter, "_get_existing_session_or_404",
+                             return_value=(object(), None)),
+                patch.object(adapter, "_conversation_history_for_session",
+                             return_value=[]),
+                patch.object(adapter, "_turn_transcript_messages", return_value=[]),
+            ):
+                resp = await cli.post(
+                    "/api/sessions/sess-1/chat/stream",
+                    json={"message": "please run echo"},
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+        run_id = captured["run_id"]
+        assert run_id and run_id.startswith("run_")
+        # Wired into _run_agent.
+        assert captured["has_notify"] is True
+        # Approval + stop endpoints have what they need *during* the turn.
+        assert captured["approval_sessions"].get(run_id) == "sess-1"
+        assert run_id in captured["statuses"]
+        assert run_id in captured["active_tasks"]
+        # The approval event reached the SSE wire with resolvable choices.
+        assert "event: approval.request" in body
+        assert "choices" in body
+        assert "run.started" in body and "run.completed" in body
+        # Registrations are cleaned up after the turn (no leaks).
+        await asyncio.sleep(0.05)
+        assert run_id not in adapter._run_approval_sessions
+        assert run_id not in adapter._active_run_tasks
+        assert run_id not in adapter._active_run_agents


### PR DESCRIPTION
## What does this PR do?

Wires interactive **approval** and **stop** into the streaming session
endpoint `POST /api/sessions/{id}/chat/stream`.

That endpoint reaches the agent through `_run_agent`, which — unlike the
`/v1/runs` path — registered nothing in the shared run maps. As a result:

- **Approval failed closed silently.** No gateway approval notifier was
  registered for the turn, so a guarded tool hit the "no callback" fallback in
  `tools/approval.py` and returned `approval_pending` to the *agent* while the
  SSE stream emitted **no** `approval.request` event and offered no way to
  resolve it. This is the session-endpoint sibling of #51871 (same root cause:
  the notifier is only wired on the runs path) and complements #51878, which
  fixes it for `/v1/chat/completions`.
- **Turns could not be stopped.** The internal `run_id` was never published in
  `_active_run_agents` / `_active_run_tasks`, so `POST /v1/runs/{run_id}/stop`
  could not find the agent to interrupt.

Rather than add new endpoints, this reuses the existing runs-API control
endpoints (`/v1/runs/{run_id}/approval`, `/v1/runs/{run_id}/stop`) unchanged —
they key purely off shared `run_id` maps and are agnostic to which handler
populated them. The streaming session turn now registers itself in those maps
and surfaces `approval.request` on its SSE stream. Full session-store history
fidelity (tool results, tool_calls, reasoning) comes for free because the
session path already replays the native conversation.

Only the streaming endpoint is wired; the synchronous `/api/sessions/{id}/chat`
cannot do interactive approval (single blocking response, no event channel) and
is left unchanged.

## Related Issue

Fixes #58853

Related: #51871 (chat-completions sibling), #51878.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix <!-- approval requests now surface + fail closed on the session stream -->

## Changes Made

- `gateway/platforms/api_server.py`:
  - `_run_agent`: add two optional, backward-compatible params —
    `approval_notify_callback` (register/unregister the gateway approval
    notifier around `run_conversation`, mirroring the `/v1/runs` inline
    wiring) and `run_id` (publish the live `AIAgent` in
    `_active_run_agents[run_id]` and clean it up in `finally` so
    `/v1/runs/{run_id}/stop` can interrupt it). Existing callers
    (`/v1/chat/completions`) pass neither and are unaffected.
  - `_handle_session_chat_stream`: define an `_approval_notify` closure that
    redacts credentials (`_redact_approval_command`) and emits
    `approval.request` on the SSE stream; register the run in
    `_run_approval_sessions` / `_run_statuses` / `_active_run_tasks` (and
    `_run_streams_created` for the orphan sweeper); set terminal run status;
    tear all registrations down on turn completion.
- `tests/gateway/test_session_chat_approval_stop.py`: new — 7 tests covering
  `_run_agent` run_id publish/cleanup, approval callback register/unregister,
  the `_approval_notify` closure (redaction + `approval.request` shape), and an
  end-to-end streaming turn that emits `approval.request` and populates the
  shared control maps, then cleans them up.
- `tests/gateway/test_approval_prompt_redaction.py`: harden the redact-before-
  sink guard to check **every** `_approval_notify` in the module (not just the
  first), so additional approval-notify transports can't skip redaction.

## How to Test

1. `pytest tests/gateway/test_session_chat_approval_stop.py tests/gateway/test_approval_prompt_redaction.py -q` — 15 pass.
2. Regression: `pytest tests/gateway/test_api_server_runs.py tests/gateway/test_api_server.py tests/run_agent/ -q` — all pass (2111 passed, 3 skipped locally).
3. Manual:
   - Start a gateway with `API_SERVER_ENABLED=1` and a tool that requires approval.
   - `POST /api/sessions/{id}/chat/stream` with a prompt that triggers the guarded tool → the SSE stream now emits `event: approval.request`.
   - `POST /v1/runs/{run_id}/approval {"choice":"once"}` (run_id from the `run.started` event) → the tool proceeds.
   - Mid-turn, `POST /v1/runs/{run_id}/stop` → the agent is interrupted.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(api-server): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (closest: #51878, different endpoint)
- [x] My PR contains only changes related to this feature
- [x] I've run the tests and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (WSL2), Python 3.11

### Documentation & Housekeeping

- [x] Docstrings updated (`_run_agent`) — no user-facing docs needed
- [x] N/A — no config keys changed
- [x] N/A — no architecture/workflow change
- [x] N/A — pure Python asyncio, no platform-specific I/O
- [x] N/A — no tool schema/behavior change
