### PR TITLE
fix(telegram): forward keepalive limits into fallback transport (stop CLOSE_WAIT fd leak)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3025,8 +3025,11 @@ class TelegramAdapter(BasePlatformAdapter):
             def _with_limits(httpx_kwargs: Optional[dict] = None) -> dict:
                 """Merge tuned keepalive limits into httpx client kwargs.
 
-                A caller-supplied ``limits`` (none today) is left untouched;
-                otherwise the CLOSE_WAIT-safe limits are injected.
+                Used by the proxy and direct-DNS branches, where httpx honours
+                the client-level ``limits`` kwarg. A caller-supplied ``limits``
+                is left untouched; otherwise the CLOSE_WAIT-safe limits are
+                injected. The fallback-IP branch does NOT use this helper — see
+                the ``_transport_kwargs`` note below for why.
                 """
                 kwargs = dict(httpx_kwargs or {})
                 if _pool_limits is not None and "limits" not in kwargs:
@@ -3055,9 +3058,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 # Keep request/update pools separate to reduce contention during
                 # polling reconnect + bot API bootstrap/delete_webhook calls.
                 # httpx ignores the client-level `limits` kwarg when a custom
-                # `transport` is supplied (#58790).  Pass the tuned limits
+                # `transport` is supplied (#58790).  Unlike the proxy/direct
+                # branches (which inject limits at the client level via
+                # `_with_limits`), this branch MUST pass the tuned limits
                 # directly into TelegramFallbackTransport so its inner
-                # AsyncHTTPTransport instances honour keepalive_expiry.
+                # AsyncHTTPTransport instances honour keepalive_expiry — do not
+                # route this through `_with_limits`, httpx would discard it.
                 _transport_kwargs: dict = {}
                 if _pool_limits is not None:
                     _transport_kwargs["limits"] = _pool_limits

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3054,17 +3054,28 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
                 # Keep request/update pools separate to reduce contention during
                 # polling reconnect + bot API bootstrap/delete_webhook calls.
+                # httpx ignores the client-level `limits` kwarg when a custom
+                # `transport` is supplied (#58790).  Pass the tuned limits
+                # directly into TelegramFallbackTransport so its inner
+                # AsyncHTTPTransport instances honour keepalive_expiry.
+                _transport_kwargs: dict = {}
+                if _pool_limits is not None:
+                    _transport_kwargs["limits"] = _pool_limits
                 request = HTTPXRequest(
                     **request_kwargs,
-                    httpx_kwargs=_with_limits(
-                        {"transport": TelegramFallbackTransport(fallback_ips)}
-                    ),
+                    httpx_kwargs={
+                        "transport": TelegramFallbackTransport(
+                            fallback_ips, **_transport_kwargs
+                        )
+                    },
                 )
                 get_updates_request = HTTPXRequest(
                     **request_kwargs,
-                    httpx_kwargs=_with_limits(
-                        {"transport": TelegramFallbackTransport(fallback_ips)}
-                    ),
+                    httpx_kwargs={
+                        "transport": TelegramFallbackTransport(
+                            fallback_ips, **_transport_kwargs
+                        )
+                    },
                 )
             elif proxy_url:
                 logger.info("[%s] Proxy detected; passing explicitly to HTTPXRequest: %s", self.name, proxy_url)

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -354,6 +354,37 @@ class TestFallbackTransportInit:
         assert len(seen_kwargs) == 2
         assert all("proxy" not in kwargs for kwargs in seen_kwargs)
 
+    def test_forwards_limits_to_inner_transports(self, monkeypatch):
+        """Verify that caller-supplied limits reach the inner
+        AsyncHTTPTransport instances (#58790).  httpx ignores the
+        client-level limits kwarg when a custom transport is
+        supplied, so the limits must be forwarded via transport_kwargs.
+        """
+        seen_kwargs = []
+
+        def factory(**kwargs):
+            seen_kwargs.append(kwargs.copy())
+            return FakeTransport([], {})
+
+        for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY", "https_proxy", "http_proxy", "all_proxy", "TELEGRAM_PROXY", "NO_PROXY", "no_proxy"):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", factory)
+
+        custom_limits = httpx.Limits(
+            max_connections=42,
+            max_keepalive_connections=10,
+            keepalive_expiry=30.0,
+        )
+        transport = tnet.TelegramFallbackTransport(
+            ["149.154.167.220"], limits=custom_limits
+        )
+
+        # 1 primary + 1 fallback = 2 AsyncHTTPTransport instances
+        assert len(seen_kwargs) == 2
+        for kw in seen_kwargs:
+            assert "limits" in kw
+            assert kw["limits"] is custom_limits
+
 
 class TestFallbackTransportClose:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The Telegram fallback-IP transport now gets the same CLOSE_WAIT-safe keepalive tuning (`keepalive_expiry=2.0`, `max_keepalive=10`) that the proxy/direct branches already receive — closing a `CLOSE_WAIT` fd leak that wedged long-lived gateways.

**Root cause:** `platform_httpx_limits()` was injected via `httpx_kwargs["limits"]`, but the fallback branch also supplies a custom `transport`. httpx's `AsyncClient._init_transport` returns a custom `transport` immediately and **ignores the client-level `limits`** — so the inner `AsyncHTTPTransport`s in `TelegramFallbackTransport` ran with httpx defaults (`keepalive_expiry=5.0`). Peer-FIN'd keepalive sockets piled up as `CLOSE_WAIT` in the general request pool (heavy during streaming `editMessageText`) until the process hit the fd limit (macOS soft limit 256) and wedged. Fixes #58790.

## Changes

- `plugins/platforms/telegram/adapter.py`: pass the tuned `_pool_limits` (which carries `max_connections=connection_pool_size` + the CLOSE_WAIT-safe keepalive) **into** `TelegramFallbackTransport` so they reach the inner transports, and drop the now-dead client-level `_with_limits({"transport": ...})` wrapping on the fallback branch (httpx discards it there).
- `tests/gateway/test_telegram_network.py`: `test_forwards_limits_to_inner_transports` — asserts caller-supplied limits reach both inner `AsyncHTTPTransport`s.

## Validation

| | Before (main) | After |
|---|---|---|
| Fallback inner transports keepalive_expiry | 5.0 (httpx default → leak) | 2.0 |
| Fallback inner transports max_keepalive | 20 (default) | 10 |
| Fallback inner transports max_connections | 100 (default) | = connection_pool_size (consistent with proxy/direct) |
| `test_telegram_network.py` | 46 passed | 47 passed |

Verified via E2E with real imports: on `upstream/main` the inner transports get NO limits (the leak); with this change they get `max_conn=<pool_size> max_keepalive=10 expiry=2.0`. ruff clean, ty 79==79 (zero net-new).

## Credit

Based on #58803 by @liuhao1024 — cherry-picked to preserve authorship. Salvaged onto current `main`; dropped unrelated blank-line churn in the test file. Duplicate #58804 by @inside-ziwu fixed the same issue via a different approach (transport self-defaulting to raw `platform_httpx_limits()`, which leaves `max_connections` unbounded and diverges from the other branches, and had no test) — both contributors identified the same root cause; #58803's implementation stays consistent with the proxy/direct branches and ships a regression test.
