### PR TITLE
fix(web): refresh sidebar status when profile switcher changes

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -373,7 +373,6 @@ export default function App() {
   const isMobile = useBelowBreakpoint(1024);
   const isDesktopCollapsed = collapsed && !isMobile;
   const tooltipWarmRef = useRef(0);
-  const sidebarStatus = useSidebarStatus();
   const isDocsRoute = pathname === "/docs" || pathname === "/docs/";
   const normalizedPath = pathname.replace(/\/$/, "") || "/";
   const isChatRoute = normalizedPath === "/chat";
@@ -661,58 +660,12 @@ export default function App() {
               )}
             </nav>
 
-            <SidebarSystemActions
-              collapsed={isDesktopCollapsed}
-              onNavigate={closeMobile}
-              status={sidebarStatus}
+            <SidebarLowerChrome
+              closeMobile={closeMobile}
+              isDesktopCollapsed={isDesktopCollapsed}
+              t={t}
               tooltipWarmRef={tooltipWarmRef}
             />
-
-            <div
-              className={cn(
-                "flex shrink-0 items-center gap-2",
-                "px-3 py-2",
-                "border-t border-current/20",
-                isDesktopCollapsed
-                  ? "lg:flex-col lg:items-start lg:gap-3 lg:py-3"
-                  : "justify-between",
-              )}
-            >
-              <div
-                className={cn(
-                  "flex min-w-0 items-center gap-2",
-                  isDesktopCollapsed && "lg:flex-col lg:items-start",
-                )}
-              >
-                <PluginSlot name="header-right" />
-
-                <SidebarIconWithTooltip
-                  collapsed={isDesktopCollapsed}
-                  label={t.theme?.switchTheme ?? "Switch theme"}
-                  tooltipWarmRef={tooltipWarmRef}
-                >
-                  <ThemeSwitcher collapsed={isDesktopCollapsed} dropUp />
-                </SidebarIconWithTooltip>
-
-                <SidebarIconWithTooltip
-                  collapsed={isDesktopCollapsed}
-                  label={t.language.switchTo}
-                  tooltipWarmRef={tooltipWarmRef}
-                >
-                  <LanguageSwitcher collapsed={isDesktopCollapsed} dropUp />
-                </SidebarIconWithTooltip>
-              </div>
-            </div>
-
-            <div
-              className={cn(
-                "flex shrink-0 flex-col",
-                isDesktopCollapsed && "lg:hidden",
-              )}
-            >
-              <AuthWidget />
-              <SidebarFooter status={sidebarStatus} />
-            </div>
           </aside>
 
           <PageHeaderProvider pluginTabs={pluginTabMeta}>
@@ -888,6 +841,72 @@ function SidebarNavLink({
         <SidebarTooltip anchor={tooltipAnchor} label={navLabel} warmRef={tooltipWarmRef} />
       )}
     </li>
+  );
+}
+
+function SidebarLowerChrome({
+  closeMobile,
+  isDesktopCollapsed,
+  t,
+  tooltipWarmRef,
+}: SidebarLowerChromeProps) {
+  const sidebarStatus = useSidebarStatus();
+
+  return (
+    <>
+      <SidebarSystemActions
+        collapsed={isDesktopCollapsed}
+        onNavigate={closeMobile}
+        status={sidebarStatus}
+        tooltipWarmRef={tooltipWarmRef}
+      />
+
+      <div
+        className={cn(
+          "flex shrink-0 items-center gap-2",
+          "px-3 py-2",
+          "border-t border-current/20",
+          isDesktopCollapsed
+            ? "lg:flex-col lg:items-start lg:gap-3 lg:py-3"
+            : "justify-between",
+        )}
+      >
+        <div
+          className={cn(
+            "flex min-w-0 items-center gap-2",
+            isDesktopCollapsed && "lg:flex-col lg:items-start",
+          )}
+        >
+          <PluginSlot name="header-right" />
+
+          <SidebarIconWithTooltip
+            collapsed={isDesktopCollapsed}
+            label={t.theme?.switchTheme ?? "Switch theme"}
+            tooltipWarmRef={tooltipWarmRef}
+          >
+            <ThemeSwitcher collapsed={isDesktopCollapsed} dropUp />
+          </SidebarIconWithTooltip>
+
+          <SidebarIconWithTooltip
+            collapsed={isDesktopCollapsed}
+            label={t.language.switchTo}
+            tooltipWarmRef={tooltipWarmRef}
+          >
+            <LanguageSwitcher collapsed={isDesktopCollapsed} dropUp />
+          </SidebarIconWithTooltip>
+        </div>
+      </div>
+
+      <div
+        className={cn(
+          "flex shrink-0 flex-col",
+          isDesktopCollapsed && "lg:hidden",
+        )}
+      >
+        <AuthWidget />
+        <SidebarFooter status={sidebarStatus} />
+      </div>
+    </>
   );
 }
 
@@ -1320,6 +1339,13 @@ interface SidebarNavLinkProps {
   closeMobile: () => void;
   collapsed: boolean;
   item: NavItem;
+  t: Translations;
+  tooltipWarmRef: TooltipWarmRef;
+}
+
+interface SidebarLowerChromeProps {
+  closeMobile: () => void;
+  isDesktopCollapsed: boolean;
   t: Translations;
   tooltipWarmRef: TooltipWarmRef;
 }

--- a/web/src/hooks/useSidebarStatus.ts
+++ b/web/src/hooks/useSidebarStatus.ts
@@ -1,17 +1,22 @@
 import { useEffect, useState } from "react";
 import { api } from "@/lib/api";
 import type { StatusResponse } from "@/lib/api";
+import { useProfileScope } from "@/contexts/useProfileScope";
 
 const POLL_MS = 10_000;
 
 /**
- * Light-weight status poll for the app shell (sidebar). The Status page uses
- * its own faster interval; we keep this slower to avoid duplicate load.
+ * Light-weight status poll for the app shell (sidebar). Must run under
+ * ProfileProvider so management profile matches the header switcher.
+ * The Sessions status overview remounts on profile change; the sidebar
+ * does not, so we refetch immediately when `profile` changes.
  */
 export function useSidebarStatus() {
+  const { profile } = useProfileScope();
   const [status, setStatus] = useState<StatusResponse | null>(null);
 
   useEffect(() => {
+    setStatus(null);
     const load = () => {
       api
         .getStatus()
@@ -21,7 +26,7 @@ export function useSidebarStatus() {
     load();
     const id = setInterval(load, POLL_MS);
     return () => clearInterval(id);
-  }, []);
+  }, [profile]);
 
   return status;
 }

--- a/web/src/lib/api.management-profile.test.ts
+++ b/web/src/lib/api.management-profile.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  getManagementProfile,
+  managementScopedRequestUrl,
+  setManagementProfile,
+} from "@/lib/api";
+
+describe("managementScopedRequestUrl", () => {
+  beforeEach(() => {
+    setManagementProfile("");
+  });
+
+  it("appends profile to /api/status when management profile is set", () => {
+    setManagementProfile("faustina");
+    expect(managementScopedRequestUrl("/api/status")).toBe(
+      "/api/status?profile=faustina",
+    );
+  });
+
+  it("leaves /api/status unchanged when management profile is empty", () => {
+    expect(managementScopedRequestUrl("/api/status")).toBe("/api/status");
+  });
+
+  it("does not double-append when url already has profile=", () => {
+    setManagementProfile("faustina");
+    expect(
+      managementScopedRequestUrl("/api/status?profile=other"),
+    ).toBe("/api/status?profile=other");
+  });
+
+  it("does not scope machine-global endpoints", () => {
+    setManagementProfile("faustina");
+    expect(managementScopedRequestUrl("/api/cron/jobs")).toBe("/api/cron/jobs");
+  });
+
+  it("setManagementProfile trims whitespace", () => {
+    setManagementProfile("  worker  ");
+    expect(getManagementProfile()).toBe("worker");
+    expect(managementScopedRequestUrl("/api/gateway")).toBe(
+      "/api/gateway?profile=worker",
+    );
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -91,6 +91,11 @@ function withManagementProfile(url: string): string {
   return `${url}${sep}profile=${encodeURIComponent(_managementProfile)}`;
 }
 
+/** Same profile injection as fetchJSON; exported for unit tests. */
+export function managementScopedRequestUrl(url: string): string {
+  return withManagementProfile(url);
+}
+
 export async function fetchJSON<T>(
   url: string,
   init?: RequestInit,


### PR DESCRIPTION
## Summary
Fixes #58434 — gateway/status badges in the sidebar shell stayed on the dashboard process profile after switching profiles in the header.

## Cause
- `fetchJSON` already scopes `/api/status` via `withManagementProfile`, but `useSidebarStatus` was invoked from `App` (above `ProfileProvider` in the React tree) with a one-shot effect (`[]` deps).
- Sessions status overview remounts on profile change (`ProfileKeyedRoutes`); the sidebar does not.

## Fix
- `SidebarLowerChrome` renders inside `ProfileProvider` and owns `useSidebarStatus`.
- Hook depends on `profile` from `useProfileScope`, clears stale state, and refetches immediately on switch.

## Tests
- `web/src/lib/api.management-profile.test.ts` — asserts `/api/status` gets `?profile=` when management profile is set.

## How to verify
1. Two profiles with different `gateway_platforms` (e.g. default vs faustina).
2. Open dashboard, switch profile in header — sidebar gateway strip / system actions should reflect the selected profile without waiting for the 10s poll.