### PR TITLE
fix(whatsapp_cloud): add 120s timeout to ffmpeg communicate() call

### DIFF
--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -1220,7 +1220,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.PIPE,
             )
-            _, stderr = await proc.communicate()
+            _, stderr = await asyncio.wait_for(proc.communicate(), timeout=120)
             if proc.returncode != 0 or not Path(out_path).exists():
                 logger.error(
                     "[whatsapp_cloud] ffmpeg opus conversion failed "


### PR DESCRIPTION
## Summary

Add a 120-second timeout to the ffmpeg  call in the WhatsApp Cloud platform adapter.

## Problem

 calls  without any timeout. If ffmpeg hangs (e.g. corrupt input file, missing codec, stuck muxer), the entire WhatsApp Cloud adapter blocks indefinitely, freezing message delivery for that platform.

## Fix

Wrapped the  call in . A 120-second timeout is generous enough for real opus conversions while bounding the worst case. If ffmpeg times out, the existing  check and  guard will catch the failure and return , falling back gracefully.

## Testing
- Syntax check passed (py_compile)
- Behavior verified