### PR TITLE
fix(desktop): guard readTextPreview against null results for binary files

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -215,9 +215,31 @@ function looksBinaryBytes(bytes: Uint8Array) {
   return suspicious / Math.min(bytes.length, 4096) > 0.12
 }
 
-async function readTextPreview(filePath: string) {
+async function readTextPreview(filePath: string): Promise<{
+  binary: boolean
+  byteSize: number
+  language: string
+  mimeType?: string
+  path: string
+  text: string | null
+  truncated: boolean
+}> {
   try {
-    return await readDesktopFileText(filePath)
+    const result = await readDesktopFileText(filePath)
+    // Guard against null/undefined results (e.g. IPC returning null for
+    // binary files). Normalize to the expected shape so callers never hit
+    // "NoneType has no attribute …".
+    if (result === null || result === undefined) {
+      return {
+        binary: true,
+        byteSize: 0,
+        language: 'text',
+        path: filePath,
+        text: null,
+        truncated: false
+      }
+    }
+    return result
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
 
@@ -240,7 +262,8 @@ async function readTextPreview(filePath: string) {
     byteSize: bytes.byteLength,
     mimeType,
     path: filePath,
-    text: new TextDecoder().decode(bytes)
+    text: new TextDecoder().decode(bytes),
+    truncated: false
   }
 }
 


### PR DESCRIPTION
Fixes #58718

When the Desktop file browser sidebar renders a folder containing binary files (.pdf, .xls, .pptx), the IPC bridge can return null/undefined for `readFileText` on those files. The previous code passed the null result straight through to callers that accessed `.binary`, `.text`, `.splitlines()` etc. without a null check, producing 'NoneType object has no attribute splitlines' errors inline in the sidebar.

## Fix
- Add an explicit null/undefined guard in `readTextPreview` that returns a normalized object (`binary: true`, `text: null`) so callers never crash.
- Add a return type annotation for clarity.

## Testing
Binary files in a folder should no longer crash the sidebar preview - instead they'll show the 'Binary file — cannot preview' fallback.