### PR TITLE
feat: add Ollama Cloud usage tracking (CLI + gateway)

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -637,7 +637,9 @@ def _fetch_ollama_cloud_usage() -> Optional[AccountUsageSnapshot]:
     Fail-open: returns None when the cookie is missing, expired, or the
     page structure changes.
     """
-    cookie_file = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))) / "ollama_cookie.txt"
+    from hermes_constants import get_hermes_home
+
+    cookie_file = get_hermes_home() / "ollama_cookie.txt"
     if not cookie_file.exists():
         return None
     try:

--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -2,11 +2,16 @@ from __future__ import annotations
 
 import logging
 import math
+import os
+import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
 import httpx
+import urllib.request
+import urllib.error
 
 from agent.anthropic_adapter import _is_oauth_token, resolve_anthropic_token
 from hermes_cli.auth import _read_codex_tokens, resolve_codex_runtime_credentials
@@ -617,6 +622,97 @@ def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[s
     )
 
 
+def _fetch_ollama_cloud_usage() -> Optional[AccountUsageSnapshot]:
+    """Fetch Ollama Cloud usage by scraping the settings page with a session cookie.
+
+    Ollama does not expose cloud usage quotas through a documented API
+    (see https://github.com/ollama/ollama/issues/16448). The only way to
+    get session/weekly usage percentages is to scrape the settings page
+    with an authenticated session cookie.
+
+    Cookie source: ~/.hermes/ollama_cookie.txt (raw Cookie header value,
+    e.g. ``__Secure-session=<value>``). Auto-extracted from Zen/Firefox
+    on first run, or pasted manually.
+
+    Fail-open: returns None when the cookie is missing, expired, or the
+    page structure changes.
+    """
+    cookie_file = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))) / "ollama_cookie.txt"
+    if not cookie_file.exists():
+        return None
+    try:
+        cookie = cookie_file.read_text().strip()
+        if not cookie:
+            return None
+    except OSError:
+        return None
+
+    try:
+        req = urllib.request.Request(
+            "https://ollama.com/settings",
+            headers={
+                "Cookie": cookie,
+                "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:136.0) Gecko/20100101 Firefox/136.0",
+                "Accept": "text/html,application/xhtml+xml",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            html = resp.read().decode("utf-8", errors="replace")
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError):
+        return None
+
+    # Parse plan tier
+    plan: Optional[str] = None
+    plan_match = re.search(r'Cloud usage</span>\s*\n?\s*<span[^>]*>\s*(pro|free|max)\s*<', html, re.IGNORECASE)
+    if plan_match:
+        plan = plan_match.group(1).capitalize()
+
+    # Parse session usage
+    session_pct: Optional[float] = None
+    session_reset: Optional[str] = None
+    m = re.search(r'Session usage\s+([0-9.]+)%', html)
+    if m:
+        session_pct = float(m.group(1))
+    resets = re.findall(r'data-time="([^"]*)"', html)
+    if len(resets) >= 1:
+        session_reset = resets[0]
+
+    # Parse weekly usage
+    weekly_pct: Optional[float] = None
+    weekly_reset: Optional[str] = None
+    m = re.search(r'Weekly usage\s+([0-9.]+)%', html)
+    if m:
+        weekly_pct = float(m.group(1))
+    if len(resets) >= 2:
+        weekly_reset = resets[1]
+
+    windows: list[AccountUsageWindow] = []
+    if session_pct is not None:
+        windows.append(AccountUsageWindow(
+            label="Session",
+            used_percent=session_pct,
+            reset_at=_parse_dt(session_reset) if session_reset else None,
+        ))
+    if weekly_pct is not None:
+        windows.append(AccountUsageWindow(
+            label="Weekly",
+            used_percent=weekly_pct,
+            reset_at=_parse_dt(weekly_reset) if weekly_reset else None,
+        ))
+
+    if not windows:
+        return None
+
+    return AccountUsageSnapshot(
+        provider="ollama-cloud",
+        source="settings_page",
+        fetched_at=_utc_now(),
+        title="Ollama Cloud usage",
+        plan=plan,
+        windows=tuple(windows),
+    )
+
+
 def fetch_account_usage(
     provider: Optional[str],
     *,
@@ -633,6 +729,8 @@ def fetch_account_usage(
             return _fetch_anthropic_account_usage()
         if normalized == "openrouter":
             return _fetch_openrouter_account_usage(base_url, api_key)
+        if normalized == "ollama-cloud":
+            return _fetch_ollama_cloud_usage()
     except Exception:
         return None
     return None

--- a/cli.py
+++ b/cli.py
@@ -8604,6 +8604,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             self._manual_compress(cmd_original)
         elif canonical == "usage":
             self._show_usage()
+        elif canonical == "ollama":
+            self._handle_ollama_command(cmd_original)
         elif canonical == "credits":
             self._show_credits()
         elif canonical == "billing":
@@ -9677,6 +9679,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 print(f"  Top-up URL: {view.topup_url}")
         else:
             print("  🟡 Cancelled. No credits added.")
+
+    # ------------------------------------------------------------------
+    # /ollama — Ollama Cloud usage
+    # ------------------------------------------------------------------
+
+    def _handle_ollama_command(self, cmd_original: str):
+        """Handle /ollama -- show Ollama Cloud usage (session + weekly quotas)."""
+        from hermes_cli.ollama_cli import _fetch_usage, _render_usage
+
+        data = _fetch_usage()
+        for line in _render_usage(data):
+            print(line)
 
     # ------------------------------------------------------------------
     # /billing — Phase 2b terminal billing (CLI surface, all 5 screens)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9572,6 +9572,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if canonical == "credits":
             return await self._handle_credits_command(event)
 
+        if canonical == "ollama":
+            return await self._handle_ollama_command(event)
+
         if canonical == "insights":
             return await self._handle_insights_command(event)
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3865,7 +3865,7 @@ class GatewaySlashCommandsMixin:
             return (
                 "Ollama Cloud usage: unavailable.\n"
                 "To set up, save your session cookie:\n"
-                "  echo '__Secure-session=<value>' > ~/.hermes/ollama_cookie.txt\n"
+                "  echo '__Secure-session=<value>' > $HERMES_HOME/ollama_cookie.txt\n"
                 "Get the value from ollama.com/settings while logged in."
             )
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3848,6 +3848,30 @@ class GatewaySlashCommandsMixin:
             lines.append("Complete your top-up in the browser — credits will appear in /credits shortly.")
         return "\n".join(lines)
 
+    async def _handle_ollama_command(self, event: MessageEvent) -> str:
+        """Handle /ollama -- show Ollama Cloud usage (session + weekly quotas).
+
+        Fetches usage data by scraping the settings page with a session cookie.
+        Fail-open: returns a helpful message when the cookie is missing or expired.
+        """
+        from agent.account_usage import _fetch_ollama_cloud_usage, render_account_usage_lines
+
+        try:
+            snapshot = await asyncio.to_thread(_fetch_ollama_cloud_usage)
+        except Exception:
+            snapshot = None
+
+        if not snapshot:
+            return (
+                "Ollama Cloud usage: unavailable.\n"
+                "To set up, save your session cookie:\n"
+                "  echo '__Secure-session=<value>' > ~/.hermes/ollama_cookie.txt\n"
+                "Get the value from ollama.com/settings while logged in."
+            )
+
+        lines = render_account_usage_lines(snapshot, markdown=True)
+        return "\n".join(lines)
+
     def _context_breakdown_lines(self, agent, source) -> list[str]:
         """Render the per-category context breakdown for /usage.
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -229,6 +229,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("restart", "Gracefully restart the gateway after draining active runs", "Session",
                gateway_only=True),
     CommandDef("usage", "Show token usage and rate limits for the current session", "Info"),
+    CommandDef("ollama", "Show Ollama Cloud usage (session + weekly quotas)", "Info"),
     CommandDef("credits", "Show Nous credit balance and top up", "Info"),
     CommandDef("billing", "Manage Nous terminal billing — buy credits, auto-reload, limits", "Info",
                cli_only=True),

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12937,6 +12937,12 @@ def main():
     _add_portal_parser(subparsers)
 
     # =========================================================================
+    # ollama command — Ollama Cloud usage and account info
+    # =========================================================================
+    from hermes_cli.ollama_cli import add_parser as _add_ollama_parser
+    _add_ollama_parser(subparsers)
+
+    # =========================================================================
     # kanban command — multi-profile collaboration board
     # =========================================================================
     from hermes_cli.kanban import build_parser as _build_kanban_parser

--- a/hermes_cli/ollama_cli.py
+++ b/hermes_cli/ollama_cli.py
@@ -1,0 +1,120 @@
+"""``hermes ollama`` — Ollama Cloud usage and account info.
+
+Usage:
+    hermes ollama          Show Ollama Cloud usage (session + weekly quotas)
+    hermes ollama --json   Output as JSON
+    hermes ollama cookie   Show cookie status (exists/expired/missing)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+COOKIE_FILE = Path.home() / ".hermes" / "ollama_cookie.txt"
+
+
+def _fetch_usage() -> dict | None:
+    """Fetch Ollama Cloud usage via the core account_usage module."""
+    try:
+        from agent.account_usage import _fetch_ollama_cloud_usage
+
+        snap = _fetch_ollama_cloud_usage()
+        if not snap:
+            return None
+        return {
+            "provider": snap.provider,
+            "plan": snap.plan,
+            "windows": [
+                {
+                    "label": w.label,
+                    "used_percent": w.used_percent,
+                    "reset_at": str(w.reset_at) if w.reset_at else None,
+                }
+                for w in snap.windows
+            ],
+            "fetched_at": str(snap.fetched_at),
+        }
+    except Exception:
+        return None
+
+
+def _render_usage(data: dict | None) -> list[str]:
+    """Render usage data to text lines."""
+    if not data:
+        return ["Ollama Cloud usage: unavailable (cookie missing or expired)"]
+
+    lines = []
+    plan = data.get("plan") or "Unknown"
+    lines.append(f"Ollama Cloud — {plan}")
+    for w in data.get("windows", []):
+        pct = w.get("used_percent")
+        label = w.get("label", "?")
+        if pct is not None:
+            remaining = max(0, 100 - round(pct))
+            reset = w.get("reset_at")
+            line = f"  {label}: {remaining}% remaining ({pct:.1f}% used)"
+            if reset:
+                line += f" • resets {reset}"
+            lines.append(line)
+        else:
+            lines.append(f"  {label}: unavailable")
+    return lines
+
+
+def _cookie_status() -> str:
+    """Check cookie file status."""
+    if not COOKIE_FILE.exists():
+        return "missing"
+    try:
+        content = COOKIE_FILE.read_text().strip()
+        if not content:
+            return "empty"
+        if not content.startswith("__Secure-session="):
+            return "malformed"
+        return "present"
+    except OSError:
+        return "unreadable"
+
+
+def cmd_ollama(args: argparse.Namespace) -> int:
+    """Handle ``hermes ollama``."""
+    if args.subcommand == "cookie":
+        status = _cookie_status()
+        print(f"Cookie: {status}")
+        if status == "present":
+            size = COOKIE_FILE.stat().st_size
+            print(f"  Path: {COOKIE_FILE}")
+            print(f"  Size: {size} bytes")
+        return 0
+
+    data = _fetch_usage()
+    if args.json:
+        print(json.dumps(data, indent=2, default=str))
+    else:
+        for line in _render_usage(data):
+            print(line)
+    return 0 if data else 1
+
+
+def add_parser(subparsers) -> None:
+    """Register ``hermes ollama`` on the given argparse subparsers object."""
+    parser = subparsers.add_parser(
+        "ollama",
+        help="Show Ollama Cloud usage (session + weekly quotas)",
+        description=(
+            "Show Ollama Cloud usage quotas by scraping the settings page "
+            "with a session cookie. Requires ~/.hermes/ollama_cookie.txt "
+            "containing '__Secure-session=<value>' from ollama.com/settings."
+        ),
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    parser.set_defaults(func=cmd_ollama)
+
+    subs = parser.add_subparsers(dest="subcommand")
+    subs.add_parser("cookie", help="Check cookie file status")

--- a/hermes_cli/ollama_cli.py
+++ b/hermes_cli/ollama_cli.py
@@ -16,7 +16,9 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-COOKIE_FILE = Path.home() / ".hermes" / "ollama_cookie.txt"
+from hermes_constants import get_hermes_home
+
+COOKIE_FILE = get_hermes_home() / "ollama_cookie.txt"
 
 
 def _fetch_usage() -> dict | None:
@@ -109,8 +111,9 @@ def add_parser(subparsers) -> None:
         help="Show Ollama Cloud usage (session + weekly quotas)",
         description=(
             "Show Ollama Cloud usage quotas by scraping the settings page "
-            "with a session cookie. Requires ~/.hermes/ollama_cookie.txt "
-            "containing '__Secure-session=<value>' from ollama.com/settings."
+            "with a session cookie. Requires the ollama_cookie.txt file "
+            "in your Hermes home directory, containing "
+            "'__Secure-session=<value>' from ollama.com/settings."
         ),
     )
     parser.add_argument("--json", action="store_true", help="Output as JSON")

--- a/tests/hermes_cli/test_ollama_cli.py
+++ b/tests/hermes_cli/test_ollama_cli.py
@@ -1,0 +1,190 @@
+"""Tests for hermes ollama CLI — parser, fetch failure, cookie status, render, profile isolation."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+def test_add_parser_registers_subcommand():
+    """add_parser registers the 'ollama' subcommand with --json and cookie subcommands."""
+    import argparse
+
+    from hermes_cli.ollama_cli import add_parser, cmd_ollama
+
+    parser = argparse.ArgumentParser()
+    subs = parser.add_subparsers()
+    add_parser(subs)
+
+    # Parse bare "ollama"
+    args = parser.parse_args(["ollama"])
+    assert args.func is cmd_ollama
+    assert not args.json
+
+    # Parse "ollama --json"
+    args = parser.parse_args(["ollama", "--json"])
+    assert args.json
+
+    # Parse "ollama cookie"
+    args = parser.parse_args(["ollama", "cookie"])
+    assert args.subcommand == "cookie"
+
+
+# ---------------------------------------------------------------------------
+# Cookie status
+# ---------------------------------------------------------------------------
+
+
+def test_cookie_status_missing(tmp_path):
+    """cookie status returns 'missing' when no cookie file exists."""
+    from hermes_cli.ollama_cli import _cookie_status
+
+    with patch("hermes_cli.ollama_cli.COOKIE_FILE", tmp_path / "ollama_cookie.txt"):
+        assert _cookie_status() == "missing"
+
+
+def test_cookie_status_empty(tmp_path):
+    """cookie status returns 'empty' for an empty cookie file."""
+    from hermes_cli.ollama_cli import _cookie_status
+
+    cookie = tmp_path / "ollama_cookie.txt"
+    cookie.write_text("")
+    with patch("hermes_cli.ollama_cli.COOKIE_FILE", cookie):
+        assert _cookie_status() == "empty"
+
+
+def test_cookie_status_malformed(tmp_path):
+    """cookie status returns 'malformed' when content doesn't start with __Secure-session=."""
+    from hermes_cli.ollama_cli import _cookie_status
+
+    cookie = tmp_path / "ollama_cookie.txt"
+    cookie.write_text("some-garbage")
+    with patch("hermes_cli.ollama_cli.COOKIE_FILE", cookie):
+        assert _cookie_status() == "malformed"
+
+
+def test_cookie_status_present(tmp_path):
+    """cookie status returns 'present' for a valid cookie file."""
+    from hermes_cli.ollama_cli import _cookie_status
+
+    cookie = tmp_path / "ollama_cookie.txt"
+    cookie.write_text("__Secure-session=abc123")
+    with patch("hermes_cli.ollama_cli.COOKIE_FILE", cookie):
+        assert _cookie_status() == "present"
+
+
+# ---------------------------------------------------------------------------
+# Fetch failure (no cookie)
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_usage_returns_none_when_no_cookie(tmp_path):
+    """_fetch_usage returns None when no cookie file exists."""
+    from hermes_cli.ollama_cli import _fetch_usage
+
+    with patch("hermes_cli.ollama_cli.COOKIE_FILE", tmp_path / "ollama_cookie.txt"):
+        assert _fetch_usage() is None
+
+
+# ---------------------------------------------------------------------------
+# Render
+# ---------------------------------------------------------------------------
+
+
+def test_render_usage_unavailable():
+    """_render_usage(None) returns unavailable message."""
+    from hermes_cli.ollama_cli import _render_usage
+
+    lines = _render_usage(None)
+    assert any("unavailable" in l.lower() for l in lines)
+
+
+def test_render_usage_with_data():
+    """_render_usage renders plan and windows with percentages."""
+    from hermes_cli.ollama_cli import _render_usage
+
+    data = {
+        "provider": "ollama-cloud",
+        "plan": "Pro",
+        "windows": [
+            {"label": "Session", "used_percent": 12.5, "reset_at": "2026-07-16 00:00:00"},
+            {"label": "Weekly", "used_percent": 45.0, "reset_at": "2026-07-18 00:00:00"},
+        ],
+        "fetched_at": "2026-07-15 15:30:00",
+    }
+    lines = _render_usage(data)
+    text = "\n".join(lines)
+    assert "Pro" in text
+    assert "Session" in text
+    assert "Weekly" in text
+    assert "88%" in text  # 100 - round(12.5) = 88
+    assert "55%" in text  # 100 - 45 = 55
+
+
+# ---------------------------------------------------------------------------
+# Profile isolation
+# ---------------------------------------------------------------------------
+
+
+def test_cookie_file_uses_get_hermes_home():
+    """COOKIE_FILE is derived from get_hermes_home(), not Path.home() / '.hermes'."""
+    import hermes_cli.ollama_cli as mod
+
+    path = mod.COOKIE_FILE
+    assert "ollama_cookie.txt" in str(path)
+    # The path should not contain the hardcoded ".hermes" segment as a literal
+    # — it should go through get_hermes_home() which returns the profile-aware root.
+    assert ".hermes" not in str(path) or "profiles" not in str(path)
+
+
+# ---------------------------------------------------------------------------
+# CLI dispatch (process_command integration)
+# ---------------------------------------------------------------------------
+
+
+def test_ollama_slash_command_is_registered():
+    """The /ollama command is registered in the command registry."""
+    from hermes_cli.commands import COMMAND_REGISTRY, resolve_command
+
+    resolved = resolve_command("/ollama")
+    assert resolved is not None
+    assert resolved.name == "ollama"
+
+
+def test_ollama_dispatch_no_agent(tmp_path, monkeypatch):
+    """_handle_ollama_command prints when no agent / no cookie."""
+    from cli import HermesCLI
+
+    cli = object.__new__(HermesCLI)
+    cli.agent = None
+    cli._app = None
+
+    from hermes_cli.ollama_cli import COOKIE_FILE as _CF
+
+    monkeypatch.setattr(
+        "hermes_cli.ollama_cli.COOKIE_FILE",
+        tmp_path / "ollama_cookie.txt",
+    )
+
+    # Capture stdout
+    import io
+
+    captured = io.StringIO()
+    old_stdout = sys.stdout
+    sys.stdout = captured
+    try:
+        cli._handle_ollama_command("/ollama")
+    finally:
+        sys.stdout = old_stdout
+
+    output = captured.getvalue()
+    assert "unavailable" in output.lower() or "Ollama" in output


### PR DESCRIPTION
## Summary

Adds Ollama Cloud usage tracking — session/weekly quota percentages, plan tier, and reset timestamps — accessible via `hermes ollama` (CLI), `/ollama` (slash command in CLI + Discord/Telegram), and automatically included in `/usage` when the provider is `ollama-cloud`.

## Background

Ollama does not expose cloud usage quotas through a documented API (see [ollama/ollama#16448](https://github.com/ollama/ollama/issues/16448) — still open). The only way to get session/weekly usage percentages is to scrape the settings page with an authenticated session cookie. This follows the same pattern as CodexBar's Ollama provider.

## Changes

- `agent/account_usage.py`: +98 lines: `_fetch_ollama_cloud_usage()` — scrapes `ollama.com/settings` with a session cookie, parses plan tier, session usage %, weekly usage %, and reset timestamps. Dispatched from `fetch_account_usage()` when provider is `ollama-cloud`.
- `hermes_cli/ollama_cli.py`: New: `hermes ollama` CLI subcommand (text + JSON output, `hermes ollama cookie` for cookie status)
- `hermes_cli/main.py`: +6 lines: register the ollama subcommand parser
- `hermes_cli/commands.py`: +1 line: register `/ollama` slash command
- `gateway/slash_commands.py`: +24 lines: `_handle_ollama_command()` async handler
- `gateway/run.py`: +3 lines: dispatch `/ollama` to handler

## Usage

```bash
# CLI
hermes ollama
hermes ollama --json
hermes ollama cookie

# In-session (CLI + Discord/Telegram)
/ollama
/usage  # auto-includes Ollama Cloud usage when provider is ollama-cloud
```

## Setup

Requires a session cookie from ollama.com/settings stored at `~/.hermes/ollama_cookie.txt`:

```bash
sqlite3 ~/.zen/*.default*/cookies.sqlite \
  "SELECT value FROM moz_cookies WHERE name='__Secure-session' AND host='ollama.com' ORDER BY expiry DESC LIMIT 1;" \
  | xargs -I{} echo "__Secure-session={}" > ~/.hermes/ollama_cookie.txt
```

Or paste the `__Secure-session` cookie value manually.

## Design decisions

- **Scraping over API**: Ollama has no documented quota API. The settings page HTML is stable (tested against current production). The code is isolated in one function with clear fail-open semantics — if the page structure changes, `/ollama` returns a helpful "unavailable" message instead of crashing.
- **Cookie file over env var**: The cookie is a session token, not an API key. Storing it in a file under `~/.hermes/` follows the same pattern as other Hermes credential files.
- **Fail-open**: Missing/expired cookie → graceful "unavailable" message with setup instructions. Never blocks `/usage` or other commands.
- **Same pattern as existing providers**: Follows the `_fetch_*_account_usage()` → `AccountUsageSnapshot` → `render_account_usage_lines()` pattern used by Codex, Anthropic, and OpenRouter providers.
