### PR TITLE
fix(session): allow base64 slashes in session keys

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -95,15 +95,13 @@ from .whatsapp_identity import (
 )
 from utils import atomic_replace
 
-# Session keys/ids flow into filesystem paths downstream (e.g.
+# Session ids flow into filesystem paths downstream (e.g.
 # ``sessions_dir / f"{session_id}.json"`` in hermes_state, request-dump
 # filenames in agent_runtime_helpers). Any value that could escape the
 # sessions directory as a path must be rejected at the entry boundary.
 # Rejects: parent traversal (``..``), a path separator anywhere (``/`` or
 # ``\``, so a non-leading Windows separator can't slip through), and a
-# leading Windows drive letter (``C:``). Legitimate session keys are
-# colon-delimited multi-segment ids (``agent:main:<platform>:...``) and
-# never contain these, so there are no false positives in practice.
+# leading Windows drive letter (``C:``).
 def _is_path_unsafe(value: object) -> bool:
     """Return True if ``value`` could traverse outside the sessions dir."""
     if not value:
@@ -116,6 +114,23 @@ def _is_path_unsafe(value: object) -> bool:
     # separator forms are already caught above — but keep an explicit guard
     # for the drive-letter prefix in case a separator was normalized away.
     return len(s) >= 2 and s[0].isalpha() and s[1] == ":"
+
+
+# Session keys are persisted as JSON object keys, not filenames, and may embed
+# platform-native identifiers. DingTalk conversation ids are base64 strings
+# whose alphabet includes ``/``; rejecting every interior slash makes those
+# sessions disappear on reload. Keep rejecting path-shaped values while
+# allowing interior slashes inside opaque key segments.
+def _is_session_key_unsafe(value: object) -> bool:
+    """Return True if a session key looks like a path-escape attempt."""
+    if not value:
+        return False
+    s = str(value)
+    if ".." in s or "\\" in s:
+        return True
+    if s.startswith(("/", "~")):
+        return True
+    return len(s) >= 2 and s[0].isalpha() and s[1] == ":" and s[2:3] in ("/", "\\")
 
 
 @dataclass
@@ -741,9 +756,14 @@ class SessionEntry:
         session_key = data["session_key"]
         session_id = data["session_id"]
 
-        # Validate path-sensitive fields to prevent directory traversal (CWE-22)
-        for _field, _val in (("session_key", session_key), ("session_id", session_id)):
-            if _is_path_unsafe(_val):
+        # Validate path-sensitive fields to prevent directory traversal (CWE-22).
+        # session_id flows into filenames and keeps the strict check; session_key
+        # is a JSON key and must tolerate base64 chat ids with interior "/".
+        for _field, _val, _checker in (
+            ("session_key", session_key, _is_session_key_unsafe),
+            ("session_id", session_id, _is_path_unsafe),
+        ):
+            if _checker(_val):
                 raise ValueError(
                     f"Invalid {_field}: potential directory traversal detected"
                 )

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1165,6 +1165,35 @@ class TestSessionEntryFromDictTraversalValidation:
         with pytest.raises(ValueError, match="session_key"):
             SessionEntry.from_dict(self._entry(session_key="agent:main:../../secret"))
 
+    def test_session_key_absolute_unix_raises(self):
+        from gateway.session import SessionEntry
+        with pytest.raises(ValueError, match="session_key"):
+            SessionEntry.from_dict(self._entry(session_key="/etc/passwd"))
+
+    def test_session_key_home_path_raises(self):
+        from gateway.session import SessionEntry
+        with pytest.raises(ValueError, match="session_key"):
+            SessionEntry.from_dict(self._entry(session_key="~/sessions"))
+
+    def test_session_key_windows_path_raises(self):
+        from gateway.session import SessionEntry
+        with pytest.raises(ValueError, match="session_key"):
+            SessionEntry.from_dict(self._entry(session_key="C:/windows/system32"))
+        with pytest.raises(ValueError, match="session_key"):
+            SessionEntry.from_dict(self._entry(session_key="agent:main:bad\\sub"))
+
+    def test_session_key_allows_dingtalk_base64_slash(self):
+        from gateway.session import SessionEntry
+
+        keys = [
+            "agent:main:dingtalk:dm:cidDAIsw68cJ7w/QyVwV0zB+KTziay5M9uOmLdzHoEi1tM=",
+            "agent:main:dingtalk:group:cidvL9m/YqbdGp1lPYxdOOEvw==:15528999368652879",
+            "agent:main:dingtalk:dm:$:LWCP_v1:$NW/8Xdhg39tkxmokXozO/Q==",
+        ]
+        for key in keys:
+            entry = SessionEntry.from_dict(self._entry(session_key=key))
+            assert entry.session_key == key
+
     def test_session_id_absolute_unix_raises(self):
         from gateway.session import SessionEntry
         with pytest.raises(ValueError, match="session_id"):
@@ -1191,8 +1220,6 @@ class TestSessionEntryFromDictTraversalValidation:
         from gateway.session import SessionEntry
         with pytest.raises(ValueError, match="session_id"):
             SessionEntry.from_dict(self._entry(session_id="good\\..\\bad"))
-        with pytest.raises(ValueError, match="session_key"):
-            SessionEntry.from_dict(self._entry(session_key="agent:main:good/sub"))
 
 
 class TestEnsureLoadedSkipsInvalidEntries:


### PR DESCRIPTION
## Summary
- keep strict path validation for `session_id`, which is used in filenames
- add a separate `session_key` validator that rejects path-shaped values but allows interior `/`
- add regression coverage for DingTalk base64 conversation ids that contain `/`

## Why
DingTalk conversation ids can be base64 strings, and base64 may contain `/`. The previous shared validator rejected any slash in both `session_id` and `session_key`, so persisted DingTalk gateway sessions with those ids could be skipped on reload.

`session_id` still uses the strict path checker. `session_key` is persisted as a JSON object key, so it can allow interior `/` while still rejecting traversal/path shapes like `..`, `/etc/passwd`, `~/sessions`, `C:/windows/system32`, and backslashes.

## Verification
- `uv run --extra dev python -m pytest tests/gateway/test_session.py -q` -> `99 passed in 2.57s`
- `uv run --extra dev python -m pytest tests/gateway/test_session_load_bool.py tests/gateway/test_session_model_override_persistence.py -q` -> `14 passed in 0.27s`
- `uv run --extra dev ruff check gateway/session.py tests/gateway/test_session.py` -> `All checks passed!`
- `git diff --check` -> passed
