### PR TITLE
fix: clamp chat completion output cap to context window

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -712,6 +712,8 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
 
     # ── chat_completions (default) ─────────────────────────────────────
     _ct = agent._get_transport()
+    _ctx_len = getattr(agent, "context_compressor", None)
+    _ctx_len = _ctx_len.context_length if _ctx_len else None
 
     # Provider detection flags
     _is_qwen = agent._is_qwen_portal()
@@ -814,6 +816,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             max_tokens=agent.max_tokens,
             ephemeral_max_output_tokens=_ephemeral_out,
             max_tokens_param_fn=agent._max_tokens_param,
+            context_length=_ctx_len,
             reasoning_config=agent.reasoning_config,
             request_overrides=agent.request_overrides,
             session_id=getattr(agent, "session_id", None),
@@ -846,6 +849,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         max_tokens=agent.max_tokens,
         ephemeral_max_output_tokens=_ephemeral_out,
         max_tokens_param_fn=agent._max_tokens_param,
+        context_length=_ctx_len,
         reasoning_config=agent.reasoning_config,
         request_overrides=agent.request_overrides,
         session_id=getattr(agent, "session_id", None),

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1228,10 +1228,18 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
     # the window this stays None, so the caller correctly falls through to
     # compression instead of futilely shrinking the output cap.
     _m_vllm_input = re.search(
-        r'prompt contains (?:at least )?(\d+)\s*input tokens', error_lower
+        r'prompt contains (?:(at least) )?(\d+)\s*input tokens', error_lower
     )
     if _m_ctx_tok and _m_vllm_input:
-        _available = int(_m_ctx_tok.group(1)) - int(_m_vllm_input.group(1))
+        # vLLM's "at least N input tokens" is a lower bound chosen from the
+        # requested output cap, not the real prompt token count.  Treating it
+        # as exact makes Hermes stair-step max_tokens down by tiny margins
+        # (65536 → 65471 → 65406 …) until recovery exhausts.  Only use exact
+        # forms; lower-bound forms should fall through to compression/preflight
+        # instead of pretending we know the available output budget.
+        if _m_vllm_input.group(1):
+            return None
+        _available = int(_m_ctx_tok.group(1)) - int(_m_vllm_input.group(2))
         if _available >= 1:
             return _available
 

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -10,6 +10,7 @@ reasoning configuration, temperature handling, and extra_body assembly.
 """
 
 import copy
+import logging
 from typing import Any, Dict
 
 from agent.lmstudio_reasoning import resolve_lmstudio_effort
@@ -17,6 +18,87 @@ from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
+
+
+logger = logging.getLogger(__name__)
+
+_OUTPUT_CAP_CONTEXT_MARGIN_TOKENS = 1024
+
+
+def _rough_chars(value: Any) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, str):
+        return len(value)
+    return len(str(value))
+
+
+def _estimate_input_tokens_for_output_cap(api_kwargs: dict[str, Any]) -> int:
+    """Cheap estimate of non-output request tokens for max_tokens clamping.
+
+    This deliberately mirrors Hermes' rough char/4 budgeting rather than
+    provider tokenization.  The clamp is a preflight guardrail: if it is still
+    too optimistic, provider error handling and compression remain as backup.
+    """
+    total_chars = 0
+    for key in ("messages", "tools", "extra_body", "response_format"):
+        total_chars += _rough_chars(api_kwargs.get(key))
+    return max(0, total_chars // 4)
+
+
+def _clamp_output_cap_to_context_window(
+    api_kwargs: dict[str, Any],
+    *,
+    context_length: Any,
+) -> None:
+    """Keep requested output budget inside the total context window.
+
+    Providers validate ``input_tokens + max_tokens <= context_length``.  Hermes
+    used to clamp max_tokens only against the model's standalone output limit,
+    so a half-full 131k local model plus a 65k default output cap failed before
+    compression had a chance to run.  Clamp the outgoing cap using the current
+    request estimate so long sessions survive model switches and large tools.
+    """
+    try:
+        ctx = int(context_length or 0)
+    except (TypeError, ValueError):
+        return
+    if ctx <= 0:
+        return
+
+    output_key = None
+    requested = None
+    for key in ("max_output_tokens", "max_completion_tokens", "max_tokens"):
+        raw = api_kwargs.get(key)
+        if raw is None:
+            continue
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            continue
+        if value > 0:
+            output_key = key
+            requested = value
+            break
+    if not output_key or requested is None:
+        return
+
+    estimated_input = _estimate_input_tokens_for_output_cap(api_kwargs)
+    available = ctx - estimated_input - _OUTPUT_CAP_CONTEXT_MARGIN_TOKENS
+    safe_cap = max(1, available)
+    if requested <= safe_cap:
+        return
+
+    api_kwargs[output_key] = safe_cap
+    logger.info(
+        "Clamped %s from %s to %s for context_length=%s estimated_input=%s margin=%s",
+        output_key,
+        requested,
+        safe_cap,
+        ctx,
+        estimated_input,
+        _OUTPUT_CAP_CONTEXT_MARGIN_TOKENS,
+    )
 
 
 def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> dict | None:
@@ -236,6 +318,7 @@ class ChatCompletionsTransport(ProviderTransport):
             max_tokens: int | None — user-configured max tokens
             ephemeral_max_output_tokens: int | None — one-shot override
             max_tokens_param_fn: callable — returns {max_tokens: N} or {max_completion_tokens: N}
+            context_length: int | None — total model context window for output-cap clamping
             reasoning_config: dict | None
             request_overrides: dict | None
             session_id: str | None
@@ -454,6 +537,11 @@ class ChatCompletionsTransport(ProviderTransport):
         if overrides:
             api_kwargs.update(overrides)
 
+        _clamp_output_cap_to_context_window(
+            api_kwargs,
+            context_length=params.get("context_length"),
+        )
+
         return api_kwargs
 
     def _build_kwargs_from_profile(self, profile, model, sanitized, tools, params):
@@ -595,6 +683,11 @@ class ChatCompletionsTransport(ProviderTransport):
                 }
             if extra_body:
                 api_kwargs["extra_body"] = extra_body
+
+        _clamp_output_cap_to_context_window(
+            api_kwargs,
+            context_length=params.get("context_length"),
+        )
 
         return api_kwargs
 

--- a/tests/test_ctx_halving_fix.py
+++ b/tests/test_ctx_halving_fix.py
@@ -74,6 +74,25 @@ class TestParseAvailableOutputTokens:
         msg = "max_tokens: 9999 > context_window: 10000 - input_tokens: 9999 = available_tokens: 1"
         assert self._parse(msg) == 1
 
+    def test_vllm_exact_input_tokens_format(self):
+        msg = (
+            "This model's maximum context length is 131072 tokens. However, "
+            "you requested 65536 output tokens and your prompt contains 70000 "
+            "input tokens, for a total of 135536 tokens."
+        )
+        assert self._parse(msg) == 61_072
+
+    def test_vllm_at_least_input_tokens_is_not_exact_available_budget(self):
+        """vLLM lower-bound wording is not the real prompt token count."""
+        msg = (
+            "This model's maximum context length is 131072 tokens. However, "
+            "you requested 65536 output tokens and your prompt contains at least "
+            "65537 input tokens, for a total of at least 131073 tokens. Please "
+            "reduce the length of the input prompt or the number of requested "
+            "output tokens."
+        )
+        assert self._parse(msg) is None
+
     # ── Should NOT detect (returns None) ─────────────────────────────────
 
     def test_prompt_too_long_is_not_output_cap_error(self):
@@ -261,6 +280,31 @@ class TestEphemeralMaxOutputTokens:
 
         kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
         assert kwargs["max_tokens"] == 8_192
+
+
+class TestChatCompletionsOutputCapClamp:
+    def _build(self, *, content_chars: int, context_length: int = 131_072, max_tokens: int = 65_536):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        transport = ChatCompletionsTransport()
+        return transport.build_kwargs(
+            model="/models/Qwen3.6-35B-A3B-NVFP4",
+            messages=[{"role": "user", "content": "x" * content_chars}],
+            tools=None,
+            max_tokens=max_tokens,
+            max_tokens_param_fn=lambda value: {"max_tokens": value},
+            context_length=context_length,
+        )
+
+    def test_clamps_output_cap_when_prompt_plus_output_would_exceed_context(self):
+        kwargs = self._build(content_chars=280_000)
+
+        assert 1 <= kwargs["max_tokens"] < 65_536
+
+    def test_leaves_output_cap_when_prompt_plus_output_fits_context(self):
+        kwargs = self._build(content_chars=4_000)
+
+        assert kwargs["max_tokens"] == 65_536
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- clamp chat-completions max_tokens/max_completion_tokens against estimated input + total context before sending
- stop treating vLLM's `prompt contains at least N input tokens` lower-bound wording as an exact available-output budget
- add regressions for the vLLM lower-bound failure and preflight output-cap clamp

## Root cause
Two real sessions (8e394ce78f32 and 1c340ab19f1f) failed on Spark/vLLM with a 131,072-token context window because Hermes requested 65,536 output tokens while the prompt was already around or above the remaining half-window. The recovery parser trusted vLLM's `at least N input tokens` wording as exact, so it stair-stepped max_tokens down by ~65 tokens per retry (65536 → 65471 → 65406 → 65341) and exhausted recovery instead of compressing or clamping safely.

## Validation
- `scripts/run_tests.sh tests/test_ctx_halving_fix.py -q` — 31 passed
- `scripts/run_tests.sh tests/agent/test_context_compressor.py -q` — 146 passed
- smoke: exact vLLM lower-bound wording parses as `None`, Spark/Qwen-shaped request clamps 65536 → 60040
- `git diff --check`