### PR TITLE
fix(aux-client): evict expired auxiliary client on 401 by refreshing under the lookup cache key

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7027,8 +7027,29 @@ def _refresh_nous_auxiliary_client(
     api_mode: Optional[str] = None,
     main_runtime: Optional[Dict[str, Any]] = None,
     is_vision: bool = False,
+    lookup_model: Optional[str] = None,
+    lookup_task: Optional[str] = None,
 ) -> Tuple[Optional[Any], Optional[str]]:
-    """Refresh Nous runtime creds, rebuild the client, and replace the cache entry."""
+    """Refresh Nous runtime creds, rebuild the client, and replace the cache entry.
+
+    ``model`` is the resolved model actually sent on the wire (e.g. the provider
+    default ``"Hermes-4-405B"``); it is stored as the entry's usable model and
+    returned to the caller. ``lookup_model`` is the model as it was passed to
+    ``_get_cached_client`` when the (now stale) client was acquired -- ``None``
+    on the default Nous config, where ``call_llm`` looks up with
+    ``resolved_model=None``. The cache KEY MUST be built from ``lookup_model`` so
+    the fresh client overwrites the exact entry the stale client is served from.
+    Keying on the resolved ``model`` instead stored under a different key (model
+    element ``"Hermes-4-405B"`` vs the lookup's ``""``), leaving the expired
+    client immortal so every auxiliary call 401s forever (#56889).
+
+    ``lookup_task`` is the task the stale client was acquired under. For
+    ``provider == "auto"`` the task participates in the cache key (task-specific
+    fallback policy), so it MUST be carried into the key here for the same
+    reason as ``lookup_model``; otherwise an auto-provider client refreshed on a
+    401 lands under the ``task=""`` key while the stale entry survives under the
+    task-scoped key (#58894).
+    """
     runtime = _resolve_nous_runtime_api(force_refresh=True)
     if runtime is None:
         return None, model
@@ -7056,7 +7077,8 @@ def _refresh_nous_auxiliary_client(
         api_mode=api_mode,
         main_runtime=main_runtime,
         is_vision=is_vision,
-        model=final_model,
+        task=lookup_task,
+        model=lookup_model,
     )
     _store_cached_client(cache_key, client, final_model, bound_loop=current_loop)
     return client, final_model
@@ -8732,6 +8754,7 @@ def _call_llm_impl(
             api_key=resolved_api_key,
             api_mode=resolved_api_mode,
             main_runtime=main_runtime,
+            task=task,
         )
         if client is None:
             # When the user explicitly chose a non-OpenRouter provider but no
@@ -9027,6 +9050,8 @@ def _call_llm_impl(
             refreshed_client, refreshed_model = _refresh_nous_auxiliary_client(
                 cache_provider=resolved_provider or "nous",
                 model=final_model,
+                lookup_model=resolved_model,
+                lookup_task=task,
                 async_mode=False,
                 base_url=resolved_base_url,
                 api_key=resolved_api_key,
@@ -9063,6 +9088,8 @@ def _call_llm_impl(
             refreshed_client, refreshed_model = _refresh_nous_auxiliary_client(
                 cache_provider=resolved_provider or "nous",
                 model=final_model,
+                lookup_model=resolved_model,
+                lookup_task=task,
                 async_mode=False,
                 base_url=resolved_base_url,
                 api_key=resolved_api_key,
@@ -9499,6 +9526,7 @@ async def _async_call_llm_impl(
             api_key=resolved_api_key,
             api_mode=resolved_api_mode,
             main_runtime=main_runtime,
+            task=task,
         )
         if client is None:
             _explicit = (resolved_provider or "").strip().lower()
@@ -9711,10 +9739,13 @@ async def _async_call_llm_impl(
             refreshed_client, refreshed_model = _refresh_nous_auxiliary_client(
                 cache_provider=resolved_provider or "nous",
                 model=final_model,
+                lookup_model=resolved_model,
+                lookup_task=task,
                 async_mode=True,
                 base_url=resolved_base_url,
                 api_key=resolved_api_key,
                 api_mode=resolved_api_mode,
+                main_runtime=main_runtime,
                 is_vision=(task == "vision"),
             )
             if refreshed_client is not None:
@@ -9746,10 +9777,13 @@ async def _async_call_llm_impl(
             refreshed_client, refreshed_model = _refresh_nous_auxiliary_client(
                 cache_provider=resolved_provider or "nous",
                 model=final_model,
+                lookup_model=resolved_model,
+                lookup_task=task,
                 async_mode=True,
                 base_url=resolved_base_url,
                 api_key=resolved_api_key,
                 api_mode=resolved_api_mode,
+                main_runtime=main_runtime,
                 is_vision=(task == "vision"),
             )
             if refreshed_client is not None:

--- a/tests/agent/test_auxiliary_client_refresh_cache_key_56889.py
+++ b/tests/agent/test_auxiliary_client_refresh_cache_key_56889.py
@@ -1,0 +1,420 @@
+"""Regression tests for #56889 and #58894: a Nous credential refresh must evict
+the stale expired-credential client under the SAME cache key call_llm looked it
+up with, across every dimension the lookup keyed on -- the model (#56889) and,
+for auto-provider acquisitions, the task (#58894).
+
+Background
+----------
+PR #56889 added the model name to the auxiliary client cache key so that
+concurrent MoA fan-out calls to the same provider but different models don't
+share (and cross-close) a single httpx client. The regression: on the default
+Nous config ``call_llm`` looks the client up with ``resolved_model=None`` (the
+key's model element is ``""``) but is handed back the resolved provider default
+(e.g. ``"Hermes-4-405B"``) as ``final_model``. On a 401 the refresh path was
+keyed on that resolved ``final_model`` instead of the ``None`` used at lookup,
+so the fresh client landed under a DIFFERENT key. The stale expired-credential
+client under ``""`` was never overwritten and stayed immortal: every auxiliary
+call 401s -> forced portal round-trip -> retry, forever.
+
+PR #58894 carries that same discipline one dimension further: for
+``provider == "auto"`` the task also participates in the key, so the primary
+acquisition site AND the 401 refresh must both fold the task in, or an
+auto-provider client refreshed on a 401 lands under the ``task=""`` key while
+the stale entry survives under the task-scoped key -- the immortal-client bug
+reappears for the common auto path.
+
+These are self-contained white-box tests: no network. The unit tests patch the
+runtime-API resolver and the openai-client factory, then call the REAL
+``_refresh_nous_auxiliary_client`` and assert the follow-up lookup returns the
+fresh client. The end-to-end tests go further: they drive the REAL ``call_llm``
+/ ``async_call_llm`` through the REAL module cache (patching only the client
+*factories*, never ``_get_cached_client`` itself) so that the acquisition and
+refresh cache keys are exercised together -- the only way to catch an
+acquisition site that stops threading a keyed dimension.
+"""
+
+import inspect
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import agent.auxiliary_client as ac
+
+
+NOUS_BASE_URL = "https://inference-api.nousresearch.com/v1"
+
+
+class _FakeClient:
+    """Minimal stand-in for an OpenAI client with a closable connection pool."""
+
+    def __init__(self, tag):
+        self.tag = tag
+        self.api_key = "key-" + tag
+        self.base_url = NOUS_BASE_URL
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def _clean_client_cache():
+    """Isolate the module-level client cache around each test."""
+    ac._client_cache.clear()
+    yield
+    ac._client_cache.clear()
+
+
+def _default_config_lookup_key():
+    """The cache key call_llm builds for a default-Nous acquisition.
+
+    Mirrors ``_get_cached_client("nous", resolved_model=None, async_mode=False,
+    ...)``: the model element of the key is ``None`` -> ``""``.
+    """
+    return ac._client_cache_key(
+        "nous",
+        async_mode=False,
+        base_url=None,
+        api_key=None,
+        api_mode=None,
+        main_runtime=None,
+        is_vision=False,
+        task=None,
+        model=None,
+    )
+
+
+def _patch_refresh_externals(monkeypatch, fresh_client):
+    monkeypatch.setattr(
+        ac,
+        "_resolve_nous_runtime_api",
+        lambda *, force_refresh=False: ("fresh-key", NOUS_BASE_URL),
+    )
+    monkeypatch.setattr(
+        ac,
+        "_create_openai_client",
+        lambda *, api_key, base_url, **kwargs: fresh_client,
+    )
+
+
+def test_refresh_evicts_stale_client_under_default_config_lookup_key(monkeypatch):
+    """After a 401 refresh, the default-config lookup must return the fresh client.
+
+    Fails on unfixed main: the refresh stores under ``model="Hermes-4-405B"``
+    while the acquisition stored under ``model=None`` -> ``""``, so the stale
+    client is never evicted.
+    """
+    lookup_key = _default_config_lookup_key()
+    stale = _FakeClient("stale-expired-creds")
+    # _get_cached_client stores (client, default_model, bound_loop). The stored
+    # default_model is the resolved provider default even though the lookup
+    # model was None.
+    ac._client_cache[lookup_key] = (stale, "Hermes-4-405B", None)
+
+    fresh = _FakeClient("fresh")
+    _patch_refresh_externals(monkeypatch, fresh)
+
+    # The 401 handler calls refresh with the RESOLVED model (final_model), which
+    # on the default config is the provider default "Hermes-4-405B" -- NOT the
+    # None the client was actually looked up with.
+    refreshed_client, refreshed_model = ac._refresh_nous_auxiliary_client(
+        cache_provider="nous",
+        model="Hermes-4-405B",
+        async_mode=False,
+        base_url=None,
+        api_key=None,
+        api_mode=None,
+        main_runtime=None,
+        is_vision=False,
+    )
+    assert refreshed_client is fresh
+    assert refreshed_model == "Hermes-4-405B"
+
+    # The next auxiliary call repeats the SAME default-config lookup (model=None).
+    # This is a pure cache hit in both the fixed and unfixed worlds (the "" key
+    # always holds something), so no real client is built.
+    served, _ = ac._get_cached_client(
+        "nous",
+        None,
+        async_mode=False,
+        base_url=None,
+        api_key=None,
+        api_mode=None,
+        main_runtime=None,
+    )
+    assert served is not stale, (
+        "stale expired-credential client is still served after refresh: the "
+        "refresh stored the fresh client under a different cache key than the "
+        "lookup key (#56889)"
+    )
+    assert served is fresh
+
+    # The stale client must be fully gone from the cache, not merely shadowed by
+    # a second entry under a different model key.
+    assert not any(entry[0] is stale for entry in ac._client_cache.values()), (
+        "stale client still present in the cache under some key after refresh"
+    )
+
+
+@pytest.mark.skipif(
+    "lookup_model" not in inspect.signature(ac._refresh_nous_auxiliary_client).parameters,
+    reason="fix not applied: _refresh_nous_auxiliary_client has no lookup_model parameter",
+)
+def test_refresh_preserves_explicit_model_key(monkeypatch):
+    """An explicit-model acquisition (MoA fan-out) must refresh under that model.
+
+    Guards the #56889 per-model keying: when the client was looked up under an
+    explicit model, the refresh must key on that same explicit model and must
+    NOT clobber the shared default-config ("") entry.
+    """
+    explicit = "Hermes-4-70B"
+    lookup_key = ac._client_cache_key(
+        "nous",
+        async_mode=False,
+        base_url=None,
+        api_key=None,
+        api_mode=None,
+        main_runtime=None,
+        is_vision=False,
+        task=None,
+        model=explicit,
+    )
+    stale = _FakeClient("stale-explicit")
+    ac._client_cache[lookup_key] = (stale, explicit, None)
+
+    fresh = _FakeClient("fresh-explicit")
+    _patch_refresh_externals(monkeypatch, fresh)
+
+    ac._refresh_nous_auxiliary_client(
+        cache_provider="nous",
+        model=explicit,
+        lookup_model=explicit,
+        async_mode=False,
+        base_url=None,
+        api_key=None,
+        api_mode=None,
+        main_runtime=None,
+        is_vision=False,
+    )
+
+    served, _ = ac._get_cached_client(
+        "nous",
+        explicit,
+        async_mode=False,
+        base_url=None,
+        api_key=None,
+        api_mode=None,
+        main_runtime=None,
+    )
+    assert served is fresh
+    # The default-config ("") key was never created by an explicit-model refresh.
+    assert _default_config_lookup_key() not in ac._client_cache
+
+
+def test_refresh_evicts_stale_auto_client_under_task_scoped_key(monkeypatch):
+    """An auto-provider refresh must carry the lookup task into the new key.
+
+    ``_client_cache_key`` folds the task into the key ONLY for ``provider ==
+    "auto"`` (auto can resolve through a task-specific fallback policy), so
+    ``_get_cached_client("auto", ..., task=task)`` stores the client under a
+    task-scoped key. The 401 refresh path must carry that same lookup task
+    through ``_refresh_nous_auxiliary_client`` into ``_client_cache_key`` -- the
+    ``task`` dimension of the #56889 keying, one element over from the model
+    dimension. Dropping it lands the fresh client under the ``task=""`` key and
+    leaves the stale expired-credential client immortal under the task-scoped
+    key, so every auto-provider auxiliary call for that task keeps 401ing
+    (#58894).
+
+    Discriminating without a signature error on unfixed code: ``lookup_task`` is
+    forwarded only when the parameter exists. On unfixed code the task is never
+    carried, the fresh client lands under the wrong key, and the task-scoped
+    lookup still serves the stale client -> the first assertion fails (rather
+    than erroring on an unknown kwarg).
+    """
+    task = "agent"
+    resolved_model = "Hermes-4-405B"
+    # The key _get_cached_client("auto", resolved_model, ..., task=task) built
+    # when the (now stale) client was acquired: task participates for "auto".
+    lookup_key = ac._client_cache_key(
+        "auto",
+        async_mode=False,
+        base_url=None,
+        api_key=None,
+        api_mode=None,
+        main_runtime=None,
+        is_vision=False,
+        task=task,
+        model=resolved_model,
+    )
+    stale = _FakeClient("stale-auto-task")
+    ac._client_cache[lookup_key] = (stale, resolved_model, None)
+
+    fresh = _FakeClient("fresh-auto-task")
+    _patch_refresh_externals(monkeypatch, fresh)
+
+    refresh_kwargs = dict(
+        cache_provider="auto",
+        model=resolved_model,
+        lookup_model=resolved_model,
+        async_mode=False,
+        base_url=None,
+        api_key=None,
+        api_mode=None,
+        main_runtime=None,
+        is_vision=False,
+    )
+    if "lookup_task" in inspect.signature(ac._refresh_nous_auxiliary_client).parameters:
+        refresh_kwargs["lookup_task"] = task
+    refreshed_client, _ = ac._refresh_nous_auxiliary_client(**refresh_kwargs)
+    assert refreshed_client is fresh
+
+    # The next auto-provider call for this task repeats the SAME task-scoped
+    # lookup. It is a pure cache hit in both worlds (that key always holds
+    # something -- stale when unfixed, fresh when fixed), so no real client is
+    # built.
+    served, _ = ac._get_cached_client(
+        "auto",
+        resolved_model,
+        async_mode=False,
+        base_url=None,
+        api_key=None,
+        api_mode=None,
+        main_runtime=None,
+        task=task,
+    )
+    assert served is not stale, (
+        "stale auto-provider client is still served after a task-scoped refresh: "
+        "the refresh dropped the task dimension of the cache key (#58894)"
+    )
+    assert served is fresh
+    # The stale client must be gone entirely, not merely shadowed by a second
+    # entry under the task="" key.
+    assert not any(entry[0] is stale for entry in ac._client_cache.values()), (
+        "stale auto client still present in the cache under some key after refresh"
+    )
+
+
+class _Auth401(Exception):
+    """A 401 the auth-error classifier recognizes (``status_code`` attribute)."""
+
+    status_code = 401
+
+
+def _nous_mock_client(*, async_mode, raises=None, returns=None):
+    """A stand-in OpenAI client whose ``chat.completions.create`` 401s or returns."""
+    client = MagicMock()
+    client.base_url = NOUS_BASE_URL
+    create = AsyncMock() if async_mode else MagicMock()
+    if raises is not None:
+        create.side_effect = raises
+    else:
+        create.return_value = returns
+    client.chat.completions.create = create
+    return client
+
+
+def test_call_llm_auto_provider_evicts_stale_client_end_to_end(monkeypatch):
+    """End-to-end: a default auto-provider 401 must evict the stale client.
+
+    The integration guard the unit refresh tests structurally cannot give: it
+    runs the REAL primary acquisition (``_get_cached_client`` at call_llm's
+    acquisition site) and the REAL 401 refresh against the REAL module cache,
+    patching only the client *factories* -- never ``_get_cached_client``, whose
+    wholesale patching in the pre-existing call_llm 401 tests is exactly why the
+    acquisition-vs-refresh key divergence went unseen. The stale client is
+    acquired under the auto+task cache key; the 401 refresh must land the fresh
+    client under that SAME key and evict the stale one. If the acquisition site
+    stops threading ``task`` (the #58894 regression) the refresh rebuilds a
+    divergent key, the stale expired-credential client survives, and the
+    stale-absence assertion fails.
+    """
+    task = "compression"
+    stale = _nous_mock_client(async_mode=False, raises=_Auth401("stale creds"))
+    fresh = _nous_mock_client(async_mode=False, returns={"ok": True})
+
+    # Force the default auto path and make the primary acquisition build `stale`.
+    monkeypatch.setattr(
+        ac, "_resolve_task_provider_model",
+        lambda *a, **k: ("auto", None, None, None, None),
+    )
+    monkeypatch.setattr(
+        ac, "resolve_provider_client",
+        lambda *a, **k: (stale, "nous-model"),
+    )
+    # The 401 refresh rebuilds a fresh client from refreshed runtime creds.
+    monkeypatch.setattr(
+        ac, "_resolve_nous_runtime_api",
+        lambda *, force_refresh=False: ("fresh-key", NOUS_BASE_URL),
+    )
+    monkeypatch.setattr(
+        ac, "_create_openai_client",
+        lambda *, api_key, base_url, **kwargs: fresh,
+    )
+    monkeypatch.setattr(ac, "_validate_llm_response", lambda resp, _task: resp)
+
+    result = ac.call_llm(task=task, messages=[{"role": "user", "content": "hi"}])
+
+    assert result == {"ok": True}
+    assert stale.chat.completions.create.call_count == 1
+    assert fresh.chat.completions.create.call_count == 1
+    # The stale expired-credential client must be gone from the cache, not merely
+    # shadowed by the fresh client under a divergent (task-dropped) key.
+    assert not any(entry[0] is stale for entry in ac._client_cache.values()), (
+        "stale auto-provider client survived the 401 refresh: the acquisition "
+        "site dropped the task dimension so the refresh keyed the fresh client "
+        "under a different cache entry (#58894)"
+    )
+    assert any(entry[0] is fresh for entry in ac._client_cache.values())
+
+
+@pytest.mark.asyncio
+async def test_async_call_llm_auto_provider_evicts_stale_client_end_to_end(monkeypatch):
+    """Async twin of the end-to-end auto-provider eviction guard.
+
+    Passing a non-None ``main_runtime`` also pins the async acquisition site's
+    ``main_runtime`` threading: for ``provider == "auto"`` the runtime is part of
+    the key, so if the async acquisition rebuilds without it (while the refresh
+    passes it) the fresh client again lands under a divergent key -- the same bug
+    class one element over. Reverting either the ``task`` or the ``main_runtime``
+    kwarg at the async acquisition site fails this test.
+    """
+    task = "session_search"
+    main_runtime = {"provider": "nous", "model": "Hermes-4-405B"}
+    stale = _nous_mock_client(async_mode=True, raises=_Auth401("stale creds"))
+    fresh = _nous_mock_client(async_mode=True, returns={"ok": True})
+
+    monkeypatch.setattr(
+        ac, "_resolve_task_provider_model",
+        lambda *a, **k: ("auto", None, None, None, None),
+    )
+    monkeypatch.setattr(
+        ac, "resolve_provider_client",
+        lambda *a, **k: (stale, "nous-model"),
+    )
+    monkeypatch.setattr(
+        ac, "_resolve_nous_runtime_api",
+        lambda *, force_refresh=False: ("fresh-key", NOUS_BASE_URL),
+    )
+    # Async refresh builds a sync client then wraps it; patch the wrap to `fresh`.
+    monkeypatch.setattr(
+        ac, "_create_openai_client",
+        lambda *, api_key, base_url, **kwargs: MagicMock(),
+    )
+    monkeypatch.setattr(ac, "_to_async_client", lambda *a, **k: (fresh, "nous-model"))
+    monkeypatch.setattr(ac, "_validate_llm_response", lambda resp, _task: resp)
+
+    result = await ac.async_call_llm(
+        task=task,
+        messages=[{"role": "user", "content": "hi"}],
+        main_runtime=main_runtime,
+    )
+
+    assert result == {"ok": True}
+    assert stale.chat.completions.create.await_count == 1
+    assert fresh.chat.completions.create.await_count == 1
+    assert not any(entry[0] is stale for entry in ac._client_cache.values()), (
+        "stale auto-provider async client survived the 401 refresh: the async "
+        "acquisition site dropped the task/main_runtime dimension so the refresh "
+        "keyed the fresh client under a different cache entry (#58894)"
+    )
+    assert any(entry[0] is fresh for entry in ac._client_cache.values())


### PR DESCRIPTION
## What does this PR do?

On the default Nous config a 401 on an auxiliary call never self-heals: `_refresh_nous_auxiliary_client` (`agent/auxiliary_client.py`) rebuilds the client, but stores it under a different cache key than the one the stale client was acquired under, so the expired-credential client is never evicted and every subsequent auxiliary call (title generation, context compression, memory, MoA) keeps fetching the dead client, 401ing, and forcing a full credential-runtime refresh instead of self-healing after the first one.

The acquire and refresh paths disagreed on three of the key's dimensions:

- **model**: `call_llm` acquires with `resolved_model=None`, so the key's model element is `""`, but the refresh keyed the rebuilt client on the resolved wire model (`final_model`, e.g. `"Hermes-4-405B"`). The fresh client landed beside the stale one instead of replacing it.
- **task**: for `provider == "auto"` the key includes the task, but the refresh neither received nor forwarded it, and the primary acquisition sites in `call_llm`/`async_call_llm` dropped it as well (only the fallback acquire passed it). An auto-provider client acquired under a non-empty task was refreshed into the `task=""` slot while the stale client survived under the task-scoped key.
- **runtime**: the async path additionally dropped `main_runtime` at acquisition and at both of its 401 refresh sites.

The refresh now rebuilds the cache key from the values the stale client was looked up under (`lookup_model`, `lookup_task`, and `main_runtime` on the async sites), and the acquisition sites pass those same values, so acquire and refresh compute the same `(provider, task, model, runtime)` key on both sync and async paths and the fresh client overwrites the stale entry in place. The resolved `final_model` is still stored as the entry's usable model and returned to the caller, preserving the per-model keying introduced in #56889 for concurrent multi-model fan-out.

## Related Issue

Fixes #58892

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`
  - `_refresh_nous_auxiliary_client`: add `lookup_model` and `lookup_task` parameters used only to build the replacement cache key; keep storing `final_model` as the entry's usable model and returning it; expand the docstring to record why the key must come from the lookup values (#56889).
  - Forward `lookup_model=resolved_model, lookup_task=task` at the four 401 refresh sites (two in `call_llm`, two in `async_call_llm`); the async sites also pass `main_runtime`, which they previously dropped.
  - Thread `task` into the primary client acquisition in `call_llm`, and `main_runtime` + `task` into the primary acquisition in `async_call_llm`, matching the fallback acquire and the refresh.
- `tests/agent/test_auxiliary_client_refresh_cache_key_56889.py` (new, 5 tests)
  - Default-config refresh (`model="Hermes-4-405B"`, lookup `model=None`) must make the `model=None` lookup return the fresh client and drop the stale entry.
  - Explicit-model refresh keys on that model and does not create or clobber the default `""` entry, which guards the #56889 per-model keying.
  - Auto-provider refresh under a non-empty task replaces the task-scoped entry instead of orphaning it under `task=""`.
  - Two end-to-end tests drive the real `call_llm`/`async_call_llm` through the real client cache; the existing 401 tests patch `_get_cached_client` wholesale, so they cannot observe acquire/refresh key divergence.
  - Each test was verified to fail when its corresponding fix hunk is reverted.

## How to Test

```
# new regression tests
pytest tests/agent/test_auxiliary_client_refresh_cache_key_56889.py -q
  -> 5 passed          (on current main without the fix: 4 failed, 1 skipped)

# the whole auxiliary-client family, on top of current main
pytest tests/agent/test_auxiliary_client*.py -q
  -> 209 passed        (10 files, including the new one)

# lint
ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_client_refresh_cache_key_56889.py
  -> All checks passed!
```

The runs above are local (Windows 11, Python 3.13, cherry-picked onto current main). Full `pytest tests/` in my environment has pre-existing collection errors from optional deps that aren't installed (unrelated to this change); the touched auxiliary path is covered by the suites above.

Green ubuntu run for this head: https://github.com/cryptoyasenka/hermes-agent/actions/runs/31056693833

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(aux-client): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate.

  This is a follow-up to the merged #56889, which added the model to the auxiliary client cache key. The neighbouring cache-key PRs address different paths: #49156 (now closed) put the `/model` runtime override in the key via `_normalize_main_runtime`; #49219 fixes the model returned on a cache miss via `_compat_model`; #8664 and #16410 ("include model in cache key") are superseded by #56889; #21016 clears the cache after a `.env` hot-reload (issue #21013). None of them touch the 401 refresh keying in `_refresh_nous_auxiliary_client` or the task/runtime threading at the client acquisition sites, which is all this PR changes.
- [x] My PR contains only changes related to this fix
- [x] I've run the affected suites locally (see How to Test). Full `pytest tests/` has pre-existing optional-dep collection errors in my environment; the touched path is covered above.
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping
- [x] I've updated relevant documentation (N/A: internal refresh helper, no doc surface)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys (N/A: no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` (N/A)
- [x] I've considered cross-platform impact (pure cache-key logic, no OS-specific calls)
- [x] I've updated tool descriptions/schemas (N/A)

