### PR TITLE
fix(matrix): advertise MATRIX_HOME_ROOM in plugin metadata

### DIFF
--- a/plugins/platforms/matrix/plugin.yaml
+++ b/plugins/platforms/matrix/plugin.yaml
@@ -31,11 +31,15 @@ optional_env:
     description: "Allow any Matrix user to trigger the bot (dev only)"
     prompt: "Allow all users? (true/false)"
     password: false
-  - name: MATRIX_HOME_CHANNEL
+  - name: MATRIX_HOME_ROOM
     description: "Default room ID for cron / notification delivery"
     prompt: "Home room ID"
     password: false
-  - name: MATRIX_HOME_CHANNEL_NAME
+  - name: MATRIX_HOME_ROOM_NAME
     description: "Display name for the Matrix home room"
     prompt: "Home room display name"
+    password: false
+  - name: MATRIX_HOME_ROOM_THREAD_ID
+    description: "Optional Matrix thread/event ID for cron / notification delivery"
+    prompt: "Home room thread ID"
     password: false

--- a/tests/test_platform_plugin_metadata.py
+++ b/tests/test_platform_plugin_metadata.py
@@ -1,0 +1,17 @@
+"""Contracts for platform metadata registered in the CLI config surface."""
+
+
+def test_matrix_metadata_registers_the_runtime_home_target_env_vars():
+    from gateway.run import _home_target_env_var, _home_thread_env_var
+    from hermes_cli.config import OPTIONAL_ENV_VARS
+
+    home_target = _home_target_env_var("matrix")
+    registered_home_vars = {
+        name for name in OPTIONAL_ENV_VARS if name.startswith("MATRIX_HOME_")
+    }
+
+    assert registered_home_vars == {
+        home_target,
+        f"{home_target}_NAME",
+        _home_thread_env_var("matrix"),
+    }

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -442,10 +442,10 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `MATRIX_PASSWORD` | Matrix password (alternative to access token) |
 | `MATRIX_ALLOWED_USERS` | Comma-separated Matrix user IDs allowed to message the bot (e.g. `@alice:matrix.org`) |
 | `MATRIX_ALLOW_ALL_USERS` | Allow any Matrix user to trigger the bot (dev only). |
-| `MATRIX_HOME_CHANNEL` | Default room ID for cron / notification delivery. |
-| `MATRIX_HOME_CHANNEL_NAME` | Display name for the Matrix home room. |
 | `MATRIX_ALLOWED_ROOMS` | Comma-separated Matrix room IDs allowed to trigger bot responses |
 | `MATRIX_HOME_ROOM` | Room ID for proactive message delivery (e.g. `!abc123:matrix.org`) |
+| `MATRIX_HOME_ROOM_NAME` | Display name for the Matrix home room. |
+| `MATRIX_HOME_ROOM_THREAD_ID` | Optional Matrix thread/event ID for cron / notification delivery. |
 | `MATRIX_ENCRYPTION` | Enable end-to-end encryption (`true`/`false`, default: `false`) |
 | `MATRIX_E2EE_MODE` | Matrix E2EE behavior: `off`, `optional`, or `required`. Overrides `MATRIX_ENCRYPTION` when set. |
 | `MATRIX_DEVICE_ID` | Stable Matrix device ID for E2EE persistence across restarts (e.g. `HERMES_BOT`). Without this, E2EE keys rotate every startup and historic-room decrypt breaks. |


### PR DESCRIPTION
## What does this PR do?

Aligns the bundled Matrix setup metadata and env-var reference with the home-target variables the runtime already reads.

Before this change, the plugin advertised `MATRIX_HOME_CHANNEL` and `MATRIX_HOME_CHANNEL_NAME`, while Matrix delivery uses `MATRIX_HOME_ROOM`, `MATRIX_HOME_ROOM_NAME`, and `MATRIX_HOME_ROOM_THREAD_ID`. This caused setup/config surfaces to offer variables that had no runtime effect.

## Related Issue

Fixes #58998

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- Replace the two stale Matrix home-channel entries in `plugins/platforms/matrix/plugin.yaml` with the three runtime-supported home-room entries.
- Remove stale names from the env-var reference and document the canonical display-name and thread variables.
- Add a behavior-level contract that compares the parsed CLI env registry with the runtime Matrix home-target helpers; it does not inspect source text.

## How to Test

```bash
scripts/run_tests.sh tests/test_platform_plugin_metadata.py tests/gateway/test_home_target_env_var.py tests/test_packaging_metadata.py -q
# 19 passed

$HOME/.hermes/hermes-agent/venv/bin/ruff check tests/test_platform_plugin_metadata.py
# All checks passed

$HOME/.hermes/hermes-agent/venv/bin/python scripts/check-windows-footguns.py --diff upstream/main
# No Windows footguns found

git diff --check upstream/main...HEAD
# passed
```

The full wrapper suite was attempted. It stopped at approximately 4.4% on three pre-existing `tests/agent/test_anthropic_adapter.py::TestRunOauthSetupToken` failures caused by live macOS Keychain state and `json.loads(MagicMock)`; that separate isolation defect is tracked in #58609.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit follows Conventional Commits
- [x] I searched for existing PRs
- [x] This PR contains only the Matrix metadata/docs/test correction
- [ ] I've run the complete test suite successfully
- [x] I've added behavior-level regression coverage
- [x] I've tested on macOS

### Documentation & Housekeeping

- [x] Relevant documentation is updated
- [x] `cli-config.yaml.example` — N/A; no config key is introduced
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A; no workflow or architecture change
- [x] Cross-platform impact considered; metadata/docs/test-only change and Windows scan passed
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

Not applicable.
