### PR TITLE
fix(mcp): skip servers already in _server_connecting to prevent duplicate spawns

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -4055,6 +4055,42 @@ class TestRegisterMcpServers:
 
         _servers.pop("srv", None)
 
+    def test_skips_servers_already_connecting(self):
+        """Servers in _server_connecting must not be spawned again (#58862)."""
+        from tools.mcp_tool import (
+            register_mcp_servers, _servers, _server_connecting, _ensure_mcp_loop,
+        )
+
+        fake_config = {"my_srv": {"command": "npx", "args": ["test"]}}
+
+        # Simulate a prior call that started connecting but hasn't finished
+        _server_connecting.add("my_srv")
+        connect_calls = []
+
+        async def fake_register(name, cfg):
+            connect_calls.append(name)
+            server = _make_mock_server(name)
+            server._registered_tool_names = [f"mcp_{name}_tool"]
+            _servers[name] = server
+            return [f"mcp_{name}_tool"]
+
+        try:
+            with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+                 patch("tools.mcp_tool._discover_and_register_server", side_effect=fake_register), \
+                 patch("tools.mcp_tool._existing_tool_names", return_value=[]):
+                _ensure_mcp_loop()
+                result = register_mcp_servers(fake_config)
+
+            # Should NOT have attempted to connect my_srv again
+            assert connect_calls == [], (
+                f"Server already in _server_connecting should be skipped, "
+                f"but connect was called for: {connect_calls}"
+            )
+            assert result == []
+        finally:
+            _server_connecting.discard("my_srv")
+            _servers.pop("my_srv", None)
+
 
 # ---------------------------------------------------------------------------
 # Tests for parallel tool call support (port from openai/codex#17667)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4387,13 +4387,17 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         logger.debug("No explicit MCP servers provided")
         return []
 
-    # Only attempt servers that aren't already connected and are enabled
-    # (enabled: false skips the server entirely without removing its config)
+    # Only attempt servers that aren't already connected (or currently
+    # connecting) and are enabled.  Checking ``_server_connecting`` prevents
+    # duplicate subprocess spawns when ``discover_mcp_tools()`` is called
+    # from multiple entry-points before the first batch finishes (#58862).
     with _lock:
         new_servers = {
             k: v
             for k, v in servers.items()
-            if k not in _servers and _parse_boolish(v.get("enabled", True), default=True)
+            if k not in _servers
+            and k not in _server_connecting
+            and _parse_boolish(v.get("enabled", True), default=True)
         }
         _server_connecting.update(new_servers)
         for srv_name in new_servers:


### PR DESCRIPTION
## What does this PR do?

Fixes a race condition in `register_mcp_servers()` that could spawn duplicate MCP server subprocesses when `discover_mcp_tools()` is called from multiple entry-points (CLI, TUI, gateway) before the first connection batch completes.

The filter that determines which servers are "new" checked `_servers` (already connected) but not `_server_connecting` (currently connecting). A concurrent second call would see the same servers as "new" and start them again, causing duplicate stdio processes that accumulate without cleanup.

## Related Issue

Fixes #58862

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py`: Added `k not in _server_connecting` guard to the `new_servers` filter in `register_mcp_servers()`. Servers that are already being connected by a prior call are now skipped, preventing duplicate subprocess spawns.
- `tests/tools/test_mcp_tool.py`: Added `test_skips_servers_already_connecting` regression test that pre-populates `_server_connecting` and verifies `register_mcp_servers()` does not attempt to connect the server again.

## How to Test

1. Run `pytest tests/tools/test_mcp_tool.py::TestRegisterMcpServers -v` — all 7 tests should pass, including the new `test_skips_servers_already_connecting`.
2. With multiple MCP servers configured, start Hermes Agent and verify in `mcp-stderr.log` that each server shows exactly one "starting MCP server" entry per boot (not multiple rapid-fire starts).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
