### PR TITLE
fix(agent): restore primary streaming preference after fallback; scope summary failure flags to the failure episode

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1358,6 +1358,26 @@ def restore_primary_runtime(agent) -> bool:
         agent._fallback_activated = False
         agent._fallback_index = 0
 
+        # ── Restore the primary's streaming preference ──
+        # ``_disable_streaming`` is agent-wide, so a fallback provider that
+        # rejected streaming leaves the flag stuck True and the restored
+        # primary would run non-streaming for the rest of the session.
+        # ``_try_activate_fallback`` snapshots the primary's value on the
+        # primary→fallback transition; put that exact value back instead of
+        # unconditionally re-enabling, so a disable the PRIMARY earned
+        # itself (e.g. Bedrock IAM streaming denial) stays sticky.
+        _saved_stream_disable = getattr(agent, "_primary_disable_streaming", None)
+        if _saved_stream_disable is not None:
+            agent._disable_streaming = _saved_stream_disable
+            agent._primary_disable_streaming = None
+
+        # NOTE: ``_unavailable_fallback_keys`` is intentionally NOT cleared
+        # here.  Entries are only added for chain entries that are locally
+        # unusable (missing key/env, unconfigured provider — see
+        # ``_fallback_entry_unavailable_without_network``) and the
+        # suppression is session-scoped by design; the gateway clears the
+        # set when the fallback config itself is reloaded.
+
         # Reset the stale-call circuit breaker (#58962): the streak measured
         # the FALLBACK provider we're leaving; the restored primary deserves
         # a fresh stream attempt before the breaker can trip again.

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1551,6 +1551,19 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         agent.api_mode = fb_api_mode
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
+        if not getattr(agent, "_fallback_activated", False):
+            # Snapshot the PRIMARY's streaming preference at the moment we
+            # leave it.  ``_disable_streaming`` is a single agent-wide flag:
+            # a fallback provider that rejects streaming flips it to True,
+            # and without a snapshot ``restore_primary_runtime`` cannot tell
+            # a fallback-only stream failure from one the primary earned
+            # itself (e.g. a Bedrock IAM streaming denial that must stay
+            # sticky for the session).  Only captured on the primary→fallback
+            # transition — chain-switching between fallbacks must not
+            # overwrite the primary's saved value.
+            agent._primary_disable_streaming = bool(
+                getattr(agent, "_disable_streaming", False)
+            )
         agent._fallback_activated = True
 
         # Rebind the credential pool to the fallback provider when the provider

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3116,22 +3116,33 @@ This compaction should PRIORITISE preserving all information related to the focu
         self._last_aux_model_failure_model = None
         self._last_compress_aborted = False
         self._last_compression_made_progress = False
-        # NOTE: do NOT reset _last_summary_auth_failure or
-        # _last_summary_network_failure here.  These flags are set by
-        # _generate_summary() on a terminal failure and are already cleared on
-        # a successful summary.  Resetting them eagerly defeats the cooldown
-        # protection: _generate_summary() returns None from the cooldown
-        # early-return without re-asserting these flags, so the abort guard
-        # below would see False and fall through to the destructive
-        # static-fallback — the exact data-loss #29559 describes.  Letting them
-        # persist across compress() calls is safe because a successful summary
-        # always clears both.
 
         # Manual /compress (force=True) bypasses the failure cooldown so the
         # user can retry immediately after an auto-compress abort.  Without
         # this, /compress would silently no-op for 30-60s after a failure.
         if force:
             self._clear_compression_failure_cooldown()
+
+        # _last_summary_auth_failure / _last_summary_network_failure are set
+        # by _generate_summary() on a terminal failure and cleared on the next
+        # successful summary.  They must NOT be cleared eagerly on every
+        # compress() call: while the failure cooldown is active,
+        # _generate_summary() short-circuits in its cooldown early-return and
+        # returns None WITHOUT re-asserting the flags, so an eager clear would
+        # let the abort guard below see False and fall through to the
+        # destructive static-fallback — the exact #29559 / #25585 data loss.
+        # But letting them persist for the whole session is wrong in the other
+        # direction: after the cooldown lapses, a stale auth/network flag from
+        # a long-resolved blip forces every later generic summary failure onto
+        # the abort path, overriding abort_on_summary_failure=False for the
+        # rest of the session.  Scope the flags to the failure episode: keep
+        # them while the cooldown is armed (the re-entrant call stays on the
+        # abort path), clear them once it has expired (force=True cleared it
+        # just above) so the next real attempt is classified fresh —
+        # _generate_summary() re-asserts them if the error persists.
+        if time.monotonic() >= self._summary_failure_cooldown_until:
+            self._last_summary_auth_failure = False
+            self._last_summary_network_failure = False
         n_messages = len(messages)
         # Only need head + 3 tail messages minimum (token budget decides the real tail size)
         _min_for_compress = self._protect_head_size(messages) + 3 + 1

--- a/tests/agent/test_summary_failure_flag_expiry.py
+++ b/tests/agent/test_summary_failure_flag_expiry.py
@@ -1,0 +1,121 @@
+"""Summary auth/network failure flags are scoped to the failure episode.
+
+``_last_summary_auth_failure`` / ``_last_summary_network_failure`` are set by
+``_generate_summary()`` on a terminal failure so ``compress()`` aborts instead
+of falling through to the destructive static-fallback (#29559 / #25585).
+
+Two invariants:
+
+1. While the failure cooldown is ARMED, a re-entrant ``compress()`` must keep
+   the flags: ``_generate_summary()`` short-circuits in its cooldown
+   early-return without re-asserting them, so clearing eagerly would drop the
+   abort guard and destroy the middle window — the #29559 data loss.
+
+2. Once the cooldown has EXPIRED, a stale flag from a long-resolved blip must
+   NOT persist for the session lifetime: it would force every later generic
+   summary failure onto the abort path, overriding
+   ``abort_on_summary_failure=False``.  ``compress()`` clears the flags at the
+   start of the call; if the error persists, the fresh ``_generate_summary()``
+   attempt re-asserts them and the abort guard still fires.
+"""
+
+import time
+from unittest.mock import patch
+
+from agent.context_compressor import ContextCompressor
+
+
+def _make_compressor():
+    with patch(
+        "agent.context_compressor.get_model_context_length",
+        return_value=100000,
+    ):
+        return ContextCompressor(
+            model="test/model",
+            threshold_percent=0.85,
+            protect_first_n=2,
+            protect_last_n=2,
+            quiet_mode=True,
+        )
+
+
+def _tiny_transcript():
+    # Small enough that compress() returns on the "cannot compress" early
+    # return — AFTER the per-call state reset block we are testing, BEFORE
+    # any summary generation / LLM machinery.
+    return [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hi"},
+    ]
+
+
+class TestFlagsPreservedWhileCooldownArmed:
+    def test_auth_flag_survives_compress_during_active_cooldown(self):
+        c = _make_compressor()
+        c._last_summary_auth_failure = True
+        c._summary_failure_cooldown_until = time.monotonic() + 60
+
+        c.compress(_tiny_transcript())
+
+        # Re-entrant compress during cooldown must stay abort-eligible.
+        assert c._last_summary_auth_failure is True
+
+    def test_network_flag_survives_compress_during_active_cooldown(self):
+        c = _make_compressor()
+        c._last_summary_network_failure = True
+        c._summary_failure_cooldown_until = time.monotonic() + 60
+
+        c.compress(_tiny_transcript())
+
+        assert c._last_summary_network_failure is True
+
+
+class TestFlagsClearedOnceCooldownExpires:
+    def test_stale_auth_flag_cleared_after_cooldown_expiry(self):
+        c = _make_compressor()
+        c._last_summary_auth_failure = True
+        c._summary_failure_cooldown_until = time.monotonic() - 1
+
+        c.compress(_tiny_transcript())
+
+        assert c._last_summary_auth_failure is False
+
+    def test_stale_network_flag_cleared_after_cooldown_expiry(self):
+        c = _make_compressor()
+        c._last_summary_network_failure = True
+        c._summary_failure_cooldown_until = time.monotonic() - 1
+
+        c.compress(_tiny_transcript())
+
+        assert c._last_summary_network_failure is False
+
+    def test_never_armed_cooldown_counts_as_expired(self):
+        # Fresh compressor: cooldown 0.0 — a stale flag (e.g. restored from
+        # persisted state) must not survive a fresh compress() call.
+        c = _make_compressor()
+        c._last_summary_auth_failure = True
+        c._last_summary_network_failure = True
+        assert c._summary_failure_cooldown_until == 0.0
+
+        c.compress(_tiny_transcript())
+
+        assert c._last_summary_auth_failure is False
+        assert c._last_summary_network_failure is False
+
+
+class TestForcedCompressClearsFlags:
+    def test_manual_force_clears_cooldown_then_flags(self):
+        # /compress (force=True) clears the cooldown first, so the flag clear
+        # applies even while the auto-compress cooldown would still be armed —
+        # the user asked for a fresh attempt; _generate_summary() re-asserts
+        # the flags if the credential/network is still broken.
+        c = _make_compressor()
+        c._last_summary_auth_failure = True
+        c._last_summary_network_failure = True
+        c._summary_failure_cooldown_until = time.monotonic() + 60
+
+        c.compress(_tiny_transcript(), force=True)
+
+        assert c._summary_failure_cooldown_until == 0.0
+        assert c._last_summary_auth_failure is False
+        assert c._last_summary_network_failure is False

--- a/tests/run_agent/test_fallback_restore_state.py
+++ b/tests/run_agent/test_fallback_restore_state.py
@@ -1,0 +1,172 @@
+"""Restore-time fallback state: streaming preference, cooldown gating, and
+session-level unavailable-key suppression.
+
+Covers the re-scoped #58984 behavior:
+
+* ``_disable_streaming`` is agent-wide, so a fallback provider that rejects
+  streaming would otherwise leave the restored PRIMARY stuck non-streaming for
+  the rest of the session.  ``_try_activate_fallback`` snapshots the primary's
+  value on the primary→fallback transition and ``restore_primary_runtime``
+  puts that exact value back — so a disable the primary earned itself (e.g. a
+  Bedrock IAM streaming denial) stays sticky, while a fallback-only disable is
+  undone.
+
+* While the primary's rate-limit cooldown is armed, ``restore_primary_runtime``
+  must stay gated WITHOUT resetting ``_fallback_index`` — the exhausted index
+  is the #24996 anti-storm throttle (see
+  tests/run_agent/test_24996_fallback_exhaustion_cooldown.py).  Once the
+  cooldown expires, restoration resets the index as usual.
+
+* ``_unavailable_fallback_keys`` records chain entries that are locally
+  unusable (missing key/env, unconfigured provider) for SESSION-level
+  suppression; restoration must not clear it.
+"""
+
+import time
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": n,
+                "description": f"{n} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for n in names
+    ]
+
+
+def _make_agent(fallback_model=None):
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-12345678",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=fallback_model,
+        )
+        agent.client = MagicMock()
+        return agent
+
+
+def _mock_client(base_url="https://api.openai.com/v1", api_key="fb-key-1234"):
+    client = MagicMock()
+    client.base_url = base_url
+    client.api_key = api_key
+    return client
+
+
+def _activate(agent):
+    with patch(
+        "agent.auxiliary_client.resolve_provider_client",
+        return_value=(_mock_client(), None),
+    ):
+        assert agent._try_activate_fallback() is True
+
+
+def _restore(agent):
+    with patch("run_agent.OpenAI", return_value=MagicMock()):
+        return agent._restore_primary_runtime()
+
+
+_FB = {"provider": "openai", "model": "gpt-4o"}
+_FB_CHAIN = [
+    {"provider": "openai", "model": "gpt-4o"},
+    {"provider": "openai", "model": "gpt-4o-mini"},
+]
+
+
+class TestStreamingPreferenceRestore:
+    def test_fallback_stream_rejection_does_not_stick_to_primary(self):
+        agent = _make_agent(fallback_model=_FB)
+        assert not getattr(agent, "_disable_streaming", False)
+
+        _activate(agent)
+        # The fallback provider rejects streaming mid-turn.
+        agent._disable_streaming = True
+
+        assert _restore(agent) is True
+        assert agent._disable_streaming is False
+
+    def test_primary_earned_disable_stays_sticky_across_fallback(self):
+        agent = _make_agent(fallback_model=_FB)
+        # The PRIMARY itself disabled streaming (e.g. Bedrock IAM denial of
+        # InvokeModelWithResponseStream) — that is session-sticky by design.
+        agent._disable_streaming = True
+
+        _activate(agent)
+        assert _restore(agent) is True
+        assert agent._disable_streaming is True
+
+    def test_chain_switch_does_not_overwrite_primary_snapshot(self):
+        agent = _make_agent(fallback_model=_FB_CHAIN)
+        assert not getattr(agent, "_disable_streaming", False)
+
+        _activate(agent)                    # primary → fallback[0]
+        agent._disable_streaming = True     # fallback[0] rejects streaming
+        _activate(agent)                    # fallback[0] → fallback[1] (chain switch)
+
+        # The chain switch must not re-snapshot the (now fallback-tainted)
+        # flag as the "primary" value.
+        assert _restore(agent) is True
+        assert agent._disable_streaming is False
+
+    def test_restore_without_prior_fallback_leaves_flag_alone(self):
+        agent = _make_agent(fallback_model=_FB)
+        agent._disable_streaming = True
+        # No fallback activation this turn: restore is a no-op and must not
+        # touch the primary's own streaming state.
+        assert _restore(agent) is False
+        assert agent._disable_streaming is True
+
+
+class TestCooldownGatingPreservesThrottleState:
+    def test_restore_during_cooldown_keeps_index_and_fallback(self):
+        agent = _make_agent(fallback_model=_FB)
+        _activate(agent)
+        fallback_model = agent.model
+        # Walk the chain to exhaustion, then arm the primary cooldown (as a
+        # rate-limit failover would).
+        agent._fallback_index = len(agent._fallback_chain)
+        agent._rate_limited_until = time.monotonic() + 60
+
+        assert _restore(agent) is False
+        # Gated restore must not reset the exhausted index — it is the
+        # cross-turn replay throttle for #24996 — nor leave the fallback.
+        assert agent._fallback_index == len(agent._fallback_chain)
+        assert agent._fallback_activated is True
+        assert agent.model == fallback_model
+
+    def test_restore_after_cooldown_expiry_resets_index(self):
+        agent = _make_agent(fallback_model=_FB)
+        _activate(agent)
+        agent._fallback_index = len(agent._fallback_chain)
+        agent._rate_limited_until = time.monotonic() - 1
+
+        assert _restore(agent) is True
+        assert agent._fallback_index == 0
+        assert agent._fallback_activated is False
+
+
+class TestUnavailableKeySuppressionIsSessionScoped:
+    def test_restore_preserves_unavailable_fallback_keys(self):
+        agent = _make_agent(fallback_model=_FB_CHAIN)
+        _activate(agent)
+        poisoned = {("openai", "gpt-4o-mini", "")}
+        agent._unavailable_fallback_keys = set(poisoned)
+
+        assert _restore(agent) is True
+        # Locally-unusable entries are suppressed for the whole session;
+        # only a fallback-config reload may clear the memo.
+        assert agent._unavailable_fallback_keys == poisoned


### PR DESCRIPTION
## Problem

Two state-restoration bugs make transient fallback/compression failures permanent for the rest of the session:

1. **`_disable_streaming` outlives the fallback that caused it.** The flag is agent-wide (`conversation_loop` reads it for every request). When a FALLBACK provider rejects streaming mid-turn, the flag stays `True` after `restore_primary_runtime()` switches back, so the primary runs non-streaming for the rest of the session even though it streams fine.

2. **Summary auth/network failure flags outlive their failure episode.** `_last_summary_auth_failure` / `_last_summary_network_failure` are only cleared by the next SUCCESSFUL summary. While the failure cooldown is armed that persistence is load-bearing (#29559/#25585): a re-entrant `compress()` short-circuits in `_generate_summary()`'s cooldown early-return without re-asserting the flags, and the abort guard needs them to avoid the destructive static-fallback. But once the cooldown expires, a stale flag from a long-resolved blip forces every later generic summary failure onto the abort path, overriding `abort_on_summary_failure=False` for the session lifetime.

## Solution

- `try_activate_fallback()` snapshots the primary's `_disable_streaming` value on the primary->fallback transition only (chain switches between fallbacks keep the original snapshot); `restore_primary_runtime()` puts that exact value back instead of unconditionally re-enabling — a disable the primary earned itself (e.g. a Bedrock IAM streaming denial) stays sticky.
- `compress()` clears the two summary-failure flags only once the failure cooldown has expired (`force=True` clears the cooldown first, so manual `/compress` always gets a fresh classification). If the credential/network is still broken, the fresh `_generate_summary()` attempt re-asserts the flags and the abort guard fires exactly as before.

Deliberately NOT changed (per review):

- `restore_primary_runtime()` does not touch `_fallback_index` while the rate-limit cooldown is armed — the exhausted index is the #24996 anti-storm throttle (`tests/run_agent/test_24996_fallback_exhaustion_cooldown.py`). A code comment now documents the invariant.
- `_unavailable_fallback_keys` is not cleared on restore — entries are locally-unusable chain entries suppressed for the session by design; only a fallback-config reload clears the memo. Also documented in a comment.

## Tests

- `tests/run_agent/test_fallback_restore_state.py` — streaming save/restore (fallback-only disable undone, primary-earned disable sticky, chain switches keep the snapshot, no-fallback restore untouched), cooldown gating preserves the exhausted index, `_unavailable_fallback_keys` survives restore.
- `tests/agent/test_summary_failure_flag_expiry.py` — flags survive compress() while the cooldown is armed, are cleared after expiry (including the never-armed case), and `force=True` clears cooldown then flags.
