### PR TITLE
feat(providers): GLM-5.2 native reasoning_effort controls (salvage #51108)

### DIFF
--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -31,6 +31,12 @@ def _is_deepseek_thinking_model(model: str | None) -> bool:
     return m == "deepseek-reasoner"
 
 
+def _is_glm_5_2_model(model: str | None) -> bool:
+    """Detect GLM-5.2 across alias spellings (glm-5.2 / glm-5-2 / glm-5p2)."""
+    m = _flat_model_name(model)
+    return any(token in m for token in ("glm-5.2", "glm-5-2", "glm-5p2"))
+
+
 class OpenCodeGoProfile(ProviderProfile):
     """OpenCode Go - model-specific reasoning controls."""
 
@@ -54,6 +60,21 @@ class OpenCodeGoProfile(ProviderProfile):
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         extra_body: dict[str, Any] = {}
         top_level: dict[str, Any] = {}
+
+        if _is_glm_5_2_model(model):
+            # GLM-5.2 on OpenCode Go uses its native OpenAI-compatible
+            # reasoning_effort knob, which has exactly two enabled levels:
+            # high and max. Map Hermes' richer scale onto those; leave the
+            # server default alone when reasoning is disabled or unset.
+            if not isinstance(reasoning_config, dict):
+                return extra_body, top_level
+            if reasoning_config.get("enabled") is False:
+                return extra_body, top_level
+            effort = (reasoning_config.get("effort") or "").strip().lower()
+            if not effort or effort == "none":
+                return extra_body, top_level
+            top_level["reasoning_effort"] = "max" if effort in {"xhigh", "max"} else "high"
+            return extra_body, top_level
 
         if _is_kimi_k2_model(model):
             # Kimi K2 on OpenCode Go uses Moonshot's native wire shape:

--- a/plugins/model-providers/zai/__init__.py
+++ b/plugins/model-providers/zai/__init__.py
@@ -16,6 +16,12 @@ When no reasoning preference is set (``reasoning_config is None``) the field
 is omitted so the server default applies, matching prior behavior.  GLM
 models before 4.5 (e.g. ``glm-4-9b``) don't accept ``thinking`` and are left
 untouched.
+
+GLM-5.2 additionally exposes a native ``reasoning_effort`` knob with exactly
+two enabled levels — ``high`` and ``max`` — on the OpenAI-compatible endpoint
+(per Z.AI / BigModel docs).  Hermes' richer effort scale is collapsed onto
+those two so the user's effort preference actually reaches the model instead
+of being silently dropped.
 """
 
 from __future__ import annotations
@@ -40,8 +46,44 @@ def _model_supports_thinking(model: str | None) -> bool:
     return (major, minor) >= (4, 5)
 
 
+def _is_glm_5_2(model: str | None) -> bool:
+    """Detect GLM-5.2 across the alias spellings providers use.
+
+    Covers the canonical ``glm-5.2`` plus the ``glm-5-2`` / ``glm-5p2``
+    variants seen on relays (Fireworks ``glm-5p2``, etc.) and any
+    vendor-prefixed form (``z-ai/glm-5.2``, ``zai-org-glm-5-2``).
+    """
+    m = (model or "").strip().lower()
+    if not m:
+        return False
+    return any(token in m for token in ("glm-5.2", "glm-5-2", "glm-5p2"))
+
+
+def _glm_5_2_reasoning_effort(reasoning_config: dict | None) -> str | None:
+    """Map Hermes reasoning effort onto GLM-5.2's native ``high``/``max``.
+
+    GLM-5.2 only supports two enabled effort levels. ``xhigh``/``max``
+    request the top tier; everything else that is enabled requests ``high``
+    (its minimum thinking level). When reasoning is explicitly disabled, or
+    no effort preference is supplied, the server default is left untouched.
+    """
+    if not isinstance(reasoning_config, dict):
+        return None
+    if reasoning_config.get("enabled") is False:
+        return None
+
+    effort = (reasoning_config.get("effort") or "").strip().lower()
+    if not effort or effort == "none":
+        return None
+
+    if effort in {"xhigh", "max"}:
+        return "max"
+    # low / medium / minimal / high all clamp to GLM-5.2's minimum: high.
+    return "high"
+
+
 class ZaiProfile(ProviderProfile):
-    """Z.AI / GLM — extra_body.thinking enabled/disabled."""
+    """Z.AI / GLM — extra_body.thinking on/off + GLM-5.2 reasoning_effort."""
 
     def build_api_kwargs_extras(
         self, *, reasoning_config: dict | None = None, model: str | None = None, **context
@@ -49,7 +91,7 @@ class ZaiProfile(ProviderProfile):
         extra_body: dict[str, Any] = {}
         top_level: dict[str, Any] = {}
 
-        if not _model_supports_thinking(model):
+        if not _model_supports_thinking(model) and not _is_glm_5_2(model):
             return extra_body, top_level
 
         # Only emit when the user expressed a preference; omitting the field
@@ -57,6 +99,11 @@ class ZaiProfile(ProviderProfile):
         if isinstance(reasoning_config, dict):
             enabled = reasoning_config.get("enabled") is not False
             extra_body["thinking"] = {"type": "enabled" if enabled else "disabled"}
+
+        if _is_glm_5_2(model):
+            effort = _glm_5_2_reasoning_effort(reasoning_config)
+            if effort is not None:
+                top_level["reasoning_effort"] = effort
 
         return extra_body, top_level
 

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -122,13 +122,68 @@ class TestOpenCodeGoDeepSeekThinking:
             assert top_level == {"reasoning_effort": "max"}
 
 
+class TestOpenCodeGoGLM52Reasoning:
+    """GLM-5.2 uses its native high/max reasoning_effort knob on OpenCode Go."""
+
+    def test_high_maps_to_high(self, opencode_go_profile):
+        extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="glm-5.2",
+        )
+        assert extra_body == {}
+        assert top_level == {"reasoning_effort": "high"}
+
+    def test_low_and_medium_clamp_up_to_high(self, opencode_go_profile):
+        for effort in ("low", "medium", "minimal"):
+            extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
+                reasoning_config={"enabled": True, "effort": effort},
+                model="glm-5.2",
+            )
+            assert extra_body == {}
+            assert top_level == {"reasoning_effort": "high"}
+
+    def test_xhigh_and_max_map_to_max(self, opencode_go_profile):
+        for effort in ("xhigh", "max"):
+            extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
+                reasoning_config={"enabled": True, "effort": effort},
+                model="z-ai/glm-5.2",
+            )
+            assert extra_body == {}
+            assert top_level == {"reasoning_effort": "max"}
+
+    def test_disabled_leaves_server_default(self, opencode_go_profile):
+        extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False, "effort": "high"},
+            model="glm-5.2",
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+    def test_no_config_leaves_server_default(self, opencode_go_profile):
+        extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
+            reasoning_config=None,
+            model="glm-5.2",
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+    @pytest.mark.parametrize("model", ["glm-5-2", "glm-5p2"])
+    def test_alias_spellings_recognized(self, opencode_go_profile, model):
+        extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "max"},
+            model=model,
+        )
+        assert top_level == {"reasoning_effort": "max"}
+
+
 class TestOpenCodeGoModelGating:
-    """Other OpenCode Go models must not receive Kimi/DeepSeek controls."""
+    """Other OpenCode Go models must not receive Kimi/DeepSeek/GLM controls."""
 
     @pytest.mark.parametrize(
         "model",
         [
             "glm-5.1",
+            "glm-5",
             "qwen3.6-plus",
             "minimax-m2.7",
             "deepseek-v3.1",

--- a/tests/plugins/model_providers/test_zai_profile.py
+++ b/tests/plugins/model_providers/test_zai_profile.py
@@ -1,10 +1,14 @@
-"""Unit tests for the Z.AI / GLM provider profile's thinking-mode wiring.
+"""Unit tests for the Z.AI / GLM provider profile's reasoning wiring.
 
 Z.AI's GLM-4.5-and-later chat models default to thinking-mode ON when the
 request omits ``thinking``.  Before the profile emitted the parameter,
 ``reasoning_config = {"enabled": False}`` was a silent no-op on the direct
 Z.AI route — users who turned thinking off kept burning thinking tokens on
 every turn (the desktop "thinking reverts to medium" report).
+
+GLM-5.2 additionally exposes a native ``reasoning_effort`` knob with two
+enabled levels (high / max) on the OpenAI-compatible ``/api/paas/v4``
+endpoint; the Hermes effort scale is collapsed onto those.
 
 These tests pin the profile's wire-shape contract so Z.AI requests stay
 correctly shaped without going live.
@@ -61,12 +65,102 @@ class TestZaiThinkingWireShape:
         assert top_level == {}
 
     def test_no_effort_levels_leak_to_top_level(self, zai_profile):
-        """GLM has no effort knob — never emit ``reasoning_effort``."""
+        """Non-5.2 GLM models have no effort knob — never emit
+        ``reasoning_effort`` for them (GLM-5.2 is the exception, below)."""
         for effort in ("minimal", "low", "medium", "high", "xhigh"):
-            _, top_level = zai_profile.build_api_kwargs_extras(
-                reasoning_config={"enabled": True, "effort": effort}, model="glm-5.2"
-            )
-            assert top_level == {}
+            for model in ("glm-5", "glm-5.1", "glm-4.6"):
+                _, top_level = zai_profile.build_api_kwargs_extras(
+                    reasoning_config={"enabled": True, "effort": effort}, model=model
+                )
+                assert top_level == {}
+
+
+class TestZaiGLM52ReasoningEffort:
+    """GLM-5.2's native ``reasoning_effort`` knob (two enabled levels)."""
+
+    def test_high_maps_to_high(self, zai_profile):
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="glm-5.2",
+        )
+        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert top_level == {"reasoning_effort": "high"}
+
+    @pytest.mark.parametrize("effort", ["low", "medium", "minimal"])
+    def test_lower_efforts_clamp_up_to_high(self, zai_profile, effort):
+        """GLM-5.2's minimum thinking level is high — lower Hermes levels
+        clamp onto it."""
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": effort},
+            model="glm-5.2",
+        )
+        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert top_level == {"reasoning_effort": "high"}
+
+    @pytest.mark.parametrize("effort", ["xhigh", "max"])
+    def test_strong_efforts_map_to_max(self, zai_profile, effort):
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": effort},
+            model="glm-5.2",
+        )
+        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert top_level == {"reasoning_effort": "max"}
+
+    def test_disabled_sends_no_effort(self, zai_profile):
+        """Disabled reasoning still sends the thinking-off marker but never
+        an effort level."""
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False, "effort": "high"},
+            model="glm-5.2",
+        )
+        assert extra_body == {"thinking": {"type": "disabled"}}
+        assert top_level == {}
+
+    def test_no_config_leaves_server_default(self, zai_profile):
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config=None,
+            model="glm-5.2",
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+    def test_no_effort_sends_no_effort_level(self, zai_profile):
+        """Enabled but no effort preference → thinking marker only; the
+        server picks its default effort."""
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True},
+            model="glm-5.2",
+        )
+        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert top_level == {}
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "z-ai/glm-5.2",
+            "glm-5-2",
+            "glm-5p2",
+            "accounts/fireworks/models/glm-5p2",
+            "zai-org-glm-5-2",
+        ],
+    )
+    def test_alias_spellings_recognized(self, zai_profile, model):
+        _, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "max"},
+            model=model,
+        )
+        assert top_level == {"reasoning_effort": "max"}
+
+    @pytest.mark.parametrize(
+        "model",
+        ["glm-5.1", "glm-5", "glm-4.7", "glm-4-9b", "", None],
+    )
+    def test_non_glm_5_2_models_get_no_effort(self, zai_profile, model):
+        _, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model=model,
+        )
+        assert top_level == {}
 
 
 class TestZaiModelGating:
@@ -110,7 +204,7 @@ class TestZaiModelGating:
 
 
 class TestZaiFullKwargsIntegration:
-    """End-to-end: the transport's full kwargs carry the thinking marker."""
+    """End-to-end: the transport's full kwargs carry the reasoning wiring."""
 
     def test_disabled_reaches_the_wire(self, zai_profile):
         from agent.transports.chat_completions import ChatCompletionsTransport
@@ -139,3 +233,18 @@ class TestZaiFullKwargsIntegration:
             provider_name="zai",
         )
         assert "thinking" not in kwargs.get("extra_body", {})
+
+    def test_glm_5_2_effort_reaches_top_level(self, zai_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="glm-5.2",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=zai_profile,
+            reasoning_config={"enabled": True, "effort": "max"},
+            base_url="https://api.z.ai/api/paas/v4",
+            provider_name="zai",
+        )
+        assert kwargs["reasoning_effort"] == "max"
+        assert kwargs["extra_body"]["thinking"] == {"type": "enabled"}


### PR DESCRIPTION
## Summary
GLM-5.2's reasoning effort preference now reaches the model on both Z.AI routes — previously it was silently dropped. Salvage of #51108 onto current main, merged with the thinking-on/off wiring that landed in the meantime (5a6720b88).

Port of [Kilo-Org/kilocode#11555](https://github.com/Kilo-Org/kilocode/pull/11555), adapted to hermes-agent's provider-profile architecture.

## Changes
- `plugins/model-providers/zai/__init__.py`: `ZaiProfile` now emits BOTH behaviors — `extra_body.thinking` enabled/disabled for GLM 4.5+ (existing, preserved) AND top-level `reasoning_effort` for GLM-5.2 (`xhigh`/`max` → `max`; lower enabled levels → `high`; disabled/unset → server default).
- `plugins/model-providers/opencode-zen/__init__.py`: same GLM-5.2 mapping added to `OpenCodeGoProfile`, alongside the existing Kimi/DeepSeek branches.
- Alias spellings recognized: `glm-5.2`, `glm-5-2`, `glm-5p2`, vendor-prefixed forms (`z-ai/glm-5.2`, `accounts/fireworks/models/glm-5p2`).
- Tests: GLM-5.2 effort cases merged into the existing `test_zai_profile.py` (thinking-wire tests kept), GLM-5.2 cases added to `test_opencode_go_profile.py`.

## Why not #51108 as-is
#51108's branch predates 5a6720b88 (thinking-off fix) and would have wholesale-replaced `zai/__init__.py`, reverting that fix and its 141-line test file. This PR merges the two behaviors instead: GLM-5.2 with effort set now sends `thinking: enabled` + `reasoning_effort` together.

## Validation
| | Before | After |
|---|---|---|
| zai GLM-5.2 effort=max | thinking marker only | `reasoning_effort: max` + `thinking: enabled` |
| zai GLM-5.2 effort=medium | thinking marker only | `reasoning_effort: high` + `thinking: enabled` |
| zai GLM-5.2 disabled | `thinking: disabled` | `thinking: disabled` (unchanged, no effort) |
| opencode-go GLM-5.2 effort=xhigh | (nothing) | `reasoning_effort: max` |
| GLM-5.1 / GLM-5 / 4.5+ thinking | unchanged | unchanged |
| Kimi / DeepSeek / MiniMax on Go | unchanged | unchanged |

69 targeted tests pass. E2E verified through the real `ChatCompletionsTransport.build_kwargs()` with real provider discovery against a temp `HERMES_HOME` — effort reaches the wire top-level, thinking marker intact, non-5.2 models unaffected.

## Infographic

![glm-5.2-reasoning-effort](https://v3b.fal.media/files/b/0aa109c1/mAFQ5FZ2R2xf2g4I__HPX_GMFlNwJS.png)
