### PR TITLE
docs(discord): correct permission integers for bot presets

### DIFF
--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -263,13 +263,13 @@ Go to the [Discord Developer Portal](https://discord.com/developers/applications
 
 | Level | Integer | What's Included |
 |-------|---------|----------------|
-| Text only | `274878286912` | View Channels, Send Messages, Read History, Embeds, Attachments, Threads, Reactions |
-| Text + Voice | `274881432640` | All above + Connect, Speak |
+| Text only | `309237763136` | View Channels, Send Messages, Read History, Embeds, Attachments, Threads, Reactions |
+| Text + Voice | `309240908864` | All above + Connect, Speak |
 
 **Re-invite the bot** with the updated permissions URL:
 
 ```
-https://discord.com/oauth2/authorize?client_id=YOUR_APP_ID&scope=bot+applications.commands&permissions=274881432640
+https://discord.com/oauth2/authorize?client_id=YOUR_APP_ID&scope=bot+applications.commands&permissions=309240908864
 ```
 
 Replace `YOUR_APP_ID` with your Application ID from the Developer Portal.

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -170,7 +170,7 @@ This method requires **Public Bot** to be set to **ON** in Step 2. If you set Pu
 You can construct the invite URL directly using this format:
 
 ```
-https://discord.com/oauth2/authorize?client_id=YOUR_APP_ID&scope=bot+applications.commands&permissions=274878286912
+https://discord.com/oauth2/authorize?client_id=YOUR_APP_ID&scope=bot+applications.commands&permissions=309237763136
 ```
 
 Replace `YOUR_APP_ID` with the Application ID from Step 1.
@@ -195,7 +195,7 @@ These are the minimum permissions your bot needs:
 | Level | Permissions Integer | What's Included |
 |-------|-------------------|-----------------|
 | Minimal | `117760` | View Channels, Send Messages, Read Message History, Attach Files |
-| Recommended | `274878286912` | All of the above plus Embed Links, Send Messages in Threads, Add Reactions |
+| Recommended | `309237763136` | All of the above plus Embed Links, Send Messages in Threads, Add Reactions |
 
 ## Step 6: Invite to Your Server
 


### PR DESCRIPTION
## Summary

The permission integers documented for the Discord text-only and voice bot presets were incorrect — they included `USE_EXTERNAL_EMOJIS` (bit 18) and excluded `CREATE_PUBLIC_THREADS` (bit 35). This caused `403 Forbidden` errors on auto-thread creation.

## Root Cause

The permission integers `274878286912` (text-only) and `274881432640` (voice) both had bit 18 set and bit 35 unset, as confirmed by the Discord permission bitfield. Issue #40389 identified the discrepancy with a debug report showing `error code: 50001 (Missing Access)` on thread creation.

## Changes

- `website/docs/user-guide/messaging/discord.md`: corrected the Recommended permissions integer (274878286912 → 309237763136) and the invite URL.
- `website/docs/user-guide/features/voice-mode.md`: corrected both Text-only (274878286912 → 309237763136) and Text+Voice (274881432640 → 309240908864) permission integers and the invite URL.

## Validation

Bitfield verification (Python):

```python
# Wrong: 274878286912 has USE_EXTERNAL_EMOJIS (bit 18) and lacks CREATE_PUBLIC_THREADS (bit 35)
wrong = 274878286912
correct = 309237763136
assert wrong & (1 << 18)  # has USE_EXTERNAL_EMOJIS
assert not (correct & (1 << 18))  # should not
assert not (wrong & (1 << 35))  # missing CREATE_PUBLIC_THREADS
assert correct & (1 << 35)  # should have
print(f"Diff: correct - wrong = {correct - wrong}")  # 34359476224 = 2^35 - 2^18
```

| Check | Result |
|---|---|
| Text-only bit 18 (USE_EXTERNAL_EMOJIS) | removed ✓ |
| Text-only bit 35 (CREATE_PUBLIC_THREADS) | added ✓ |
| Voice bit 18 | removed ✓ |
| Voice bit 35 | added ✓ |
| `npx docusaurus build` | SUCCESS |

Fixes #40389