### PR TITLE
refactor(gateway): replace len(x)==0/len(x)>0 with idiomatic Python

### DIFF
--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -1762,7 +1762,7 @@ class ExtractContentMiddleware(InboundMiddleware):
                 # Prefer medium image (index 1), fallback to index 0
                 if len(image_info_array) > 1 and isinstance(image_info_array[1], dict):
                     image_info = image_info_array[1]
-                elif len(image_info_array) > 0 and isinstance(image_info_array[0], dict):
+                elif image_info_array and isinstance(image_info_array[0], dict):
                     image_info = image_info_array[0]
                 image_url = str((image_info or {}).get("url") or "").strip()
                 rid = cls._parse_resource_id(image_url)
@@ -1862,7 +1862,7 @@ class ExtractContentMiddleware(InboundMiddleware):
                 image_info = None
                 if len(image_info_array) > 1 and isinstance(image_info_array[1], dict):
                     image_info = image_info_array[1]
-                elif len(image_info_array) > 0 and isinstance(image_info_array[0], dict):
+                elif image_info_array and isinstance(image_info_array[0], dict):
                     image_info = image_info_array[0]
                 image_url = str((image_info or {}).get("url") or "").strip()
                 if image_url:
@@ -4846,7 +4846,7 @@ class MessageSender:
         Returns:
             Error description (str) if validation fails, otherwise None.
         """
-        if file_bytes is None or len(file_bytes) == 0:
+        if not file_bytes:
             return f"Empty file: {filename}"
         max_bytes = max_size_mb * 1024 * 1024
         if len(file_bytes) > max_bytes:

--- a/gateway/relay/auth.py
+++ b/gateway/relay/auth.py
@@ -67,7 +67,7 @@ def verify_signature(payload: str, sig_hex: str, secrets: Sequence[str]) -> bool
         sig_buf = bytes.fromhex(sig_hex)
     except (ValueError, TypeError):
         return False
-    if len(sig_buf) == 0:
+    if not sig_buf:
         return False
     for secret in secrets:
         if not secret:

--- a/gateway/scale_to_zero.py
+++ b/gateway/scale_to_zero.py
@@ -80,7 +80,7 @@ def messaging_is_relay_only_or_absent(platforms: Iterable[Any]) -> bool:
     """
     names = {_platform_name(p) for p in platforms}
     names.discard("relay")
-    return len(names) == 0
+    return not names
 
 
 def _platform_name(platform: Any) -> str:


### PR DESCRIPTION
## Summary

Replace `len(x) == 0` with `not x` and `len(x) > 0` with truthy `x` checks across gateway/ modules. These are semantically equivalent but more idiomatic and readable in Python.

## Changes

- `gateway/relay/auth.py`: `len(sig_buf) == 0` → `not sig_buf`
- `gateway/scale_to_zero.py`: `len(names) == 0` → `not names`
- `gateway/platforms/yuanbao.py`: `len(file_bytes) == 0` → `not file_bytes` + `len(image_info_array) > 0` → `image_info_array` (×2)

## Validation

| Check | Result |
|---|---|
| `ruff check` on changed files | clean |
| File-level comparison (diff) | 5 changes, 5 unchanged — semantics preserved |

Follows the same pattern as #58842 (AlexFucuson9).