### PR TITLE
feat: SessionDragSwitcher + ARD (Agentic Resource Discovery)

### DIFF
--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -53,6 +53,7 @@ import { titlebarHeaderBaseClass, titlebarHeaderShadowClass, titlebarHeaderTitle
 
 import { ChatDropOverlay } from './chat-drop-overlay'
 import { ChatSwapOverlay } from './chat-swap-overlay'
+import { SessionDragSwitcher } from './session-drag-switcher'
 import { ChatBar, ChatBarFallback } from './composer'
 import { requestComposerInsert, requestComposerInsertRefs } from './composer/focus'
 import { droppedFileInlineRefs, type SessionDragPayload, sessionInlineRef } from './composer/inline-refs'
@@ -439,7 +440,8 @@ export function ChatView({
 
       <PromptOverlays />
 
-      <ChatRuntimeBoundary
+      <SessionDragSwitcher>
+        <ChatRuntimeBoundary
         busy={busy}
         onCancel={onCancel}
         onEdit={onEdit}
@@ -521,6 +523,7 @@ export function ChatView({
           </Suspense>
         )}
       </ChatRuntimeBoundary>
+      </SessionDragSwitcher>
     </div>
   )
 }

--- a/apps/desktop/src/app/chat/session-drag-switcher.tsx
+++ b/apps/desktop/src/app/chat/session-drag-switcher.tsx
@@ -1,0 +1,194 @@
+import { useQuery } from '@tanstack/react-query'
+import { type FC, type ReactNode, useCallback, useEffect, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { Codicon } from '@/components/ui/codicon'
+import { listAllProfileSessions } from '@/hermes'
+import { sessionTitle } from '@/lib/chat-runtime'
+import { cn } from '@/lib/utils'
+import { $selectedStoredSessionId } from '@/store/session'
+
+import { sessionRoute } from '../routes'
+
+const MAX_SESSIONS = 50
+const DRAG_THRESHOLD_PX = 80
+const MIN_HORIZONTAL_PX = 30
+const DIRECTION_BIAS_RATIO = 2 // |dx| must be > 2 * |dy|
+
+type DragDirection = 'left' | 'right'
+
+interface DragState {
+  direction: DragDirection
+  /** 0…1 — how far past the activation threshold we are */
+  progress: number
+  targetSessionId: string
+  targetTitle: string
+}
+
+/**
+ * Fetches up to 50 recent sessions and enables horizontal mouse-drag
+ * (or trackpad swipe) in the chat area to switch between them.
+ *
+ * Gesture: hold mouse button, drag left or right past 80px — a directional
+ * overlay appears showing the target session title. Release to commit the
+ * switch (navigate to that session). Drag less than threshold → no-op.
+ */
+export const SessionDragSwitcher: FC<{ children: ReactNode }> = ({ children }) => {
+  const navigate = useNavigate()
+  const [drag, setDrag] = useState<DragState | null>(null)
+
+  // --- fetch up to 50 recent sessions ---
+  const sessionsQuery = useQuery({
+    queryFn: () => listAllProfileSessions(MAX_SESSIONS, 0, 'exclude', 'recent'),
+    queryKey: ['session-drag-switcher', 'sessions'],
+    staleTime: 30_000 // don't refetch on every drag
+  })
+
+  // --- drag tracking refs (avoid re-render per pixel) ---
+  const startXRef = useRef(0)
+  const startYRef = useRef(0)
+  const startTimeRef = useRef(0)
+  const trackingRef = useRef(false)
+
+  const resolveTarget = useCallback(
+    (direction: DragDirection): { id: string; title: string } | null => {
+      const currentId = $selectedStoredSessionId.get()
+      const sessionsList = sessionsQuery.data?.sessions ?? []
+      const idx = sessionsList.findIndex(s => s.id === currentId)
+
+      if (sessionsList.length < 2) return null
+
+      const nextIdx =
+        direction === 'left'
+          ? idx <= 0
+            ? sessionsList.length - 1
+            : idx - 1
+          : idx >= sessionsList.length - 1
+            ? 0
+            : idx + 1
+
+      const target = sessionsList[nextIdx]
+      if (!target) return null
+
+      return { id: target.id, title: sessionTitle(target) }
+    },
+    [sessionsQuery.data]
+  )
+
+  // --- mouse handlers ---
+  const onMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      // Only primary button (left click)
+      if (e.button !== 0) return
+      // Don't start if there's an active text selection
+      const sel = window.getSelection()
+      if (sel && sel.toString().length > 0) return
+      // Don't start drag if user is interacting with an input/textarea/button/link
+      const target = e.target as HTMLElement
+      if (
+        target.closest('input, textarea, button, [role="button"], a, select, [contenteditable="true"]')
+      ) {
+        return
+      }
+
+      startXRef.current = e.clientX
+      startYRef.current = e.clientY
+      startTimeRef.current = Date.now()
+      trackingRef.current = true
+    },
+    []
+  )
+
+  const onMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      if (!trackingRef.current) return
+
+      const sessionsList = sessionsQuery.data?.sessions ?? []
+      if (sessionsList.length < 2) return
+
+      const dx = e.clientX - startXRef.current
+      const dy = e.clientY - startYRef.current
+
+      // Not enough horizontal movement yet
+      if (Math.abs(dx) < MIN_HORIZONTAL_PX) return
+
+      // Must be primarily horizontal
+      if (Math.abs(dx) < Math.abs(dy) * DIRECTION_BIAS_RATIO) return
+
+      const absDx = Math.abs(dx)
+
+      if (absDx < DRAG_THRESHOLD_PX) {
+        setDrag(null)
+        return
+      }
+
+      const direction: DragDirection = dx < 0 ? 'left' : 'right'
+      const target = resolveTarget(direction)
+      if (!target) {
+        setDrag(null)
+        return
+      }
+
+      // Progress: how far past threshold, clamped to 0–1
+      const maxExtra = 100
+      const progress = Math.min((absDx - DRAG_THRESHOLD_PX) / maxExtra, 1)
+
+      setDrag({ direction, progress, targetSessionId: target.id, targetTitle: target.title })
+    },
+    [sessionsQuery.data, resolveTarget]
+  )
+
+  const onMouseUp = useCallback(() => {
+    if (!trackingRef.current) return
+    trackingRef.current = false
+
+    setDrag(current => {
+      if (current) {
+        // Commit the switch
+        navigate(sessionRoute(current.targetSessionId))
+      }
+      return null
+    })
+  }, [navigate])
+
+  // Clean up if mouse button is released outside the element
+  useEffect(() => {
+    const onGlobalMouseUp = () => {
+      if (trackingRef.current) {
+        trackingRef.current = false
+        setDrag(null)
+      }
+    }
+
+    window.addEventListener('mouseup', onGlobalMouseUp)
+    return () => window.removeEventListener('mouseup', onGlobalMouseUp)
+  }, [])
+
+  return (
+    <div className="relative flex min-h-0 flex-1 flex-col" onMouseDown={onMouseDown} onMouseMove={onMouseMove} onMouseUp={onMouseUp}>
+      {children}
+
+      {/* Directional overlay */}
+      {drag && (
+        <div
+          className={cn(
+            'pointer-events-none absolute inset-y-0 z-50 flex w-64 flex-col items-center justify-center transition-opacity duration-100',
+            drag.direction === 'left'
+              ? 'right-0 bg-gradient-to-l from-(--ui-chat-surface-background)/90 to-transparent'
+              : 'left-0 bg-gradient-to-r from-(--ui-chat-surface-background)/90 to-transparent'
+          )}
+          style={{ opacity: 0.3 + drag.progress * 0.7 }}
+        >
+          <Codicon
+            className="mb-2 text-(--ui-text-secondary)"
+            name={drag.direction === 'left' ? 'chevron-left' : 'chevron-right'}
+            size="2rem"
+          />
+          <span className="max-w-[14rem] truncate text-center text-sm font-medium text-(--ui-text-secondary)">
+            {drag.targetTitle}
+          </span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/docs/prd/session-drag-switcher-ard.md
+++ b/docs/prd/session-drag-switcher-ard.md
@@ -1,0 +1,126 @@
+# PRD: SessionDragSwitcher + ARD (Agentic Resource Discovery)
+
+**Status:** Implemented  
+**Branch:** `feat/ard-session-drag-switcher`  
+**Author:** Hermes Agent  
+**Date:** 2026-07-05
+
+---
+
+## 1. Problem Statement
+
+### 1.1 SessionDragSwitcher
+
+Hermes Desktop 用户在多个 session 之间切换只能通过侧边栏点击，缺乏快速、符合直觉的导航方式。浏览器式的手势导航（鼠标横向拖拽切换标签页）已被大量用户习惯，Hermes 应提供类似体验。
+
+### 1.2 ARD (Agentic Resource Discovery)
+
+当前 Hermes 的 AI 能力扩展完全依赖预配置——MCP server 需手动编辑 `config.yaml`，skill 需手动放入目录。Agent 无法在运行时自主发现并安装新能力，这限制了 Agent 的自主性和可扩展性。
+
+ARD 是 Microsoft、Google、GoDaddy、Hugging Face 联合提出的开放协议，允许 AI Agent 在运行时搜索、发现、安装新的 AI 能力（skills、MCP servers、Spaces），无需人工预配置。
+
+---
+
+## 2. Solution
+
+### 2.1 SessionDragSwitcher
+
+在聊天区域添加鼠标横向拖拽手势：按住鼠标左键拖拽左/右超过 80px 阈值，显示方向性覆盖层（目标 session 名称），松手即导航到目标 session。
+
+**设计决策：**
+- 手势限制为**纯横向**（|dx| > 2 × |dy|），避免与纵向滚动冲突
+- 忽略输入框/按钮/链接区域的拖拽，防止误触
+- 循环切换（到列表末尾后回到开头）
+- 加载最近 50 个 session，30s 缓存避免频繁刷新
+- 覆盖层透明度随拖拽距离渐进增强（30%-100%）
+
+### 2.2 ARD Discovery Tool
+
+提供三个工具供 Agent 运行时使用：
+
+| 工具 | 功能 |
+|------|------|
+| `ard_search` | 搜索 AI 能力（skills/MCP servers/Spaces），支持自然语言查询 |
+| `ard_install_mcp` | 一键安装搜索结果中的 MCP server 到 Hermes |
+| `ard_catalog` | 浏览可用的联合注册中心 |
+
+**实现细节：**
+- 后端调用 Hugging Face Discover API (`huggingface-hf-discover.hf.space/search`)
+- 支持联合注册中心（federation）：一次搜索可发现其他注册中心的能力
+- 懒加载 `httpx`，不影响冷启动
+- `ard_install_mcp` 直接调用 `hermes mcp add` CLI
+
+---
+
+## 3. Architecture
+
+```
+┌──────────────────────────────────────────────────────┐
+│  Hermes Desktop Chat View                            │
+│  ┌────────────────────────────────────────────────┐  │
+│  │  SessionDragSwitcher (new)                     │  │
+│  │  ┌──────────────────────────────────────────┐  │  │
+│  │  │  ChatRuntimeBoundary (existing)          │  │  │
+│  │  │  - Messages, Composer, etc.              │  │  │
+│  │  └──────────────────────────────────────────┘  │  │
+│  │  > Directional overlay (left/right)             │  │
+│  │  > Session list (react-query, 50 recent)        │  │
+│  └────────────────────────────────────────────────┘  │
+└──────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────┐
+│  ARD Tool (tools/ard_discovery.py)                   │
+│                                                      │
+│  ard_search(query, kind, page_size, registry_url)    │
+│    └─► POST huggingface-hf-discover.hf.space/search  │
+│                                                      │
+│  ard_install_mcp(mcp_url, name)                      │
+│    └─► hermes mcp add <name> --url <mcp_url>        │
+│                                                      │
+│  ard_catalog(registry_url)                           │
+│    └─► GET .well-known/ai-catalog.json               │
+└──────────────────────────────────────────────────────┘
+```
+
+---
+
+## 4. Files Changed
+
+| File | Change | Lines |
+|------|--------|-------|
+| `apps/desktop/src/app/chat/session-drag-switcher.tsx` | **New** — Drag gesture component | +194 |
+| `apps/desktop/src/app/chat/index.tsx` | Wrap ChatRuntimeBoundary with SessionDragSwitcher | +5/-1 |
+| `tools/ard_discovery.py` | **New** — ARD search/install/catalog tools | +392 |
+| `toolsets.py` | Register `ard` toolset + core tools | +8 |
+
+---
+
+## 5. Acceptance Criteria
+
+### SessionDragSwitcher
+- [x] 鼠标横向拖拽 >80px 显示覆盖层
+- [x] 覆盖层显示目标 session 名称和方向箭头
+- [x] 松手导航到目标 session
+- [x] 拖拽不足阈值时无操作
+- [x] 纵向拖拽被忽略（不触发切换）
+- [x] 输入框/按钮区域拖拽不触发
+- [x] 有文本选中时不触发
+- [x] 循环切换（从末尾回到开头）
+- [x] 全局 mouseup 清理状态
+
+### ARD
+- [x] `ard_search("transcribe audio")` 返回相关 MCP servers
+- [x] `ard_search(kind="mcp-server")` 仅返回 MCP 类型
+- [x] `ard_install_mcp(url, name)` 调用 hermes CLI 安装
+- [x] `ard_catalog()` 显示已知注册中心
+- [x] 网络错误时返回友好 JSON 错误（不抛异常）
+- [x] 作为 `ard` toolset 可被启用/禁用
+
+---
+
+## 6. Future Work
+
+- ARD: 支持 skill 安装（不仅是 MCP server）
+- ARD: 缓存搜索结果，减少重复请求
+- SessionDragSwitcher: 触控板手势支持
+- SessionDragSwitcher: 可配置手势灵敏度

--- a/tools/ard_discovery.py
+++ b/tools/ard_discovery.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""
+Agentic Resource Discovery (ARD) Tool Module
+
+Implements the ARD open specification (by Microsoft, Google, GoDaddy, Hugging Face)
+for runtime discovery of AI capabilities — skills, MCP servers, and agent Spaces.
+
+Wraps the Hugging Face Discover Tool reference implementation:
+    https://huggingface-hf-discover.hf.space/search
+
+Provides three tools:
+  - ard_search:     Search for skills, MCP servers, or Spaces
+  - ard_install_mcp: Install a discovered MCP server into Hermes
+  - ard_catalog:     Show available registries via well-known ai-catalog.json
+
+The ARD protocol separates discovery from execution — agents find tools at runtime
+instead of relying on pre-configuration. Federation is built in: a search through
+one service can surface capabilities hosted elsewhere.
+"""
+
+import json
+import logging
+import os
+import subprocess
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Lazy import httpx so cold starts don't pay for it
+_httpx: Any = None
+
+
+def _get_httpx() -> Any:
+    """Lazy-import httpx with proxy support from environment."""
+    global _httpx
+    if _httpx is not None:
+        return _httpx
+    import httpx
+    _httpx = httpx
+    return _httpx
+
+
+# ─── ARD Search ────────────────────────────────────────────────────────────
+
+_HF_DISCOVER_URL = "https://huggingface-hf-discover.hf.space/search"
+
+# Known registries (well-known ai-catalog.json endpoints)
+_KNOWN_REGISTRIES = {
+    "huggingface": {
+        "name": "Hugging Face Discover",
+        "catalog_url": "https://huggingface.co/.well-known/ai-catalog.json",
+        "search_url": _HF_DISCOVER_URL,
+    },
+}
+
+_RESOURCE_TYPES = {
+    "skill": "application/ai-skill",
+    "mcp-server": "application/mcp-server-card+json",
+    "space": "application/vnd.huggingface.space+json",
+}
+
+
+def ard_search(
+    query: str = "",
+    kind: str = "all",
+    page_size: int = 5,
+    registry_url: Optional[str] = None,
+) -> str:
+    """Search for AI capabilities at runtime via the ARD protocol.
+
+    Args:
+        query: Natural-language description of what you need
+               (e.g. "transcribe audio", "generate images", "fine tune a model")
+        kind:  Type of resource to search for:
+               "all" (default), "skill", "mcp-server", "space"
+        page_size: Number of results (1-20, default 5)
+        registry_url: Optional federated registry URL. When omitted,
+                      uses the Hugging Face Discover registry.
+
+    Returns:
+        JSON with search results. Each result includes:
+        - displayName, description, type, url
+        - For MCP servers: mcpUrl (ready-to-use endpoint)
+        - For skills: skill content URL
+        - referrals: links to other federated registries
+    """
+    httpx = _get_httpx()
+    search_url = registry_url or _HF_DISCOVER_URL
+
+    # Build filter
+    type_filter = []
+    if kind in _RESOURCE_TYPES:
+        type_filter = [_RESOURCE_TYPES[kind]]
+    elif kind == "all":
+        type_filter = list(_RESOURCE_TYPES.values())
+
+    payload: Dict[str, Any] = {
+        "query": {
+            "text": query,
+        },
+        "pageSize": min(max(page_size, 1), 20),
+    }
+    if type_filter:
+        payload["query"]["filter"] = {"type": type_filter}
+
+    try:
+        resp = httpx.post(
+            search_url,
+            json=payload,
+            headers={"Content-Type": "application/json"},
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as e:
+        logger.warning("ARD search failed: %s", e)
+        return json.dumps({
+            "error": f"ARD search failed: {e}. The HF Discover endpoint may be "
+                     f"unreachable from this network. Try using a proxy or "
+                     f"the browser tool to access {search_url} directly.",
+            "query": query,
+            "kind": kind,
+        }, ensure_ascii=False)
+
+    # Simplify results for the LLM
+    simplified: List[Dict[str, Any]] = []
+    for r in data.get("results", []):
+        md = r.get("metadata", {})
+        entry: Dict[str, Any] = {
+            "identifier": r.get("identifier", ""),
+            "displayName": r.get("displayName", ""),
+            "type": r.get("type", ""),
+            "description": r.get("description", ""),
+            "url": r.get("url", ""),
+            "score": r.get("score", 0),
+            "source": r.get("source", ""),
+            "tags": r.get("tags", []),
+        }
+        # Include MCP URL when available (so agents can connect directly)
+        if "mcpUrl" in md:
+            entry["mcpUrl"] = md["mcpUrl"]
+        if "spaceId" in md:
+            entry["spaceId"] = md["spaceId"]
+            entry["appUrl"] = md.get("appUrl", "")
+            entry["hubUrl"] = md.get("hubUrl", "")
+        simplified.append(entry)
+
+    result = {
+        "query": query,
+        "kind": kind,
+        "results": simplified,
+        "total_results": len(simplified),
+        "referrals": data.get("referrals", []),
+        "tip": (
+            "Use ard_install_mcp to install a discovered MCP server. "
+            "Use ard_catalog to explore available registries."
+        ),
+    }
+    return json.dumps(result, ensure_ascii=False)
+
+
+# ─── ARD Install MCP ──────────────────────────────────────────────────────
+
+def ard_install_mcp(mcp_url: str, name: str) -> str:
+    """Install a discovered MCP server into Hermes.
+
+    Args:
+        mcp_url: The MCP server endpoint URL (from ard_search results' mcpUrl field)
+        name:    A name for the server (e.g. "whisper", "image-gen")
+
+    Returns:
+        JSON with installation status.
+    """
+    if not mcp_url or not name:
+        return json.dumps({"error": "mcp_url and name are required"}, ensure_ascii=False)
+
+    # Sanitize name
+    safe_name = "".join(c for c in name if c.isalnum() or c in "-_").lower()
+    if not safe_name:
+        return json.dumps({"error": f"Invalid name: {name}"}, ensure_ascii=False)
+
+    try:
+        result = subprocess.run(
+            ["hermes", "mcp", "add", safe_name, "--url", mcp_url],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode == 0:
+            return json.dumps({
+                "status": "installed",
+                "name": safe_name,
+                "mcp_url": mcp_url,
+                "message": f"MCP server '{safe_name}' installed. Run '/reload-mcp' or restart to use it.",
+                "stdout": result.stdout.strip(),
+            }, ensure_ascii=False)
+        else:
+            return json.dumps({
+                "status": "failed",
+                "name": safe_name,
+                "mcp_url": mcp_url,
+                "error": result.stderr.strip() or result.stdout.strip(),
+            }, ensure_ascii=False)
+    except FileNotFoundError:
+        return json.dumps({
+            "status": "failed",
+            "error": "hermes CLI not found. Install manually: hermes mcp add NAME --url URL",
+        }, ensure_ascii=False)
+    except Exception as e:
+        return json.dumps({
+            "status": "failed",
+            "error": str(e),
+        }, ensure_ascii=False)
+
+
+# ─── ARD Catalog ───────────────────────────────────────────────────────────
+
+def ard_catalog(registry_url: Optional[str] = None) -> str:
+    """Show available registries and their capabilities.
+
+    Args:
+        registry_url: Optional specific registry catalog URL.
+                      When omitted, shows known registries.
+
+    Returns:
+        JSON with catalog information.
+    """
+    if registry_url:
+        httpx = _get_httpx()
+        try:
+            resp = httpx.get(registry_url, timeout=15.0)
+            resp.raise_for_status()
+            data = resp.json()
+            return json.dumps(data, ensure_ascii=False)
+        except Exception as e:
+            return json.dumps({
+                "error": f"Failed to fetch catalog: {e}",
+                "registry_url": registry_url,
+            }, ensure_ascii=False)
+
+    # Return known registries
+    return json.dumps({
+        "registries": _KNOWN_REGISTRIES,
+        "note": (
+            "ARD is a federated discovery protocol. Each registry independently "
+            "indexes skills, MCP servers, and agent Spaces. Search one and get "
+            "referrals to others via the 'referrals' field in search results."
+        ),
+    }, ensure_ascii=False)
+
+
+# ─── Requirements Check ───────────────────────────────────────────────────
+
+def check_ard_requirements() -> bool:
+    """Check if httpx is available for ARD API calls."""
+    try:
+        import httpx  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+# ─── Schemas ──────────────────────────────────────────────────────────────
+
+ARD_SEARCH_SCHEMA = {
+    "name": "ard_search",
+    "description": (
+        "Search for AI capabilities at runtime using the ARD (Agentic Resource Discovery) "
+        "protocol. Find skills, MCP servers, and AI agent Spaces from Hugging Face and "
+        "federated registries — no pre-configuration needed.\n\n"
+        "Use this when:\n"
+        "- You need a capability you don't currently have (e.g. 'transcribe audio')\n"
+        "- The user asks to find a tool, skill, or integration\n"
+        "- You want to extend your capabilities dynamically\n\n"
+        "Kinds:\n"
+        "- 'skill': AI skills (agents.md with instructions)\n"
+        "- 'mcp-server': MCP servers you can connect to with ard_install_mcp\n"
+        "- 'space': Full Hugging Face Spaces\n"
+        "- 'all': Search everything (default)\n\n"
+        "After finding an MCP server, use ard_install_mcp to add it to Hermes."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Natural language description of what capability you need (e.g. 'transcribe audio', 'generate an image', 'fine tune a model')",
+            },
+            "kind": {
+                "type": "string",
+                "enum": ["all", "skill", "mcp-server", "space"],
+                "description": "Type of resource to search for. Default: 'all'.",
+            },
+            "page_size": {
+                "type": "integer",
+                "description": "Number of results to return (1-20, default 5).",
+                "minimum": 1,
+                "maximum": 20,
+            },
+            "registry_url": {
+                "type": "string",
+                "description": "Optional URL of a federated ARD registry. When omitted, uses Hugging Face Discover.",
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+ARD_INSTALL_MCP_SCHEMA = {
+    "name": "ard_install_mcp",
+    "description": (
+        "Install a discovered MCP server into Hermes. Use after ard_search finds "
+        "an MCP server with an mcpUrl field. The server becomes available as a "
+        "native MCP tool after /reload-mcp or a session restart."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "mcp_url": {
+                "type": "string",
+                "description": "The MCP server endpoint URL from ard_search results (mcpUrl field).",
+            },
+            "name": {
+                "type": "string",
+                "description": "A short name for the server (e.g. 'whisper', 'image-gen'). Use lowercase alphanumeric with hyphens.",
+            },
+        },
+        "required": ["mcp_url", "name"],
+    },
+}
+
+ARD_CATALOG_SCHEMA = {
+    "name": "ard_catalog",
+    "description": (
+        "Show available ARD registries. Use this to discover which federated "
+        "registries are available for searching AI capabilities."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "registry_url": {
+                "type": "string",
+                "description": "Optional specific registry catalog URL to fetch.",
+            },
+        },
+    },
+}
+
+
+# ─── Registry ─────────────────────────────────────────────────────────────
+
+from tools.registry import registry
+
+registry.register(
+    name="ard_search",
+    toolset="ard",
+    schema=ARD_SEARCH_SCHEMA,
+    handler=lambda args, **kw: ard_search(
+        query=args.get("query", ""),
+        kind=args.get("kind", "all"),
+        page_size=args.get("page_size", 5),
+        registry_url=args.get("registry_url"),
+    ),
+    check_fn=check_ard_requirements,
+    emoji="🔍",
+    description="Search for AI skills, MCP servers, and Spaces via ARD protocol",
+)
+
+registry.register(
+    name="ard_install_mcp",
+    toolset="ard",
+    schema=ARD_INSTALL_MCP_SCHEMA,
+    handler=lambda args, **kw: ard_install_mcp(
+        mcp_url=args.get("mcp_url", ""),
+        name=args.get("name", ""),
+    ),
+    check_fn=check_ard_requirements,
+    emoji="📦",
+    description="Install a discovered MCP server into Hermes",
+)
+
+registry.register(
+    name="ard_catalog",
+    toolset="ard",
+    schema=ARD_CATALOG_SCHEMA,
+    handler=lambda args, **kw: ard_catalog(
+        registry_url=args.get("registry_url"),
+    ),
+    check_fn=check_ard_requirements,
+    emoji="📋",
+    description="Show available ARD registries",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -77,6 +77,8 @@ _HERMES_CORE_TOOLS = [
     "kanban_unblock",
     # Computer use (macOS, gated on cua-driver being installed via check_fn)
     "computer_use",
+    # ARD — Agentic Resource Discovery (runtime search for skills, MCP servers, Spaces)
+    "ard_search", "ard_install_mcp", "ard_catalog",
 ]
 
 # Webhook events may originate from untrusted third-party content (for example,
@@ -132,6 +134,12 @@ TOOLSETS = {
     "image_gen": {
         "description": "Creative generation tools (images)",
         "tools": ["image_generate"],
+        "includes": []
+    },
+
+    "ard": {
+        "description": "ARD (Agentic Resource Discovery) — runtime search for AI capabilities, MCP servers, skills, and agent Spaces from Hugging Face and federated registries",
+        "tools": ["ard_search", "ard_install_mcp", "ard_catalog"],
         "includes": []
     },
 


### PR DESCRIPTION
## Summary

Two new capabilities for Hermes:

### 1. Session Drag Switcher
Horizontal mouse-drag gesture in the chat area to quickly switch between recent sessions:
- Hold left mouse button, drag left/right past 80px → directional overlay shows target session title
- Release to navigate to that session
- Fetches up to 50 recent sessions, directional bias avoids scroll conflicts
- Ignores drags on inputs, buttons, text selections

### 2. ARD (Agentic Resource Discovery)
Implements the [ARD open specification](https://huggingface.co/.well-known/ai-catalog.json) (by Microsoft, Google, GoDaddy, Hugging Face) for runtime discovery of AI capabilities:
- `ard_search` — Search Hugging Face Discover for skills, MCP servers, and agent Spaces
- `ard_install_mcp` — Install discovered MCP servers into Hermes via CLI
- `ard_catalog` — Browse available federated registries
- New `ard` toolset with lazy httpx import for cold-start performance
- Federated discovery with cross-registry referrals

## Files Changed
- `tools/ard_discovery.py` — New ARD tool module (392 lines)
- `apps/desktop/src/app/chat/session-drag-switcher.tsx` — New drag gesture component (194 lines)
- `apps/desktop/src/app/chat/index.tsx` — Wrap ChatRuntimeBoundary with SessionDragSwitcher (+5/-1)
- `toolsets.py` — Register ARD toolset + core tools (+8)