### PR TITLE
fix(docs): replace broken NeurIPS style files URL with conference homepage

### DIFF
--- a/website/docs/user-guide/skills/bundled/research/research-research-paper-writing.md
+++ b/website/docs/user-guide/skills/bundled/research/research-research-paper-writing.md
@@ -2392,4 +2392,4 @@ See [templates/README.md](https://github.com/NousResearch/hermes-agent/blob/main
 
 **APIs:** [Semantic Scholar](https://api.semanticscholar.org/api-docs/) | [CrossRef](https://www.crossref.org/documentation/retrieve-metadata/rest-api/) | [arXiv](https://info.arxiv.org/help/api/basics.html)
 
-**Venues:** [NeurIPS](https://neurips.cc/Conferences/2025/PaperInformation/StyleFiles) | [ICML](https://icml.cc/Conferences/2025/AuthorInstructions) | [ICLR](https://iclr.cc/Conferences/2026/AuthorGuide) | [ACL](https://github.com/acl-org/acl-style-files)
+**Venues:** [NeurIPS](https://neurips.cc/Conferences/2025) | [ICML](https://icml.cc/Conferences/2025/AuthorInstructions) | [ICLR](https://iclr.cc/Conferences/2026/AuthorGuide) | [ACL](https://github.com/acl-org/acl-style-files)


### PR DESCRIPTION
The URL `https://neurips.cc/Conferences/2025/PaperInformation/StyleFiles` returns 404 (broken since 2024). Replaced with the stable conference homepage `https://neurips.cc/Conferences/2025` which is the canonical location for author resources.