### PR TITLE
fix: idiomatic Python checks in hermes_cli

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1797,7 +1797,7 @@ class SlashCommandCompleter(Completer):
         trailing_space = sub_text.endswith(" ")
 
         # Subcommand stage: zero words typed, or completing the first word.
-        if len(parts) == 0 or (len(parts) == 1 and not trailing_space):
+        if not parts or (len(parts) == 1 and not trailing_space):
             partial = sub_text if not trailing_space else ""
             for sub in SUBS:
                 if sub.startswith(partial.lower()) and sub != partial.lower():

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5435,9 +5435,9 @@ def _is_service_running() -> bool:
         if gateway_windows.is_installed():
             # "installed" doesn't necessarily mean "running" on Windows. The
             # canonical check is whether a gateway process actually exists.
-            return len(find_gateway_pids()) > 0
+            return bool(find_gateway_pids())
     # Check for manual processes
-    return len(find_gateway_pids()) > 0
+    return bool(find_gateway_pids())
 
 
 def _setup_weixin():

--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -17,7 +17,7 @@ def _has_configured_mcp_servers() -> bool:
         from hermes_cli.config import read_raw_config
 
         mcp_servers = (read_raw_config() or {}).get("mcp_servers")
-        return isinstance(mcp_servers, dict) and len(mcp_servers) > 0
+        return isinstance(mcp_servers, dict) and mcp_servers
     except Exception:
         # Be conservative: if config probing fails, try discovery in the
         # background so startup still can't block.


### PR DESCRIPTION
Replace non-idiomatic `len(x) > 0` / `len(x) == 0` patterns with proper Pythonic equivalents in `hermes_cli/`.

**Changes:**

- `hermes_cli/commands.py`: `len(parts) == 0` → `not parts` (line 1800)
- `hermes_cli/mcp_startup.py`: `len(mcp_servers) > 0` → bare `mcp_servers` (line 20)
- `hermes_cli/gateway.py`: `len(find_gateway_pids()) > 0` → `bool(find_gateway_pids())` (lines 5438, 5440)