### PR TITLE
feat(memory): add on_skill_write hook to MemoryProvider ABC and bridge

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -71,6 +71,40 @@ def agent_runtime_owns_post_tool_hook(agent: Any, function_name: str) -> bool:
     return bool(memory_manager and memory_manager.has_tool(function_name))
 
 
+def mirror_skill_write_to_memory_providers(
+    agent: Any,
+    function_name: str,
+    tool_result: Any,
+    tool_args: Dict[str, Any],
+    *,
+    task_id: str = "",
+    tool_call_id: Optional[str] = None,
+) -> None:
+    """Mirror a committed built-in skill_manage write to external providers.
+
+    Shared by both executor paths (the sequential inline dispatcher in
+    agent/tool_executor.py and the concurrent ``invoke_tool`` below) so skill
+    writes are observed consistently regardless of which executor ran the
+    tool. No-op for every other tool. All gating (committed-only, mutating
+    actions, action→payload mapping) lives behind the manager interface
+    (``MemoryManager.notify_skill_tool_write``).
+    """
+    if function_name != "skill_manage":
+        return
+    memory_manager = getattr(agent, "_memory_manager", None)
+    if not memory_manager:
+        return
+    memory_manager.notify_skill_tool_write(
+        tool_result,
+        tool_args,
+        build_metadata=lambda: agent._build_memory_write_metadata(
+            task_id=task_id,
+            tool_call_id=tool_call_id,
+            tool_name="skill_manage",
+        ),
+    )
+
+
 def convert_to_trajectory_format(agent, messages: List[Dict[str, Any]], user_query: str, completed: bool) -> List[Dict[str, Any]]:
     """
     Convert internal message format to trajectory format for saving.
@@ -2402,7 +2436,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             return _finish_agent_tool(agent._dispatch_delegate_task(next_args), next_args)
     else:
         def _execute(next_args: dict) -> Any:
-            return _ra().handle_function_call(
+            result = _ra().handle_function_call(
                 function_name, next_args, effective_task_id,
                 tool_call_id=tool_call_id,
                 session_id=agent.session_id or "",
@@ -2415,6 +2449,15 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),
                 tool_request_middleware_trace=list(_tool_middleware_trace),
             )
+            # Mirror successful built-in skill_manage writes to external
+            # providers — parity with the sequential executor path and with
+            # the memory-tool branch above.
+            mirror_skill_write_to_memory_providers(
+                agent, function_name, result, next_args,
+                task_id=effective_task_id,
+                tool_call_id=tool_call_id,
+            )
+            return result
 
     from hermes_cli.middleware import run_tool_execution_middleware
 

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -594,8 +594,14 @@ def build_memory_write_metadata(
     execution_context: Optional[str] = None,
     task_id: Optional[str] = None,
     tool_call_id: Optional[str] = None,
+    tool_name: str = "memory",
 ) -> Dict[str, Any]:
-    """Build provenance metadata for external memory-provider mirrors."""
+    """Build provenance metadata for external memory-provider mirrors.
+
+    ``tool_name`` identifies the built-in tool that produced the write —
+    ``memory`` for MEMORY.md/USER.md writes, ``skill_manage`` for skill
+    writes mirrored via ``on_skill_write``.
+    """
     metadata: Dict[str, Any] = {
         "write_origin": write_origin or getattr(agent, "_memory_write_origin", "assistant_tool"),
         "execution_context": (
@@ -605,7 +611,7 @@ def build_memory_write_metadata(
         "session_id": agent.session_id or "",
         "parent_session_id": agent._parent_session_id or "",
         "platform": agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
-        "tool_name": "memory",
+        "tool_name": tool_name,
     }
     if task_id:
         metadata["task_id"] = task_id

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -955,11 +955,41 @@ class MemoryManager:
                     provider.name, e,
                 )
 
+    def on_skill_write(
+        self,
+        action: str,
+        name: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Notify external providers when the built-in skill_manage tool writes.
+
+        Skips the builtin provider itself (it's the source of the write).
+        """
+        for provider in self._providers:
+            if provider.name == "builtin":
+                continue
+            try:
+                provider.on_skill_write(action, name, content, metadata=dict(metadata or {}))
+            except Exception as e:
+                logger.debug(
+                    "Memory provider '%s' on_skill_write failed: %s",
+                    provider.name, e,
+                )
+
     # Actions the bridge mirrors to external providers. The built-in memory
     # tool can also return non-mutating shapes (errors, staged-for-approval
     # records); those are filtered out by ``notify_memory_tool_write`` before
     # we ever reach a provider.
     _MIRRORED_MEMORY_ACTIONS = {"add", "replace", "remove"}
+
+    # Mutating skill_manage actions that external providers may care about.
+    # Read-only actions (read, list, search, etc.) are excluded — providers
+    # only need to know about writes they should mirror.
+    _MIRRORED_SKILL_ACTIONS = {
+        "create", "edit", "patch", "delete",
+        "write_file", "remove_file",
+    }
 
     @staticmethod
     def _memory_tool_result_succeeded(result: Any) -> bool:
@@ -1035,6 +1065,42 @@ class MemoryManager:
                 )
             except Exception as e:
                 logger.debug("notify_memory_tool_write failed for op %s: %s", action, e)
+
+    def notify_skill_tool_write(
+        self,
+        tool_result: Any,
+        tool_args: Dict[str, Any],
+        *,
+        build_metadata: Optional[Callable[[], Dict[str, Any]]] = None,
+    ) -> None:
+        """Mirror a built-in skill_manage tool call to external providers.
+
+        This is the single entry point the agent loop calls after running the
+        built-in ``skill_manage`` tool. All the decisions about *whether* and
+        *what* to mirror live here, behind the manager interface — the loop
+        only hands over the raw tool result and args:
+
+        * gate on a committed (non-staged, successful) write,
+        * keep only mutating actions (create/edit/patch/delete/write_file/remove_file),
+        * build provenance metadata.
+
+        ``build_metadata`` is an optional agent-side callable (the loop knows
+        session/task/tool-call provenance the manager does not).
+        """
+        if not self._memory_tool_result_succeeded(tool_result):
+            return
+
+        action = str(tool_args.get("action") or "")
+        if action not in self._MIRRORED_SKILL_ACTIONS:
+            return
+
+        name = str(tool_args.get("name") or "")
+        content = str(tool_args.get("content") or "")
+        try:
+            metadata = dict(build_metadata() if build_metadata else {})
+            self.on_skill_write(action, name, content, metadata=metadata)
+        except Exception as e:
+            logger.debug("notify_skill_tool_write failed for action %s: %s", action, e)
 
     def on_delegation(self, task: str, result: str, *,
                       child_session_id: str = "", **kwargs) -> None:

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -1082,10 +1082,19 @@ class MemoryManager:
 
         * gate on a committed (non-staged, successful) write,
         * keep only mutating actions (create/edit/patch/delete/write_file/remove_file),
+        * map the action to its content field (create/edit → ``content``,
+          patch → ``new_string``, write_file → ``file_content``),
+        * preserve supporting-file identity (``file_path``) and the replaced
+          patch text (``old_string``) as metadata,
         * build provenance metadata.
 
         ``build_metadata`` is an optional agent-side callable (the loop knows
         session/task/tool-call provenance the manager does not).
+
+        Staged writes (``staged: true`` results) are skipped here; when the
+        user approves one, the approval-replay path
+        (``hermes_cli.write_approval_commands._apply_one``) calls this method
+        again with the replay result, so approved writes are still mirrored.
         """
         if not self._memory_tool_result_succeeded(tool_result):
             return
@@ -1095,9 +1104,33 @@ class MemoryManager:
             return
 
         name = str(tool_args.get("name") or "")
-        content = str(tool_args.get("content") or "")
+        # skill_manage carries its write payload in action-specific fields:
+        # create/edit send the full SKILL.md as ``content``, patch sends the
+        # replacement text as ``new_string``, write_file sends the supporting
+        # file body as ``file_content``. delete/remove_file carry no content.
+        if action in {"create", "edit"}:
+            content = str(tool_args.get("content") or "")
+        elif action == "patch":
+            content = str(tool_args.get("new_string") or "")
+        elif action == "write_file":
+            content = str(tool_args.get("file_content") or "")
+        else:  # delete / remove_file
+            content = ""
         try:
             metadata = dict(build_metadata() if build_metadata else {})
+            # Preserve supporting-file identity: patch (with a file target),
+            # write_file, and remove_file mutate a file inside the skill dir —
+            # without this the provider only sees the skill name.
+            file_path = tool_args.get("file_path")
+            if file_path:
+                metadata["file_path"] = str(file_path)
+            # Parity with on_memory_write's ``old_text``: forward the replaced
+            # text for patch so providers can mirror the edit, not just the
+            # replacement.
+            if action == "patch":
+                old_string = tool_args.get("old_string")
+                if old_string:
+                    metadata["old_string"] = str(old_string)
             self.on_skill_write(action, name, content, metadata=metadata)
         except Exception as e:
             logger.debug("notify_skill_tool_write failed for action %s: %s", action, e)

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -307,11 +307,23 @@ class MemoryProvider(ABC):
         """Called when the built-in skill_manage tool writes a skill/file.
 
         action: 'create', 'edit', 'patch', 'delete', 'write_file', 'remove_file'
-        name: skill name (e.g. 'my-skill') or relative file path
-        content: the file/skill content written
+        name: the skill name (e.g. 'my-skill')
+        content: the written payload, mapped per action —
+          create/edit: the full SKILL.md text
+          patch: the replacement text (``new_string``)
+          write_file: the supporting file body (``file_content``)
+          delete/remove_file: empty string
         metadata: structured provenance for the write. Common keys include
           ``write_origin``, ``execution_context``, ``session_id``,
           ``parent_session_id``, ``platform``, and ``tool_name``.
+          Supporting-file mutations (write_file, remove_file, and patch with
+          a file target) also carry ``file_path`` (path relative to the skill
+          directory, e.g. 'references/api.md'); patch also carries
+          ``old_string`` (the replaced text).
+
+        Only committed writes are mirrored: failed writes and writes staged
+        for approval never reach this hook; approved staged writes fire it
+        from the approval-replay path instead.
 
         Use to mirror built-in skill writes to your backend.
         """

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -27,6 +27,7 @@ Optional hooks (override to opt in):
   on_session_switch(new_session_id, **kwargs) — mid-process session_id rotation
   on_pre_compress(messages) -> str       — extract before context compression
   on_memory_write(action, target, content, metadata=None) — mirror built-in memory writes
+  on_skill_write(action, name, content, metadata=None) — mirror built-in skill_manage writes
   on_delegation(task, result, **kwargs)  — parent-side observation of subagent work
   backup_paths() -> list[str]            — extra on-disk paths to include in `hermes backup`
 """
@@ -294,6 +295,25 @@ class MemoryProvider(ABC):
           ``parent_session_id``, ``platform``, and ``tool_name``.
 
         Use to mirror built-in memory writes to your backend.
+        """
+
+    def on_skill_write(
+        self,
+        action: str,
+        name: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Called when the built-in skill_manage tool writes a skill/file.
+
+        action: 'create', 'edit', 'patch', 'delete', 'write_file', 'remove_file'
+        name: skill name (e.g. 'my-skill') or relative file path
+        content: the file/skill content written
+        metadata: structured provenance for the write. Common keys include
+          ``write_origin``, ``execution_context``, ``session_id``,
+          ``parent_session_id``, ``platform``, and ``tool_name``.
+
+        Use to mirror built-in skill writes to your backend.
         """
 
     def backup_paths(self) -> List[str]:

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1557,6 +1557,18 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_result = f"Error executing tool '{function_name}': {tool_error}"
                 logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
             tool_duration = time.time() - tool_start_time
+            # Mirror successful built-in skill_manage writes to external
+            # providers. All gating lives behind the manager interface
+            # (MemoryManager.notify_skill_tool_write).
+            if function_name == "skill_manage" and agent._memory_manager:
+                agent._memory_manager.notify_skill_tool_write(
+                    function_result,
+                    function_args,
+                    build_metadata=lambda: agent._build_memory_write_metadata(
+                        task_id=effective_task_id,
+                        tool_call_id=getattr(tool_call, "id", None),
+                    ),
+                )
 
         if isinstance(function_result, str):
             result_preview = function_result if agent.verbose_logging else (

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1560,15 +1560,12 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             # Mirror successful built-in skill_manage writes to external
             # providers. All gating lives behind the manager interface
             # (MemoryManager.notify_skill_tool_write).
-            if function_name == "skill_manage" and agent._memory_manager:
-                agent._memory_manager.notify_skill_tool_write(
-                    function_result,
-                    function_args,
-                    build_metadata=lambda: agent._build_memory_write_metadata(
-                        task_id=effective_task_id,
-                        tool_call_id=getattr(tool_call, "id", None),
-                    ),
-                )
+            from agent.agent_runtime_helpers import mirror_skill_write_to_memory_providers
+            mirror_skill_write_to_memory_providers(
+                agent, function_name, function_result, function_args,
+                task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", None),
+            )
 
         if isinstance(function_result, str):
             result_preview = function_result if agent.verbose_logging else (

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2913,8 +2913,23 @@ class GatewaySlashCommandsMixin:
             # New setting must take effect next message → drop cached agent.
             self._evict_cached_agent(session_key)
 
+        # Thread the cached agent's memory manager (when this session has a
+        # live agent) so approved skill writes are mirrored to external memory
+        # providers — the staged write bypassed the agent-loop bridge, and the
+        # approval replay is where the write actually commits. Best-effort: a
+        # session without a cached agent simply skips the mirror.
+        _memory_manager = None
+        _cache_lock = getattr(self, "_agent_cache_lock", None)
+        if _cache_lock is not None:
+            with _cache_lock:
+                _cached = self._agent_cache.get(session_key)
+            _cached_agent = _cached[0] if isinstance(_cached, tuple) else _cached
+            _memory_manager = getattr(_cached_agent, "_memory_manager", None)
+
         out = handle_pending_subcommand(
-            wa.SKILLS, args, set_mode_fn=_set_approval,
+            wa.SKILLS, args,
+            memory_manager=_memory_manager,
+            set_mode_fn=_set_approval,
         )
         if out is None:
             return ("Unknown /skills subcommand on this platform. Use: pending, "

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1525,8 +1525,14 @@ class CLICommandsMixin:
                                         "deny", "drop", "diff", "approval", "mode"}:
             from hermes_cli.write_approval_commands import handle_pending_subcommand
             from tools import write_approval as wa
+            # Thread the live agent's memory manager so approved skill writes
+            # are mirrored to external memory providers (the staged write
+            # bypassed the agent-loop bridge; approval replay is where the
+            # write actually commits).
+            _agent = getattr(self, "agent", None)
             out = handle_pending_subcommand(
                 wa.SKILLS, args,
+                memory_manager=getattr(_agent, "_memory_manager", None),
                 set_mode_fn=lambda enabled: self._save_write_approval("skills", enabled),
             )
             if out is not None:

--- a/hermes_cli/write_approval_commands.py
+++ b/hermes_cli/write_approval_commands.py
@@ -16,9 +16,12 @@ platform the gateway truncates it and points the user at the dashboard / file.
 from __future__ import annotations
 
 import json
+import logging
 from typing import List, Optional
 
 from tools import write_approval as wa
+
+logger = logging.getLogger(__name__)
 
 
 def _fmt_state(subsystem: str) -> str:
@@ -56,6 +59,7 @@ def handle_pending_subcommand(
     args: List[str],
     *,
     memory_store=None,
+    memory_manager=None,
     set_mode_fn=None,
 ) -> Optional[str]:
     """Dispatch a /memory or /skills subcommand.
@@ -66,6 +70,11 @@ def handle_pending_subcommand(
         memory_store: live MemoryStore for applying approved memory writes
             (CLI passes ``self.agent._memory_store``; gateway applies against a
             freshly loaded store).
+        memory_manager: optional live MemoryManager. When provided, approved
+            skill writes are mirrored to external memory providers via
+            ``notify_skill_tool_write`` — the staged write bypassed the
+            agent-loop bridge, so the approval replay is the only point where
+            the committed write can be observed.
         set_mode_fn: optional callable ``(enabled: bool) -> None`` that
             persists the new write_approval boolean to config (gateway provides
             this; CLI uses its own ``save_config_value`` and passes a closure).
@@ -85,7 +94,7 @@ def handle_pending_subcommand(
         return _fmt_pending_list(subsystem)
 
     if sub in {"approve", "apply"}:
-        return _approve(subsystem, rest, memory_store)
+        return _approve(subsystem, rest, memory_store, memory_manager)
 
     if sub in {"reject", "deny", "drop"}:
         return _reject(subsystem, rest)
@@ -105,7 +114,7 @@ def _resolve_one(subsystem: str, rest: List[str]):
     return rest[0], None
 
 
-def _approve(subsystem: str, rest: List[str], memory_store) -> str:
+def _approve(subsystem: str, rest: List[str], memory_store, memory_manager=None) -> str:
     target, err = _resolve_one(subsystem, rest)
     if err or target is None:
         return err or f"Usage: /{subsystem} approve <id>"
@@ -124,7 +133,7 @@ def _approve(subsystem: str, rest: List[str], memory_store) -> str:
 
     applied, failed = 0, []
     for rec in targets:
-        ok, msg = _apply_one(subsystem, rec, memory_store)
+        ok, msg = _apply_one(subsystem, rec, memory_store, memory_manager)
         if ok:
             wa.discard_pending(subsystem, rec["id"])
             applied += 1
@@ -138,7 +147,7 @@ def _approve(subsystem: str, rest: List[str], memory_store) -> str:
     return "\n".join(out)
 
 
-def _apply_one(subsystem: str, rec, memory_store):
+def _apply_one(subsystem: str, rec, memory_store, memory_manager=None):
     payload = rec.get("payload", {})
     try:
         if subsystem == wa.MEMORY:
@@ -149,10 +158,40 @@ def _apply_one(subsystem: str, rec, memory_store):
             return bool(result.get("success")), result.get("error", "")
         else:
             from tools.skill_manager_tool import apply_skill_pending
-            result = json.loads(apply_skill_pending(payload))
-            return bool(result.get("success")), result.get("error", "")
+            raw_result = apply_skill_pending(payload)
+            result = json.loads(raw_result)
+            ok = bool(result.get("success"))
+            if ok and memory_manager is not None:
+                # The staged write was (correctly) skipped by the agent-loop
+                # bridge; the approval replay is where it actually commits, so
+                # mirror it to external providers here. Best-effort: a provider
+                # failure must never fail the approval itself.
+                _notify_skill_replay(memory_manager, raw_result, payload, rec)
+            return ok, result.get("error", "")
     except Exception as e:
         return False, str(e)
+
+
+def _notify_skill_replay(memory_manager, raw_result: str, payload, rec) -> None:
+    """Mirror an approved skill write to external memory providers.
+
+    The payload is the staged ``skill_manage`` kwargs recorded by the write
+    gate, so ``notify_skill_tool_write`` sees the exact argument shape a live
+    tool call would produce. Provenance marks the write as an approval replay
+    while preserving the origin that staged it.
+    """
+    try:
+        memory_manager.notify_skill_tool_write(
+            raw_result,
+            payload,
+            build_metadata=lambda: {
+                "write_origin": rec.get("origin") or "foreground",
+                "execution_context": "approval_replay",
+                "tool_name": "skill_manage",
+            },
+        )
+    except Exception:
+        logger.debug("skill approval-replay provider notify failed", exc_info=True)
 
 
 def _reject(subsystem: str, rest: List[str]) -> str:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1670,6 +1670,7 @@ class AIAgent:
         execution_context: Optional[str] = None,
         task_id: Optional[str] = None,
         tool_call_id: Optional[str] = None,
+        tool_name: str = "memory",
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.background_review.build_memory_write_metadata``."""
         from agent.background_review import build_memory_write_metadata
@@ -1679,6 +1680,7 @@ class AIAgent:
             execution_context=execution_context,
             task_id=task_id,
             tool_call_id=tool_call_id,
+            tool_name=tool_name,
         )
 
     def _apply_persist_user_message_override(self, messages: List[Dict]) -> None:

--- a/tests/agent/test_skill_write_bridge.py
+++ b/tests/agent/test_skill_write_bridge.py
@@ -1,0 +1,243 @@
+"""Behavior tests for the built-in skill_manage → external provider bridge.
+
+The bridge lives behind the MemoryManager interface
+(``MemoryManager.notify_skill_tool_write``): the agent loop (and the
+approval-replay path) hands over the raw skill_manage tool result + args, and
+the manager decides whether/what to mirror to external providers. These tests
+drive that method with a fake external provider and assert which
+``on_skill_write`` calls land — in particular the action-aware content mapping
+(create/edit → ``content``, patch → ``new_string``, write_file →
+``file_content``) and the supporting-file ``file_path`` metadata.
+"""
+
+import json
+
+import pytest
+
+from agent.memory_manager import MemoryManager
+from agent.memory_provider import MemoryProvider
+
+
+class _RecordingProvider(MemoryProvider):
+    """Minimal external provider that records on_skill_write calls."""
+
+    def __init__(self) -> None:
+        self.calls = []
+
+    @property
+    def name(self) -> str:
+        return "recording"
+
+    def is_available(self) -> bool:
+        return True
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        pass
+
+    def get_tool_schemas(self):
+        return []
+
+    def shutdown(self) -> None:
+        pass
+
+    def on_skill_write(self, action, name, content, metadata=None):
+        self.calls.append({
+            "action": action,
+            "name": name,
+            "content": content,
+            "metadata": dict(metadata or {}),
+        })
+
+
+def _manager_with_provider():
+    mgr = MemoryManager()
+    provider = _RecordingProvider()
+    mgr.add_provider(provider)
+    return mgr, provider
+
+
+_SKILL_MD = "---\nname: my-skill\ndescription: d\n---\n\nBody.\n"
+
+
+# ---------------------------------------------------------------------------
+# Action-aware content mapping
+# ---------------------------------------------------------------------------
+
+def test_create_mirrors_full_skill_content():
+    mgr, provider = _manager_with_provider()
+    mgr.notify_skill_tool_write(
+        json.dumps({"success": True}),
+        {"action": "create", "name": "my-skill", "content": _SKILL_MD},
+    )
+    assert provider.calls == [
+        {"action": "create", "name": "my-skill", "content": _SKILL_MD,
+         "metadata": {}},
+    ]
+
+
+def test_edit_mirrors_full_skill_content():
+    mgr, provider = _manager_with_provider()
+    mgr.notify_skill_tool_write(
+        json.dumps({"success": True}),
+        {"action": "edit", "name": "my-skill", "content": _SKILL_MD},
+    )
+    assert provider.calls == [
+        {"action": "edit", "name": "my-skill", "content": _SKILL_MD,
+         "metadata": {}},
+    ]
+
+
+def test_patch_mirrors_new_string_and_old_string_metadata():
+    # patch sends its payload as new_string, NOT content — the bridge must
+    # not forward an empty payload.
+    mgr, provider = _manager_with_provider()
+    mgr.notify_skill_tool_write(
+        json.dumps({"success": True}),
+        {"action": "patch", "name": "my-skill",
+         "old_string": "old text", "new_string": "new text"},
+    )
+    assert provider.calls == [
+        {"action": "patch", "name": "my-skill", "content": "new text",
+         "metadata": {"old_string": "old text"}},
+    ]
+
+
+def test_patch_of_supporting_file_preserves_file_path():
+    mgr, provider = _manager_with_provider()
+    mgr.notify_skill_tool_write(
+        json.dumps({"success": True}),
+        {"action": "patch", "name": "my-skill", "file_path": "references/api.md",
+         "old_string": "v1", "new_string": "v2"},
+    )
+    assert provider.calls == [
+        {"action": "patch", "name": "my-skill", "content": "v2",
+         "metadata": {"file_path": "references/api.md", "old_string": "v1"}},
+    ]
+
+
+def test_write_file_mirrors_file_content_and_file_path():
+    # write_file sends its payload as file_content, NOT content.
+    mgr, provider = _manager_with_provider()
+    mgr.notify_skill_tool_write(
+        json.dumps({"success": True}),
+        {"action": "write_file", "name": "my-skill",
+         "file_path": "references/guide.md", "file_content": "# Guide\n"},
+    )
+    assert provider.calls == [
+        {"action": "write_file", "name": "my-skill", "content": "# Guide\n",
+         "metadata": {"file_path": "references/guide.md"}},
+    ]
+
+
+def test_remove_file_has_empty_content_but_keeps_file_path():
+    mgr, provider = _manager_with_provider()
+    mgr.notify_skill_tool_write(
+        json.dumps({"success": True}),
+        {"action": "remove_file", "name": "my-skill",
+         "file_path": "references/stale.md"},
+    )
+    assert provider.calls == [
+        {"action": "remove_file", "name": "my-skill", "content": "",
+         "metadata": {"file_path": "references/stale.md"}},
+    ]
+
+
+def test_delete_has_empty_content():
+    mgr, provider = _manager_with_provider()
+    mgr.notify_skill_tool_write(
+        json.dumps({"success": True}),
+        {"action": "delete", "name": "my-skill"},
+    )
+    assert provider.calls == [
+        {"action": "delete", "name": "my-skill", "content": "", "metadata": {}},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Committed-write gating
+# ---------------------------------------------------------------------------
+
+def test_skips_failed_skill_write():
+    mgr, provider = _manager_with_provider()
+    mgr.notify_skill_tool_write(
+        json.dumps({"success": False, "error": "Skill not found"}),
+        {"action": "edit", "name": "my-skill", "content": _SKILL_MD},
+    )
+    assert provider.calls == []
+
+
+def test_skips_staged_skill_write():
+    # A write staged for approval has not committed — providers must not be
+    # told about it. (The approval-replay path re-notifies once it commits.)
+    mgr, provider = _manager_with_provider()
+    mgr.notify_skill_tool_write(
+        json.dumps({"success": True, "staged": True, "pending_id": "abc123"}),
+        {"action": "create", "name": "my-skill", "content": _SKILL_MD},
+    )
+    assert provider.calls == []
+
+
+@pytest.mark.parametrize("tool_result", [None, [], object(), "not-json"])
+def test_skips_unrecognized_tool_result_shape(tool_result):
+    mgr, provider = _manager_with_provider()
+    mgr.notify_skill_tool_write(
+        tool_result,
+        {"action": "create", "name": "my-skill", "content": _SKILL_MD},
+    )
+    assert provider.calls == []
+
+
+def test_non_mutating_actions_are_not_mirrored():
+    mgr, provider = _manager_with_provider()
+    for action in ("read", "list", "search", ""):
+        mgr.notify_skill_tool_write(
+            json.dumps({"success": True}),
+            {"action": action, "name": "my-skill"},
+        )
+    assert provider.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Metadata plumbing
+# ---------------------------------------------------------------------------
+
+def test_build_metadata_callback_is_merged_with_bridge_metadata():
+    mgr, provider = _manager_with_provider()
+    mgr.notify_skill_tool_write(
+        json.dumps({"success": True}),
+        {"action": "write_file", "name": "my-skill",
+         "file_path": "scripts/run.py", "file_content": "print('hi')\n"},
+        build_metadata=lambda: {"session_id": "s1", "tool_name": "skill_manage"},
+    )
+    assert provider.calls == [
+        {
+            "action": "write_file",
+            "name": "my-skill",
+            "content": "print('hi')\n",
+            "metadata": {
+                "session_id": "s1",
+                "tool_name": "skill_manage",
+                "file_path": "scripts/run.py",
+            },
+        }
+    ]
+
+
+def test_provider_exception_does_not_raise():
+    mgr, _ = _manager_with_provider()
+
+    class _Exploding(_RecordingProvider):
+        @property
+        def name(self):
+            return "exploding"
+
+        def on_skill_write(self, action, name, content, metadata=None):
+            raise RuntimeError("backend down")
+
+    mgr2 = MemoryManager()
+    mgr2.add_provider(_Exploding())
+    # Must not raise — provider failures never break the tool loop.
+    mgr2.notify_skill_tool_write(
+        json.dumps({"success": True}),
+        {"action": "create", "name": "my-skill", "content": _SKILL_MD},
+    )

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -490,3 +490,177 @@ class TestSkillGist:
         assert wa.skill_gist("remove_file", "demo", file_path="a.py") == "remove a.py from 'demo'"
         assert wa.skill_gist("delete", "demo") == "delete skill 'demo'"
         assert wa.skill_gist("unknown", "demo") == "unknown 'demo'"
+
+
+# ---------------------------------------------------------------------------
+# Approval replay → external memory-provider mirror
+# ---------------------------------------------------------------------------
+
+def _recording_manager():
+    """Real MemoryManager wired to a minimal recording external provider."""
+    from agent.memory_manager import MemoryManager
+    from agent.memory_provider import MemoryProvider
+
+    class _Recording(MemoryProvider):
+        def __init__(self):
+            self.calls = []
+
+        @property
+        def name(self):
+            return "recording"
+
+        def is_available(self):
+            return True
+
+        def initialize(self, session_id, **kwargs):
+            pass
+
+        def get_tool_schemas(self):
+            return []
+
+        def on_skill_write(self, action, name, content, metadata=None):
+            self.calls.append({
+                "action": action, "name": name, "content": content,
+                "metadata": dict(metadata or {}),
+            })
+
+    mgr = MemoryManager()
+    provider = _Recording()
+    mgr.add_provider(provider)
+    return mgr, provider
+
+
+def test_skill_approve_mirrors_to_external_provider(hermes_home):
+    # A staged skill write bypasses the agent-loop bridge (correctly — it has
+    # not committed). Approving it replays via apply_skill_pending, and THAT
+    # is where external providers must be notified.
+    import importlib
+    import tools.skill_manager_tool as smt
+    importlib.reload(smt)
+    from tools import write_approval as wa
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+
+    mgr, provider = _recording_manager()
+    _set_approval("skills", True)
+    r = json.loads(smt.skill_manage("create", "mirrored-skill", content=_SKILL))
+    assert r.get("staged") is True
+    assert provider.calls == []  # staged ≠ committed: nothing mirrored yet
+
+    out = handle_pending_subcommand(
+        wa.SKILLS, ["approve", r["pending_id"]], memory_manager=mgr,
+    )
+    assert "Approved 1" in out
+    assert smt._find_skill("mirrored-skill") is not None
+    assert len(provider.calls) == 1
+    call = provider.calls[0]
+    assert call["action"] == "create"
+    assert call["name"] == "mirrored-skill"
+    assert call["content"] == _SKILL
+    assert call["metadata"]["execution_context"] == "approval_replay"
+    assert call["metadata"]["tool_name"] == "skill_manage"
+    assert call["metadata"]["write_origin"] == "foreground"
+
+
+def test_skill_approve_replay_maps_patch_arguments(hermes_home):
+    # The staged payload preserves skill_manage's argument shape (patch uses
+    # new_string, not content) — the replay notification must map it the same
+    # way the live bridge does.
+    import importlib
+    import tools.skill_manager_tool as smt
+    importlib.reload(smt)
+    from tools import write_approval as wa
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+
+    # Create the skill with the gate off, then stage a patch with it on.
+    r = json.loads(smt.skill_manage("create", "patched-skill", content=_SKILL))
+    assert r["success"] is True
+    _set_approval("skills", True)
+    r = json.loads(smt.skill_manage(
+        "patch", "patched-skill", old_string="body", new_string="patched body"))
+    assert r.get("staged") is True
+
+    mgr, provider = _recording_manager()
+    out = handle_pending_subcommand(
+        wa.SKILLS, ["approve", r["pending_id"]], memory_manager=mgr,
+    )
+    assert "Approved 1" in out
+    assert len(provider.calls) == 1
+    call = provider.calls[0]
+    assert call["action"] == "patch"
+    assert call["content"] == "patched body"
+    assert call["metadata"]["old_string"] == "body"
+
+
+def test_skill_approve_failed_replay_does_not_notify(hermes_home):
+    # A replay that fails (skill vanished between staging and approval) must
+    # not notify providers — nothing was committed.
+    from tools import write_approval as wa
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+
+    rec = wa.stage_write(
+        "skills",
+        {"action": "edit", "name": "ghost-skill-does-not-exist", "content": _SKILL},
+        summary="edit ghost", origin="foreground",
+    )
+    mgr, provider = _recording_manager()
+    out = handle_pending_subcommand(
+        wa.SKILLS, ["approve", rec["id"]], memory_manager=mgr,
+    )
+    assert "Failed" in out
+    assert provider.calls == []
+
+
+def test_skill_approve_without_manager_still_applies(hermes_home):
+    # No live memory manager (e.g. gateway session with no cached agent) —
+    # the approval itself must still work exactly as before.
+    import importlib
+    import tools.skill_manager_tool as smt
+    importlib.reload(smt)
+    from tools import write_approval as wa
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+
+    _set_approval("skills", True)
+    r = json.loads(smt.skill_manage("create", "unmirrored-skill", content=_SKILL))
+    out = handle_pending_subcommand(wa.SKILLS, ["approve", r["pending_id"]])
+    assert "Approved 1" in out
+    assert smt._find_skill("unmirrored-skill") is not None
+
+
+def test_skill_approve_provider_failure_does_not_fail_approval(hermes_home):
+    # Mirroring is best-effort: an exploding provider must never break the
+    # user's approval.
+    import importlib
+    import tools.skill_manager_tool as smt
+    importlib.reload(smt)
+    from tools import write_approval as wa
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from agent.memory_manager import MemoryManager
+    from agent.memory_provider import MemoryProvider
+
+    class _Exploding(MemoryProvider):
+        @property
+        def name(self):
+            return "exploding"
+
+        def is_available(self):
+            return True
+
+        def initialize(self, session_id, **kwargs):
+            pass
+
+        def get_tool_schemas(self):
+            return []
+
+        def on_skill_write(self, action, name, content, metadata=None):
+            raise RuntimeError("backend down")
+
+    mgr = MemoryManager()
+    mgr.add_provider(_Exploding())
+
+    _set_approval("skills", True)
+    r = json.loads(smt.skill_manage("create", "resilient-skill", content=_SKILL))
+    out = handle_pending_subcommand(
+        wa.SKILLS, ["approve", r["pending_id"]], memory_manager=mgr,
+    )
+    assert "Approved 1" in out
+    assert smt._find_skill("resilient-skill") is not None

--- a/website/docs/developer-guide/memory-provider-plugin.md
+++ b/website/docs/developer-guide/memory-provider-plugin.md
@@ -81,7 +81,32 @@ class MyMemoryProvider(MemoryProvider):
 | `on_session_end(messages)` | Conversation ends | Final extraction/flush |
 | `on_pre_compress(messages)` | Before context compression | Save insights before discard |
 | `on_memory_write(action, target, content)` | Built-in memory writes | Mirror to your backend |
+| `on_skill_write(action, name, content)` | Built-in skill_manage writes | Mirror to your backend |
 | `shutdown()` | Process exit | Clean up connections |
+
+#### Mirroring skill writes: `on_skill_write`
+
+`on_skill_write(action, name, content, metadata=None)` fires when the built-in
+`skill_manage` tool commits a write. `action` is one of `create`, `edit`,
+`patch`, `delete`, `write_file`, `remove_file`; `name` is the skill name.
+
+`content` is mapped from the action's own payload field:
+
+| Action | `content` carries | Extra `metadata` keys |
+|--------|-------------------|-----------------------|
+| `create`, `edit` | full SKILL.md text (`content`) | — |
+| `patch` | replacement text (`new_string`) | `old_string`; `file_path` when patching a supporting file |
+| `write_file` | supporting file body (`file_content`) | `file_path` (relative, e.g. `references/api.md`) |
+| `delete`, `remove_file` | empty string | `file_path` for `remove_file` |
+
+`metadata` also carries write provenance: `write_origin`, `execution_context`,
+`session_id`, `parent_session_id`, `platform`, and `tool_name`
+(`"skill_manage"`).
+
+Only **committed** writes are mirrored. Failed writes and writes staged by the
+`skills.write_approval` gate never reach the hook; when the user later approves
+a staged write, the hook fires from the approval-replay path with
+`execution_context: "approval_replay"`.
 
 ## Config Schema
 


### PR DESCRIPTION
## Problem

External memory providers (Honcho, Hindsight, Mem0, OpenViking, etc.) can mirror built-in `memory` tool writes via the `on_memory_write` hook, but there is no equivalent hook for `skill_manage` writes. Providers miss skill creation, editing, and file writes -- a blind spot in the agent observable behavior.

## Solution

Add the missing `on_skill_write` bridge following the same pattern as `on_memory_write`:

### MemoryProvider ABC
- Add `on_skill_write(action, name, content, metadata=None)` optional hook

### MemoryManager
- `on_skill_write()` -- notify external providers when skill_manage writes
- `notify_skill_tool_write()` -- bridge gated on committed (non-staged, successful) writes and mutating actions only
- Action-aware payload mapping: `create`/`edit` -> `content`, `patch` -> `new_string`, `write_file` -> `file_content`; `delete`/`remove_file` carry no content. Supporting-file identity (`file_path`) and the replaced patch text (`old_string`) are preserved as metadata.
- `_MIRRORED_SKILL_ACTIONS` -- {create, edit, patch, delete, write_file, remove_file}

### Executor wiring
- Both executor paths (sequential dispatch in `agent/tool_executor.py` and the concurrent `invoke_tool`) mirror skill_manage writes through a shared helper, `mirror_skill_write_to_memory_providers`.

### Approval replay
- Writes staged by the `skills.write_approval` gate are (correctly) not mirrored at staging time -- but approval later calls `apply_skill_pending()` directly, bypassing the agent-loop bridge. `_apply_one` in `hermes_cli/write_approval_commands.py` now notifies the manager after a successful replay (CLI passes the live agent's manager; the gateway passes the cached agent's manager when one exists), with `execution_context: "approval_replay"` provenance. Best-effort: provider failures never break the approval.

### Provenance
- `build_memory_write_metadata` gains a `tool_name` param so skill events carry `tool_name="skill_manage"` instead of `"memory"`.

### Docs
- The full `on_skill_write` contract (per-action payload mapping, metadata keys, committed-only gating, approval-replay provenance) is documented in `website/docs/developer-guide/memory-provider-plugin.md`.

## Tests

- `tests/agent/test_skill_write_bridge.py` -- action->payload mapping for every mutating action, staged/failed-write gating, non-mutating actions ignored, metadata plumbing, provider-exception isolation.
- `tests/tools/test_write_approval.py` -- approval-replay mirroring (create + patch argument shapes), failed replays don't notify, approval works without a manager, provider failure doesn't fail the approval.

## Design

Follows existing on_memory_write architecture exactly. Backward compatible: providers ignore unknown hooks by default.
