### PR TITLE
fix(mcp): guard against duplicate spawns and stale connecting entries (#58862)

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -4055,6 +4055,78 @@ class TestRegisterMcpServers:
 
         _servers.pop("srv", None)
 
+    def test_discover_mcp_tools_skips_connecting_servers(self):
+        """discover_mcp_tools() also skips servers already in _server_connecting."""
+        from tools.mcp_tool import (
+            discover_mcp_tools, _servers, _server_connecting, _ensure_mcp_loop,
+        )
+
+        fake_config = {"my_srv": {"command": "npx", "args": ["test"]}}
+        connect_calls = []
+
+        async def fake_connect(name, cfg):
+            connect_calls.append(name)
+            server = _make_mock_server(name)
+            server._registered_tool_names = [f"mcp_{name}_tool"]
+            _servers[name] = server
+            return server
+
+        try:
+            with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+                 patch("tools.mcp_tool._load_mcp_config", return_value=fake_config), \
+                 patch("tools.mcp_tool._connect_server", side_effect=fake_connect), \
+                 patch("tools.mcp_tool._existing_tool_names", return_value=[]):
+                _ensure_mcp_loop()
+
+                # Pre-populate _server_connecting as if another call is in progress
+                _server_connecting.add("my_srv")
+
+                result = discover_mcp_tools()
+
+            # Should NOT have attempted to connect my_srv again
+            assert connect_calls == [], (
+                f"Server already in _server_connecting should be skipped by "
+                f"discover_mcp_tools, but connect was called for: {connect_calls}"
+            )
+            assert result == []
+        finally:
+            _server_connecting.discard("my_srv")
+            _servers.pop("my_srv", None)
+
+    def test_register_mcp_servers_clears_stale_connecting_on_timeout(self):
+        """Stale entries in _server_connecting are cleaned up after timeout (#58862)."""
+        from tools.mcp_tool import (
+            register_mcp_servers, _servers, _server_connecting, _server_connect_errors, _ensure_mcp_loop,
+        )
+
+        fake_config = {"srv_a": {"command": "npx", "args": ["a"]}, "srv_b": {"command": "npx", "args": ["b"]}}
+
+        # Simulate that srv_a is already connecting from another call
+        _server_connecting.add("srv_a")
+
+        # Make _run_on_mcp_loop raise TimeoutError — this happens after
+        # srv_b has been added to new_servers and _server_connecting,
+        # but before _discover_all finishes.
+        with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+             patch("tools.mcp_tool._load_mcp_config", return_value=fake_config), \
+             patch("tools.mcp_tool._run_on_mcp_loop", side_effect=TimeoutError("timed out")), \
+             patch("tools.mcp_tool._existing_tool_names", return_value=[]):
+            _ensure_mcp_loop()
+
+            with pytest.raises(TimeoutError):
+                register_mcp_servers(fake_config)
+
+        # After timeout, srv_b (which was in new_servers and added to _server_connecting)
+        # should have been cleaned up from _server_connecting.
+        # srv_a should remain since it was added externally and not part of new_servers.
+        assert "srv_b" not in _server_connecting, (
+            "Stale server added during this call should have been removed from _server_connecting after timeout"
+        )
+        # Cleanup
+        _server_connecting.discard("srv_a")
+        _servers.pop("srv_a", None)
+        _servers.pop("srv_b", None)
+
 
 # ---------------------------------------------------------------------------
 # Tests for parallel tool call support (port from openai/codex#17667)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4387,13 +4387,18 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         logger.debug("No explicit MCP servers provided")
         return []
 
-    # Only attempt servers that aren't already connected and are enabled
-    # (enabled: false skips the server entirely without removing its config)
+    # Only attempt servers that aren't already connected (or currently
+    # connecting) and are enabled.  Checking ``_server_connecting`` prevents
+    # duplicate subprocess spawns when ``discover_mcp_tools()`` is called
+    # from multiple entry-points before the first batch finishes (#58862).
     with _lock:
+        connecting = set(_server_connecting)
         new_servers = {
             k: v
             for k, v in servers.items()
-            if k not in _servers and _parse_boolish(v.get("enabled", True), default=True)
+            if k not in _servers
+            and k not in connecting
+            and _parse_boolish(v.get("enabled", True), default=True)
         }
         _server_connecting.update(new_servers)
         for srv_name in new_servers:
@@ -4452,6 +4457,28 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         _set_interrupt(False)
     try:
         _run_on_mcp_loop(_discover_all, timeout=120)
+    except (TimeoutError, InterruptedError) as _e:
+        # When the outer timeout fires or the user interrupts,
+        # _discover_all's gather may not have finished, leaving
+        # entries stranded in _server_connecting.  Those stale
+        # entries would block future reconnection attempts (#58862).
+        with _lock:
+            stale = [n for n in new_servers if n in _server_connecting]
+            if stale:
+                logger.warning(
+                    "MCP discovery %s while %d server(s) were still "
+                    "connecting; clearing stale connecting set: %s",
+                    "timed out" if isinstance(_e, TimeoutError) else "interrupted",
+                    len(stale),
+                    ", ".join(stale),
+                )
+                _server_connecting.difference_update(stale)
+                for _sn in stale:
+                    _server_connect_errors.setdefault(
+                        _sn,
+                        f"Connection attempt {'timed out' if isinstance(_e, TimeoutError) else 'interrupted'} during discovery",
+                    )
+        raise
     finally:
         if _was_interrupted:
             _set_interrupt(True)
@@ -4495,10 +4522,13 @@ def discover_mcp_tools() -> List[str]:
         return []
 
     with _lock:
+        connecting = set(_server_connecting)
         new_server_names = [
             name
             for name, cfg in servers.items()
-            if name not in _servers and _parse_boolish(cfg.get("enabled", True), default=True)
+            if name not in _servers
+            and name not in connecting
+            and _parse_boolish(cfg.get("enabled", True), default=True)
         ]
 
     tool_names = register_mcp_servers(servers)


### PR DESCRIPTION
This PR improves upon PR #58867 by addressing two additional issues: (1) discover_mcp_tools() also needs _server_connecting check, (2) stale _server_connecting entries after timeout/interrupt need cleanup. See commit message for details. Fixes #58862.