### PR TITLE
feat(agent): add lightweight per-turn tool-call pattern detector

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -77,6 +77,8 @@ class ToolCallGuardrailConfig:
     same_tool_failure_halt_after: int = 8
     no_progress_warn_after: int = 2
     no_progress_block_after: int = 5
+    repeated_success_warn_after: int = 4
+    turn_volume_warn_after: int = 25
     idempotent_tools: frozenset[str] = field(default_factory=lambda: IDEMPOTENT_TOOL_NAMES)
     mutating_tools: frozenset[str] = field(default_factory=lambda: MUTATING_TOOL_NAMES)
 
@@ -120,6 +122,14 @@ class ToolCallGuardrailConfig:
             no_progress_block_after=_positive_int(
                 hard_stop_after.get("idempotent_no_progress", data.get("no_progress_block_after")),
                 defaults.no_progress_block_after,
+            ),
+            repeated_success_warn_after=_positive_int(
+                warn_after.get("repeated_success", data.get("repeated_success_warn_after")),
+                defaults.repeated_success_warn_after,
+            ),
+            turn_volume_warn_after=_positive_int(
+                warn_after.get("turn_volume", data.get("turn_volume_warn_after")),
+                defaults.turn_volume_warn_after,
             ),
         )
 
@@ -222,7 +232,14 @@ def classify_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str
 
 
 class ToolCallGuardrailController:
-    """Per-turn controller for repeated failed/non-progressing tool calls."""
+    """Per-turn controller for repeated failed/non-progressing tool calls.
+
+    Also tracks two success-side redundancy signals the failure detectors do
+    not cover: consecutive identical *successful* calls on non-idempotent
+    tools (``repeated_success_warning``) and total completed tool-call volume
+    for the turn (``turn_volume_warning``, emitted once per turn). Both are
+    warn-only: they never block or halt execution.
+    """
 
     def __init__(self, config: ToolCallGuardrailConfig | None = None):
         self.config = config or ToolCallGuardrailConfig()
@@ -232,6 +249,10 @@ class ToolCallGuardrailController:
         self._exact_failure_counts: dict[ToolCallSignature, int] = {}
         self._same_tool_failure_counts: dict[str, int] = {}
         self._no_progress: dict[ToolCallSignature, tuple[str, int]] = {}
+        self._success_streak_sig: ToolCallSignature | None = None
+        self._success_streak_count: int = 0
+        self._calls_this_turn: int = 0
+        self._turn_volume_warned: bool = False
         self._halt_decision: ToolGuardrailDecision | None = None
 
     @property
@@ -295,10 +316,14 @@ class ToolCallGuardrailController:
         if failed is None:
             failed, _ = classify_tool_failure(tool_name, result)
 
+        self._calls_this_turn += 1
+
         if failed:
             exact_count = self._exact_failure_counts.get(signature, 0) + 1
             self._exact_failure_counts[signature] = exact_count
             self._no_progress.pop(signature, None)
+            self._success_streak_sig = None
+            self._success_streak_count = 0
 
             same_count = self._same_tool_failure_counts.get(tool_name, 0) + 1
             self._same_tool_failure_counts[tool_name] = same_count
@@ -342,13 +367,50 @@ class ToolCallGuardrailController:
                     signature=signature,
                 )
 
+            volume_decision = self._turn_volume_decision(tool_name, signature)
+            if volume_decision is not None:
+                return volume_decision
+
             return ToolGuardrailDecision(tool_name=tool_name, count=exact_count, signature=signature)
 
         self._exact_failure_counts.pop(signature, None)
         self._same_tool_failure_counts.pop(tool_name, None)
 
+        # Consecutive identical *successful* calls. Failures and any
+        # different call break the streak; only successes extend it.
+        if self._success_streak_sig == signature:
+            self._success_streak_count += 1
+        else:
+            self._success_streak_sig = signature
+            self._success_streak_count = 1
+
         if not self._is_idempotent(tool_name):
             self._no_progress.pop(signature, None)
+            # Idempotent tools are covered by the no-progress detector below
+            # (identical args AND identical result). Non-idempotent tools get
+            # the streak warning instead: repeating the exact same mutating
+            # call and having it succeed every time is redundant work the
+            # failure-only detectors never see.
+            if (
+                self.config.warnings_enabled
+                and self._success_streak_count >= self.config.repeated_success_warn_after
+            ):
+                return ToolGuardrailDecision(
+                    action="warn",
+                    code="repeated_success_warning",
+                    message=(
+                        f"{tool_name} succeeded {self._success_streak_count} times in a row "
+                        "with identical arguments. The repeated calls look redundant; use "
+                        "the result you already have, or change the arguments or approach "
+                        "instead of repeating the same call."
+                    ),
+                    tool_name=tool_name,
+                    count=self._success_streak_count,
+                    signature=signature,
+                )
+            volume_decision = self._turn_volume_decision(tool_name, signature)
+            if volume_decision is not None:
+                return volume_decision
             return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
 
         result_hash = _result_hash(result)
@@ -372,12 +434,45 @@ class ToolCallGuardrailController:
                 signature=signature,
             )
 
+        volume_decision = self._turn_volume_decision(tool_name, signature)
+        if volume_decision is not None:
+            return volume_decision
+
         return ToolGuardrailDecision(tool_name=tool_name, count=repeat_count, signature=signature)
 
     def _is_idempotent(self, tool_name: str) -> bool:
         if tool_name in self.config.mutating_tools:
             return False
         return tool_name in self.config.idempotent_tools
+
+    def _turn_volume_decision(
+        self, tool_name: str, signature: ToolCallSignature
+    ) -> ToolGuardrailDecision | None:
+        """Warn once per turn when completed tool-call volume gets high.
+
+        Emitted at most once per turn so a legitimately busy turn is nudged
+        a single time instead of having every subsequent tool result decorated
+        with the same warning.
+        """
+        if not self.config.warnings_enabled:
+            return None
+        if self._turn_volume_warned:
+            return None
+        if self._calls_this_turn < self.config.turn_volume_warn_after:
+            return None
+        self._turn_volume_warned = True
+        return ToolGuardrailDecision(
+            action="warn",
+            code="turn_volume_warning",
+            message=(
+                f"This turn has already made {self._calls_this_turn} tool calls. "
+                "Step back and check whether the remaining work can be finished "
+                "more directly instead of continuing to iterate call by call."
+            ),
+            tool_name=tool_name,
+            count=self._calls_this_turn,
+            signature=signature,
+        )
 
 
 def toolguard_synthetic_result(decision: ToolGuardrailDecision) -> str:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1410,6 +1410,8 @@ DEFAULT_CONFIG = {
             "exact_failure": 2,
             "same_tool_failure": 3,
             "idempotent_no_progress": 2,
+            "repeated_success": 4,
+            "turn_volume": 25,
         },
         "hard_stop_after": {
             "exact_failure": 5,

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -44,6 +44,8 @@ def test_default_config_is_soft_warning_only_with_hard_stop_disabled():
     assert cfg.exact_failure_block_after == 5
     assert cfg.same_tool_failure_halt_after == 8
     assert cfg.no_progress_block_after == 5
+    assert cfg.repeated_success_warn_after == 4
+    assert cfg.turn_volume_warn_after == 25
 
 
 def test_config_parses_nested_warn_and_hard_stop_thresholds():
@@ -55,6 +57,8 @@ def test_config_parses_nested_warn_and_hard_stop_thresholds():
                 "exact_failure": 3,
                 "same_tool_failure": 4,
                 "idempotent_no_progress": 5,
+                "repeated_success": 6,
+                "turn_volume": 30,
             },
             "hard_stop_after": {
                 "exact_failure": 6,
@@ -72,6 +76,8 @@ def test_config_parses_nested_warn_and_hard_stop_thresholds():
     assert cfg.exact_failure_block_after == 6
     assert cfg.same_tool_failure_halt_after == 7
     assert cfg.no_progress_block_after == 8
+    assert cfg.repeated_success_warn_after == 6
+    assert cfg.turn_volume_warn_after == 30
 
 
 def test_default_repeated_identical_failed_call_warns_without_blocking():
@@ -256,3 +262,139 @@ def test_reset_for_turn_clears_bounded_guardrail_state():
 
     assert controller.before_call("web_search", {"query": "same"}).action == "allow"
     assert controller.before_call("read_file", {"path": "/tmp/x"}).action == "allow"
+
+def test_repeated_identical_success_on_mutating_tool_warns_without_blocking():
+    controller = ToolCallGuardrailController()
+    args = {"command": "ls -la /tmp"}
+
+    decisions = []
+    for _ in range(5):
+        assert controller.before_call("terminal", args).action == "allow"
+        decisions.append(
+            controller.after_call("terminal", args, '{"exit_code":0}', failed=False)
+        )
+
+    assert [d.action for d in decisions[:3]] == ["allow", "allow", "allow"]
+    assert [d.action for d in decisions[3:]] == ["warn", "warn"]
+    assert {d.code for d in decisions[3:]} == {"repeated_success_warning"}
+    assert decisions[3].count == 4
+    assert decisions[4].count == 5
+    assert "redundant" in decisions[3].message
+    # Warn-only: execution is never prevented and no halt is recorded.
+    assert controller.before_call("terminal", args).action == "allow"
+    assert controller.halt_decision is None
+
+
+def test_success_streak_broken_by_different_args_or_failure():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(repeated_success_warn_after=3)
+    )
+
+    # Two identical successes, then different args: streak restarts.
+    controller.after_call("terminal", {"command": "a"}, '{"exit_code":0}', failed=False)
+    controller.after_call("terminal", {"command": "a"}, '{"exit_code":0}', failed=False)
+    controller.after_call("terminal", {"command": "b"}, '{"exit_code":0}', failed=False)
+    third = controller.after_call("terminal", {"command": "a"}, '{"exit_code":0}', failed=False)
+    assert third.action == "allow"
+
+    # Two identical successes, then a failure of the same call: streak resets.
+    controller.reset_for_turn()
+    controller.after_call("terminal", {"command": "a"}, '{"exit_code":0}', failed=False)
+    controller.after_call("terminal", {"command": "a"}, '{"exit_code":0}', failed=False)
+    controller.after_call("terminal", {"command": "a"}, '{"exit_code":1}', failed=True)
+    after_failure = controller.after_call(
+        "terminal", {"command": "a"}, '{"exit_code":0}', failed=False
+    )
+    assert after_failure.action == "allow"
+
+
+def test_idempotent_tools_use_no_progress_code_not_repeated_success():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(repeated_success_warn_after=2, no_progress_warn_after=2)
+    )
+    args = {"path": "/tmp/same.txt"}
+
+    first = controller.after_call("read_file", args, "same contents", failed=False)
+    second = controller.after_call("read_file", args, "same contents", failed=False)
+
+    assert first.action == "allow"
+    assert second.action == "warn"
+    assert second.code == "idempotent_no_progress_warning"
+
+    # Identical args but progressing results (e.g. polling) must not warn as
+    # a redundant-success loop: no-progress covers the idempotent family.
+    controller.reset_for_turn()
+    a = controller.after_call("read_file", args, "contents v1", failed=False)
+    b = controller.after_call("read_file", args, "contents v2", failed=False)
+    c = controller.after_call("read_file", args, "contents v3", failed=False)
+    assert [a.action, b.action, c.action] == ["allow", "allow", "allow"]
+
+
+def test_turn_volume_warns_once_per_turn_and_resets_at_turn_boundary():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(turn_volume_warn_after=3)
+    )
+
+    first = controller.after_call("web_search", {"query": "q1"}, "r1", failed=False)
+    second = controller.after_call("terminal", {"command": "c1"}, '{"exit_code":0}', failed=False)
+    third = controller.after_call("write_file", {"path": "/tmp/a", "content": "x"}, "ok", failed=False)
+    fourth = controller.after_call("web_search", {"query": "q2"}, "r2", failed=False)
+
+    assert [first.action, second.action] == ["allow", "allow"]
+    assert third.action == "warn"
+    assert third.code == "turn_volume_warning"
+    assert third.count == 3
+    # Only once per turn — subsequent calls stay allow.
+    assert fourth.action == "allow"
+    assert controller.halt_decision is None
+
+    controller.reset_for_turn()
+    after_reset = controller.after_call("web_search", {"query": "q3"}, "r3", failed=False)
+    assert after_reset.action == "allow"
+
+
+def test_turn_volume_counts_failed_calls_too():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            turn_volume_warn_after=2,
+            exact_failure_warn_after=99,
+            same_tool_failure_warn_after=99,
+        )
+    )
+
+    first = controller.after_call("terminal", {"command": "a"}, '{"exit_code":1}', failed=True)
+    second = controller.after_call("terminal", {"command": "b"}, '{"exit_code":1}', failed=True)
+
+    assert first.action == "allow"
+    assert second.action == "warn"
+    assert second.code == "turn_volume_warning"
+
+
+def test_warnings_disabled_suppresses_success_and_volume_warnings():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            warnings_enabled=False,
+            repeated_success_warn_after=2,
+            turn_volume_warn_after=2,
+        )
+    )
+    args = {"command": "same"}
+
+    for _ in range(4):
+        decision = controller.after_call("terminal", args, '{"exit_code":0}', failed=False)
+        assert decision.action == "allow"
+
+
+def test_reset_for_turn_clears_success_streak_state():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(repeated_success_warn_after=3)
+    )
+    args = {"command": "same"}
+    controller.after_call("terminal", args, '{"exit_code":0}', failed=False)
+    controller.after_call("terminal", args, '{"exit_code":0}', failed=False)
+
+    controller.reset_for_turn()
+
+    # Streak restarted: the third identical success is call #1 of the new turn.
+    resumed = controller.after_call("terminal", args, '{"exit_code":0}', failed=False)
+    assert resumed.action == "allow"

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -353,3 +353,78 @@ def test_guardrail_halt_emits_final_response_through_stream_delta_callback():
     assert halt_text in text_deltas, (
         f"halt message was never streamed; callback only saw {deltas!r}"
     )
+
+def test_sequential_path_appends_repeated_success_warning_to_tool_result():
+    """A redundant *successful* loop must warn through the same model-visible
+    channel as failure warnings: guidance appended to the tool result."""
+    agent = _make_agent("terminal")
+    args = {"command": "ls -la"}
+    for _ in range(3):
+        agent._tool_guardrails.after_call(
+            "terminal", args, json.dumps({"exit_code": 0}), failed=False
+        )
+    tc = _mock_tool_call("terminal", json.dumps(args), "c-redundant")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    with patch("run_agent.handle_function_call", return_value=json.dumps({"exit_code": 0})) as mock_hfc:
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+
+    mock_hfc.assert_called_once()  # warn-only: execution still happens
+    assert [m["role"] for m in messages] == ["tool"]
+    assert messages[0]["tool_call_id"] == "c-redundant"
+    content = messages[0]["content"]
+    assert "Tool loop warning" in content
+    assert "repeated_success_warning" in content
+    assert agent._tool_guardrail_halt_decision is None
+
+
+def test_concurrent_path_emits_turn_volume_warning_exactly_once():
+    agent = _make_agent(
+        "web_search",
+        config={"tool_loop_guardrails": {"warn_after": {"turn_volume": 3}}},
+    )
+    calls = [
+        _mock_tool_call("web_search", json.dumps({"query": f"q{i}"}), f"c-{i}")
+        for i in range(3)
+    ]
+    msg = SimpleNamespace(content="", tool_calls=calls)
+    messages = []
+
+    def fake_handle(name, args, task_id, **kwargs):
+        return json.dumps({"ok": args["query"]})
+
+    with patch("run_agent.handle_function_call", side_effect=fake_handle):
+        agent._execute_tool_calls_concurrent(msg, messages, "task-1")
+
+    assert len(messages) == 3
+    volume_hits = [m for m in messages if "turn_volume_warning" in m["content"]]
+    assert len(volume_hits) == 1
+    assert "Tool loop warning" in volume_hits[0]["content"]
+    assert agent._tool_guardrail_halt_decision is None
+
+
+def test_repeated_success_streak_resets_at_turn_boundary():
+    """build_turn_context resets the controller, so a streak accumulated in
+    one turn must not warn on the first identical call of the next turn."""
+    agent = _make_agent("terminal", max_iterations=5)
+    args = {"command": "ls"}
+    for _ in range(3):
+        agent._tool_guardrails.after_call(
+            "terminal", args, json.dumps({"exit_code": 0}), failed=False
+        )
+
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content="done", finish_reason="stop", tool_calls=None)
+    ]
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        agent.run_conversation("hello")
+
+    decision = agent._tool_guardrails.after_call(
+        "terminal", args, json.dumps({"exit_code": 0}), failed=False
+    )
+    assert decision.action == "allow"

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1393,7 +1393,7 @@ agent:
 
 ## Tool-Loop Guardrails
 
-Hermes detects when the agent is stuck in an unproductive tool-calling loop — the same tool call failing repeatedly, the same tool failing over and over, or an idempotent call returning the same result with no progress. By default it injects a **warning** into the tool result so the model self-corrects; it does not hard-stop, since a person watching the CLI/TUI can intervene.
+Hermes detects when the agent is stuck in an unproductive tool-calling loop — the same tool call failing repeatedly, the same tool failing over and over, an idempotent call returning the same result with no progress, the same *successful* call repeated back-to-back, or an unusually high number of tool calls in a single turn. By default it injects a **warning** into the tool result so the model self-corrects; it does not hard-stop, since a person watching the CLI/TUI can intervene.
 
 For unattended gateway / server deployments, enable hard stops so a stuck agent is circuit-broken instead of burning the iteration budget:
 
@@ -1405,13 +1405,15 @@ tool_loop_guardrails:
     exact_failure: 2           # identical failing call repeated N times
     same_tool_failure: 3       # same tool failing N times (different args)
     idempotent_no_progress: 2  # same result, no progress, N times
+    repeated_success: 4        # identical successful call repeated N times in a row (non-idempotent tools)
+    turn_volume: 25            # completed tool calls in one turn reach N (warns once per turn)
   hard_stop_after:
     exact_failure: 5
     same_tool_failure: 8
     idempotent_no_progress: 5
 ```
 
-`hard_stop_enabled` defaults to `false` because interactive sessions have a human in the loop. In unattended deployments (gateway, cron, kanban workers) set it to `true` so repeated failures are blocked rather than only warned. See also [Docker / unattended deployments](docker.md).
+`hard_stop_enabled` defaults to `false` because interactive sessions have a human in the loop. In unattended deployments (gateway, cron, kanban workers) set it to `true` so repeated failures are blocked rather than only warned. See also [Docker / unattended deployments](docker.md). The `repeated_success` and `turn_volume` detectors are warn-only: they inject guidance into the tool result but never block or halt the turn.
 
 ## TTS Configuration
 


### PR DESCRIPTION
## Problem

The existing tool-loop guardrails only observe failures and idempotent no-progress repeats. Redundant *successful* tool calls -- the model calling the same non-idempotent tool with identical args repeatedly, each call succeeding -- and unusually high per-turn tool volume produce no feedback at all.

## Solution

Extend the established `ToolCallGuardrailController` (no parallel detector class) with two warn-only signals:

- **`repeated_success_warning`** -- consecutive identical successful calls on non-idempotent tools (default 4+). Idempotent tools stay covered by the existing `idempotent_no_progress` detector, so polling loops that make progress do not warn.
- **`turn_volume_warning`** -- completed tool calls in one turn reach a threshold (default 25); emitted once per turn.

Both decisions flow through the existing `after_call` observation path (`_append_guardrail_observation` in both the sequential and concurrent executor paths), so the guidance is appended to the tool result itself -- model-visible on every platform (CLI, TUI, gateway, library), not printed to a CLI-only channel. Per-turn state is cleared by the existing `reset_for_turn()` wiring at each turn boundary.

Configurable via `tool_loop_guardrails.warn_after.repeated_success` / `.turn_volume`; documented in `configuration.md`. Neither signal can block or halt.

## Tests

- Pure controller: streak warn/threshold, streak broken by different args or a failure, idempotent tools keep the no-progress code (and progressing polls never warn), volume warns once per turn and counts failures, `warnings_enabled: false` suppresses both, `reset_for_turn` clears all new state, config parsing defaults + overrides.
- Runtime: warning delivered into the tool result through the sequential path and the concurrent path; turn-boundary reset regression via `run_conversation`.