### PR TITLE
fix(agent): re-sync model identity when LM Studio swaps model mid-session

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1140,6 +1140,44 @@ def rewrite_prompt_model_identity(agent, model: str, provider: str) -> None:
     agent._cached_system_prompt = sp
 
 
+def sync_lmstudio_active_model(agent, response) -> None:
+    """Re-point the cached identity when LM Studio serves a different model.
+
+    LM Studio (and other local OpenAI-compatible servers) let the user swap the
+    loaded model from the app while a Hermes session stays open.  ``agent.model``
+    and the ``Model:`` line in the cached system prompt are resolved once at
+    session start, so after a swap the agent keeps reporting the original model
+    when asked about its inference engine — only a brand-new session picks up the
+    change (#54454).
+
+    Every chat-completion response echoes the model that actually served it, so
+    when that live name diverges from ``agent.model`` we adopt it and rewrite the
+    cached identity via :func:`rewrite_prompt_model_identity` (the same in-place,
+    non-persisted rewrite already used for provider failover).  Scoped to the
+    ``lmstudio`` provider — the only path where the server-side model changes
+    underneath a live session — so no other provider's identity is touched.
+    """
+    if (getattr(agent, "provider", "") or "").strip().lower() != "lmstudio":
+        return
+    live_model = getattr(response, "model", None)
+    if not isinstance(live_model, str) or not live_model.strip():
+        return
+    live_model = live_model.strip()
+    current = (getattr(agent, "model", "") or "").strip()
+    if not current:
+        return
+    try:
+        from agent.model_metadata import _model_id_matches
+
+        if _model_id_matches(live_model, current) or _model_id_matches(current, live_model):
+            return
+    except Exception:
+        if live_model == current:
+            return
+    agent.model = live_model
+    rewrite_prompt_model_identity(agent, live_model, agent.provider)
+
+
 def _fallback_entry_key(fb: dict) -> tuple[str, str, str]:
     return (
         str(fb.get("provider") or "").strip().lower(),

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2263,6 +2263,15 @@ def run_conversation(
                     except Exception:
                         pass
                 agent._touch_activity(f"API call #{api_call_count} completed")
+                # LM Studio users can swap the loaded model from the app while a
+                # session is open; the response echoes the live model, so re-sync
+                # the cached identity when it drifts (#54454).
+                if agent.provider == "lmstudio":
+                    try:
+                        from agent.chat_completion_helpers import sync_lmstudio_active_model
+                        sync_lmstudio_active_model(agent, response)
+                    except Exception:
+                        pass
                 break  # Success, exit retry loop
 
             except InterruptedError:

--- a/tests/agent/test_failover_identity.py
+++ b/tests/agent/test_failover_identity.py
@@ -10,7 +10,10 @@ gpt-5.4-mini after a Codex usage-limit 429.
 
 from types import SimpleNamespace
 
-from agent.chat_completion_helpers import rewrite_prompt_model_identity
+from agent.chat_completion_helpers import (
+    rewrite_prompt_model_identity,
+    sync_lmstudio_active_model,
+)
 from agent.conversation_loop import _sync_failover_system_message
 
 
@@ -68,6 +71,62 @@ class TestRewritePromptModelIdentity:
         agent = _agent()
         rewrite_prompt_model_identity(agent, "", "")
         assert agent._cached_system_prompt == _PROMPT
+
+
+_LMSTUDIO_PROMPT = (
+    "You are a helpful assistant.\n"
+    "\n"
+    "Conversation started: Wednesday, June 10, 2026\n"
+    "Model: gemma-3-4b\n"
+    "Provider: lmstudio"
+)
+
+
+def _lmstudio_agent(model="gemma-3-4b", prompt=_LMSTUDIO_PROMPT):
+    return SimpleNamespace(
+        provider="lmstudio",
+        model=model,
+        _cached_system_prompt=prompt,
+        ephemeral_system_prompt=None,
+    )
+
+
+class TestSyncLmstudioActiveModel:
+    def test_adopts_swapped_model_and_rewrites_identity(self):
+        # User swapped Gemma -> Qwen in the LM Studio app mid-session (#54454).
+        agent = _lmstudio_agent()
+        sync_lmstudio_active_model(agent, SimpleNamespace(model="qwen3-6b"))
+        assert agent.model == "qwen3-6b"
+        assert "Model: qwen3-6b" in agent._cached_system_prompt
+        assert "Model: gemma-3-4b" not in agent._cached_system_prompt
+
+    def test_noop_when_model_unchanged(self):
+        agent = _lmstudio_agent()
+        sync_lmstudio_active_model(agent, SimpleNamespace(model="gemma-3-4b"))
+        assert agent.model == "gemma-3-4b"
+        assert agent._cached_system_prompt == _LMSTUDIO_PROMPT
+
+    def test_noop_on_slug_vs_basename_match(self):
+        # LM Studio native API returns "publisher/slug"; the configured value is
+        # the bare slug — these are the same model, not a drift.
+        agent = _lmstudio_agent(model="gemma-3-4b")
+        sync_lmstudio_active_model(agent, SimpleNamespace(model="google/gemma-3-4b"))
+        assert agent.model == "gemma-3-4b"
+        assert agent._cached_system_prompt == _LMSTUDIO_PROMPT
+
+    def test_noop_for_non_lmstudio_provider(self):
+        agent = _lmstudio_agent()
+        agent.provider = "openai"
+        sync_lmstudio_active_model(agent, SimpleNamespace(model="qwen3-6b"))
+        assert agent.model == "gemma-3-4b"
+        assert agent._cached_system_prompt == _LMSTUDIO_PROMPT
+
+    def test_noop_when_response_has_no_model(self):
+        agent = _lmstudio_agent()
+        sync_lmstudio_active_model(agent, SimpleNamespace(model=None))
+        assert agent.model == "gemma-3-4b"
+        sync_lmstudio_active_model(agent, SimpleNamespace(model="   "))
+        assert agent.model == "gemma-3-4b"
 
 
 class TestSyncFailoverSystemMessage:


### PR DESCRIPTION
## What does this PR do?

With LM Studio (a local OpenAI-compatible provider), the loaded model can be swapped from the LM Studio app while a Hermes session stays open. When that happens, asking the agent which inference engine it is running keeps returning the model that was loaded at session start. Only a brand-new session picks up the change.

**Root cause.** The system prompt's `Model:`/`Provider:` identity lines are built once at session start from `agent.model` and cached for the life of the session (for prefix-cache stability). When the user answers "what model are you", the model reads those cached lines. `agent.model` is resolved from LM Studio's loaded model at startup, which is why a new session reports correctly, but nothing re-syncs the cached identity when LM Studio swaps the model underneath a live session.

**Fix.** Every chat-completion response echoes the model that actually served it (`response.model`). After a successful LM Studio response, compare that live name against `agent.model`; when it genuinely diverges, adopt the live name and rewrite the cached identity via the existing `rewrite_prompt_model_identity` helper — the same in-place, non-persisted rewrite already used for provider failover, so the stored prompt is untouched and the prefix cache stays coherent when the primary is restored. Scoped to the `lmstudio` provider so no other provider's identity is touched. LM Studio's native API returns models as `publisher/slug`; the comparison uses the existing `_model_id_matches` so a slug-vs-basename form of the *same* model is not treated as a drift.

## Related Issue

Fixes #54454

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py`: add `sync_lmstudio_active_model(agent, response)` — LM Studio-scoped, reuses `rewrite_prompt_model_identity` + `_model_id_matches`.
- `agent/conversation_loop.py`: call it once per successful API response on the LM Studio path (guarded, best-effort).
- `tests/agent/test_failover_identity.py`: 5 new cases (adopt-on-swap, no-op unchanged, no-op on slug-vs-basename, no-op for non-lmstudio provider, no-op when response has no model).

## How to Test

1. Start LM Studio serving a model (e.g. `gemma-3-4b`); start a Hermes session and ask which model it is → reports gemma.
2. Without restarting Hermes, swap the loaded model in LM Studio to e.g. `qwen3-6b`.
3. Ask again which model it is → now reports qwen (previously still reported gemma until a new session).

Automated:

```
pytest tests/agent/test_failover_identity.py -q          # 14 passed (5 new)
pytest tests/hermes_cli/test_model_switch_context_display.py tests/agent/test_model_metadata.py -q   # 125 passed
ruff check agent/chat_completion_helpers.py agent/conversation_loop.py tests/agent/test_failover_identity.py   # clean
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs (the open LM Studio PRs — #46106, #50493, #41367, #29988 — cover model *loading/switching* and probe caching, not identity *reporting*; none touch this path)
- [x] My PR contains only changes related to this fix
- [x] Tests pass for the touched modules (`pytest tests/agent/test_failover_identity.py -q`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (unit tests + logic)

### Documentation & Housekeeping

- [x] N/A — no docs/config/schema/tool changes
- [x] Cross-platform: pure Python string/attribute logic, no platform-specific code

## Notes

The change is scoped to the `lmstudio` provider and reuses the existing `rewrite_prompt_model_identity` helper (the same in-place, non-persisted rewrite already used for provider failover), so the stored prompt and prefix cache stay coherent.

One honest caveat: I verified this with unit tests and by tracing the code path, not with a live LM Studio model swap on my machine, so the interactive step under "How to Test" is written from the code rather than a captured session. The 5 new cases in `test_failover_identity.py` cover the divergence + adopt + `publisher/slug` matching, and the related `test_model_switch_context_display.py` / `test_model_metadata.py` suites still pass (125 total), so the behaviour is exercised end-to-end at the unit level.

Happy to adjust the hook point (currently once per successful response on the lmstudio path) or the comparison per your preferences.

