### PR TITLE
feat: declarative cross-channel forwarding plugin

### DIFF
--- a/plugins/forwarding/__init__.py
+++ b/plugins/forwarding/__init__.py
@@ -1,0 +1,138 @@
+"""forwarding plugin — declarative cross-channel message relay.
+
+Rules live in ``$HERMES_HOME/forwarding-rules.json``::
+
+    {"rules": [
+        {"from": {"platform": "wecom",    "chat": "<source jid>"},
+         "to":   {"platform": "whatsapp", "chat": "<target jid>"},
+         "forward_only": false, "media": true, "prefix": ""}
+    ]}
+
+On every inbound user message (``pre_gateway_dispatch``), each matching rule
+relays the text — and the first image when ``media: true`` — to the target
+chat via the target platform's connected adapter. ``forward_only: true`` also
+drops the message from the agent (pure relay, no reply). Relay sends are
+scheduled on the running loop and best-effort: a failure is logged and never
+blocks the originating message.
+
+The rules file is hot-reloaded on mtime change, so edits take effect without a
+gateway restart.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_RULES_CACHE: Optional[Dict[str, Any]] = None
+_RULES_MTIME: float = -1.0
+
+
+def _rules_path() -> Path:
+    home = os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes")
+    return Path(home) / "forwarding-rules.json"
+
+
+def _load_rules() -> List[Dict[str, Any]]:
+    """Return the rule list, hot-reloading the file on mtime change."""
+    global _RULES_CACHE, _RULES_MTIME
+    path = _rules_path()
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        _RULES_CACHE, _RULES_MTIME = {"rules": []}, -1.0
+        return []
+    if _RULES_CACHE is None or mtime != _RULES_MTIME:
+        try:
+            _RULES_CACHE = json.loads(path.read_text(encoding="utf-8"))
+            _RULES_MTIME = mtime
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("forwarding: could not parse %s: %s", path, exc)
+            _RULES_CACHE = {"rules": []}
+    rules = (_RULES_CACHE or {}).get("rules") or []
+    return [r for r in rules if isinstance(r, dict)]
+
+
+def _platform_value(platform: Any) -> str:
+    return str(getattr(platform, "value", platform) or "").strip().lower()
+
+
+def _rule_matches(rule: Dict[str, Any], src_platform: str, src_chat: str) -> bool:
+    frm = rule.get("from") or {}
+    return (
+        str(frm.get("platform", "")).strip().lower() == src_platform
+        and str(frm.get("chat", "")).strip() == src_chat
+    )
+
+
+async def _relay(gateway: Any, rule: Dict[str, Any], text: str, media_urls: List[str]) -> None:
+    """Send one relayed message to the rule's target chat (best-effort)."""
+    from gateway.config import Platform
+
+    to = rule.get("to") or {}
+    try:
+        target_platform = Platform(str(to.get("platform", "")).strip().lower())
+    except ValueError:
+        logger.warning("forwarding: unknown target platform %r", to.get("platform"))
+        return
+    adapter = (getattr(gateway, "adapters", {}) or {}).get(target_platform)
+    if adapter is None:
+        logger.warning("forwarding: target platform %s not connected", target_platform)
+        return
+    target_chat = str(to.get("chat", "")).strip()
+    if not target_chat:
+        return
+
+    prefix = str(rule.get("prefix") or "")
+    body = f"{prefix}{text}" if text else prefix
+    try:
+        if body.strip():
+            await adapter.send(target_chat, body)
+        if rule.get("media") and media_urls:
+            # Relay the first image best-effort; other media types are a
+            # follow-up (the common recruitment/announce case is text+image).
+            try:
+                await adapter.send_image(target_chat, media_urls[0], caption=None)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("forwarding: media relay failed: %s", exc)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "forwarding: relay to %s/%s failed: %s", target_platform, target_chat, exc
+        )
+
+
+def _on_inbound(event: Any = None, gateway: Any = None, **_: Any) -> Optional[Dict[str, Any]]:
+    """pre_gateway_dispatch hook: relay matching inbound messages."""
+    if event is None or gateway is None:
+        return None
+    source = getattr(event, "source", None)
+    src_platform = _platform_value(getattr(source, "platform", None))
+    src_chat = str(getattr(source, "chat_id", "") or "").strip()
+    if not src_platform or not src_chat:
+        return None
+
+    matched = [r for r in _load_rules() if _rule_matches(r, src_platform, src_chat)]
+    if not matched:
+        return None
+
+    text = getattr(event, "text", "") or ""
+    media_urls = [u for u in (getattr(event, "media_urls", None) or []) if isinstance(u, str)]
+    for rule in matched:
+        try:
+            asyncio.get_running_loop().create_task(_relay(gateway, rule, text, media_urls))
+        except RuntimeError:
+            logger.warning("forwarding: no running loop; relay skipped")
+
+    if any(r.get("forward_only") for r in matched):
+        return {"action": "skip", "reason": "forwarded"}
+    return None
+
+
+def register(ctx: Any) -> None:
+    ctx.register_hook("pre_gateway_dispatch", _on_inbound)

--- a/plugins/forwarding/plugin.yaml
+++ b/plugins/forwarding/plugin.yaml
@@ -1,0 +1,15 @@
+name: forwarding
+label: Cross-channel Forwarding
+kind: plugin
+version: 1.0.0
+description: >
+  Declarative cross-channel message forwarding. Rules in
+  ``$HERMES_HOME/forwarding-rules.json`` relay inbound messages (text, and the
+  first image when ``media: true``) from one chat to another — across
+  platforms (e.g. WeCom group → WhatsApp group, WhatsApp group → Telegram).
+  Runs on the ``pre_gateway_dispatch`` hook; ``forward_only: true`` relays and
+  drops the message so the agent does not also reply. Best-effort: relay
+  failures are logged and never block the originating message.
+author: Hermes Agent contributors
+hooks:
+  - pre_gateway_dispatch

--- a/tests/gateway/test_forwarding_plugin.py
+++ b/tests/gateway/test_forwarding_plugin.py
@@ -1,0 +1,130 @@
+"""Tests for the declarative cross-channel forwarding plugin.
+
+The plugin registers a ``pre_gateway_dispatch`` hook that reads rules from
+``$HERMES_HOME/forwarding-rules.json`` and relays matching inbound messages
+(text + first image) to a target chat via the target platform's adapter.
+``forward_only: true`` also drops the message so the agent does not reply.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import types
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+import plugins.forwarding as fwd
+
+
+@pytest.fixture(autouse=True)
+def _rules_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    # reset the module cache between tests
+    fwd._RULES_CACHE = None
+    fwd._RULES_MTIME = -1.0
+    return tmp_path
+
+
+def _write_rules(home, rules):
+    (home / "forwarding-rules.json").write_text(json.dumps({"rules": rules}), encoding="utf-8")
+
+
+def _event(platform, chat_id, text="hello", media_urls=None):
+    source = types.SimpleNamespace(platform=platform, chat_id=chat_id)
+    return types.SimpleNamespace(source=source, text=text, media_urls=media_urls or [])
+
+
+def _gateway_with(target_platform):
+    adapter = types.SimpleNamespace(send=AsyncMock(), send_image=AsyncMock())
+    gw = types.SimpleNamespace(adapters={target_platform: adapter})
+    return gw, adapter
+
+
+def test_no_rules_is_noop(_rules_file):
+    gw, adapter = _gateway_with(Platform.TELEGRAM)
+    ev = _event(Platform.WHATSAPP, "120@g.us")
+    assert fwd._on_inbound(event=ev, gateway=gw) is None
+    adapter.send.assert_not_called()
+
+
+def test_matching_rule_relays_text(_rules_file):
+    _write_rules(_rules_file, [
+        {"from": {"platform": "whatsapp", "chat": "120@g.us"},
+         "to": {"platform": "telegram", "chat": "-100999"}},
+    ])
+    gw, adapter = _gateway_with(Platform.TELEGRAM)
+
+    async def run():
+        res = fwd._on_inbound(event=_event(Platform.WHATSAPP, "120@g.us", "job alert"), gateway=gw)
+        await asyncio.sleep(0)  # let the scheduled relay task run
+        return res
+
+    res = asyncio.run(run())
+    assert res is None  # not forward_only → agent still processes
+    adapter.send.assert_awaited_once_with("-100999", "job alert")
+
+
+def test_forward_only_drops_message(_rules_file):
+    _write_rules(_rules_file, [
+        {"from": {"platform": "wecom", "chat": "src"},
+         "to": {"platform": "whatsapp", "chat": "dst@g.us"},
+         "forward_only": True},
+    ])
+    gw, adapter = _gateway_with(Platform.WHATSAPP)
+
+    async def run():
+        res = fwd._on_inbound(event=_event(Platform.WECOM, "src", "notice"), gateway=gw)
+        await asyncio.sleep(0)
+        return res
+
+    res = asyncio.run(run())
+    assert res == {"action": "skip", "reason": "forwarded"}
+    adapter.send.assert_awaited_once_with("dst@g.us", "notice")
+
+
+def test_prefix_and_media(_rules_file):
+    _write_rules(_rules_file, [
+        {"from": {"platform": "whatsapp", "chat": "a@g.us"},
+         "to": {"platform": "telegram", "chat": "-1"},
+         "media": True, "prefix": "[fwd] "},
+    ])
+    gw, adapter = _gateway_with(Platform.TELEGRAM)
+
+    async def run():
+        fwd._on_inbound(
+            event=_event(Platform.WHATSAPP, "a@g.us", "pic", media_urls=["/tmp/x.jpg", "/tmp/y.jpg"]),
+            gateway=gw,
+        )
+        await asyncio.sleep(0)
+
+    asyncio.run(run())
+    adapter.send.assert_awaited_once_with("-1", "[fwd] pic")
+    adapter.send_image.assert_awaited_once_with("-1", "/tmp/x.jpg", caption=None)
+
+
+def test_unconnected_target_is_safe(_rules_file):
+    _write_rules(_rules_file, [
+        {"from": {"platform": "whatsapp", "chat": "a@g.us"},
+         "to": {"platform": "telegram", "chat": "-1"}},
+    ])
+    gw = types.SimpleNamespace(adapters={})  # telegram not connected
+
+    async def run():
+        return fwd._on_inbound(event=_event(Platform.WHATSAPP, "a@g.us"), gateway=gw)
+
+    # must not raise even though the target adapter is missing
+    assert asyncio.run(run()) is None
+
+
+def test_non_matching_chat_ignored(_rules_file):
+    _write_rules(_rules_file, [
+        {"from": {"platform": "whatsapp", "chat": "a@g.us"},
+         "to": {"platform": "telegram", "chat": "-1"}},
+    ])
+    gw, adapter = _gateway_with(Platform.TELEGRAM)
+    res = fwd._on_inbound(event=_event(Platform.WHATSAPP, "OTHER@g.us"), gateway=gw)
+    assert res is None
+    adapter.send.assert_not_called()


### PR DESCRIPTION
## What

A `forwarding` plugin that relays inbound messages from one chat to another — across platforms — driven by a declarative rules file, no agent involvement.

## Why

Cross-channel relaying (e.g. a WeCom group → a WhatsApp group, or a WhatsApp announcements group → Telegram) is a common ops need that currently requires an agent to actively `send_message` or a hand-written cron. This makes it a config-driven, deterministic behavior.

## How

- `plugins/forwarding/` — registers a `pre_gateway_dispatch` hook.
- Rules live in `$HERMES_HOME/forwarding-rules.json`:
  ```json
  {"rules": [
    {"from": {"platform": "wecom", "chat": "<src>"},
     "to":   {"platform": "whatsapp", "chat": "<dst>"},
     "forward_only": false, "media": true, "prefix": ""}
  ]}
  ```
- On each inbound user message, matching rules relay the text (and the first image when `media: true`) to the target chat via the target platform's connected adapter (`gateway.adapters[...]`).
- `forward_only: true` relays and returns `{"action": "skip"}` so the agent does not also reply (pure relay).
- Rules hot-reload on mtime; relay sends are scheduled on the running loop and best-effort — a failure is logged and never blocks the originating message.

## Tests

- 6 new tests (`tests/gateway/test_forwarding_plugin.py`): no-rules no-op, text relay, forward_only drop, prefix + image relay, unconnected target is safe, non-matching chat ignored.
- 156 existing plugin/config tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)