### PR TITLE
fix(gateway): drain in-flight cron delivery on restart instead of dropping it (#58818)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19663,6 +19663,37 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     InProcessCronScheduler().start(stop_event, adapters=adapters, loop=loop, interval=interval)
 
 
+# Upper bound for cooperatively draining the cron ticker on shutdown. The cron
+# thread delivers via ``safe_schedule_threadsafe`` and blocks on
+# ``future.result(timeout=60)`` (see cron/scheduler.py::_deliver_result), so a
+# single in-flight delivery unblocks within ~60s. The extra margin covers the
+# hop back through run_one_job's bookkeeping.
+_CRON_SHUTDOWN_DRAIN_TIMEOUT = 65.0
+
+
+async def _await_thread_exit(
+    thread: Optional[threading.Thread], timeout: float, poll: float = 0.1
+) -> bool:
+    """Wait for a daemon thread to exit WITHOUT blocking the event loop.
+
+    A synchronous ``thread.join()`` here would freeze the event loop — fatal
+    for the cron ticker, whose in-flight delivery is a coroutine scheduled onto
+    *this* loop via ``safe_schedule_threadsafe``. Blocking the loop deadlocks
+    that delivery (the loop can never run it), so ``join(timeout=5)`` always
+    times out and the message is silently dropped on restart (#58818).
+
+    Polling ``is_alive()`` with ``await asyncio.sleep`` keeps the loop running
+    so the pending delivery completes, then the ticker sees ``stop_event`` and
+    exits. Returns True if the thread exited within ``timeout``.
+    """
+    if thread is None:
+        return True
+    deadline = asyncio.get_running_loop().time() + max(0.0, timeout)
+    while thread.is_alive() and asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(poll)
+    return not thread.is_alive()
+
+
 async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = False, verbosity: Optional[int] = 0) -> bool:
     """
     Start the gateway and run until interrupted.
@@ -20157,14 +20188,26 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             logger.error("Gateway exiting with failure: %s", runner.exit_reason)
         return False
     
-    # Stop cron scheduler + housekeeping cleanly
+    # Stop cron scheduler + housekeeping cleanly.
+    #
+    # These MUST be awaited cooperatively, not join()ed. A cron delivery in
+    # flight when the gateway restarts is a coroutine scheduled onto THIS event
+    # loop (safe_schedule_threadsafe); the ticker thread is blocked on its
+    # future.result(). A synchronous cron_thread.join() would block the loop,
+    # so that delivery could never run — it timed out and the message was
+    # silently dropped (#58818). Awaiting keeps the loop alive so the in-flight
+    # delivery finishes before we tear down.
     cron_stop.set()
     try:
         cron_provider.stop()
     except Exception as e:
         logger.debug("Cron provider stop() error: %s", e)
-    cron_thread.join(timeout=5)
-    housekeeping_thread.join(timeout=5)
+    if not await _await_thread_exit(cron_thread, timeout=_CRON_SHUTDOWN_DRAIN_TIMEOUT):
+        logger.warning(
+            "Cron ticker did not exit within %.0fs of shutdown — an in-flight "
+            "delivery may have been dropped.", _CRON_SHUTDOWN_DRAIN_TIMEOUT,
+        )
+    await _await_thread_exit(housekeeping_thread, timeout=5)
 
     # Stop the planned-stop watcher (daemon=True so this is belt-and-suspenders).
     _planned_stop_watcher_stop.set()

--- a/tests/gateway/test_cron_shutdown_drain.py
+++ b/tests/gateway/test_cron_shutdown_drain.py
@@ -1,0 +1,73 @@
+"""Regression tests for #58818.
+
+On restart the gateway must drain an in-flight cron delivery instead of
+dropping it. A cron delivery is a coroutine scheduled onto the gateway event
+loop (``safe_schedule_threadsafe``) while the ticker thread blocks on its
+future. The shutdown wait therefore must NOT block the loop with a synchronous
+``thread.join()`` — doing so deadlocks the delivery (the loop can never run it)
+and the message is silently lost. ``_await_thread_exit`` waits cooperatively so
+the pending delivery completes first.
+"""
+import asyncio
+import threading
+
+import pytest
+
+import gateway.run as gateway_run
+
+
+@pytest.mark.asyncio
+async def test_await_thread_exit_lets_loop_scheduled_delivery_complete():
+    # Reproduces the drop: the worker schedules a coroutine onto THIS loop and
+    # blocks on its result, exactly like cron/_deliver_result. A blocking join
+    # would deadlock it; the cooperative wait lets it finish.
+    loop = asyncio.get_running_loop()
+    delivered = threading.Event()
+    worker_done = threading.Event()
+
+    async def _delivery():
+        await asyncio.sleep(0.05)
+        delivered.set()
+        return "ok"
+
+    def _cron_worker():
+        fut = asyncio.run_coroutine_threadsafe(_delivery(), loop)
+        fut.result(timeout=10)
+        worker_done.set()
+
+    thread = threading.Thread(target=_cron_worker, daemon=True)
+    thread.start()
+
+    exited = await gateway_run._await_thread_exit(thread, timeout=10)
+
+    assert exited is True
+    assert delivered.is_set(), "in-flight delivery coroutine never ran (loop was blocked)"
+    assert worker_done.is_set()
+
+
+@pytest.mark.asyncio
+async def test_await_thread_exit_returns_false_on_timeout():
+    keep_alive = threading.Event()
+
+    def _spin():
+        keep_alive.wait(5)
+
+    thread = threading.Thread(target=_spin, daemon=True)
+    thread.start()
+    try:
+        exited = await gateway_run._await_thread_exit(thread, timeout=0.2, poll=0.02)
+        assert exited is False
+        assert thread.is_alive()
+    finally:
+        keep_alive.set()
+        thread.join(timeout=2)
+
+
+@pytest.mark.asyncio
+async def test_await_thread_exit_handles_none_and_dead_thread():
+    assert await gateway_run._await_thread_exit(None, timeout=1) is True
+
+    thread = threading.Thread(target=lambda: None, daemon=True)
+    thread.start()
+    thread.join(timeout=2)
+    assert await gateway_run._await_thread_exit(thread, timeout=1) is True


### PR DESCRIPTION
Fixes #58818

## Summary

When the gateway restarts while a cron job's delivery is in flight, the message is silently dropped. Root cause is a loop-blocking join, not just a timing race.

A cron delivery via a live adapter runs as a coroutine scheduled onto the **gateway event loop** (`safe_schedule_threadsafe`), while the cron ticker thread blocks on `future.result(timeout=60)` (see `cron/scheduler.py::_deliver_result`). On shutdown, `start_gateway` cleaned up with:

```python
cron_thread.join(timeout=5)
```

A synchronous `join()` **blocks the event loop thread**. So the pending delivery coroutine queued on that loop can never run — the ticker stays blocked on its future, the 5s join always times out, the thread is abandoned, and the process exits with the message unsent. Because the default `agent.restart_drain_timeout` is `0`, this reproduces on essentially every restart that lands during a delivery (matching the reporter's two-morning digest loss).

## Fix

Replace the blocking joins with `_await_thread_exit()`, which polls `is_alive()` via `await asyncio.sleep` so the event loop keeps running and finishes the queued delivery before teardown. The cron wait is bounded by the delivery future's own 60s ceiling (plus margin, `_CRON_SHUTDOWN_DRAIN_TIMEOUT = 65s`); housekeeping keeps a short bound. When no delivery is in flight the ticker exits on `stop_event` immediately, so shutdown stays snappy.

## Changes

- `gateway/run.py` — add `_await_thread_exit()`; use it for the cron and housekeeping threads on shutdown instead of `thread.join()`.
- `tests/gateway/test_cron_shutdown_drain.py` — regression test reproducing the deadlock (a worker blocked on a loop-scheduled coroutine now completes), plus timeout and None/dead-thread coverage.

## Test plan

- [x] `scripts/run_tests.sh tests/gateway/test_cron_shutdown_drain.py -q` (3 passed)
- [x] `scripts/run_tests.sh tests/gateway/test_gateway_shutdown.py tests/gateway/test_gateway_process_exit.py -q` (27 passed)