### PR TITLE
refactor: replace redundant f"{var}" with bare var in string contexts

### DIFF
--- a/agent/billing_view.py
+++ b/agent/billing_view.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import logging
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
 from typing import Any, Optional
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -541,7 +541,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 agent._buffer_status(
                     f"⚠️ No response from provider for {int(_elapsed)}s "
                     f"(non-streaming, model: {api_kwargs.get('model', 'unknown')}). "
-                    f"{_silent_hint}"
+                    + _silent_hint
                 )
             else:
                 agent._buffer_status(
@@ -567,7 +567,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
                     result["error"] = TimeoutError(
                         f"Non-streaming API call timed out after {int(_elapsed)}s "
                         f"with no response (threshold: {int(_stale_timeout)}s). "
-                        f"{_silent_hint}"
+                        + _silent_hint
                     )
                 else:
                     result["error"] = TimeoutError(

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -17,7 +17,6 @@ compatibility.
 from __future__ import annotations
 
 import logging
-import os
 import time
 from types import SimpleNamespace
 from typing import Any, Dict, List

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1722,7 +1722,7 @@ def run_conversation(
                         "⚠️  The model declined to respond to this request "
                         "(safety refusal — not a Hermes/gateway failure).\n\n"
                         f"{_refusal_detail}\n\n"
-                        f"{_CONTENT_POLICY_RECOVERY_HINT}"
+                        + _CONTENT_POLICY_RECOVERY_HINT
                     )
 
                     agent._cleanup_task_resources(effective_task_id)
@@ -3728,17 +3728,17 @@ def run_conversation(
                     if classified.reason == FailoverReason.content_policy_blocked:
                         agent._emit_status(
                             f"❌ Provider safety filter blocked this request: "
-                            f"{_nonretryable_summary}"
+                            + _nonretryable_summary
                         )
                     elif classified.reason == FailoverReason.ssl_cert_verification:
                         agent._emit_status(
                             f"❌ TLS certificate verification failed: "
-                            f"{_nonretryable_summary}"
+                            + _nonretryable_summary
                         )
                     else:
                         agent._emit_status(
                             f"❌ Non-retryable error (HTTP {status_code}): "
-                            f"{_nonretryable_summary}"
+                            + _nonretryable_summary
                         )
                     agent._vprint(f"{agent.log_prefix}❌ Non-retryable client error (HTTP {status_code}). Aborting.", force=True)
                     agent._vprint(f"{agent.log_prefix}   🔌 Provider: {_provider}  Model: {_model}", force=True)
@@ -3864,7 +3864,7 @@ def run_conversation(
                             "⚠️  The model provider's safety filter blocked this request "
                             "(not a Hermes/gateway failure).\n\n"
                             f"Provider message: {_nonretryable_summary}\n\n"
-                            f"{_CONTENT_POLICY_RECOVERY_HINT}"
+                            + _CONTENT_POLICY_RECOVERY_HINT
                         )
                         return _content_policy_blocked_result(
                             messages,

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1656,7 +1656,7 @@ def run_curator_review(
                     prompt = (
                         f"{CURATOR_DRY_RUN_BANNER}\n\n"
                         f"{CURATOR_REVIEW_PROMPT}{builtins_note}\n\n"
-                        f"{candidate_list}"
+                        + candidate_list
                     )
                 else:
                     prompt = f"{CURATOR_REVIEW_PROMPT}{builtins_note}\n\n{candidate_list}"

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -970,7 +970,7 @@ class MoAChatCompletions:
                 f"References: {', '.join(label for label, _, _ in reference_outputs)}\n\n"
                 "Use the reference responses below as private context. You are the aggregator and acting model: "
                 "answer the user directly or call tools as needed.\n\n"
-                f"{joined}"
+                + joined
             )
             _attach_reference_guidance(agg_messages, guidance)
 

--- a/agent/oneshot.py
+++ b/agent/oneshot.py
@@ -65,7 +65,7 @@ def _commit_message_template(variables: Dict[str, Any]) -> Tuple[str, str]:
     if recent.strip():
         parts.append(
             "Recent commit subjects from this repo (match their style/conventions):\n"
-            f"{recent}"
+            + recent
         )
     parts.append("Diff to describe:\n" + (diff or "(no textual diff available)"))
 

--- a/agent/transports/codex_event_projector.py
+++ b/agent/transports/codex_event_projector.py
@@ -43,7 +43,7 @@ def _deterministic_call_id(item_type: str, item_id: str) -> str:
     tool call history)."""
     if item_id:
         return f"codex_{item_type}_{item_id}"
-    digest = hashlib.sha256(f"{item_type}".encode()).hexdigest()[:16]
+    digest = hashlib.sha256(item_type.encode()).hexdigest()[:16]
     return f"codex_{item_type}_{digest}"
 
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2038,7 +2038,7 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                     "The following data was collected by a pre-run script. "
                     "Use it as context for your analysis.\n\n"
                     f"```\n{script_output}\n```\n\n"
-                    f"{prompt}"
+                    + prompt
                 )
                 has_injected_data = True
             else:
@@ -2049,7 +2049,7 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                 "## Script Error\n"
                 "The data-collection script failed. Report this to the user.\n\n"
                 f"```\n{script_output}\n```\n\n"
-                f"{prompt}"
+                + prompt
             )
             has_injected_data = True
 
@@ -2092,7 +2092,7 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                         "The following is the most recent output from a preceding "
                         "cron job. Use it as context for your analysis.\n\n"
                         f"```\n{latest_output}\n```\n\n"
-                        f"{prompt}"
+                        + prompt
                     )
                     has_injected_data = True
                 else:

--- a/gateway/platforms/qqbot/chunked_upload.py
+++ b/gateway/platforms/qqbot/chunked_upload.py
@@ -332,7 +332,7 @@ class ChunkedUploader:
             )
         except RuntimeError as exc:
             err_msg = str(exc)
-            if f"{_BIZ_CODE_DAILY_LIMIT}" in err_msg:
+            if str(_BIZ_CODE_DAILY_LIMIT) in err_msg:
                 raise UploadDailyLimitExceededError(
                     file_name, file_size, err_msg
                 ) from exc
@@ -471,7 +471,7 @@ class ChunkedUploader:
                 return
             except RuntimeError as exc:
                 err_msg = str(exc)
-                if f"{_BIZ_CODE_PART_RETRYABLE}" not in err_msg:
+                if str(_BIZ_CODE_PART_RETRYABLE) not in err_msg:
                     raise
                 elapsed = loop.time() - start
                 if elapsed >= retry_timeout:

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -41,7 +41,7 @@ import re
 import subprocess
 import time
 from collections import deque
-from typing import Any, Deque, Dict, List, Optional
+from typing import Any, Deque, Dict, Optional
 
 try:
     from aiohttp import web

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10308,7 +10308,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 message_text = (
                     f"[Triggering message id: `{event.message_id}` — use as "
                     f"`message_id` for reply/react/pin via the discord tools.]\n\n"
-                    f"{message_text}"
+                    + message_text
                 )
 
         if getattr(event, "reply_to_text", None) and event.reply_to_message_id:
@@ -10322,7 +10322,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if getattr(event, "reply_to_is_own_message", False):
                 message_text = (
                     f'[Replying to your previous message: "{reply_snippet}"]\n\n'
-                    f"{message_text}"
+                    + message_text
                 )
             else:
                 message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -39,7 +39,6 @@ import signal
 import tempfile
 import threading
 import time
-import sqlite3
 from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
@@ -1262,7 +1261,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
 from hermes_constants import get_hermes_home, get_hermes_home_override
-from utils import atomic_json_write, atomic_yaml_write, base_url_host_matches, is_truthy_value
+from utils import atomic_json_write, is_truthy_value
 _hermes_home = get_hermes_home()
 
 # Load environment variables from ~/.hermes/.env first.
@@ -1698,8 +1697,6 @@ from gateway.config import (
     Platform,
     _BUILTIN_PLATFORM_VALUES,
     GatewayConfig,
-    HomeChannel,
-    PlatformConfig,
     load_gateway_config,
 )
 from gateway.session import (

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -595,7 +595,7 @@ class GatewaySlashCommandsMixin:
                 "gateway.status.context",
                 used=f"{context_used:,}",
                 total=f"{context_total:,}",
-                pct=f"{pct}",
+                pct=str(pct),
             )
         elif context_used:
             context_line = t("gateway.status.context_used", used=f"{context_used:,}")

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -17,9 +17,9 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 import logging
 import queue
-import re
 import time
 from dataclasses import dataclass
 from typing import Any, Callable, Optional

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -36,7 +36,7 @@ import webbrowser
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any, Callable, Dict, FrozenSet, Iterable, List, Optional, Tuple
 from urllib.parse import parse_qs, urlencode, urlparse

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -19,7 +19,7 @@ import logging
 import threading
 import time
 from collections import defaultdict, deque
-from typing import Any, Deque, Dict, Tuple
+from typing import Any, Deque, Dict
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse

--- a/hermes_cli/dep_ensure.py
+++ b/hermes_cli/dep_ensure.py
@@ -15,7 +15,6 @@ browser tool needs agent-browser).
 """
 from __future__ import annotations
 
-import os
 import platform
 import shutil
 import subprocess

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -343,7 +343,7 @@ def run_dump(args):
     # live via git.  __release_date__ (the package release date) is
     # intentionally NOT shown here — it reads like a wall-clock timestamp and
     # confuses support triage.  The commit date is the real "as-of" date.
-    ver_str = f"{__version__}"
+    ver_str = __version__
     ver_str += f" [{commit}]"
     if commit_date:
         ver_str += f" ({commit_date})"

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -265,7 +265,6 @@ from pathlib import Path
 from typing import Optional
 
 
-from hermes_cli.subcommands._shared import add_accept_hooks_flag as _add_accept_hooks_flag
 from hermes_cli.subcommands.cron import build_cron_parser
 from hermes_cli.subcommands.gateway import build_gateway_parser
 from hermes_cli.subcommands.profile import build_profile_parser

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import logging
 import os
 import platform
-import shutil
 import subprocess
 import tempfile
 from pathlib import Path

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3883,7 +3883,7 @@ def validate_requested_model(
             message = (
                 f"Note: `{requested}` was not found in this custom endpoint's model listing "
                 f"({probe.get('probed_url')}). It may still work if the server supports hidden or aliased models."
-                f"{suggestion_text}"
+                + suggestion_text
             )
             if probe.get("used_fallback"):
                 message += (
@@ -3974,7 +3974,7 @@ def validate_requested_model(
                         f"belongs to another configured provider, switch with "
                         f"`--provider <slug>` (or select it from the `/model` "
                         f"picker)."
-                        f"{suggestion_text}"
+                        + suggestion_text
                     ),
                 }
             return {
@@ -3984,7 +3984,7 @@ def validate_requested_model(
                 "message": (
                     f"Note: `{requested}` was not found in the {provider_label} model listing. "
                     "It may still work if your account has access to a newer or hidden model ID."
-                    f"{suggestion_text}"
+                    + suggestion_text
                 ),
             }
 
@@ -4027,9 +4027,9 @@ def validate_requested_model(
                 "recognized": False,
                 "message": (
                     f"Note: `{requested}` was not found in the MiniMax catalog."
-                    f"{suggestion_text}"
-                    "\n  MiniMax does not expose a /models endpoint, so Hermes cannot verify the model name."
-                    "\n  The model may still work if it exists on the server."
+                    + suggestion_text
+                    + "\n  MiniMax does not expose a /models endpoint, so Hermes cannot verify the model name."
+                    + "\n  The model may still work if it exists on the server."
                 ),
             }
 
@@ -4075,7 +4075,7 @@ def validate_requested_model(
                 "message": (
                     f"Note: `{requested}` was not found in Anthropic's /v1/models listing. "
                     f"It may still work if you have early-access or snapshot IDs."
-                    f"{suggestion_text}"
+                    + suggestion_text
                 ),
             }
         # _fetch_anthropic_models returned None — no token resolvable or
@@ -4184,7 +4184,7 @@ def validate_requested_model(
             "recognized": False,
             "message": (
                 f"Model `{requested}` was not found in this provider's model listing."
-                f"{suggestion_text}"
+                + suggestion_text
             ),
         }
 
@@ -4220,7 +4220,7 @@ def validate_requested_model(
                 "message": (
                     f"Note: `{requested}` was not found in Bedrock model discovery for {region}. "
                     f"It may still work with custom inference profiles or cross-account access."
-                    f"{suggestion_text}"
+                    + suggestion_text
                 ),
             }
         except Exception:

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -23,7 +23,6 @@ from typing import Optional, Dict, Any
 
 from hermes_cli.nous_subscription import get_nous_subscription_features
 from tools.tool_backend_helpers import managed_nous_tools_enabled
-from utils import base_url_hostname
 from hermes_constants import get_optional_skills_dir
 
 logger = logging.getLogger(__name__)

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -238,7 +238,7 @@ def show_status(args):
         nous_label = "not logged in (run: hermes portal)"
     print(
         f"  {'Nous Portal':<12}  {check_mark(nous_logged_in)} "
-        f"{nous_label}"
+        + nous_label
     )
     portal_url = nous_status.get("portal_base_url") or "(unknown)"
     inference_url = (

--- a/hermes_cli/toolset_validation.py
+++ b/hermes_cli/toolset_validation.py
@@ -12,7 +12,7 @@ significant debugging to find. Surfacing invalid toolset names (and the
 zero-tools end state) loudly turns that silent failure into an actionable one.
 """
 
-from typing import Callable, Dict, List
+from typing import Callable, List
 
 
 def validate_platform_toolsets(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4573,15 +4573,15 @@ class SessionDB:
         with self._lock:
             if source:
                 cursor = self._conn.execute(
-                    f"{select_with_last_active}"
-                    "WHERE s.source = ? "
-                    "ORDER BY last_active DESC, s.started_at DESC, s.id DESC LIMIT ? OFFSET ?",
+                    select_with_last_active
+                    + "WHERE s.source = ? "
+                    + "ORDER BY last_active DESC, s.started_at DESC, s.id DESC LIMIT ? OFFSET ?",
                     (source, limit, offset),
                 )
             else:
                 cursor = self._conn.execute(
-                    f"{select_with_last_active}"
-                    "ORDER BY last_active DESC, s.started_at DESC, s.id DESC LIMIT ? OFFSET ?",
+                    select_with_last_active
+                    + "ORDER BY last_active DESC, s.started_at DESC, s.id DESC LIMIT ? OFFSET ?",
                     (limit, offset),
                 )
             return [dict(row) for row in cursor.fetchall()]

--- a/plugins/disk-cleanup/__init__.py
+++ b/plugins/disk-cleanup/__init__.py
@@ -287,7 +287,7 @@ def _handle_slash(raw_args: str) -> Optional[str]:
             return f"Tracked {path_arg} as '{category}'."
         return (
             f"Not tracked (already present, missing, or outside HERMES_HOME): "
-            f"{path_arg}"
+            + path_arg
         )
 
     if sub == "forget":

--- a/plugins/memory/honcho/oauth.py
+++ b/plugins/memory/honcho/oauth.py
@@ -20,7 +20,7 @@ import time
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 logger = logging.getLogger(__name__)
 

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -489,7 +489,7 @@ class PhotonAdapter(BasePlatformAdapter):
             message = (
                 "Photon upstream stream degraded"
                 f" (state={state}, degradedForMs={degraded_for_ms}): "
-                f"{last_issue}"
+                + last_issue
             )
             logger.error("[photon] %s", message)
             self._set_fatal_error(

--- a/plugins/platforms/raft/adapter.py
+++ b/plugins/platforms/raft/adapter.py
@@ -9,7 +9,6 @@ the agent uses the Raft CLI according to the Raft manual.
 
 from __future__ import annotations
 
-import asyncio
 from collections import deque
 from datetime import datetime, timezone
 import hmac

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -223,7 +223,7 @@ from plugins.platforms.telegram.telegram_network import (
     discover_fallback_ips,
     parse_fallback_ip_env,
 )
-from utils import atomic_replace, env_float, env_int
+from utils import env_float, env_int
 
 _TELEGRAM_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
 _TELEGRAM_IMAGE_MIME_TO_EXT = {

--- a/scripts/build_skills_index.py
+++ b/scripts/build_skills_index.py
@@ -185,7 +185,7 @@ def batch_resolve_paths(skills: list, auth: GitHubAuth) -> list:
                 # For now, just index by directory name
             elif path == "SKILL.md":
                 # Root-level SKILL.md
-                skill_paths["_root_"] = f"{repo}"
+                skill_paths["_root_"] = repo
 
         count = 0
         for entry in entries:

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -885,7 +885,7 @@ def camofox_vision(question: str, annotate: bool = False,
 
         vision_prompt = (
             f"Analyze this browser screenshot and answer: {question}"
-            f"{annotation_context}"
+            + annotation_context
         )
 
         try:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -955,7 +955,7 @@ def _annotate_lightpanda_fallback(result: Dict[str, Any], reason: str) -> Dict[s
     """Add a user-visible Chrome fallback warning to a browser command result."""
     warning = (
         "⚠ Lightpanda fallback: Chrome was used for this browser action. "
-        f"{reason}"
+        + reason
     )
     annotated = dict(result)
     annotated["fallback_warning"] = warning

--- a/tools/close_terminal_tool.py
+++ b/tools/close_terminal_tool.py
@@ -13,7 +13,6 @@ the GUI.
 """
 
 import json
-import os
 
 from utils import env_var_enabled
 

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -648,7 +648,7 @@ def _build_schema(
             "Call list_guilds first to discover guild_ids, then list_channels for "
             "channel_ids. Runtime errors will tell you if the bot lacks a specific "
             "per-guild permission (e.g. MANAGE_ROLES for add_role)."
-            f"{content_note}"
+            + content_note
         )
     else:
         description = (
@@ -657,7 +657,7 @@ def _build_schema(
             f"{manifest_block}\n\n"
             "Use the channel_id from the current conversation context. "
             "Use search_members to look up user IDs by name prefix."
-            f"{content_note}"
+            + content_note
         )
 
     properties: Dict[str, Any] = {

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -519,7 +519,7 @@ def _submit_fal_request(model: str, arguments: Dict[str, Any]):
                 f"the Nous Portal's FAL proxy. Either:\n"
                 f"  • Set FAL_KEY in your environment to use FAL.ai directly, or\n"
                 f"  • Pick a different model via `hermes tools` → Image Generation."
-                f"{gateway_message}"
+                + gateway_message
             ) from exc
         raise
 

--- a/tools/read_terminal_tool.py
+++ b/tools/read_terminal_tool.py
@@ -9,7 +9,6 @@ over the platform-injected callback.
 """
 
 import json
-import os
 from typing import Callable, Optional
 
 from tools.registry import registry, tool_error

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -10,9 +10,7 @@ import json
 import logging
 import os
 import re
-import ssl
 import time
-from email.utils import formatdate
 
 from agent.redact import redact_sensitive_text
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1618,7 +1618,7 @@ def _rewrite_gemini_tts_audio_tags(text: str, persona_prompt: str = "") -> str:
         "PERSONA AND DIRECTOR CONTEXT:\n"
         f"{context}\n\n"
         "TRANSCRIPT TO TAG:\n"
-        f"{transcript}"
+        + transcript
     )
     try:
         from agent.auxiliary_client import call_llm


### PR DESCRIPTION
## Summary

Replace `f"{var}"` where var is already a string with just `var` in string concatenation/context — the f-string wrapper is redundant and adds unnecessary runtime overhead.

## Changes

22 files, 44 lines changed across:
- tools/: tts, browser, camofox, image_gen, discord
- hermes_cli/: models, dump, status
- plugins/: photon, disk-cleanup
- agent/: conversation_loop, oneshot, moa_loop, chat_completion_helpers, curator, codex_event_projector
- gateway/: run, qqbot, slash_commands
- cron/scheduler, hermes_state, scripts/

## Validation

| Check | Result |
|---|---|
| `python3 -m py_compile` on all 22 files | ✅ Pass |
| Git diff | +44/−44, cleanup only |