### PR TITLE
feat(skills): per-turn skill load deduplication for skill_view

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -148,7 +148,7 @@ def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tu
         normalized = normalize_skill_lookup_name(raw_identifier)
 
         loaded_skill = json.loads(
-            skill_view(normalized, task_id=task_id, preprocess=False)
+            skill_view(normalized, task_id=task_id, preprocess=False, _skip_dedup=True)
         )
     except Exception:
         return None

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -233,6 +233,11 @@ def build_turn_context(
     agent._unicode_sanitization_passes = 0
     agent._tool_guardrails.reset_for_turn()
     agent._tool_guardrail_halt_decision = None
+    try:
+        from tools.skills_tool import reset_skill_load_cache
+        reset_skill_load_cache()
+    except Exception:
+        pass
     _reset_consol = getattr(agent._memory_store, "reset_consolidation_failures", None)
     if callable(_reset_consol):
         _reset_consol()

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -233,6 +233,10 @@ def build_turn_context(
     agent._unicode_sanitization_passes = 0
     agent._tool_guardrails.reset_for_turn()
     agent._tool_guardrail_halt_decision = None
+    # Bind a fresh per-turn skill_view dedup set. The state lives in a
+    # ContextVar, so this only affects the current turn's context (copied
+    # into the executor per session task) — it can never clear another
+    # concurrently running session's dedup state.
     try:
         from tools.skills_tool import reset_skill_load_cache
         reset_skill_load_cache()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -419,6 +419,22 @@ def _isolate_hermes_home(_hermetic_environment):
 # approvals from one test's session into another's.
 
 
+@pytest.fixture(autouse=True)
+def _reset_skill_dedup_cache():
+    """Per-turn skill-view dedup global must not leak across tests in a file.
+
+    ``tools.skills_tool._loaded_skill_keys`` tracks (name, file_path) so
+    skill_view can short-circuit within a single turn. Within a test file
+    every test starts a fresh turn, so the cache must be empty.
+    """
+    try:
+        from tools.skills_tool import reset_skill_load_cache
+
+        reset_skill_load_cache()
+    except Exception:
+        pass
+
+
 @pytest.fixture()
 def tmp_dir(tmp_path):
     """Provide a temporary directory that is cleaned up automatically."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -421,16 +421,19 @@ def _isolate_hermes_home(_hermetic_environment):
 
 @pytest.fixture(autouse=True)
 def _reset_skill_dedup_cache():
-    """Per-turn skill-view dedup global must not leak across tests in a file.
+    """Per-turn skill-view dedup state must not leak across tests.
 
-    ``tools.skills_tool._loaded_skill_keys`` tracks (name, file_path) so
-    skill_view can short-circuit within a single turn. Within a test file
-    every test starts a fresh turn, so the cache must be empty.
+    ``tools.skills_tool`` tracks (name, file_path) pairs in a ContextVar-bound
+    set so skill_view can short-circuit within a single turn. pytest runs
+    tests on one thread (one context), so a test that activates the dedup set
+    (via build_turn_context or reset_skill_load_cache) would otherwise leak an
+    active set into later tests. Unbind it so every test starts with dedup
+    inactive, exactly like a fresh process.
     """
     try:
-        from tools.skills_tool import reset_skill_load_cache
+        from tools.skills_tool import clear_skill_load_cache
 
-        reset_skill_load_cache()
+        clear_skill_load_cache()
     except Exception:
         pass
 

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -14,6 +14,7 @@ from tools.skills_tool import (
     _parse_tags,
     _get_category_from_path,
     _find_all_skills,
+    reset_skill_load_cache,
     skill_matches_platform,
     skills_list,
     skill_view,
@@ -1370,3 +1371,164 @@ class TestSkillViewCollisionDetection:
         result = json.loads(raw)
         assert result["success"] is True
         assert "LOCAL BODY" in result["content"]
+
+
+# ---------------------------------------------------------------------------
+# skill_view per-turn dedup
+# ---------------------------------------------------------------------------
+
+
+class TestSkillViewPerTurnDedup:
+    """Behavioral coverage for ContextVar-scoped per-turn skill_view dedup."""
+
+    def test_duplicate_load_within_turn_returns_already_loaded(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "dedup-skill", body="FULL BODY")
+            reset_skill_load_cache()  # turn start
+
+            first = json.loads(skill_view("dedup-skill"))
+            second = json.loads(skill_view("dedup-skill"))
+
+        assert first["success"] is True
+        assert "FULL BODY" in first["content"]
+        assert "already_loaded" not in first
+        assert second["success"] is True
+        assert second["already_loaded"] is True
+        assert second["content"] is None
+
+    def test_dedup_inactive_without_turn_context(self, tmp_path):
+        """No turn bound (library/one-shot callers): every call does real work."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "no-turn", body="FULL BODY")
+            first = json.loads(skill_view("no-turn"))
+            second = json.loads(skill_view("no-turn"))
+
+        for result in (first, second):
+            assert result["success"] is True
+            assert "FULL BODY" in result["content"]
+            assert "already_loaded" not in result
+
+    def test_failed_first_call_retries_real_path(self, tmp_path):
+        """A failed call must NOT mark the key: the retry hits the real path."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = _make_skill(tmp_path, "retry-skill")
+            reset_skill_load_cache()
+
+            # First call fails: the linked file does not exist yet.
+            first = json.loads(
+                skill_view("retry-skill", file_path="references/api.md")
+            )
+            assert first["success"] is False
+
+            # The failure repeats verbatim (a real error, not a synthetic
+            # already_loaded success with null content)...
+            again = json.loads(
+                skill_view("retry-skill", file_path="references/api.md")
+            )
+            assert again["success"] is False
+            assert "already_loaded" not in again
+
+            # ...and once the file appears, the same call really succeeds.
+            refs = skill_dir / "references"
+            refs.mkdir()
+            (refs / "api.md").write_text("# API\nEndpoint info.")
+            third = json.loads(
+                skill_view("retry-skill", file_path="references/api.md")
+            )
+
+        assert third["success"] is True
+        assert "Endpoint info" in third["content"]
+
+    def test_missing_skill_error_not_deduped(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "some-skill")
+            reset_skill_load_cache()
+            first = json.loads(skill_view("nope"))
+            second = json.loads(skill_view("nope"))
+
+        for result in (first, second):
+            assert result["success"] is False
+            assert "already_loaded" not in result
+
+    def test_reset_between_turns_allows_reload(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "turn-skill", body="FULL BODY")
+            reset_skill_load_cache()  # turn 1
+            assert "FULL BODY" in json.loads(skill_view("turn-skill"))["content"]
+            assert json.loads(skill_view("turn-skill"))["already_loaded"] is True
+
+            reset_skill_load_cache()  # turn 2 boundary
+            reloaded = json.loads(skill_view("turn-skill"))
+
+        assert reloaded["success"] is True
+        assert "FULL BODY" in reloaded["content"]
+        assert "already_loaded" not in reloaded
+
+    def test_linked_file_keyed_separately_from_main_skill(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = _make_skill(tmp_path, "files-skill", body="MAIN BODY")
+            refs = skill_dir / "references"
+            refs.mkdir()
+            (refs / "api.md").write_text("# API\nEndpoint info.")
+            reset_skill_load_cache()
+
+            main = json.loads(skill_view("files-skill"))
+            linked = json.loads(
+                skill_view("files-skill", file_path="references/api.md")
+            )
+            linked_again = json.loads(
+                skill_view("files-skill", file_path="references/api.md")
+            )
+
+        assert "MAIN BODY" in main["content"]
+        # A different (name, file_path) key is not deduped by the main load...
+        assert linked["success"] is True
+        assert "Endpoint info" in linked["content"]
+        # ...but repeating the same file view within the turn is.
+        assert linked_again["already_loaded"] is True
+        assert linked_again["file"] == "references/api.md"
+
+    def test_concurrent_turn_contexts_are_isolated(self, tmp_path):
+        """Two turns (e.g. two gateway sessions) must not share dedup state.
+
+        Each gateway session task's context is copied into the shared
+        executor (gateway/run.py::_run_in_executor_with_context), so two
+        concurrently scheduled turns run in distinct contexts. Simulate that
+        with two contextvars.Context objects interleaved on one thread.
+        """
+        import contextvars
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "shared-skill", body="FULL BODY")
+            turn_a = contextvars.copy_context()
+            turn_b = contextvars.copy_context()
+            turn_a.run(reset_skill_load_cache)
+            turn_b.run(reset_skill_load_cache)
+
+            # Turn A loads the skill.
+            first_a = json.loads(turn_a.run(skill_view, "shared-skill"))
+            assert "FULL BODY" in first_a["content"]
+
+            # Turn B starting/resetting must not clear A's active state...
+            turn_b.run(reset_skill_load_cache)
+            second_a = json.loads(turn_a.run(skill_view, "shared-skill"))
+            assert second_a["already_loaded"] is True
+
+            # ...and A's load must not have marked the skill in B.
+            first_b = json.loads(turn_b.run(skill_view, "shared-skill"))
+            assert first_b["success"] is True
+            assert "FULL BODY" in first_b["content"]
+            assert "already_loaded" not in first_b
+
+    def test_skip_dedup_bypasses_cache_for_internal_loaders(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "internal-skill", body="FULL BODY")
+            reset_skill_load_cache()
+
+            assert "FULL BODY" in json.loads(skill_view("internal-skill"))["content"]
+            # Internal loaders (_load_skill_payload) always get the payload...
+            bypass = json.loads(skill_view("internal-skill", _skip_dedup=True))
+            assert "FULL BODY" in bypass["content"]
+            # ...while normal tool calls stay deduped.
+            deduped = json.loads(skill_view("internal-skill"))
+            assert deduped["already_loaded"] is True

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -87,6 +87,17 @@ from agent.skill_utils import (
 
 logger = logging.getLogger(__name__)
 
+# Per-turn skill load deduplication: track (name, file_path) pairs loaded
+# during the current turn so the same skill (or linked file) is never
+# re-read, re-parsed, or re-processed within a single turn.
+_loaded_skill_keys: set = set()
+
+
+def reset_skill_load_cache() -> None:
+    """Clear the per-turn skill-load dedup set (called at turn start)."""
+    _loaded_skill_keys.clear()
+
+
 # Per-session skill discovery cache.  _find_all_skills() re-reads every
 # SKILL.md on every call; with hundreds of skills this is wasteful.
 # Cache validation (mirrors hermes_cli/profiles.py::_count_skills, d5eee133e):
@@ -994,6 +1005,22 @@ def skill_view(
                 },
                 ensure_ascii=False,
             )
+
+        # Per-turn dedup: if this exact (name, file_path) was already loaded
+        # during the current turn, skip re-reading and re-processing the file.
+        _dedup_key = (name, file_path)
+        if _dedup_key in _loaded_skill_keys:
+            return json.dumps(
+                {
+                    "success": True,
+                    "name": name,
+                    "content": None,
+                    "already_loaded": True,
+                    "note": "This skill was already loaded during the current turn.",
+                },
+                ensure_ascii=False,
+            )
+        _loaded_skill_keys.add(_dedup_key)
 
         local_category_name: str | None = None
         # ── Qualified name dispatch (plugin skills) ──────────────────

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -974,6 +974,7 @@ def skill_view(
     file_path: str = None,
     task_id: str = None,
     preprocess: bool = True,
+    _skip_dedup: bool = False,
 ) -> str:
     """
     View the content of a skill or a specific file within a skill directory.
@@ -1008,19 +1009,22 @@ def skill_view(
 
         # Per-turn dedup: if this exact (name, file_path) was already loaded
         # during the current turn, skip re-reading and re-processing the file.
+        # Internal loaders (e.g. _load_skill_payload) pass _skip_dedup=True
+        # because they need the full payload every time.
         _dedup_key = (name, file_path)
-        if _dedup_key in _loaded_skill_keys:
-            return json.dumps(
-                {
-                    "success": True,
-                    "name": name,
-                    "content": None,
-                    "already_loaded": True,
-                    "note": "This skill was already loaded during the current turn.",
-                },
-                ensure_ascii=False,
-            )
-        _loaded_skill_keys.add(_dedup_key)
+        if not _skip_dedup:
+            if _dedup_key in _loaded_skill_keys:
+                return json.dumps(
+                    {
+                        "success": True,
+                        "name": name,
+                        "content": None,
+                        "already_loaded": True,
+                        "note": "This skill was already loaded during the current turn.",
+                    },
+                    ensure_ascii=False,
+                )
+            _loaded_skill_keys.add(_dedup_key)
 
         local_category_name: str | None = None
         # ── Qualified name dispatch (plugin skills) ──────────────────

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -69,6 +69,7 @@ Usage:
 import json
 import logging
 import time
+from contextvars import ContextVar
 
 from hermes_constants import get_hermes_home, display_hermes_home
 import os
@@ -90,12 +91,45 @@ logger = logging.getLogger(__name__)
 # Per-turn skill load deduplication: track (name, file_path) pairs loaded
 # during the current turn so the same skill (or linked file) is never
 # re-read, re-parsed, or re-processed within a single turn.
-_loaded_skill_keys: set = set()
+#
+# The set is bound to a ContextVar — NOT a module global — so state is scoped
+# to the executing turn:
+#
+#   * the gateway copies each session task's context into the shared executor
+#     (``gateway/run.py::_run_in_executor_with_context`` does ``copy_context()``
+#     + ``ctx.run``), and tool worker threads re-copy the agent thread's
+#     context (``tools/thread_context.py::propagate_context_to_thread``), so
+#     every thread participating in one turn shares this turn's set while
+#     concurrently scheduled sessions each see their own;
+#   * ``build_turn_context()`` binds a FRESH set at turn start via
+#     ``reset_skill_load_cache()``, so one session starting a turn can never
+#     clear (or populate) another session's active turn.
+#
+# The default ``None`` means "no turn bound" (direct library callers, one-shot
+# scripts, contexts that never ran a turn prologue): dedup is disabled there
+# rather than falling back to shared process-global state.
+_turn_loaded_skill_keys: ContextVar[Optional[set]] = ContextVar(
+    "skills_tool_turn_loaded_keys", default=None
+)
 
 
 def reset_skill_load_cache() -> None:
-    """Clear the per-turn skill-load dedup set (called at turn start)."""
-    _loaded_skill_keys.clear()
+    """Bind a fresh, empty per-turn dedup set to the current context.
+
+    Called from the turn prologue (``agent/turn_context.py``); activates
+    per-turn skill_view dedup for the duration of the turn.
+    """
+    _turn_loaded_skill_keys.set(set())
+
+
+def clear_skill_load_cache() -> None:
+    """Unbind the per-turn dedup set — dedup becomes inactive.
+
+    Used by tests (and any caller tearing down a turn context) to guarantee
+    a previously bound dedup set can't leak into unrelated code running in
+    the same context.
+    """
+    _turn_loaded_skill_keys.set(None)
 
 
 # Per-session skill discovery cache.  _find_all_skills() re-reads every
@@ -987,10 +1021,61 @@ def skill_view(
         preprocess: Apply configured SKILL.md template and inline shell rendering
             to main skill content. Internal slash/preload callers disable this
             because they render the skill message themselves.
+        _skip_dedup: Internal loaders (e.g. ``_load_skill_payload``) pass True
+            because they need the full payload every time.
 
     Returns:
         JSON string with skill content or error message
+
+    Per-turn dedup: when a turn context is active (``reset_skill_load_cache``
+    was called in the current context), a repeated view of the same
+    ``(name, file_path)`` within the turn short-circuits with
+    ``already_loaded: true`` instead of re-reading and re-processing the
+    file. Only *successful* loads are marked — a failed call leaves the key
+    unmarked so the next identical call retries the real path and surfaces
+    the real result.
     """
+    loaded_keys = None if _skip_dedup else _turn_loaded_skill_keys.get()
+    dedup_key = (name, file_path)
+
+    if loaded_keys is not None and dedup_key in loaded_keys:
+        already = {
+            "success": True,
+            "name": name,
+            "content": None,
+            "already_loaded": True,
+            "note": "This skill was already loaded during the current turn.",
+        }
+        if file_path:
+            already["file"] = file_path
+        return json.dumps(already, ensure_ascii=False)
+
+    result = _skill_view_impl(
+        name, file_path=file_path, task_id=task_id, preprocess=preprocess
+    )
+
+    if loaded_keys is not None:
+        # Mark AFTER the load completes, and only when it actually succeeded.
+        # Resolution, security checks, readiness probing, linked-file
+        # validation, and the reads themselves all happen inside the impl and
+        # any of them can fail; marking up front would turn the next
+        # identical call into a synthetic success with null content.
+        try:
+            if json.loads(result).get("success") is True:
+                loaded_keys.add(dedup_key)
+        except Exception:
+            logger.debug("skill_view dedup marking skipped", exc_info=True)
+
+    return result
+
+
+def _skill_view_impl(
+    name: str,
+    file_path: str = None,
+    task_id: str = None,
+    preprocess: bool = True,
+) -> str:
+    """Uncached ``skill_view`` body — see the public wrapper for the contract."""
     try:
         # Validate before the ':' qualified-name dispatch so a Windows drive
         # path (e.g. C:\skills\foo) can't be reinterpreted as a plugin
@@ -1006,25 +1091,6 @@ def skill_view(
                 },
                 ensure_ascii=False,
             )
-
-        # Per-turn dedup: if this exact (name, file_path) was already loaded
-        # during the current turn, skip re-reading and re-processing the file.
-        # Internal loaders (e.g. _load_skill_payload) pass _skip_dedup=True
-        # because they need the full payload every time.
-        _dedup_key = (name, file_path)
-        if not _skip_dedup:
-            if _dedup_key in _loaded_skill_keys:
-                return json.dumps(
-                    {
-                        "success": True,
-                        "name": name,
-                        "content": None,
-                        "already_loaded": True,
-                        "note": "This skill was already loaded during the current turn.",
-                    },
-                    ensure_ascii=False,
-                )
-            _loaded_skill_keys.add(_dedup_key)
 
         local_category_name: str | None = None
         # ── Qualified name dispatch (plugin skills) ──────────────────


### PR DESCRIPTION
## Problem

When the agent calls `skill_view` multiple times for the same skill within a single turn (common in complex multi-step tasks), the skill content is loaded and preprocessed from disk each time. This wastes I/O and produces duplicate verbose output.

## Solution

Add per-turn deduplication for `skill_view`:

- Track loaded skill keys in `_loaded_skill_keys` set
- Skip re-loading when the same (name, file_path) combination is requested again within the same turn
- Provide `reset_skill_load_cache()` to clear the cache at turn boundaries
- The cache is reset at each turn start via the agent loop

This is a lightweight optimization that avoids redundant disk reads and keeps tool output concise when the agent re-inspects skill content it has already loaded this turn.
