### PR TITLE
fix(gateway): propagate session id in session env

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14458,6 +14458,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             user_id=str(context.source.user_id) if context.source.user_id else "",
             user_name=str(context.source.user_name) if context.source.user_name else "",
             session_key=context.session_key,
+            session_id=context.session_id,
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",
             async_delivery=_async_delivery,

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -244,6 +244,29 @@ def test_set_session_env_includes_session_key():
     assert get_session_env("HERMES_SESSION_KEY") != "tg:-1001:17585"
 
 
+def test_set_session_env_includes_session_id():
+    """_set_session_env should propagate session_id from SessionContext."""
+    runner = object.__new__(GatewayRunner)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_name="Group",
+        chat_type="group",
+        thread_id="17585",
+    )
+    context = SessionContext(
+        source=source,
+        connected_platforms=[],
+        home_channels={},
+        session_id="session-20260705",
+    )
+
+    tokens = runner._set_session_env(context)
+    assert get_session_env("HERMES_SESSION_ID") == "session-20260705"
+    runner._clear_session_env(tokens)
+    assert get_session_env("HERMES_SESSION_ID") != "session-20260705"
+
+
 def test_session_key_no_race_condition_with_contextvars(monkeypatch):
     """Prove contextvars isolates SESSION_KEY across concurrent async tasks.
 
@@ -393,4 +416,3 @@ async def test_gateway_executor_refuses_resurrection_after_shutdown():
             await runner._run_in_executor_with_context(lambda: "second")
     finally:
         runner._shutdown_executor()
-


### PR DESCRIPTION
## Summary
- pass `context.session_id` into `set_session_vars()` from `GatewayRunner._set_session_env()`
- add regression coverage showing `HERMES_SESSION_ID` is populated from `SessionContext.session_id`

## Why
`SessionContext` already carries `session_id`, and `gateway.session_context.set_session_vars()` already accepts `session_id`. The gateway binding path was only passing `session_key`, so `HERMES_SESSION_ID` was left empty for code that reads session context via `get_session_env("HERMES_SESSION_ID")`.

## Verification
- `uv run --extra dev python -m pytest tests/gateway/test_session_env.py -q` -> `17 passed in 0.52s`
- `uv run --extra dev ruff check gateway/run.py tests/gateway/test_session_env.py` -> `All checks passed!`
- `git diff --check` -> passed
