### PR TITLE
fix(gateway): inline _auto_continue_freshness_window — decouple from gateway.session

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -619,19 +619,25 @@ def _coerce_gateway_timestamp(value: Any) -> Optional[float]:
 def _auto_continue_freshness_window() -> float:
     """Return the configured auto-continue freshness window in seconds.
 
-    Thin wrapper that delegates to the canonical implementation in
-    ``gateway.session`` (the single source of truth shared with the
-    routing-time zombie gate in ``get_or_create_session``).  Reads
-    ``HERMES_AUTO_CONTINUE_FRESHNESS`` (bridged from ``config.yaml``
+    Reads ``HERMES_AUTO_CONTINUE_FRESHNESS`` (bridged from ``config.yaml``
     ``agent.gateway_auto_continue_freshness`` at gateway startup, same
-    pattern as ``HERMES_AGENT_TIMEOUT``).  Falls back to the module default
-    when unset or malformed.  Non-positive values disable the freshness gate
-    (restores the pre-fix "always fresh" behaviour for users who want to opt
-    out).  Kept here so existing call sites and test patches importing it
-    from ``gateway.run`` continue to work.
+    pattern as ``HERMES_AGENT_TIMEOUT``).  Falls back to 3600 s when unset
+    or malformed.  Non-positive values disable the freshness gate (restores
+    the pre-fix "always fresh" behaviour for users who want to opt out).
+
+    Previously delegated to ``gateway.session.auto_continue_freshness_window``
+    via a lazy import.  That coupling means any refactor that moves or removes
+    the symbol in ``gateway.session`` silently turns into a startup
+    ``ImportError`` crash-loop with no warning until the gateway tries to boot.
+    Inlined here so the function is self-contained and refactor-safe.
     """
-    from gateway.session import auto_continue_freshness_window
-    return auto_continue_freshness_window()
+    raw = os.environ.get("HERMES_AUTO_CONTINUE_FRESHNESS")
+    if raw is None or raw == "":
+        return 3600.0
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return 3600.0
 
 
 def _float_env(name: str, default: float) -> float:


### PR DESCRIPTION
## Problem

Fixes #58955

`_auto_continue_freshness_window()` in `gateway/run.py` is a thin lazy-import wrapper over `gateway.session.auto_continue_freshness_window`. Any refactor that moves or removes that symbol causes the gateway to crash on every startup:

```
ImportError: cannot import name 'auto_continue_freshness_window' from 'gateway.session'
```

The crash is inside `_schedule_resume_pending_sessions()` — the gateway never finishes `runner.start()`. systemd restarts immediately, producing a crash-loop with no user-visible warning.

The hidden coupling is invisible to linters and static analysis; it only manifests at runtime when the gateway boots.

## Fix

Inline the three-line env-read logic directly into `_auto_continue_freshness_window()`. No inter-module import, no hidden coupling. The public signature is unchanged; all existing call sites are unaffected.

```python
# Before
def _auto_continue_freshness_window() -> float:
    from gateway.session import auto_continue_freshness_window
    return auto_continue_freshness_window()

# After
def _auto_continue_freshness_window() -> float:
    raw = os.environ.get("HERMES_AUTO_CONTINUE_FRESHNESS")
    if raw is None or raw == "":
        return 3600.0
    try:
        return float(raw)
    except (TypeError, ValueError):
        return 3600.0
```

## Testing

Verified locally: gateway starts cleanly after removing `auto_continue_freshness_window` from `gateway/session.py`. Before this fix the same removal caused a crash-loop.