### PR TITLE
fix(api-server): preserve assistant text after inline images on history round-trip

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -474,6 +474,38 @@ def _auto_truncate_response_history(
     return [conversation_history[index] for index in sorted(kept_indices)]
 
 
+# Inline base64 image data URLs (emitted by _resolve_media_to_data_urls as
+# ``![image](data:image/...;base64,...)``) can reach ~7 MB, well past
+# MAX_NORMALIZED_TEXT_LENGTH. A blunt slice would cut one mid-base64 and drop
+# any text after it, silently losing assistant prose on the history round-trip.
+# Elide the payload before the length cap so the surrounding text survives.
+_INLINE_IMAGE_DATA_URL_RE = re.compile(r"data:image/[A-Za-z0-9.+-]+;base64,[A-Za-z0-9+/=]+")
+
+
+def _elide_inline_image_data_urls(text: str) -> str:
+    if "data:image/" not in text:
+        return text
+
+    def _repl(match: "re.Match[str]") -> str:
+        return f"data:image/...;base64,<{len(match.group(0))} chars elided>"
+
+    return _INLINE_IMAGE_DATA_URL_RE.sub(_repl, text)
+
+
+def _cap_normalized_text(text: str) -> str:
+    """Elide oversized inline image data URLs, then enforce the normalized-text cap.
+
+    A single inline base64 image can exceed MAX_NORMALIZED_TEXT_LENGTH on its own,
+    so a blunt slice would cut it mid-payload and drop any assistant text after it.
+    Text within the cap is returned unchanged; only when it is over the cap do we
+    elide the image payloads first, so the surrounding text survives.
+    """
+    if len(text) <= MAX_NORMALIZED_TEXT_LENGTH:
+        return text
+    text = _elide_inline_image_data_urls(text)
+    return text[:MAX_NORMALIZED_TEXT_LENGTH] if len(text) > MAX_NORMALIZED_TEXT_LENGTH else text
+
+
 def _normalize_chat_content(
     content: Any, *, _max_depth: int = 10, _depth: int = 0,
 ) -> str:
@@ -495,7 +527,7 @@ def _normalize_chat_content(
     if content is None:
         return ""
     if isinstance(content, str):
-        return content[:MAX_NORMALIZED_TEXT_LENGTH] if len(content) > MAX_NORMALIZED_TEXT_LENGTH else content
+        return _cap_normalized_text(content)
 
     if isinstance(content, list):
         parts: List[str] = []
@@ -504,7 +536,7 @@ def _normalize_chat_content(
         for item in items:
             if isinstance(item, str):
                 if item:
-                    part = item[:MAX_NORMALIZED_TEXT_LENGTH]
+                    part = _cap_normalized_text(item)
                     parts.append(part)
                     total_len += len(part)
             elif isinstance(item, dict):
@@ -513,7 +545,7 @@ def _normalize_chat_content(
                     text = item.get("text", "")
                     if text:
                         try:
-                            part = str(text)[:MAX_NORMALIZED_TEXT_LENGTH]
+                            part = _cap_normalized_text(str(text))
                             parts.append(part)
                             total_len += len(part)
                         except Exception:
@@ -528,12 +560,12 @@ def _normalize_chat_content(
             if total_len >= MAX_NORMALIZED_TEXT_LENGTH:
                 break
         result = "\n".join(parts)
-        return result[:MAX_NORMALIZED_TEXT_LENGTH] if len(result) > MAX_NORMALIZED_TEXT_LENGTH else result
+        return _cap_normalized_text(result)
 
     # Fallback for unexpected types (int, float, bool, etc.)
     try:
         result = str(content)
-        return result[:MAX_NORMALIZED_TEXT_LENGTH] if len(result) > MAX_NORMALIZED_TEXT_LENGTH else result
+        return _cap_normalized_text(result)
     except Exception:
         return ""
 
@@ -568,7 +600,7 @@ def _normalize_multimodal_content(content: Any) -> Any:
     if content is None:
         return ""
     if isinstance(content, str):
-        return content[:MAX_NORMALIZED_TEXT_LENGTH] if len(content) > MAX_NORMALIZED_TEXT_LENGTH else content
+        return _cap_normalized_text(content)
     if not isinstance(content, list):
         # Mirror the legacy text-normalizer's fallback so callers that
         # pre-existed image support still get a string back.
@@ -581,7 +613,7 @@ def _normalize_multimodal_content(content: Any) -> Any:
     for part in items:
         if isinstance(part, str):
             if part:
-                trimmed = part[:MAX_NORMALIZED_TEXT_LENGTH]
+                trimmed = _cap_normalized_text(part)
                 normalized_parts.append({"type": "text", "text": trimmed})
                 text_accum_len += len(trimmed)
             continue
@@ -602,7 +634,7 @@ def _normalize_multimodal_content(content: Any) -> Any:
             if not isinstance(text, str):
                 text = str(text)
             if text:
-                trimmed = text[:MAX_NORMALIZED_TEXT_LENGTH]
+                trimmed = _cap_normalized_text(text)
                 normalized_parts.append({"type": "text", "text": trimmed})
                 text_accum_len += len(trimmed)
             continue

--- a/tests/gateway/test_api_server_inline_image_roundtrip.py
+++ b/tests/gateway/test_api_server_inline_image_roundtrip.py
@@ -1,0 +1,101 @@
+"""Round-trip regression for inline MEDIA image data URLs (api_server).
+
+``_resolve_media_to_data_urls`` inlines ``MEDIA:`` tags as ``![image](data:...)``
+markdown in outbound assistant text (up to a ~7 MB base64 payload). When a
+stateless OpenAI-compatible client echoes that assistant turn back in
+``messages[]``, ``_normalize_multimodal_content`` used to slice the whole string
+at ``MAX_NORMALIZED_TEXT_LENGTH``, cutting the data URL mid-base64 and dropping
+any assistant text after the image. The legacy ``_normalize_chat_content`` had
+the same bare slices on its string and list paths. These tests pin that the
+surrounding text survives while the oversized payload is elided.
+"""
+
+from gateway.platforms.api_server import (
+    _normalize_chat_content,
+    _normalize_multimodal_content,
+    MAX_NORMALIZED_TEXT_LENGTH,
+)
+
+
+def _big_data_url(total_chars: int = MAX_NORMALIZED_TEXT_LENGTH * 2) -> str:
+    payload = "A" * total_chars
+    return f"data:image/png;base64,{payload}"
+
+
+def test_assistant_text_after_inline_image_survives_string_roundtrip():
+    prefix = "Here is the chart you asked for:\n\n"
+    tail = "\n\nThe chart shows a 20 percent increase in Q3. SUFFIX_MARKER_KEEP"
+    content = f"{prefix}![image]({_big_data_url()})" + tail
+    assert len(content) > MAX_NORMALIZED_TEXT_LENGTH
+
+    result = _normalize_multimodal_content(content)
+
+    assert isinstance(result, str)
+    assert "SUFFIX_MARKER_KEEP" in result
+    assert "AAAAAAAAAA" not in result
+    assert len(result) <= MAX_NORMALIZED_TEXT_LENGTH
+
+
+def test_assistant_text_after_inline_image_survives_list_text_part():
+    tail = " ... SUFFIX_MARKER_KEEP"
+    text = f"before ![image]({_big_data_url()}) after{tail}"
+    content = [{"type": "text", "text": text}]
+
+    result = _normalize_multimodal_content(content)
+
+    joined = result if isinstance(result, str) else "\n".join(
+        p.get("text", "") for p in result if isinstance(p, dict)
+    )
+    assert "SUFFIX_MARKER_KEEP" in joined
+    assert "AAAAAAAAAA" not in joined
+
+
+def test_structured_image_url_part_is_untouched():
+    tiny = "data:image/png;base64,iVBORw0KGgo="
+    content = [
+        {"type": "text", "text": "look at this"},
+        {"type": "image_url", "image_url": {"url": tiny}},
+    ]
+    result = _normalize_multimodal_content(content)
+    assert isinstance(result, list)
+    urls = [
+        p["image_url"]["url"]
+        for p in result
+        if isinstance(p, dict) and p.get("type") == "image_url"
+    ]
+    assert tiny in urls
+
+
+def test_plain_oversized_text_still_capped():
+    content = "B" * (MAX_NORMALIZED_TEXT_LENGTH * 2)
+    result = _normalize_multimodal_content(content)
+    assert isinstance(result, str)
+    assert len(result) == MAX_NORMALIZED_TEXT_LENGTH
+
+
+def test_short_text_passthrough():
+    content = "just a short normal message"
+    assert _normalize_multimodal_content(content) == content
+
+
+def test_assistant_text_after_inline_image_survives_chat_content_string():
+    tail = "\n\nThe chart shows a 20 percent increase in Q3. SUFFIX_MARKER_KEEP"
+    content = f"Here is the chart:\n\n![image]({_big_data_url()})" + tail
+    assert len(content) > MAX_NORMALIZED_TEXT_LENGTH
+
+    result = _normalize_chat_content(content)
+
+    assert "SUFFIX_MARKER_KEEP" in result
+    assert "AAAAAAAAAA" not in result
+    assert len(result) <= MAX_NORMALIZED_TEXT_LENGTH
+
+
+def test_assistant_text_after_inline_image_survives_chat_content_list_items():
+    str_item = f"str item ![image]({_big_data_url()}) STR_MARKER_KEEP"
+    dict_item = {"type": "text", "text": f"dict item ![image]({_big_data_url()}) DICT_MARKER_KEEP"}
+
+    result = _normalize_chat_content([str_item, dict_item])
+
+    assert "STR_MARKER_KEEP" in result
+    assert "DICT_MARKER_KEEP" in result
+    assert "AAAAAAAAAA" not in result


### PR DESCRIPTION
## What does this PR do?

Assistant messages that contain an inline image can silently lose the text after the image when the conversation is echoed back to the server.

`_resolve_media_to_data_urls` (`gateway/platforms/api_server.py`) inlines `MEDIA:` image tags into outbound assistant text as base64 `data:image/...;base64,...` URLs. A small 200 KB screenshot already becomes ~273 K characters; the code's own inlining ceiling is 5 MB (~7 M characters). When a stateless OpenAI-compatible client echoes that assistant turn back in `messages[]`, the inbound normalizers `_normalize_multimodal_content` / `_normalize_chat_content` cap the text with a plain `text[:MAX_NORMALIZED_TEXT_LENGTH]` (64 KB). A single inline image is larger than that cap on its own, so the slice lands inside the base64 and drops every character after it, including any assistant prose that followed the image. Nothing is raised or logged.

This PR elides inline image data URLs to a short placeholder before the length cap runs, so the surrounding text survives. Text within the cap is returned unchanged, so there is no behavior change for normal messages; only already-oversized text has its image payloads shortened.

## Related Issue

Fixes #58863

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py`
  - Add `_cap_normalized_text(text)`: returns `text` unchanged when `len(text) <= MAX_NORMALIZED_TEXT_LENGTH`; otherwise elides inline `data:image/...;base64,...` payloads to `data:image/...;base64,<N chars elided>` (helper `_elide_inline_image_data_urls`) and then enforces the cap.
  - Replace the 8 bare `text[:MAX_NORMALIZED_TEXT_LENGTH]` slices with `_cap_normalized_text(...)`: 5 in `_normalize_chat_content` (string branch, list str item, list text-part, final join, scalar fallback) and 3 in `_normalize_multimodal_content` (string branch, list str item, list text-part).
  - The structured `image_url` / `input_image` handling and the `MAX_CONTENT_LIST_SIZE` list caps are left untouched.
- `tests/gateway/test_api_server_inline_image_roundtrip.py` (new, 7 tests)
  - assistant text after an oversized inline image survives the string round-trip (fails on `main`)
  - same for a list text-part (fails on `main`)
  - same two shapes through the legacy `_normalize_chat_content` (string branch, and a list mixing a bare str item with a text-part; both fail on `main`)
  - structured `image_url` part is left untouched
  - plain oversized text is still capped to exactly `MAX_NORMALIZED_TEXT_LENGTH`
  - short text passes through unchanged

## How to Test

Standalone repro (no network, no model). It simulates the outbound inline, then the inbound normalize:

```
BEFORE (main):
  outbound (inlined) length       : 273,213 chars
  echoed after ingest normalize   : 65,536 chars
  assistant tail text survived?   : False
  last 60 chars fed to model      : ...'rq6urq6urq6u...'   (mid-base64)

AFTER (this PR):
  echoed after ingest normalize   : 154 chars
  assistant tail text survived?   : True
  last 60 chars fed to model      : ...'he root cause is the missing null check in parser.c line 42.'
```

Test suite:
1. `pytest tests/gateway/test_api_server_inline_image_roundtrip.py -q` -> 7 passed. On `main`, the four "survives" tests fail.
2. `pytest tests/gateway/test_api_server*.py -q` -> 178 passed (the full api_server suite, 11 files, including the new one).
3. `ruff check gateway/platforms/api_server.py` -> All checks passed!

The runs above are local (Windows 11, Python 3.13, cherry-picked onto current main).

Green ubuntu run for this head: https://github.com/cryptoyasenka/hermes-agent/actions/runs/31056707180

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(api-server): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate.

  Closest is #43623, which caps inline image data URLs in `tui_gateway/server.py` to stop a TUI renderer RangeError crash. That is a different file and a different symptom (renderer crash, not silent server-side truncation); the `api_server.py` normalize path this PR fixes is not covered there.
- [x] My PR contains only changes related to this fix
- [x] I've run the api_server suite locally: `pytest tests/gateway/test_api_server*.py -q` -> 178 passed. (Full `pytest tests/ -q` in my environment has pre-existing collection errors from optional deps not installed, e.g. `pyperclip` and the MCP extras; those modules aren't touched by this PR.)
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping
- [x] I've updated relevant documentation (N/A: internal helper, no doc surface)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys (N/A: no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` (N/A)
- [x] I've considered cross-platform impact (pure string logic, no OS-specific calls)
- [x] I've updated tool descriptions/schemas (N/A)


