### PR TITLE
fix: strip empty tool_calls before sending to strict APIs

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3989,7 +3989,9 @@ class SessionDB:
                 msg["tool_name"] = row["tool_name"]
             if row["tool_calls"]:
                 try:
-                    msg["tool_calls"] = json.loads(row["tool_calls"])
+                    parsed = json.loads(row["tool_calls"])
+                    if parsed:  # only set if non-empty
+                        msg["tool_calls"] = parsed
                 except (json.JSONDecodeError, TypeError):
                     logger.warning("Failed to deserialize tool_calls in conversation replay, falling back to []")
                     msg["tool_calls"] = []

--- a/run_agent.py
+++ b/run_agent.py
@@ -5540,6 +5540,11 @@ class AIAgent:
         tool_calls = api_msg.get("tool_calls")
         if not isinstance(tool_calls, list):
             return api_msg
+        if not tool_calls:
+            # Empty array rejected by strict providers (DeepSeek, Mistral, etc.)
+            # with HTTP 400. Strip the key so the message has no tool_calls field.
+            api_msg.pop("tool_calls", None)
+            return api_msg
         from agent.transports.chat_completions import _model_consumes_thought_signature
         _STRIP_KEYS = {"call_id", "response_item_id"}
         if not _model_consumes_thought_signature(model):


### PR DESCRIPTION
## Problem

Conversations with 100+ messages on strict providers (DeepSeek, Mistral, Fireworks, Moonshot/Kimi) eventually hit:

```
HTTP 400: Invalid 'messages[409].tool_calls': empty array. Expected an array with minimum length 1, but got an empty array instead.
```

This happens because a message in the conversation history carries `tool_calls: []` instead of having no `tool_calls` field. The empty array gets replayed verbatim to the provider, which rejects it.

## Root cause

Two paths converge:

1. **`get_messages_as_conversation`** (`hermes_state.py`): when the DB stores `"[]"` (JSON-encoded empty array), it's parsed and set as `msg["tool_calls"] = []` — the key is present with an empty list.

2. **`_sanitize_tool_calls_for_strict_api`** (`run_agent.py`): checks `isinstance(tool_calls, list)` but doesn't guard against empty lists, so `[]` passes through unchanged to the provider.

## Fix

Two defence layers:

- **`hermes_state.py`** — only set `tool_calls` on the hydrated message if the parsed JSON is non-empty.
- **`run_agent.py`** — in `_sanitize_tool_calls_for_strict_api`, pop the key entirely when `tool_calls` is an empty list.

The first layer prevents `[]` from entering the live history; the second catches any remaining case at the API boundary.

## Verification

- Existing strict API validation tests pass (4/4)
- Tool call incremental persistence tests pass (3/3)
- Message sequence repair tests pass (33/33)
- Syntax-checked with `ast.parse`

## Changes

| File | Δ |
|---|---|
| `run_agent.py` | +5 lines (guard in `_sanitize_tool_calls_for_strict_api`) |
| `hermes_state.py` | +2/−1 (only set `tool_calls` when parsed result is non-empty) |