### PR TITLE
fix(computer-use): sanitize subprocess env in cua-driver CLI fallback transport

### DIFF
--- a/tests/computer_use/test_cua_cli_fallback_env.py
+++ b/tests/computer_use/test_cua_cli_fallback_env.py
@@ -1,0 +1,73 @@
+"""Regression test: the cua-driver CLI-fallback transport must sanitize the
+subprocess environment like every other cua-driver spawn site.
+
+``_CuaDriverSession._call_tool_via_cli()`` (the EAGAIN/silent-empty MCP
+fallback) invoked ``subprocess.run`` with no ``env=`` at all, so the
+third-party ``cua-driver`` binary inherited the full, unsanitized parent
+environment — including provider API keys and other Hermes-managed
+secrets that ``_lifecycle_coro``'s primary MCP spawn already strips via
+``_sanitize_subprocess_env(cua_driver_child_env())``.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+from tools.computer_use.cua_backend import _CuaDriverSession
+
+
+def _make_session() -> _CuaDriverSession:
+    # _call_tool_via_cli() doesn't touch any instance state (bridge/session/
+    # capabilities); bypass __init__ so the test doesn't need a real
+    # _AsyncBridge.
+    return object.__new__(_CuaDriverSession)
+
+
+def _fake_completed_process(stdout: str) -> MagicMock:
+    proc = MagicMock()
+    proc.stdout = stdout
+    proc.stderr = ""
+    proc.returncode = 0
+    return proc
+
+
+def test_cli_fallback_strips_provider_secret_from_subprocess_env(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-super-secret-should-not-leak")
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["env"] = kwargs.get("env")
+        return _fake_completed_process(json.dumps({"tree_markdown": "root"}))
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    session = _make_session()
+    result = session._call_tool_via_cli("list_windows", {}, timeout=5.0)
+
+    assert result["isError"] is False
+    assert captured["env"] is not None, "subprocess.run must receive an explicit env="
+    assert "ANTHROPIC_API_KEY" not in captured["env"]
+    # Sanitization filters secrets, not everything — an ordinary var survives.
+    assert captured["env"].get("PATH") == "/usr/bin:/bin"
+
+
+def test_cli_fallback_applies_telemetry_policy(monkeypatch):
+    """The env should also go through cua_driver_child_env(), like every
+    other cua-driver spawn site, not just _sanitize_subprocess_env alone."""
+    monkeypatch.delenv("HERMES_CUA_TELEMETRY", raising=False)
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["env"] = kwargs.get("env")
+        return _fake_completed_process(json.dumps({"tree_markdown": "root"}))
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    session = _make_session()
+    session._call_tool_via_cli("list_windows", {}, timeout=5.0)
+
+    # cua_driver_child_env() injects this when telemetry is disabled
+    # (the default) — confirms the fallback goes through the same helper
+    # the sanctioned spawn site uses, not an ad hoc env dict.
+    assert captured["env"].get("CUA_DRIVER_RS_TELEMETRY_ENABLED") == "0"

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -894,6 +894,7 @@ class _CuaDriverSession:
         import subprocess as _subprocess
         import tempfile as _tempfile
         import time as _time
+        from tools.environments.local import _sanitize_subprocess_env
 
         call_args = dict(args)
         shot_file: Optional[str] = None
@@ -911,7 +912,8 @@ class _CuaDriverSession:
             for attempt in range(attempts):
                 try:
                     proc = _subprocess.run(
-                        cmd, capture_output=True, text=True, timeout=max(15.0, timeout)
+                        cmd, capture_output=True, text=True, timeout=max(15.0, timeout),
+                        env=_sanitize_subprocess_env(cua_driver_child_env()),
                     )
                 except Exception as e:  # pragma: no cover - subprocess spawn failure
                     raise RuntimeError(f"cua-driver CLI fallback for {name} failed to spawn: {e}") from e


### PR DESCRIPTION
## What does this PR do?
`_CuaDriverSession._call_tool_via_cli()` (`tools/computer_use/cua_backend.py:874`) is the CLI-fallback transport used when the `cua-driver mcp` stdio bridge hits a transient EAGAIN or returns an empty capture — per its own docstring, this can fire "intermittently and on some machines persistently," making it the de facto transport for every computer-use tool call on affected machines.

It spawns `cua-driver call <tool> <json>` via `subprocess.run(cmd, capture_output=True, text=True, timeout=...)` with **no `env=` argument at all**, so the child process inherits the full, unsanitized parent environment.

The sanctioned MCP spawn site in the same file (`_lifecycle_coro`, line 616) already applies:
```python
env=_sanitize_subprocess_env(cua_driver_child_env())
```
before opening the stdio client — the same policy `#53503`/`#55709` established for other subprocess spawn points in this codebase (provider API keys and other Hermes-managed secrets have no legitimate reason to reach a third-party binary). This CLI-fallback path, added alongside the EAGAIN/silent-empty-capture hardening, missed it.

## Related Issue
No filed issue — found via manual review of the cua-driver subsystem's recent commits.

## Type of Change
- [x] 🔒 Security fix (unsanitized subprocess env — same class as #53503/#55709)

## Changes Made
- `tools/computer_use/cua_backend.py`: apply `env=_sanitize_subprocess_env(cua_driver_child_env())` to the `subprocess.run()` call in `_call_tool_via_cli()`, mirroring the sanctioned spawn site exactly (+2 lines)
- `tests/computer_use/test_cua_cli_fallback_env.py`: new regression tests confirming (1) a provider secret (`ANTHROPIC_API_KEY`) is stripped from the subprocess env, and (2) the same telemetry policy (`CUA_DRIVER_RS_TELEMETRY_ENABLED`) applies as the sanctioned spawn site

## How to Test
```
pytest tests/computer_use/ tests/tools/test_computer_use.py tests/tools/test_computer_use_capture_routing.py tests/tools/test_computer_use_null_pid_windows.py tests/tools/test_computer_use_vision_routing.py tests/hermes_cli/test_install_cua_driver.py -v
```
Mutation-verified: both new tests fail against the pre-fix code (`env=None` reaches the mocked `subprocess.run`).

## Checklist
- [x] Contributing Guide read | Conventional Commits | No duplicate PR found (searched `_call_tool_via_cli env`, `cua-driver CLI fallback env sanitize`, `cua_backend subprocess`)
- [x] Scoped to this one call site | Tests added | Platform: macOS
- [x] Docs — N/A | Cross-platform — N/A (subprocess env handling is OS-agnostic; behavior mirrors the existing sanctioned spawn site)