### PR TITLE
fix(gateway): transcribe voice messages in clarify intercept

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8823,6 +8823,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _pending_clarify = None
         if _pending_clarify is not None and _clarify_mod is not None:
             _raw_clarify_reply = (event.text or "").strip()
+            # Voice/audio messages arrive with empty event.text — the
+            # cached media file is on event.media_urls but STT has not
+            # run yet (it happens later in _handle_message_with_agent).
+            # Transcribe inline so the clarify intercept can resolve.
+            if not _raw_clarify_reply and getattr(event, "media_urls", None):
+                _voice_paths = [
+                    p
+                    for i, p in enumerate(event.media_urls)
+                    if getattr(event, "message_type", None)
+                    in (MessageType.VOICE, MessageType.AUDIO)
+                    or (
+                        i < len(getattr(event, "media_types", []) or [])
+                        and (event.media_types[i] or "").startswith("audio/")
+                    )
+                ]
+                if _voice_paths:
+                    try:
+                        from tools.transcription_tools import transcribe_audio
+                        import asyncio as _aio
+                        _parts: list[str] = []
+                        for _vp in _voice_paths:
+                            _r = await _aio.to_thread(transcribe_audio, _vp)
+                            if _r.get("success") and _r.get("transcript"):
+                                _parts.append(_r["transcript"])
+                        if _parts:
+                            _raw_clarify_reply = " ".join(_parts)
+                    except Exception:
+                        logger.debug(
+                            "Clarify voice transcription failed",
+                            exc_info=True,
+                        )
             # Skip slash commands — the user clearly wanted to issue a
             # command, not answer the clarify.  Leave the clarify pending
             # so the user can retry; if it times out, the agent unblocks

--- a/tests/gateway/test_clarify_voice_response.py
+++ b/tests/gateway/test_clarify_voice_response.py
@@ -1,0 +1,185 @@
+"""Regression: voice messages must resolve pending clarify prompts.
+
+When the Telegram clarify tool is waiting for a text response and the user
+sends a voice message, the gateway's clarify intercept reads ``event.text``
+(which is empty for voice messages) and ignores the audio.  The STT
+transcription that would populate the text happens later in
+``_handle_message_with_agent``, after the intercept window has closed.
+
+Fix: transcribe voice/audio media inline inside the clarify intercept block
+before checking ``event.text``.
+"""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource, build_session_key
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _voice_event(media_path="/tmp/test_voice.ogg"):
+    """Create a voice message event with empty text and a cached audio URL."""
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="private",
+        user_id="user1",
+    )
+    return MessageEvent(
+        text="",
+        message_type=MessageType.VOICE,
+        source=source,
+        message_id="msg-voice-1",
+        media_urls=[media_path],
+        media_types=["audio/ogg"],
+    )
+
+
+def _text_event(text="custom answer"):
+    """Create a plain text message event."""
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="private",
+        user_id="user1",
+    )
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="msg-text-1",
+    )
+
+
+def _clear_clarify_state():
+    from tools import clarify_gateway as cm
+    with cm._lock:
+        cm._entries.clear()
+        cm._session_index.clear()
+        cm._notify_cbs.clear()
+
+
+@pytest.mark.asyncio
+async def test_voice_message_resolves_pending_clarify(tmp_path):
+    """A voice message must resolve a pending clarify via STT transcription."""
+    _clear_clarify_state()
+    from tools import clarify_gateway as cm
+
+    # Set up a minimal GatewayRunner
+    (tmp_path / "config.yaml").write_text("", encoding="utf-8")
+    import gateway.run as gateway_run
+    with patch.object(gateway_run, "_hermes_home", tmp_path):
+        runner = gateway_run.GatewayRunner(GatewayConfig())
+
+    # Register a mock adapter
+    adapter = MagicMock()
+    adapter.config = MagicMock()
+    adapter.config.extra = {}
+    adapter.send = AsyncMock()
+    runner.adapters[Platform.TELEGRAM] = adapter
+
+    event = _voice_event()
+    session_key = build_session_key(event.source)
+
+    # Register a pending clarify
+    cm.register("clarify-voice-1", session_key, "What is your name?", None)
+
+    # Mock STT transcription to return a transcript
+    mock_transcribe = MagicMock(return_value={
+        "success": True,
+        "transcript": "My name is Alice",
+    })
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        mock_transcribe,
+    ):
+        # _handle_message returns "" when clarify is resolved
+        result = await runner._handle_message(event)
+
+    assert result == "", "clarify intercept should return empty string"
+    mock_transcribe.assert_called_once()
+
+    # Verify the clarify entry was resolved (event set, response populated)
+    entry = cm._entries.get("clarify-voice-1")
+    assert entry is not None, "entry should still exist after resolution"
+    assert entry.event.is_set(), "clarify event should be set after resolution"
+    assert entry.response == "My name is Alice", (
+        f"expected transcript as response, got: {entry.response!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_voice_stt_failure_does_not_crash(tmp_path):
+    """STT failure during clarify intercept must not crash the gateway."""
+    _clear_clarify_state()
+    from tools import clarify_gateway as cm
+
+    (tmp_path / "config.yaml").write_text("", encoding="utf-8")
+    import gateway.run as gateway_run
+    with patch.object(gateway_run, "_hermes_home", tmp_path):
+        runner = gateway_run.GatewayRunner(GatewayConfig())
+
+    adapter = MagicMock()
+    adapter.config = MagicMock()
+    adapter.config.extra = {}
+    adapter.send = AsyncMock()
+    runner.adapters[Platform.TELEGRAM] = adapter
+
+    event = _voice_event()
+    session_key = build_session_key(event.source)
+    cm.register("clarify-voice-fail", session_key, "What?", None)
+
+    # Mock STT to raise an exception
+    def _failing_transcribe(path):
+        raise RuntimeError("STT provider unavailable")
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        side_effect=_failing_transcribe,
+    ):
+        # Should not crash; falls through to normal dispatch
+        result = await runner._handle_message(event)
+
+    # Clarify should still be pending (event NOT set)
+    entry = cm._entries.get("clarify-voice-fail")
+    assert entry is not None
+    assert not entry.event.is_set(), "clarify should remain unresolved on STT failure"
+
+
+@pytest.mark.asyncio
+async def test_text_message_still_resolves_clarify(tmp_path):
+    """Plain text messages must still resolve clarify (no regression)."""
+    _clear_clarify_state()
+    from tools import clarify_gateway as cm
+
+    (tmp_path / "config.yaml").write_text("", encoding="utf-8")
+    import gateway.run as gateway_run
+    with patch.object(gateway_run, "_hermes_home", tmp_path):
+        runner = gateway_run.GatewayRunner(GatewayConfig())
+
+    adapter = MagicMock()
+    adapter.config = MagicMock()
+    adapter.config.extra = {}
+    adapter.send = AsyncMock()
+    runner.adapters[Platform.TELEGRAM] = adapter
+
+    event = _text_event("Alice")
+    session_key = build_session_key(event.source)
+    cm.register("clarify-text-1", session_key, "What is your name?", None)
+
+    result = await runner._handle_message(event)
+    assert result == "", "text clarify should still work"
+
+    entry = cm._entries.get("clarify-text-1")
+    assert entry is not None
+    assert entry.event.is_set(), "clarify event should be set after text response"
+    assert entry.response == "Alice"


### PR DESCRIPTION
## What does this PR do?

When a voice message arrives while the clarify tool is waiting for a text response, the gateway's clarify intercept reads `event.text` (which is empty for voice messages) and ignores the audio. The STT transcription that would populate the text happens later in `_handle_message_with_agent`, after the intercept window has already closed.

This PR adds inline STT transcription inside the clarify intercept block so voice messages correctly resolve pending clarify prompts.

## Related Issue

Fixes #56739

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` (+31 lines): In the clarify intercept block, when `event.text` is empty and `event.media_urls` contains voice/audio media, transcribe the audio using `transcribe_audio` before checking the clarify response. STT failures are caught and logged so the gateway never crashes.
- `tests/gateway/test_clarify_voice_response.py` (new): 3 regression tests covering voice→clarify resolution, STT failure resilience, and text-message no-regression.

## How to Test

1. Connect Hermes to Telegram via the gateway with STT enabled.
2. Send a message that triggers the clarify tool (e.g., an ambiguous question).
3. When the clarify prompt appears, reply with a **voice message** instead of text.
4. The voice message should be transcribed and used as the clarify response. Previously it was silently ignored.
5. Run `pytest tests/gateway/test_clarify_voice_response.py tests/gateway/test_clarify_active_session_bypass.py tests/tools/test_clarify_gateway.py -q` — all tests should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
