### PR TITLE
fix(agent): reasoning delivered duplicated (2-4x) to gateway consumers

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1549,7 +1549,17 @@ def extract_reasoning(agent, assistant_message) -> Optional[str]:
                     or detail.get('content')
                     or detail.get('text')
                 )
-                if summary and summary not in reasoning_parts:
+                # Substring containment, NOT list membership: streamed
+                # responses carry the SAME reasoning twice — once as the
+                # accumulated ``reasoning``/``reasoning_content`` string and
+                # again chunked across reasoning_details thinking blocks.
+                # Each individual block != the accumulated string exactly,
+                # so an equality test appends every block on top of the
+                # full text and the stored reasoning comes out doubled
+                # (observed 2026-07-16: state.db rows byte-identical to
+                # blocks-joined × 2). A block whose text already appears
+                # inside a collected part is a re-delivery, not new content.
+                if summary and not any(summary in part for part in reasoning_parts):
                     reasoning_parts.append(summary)
 
     # Some providers embed reasoning directly inside assistant content

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3925,8 +3925,17 @@ def normalize_reasoning_delta(accumulated: str, delta: str) -> str:
         return ""
     if not accumulated:
         return delta
-    # Case 1+2: cumulative snapshot / exact echo.
-    if delta.startswith(accumulated):
+    # Case 1+2: cumulative snapshot / exact echo — gated on the accumulated
+    # text being long enough to make a startswith match meaningful. Early in
+    # the stream a SHORT accumulated prefix ("the") is trivially also the
+    # prefix of a legitimate repeated token ("the" again), and an ungated
+    # test silently dropped such tokens (caught by randomized stress tests,
+    # 2026-07-16: streams starting with a repeated word lost the repeat).
+    # The gate is safe for the misbehaviors this function exists to fix:
+    # both observed modes (trailing full-text echo, post-reconnect window
+    # re-delivery) occur late in a stream, when the accumulated text is far
+    # past 24 chars and the gate has long since engaged.
+    if len(accumulated) >= _MIN_REASONING_OVERLAP and delta.startswith(accumulated):
         return delta[len(accumulated):]
     # Case 3: overlapping re-delivery — longest suffix of ``accumulated``
     # that is a prefix of ``delta``, gated to ≥ _MIN_REASONING_OVERLAP so

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -517,6 +517,14 @@ def interruptible_api_call(agent, api_kwargs: dict):
     the main retry loop can try again with backoff / credential rotation /
     provider fallback.
     """
+    # New response starting — clear the per-response reasoning-delivery
+    # latch so a stale value from a previous (possibly aborted) response
+    # can never suppress this response's reasoning delivery. Consumed by
+    # build_assistant_message; set by _fire_reasoning_delta. Cleared
+    # before the direct-call branch so ALL paths (including cron/inline)
+    # start each response with a clean latch.
+    agent._reasoning_streamed_this_response = False
+
     # Cron and other non-interactive, nested-pool contexts must not spawn the
     # interrupt worker — it wedges before the socket opens on the 2nd+ call
     # (#62151). Run inline instead. See should_use_direct_api_call.
@@ -1265,22 +1273,42 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
         logging.debug(f"Captured reasoning ({len(reasoning_text)} chars): {reasoning_text}")
 
     if reasoning_text and agent.reasoning_callback:
-        # Skip the callback when this response's reasoning was already
-        # delivered incrementally via _fire_reasoning_delta (structured
-        # reasoning_content deltas or streamed <think> tag extraction) —
-        # read-and-clear the latch it sets. Re-firing here handed consumers
-        # the SAME reasoning twice: once as deltas, once as the full
-        # accumulated text (observed as 2-4x duplicated sentences on the
-        # Slack native task cards, 2026-07-05). The previous guard tested
-        # ``stream_delta_callback``/``_stream_callback``, but those are the
-        # *text*-streaming consumers — None on gateway platforms even while
-        # reasoning deltas stream fine — so the guard never tripped there.
-        # When nothing streamed (non-streaming modes: batch, quiet,
-        # streaming-disabled providers), the latch is unset and we fire so
-        # those consumers still get reasoning exactly once.
+        # Deliver reasoning to the callback EXACTLY ONCE per response.
+        # Two independent suppression signals, and BOTH must be checked:
+        #
+        #   (a) the per-response latch set by _fire_reasoning_delta —
+        #       structured reasoning deltas were already delivered
+        #       incrementally to THIS callback during streaming. Gateway
+        #       platforms register reasoning_callback while the *text*
+        #       stream callbacks are None, so signal (b) alone never trips
+        #       there and consumers received every reasoning burst twice:
+        #       once as deltas, once as this full accumulated re-fire
+        #       (observed as 2-4x duplicated sentences on the Slack native
+        #       task cards, 2026-07-05).
+        #
+        #   (b) active text-stream consumers — reasoning that arrives
+        #       inline as <think>/<REASONING_SCRATCHPAD> tags in content is
+        #       extracted and displayed by the CLI's tag-extraction path
+        #       (cli.py _stream_reasoning_delta), which never touches the
+        #       agent latch, so signal (a) alone would re-fire here and
+        #       duplicate the CLI reasoning box. Regression contract:
+        #       tests/cli/test_reasoning_command.py
+        #       (TestReasoningDeltasFiredFlag streaming-active cases).
+        #
+        # When neither signal tripped (non-streaming modes: gateway turns
+        # without reasoning deltas, batch, quiet, streaming-disabled
+        # providers), fire so those consumers still get reasoning exactly
+        # once. The latch is read-and-cleared here and additionally reset
+        # at the start of every API call (interruptible_api_call /
+        # interruptible_streaming_api_call) so a stale value from an
+        # aborted response can never suppress a later delivery.
         _already_streamed = getattr(agent, "_reasoning_streamed_this_response", False)
         agent._reasoning_streamed_this_response = False
-        if not _already_streamed:
+        _text_stream_active = bool(
+            getattr(agent, "stream_delta_callback", None)
+            or getattr(agent, "_stream_callback", None)
+        )
+        if not _already_streamed and not _text_stream_active:
             try:
                 agent.reasoning_callback(reasoning_text)
             except Exception:
@@ -2258,6 +2286,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     if agent._interrupt_requested:
         raise InterruptedError("Agent interrupted before streaming API call")
 
+    # New response starting — clear the per-response reasoning-delivery
+    # latch (see the matching comment in interruptible_api_call). The
+    # delegating branches below (direct-call, codex) re-clear via
+    # _interruptible_api_call; clearing here covers the streaming paths.
+    agent._reasoning_streamed_this_response = False
+
     # Cron and other non-interactive, nested-pool contexts deadlock on the
     # spawned worker thread (#62151). They also have no stream consumer, so the
     # deltas this path produces go nowhere. Delegate to the non-streaming entry
@@ -2828,14 +2862,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # reasoning_callback, CLI display) sits downstream of.
             reasoning_text = getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None)
             if reasoning_text:
-                _acc = "".join(reasoning_parts)
-                if _acc and reasoning_text.startswith(_acc):
-                    # Cumulative snapshot (full text so far + maybe new
-                    # tokens): keep only the new suffix.
-                    reasoning_text = reasoning_text[len(_acc):]
-                elif _acc and (reasoning_text in _acc):
-                    # Exact echo of text already accumulated: drop.
-                    reasoning_text = ""
+                reasoning_text = normalize_reasoning_delta(
+                    "".join(reasoning_parts), reasoning_text
+                )
                 if reasoning_text:
                     reasoning_parts.append(reasoning_text)
                     _fire_first_delta()
@@ -3854,6 +3883,61 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         _reset_stale_streak(agent)
     return result["response"]
 
+# Minimum suffix/prefix overlap (chars) treated as a provider re-delivery
+# rather than legitimate repetition. 24 chars ≈ 6+ tokens — far beyond any
+# plausible legitimate immediate repetition at a token boundary, while
+# reconnect re-deliveries observed in practice overlap by hundreds+ chars.
+_MIN_REASONING_OVERLAP = 24
+
+
+def normalize_reasoning_delta(accumulated: str, delta: str) -> str:
+    """Normalize one incoming reasoning delta against the accumulated text.
+
+    Providers are not consistent about what a reasoning "delta" contains.
+    Three provider misbehaviors are corrected here (all observed in the
+    wild, 2026-07-05 — state.db rows with byte-identical doubled halves):
+
+    1. **Cumulative snapshot** — the chunk re-sends the ENTIRE accumulated
+       reasoning so far (optionally plus new tokens). Detected via
+       ``delta.startswith(accumulated)``; only the new suffix is kept.
+    2. **Exact echo** — the chunk is a byte-identical re-send of the full
+       accumulated text. Dropped (this is case 1 with an empty suffix).
+    3. **Overlapping re-delivery** — after an internal reconnect the
+       provider re-sends a trailing window of already-delivered text
+       followed by new tokens. Detected via a longest suffix(accumulated)/
+       prefix(delta) match; the overlapped head is trimmed.
+
+    A minimum-overlap gate (``_MIN_REASONING_OVERLAP`` chars) protects
+    legitimate repetition: real reasoning frequently repeats short
+    substrings ("the", " so ", word fragments at token boundaries), and a
+    naive containment test (``delta in accumulated``) silently discards
+    such valid tokens. Short overlaps are therefore treated as genuinely
+    new text and appended verbatim — for true incremental token streams
+    (deltas a few chars long) this function is a near-passthrough.
+    Duplicating a few chars in the pathological case is recoverable noise;
+    dropping real tokens is silent data loss, so the gate errs toward
+    appending.
+
+    Returns the (possibly trimmed) text to append, or "" when the delta
+    carries nothing new.
+    """
+    if not delta:
+        return ""
+    if not accumulated:
+        return delta
+    # Case 1+2: cumulative snapshot / exact echo.
+    if delta.startswith(accumulated):
+        return delta[len(accumulated):]
+    # Case 3: overlapping re-delivery — longest suffix of ``accumulated``
+    # that is a prefix of ``delta``, gated to ≥ _MIN_REASONING_OVERLAP so
+    # legitimate short repetitions are never eaten.
+    max_probe = min(len(accumulated), len(delta))
+    for probe in range(max_probe, _MIN_REASONING_OVERLAP - 1, -1):
+        if accumulated.endswith(delta[:probe]):
+            return delta[probe:]
+    return delta
+
+
 # ── Provider fallback ──────────────────────────────────────────────────
 
 
@@ -3862,6 +3946,7 @@ __all__ = [
     "interruptible_api_call",
     "build_api_kwargs",
     "build_assistant_message",
+    "normalize_reasoning_delta",
     "try_activate_fallback",
     "handle_max_iterations",
     "cleanup_task_resources",

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1265,15 +1265,22 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
         logging.debug(f"Captured reasoning ({len(reasoning_text)} chars): {reasoning_text}")
 
     if reasoning_text and agent.reasoning_callback:
-        # Skip callback when streaming is active — reasoning was already
-        # displayed during the stream via one of two paths:
-        #   (a) _fire_reasoning_delta (structured reasoning_content deltas)
-        #   (b) _stream_delta tag extraction (<think>/<REASONING_SCRATCHPAD>)
-        # When streaming is NOT active, always fire so non-streaming modes
-        # (gateway, batch, quiet) still get reasoning.
-        # Any reasoning that wasn't shown during streaming is caught by the
-        # CLI post-response display fallback (cli.py _reasoning_shown_this_turn).
-        if not agent.stream_delta_callback and not agent._stream_callback:
+        # Skip the callback when this response's reasoning was already
+        # delivered incrementally via _fire_reasoning_delta (structured
+        # reasoning_content deltas or streamed <think> tag extraction) —
+        # read-and-clear the latch it sets. Re-firing here handed consumers
+        # the SAME reasoning twice: once as deltas, once as the full
+        # accumulated text (observed as 2-4x duplicated sentences on the
+        # Slack native task cards, 2026-07-05). The previous guard tested
+        # ``stream_delta_callback``/``_stream_callback``, but those are the
+        # *text*-streaming consumers — None on gateway platforms even while
+        # reasoning deltas stream fine — so the guard never tripped there.
+        # When nothing streamed (non-streaming modes: batch, quiet,
+        # streaming-disabled providers), the latch is unset and we fire so
+        # those consumers still get reasoning exactly once.
+        _already_streamed = getattr(agent, "_reasoning_streamed_this_response", False)
+        agent._reasoning_streamed_this_response = False
+        if not _already_streamed:
             try:
                 agent.reasoning_callback(reasoning_text)
             except Exception:
@@ -2809,12 +2816,30 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             if hasattr(chunk, "model") and chunk.model:
                 model_name = chunk.model
 
-            # Accumulate reasoning content
+            # Accumulate reasoning content. Providers are not consistent
+            # about what a reasoning "delta" contains: most send true
+            # incremental tokens, but some re-send the ENTIRE accumulated
+            # reasoning as a trailing chunk (cumulative echo) or re-deliver
+            # an overlapping window after an internal reconnect. Naively
+            # appending stores the reasoning doubled (observed 2026-07-05:
+            # state.db rows with byte-identical doubled halves) and fires
+            # duplicated text at reasoning consumers. Normalize here — the
+            # single chokepoint every consumer (trajectory storage,
+            # reasoning_callback, CLI display) sits downstream of.
             reasoning_text = getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None)
             if reasoning_text:
-                reasoning_parts.append(reasoning_text)
-                _fire_first_delta()
-                agent._fire_reasoning_delta(reasoning_text)
+                _acc = "".join(reasoning_parts)
+                if _acc and reasoning_text.startswith(_acc):
+                    # Cumulative snapshot (full text so far + maybe new
+                    # tokens): keep only the new suffix.
+                    reasoning_text = reasoning_text[len(_acc):]
+                elif _acc and (reasoning_text in _acc):
+                    # Exact echo of text already accumulated: drop.
+                    reasoning_text = ""
+                if reasoning_text:
+                    reasoning_parts.append(reasoning_text)
+                    _fire_first_delta()
+                    agent._fire_reasoning_delta(reasoning_text)
 
             # Accumulate text content — fire callback only when no tool calls
             if delta and delta.content:

--- a/contributors/emails/carnie-bot@openclaw.local
+++ b/contributors/emails/carnie-bot@openclaw.local
@@ -1,0 +1,2 @@
+menhguin
+# Carnie agent commits — PRs #59009 / #59010

--- a/run_agent.py
+++ b/run_agent.py
@@ -5217,11 +5217,15 @@ class AIAgent:
         """Fire reasoning callback if registered.
 
         Also latches ``_reasoning_streamed_this_response`` so the
-        post-completion path in ``_build_assistant_message`` can tell that
-        reasoning was already delivered incrementally and skip its full-text
-        re-fire (previously it guessed via ``stream_delta_callback``, which
-        is the *text*-streaming consumer — None on gateway platforms — so
-        gateway consumers received every reasoning burst twice).
+        post-completion path in ``build_assistant_message`` can tell that
+        reasoning was already delivered incrementally to the reasoning
+        callback and skip its full-text re-fire. This latch is one of two
+        suppression signals checked there — the other is active text-stream
+        consumers, which covers the CLI's <think>-tag extraction path
+        (cli.py _stream_reasoning_delta) that displays reasoning without
+        going through this method. The latch is cleared at the start of
+        every API call (interruptible_api_call /
+        interruptible_streaming_api_call), scoping it to a single response.
         """
         # Single-writer guard (#65991): fence out a superseded stream's
         # reasoning deltas the same way as content deltas.

--- a/run_agent.py
+++ b/run_agent.py
@@ -5214,7 +5214,15 @@ class AIAgent:
             self._record_streamed_assistant_text(text)
 
     def _fire_reasoning_delta(self, text: str) -> None:
-        """Fire reasoning callback if registered."""
+        """Fire reasoning callback if registered.
+
+        Also latches ``_reasoning_streamed_this_response`` so the
+        post-completion path in ``_build_assistant_message`` can tell that
+        reasoning was already delivered incrementally and skip its full-text
+        re-fire (previously it guessed via ``stream_delta_callback``, which
+        is the *text*-streaming consumer — None on gateway platforms — so
+        gateway consumers received every reasoning burst twice).
+        """
         # Single-writer guard (#65991): fence out a superseded stream's
         # reasoning deltas the same way as content deltas.
         if self._stream_writer_superseded():
@@ -5222,6 +5230,7 @@ class AIAgent:
             return
         cb = self.reasoning_callback
         if cb is not None:
+            self._reasoning_streamed_this_response = True
             try:
                 cb(text)
             except Exception:

--- a/tests/agent/test_reasoning_delivery_dedup_59009.py
+++ b/tests/agent/test_reasoning_delivery_dedup_59009.py
@@ -267,5 +267,67 @@ class TestNormalizeReasoningDelta(unittest.TestCase):
         self.assertEqual(fired, ["Let me ", "think about ", "merging."])
 
 
+class TestExtractReasoningDetailsDedup(unittest.TestCase):
+    """extract_reasoning must not double reasoning when a streamed response
+    carries BOTH the accumulated ``reasoning`` string AND reasoning_details
+    thinking blocks of the same content (dogfood-observed 2026-07-16:
+    state.db reasoning columns byte-identical to blocks-joined × 2, because
+    the old dedup was exact list membership and each individual block never
+    equals the accumulated string)."""
+
+    def _agent(self):
+        return SimpleNamespace()
+
+    def test_accumulated_plus_matching_blocks_not_doubled(self):
+        from agent.agent_runtime_helpers import extract_reasoning
+
+        blocks = [
+            {"type": "thinking", "thinking": "First chunk of thinking."},
+            {"type": "thinking", "thinking": "Second, different chunk."},
+        ]
+        accumulated = "First chunk of thinking.\n\nSecond, different chunk."
+        msg = SimpleNamespace(
+            reasoning=accumulated,
+            reasoning_content=None,
+            reasoning_details=blocks,
+            content="final answer",
+        )
+        self.assertEqual(extract_reasoning(self._agent(), msg), accumulated)
+
+    def test_distinct_blocks_all_survive(self):
+        from agent.agent_runtime_helpers import extract_reasoning
+
+        msg = SimpleNamespace(
+            reasoning=None,
+            reasoning_content=None,
+            reasoning_details=[
+                {"type": "thinking", "thinking": "Alpha block."},
+                {"type": "thinking", "thinking": "Beta block, different."},
+            ],
+            content="x",
+        )
+        self.assertEqual(
+            extract_reasoning(self._agent(), msg),
+            "Alpha block.\n\nBeta block, different.",
+        )
+
+    def test_genuinely_new_detail_content_kept(self):
+        from agent.agent_runtime_helpers import extract_reasoning
+
+        msg = SimpleNamespace(
+            reasoning="Streamed text.",
+            reasoning_content=None,
+            reasoning_details=[
+                {"type": "thinking", "thinking": "Streamed text."},
+                {"type": "thinking", "thinking": "Novel unseen block."},
+            ],
+            content="x",
+        )
+        self.assertEqual(
+            extract_reasoning(self._agent(), msg),
+            "Streamed text.\n\nNovel unseen block.",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/agent/test_reasoning_delivery_dedup_59009.py
+++ b/tests/agent/test_reasoning_delivery_dedup_59009.py
@@ -1,0 +1,271 @@
+"""Regression guards for #59009 — reasoning delivered duplicated (2-4x) to
+gateway consumers.
+
+Two independent bugs produced duplicated reasoning:
+
+1. **Post-completion re-fire on gateway platforms.** Gateway consumers
+   register ``reasoning_callback`` while the *text*-stream callbacks
+   (``stream_delta_callback`` / ``_stream_callback``) are None. The old
+   guard in ``build_assistant_message`` only tested the text-stream
+   callbacks, so reasoning that had already been streamed incrementally
+   via ``_fire_reasoning_delta`` was re-fired again as one accumulated
+   blob — every reasoning burst arrived twice.
+
+   The fix latches ``_reasoning_streamed_this_response`` inside
+   ``_fire_reasoning_delta`` and checks BOTH signals in
+   ``build_assistant_message``: the latch (gateway reasoning-delta path)
+   and active text-stream consumers (CLI <think>-tag extraction path,
+   which displays reasoning without touching the latch — see
+   tests/cli/test_reasoning_command.py TestReasoningDeltasFiredFlag).
+
+2. **Provider delta misbehavior.** Some providers re-send the entire
+   accumulated reasoning as a trailing chunk (cumulative echo) or
+   re-deliver an overlapping window after an internal reconnect. Naive
+   appending stored the reasoning doubled. ``normalize_reasoning_delta``
+   corrects both — with a minimum-overlap gate so legitimate short
+   repetitions ("the", token fragments) are never dropped.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from run_agent import AIAgent
+from agent.chat_completion_helpers import (
+    _MIN_REASONING_OVERLAP,
+    normalize_reasoning_delta,
+)
+
+
+def _make_agent(**overrides):
+    agent = AIAgent.__new__(AIAgent)
+    agent.reasoning_callback = None
+    agent.stream_delta_callback = None
+    agent._stream_callback = None
+    agent.verbose_logging = False
+    for key, value in overrides.items():
+        setattr(agent, key, value)
+    return agent
+
+
+class TestGatewayShapedCallbacks(unittest.TestCase):
+    """Gateway platforms: reasoning_callback set, text-stream callbacks None."""
+
+    def test_streamed_reasoning_not_refired_post_completion(self):
+        """The core #59009 duplication: deltas streamed to the reasoning
+        callback must NOT be re-fired as a full blob by
+        build_assistant_message, even though text-stream callbacks are None
+        (the exact callback shape the gateway configures)."""
+        agent = _make_agent()
+        captured = []
+        agent.reasoning_callback = lambda t: captured.append(t)
+
+        # Simulate the streaming loop delivering reasoning deltas.
+        agent._fire_reasoning_delta("Let me think ")
+        agent._fire_reasoning_delta("about merging.")
+        self.assertEqual(captured, ["Let me think ", "about merging."])
+
+        # Post-completion: the accumulated reasoning arrives on the message.
+        msg = SimpleNamespace(
+            content="I'll merge that.",
+            tool_calls=None,
+            reasoning_content="Let me think about merging.",
+            reasoning=None,
+            reasoning_details=None,
+        )
+        agent._build_assistant_message(msg, "stop")
+
+        # No third (duplicated, accumulated) delivery.
+        self.assertEqual(captured, ["Let me think ", "about merging."])
+
+    def test_non_streamed_reasoning_fires_exactly_once(self):
+        """When nothing streamed (non-streaming gateway turn), the
+        post-completion path must still deliver reasoning — exactly once."""
+        agent = _make_agent()
+        captured = []
+        agent.reasoning_callback = lambda t: captured.append(t)
+
+        msg = SimpleNamespace(
+            content="Done.",
+            tool_calls=None,
+            reasoning_content="Reasoning that never streamed.",
+            reasoning=None,
+            reasoning_details=None,
+        )
+        agent._build_assistant_message(msg, "stop")
+        self.assertEqual(captured, ["Reasoning that never streamed."])
+
+    def test_latch_is_read_and_cleared(self):
+        """The latch must be scoped to a single response: consumed by one
+        build_assistant_message call, so the NEXT response (no streaming)
+        still gets its reasoning delivered."""
+        agent = _make_agent()
+        captured = []
+        agent.reasoning_callback = lambda t: captured.append(t)
+
+        agent._fire_reasoning_delta("First response reasoning.")
+        msg1 = SimpleNamespace(
+            content="One.",
+            tool_calls=None,
+            reasoning_content="First response reasoning.",
+            reasoning=None,
+            reasoning_details=None,
+        )
+        agent._build_assistant_message(msg1, "stop")
+
+        # Second response: nothing streamed. Must fire.
+        msg2 = SimpleNamespace(
+            content="Two.",
+            tool_calls=None,
+            reasoning_content="Second response reasoning.",
+            reasoning=None,
+            reasoning_details=None,
+        )
+        agent._build_assistant_message(msg2, "stop")
+
+        self.assertEqual(
+            captured,
+            ["First response reasoning.", "Second response reasoning."],
+        )
+
+    def test_stale_latch_does_not_leak_without_callback_delivery(self):
+        """_fire_reasoning_delta with no callback registered must NOT set
+        the latch — nothing was delivered, so build_assistant_message
+        (with a callback registered later, e.g. gateway wiring order)
+        must still fire."""
+        agent = _make_agent()
+        agent._fire_reasoning_delta("dropped — no consumer")
+
+        captured = []
+        agent.reasoning_callback = lambda t: captured.append(t)
+        msg = SimpleNamespace(
+            content="Done.",
+            tool_calls=None,
+            reasoning_content="Now-visible reasoning.",
+            reasoning=None,
+            reasoning_details=None,
+        )
+        agent._build_assistant_message(msg, "stop")
+        self.assertEqual(captured, ["Now-visible reasoning."])
+
+
+class TestCliShapedCallbacks(unittest.TestCase):
+    """CLI tag-extraction path: text-stream callbacks active, reasoning
+    arrives inline in content — the latch never trips, but the existing
+    text-stream suppression must be retained (regression contract also
+    pinned in tests/cli/test_reasoning_command.py)."""
+
+    def test_text_stream_active_suppresses_post_completion_fire(self):
+        agent = _make_agent()
+        captured = []
+        agent.reasoning_callback = lambda t: captured.append(t)
+        agent.stream_delta_callback = lambda t: None  # streaming active
+
+        # Reasoning came via content tag extraction (cli.py
+        # _stream_reasoning_delta) — agent latch untouched.
+        msg = SimpleNamespace(
+            content="I'll merge that.",
+            tool_calls=None,
+            reasoning_content="Let me merge the PR.",
+            reasoning=None,
+            reasoning_details=None,
+        )
+        agent._build_assistant_message(msg, "stop")
+        self.assertEqual(captured, [])
+
+    def test_internal_stream_callback_also_suppresses(self):
+        agent = _make_agent()
+        captured = []
+        agent.reasoning_callback = lambda t: captured.append(t)
+        agent._stream_callback = lambda t: None
+        msg = SimpleNamespace(
+            content="Done.",
+            tool_calls=None,
+            reasoning_content="Reasoning.",
+            reasoning=None,
+            reasoning_details=None,
+        )
+        agent._build_assistant_message(msg, "stop")
+        self.assertEqual(captured, [])
+
+
+class TestNormalizeReasoningDelta(unittest.TestCase):
+    """Provider delta normalization: dedupe cumulative echoes and reconnect
+    overlaps WITHOUT dropping legitimate repeated tokens."""
+
+    def test_empty_delta(self):
+        self.assertEqual(normalize_reasoning_delta("abc", ""), "")
+
+    def test_first_delta_passthrough(self):
+        self.assertEqual(normalize_reasoning_delta("", "Hello"), "Hello")
+
+    def test_incremental_tokens_passthrough(self):
+        """Normal providers: true incremental tokens append verbatim."""
+        acc = "Let me think"
+        self.assertEqual(normalize_reasoning_delta(acc, " about"), " about")
+
+    def test_cumulative_snapshot_keeps_new_suffix(self):
+        acc = "Let me think"
+        delta = "Let me think about merging."
+        self.assertEqual(
+            normalize_reasoning_delta(acc, delta), " about merging."
+        )
+
+    def test_exact_echo_dropped(self):
+        """The doubled-halves bug: provider re-sends the full accumulated
+        reasoning as a trailing chunk. Must be dropped entirely."""
+        acc = "Full reasoning text that already streamed."
+        self.assertEqual(normalize_reasoning_delta(acc, acc), "")
+
+    def test_reconnect_overlap_trimmed(self):
+        """Overlapping re-delivery: delta re-sends a long tail of already
+        delivered text followed by new tokens — overlapped head trimmed."""
+        overlap = "x" * (_MIN_REASONING_OVERLAP + 10)
+        acc = "prefix text " + overlap
+        delta = overlap + " NEW TOKENS"
+        self.assertEqual(normalize_reasoning_delta(acc, delta), " NEW TOKENS")
+
+    def test_short_repeated_token_not_dropped(self):
+        """The reviewer-flagged over-broad case: a short delta that happens
+        to be a substring of earlier text is LEGITIMATE repetition and must
+        be appended, not discarded."""
+        acc = "I think the answer is that the list"
+        # " the" appears twice in acc already — still a valid new token.
+        self.assertEqual(normalize_reasoning_delta(acc, " the"), " the")
+
+    def test_short_suffix_overlap_not_trimmed(self):
+        """Suffix/prefix overlaps below the gate are treated as legitimate
+        text (e.g. 'so ' ending acc and starting delta), not re-delivery."""
+        acc = "and so "
+        delta = "so what happens next"
+        self.assertEqual(normalize_reasoning_delta(acc, delta), delta)
+
+    def test_repeated_phrase_verbatim_not_dropped(self):
+        """A repeated phrase that is NOT a suffix/prefix overlap (appears
+        mid-accumulated-text) must never be dropped, regardless of length."""
+        phrase = "check the merge conflicts carefully before pushing"
+        acc = f"First I will {phrase} and then run tests. Next"
+        self.assertEqual(normalize_reasoning_delta(acc, phrase), phrase)
+
+    def test_streaming_loop_dedupes_cumulative_echo_end_to_end(self):
+        """Wire the normalizer the way the streaming loop uses it and feed
+        the observed provider misbehavior: tokens then a full echo."""
+        parts = []
+        fired = []
+
+        def _consume(chunk_text):
+            text = normalize_reasoning_delta("".join(parts), chunk_text)
+            if text:
+                parts.append(text)
+                fired.append(text)
+
+        _consume("Let me ")
+        _consume("think about ")
+        _consume("merging.")
+        _consume("Let me think about merging.")  # trailing cumulative echo
+
+        self.assertEqual("".join(parts), "Let me think about merging.")
+        self.assertEqual(fired, ["Let me ", "think about ", "merging."])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agent/test_reasoning_delivery_dedup_59009.py
+++ b/tests/agent/test_reasoning_delivery_dedup_59009.py
@@ -204,11 +204,22 @@ class TestNormalizeReasoningDelta(unittest.TestCase):
         self.assertEqual(normalize_reasoning_delta(acc, " about"), " about")
 
     def test_cumulative_snapshot_keeps_new_suffix(self):
-        acc = "Let me think"
-        delta = "Let me think about merging."
+        acc = "Let me think about this problem carefully"  # past the gate
+        delta = acc + " and then merge."
         self.assertEqual(
-            normalize_reasoning_delta(acc, delta), " about merging."
+            normalize_reasoning_delta(acc, delta), " and then merge."
         )
+
+    def test_early_stream_snapshot_below_gate_appends_verbatim(self):
+        """Contract: below _MIN_REASONING_OVERLAP accumulated chars the
+        snapshot branch does NOT engage — a short prefix match is
+        indistinguishable from legitimate repetition ("the" + "the quick"),
+        and dropping real tokens is worse than briefly duplicating a short
+        one. Cumulative providers self-heal via the overlap branch once
+        past the gate."""
+        acc = "the "
+        delta = "the quick"
+        self.assertEqual(normalize_reasoning_delta(acc, delta), delta)
 
     def test_exact_echo_dropped(self):
         """The doubled-halves bug: provider re-sends the full accumulated


### PR DESCRIPTION
## What

Reasoning text reaches \`reasoning_callback\` consumers duplicated (2-4×) on gateway platforms. Two independent root causes, both fixed at their source. ~50 lines across 2 files, no behavior change for CLI or non-streaming modes.

## Why (mechanisms)

**1. Post-completion double-fire** — \`_build_assistant_message\` (agent/chat_completion_helpers.py) re-fires \`reasoning_callback\` with the full accumulated reasoning after streaming already delivered the same text as deltas. Its "skip when already streamed" guard tests \`stream_delta_callback\` / \`_stream_callback\` — the **text**-streaming consumers — which are \`None\` on gateway platforms even while reasoning deltas stream fine. So the guard never trips there and every burst is delivered twice. The CLI is unaffected because it always sets \`stream_delta_callback\`, which is why this went unnoticed.

Fix: \`_fire_reasoning_delta\` latches \`_reasoning_streamed_this_response\`; the completion path reads-and-clears the latch and fires only when nothing streamed — batch/quiet/non-streaming providers still receive reasoning exactly once.

**2. Cumulative delta echoes** — some providers re-send the *entire accumulated reasoning* as a trailing delta chunk, or re-deliver overlapping windows after internal reconnects. Naive \`reasoning_parts.append()\` then stores the reasoning doubled and fires duplicated text at consumers. Reproducible artifact: sessions-DB \`messages.reasoning\` rows that are two byte-identical halves.

Fix: normalize at the accumulation chokepoint (trajectory storage, \`reasoning_callback\`, and CLI display all sit downstream of it): suffix-strip cumulative snapshots, drop exact echoes, pass true deltas through unchanged.

## How to test

- Latch: stream deltas then complete → callback receives deltas only (no full-text re-fire); non-streaming turn → exactly one full-text fire; latch clears between turns.
- Normalizer: true deltas pass unchanged; cumulative snapshot (\`acc + new\`) → only \`new\` appended; exact echo → dropped.
- Live repro (pre-fix): wire any \`reasoning_callback\` on a gateway platform with a reasoning-streaming provider — each burst arrives twice; check stored \`messages.reasoning\` for doubled halves.

## Platforms tested

macOS arm64 (Apple Silicon), Hermes 2026.7.1, gateway (Slack) + CLI paths, live provider traffic over several hours.

## Context

Found while building Slack-native task cards that render reasoning on-card (sibling PR); the fixes stand alone and benefit any gateway platform that wires \`reasoning_callback\`.