### PR TITLE
fix(gateway): normalize image attachment inputs

### DIFF
--- a/gateway/platforms/yuanbao_media.py
+++ b/gateway/platforms/yuanbao_media.py
@@ -92,9 +92,13 @@ def guess_mime_type(filename: str) -> str:
     return _EXT_TO_MIME.get(ext, "application/octet-stream")
 
 
+def _normalize_mime_type(mime_type: str) -> str:
+    return mime_type.split(";", 1)[0].strip().lower()
+
+
 def is_image(filename: str, mime_type: str = "") -> bool:
     """判断是否为图片类型。"""
-    if mime_type.startswith("image/"):
+    if _normalize_mime_type(mime_type).startswith("image/"):
         return True
     ext = os.path.splitext(filename)[-1].lower()
     return ext in {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".heic", ".tiff", ".ico"}
@@ -102,7 +106,7 @@ def is_image(filename: str, mime_type: str = "") -> bool:
 
 def get_image_format(mime_type: str) -> int:
     """获取 TIM 图片格式编号。"""
-    return _MIME_TO_IMAGE_FORMAT.get(mime_type.lower(), 255)
+    return _MIME_TO_IMAGE_FORMAT.get(_normalize_mime_type(mime_type), 255)
 
 
 def md5_hex(data: bytes) -> str:

--- a/tests/gateway/test_yuanbao_media_mime.py
+++ b/tests/gateway/test_yuanbao_media_mime.py
@@ -1,0 +1,7 @@
+from gateway.platforms.yuanbao_media import get_image_format, is_image
+
+
+def test_yuanbao_image_mime_parameters_are_ignored():
+    assert is_image("upload.bin", "image/gif; charset=binary") is True
+    assert get_image_format("image/gif; charset=binary") == 2
+    assert get_image_format(" IMAGE/PNG ; charset=utf-8") == 3

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7764,6 +7764,24 @@ def test_image_attach_bytes_accepts_data_url_prefix(monkeypatch, tmp_path):
     assert resp["result"]["attached"] is True
 
 
+def test_image_attach_bytes_accepts_unpadded_base64(monkeypatch, tmp_path):
+    _attach_bytes_cli(monkeypatch)
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    server._sessions["abx_unpadded"] = _session()
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "image.attach_bytes",
+            "params": {
+                "session_id": "abx_unpadded",
+                "content_base64": _PNG_1X1_B64.rstrip("="),
+            },
+        }
+    )
+    assert resp["result"]["attached"] is True
+
+
 def test_image_attach_bytes_data_alias_and_magic_sniff(monkeypatch, tmp_path):
     """Older desktop builds send `data` (not content_base64); ext sniffed from bytes."""
     _attach_bytes_cli(monkeypatch)
@@ -7901,6 +7919,8 @@ def test_decode_attach_base64_helper():
     )
     # whitespace inside payload is tolerated
     assert server._decode_attach_base64(raw[:4] + "\n" + raw[4:], mime_prefix="image/") == b"hello"
+    assert server._decode_attach_base64(raw.rstrip("="), mime_prefix="image/") == b"hello"
+    assert server._decode_attach_base64("A", mime_prefix="image/") is None
     assert server._decode_attach_base64("@@@", mime_prefix="image/") is None
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9075,6 +9075,11 @@ def _decode_attach_base64(raw: str, *, mime_prefix: str) -> bytes | None:
     if m:
         cleaned = m.group(1)
     cleaned = _re.sub(r"\s+", "", cleaned)
+    remainder = len(cleaned) % 4
+    if remainder == 1:
+        return None
+    if remainder:
+        cleaned += "=" * (4 - remainder)
     try:
         return _base64.b64decode(cleaned, validate=True)
     except Exception:


### PR DESCRIPTION
## What does this PR do?

Normalizes two gateway image input paths:

- `image.attach_bytes` now accepts base64 payloads with omitted canonical padding while still rejecting impossible base64 lengths and invalid characters.
- Yuanbao image MIME handling now ignores MIME parameters such as `; charset=binary` before checking `is_image()` or mapping TIM `image_format`.

These are small input-normalization fixes for remote image uploads/media routing.

## Related Issue

Fixes #58791
Fixes #58797

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added base64 padding normalization in `tui_gateway/server.py`.
- Added regression coverage for unpadded `image.attach_bytes` uploads and invalid remainder handling in `tests/test_tui_gateway_server.py`.
- Added Yuanbao MIME parameter normalization in `gateway/platforms/yuanbao_media.py`.
- Added Yuanbao MIME regression coverage in `tests/gateway/test_yuanbao_media_mime.py`.

## How to Test

1. `uv run --extra dev pytest tests/test_tui_gateway_server.py -k "image_attach_bytes or decode_attach_base64"`
2. `uv run --extra dev pytest tests/gateway/test_yuanbao_media_mime.py`
3. `uv run --extra dev ruff check tui_gateway/server.py gateway/platforms/yuanbao_media.py tests/test_tui_gateway_server.py tests/gateway/test_yuanbao_media_mime.py`
4. `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x, Python 3.12.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure string/base64 handling
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A

## Screenshots / Logs

Focused validation:

```text
tests/test_tui_gateway_server.py ........
8 passed, 297 deselected

tests/gateway/test_yuanbao_media_mime.py .
1 passed

ruff check: All checks passed
git diff --check: clean
```
