### PR TITLE
fix: preserve save_traces/trace_dir when saving MOA config via Desktop UI

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4486,6 +4486,14 @@ def set_moa_models(body: MoaConfigPayload, profile: Optional[str] = None):
                     "enabled": body.enabled,
                 }
             normalized = normalize_moa_config(raw)
+            # Preserve save_traces / trace_dir from the existing config.
+            # These live at the top level of cfg["moa"] but are not part
+            # of the MoaConfigPayload model, so normalize_moa_config()
+            # never includes them in its return dict.
+            _prev_moa = cfg.get("moa", {})
+            for _key in ("save_traces", "trace_dir"):
+                if _key in _prev_moa and _key not in normalized:
+                    normalized[_key] = _prev_moa[_key]
             cfg["moa"] = normalized
             save_config(cfg)
             return {"ok": True, **normalized}

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -510,6 +510,44 @@ class TestWebServerEndpoints:
         assert cfg["moa"]["reference_models"] == payload["reference_models"]
         assert cfg["moa"]["aggregator"] == payload["aggregator"]
 
+    def test_put_moa_models_preserves_save_traces_and_trace_dir(self):
+        """PUT /api/model/moa must not silently drop save_traces / trace_dir
+        that live in cfg['moa'] but are not part of MoaConfigPayload.
+
+        Regression test for issue #58819.
+        """
+        from hermes_cli.config import load_config, save_config
+
+        # Seed the existing config with save_traces + trace_dir.
+        cfg = load_config()
+        cfg.setdefault("moa", {})
+        cfg["moa"]["save_traces"] = True
+        cfg["moa"]["trace_dir"] = "/tmp/moa-traces"
+        save_config(cfg)
+
+        payload = {
+            "reference_models": [
+                {"provider": "openai-codex", "model": "gpt-5.5"},
+                {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"},
+            ],
+            "aggregator": {"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
+            "reference_temperature": 0.7,
+            "aggregator_temperature": 0.3,
+            "max_tokens": 8192,
+            "enabled": True,
+        }
+
+        resp = self.client.put("/api/model/moa", json=payload)
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+
+        cfg = load_config()
+        # The new fields must have been preserved.
+        assert cfg["moa"]["save_traces"] is True
+        assert cfg["moa"]["trace_dir"] == "/tmp/moa-traces"
+        # The payload fields must have been updated.
+        assert cfg["moa"]["max_tokens"] == 8192
+
     # ── GET /api/media (remote image display) ───────────────────────────
 
     def test_get_media_serves_image_in_root(self):


### PR DESCRIPTION
Fixes #58819

The Desktop MOA settings panel calls `PUT /api/model/moa` to save preset changes. The endpoint's `MoaConfigPayload` Pydantic model does not declare `save_traces` or `trace_dir` fields, and `set_moa_models` does a wholesale overwrite of `cfg["moa"]`. This silently drops any `save_traces`/`trace_dir` values set by hand-editing `config.yaml`.

## Fix
After `normalize_moa_config()` builds the new dict, copy over `save_traces` and `trace_dir` from the previous `cfg["moa"]` if they exist and weren't included in the normalized result.

## Test
Added regression test `test_put_moa_models_preserves_save_traces_and_trace_dir` that:
1. Seeds config with `save_traces: true` and `trace_dir`
2. Saves MOA config via the API endpoint
3. Verifies both fields are preserved after the save