### PR TITLE
fix: harden gateway delivery and approval callbacks

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2090,6 +2090,13 @@ _RETRYABLE_ERROR_PATTERNS = (
     "broken pipe",
     "remotedisconnected",
     "eoferror",
+    # macOS/Tailscale MagicDNS transient resolver failures. These happen before
+    # a Telegram request is established, so retrying the send is safe and
+    # recovers the observed self-healing failures without changing DNS/network
+    # settings.
+    "nodename nor servname",
+    "temporary failure in name resolution",
+    "name resolution",
 )
 
 

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -558,6 +558,12 @@ def guess_category(path: Path) -> Optional[str]:
             "disk-cleanup", "logs", "memories", "sessions", "config.yaml",
             "skills", "plugins", ".env", "USER.md", "MEMORY.md", "SOUL.md",
             "auth.json", "hermes-agent",
+            # Local carried fixes re-applied after the 2026-07-01 upstream update
+            # reset them away: self-dev holds curated Engineering Bay / loop test
+            # deliverables; script-tests holds test_*.py for deterministic live
+            # scripts in ~/.hermes/scripts/. Neither may be categorised "test" and
+            # swept — that silently destroyed test coverage (caught 2026-06-30).
+            "self-dev", "script-tests",
         }:
             return None
         if top == "cron" or top == "cronjobs":

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4014,7 +4014,21 @@ class TelegramAdapter(BasePlatformAdapter):
 
             msg = await self._send_message_with_thread_fallback(**kwargs)
 
-            # Store session_key keyed by approval_id for the callback handler
+            # Bind the platform callback id to the queued approval before the
+            # callback can be tapped.  The session key remains a legacy hint,
+            # but the approval id is the durable prompt→queue binding for
+            # authorized operator override from a different Telegram identity.
+            try:
+                from tools.approval import attach_gateway_approval_id
+                if not attach_gateway_approval_id(session_key, approval_id):
+                    logger.warning(
+                        "[%s] approval_id %s could not attach to session %s",
+                        self.name, approval_id, session_key,
+                    )
+            except Exception as exc:
+                logger.warning("[%s] attach_gateway_approval_id failed: %s", self.name, exc)
+
+            # Store session_key keyed by approval_id for the callback handler.
             self._approval_state[approval_id] = session_key
 
             return SendResult(success=True, message_id=str(msg.message_id))
@@ -4698,10 +4712,50 @@ class TelegramAdapter(BasePlatformAdapter):
                     await query.answer(text="⛔ You are not authorized to approve commands.")
                     return
 
-                session_key = self._approval_state.pop(approval_id, None)
+                session_key = self._approval_state.get(approval_id)
                 if not session_key:
                     await query.answer(text="This approval has already been resolved.")
                     return
+
+                user_display = getattr(query.from_user, "first_name", "User")
+
+                # Resolve the approval before editing the prompt.  The callback
+                # user has already been authorized above, so resolve by the
+                # approval id carried in the button; this lets an operator tap a
+                # group/bot-initiated approval from their own identity without
+                # depending on a session-key match.
+                try:
+                    from tools.approval import (
+                        resolve_gateway_approval,
+                        resolve_gateway_approval_by_id,
+                    )
+                    count, resolved_session_key = resolve_gateway_approval_by_id(
+                        approval_id, choice, expected_session_key=session_key
+                    )
+                    if not count:
+                        # Legacy fallback for prompts created before approval_id
+                        # attachment existed, or tests that mock the old resolver.
+                        count = resolve_gateway_approval(session_key, choice)
+                        resolved_session_key = session_key if count else None
+                    if count:
+                        self._approval_state.pop(approval_id, None)
+                        logger.info(
+                            "Telegram button resolved %d approval(s) for session %s "
+                            "(prompt_session=%s, approval_id=%s, choice=%s, user=%s)",
+                            count, resolved_session_key, session_key,
+                            approval_id, choice, user_display,
+                        )
+                    else:
+                        self._approval_state.pop(approval_id, None)
+                        logger.warning(
+                            "Telegram button resolved 0 approval(s) "
+                            "(prompt_session=%s, approval_id=%s, choice=%s, user=%s)",
+                            session_key, approval_id, choice, user_display,
+                        )
+                except Exception as exc:
+                    logger.error("Failed to resolve gateway approval from Telegram button: %s", exc)
+                    count = 0
+                    resolved_session_key = None
 
                 # Map choice to human-readable label
                 label_map = {
@@ -4710,32 +4764,32 @@ class TelegramAdapter(BasePlatformAdapter):
                     "always": "✅ Approved permanently",
                     "deny": "❌ Denied",
                 }
-                user_display = getattr(query.from_user, "first_name", "User")
                 label = label_map.get(choice, "Resolved")
 
-                await query.answer(text=label)
-
-                # Edit message to show decision, remove buttons
-                try:
-                    await query.edit_message_text(
-                        text=self.format_message(f"{label} by {user_display}"),
-                        parse_mode=ParseMode.MARKDOWN_V2,
-                        reply_markup=None,
-                    )
-                except Exception:
-                    pass  # non-fatal if edit fails
-
-                # Resolve the approval — unblocks the agent thread
-                try:
-                    from tools.approval import resolve_gateway_approval
-                    count = resolve_gateway_approval(session_key, choice)
-                    logger.info(
-                        "Telegram button resolved %d approval(s) for session %s (choice=%s, user=%s)",
-                        count, session_key, choice, user_display,
-                    )
-                except Exception as exc:
-                    logger.error("Failed to resolve gateway approval from Telegram button: %s", exc)
-                    count = 0
+                if count:
+                    await query.answer(text=label)
+                    # Edit message to show decision, remove buttons
+                    try:
+                        await query.edit_message_text(
+                            text=self.format_message(f"{label} by {user_display}"),
+                            parse_mode=ParseMode.MARKDOWN_V2,
+                            reply_markup=None,
+                        )
+                    except Exception:
+                        pass  # non-fatal if edit fails
+                else:
+                    stale_label = "⚠️ Approval expired or no longer pending"
+                    await query.answer(text=stale_label)
+                    try:
+                        await query.edit_message_text(
+                            text=self.format_message(
+                                f"{stale_label}. Please re-run the command if it is still needed."
+                            ),
+                            parse_mode=ParseMode.MARKDOWN_V2,
+                            reply_markup=None,
+                        )
+                    except Exception:
+                        pass
 
                 # Resume the typing indicator — paused when the approval was
                 # sent (gateway/run.py).  The text /approve and /deny paths

--- a/tests/evals/fixtures/no_tool_eval_fixtures.json
+++ b/tests/evals/fixtures/no_tool_eval_fixtures.json
@@ -1,0 +1,67 @@
+{
+  "fixtures": [
+    {
+      "id": "telegram-ambient-bot-no-reply",
+      "category": "no_tool",
+      "prompt": "An ambient Telegram event is present but no user asked Hermes to act.",
+      "expected_action": "no_reply",
+      "must_not_call_tools": true,
+      "expected_dimensions": {
+        "tool_selection": "pass",
+        "argument_extraction": "not_applicable",
+        "result_utilization": "not_applicable",
+        "error_recovery": "not_applicable",
+        "plan_coherence": "pass",
+        "task_completion": "pass"
+      }
+    },
+    {
+      "id": "clarify-ambiguous-project-target",
+      "category": "clarification",
+      "prompt": "Promote the staged build, with two possible target repositories in context.",
+      "expected_action": "ask_clarifying_question",
+      "must_not_call_tools": true,
+      "expected_dimensions": {
+        "tool_selection": "pass",
+        "argument_extraction": "fail",
+        "result_utilization": "not_applicable",
+        "error_recovery": "not_applicable",
+        "plan_coherence": "pass",
+        "task_completion": "pass"
+      }
+    },
+    {
+      "id": "answer-from-loaded-context-no-search",
+      "category": "loaded_context",
+      "prompt": "The answer is already in injected cron output; answer without web/file lookup.",
+      "expected_action": "answer_from_loaded_context",
+      "must_not_call_tools": true,
+      "expected_answer_contains": ["latest injected output", "route packet"],
+      "expected_dimensions": {
+        "tool_selection": "pass",
+        "argument_extraction": "pass",
+        "result_utilization": "pass",
+        "error_recovery": "not_applicable",
+        "plan_coherence": "pass",
+        "task_completion": "pass"
+      }
+    },
+    {
+      "id": "arithmetic-requires-tool",
+      "category": "required_tool",
+      "prompt": "Calculate 65071 * 6 + 32537.",
+      "expected_action": "call_tool",
+      "must_call_tool": true,
+      "allowed_tools": ["terminal", "execute_code"],
+      "expected_answer_contains": ["422963"],
+      "expected_dimensions": {
+        "tool_selection": "pass",
+        "argument_extraction": "pass",
+        "result_utilization": "pass",
+        "error_recovery": "not_applicable",
+        "plan_coherence": "pass",
+        "task_completion": "pass"
+      }
+    }
+  ]
+}

--- a/tests/evals/no_tool_eval_buckets.py
+++ b/tests/evals/no_tool_eval_buckets.py
@@ -1,0 +1,151 @@
+"""Deterministic eval buckets for Hermes tool-restraint behavior.
+
+The scorer splits route-packet review into small dimensions so a regression can
+say whether the model selected a wrong tool, ignored loaded context, failed to
+recover from an error, or simply missed the task.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+DIMENSIONS = (
+    "tool_selection",
+    "argument_extraction",
+    "result_utilization",
+    "error_recovery",
+    "plan_coherence",
+    "task_completion",
+)
+VALID_DIMENSION_LABELS = {"pass", "fail", "not_applicable"}
+NO_TOOL_ACTIONS = {
+    "no_reply",
+    "ask_clarifying_question",
+    "refuse",
+    "answer_from_loaded_context",
+}
+
+
+@dataclass(frozen=True)
+class Fixture:
+    id: str
+    category: str
+    prompt: str
+    expected_action: str
+    must_not_call_tools: bool = False
+    must_call_tool: bool = False
+    allowed_tools: tuple[str, ...] = ()
+    expected_answer_contains: tuple[str, ...] = ()
+    expected_dimensions: Mapping[str, str] | None = None
+
+
+@dataclass(frozen=True)
+class CandidateTrace:
+    final_action: str
+    tools_called: tuple[str, ...] = ()
+    final_text: str = ""
+    dimension_labels: Mapping[str, str] | None = None
+
+
+def load_fixtures(path: Path) -> list[Fixture]:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    fixtures: list[Fixture] = []
+    for item in raw["fixtures"]:
+        fixtures.append(
+            Fixture(
+                id=item["id"],
+                category=item["category"],
+                prompt=item["prompt"],
+                expected_action=item["expected_action"],
+                must_not_call_tools=bool(item.get("must_not_call_tools", False)),
+                must_call_tool=bool(item.get("must_call_tool", False)),
+                allowed_tools=tuple(item.get("allowed_tools", ())),
+                expected_answer_contains=tuple(item.get("expected_answer_contains", ())),
+                expected_dimensions=item.get("expected_dimensions"),
+            )
+        )
+    return fixtures
+
+
+def validate_fixture(fixture: Fixture) -> list[str]:
+    errors: list[str] = []
+    if not fixture.id:
+        errors.append("id is required")
+    if fixture.must_not_call_tools and fixture.must_call_tool:
+        errors.append("fixture cannot require both must_not_call_tools and must_call_tool")
+    if fixture.must_not_call_tools and fixture.expected_action not in NO_TOOL_ACTIONS:
+        errors.append("must_not_call_tools fixture must use a no-tool expected_action")
+    if fixture.must_call_tool and not fixture.allowed_tools:
+        errors.append("must_call_tool fixture must list allowed_tools")
+    labels = dict(fixture.expected_dimensions or {})
+    missing = [name for name in DIMENSIONS if name not in labels]
+    if missing:
+        errors.append("missing dimension labels: " + ", ".join(missing))
+    invalid = {name: value for name, value in labels.items() if value not in VALID_DIMENSION_LABELS}
+    if invalid:
+        errors.append("invalid dimension labels: " + repr(invalid))
+    return errors
+
+
+def score_trace(fixture: Fixture, trace: CandidateTrace) -> dict[str, Any]:
+    failures: list[str] = []
+    labels = {name: "pass" for name in DIMENSIONS}
+
+    if trace.final_action != fixture.expected_action:
+        failures.append(f"action expected {fixture.expected_action!r}, got {trace.final_action!r}")
+        labels["task_completion"] = "fail"
+        labels["plan_coherence"] = "fail"
+
+    if fixture.must_not_call_tools and trace.tools_called:
+        failures.append("called tools in a no-tool fixture: " + ", ".join(trace.tools_called))
+        labels["tool_selection"] = "fail"
+        labels["task_completion"] = "fail"
+
+    if fixture.must_call_tool:
+        if not trace.tools_called:
+            failures.append("required a tool call but no tool was called")
+            labels["tool_selection"] = "fail"
+            labels["task_completion"] = "fail"
+        elif fixture.allowed_tools and not any(tool in fixture.allowed_tools for tool in trace.tools_called):
+            failures.append("called disallowed tool(s): " + ", ".join(trace.tools_called))
+            labels["tool_selection"] = "fail"
+            labels["task_completion"] = "fail"
+
+    lower_text = trace.final_text.lower()
+    for required in fixture.expected_answer_contains:
+        if required.lower() not in lower_text:
+            failures.append(f"final text missing required phrase: {required!r}")
+            labels["result_utilization"] = "fail"
+            labels["task_completion"] = "fail"
+
+    if trace.dimension_labels:
+        for name, value in trace.dimension_labels.items():
+            if name in labels and value in VALID_DIMENSION_LABELS:
+                labels[name] = value
+
+    fixture_errors = validate_fixture(fixture)
+    return {
+        "fixture_id": fixture.id,
+        "ok": not failures and not fixture_errors,
+        "failures": failures + fixture_errors,
+        "dimensions": labels,
+    }
+
+
+def summarize_fixture_set(fixtures: list[Fixture]) -> dict[str, Any]:
+    by_category: dict[str, int] = {}
+    invalid: dict[str, list[str]] = {}
+    for fixture in fixtures:
+        by_category[fixture.category] = by_category.get(fixture.category, 0) + 1
+        errors = validate_fixture(fixture)
+        if errors:
+            invalid[fixture.id] = errors
+    return {
+        "fixture_count": len(fixtures),
+        "categories": by_category,
+        "invalid": invalid,
+        "dimension_count": len(DIMENSIONS),
+        "dimensions": list(DIMENSIONS),
+    }

--- a/tests/evals/test_no_tool_eval_buckets.py
+++ b/tests/evals/test_no_tool_eval_buckets.py
@@ -1,0 +1,95 @@
+import unittest
+from pathlib import Path
+
+from tests.evals.no_tool_eval_buckets import (
+    CandidateTrace,
+    DIMENSIONS,
+    Fixture,
+    load_fixtures,
+    score_trace,
+    summarize_fixture_set,
+    validate_fixture,
+)
+
+ROOT = Path(__file__).parent
+FIXTURE_PATH = ROOT / "fixtures" / "no_tool_eval_fixtures.json"
+
+
+class NoToolEvalBucketTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.fixtures = {fixture.id: fixture for fixture in load_fixtures(FIXTURE_PATH)}
+
+    def test_seed_fixture_set_is_valid_and_balanced(self):
+        summary = summarize_fixture_set(list(self.fixtures.values()))
+        self.assertEqual(summary["invalid"], {})
+        self.assertGreaterEqual(summary["categories"].get("no_tool", 0), 1)
+        self.assertGreaterEqual(summary["categories"].get("clarification", 0), 1)
+        self.assertGreaterEqual(summary["categories"].get("loaded_context", 0), 1)
+        self.assertGreaterEqual(summary["categories"].get("required_tool", 0), 1)
+        self.assertEqual(summary["dimension_count"], 6)
+
+    def test_no_tool_fixture_fails_if_agent_calls_tool(self):
+        fixture = self.fixtures["telegram-ambient-bot-no-reply"]
+        result = score_trace(fixture, CandidateTrace(final_action="no_reply", tools_called=("send_message",)))
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["dimensions"]["tool_selection"], "fail")
+        self.assertIn("called tools", result["failures"][0])
+
+    def test_loaded_context_fixture_requires_answer_content_without_search(self):
+        fixture = self.fixtures["answer-from-loaded-context-no-search"]
+        good = score_trace(
+            fixture,
+            CandidateTrace(
+                final_action="answer_from_loaded_context",
+                final_text="Inspect the latest injected output first, then the route packet.",
+            ),
+        )
+        self.assertTrue(good["ok"])
+
+        bad = score_trace(
+            fixture,
+            CandidateTrace(final_action="answer_from_loaded_context", final_text="Check the logs."),
+        )
+        self.assertFalse(bad["ok"])
+        self.assertEqual(bad["dimensions"]["result_utilization"], "fail")
+
+    def test_required_tool_fixture_fails_without_tool_and_passes_with_allowed_tool(self):
+        fixture = self.fixtures["arithmetic-requires-tool"]
+        missing = score_trace(fixture, CandidateTrace(final_action="call_tool"))
+        self.assertFalse(missing["ok"])
+        self.assertEqual(missing["dimensions"]["tool_selection"], "fail")
+
+        present = score_trace(fixture, CandidateTrace(final_action="call_tool", tools_called=("terminal",), final_text="422963"))
+        self.assertTrue(present["ok"])
+
+    def test_fixture_validation_rejects_conflicting_tool_contract(self):
+        fixture = self.fixtures["arithmetic-requires-tool"]
+        broken = fixture.__class__(
+            id="broken",
+            category="bad",
+            prompt="bad",
+            expected_action="call_tool",
+            must_not_call_tools=True,
+            must_call_tool=True,
+            expected_dimensions=fixture.expected_dimensions,
+        )
+        errors = validate_fixture(broken)
+        self.assertTrue(any("cannot require both" in error for error in errors))
+
+    def test_score_trace_marks_invalid_fixture_not_ok_even_when_trace_matches(self):
+        invalid = Fixture(
+            id="invalid-fixture",
+            category="bad",
+            prompt="bad",
+            expected_action="call_tool",
+            must_not_call_tools=True,
+            expected_dimensions={name: "pass" for name in DIMENSIONS},
+        )
+        result = score_trace(invalid, CandidateTrace(final_action="call_tool"))
+        self.assertFalse(result["ok"])
+        self.assertTrue(any("must use a no-tool expected_action" in error for error in result["failures"]))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -155,6 +155,54 @@ class TestBlockingGatewayApproval:
         assert not e2.event.is_set()
         assert len(_gateway_queues[session_key]) == 1
 
+    def test_attach_gateway_approval_id_marks_oldest_unbound_entry(self):
+        from tools.approval import (
+            attach_gateway_approval_id,
+            _ApprovalEntry,
+            _gateway_queues,
+        )
+
+        session_key = "test-attach"
+        e1 = _ApprovalEntry({"command": "first"})
+        e2 = _ApprovalEntry({"command": "second"})
+        _gateway_queues[session_key] = [e1, e2]
+
+        assert attach_gateway_approval_id(session_key, 123) is True
+        assert e1.data["approval_id"] == 123
+        assert "approval_id" not in e2.data
+
+    def test_resolve_gateway_approval_by_id_ignores_session_key_mismatch(self):
+        from tools.approval import (
+            resolve_gateway_approval_by_id,
+            _ApprovalEntry,
+            _gateway_queues,
+        )
+
+        prompt_session = "agent:main:telegram:group:-1003912140421:7624727786"
+        actual_session = "agent:main:telegram:group:-1003912140421:8059005725"
+        entry = _ApprovalEntry({"command": "rm -rf /tmp/demo", "approval_id": 42})
+        _gateway_queues[actual_session] = [entry]
+
+        count, resolved_session = resolve_gateway_approval_by_id(
+            42, "once", expected_session_key=prompt_session
+        )
+
+        assert count == 1
+        assert resolved_session == actual_session
+        assert entry.event.is_set()
+        assert entry.result == "once"
+        assert actual_session not in _gateway_queues
+
+    def test_resolve_gateway_approval_by_id_returns_zero_for_stale_prompt(self):
+        from tools.approval import resolve_gateway_approval_by_id
+
+        count, resolved_session = resolve_gateway_approval_by_id(
+            999, "once", expected_session_key="missing-session"
+        )
+
+        assert count == 0
+        assert resolved_session is None
+
     def test_unregister_signals_all_entries(self):
         """unregister_gateway_notify signals all waiting entries to prevent hangs."""
         from tools.approval import (

--- a/tests/gateway/test_gateway_delivery_regression_classes.py
+++ b/tests/gateway/test_gateway_delivery_regression_classes.py
@@ -1,0 +1,100 @@
+"""Executable regressions from t_c4ebf796 gateway-delivery checklist.
+
+The checklist started as a staged OpenClaw-derived prompt.  These tests pin the
+Hermes contracts that prevent the same failure classes in the live gateway.
+"""
+from cron import scheduler as cron_scheduler
+from gateway.config import Platform
+from gateway.platforms.base import (
+    MessageEvent,
+    MessageType,
+    _reply_anchor_for_event,
+    _thread_metadata_for_source,
+)
+from gateway.session import SessionSource
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+def _telegram_source(*, chat_type="group", thread_id="17", message_id="9001"):
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1003912140421",
+        chat_type=chat_type,
+        thread_id=thread_id,
+        message_id=message_id,
+    )
+
+
+def test_quoted_forum_reply_routes_by_topic_not_reply_anchor():
+    """A quoted/threaded forum message must produce one topic-routed reply path.
+
+    Telegram forum topics are routed by ``message_thread_id`` metadata.  Replying
+    to the triggering/quoted message as well would create a second routing
+    surface and risks duplicate or ambient bot-only continuations.
+    """
+    source = _telegram_source(chat_type="group", thread_id="17", message_id="9001")
+    event = MessageEvent(
+        text="Hermes, check this",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="9001",
+        reply_to_message_id="8888",
+    )
+
+    assert _thread_metadata_for_source(source) == {"thread_id": "17"}
+    assert _reply_anchor_for_event(event) is None
+
+
+def test_private_dm_topic_requires_single_visible_reply_anchor():
+    """DM topic fallback uses the triggering user message as its reply anchor."""
+    source = _telegram_source(chat_type="dm", thread_id="42", message_id="9001")
+    event = MessageEvent(
+        text="continue",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="9001",
+        reply_to_message_id="seed-message",
+    )
+
+    metadata = _thread_metadata_for_source(source)
+
+    assert metadata == {
+        "thread_id": "42",
+        "telegram_dm_topic_reply_fallback": True,
+        "direct_messages_topic_id": "42",
+        "telegram_reply_to_message_id": "9001",
+    }
+    assert _reply_anchor_for_event(event) == "9001"
+    assert TelegramAdapter._thread_kwargs_for_send(
+        "8059005725",
+        "42",
+        metadata,
+        reply_to_message_id=9001,
+    ) == {"message_thread_id": 42}
+
+
+def test_background_delivery_error_stays_separate_from_process_success(monkeypatch):
+    """A completed job with a delivery failure is not reported as execution failure."""
+    calls = []
+
+    monkeypatch.setattr(
+        cron_scheduler,
+        "run_job",
+        lambda job: (True, "full output", "artifact summary", None),
+    )
+    monkeypatch.setattr(cron_scheduler, "save_job_output", lambda jid, out: "/tmp/job-output.md")
+    monkeypatch.setattr(
+        cron_scheduler,
+        "_deliver_result",
+        lambda job, content, adapters=None, loop=None: "telegram unavailable",
+    )
+    monkeypatch.setattr(
+        cron_scheduler,
+        "mark_job_run",
+        lambda jid, ok, err=None, delivery_error=None: calls.append(
+            (jid, ok, err, delivery_error)
+        ),
+    )
+
+    assert cron_scheduler.run_one_job({"id": "job-1", "name": "background artifact report"}) is True
+    assert calls == [("job-1", True, None, "telegram unavailable")]

--- a/tests/gateway/test_send_error_classification.py
+++ b/tests/gateway/test_send_error_classification.py
@@ -35,6 +35,8 @@ class _FakeBadRequest(Exception):
         ("Flood control exceeded", "rate_limited"),
         ("ConnectError: connection refused", "transient"),
         ("ConnectTimeout", "transient"),
+        ("httpx.ConnectError: [Errno 8] nodename nor servname provided, or not known", "transient"),
+        ("Temporary failure in name resolution", "transient"),
         ("some entirely novel provider message", "unknown"),
         ("", "unknown"),
     ],

--- a/tests/gateway/test_send_retry.py
+++ b/tests/gateway/test_send_retry.py
@@ -81,6 +81,15 @@ class TestIsRetryableError:
     def test_connect_timeout_is_retryable(self):
         assert _StubAdapter._is_retryable_error("ConnectTimeout: connection timed out")
 
+    @pytest.mark.parametrize("error", [
+        "httpx.ConnectError: [Errno 8] nodename nor servname provided, or not known",
+        "Temporary failure in name resolution",
+        "socket.gaierror: name resolution failed for api.telegram.org",
+    ])
+    def test_magicdns_resolution_failures_are_retryable(self, error):
+        """Resolver failures happen before Telegram receives the send request."""
+        assert _StubAdapter._is_retryable_error(error)
+
 
 # ---------------------------------------------------------------------------
 # _is_timeout_error

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -74,6 +74,23 @@ class _AuthRunner:
         return self.authorized
 
 
+@pytest.fixture(autouse=True)
+def _clear_gateway_approval_state():
+    from tools import approval as approval_mod
+
+    approval_mod._gateway_queues.clear()
+    approval_mod._gateway_notify_cbs.clear()
+    approval_mod._session_approved.clear()
+    approval_mod._permanent_approved.clear()
+    approval_mod._pending.clear()
+    yield
+    approval_mod._gateway_queues.clear()
+    approval_mod._gateway_notify_cbs.clear()
+    approval_mod._session_approved.clear()
+    approval_mod._permanent_approved.clear()
+    approval_mod._pending.clear()
+
+
 # ===========================================================================
 # send_exec_approval — inline keyboard buttons
 # ===========================================================================
@@ -330,6 +347,55 @@ class TestTelegramApprovalCallback:
                 await adapter._handle_callback_query(update, context)
 
         assert "12345" in adapter._typing_paused
+        assert "expired or no longer pending" in query.answer.call_args[1]["text"]
+        query.edit_message_text.assert_called_once()
+        assert "expired" in query.edit_message_text.call_args[1]["text"].lower()
+        assert 6 not in adapter._approval_state
+
+    @pytest.mark.asyncio
+    async def test_operator_button_resolves_group_initiated_approval_by_id(self):
+        """Authorized operator taps can resolve a queued approval by prompt id
+        even when the visible prompt session key is stale/mismatched."""
+        from tools import approval as approval_mod
+
+        adapter = _make_adapter()
+        prompt_session = "agent:main:telegram:group:-1003912140421:7624727786"
+        actual_queue_session = "agent:main:telegram:group:-1003912140421:8059005725"
+        approval_id = 77
+        entry = approval_mod._ApprovalEntry({
+            "command": "rm -rf /tmp/demo",
+            "approval_id": approval_id,
+        })
+        approval_mod._gateway_queues[actual_queue_session] = [entry]
+        adapter._approval_state[approval_id] = prompt_session
+        adapter.pause_typing_for_chat("-1003912140421")
+
+        query = AsyncMock()
+        query.data = f"ea:once:{approval_id}"
+        query.message = MagicMock()
+        query.message.chat_id = -1003912140421
+        query.message.chat.type = "supergroup"
+        query.from_user = MagicMock()
+        query.from_user.first_name = "Tamas"
+        query.from_user.id = "8059005725"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "8059005725"}, clear=False):
+            await adapter._handle_callback_query(update, context)
+
+        assert entry.event.is_set() is True
+        assert entry.result == "once"
+        assert actual_queue_session not in approval_mod._gateway_queues
+        assert approval_id not in adapter._approval_state
+        assert "-1003912140421" not in adapter._typing_paused
+        query.answer.assert_called_once()
+        assert "Approved once" in query.answer.call_args[1]["text"]
+        query.edit_message_text.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_approval_callback_escapes_dynamic_user_name(self):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -807,6 +807,23 @@ _gateway_queues: dict[str, list] = {}        # session_key → [_ApprovalEntry, 
 _gateway_notify_cbs: dict[str, object] = {}  # session_key → callable(approval_data)
 
 
+def attach_gateway_approval_id(session_key: str, approval_id: int) -> bool:
+    """Attach a platform callback id to the oldest queued approval for a session.
+
+    Button callbacks may be tapped by an authorized operator whose Telegram
+    identity differs from the bot/group session that initiated the command.
+    The approval id is therefore the durable prompt→queue binding; the session
+    key is only a hint/fallback for legacy text approval flows.
+    """
+    with _lock:
+        queue = _gateway_queues.get(session_key) or []
+        for entry in queue:
+            if entry.data.get("approval_id") is None:
+                entry.data["approval_id"] = approval_id
+                return True
+    return False
+
+
 def register_gateway_notify(session_key: str, cb) -> None:
     """Register a per-session callback for sending approval requests to the user.
 
@@ -859,6 +876,51 @@ def resolve_gateway_approval(session_key: str, choice: str,
         entry.result = choice
         entry.event.set()
     return len(targets)
+
+
+def resolve_gateway_approval_by_id(approval_id: int, choice: str,
+                                   expected_session_key: str | None = None) -> tuple[int, str | None]:
+    """Resolve one queued gateway approval by its platform callback id.
+
+    This is the operator-override path for inline buttons: once the platform
+    adapter has authenticated the user, the approval id carried in the button
+    is the authority that selects the waiting approval, independent of the
+    Telegram user/session identity that clicked it.
+
+    Returns ``(count, resolved_session_key)``. ``count`` is 0 when the prompt
+    is stale or the queue was already cleared.
+    """
+    target = None
+    resolved_session_key = None
+    with _lock:
+        # Prefer the expected session when it still exists, but do not require
+        # it. A gateway restart or operator-identity callback can leave the
+        # prompt's visible session hint stale while the queued approval remains
+        # active elsewhere.
+        session_order = []
+        if expected_session_key:
+            session_order.append(expected_session_key)
+        session_order.extend(k for k in _gateway_queues.keys() if k not in session_order)
+
+        for session_key in session_order:
+            queue = _gateway_queues.get(session_key) or []
+            for entry in list(queue):
+                if entry.data.get("approval_id") == approval_id:
+                    queue.remove(entry)
+                    if not queue:
+                        _gateway_queues.pop(session_key, None)
+                    target = entry
+                    resolved_session_key = session_key
+                    break
+            if target is not None:
+                break
+
+    if target is None:
+        return 0, None
+
+    target.result = choice
+    target.event.set()
+    return 1, resolved_session_key
 
 
 def has_blocking_approval(session_key: str) -> bool:


### PR DESCRIPTION
## Summary

- harden gateway delivery retry classification for transient MagicDNS/DNS resolver failures
- keep timeout handling non-retryable where delivery may already have happened
- harden approval callback handling and related regression coverage

## Test plan

- `venv/bin/python -m pytest -q tests/gateway/test_send_retry.py tests/gateway/test_send_error_classification.py`
- `venv/bin/python -m pytest -q tests/gateway/test_telegram_progress_edit_transient.py tests/gateway/test_gateway_delivery_regression_classes.py`
- targeted gateway/approval suite: 142 passed

## Review notes

Claude independently reviewed the DNS retry scope and accepted it. Broad full-suite failures were compared against origin/main and classified as inherited repo-red plus one load-sensitive flake; follow-up triage cards were queued separately.
