### PR TITLE
feat: Facebook Messenger + Instagram DM platform plugins

### DIFF
--- a/plugins/platforms/instagram/__init__.py
+++ b/plugins/platforms/instagram/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import register
+
+__all__ = ["register"]

--- a/plugins/platforms/instagram/adapter.py
+++ b/plugins/platforms/instagram/adapter.py
@@ -1,0 +1,149 @@
+"""Instagram DM platform plugin for Hermes Agent.
+
+Bundled platform plugin — registers via ``ctx.register_platform()`` with
+zero core edits.  Instagram Direct Messages are the second surface of a
+Meta app: an Instagram professional account is linked to a Facebook
+Page, events arrive on the SAME webhook callback as Messenger (payloads
+carry ``object: "instagram"``), and sends go through the same Graph API
+``/me/messages`` endpoint with the same Page access token.
+
+All protocol machinery therefore lives in
+:mod:`plugins.platforms.messenger.meta_common`, shared with the
+``messenger`` plugin the way the two WhatsApp core adapters share
+``gateway/platforms/whatsapp_common.py``.  When both plugins are enabled
+they attach to ONE shared webhook listener and events are routed to the
+right adapter by the payload's ``object`` field, so sessions are
+recorded under the correct platform (``instagram`` vs ``messenger``).
+
+Setup summary (full guide: website/docs/user-guide/messaging/instagram.md):
+
+1. Link an Instagram professional account to the Facebook Page of your
+   Meta app and add the Instagram product to the app.
+2. Use the same shared credentials as Messenger in ``~/.hermes/.env``
+   (``META_PAGE_ACCESS_TOKEN``, ``META_APP_SECRET``,
+   ``META_VERIFY_TOKEN``) plus ``INSTAGRAM_ENABLED=true``.
+3. Subscribe the app's Instagram webhook to ``messages`` — the callback
+   URL is the same one Messenger uses (default
+   ``127.0.0.1:8647/meta/webhook`` behind your HTTPS proxy/tunnel).
+4. Gate access with ``INSTAGRAM_ALLOWED_USERS`` (comma-separated
+   Instagram-scoped IDs) or ``INSTAGRAM_ALLOW_ALL_USERS=true`` for a
+   public customer bot.
+"""
+
+from __future__ import annotations
+
+from plugins.platforms.messenger.meta_common import (
+    INSTAGRAM_MAX_CHARS,
+    INSTAGRAM_SAFE_CHARS,
+    MetaBaseAdapter,
+    make_check_requirements,
+    make_env_enablement,
+    make_is_connected,
+    make_standalone_send,
+)
+
+
+class InstagramAdapter(MetaBaseAdapter):
+    """Instagram DM adapter (Meta webhook + Graph API)."""
+
+    PLATFORM_NAME = "instagram"
+    ENV_PREFIX = "INSTAGRAM"
+    CHAT_LABEL = "Instagram DM"
+    MAX_MESSAGE_LENGTH = INSTAGRAM_MAX_CHARS
+    SAFE_CHUNK_CHARS = INSTAGRAM_SAFE_CHARS
+
+
+check_requirements = make_check_requirements("INSTAGRAM")
+is_connected = make_is_connected("INSTAGRAM")
+validate_config = is_connected
+_env_enablement = make_env_enablement("INSTAGRAM")
+_standalone_send = make_standalone_send(InstagramAdapter)
+
+PLATFORM_HINT = (
+    "You are on Instagram Direct Messages talking with the user. "
+    "Instagram does NOT render markdown — reply in plain text and keep "
+    "replies short and conversational; messages are hard-capped at 1000 "
+    "characters and chunked accordingly. Publicly reachable image URLs "
+    "in your MEDIA/image tool results are sent as native photos; local "
+    "file attachments cannot be uploaded — share a link instead."
+)
+
+
+def interactive_setup() -> None:
+    """Minimal stdin wizard for ``hermes gateway setup`` → Instagram."""
+    print()
+    print("Instagram DM (Meta) setup")
+    print("-------------------------")
+    print("Instagram shares its Meta app credentials with Messenger:")
+    print("1. Link an Instagram professional account to your Facebook Page.")
+    print("2. If you already configured Messenger, the META_* values below")
+    print("   are the same — just press Enter to keep them.")
+    print()
+
+    try:
+        from hermes_cli.config import get_env_value, save_env_value
+    except ImportError:
+        print(
+            "hermes_cli.config not available; set META_* and INSTAGRAM_* "
+            "vars manually in ~/.hermes/.env"
+        )
+        return
+
+    def _prompt(var: str, prompt: str, *, secret: bool = False) -> None:
+        existing = get_env_value(var)
+        suffix = " [keep current]" if existing else ""
+        try:
+            if secret:
+                from hermes_cli.secret_prompt import masked_secret_prompt
+                value = masked_secret_prompt(f"{prompt}{suffix}: ")
+            else:
+                value = input(f"{prompt}{suffix}: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return
+        if value:
+            save_env_value(var, value)
+
+    _prompt("META_PAGE_ACCESS_TOKEN", "Page access token", secret=True)
+    _prompt("META_APP_SECRET", "App secret", secret=True)
+    _prompt("META_VERIFY_TOKEN", "Webhook verify token", secret=True)
+    _prompt(
+        "INSTAGRAM_ALLOWED_USERS",
+        "Allowed Instagram-scoped IDs (comma-separated; blank=skip — set "
+        "INSTAGRAM_ALLOW_ALL_USERS=true for a public bot)",
+    )
+    save_env_value("INSTAGRAM_ENABLED", "true")
+    print()
+    print("Done. Subscribe the app's Instagram webhook to 'messages' in the")
+    print("Meta developer portal — the callback URL and verify token are the")
+    print("same ones Messenger uses (default /meta/webhook on port 8647).")
+
+
+def register(ctx) -> None:
+    """Plugin entry point — called by the Hermes plugin system."""
+    ctx.register_platform(
+        name="instagram",
+        label="Instagram DM (Meta)",
+        adapter_factory=lambda cfg: InstagramAdapter(cfg),
+        check_fn=check_requirements,
+        validate_config=validate_config,
+        is_connected=is_connected,
+        required_env=[
+            "INSTAGRAM_ENABLED",
+            "META_PAGE_ACCESS_TOKEN",
+            "META_APP_SECRET",
+            "META_VERIFY_TOKEN",
+        ],
+        install_hint="pip install aiohttp",
+        setup_fn=interactive_setup,
+        env_enablement_fn=_env_enablement,
+        cron_deliver_env_var="INSTAGRAM_HOME_CHANNEL",
+        standalone_sender_fn=_standalone_send,
+        allowed_users_env="INSTAGRAM_ALLOWED_USERS",
+        allow_all_env="INSTAGRAM_ALLOW_ALL_USERS",
+        max_message_length=INSTAGRAM_MAX_CHARS,
+        emoji="📸",
+        pii_safe=False,
+        allow_update_command=True,
+        platform_hint=PLATFORM_HINT,
+    )

--- a/plugins/platforms/instagram/plugin.yaml
+++ b/plugins/platforms/instagram/plugin.yaml
@@ -1,0 +1,65 @@
+name: instagram-platform
+label: Instagram DM (Meta)
+kind: platform
+version: 1.0.0
+description: >
+  Instagram Direct Messages gateway adapter for Hermes Agent.
+  Instagram is the second surface of a Meta app: it shares the
+  messenger plugin's credentials, webhook listener, and Graph API send
+  pipeline (see plugins/platforms/messenger/meta_common.py). Events
+  arrive on the same callback URL as Messenger and are routed here by
+  the payload's top-level "object" field, so sessions are recorded
+  under the instagram platform. Outbound messages are chunked at
+  Instagram's 1000-character limit.
+author: Hermes Agent contributors
+# ``requires_env`` and ``optional_env`` entries are surfaced in the
+# ``hermes config`` UI via the platform-plugin env var injector in
+# ``hermes_cli/config.py``.
+requires_env:
+  - name: INSTAGRAM_ENABLED
+    description: "Enable the Instagram DM adapter (true/false). Required because the META_* credentials are shared with the Messenger plugin."
+    prompt: "Enable Instagram DM? (true/false)"
+    password: false
+  - name: META_PAGE_ACCESS_TOKEN
+    description: "Meta Page access token used for Graph API sends (shared with the Messenger plugin)"
+    prompt: "Page access token"
+    url: "https://developers.facebook.com/apps/"
+    password: true
+  - name: META_APP_SECRET
+    description: "Meta app secret — validates the X-Hub-Signature-256 header on every webhook POST"
+    prompt: "App secret"
+    url: "https://developers.facebook.com/apps/"
+    password: true
+  - name: META_VERIFY_TOKEN
+    description: "Webhook verification handshake token (any random string; must match the Meta developer portal)"
+    prompt: "Webhook verify token"
+    password: true
+optional_env:
+  - name: INSTAGRAM_ALLOWED_USERS
+    description: "Comma-separated Instagram-scoped user IDs (IGSIDs) allowed to talk to the bot"
+    prompt: "Allowed IGSIDs (comma-separated)"
+    password: false
+  - name: INSTAGRAM_ALLOW_ALL_USERS
+    description: "Allow any Instagram user to talk to the bot (for public customer-facing bots)"
+    prompt: "Allow all users? (true/false)"
+    password: false
+  - name: INSTAGRAM_HOME_CHANNEL
+    description: "Default IGSID for cron / notification delivery"
+    prompt: "Home channel IGSID (or empty)"
+    password: false
+  - name: META_WEBHOOK_PORT
+    description: "Webhook listen port shared by both Meta surfaces (default: 8647)"
+    prompt: "Webhook port"
+    password: false
+  - name: META_WEBHOOK_HOST
+    description: "Webhook bind host (default: 127.0.0.1 — front with an HTTPS reverse proxy or tunnel)"
+    prompt: "Webhook host"
+    password: false
+  - name: META_WEBHOOK_PATH
+    description: "Webhook path (default: /meta/webhook — do not strip the prefix at the proxy)"
+    prompt: "Webhook path"
+    password: false
+  - name: META_GRAPH_API_BASE
+    description: "Graph API base URL override (default: https://graph.facebook.com/v23.0)"
+    prompt: "Graph API base URL"
+    password: false

--- a/plugins/platforms/messenger/__init__.py
+++ b/plugins/platforms/messenger/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import register
+
+__all__ = ["register"]

--- a/plugins/platforms/messenger/adapter.py
+++ b/plugins/platforms/messenger/adapter.py
@@ -1,0 +1,147 @@
+"""Facebook Messenger (Meta Page DM) platform plugin for Hermes Agent.
+
+Bundled platform plugin — registers via ``ctx.register_platform()`` with
+zero core edits.  All protocol machinery (shared webhook server, HMAC
+signature validation, Graph API sends) lives in :mod:`.meta_common`,
+which the sibling ``instagram`` plugin shares: both surfaces belong to
+one Meta app, receive events on the SAME webhook callback (routed by the
+payload's top-level ``object`` field) and send through the same
+``/me/messages`` endpoint with the same Page access token.
+
+Setup summary (full guide: website/docs/user-guide/messaging/messenger.md):
+
+1. Create a Meta app with the Messenger product and generate a Page
+   access token for your Facebook Page.
+2. In ``~/.hermes/.env`` set the shared credentials —
+   ``META_PAGE_ACCESS_TOKEN``, ``META_APP_SECRET``, ``META_VERIFY_TOKEN``
+   — plus ``MESSENGER_ENABLED=true``.
+3. Expose the webhook (default ``127.0.0.1:8647/meta/webhook``) via a
+   public HTTPS reverse proxy or tunnel and subscribe the Page webhook
+   to ``messages`` with that callback URL.
+4. Gate access with ``MESSENGER_ALLOWED_USERS`` (comma-separated PSIDs)
+   or ``MESSENGER_ALLOW_ALL_USERS=true`` for a public customer bot.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+from plugins.platforms.messenger.meta_common import (
+    MESSENGER_MAX_CHARS,
+    MESSENGER_SAFE_CHARS,
+    MetaBaseAdapter,
+    make_check_requirements,
+    make_env_enablement,
+    make_is_connected,
+    make_standalone_send,
+)
+
+
+class MessengerAdapter(MetaBaseAdapter):
+    """Facebook Messenger Page-DM adapter (Meta webhook + Graph API)."""
+
+    PLATFORM_NAME = "messenger"
+    ENV_PREFIX = "MESSENGER"
+    CHAT_LABEL = "Messenger DM"
+    MAX_MESSAGE_LENGTH = MESSENGER_MAX_CHARS
+    SAFE_CHUNK_CHARS = MESSENGER_SAFE_CHARS
+
+
+check_requirements = make_check_requirements("MESSENGER")
+is_connected = make_is_connected("MESSENGER")
+validate_config = is_connected
+_env_enablement = make_env_enablement("MESSENGER")
+_standalone_send = make_standalone_send(MessengerAdapter)
+
+PLATFORM_HINT = (
+    "You are on Facebook Messenger talking with the user in a direct "
+    "message. Messenger does NOT render markdown — asterisks and hashes "
+    "show literally, so reply in plain text and keep replies short and "
+    "conversational. Messages are chunked at 2000 characters. Publicly "
+    "reachable image URLs in your MEDIA/image tool results are sent as "
+    "native photos; local file attachments cannot be uploaded — share a "
+    "link instead."
+)
+
+
+def interactive_setup() -> None:
+    """Minimal stdin wizard for ``hermes gateway setup`` → Messenger."""
+    print()
+    print("Facebook Messenger (Meta) setup")
+    print("-------------------------------")
+    print("1. Create a Meta app with the Messenger product:")
+    print("   https://developers.facebook.com/apps/")
+    print("2. Generate a Page access token for your Facebook Page and copy")
+    print("   the app secret from App settings > Basic.")
+    print("3. Pick any random string as your webhook verify token.")
+    print()
+
+    try:
+        from hermes_cli.config import get_env_value, save_env_value
+    except ImportError:
+        print(
+            "hermes_cli.config not available; set META_* and MESSENGER_* "
+            "vars manually in ~/.hermes/.env"
+        )
+        return
+
+    def _prompt(var: str, prompt: str, *, secret: bool = False) -> None:
+        existing = get_env_value(var)
+        suffix = " [keep current]" if existing else ""
+        try:
+            if secret:
+                from hermes_cli.secret_prompt import masked_secret_prompt
+                value = masked_secret_prompt(f"{prompt}{suffix}: ")
+            else:
+                value = input(f"{prompt}{suffix}: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return
+        if value:
+            save_env_value(var, value)
+
+    _prompt("META_PAGE_ACCESS_TOKEN", "Page access token", secret=True)
+    _prompt("META_APP_SECRET", "App secret", secret=True)
+    _prompt("META_VERIFY_TOKEN", "Webhook verify token", secret=True)
+    _prompt(
+        "MESSENGER_ALLOWED_USERS",
+        "Allowed PSIDs (comma-separated; blank=skip — set "
+        "MESSENGER_ALLOW_ALL_USERS=true for a public bot)",
+    )
+    save_env_value("MESSENGER_ENABLED", "true")
+    print()
+    print("Done. Expose http://127.0.0.1:8647/meta/webhook via public HTTPS")
+    print("(reverse proxy or tunnel), then in the Meta developer portal set")
+    print("that URL + your verify token as the Messenger webhook callback and")
+    print("subscribe the Page to 'messages'.")
+
+
+def register(ctx) -> None:
+    """Plugin entry point — called by the Hermes plugin system."""
+    ctx.register_platform(
+        name="messenger",
+        label="Messenger (Meta)",
+        adapter_factory=lambda cfg: MessengerAdapter(cfg),
+        check_fn=check_requirements,
+        validate_config=validate_config,
+        is_connected=is_connected,
+        required_env=[
+            "MESSENGER_ENABLED",
+            "META_PAGE_ACCESS_TOKEN",
+            "META_APP_SECRET",
+            "META_VERIFY_TOKEN",
+        ],
+        install_hint="pip install aiohttp",
+        setup_fn=interactive_setup,
+        env_enablement_fn=_env_enablement,
+        cron_deliver_env_var="MESSENGER_HOME_CHANNEL",
+        standalone_sender_fn=_standalone_send,
+        allowed_users_env="MESSENGER_ALLOWED_USERS",
+        allow_all_env="MESSENGER_ALLOW_ALL_USERS",
+        max_message_length=MESSENGER_MAX_CHARS,
+        emoji="💠",
+        pii_safe=False,
+        allow_update_command=True,
+        platform_hint=PLATFORM_HINT,
+    )

--- a/plugins/platforms/messenger/meta_common.py
+++ b/plugins/platforms/messenger/meta_common.py
@@ -1,0 +1,851 @@
+"""Shared Meta Graph API machinery for the Messenger and Instagram plugins.
+
+Facebook Messenger (Page DMs) and Instagram DMs are two surfaces of the
+same Meta app: one webhook subscription, one ``X-Hub-Signature-256``
+app-secret, one Page access token, and the same Graph API
+``/me/messages`` send endpoint.  Meta delivers events for both surfaces
+to the SAME callback URL and distinguishes them by the payload's
+top-level ``object`` field (``"page"`` vs ``"instagram"``).
+
+Because of that, the two platform plugins (``plugins/platforms/messenger``
+and ``plugins/platforms/instagram``) share this module the same way the
+two WhatsApp core adapters share ``gateway/platforms/whatsapp_common.py``:
+
+* :class:`MetaBaseAdapter` — everything protocol-level: the aiohttp
+  webhook server (ONE listener shared by both adapters when both are
+  enabled), the GET verification handshake, HMAC signature validation,
+  ``object``-based event routing, echo/receipt filtering, attachment
+  download + caching, and Graph API sends.
+* Each plugin's ``adapter.py`` subclasses it with surface-specific
+  constants (platform name, chunk limit, env prefix) and registers its
+  own ``PlatformEntry``.
+
+The module lives inside the ``messenger`` plugin package (Messenger is
+the primary surface — an Instagram professional account must be linked
+to a Facebook Page to use the Instagram Messaging API at all) and the
+``instagram`` plugin imports it via its canonical absolute path, so both
+plugin modules observe the same shared-server state.
+
+Environment variables (shared Meta app credentials):
+
+* ``META_PAGE_ACCESS_TOKEN`` — Page access token used for all sends.
+* ``META_APP_SECRET``        — app secret; every webhook POST must carry
+  a valid ``X-Hub-Signature-256`` or it is rejected with 403.
+* ``META_VERIFY_TOKEN``      — webhook verification handshake token.
+* ``META_WEBHOOK_HOST`` / ``META_WEBHOOK_PORT`` / ``META_WEBHOOK_PATH``
+  — listener binding (defaults ``127.0.0.1:8647`` at ``/meta/webhook``;
+  front it with an HTTPS reverse proxy or tunnel, do not strip the path
+  prefix).
+* ``META_GRAPH_API_BASE``    — Graph API base URL override (default
+  ``https://graph.facebook.com/v23.0``); also used to point tests at a
+  mock server.
+
+Per-surface enablement and gating are namespaced by each plugin
+(``MESSENGER_*`` / ``INSTAGRAM_*``) — see the plugin ``adapter.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+logger = logging.getLogger(__name__)
+
+from gateway.config import Platform
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+    cache_audio_from_bytes,
+    cache_document_from_bytes,
+    cache_image_from_bytes,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_GRAPH_API_BASE = "https://graph.facebook.com/v23.0"
+DEFAULT_WEBHOOK_HOST = "127.0.0.1"
+DEFAULT_WEBHOOK_PORT = 8647
+DEFAULT_WEBHOOK_PATH = "/meta/webhook"
+
+# Webhook payloads are small JSON; attachments arrive as CDN URLs.
+WEBHOOK_BODY_MAX_BYTES = 2 * 1024 * 1024
+# Cap for downloading a single inbound attachment from Meta's CDN.
+MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024
+
+# Graph API text limits: Messenger 2000 chars, Instagram 1000 chars.
+# Chunk below the hard limit to leave headroom for the ``(1/3)`` chunk
+# indicators appended by ``truncate_message``.
+MESSENGER_MAX_CHARS = 2000
+MESSENGER_SAFE_CHARS = 1900
+INSTAGRAM_MAX_CHARS = 1000
+INSTAGRAM_SAFE_CHARS = 950
+
+_IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
+_AUDIO_EXTS = {".mp3", ".mp4", ".m4a", ".ogg", ".wav", ".aac"}
+
+
+# ---------------------------------------------------------------------------
+# Small helpers (module-level so they are unit-testable)
+# ---------------------------------------------------------------------------
+
+def truthy_env(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def redact_meta_id(value: Any) -> str:
+    """Partially mask a PSID/IGSID for log output."""
+    s = str(value or "")
+    if len(s) <= 6:
+        return "***"
+    return f"{s[:4]}…{s[-2:]}"
+
+
+def verify_meta_signature(body: bytes, signature_header: str, app_secret: str) -> bool:
+    """Validate a webhook POST's ``X-Hub-Signature-256`` header.
+
+    The header value is ``sha256=<hex HMAC-SHA256 of the raw body keyed by
+    the app secret>``.  Empty header or empty secret fails closed.
+    """
+    if not signature_header or not app_secret:
+        return False
+    expected = "sha256=" + hmac.new(
+        app_secret.encode("utf-8"), body, hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(signature_header, expected)
+
+
+def platform_for_webhook_object(obj: str) -> Optional[str]:
+    """Map a webhook payload's top-level ``object`` to a platform name.
+
+    ``page`` events are Messenger, ``instagram`` events are Instagram DM.
+    Anything else (e.g. ``whatsapp_business_account`` from an over-broad
+    app subscription) is not ours — return ``None`` so the caller drops it.
+    """
+    if obj == "page":
+        return "messenger"
+    if obj == "instagram":
+        return "instagram"
+    return None
+
+
+def classify_attachment(att_type: str, url: str) -> Tuple[str, str]:
+    """Return ``(kind, ext)`` for an inbound attachment.
+
+    ``kind`` is one of ``image`` / ``audio`` / ``document`` and decides
+    which media cache the payload lands in; ``ext`` is a normalized file
+    extension for the cache filename.
+    """
+    ext = os.path.splitext(url.split("?", 1)[0])[1].lower()
+    if att_type == "image":
+        return "image", (ext if ext in _IMAGE_EXTS else ".jpg")
+    if att_type == "audio":
+        return "audio", (ext if ext in _AUDIO_EXTS else ".mp4")
+    return "document", (ext or ".bin")
+
+
+# ---------------------------------------------------------------------------
+# Shared webhook server
+# ---------------------------------------------------------------------------
+
+class _SharedWebhookServer:
+    """One aiohttp listener shared by every connected Meta adapter.
+
+    Both surfaces receive events on the same callback URL, so when both
+    plugins are enabled only one TCP listener must exist.  Adapters
+    attach on ``connect()`` and detach on ``disconnect()``; the listener
+    is started by the first attach and stopped by the last detach.
+    """
+
+    def __init__(self) -> None:
+        self.adapters: Dict[str, "MetaBaseAdapter"] = {}
+        self._runner = None
+        self._site = None
+        self._lock = asyncio.Lock()
+        self._host = ""
+        self._port = 0
+        self._path = ""
+
+    @property
+    def running(self) -> bool:
+        return self._runner is not None
+
+    async def attach(self, adapter: "MetaBaseAdapter") -> bool:
+        from aiohttp import web
+
+        async with self._lock:
+            self.adapters[adapter.PLATFORM_NAME] = adapter
+            if self.running:
+                if (adapter.webhook_host, adapter.webhook_port) != (self._host, self._port):
+                    logger.warning(
+                        "Meta: %s configured %s:%s but the shared webhook "
+                        "server is already bound to %s:%s — attaching to the "
+                        "existing listener (both surfaces share one callback "
+                        "URL; configure META_WEBHOOK_HOST/PORT once).",
+                        adapter.PLATFORM_NAME,
+                        adapter.webhook_host,
+                        adapter.webhook_port,
+                        self._host,
+                        self._port,
+                    )
+                else:
+                    logger.info(
+                        "Meta: %s attached to shared webhook server on %s:%s%s",
+                        adapter.PLATFORM_NAME, self._host, self._port, self._path,
+                    )
+                return True
+
+            app = web.Application(client_max_size=WEBHOOK_BODY_MAX_BYTES)
+            path = adapter.webhook_path
+            app.router.add_get(path, self._handle_verify)
+            app.router.add_post(path, self._handle_event)
+            app.router.add_get(f"{path}/health", self._handle_health)
+
+            runner = web.AppRunner(app)
+            try:
+                await runner.setup()
+                site = web.TCPSite(runner, adapter.webhook_host, adapter.webhook_port)
+                await site.start()
+            except OSError as exc:
+                self.adapters.pop(adapter.PLATFORM_NAME, None)
+                try:
+                    await runner.cleanup()
+                except Exception:
+                    pass
+                logger.error(
+                    "Meta: could not bind webhook server on %s:%s: %s",
+                    adapter.webhook_host, adapter.webhook_port, exc,
+                )
+                return False
+
+            self._runner, self._site = runner, site
+            self._host, self._port, self._path = (
+                adapter.webhook_host, adapter.webhook_port, path,
+            )
+            logger.info(
+                "Meta: webhook server listening on %s:%s%s",
+                self._host, self._port, self._path,
+            )
+            return True
+
+    async def detach(self, adapter: "MetaBaseAdapter") -> None:
+        async with self._lock:
+            self.adapters.pop(adapter.PLATFORM_NAME, None)
+            runner = self._runner
+            if self.adapters or runner is None:
+                return
+            try:
+                await runner.cleanup()
+            except Exception as exc:
+                logger.debug("Meta: webhook server cleanup failed: %s", exc)
+            self._runner = None
+            self._site = None
+            logger.info("Meta: webhook server stopped")
+
+    def _any_adapter(self) -> Optional["MetaBaseAdapter"]:
+        for adapter in self.adapters.values():
+            return adapter
+        return None
+
+    # -- HTTP handlers ------------------------------------------------------
+
+    async def _handle_health(self, request) -> Any:
+        from aiohttp import web
+        return web.json_response(
+            {"status": "ok", "platforms": sorted(self.adapters.keys())}
+        )
+
+    async def _handle_verify(self, request) -> Any:
+        """GET — Meta webhook verification handshake."""
+        from aiohttp import web
+
+        adapter = self._any_adapter()
+        verify_token = adapter.verify_token if adapter else ""
+        mode = request.query.get("hub.mode", "")
+        token = request.query.get("hub.verify_token", "")
+        challenge = request.query.get("hub.challenge", "")
+        if (
+            mode == "subscribe"
+            and verify_token
+            and hmac.compare_digest(token, verify_token)
+        ):
+            logger.info("Meta: webhook verification handshake OK")
+            return web.Response(text=challenge, content_type="text/plain")
+        logger.warning("Meta: webhook verification failed (mode=%r)", mode)
+        return web.Response(status=403, text="verification failed")
+
+    async def _handle_event(self, request) -> Any:
+        """POST — inbound webhook events for both surfaces."""
+        from aiohttp import web
+
+        try:
+            body = await request.read()
+        except Exception:
+            return web.Response(status=400, text="bad request")
+        if len(body) > WEBHOOK_BODY_MAX_BYTES:
+            return web.Response(status=413, text="payload too large")
+
+        adapter = self._any_adapter()
+        app_secret = adapter.app_secret if adapter else ""
+        signature = request.headers.get("X-Hub-Signature-256", "")
+        if not verify_meta_signature(body, signature, app_secret):
+            logger.warning("Meta: invalid X-Hub-Signature-256 — rejecting event")
+            return web.Response(status=403, text="invalid signature")
+
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            logger.warning("Meta: non-JSON webhook body ignored")
+            return web.Response(status=200, text="EVENT_RECEIVED")
+
+        target_name = platform_for_webhook_object(payload.get("object", ""))
+        target = self.adapters.get(target_name) if target_name else None
+        if target is None:
+            logger.warning(
+                "Meta: %r event received but no adapter for it is connected — dropped",
+                payload.get("object", ""),
+            )
+            return web.Response(status=200, text="EVENT_RECEIVED")
+
+        for entry in payload.get("entry", []) or []:
+            for messaging in entry.get("messaging", []) or []:
+                try:
+                    await target._process_messaging(messaging)
+                except Exception:
+                    logger.exception(
+                        "Meta: failed to process %s event", target.PLATFORM_NAME
+                    )
+
+        # Always ACK fast — Meta retries and eventually disables webhooks
+        # that respond slowly or with errors.
+        return web.Response(status=200, text="EVENT_RECEIVED")
+
+
+# Module-level singleton: both plugin adapters import THIS module (the
+# instagram plugin uses the canonical ``plugins.platforms.messenger.
+# meta_common`` path), so they share one server instance.
+_shared_server = _SharedWebhookServer()
+
+
+# ---------------------------------------------------------------------------
+# Base adapter
+# ---------------------------------------------------------------------------
+
+class MetaBaseAdapter(BasePlatformAdapter):
+    """Common behavior for the Messenger and Instagram DM adapters.
+
+    Subclasses set the class constants below and inherit the entire
+    webhook + Graph API pipeline.
+    """
+
+    # -- subclass contract ---------------------------------------------------
+    PLATFORM_NAME: str = ""       # "messenger" | "instagram"
+    ENV_PREFIX: str = ""          # "MESSENGER" | "INSTAGRAM"
+    CHAT_LABEL: str = ""          # e.g. "Messenger DM"
+    MAX_MESSAGE_LENGTH: int = MESSENGER_MAX_CHARS
+    SAFE_CHUNK_CHARS: int = MESSENGER_SAFE_CHARS
+
+    def __init__(self, config, **kwargs):
+        super().__init__(config=config, platform=Platform(self.PLATFORM_NAME))
+        extra = getattr(config, "extra", {}) or {}
+
+        # Shared Meta app credentials (env wins, config extra as fallback).
+        self.page_access_token: str = (
+            os.getenv("META_PAGE_ACCESS_TOKEN")
+            or extra.get("page_access_token", "")
+        )
+        self.app_secret: str = (
+            os.getenv("META_APP_SECRET") or extra.get("app_secret", "")
+        )
+        self.verify_token: str = (
+            os.getenv("META_VERIFY_TOKEN") or extra.get("verify_token", "")
+        )
+
+        # Webhook listener binding (shared by both surfaces).
+        self.webhook_host: str = (
+            os.getenv("META_WEBHOOK_HOST") or extra.get("host", DEFAULT_WEBHOOK_HOST)
+        )
+        try:
+            self.webhook_port: int = int(
+                os.getenv("META_WEBHOOK_PORT")
+                or extra.get("port", DEFAULT_WEBHOOK_PORT)
+            )
+        except (TypeError, ValueError):
+            self.webhook_port = DEFAULT_WEBHOOK_PORT
+        self.webhook_path: str = (
+            os.getenv("META_WEBHOOK_PATH")
+            or extra.get("webhook_path", DEFAULT_WEBHOOK_PATH)
+        )
+
+        self.graph_api_base: str = (
+            os.getenv("META_GRAPH_API_BASE")
+            or extra.get("graph_api_base", DEFAULT_GRAPH_API_BASE)
+        ).rstrip("/")
+
+        # One-shot warning latch for missing send credentials.
+        self._warned_no_token = False
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        missing = [
+            name
+            for name, value in (
+                ("META_PAGE_ACCESS_TOKEN", self.page_access_token),
+                ("META_APP_SECRET", self.app_secret),
+                ("META_VERIFY_TOKEN", self.verify_token),
+            )
+            if not value
+        ]
+        if missing:
+            self._set_fatal_error(
+                "config_missing",
+                f"{' and '.join(missing)} must be set for the "
+                f"{self.PLATFORM_NAME} adapter",
+                retryable=False,
+            )
+            return False
+
+        try:
+            import aiohttp  # noqa: F401
+        except ImportError:
+            self._set_fatal_error(
+                "missing_dep",
+                "aiohttp is required for the Meta adapters — install with "
+                "`pip install aiohttp`",
+                retryable=False,
+            )
+            return False
+
+        if not await _shared_server.attach(self):
+            self._set_fatal_error(
+                "bind_failed",
+                f"Could not bind Meta webhook server on "
+                f"{self.webhook_host}:{self.webhook_port}",
+                retryable=True,
+            )
+            return False
+
+        self._mark_connected()
+        return True
+
+    async def disconnect(self) -> None:
+        self._mark_disconnected()
+        await _shared_server.detach(self)
+        logger.info("Meta: %s disconnected", self.PLATFORM_NAME)
+
+    # ------------------------------------------------------------------
+    # Inbound
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _skip_reason(messaging: Dict[str, Any]) -> Optional[str]:
+        """Classify a webhook ``messaging`` item we must NOT feed the agent."""
+        if "delivery" in messaging or "read" in messaging:
+            return "receipt"
+        message = messaging.get("message")
+        if not isinstance(message, dict):
+            return "non-message"
+        if message.get("is_echo"):
+            return "echo"
+        if not str((messaging.get("sender") or {}).get("id", "")):
+            return "no-sender"
+        return None
+
+    async def _process_messaging(self, messaging: Dict[str, Any]) -> None:
+        """Turn one ``entry[].messaging[]`` item into a MessageEvent."""
+        skip = self._skip_reason(messaging)
+        if skip is not None:
+            logger.debug(
+                "Meta(%s): skipping %s event", self.PLATFORM_NAME, skip
+            )
+            return
+
+        sender_id = str((messaging.get("sender") or {}).get("id", ""))
+        recipient_id = str((messaging.get("recipient") or {}).get("id", ""))
+        message = messaging["message"]
+
+        text = message.get("text") or ""
+        media_urls: List[str] = []
+        media_types: List[str] = []
+        message_type = MessageType.TEXT
+
+        for att in message.get("attachments", []) or []:
+            att_type = att.get("type", "")
+            url = (att.get("payload") or {}).get("url", "")
+            if not url:
+                continue
+            data = await self._download_attachment(url)
+            if data is None:
+                continue
+            kind, ext = classify_attachment(att_type, url)
+            if kind == "image":
+                path = cache_image_from_bytes(data, ext=ext)
+                mtype = f"image/{ext.lstrip('.')}"
+                fallback = MessageType.PHOTO
+            elif kind == "audio":
+                path = cache_audio_from_bytes(data, ext=ext)
+                mtype = f"audio/{ext.lstrip('.')}"
+                fallback = MessageType.VOICE
+            else:
+                filename = (
+                    os.path.basename(url.split("?", 1)[0]) or f"attachment{ext}"
+                )
+                path = cache_document_from_bytes(data, filename)
+                mtype = att_type or "file"
+                fallback = (
+                    MessageType.VIDEO if att_type == "video"
+                    else MessageType.DOCUMENT
+                )
+            if path:
+                media_urls.append(path)
+                media_types.append(mtype)
+                if message_type == MessageType.TEXT:
+                    message_type = fallback
+
+        if not text and not media_urls:
+            logger.debug(
+                "Meta(%s): empty message from %s ignored "
+                "(unsupported attachment?)",
+                self.PLATFORM_NAME, redact_meta_id(sender_id),
+            )
+            return
+
+        source = self.build_source(
+            chat_id=sender_id,
+            chat_name=self.CHAT_LABEL,
+            chat_type="dm",
+            user_id=sender_id,
+            # The receiving Page / IG professional-account id — kept so
+            # multi-page routing has an anchor if it's ever needed.
+            chat_id_alt=recipient_id or None,
+        )
+        event = MessageEvent(
+            text=text,
+            message_type=message_type,
+            source=source,
+            raw_message=messaging,
+            message_id=message.get("mid"),
+            media_urls=media_urls,
+            media_types=media_types,
+        )
+        logger.info(
+            "Meta(%s): message from %s text_len=%d media=%d",
+            self.PLATFORM_NAME,
+            redact_meta_id(sender_id),
+            len(text),
+            len(media_urls),
+        )
+        # Dispatch in the background so the webhook 200s immediately —
+        # Meta disables webhooks that respond slowly.
+        task = asyncio.create_task(self.handle_message(event))
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+
+    async def _download_attachment(self, url: str) -> Optional[bytes]:
+        """Download an inbound attachment from Meta's CDN (None on failure)."""
+        import aiohttp
+
+        try:
+            timeout = aiohttp.ClientTimeout(total=60)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.get(url) as resp:
+                    if resp.status != 200:
+                        logger.warning(
+                            "Meta(%s): attachment download HTTP %d",
+                            self.PLATFORM_NAME, resp.status,
+                        )
+                        return None
+                    if (resp.content_length or 0) > MAX_ATTACHMENT_BYTES:
+                        logger.warning(
+                            "Meta(%s): attachment exceeds %d bytes, skipped",
+                            self.PLATFORM_NAME, MAX_ATTACHMENT_BYTES,
+                        )
+                        return None
+                    data = await resp.content.read(MAX_ATTACHMENT_BYTES + 1)
+                    if len(data) > MAX_ATTACHMENT_BYTES:
+                        logger.warning(
+                            "Meta(%s): attachment exceeds %d bytes, skipped",
+                            self.PLATFORM_NAME, MAX_ATTACHMENT_BYTES,
+                        )
+                        return None
+                    return data
+        except Exception as exc:
+            logger.warning(
+                "Meta(%s): attachment download failed: %s",
+                self.PLATFORM_NAME, exc,
+            )
+            return None
+
+    # ------------------------------------------------------------------
+    # Outbound (Graph API /me/messages, shared by both surfaces)
+    # ------------------------------------------------------------------
+
+    async def _graph_post(
+        self, endpoint: str, payload: Dict[str, Any]
+    ) -> Tuple[bool, Dict[str, Any]]:
+        """POST to the Graph API. Returns ``(ok, response_json)``.
+
+        The access token travels as a query parameter, so the URL is
+        never logged — only the endpoint name and the error body.
+        """
+        import aiohttp
+
+        if not self.page_access_token:
+            if not self._warned_no_token:
+                logger.error(
+                    "Meta(%s): META_PAGE_ACCESS_TOKEN not configured — "
+                    "cannot send", self.PLATFORM_NAME,
+                )
+                self._warned_no_token = True
+            return False, {
+                "error": {"message": "META_PAGE_ACCESS_TOKEN not configured"}
+            }
+
+        url = f"{self.graph_api_base}/{endpoint}"
+        try:
+            timeout = aiohttp.ClientTimeout(total=30)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.post(
+                    url,
+                    params={"access_token": self.page_access_token},
+                    json=payload,
+                ) as resp:
+                    try:
+                        data = await resp.json()
+                    except Exception:
+                        data = {"error": {"message": await resp.text()}}
+                    if resp.status == 200:
+                        return True, data
+                    logger.error(
+                        "Meta(%s): Graph API %s HTTP %d: %s",
+                        self.PLATFORM_NAME,
+                        endpoint,
+                        resp.status,
+                        json.dumps(data.get("error", data))[:500],
+                    )
+                    return False, data
+        except Exception as exc:
+            logger.error(
+                "Meta(%s): Graph API request failed: %s",
+                self.PLATFORM_NAME, exc,
+            )
+            return False, {"error": {"message": str(exc), "transient": True}}
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send text via ``/me/messages`` (chunked to the surface limit)."""
+        if not content or not content.strip():
+            return SendResult(success=False, error="Empty message")
+
+        chunks = self.truncate_message(content, self.SAFE_CHUNK_CHARS)
+        last_mid: Optional[str] = None
+        for chunk in chunks:
+            ok, data = await self._graph_post(
+                "me/messages",
+                {
+                    "recipient": {"id": str(chat_id)},
+                    "messaging_type": "RESPONSE",
+                    "message": {"text": chunk},
+                },
+            )
+            if not ok:
+                err = (data.get("error") or {}).get("message", "unknown error")
+                return SendResult(
+                    success=False,
+                    error=err,
+                    raw_response=data,
+                    retryable=bool((data.get("error") or {}).get("transient")),
+                )
+            last_mid = data.get("message_id")
+        return SendResult(success=True, message_id=last_mid)
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        """Best-effort ``typing_on`` sender action."""
+        try:
+            await self._graph_post(
+                "me/messages",
+                {
+                    "recipient": {"id": str(chat_id)},
+                    "sender_action": "typing_on",
+                },
+            )
+        except Exception as exc:
+            logger.debug(
+                "Meta(%s): send_typing failed: %s", self.PLATFORM_NAME, exc
+            )
+
+    async def send_image(
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an image by public URL as a native attachment."""
+        ok, data = await self._graph_post(
+            "me/messages",
+            {
+                "recipient": {"id": str(chat_id)},
+                "messaging_type": "RESPONSE",
+                "message": {
+                    "attachment": {
+                        "type": "image",
+                        "payload": {"url": image_url, "is_reusable": False},
+                    }
+                },
+            },
+        )
+        if not ok:
+            err = (data.get("error") or {}).get("message", "unknown error")
+            return SendResult(success=False, error=err, raw_response=data)
+        if caption and caption.strip():
+            return await self.send(chat_id, caption)
+        return SendResult(success=True, message_id=data.get("message_id"))
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        return {"name": self.CHAT_LABEL, "type": "dm", "chat_id": str(chat_id)}
+
+
+# ---------------------------------------------------------------------------
+# Shared PlatformEntry helper functions
+# ---------------------------------------------------------------------------
+
+def _have_meta_credentials(extra: Optional[Dict[str, Any]] = None) -> bool:
+    extra = extra or {}
+    return bool(
+        (os.getenv("META_PAGE_ACCESS_TOKEN") or extra.get("page_access_token"))
+        and (os.getenv("META_APP_SECRET") or extra.get("app_secret"))
+        and (os.getenv("META_VERIFY_TOKEN") or extra.get("verify_token"))
+    )
+
+
+def make_check_requirements(env_prefix: str):
+    """Build a ``check_fn`` for one surface.
+
+    Requires the surface's explicit ``<PREFIX>_ENABLED`` opt-in (the Meta
+    credentials are shared, so their presence alone cannot tell WHICH
+    surface the user wants), the shared credentials, and aiohttp.
+    """
+
+    def check_requirements() -> bool:
+        if not truthy_env(f"{env_prefix}_ENABLED"):
+            return False
+        if not _have_meta_credentials():
+            return False
+        try:
+            import aiohttp  # noqa: F401
+        except ImportError:
+            return False
+        return True
+
+    return check_requirements
+
+
+def make_is_connected(env_prefix: str):
+    """Build ``is_connected``/``validate_config`` for one surface."""
+
+    def is_connected(config) -> bool:
+        extra = getattr(config, "extra", {}) or {}
+        return truthy_env(f"{env_prefix}_ENABLED") and _have_meta_credentials(extra)
+
+    return is_connected
+
+
+def make_env_enablement(env_prefix: str):
+    """Build an ``env_enablement_fn`` seeding PlatformConfig.extra from env.
+
+    Lets ``hermes status`` / ``get_connected_platforms()`` reflect an
+    env-only setup before the adapter is instantiated.
+    """
+
+    def _env_enablement() -> Optional[Dict[str, Any]]:
+        if not truthy_env(f"{env_prefix}_ENABLED"):
+            return None
+        if not _have_meta_credentials():
+            return None
+        seeded: Dict[str, Any] = {}
+        if os.getenv("META_WEBHOOK_PORT"):
+            try:
+                seeded["port"] = int(os.environ["META_WEBHOOK_PORT"])
+            except ValueError:
+                pass
+        if os.getenv("META_WEBHOOK_HOST"):
+            seeded["host"] = os.environ["META_WEBHOOK_HOST"]
+        if os.getenv("META_WEBHOOK_PATH"):
+            seeded["webhook_path"] = os.environ["META_WEBHOOK_PATH"]
+        home = os.getenv(f"{env_prefix}_HOME_CHANNEL", "").strip()
+        if home:
+            seeded["home_channel"] = {
+                "chat_id": home,
+                "name": os.getenv(f"{env_prefix}_HOME_CHANNEL_NAME", "Home"),
+            }
+        return seeded
+
+    return _env_enablement
+
+
+def make_standalone_send(adapter_cls):
+    """Build a ``standalone_sender_fn`` for one surface.
+
+    Sends via the Graph API without a live gateway adapter (the send
+    pipeline is stateless HTTP), so ``deliver=messenger:...`` /
+    ``deliver=instagram:...`` cron jobs work when cron runs in a separate
+    process from the gateway.
+    """
+
+    async def _standalone_send(
+        pconfig,
+        chat_id: str,
+        message: str,
+        *,
+        thread_id: Optional[str] = None,
+        media_files: Optional[List[str]] = None,
+        force_document: bool = False,
+    ) -> Dict[str, Any]:
+        # thread_id accepted for signature parity; Meta DMs have no threads.
+        try:
+            adapter = adapter_cls(pconfig)
+        except Exception as exc:
+            return {"error": f"{adapter_cls.PLATFORM_NAME} init failed: {exc}"}
+        if not adapter.page_access_token:
+            return {
+                "error": (
+                    f"{adapter_cls.PLATFORM_NAME} standalone send: "
+                    "META_PAGE_ACCESS_TOKEN not configured"
+                )
+            }
+        text = message or ""
+        if media_files:
+            # Graph API attachments need a public URL; local cron artifacts
+            # aren't reachable, so surface them as a note instead of
+            # silently dropping.
+            text = (
+                f"{text}\n[{len(media_files)} attachment(s) generated; "
+                "not deliverable from cron]"
+            ).strip()
+        result = await adapter.send(chat_id, text)
+        if not result.success:
+            return {"error": result.error or "send failed"}
+        return {"success": True, "message_id": result.message_id}
+
+    return _standalone_send

--- a/plugins/platforms/messenger/plugin.yaml
+++ b/plugins/platforms/messenger/plugin.yaml
@@ -1,0 +1,65 @@
+name: messenger-platform
+label: Messenger (Meta)
+kind: platform
+version: 1.0.0
+description: >
+  Facebook Messenger (Meta Page DM) gateway adapter for Hermes Agent.
+  Runs an aiohttp webhook server (shared with the Instagram plugin —
+  both surfaces of one Meta app deliver to the same callback URL) with
+  X-Hub-Signature-256 HMAC validation, relays Page DMs to the agent,
+  and replies through the Graph API /me/messages endpoint. Inbound
+  image/audio/video/file attachments are downloaded from Meta's CDN and
+  cached for the vision/file tools; echo events and delivery/read
+  receipts are filtered.
+author: Hermes Agent contributors
+# ``requires_env`` and ``optional_env`` entries are surfaced in the
+# ``hermes config`` UI via the platform-plugin env var injector in
+# ``hermes_cli/config.py``.
+requires_env:
+  - name: MESSENGER_ENABLED
+    description: "Enable the Facebook Messenger adapter (true/false). Required because the META_* credentials are shared with the Instagram plugin."
+    prompt: "Enable Messenger? (true/false)"
+    password: false
+  - name: META_PAGE_ACCESS_TOKEN
+    description: "Meta Page access token used for Graph API sends (shared with the Instagram plugin)"
+    prompt: "Page access token"
+    url: "https://developers.facebook.com/apps/"
+    password: true
+  - name: META_APP_SECRET
+    description: "Meta app secret — validates the X-Hub-Signature-256 header on every webhook POST"
+    prompt: "App secret"
+    url: "https://developers.facebook.com/apps/"
+    password: true
+  - name: META_VERIFY_TOKEN
+    description: "Webhook verification handshake token (any random string; must match the Meta developer portal)"
+    prompt: "Webhook verify token"
+    password: true
+optional_env:
+  - name: MESSENGER_ALLOWED_USERS
+    description: "Comma-separated page-scoped user IDs (PSIDs) allowed to talk to the bot"
+    prompt: "Allowed PSIDs (comma-separated)"
+    password: false
+  - name: MESSENGER_ALLOW_ALL_USERS
+    description: "Allow any Messenger user to talk to the bot (for public customer-facing bots)"
+    prompt: "Allow all users? (true/false)"
+    password: false
+  - name: MESSENGER_HOME_CHANNEL
+    description: "Default PSID for cron / notification delivery"
+    prompt: "Home channel PSID (or empty)"
+    password: false
+  - name: META_WEBHOOK_PORT
+    description: "Webhook listen port shared by both Meta surfaces (default: 8647)"
+    prompt: "Webhook port"
+    password: false
+  - name: META_WEBHOOK_HOST
+    description: "Webhook bind host (default: 127.0.0.1 — front with an HTTPS reverse proxy or tunnel)"
+    prompt: "Webhook host"
+    password: false
+  - name: META_WEBHOOK_PATH
+    description: "Webhook path (default: /meta/webhook — do not strip the prefix at the proxy)"
+    prompt: "Webhook path"
+    password: false
+  - name: META_GRAPH_API_BASE
+    description: "Graph API base URL override (default: https://graph.facebook.com/v23.0)"
+    prompt: "Graph API base URL"
+    password: false

--- a/tests/gateway/test_meta_plugins.py
+++ b/tests/gateway/test_meta_plugins.py
@@ -1,0 +1,660 @@
+"""Tests for the Meta platform plugins (Facebook Messenger + Instagram DM).
+
+Both plugins share ``plugins/platforms/messenger/meta_common.py`` — one
+Meta app, one webhook callback, one Graph API send pipeline. Coverage:
+
+1. webhook signature verification (X-Hub-Signature-256) + fail-closed edges
+2. ``object``-field routing (page → messenger, instagram → instagram)
+3. echo / delivery / read receipt filtering
+4. attachment classification (image / audio / document + ext normalization)
+5. adapter env/config parsing and per-surface chunk limits
+6. inbound ``_process_messaging`` → MessageEvent dispatch
+7. outbound send chunking + payload shape, send_image, failure paths
+8. webhook GET verification handshake + POST signature gate
+9. register() metadata for BOTH plugins + shared-module identity
+10. enablement gating (ENABLED flag + shared credentials) and env seeding
+11. standalone (out-of-process cron) send
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+try:
+    import aiohttp  # noqa: F401
+    _HAS_AIOHTTP = True
+except ImportError:
+    _HAS_AIOHTTP = False
+
+from gateway.config import PlatformConfig
+from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+
+_messenger = load_plugin_adapter("messenger")
+_instagram = load_plugin_adapter("instagram")
+
+# The shared protocol module — imported via its canonical path so tests
+# exercise the same module object both plugin adapters use.
+from plugins.platforms.messenger import meta_common
+
+MessengerAdapter = _messenger.MessengerAdapter
+InstagramAdapter = _instagram.InstagramAdapter
+
+CREDS = {
+    "META_PAGE_ACCESS_TOKEN": "page-token",
+    "META_APP_SECRET": "app-secret",
+    "META_VERIFY_TOKEN": "verify-token",
+}
+
+
+def _set_creds(monkeypatch, **overrides):
+    for key, value in {**CREDS, **overrides}.items():
+        if value is None:
+            monkeypatch.delenv(key, raising=False)
+        else:
+            monkeypatch.setenv(key, value)
+
+
+def _clear_meta_env(monkeypatch):
+    for key in (
+        *CREDS,
+        "MESSENGER_ENABLED",
+        "INSTAGRAM_ENABLED",
+        "META_WEBHOOK_HOST",
+        "META_WEBHOOK_PORT",
+        "META_WEBHOOK_PATH",
+        "META_GRAPH_API_BASE",
+        "MESSENGER_HOME_CHANNEL",
+        "INSTAGRAM_HOME_CHANNEL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _sign(body: bytes, secret: str = "app-secret") -> str:
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+def _adapter(monkeypatch, cls=MessengerAdapter, **env):
+    _clear_meta_env(monkeypatch)
+    _set_creds(monkeypatch)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    return cls(PlatformConfig())
+
+
+# ---------------------------------------------------------------------------
+# 1. Signature verification
+# ---------------------------------------------------------------------------
+
+class TestSignature:
+
+    def test_valid_signature_passes(self):
+        body = b'{"object": "page"}'
+        assert meta_common.verify_meta_signature(body, _sign(body), "app-secret")
+
+    def test_tampered_body_rejected(self):
+        body = b'{"object": "page"}'
+        sig = _sign(body)
+        assert not meta_common.verify_meta_signature(body + b" ", sig, "app-secret")
+
+    def test_wrong_secret_rejected(self):
+        body = b"x"
+        assert not meta_common.verify_meta_signature(body, _sign(body), "other")
+
+    def test_empty_signature_rejected(self):
+        assert not meta_common.verify_meta_signature(b"x", "", "app-secret")
+
+    def test_empty_secret_fails_closed(self):
+        body = b"x"
+        assert not meta_common.verify_meta_signature(body, _sign(body), "")
+
+
+# ---------------------------------------------------------------------------
+# 2. object-field routing
+# ---------------------------------------------------------------------------
+
+class TestObjectRouting:
+
+    def test_page_routes_to_messenger(self):
+        assert meta_common.platform_for_webhook_object("page") == "messenger"
+
+    def test_instagram_routes_to_instagram(self):
+        assert meta_common.platform_for_webhook_object("instagram") == "instagram"
+
+    @pytest.mark.parametrize("obj", ["whatsapp_business_account", "user", "", "PAGE"])
+    def test_unknown_objects_dropped(self, obj):
+        assert meta_common.platform_for_webhook_object(obj) is None
+
+
+# ---------------------------------------------------------------------------
+# 3. receipt / echo filtering
+# ---------------------------------------------------------------------------
+
+class TestSkipReasons:
+
+    def test_delivery_receipt_skipped(self):
+        m = {"sender": {"id": "1"}, "delivery": {"mids": []}}
+        assert meta_common.MetaBaseAdapter._skip_reason(m) == "receipt"
+
+    def test_read_receipt_skipped(self):
+        m = {"sender": {"id": "1"}, "read": {"watermark": 1}}
+        assert meta_common.MetaBaseAdapter._skip_reason(m) == "receipt"
+
+    def test_echo_skipped(self):
+        m = {"sender": {"id": "1"}, "message": {"is_echo": True, "text": "hi"}}
+        assert meta_common.MetaBaseAdapter._skip_reason(m) == "echo"
+
+    def test_non_message_event_skipped(self):
+        m = {"sender": {"id": "1"}, "postback": {"payload": "x"}}
+        assert meta_common.MetaBaseAdapter._skip_reason(m) == "non-message"
+
+    def test_missing_sender_skipped(self):
+        m = {"message": {"text": "hi"}}
+        assert meta_common.MetaBaseAdapter._skip_reason(m) == "no-sender"
+
+    def test_real_message_not_skipped(self):
+        m = {"sender": {"id": "1"}, "message": {"mid": "m1", "text": "hi"}}
+        assert meta_common.MetaBaseAdapter._skip_reason(m) is None
+
+
+# ---------------------------------------------------------------------------
+# 4. attachment classification
+# ---------------------------------------------------------------------------
+
+class TestAttachmentClassification:
+
+    def test_image_known_ext(self):
+        assert meta_common.classify_attachment(
+            "image", "https://cdn/x.png?sig=1"
+        ) == ("image", ".png")
+
+    def test_image_unknown_ext_normalized(self):
+        assert meta_common.classify_attachment(
+            "image", "https://cdn/x.heic"
+        ) == ("image", ".jpg")
+
+    def test_audio(self):
+        assert meta_common.classify_attachment(
+            "audio", "https://cdn/voice.mp4"
+        ) == ("audio", ".mp4")
+
+    def test_video_is_document_kind(self):
+        kind, ext = meta_common.classify_attachment("video", "https://cdn/v.mp4")
+        assert kind == "document"
+
+    def test_file_without_ext(self):
+        assert meta_common.classify_attachment("file", "https://cdn/blob") == (
+            "document", ".bin",
+        )
+
+    def test_redact_meta_id(self):
+        assert meta_common.redact_meta_id("1234567890123") == "1234…23"
+        assert meta_common.redact_meta_id("123") == "***"
+        assert meta_common.redact_meta_id(None) == "***"
+
+
+# ---------------------------------------------------------------------------
+# 5. adapter construction / config parsing
+# ---------------------------------------------------------------------------
+
+class TestAdapterInit:
+
+    def test_env_credentials_and_defaults(self, monkeypatch):
+        adapter = _adapter(monkeypatch)
+        assert adapter.page_access_token == "page-token"
+        assert adapter.app_secret == "app-secret"
+        assert adapter.verify_token == "verify-token"
+        assert adapter.webhook_host == meta_common.DEFAULT_WEBHOOK_HOST
+        assert adapter.webhook_port == meta_common.DEFAULT_WEBHOOK_PORT
+        assert adapter.webhook_path == meta_common.DEFAULT_WEBHOOK_PATH
+        assert adapter.graph_api_base == meta_common.DEFAULT_GRAPH_API_BASE
+
+    def test_extra_fallback_when_env_missing(self, monkeypatch):
+        _clear_meta_env(monkeypatch)
+        cfg = PlatformConfig(
+            extra={
+                "page_access_token": "extra-token",
+                "app_secret": "extra-secret",
+                "verify_token": "extra-verify",
+                "port": 9999,
+            }
+        )
+        adapter = MessengerAdapter(cfg)
+        assert adapter.page_access_token == "extra-token"
+        assert adapter.webhook_port == 9999
+
+    def test_bad_port_falls_back(self, monkeypatch):
+        adapter = _adapter(monkeypatch, META_WEBHOOK_PORT="not-a-port")
+        assert adapter.webhook_port == meta_common.DEFAULT_WEBHOOK_PORT
+
+    def test_platform_identity_and_chunk_limits(self, monkeypatch):
+        msgr = _adapter(monkeypatch)
+        insta = _adapter(monkeypatch, cls=InstagramAdapter)
+        assert msgr.platform.value == "messenger"
+        assert insta.platform.value == "instagram"
+        assert msgr.SAFE_CHUNK_CHARS == meta_common.MESSENGER_SAFE_CHARS
+        assert insta.SAFE_CHUNK_CHARS == meta_common.INSTAGRAM_SAFE_CHARS
+        assert msgr.MAX_MESSAGE_LENGTH == 2000
+        assert insta.MAX_MESSAGE_LENGTH == 1000
+
+    def test_both_plugins_share_one_common_module(self):
+        # The instagram plugin must reuse the messenger plugin's shared
+        # module (same object in sys.modules) so the webhook server state
+        # is shared when both surfaces are enabled.
+        assert _instagram.MetaBaseAdapter is meta_common.MetaBaseAdapter
+        assert _messenger.MetaBaseAdapter is meta_common.MetaBaseAdapter
+        assert issubclass(MessengerAdapter, meta_common.MetaBaseAdapter)
+        assert issubclass(InstagramAdapter, meta_common.MetaBaseAdapter)
+
+
+# ---------------------------------------------------------------------------
+# 6. inbound message processing
+# ---------------------------------------------------------------------------
+
+class TestInbound:
+
+    def _process(self, adapter, messaging):
+        adapter.handle_message = AsyncMock()
+
+        async def _run():
+            await adapter._process_messaging(messaging)
+            while adapter._background_tasks:
+                await asyncio.gather(*list(adapter._background_tasks))
+
+        asyncio.run(_run())
+        return adapter.handle_message
+
+    def test_text_message_dispatched(self, monkeypatch):
+        adapter = _adapter(monkeypatch)
+        handle = self._process(
+            adapter,
+            {
+                "sender": {"id": "111"},
+                "recipient": {"id": "222"},
+                "message": {"mid": "m-1", "text": "hello"},
+            },
+        )
+        assert handle.await_count == 1
+        event = handle.await_args.args[0]
+        assert event.text == "hello"
+        assert event.message_id == "m-1"
+        assert event.source.platform.value == "messenger"
+        assert event.source.chat_id == "111"
+        assert event.source.chat_type == "dm"
+        assert event.source.chat_id_alt == "222"
+
+    def test_instagram_message_records_instagram_platform(self, monkeypatch):
+        adapter = _adapter(monkeypatch, cls=InstagramAdapter)
+        handle = self._process(
+            adapter,
+            {
+                "sender": {"id": "ig-1"},
+                "recipient": {"id": "ig-acct"},
+                "message": {"mid": "m-2", "text": "hi"},
+            },
+        )
+        event = handle.await_args.args[0]
+        assert event.source.platform.value == "instagram"
+        assert event.source.chat_name == "Instagram DM"
+
+    def test_echo_not_dispatched(self, monkeypatch):
+        adapter = _adapter(monkeypatch)
+        handle = self._process(
+            adapter,
+            {"sender": {"id": "111"}, "message": {"is_echo": True, "text": "x"}},
+        )
+        assert handle.await_count == 0
+
+    def test_receipt_not_dispatched(self, monkeypatch):
+        adapter = _adapter(monkeypatch)
+        handle = self._process(
+            adapter, {"sender": {"id": "111"}, "delivery": {"mids": ["m"]}}
+        )
+        assert handle.await_count == 0
+
+    def test_empty_message_not_dispatched(self, monkeypatch):
+        adapter = _adapter(monkeypatch)
+        handle = self._process(
+            adapter, {"sender": {"id": "111"}, "message": {"mid": "m-3"}}
+        )
+        assert handle.await_count == 0
+
+    def test_image_attachment_cached(self, monkeypatch, tmp_path):
+        adapter = _adapter(monkeypatch)
+        adapter._download_attachment = AsyncMock(return_value=b"\x89PNG data")
+        cached = tmp_path / "img.png"
+
+        def fake_cache(data, ext=".jpg"):
+            cached.write_bytes(data)
+            return str(cached)
+
+        monkeypatch.setattr(meta_common, "cache_image_from_bytes", fake_cache)
+        handle = self._process(
+            adapter,
+            {
+                "sender": {"id": "111"},
+                "message": {
+                    "mid": "m-4",
+                    "attachments": [
+                        {"type": "image", "payload": {"url": "https://cdn/x.png"}}
+                    ],
+                },
+            },
+        )
+        event = handle.await_args.args[0]
+        assert event.media_urls == [str(cached)]
+        assert event.message_type.value == "photo"
+
+
+# ---------------------------------------------------------------------------
+# 7. outbound sends
+# ---------------------------------------------------------------------------
+
+class TestOutbound:
+
+    def _patched(self, monkeypatch, cls=MessengerAdapter, ok=True):
+        adapter = _adapter(monkeypatch, cls=cls)
+        calls = []
+
+        async def fake_graph_post(endpoint, payload):
+            calls.append((endpoint, payload))
+            if ok:
+                return True, {"message_id": f"mid-{len(calls)}"}
+            return False, {"error": {"message": "boom"}}
+
+        adapter._graph_post = fake_graph_post
+        return adapter, calls
+
+    def test_send_payload_shape(self, monkeypatch):
+        adapter, calls = self._patched(monkeypatch)
+        result = asyncio.run(adapter.send("111", "hello"))
+        assert result.success and result.message_id == "mid-1"
+        endpoint, payload = calls[0]
+        assert endpoint == "me/messages"
+        assert payload["recipient"] == {"id": "111"}
+        assert payload["messaging_type"] == "RESPONSE"
+        assert payload["message"] == {"text": "hello"}
+
+    def test_send_chunks_long_message(self, monkeypatch):
+        adapter, calls = self._patched(monkeypatch)
+        result = asyncio.run(adapter.send("111", "x" * 4000))
+        assert result.success
+        assert len(calls) > 1
+        for _, payload in calls:
+            assert len(payload["message"]["text"]) <= meta_common.MESSENGER_SAFE_CHARS
+
+    def test_instagram_uses_tighter_chunks(self, monkeypatch):
+        adapter, calls = self._patched(monkeypatch, cls=InstagramAdapter)
+        asyncio.run(adapter.send("ig-1", "x" * 1500))
+        assert len(calls) == 2
+        for _, payload in calls:
+            assert len(payload["message"]["text"]) <= meta_common.INSTAGRAM_SAFE_CHARS
+
+    def test_send_empty_rejected(self, monkeypatch):
+        adapter, calls = self._patched(monkeypatch)
+        result = asyncio.run(adapter.send("111", "   "))
+        assert not result.success
+        assert calls == []
+
+    def test_send_error_surfaced(self, monkeypatch):
+        adapter, _ = self._patched(monkeypatch, ok=False)
+        result = asyncio.run(adapter.send("111", "hello"))
+        assert not result.success
+        assert result.error == "boom"
+
+    def test_send_image_attachment_then_caption(self, monkeypatch):
+        adapter, calls = self._patched(monkeypatch)
+        result = asyncio.run(
+            adapter.send_image("111", "https://img/x.png", caption="look")
+        )
+        assert result.success
+        _, first = calls[0]
+        assert first["message"]["attachment"]["type"] == "image"
+        assert first["message"]["attachment"]["payload"]["url"] == "https://img/x.png"
+        _, second = calls[1]
+        assert second["message"] == {"text": "look"}
+
+    def test_get_chat_info(self, monkeypatch):
+        adapter = _adapter(monkeypatch)
+        info = asyncio.run(adapter.get_chat_info("111"))
+        assert info == {"name": "Messenger DM", "type": "dm", "chat_id": "111"}
+
+
+# ---------------------------------------------------------------------------
+# 8. webhook HTTP handlers
+# ---------------------------------------------------------------------------
+
+def _fake_request(body: bytes = b"", headers=None, query=None):
+    async def _read():
+        return body
+
+    return SimpleNamespace(
+        read=_read, headers=headers or {}, query=query or {},
+    )
+
+
+@pytest.mark.skipif(
+    not _HAS_AIOHTTP,
+    reason="aiohttp not installed (CI installs it via --extra all)",
+)
+class TestWebhookHandlers:
+    """Handler tests build real aiohttp ``web.Response`` objects."""
+
+    def _server_with(self, adapter):
+        server = meta_common._SharedWebhookServer()
+        server.adapters[adapter.PLATFORM_NAME] = adapter
+        return server
+
+    def test_verify_handshake_ok(self, monkeypatch):
+        adapter = _adapter(monkeypatch)
+        server = self._server_with(adapter)
+        request = _fake_request(query={
+            "hub.mode": "subscribe",
+            "hub.verify_token": "verify-token",
+            "hub.challenge": "challenge-123",
+        })
+        response = asyncio.run(server._handle_verify(request))
+        assert response.status == 200
+        assert response.text == "challenge-123"
+
+    def test_verify_handshake_bad_token(self, monkeypatch):
+        adapter = _adapter(monkeypatch)
+        server = self._server_with(adapter)
+        request = _fake_request(query={
+            "hub.mode": "subscribe",
+            "hub.verify_token": "wrong",
+            "hub.challenge": "c",
+        })
+        response = asyncio.run(server._handle_verify(request))
+        assert response.status == 403
+
+    def test_event_bad_signature_rejected(self, monkeypatch):
+        adapter = _adapter(monkeypatch)
+        adapter._process_messaging = AsyncMock()
+        server = self._server_with(adapter)
+        body = json.dumps({"object": "page", "entry": []}).encode()
+        request = _fake_request(
+            body=body, headers={"X-Hub-Signature-256": "sha256=deadbeef"}
+        )
+        response = asyncio.run(server._handle_event(request))
+        assert response.status == 403
+        assert adapter._process_messaging.await_count == 0
+
+    def test_event_routed_to_matching_adapter(self, monkeypatch):
+        msgr = _adapter(monkeypatch)
+        insta = _adapter(monkeypatch, cls=InstagramAdapter)
+        msgr._process_messaging = AsyncMock()
+        insta._process_messaging = AsyncMock()
+        server = self._server_with(msgr)
+        server.adapters["instagram"] = insta
+
+        messaging = {"sender": {"id": "ig"}, "message": {"text": "hi"}}
+        body = json.dumps(
+            {"object": "instagram", "entry": [{"messaging": [messaging]}]}
+        ).encode()
+        request = _fake_request(
+            body=body, headers={"X-Hub-Signature-256": _sign(body)}
+        )
+        response = asyncio.run(server._handle_event(request))
+        assert response.status == 200
+        assert insta._process_messaging.await_count == 1
+        assert msgr._process_messaging.await_count == 0
+
+    def test_event_for_unconnected_surface_dropped(self, monkeypatch):
+        msgr = _adapter(monkeypatch)
+        msgr._process_messaging = AsyncMock()
+        server = self._server_with(msgr)
+        body = json.dumps(
+            {"object": "instagram", "entry": [{"messaging": [{}]}]}
+        ).encode()
+        request = _fake_request(
+            body=body, headers={"X-Hub-Signature-256": _sign(body)}
+        )
+        response = asyncio.run(server._handle_event(request))
+        # Still 200 so Meta doesn't disable the webhook, but nothing dispatched.
+        assert response.status == 200
+        assert msgr._process_messaging.await_count == 0
+
+
+class TestConnectGate:
+
+    def test_connect_fails_without_credentials(self, monkeypatch):
+        _clear_meta_env(monkeypatch)
+        adapter = MessengerAdapter(PlatformConfig())
+        assert asyncio.run(adapter.connect()) is False
+
+
+# ---------------------------------------------------------------------------
+# 9-10. registration metadata + enablement gating
+# ---------------------------------------------------------------------------
+
+class _FakeCtx:
+    def __init__(self):
+        self.platforms = {}
+
+    def register_platform(self, **kwargs):
+        self.platforms[kwargs["name"]] = kwargs
+
+
+class TestRegistration:
+
+    @pytest.mark.parametrize(
+        "module,name,prefix,limit",
+        [
+            (_messenger, "messenger", "MESSENGER", 2000),
+            (_instagram, "instagram", "INSTAGRAM", 1000),
+        ],
+    )
+    def test_register_metadata(self, module, name, prefix, limit):
+        ctx = _FakeCtx()
+        module.register(ctx)
+        entry = ctx.platforms[name]
+        assert entry["allowed_users_env"] == f"{prefix}_ALLOWED_USERS"
+        assert entry["allow_all_env"] == f"{prefix}_ALLOW_ALL_USERS"
+        assert entry["cron_deliver_env_var"] == f"{prefix}_HOME_CHANNEL"
+        assert entry["max_message_length"] == limit
+        assert entry["platform_hint"]
+        assert callable(entry["standalone_sender_fn"])
+        assert callable(entry["env_enablement_fn"])
+        assert f"{prefix}_ENABLED" in entry["required_env"]
+        for var in CREDS:
+            assert var in entry["required_env"]
+
+    def test_not_connected_without_enable_flag(self, monkeypatch):
+        _clear_meta_env(monkeypatch)
+        _set_creds(monkeypatch)
+        assert not _messenger.is_connected(PlatformConfig())
+        assert not _messenger.check_requirements()
+
+    def test_connected_with_enable_flag_and_creds(self, monkeypatch):
+        _clear_meta_env(monkeypatch)
+        _set_creds(monkeypatch)
+        monkeypatch.setenv("MESSENGER_ENABLED", "true")
+        # check_requirements needs an importable aiohttp; fake it so this
+        # test also runs in minimal envs (CI installs the real one).
+        monkeypatch.setitem(sys.modules, "aiohttp", types.ModuleType("aiohttp"))
+        assert _messenger.is_connected(PlatformConfig())
+        assert _messenger.check_requirements()
+        # Instagram stays off — per-surface opt-in is independent.
+        assert not _instagram.is_connected(PlatformConfig())
+
+    def test_not_connected_without_credentials(self, monkeypatch):
+        _clear_meta_env(monkeypatch)
+        monkeypatch.setenv("MESSENGER_ENABLED", "true")
+        assert not _messenger.is_connected(PlatformConfig())
+        assert not _messenger.check_requirements()
+
+    def test_env_enablement_seeds_extras(self, monkeypatch):
+        _clear_meta_env(monkeypatch)
+        _set_creds(monkeypatch)
+        monkeypatch.setenv("MESSENGER_ENABLED", "true")
+        monkeypatch.setenv("META_WEBHOOK_PORT", "9001")
+        monkeypatch.setenv("MESSENGER_HOME_CHANNEL", "psid-1")
+        seeded = _messenger._env_enablement()
+        assert seeded["port"] == 9001
+        assert seeded["home_channel"] == {"chat_id": "psid-1", "name": "Home"}
+
+    def test_env_enablement_none_when_disabled(self, monkeypatch):
+        _clear_meta_env(monkeypatch)
+        _set_creds(monkeypatch)
+        assert _messenger._env_enablement() is None
+
+
+# ---------------------------------------------------------------------------
+# 11. standalone (cron) send
+# ---------------------------------------------------------------------------
+
+class TestStandaloneSend:
+
+    def test_standalone_send_success(self, monkeypatch):
+        _clear_meta_env(monkeypatch)
+        _set_creds(monkeypatch)
+        payloads = []
+
+        async def fake_graph_post(self, endpoint, payload):
+            payloads.append(payload)
+            return True, {"message_id": "mid-9"}
+
+        monkeypatch.setattr(
+            meta_common.MetaBaseAdapter, "_graph_post", fake_graph_post
+        )
+        result = asyncio.run(
+            _messenger._standalone_send(PlatformConfig(), "111", "cron says hi")
+        )
+        assert result == {"success": True, "message_id": "mid-9"}
+        assert payloads[0]["message"] == {"text": "cron says hi"}
+
+    def test_standalone_send_notes_undeliverable_media(self, monkeypatch):
+        _clear_meta_env(monkeypatch)
+        _set_creds(monkeypatch)
+        payloads = []
+
+        async def fake_graph_post(self, endpoint, payload):
+            payloads.append(payload)
+            return True, {"message_id": "mid-10"}
+
+        monkeypatch.setattr(
+            meta_common.MetaBaseAdapter, "_graph_post", fake_graph_post
+        )
+        result = asyncio.run(
+            _instagram._standalone_send(
+                PlatformConfig(), "ig-1", "report", media_files=["/tmp/a.png"]
+            )
+        )
+        assert result["success"]
+        assert "1 attachment(s)" in payloads[0]["message"]["text"]
+
+    def test_standalone_send_requires_token(self, monkeypatch):
+        _clear_meta_env(monkeypatch)
+        result = asyncio.run(
+            _messenger._standalone_send(PlatformConfig(), "111", "hi")
+        )
+        assert "error" in result

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 1
 title: "Messaging Gateway"
-description: "Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Yuanbao, Microsoft Teams, LINE, Raft, Webhooks, or any OpenAI-compatible frontend via the API server — architecture and setup overview"
+description: "Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Messenger, Instagram, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Yuanbao, Microsoft Teams, LINE, Raft, Webhooks, or any OpenAI-compatible frontend via the API server — architecture and setup overview"
 ---
 
 # Messaging Gateway
 
-Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Feishu/Lark, WeCom, Weixin, BlueBubbles (iMessage), QQ, Yuanbao, Microsoft Teams, LINE, ntfy, or your browser. The gateway is a single background process that connects to all your configured platforms, handles sessions, runs cron jobs, and delivers voice messages.
+Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Facebook Messenger, Instagram, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Feishu/Lark, WeCom, Weixin, BlueBubbles (iMessage), QQ, Yuanbao, Microsoft Teams, LINE, ntfy, or your browser. The gateway is a single background process that connects to all your configured platforms, handles sessions, runs cron jobs, and delivers voice messages.
 
 For the full voice feature set — including CLI microphone mode, spoken replies in messaging, and Discord voice-channel conversations — see [Voice Mode](/user-guide/features/voice-mode) and [Use Voice Mode with Hermes](/guides/use-voice-mode-with-hermes).
 
@@ -23,6 +23,8 @@ Bots need both a model provider and tool providers (TTS, web). A [Nous Portal](/
 | Slack | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Google Chat | — | ✅ | ✅ | ✅ | — | ✅ | — |
 | WhatsApp | — | ✅ | ✅ | — | — | ✅ | ✅ |
+| Messenger | — | ✅ | — | — | — | ✅ | — |
+| Instagram DM | — | ✅ | — | — | — | ✅ | — |
 | Signal | — | ✅ | ✅ | — | — | ✅ | ✅ |
 | SMS | — | — | — | — | — | — | — |
 | Email | — | ✅ | ✅ | ✅ | — | — | — |
@@ -54,6 +56,8 @@ flowchart TB
             tg[Telegram]
             dc[Discord]
             wa[WhatsApp]
+            fbm[Messenger]
+            ig[Instagram DM]
             sl[Slack]
             gc[Google Chat]
             sig[Signal]
@@ -83,6 +87,8 @@ flowchart TB
     tg --> store
     dc --> store
     wa --> store
+    fbm --> store
+    ig --> store
     sl --> store
     gc --> store
     sig --> store
@@ -653,6 +659,8 @@ Defaults to `false`. Only platforms whose adapter implements `delete_message` ho
 - [Google Chat Setup](google_chat.md)
 - [WhatsApp Setup](whatsapp.md)
 - [WhatsApp Business Cloud API Setup](whatsapp-cloud.md)
+- [Messenger Setup](messenger.md)
+- [Instagram DM Setup](instagram.md)
 - [Signal Setup](signal.md)
 - [SMS Setup (Twilio)](sms.md)
 - [Email Setup](email.md)

--- a/website/docs/user-guide/messaging/instagram.md
+++ b/website/docs/user-guide/messaging/instagram.md
@@ -1,0 +1,85 @@
+---
+sidebar_position: 9
+title: "Instagram DM"
+description: "Set up Hermes Agent as an Instagram Direct Messages bot (Meta Graph API)"
+---
+
+# Instagram DM Setup
+
+Run Hermes Agent as the DM bot behind an Instagram professional account via Meta's official Instagram Messaging API. The adapter lives as a bundled platform plugin under `plugins/platforms/instagram/`.
+
+Instagram is the second surface of a [Messenger](messenger.md) Meta app: an Instagram professional account is linked to a Facebook Page, credentials are shared (`META_*`), events arrive on the **same webhook callback URL** as Messenger, and sends go through the same Graph API `/me/messages` endpoint. When both platforms are enabled they share one webhook listener; Hermes routes each event by the payload's top-level `object` field (`page` → messenger, `instagram` → instagram), so sessions are recorded under the correct platform.
+
+> Run `hermes gateway setup` and pick **Instagram DM (Meta)** for a guided walk-through.
+
+## Prerequisites
+
+- An **Instagram professional account** (Business or Creator) linked to a Facebook Page.
+- A Meta app with the **Instagram** product added (and **Messenger** if you also want Page DMs).
+- If you already set up [Messenger](messenger.md), the credentials below are the same — you only add `INSTAGRAM_ENABLED=true` and the Instagram webhook subscription.
+
+:::warning App Review
+Until your app passes Meta App Review with the `instagram_manage_messages` permission, only app admins/developers/testers can DM the account through the API. Public customer-facing bots need App Review.
+:::
+
+---
+
+## Configuration
+
+Add to `~/.hermes/.env`:
+
+```env
+# Shared Meta app credentials (same values serve Messenger)
+META_PAGE_ACCESS_TOKEN=EAAG...
+META_APP_SECRET=0123456789abcdef...
+META_VERIFY_TOKEN=any-random-string
+
+# Enable the Instagram surface
+INSTAGRAM_ENABLED=true
+
+# Gate access: specific Instagram-scoped user IDs (IGSIDs), or allow everyone
+INSTAGRAM_ALLOWED_USERS=17841400000000000
+# INSTAGRAM_ALLOW_ALL_USERS=true   # public customer-facing bot
+
+# Optional: default recipient for cron jobs / notifications
+# INSTAGRAM_HOME_CHANNEL=17841400000000000
+```
+
+`INSTAGRAM_ENABLED` is required — the `META_*` credentials are shared with the Messenger plugin, so each surface needs its own explicit opt-in.
+
+## Webhook
+
+The webhook listener, exposure steps, and signature validation are identical to [Messenger's](messenger.md#step-2-expose-the-webhook) (default `127.0.0.1:8647/meta/webhook`). In the Meta developer portal, additionally subscribe the app's **Instagram** webhook object to the **messages** field — the callback URL and verify token are the same ones Messenger uses.
+
+## Message behavior
+
+- Outbound text is chunked at 950 characters (Instagram's hard limit is 1000; the headroom carries `(1/3)` chunk indicators).
+- The agent is told not to use markdown — Instagram renders it literally.
+- Publicly reachable image URLs produced by the agent are sent as native photos; local files can't be uploaded through the Send API, so the agent shares links instead.
+- Inbound image/audio/video attachments (including story mentions with media URLs) are downloaded from Meta's CDN and cached for the vision/file tools.
+- IGSIDs are Instagram-scoped IDs — a different namespace from Messenger PSIDs, even for the same human.
+
+## Cron delivery
+
+`deliver=instagram` uses `INSTAGRAM_HOME_CHANNEL`; `deliver=instagram:<IGSID>` targets a specific user. Both work when cron runs in a separate process from the gateway (the plugin registers a standalone sender).
+
+## Environment variable reference
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `META_PAGE_ACCESS_TOKEN` | ✅ | Page access token (shared with Messenger) |
+| `META_APP_SECRET` | ✅ | App secret for webhook signature validation |
+| `META_VERIFY_TOKEN` | ✅ | Webhook verification handshake token |
+| `INSTAGRAM_ENABLED` | ✅ | Explicit opt-in for the Instagram surface |
+| `INSTAGRAM_ALLOWED_USERS` | — | Comma-separated allowed IGSIDs |
+| `INSTAGRAM_ALLOW_ALL_USERS` | — | Allow every user (public bots) |
+| `INSTAGRAM_HOME_CHANNEL` | — | Default IGSID for cron/notification delivery |
+| `META_WEBHOOK_HOST` | — | Bind host (default `127.0.0.1`, shared) |
+| `META_WEBHOOK_PORT` | — | Listen port (default `8647`, shared) |
+| `META_WEBHOOK_PATH` | — | Webhook path (default `/meta/webhook`, shared) |
+| `META_GRAPH_API_BASE` | — | Graph API base URL override |
+
+## Next Steps
+
+- [Messenger Setup](messenger.md) — full webhook exposure walk-through
+- [WhatsApp Business Cloud API Setup](whatsapp-cloud.md) — Meta's other Graph-webhook platform

--- a/website/docs/user-guide/messaging/messenger.md
+++ b/website/docs/user-guide/messaging/messenger.md
@@ -1,0 +1,124 @@
+---
+sidebar_position: 8
+title: "Messenger"
+description: "Set up Hermes Agent as a Facebook Messenger Page bot (Meta Graph API)"
+---
+
+# Facebook Messenger Setup
+
+Run Hermes Agent as the DM bot behind a Facebook Page via Meta's official Messenger Platform. The adapter lives as a bundled platform plugin under `plugins/platforms/messenger/` — no core edits, just enable it like any other platform.
+
+Messenger shares its Meta app with [Instagram DM](instagram.md): one set of credentials, one webhook callback URL, one Graph API send pipeline. If you enable both platforms they share a single webhook listener, and events are routed to the right adapter automatically.
+
+> Run `hermes gateway setup` and pick **Messenger (Meta)** for a guided walk-through.
+
+## How the bot responds
+
+| Context | Behavior |
+|---------|----------|
+| **Page DM** (PSIDs) | Responds to every message from an allowed user |
+| **Group threads** | Not supported by the Messenger Platform API |
+
+Inbound text, images, audio, video, and file attachments are handled — media is downloaded from Meta's CDN and cached for the vision/file tools. Echo events and delivery/read receipts are filtered so the bot never replies to itself.
+
+---
+
+## Step 1: Create a Meta app
+
+1. Go to [Meta for Developers](https://developers.facebook.com/apps/) and create an app (type **Business**).
+2. Add the **Messenger** product.
+3. Under **Messenger > Messenger API settings**, connect your Facebook Page and **Generate token** — this is your Page access token.
+4. Copy the **App secret** from **App settings > Basic**.
+5. Invent a random string to use as your webhook **verify token**.
+
+:::warning App Review
+Until your app passes Meta App Review with the `pages_messaging` permission, only app admins/developers/testers can message the Page. That is enough for personal use and development — add your own Facebook account as an app admin. Public customer-facing bots need App Review.
+:::
+
+---
+
+## Step 2: Expose the webhook
+
+Meta delivers webhooks over public HTTPS. The adapter listens on `127.0.0.1:8647` at `/meta/webhook` by default — override with `META_WEBHOOK_HOST` / `META_WEBHOOK_PORT` / `META_WEBHOOK_PATH`.
+
+```bash
+# Cloudflare Tunnel (recommended for production — fixed hostname)
+cloudflared tunnel --url http://localhost:8647
+
+# ngrok (good for dev)
+ngrok http 8647
+```
+
+If you front it with a reverse proxy, forward the path **unchanged** (do not strip the `/meta/webhook` prefix).
+
+---
+
+## Step 3: Configure Hermes
+
+Add to `~/.hermes/.env`:
+
+```env
+# Shared Meta app credentials (same values serve Instagram DM)
+META_PAGE_ACCESS_TOKEN=EAAG...
+META_APP_SECRET=0123456789abcdef...
+META_VERIFY_TOKEN=any-random-string
+
+# Enable the Messenger surface
+MESSENGER_ENABLED=true
+
+# Gate access: specific page-scoped user IDs (PSIDs), or allow everyone
+MESSENGER_ALLOWED_USERS=24681357902468
+# MESSENGER_ALLOW_ALL_USERS=true   # public customer-facing bot
+
+# Optional: default recipient for cron jobs / notifications
+# MESSENGER_HOME_CHANNEL=24681357902468
+```
+
+`MESSENGER_ENABLED` is required — the `META_*` credentials are shared with the Instagram plugin, so each surface needs its own explicit opt-in.
+
+Every webhook POST must carry a valid `X-Hub-Signature-256` header (HMAC-SHA256 of the raw body keyed by `META_APP_SECRET`); events that fail validation are rejected with `403`.
+
+---
+
+## Step 4: Subscribe the webhook
+
+1. Start the gateway: `hermes gateway`
+2. Verify the local listener: `curl "http://127.0.0.1:8647/meta/webhook/health"`
+3. In the Meta developer portal under **Messenger > Messenger API settings > Webhooks**, set the callback URL to `https://<public-host>/meta/webhook` and the verify token to your `META_VERIFY_TOKEN`, then click **Verify and save**.
+4. Subscribe the Page to the **messages** webhook field.
+5. DM your Page from an allowed account — the agent should answer.
+
+---
+
+## Message behavior
+
+- Outbound text is chunked at 1900 characters (Messenger's hard limit is 2000; the headroom carries `(1/3)` chunk indicators).
+- The agent is told not to use markdown — Messenger renders it literally.
+- Publicly reachable image URLs produced by the agent are sent as native photo attachments; local files can't be uploaded through the Send API, so the agent shares links instead.
+- A `typing_on` sender action is sent while the agent is thinking.
+- PSIDs are page-scoped: the same person has a different ID on every Page, and Instagram IDs are a separate namespace.
+
+## Cron delivery
+
+`deliver=messenger` uses `MESSENGER_HOME_CHANNEL`; `deliver=messenger:<PSID>` targets a specific user. Both work when cron runs in a separate process from the gateway (the plugin registers a standalone sender).
+
+## Environment variable reference
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `META_PAGE_ACCESS_TOKEN` | ✅ | Page access token (shared with Instagram) |
+| `META_APP_SECRET` | ✅ | App secret for webhook signature validation |
+| `META_VERIFY_TOKEN` | ✅ | Webhook verification handshake token |
+| `MESSENGER_ENABLED` | ✅ | Explicit opt-in for the Messenger surface |
+| `MESSENGER_ALLOWED_USERS` | — | Comma-separated allowed PSIDs |
+| `MESSENGER_ALLOW_ALL_USERS` | — | Allow every user (public bots) |
+| `MESSENGER_HOME_CHANNEL` | — | Default PSID for cron/notification delivery |
+| `META_WEBHOOK_HOST` | — | Bind host (default `127.0.0.1`) |
+| `META_WEBHOOK_PORT` | — | Listen port (default `8647`) |
+| `META_WEBHOOK_PATH` | — | Webhook path (default `/meta/webhook`) |
+| `META_GRAPH_API_BASE` | — | Graph API base URL override |
+
+## Next Steps
+
+- [Instagram DM Setup](instagram.md) — the second surface of the same Meta app
+- [WhatsApp Business Cloud API Setup](whatsapp-cloud.md) — Meta's other Graph-webhook platform

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -613,6 +613,8 @@ const sidebars: SidebarsConfig = {
             'user-guide/messaging/slack',
             'user-guide/messaging/whatsapp',
             'user-guide/messaging/whatsapp-cloud',
+            'user-guide/messaging/messenger',
+            'user-guide/messaging/instagram',
             'user-guide/messaging/signal',
             'user-guide/messaging/email',
             'user-guide/messaging/sms',


### PR DESCRIPTION
## What

Two bundled platform plugins that add Meta Facebook Messenger (Page DM) and Instagram DM as Hermes gateway platforms, sharing one Meta app / webhook.

## Why

Messenger and Instagram DMs are a common customer-service surface for businesses already on WhatsApp/Telegram. This lets a Hermes agent handle Page and IG DMs natively alongside the other platforms.

## How

- `plugins/platforms/messenger/` and `plugins/platforms/instagram/` — standard `kind: platform` plugins (matching the discord/telegram plugin layout), each with `plugin.yaml` + `adapter.py`.
- `plugins/platforms/messenger/meta_common.py` — shared logic (both surfaces of one Meta app deliver to the same callback URL): an aiohttp webhook server with `X-Hub-Signature-256` HMAC validation, Graph API `/me/messages` sends, inbound image/audio/video/file download+cache for the vision/file tools, and echo/delivery/read-receipt filtering.
- Credentials are env-only (`META_PAGE_ACCESS_TOKEN`, `META_APP_SECRET`, `META_VERIFY_TOKEN`), surfaced through the platform-plugin env injector — no hardcoded config.
- Purely additive: no changes to engine core.

## Tests

- 57 tests (`tests/gateway/test_meta_plugins.py`): webhook signature validation, event parsing, echo filtering, send path, attachment handling, Instagram/Messenger routing.

## Notes

Rebased onto current `main` (v0.18.0); cherry-picks cleanly with no core changes. Docs under `website/docs/user-guide/messaging/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)