### PR TITLE
feat(error-classifier): add Chinese provider error patterns

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -104,6 +104,7 @@ class ClassifiedError:
 _BILLING_PATTERNS = [
     "insufficient credits",
     "insufficient_quota",
+        "insufficient account balance",
     "insufficient balance",
     "credit balance",
     "credits exhausted",
@@ -140,6 +141,10 @@ _RATE_LIMIT_PATTERNS = [
     "throttlingexception",
     "too many concurrent requests",
     "servicequotaexceededexception",
+    # Chinese provider patterns
+    "限流",
+    "小时限制",
+    "每周限制",
 ]
 
 # Patterns that indicate provider-side overload, NOT a per-credential rate
@@ -173,6 +178,11 @@ _USAGE_LIMIT_PATTERNS = [
     "quota",
     "limit exceeded",
     "key limit exceeded",
+    # Chinese provider patterns (Alibaba Bailian, Qianfan, Volcengine, etc.)
+    "超过套餐",
+    "用量已超过",
+    "配额",
+    "额度",
 ]
 
 # Patterns confirming usage limit is transient (not billing)
@@ -185,6 +195,9 @@ _USAGE_LIMIT_TRANSIENT_SIGNALS = [
     "requests remaining",
     "periodic",
     "window",
+    # Chinese provider transient signals
+    "请等用量刷新",
+    "刷新后使用",
 ]
 
 # Payload-too-large patterns detected from message text (no status_code attr).
@@ -394,6 +407,9 @@ _AUTH_PATTERNS = [
     "token expired",
     "token revoked",
     "access denied",
+    # Coding Plan gateway auth failures (Alibaba Bailian, etc.)
+    "remote validation failed",
+    "authentication requests failed",
 ]
 
 # Anthropic thinking block signature patterns
@@ -450,6 +466,7 @@ _SERVER_DISCONNECT_PATTERNS = [
     "network connection lost",
     "unexpected eof",
     "incomplete chunked read",
+    "bad gateway",
 ]
 
 # SSL certificate verification failures — deterministic, NOT transient.
@@ -1260,6 +1277,7 @@ def _classify_by_error_code(
 
     if code_lower in {
         "insufficient_quota",
+        "insufficient account balance",
         "billing_not_active",
         "payment_required",
         "insufficient_credits",


### PR DESCRIPTION
## What does this PR do?

Hermes-Agent currently only recognizes English error messages for billing, rate-limit, usage-limit, auth, and server-disconnect classification. When connecting to Chinese AI provider gateways (Alibaba Bailian, Baidu Qianfan, Volcengine, Tencent LKEAP, ModelScope, etc.), the error messages are in Chinese, causing misclassification — these errors fall through to generic retry/fail instead of being correctly identified as billing issues, rate limits, or auth failures.

This PR adds Chinese error patterns to 6 pattern lists in `agent/error_classifier.py`, enabling correct classification and smart failover for users connecting to Chinese AI platforms.

## Related Issue

No existing issue found — this was discovered through real-world usage with Chinese provider gateways.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/error_classifier.py` — Added patterns to 6 lists:
  - `_BILLING_PATTERNS`: `"insufficient account balance"` (Alibaba Cloud / Volcengine billing)
  - `_RATE_LIMIT_PATTERNS`: `限流`, `小时限制`, `每周限制` (rate limiting)
  - `_USAGE_LIMIT_PATTERNS`: `超过套餐`, `用量已超过`, `配额`, `额度` (quota exceeded)
  - `_USAGE_LIMIT_TRANSIENT_SIGNALS`: `请等用量刷新`, `刷新后使用` (wait for refresh)
  - `_AUTH_PATTERNS`: `"remote validation failed"`, `"authentication requests failed"` (Coding Plan gateway auth)
  - `_SERVER_DISCONNECT_PATTERNS`: `"bad gateway"` (502 from proxies)

## How to Test

1. Trigger a rate-limit error from a Chinese provider (e.g., Volcengine Coding Plan with exceeded weekly quota)
2. Verify the error is classified as `usage_limit` / `rate_limit` instead of `unknown`
3. Confirm that failover behavior triggers correctly (rotate credential or fallback provider)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — or N/A
- [x] I've considered cross-platform impact — or N/A
- [x] I've updated tool descriptions/schemas — or N/A

## Screenshots / Logs

Error messages from Volcengine Coding Plan when weekly quota is exceeded:
```
{"error":{"code":"Forbidden","message":"用量已超过套餐限制，请等用量刷新后再使用"}}
```
Before this PR: classified as `unknown` → triggers generic retry (fails again)
After this PR: classified as `usage_limit` with transient signal → correct failover to next provider