### PR TITLE
fix(dashboard-auth): skip auto-SSO redirect for password-only providers

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -182,9 +182,14 @@ def _auto_sso_response(request: Request) -> Response | None:
         # Zero → nothing to redirect to. Two+ → user must choose at /login.
         return None
 
-    from hermes_cli.dashboard_auth.prefix import prefix_from_request
-
     provider = providers[0]
+    # Password-only providers (basic auth, etc.) have no OAuth redirect flow.
+    # Auto-redirecting to /auth/login would call start_login() and raise
+    # NotImplementedError. Fall through to /login so the password form renders.
+    if getattr(provider, "supports_password", False):
+        return None
+
+    from hermes_cli.dashboard_auth.prefix import prefix_from_request
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote


### PR DESCRIPTION
The auto-initiated SSO redirect added in f5ecbe1ec assumes every interactive provider speaks OAuth (has a `start_login()` method). When the only registered provider is `BasicAuthProvider` (`supports_password=True`), the redirect to `/auth/login?provider=basic` calls `start_login()` which raises `NotImplementedError` — password-only providers have no OAuth redirect flow.

**Root cause:** `_auto_sso_response()` checks whether the single provider is interactive (`supports_session=True`) but doesn't distinguish password-based providers from OAuth-based ones.

**Fix:** Check `supports_password` on the single provider. When `True`, return `None` so the call falls through to the `/login` interstitial, which correctly renders the password form.

**Reproduction:**
1. Configure `dashboard.basic_auth` with `username` and `password_hash` in config.yaml
2. Visit `http://localhost:9119/`
3. Dashboard returns 500 Internal Server Error instead of the login page

cc @benbarclay @teknium1