### PR TITLE
fix(dingtalk): preserve replied text context

### DIFF
--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -117,6 +117,32 @@ DINGTALK_TYPE_MAPPING = {
 }
 
 
+def _get_text_extensions(message: "ChatbotMessage") -> Dict[str, Any]:
+    """Return DingTalk text extensions for SDK object and dict payload shapes."""
+    text = getattr(message, "text", None)
+    extensions = getattr(text, "extensions", None)
+    if isinstance(extensions, dict):
+        return extensions
+    if isinstance(text, dict):
+        extensions = text.get("extensions") or text.get("extension")
+        if isinstance(extensions, dict):
+            return extensions
+    return {}
+
+
+def _extract_replied_text_original(replied: Dict[str, Any]) -> str:
+    """Best-effort extraction of a DingTalk replied message's text."""
+    content = replied.get("content")
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, dict):
+        for key in ("content", "text", "value"):
+            value = content.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return ""
+
+
 def check_dingtalk_requirements() -> bool:
     """Check if DingTalk dependencies are available and configured.
 
@@ -689,6 +715,26 @@ class DingTalkAdapter(BasePlatformAdapter):
         except (ValueError, OSError, TypeError):
             timestamp = datetime.now(tz=timezone.utc)
 
+        reply_kwargs: Dict[str, Any] = {}
+        try:
+            replied = _get_text_extensions(message).get("repliedMsg")
+            if isinstance(replied, dict):
+                reply_to_message_id = str(
+                    replied.get("msgId") or replied.get("msgid") or ""
+                ).strip()
+                reply_type = str(
+                    replied.get("msgType") or replied.get("msgtype") or ""
+                ).lower()
+                reply_text = _extract_replied_text_original(replied)
+                if reply_to_message_id and reply_text and reply_type != "file":
+                    reply_kwargs = {
+                        "reply_to_message_id": reply_to_message_id,
+                        "reply_to_text": reply_text,
+                        "reply_to_is_own_message": False,
+                    }
+        except Exception:
+            logger.debug("[%s] Failed to extract DingTalk reply context", self.name, exc_info=True)
+
         event = MessageEvent(
             text=text,
             message_type=msg_type,
@@ -698,6 +744,7 @@ class DingTalkAdapter(BasePlatformAdapter):
             media_urls=media_urls,
             media_types=media_types,
             timestamp=timestamp,
+            **reply_kwargs,
         )
 
         logger.debug(

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -683,6 +683,69 @@ class TestAllowedUsersGate:
         assert adapter._is_user_allowed("dave", "") is False
 
 
+class TestDingTalkReplyContext:
+
+    def _message_with_reply(self, replied):
+        return SimpleNamespace(
+            message_id="msg-001",
+            conversation_id="conv-1",
+            conversation_type="1",
+            sender_id="user-1",
+            sender_nick="Alice",
+            sender_staff_id="staff-1",
+            text=SimpleNamespace(
+                content="what about this?",
+                extensions={"repliedMsg": replied},
+            ),
+            rich_text_content=None,
+            rich_text=None,
+            session_webhook="",
+            session_webhook_expired_time=0,
+            create_at=0,
+        )
+
+    @pytest.mark.asyncio
+    async def test_on_message_preserves_replied_text(self, monkeypatch):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+
+        monkeypatch.delenv("DINGTALK_ALLOWED_USERS", raising=False)
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._resolve_media_codes = AsyncMock()
+        adapter.handle_message = AsyncMock()
+
+        await adapter._on_message(
+            self._message_with_reply(
+                {
+                    "msgId": "quoted-msg-1",
+                    "msgType": "text",
+                    "content": {"content": "original DingTalk message"},
+                }
+            )
+        )
+
+        event = adapter.handle_message.await_args.args[0]
+        assert event.reply_to_message_id == "quoted-msg-1"
+        assert event.reply_to_text == "original DingTalk message"
+        assert event.reply_to_is_own_message is False
+
+    @pytest.mark.asyncio
+    async def test_on_message_without_replied_text_leaves_context_empty(self, monkeypatch):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+
+        monkeypatch.delenv("DINGTALK_ALLOWED_USERS", raising=False)
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._resolve_media_codes = AsyncMock()
+        adapter.handle_message = AsyncMock()
+
+        await adapter._on_message(
+            self._message_with_reply({"msgId": "quoted-msg-2", "msgType": "text"})
+        )
+
+        event = adapter.handle_message.await_args.args[0]
+        assert event.reply_to_message_id is None
+        assert event.reply_to_text is None
+
+
 class TestMentionPatterns:
 
     def test_empty_patterns_list(self, monkeypatch):


### PR DESCRIPTION
## Summary
- extract DingTalk `text.extensions.repliedMsg` from both SDK object and dict payload shapes
- populate `MessageEvent.reply_to_message_id` / `reply_to_text` when DingTalk includes the replied message text
- keep missing replied text as empty context instead of inventing a placeholder

## Why
The gateway already injects reply context when platform adapters populate `reply_to_text`. DingTalk callbacks can carry a `repliedMsg` object under text extensions, but the adapter was not translating it into the shared `MessageEvent` reply fields, so the agent lost explicit quote context.

This PR intentionally handles only callbacks where DingTalk provides the original replied text. If DingTalk sends only the replied message id/type without text, the adapter leaves reply context empty.

## Verification
- `uv run --extra dev python -m pytest tests/gateway/test_dingtalk.py -q` -> `70 passed in 0.95s`
- `uv run --extra dev ruff check plugins/platforms/dingtalk/adapter.py tests/gateway/test_dingtalk.py` -> `All checks passed!`
- `git diff --check` -> passed
