### PR TITLE
feat(skills): add authoring standards tests + reject empty name in frontmatter

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -146,6 +146,46 @@ class TestValidateFrontmatter:
 
 
 # ---------------------------------------------------------------------------
+# authoring standards — guardrails that catch the most common SKILL.md mistakes
+# ---------------------------------------------------------------------------
+
+
+class TestSkillAuthoringStandards:
+    """Catch common authoring mistakes that cause silent failures downstream."""
+
+    def test_bom_before_frontmatter_rejected(self):
+        """UTF-8 BOM before --- causes parse_frontmatter to miss the header."""
+        content = "﻿---\nname: test\ndescription: desc\n---\n\nBody.\n"
+        err = _validate_frontmatter(content)
+        assert err is not None, "BOM before frontmatter should fail validation"
+
+    def test_leading_blank_line_before_frontmatter_rejected(self):
+        """A blank line before --- means the frontmatter opener is not at pos 0."""
+        content = "\n---\nname: test\ndescription: desc\n---\n\nBody.\n"
+        err = _validate_frontmatter(content)
+        assert err is not None, "leading blank line should fail validation"
+
+    def test_description_stripped_of_leading_trailing_whitespace(self):
+        """Description values with accidental whitespace should still validate."""
+        content = (
+            "---\n"
+            "name: test\n"
+            "description:   padded description with spaces   \n"
+            "---\n\nBody.\n"
+        )
+        err = _validate_frontmatter(content)
+        assert err is None, (
+            "description with accidental whitespace should still be valid"
+        )
+
+    def test_empty_name_after_trim_rejected(self):
+        """A name that is only whitespace must not pass validation."""
+        content = "---\nname:    \ndescription: desc\n---\n\nBody.\n"
+        err = _validate_frontmatter(content)
+        assert err is not None, "whitespace-only name should fail"
+
+
+# ---------------------------------------------------------------------------
 # _validate_file_path — path traversal prevention
 # ---------------------------------------------------------------------------
 

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -532,6 +532,9 @@ def _validate_frontmatter(content: str) -> Optional[str]:
 
     if "name" not in parsed:
         return "Frontmatter must include 'name' field."
+    name_val = parsed["name"]
+    if name_val is None or not str(name_val).strip():
+        return "Frontmatter 'name' field must not be empty."
     if "description" not in parsed:
         return "Frontmatter must include 'description' field."
     if len(str(parsed["description"])) > MAX_DESCRIPTION_LENGTH:


### PR DESCRIPTION
## Problem

SKILL.md files with common authoring mistakes pass validation silently but fail downstream: BOM before frontmatter, leading blank lines, whitespace-only name fields. The `_validate_frontmatter` function checks that `name` exists but does not check that the value is non-empty.

## Solution

### New tests (`tests/tools/test_skill_manager_tool.py`)
Add `TestSkillAuthoringStandards` with 4 tests:
- UTF-8 BOM before `---` opener is rejected
- Leading blank line before `---` is rejected
- Description with accidental leading/trailing whitespace still validates
- Whitespace-only name (null or empty string) is rejected

### Validation fix (`tools/skill_manager_tool.py`)
`_validate_frontmatter`: check that name value is non-null and non-empty after strip. The YAML parser returns `null` for `name:    ` (trailing spaces), which the existing check `"name" in parsed` does not catch.
