### PR TITLE
feat(whatsapp): per-chat channel_prompts (persona per group/DM)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2395,6 +2395,7 @@ DEFAULT_CONFIG = {
         # Default (None) uses the built-in "⚕ *Hermes Agent*" header.
         # Set to "" (empty string) to disable the header entirely.
         # Supports \n for newlines, e.g. "🤖 *My Bot*\n──────\n"
+        "channel_prompts": {},         # Per-chat ephemeral system prompts, keyed by chat JID (group @g.us / DM @s.whatsapp.net)
     },
 
     # Telegram platform settings (gateway mode)

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1356,12 +1356,23 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             chat_type = "group" if is_group else "dm"
             
             # Build source
+            _chat_id = data.get("chatId", "")
             source = self.build_source(
-                chat_id=data.get("chatId", ""),
+                chat_id=_chat_id,
                 chat_name=data.get("chatName"),
                 chat_type=chat_type,
                 user_id=data.get("senderId"),
                 user_name=data.get("senderName"),
+            )
+
+            # Per-chat ephemeral system prompt (keyed by chat JID) — lets one
+            # WhatsApp connection give different groups/DMs a different persona,
+            # matching the channel_prompts support in the telegram/slack/discord
+            # adapters. Empty config → None → no override.
+            from gateway.platforms.base import resolve_channel_prompt
+            _channel_prompt = (
+                resolve_channel_prompt(self.config.extra, str(_chat_id))
+                if _chat_id else None
             )
             
             # Download media URLs to the local cache so agent tools
@@ -1514,6 +1525,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 reply_to_text=reply_to_text,
                 reply_to_author_id=reply_to_author_id,
                 reply_to_is_own_message=reply_to_is_own_message,
+                channel_prompt=_channel_prompt,
             )
         except Exception as e:
             print(f"[{self.name}] Error building event: {e}")

--- a/tests/gateway/test_whatsapp_channel_prompts.py
+++ b/tests/gateway/test_whatsapp_channel_prompts.py
@@ -1,0 +1,103 @@
+"""Tests for WhatsApp per-chat ephemeral system prompts (``channel_prompts``).
+
+One WhatsApp connection can give different chats a different persona by keying
+``channel_prompts`` on the chat JID (group ``@g.us`` / DM ``@s.whatsapp.net``),
+matching the support already present in the telegram/slack/discord adapters.
+The adapter resolves the prompt in ``_build_message_event`` via the shared
+``gateway.platforms.base.resolve_channel_prompt`` helper and attaches it to
+``MessageEvent.channel_prompt``; the agent then applies it as an ephemeral
+system-prompt override for that turn. No match → ``None`` → no override.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+
+@pytest.fixture(autouse=True)
+def _whatsapp_open_optin(monkeypatch):
+    monkeypatch.setenv("WHATSAPP_ALLOW_ALL_USERS", "true")
+
+
+def _make_adapter(channel_prompts=None):
+    adapter = WhatsAppAdapter.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+    adapter.config = PlatformConfig(
+        enabled=True,
+        extra={"channel_prompts": channel_prompts or {}},
+    )
+    adapter._message_handler = AsyncMock()
+    adapter._dm_policy = "open"
+    adapter._allow_from = set()
+    adapter._group_policy = "open"
+    adapter._group_allow_from = set()
+    adapter._mention_patterns = []
+    adapter._free_response_chats = set()
+    adapter._whatsapp_free_response_chats = lambda: set()
+    return adapter
+
+
+_DM_JID = "6281234567890@s.whatsapp.net"
+_GROUP_JID = "120363000000000000@g.us"
+
+
+def _payload(chat_id, is_group=False, **overrides):
+    payload = {
+        "messageId": "M1",
+        "chatId": chat_id,
+        "senderId": _DM_JID,
+        "senderName": "Customer",
+        "chatName": "Customer",
+        "isGroup": is_group,
+        "body": "hello",
+        "hasMedia": False,
+        "mediaType": "",
+        "mediaUrls": [],
+        "mentionedIds": [],
+        "quotedParticipant": "",
+        "botIds": [],
+        "timestamp": 0,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_dm_channel_prompt_applied():
+    adapter = _make_adapter({_DM_JID: "You are the after-sales concierge."})
+    event = asyncio.run(adapter._build_message_event(_payload(_DM_JID)))
+    assert event is not None
+    assert event.channel_prompt == "You are the after-sales concierge."
+
+
+def test_group_channel_prompt_applied():
+    adapter = _make_adapter({_GROUP_JID: "You are the recruitment desk for this group."})
+    event = asyncio.run(adapter._build_message_event(_payload(_GROUP_JID, is_group=True)))
+    assert event is not None
+    assert event.channel_prompt == "You are the recruitment desk for this group."
+
+
+def test_unlisted_chat_gets_no_prompt():
+    adapter = _make_adapter({_GROUP_JID: "group persona"})
+    event = asyncio.run(adapter._build_message_event(_payload(_DM_JID)))
+    assert event is not None
+    assert event.channel_prompt is None
+
+
+def test_empty_config_is_none():
+    adapter = _make_adapter({})
+    event = asyncio.run(adapter._build_message_event(_payload(_DM_JID)))
+    assert event is not None
+    assert event.channel_prompt is None
+
+
+def test_blank_prompt_treated_as_absent():
+    adapter = _make_adapter({_DM_JID: "   "})
+    event = asyncio.run(adapter._build_message_event(_payload(_DM_JID)))
+    assert event is not None
+    assert event.channel_prompt is None


### PR DESCRIPTION
## What

The WhatsApp adapter was the only chat platform without `channel_prompts`. Telegram, Slack, Discord, Mattermost and Feishu already resolve a per-chat ephemeral system prompt via `gateway.platforms.base.resolve_channel_prompt`. This wires the same into WhatsApp.

## Why

One WhatsApp connection often serves several distinct groups/DMs that want different behavior (e.g. a support group vs an announcements group). Without `channel_prompts`, WhatsApp users had to run a separate gateway per persona. This brings WhatsApp to parity with the other chat platforms.

## How

- `hermes_cli/config.py`: add `channel_prompts: {}` to the `whatsapp` platform config (keyed by chat JID — group `@g.us` / DM `@s.whatsapp.net`). It flows into `config.extra` via the existing whatsapp config bridge.
- `plugins/platforms/whatsapp/adapter.py`: in `_build_message_event`, resolve the per-chat prompt via the shared `resolve_channel_prompt` helper and attach it to `MessageEvent.channel_prompt`. Empty config is a no-op (`None`).

## Tests

- 5 new tests (`tests/gateway/test_whatsapp_channel_prompts.py`): DM prompt, group prompt, unlisted chat → None, empty config → None, blank prompt treated as absent.
- 136 existing WhatsApp / channel-prompt tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)