### PR TITLE
fix(dashboard): prevent auto-SSO redirect for basic auth provider

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -185,6 +185,11 @@ def _auto_sso_response(request: Request) -> Response | None:
     from hermes_cli.dashboard_auth.prefix import prefix_from_request
 
     provider = providers[0]
+    # Basic auth (password) has no OAuth redirect flow; auto-redirecting to
+    # /auth/login would just NotImplementedError. Let /login render.
+    if provider.name == "basic":
+        return None
+
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote


### PR DESCRIPTION
When only the Basic Auth (password) provider is registered, the middleware incorrectly attempts to auto-initiate an OAuth redirect flow, leading to a NotImplementedError. This patch skips the auto-SSO logic if the single registered provider is 'basic'.