### PR TITLE
fix(dashboard): substitute wildcard bind host with loopback for WS URLs

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12784,10 +12784,15 @@ def _build_gateway_ws_url() -> Optional[str]:
     if not host or not port:
         return None
 
+    # The PTY child runs in the same container; wildcard bind addresses
+    # (0.0.0.0 / ::) should resolve to loopback so that a forward proxy
+    # configured via HTTPS_PROXY does not intercept the WS connection.
+    client_host = "127.0.0.1" if host in ("0.0.0.0", "::") else host
+
     netloc = (
-        f"[{host}]:{port}"
-        if ":" in host and not host.startswith("[")
-        else f"{host}:{port}"
+        f"[{client_host}]:{port}"
+        if ":" in client_host and not client_host.startswith("[")
+        else f"{client_host}:{port}"
     )
 
     if getattr(app.state, "auth_required", False):
@@ -12851,7 +12856,10 @@ def _build_sidecar_url(channel: str) -> Optional[str]:
     if not host or not port:
         return None
 
-    netloc = f"[{host}]:{port}" if ":" in host and not host.startswith("[") else f"{host}:{port}"
+    # Same loopback substitution as _build_gateway_ws_url — the PTY child
+    # is co-located with the server.
+    client_host = "127.0.0.1" if host in ("0.0.0.0", "::") else host
+    netloc = f"[{client_host}]:{port}" if ":" in client_host and not client_host.startswith("[") else f"{client_host}:{port}"
 
     if getattr(app.state, "auth_required", False):
         # Gated mode — use the internal credential so the WS upgrade survives

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -618,3 +618,49 @@ class TestGatewayWsUrl:
             assert web_server._build_gateway_ws_url() is None
         finally:
             web_server.app.state.bound_host = "fly-app.fly.dev"
+
+
+# ---------------------------------------------------------------------------
+# Wildcard → loopback substitution — both _build_gateway_ws_url and
+# _build_sidecar_url must replace 0.0.0.0 / :: with 127.0.0.1 so that
+# co-located PTY children do not route through a forward proxy.
+# ---------------------------------------------------------------------------
+
+
+class TestWildcardLoopbackSubstitution:
+    """Regression tests for GitHub #58993."""
+
+    @pytest.mark.parametrize("wildcard", ["0.0.0.0", "::"])
+    def test_gateway_ws_substitutes_loopback(self, loopback_app, wildcard):
+        web_server.app.state.bound_host = wildcard
+        try:
+            url = web_server._build_gateway_ws_url()
+            assert url is not None
+            assert "127.0.0.1" in url
+            assert "0.0.0.0" not in url
+            assert "::" not in url
+        finally:
+            web_server.app.state.bound_host = "127.0.0.1"
+
+    @pytest.mark.parametrize("wildcard", ["0.0.0.0", "::"])
+    def test_sidecar_substitutes_loopback(self, loopback_app, wildcard):
+        web_server.app.state.bound_host = wildcard
+        try:
+            url = web_server._build_sidecar_url("ch-1")
+            assert url is not None
+            assert "127.0.0.1" in url
+            assert "0.0.0.0" not in url
+            assert "::" not in url
+        finally:
+            web_server.app.state.bound_host = "127.0.0.1"
+
+    def test_non_wildcard_preserved(self, loopback_app):
+        """A specific LAN address should pass through untouched."""
+        web_server.app.state.bound_host = "192.168.1.10"
+        try:
+            url = web_server._build_gateway_ws_url()
+            assert url is not None
+            assert "192.168.1.10" in url
+            assert "127.0.0.1" not in url
+        finally:
+            web_server.app.state.bound_host = "127.0.0.1"


### PR DESCRIPTION
## What does this PR do?

When `HERMES_DASHBOARD_HOST=0.0.0.0` (typical in Docker behind a reverse proxy), the dashboard's PTY child builds its WS URLs using the raw bind host `0.0.0.0`. A forward proxy configured via `HTTPS_PROXY` intercepts the connection and fails because `0.0.0.0` is not a routable address.

This fix substitutes wildcard bind addresses (`0.0.0.0` / `::`) with `127.0.0.1` in the client-side netloc of both `_build_gateway_ws_url()` and `_build_sidecar_url()`. The bind address for external reachability is unchanged; only the co-located PTY child's dial target uses loopback.

## Related Issue

Fixes #58993

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py`: Add loopback substitution (`client_host = "127.0.0.1" if host in ("0.0.0.0", "::") else host`) in `_build_gateway_ws_url()` and `_build_sidecar_url()` before constructing the netloc. IPv6 bracket handling preserved.
- `tests/hermes_cli/test_dashboard_auth_ws_auth.py`: Add `TestWildcardLoopbackSubstitution` with 5 test cases covering `0.0.0.0`, `::`, and non-wildcard passthrough for both functions.

## How to Test

1. Run `pytest tests/hermes_cli/test_dashboard_auth_ws_auth.py -q` — all 55 tests should pass (50 existing + 5 new).
2. In a Docker container, set `HERMES_DASHBOARD_HOST=0.0.0.0` and configure `HTTPS_PROXY=http://proxy:3128` with `NO_PROXY` not including `0.0.0.0`. The dashboard chat tab should connect successfully (previously it would fail with "gateway websocket connection failed").

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
