### PR TITLE
feat(desktop): add user prompt copy action

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -6,6 +6,7 @@ import { messageAttachmentRefs, messageContentText } from '@/components/assistan
 import { type RestoreMessageTarget } from '@/components/assistant-ui/thread/types'
 import { UserMessageText } from '@/components/assistant-ui/thread/user-message-text'
 import { Codicon } from '@/components/ui/codicon'
+import { CopyButton } from '@/components/ui/copy-button'
 import { useResizeObserver } from '@/hooks/use-resize-observer'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
@@ -293,8 +294,19 @@ export const UserMessage: FC<{
                   </button>
                 </ActionBarPrimitive.Edit>
               )}
-              {(showStop || showRestore) && (
-                <div className="pointer-events-none absolute right-2 bottom-2 z-10 flex items-center justify-center opacity-0 transition-opacity group-hover/user-message:opacity-100 group-focus-within/user-message:opacity-100">
+              {hasBody && (
+                <div className="pointer-events-none absolute right-2 bottom-2 z-10 flex items-center justify-center gap-0.5 opacity-0 transition-opacity group-hover/user-message:opacity-100 group-focus-within/user-message:opacity-100">
+                  <CopyButton
+                    appearance="icon"
+                    buttonSize="icon"
+                    className={cn('pointer-events-auto size-6', USER_ACTION_ICON_BUTTON_CLASS)}
+                    iconClassName="size-3.5"
+                    label={copy.copy}
+                    preventDefault
+                    side="top"
+                    stopPropagation
+                    text={messageText}
+                  />
                   {showStop ? (
                     <button
                       aria-label={copy.stop}
@@ -309,7 +321,7 @@ export const UserMessage: FC<{
                     >
                       {StopGlyph}
                     </button>
-                  ) : (
+                  ) : showRestore ? (
                     <button
                       aria-label={copy.restoreCheckpoint}
                       className={cn('pointer-events-auto size-6', USER_ACTION_ICON_BUTTON_CLASS)}
@@ -331,7 +343,7 @@ export const UserMessage: FC<{
                     >
                       <Codicon name="discard" size="0.875rem" />
                     </button>
-                  )}
+                  ) : null}
                 </div>
               )}
             </div>

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -303,7 +303,6 @@ export const UserMessage: FC<{
                     iconClassName="size-3.5"
                     label={copy.copy}
                     preventDefault
-                    side="top"
                     stopPropagation
                     text={messageText}
                   />


### PR DESCRIPTION
## Summary

Adds a compact copy action to user message bubbles in the desktop chat thread.

## Why

Users often need to reuse, debug, or share a previous prompt. Today, copying a long user prompt requires manual text selection and scrolling, which is slow and error-prone. Assistant messages already expose copy affordances; user prompts should have the same one-click workflow.

## Changes

- Derives plain message text from the existing message content helper.
- Shows a compact copy icon for user messages that contain body text.
- Preserves existing edit, restore, and stop behavior.
- Prevents the copy click from triggering edit/restore bubble actions.

## Validation

- `cd apps/desktop && npm run typecheck`
- `cd apps/desktop && npx eslint src/components/assistant-ui/thread/user-message.tsx`
