### PR TITLE
fix(pairing): merge split legacy/new pairing store dirs at startup (salvage #31041)

### DIFF
--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -33,7 +33,7 @@ from gateway.whatsapp_identity import (
     expand_whatsapp_aliases,
     normalize_whatsapp_identifier,
 )
-from hermes_constants import get_hermes_dir
+from hermes_constants import get_hermes_dir, get_hermes_home
 from utils import atomic_replace
 
 logger = logging.getLogger(__name__)
@@ -161,6 +161,51 @@ def _sync_allowlist_remove(platform: str, user_id: str) -> None:
         pass
 
 
+def _load_json_file(path: Path) -> dict:
+    if path.exists():
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            return data if isinstance(data, dict) else {}
+        except (json.JSONDecodeError, OSError):
+            return {}
+    return {}
+
+
+def _merge_pairing_dir(active_dir: Path, alternate_dir: Path) -> None:
+    """Merge split legacy/new pairing data into the active PairingStore dir.
+
+    Older installs use ``{HERMES_HOME}/pairing`` while newer code/docs may
+    write ``{HERMES_HOME}/platforms/pairing``. If both directories exist, the
+    gateway must not silently ignore approved users sitting in the inactive
+    location; otherwise already-paired Feishu users get asked for a fresh code.
+    """
+    if not alternate_dir.exists() or active_dir.resolve() == alternate_dir.resolve():
+        return
+    active_dir.mkdir(parents=True, exist_ok=True)
+    for src in alternate_dir.glob("*.json"):
+        if not src.is_file():
+            continue
+        dest = active_dir / src.name
+        merged = _load_json_file(src)
+        if not merged:
+            continue
+        current = _load_json_file(dest)
+        before = dict(current)
+        # Active data wins on key conflict; otherwise union the inactive data.
+        merged.update(current)
+        if merged != before:
+            _secure_write(dest, json.dumps(merged, indent=2, ensure_ascii=False))
+
+
+def _migrate_split_pairing_dirs() -> None:
+    home = get_hermes_home()
+    old_dir = home / "pairing"
+    new_dir = home / "platforms" / "pairing"
+    active = PAIRING_DIR
+    alternate = new_dir if active.resolve() == old_dir.resolve() else old_dir
+    _merge_pairing_dir(active, alternate)
+
+
 def _secure_write(path: Path, data: str) -> None:
     """Write data to file with restrictive permissions (owner read/write only).
 
@@ -212,6 +257,11 @@ class PairingStore:
         else:
             self._dir = PAIRING_DIR
         self._dir.mkdir(parents=True, exist_ok=True)
+        if not profile:
+            # Heal installs whose global pairing data ended up split across
+            # the legacy and new directories (per-profile stores never had
+            # the legacy/new split).
+            _migrate_split_pairing_dirs()
         # Protects all read-modify-write cycles. The gateway runs multiple
         # platform adapters concurrently in threads sharing one PairingStore.
         self._lock = threading.RLock()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -61,6 +61,7 @@ AUTHOR_MAP = {
     "39274208+falkoro@users.noreply.github.com": "falkoro",  # PRs #58519/#58520 salvage (config: env-ref-aware load_config cache invalidation; auxiliary: honor auxiliary.<task>.base_url/api_key with explicit provider arg)
     "3723267+kevinrajaram@users.noreply.github.com": "kevinrajaram",  # PR #3850 salvage (gateway: add POSIX system dirs to PATH so launchctl/systemctl resolve under UV's minimal-PATH bundled Python; #3849)
     "lord-dubious@users.noreply.github.com": "lord-dubious",  # PR #58453 salvage (preserve static custom provider models declared as dict rows)
+    "williamumu@users.noreply.github.com": "williamumu",  # PR #31041 salvage (pairing: merge split legacy/new pairing store dirs at PairingStore init so approved users aren't re-prompted to pair)
     "jonathan@mintrx.com": "JAlmanzarMint",  # PR #52688 salvage (vision: rasterize SVG / re-encode unsupported raster formats to PNG before embedding), folded into #57890
     "al3060388206@gmail.com": "ooiuuii",  # PR #58466/#58377 salvage (redact: fireworks fw-/fpk_ prefixes; telegram: redact bot tokens out of transport error strings). Also PR #58433 salvage (codex: accept recorded final_text when app-server omits turn/completed) and PR #58472 salvage (gateway: cap proxy SSE line buffer at 16MiB).
     "Jigoooo@users.noreply.github.com": "Jigoooo",  # PR #58474 salvage (auxiliary: fall back to token resolver when anthropic pool has no usable entry)

--- a/tests/gateway/test_pairing.py
+++ b/tests/gateway/test_pairing.py
@@ -27,6 +27,48 @@ def _make_store(tmp_path):
         return PairingStore()
 
 
+class TestSplitPairingDirMigration:
+    def test_merges_new_approved_into_active_legacy_dir(self, tmp_path):
+        home = tmp_path / "home"
+        legacy = home / "pairing"
+        new = home / "platforms" / "pairing"
+        legacy.mkdir(parents=True)
+        new.mkdir(parents=True)
+        (new / "feishu-approved.json").write_text(json.dumps({
+            "ou_user": {"user_name": "Alice", "approved_at": 123.0}
+        }))
+
+        with patch("gateway.pairing.PAIRING_DIR", legacy), patch("gateway.pairing.get_hermes_home", return_value=home):
+            store = PairingStore()
+            assert store.is_approved("feishu", "ou_user") is True
+
+        migrated = json.loads((legacy / "feishu-approved.json").read_text())
+        assert "ou_user" in migrated
+
+    def test_active_entries_win_when_merging_split_dirs(self, tmp_path):
+        home = tmp_path / "home"
+        legacy = home / "pairing"
+        new = home / "platforms" / "pairing"
+        legacy.mkdir(parents=True)
+        new.mkdir(parents=True)
+        (legacy / "feishu-approved.json").write_text(json.dumps({
+            "ou_user": {"user_name": "Active", "approved_at": 2.0}
+        }))
+        (new / "feishu-approved.json").write_text(json.dumps({
+            "ou_user": {"user_name": "Inactive", "approved_at": 1.0},
+            "ou_other": {"user_name": "Other", "approved_at": 1.0},
+        }))
+
+        with patch("gateway.pairing.PAIRING_DIR", legacy), patch("gateway.pairing.get_hermes_home", return_value=home):
+            store = PairingStore()
+            assert store.is_approved("feishu", "ou_user") is True
+            assert store.is_approved("feishu", "ou_other") is True
+
+        migrated = json.loads((legacy / "feishu-approved.json").read_text())
+        assert migrated["ou_user"]["user_name"] == "Active"
+        assert migrated["ou_other"]["user_name"] == "Other"
+
+
 # ---------------------------------------------------------------------------
 # _secure_write
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Salvage of PR #31041 by @williamumu: already-paired gateway users are no longer re-prompted to pair when their approved-user data sits in the inactive pairing directory — `PairingStore.__init__` now merges the split legacy (`~/.hermes/pairing/`) and new (`~/.hermes/platforms/pairing/`) stores at startup.

Root cause: `PAIRING_DIR` resolves via `get_hermes_dir("platforms/pairing", "pairing")`; installs can end up with data split across both locations (#27602 pattern — e.g. a legacy dir holding only `_rate_limits.json` wins resolution and orphans the approved file in `platforms/pairing/`). The merged #27602 predicate fix (`_legacy_path_has_content`) stopped *empty* legacy dirs from shadowing, but does nothing for installs already split with content on both sides. This heals those installs.

## Changes
- `gateway/pairing.py`: `_migrate_split_pairing_dirs()` runs at `PairingStore.__init__` — unions JSON files from the inactive dir into the active one; active data wins key conflicts
- `tests/gateway/test_pairing.py`: 2 regression tests for the split-dir migration
- `scripts/release.py`: AUTHOR_MAP entry for williamumu

## Validation
| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/gateway/test_pairing.py` | 45 passed, 0 failed |
| E2E (real imports, temp HERMES_HOME): approved user in `platforms/pairing/`, legacy dir active w/ rate-limit junk | `is_approved` True after init merge |
| E2E: both dirs populated, conflicting entry | union honored, active entry wins |
| E2E: clean install (new dir only) | no merge, no spurious legacy dir |

Contributor commit cherry-picked with authorship preserved. Closes #31041's underlying report; related: #27602, #15733, community report from @LastAnswerX (Telegram re-pairing on WSL).

## Infographic

![split-pairing-stores-merged](https://v3b.fal.media/files/b/0aa10865/VhdhZJBAM-JK0U7FZEsv0_M58FSjA7.png)
