### PR TITLE
fix(gateway): re-check every stacked skill against the platform-disabled list

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9894,6 +9894,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     except Exception:
                         _build_stacked = None
                         extra_keys, stacked_instruction = [], user_instruction
+                    if extra_keys and _plat:
+                        # split_stacked_skill_commands() only resolves that
+                        # each extra token is a KNOWN skill command — like
+                        # get_skill_commands() itself, it has no per-platform
+                        # view. Re-check every stacked skill (not just the
+                        # leading one above) against the same disabled list,
+                        # or a skill an operator disabled for this platform
+                        # still gets its full content loaded via the stack.
+                        from agent.skill_utils import get_disabled_skill_names as _get_plat_disabled
+                        _plat_disabled = _get_plat_disabled(platform=_plat)
+                        _disabled_extra = [
+                            skill_cmds.get(k, {}).get("name", "")
+                            for k in extra_keys
+                            if skill_cmds.get(k, {}).get("name", "") in _plat_disabled
+                        ]
+                        if _disabled_extra:
+                            return (
+                                f"The **{', '.join(_disabled_extra)}** skill(s) in this "
+                                f"stacked invocation are disabled for {_plat}.\n"
+                                f"Enable them with: `hermes skills config`"
+                            )
                     if extra_keys and _build_stacked is not None:
                         stacked_result = _build_stacked(
                             [cmd_key, *extra_keys],

--- a/tests/gateway/test_stacked_skill_platform_disabled.py
+++ b/tests/gateway/test_stacked_skill_platform_disabled.py
@@ -1,0 +1,163 @@
+"""Regression test for stacked slash-skill invocations bypassing the
+per-platform ``skills.platform_disabled`` gate.
+
+``/skill-a /skill-b do XYZ`` loads every leading skill (up to 5), not just
+the first (``agent.skill_commands.split_stacked_skill_commands`` /
+``build_stacked_skill_invocation_message``). ``gateway.run.GatewayRunner.
+_handle_message`` already re-checks the FIRST skill against the
+per-platform disabled list before dispatch (``get_skill_commands()`` only
+applies the *global* disabled list at scan time), but did not extend that
+same check to the additional stacked skills — a skill an operator disabled
+for a given platform still had its full SKILL.md content injected into the
+agent's context for that turn if it was stacked behind an allowed one.
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(
+        emit=AsyncMock(),
+        emit_collect=AsyncMock(return_value=[]),
+        loaded_hooks=False,
+    )
+
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    from gateway.run import GatewayRunner as _GR
+    runner._session_key_for_source = _GR._session_key_for_source.__get__(runner, _GR)
+    return runner
+
+
+def _make_skill(skills_dir, name, body="content"):
+    sd = skills_dir / name
+    sd.mkdir(parents=True, exist_ok=True)
+    (sd / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: desc {name}\n---\n\n# {name}\n\n{body}\n"
+    )
+
+
+@pytest.fixture
+def skills_env(tmp_path, monkeypatch):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    import tools.skills_tool as skills_tool_module
+    monkeypatch.setattr(skills_tool_module, "SKILLS_DIR", skills_dir)
+    import agent.skill_commands as skill_commands_mod
+    skill_commands_mod._skill_commands = {}
+    skill_commands_mod._skill_commands_platform = None
+    return skills_dir
+
+
+@pytest.mark.asyncio
+async def test_stacked_second_skill_disabled_for_platform_is_blocked(monkeypatch, skills_env):
+    """The whole stacked invocation is rejected when a NON-leading stacked
+    skill is disabled for the message's platform — it must not silently load
+    that skill's content just because only the first skill was checked."""
+    import gateway.run as gateway_run
+    import agent.skill_utils as skill_utils_mod
+
+    _make_skill(skills_env, "allowed-skill")
+    _make_skill(skills_env, "disabled-skill")
+
+    monkeypatch.setattr(
+        skill_utils_mod,
+        "get_disabled_skill_names",
+        lambda platform=None: {"disabled-skill"} if platform == "telegram" else set(),
+    )
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    runner = _make_runner()
+    result = await runner._handle_message(
+        _make_event("/allowed-skill /disabled-skill do something")
+    )
+
+    assert result is not None
+    assert "disabled-skill" in result
+    assert "disabled for telegram" in result
+
+
+@pytest.mark.asyncio
+async def test_stacked_all_enabled_skills_still_load(monkeypatch, skills_env):
+    """Positive control: the new platform-disabled check must not over-block
+    a stacked invocation where every skill is actually enabled."""
+    import gateway.run as gateway_run
+    import agent.skill_utils as skill_utils_mod
+
+    _make_skill(skills_env, "alpha-skill", body="ALPHA BODY MARKER")
+    _make_skill(skills_env, "beta-skill", body="BETA BODY MARKER")
+
+    monkeypatch.setattr(
+        skill_utils_mod, "get_disabled_skill_names", lambda platform=None: set()
+    )
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    runner = _make_runner()
+    event = _make_event("/alpha-skill /beta-skill do something")
+    result = await runner._handle_message(event)
+
+    # Not rejected: the handler falls through to normal message processing
+    # with event.text rewritten to the combined stacked-skill payload.
+    assert result is None or "disabled for" not in result
+    assert "ALPHA BODY MARKER" in event.text
+    assert "BETA BODY MARKER" in event.text


### PR DESCRIPTION
## What does this PR do?
`_handle_message()` re-checks a slash-skill command's per-platform disabled status before dispatch, because `get_skill_commands()` only applies the *global* disabled list at scan time (`gateway/run.py`, near `resolve_skill_command_key`). That re-check only covered the **leading** skill.

Stacked slash-skill invocations (`/skill-a /skill-b do XYZ`, #57987) resolve additional `/skill` tokens via `split_stacked_skill_commands()` and load every one of them through `build_stacked_skill_invocation_message()` → `_load_skill_payload()`, which does path/trust-root validation only — no disabled-status check at all.

Result: a skill an operator explicitly disabled for a platform via `skills.platform_disabled` (e.g. a risky/high-privilege skill kept enabled on the operator's own CLI but disabled on Telegram/Discord where senders are untrusted external users) could still have its full SKILL.md content injected into the agent's context for that turn, as long as it was typed after an allowed skill:

```
/allowed-skill /disabled-skill do something
```

Only `allowed-skill` was checked; `disabled-skill` loaded anyway.

Fix: after computing the stacked `extra_keys`, look up each one's skill name and re-check it against the same `get_disabled_skill_names(platform=...)` set already used for the leading skill. If any stacked skill is disabled for the platform, the whole invocation is rejected with the same style of message the leading-skill check already returns, rather than partially loading it.

## Related Issue
No filed issue — found via manual review of the stacked-skill dispatch path added in #57987.

## Type of Change
- [x] 🔒 Security fix (access-control bypass on `skills.platform_disabled`)

## Changes Made
- `gateway/run.py`: re-check `extra_keys` against the per-platform disabled list before building the stacked-skill message (+18 lines)
- `tests/gateway/test_stacked_skill_platform_disabled.py`: new regression test driving `GatewayRunner._handle_message` end-to-end with a stacked invocation where the second skill is platform-disabled, plus a positive control confirming an all-enabled stack still loads normally

## How to Test
```
pytest tests/gateway/test_stacked_skill_platform_disabled.py tests/gateway/test_bundles_command.py tests/gateway/test_reload_skills_command.py tests/gateway/test_unavailable_skill_hint.py tests/agent/test_skill_commands.py -v
```
Mutation-verified: the new blocking test fails (falls through into full agent execution instead of returning the disabled-skill message) against the pre-fix code.

## Checklist
- [x] Contributing Guide read | Conventional Commits | No duplicate PR found (searched `stacked skill platform disabled`, `split_stacked_skill_commands`, `build_stacked_skill_invocation_message`)
- [x] Scoped to this one gap | Tests added | Platform: macOS
- [x] Docs — N/A | Cross-platform — N/A (pure Python logic, no OS-specific behavior)