### PR TITLE
fix(dingtalk): ack raw callbacks after lazy SDK import

### DIFF
--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -1432,6 +1432,23 @@ class _IncomingHandler(
         """
         return
 
+    async def raw_process(self, callback_message: "CallbackMessage"):
+        """Return the SDK-level ACK for a raw DingTalk callback.
+
+        When dingtalk-stream is imported lazily, this handler class may have
+        been defined with ``object`` as its base class, so it cannot rely on
+        inheriting ``CallbackHandler.raw_process()`` from the SDK.
+        """
+        code, response = await self.process(callback_message)
+        ack_message = AckMessage()
+        ack_message.code = code
+        ack_message.headers.message_id = getattr(
+            getattr(callback_message, "headers", None), "message_id", None
+        )
+        ack_message.headers.content_type = "application/json"
+        ack_message.data = {"response": response}
+        return ack_message
+
     async def process(self, message: "CallbackMessage"):
         """Called by dingtalk-stream (>=0.20) when a message arrives.
 

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -788,6 +788,46 @@ class TestIncomingHandlerProcess:
     so the SDK ACK is returned immediately."""
 
     @pytest.mark.asyncio
+    async def test_raw_process_wraps_process_result_as_sdk_ack(self, monkeypatch):
+        """raw_process must build the AckMessage shape expected by the SDK."""
+        import plugins.platforms.dingtalk.adapter as dt
+
+        class FakeAckMessage:
+            STATUS_OK = 200
+            STATUS_SYSTEM_EXCEPTION = 500
+
+            def __init__(self):
+                self.code = None
+                self.headers = SimpleNamespace(message_id=None, content_type=None)
+                self.data = {}
+
+        monkeypatch.setattr(dt, "AckMessage", FakeAckMessage)
+
+        adapter = dt.DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._on_message = AsyncMock()
+        handler = dt._IncomingHandler(adapter, asyncio.get_running_loop())
+
+        callback = SimpleNamespace(
+            headers=SimpleNamespace(message_id="callback-msg-001"),
+            data={
+                "msgtype": "text",
+                "text": {"content": "hello"},
+                "senderId": "user1",
+                "conversationId": "conv1",
+            },
+        )
+
+        ack = await handler.raw_process(callback)
+
+        assert ack.code == 200
+        assert ack.headers.message_id == "callback-msg-001"
+        assert ack.headers.content_type == "application/json"
+        assert ack.data == {"response": "OK"}
+
+        await asyncio.sleep(0.05)
+        adapter._on_message.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_process_extracts_session_webhook(self):
         """session_webhook must be populated from callback data."""
         from plugins.platforms.dingtalk.adapter import _IncomingHandler, DingTalkAdapter


### PR DESCRIPTION
## Summary
- add an explicit `_IncomingHandler.raw_process()` wrapper for DingTalk callbacks
- return the SDK AckMessage shape with `code`, `headers.message_id`, `headers.content_type`, and `data.response`
- cover the ACK shape in `tests/gateway/test_dingtalk.py`

## Why
`dingtalk-stream==0.24.3` routes callback frames through `handler.raw_process(msg)`. Hermes can define `_IncomingHandler` before the optional DingTalk SDK is available, which means the class may have `object` as its base and cannot rely on inheriting the SDK `CallbackHandler.raw_process()`.

## Verification
- `uv run --extra dev python -m pytest tests/gateway/test_dingtalk.py -q` -> `69 passed in 3.05s`
- `uv run --extra dev ruff check plugins/platforms/dingtalk/adapter.py tests/gateway/test_dingtalk.py` -> `All checks passed!`
- `git diff --check` -> passed
