### PR TITLE
fix(gateway): drain in-flight cron delivery on restart instead of dropping it (#58818)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19737,6 +19737,37 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     InProcessCronScheduler().start(stop_event, adapters=adapters, loop=loop, interval=interval)
 
 
+# Upper bound for cooperatively draining the cron ticker on shutdown. The cron
+# thread delivers via ``safe_schedule_threadsafe`` and blocks on
+# ``future.result(timeout=60)`` (see cron/scheduler.py::_deliver_result), so a
+# single in-flight delivery unblocks within ~60s. The extra margin covers the
+# hop back through run_one_job's bookkeeping.
+_CRON_SHUTDOWN_DRAIN_TIMEOUT = 65.0
+
+
+async def _await_thread_exit(
+    thread: Optional[threading.Thread], timeout: float, poll: float = 0.1
+) -> bool:
+    """Wait for a daemon thread to exit WITHOUT blocking the event loop.
+
+    A synchronous ``thread.join()`` here would freeze the event loop — fatal
+    for the cron ticker, whose in-flight delivery is a coroutine scheduled onto
+    *this* loop via ``safe_schedule_threadsafe``. Blocking the loop deadlocks
+    that delivery (the loop can never run it), so ``join(timeout=5)`` always
+    times out and the message is silently dropped on restart (#58818).
+
+    Polling ``is_alive()`` with ``await asyncio.sleep`` keeps the loop running
+    so the pending delivery completes, then the ticker sees ``stop_event`` and
+    exits. Returns True if the thread exited within ``timeout``.
+    """
+    if thread is None:
+        return True
+    deadline = asyncio.get_running_loop().time() + max(0.0, timeout)
+    while thread.is_alive() and asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(poll)
+    return not thread.is_alive()
+
+
 async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = False, verbosity: Optional[int] = 0) -> bool:
     """
     Start the gateway and run until interrupted.
@@ -20231,14 +20262,26 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             logger.error("Gateway exiting with failure: %s", runner.exit_reason)
         return False
     
-    # Stop cron scheduler + housekeeping cleanly
+    # Stop cron scheduler + housekeeping cleanly.
+    #
+    # These MUST be awaited cooperatively, not join()ed. A cron delivery in
+    # flight when the gateway restarts is a coroutine scheduled onto THIS event
+    # loop (safe_schedule_threadsafe); the ticker thread is blocked on its
+    # future.result(). A synchronous cron_thread.join() would block the loop,
+    # so that delivery could never run — it timed out and the message was
+    # silently dropped (#58818). Awaiting keeps the loop alive so the in-flight
+    # delivery finishes before we tear down.
     cron_stop.set()
     try:
         cron_provider.stop()
     except Exception as e:
         logger.debug("Cron provider stop() error: %s", e)
-    cron_thread.join(timeout=5)
-    housekeeping_thread.join(timeout=5)
+    if not await _await_thread_exit(cron_thread, timeout=_CRON_SHUTDOWN_DRAIN_TIMEOUT):
+        logger.warning(
+            "Cron ticker did not exit within %.0fs of shutdown — an in-flight "
+            "delivery may have been dropped.", _CRON_SHUTDOWN_DRAIN_TIMEOUT,
+        )
+    await _await_thread_exit(housekeeping_thread, timeout=5)
 
     # Stop the planned-stop watcher (daemon=True so this is belt-and-suspenders).
     _planned_stop_watcher_stop.set()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19744,6 +19744,17 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
 # hop back through run_one_job's bookkeeping.
 _CRON_SHUTDOWN_DRAIN_TIMEOUT = 65.0
 
+# Upper bound for cooperatively draining the housekeeping ticker on shutdown.
+# Housekeeping periodically refreshes the channel directory via
+# ``safe_schedule_threadsafe(build_channel_directory(...), loop)`` and blocks on
+# ``fut.result(timeout=30)`` (see ``_start_gateway_housekeeping``) — the same
+# loop-scheduled-future pattern as cron. So the cooperative bound must cover
+# that 30s future (plus margin) rather than the old 5s join, otherwise a
+# channel-directory refresh in flight at shutdown gets abandoned mid-resolve.
+# Unlike a dropped cron delivery this is not user-facing (it self-heals on the
+# next tick), but bounding it correctly keeps the drain honest.
+_HOUSEKEEPING_SHUTDOWN_DRAIN_TIMEOUT = 35.0
+
 
 async def _await_thread_exit(
     thread: Optional[threading.Thread], timeout: float, poll: float = 0.1
@@ -20281,7 +20292,9 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             "Cron ticker did not exit within %.0fs of shutdown — an in-flight "
             "delivery may have been dropped.", _CRON_SHUTDOWN_DRAIN_TIMEOUT,
         )
-    await _await_thread_exit(housekeeping_thread, timeout=5)
+    await _await_thread_exit(
+        housekeeping_thread, timeout=_HOUSEKEEPING_SHUTDOWN_DRAIN_TIMEOUT
+    )
 
     # Stop the planned-stop watcher (daemon=True so this is belt-and-suspenders).
     _planned_stop_watcher_stop.set()

--- a/tests/gateway/test_cron_shutdown_drain.py
+++ b/tests/gateway/test_cron_shutdown_drain.py
@@ -1,0 +1,73 @@
+"""Regression tests for #58818.
+
+On restart the gateway must drain an in-flight cron delivery instead of
+dropping it. A cron delivery is a coroutine scheduled onto the gateway event
+loop (``safe_schedule_threadsafe``) while the ticker thread blocks on its
+future. The shutdown wait therefore must NOT block the loop with a synchronous
+``thread.join()`` — doing so deadlocks the delivery (the loop can never run it)
+and the message is silently lost. ``_await_thread_exit`` waits cooperatively so
+the pending delivery completes first.
+"""
+import asyncio
+import threading
+
+import pytest
+
+import gateway.run as gateway_run
+
+
+@pytest.mark.asyncio
+async def test_await_thread_exit_lets_loop_scheduled_delivery_complete():
+    # Reproduces the drop: the worker schedules a coroutine onto THIS loop and
+    # blocks on its result, exactly like cron/_deliver_result. A blocking join
+    # would deadlock it; the cooperative wait lets it finish.
+    loop = asyncio.get_running_loop()
+    delivered = threading.Event()
+    worker_done = threading.Event()
+
+    async def _delivery():
+        await asyncio.sleep(0.05)
+        delivered.set()
+        return "ok"
+
+    def _cron_worker():
+        fut = asyncio.run_coroutine_threadsafe(_delivery(), loop)
+        fut.result(timeout=10)
+        worker_done.set()
+
+    thread = threading.Thread(target=_cron_worker, daemon=True)
+    thread.start()
+
+    exited = await gateway_run._await_thread_exit(thread, timeout=10)
+
+    assert exited is True
+    assert delivered.is_set(), "in-flight delivery coroutine never ran (loop was blocked)"
+    assert worker_done.is_set()
+
+
+@pytest.mark.asyncio
+async def test_await_thread_exit_returns_false_on_timeout():
+    keep_alive = threading.Event()
+
+    def _spin():
+        keep_alive.wait(5)
+
+    thread = threading.Thread(target=_spin, daemon=True)
+    thread.start()
+    try:
+        exited = await gateway_run._await_thread_exit(thread, timeout=0.2, poll=0.02)
+        assert exited is False
+        assert thread.is_alive()
+    finally:
+        keep_alive.set()
+        thread.join(timeout=2)
+
+
+@pytest.mark.asyncio
+async def test_await_thread_exit_handles_none_and_dead_thread():
+    assert await gateway_run._await_thread_exit(None, timeout=1) is True
+
+    thread = threading.Thread(target=lambda: None, daemon=True)
+    thread.start()
+    thread.join(timeout=2)
+    assert await gateway_run._await_thread_exit(thread, timeout=1) is True


### PR DESCRIPTION
## Summary

On gateway restart, an in-flight cron delivery is now drained instead of silently dropped. Fixes #58818.

**Root cause (a deadlock, not just a timing race):** `start_gateway` is `async` and run via `asyncio.run()`, so its shutdown body executes on the gateway event loop thread. A cron delivery is a coroutine scheduled onto that same loop via `safe_schedule_threadsafe`, while the cron ticker thread blocks on `future.result(timeout=60)` (`cron/scheduler.py::_deliver_result`). The old `cron_thread.join(timeout=5)` blocked the loop thread — so the queued delivery coroutine could never run, the ticker stayed blocked on its future, the 5s join always timed out, and the process exited with the message unsent. With the default `agent.restart_drain_timeout=0` this reproduced on essentially every restart landing during a delivery (the reporter's two lost morning digests).

## Changes

- `gateway/run.py`: add `_await_thread_exit()` (polls `is_alive()` via `await asyncio.sleep`, keeping the loop alive) and use it for the cron + housekeeping threads on shutdown instead of `thread.join()`. Cron bounded at 65s (delivery future's own 60s ceiling + margin).
- `gateway/run.py` (follow-up): the housekeeping thread uses the **same** loop-scheduled-future pattern — it refreshes the channel directory via `safe_schedule_threadsafe(build_channel_directory(...), loop)` and blocks on `fut.result(timeout=30)`. The initial fix swapped its `join(5)` for `_await_thread_exit(5)` (a strict improvement), but the 5s bound was shorter than its own 30s future, so a refresh in flight at shutdown was still abandoned. Bound the housekeeping drain at 35s (30s future + margin) via a dedicated `_HOUSEKEEPING_SHUTDOWN_DRAIN_TIMEOUT` constant. Not user-facing (self-heals next tick) but keeps the cooperative drain honest across both threads.
- `tests/gateway/test_cron_shutdown_drain.py`: regression tests — a worker blocked on a loop-scheduled coroutine now completes (a blocking join would deadlock it), plus timeout and None/dead-thread coverage.

## Validation

| | Before (main) | After |
|---|---|---|
| Clean restart, no delivery | fast exit | fast exit (~0.1s, one poll) — no regression |
| Restart during cron delivery | loop frozen → delivery dropped | loop stays alive → delivery completes |
| Restart during housekeeping refresh | (join froze loop) | drained over its 30s future (35s bound) |
| `test_cron_shutdown_drain.py` | — | 3 passed |
| adjacent shutdown/process_exit suites | 27 passed | 27 passed (30 incl. new file) |
| broad `-k shutdown/restart/cron/drain/process_exit` | — | 382 passed, 0 failed |

E2E (real imports): idle restart drains in 0.10s (no 65s regression); in-flight cron delivery completes; in-flight housekeeping refresh completes. ruff clean, ty 142==142 (zero net-new).

## Credit

Based on #58874 by @HexLab98 — cherry-picked to preserve authorship (two commits). Salvaged onto current `main`; added the housekeeping-drain follow-up above (my commit) after a sibling-site audit found the same deadlock class on the housekeeping path.
