### PR TITLE
feat(desktop): copy prompt and response together

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -45,6 +45,7 @@ interface MessageActionProps {
    *  streaming delta flush (the text changes ~30×/s), which profiling showed
    *  was a large slice of per-token script time on long transcripts. */
   getMessageText: () => string
+  getPromptResponseText?: () => string
   onBranchInNewChat?: (messageId: string) => void
 }
 
@@ -72,6 +73,19 @@ export const AssistantMessage: FC<{
   const completedText = useAuiState(s =>
     s.message.status?.type === 'running' ? '' : messageContentText(s.message.content)
   )
+  const previousUserText = useAuiState(s => {
+    const index = s.thread.messages.findIndex(message => message.id === s.message.id)
+
+    for (let i = index - 1; i >= 0; i--) {
+      const message = s.thread.messages[i]
+
+      if (message?.role === 'user') {
+        return messageContentText(message.content)
+      }
+    }
+
+    return ''
+  })
 
   const previewTargets = useMemo(() => {
     if (!completedText || !/(https?:\/\/|file:\/\/)/i.test(completedText)) {
@@ -82,6 +96,16 @@ export const AssistantMessage: FC<{
   }, [completedText])
 
   const getMessageText = useCallback(() => messageContentText(messageRuntime.getState().content), [messageRuntime])
+  const getPromptResponseText = useCallback(() => {
+    const prompt = previousUserText.trim()
+    const response = getMessageText().trim()
+
+    if (!prompt) {
+      return response
+    }
+
+    return `User prompt:\n${prompt}\n\nAssistant response:\n${response}`
+  }, [getMessageText, previousUserText])
 
   const enterRef = useEnterAnimation(isRunning, `assistant-message:${messageId}`)
 
@@ -131,13 +155,23 @@ export const AssistantMessage: FC<{
         </MessagePrimitive.Error>
       </div>
       {hasVisibleText && (
-        <AssistantFooter getMessageText={getMessageText} messageId={messageId} onBranchInNewChat={onBranchInNewChat} />
+        <AssistantFooter
+          getMessageText={getMessageText}
+          getPromptResponseText={getPromptResponseText}
+          messageId={messageId}
+          onBranchInNewChat={onBranchInNewChat}
+        />
       )}
     </MessagePrimitive.Root>
   )
 }
 
-const AssistantActionBar: FC<MessageActionProps> = ({ messageId, getMessageText, onBranchInNewChat }) => {
+const AssistantActionBar: FC<MessageActionProps> = ({
+  messageId,
+  getMessageText,
+  getPromptResponseText,
+  onBranchInNewChat
+}) => {
   const { t } = useI18n()
   const copy = t.assistant.thread
   const [menuOpen, setMenuOpen] = useState(false)
@@ -172,6 +206,9 @@ const AssistantActionBar: FC<MessageActionProps> = ({ messageId, getMessageText,
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start" onCloseAutoFocus={e => e.preventDefault()} sideOffset={6}>
             <MessageTimestamp />
+            {getPromptResponseText && (
+              <CopyButton appearance="menu-item" label={copy.copyPromptAndResponse} text={getPromptResponseText} />
+            )}
             <DropdownMenuItem onSelect={() => onBranchInNewChat?.(messageId)}>
               <GitBranchIcon />
               {copy.branchNewChat}

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -73,6 +73,7 @@ export const AssistantMessage: FC<{
   const completedText = useAuiState(s =>
     s.message.status?.type === 'running' ? '' : messageContentText(s.message.content)
   )
+
   const previousUserText = useAuiState(s => {
     const index = s.thread.messages.findIndex(message => message.id === s.message.id)
 
@@ -96,6 +97,7 @@ export const AssistantMessage: FC<{
   }, [completedText])
 
   const getMessageText = useCallback(() => messageContentText(messageRuntime.getState().content), [messageRuntime])
+
   const getPromptResponseText = useCallback(() => {
     const prompt = previousUserText.trim()
     const response = getMessageText().trim()

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2226,6 +2226,7 @@ export const en: Translations = {
       today: time => `Today, ${time}`,
       yesterday: time => `Yesterday, ${time}`,
       copy: 'Copy',
+      copyPromptAndResponse: 'Copy prompt + response',
       refresh: 'Refresh',
       moreActions: 'More actions',
       branchNewChat: 'Branch in new chat',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2205,6 +2205,7 @@ export const ja = defineLocale({
       today: time => `今日 ${time}`,
       yesterday: time => `昨日 ${time}`,
       copy: 'コピー',
+      copyPromptAndResponse: 'プロンプトと応答をコピー',
       refresh: '更新',
       moreActions: 'その他のアクション',
       branchNewChat: '新しいチャットでブランチ',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1861,6 +1861,7 @@ export interface Translations {
       today: (time: string) => string
       yesterday: (time: string) => string
       copy: string
+      copyPromptAndResponse: string
       refresh: string
       moreActions: string
       branchNewChat: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2138,6 +2138,7 @@ export const zhHant = defineLocale({
       today: time => `今天，${time}`,
       yesterday: time => `昨天，${time}`,
       copy: '複製',
+      copyPromptAndResponse: '複製提示與回覆',
       refresh: '重新整理',
       moreActions: '更多動作',
       branchNewChat: '在新聊天中分支',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2390,6 +2390,7 @@ export const zh: Translations = {
       today: time => `今天，${time}`,
       yesterday: time => `昨天，${time}`,
       copy: '复制',
+      copyPromptAndResponse: '复制提示和回复',
       refresh: '刷新',
       moreActions: '更多操作',
       branchNewChat: '在新对话中分支',


### PR DESCRIPTION
## Summary

Adds an assistant message action to copy the preceding user prompt together with the assistant response.

## Why

A single assistant response is useful, but many real handoffs need the question and answer together: bug reports, docs drafts, issue creation, sharing with teammates, or moving context into another tool. Without this, users have to manually select multiple message bubbles and clean up the copied result.

## Changes

- Adds a `Copy prompt + response` action to assistant messages when a matching user prompt is available.
- Formats the copied bundle with clear `User prompt` and `Assistant response` sections.
- Adds localized strings and updates the i18n type contract.
- Reuses the existing clipboard/copy infrastructure instead of adding another path.

## Validation

- `cd apps/desktop && npm run typecheck`
- `cd apps/desktop && npx eslint src/components/assistant-ui/thread/assistant-message.tsx src/i18n/en.ts src/i18n/ja.ts src/i18n/types.ts src/i18n/zh-hant.ts src/i18n/zh.ts`
