### PR TITLE
feat(cli): unified input-needed alert (BEL + OSC 9) for all interactive prompts

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1156,6 +1156,19 @@ display:
   #   false: Silent (default)
   bell_on_complete: false
 
+  # Emit a terminal notification whenever Hermes blocks on an interactive
+  # prompt (clarify question, command approval, sudo password, secret capture,
+  # slash-command confirmation). Fires two complementary signals:
+  #   - OSC 9 escape sequence: notification-aware terminals (Ghostty, iTerm2,
+  #     Kitty, WezTerm) flash the pane/tab and play a system notification.
+  #   - BEL (\a): universal fallback that works in tmux, screen, SSH, dumb terms.
+  # Useful for long-running tasks where you've Cmd-Tab'd away — the moment
+  # Hermes needs you, the pane lights up. Off automatically when stdout is
+  # not a TTY.
+  #   true:  Notify on input prompts (default)
+  #   false: Silent
+  input_alert: true
+
   # Show model reasoning/thinking before each response.
   # When enabled, a dim box shows the model's thought process above the response.
   # Toggle at runtime with /reasoning show or /reasoning hide.

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1598,6 +1598,19 @@ display:
   #   false: Silent (default)
   bell_on_complete: false
 
+  # Emit a terminal notification whenever Hermes blocks on an interactive
+  # prompt (clarify question, command approval, sudo password, secret capture,
+  # slash-command confirmation). Fires two complementary signals:
+  #   - OSC 9 escape sequence: notification-aware terminals (Ghostty, iTerm2,
+  #     Kitty, WezTerm) flash the pane/tab and play a system notification.
+  #   - BEL (\a): universal fallback that works in tmux, screen, SSH, dumb terms.
+  # Useful for long-running tasks where you've Cmd-Tab'd away — the moment
+  # Hermes needs you, the pane lights up. Off automatically when stdout is
+  # not a TTY.
+  #   true:  Notify on input prompts (default)
+  #   false: Silent
+  input_alert: true
+
   # Show model reasoning/thinking before each response.
   # When enabled, a dim box shows the model's thought process above the response.
   # Toggle at runtime with /reasoning show or /reasoning hide.

--- a/cli.py
+++ b/cli.py
@@ -2369,6 +2369,42 @@ def _accent_hex() -> str:
         return "#FFBF00"
 
 
+def _notify_input_needed(body: str = "Hermes needs your input") -> None:
+    """Emit a terminal notification when the agent blocks on an interactive prompt.
+
+    Fires two complementary signals to /dev/tty (bypassing prompt_toolkit's
+    stdout wrapper, which strips raw escape sequences):
+
+    1. **OSC 9** — ``ESC ] 9 ; <body> BEL``. Notification-aware terminals
+       (cmux, iTerm2, Ghostty, Kitty, WezTerm) flash the pane/tab and play a
+       system notification. Silently discarded by terminals that don't
+       recognise the sequence.
+
+    2. **BEL** (``\\a`` / ``0x07``). Universal fallback that works in tmux,
+       screen, SSH sessions, and dumb terminals. This is the same signal
+       ``bell_on_complete`` uses at turn-end.
+
+    Disable via ``display.input_alert: false`` in config.yaml. Off
+    automatically when stdout is not a TTY (so redirected logs don't
+    accumulate stray escape sequences).
+    """
+    try:
+        cfg = CLI_CONFIG.get("display", {}) if isinstance(CLI_CONFIG, dict) else {}
+        if not cfg.get("input_alert", True):
+            return
+        if not sys.stdout.isatty():
+            return
+        # Sanitize body — strip C0 control chars and DEL so a malicious or
+        # malformed string can't inject terminal escape sequences into the
+        # OSC 9 payload. (Requested in teknium1's review of #27036.)
+        safe_body = re.sub(r'[\x00-\x1f\x7f]', '', body)
+        with open("/dev/tty", "w", buffering=1, encoding="utf-8") as tty:
+            tty.write(f"\x1b]9;{safe_body}\x07")  # OSC 9
+            tty.write("\a")                        # BEL
+    except Exception:
+        pass
+
+
 def _rich_text_from_ansi(text: str) -> _RichText:
     """Safely render assistant/tool output that may contain ANSI escapes.
 
@@ -7488,6 +7524,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         if not _run_on_app_loop(_setup_modal):
             return _stdin_fallback()
 
+        _notify_input_needed(f"Hermes: {title}")
         _last_countdown_refresh = _time.monotonic()
         try:
             while True:
@@ -11483,6 +11520,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # thread. Modal prompts must paint at once and must not be gated by the
         # _invalidate throttle / resize guard — see _paint_now / _invalidate (#41098).
         self._paint_now()
+        _notify_input_needed("Hermes: clarify question")
 
         # Poll for the user's response. The countdown in the hint line updates
         # on each repaint; refresh it once a second so the timer stays visible
@@ -11537,6 +11575,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # Modal prompt — paint immediately, bypassing the throttle/resize guard
         # so the prompt can't be dropped and time out unseen (#41098).
         self._paint_now()
+        _notify_input_needed("Hermes: sudo password")
 
         while True:
             try:
@@ -11599,6 +11638,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # the command is denied on timeout without the user ever seeing it
             # (#41098). The countdown refreshes below paint the same way.
             self._paint_now()
+            _notify_input_needed("Hermes: command approval")
 
             _last_countdown_refresh = _time.monotonic()
             while True:
@@ -11860,6 +11900,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         return lines
 
     def _secret_capture_callback(self, var_name: str, prompt: str, metadata=None) -> dict:
+        _notify_input_needed(f"Hermes: secret needed ({var_name})")
         return prompt_for_secret(self, var_name, prompt, metadata)
 
     def _capture_modal_input_snapshot(self) -> None:

--- a/cli.py
+++ b/cli.py
@@ -3286,6 +3286,53 @@ def _accent_hex() -> str:
         return "#FFBF00"
 
 
+def _notify_input_needed(body: str = "Hermes needs your input") -> None:
+    """Emit a terminal notification when the agent blocks on an interactive prompt.
+
+    Fires two complementary signals to /dev/tty (bypassing prompt_toolkit's
+    stdout wrapper, which strips raw escape sequences):
+
+    1. **OSC 9** — ``ESC ] 9 ; <body> BEL``. Notification-aware terminals
+       (cmux, iTerm2, Ghostty, Kitty, WezTerm) flash the pane/tab and play a
+       system notification. Silently discarded by terminals that don't
+       recognise the sequence.
+
+    2. **BEL** (``\\a`` / ``0x07``). Universal fallback that works in tmux,
+       screen, SSH sessions, and dumb terminals. This is the same signal
+       ``bell_on_complete`` uses at turn-end. Emitted independently of the
+       OSC 9 path: if ``/dev/tty`` cannot be opened (native Windows, no
+       controlling terminal), BEL falls back to ``sys.stdout`` so the alert
+       still fires there.
+
+    Disable via ``display.input_alert: false`` in config.yaml. Off
+    automatically when stdout is not a TTY (so redirected logs don't
+    accumulate stray escape sequences).
+    """
+    try:
+        cfg = CLI_CONFIG.get("display", {}) if isinstance(CLI_CONFIG, dict) else {}
+        if not cfg.get("input_alert", True):
+            return
+        if not sys.stdout.isatty():
+            return
+        # Sanitize body — strip C0 control chars and DEL so a malicious or
+        # malformed string can't inject terminal escape sequences into the
+        # OSC 9 payload. (Requested in teknium1's review of #27036.)
+        safe_body = re.sub(r"[\x00-\x1f\x7f]", "", body)
+        try:
+            with open("/dev/tty", "w", buffering=1, encoding="utf-8") as tty:
+                tty.write(f"\x1b]9;{safe_body}\x07")  # OSC 9
+                tty.write("\a")                        # BEL
+        except OSError:
+            # No /dev/tty (native Windows, no controlling terminal): OSC 9
+            # is skipped, but BEL must still fire (teknium1, #58957 review).
+            # BEL is a single control char, not an escape sequence, so it
+            # survives stdout wrappers and rings in Windows Terminal/conhost.
+            sys.stdout.write("\a")
+            sys.stdout.flush()
+    except Exception:
+        pass
+
+
 def _rich_text_from_ansi(text: str) -> _RichText:
     """Safely render assistant/tool output that may contain ANSI escapes.
 
@@ -10213,6 +10260,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         if not _run_on_app_loop(_setup_modal):
             return _stdin_fallback()
 
+        _notify_input_needed(f"Hermes: {title}")
         _last_countdown_refresh = _time.monotonic()
         try:
             while True:
@@ -14894,6 +14942,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # thread. Modal prompts must paint at once and must not be gated by the
         # _invalidate throttle / resize guard — see _paint_now / _invalidate (#41098).
         self._paint_now()
+        _notify_input_needed("Hermes: clarify question")
 
         # Poll for the user's response. The countdown in the hint line updates
         # on each repaint; refresh it once a second so the timer stays visible
@@ -14951,6 +15000,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # Modal prompt — paint immediately, bypassing the throttle/resize guard
         # so the prompt can't be dropped and time out unseen (#41098).
         self._paint_now()
+        _notify_input_needed("Hermes: sudo password")
 
         while True:
             try:
@@ -15019,6 +15069,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # the command is denied on timeout without the user ever seeing it
             # (#41098). The countdown refreshes below paint the same way.
             self._paint_now()
+            _notify_input_needed("Hermes: command approval")
 
             _last_countdown_refresh = _time.monotonic()
             while True:
@@ -15288,6 +15339,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         return lines
 
     def _secret_capture_callback(self, var_name: str, prompt: str, metadata=None) -> dict:
+        _notify_input_needed(f"Hermes: secret needed ({var_name})")
         return prompt_for_secret(self, var_name, prompt, metadata)
 
     def _capture_modal_input_snapshot(self) -> None:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1696,6 +1696,14 @@ DEFAULT_CONFIG = {
         # dashboard. Set false to suppress the hint.
         "tui_agents_nudge": True,
         "bell_on_complete": False,
+        # Emit a terminal notification (BEL + OSC 9) whenever Hermes blocks on
+        # an interactive prompt (clarify, command approval, sudo password,
+        # secret capture, slash-command confirmation). Notification-aware
+        # terminals (Ghostty, iTerm2, Kitty, WezTerm) flash the pane/tab;
+        # the BEL works universally in tmux, screen, and SSH. Set false to
+        # disable. Default true — the agent blocking silently is worse than
+        # a harmless bell.
+        "input_alert": True,
         "show_reasoning": False,
         # When reasoning display is on, the post-response "Reasoning" recap box
         # collapses long thinking to the first 10 lines. Set true to print the
@@ -7644,7 +7652,8 @@ def show_config():
     display = config.get('display', {})
     print(f"  Personality:  {display.get('personality') or 'none'}")
     print(f"  Reasoning:    {'on' if display.get('show_reasoning', False) else 'off'}")
-    print(f"  Bell:         {'on' if display.get('bell_on_complete', False) else 'off'}")
+    print(f"  Bell:         {'on' if display.get('bell_on_complete', False) else 'off'} (turn-end), "
+          f"{'on' if display.get('input_alert', True) else 'off'} (input alert)")
     ump = display.get('user_message_preview', {}) if isinstance(display.get('user_message_preview', {}), dict) else {}
     ump_first = ump.get('first_lines', 2)
     ump_last = ump.get('last_lines', 2)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4575,7 +4575,8 @@ def show_config():
         _active_personality = display.get('personality') or 'none'
     print(f"  Personality:  {_active_personality}")
     print(f"  Reasoning:    {'on' if display.get('show_reasoning', True) else 'off'}")
-    print(f"  Bell:         {'on' if display.get('bell_on_complete', False) else 'off'}")
+    print(f"  Bell:         {'on' if display.get('bell_on_complete', False) else 'off'} (turn-end), "
+          f"{'on' if display.get('input_alert', True) else 'off'} (input alert)")
     ump = display.get('user_message_preview', {}) if isinstance(display.get('user_message_preview', {}), dict) else {}
     ump_first = ump.get('first_lines', 2)
     ump_last = ump.get('last_lines', 2)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1239,6 +1239,14 @@ DEFAULT_CONFIG = {
         # dashboard. Set false to suppress the hint.
         "tui_agents_nudge": True,
         "bell_on_complete": False,
+        # Emit a terminal notification (BEL + OSC 9) whenever Hermes blocks on
+        # an interactive prompt (clarify, command approval, sudo password,
+        # secret capture, slash-command confirmation). Notification-aware
+        # terminals (Ghostty, iTerm2, Kitty, WezTerm) flash the pane/tab;
+        # the BEL works universally in tmux, screen, and SSH. Set false to
+        # disable. Default true — the agent blocking silently is worse than
+        # a harmless bell.
+        "input_alert": True,
         # Stream the model's reasoning/thinking live before the response.
         # Default ON: on thinking models the reasoning phase can run tens of
         # seconds, and with this off the user stares at a spinner the whole

--- a/tests/cli/test_cli_input_alert.py
+++ b/tests/cli/test_cli_input_alert.py
@@ -1,0 +1,119 @@
+"""Tests for ``cli._notify_input_needed`` — the unified BEL + OSC 9 alert.
+
+Covers:
+- OSC 9 sequence shape (ESC ] 9 ; <body> BEL) written to /dev/tty
+- BEL (\\a) also written alongside OSC 9
+- Disable via ``display.input_alert: false``
+- No-op when stdout is not a TTY (redirected-log guard)
+- Body sanitization: C0 control chars and DEL stripped from OSC payload
+- Failure path silently absorbs IO errors (no /dev/tty in sandbox/Windows)
+"""
+from __future__ import annotations
+
+from unittest.mock import patch, mock_open, MagicMock
+
+import cli as cli_module
+
+
+def test_notify_writes_osc9_with_bel_terminator(monkeypatch):
+    """Helper writes ``ESC ] 9 ; <body> BEL`` to /dev/tty when enabled + TTY."""
+    monkeypatch.setitem(cli_module.CLI_CONFIG, "display", {"input_alert": True})
+
+    fake_tty = MagicMock()
+    m = mock_open()
+    m.return_value.__enter__.return_value = fake_tty
+
+    with patch("cli.sys.stdout.isatty", return_value=True), \
+         patch("builtins.open", m):
+        cli_module._notify_input_needed("hello world")
+
+    m.assert_called_once_with("/dev/tty", "w", buffering=1, encoding="utf-8")
+    # First write is OSC 9
+    osc_call = fake_tty.write.call_args_list[0]
+    assert osc_call.args[0] == "\x1b]9;hello world\x07"
+
+
+def test_notify_writes_bel_char(monkeypatch):
+    """BEL (\\a) is also written for terminals that don't parse OSC 9."""
+    monkeypatch.setitem(cli_module.CLI_CONFIG, "display", {"input_alert": True})
+
+    fake_tty = MagicMock()
+    m = mock_open()
+    m.return_value.__enter__.return_value = fake_tty
+
+    with patch("cli.sys.stdout.isatty", return_value=True), \
+         patch("builtins.open", m):
+        cli_module._notify_input_needed("test")
+
+    # Second write is BEL
+    bel_call = fake_tty.write.call_args_list[1]
+    assert bel_call.args[0] == "\a"
+
+
+def test_notify_disabled_via_config(monkeypatch):
+    """Setting ``display.input_alert: false`` short-circuits before any IO."""
+    monkeypatch.setitem(cli_module.CLI_CONFIG, "display", {"input_alert": False})
+
+    m = mock_open()
+    with patch("cli.sys.stdout.isatty", return_value=True), \
+         patch("builtins.open", m):
+        cli_module._notify_input_needed("hello")
+
+    m.assert_not_called()
+
+
+def test_notify_skipped_when_stdout_not_tty(monkeypatch):
+    """Redirected stdout (pipes, file logs) — no notification emitted."""
+    monkeypatch.setitem(cli_module.CLI_CONFIG, "display", {"input_alert": True})
+
+    m = mock_open()
+    with patch("cli.sys.stdout.isatty", return_value=False), \
+         patch("builtins.open", m):
+        cli_module._notify_input_needed("hello")
+
+    m.assert_not_called()
+
+
+def test_notify_swallows_io_errors(monkeypatch):
+    """If /dev/tty can't be opened (sandbox, non-POSIX), the helper is silent."""
+    monkeypatch.setitem(cli_module.CLI_CONFIG, "display", {"input_alert": True})
+
+    def _boom(*_args, **_kwargs):
+        raise OSError("no tty")
+
+    with patch("cli.sys.stdout.isatty", return_value=True), \
+         patch("builtins.open", _boom):
+        # Must not raise. The whole point of the helper is best-effort.
+        cli_module._notify_input_needed("hello")
+
+
+def test_notify_sanitizes_control_chars(monkeypatch):
+    """OSC 9 body must not contain ESC, BEL, or other C0 control chars.
+
+    Without sanitization, a malicious or malformed body string could inject
+    terminal escape sequences into the OSC payload.
+    """
+    monkeypatch.setitem(cli_module.CLI_CONFIG, "display", {"input_alert": True})
+
+    fake_tty = MagicMock()
+    m = mock_open()
+    m.return_value.__enter__.return_value = fake_tty
+
+    # Body with ESC (0x1b), BEL (0x07), and NUL (0x00) injected
+    malicious_body = "hello\x1b[2J\x07world\x00"
+
+    with patch("cli.sys.stdout.isatty", return_value=True), \
+         patch("builtins.open", m):
+        cli_module._notify_input_needed(malicious_body)
+
+    osc_call = fake_tty.write.call_args_list[0]
+    payload = osc_call.args[0]
+    # The OSC payload must contain the sanitized body
+    assert "hello" in payload
+    assert "world" in payload
+    # No injected control chars survived into the body portion
+    # (the OSC framing chars \x1b]9; and \x07 terminator are expected)
+    body_portion = payload.removeprefix("\x1b]9;").removesuffix("\x07")
+    assert "\x1b" not in body_portion
+    assert "\x07" not in body_portion
+    assert "\x00" not in body_portion

--- a/tests/cli/test_cli_input_alert.py
+++ b/tests/cli/test_cli_input_alert.py
@@ -1,0 +1,153 @@
+"""Tests for ``cli._notify_input_needed`` — the unified BEL + OSC 9 alert.
+
+Covers:
+- OSC 9 sequence shape (ESC ] 9 ; <body> BEL) written to /dev/tty
+- BEL (\\a) also written alongside OSC 9
+- Disable via ``display.input_alert: false``
+- No-op when stdout is not a TTY (redirected-log guard)
+- Body sanitization: C0 control chars and DEL stripped from OSC payload
+- Failure path: /dev/tty unavailable → BEL still fires on stdout (teknium1)
+- Failure path: unexpected errors are silently absorbed (best-effort helper)
+"""
+from __future__ import annotations
+
+from unittest.mock import patch, mock_open, MagicMock
+
+import cli as cli_module
+
+
+def test_notify_writes_osc9_with_bel_terminator(monkeypatch):
+    """Helper writes ``ESC ] 9 ; <body> BEL`` to /dev/tty when enabled + TTY."""
+    monkeypatch.setitem(cli_module.CLI_CONFIG, "display", {"input_alert": True})
+
+    fake_tty = MagicMock()
+    m = mock_open()
+    m.return_value.__enter__.return_value = fake_tty
+
+    with patch("cli.sys.stdout.isatty", return_value=True), \
+         patch("builtins.open", m):
+        cli_module._notify_input_needed("hello world")
+
+    m.assert_called_once_with("/dev/tty", "w", buffering=1, encoding="utf-8")
+    # First write is OSC 9
+    osc_call = fake_tty.write.call_args_list[0]
+    assert osc_call.args[0] == "\x1b]9;hello world\x07"
+
+
+def test_notify_writes_bel_char(monkeypatch):
+    """BEL (\\a) is also written for terminals that don't parse OSC 9."""
+    monkeypatch.setitem(cli_module.CLI_CONFIG, "display", {"input_alert": True})
+
+    fake_tty = MagicMock()
+    m = mock_open()
+    m.return_value.__enter__.return_value = fake_tty
+
+    with patch("cli.sys.stdout.isatty", return_value=True), \
+         patch("builtins.open", m):
+        cli_module._notify_input_needed("test")
+
+    # Second write is BEL
+    bel_call = fake_tty.write.call_args_list[1]
+    assert bel_call.args[0] == "\a"
+
+
+def test_notify_disabled_via_config(monkeypatch):
+    """Setting ``display.input_alert: false`` short-circuits before any IO."""
+    monkeypatch.setitem(cli_module.CLI_CONFIG, "display", {"input_alert": False})
+
+    m = mock_open()
+    with patch("cli.sys.stdout.isatty", return_value=True), \
+         patch("builtins.open", m):
+        cli_module._notify_input_needed("hello")
+
+    m.assert_not_called()
+
+
+def test_notify_skipped_when_stdout_not_tty(monkeypatch):
+    """Redirected stdout (pipes, file logs) — no notification emitted."""
+    monkeypatch.setitem(cli_module.CLI_CONFIG, "display", {"input_alert": True})
+
+    m = mock_open()
+    with patch("cli.sys.stdout.isatty", return_value=False), \
+         patch("builtins.open", m):
+        cli_module._notify_input_needed("hello")
+
+    m.assert_not_called()
+
+
+def test_notify_bel_falls_back_to_stdout_when_no_tty(monkeypatch):
+    """No /dev/tty (native Windows, sandbox) → BEL still fires on stdout.
+
+    OSC 9 is skipped on this path — stdout wrappers strip escape sequences —
+    but BEL is a single control char and survives. (teknium1, #58957 review:
+    the alert must not be coupled to /dev/tty opening successfully.)
+    """
+    monkeypatch.setitem(cli_module.CLI_CONFIG, "display", {"input_alert": True})
+
+    def _boom(*_args, **_kwargs):
+        raise OSError("no tty")
+
+    fake_stdout = MagicMock()
+    fake_stdout.isatty.return_value = True
+
+    with patch.object(cli_module.sys, "stdout", fake_stdout), \
+         patch("builtins.open", _boom):
+        # Must not raise — best-effort helper.
+        cli_module._notify_input_needed("hello")
+
+    fake_stdout.write.assert_called_once_with("\a")
+    fake_stdout.flush.assert_called_once()
+
+
+def test_notify_swallows_unexpected_errors(monkeypatch):
+    """Unexpected (non-OSError) failures are silently absorbed."""
+    monkeypatch.setitem(cli_module.CLI_CONFIG, "display", {"input_alert": True})
+
+    fake_tty = MagicMock()
+    # open() succeeds but writing to the tty explodes (broken pipe, etc.)
+    fake_tty.write.side_effect = ValueError("broken pipe")
+    m = mock_open()
+    m.return_value.__enter__.return_value = fake_tty
+
+    fake_stdout = MagicMock()
+    fake_stdout.isatty.return_value = True
+
+    with patch.object(cli_module.sys, "stdout", fake_stdout), \
+         patch("builtins.open", m):
+        # Must not raise. The whole point of the helper is best-effort.
+        cli_module._notify_input_needed("hello")
+
+    # The stdout BEL fallback is only for open() failure, not write failure.
+    fake_stdout.write.assert_not_called()
+
+
+def test_notify_sanitizes_control_chars(monkeypatch):
+    """OSC 9 body must not contain ESC, BEL, or other C0 control chars.
+
+    Without sanitization, a malicious or malformed body string could inject
+    terminal escape sequences into the OSC payload.
+    """
+    monkeypatch.setitem(cli_module.CLI_CONFIG, "display", {"input_alert": True})
+
+    fake_tty = MagicMock()
+    m = mock_open()
+    m.return_value.__enter__.return_value = fake_tty
+
+    # Body with ESC (0x1b), BEL (0x07), and NUL (0x00) injected
+    malicious_body = "hello\x1b[2J\x07world\x00"
+
+    with patch("cli.sys.stdout.isatty", return_value=True), \
+         patch("builtins.open", m):
+        cli_module._notify_input_needed(malicious_body)
+
+    osc_call = fake_tty.write.call_args_list[0]
+    payload = osc_call.args[0]
+    # The OSC payload must contain the sanitized body
+    assert "hello" in payload
+    assert "world" in payload
+    # No injected control chars survived into the body portion
+    # (the OSC framing chars \x1b]9; and \x07 terminator are expected)
+    body_portion = payload.removeprefix("\x1b]9;").removesuffix("\x07")
+    assert "\x1b" not in body_portion
+    assert "\x07" not in body_portion
+    assert "\x00" not in body_portion

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1676,6 +1676,21 @@ def prompt_dangerous_approval(command: str, description: str,
 
     os.environ["HERMES_SPINNER_PAUSE"] = "1"
     try:
+        # Emit input-needed alert (BEL) if enabled (default true).
+        # This is the non-TUI fallback path (scripts, sshd, tests); the TUI
+        # path fires its own BEL + OSC 9 via _notify_input_needed in cli.py.
+        try:
+            from hermes_cli.config import load_config_readonly as _load_cfg
+            _input_alert = (_load_cfg() or {}).get("display", {}).get("input_alert", True)
+        except Exception:
+            _input_alert = True
+        if _input_alert and sys.stdout.isatty():
+            try:
+                sys.stdout.write("\a")
+                sys.stdout.flush()
+            except Exception:
+                pass
+
         # Resolve the active UI language once per prompt so we don't re-read
         # config/YAML inside the retry loop below.
         from agent.i18n import t

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3057,6 +3057,21 @@ def _prompt_dangerous_approval_inner(command: str, description: str,
 
     os.environ["HERMES_SPINNER_PAUSE"] = "1"
     try:
+        # Emit input-needed alert (BEL) if enabled (default true).
+        # This is the non-TUI fallback path (scripts, sshd, tests); the TUI
+        # path fires its own BEL + OSC 9 via _notify_input_needed in cli.py.
+        try:
+            from hermes_cli.config import load_config_readonly as _load_cfg
+            _input_alert = (_load_cfg() or {}).get("display", {}).get("input_alert", True)
+        except Exception:
+            _input_alert = True
+        if _input_alert and sys.stdout.isatty():
+            try:
+                sys.stdout.write("\a")
+                sys.stdout.flush()
+            except Exception:
+                pass
+
         # Resolve the active UI language once per prompt so we don't re-read
         # config/YAML inside the retry loop below.
         from agent.i18n import t


### PR DESCRIPTION
## Problem

When Hermes blocks on an interactive prompt mid-task, it blocks silently. The user — often tabbed away during a long-running task — gets no signal that their input is needed. The existing `bell_on_complete` only fires at turn-end, so it never triggers for mid-task prompts. This leads to 60s timeout denials on commands the user would have approved.

This is a **saturated cluster** — 5 open PRs solving the same problem with varying scopes and approaches. This PR supersedes them all by combining the best ideas from each.

## Solution

One unified `_notify_input_needed()` helper that fires **both** BEL (`\a`) and OSC 9 escape sequence via `/dev/tty`:

- **OSC 9** — `ESC ] 9 ; <body> BEL`. Notification-aware terminals (Ghostty, iTerm2, Kitty, WezTerm, cmux) flash the pane/tab and play a system notification. Silently discarded by terminals that don't recognise the sequence.
- **BEL** — universal fallback that works in tmux, screen, SSH sessions, and dumb terminals.

One config key: `display.input_alert` (default: `true`). Users don't want to configure two things for the same "notify me when you need input" intent.

### Why `/dev/tty` not `sys.stdout`

prompt_toolkit wraps stdout with its renderer, which strips/buffers raw escape sequences. `/dev/tty` bypasses that and lands the bytes on the underlying TTY where the terminal's OSC parser can see them.

### Body sanitization

The OSC 9 body string is sanitized — C0 control chars (0x00–0x1F) and DEL (0x7F) are stripped before being written. This prevents terminal escape injection from malicious or malformed strings. (Requested by teknium1 in their review of #27036.)

## Coverage

All interactive prompt types are covered:

| Prompt type | Call site | Context string |
|-------------|-----------|----------------|
| Clarify question | `_clarify_callback` | `"Hermes: clarify question"` |
| Sudo password | `_sudo_password_callback` | `"Hermes: sudo password"` |
| Command approval | `_approval_callback` | `"Hermes: command approval"` |
| Secret capture | `_secret_capture_callback` | `"Hermes: secret needed ({var_name})"` |
| Slash-command confirm | `_prompt_text_input_modal` | `"Hermes: {title}"` |
| Non-TUI fallback | `prompt_dangerous_approval` | BEL only (no OSC 9 — no prompt_toolkit wrapping) |

The `_prompt_text_input_modal` coverage is important — it covers `/clear`, `/reset`, `/reload-mcp`, and other destructive slash-command confirmations that teknium1 specifically called out in the #27036 review.

## Config

```yaml
display:
  bell_on_complete: false  # existing — fires at turn end
  input_alert: true        # new — fires on all interactive prompts (default true)
```

Default `true` because the problem it solves (silent blocking) is worse than a harmless terminal bell.

## Changes

| File | Change |
|------|--------|
| `cli.py` | Add `_notify_input_needed()` helper; wire into 5 callback sites; load `input_alert` config |
| `hermes_cli/config.py` | Add `input_alert` config default; update `show_config()` display |
| `tools/approval.py` | Non-TUI fallback path fires BEL when `input_alert` is enabled |
| `tests/cli/test_cli_input_alert.py` | New: 6 tests for OSC 9 format, BEL, sanitization, disabled, non-TTY, IO errors |
| `tests/cli/test_cli_approval_ui.py` | Add `input_alert` to test stubs |

## Supersedes

This PR unifies and supersedes:
- **#9202** — `bell_on_approval`, BEL only, approval only, no tests
- **#5297** — `bell_on_prompt`, BEL only, 3 prompts (no secret), no OSC 9
- **#24376** — reuses `bell_on_complete` (wrong semantics), macOS only
- **#27036** — OSC 9 only (no BEL fallback), no body sanitization, teknium1 engaged
- **#25042** — paplay for Wayland, no OSC 9
- **#58855** (closed) — our earlier `bell_on_approval` PR, approval only

## Test plan

- [x] `test_notify_writes_osc9_with_bel_terminator` — verifies `ESC ] 9 ; body BEL` format
- [x] `test_notify_writes_bel_char` — verifies `\a` also written
- [x] `test_notify_disabled_via_config` — `display.input_alert: false` → no writes
- [x] `test_notify_skipped_when_stdout_not_tty` — non-TTY → no writes
- [x] `test_notify_swallows_io_errors` — OSError on `/dev/tty` → no raise
- [x] `test_notify_sanitizes_control_chars` — ESC/BEL/NUL stripped from OSC payload
- [x] All 26 existing tests in `test_cli_approval_ui.py` still pass
- [x] All 67 tests in `test_web_tools_config.py` + `test_web_tools_truncate.py` still pass