### PR TITLE
fix(gateway): notify user and write correct end_reason for resume_pending_expired resets

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10571,6 +10571,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 context_note = "[System note: The user's previous session was stopped and suspended. This is a fresh conversation with no prior context.]"
             elif reset_reason == "daily":
                 context_note = "[System note: The user's session was automatically reset by the daily schedule. This is a fresh conversation with no prior context.]"
+            elif reset_reason == "resume_pending_expired":
+                context_note = "[System note: The previous gateway session could not be recovered after a restart (API recovery timed out). This is a fresh conversation — use /resume to restore history if needed.]"
             else:
                 context_note = "[System note: The user's previous session expired due to inactivity. This is a fresh conversation with no prior context.]"
             context_prompt = context_note + "\n\n" + context_prompt
@@ -10586,9 +10588,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 platform_name = source.platform.value if source.platform else ""
                 had_activity = getattr(session_entry, 'reset_had_activity', False)
-                # Suspended sessions always notify (they were explicitly stopped
-                # or crashed mid-operation) — skip the policy check.
-                should_notify = reset_reason == "suspended" or (
+                # Suspended and restart-recovery-expired sessions always notify
+                # regardless of policy.notify — the user had an active session
+                # that was silently replaced, so they need to know they can
+                # /resume it.  Idle/daily resets respect the policy flag.
+                should_notify = reset_reason in {"suspended", "resume_pending_expired"} or (
                     policy.notify
                     and had_activity
                     and platform_name not in policy.notify_exclude_platforms
@@ -10598,6 +10602,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if adapter:
                         if reset_reason == "suspended":
                             reason_text = "previous session was stopped or interrupted"
+                        elif reset_reason == "resume_pending_expired":
+                            reason_text = "gateway restart recovery timed out"
                         elif reset_reason == "daily":
                             reason_text = f"daily schedule at {policy.at_hour}:00"
                         else:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1606,8 +1606,12 @@ class SessionStore:
 
         # SQLite operations outside the lock
         if self._db and db_end_session_id:
+            # Use the specific reset reason so state.db is auditable (e.g.
+            # "resume_pending_expired" is distinguishable from a normal
+            # "session_reset" caused by idle/daily expiry).
+            _db_end_reason = auto_reset_reason if auto_reset_reason else "session_reset"
             try:
-                self._db.end_session(db_end_session_id, "session_reset")
+                self._db.end_session(db_end_session_id, _db_end_reason)
             except Exception as e:
                 logger.debug("Session DB operation failed: %s", e)
 

--- a/tests/gateway/test_session_reset_notify.py
+++ b/tests/gateway/test_session_reset_notify.py
@@ -5,10 +5,11 @@ Verifies that:
 - SessionEntry captures auto_reset_reason
 - SessionResetPolicy.notify controls whether notifications are sent
 - notify_exclude_platforms skips notifications for excluded platforms
+- resume_pending_expired auto-reset sets the correct reason and DB end_reason
 """
 
 from datetime import datetime, timedelta
-
+from unittest.mock import MagicMock, patch
 
 from gateway.config import (
     GatewayConfig,
@@ -278,3 +279,146 @@ class TestSessionEntryAutoResetRoundtrip:
         assert reloaded.was_auto_reset is False
         assert reloaded.auto_reset_reason is None
         assert reloaded.reset_had_activity is False
+
+
+# ---------------------------------------------------------------------------
+# resume_pending_expired: auto_reset_reason and DB end_reason (#58933)
+# ---------------------------------------------------------------------------
+
+def _make_db_mock() -> MagicMock:
+    """Return a SessionDB mock with safe defaults for all lookup methods."""
+    db = MagicMock()
+    db.get_session.return_value = None
+    db.get_compression_tip.return_value = None  # avoids MagicMock leaking into session_id
+    db.find_latest_gateway_session_for_peer.return_value = None
+    db.reopen_session.return_value = None
+    db.create_session.return_value = None
+    return db
+
+
+def _make_store_with_db(tmp_path, db_mock=None, policy=None) -> SessionStore:
+    """Build a SessionStore with a mock SessionDB, bypassing disk load."""
+    cfg_policy = policy or SessionResetPolicy(mode="none")
+    config = GatewayConfig(default_reset_policy=cfg_policy)
+    with patch("gateway.session.SessionStore._ensure_loaded"):
+        store = SessionStore(sessions_dir=tmp_path, config=config)
+    store._db = db_mock if db_mock is not None else _make_db_mock()
+    store._loaded = True
+    return store
+
+
+class TestResumePendingExpiredAutoReset:
+    """resume_pending sessions past the freshness window should fire
+    was_auto_reset=True with auto_reset_reason='resume_pending_expired' and
+    persist that reason to state.db (#58933)."""
+
+    def _seed_stale_resume_pending(self, store, source, freshness_seconds=3600):
+        """Create a session, mark it resume_pending, then backdate the mark
+        past the freshness window so get_or_create_session treats it as a
+        zombie."""
+        entry = store.get_or_create_session(source)
+        store.mark_resume_pending(entry.session_key)
+        with store._lock:
+            entry = store._entries[entry.session_key]
+            entry.last_resume_marked_at = (
+                datetime.now() - timedelta(seconds=freshness_seconds + 60)
+            )
+            entry.updated_at = datetime.now()  # keep updated_at fresh
+            store._save()
+        return entry
+
+    def test_stale_resume_pending_sets_auto_reset_reason(
+        self, tmp_path, monkeypatch
+    ):
+        """Stale resume_pending triggers was_auto_reset=True with reason
+        'resume_pending_expired', NOT 'idle'."""
+        monkeypatch.setenv("HERMES_AUTO_CONTINUE_FRESHNESS", "3600")
+        store = _make_store_with_db(tmp_path)
+        source = _make_source()
+
+        old = self._seed_stale_resume_pending(store, source)
+
+        new = store.get_or_create_session(source)
+
+        assert new.session_id != old.session_id, "should have created a new session"
+        assert new.was_auto_reset is True
+        assert new.auto_reset_reason == "resume_pending_expired"
+
+    def test_stale_resume_pending_had_activity_flag(
+        self, tmp_path, monkeypatch
+    ):
+        """reset_had_activity reflects whether the old session was used."""
+        monkeypatch.setenv("HERMES_AUTO_CONTINUE_FRESHNESS", "3600")
+        store = _make_store_with_db(tmp_path)
+        source = _make_source()
+
+        old = self._seed_stale_resume_pending(store, source)
+        # Simulate some conversation on the old session.
+        with store._lock:
+            old.last_prompt_tokens = 50_000
+            store._save()
+
+        new = store.get_or_create_session(source)
+        assert new.reset_had_activity is True
+
+    def test_stale_resume_pending_db_end_reason_is_specific(
+        self, tmp_path, monkeypatch
+    ):
+        """state.db must record end_reason='resume_pending_expired', NOT the
+        generic 'session_reset', so the event is auditable (#58933 fix)."""
+        monkeypatch.setenv("HERMES_AUTO_CONTINUE_FRESHNESS", "3600")
+        db = _make_db_mock()
+        store = _make_store_with_db(tmp_path, db)
+        source = _make_source()
+
+        old = self._seed_stale_resume_pending(store, source)
+        store.get_or_create_session(source)
+
+        db.end_session.assert_called_once()
+        ended_id, ended_reason = db.end_session.call_args.args
+        assert ended_id == old.session_id
+        assert ended_reason == "resume_pending_expired", (
+            f"expected 'resume_pending_expired', got {ended_reason!r} — "
+            "the DB end_reason must not be the generic 'session_reset'"
+        )
+
+    def test_idle_reset_db_end_reason_reflects_idle(
+        self, tmp_path
+    ):
+        """Regular idle auto-reset persists 'idle' as end_reason so that all
+        auto-reset paths are auditable (#58933 should not regress the common
+        idle/daily path)."""
+        db = _make_db_mock()
+        store = _make_store_with_db(
+            tmp_path, db, policy=SessionResetPolicy(mode="idle", idle_minutes=1)
+        )
+        source = _make_source()
+
+        entry = store.get_or_create_session(source)
+        # Age past idle threshold.
+        with store._lock:
+            entry.updated_at = datetime.now() - timedelta(minutes=5)
+            store._save()
+
+        store.get_or_create_session(source)
+
+        db.end_session.assert_called_once()
+        _, ended_reason = db.end_session.call_args.args
+        assert ended_reason == "idle"
+
+    def test_freshness_disabled_skips_resume_pending_expired(
+        self, tmp_path, monkeypatch
+    ):
+        """When gateway_auto_continue_freshness=0, resume_pending is never
+        expired — the same session is returned regardless of age."""
+        monkeypatch.setenv("HERMES_AUTO_CONTINUE_FRESHNESS", "0")
+        db = _make_db_mock()
+        store = _make_store_with_db(tmp_path, db)
+        source = _make_source()
+
+        old = self._seed_stale_resume_pending(store, source, freshness_seconds=999_999)
+
+        refreshed = store.get_or_create_session(source)
+        # Freshness disabled → same session, no DB end_session call.
+        assert refreshed.session_id == old.session_id
+        db.end_session.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

When a gateway session has `resume_pending=True` (set after a drain-timeout restart) and API recovery fails — e.g. repeated timeouts on a large context — the `resume_pending` marker is never cleared. After `gateway_auto_continue_freshness` seconds the next inbound message silently creates a new session. Two implementation gaps existed in that path:

1. **No user notification.** `resume_pending_expired` fell into the generic `else` branch in `_handle_message_with_agent`, which produced the wrong wording ("inactive for Xh") and, for `session_reset.mode: none` users, was gated behind `policy.notify` — which evaluates to `False` on that mode — so no notice was ever sent.
2. **Generic DB end_reason.** The old session was always closed with the hardcoded string `"session_reset"`, making it impossible to distinguish a restart-recovery timeout from a normal idle/daily reset in post-mortem analysis.

This PR fixes both gaps:
- Adds an explicit `resume_pending_expired` case with correct agent system note and user notification (always fires, like `suspended`)
- Passes `auto_reset_reason` as the DB `end_reason` so every auto-reset path is auditable

## Related Issue

Fixes #58933

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- **`gateway/run.py`** (`_handle_message_with_agent`, `_was_auto_reset` block):
  - Added `elif reset_reason == "resume_pending_expired":` for the agent context note: `"gateway restart recovery timed out"`
  - Added `"resume_pending_expired"` to the `should_notify` always-on set (alongside `"suspended"`) — restores history-context awareness without depending on `session_reset` policy config
  - Added `elif reset_reason == "resume_pending_expired":` for `reason_text` in the user-facing notice: `"gateway restart recovery timed out"`

- **`gateway/session.py`** (`get_or_create_session`, SQLite section outside lock):
  - Replaced hardcoded `"session_reset"` with `auto_reset_reason if auto_reset_reason else "session_reset"`, so `resume_pending_expired`, `suspended`, `idle`, and `daily` resets all record their specific reason in `state.db`

- **`tests/gateway/test_session_reset_notify.py`**:
  - Added `_make_db_mock()` helper with safe defaults for all DB lookup methods (prevents MagicMock leaking into `session_id` via the compression-tip heal path)
  - Added `TestResumePendingExpiredAutoReset` class with 5 new tests:
    - `test_stale_resume_pending_sets_auto_reset_reason` — `auto_reset_reason == "resume_pending_expired"` when freshness expires
    - `test_stale_resume_pending_had_activity_flag` — `reset_had_activity` reflects token usage
    - `test_stale_resume_pending_db_end_reason_is_specific` — `db.end_session` called with `"resume_pending_expired"` not `"session_reset"`
    - `test_idle_reset_db_end_reason_reflects_idle` — idle path non-regression
    - `test_freshness_disabled_skips_resume_pending_expired` — `HERMES_AUTO_CONTINUE_FRESHNESS=0` disables the gate

## How to Test

1. Start gateway with a large-context session on any platform
2. Restart gateway in a way that causes drain timeout (`Skipping .clean_shutdown marker`)
3. Verify session is marked `resume_pending=True` in `sessions.json`
4. Simulate API failures during recovery so `resume_pending` is never cleared
5. Wait longer than `gateway_auto_continue_freshness` (default 3600s) then send a message
6. **Before this fix:** silent new session, no notice, old session ends with `"session_reset"` in state.db
7. **After this fix:** user receives `◐ Session automatically reset (gateway restart recovery timed out). ...`, old session ends with `"resume_pending_expired"` in state.db

Or run the new unit tests:
```bash
pytest tests/gateway/test_session_reset_notify.py -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_session_reset_notify.py -v` and all 21 tests pass
- [x] I've added tests for my changes (5 new tests in `TestResumePendingExpiredAutoReset`)
- [x] I've tested on my platform: Ubuntu 22.04 (Linux 6.8.0-124-generic), reproduced from production logs

### Documentation & Housekeeping

- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new config keys)
- [x] I've considered cross-platform impact — N/A (pure Python logic, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Log evidence from two independent production profiles (dingding, bala) that triggered this bug simultaneously at ~19:22 on 2026-07-05 (~1h52m after the 17:30 restart):

```
# Profile A — before fix
17:30:09 Skipping .clean_shutdown marker (drain timeout)
17:30:52 [57182b] attempting auto-resume (history=2126, ~369k tokens)
17:41:06 Stream stale — killing connection
17:42:01 API call failed after 3 retries
# gap: resume_pending never cleared, user inactive
19:22:32 inbound msg='小可'
19:22:32 [3dc5bf3f] conversation turn: history=0   ← silent new session
19:22:36 title_generation → "召唤小可"           ← no hint a switch occurred

# Profile B — same pattern, 19:23
19:23:51 [d107459d] conversation turn: history=0
19:23:56 title_generation → "可爱的中文打招呼"
```

After this fix, both users would have received:
```
◐ Session automatically reset (gateway restart recovery timed out).
Conversation history cleared.
Use /resume to browse and restore a previous session.
Adjust reset timing in config.yaml under session_reset.
```

Made with [Cursor](https://cursor.com)