### PR TITLE
fix(feishu): send WebSocket CLOSE frame on disconnect

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1756,10 +1756,49 @@ class FeishuAdapter(BasePlatformAdapter):
         await self._cancel_pending_tasks(self._pending_text_batch_tasks)
         await self._cancel_pending_tasks(self._pending_media_batch_tasks)
         self._reset_batch_buffers()
+
+        # Send a WebSocket CLOSE frame to Feishu BEFORE tearing down the
+        # thread loop. Without this, Feishu's server never learns the
+        # connection is dead and continues routing messages to the stale
+        # endpoint — the channel goes silent until the server-side
+        # CLOSE-WAIT expires (minutes to hours). See issue #10202.
+        #
+        # ``_disable_websocket_auto_reconnect()`` nils ``self._ws_client``,
+        # so capture the client reference first.
+        ws_client = self._ws_client
+        ws_thread_loop = self._ws_thread_loop
         self._disable_websocket_auto_reconnect()
         await self._stop_webhook_server()
 
-        ws_thread_loop = self._ws_thread_loop
+        if (
+            ws_client is not None
+            and ws_thread_loop is not None
+            and not ws_thread_loop.is_closed()
+            and hasattr(ws_client, "_disconnect")
+        ):
+            try:
+                future = asyncio.run_coroutine_threadsafe(
+                    ws_client._disconnect(), ws_thread_loop
+                )
+                # 5s is generous — the CLOSE frame is a single WebSocket
+                # control frame. If it takes longer than that the
+                # connection is already wedged and we gain nothing by
+                # waiting further.
+                await asyncio.wait_for(asyncio.wrap_future(future), timeout=5.0)
+                logger.debug("[Feishu] Sent WebSocket CLOSE frame to Feishu")
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "[Feishu] CLOSE frame not acknowledged within 5s — "
+                    "Feishu may briefly route messages to the stale "
+                    "connection until server-side timeout"
+                )
+            except Exception as exc:
+                logger.debug(
+                    "[Feishu] Could not send WebSocket CLOSE frame: %s",
+                    exc,
+                    exc_info=True,
+                )
+
         if ws_thread_loop is not None and not ws_thread_loop.is_closed():
             logger.debug("[Feishu] Cancelling websocket thread tasks and stopping loop")
 

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -252,6 +252,77 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         )
         release_lock.assert_called_once_with("feishu-app-id", "cli_app")
 
+    def test_disconnect_sends_websocket_close_frame(self):
+        """Regression test for #10202: disconnect() must call the WSS
+        client's ``_disconnect()`` coroutine so a WebSocket CLOSE frame
+        is sent to Feishu. Without this, Feishu's server continues
+        routing to the stale connection, silencing the channel.
+        """
+        import threading
+        from types import SimpleNamespace
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        # Real thread loop to schedule the close coroutine on.
+        ws_thread_loop = asyncio.new_event_loop()
+        ready = threading.Event()
+
+        def _run_loop() -> None:
+            asyncio.set_event_loop(ws_thread_loop)
+            ready.set()
+            ws_thread_loop.run_forever()
+
+        thread = threading.Thread(target=_run_loop, daemon=True)
+        thread.start()
+        ready.wait()
+
+        close_called = threading.Event()
+
+        async def _fake_disconnect() -> None:
+            close_called.set()
+
+        ws_client = SimpleNamespace(_disconnect=_fake_disconnect, _auto_reconnect=True)
+        adapter._ws_client = ws_client
+        adapter._ws_thread_loop = ws_thread_loop
+        adapter._ws_future = None
+
+        try:
+            asyncio.run(adapter.disconnect())
+        finally:
+            if not ws_thread_loop.is_closed():
+                ws_thread_loop.call_soon_threadsafe(ws_thread_loop.stop)
+            thread.join(timeout=2.0)
+            if not ws_thread_loop.is_closed():
+                ws_thread_loop.close()
+
+        self.assertTrue(
+            close_called.is_set(),
+            "disconnect() must schedule ws_client._disconnect() on the ws thread loop",
+        )
+        # _disable_websocket_auto_reconnect() must still run.
+        self.assertIsNone(adapter._ws_client)
+
+    def test_disconnect_tolerates_missing_internal_disconnect(self):
+        """If the lark_oapi client layout changes and ``_disconnect``
+        disappears, disconnect() must not raise — fall through to the
+        existing task-cancel path.
+        """
+        from types import SimpleNamespace
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        # No ``_disconnect`` attribute — ``hasattr`` guard should skip.
+        adapter._ws_client = SimpleNamespace(_auto_reconnect=True)
+        adapter._ws_thread_loop = None
+        adapter._ws_future = None
+
+        # Must not raise.
+        asyncio.run(adapter.disconnect())
+        self.assertIsNone(adapter._ws_client)
+
     @patch.dict(os.environ, {
         "FEISHU_APP_ID": "cli_app",
         "FEISHU_APP_SECRET": "secret_app",

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -261,7 +261,7 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         import threading
         from types import SimpleNamespace
         from gateway.config import PlatformConfig
-        from gateway.platforms.feishu import FeishuAdapter
+        from plugins.platforms.feishu.adapter import FeishuAdapter
 
         adapter = FeishuAdapter(PlatformConfig())
 
@@ -311,7 +311,7 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         """
         from types import SimpleNamespace
         from gateway.config import PlatformConfig
-        from gateway.platforms.feishu import FeishuAdapter
+        from plugins.platforms.feishu.adapter import FeishuAdapter
 
         adapter = FeishuAdapter(PlatformConfig())
         # No ``_disconnect`` attribute — ``hasattr`` guard should skip.


### PR DESCRIPTION
## Summary
Feishu channel no longer goes silent after gateway restart / `--replace` / `hermes update` / `hermes dashboard`. Closes #10202, closes #16354.

Salvage of #16354 (original branch predates the platform-plugin relocation; the fix now lands in `plugins/platforms/feishu/adapter.py`).

## Root cause
`disconnect()` cancelled the WSS-thread's pending tasks and stopped the loop, but never called the lark SDK client's `_disconnect()` coroutine — so no WebSocket CLOSE frame was ever sent to Feishu. Feishu's server kept routing messages to the stale endpoint until server-side CLOSE-WAIT timeout (minutes to hours). Every shutdown path was affected: systemd restart, `hermes update`, `hermes gateway restart`, and `--replace` takeovers.

## Changes
- `plugins/platforms/feishu/adapter.py`: before tearing down the WSS thread loop, schedule `ws_client._disconnect()` on that loop via `run_coroutine_threadsafe` with a 5s timeout. `hasattr` guard + broad `except` keeps disconnect resilient if the SDK's internals shift in a future release.
- `tests/gateway/test_feishu.py`: +2 tests — one asserts `_disconnect()` is invoked on the thread loop, one asserts we tolerate a future SDK that drops `_disconnect`. Follow-up commit updates the salvaged tests' imports to the relocated adapter path.

## Validation
| | Before | After |
|---|---|---|
| CLOSE frame sent on shutdown | no | yes |
| `tests/gateway/test_feishu.py` | 205 pass | 207 pass |
| SDK `_disconnect` verified as coroutine on installed lark_oapi | — | yes |

Scope: Feishu only. DingTalk and WeCom already close their sockets correctly; WeiXin uses long-polling and has no WSS state.

## Infographic
![Feishu WebSocket CLOSE frame fix](https://v3b.fal.media/files/b/0aa109a1/pYzJ27xBWlXJKKUkMEoNh_5TAeJp8Z.png)
