### PR TITLE
fix(dashboard): skip auto-SSO redirect for password-only providers

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -185,6 +185,15 @@ def _auto_sso_response(request: Request) -> Response | None:
     from hermes_cli.dashboard_auth.prefix import prefix_from_request
 
     provider = providers[0]
+
+    # Password-only providers (e.g. BasicAuth) have no OAuth redirect flow;
+    # their /login page renders a credential form that POSTs to
+    # /auth/password-login. Auto-redirecting to /auth/login would call
+    # start_login() which raises NotImplementedError — crash, HTTP 500.
+    # Fall through to /login so the user sees the credential form.
+    if getattr(provider, "supports_password", False):
+        return None
+
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote

--- a/tests/hermes_cli/test_dashboard_auth_401_reauth.py
+++ b/tests/hermes_cli/test_dashboard_auth_401_reauth.py
@@ -406,6 +406,37 @@ class TestAutoSsoRedirect:
         assert r.headers["location"].startswith("/login")
         assert "/auth/login" not in r.headers["location"]
 
+    def test_password_only_provider_skips_auto_sso(self, gated_app):
+        """A password-only provider (e.g. BasicAuth) has no OAuth redirect
+        flow. Auto-SSO must NOT redirect to /auth/login (which would call
+        start_login() → NotImplementedError → HTTP 500). Instead it should
+        fall through to the /login interstitial that renders a credential
+        form."""
+        from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+        from hermes_cli.dashboard_auth import clear_providers, register_provider
+        from hermes_cli.dashboard_auth.base import LoginStart
+
+        # Replace the stub with a password-only provider.
+        clear_providers()
+
+        class _PasswordOnly(StubAuthProvider):
+            name = "basic"
+            display_name = "Password Login"
+            supports_password = True
+
+            def start_login(self, *, redirect_uri: str) -> LoginStart:
+                raise NotImplementedError(
+                    "BasicAuthProvider is password-only; "
+                    "there is no OAuth redirect flow."
+                )
+
+        register_provider(_PasswordOnly())
+        r = gated_app.get("/sessions", follow_redirects=False)
+        # Should fall through to /login, NOT redirect to /auth/login.
+        assert r.status_code == 302
+        assert r.headers["location"].startswith("/login")
+        assert "/auth/login" not in r.headers["location"]
+
 
 # ---------------------------------------------------------------------------
 # Gate middleware: same-origin next= validation


### PR DESCRIPTION
## What does this PR do?

Fixes an HTTP 500 crash when `BasicAuthProvider` (password-only) is the sole registered auth provider. The auto-SSO optimization in `_auto_sso_response()` unconditionally redirects to `/auth/login`, which calls `start_login()` — but password-only providers raise `NotImplementedError` there, crashing the request.

The fix adds a guard: if the single provider has `supports_password=True`, auto-SSO falls through to the `/login` interstitial that already renders a credential form.

## Related Issue

Fixes #58921

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/dashboard_auth/middleware.py` — add `supports_password` guard in `_auto_sso_response()` before constructing the `/auth/login` redirect URL (9 lines added)
- `tests/hermes_cli/test_dashboard_auth_401_reauth.py` — add `test_password_only_provider_skips_auto_sso` that registers a password-only stub provider and asserts the gate falls through to `/login` instead of redirecting to `/auth/login` (31 lines added)

## How to Test

1. Run `pytest tests/hermes_cli/test_dashboard_auth_401_reauth.py::TestAutoSsoRedirect -xvs` — all 6 tests should pass, including the new `test_password_only_provider_skips_auto_sso`.
2. Run `pytest tests/hermes_cli/test_dashboard_auth_401_reauth.py -q` — all 45 tests should pass (no regressions).
3. Manual: configure `hermes dashboard` with only `BasicAuthProvider`, open the URL unauthenticated → should see the login form (not HTTP 500).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — or N/A
- [x] I've considered cross-platform impact — or N/A
- [x] I've updated tool descriptions/schemas — or N/A

## Screenshots / Logs

N/A
