### PR TITLE
fix: replace len(x) == 0 / len(x) > 0 with idiomatic Python truthiness checks

### DIFF
--- a/optional-skills/finance/dcf-model/scripts/validate_dcf.py
+++ b/optional-skills/finance/dcf-model/scripts/validate_dcf.py
@@ -46,7 +46,7 @@ class DCFModelValidator:
         results = {
             'file': self.excel_path,
             'validation_date': datetime.now().isoformat(),
-            'status': 'PASS' if len(self.errors) == 0 else 'FAIL',
+            'status': 'PASS' if not self.errors else 'FAIL',
             'error_count': len(self.errors),
             'warning_count': len(self.warnings),
             'errors': self.errors,

--- a/optional-skills/finance/stocks/scripts/stocks_client.py
+++ b/optional-skills/finance/stocks/scripts/stocks_client.py
@@ -279,7 +279,7 @@ def extract_quote_from_chart(symbol: str, chart_data: dict) -> dict:
     }
 
     chart = safe_get(chart_data, "chart", "result")
-    if not chart or not isinstance(chart, list) or len(chart) == 0:
+    if not chart or not isinstance(chart, list) or not chart:
         return result
 
     r = chart[0]
@@ -320,7 +320,7 @@ def extract_quote_summary_fields(qs_data: dict) -> dict:
     }
 
     result = safe_get(qs_data, "quoteSummary", "result")
-    if not result or not isinstance(result, list) or len(result) == 0:
+    if not result or not isinstance(result, list) or not result:
         return out
 
     r = result[0]
@@ -455,7 +455,7 @@ def cmd_history(symbol: str, range_: str = "1mo") -> None:
         return
 
     chart = safe_get(chart_data, "chart", "result")
-    if not chart or not isinstance(chart, list) or len(chart) == 0:
+    if not chart or not isinstance(chart, list) or not chart:
         err = safe_get(chart_data, "chart", "error", "description") or "Unknown error"
         print_json({"error": err, "symbol": sym, "data_source": "Yahoo Finance"})
         return
@@ -616,7 +616,7 @@ def cmd_crypto(symbol: str, vs: str = "USD") -> None:
         return
 
     chart = safe_get(chart_data, "chart", "result")
-    if not chart or not isinstance(chart, list) or len(chart) == 0:
+    if not chart or not isinstance(chart, list) or not chart:
         err = safe_get(chart_data, "chart", "error", "description") or "Symbol not found"
         print_json({"error": err, "symbol": ticker, "data_source": "Yahoo Finance"})
         return

--- a/optional-skills/security/godmode/scripts/auto_jailbreak.py
+++ b/optional-skills/security/godmode/scripts/auto_jailbreak.py
@@ -46,7 +46,7 @@ _race_path = _SCRIPTS_DIR / "godmode_race.py"
 
 # Use the calling frame's globals so functions are accessible everywhere
 import inspect as _inspect
-_caller_globals = _inspect.stack()[0][0].f_globals if len(_inspect.stack()) > 0 else globals()
+_caller_globals = _inspect.stack()[0][0].f_globals if _inspect.stack() else globals()
 
 if _parseltongue_path.exists():
     exec(compile(open(_parseltongue_path).read(), str(_parseltongue_path), 'exec'), _caller_globals)

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1013,7 +1013,7 @@ class HonchoMemoryProvider(MemoryProvider):
             # pass 2: reconciliation
             return (
                 f"Prior passes produced:\n\n"
-                f"Pass 1:\n{prior_results[0] if len(prior_results) > 0 else '(empty)'}\n\n"
+                f"Pass 1:\n{prior_results[0] if prior_results else '(empty)'}\n\n"
                 f"Pass 2:\n{prior_results[1] if len(prior_results) > 1 else '(empty)'}\n\n"
                 "Do these assessments cohere? Reconcile any contradictions "
                 "and produce a final, concise synthesis of what matters most "

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1218,7 +1218,7 @@ class MatrixAdapter(BasePlatformAdapter):
                         )
                         if len(all_devices) == 1:
                             client.device_id = next(iter(all_devices))
-                        elif len(all_devices) == 0:
+                        elif not all_devices:
                             logger.warning(
                                 "Matrix: no devices found for %s — "
                                 "key verification will be skipped",

--- a/skills/creative/comfyui/scripts/run_batch.py
+++ b/skills/creative/comfyui/scripts/run_batch.py
@@ -144,7 +144,7 @@ def main(argv: list[str] | None = None) -> int:
         if not isinstance(sweep, dict):
             emit_json({"error": "--sweep must be a JSON object {param: [values]}"})
             return 1
-        empty = [k for k, v in sweep.items() if isinstance(v, list) and len(v) == 0]
+        empty = [k for k, v in sweep.items() if isinstance(v, list) and not v]
         if empty:
             emit_json({"error": f"--sweep parameters have empty value lists: {empty}"})
             return 1

--- a/skills/productivity/maps/scripts/maps_client.py
+++ b/skills/productivity/maps/scripts/maps_client.py
@@ -525,7 +525,7 @@ def cmd_search(args):
             "osm_type":     item.get("osm_type", ""),
             "osm_id":       item.get("osm_id", ""),
             "bounding_box": {
-                "min_lat": float(bb[0]) if len(bb) > 0 else None,
+                "min_lat": float(bb[0]) if bb else None,
                 "max_lat": float(bb[1]) if len(bb) > 1 else None,
                 "min_lon": float(bb[2]) if len(bb) > 2 else None,
                 "max_lon": float(bb[3]) if len(bb) > 3 else None,


### PR DESCRIPTION
## Summary

Replace non-idiomatic `len(x) == 0` / `len(x) > 0` patterns with Pythonic truthiness checks (`not x` / `x`) across `skills/`, `plugins/`, and `optional-skills/`.

## Changes

| File | Before | After |
|------|--------|-------|
| `plugins/platforms/matrix/adapter.py` | `len(all_devices) == 0` | `not all_devices` |
| `plugins/memory/honcho/__init__.py` | `len(prior_results) > 0` | `prior_results` |
| `skills/creative/comfyui/scripts/run_batch.py` | `len(v) == 0` | `not v` |
| `skills/productivity/maps/scripts/maps_client.py` | `len(bb) > 0` | `bb` |
| `optional-skills/finance/dcf-model/scripts/validate_dcf.py` | `len(self.errors) == 0` | `not self.errors` |
| `optional-skills/finance/stocks/scripts/stocks_client.py` | `len(chart) == 0` (×3), `len(result) == 0` (×1) | `not chart` (×3), `not result` (×1) |
| `optional-skills/security/godmode/scripts/auto_jailbreak.py` | `len(_inspect.stack()) > 0` | `_inspect.stack()` |

## Rationale

Python containers (lists, dicts, sets, strings) are falsy when empty, so `if not x:` is the idiomatic way to check emptiness. These changes make the code more readable and consistent with Python best practices without changing behavior.