### PR TITLE
fix: scope desktop messaging sessions to active profile

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -1004,7 +1004,8 @@ export function ChatSidebar({
 
   const showSessionSkeletons = sessionsLoading && sortedSessions.length === 0
 
-  const showSessionSections = showSessionSkeletons || sortedSessions.length > 0 || projectModel.length > 0
+  const showSessionSections =
+    showSessionSkeletons || sortedSessions.length > 0 || projectModel.length > 0 || messagingGroups.length > 0 || cronJobs.length > 0
 
   // Each reorderable list reports its OWN new id order; persisting is a direct,
   // typed write — no id-prefix sniffing to figure out which level moved.
@@ -1332,7 +1333,6 @@ export function ChatSidebar({
             )}
 
             {!trimmedQuery &&
-              !worktreeGroupingActive &&
               messagingGroups.map(group => {
                 const visible = messagingVisible[group.sourceId] ?? NON_SESSION_INITIAL_ROWS
                 const shownSessions = group.sessions.slice(0, visible)

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -1,0 +1,99 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { listAllProfileSessions } from '@/hermes'
+import { $messagingSessions, setMessagingSessions } from '@/store/session'
+
+import { useSessionListActions } from './use-session-list-actions'
+
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getCronJobs: vi.fn(async () => []),
+  listAllProfileSessions: vi.fn(async () => ({
+    limit: 0,
+    offset: 0,
+    sessions: [],
+    total: 0
+  }))
+}))
+
+const listAllProfileSessionsMock = vi.mocked(listAllProfileSessions)
+
+describe('useSessionListActions messaging profile scoping', () => {
+  afterEach(() => {
+    cleanup()
+    setMessagingSessions([])
+    vi.clearAllMocks()
+  })
+
+  it('fetches messaging sessions from the active profile instead of all profiles', async () => {
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'default' }))
+
+    await act(async () => {
+      await result.current.refreshMessagingSessions()
+    })
+
+    expect(listAllProfileSessionsMock).toHaveBeenCalledWith(
+      expect.any(Number),
+      1,
+      'exclude',
+      'recent',
+      'default',
+      expect.objectContaining({
+        excludeSources: expect.arrayContaining(['cron', 'cli', 'tui', 'desktop'])
+      })
+    )
+  })
+
+  it('keeps the cross-profile messaging slice only in the explicit all-profiles view', async () => {
+    const { result } = renderHook(() => useSessionListActions({ profileScope: '__all__' }))
+
+    await act(async () => {
+      await result.current.refreshMessagingSessions()
+    })
+
+    expect(listAllProfileSessionsMock).toHaveBeenCalledWith(
+      expect.any(Number),
+      1,
+      'exclude',
+      'recent',
+      'all',
+      expect.any(Object)
+    )
+  })
+
+  it('uses the active profile when loading more rows for a single messaging platform', async () => {
+    $messagingSessions.set([
+      {
+        ended_at: null,
+        id: 'telegram-1',
+        input_tokens: 0,
+        is_active: false,
+        last_active: 1,
+        message_count: 1,
+        model: null,
+        output_tokens: 0,
+        preview: null,
+        source: 'telegram',
+        started_at: 1,
+        title: 'telegram chat',
+        tool_call_count: 0
+      }
+    ])
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'telegram' }))
+
+    await act(async () => {
+      await result.current.loadMoreMessagingForPlatform('telegram')
+    })
+
+    expect(listAllProfileSessionsMock).toHaveBeenCalledWith(
+      expect.any(Number),
+      1,
+      'exclude',
+      'recent',
+      'telegram',
+      { source: 'telegram' }
+    )
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -99,7 +99,8 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
   // seeds every platform; the sidebar splits the rows per source.
   const refreshMessagingSessions = useCallback(async () => {
     try {
-      const result = await listAllProfileSessions(MESSAGING_SECTION_LIMIT, 1, 'exclude', 'recent', 'all', {
+      const sessionProfile = profileScope === ALL_PROFILES ? 'all' : profileScope
+      const result = await listAllProfileSessions(MESSAGING_SECTION_LIMIT, 1, 'exclude', 'recent', sessionProfile, {
         excludeSources: MESSAGING_EXCLUDED_SOURCES
       })
 
@@ -114,7 +115,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
     } catch {
       // Non-fatal: the messaging sections just stay empty/stale.
     }
-  }, [])
+  }, [profileScope])
 
   // Page a single platform's section independently (mirrors the per-profile
   // pager): fetch that source's next window and merge it back in place, leaving
@@ -123,9 +124,17 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
     const inPlatform = (s: SessionInfo) => normalizeSessionSource(s.source) === platform
     const loaded = $messagingSessions.get().filter(inPlatform).length
 
-    const result = await listAllProfileSessions(loaded + SIDEBAR_SESSIONS_PAGE_SIZE, 1, 'exclude', 'recent', 'all', {
-      source: platform
-    })
+    const sessionProfile = profileScope === ALL_PROFILES ? 'all' : profileScope
+    const result = await listAllProfileSessions(
+      loaded + SIDEBAR_SESSIONS_PAGE_SIZE,
+      1,
+      'exclude',
+      'recent',
+      sessionProfile,
+      {
+        source: platform
+      }
+    )
 
     const incoming = result.sessions.filter(s => normalizeSessionSource(s.source) === platform)
 
@@ -136,7 +145,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
 
     const total = result.total ?? incoming.length
     setMessagingPlatformTotals(prev => ({ ...prev, [platform]: Math.max(total, incoming.length) }))
-  }, [])
+  }, [profileScope])
 
   // Cron *jobs* drive the sidebar "Cron jobs" section. Jobs are created
   // synchronously (agent tool call or the cron UI), so refreshing here right

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -781,6 +781,45 @@ class TestWebServerEndpoints:
         assert row["is_default_profile"] is True
         assert isinstance(data.get("errors"), list)
 
+    def test_profiles_sessions_filters_to_requested_profile(self):
+        """The Desktop sidebar's profile-scoped slices must not leak rows from
+        sibling profiles when callers pass /api/profiles/sessions?profile=name."""
+        from hermes_state import SessionDB
+        from hermes_cli import profiles as profiles_mod
+
+        telegram_home = profiles_mod.get_profile_dir("telegram")
+        telegram_home.mkdir(parents=True)
+
+        default_db = SessionDB()
+        try:
+            default_db.create_session(session_id="default-chat", source="cli")
+            default_db.append_message("default-chat", role="user", content="default")
+        finally:
+            default_db.close()
+
+        telegram_db = SessionDB(db_path=telegram_home / "state.db")
+        try:
+            telegram_db.create_session(session_id="telegram-chat", source="telegram")
+            telegram_db.append_message("telegram-chat", role="user", content="telegram")
+        finally:
+            telegram_db.close()
+
+        default_resp = self.client.get("/api/profiles/sessions?profile=default&limit=20&min_messages=0")
+        assert default_resp.status_code == 200
+        default_ids = {s["id"] for s in default_resp.json()["sessions"]}
+        assert "default-chat" in default_ids
+        assert "telegram-chat" not in default_ids
+
+        telegram_resp = self.client.get("/api/profiles/sessions?profile=telegram&limit=20&min_messages=0")
+        assert telegram_resp.status_code == 200
+        telegram_rows = telegram_resp.json()["sessions"]
+        telegram_ids = {s["id"] for s in telegram_rows}
+        assert "telegram-chat" in telegram_ids
+        assert "default-chat" not in telegram_ids
+        row = next(s for s in telegram_rows if s["id"] == "telegram-chat")
+        assert row["profile"] == "telegram"
+        assert row["is_default_profile"] is False
+
     def test_profiles_sessions_rejects_unknown_archived_value(self):
         resp = self.client.get("/api/profiles/sessions?archived=bogus")
         assert resp.status_code == 400


### PR DESCRIPTION
## What does this PR do?

Fixes Desktop sidebar profile leakage for external messaging sessions.

Previously, the Desktop sidebar's messaging slice always queried `/api/profiles/sessions` with `profile=all`. In multi-profile setups, this could surface Telegram sessions from a dedicated `telegram` profile while the user was viewing the `default` profile.

This PR scopes messaging session fetches to the active sidebar profile, while preserving the explicit all-profiles view behavior. It also keeps messaging sections renderable when the sidebar is in Projects/Worktree grouped mode, so a profile that only has Telegram sessions still shows its Telegram section instead of an empty session state.

## Related Issue

N/A no issue filed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-session-list-actions.ts`
  - Scope `refreshMessagingSessions()` to the current `profileScope` instead of always using `profile=all`.
  - Scope `loadMoreMessagingForPlatform()` to the current `profileScope` as well.
- `apps/desktop/src/app/chat/sidebar/index.tsx`
  - Count messaging and cron groups when deciding whether the sidebar should show session sections instead of the blank state.
  - Allow messaging sections to render even when Projects/Worktree grouped mode is active.
- `apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx`
  - Add regression tests for profile-scoped messaging fetches and the all-profiles exception.
- `tests/hermes_cli/test_web_server.py`
  - Add backend regression coverage for `/api/profiles/sessions?profile=<name>` filtering so sibling profile rows do not leak.

## How to Test

1. Run the focused Desktop UI tests:
   ```bash
   cd apps/desktop
   npm run test:ui -- src/app/session/hooks/use-session-list-actions.test.tsx src/hermes.test.ts
   ```
2. Run Desktop typecheck and build:
   ```bash
   cd apps/desktop
   npm run typecheck
   npm run build
   ```
3. Run the focused backend regression test:
   ```bash
   python3 -m pytest tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_profiles_sessions_filters_to_requested_profile -q
   ```
4. Manual verification in Desktop with separate `default` and `telegram` profiles:
   - `default` profile: Telegram section/sessions are not shown.
   - `telegram` profile: Telegram section is shown with Telegram sessions.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 Ubuntu on Windows

### Documentation & Housekeeping

- [x] N/A
- [x] N/A
- [x] N/A
- [x] N/A
- [x] N/A

## Screenshots / Logs

Focused verification completed locally:

```text
npm run test:ui -- src/app/session/hooks/use-session-list-actions.test.tsx src/hermes.test.ts
— 2 test files passed, 10 tests passed

npm run typecheck
— tsc -p . --noEmit

python3 -m pytest tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_profiles_sessions_filters_to_requested_profile -q
— 1 passed

npm run build
— built
— assert-dist-built
```

Manual Desktop check:

- `default` profile: no Telegram section/sessions shown.
- `telegram` profile: Telegram section shown with Telegram sessions.
