### PR TITLE
fix(moa): preserve save_traces and trace_dir when saving MoA presets via the web API

### DIFF
--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -102,6 +102,8 @@ def _default_preset() -> dict[str, Any]:
         "reference_max_tokens": None,
         "fanout": "per_iteration",
         "enabled": True,
+        "save_traces": False,
+        "trace_dir": "",
     }
 
 
@@ -145,6 +147,8 @@ def _normalize_preset(raw: Any) -> dict[str, Any]:
         # aggregator gets their upfront plan-level advice, then acts alone
         # for the rest of the tool loop.
         "fanout": _coerce_fanout(raw.get("fanout")),
+        "save_traces": bool(raw.get("save_traces", False)),
+        "trace_dir": str(raw.get("trace_dir") or ""),
     }
 
 
@@ -193,6 +197,8 @@ def normalize_moa_config(raw: Any) -> dict[str, Any]:
         "reference_max_tokens": active.get("reference_max_tokens"),
         "fanout": active.get("fanout", "per_iteration"),
         "enabled": active["enabled"],
+        "save_traces": active.get("save_traces", False),
+        "trace_dir": active.get("trace_dir", ""),
     }
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -958,6 +958,8 @@ class MoaPresetPayload(BaseModel):
     aggregator_temperature: Optional[float] = None
     max_tokens: int = 4096
     enabled: bool = True
+    save_traces: Optional[bool] = None
+    trace_dir: Optional[str] = None
 
 
 class MoaConfigPayload(BaseModel):
@@ -973,6 +975,8 @@ class MoaConfigPayload(BaseModel):
     max_tokens: int = 4096
     enabled: bool = True
     profile: Optional[str] = None
+    save_traces: Optional[bool] = None
+    trace_dir: Optional[str] = None
 
 
 def _normalize_main_model_assignment(provider: str, model: str) -> tuple[str, str]:
@@ -4472,6 +4476,8 @@ def set_moa_models(body: MoaConfigPayload, profile: Optional[str] = None):
                             "aggregator_temperature": preset.aggregator_temperature,
                             "max_tokens": preset.max_tokens,
                             "enabled": preset.enabled,
+                            "save_traces": preset.save_traces,
+                            "trace_dir": preset.trace_dir,
                         }
                         for name, preset in body.presets.items()
                     },
@@ -4484,6 +4490,8 @@ def set_moa_models(body: MoaConfigPayload, profile: Optional[str] = None):
                     "aggregator_temperature": body.aggregator_temperature,
                     "max_tokens": body.max_tokens,
                     "enabled": body.enabled,
+                    "save_traces": body.save_traces,
+                    "trace_dir": body.trace_dir,
                 }
             normalized = normalize_moa_config(raw)
             cfg["moa"] = normalized

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -510,6 +510,59 @@ class TestWebServerEndpoints:
         assert cfg["moa"]["reference_models"] == payload["reference_models"]
         assert cfg["moa"]["aggregator"] == payload["aggregator"]
 
+    def test_put_moa_models_preserves_save_traces_and_trace_dir(self):
+        """PUT /api/model/moa round-trips save_traces and trace_dir."""
+        from hermes_cli.config import load_config
+
+        payload = {
+            "reference_models": [
+                {"provider": "openai-codex", "model": "gpt-5.5"},
+            ],
+            "aggregator": {"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
+            "enabled": True,
+            "save_traces": True,
+            "trace_dir": "/tmp/moa-test-traces",
+        }
+
+        resp = self.client.put("/api/model/moa", json=payload)
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+        cfg = load_config()
+        assert cfg["moa"]["save_traces"] is True
+        assert cfg["moa"]["trace_dir"] == "/tmp/moa-test-traces"
+
+    def test_put_moa_models_preset_preserves_save_traces_and_trace_dir(self):
+        """PUT /api/model/moa preset branch round-trips save_traces and trace_dir."""
+        from hermes_cli.config import load_config
+
+        payload = {
+            "default_preset": "default",
+            "active_preset": "default",
+            "presets": {
+                "default": {
+                    "reference_models": [
+                        {"provider": "openai-codex", "model": "gpt-5.5"},
+                    ],
+                    "aggregator": {
+                        "provider": "openrouter",
+                        "model": "anthropic/claude-opus-4.8",
+                    },
+                    "enabled": True,
+                    "save_traces": True,
+                    "trace_dir": "/tmp/moa-preset-traces",
+                },
+            },
+        }
+
+        resp = self.client.put("/api/model/moa", json=payload)
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+        cfg = load_config()
+        assert cfg["moa"]["save_traces"] is True
+        assert cfg["moa"]["trace_dir"] == "/tmp/moa-preset-traces"
+        assert cfg["moa"]["presets"]["default"]["save_traces"] is True
+        assert cfg["moa"]["presets"]["default"]["trace_dir"] == "/tmp/moa-preset-traces"
+
     # ── GET /api/media (remote image display) ───────────────────────────
 
     def test_get_media_serves_image_in_root(self):


### PR DESCRIPTION
## Summary

`PUT /api/model/moa` payload models (`MoaPresetPayload` / `MoaConfigPayload`) and the `set_moa_models` persistence builders never carried `save_traces` or `trace_dir`. Because `set_moa_models` wholesale-overwrites `cfg["moa"]` with `normalize_moa_config(raw)` (rather than a read-modify-write merge), and `_normalize_preset` defaulted the two missing keys to `False` / `""`, every save through the dashboard/desktop silently dropped any hand-edited `save_traces: true` and `trace_dir` values — without warning and without any log entry.

`GET /api/model/moa` already returned both fields (`moa_config.py`), and the CLI `hermes moa config` path preserved them via read-modify-write — so the web `PUT` was the one path that dropped them. A user who enabled trace persistence by hand-editing `~/.hermes/config.yaml` lost it on the very next dashboard save, and MoA runs silently stopped producing JSONL trace files.

Mirrors the same bug class PR #58143 fixed for `reference_max_tokens` and `fanout`.

---

## Changes

**`hermes_cli/web_server.py`**
- Added `save_traces: Optional[bool] = None` and `trace_dir: Optional[str] = None` to `MoaPresetPayload` and `MoaConfigPayload`.
- Both fields written in the `set_moa_models` per-preset dict builder and the legacy flat-payload dict builder.

**`hermes_cli/moa_config.py`**
- Added `save_traces` / `trace_dir` to `_default_preset()` (defaulting to `False` / `""`).
- Forwarded through `_normalize_preset()` (coercing via `bool()` / `str()`).
- Included both in `normalize_moa_config()` flattened output so `GET /api/model/moa` continues to return them.

**`tests/hermes_cli/test_web_server.py`** — 2 new regression tests:
- `test_put_moa_models_preserves_save_traces_and_trace_dir` — legacy flat-payload branch: round-trips a `PUT` with `save_traces: True` + `trace_dir` and asserts both persist in `config.yaml`.
- `test_put_moa_models_preset_preserves_save_traces_and_trace_dir` — preset branch: same round-trip assertion for the preset payload path.

---

## How to Test

```bash
uv run --with pytest python3 -m pytest \
  tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_put_moa_models_preserves_save_traces_and_trace_dir \
  tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_put_moa_models_preset_preserves_save_traces_and_trace_dir \
  tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_get_moa_models_returns_provider_model_slots \
  tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_put_moa_models_persists_provider_model_slots \
  -xvs -o 'addopts='
```

Before the fix, both new tests fail: a `PUT` carrying `save_traces: True` and `trace_dir: "/tmp/x"` round-trips back to `False` / `""`. After the fix, both persist. All 4 MoA web server tests pass (2 new + 2 existing), zero regressions.

---

## Checklist

- [x] Tests pass — 4/4 (2 new + 2 existing), zero regressions
- [x] Tested on Linux (WSL2, Python 3.11)
- [x] Follows Contributing Guide and Conventional Commits
- [x] No duplicate PRs — searched existing
- [x] Changes scoped to this fix only — no unrelated commits
- [x] Documentation — N/A (both keys already documented in `hermes_cli/config.py DEFAULT_CONFIG`; `cli-config.yaml.example` already includes them in the MoA block)
- [x] No tool schema or architecture changes

---

## Risk & Impact

**Low.** Additive field wiring only — no existing normalization logic is changed. The `None` default on both new payload fields means existing callers that omit them get the same `False` / `""` default as before. The fix closes the write path that silently dropped hand-edited values; read path (`GET`) and CLI path are unchanged.

**Type:** 🐛 Bug fix
**Fixes:** #58819