### PR TITLE
fix(redact): skip env-lookup exception for JSON/YAML config field redaction

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -570,6 +570,11 @@ def redact_sensitive_text(
         if ":" in text and '"' in text:
             def _redact_json(m):
                 key, value = m.group(1), m.group(2)
+                # Same programmatic-env-lookup exception as _redact_env above
+                # (issue #2852): "apiKey": "os.getenv('X')" is a code snippet,
+                # not a leaked secret value.
+                if _ENV_LOOKUP_VALUE_RE.match(value):
+                    return m.group(0)
                 return f'{key}: "{_mask_token(value)}"'
             text = _JSON_FIELD_RE.sub(_redact_json, text)
 
@@ -579,6 +584,11 @@ def redact_sensitive_text(
         if ":" in text and "://" not in text:
             def _redact_yaml(m):
                 key, sep, value = m.group(1), m.group(2), m.group(3)
+                # Same programmatic-env-lookup exception as _redact_env above
+                # (issue #2852): api_key: os.getenv('X') is a code snippet,
+                # not a leaked secret value.
+                if _ENV_LOOKUP_VALUE_RE.match(value):
+                    return m.group(0)
                 return f"{key}{sep}{_mask_token(value)}"
             text = _YAML_ASSIGN_RE.sub(_redact_yaml, text)
 

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -185,6 +185,34 @@ class TestEnvLookupPreserved:
         result = redact_sensitive_text(text, force=True)
         assert "os.getenv('HOMEASSISTANT_TOKEN')" in result
 
+    def test_json_field_os_getenv_preserved(self):
+        # _redact_env has the env-lookup exception; _redact_json (a separate
+        # closure, JSON key: "value" syntax) did not, and mangled this into
+        # '"apiKey": "os.get...EY')"'.
+        text = '{"apiKey": "os.getenv(\'OPENAI_API_KEY\')"}'
+        assert redact_sensitive_text(text, force=True) == text
+
+    def test_json_field_os_environ_get_preserved(self):
+        text = '{"token": "os.environ.get(\'MY_TOKEN\')"}'
+        assert redact_sensitive_text(text, force=True) == text
+
+    def test_json_field_real_value_still_redacted(self):
+        text = '{"apiKey": "sk-realSecretValue1234567890"}'
+        result = redact_sensitive_text(text, force=True)
+        assert "sk-realSecretValue1234567890" not in result
+
+    def test_yaml_field_os_getenv_preserved(self):
+        # Same exception missing from _redact_yaml (unquoted key: value
+        # syntax) — mangled 'api_key: os.getenv("OPENAI_API_KEY")' into
+        # 'api_key: os.get...EY")'.
+        text = 'api_key: os.getenv("OPENAI_API_KEY")'
+        assert redact_sensitive_text(text, force=True) == text
+
+    def test_yaml_field_real_value_still_redacted(self):
+        text = "api_key: sk-realSecretValue1234567890"
+        result = redact_sensitive_text(text, force=True)
+        assert "sk-realSecretValue1234567890" not in result
+
 
 class TestJsonFields:
     def test_json_api_key(self):


### PR DESCRIPTION
## What does this PR do?
`_redact_env` (`agent/redact.py`) already skips redaction when a `KEY=value` assignment's value is a programmatic env lookup (`os.getenv(...)`, `os.environ[...]`, `process.env.X`) via `_ENV_LOOKUP_VALUE_RE`, per issue #2852 — masking it would corrupt a code snippet in prose/logs, not redact an actual secret.

`_redact_json` (JSON `"key": "value"` syntax) and `_redact_yaml` (unquoted `key: value` syntax) are two separate closures in the same `redact_sensitive_text()` function and never got the same check, so the identical code-snippet-in-config-syntax case still gets mangled:

```
{"apiKey": "os.getenv('OPENAI_API_KEY')"}  ->  {"apiKey": "os.get...EY')"}
api_key: os.getenv("OPENAI_API_KEY")       ->  api_key: os.get...EY")
```

Verified live against current `main` before writing the fix.

## Related Issue
Same underlying issue as the `_redact_env` fix: #2852 (JSON/YAML syntax sites not yet covered).

## Type of Change
- [x] 🐛 Bug fix (data corruption — over-redaction mangles a legitimate code snippet, not a security leak)

## Changes Made
- `agent/redact.py`: apply the same `_ENV_LOOKUP_VALUE_RE.match(value)` check in both `_redact_json` and `_redact_yaml` closures before masking, mirroring `_redact_env` exactly (+16 lines)
- `tests/agent/test_redact.py`: 5 new tests in `TestEnvLookupPreserved` — env-lookup preserved in both JSON and YAML syntax, plus positive controls confirming real secret values in the same syntaxes are still redacted

## How to Test
```
pytest tests/agent/test_redact.py tests/tools/test_browser_secret_exfil.py tests/gateway/test_tool_log_mode.py tests/gateway/test_signal.py -v
```
Mutation-verified: all 3 corruption-repro tests fail against the pre-fix code.

## Checklist
- [x] Contributing Guide read | Conventional Commits | No duplicate PR found (searched `_redact_json _redact_yaml env-lookup`, `redact.py os.getenv json yaml corruption`, `2852 redact json yaml`)
- [x] Scoped to this one exception check | Tests added | Platform: macOS
- [x] Docs — N/A | Cross-platform — N/A (pure Python regex logic)