### PR TITLE
fix(skills): surface warning when skill preprocessing fails silently

### DIFF
--- a/agent/skill_preprocessing.py
+++ b/agent/skill_preprocessing.py
@@ -22,6 +22,23 @@ _INLINE_SHELL_RE = re.compile(r"!`([^`\n]+)`")
 _INLINE_SHELL_MAX_OUTPUT = 4000
 
 
+def has_preprocessable_tokens(content: str) -> bool:
+    """True if *content* contains anything the preprocessor would rewrite.
+
+    Matches exactly the tokens preprocessing recognizes: the two supported
+    template variables (``${HERMES_SKILL_DIR}`` / ``${HERMES_SESSION_ID}``,
+    see ``_SKILL_TEMPLATE_RE``) and inline-shell snippets (``!`cmd```, see
+    ``_INLINE_SHELL_RE``). Ordinary shell parameter expansion such as
+    ``${HOME}`` does NOT count — the preprocessor never touches it, so a
+    preprocessing failure changes nothing about it.
+    """
+    if not content:
+        return False
+    return bool(
+        _SKILL_TEMPLATE_RE.search(content) or _INLINE_SHELL_RE.search(content)
+    )
+
+
 def load_skills_config() -> dict:
     """Load the ``skills`` section of config.yaml (best-effort)."""
     try:

--- a/tests/test_plugin_skills.py
+++ b/tests/test_plugin_skills.py
@@ -385,3 +385,65 @@ class TestBundleContextBanner:
         self._setup_bundle(tmp_path)
         result = json.loads(skill_view("myplugin:foo"))
         assert "foo body." in result["content"]
+
+
+class TestPluginSkillPreprocessFailureWarning:
+    """Plugin skills must surface the same preprocess-failure warning as
+    local skills instead of silently serving raw content."""
+
+    @pytest.fixture(autouse=True)
+    def _isolate(self, tmp_path, monkeypatch):
+        from hermes_cli import plugins as plugins_mod
+        from hermes_cli.plugins import PluginManager
+
+        self.pm = PluginManager()
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", self.pm)
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", empty)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    def _register_skill(self, tmp_path, body):
+        d = tmp_path / "plugins" / "myplugin" / "skills" / "tokened"
+        d.mkdir(parents=True, exist_ok=True)
+        md = d / "SKILL.md"
+        md.write_text(
+            f"---\nname: tokened\ndescription: tokened desc\n---\n\n{body}\n"
+        )
+        self.pm._plugin_skills["myplugin:tokened"] = {
+            "path": md, "plugin": "myplugin", "bare_name": "tokened", "description": "",
+        }
+
+    def test_raised_preprocess_surfaces_warning(self, tmp_path):
+        from unittest.mock import patch
+
+        from tools.skills_tool import skill_view
+
+        self._register_skill(tmp_path, "Run ${HERMES_SKILL_DIR}/scripts/do.sh")
+        with patch(
+            "agent.skill_preprocessing.preprocess_skill_content",
+            side_effect=RuntimeError("preprocess exploded"),
+        ):
+            result = json.loads(skill_view("myplugin:tokened"))
+
+        assert result["success"] is True
+        # Banner is present (after the bundle-context banner) and the raw
+        # content is preserved.
+        assert "[WARNING: Skill preprocessing failed" in result["content"]
+        assert "Run ${HERMES_SKILL_DIR}/scripts/do.sh" in result["content"]
+
+    def test_raised_preprocess_no_warning_for_plain_shell(self, tmp_path):
+        from unittest.mock import patch
+
+        from tools.skills_tool import skill_view
+
+        self._register_skill(tmp_path, "Run ${HOME}/bin/tool --flag")
+        with patch(
+            "agent.skill_preprocessing.preprocess_skill_content",
+            side_effect=RuntimeError("preprocess exploded"),
+        ):
+            result = json.loads(skill_view("myplugin:tokened"))
+
+        assert result["success"] is True
+        assert "[WARNING" not in result["content"]
+        assert "Run ${HOME}/bin/tool --flag" in result["content"]

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -457,6 +457,71 @@ class TestSkillView:
         assert "Current date: !`printf SHOULD_NOT_RUN`" in result["content"]
         assert "Current date: SHOULD_NOT_RUN" not in result["content"]
 
+    def test_preprocess_failure_surfaces_warning_for_template_vars(self, tmp_path):
+        """A raised preprocess_skill_content must not fall back silently
+        when the content contains supported ${HERMES_*} tokens."""
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch(
+                "agent.skill_preprocessing.preprocess_skill_content",
+                side_effect=RuntimeError("preprocess exploded"),
+            ),
+        ):
+            _make_skill(
+                tmp_path,
+                "broken-preprocess",
+                body="Run ${HERMES_SKILL_DIR}/scripts/do.sh",
+            )
+            raw = skill_view("broken-preprocess", task_id="session-123")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["content"].startswith("[WARNING: Skill preprocessing failed")
+        # The raw, unprocessed content is preserved after the banner.
+        assert "Run ${HERMES_SKILL_DIR}/scripts/do.sh" in result["content"]
+
+    def test_preprocess_failure_surfaces_warning_for_inline_shell(self, tmp_path):
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch(
+                "agent.skill_preprocessing.preprocess_skill_content",
+                side_effect=RuntimeError("preprocess exploded"),
+            ),
+        ):
+            _make_skill(
+                tmp_path,
+                "broken-inline",
+                body="Current date: !`date +%Y-%m-%d`",
+            )
+            raw = skill_view("broken-inline")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["content"].startswith("[WARNING: Skill preprocessing failed")
+        assert "!`date +%Y-%m-%d`" in result["content"]
+
+    def test_preprocess_failure_no_warning_for_plain_shell_syntax(self, tmp_path):
+        """${HOME} is ordinary shell parameter expansion — the preprocessor
+        never touches it, so its presence must not trigger the banner."""
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch(
+                "agent.skill_preprocessing.preprocess_skill_content",
+                side_effect=RuntimeError("preprocess exploded"),
+            ),
+        ):
+            _make_skill(
+                tmp_path,
+                "plain-shell",
+                body="Run ${HOME}/bin/tool --flag && echo ${PATH}",
+            )
+            raw = skill_view("plain-shell")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "[WARNING" not in result["content"]
+        assert "Run ${HOME}/bin/tool --flag" in result["content"]
+
     def test_view_nonexistent_skill(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             _make_skill(tmp_path, "other-skill")

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -757,6 +757,38 @@ def skills_list(category: str = None, task_id: str = None) -> str:
 # ── Plugin skill serving ──────────────────────────────────────────────────
 
 
+_PREPROCESS_FAILURE_WARNING = (
+    "[WARNING: Skill preprocessing failed — template variables "
+    "(${HERMES_SKILL_DIR}, ${HERMES_SESSION_ID}) and inline shell snippets "
+    "(!`cmd`) in this skill were NOT resolved. Treat them as literal text.]\n\n"
+)
+
+
+def _preprocess_failure_fallback(content: str, skill_label: str) -> str:
+    """Raw-content fallback for a raised ``preprocess_skill_content``.
+
+    Returns *content* unchanged, prefixed with a warning banner when — and
+    only when — it contains tokens the preprocessor would actually have
+    rewritten (the two supported ``${HERMES_*}`` template variables or an
+    inline ``!`cmd``` shell snippet, per ``agent/skill_preprocessing.py``).
+    Ordinary shell syntax such as ``${HOME}`` is never flagged. Used by both
+    the local-skill and plugin-skill paths so neither falls back silently.
+    """
+    logger.debug(
+        "Could not preprocess skill content for %s", skill_label, exc_info=True
+    )
+    try:
+        from agent.skill_preprocessing import has_preprocessable_tokens
+
+        if not has_preprocessable_tokens(content):
+            return content
+    except Exception:
+        # Token detection itself failing must not mask the skill content;
+        # serve it raw rather than guessing about a banner.
+        return content
+    return _PREPROCESS_FAILURE_WARNING + content
+
+
 def _serve_plugin_skill(
     skill_md: Path,
     namespace: str,
@@ -844,8 +876,8 @@ def _serve_plugin_skill(
                 session_id=session_id,
             )
         except Exception:
-            logger.debug(
-                "Could not preprocess plugin skill %s:%s", namespace, bare, exc_info=True
+            rendered_content = _preprocess_failure_fallback(
+                content, f"{namespace}:{bare}"
             )
 
     return json.dumps(
@@ -1459,20 +1491,13 @@ def skill_view(
                     session_id=task_id,
                 )
             except Exception:
-                logger.debug(
-                    "Could not preprocess skill content for %s", skill_name, exc_info=True
+                # Surface a warning (when supported tokens are present) so
+                # the agent knows template variables and inline shell
+                # snippets were NOT resolved — otherwise it may treat
+                # ${HERMES_SKILL_DIR} as a literal path.
+                rendered_content = _preprocess_failure_fallback(
+                    content, skill_name
                 )
-                # Surface a warning so the agent knows template variables
-                # and inline shell snippets were NOT resolved. Without this
-                # the model may treat ${HERMES_SKILL_DIR} as a literal path.
-                if any(marker in content for marker in ("${", "!`")):
-                    rendered_content = (
-                        "[WARNING: Skill preprocessing failed — template "
-                        "variables (e.g. ${HERMES_SKILL_DIR}) and inline "
-                        "shell snippets (!`cmd`) in this skill were NOT "
-                        "resolved. Treat them as literal text.]\n\n"
-                        + content
-                    )
 
         result = {
             "success": True,

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1462,6 +1462,17 @@ def skill_view(
                 logger.debug(
                     "Could not preprocess skill content for %s", skill_name, exc_info=True
                 )
+                # Surface a warning so the agent knows template variables
+                # and inline shell snippets were NOT resolved. Without this
+                # the model may treat ${HERMES_SKILL_DIR} as a literal path.
+                if any(marker in content for marker in ("${", "!`")):
+                    rendered_content = (
+                        "[WARNING: Skill preprocessing failed — template "
+                        "variables (e.g. ${HERMES_SKILL_DIR}) and inline "
+                        "shell snippets (!`cmd`) in this skill were NOT "
+                        "resolved. Treat them as literal text.]\n\n"
+                        + content
+                    )
 
         result = {
             "success": True,


### PR DESCRIPTION
## Summary

When `preprocess_skill_content()` raises an exception, the error is logged at DEBUG level only and raw content with unresolved template markers (`${HERMES_SKILL_DIR}`, `!`...``) is returned to the agent. The model may treat these markers as literal text—writing paths with `${HERMES_SKILL_DIR}` to disk instead of the actual path.

## Fix

+11 lines: add a warning prefix to the rendered content when preprocessing fails and the content contains template markers or inline shell snippets. The prefix tells the agent the markers were not resolved.

## Files

`tools/skills_tool.py` — `skill_view()` function