### PR TITLE
fix: idiomatic Python improvements in tui_gateway/, agent/, and tools/

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1198,7 +1198,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # _fallback_index=0 and re-marshaling the whole context across every
         # provider again.  Guards the cross-turn replay storm in #24996.
         if (
-            len(agent._fallback_chain) > 0
+            agent._fallback_chain
             and reason not in {FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit}
         ):
             _existing_cooldown = getattr(agent, "_rate_limited_until", 0) or 0

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -898,7 +898,7 @@ def image_generate_tool(
     start_time = datetime.datetime.now()
 
     try:
-        if not prompt or not isinstance(prompt, str) or len(prompt.strip()) == 0:
+        if not prompt or not isinstance(prompt, str) or not prompt.strip():
             raise ValueError("Prompt is required and must be a non-empty string")
 
         if not (fal_key_is_configured() or _resolve_managed_fal_gateway()):

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -316,7 +316,7 @@ def main():
     try:
         from hermes_cli.config import read_raw_config
         _mcp_servers = (read_raw_config() or {}).get("mcp_servers")
-        _has_mcp_servers = isinstance(_mcp_servers, dict) and len(_mcp_servers) > 0
+        _has_mcp_servers = isinstance(_mcp_servers, dict) and _mcp_servers
     except Exception:
         # Be conservative: if we can't decide, fall back to attempting
         # discovery (still backgrounded, so it can't block startup).

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12150,7 +12150,7 @@ def _details_completions(text: str) -> list[dict] | None:
     sections = ("thinking", "tools", "subagents", "activity")
     modes = ("hidden", "collapsed", "expanded")
 
-    if not body or (len(parts) == 0 and has_trailing_space):
+    if not body or (not parts and has_trailing_space):
         return [
             *[
                 _details_root_completion_item(


### PR DESCRIPTION
## Summary

Replaces explicit `len()` / `len(...) == 0` checks with idiomatic Python truthiness throughout the codebase.

## Changes

| File | Before | After |
|------|--------|-------|
| `tui_gateway/server.py:12153` | `len(parts) == 0` | `not parts` |
| `tui_gateway/entry.py:319` | `len(_mcp_servers) > 0` | `_mcp_servers` (truthy) |
| `agent/chat_completion_helpers.py:1201` | `len(agent._fallback_chain) > 0` | `agent._fallback_chain` (truthy) |
| `tools/image_generation_tool.py:901` | `len(prompt.strip()) == 0` | `not prompt.strip()` |

All four are semantically equivalent — relying on Python's implicit truthiness for non-empty lists, dicts, and strings.