### PR TITLE
feat(gateway): add opt-in MEDIA_CAPTION directive for native media captions

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -8,6 +8,7 @@ and implement the required methods.
 import asyncio
 import inspect
 import ipaddress
+import json
 import logging
 import os
 import random
@@ -1484,6 +1485,18 @@ MEDIA_EXTENSIONLESS_TAG_RE = re.compile(
     r'''(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|'''
     r'''(?:~/|/|[A-Za-z]:[/\\])[^\s\n`"']+)'''
     r'''[`"']?\s*''',
+    re.IGNORECASE,
+)
+
+# Structured directive for native media captions (videos and images). The
+# legacy markdown-image path (![alt](https://...)) is not intercepted; this
+# directive is opt-in per media file and requires an explicit "type".
+# Examples:
+#   MEDIA_CAPTION:{"path":"/tmp/tour.mp4","caption":"Tour do decorado.","type":"video"}
+#   MEDIA_CAPTION:{"path":"/tmp/planta.jpg","caption":"Planta do 2 quartos.","type":"image"}
+MEDIA_CAPTION_RE = re.compile(
+    r'MEDIA_CAPTION:\s*'
+    r'(?P<payload>\{[^}]*?"type"\s*:\s*"(?:video|image)"[^}]*\})',
     re.IGNORECASE,
 )
 
@@ -3686,13 +3699,114 @@ class BasePlatformAdapter(ABC):
         """
         if (
             "MEDIA:" not in text
+            and "MEDIA_CAPTION:" not in text
             and "[[audio_as_voice]]" not in text
             and "[[as_document]]" not in text
         ):
             return text
         cleaned = _strip_media_tag_directives(text)
+        cleaned = MEDIA_CAPTION_RE.sub("", cleaned)
+        cleaned = re.sub(r'[ \t]+$', '', cleaned, flags=re.MULTILINE)
         cleaned = re.sub(r'\n{3,}', '\n\n', cleaned)
         return cleaned.rstrip()
+
+    @staticmethod
+    def extract_captioned_media(content: str) -> Tuple[List[Dict[str, Any]], str]:
+        """Extract safe local videos/images carrying an explicit native caption.
+
+        Each accepted item requires an explicit ``"type"`` ("video" or
+        "image") whose declared type must agree with the file extension.
+        The legacy markdown-image path (``![alt](https://...)``) is not
+        intercepted, so existing flows are unaffected unless a tool opts in
+        by emitting ``MEDIA_CAPTION:`` directives.
+        """
+        if "MEDIA_CAPTION:" not in content:
+            return [], content
+
+        items: List[Dict[str, Any]] = []
+        valid_spans: List[Tuple[int, int]] = []
+        scan_content = BasePlatformAdapter._mask_protected_spans(content)
+        exts_by_type = {
+            "video": {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp', '.m4v'},
+            "image": {'.jpg', '.jpeg', '.png', '.webp', '.gif'},
+        }
+
+        for match in MEDIA_CAPTION_RE.finditer(scan_content):
+            payload_text = content[match.start("payload"):match.end("payload")]
+            try:
+                payload = json.loads(payload_text)
+            except (TypeError, ValueError):
+                continue
+            if not isinstance(payload, dict):
+                continue
+
+            raw_path = str(payload.get("path") or "").strip()
+            media_type = str(payload.get("type") or "").strip().lower()
+            if not raw_path:
+                continue
+            allowed_exts = exts_by_type.get(media_type)
+            if not allowed_exts:
+                continue
+            if Path(raw_path).suffix.lower() not in allowed_exts:
+                continue
+
+            safe_path = validate_media_delivery_path(os.path.expanduser(raw_path))
+            if not safe_path:
+                logger.warning(
+                    "Skipping unsafe MEDIA_CAPTION %s path: %s",
+                    media_type,
+                    _log_safe_path(raw_path),
+                )
+                continue
+
+            items.append({
+                "path": safe_path,
+                "type": media_type,
+                "caption": str(payload.get("caption") or "").strip() or None,
+            })
+            valid_spans.append((match.start(), match.end()))
+
+        if not valid_spans:
+            return [], content
+
+        chars = list(content)
+        for start, end in valid_spans:
+            for idx in range(start, end):
+                if chars[idx] != '\n':
+                    chars[idx] = ' '
+        cleaned = ''.join(chars)
+        # Blanked directive spans leave whitespace-only lines behind; strip
+        # trailing spaces per line so the remaining text has no floating gaps.
+        cleaned = re.sub(r'[ \t]+$', '', cleaned, flags=re.MULTILINE)
+        cleaned = re.sub(r'\n{3,}', '\n\n', cleaned).strip()
+        return items, cleaned
+
+    @staticmethod
+    def split_captioned_media_text(content: str) -> Tuple[str, str]:
+        """Split text around MEDIA_CAPTION directives into (opening, closing).
+
+        Captioned media are delivered as native media bubbles between the
+        text that precedes the first directive and the text that follows the
+        last one. Callers use the pair to keep the natural reading order:
+        [opening] [media+caption ...] [closing]. Both segments come back
+        display-cleaned (no residual directives). Returns ("", "") when the
+        content carries no MEDIA_CAPTION directive.
+        """
+        if "MEDIA_CAPTION:" not in content:
+            return "", ""
+        scan_content = BasePlatformAdapter._mask_protected_spans(content)
+        matches = list(MEDIA_CAPTION_RE.finditer(scan_content))
+        if not matches:
+            return "", ""
+        opening = content[:matches[0].start()]
+        closing = content[matches[-1].end():]
+        # strip_media_directives_for_display early-returns unchanged when the
+        # segment carries no directive, so strip the border whitespace left by
+        # the removed directive spans ourselves — otherwise the opening bubble
+        # keeps a trailing blank line and the closing message leads with one.
+        opening = BasePlatformAdapter.strip_media_directives_for_display(opening).strip()
+        closing = BasePlatformAdapter.strip_media_directives_for_display(closing).strip()
+        return opening, closing
 
     @staticmethod
     def extract_local_files(content: str) -> Tuple[List[str], str]:
@@ -4900,6 +5014,10 @@ class BasePlatformAdapter(ABC):
                 # Pre-extract snapshot for the #29346 recovery/invariant below.
                 _response_pre_extract = response
 
+                # Extract captioned media first. This is intentionally separate
+                # from extract_images(), preserving the established image path.
+                captioned_media, response = self.extract_captioned_media(response)
+
                 # Extract MEDIA:<path> tags (from TTS tool) before other processing
                 media_files, response = self.extract_media(response)
                 media_files = self.filter_media_delivery_paths(media_files)
@@ -4929,7 +5047,7 @@ class BasePlatformAdapter(ABC):
                 # empty text with no attachment, and the `if text_content` guard
                 # below then drops it silently. Recover on every platform (#33842
                 # was Discord-only); the guard avoids duplicating an attachment.
-                if not (text_content or images or local_files or media_files):
+                if not (text_content or images or local_files or media_files or captioned_media):
                     # Recover from the post-extract_media `response`, not the raw
                     # snapshot: extract_media already stripped MEDIA (incl. spaced
                     # paths) with its full grammar, so no fragment can leak.
@@ -5134,11 +5252,46 @@ class BasePlatformAdapter(ABC):
                     except Exception as file_err:
                         logger.error("[%s] Error sending local file %s: %s", self.name, file_path, file_err)
 
+                # Captioned media use the native adapter methods so the caption
+                # rides on the media bubble itself. Preserves item order.
+                for item in captioned_media:
+                    if human_delay > 0:
+                        await asyncio.sleep(human_delay)
+                    try:
+                        if item.get("type") == "image":
+                            result = await self.send_image_file(
+                                chat_id=event.source.chat_id,
+                                image_path=item["path"],
+                                caption=item.get("caption"),
+                                metadata=_final_thread_metadata,
+                            )
+                        else:
+                            result = await self.send_video(
+                                chat_id=event.source.chat_id,
+                                video_path=item["path"],
+                                caption=item.get("caption"),
+                                metadata=_final_thread_metadata,
+                            )
+                        if not result.success:
+                            logger.warning(
+                                "[%s] Failed to send captioned %s: %s",
+                                self.name,
+                                item.get("type"),
+                                result.error,
+                            )
+                    except Exception as media_err:
+                        logger.warning(
+                            "[%s] Error sending captioned %s: %s",
+                            self.name,
+                            item.get("type"),
+                            media_err,
+                        )
+
                 # A3 (#29346): if a non-empty response produced nothing
                 # deliverable, fail loudly rather than dropping it in silence.
                 _anything_delivered = (
                     delivery_attempted or _tts_caption_delivered
-                    or images or local_files or media_files
+                    or images or local_files or media_files or captioned_media
                 )
                 if not _anything_delivered and _response_pre_extract.strip():
                     logger.error(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11667,6 +11667,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         await self._deliver_media_from_response(
                             response, event, _media_adapter,
                         )
+                        # Closing text deferred by the captioned-media reorder
+                        # (see the suppress/transform branches): it must land
+                        # after the media bubbles to keep the reading order
+                        # [opening] [media+caption ...] [closing].
+                        _mc_trailing = agent_result.get("media_caption_trailing")
+                        if _mc_trailing:
+                            try:
+                                await _media_adapter.send(
+                                    source.chat_id,
+                                    _mc_trailing,
+                                    metadata=self._thread_metadata_for_source(source, self._reply_anchor_for_event(event)),
+                                )
+                            except Exception as _mc_e:
+                                logger.warning(
+                                    "Captioned-media trailing text send failed: %s",
+                                    _mc_e,
+                                )
                 # Streaming already delivered the body text, but the footer was
                 # intentionally held back (see the `not already_sent` gate above).
                 # Send it now as a small trailing message so Telegram/Discord/etc.
@@ -12703,6 +12720,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             from gateway.platforms.base import BasePlatformAdapter, should_send_media_as_audio
 
+            captioned_media, response = adapter.extract_captioned_media(response)
             media_files, cleaned = adapter.extract_media(response)
             media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
             # Chain the cleaned text through each extractor (extract_media →
@@ -12717,6 +12735,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             local_files = BasePlatformAdapter.filter_local_delivery_paths(local_files)
 
             _thread_meta = self._thread_metadata_for_source(event.source, self._reply_anchor_for_event(event))
+
+            # Captioned media ride the native adapter methods so the caption
+            # stays attached to the media bubble itself. Preserves item order.
+            for item in captioned_media:
+                try:
+                    if item.get("type") == "image":
+                        result = await adapter.send_image_file(
+                            chat_id=event.source.chat_id,
+                            image_path=item["path"],
+                            caption=item.get("caption"),
+                            metadata=_thread_meta,
+                        )
+                    else:
+                        result = await adapter.send_video(
+                            chat_id=event.source.chat_id,
+                            video_path=item["path"],
+                            caption=item.get("caption"),
+                            metadata=_thread_meta,
+                        )
+                    if not getattr(result, "success", False):
+                        logger.warning(
+                            "[%s] Post-stream captioned media delivery failed: %s",
+                            adapter.name,
+                            getattr(result, "error", None),
+                        )
+                except Exception as e:
+                    logger.warning(
+                        "[%s] Post-stream captioned media delivery failed: %s",
+                        adapter.name,
+                        e,
+                    )
 
             _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
             _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
@@ -19354,16 +19403,69 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _content_delivered,
                 )
                 response["already_sent"] = True
+                # Captioned-media reading order: the streamed bubble shows the
+                # whole display text (opening + closing merged, directives
+                # stripped) while the media itself only lands afterwards via
+                # _deliver_media_from_response. Shrink the bubble to the text
+                # that precedes the first MEDIA_CAPTION directive and defer
+                # the text that follows the last one to a trailing message
+                # sent after the media (see the already_sent path), restoring
+                # [opening] [media+caption ...] [closing].
+                _mc_final = response.get("final_response") or ""
+                if _sc is not None and "MEDIA_CAPTION:" in _mc_final:
+                    from gateway.platforms.base import BasePlatformAdapter as _BPA_mc
+                    _mc_pre, _mc_post = _BPA_mc.split_captioned_media_text(_mc_final)
+                    _mc_msg_id = _sc.message_id
+                    if _mc_msg_id and _mc_pre.strip():
+                        try:
+                            await _sc.adapter.edit_message(
+                                chat_id=source.chat_id,
+                                message_id=_mc_msg_id,
+                                content=_mc_pre,
+                                finalize=True,
+                            )
+                            if _mc_post.strip():
+                                response["media_caption_trailing"] = _mc_post
+                        except Exception as _mc_err:
+                            # Keep the merged bubble on failure — media still
+                            # arrives right after, just without the reorder.
+                            logger.warning(
+                                "Captioned-media bubble reorder failed for session %s: %s",
+                                session_key or "?", _mc_err,
+                            )
             elif not _is_empty_sentinel and _transformed and _sc is not None:
                 # Plugin hooks transformed the response after streaming — edit the
                 # existing streamed message instead of sending a duplicate.
+                # Strip media directives (MEDIA:/MEDIA_CAPTION:) before editing:
+                # the edit is display-only, and the media itself is delivered by
+                # _deliver_media_from_response right after (already_sent path).
+                from gateway.platforms.base import BasePlatformAdapter as _BPA_edit
+                _display_final = _BPA_edit.strip_media_directives_for_display(
+                    response["final_response"]
+                )
+                # Same reading-order fix as the non-transformed branch above:
+                # keep only the opening text in the edited bubble and defer the
+                # closing text until after the captioned media is delivered.
+                if "MEDIA_CAPTION:" in response["final_response"]:
+                    _mc_pre, _mc_post = _BPA_edit.split_captioned_media_text(
+                        response["final_response"]
+                    )
+                    if _mc_pre.strip():
+                        _display_final = _mc_pre
+                        if _mc_post.strip():
+                            response["media_caption_trailing"] = _mc_post
                 _sc_msg_id = _sc.message_id
-                if _sc_msg_id:
+                if _sc_msg_id and not _display_final.strip():
+                    # Transformed response is pure media directives — nothing
+                    # textual to edit in; keep the streamed text and let the
+                    # media delivery below handle the attachments.
+                    response["already_sent"] = True
+                elif _sc_msg_id:
                     try:
                         await _sc.adapter.edit_message(
                             chat_id=source.chat_id,
                             message_id=_sc_msg_id,
-                            content=response["final_response"],
+                            content=_display_final,
                             finalize=True,
                         )
                         response["already_sent"] = True

--- a/tests/gateway/test_media_caption_directive.py
+++ b/tests/gateway/test_media_caption_directive.py
@@ -1,0 +1,147 @@
+"""
+Tests for the opt-in ``MEDIA_CAPTION`` directive.
+
+``MEDIA_CAPTION:{"path": ..., "caption": ..., "type": "image"|"video"}``
+lets a tool request that a local image/video be delivered as a native
+media bubble with the caption attached to the bubble itself, instead of
+the caption landing as a separate text message. The directive is opt-in:
+plain ``MEDIA:`` tags and markdown images (``![alt](url)``) are untouched,
+so existing flows are unaffected.
+
+Coverage:
+- ``extract_captioned_media`` parses valid directives and rejects unsafe /
+  malformed / type-mismatched ones.
+- ``split_captioned_media_text`` partitions the surrounding text into the
+  opening (before the first directive) and closing (after the last) so the
+  gateway can preserve ``[opening] [media+caption ...] [closing]`` order.
+- ``strip_media_directives_for_display`` hides the raw directive from the
+  streamed text.
+"""
+
+import pytest
+
+from gateway.platforms.base import BasePlatformAdapter
+
+
+# A 1x1 PNG so validate_media_delivery_path() sees a real, non-empty file.
+_PNG_BYTES = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00\x01"
+    b"\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+@pytest.fixture
+def image_file(tmp_path):
+    p = tmp_path / "planta.png"
+    p.write_bytes(_PNG_BYTES)
+    return str(p)
+
+
+@pytest.fixture
+def second_image_file(tmp_path):
+    p = tmp_path / "cozinha.jpg"
+    p.write_bytes(_PNG_BYTES)
+    return str(p)
+
+
+class TestExtractCaptionedMedia:
+    def test_no_directive_is_noop(self):
+        text = "Just a regular reply with no media."
+        items, cleaned = BasePlatformAdapter.extract_captioned_media(text)
+        assert items == []
+        assert cleaned == text
+
+    def test_single_image_directive(self, image_file):
+        text = (
+            "Here is the material:\n\n"
+            'MEDIA_CAPTION:{"path": "%s", "caption": "Floor plan", "type": "image"}'
+            % image_file
+        )
+        items, cleaned = BasePlatformAdapter.extract_captioned_media(text)
+        assert len(items) == 1
+        assert items[0]["type"] == "image"
+        assert items[0]["path"].endswith("planta.png")
+        assert items[0]["caption"] == "Floor plan"
+        # The raw directive must not survive into the display text.
+        assert "MEDIA_CAPTION" not in cleaned
+        assert "Here is the material:" in cleaned
+
+    def test_multiple_directives_preserve_order(self, image_file, second_image_file):
+        text = (
+            'MEDIA_CAPTION:{"path": "%s", "caption": "First", "type": "image"}\n\n'
+            'MEDIA_CAPTION:{"path": "%s", "caption": "Second", "type": "image"}'
+            % (image_file, second_image_file)
+        )
+        items, _ = BasePlatformAdapter.extract_captioned_media(text)
+        assert [i["caption"] for i in items] == ["First", "Second"]
+
+    def test_missing_caption_yields_none(self, image_file):
+        text = 'MEDIA_CAPTION:{"path": "%s", "type": "image"}' % image_file
+        items, _ = BasePlatformAdapter.extract_captioned_media(text)
+        assert len(items) == 1
+        assert items[0]["caption"] is None
+
+    def test_type_must_match_extension(self, image_file):
+        # Declared as video but the file is a .png -> rejected.
+        text = 'MEDIA_CAPTION:{"path": "%s", "caption": "x", "type": "video"}' % image_file
+        items, cleaned = BasePlatformAdapter.extract_captioned_media(text)
+        assert items == []
+        assert cleaned == text
+
+    def test_unknown_type_rejected(self, tmp_path):
+        doc = tmp_path / "contract.pdf"
+        doc.write_bytes(b"%PDF-1.4 fake")
+        text = 'MEDIA_CAPTION:{"path": "%s", "caption": "x", "type": "document"}' % str(doc)
+        items, _ = BasePlatformAdapter.extract_captioned_media(text)
+        assert items == []
+
+    def test_nonexistent_path_rejected(self):
+        text = 'MEDIA_CAPTION:{"path": "/tmp/does-not-exist-1234.png", "caption": "x", "type": "image"}'
+        items, _ = BasePlatformAdapter.extract_captioned_media(text)
+        assert items == []
+
+    def test_malformed_json_ignored(self):
+        text = 'MEDIA_CAPTION:{"path": "/tmp/a.png", "caption": '
+        items, cleaned = BasePlatformAdapter.extract_captioned_media(text)
+        assert items == []
+        assert cleaned == text
+
+    def test_markdown_image_is_not_intercepted(self):
+        # The legacy markdown-image path stays opt-out.
+        text = "![cat](https://example.com/cat.png)"
+        items, cleaned = BasePlatformAdapter.extract_captioned_media(text)
+        assert items == []
+        assert cleaned == text
+
+
+class TestSplitCaptionedMediaText:
+    def test_no_directive_returns_empty_pair(self):
+        assert BasePlatformAdapter.split_captioned_media_text("plain text") == ("", "")
+
+    def test_opening_and_closing_are_partitioned(self, image_file, second_image_file):
+        text = (
+            "Here is the material:\n\n"
+            'MEDIA_CAPTION:{"path": "%s", "caption": "First", "type": "image"}\n\n'
+            'MEDIA_CAPTION:{"path": "%s", "caption": "Second", "type": "image"}\n\n'
+            "Anything else?"
+        ) % (image_file, second_image_file)
+        opening, closing = BasePlatformAdapter.split_captioned_media_text(text)
+        assert opening == "Here is the material:"
+        assert closing == "Anything else?"
+        # Neither segment leaks a raw directive.
+        assert "MEDIA_CAPTION" not in opening
+        assert "MEDIA_CAPTION" not in closing
+
+
+class TestStripForDisplay:
+    def test_directive_removed_from_display(self, image_file):
+        text = (
+            "Here is the material:\n\n"
+            'MEDIA_CAPTION:{"path": "%s", "caption": "Floor plan", "type": "image"}\n\n'
+            "Anything else?"
+        ) % image_file
+        cleaned = BasePlatformAdapter.strip_media_directives_for_display(text)
+        assert "MEDIA_CAPTION" not in cleaned
+        assert "Here is the material:" in cleaned
+        assert "Anything else?" in cleaned


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in `MEDIA_CAPTION` directive so a tool can have a local image or
video delivered as a **native media bubble with the caption attached to the
bubble itself**, instead of the caption arriving as a separate text message
before the media.

Today a tool that wants to send media with explanatory text emits `MEDIA:<path>`
plus the text, and platforms (Telegram, WhatsApp, …) deliver the text as its own
message *before* the media bubble. For an assistant sending several photos, each
with its own description, the result is a wall of captions followed by a wall of
images, with no association between them.

With this change a tool can instead emit:

```
MEDIA_CAPTION:{"path": "/path/to/planta.png", "caption": "2-bedroom floor plan", "type": "image"}
MEDIA_CAPTION:{"path": "/path/to/tour.mp4", "caption": "Model unit tour", "type": "video"}
```

and each file is delivered through the adapter's native `send_image_file` /
`send_video` with the caption attached to that bubble.

> **Attribution:** this change was drafted with AI assistance and then reviewed,
> tested, and validated by a human maintainer before submission. It was verified
> end-to-end against a live gateway (Telegram); a human owns and stands behind the
> change.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/platforms/base.py`
  - `MEDIA_CAPTION_RE` — regex for the directive.
  - `extract_captioned_media(content) -> (items, cleaned)` — parses directives
    into `{path, type, caption}`, requiring an explicit `type` (`image`/`video`)
    that must agree with the file extension, and routing every path through the
    existing `validate_media_delivery_path` (same denylist / traversal / symlink
    checks as `MEDIA:`). Malformed JSON, unknown types, type/extension
    mismatches, and unsafe paths are skipped, leaving that text untouched.
  - `split_captioned_media_text(content) -> (opening, closing)` — returns the
    display text before the first directive and after the last, so callers can
    preserve `[opening] [media+caption ...] [closing]` order.
  - `strip_media_directives_for_display` now also strips `MEDIA_CAPTION:` so the
    raw directive never shows in the streamed text.
- `gateway/run.py`
  - `_deliver_media_from_response` extracts captioned media and delivers each
    item via the adapter's native captioned send, preserving order.
  - After streaming, the streamed bubble is trimmed to the opening text and the
    closing text is sent as a trailing message **after** the media
    (`media_caption_trailing`), so reading order is preserved. If the bubble edit
    fails it falls back to the existing merged-bubble behavior — media still
    arrives.
- `tests/gateway/test_media_caption_directive.py` — unit tests for extraction,
  ordering, type/extension validation, unsafe-path rejection, malformed input,
  the opt-out of markdown images, and the opening/closing split.

## Design notes

- **Opt-in and backward-compatible.** Nothing changes for `MEDIA:` tags or
  markdown images (`![alt](url)`); a response with no `MEDIA_CAPTION:` takes an
  early-return fast path. Adapters that don't implement native captioned sends
  are unaffected — tools simply keep using `MEDIA:`.
- **Reuses existing safety.** Paths go through `validate_media_delivery_path`, so
  the same prompt-injection / credential-exfil rejections apply
  (`/etc/passwd`, `~/.ssh/id_rsa`, the Hermes credential store, …).
- **Type/extension agreement** prevents a directive from mislabeling a file
  (e.g. declaring a `.png` as `video`), which would otherwise reach the wrong
  adapter method.

## How to Test

1. From a tool, return a response containing one or more
   `MEDIA_CAPTION:{"path": "<local image/video>", "caption": "...", "type": "image"|"video"}`
   directives, with optional text before the first and after the last.
2. On Telegram/WhatsApp, confirm each media bubble carries its caption natively,
   the opening text is its own bubble before the media, and the closing text is a
   single message after the media — i.e. `[opening] [media+caption …] [closing]`.
3. Confirm a `MEDIA_CAPTION` pointing at a denied path (e.g. `~/.ssh/id_rsa`) is
   not delivered and stays as-is in the text.
4. Unit tests: `pytest tests/gateway/test_media_caption_directive.py -q`.

## Platforms tested

- Ubuntu 24.04 (WSL2), Telegram — validated end-to-end: four images, each with a
  native caption, correct opening/closing order.
- The added unit assertions were additionally exercised against the live gateway
  runtime; the full suite runs in CI.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat(gateway): …`)
- [x] PR contains only changes related to this feature
- [x] Added tests for the change
- [x] Considered cross-platform impact (pure-Python string/path handling; paths
      go through the existing `validate_media_delivery_path`)
