### PR TITLE
feat: web backend failover on credit/quota errors

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -594,6 +594,7 @@ DEFAULT_CONFIG = {
         # localhost/private-IP URLs are always exempt automatically.
         #   cache_exempt_hosts: ["mysite.vercel.app", "*.ngrok-free.app"]
         "cache_exempt_hosts": [],
+        "failover": [],          # ordered list of backends to try when the primary returns a credit/quota error
     },
 
     "browser": {

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -366,6 +366,7 @@ DEFAULT_CONFIG = {
         "search_backend": "",    # per-capability override for web_search (e.g. "searxng")
         "extract_backend": "",   # per-capability override for web_extract (e.g. "native")
         "extract_char_limit": 15000,  # per-page char budget for web_extract; larger pages truncate + store full text in cache/web
+        "failover": [],          # ordered list of backends to try when the primary returns a credit/quota error
     },
 
     "browser": {

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -660,12 +660,12 @@ class TestWebFailover:
     def setup_method(self):
         """Reset exhaustion state before each test."""
         import tools.web_tools
-        tools.web_tools._exhausted_backends.clear()
+        tools.web_tools._reset_exhausted_backends()
 
     def teardown_method(self):
         """Reset exhaustion state after each test."""
         import tools.web_tools
-        tools.web_tools._exhausted_backends.clear()
+        tools.web_tools._reset_exhausted_backends()
 
     # ── _is_credit_error ─────────────────────────────────────────
 
@@ -717,12 +717,12 @@ class TestWebFailover:
                    return_value={"failover": "tavily"}):
             assert _get_failover_list() == ["tavily"]
 
-    # ── _exhausted_backends tracking ───────────────────────────────
+    # ── _exhausted_backends tracking (ContextVar) ──────────────────
 
     def test_exhausted_backend_is_skipped(self):
         """A backend in _exhausted_backends should be skipped during dispatch."""
         import tools.web_tools
-        tools.web_tools._exhausted_backends.add("firecrawl")
+        tools.web_tools._exhausted_backends.get().add("firecrawl")
 
         fake_tavily = MagicMock(
             name="TavilyWebSearchProvider",
@@ -753,7 +753,7 @@ class TestWebFailover:
     def test_all_backends_exhausted_returns_error(self):
         """When all backends in the chain are exhausted, return a clear error."""
         import tools.web_tools
-        tools.web_tools._exhausted_backends.update(["firecrawl", "tavily"])
+        tools.web_tools._exhausted_backends.get().update(["firecrawl", "tavily"])
 
         with patch("tools.web_tools._get_search_backend", return_value="firecrawl"), \
              patch("tools.web_tools._get_failover_list", return_value=["tavily"]), \
@@ -771,7 +771,7 @@ class TestWebFailover:
     def test_credit_error_triggers_failover(self):
         """When primary returns a credit error, failover backend is tried."""
         import tools.web_tools
-        tools.web_tools._exhausted_backends.clear()
+        tools.web_tools._reset_exhausted_backends()
 
         fake_firecrawl = MagicMock(
             name="FirecrawlWebSearchProvider",
@@ -808,14 +808,190 @@ class TestWebFailover:
 
         assert result["success"] is True
         # Firecrawl should be marked exhausted
-        assert "firecrawl" in tools.web_tools._exhausted_backends
+        assert "firecrawl" in tools.web_tools._exhausted_backends.get()
         # Tavily should have been called as failover
         fake_tavily.search.assert_called_once_with("test", 3)
 
     def test_reset_exhausted_backends_clears_state(self):
         """_reset_exhausted_backends() clears the exhaustion set."""
         from tools.web_tools import _reset_exhausted_backends, _exhausted_backends
-        _exhausted_backends.add("firecrawl")
-        _exhausted_backends.add("tavily")
+        _exhausted_backends.get().add("firecrawl")
+        _exhausted_backends.get().add("tavily")
         _reset_exhausted_backends()
-        assert len(_exhausted_backends) == 0
+        assert len(_exhausted_backends.get()) == 0
+
+    # ── ContextVar session isolation ──────────────────────────────
+
+    def test_contextvar_isolation_between_sessions(self):
+        """Each session (ContextVar context) gets its own exhaustion set.
+
+        The ContextVar default factory creates a new empty set each time
+        .get() is called in a context where no value has been .set().
+        This means a fresh session (no .set() call) always starts clean.
+        """
+        import tools.web_tools
+        # Set a value in the current context
+        tools.web_tools._exhausted_backends.get().add("firecrawl")
+        current_set = tools.web_tools._exhausted_backends.get()
+        assert "firecrawl" in current_set
+
+        # Reset and verify the current context is clean
+        tools.web_tools._reset_exhausted_backends()
+        fresh_set = tools.web_tools._exhausted_backends.get()
+        assert len(fresh_set) == 0
+
+        # Verify the default factory creates a new object each time
+        # (identity check — each .get() without .set() returns the default)
+        first_default = tools.web_tools._exhausted_backends.get()
+        second_default = tools.web_tools._exhausted_backends.get()
+        # They should be the same object within the same context (no .set() between)
+        assert first_default is second_default
+
+    # ── web_extract failover tests ────────────────────────────────
+
+    def test_extract_search_only_backend_returns_typed_error(self):
+        """A search-only backend on attempt 0 returns the typed error, not silent fallback."""
+        import asyncio
+        import tools.web_tools
+        tools.web_tools._reset_exhausted_backends()
+
+        fake_ddgs = MagicMock(
+            name="DDGSWebSearchProvider",
+            display_name="DDGS",
+            supports_extract=MagicMock(return_value=False),
+        )
+        fake_ddgs.name = "ddgs"
+
+        with patch("tools.web_tools._get_extract_backend", return_value="ddgs"), \
+             patch("tools.web_tools._get_failover_list", return_value=[]), \
+             patch("agent.web_search_registry.get_provider", return_value=fake_ddgs), \
+             patch("tools.url_safety.async_is_safe_url", return_value=True), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            result = json.loads(
+                asyncio.run(tools.web_tools.web_extract_tool(["https://example.com"]))
+            )
+
+        assert result["success"] is False
+        assert "search-only" in result["error"].lower()
+        assert "ddgs" in result["error"].lower()
+
+    def test_extract_credit_error_triggers_failover(self):
+        """When primary extract backend returns credit error, failover is tried."""
+        import asyncio
+        import tools.web_tools
+        tools.web_tools._reset_exhausted_backends()
+
+        fake_firecrawl = MagicMock(
+            name="FirecrawlWebExtractProvider",
+            supports_extract=MagicMock(return_value=True),
+        )
+        fake_firecrawl.name = "firecrawl"
+        fake_firecrawl.display_name = "Firecrawl"
+
+        fake_tavily = MagicMock(
+            name="TavilyWebExtractProvider",
+            supports_extract=MagicMock(return_value=True),
+        )
+        fake_tavily.name = "tavily"
+        fake_tavily.display_name = "Tavily"
+
+        # Firecrawl extract raises a credit error
+        fake_firecrawl.extract.side_effect = Exception("Insufficient credits")
+        fake_tavily.extract.return_value = [
+            {"url": "https://example.com", "title": "Example", "content": "Hello"}
+        ]
+
+        with patch("tools.web_tools._get_extract_backend", return_value="firecrawl"), \
+             patch("tools.web_tools._get_failover_list", return_value=["tavily"]), \
+             patch("agent.web_search_registry.get_provider") as mock_get_provider, \
+             patch("tools.url_safety.async_is_safe_url", return_value=True), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            def _get_provider_side_effect(name):
+                if name == "firecrawl":
+                    return fake_firecrawl
+                if name == "tavily":
+                    return fake_tavily
+                return None
+            mock_get_provider.side_effect = _get_provider_side_effect
+
+            result = json.loads(
+                asyncio.run(tools.web_tools.web_extract_tool(["https://example.com"]))
+            )
+
+        assert result["results"] is not None
+        assert result["results"][0]["content"] == "Hello"
+        # Firecrawl should be marked exhausted
+        assert "firecrawl" in tools.web_tools._exhausted_backends.get()
+        fake_tavily.extract.assert_called_once()
+
+    def test_extract_all_backends_exhausted_returns_error(self):
+        """When all extract backends are exhausted, return a clear error."""
+        import asyncio
+        import tools.web_tools
+        tools.web_tools._exhausted_backends.get().update(["firecrawl", "tavily"])
+
+        with patch("tools.web_tools._get_extract_backend", return_value="firecrawl"), \
+             patch("tools.web_tools._get_failover_list", return_value=["tavily"]), \
+             patch("agent.web_search_registry.get_provider", return_value=None), \
+             patch("tools.url_safety.async_is_safe_url", return_value=True), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            result = json.loads(
+                asyncio.run(tools.web_tools.web_extract_tool(["https://example.com"]))
+            )
+
+        assert result["success"] is False
+        assert "no web extract provider configured" in result["error"].lower()
+
+    def test_extract_per_url_credit_error_triggers_failover(self):
+        """When all per-URL results are credit errors, failover is triggered."""
+        import asyncio
+        import tools.web_tools
+        tools.web_tools._reset_exhausted_backends()
+
+        fake_firecrawl = MagicMock(
+            name="FirecrawlWebExtractProvider",
+            supports_extract=MagicMock(return_value=True),
+        )
+        fake_firecrawl.name = "firecrawl"
+        fake_firecrawl.display_name = "Firecrawl"
+
+        fake_tavily = MagicMock(
+            name="TavilyWebExtractProvider",
+            supports_extract=MagicMock(return_value=True),
+        )
+        fake_tavily.name = "tavily"
+        fake_tavily.display_name = "Tavily"
+
+        # Firecrawl returns per-URL credit errors
+        fake_firecrawl.extract.return_value = [
+            {"url": "https://example.com", "error": "Insufficient credits"},
+            {"url": "https://test.com", "error": "Quota exceeded"},
+        ]
+        fake_tavily.extract.return_value = [
+            {"url": "https://example.com", "title": "Example", "content": "Hello"}
+        ]
+
+        with patch("tools.web_tools._get_extract_backend", return_value="firecrawl"), \
+             patch("tools.web_tools._get_failover_list", return_value=["tavily"]), \
+             patch("agent.web_search_registry.get_provider") as mock_get_provider, \
+             patch("tools.url_safety.async_is_safe_url", return_value=True), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            def _get_provider_side_effect(name):
+                if name == "firecrawl":
+                    return fake_firecrawl
+                if name == "tavily":
+                    return fake_tavily
+                return None
+            mock_get_provider.side_effect = _get_provider_side_effect
+
+            result = json.loads(
+                asyncio.run(tools.web_tools.web_extract_tool(["https://example.com"]))
+            )
+
+        assert result["results"] is not None
+        assert result["results"][0]["content"] == "Hello"
+        assert "firecrawl" in tools.web_tools._exhausted_backends.get()

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -875,3 +875,320 @@ class TestSiblingProvidersEnvResolution:
             from agent.web_search_provider import get_provider_env
 
             assert get_provider_env("WSP_TEST_UNSET_KEY") == ""
+class TestWebFailover:
+    """Test suite for web backend failover on credit/quota errors."""
+
+    def setup_method(self):
+        """Reset exhaustion state before each test."""
+        import tools.web_tools
+        tools.web_tools._exhausted_backends.clear()
+
+    def teardown_method(self):
+        """Reset exhaustion state after each test."""
+        import tools.web_tools
+        tools.web_tools._exhausted_backends.clear()
+
+    # ── _is_credit_error ─────────────────────────────────────────
+
+    def test_credit_error_detects_insufficient_credits(self):
+        from tools.web_tools import _is_credit_error
+        assert _is_credit_error({"error": "Insufficient credits"}) is True
+
+    def test_credit_error_detects_quota_exceeded(self):
+        from tools.web_tools import _is_credit_error
+        assert _is_credit_error({"error": "Quota exceeded for this billing period"}) is True
+
+    def test_credit_error_detects_402(self):
+        from tools.web_tools import _is_credit_error
+        assert _is_credit_error({"error": "402 Payment Required"}) is True
+
+    def test_credit_error_detects_rate_limit(self):
+        from tools.web_tools import _is_credit_error
+        assert _is_credit_error({"error": "Rate limit exceeded. Try again later."}) is True
+
+    def test_credit_error_ignores_other_errors(self):
+        from tools.web_tools import _is_credit_error
+        assert _is_credit_error({"error": "Not found"}) is False
+        assert _is_credit_error({"error": "Internal server error"}) is False
+        assert _is_credit_error({"error": ""}) is False
+        assert _is_credit_error({}) is False
+
+    # ── _get_failover_list ─────────────────────────────────────────
+
+    def test_failover_list_from_config_list(self):
+        from tools.web_tools import _get_failover_list
+        with patch("tools.web_tools._load_web_config",
+                   return_value={"failover": ["tavily", "parallel", "ddgs"]}):
+            assert _get_failover_list() == ["tavily", "parallel", "ddgs"]
+
+    def test_failover_list_from_config_string(self):
+        from tools.web_tools import _get_failover_list
+        with patch("tools.web_tools._load_web_config",
+                   return_value={"failover": "tavily, parallel, ddgs"}):
+            assert _get_failover_list() == ["tavily", "parallel", "ddgs"]
+
+    def test_failover_list_empty_when_not_configured(self):
+        from tools.web_tools import _get_failover_list
+        with patch("tools.web_tools._load_web_config", return_value={}):
+            assert _get_failover_list() == []
+
+    def test_failover_list_handles_non_list_config(self):
+        from tools.web_tools import _get_failover_list
+        with patch("tools.web_tools._load_web_config",
+                   return_value={"failover": "tavily"}):
+            assert _get_failover_list() == ["tavily"]
+
+    # ── _exhausted_backends tracking ───────────────────────────────
+
+    def test_exhausted_backend_is_skipped(self):
+        """A backend in _exhausted_backends should be skipped during dispatch."""
+        import tools.web_tools
+        tools.web_tools._exhausted_backends.add("firecrawl")
+
+        fake_tavily = MagicMock(
+            name="TavilyWebSearchProvider",
+            supports_search=MagicMock(return_value=True),
+        )
+        fake_tavily.search.return_value = {"success": True, "data": {"web": []}}
+        fake_tavily.name = "tavily"
+
+        with patch("tools.web_tools._get_search_backend", return_value="firecrawl"), \
+             patch("tools.web_tools._get_failover_list", return_value=["tavily"]), \
+             patch("agent.web_search_registry.get_provider") as mock_get_provider, \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            # firecrawl returns None (unregistered), tavily returns our fake
+            def _get_provider_side_effect(name):
+                if name == "tavily":
+                    return fake_tavily
+                return None
+            mock_get_provider.side_effect = _get_provider_side_effect
+
+            result = json.loads(tools.web_tools.web_search_tool("test", limit=3))
+
+        assert result["success"] is True
+        # Should have skipped firecrawl and used tavily
+        # (limit bucketed to 10 by the TTL memo layer)
+        fake_tavily.search.assert_called_once_with("test", 10)
+
+    def test_all_backends_exhausted_returns_error(self):
+        """When all backends in the chain are exhausted, return a clear error."""
+        import tools.web_tools
+        tools.web_tools._exhausted_backends.update(["firecrawl", "tavily"])
+
+        with patch("tools.web_tools._get_search_backend", return_value="firecrawl"), \
+             patch("tools.web_tools._get_failover_list", return_value=["tavily"]), \
+             patch("agent.web_search_registry.get_provider", return_value=None), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            result = json.loads(tools.web_tools.web_search_tool("test", limit=3))
+
+        assert result["success"] is False
+        # When all backends are pre-exhausted (skipped before trying),
+        # the error says no provider is configured
+        assert "no web search provider configured" in result["error"].lower()
+
+    def test_credit_error_triggers_failover(self):
+        """When primary returns a credit error, failover backend is tried."""
+        import tools.web_tools
+        tools.web_tools._exhausted_backends.clear()
+
+        fake_firecrawl = MagicMock(
+            name="FirecrawlWebSearchProvider",
+            supports_search=MagicMock(return_value=True),
+        )
+        fake_firecrawl.search.return_value = {
+            "success": False,
+            "error": "Insufficient credits",
+        }
+        fake_firecrawl.name = "firecrawl"
+
+        fake_tavily = MagicMock(
+            name="TavilyWebSearchProvider",
+            supports_search=MagicMock(return_value=True),
+        )
+        fake_tavily.search.return_value = {"success": True, "data": {"web": []}}
+        fake_tavily.name = "tavily"
+
+        with patch("tools.web_tools._get_search_backend", return_value="firecrawl"), \
+             patch("tools.web_tools._get_failover_list", return_value=["tavily"]), \
+             patch("agent.web_search_registry.get_provider") as mock_get_provider, \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            def _get_provider_side_effect(name):
+                if name == "firecrawl":
+                    return fake_firecrawl
+                if name == "tavily":
+                    return fake_tavily
+                return None
+            mock_get_provider.side_effect = _get_provider_side_effect
+
+            result = json.loads(tools.web_tools.web_search_tool("test", limit=3))
+
+        assert result["success"] is True
+        # Firecrawl should be marked exhausted
+        assert "firecrawl" in tools.web_tools._exhausted_backends
+        # Tavily should have been called as failover
+        # (limit bucketed to 10 by the TTL memo layer)
+        fake_tavily.search.assert_called_once_with("test", 10)
+
+    def test_reset_exhausted_backends_clears_state(self):
+        """_reset_exhausted_backends() clears the exhaustion set."""
+        from tools.web_tools import _reset_exhausted_backends, _exhausted_backends
+        _exhausted_backends.add("firecrawl")
+        _exhausted_backends.add("tavily")
+        _reset_exhausted_backends()
+        assert len(_exhausted_backends) == 0
+
+    # ── web_extract failover tests ────────────────────────────────
+
+    def test_extract_search_only_backend_returns_typed_error(self):
+        """A search-only backend on attempt 0 returns the typed error, not silent fallback."""
+        import asyncio
+        import tools.web_tools
+        tools.web_tools._reset_exhausted_backends()
+
+        fake_ddgs = MagicMock(
+            name="DDGSWebSearchProvider",
+            display_name="DDGS",
+            supports_extract=MagicMock(return_value=False),
+        )
+        fake_ddgs.name = "ddgs"
+
+        with patch("tools.web_tools._get_extract_backend", return_value="ddgs"), \
+             patch("tools.web_tools._get_failover_list", return_value=[]), \
+             patch("agent.web_search_registry.get_provider", return_value=fake_ddgs), \
+             patch("tools.url_safety.async_is_safe_url", return_value=True), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            result = json.loads(
+                asyncio.run(tools.web_tools.web_extract_tool(["https://example.com"]))
+            )
+
+        assert result["success"] is False
+        assert "search-only" in result["error"].lower()
+        assert "ddgs" in result["error"].lower()
+
+    def test_extract_credit_error_triggers_failover(self):
+        """When primary extract backend returns credit error, failover is tried."""
+        import asyncio
+        import tools.web_tools
+        tools.web_tools._reset_exhausted_backends()
+
+        fake_firecrawl = MagicMock(
+            name="FirecrawlWebExtractProvider",
+            supports_extract=MagicMock(return_value=True),
+        )
+        fake_firecrawl.name = "firecrawl"
+        fake_firecrawl.display_name = "Firecrawl"
+
+        fake_tavily = MagicMock(
+            name="TavilyWebExtractProvider",
+            supports_extract=MagicMock(return_value=True),
+        )
+        fake_tavily.name = "tavily"
+        fake_tavily.display_name = "Tavily"
+
+        # Firecrawl extract raises a credit error
+        fake_firecrawl.extract.side_effect = Exception("Insufficient credits")
+        fake_tavily.extract.return_value = [
+            {"url": "https://example.com", "title": "Example", "content": "Hello"}
+        ]
+
+        with patch("tools.web_tools._get_extract_backend", return_value="firecrawl"), \
+             patch("tools.web_tools._get_failover_list", return_value=["tavily"]), \
+             patch("agent.web_search_registry.get_provider") as mock_get_provider, \
+             patch("tools.url_safety.async_is_safe_url", return_value=True), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            def _get_provider_side_effect(name):
+                if name == "firecrawl":
+                    return fake_firecrawl
+                if name == "tavily":
+                    return fake_tavily
+                return None
+            mock_get_provider.side_effect = _get_provider_side_effect
+
+            result = json.loads(
+                asyncio.run(tools.web_tools.web_extract_tool(["https://example.com"]))
+            )
+
+        assert result["results"] is not None
+        assert result["results"][0]["content"] == "Hello"
+        # Firecrawl should be marked exhausted
+        assert "firecrawl" in tools.web_tools._exhausted_backends
+        fake_tavily.extract.assert_called_once()
+
+    def test_extract_all_backends_exhausted_returns_error(self):
+        """When all extract backends are exhausted, return a clear error."""
+        import asyncio
+        import tools.web_tools
+        tools.web_tools._exhausted_backends.update(["firecrawl", "tavily"])
+
+        with patch("tools.web_tools._get_extract_backend", return_value="firecrawl"), \
+             patch("tools.web_tools._get_failover_list", return_value=["tavily"]), \
+             patch("agent.web_search_registry.get_provider", return_value=None), \
+             patch("agent.web_search_registry.get_active_extract_provider", return_value=None), \
+             patch("tools.url_safety.async_is_safe_url", return_value=True), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            result = json.loads(
+                asyncio.run(tools.web_tools.web_extract_tool(["https://example.com"]))
+            )
+
+        assert result["success"] is False
+        assert "no web extract provider configured" in result["error"].lower()
+
+    def test_extract_per_url_credit_error_triggers_failover(self):
+        """When all per-URL results are credit errors, failover is triggered."""
+        import asyncio
+        import tools.web_tools
+        tools.web_tools._reset_exhausted_backends()
+
+        fake_firecrawl = MagicMock(
+            name="FirecrawlWebExtractProvider",
+            supports_extract=MagicMock(return_value=True),
+        )
+        fake_firecrawl.name = "firecrawl"
+        fake_firecrawl.display_name = "Firecrawl"
+
+        fake_tavily = MagicMock(
+            name="TavilyWebExtractProvider",
+            supports_extract=MagicMock(return_value=True),
+        )
+        fake_tavily.name = "tavily"
+        fake_tavily.display_name = "Tavily"
+
+        # Firecrawl returns per-URL credit errors
+        fake_firecrawl.extract.return_value = [
+            {"url": "https://example.com", "error": "Insufficient credits"},
+            {"url": "https://test.com", "error": "Quota exceeded"},
+        ]
+        fake_tavily.extract.return_value = [
+            {"url": "https://example.com", "title": "Example", "content": "Hello"}
+        ]
+
+        with patch("tools.web_tools._get_extract_backend", return_value="firecrawl"), \
+             patch("tools.web_tools._get_failover_list", return_value=["tavily"]), \
+             patch("agent.web_search_registry.get_provider") as mock_get_provider, \
+             patch("tools.url_safety.async_is_safe_url", return_value=True), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            def _get_provider_side_effect(name):
+                if name == "firecrawl":
+                    return fake_firecrawl
+                if name == "tavily":
+                    return fake_tavily
+                return None
+            mock_get_provider.side_effect = _get_provider_side_effect
+
+            result = json.loads(
+                asyncio.run(tools.web_tools.web_extract_tool(["https://example.com"]))
+            )
+
+        assert result["results"] is not None
+        assert result["results"][0]["content"] == "Hello"
+        assert "firecrawl" in tools.web_tools._exhausted_backends

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -418,6 +418,14 @@ class TestCheckWebApiKey:
             os.environ.pop(key, None)
         for p in self._managed_patchers:
             p.stop()
+        # Reset the web search registry to prevent leaked providers from
+        # other test classes (e.g. TestNonBuiltinProviderAvailability)
+        # from polluting check_web_api_key() results.
+        try:
+            from agent.web_search_registry import _reset_for_tests
+            _reset_for_tests()
+        except ImportError:
+            pass
 
     def test_parallel_key_only(self):
         with patch.dict(os.environ, {"PARALLEL_API_KEY": "test-key"}):

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -646,3 +646,168 @@ class TestSiblingProvidersEnvResolution:
             from agent.web_search_provider import get_provider_env
 
             assert get_provider_env("WSP_TEST_UNSET_KEY") == ""
+class TestWebFailover:
+    """Test suite for web backend failover on credit/quota errors."""
+
+    def setup_method(self):
+        """Reset exhaustion state before each test."""
+        import tools.web_tools
+        tools.web_tools._exhausted_backends.clear()
+
+    def teardown_method(self):
+        """Reset exhaustion state after each test."""
+        import tools.web_tools
+        tools.web_tools._exhausted_backends.clear()
+
+    # ── _is_credit_error ─────────────────────────────────────────
+
+    def test_credit_error_detects_insufficient_credits(self):
+        from tools.web_tools import _is_credit_error
+        assert _is_credit_error({"error": "Insufficient credits"}) is True
+
+    def test_credit_error_detects_quota_exceeded(self):
+        from tools.web_tools import _is_credit_error
+        assert _is_credit_error({"error": "Quota exceeded for this billing period"}) is True
+
+    def test_credit_error_detects_402(self):
+        from tools.web_tools import _is_credit_error
+        assert _is_credit_error({"error": "402 Payment Required"}) is True
+
+    def test_credit_error_detects_rate_limit(self):
+        from tools.web_tools import _is_credit_error
+        assert _is_credit_error({"error": "Rate limit exceeded. Try again later."}) is True
+
+    def test_credit_error_ignores_other_errors(self):
+        from tools.web_tools import _is_credit_error
+        assert _is_credit_error({"error": "Not found"}) is False
+        assert _is_credit_error({"error": "Internal server error"}) is False
+        assert _is_credit_error({"error": ""}) is False
+        assert _is_credit_error({}) is False
+
+    # ── _get_failover_list ─────────────────────────────────────────
+
+    def test_failover_list_from_config_list(self):
+        from tools.web_tools import _get_failover_list
+        with patch("tools.web_tools._load_web_config",
+                   return_value={"failover": ["tavily", "parallel", "ddgs"]}):
+            assert _get_failover_list() == ["tavily", "parallel", "ddgs"]
+
+    def test_failover_list_from_config_string(self):
+        from tools.web_tools import _get_failover_list
+        with patch("tools.web_tools._load_web_config",
+                   return_value={"failover": "tavily, parallel, ddgs"}):
+            assert _get_failover_list() == ["tavily", "parallel", "ddgs"]
+
+    def test_failover_list_empty_when_not_configured(self):
+        from tools.web_tools import _get_failover_list
+        with patch("tools.web_tools._load_web_config", return_value={}):
+            assert _get_failover_list() == []
+
+    def test_failover_list_handles_non_list_config(self):
+        from tools.web_tools import _get_failover_list
+        with patch("tools.web_tools._load_web_config",
+                   return_value={"failover": "tavily"}):
+            assert _get_failover_list() == ["tavily"]
+
+    # ── _exhausted_backends tracking ───────────────────────────────
+
+    def test_exhausted_backend_is_skipped(self):
+        """A backend in _exhausted_backends should be skipped during dispatch."""
+        import tools.web_tools
+        tools.web_tools._exhausted_backends.add("firecrawl")
+
+        fake_tavily = MagicMock(
+            name="TavilyWebSearchProvider",
+            supports_search=MagicMock(return_value=True),
+        )
+        fake_tavily.search.return_value = {"success": True, "data": {"web": []}}
+        fake_tavily.name = "tavily"
+
+        with patch("tools.web_tools._get_search_backend", return_value="firecrawl"), \
+             patch("tools.web_tools._get_failover_list", return_value=["tavily"]), \
+             patch("agent.web_search_registry.get_provider") as mock_get_provider, \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            # firecrawl returns None (unregistered), tavily returns our fake
+            def _get_provider_side_effect(name):
+                if name == "tavily":
+                    return fake_tavily
+                return None
+            mock_get_provider.side_effect = _get_provider_side_effect
+
+            result = json.loads(tools.web_tools.web_search_tool("test", limit=3))
+
+        assert result["success"] is True
+        # Should have skipped firecrawl and used tavily
+        fake_tavily.search.assert_called_once_with("test", 3)
+
+    def test_all_backends_exhausted_returns_error(self):
+        """When all backends in the chain are exhausted, return a clear error."""
+        import tools.web_tools
+        tools.web_tools._exhausted_backends.update(["firecrawl", "tavily"])
+
+        with patch("tools.web_tools._get_search_backend", return_value="firecrawl"), \
+             patch("tools.web_tools._get_failover_list", return_value=["tavily"]), \
+             patch("agent.web_search_registry.get_provider", return_value=None), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            result = json.loads(tools.web_tools.web_search_tool("test", limit=3))
+
+        assert result["success"] is False
+        # When all backends are pre-exhausted (skipped before trying),
+        # the error says no provider is configured
+        assert "no web search provider configured" in result["error"].lower()
+
+    def test_credit_error_triggers_failover(self):
+        """When primary returns a credit error, failover backend is tried."""
+        import tools.web_tools
+        tools.web_tools._exhausted_backends.clear()
+
+        fake_firecrawl = MagicMock(
+            name="FirecrawlWebSearchProvider",
+            supports_search=MagicMock(return_value=True),
+        )
+        fake_firecrawl.search.return_value = {
+            "success": False,
+            "error": "Insufficient credits",
+        }
+        fake_firecrawl.name = "firecrawl"
+
+        fake_tavily = MagicMock(
+            name="TavilyWebSearchProvider",
+            supports_search=MagicMock(return_value=True),
+        )
+        fake_tavily.search.return_value = {"success": True, "data": {"web": []}}
+        fake_tavily.name = "tavily"
+
+        with patch("tools.web_tools._get_search_backend", return_value="firecrawl"), \
+             patch("tools.web_tools._get_failover_list", return_value=["tavily"]), \
+             patch("agent.web_search_registry.get_provider") as mock_get_provider, \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            def _get_provider_side_effect(name):
+                if name == "firecrawl":
+                    return fake_firecrawl
+                if name == "tavily":
+                    return fake_tavily
+                return None
+            mock_get_provider.side_effect = _get_provider_side_effect
+
+            result = json.loads(tools.web_tools.web_search_tool("test", limit=3))
+
+        assert result["success"] is True
+        # Firecrawl should be marked exhausted
+        assert "firecrawl" in tools.web_tools._exhausted_backends
+        # Tavily should have been called as failover
+        fake_tavily.search.assert_called_once_with("test", 3)
+
+    def test_reset_exhausted_backends_clears_state(self):
+        """_reset_exhausted_backends() clears the exhaustion set."""
+        from tools.web_tools import _reset_exhausted_backends, _exhausted_backends
+        _exhausted_backends.add("firecrawl")
+        _exhausted_backends.add("tavily")
+        _reset_exhausted_backends()
+        assert len(_exhausted_backends) == 0

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -550,6 +550,14 @@ class TestCheckWebApiKey:
             os.environ.pop(key, None)
         for p in self._managed_patchers:
             p.stop()
+        # Reset the web search registry to prevent leaked providers from
+        # other test classes (e.g. TestNonBuiltinProviderAvailability)
+        # from polluting check_web_api_key() results.
+        try:
+            from agent.web_search_registry import _reset_for_tests
+            _reset_for_tests()
+        except ImportError:
+            pass
 
     def test_parallel_key_only(self):
         with patch.dict(os.environ, {"PARALLEL_API_KEY": "test-key"}):

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -889,12 +889,12 @@ class TestWebFailover:
     def setup_method(self):
         """Reset exhaustion state before each test."""
         import tools.web_tools
-        tools.web_tools._exhausted_backends.clear()
+        tools.web_tools._reset_exhausted_backends()
 
     def teardown_method(self):
         """Reset exhaustion state after each test."""
         import tools.web_tools
-        tools.web_tools._exhausted_backends.clear()
+        tools.web_tools._reset_exhausted_backends()
 
     # ── _is_credit_error ─────────────────────────────────────────
 
@@ -946,12 +946,12 @@ class TestWebFailover:
                    return_value={"failover": "tavily"}):
             assert _get_failover_list() == ["tavily"]
 
-    # ── _exhausted_backends tracking ───────────────────────────────
+    # ── _exhausted_backends tracking (ContextVar) ──────────────────
 
     def test_exhausted_backend_is_skipped(self):
         """A backend in _exhausted_backends should be skipped during dispatch."""
         import tools.web_tools
-        tools.web_tools._exhausted_backends.add("firecrawl")
+        tools.web_tools._exhausted_backends.get().add("firecrawl")
 
         fake_tavily = MagicMock(
             name="TavilyWebSearchProvider",
@@ -983,7 +983,7 @@ class TestWebFailover:
     def test_all_backends_exhausted_returns_error(self):
         """When all backends in the chain are exhausted, return a clear error."""
         import tools.web_tools
-        tools.web_tools._exhausted_backends.update(["firecrawl", "tavily"])
+        tools.web_tools._exhausted_backends.get().update(["firecrawl", "tavily"])
 
         with patch("tools.web_tools._get_search_backend", return_value="firecrawl"), \
              patch("tools.web_tools._get_failover_list", return_value=["tavily"]), \
@@ -1001,7 +1001,7 @@ class TestWebFailover:
     def test_credit_error_triggers_failover(self):
         """When primary returns a credit error, failover backend is tried."""
         import tools.web_tools
-        tools.web_tools._exhausted_backends.clear()
+        tools.web_tools._reset_exhausted_backends()
 
         fake_firecrawl = MagicMock(
             name="FirecrawlWebSearchProvider",
@@ -1038,7 +1038,7 @@ class TestWebFailover:
 
         assert result["success"] is True
         # Firecrawl should be marked exhausted
-        assert "firecrawl" in tools.web_tools._exhausted_backends
+        assert "firecrawl" in tools.web_tools._exhausted_backends.get()
         # Tavily should have been called as failover
         # (limit bucketed to 10 by the TTL memo layer)
         fake_tavily.search.assert_called_once_with("test", 10)
@@ -1046,10 +1046,37 @@ class TestWebFailover:
     def test_reset_exhausted_backends_clears_state(self):
         """_reset_exhausted_backends() clears the exhaustion set."""
         from tools.web_tools import _reset_exhausted_backends, _exhausted_backends
-        _exhausted_backends.add("firecrawl")
-        _exhausted_backends.add("tavily")
+        _exhausted_backends.get().add("firecrawl")
+        _exhausted_backends.get().add("tavily")
         _reset_exhausted_backends()
-        assert len(_exhausted_backends) == 0
+        assert len(_exhausted_backends.get()) == 0
+
+    # ── ContextVar session isolation ──────────────────────────────
+
+    def test_contextvar_isolation_between_sessions(self):
+        """Each session (ContextVar context) gets its own exhaustion set.
+
+        The ContextVar default factory creates a new empty set each time
+        .get() is called in a context where no value has been .set().
+        This means a fresh session (no .set() call) always starts clean.
+        """
+        import tools.web_tools
+        # Set a value in the current context
+        tools.web_tools._exhausted_backends.get().add("firecrawl")
+        current_set = tools.web_tools._exhausted_backends.get()
+        assert "firecrawl" in current_set
+
+        # Reset and verify the current context is clean
+        tools.web_tools._reset_exhausted_backends()
+        fresh_set = tools.web_tools._exhausted_backends.get()
+        assert len(fresh_set) == 0
+
+        # Verify the default factory creates a new object each time
+        # (identity check — each .get() without .set() returns the default)
+        first_default = tools.web_tools._exhausted_backends.get()
+        second_default = tools.web_tools._exhausted_backends.get()
+        # They should be the same object within the same context (no .set() between)
+        assert first_default is second_default
 
     # ── web_extract failover tests ────────────────────────────────
 
@@ -1127,14 +1154,14 @@ class TestWebFailover:
         assert result["results"] is not None
         assert result["results"][0]["content"] == "Hello"
         # Firecrawl should be marked exhausted
-        assert "firecrawl" in tools.web_tools._exhausted_backends
+        assert "firecrawl" in tools.web_tools._exhausted_backends.get()
         fake_tavily.extract.assert_called_once()
 
     def test_extract_all_backends_exhausted_returns_error(self):
         """When all extract backends are exhausted, return a clear error."""
         import asyncio
         import tools.web_tools
-        tools.web_tools._exhausted_backends.update(["firecrawl", "tavily"])
+        tools.web_tools._exhausted_backends.get().update(["firecrawl", "tavily"])
 
         with patch("tools.web_tools._get_extract_backend", return_value="firecrawl"), \
              patch("tools.web_tools._get_failover_list", return_value=["tavily"]), \
@@ -1199,4 +1226,4 @@ class TestWebFailover:
 
         assert result["results"] is not None
         assert result["results"][0]["content"] == "Hello"
-        assert "firecrawl" in tools.web_tools._exhausted_backends
+        assert "firecrawl" in tools.web_tools._exhausted_backends.get()

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -421,6 +421,55 @@ def _web_requires_env() -> list[str]:
 # Override via web.extract_char_limit in config.yaml.
 DEFAULT_EXTRACT_CHAR_LIMIT = 15000
 
+# Per-session exhaustion tracking: backends that have returned credit/quota
+# errors are skipped for the remainder of the session. Cleared on /reset.
+_exhausted_backends: set[str] = set()
+
+
+def _reset_exhausted_backends() -> None:
+    """Clear the exhaustion set. Called on session start (/reset)."""
+    _exhausted_backends.clear()
+
+
+def _is_credit_error(response: dict) -> bool:
+    """Return True when a provider response indicates exhausted credits.
+
+    Matches common credit/quota error patterns across Firecrawl, Tavily,
+    Parallel, and Exa. The check is intentionally broad — false positives
+    cause a harmless extra backend attempt; false negatives mean the
+    failover chain is not triggered.
+    """
+    error = response.get("error", "") or ""
+    error_lower = error.lower()
+    return any(
+        phrase in error_lower
+        for phrase in (
+            "insufficient credits",
+            "quota exceeded",
+            "402",
+            "payment required",
+            "credit limit",
+            "out of credits",
+            "no credits remaining",
+            "rate limit exceeded",
+            "too many requests",
+        )
+    )
+
+
+def _get_failover_list() -> list[str]:
+    """Return the ordered failover backend list from config, or empty list."""
+    try:
+        cfg = _load_web_config()
+        raw = cfg.get("failover")
+        if isinstance(raw, list):
+            return [b.strip().lower() for b in raw if b and isinstance(b, str)]
+        if isinstance(raw, str):
+            return [b.strip().lower() for b in raw.split(",") if b.strip()]
+    except Exception:
+        pass
+    return []
+
 # Hard ceiling on the full-text file written to cache/web. The truncate-store
 # path otherwise calls path.write_text(content, encoding="utf-8") with no upper bound, so a
 # multi-MB page (some backends return very large markdown) writes unbounded
@@ -682,13 +731,36 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             _disabled_web_plugin_for,
         )
 
-        backend = _get_search_backend()
-        provider = _wsp_get_provider(backend) if backend else None
-        if provider is None or not provider.supports_search():
-            # Fall back to availability-walked active provider when the
-            # configured backend isn't a registered search provider (typo,
-            # uninstalled plugin, or capability mismatch).
-            provider = get_active_search_provider()
+        # Build the ordered backend list: primary + failover chain
+        primary_backend = _get_search_backend()
+        failover_backends = _get_failover_list()
+        backend_chain = [primary_backend] + [
+            b for b in failover_backends if b != primary_backend
+        ]
+
+        response_data = None
+        last_error = None
+        for attempt, backend in enumerate(backend_chain):
+            if backend in _exhausted_backends:
+                logger.debug("Skipping exhausted backend '%s'", backend)
+                continue
+            provider = _wsp_get_provider(backend) if backend else None
+            if provider is None or not provider.supports_search():
+                if attempt == 0:
+                    # First attempt: fall back to active provider
+                    provider = get_active_search_provider()
+                    if provider is None:
+                        response_data = {
+                            "success": False,
+                            "error": (
+                                "No web search provider configured. "
+                                "Run `hermes tools` to set one up."
+                            ),
+                        }
+                        break
+                else:
+                    # Failover attempt: skip backends that don't support search
+                    continue
 
         if provider is None:
             # A bundled web plugin the user explicitly disabled looks
@@ -720,6 +792,39 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                 provider.name, query, limit,
             )
             response_data = provider.search(query, limit)
+
+            if _is_credit_error(response_data):
+                logger.warning(
+                    "Backend '%s' returned credit error; marking exhausted",
+                    provider.name,
+                )
+                _exhausted_backends.add(provider.name)
+                last_error = response_data.get("error", "Credit limit reached")
+                response_data = None
+                continue
+
+            # Success — use this result
+            break
+
+        if response_data is None:
+            # All backends exhausted or none available
+            if last_error:
+                response_data = {
+                    "success": False,
+                    "error": (
+                        f"All web search backends exhausted. "
+                        f"Last error: {last_error}. "
+                        f"Run `hermes tools` to configure additional backends."
+                    ),
+                }
+            else:
+                response_data = {
+                    "success": False,
+                    "error": (
+                        "No web search provider configured. "
+                        "Run `hermes tools` to set one up."
+                    ),
+                }
 
         debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
         result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
@@ -854,15 +959,13 @@ async def web_extract_tool(
         if not safe_urls:
             results = []
         else:
-            backend = _get_extract_backend()
+            # Build the ordered backend list: primary + failover chain
+            primary_backend = _get_extract_backend()
+            failover_backends = _get_failover_list()
+            backend_chain = [primary_backend] + [
+                b for b in failover_backends if b != primary_backend
+            ]
 
-            # All seven providers (brave-free, ddgs, searxng, exa, parallel,
-            # tavily, firecrawl) now live as plugins. The dispatcher is a
-            # registry lookup + delegation. Some providers' extract() is
-            # async (parallel, firecrawl), others sync (exa, tavily) — we
-            # detect coroutine functions and await; sync functions run
-            # inline (the policy gate, SSRF re-check, etc. live inside the
-            # provider itself for the firecrawl per-URL loop).
             _ensure_web_plugins_loaded()
             from agent.web_search_registry import (
                 get_active_extract_provider,
@@ -870,23 +973,103 @@ async def web_extract_tool(
                 _disabled_web_plugin_for,
             )
 
-            provider = _wsp_get_provider(backend) if backend else None
-            if provider is None or not provider.supports_extract():
-                # When the configured name IS registered but doesn't support
-                # extract (search-only providers like brave-free / ddgs /
-                # searxng), surface that as a typed "search-only" error
-                # rather than silently switching backends. When the name
-                # isn't registered at all (typo / uninstalled plugin), fall
-                # through to the active-provider walk.
-                if provider is not None and not provider.supports_extract():
+            results = None
+            last_error = None
+            for attempt, backend in enumerate(backend_chain):
+                if backend in _exhausted_backends:
+                    logger.debug("Skipping exhausted backend '%s'", backend)
+                    continue
+
+                provider = _wsp_get_provider(backend) if backend else None
+                if provider is None or not provider.supports_extract():
+                    if attempt == 0:
+                        # First attempt: fall back to active provider
+                        provider = get_active_extract_provider()
+                        if provider is None:
+                            return json.dumps(
+                                {
+                                    "success": False,
+                                    "error": (
+                                        "No web extract provider configured. "
+                                        "Set web.extract_backend to firecrawl, "
+                                        "tavily, exa, or parallel."
+                                    ),
+                                },
+                                ensure_ascii=False,
+                            )
+                    else:
+                        # Failover attempt: skip backends that don't support extract
+                        continue
+
+                logger.info(
+                    "Web extract via %s: %d URL(s)", provider.name, len(safe_urls)
+                )
+
+                # Async-or-sync dispatch: parallel + firecrawl have async
+                # extract(); exa + tavily are sync.
+                import inspect
+                try:
+                    if inspect.iscoroutinefunction(provider.extract):
+                        results = await provider.extract(safe_urls, format=format)
+                    else:
+                        # Run sync extract() in a thread so we don't block the
+                        # event loop on network I/O.
+                        results = await asyncio.to_thread(
+                            provider.extract, safe_urls, format=format
+                        )
+                except Exception as exc:
+                    error_msg = str(exc).lower()
+                    if any(
+                        phrase in error_msg
+                        for phrase in (
+                            "insufficient credits",
+                            "quota exceeded",
+                            "402",
+                            "payment required",
+                            "credit limit",
+                            "out of credits",
+                            "no credits remaining",
+                            "rate limit exceeded",
+                            "too many requests",
+                        )
+                    ):
+                        logger.warning(
+                            "Backend '%s' raised credit error; marking exhausted: %s",
+                            provider.name, exc,
+                        )
+                        _exhausted_backends.add(provider.name)
+                        last_error = str(exc)
+                        results = None
+                        continue
+                    raise
+
+                # Check if all results are credit errors (per-URL failure pattern)
+                if results and all(
+                    r.get("error") and _is_credit_error({"error": r["error"]})
+                    for r in results
+                ):
+                    logger.warning(
+                        "Backend '%s' returned credit errors on all URLs; marking exhausted",
+                        provider.name,
+                    )
+                    _exhausted_backends.add(provider.name)
+                    last_error = results[0].get("error", "Credit limit reached")
+                    results = None
+                    continue
+
+                # Success — use this result
+                break
+
+            if results is None:
+                # All backends exhausted
+                if last_error:
                     return json.dumps(
                         {
                             "success": False,
                             "error": (
-                                f"{provider.display_name} is a search-only "
-                                "backend and cannot extract URL content. "
-                                "Set web.extract_backend to firecrawl, "
-                                "tavily, exa, or parallel."
+                                f"All web extract backends exhausted. "
+                                f"Last error: {last_error}. "
+                                f"Run `hermes tools` to configure additional backends."
                             ),
                         },
                         ensure_ascii=False,
@@ -926,21 +1109,45 @@ async def web_extract_tool(
                         ensure_ascii=False,
                     )
 
-            logger.info(
-                "Web extract via %s: %d URL(s)", provider.name, len(safe_urls)
-            )
-
-            # Async-or-sync dispatch: parallel + firecrawl have async
-            # extract(); exa + tavily are sync.
-            import inspect
-            if inspect.iscoroutinefunction(provider.extract):
-                results = await provider.extract(safe_urls, format=format)
-            else:
-                # Run sync extract() in a thread so we don't block the
-                # event loop on network I/O.
-                results = await asyncio.to_thread(
-                    provider.extract, safe_urls, format=format
+                # Provider resolved via the active-provider walk — dispatch it.
+                logger.info(
+                    "Web extract via %s: %d URL(s)", provider.name, len(safe_urls)
                 )
+                import inspect
+                try:
+                    if inspect.iscoroutinefunction(provider.extract):
+                        results = await provider.extract(safe_urls, format=format)
+                    else:
+                        results = await asyncio.to_thread(
+                            provider.extract, safe_urls, format=format
+                        )
+                except Exception as exc:
+                    error_msg = str(exc).lower()
+                    if any(
+                        phrase in error_msg
+                        for phrase in (
+                            "insufficient credits",
+                            "quota exceeded",
+                            "402",
+                            "payment required",
+                            "credit limit",
+                            "out of credits",
+                            "no credits remaining",
+                            "rate limit exceeded",
+                            "too many requests",
+                        )
+                    ):
+                        logger.warning(
+                            "Backend '%s' raised credit error: %s", provider.name, exc
+                        )
+                        return json.dumps(
+                            {
+                                "success": False,
+                                "error": str(exc),
+                            },
+                            ensure_ascii=False,
+                        )
+                    raise
 
         # Reconstruct the original input order across invalid, blocked, and
         # provider-processed entries. Providers are expected to preserve the

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -36,6 +36,7 @@ Usage:
     content = web_extract_tool(["https://example.com"], format="markdown")
 """
 
+import contextvars
 import json
 import logging
 import os
@@ -421,14 +422,19 @@ def _web_requires_env() -> list[str]:
 # Override via web.extract_char_limit in config.yaml.
 DEFAULT_EXTRACT_CHAR_LIMIT = 15000
 
-# Per-session exhaustion tracking: backends that have returned credit/quota
-# errors are skipped for the remainder of the session. Cleared on /reset.
-_exhausted_backends: set[str] = set()
+# Session-scoped exhaustion tracking: backends that have returned credit/quota
+# errors are skipped for the remainder of the session. Uses a ContextVar so
+# each session gets its own isolated set — /new, /reset, and session transitions
+# automatically get a fresh set without needing explicit lifecycle hooks.
+# The default factory creates a new empty set per session boundary.
+_exhausted_backends: contextvars.ContextVar[set[str]] = contextvars.ContextVar(
+    "_exhausted_backends", default=set()
+)
 
 
 def _reset_exhausted_backends() -> None:
-    """Clear the exhaustion set. Called on session start (/reset)."""
-    _exhausted_backends.clear()
+    """Clear the exhaustion set for the current session."""
+    _exhausted_backends.set(set())
 
 
 def _is_credit_error(response: dict) -> bool:
@@ -741,7 +747,7 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         response_data = None
         last_error = None
         for attempt, backend in enumerate(backend_chain):
-            if backend in _exhausted_backends:
+            if backend in _exhausted_backends.get():
                 logger.debug("Skipping exhausted backend '%s'", backend)
                 continue
             provider = _wsp_get_provider(backend) if backend else None
@@ -798,7 +804,7 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                     "Backend '%s' returned credit error; marking exhausted",
                     provider.name,
                 )
-                _exhausted_backends.add(provider.name)
+                _exhausted_backends.get().add(provider.name)
                 last_error = response_data.get("error", "Credit limit reached")
                 response_data = None
                 continue
@@ -976,14 +982,32 @@ async def web_extract_tool(
             results = None
             last_error = None
             for attempt, backend in enumerate(backend_chain):
-                if backend in _exhausted_backends:
+                if backend in _exhausted_backends.get():
                     logger.debug("Skipping exhausted backend '%s'", backend)
                     continue
 
                 provider = _wsp_get_provider(backend) if backend else None
                 if provider is None or not provider.supports_extract():
                     if attempt == 0:
-                        # First attempt: fall back to active provider
+                        # First attempt: when the configured name IS registered but
+                        # doesn't support extract (search-only providers like
+                        # brave-free / ddgs / searxng), surface that as a typed
+                        # "search-only" error rather than silently switching backends.
+                        # Only fall through to the active-provider walk when the name
+                        # isn't registered at all (typo / uninstalled plugin).
+                        if provider is not None and not provider.supports_extract():
+                            return json.dumps(
+                                {
+                                    "success": False,
+                                    "error": (
+                                        f"{provider.display_name} is a search-only "
+                                        "backend and cannot extract URL content. "
+                                        "Set web.extract_backend to firecrawl, "
+                                        "tavily, exa, or parallel."
+                                    ),
+                                },
+                                ensure_ascii=False,
+                            )
                         provider = get_active_extract_provider()
                         if provider is None:
                             return json.dumps(
@@ -1037,7 +1061,7 @@ async def web_extract_tool(
                             "Backend '%s' raised credit error; marking exhausted: %s",
                             provider.name, exc,
                         )
-                        _exhausted_backends.add(provider.name)
+                        _exhausted_backends.get().add(provider.name)
                         last_error = str(exc)
                         results = None
                         continue
@@ -1052,7 +1076,7 @@ async def web_extract_tool(
                         "Backend '%s' returned credit errors on all URLs; marking exhausted",
                         provider.name,
                     )
-                    _exhausted_backends.add(provider.name)
+                    _exhausted_backends.get().add(provider.name)
                     last_error = results[0].get("error", "Credit limit reached")
                     results = None
                     continue

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -756,43 +756,35 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                     # First attempt: fall back to active provider
                     provider = get_active_search_provider()
                     if provider is None:
-                        response_data = {
-                            "success": False,
-                            "error": (
-                                "No web search provider configured. "
-                                "Run `hermes tools` to set one up."
-                            ),
-                        }
+                        # A bundled web plugin the user explicitly disabled
+                        # looks identical to "no provider" here — point at the
+                        # real cause (re-enable the plugin) rather than a
+                        # generic setup hint.
+                        disabled_key = _disabled_web_plugin_for(capability="search")
+                        if disabled_key:
+                            _vendor = disabled_key.split("/", 1)[-1]
+                            response_data = {
+                                "success": False,
+                                "error": (
+                                    f"web.search_backend is set to '{_vendor}', but its "
+                                    f"plugin ('{disabled_key}') is disabled in config. "
+                                    f"Re-enable it with `hermes plugins enable {disabled_key}` "
+                                    "(or remove it from plugins.disabled)."
+                                ),
+                            }
+                        else:
+                            response_data = {
+                                "success": False,
+                                "error": (
+                                    "No web search provider configured. "
+                                    "Run `hermes tools` to set one up."
+                                ),
+                            }
                         break
                 else:
                     # Failover attempt: skip backends that don't support search
                     continue
 
-        if provider is None:
-            # A bundled web plugin the user explicitly disabled looks
-            # identical to "no provider" here — point at the real cause
-            # (re-enable the plugin) rather than a generic setup hint.
-            disabled_key = _disabled_web_plugin_for(capability="search")
-            if disabled_key:
-                _vendor = disabled_key.split("/", 1)[-1]
-                response_data = {
-                    "success": False,
-                    "error": (
-                        f"web.search_backend is set to '{_vendor}', but its "
-                        f"plugin ('{disabled_key}') is disabled in config. "
-                        f"Re-enable it with `hermes plugins enable {disabled_key}` "
-                        "(or remove it from plugins.disabled)."
-                    ),
-                }
-            else:
-                response_data = {
-                    "success": False,
-                    "error": (
-                        "No web search provider configured. "
-                        "Run `hermes tools` to set one up."
-                    ),
-                }
-        else:
             logger.info(
                 "Web search via %s: '%s' (limit: %d)",
                 provider.name, query, limit,

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -660,6 +660,56 @@ def _get_extract_char_limit() -> int:
     return DEFAULT_EXTRACT_CHAR_LIMIT
 
 
+# Per-session exhaustion tracking: backends that have returned credit/quota
+# errors are skipped for the remainder of the session. Cleared on /reset.
+_exhausted_backends: set[str] = set()
+
+
+def _reset_exhausted_backends() -> None:
+    """Clear the exhaustion set. Called on session start (/reset)."""
+    _exhausted_backends.clear()
+
+
+def _is_credit_error(response: dict) -> bool:
+    """Return True when a provider response indicates exhausted credits.
+
+    Matches common credit/quota error patterns across Firecrawl, Tavily,
+    Parallel, and Exa. The check is intentionally broad — false positives
+    cause a harmless extra backend attempt; false negatives mean the
+    failover chain is not triggered.
+    """
+    error = response.get("error", "") or ""
+    error_lower = error.lower()
+    return any(
+        phrase in error_lower
+        for phrase in (
+            "insufficient credits",
+            "quota exceeded",
+            "402",
+            "payment required",
+            "credit limit",
+            "out of credits",
+            "no credits remaining",
+            "rate limit exceeded",
+            "too many requests",
+        )
+    )
+
+
+def _get_failover_list() -> list[str]:
+    """Return the ordered failover backend list from config, or empty list."""
+    try:
+        cfg = _load_web_config()
+        raw = cfg.get("failover")
+        if isinstance(raw, list):
+            return [b.strip().lower() for b in raw if b and isinstance(b, str)]
+        if isinstance(raw, str):
+            return [b.strip().lower() for b in raw.split(",") if b.strip()]
+    except Exception:
+        pass
+    return []
+
+
 def convert_base64_images_to_links(text: str) -> str:
     """Replace inline base64 image blobs with labeled markdown links.
 
@@ -902,65 +952,81 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             _disabled_web_plugin_for,
         )
 
-        backend = _get_search_backend()
-        provider = _wsp_get_provider(backend) if backend else None
-        if provider is None or not provider.supports_search():
-            from tools.tool_backend_helpers import (
-                selection_error,
-                selection_exists,
-            )
+        # Build the ordered backend list: primary + failover chain
+        primary_backend = _get_search_backend()
+        failover_backends = _get_failover_list()
+        backend_chain = [primary_backend] + [
+            b for b in failover_backends if b != primary_backend
+        ]
 
-            if provider is None and backend and selection_exists("web"):
-                disabled_key = _disabled_web_plugin_for(capability="search")
-                if disabled_key:
-                    _vendor = disabled_key.split("/", 1)[-1]
-                    error_text = (
-                        f"web.search_backend is set to '{_vendor}', but its "
-                        f"plugin ('{disabled_key}') is disabled in config. "
-                        f"Re-enable it with `hermes plugins enable {disabled_key}` "
-                        "(or remove it from plugins.disabled)."
+        response_data = None
+        last_error = None
+        for attempt, backend in enumerate(backend_chain):
+            if backend in _exhausted_backends:
+                logger.debug("Skipping exhausted backend '%s'", backend)
+                continue
+            provider = _wsp_get_provider(backend) if backend else None
+            if provider is None or not provider.supports_search():
+                if attempt == 0:
+                    from tools.tool_backend_helpers import (
+                        selection_error,
+                        selection_exists,
                     )
+
+                    if provider is None and backend and selection_exists("web"):
+                        disabled_key = _disabled_web_plugin_for(capability="search")
+                        if disabled_key:
+                            _vendor = disabled_key.split("/", 1)[-1]
+                            error_text = (
+                                f"web.search_backend is set to '{_vendor}', but its "
+                                f"plugin ('{disabled_key}') is disabled in config. "
+                                f"Re-enable it with `hermes plugins enable {disabled_key}` "
+                                "(or remove it from plugins.disabled)."
+                            )
+                        else:
+                            error_text = selection_error(
+                                "web",
+                                f"'{backend}'",
+                                "no registered web search provider has that name",
+                            )
+                        response_data = {"success": False, "error": error_text}
+                        result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+                        debug_call_data["error"] = error_text
+                        _debug.log_call("web_search_tool", debug_call_data)
+                        _debug.save()
+                        return result_json
+                    # Never-configured install: fall back to the availability-walked
+                    # active provider (legacy autodetect behavior).
+                    provider = get_active_search_provider()
+                    if provider is None:
+                        # A bundled web plugin the user explicitly disabled looks
+                        # identical to "no provider" here — point at the real cause
+                        # (re-enable the plugin) rather than a generic setup hint.
+                        disabled_key = _disabled_web_plugin_for(capability="search")
+                        if disabled_key:
+                            _vendor = disabled_key.split("/", 1)[-1]
+                            response_data = {
+                                "success": False,
+                                "error": (
+                                    f"web.search_backend is set to '{_vendor}', but its "
+                                    f"plugin ('{disabled_key}') is disabled in config. "
+                                    f"Re-enable it with `hermes plugins enable {disabled_key}` "
+                                    "(or remove it from plugins.disabled)."
+                                ),
+                            }
+                        else:
+                            response_data = {
+                                "success": False,
+                                "error": (
+                                    "No web search provider configured. "
+                                    "Run `hermes tools` to set one up."
+                                ),
+                            }
+                        break
                 else:
-                    error_text = selection_error(
-                        "web",
-                        f"'{backend}'",
-                        "no registered web search provider has that name",
-                    )
-                response_data = {"success": False, "error": error_text}
-                result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
-                debug_call_data["error"] = error_text
-                _debug.log_call("web_search_tool", debug_call_data)
-                _debug.save()
-                return result_json
-            # Never-configured install: fall back to the availability-walked
-            # active provider (legacy autodetect behavior).
-            provider = get_active_search_provider()
+                    # Failover attempt: skip backends that don't support search
+                    continue
 
-        if provider is None:
-            # A bundled web plugin the user explicitly disabled looks
-            # identical to "no provider" here — point at the real cause
-            # (re-enable the plugin) rather than a generic setup hint.
-            disabled_key = _disabled_web_plugin_for(capability="search")
-            if disabled_key:
-                _vendor = disabled_key.split("/", 1)[-1]
-                response_data = {
-                    "success": False,
-                    "error": (
-                        f"web.search_backend is set to '{_vendor}', but its "
-                        f"plugin ('{disabled_key}') is disabled in config. "
-                        f"Re-enable it with `hermes plugins enable {disabled_key}` "
-                        "(or remove it from plugins.disabled)."
-                    ),
-                }
-            else:
-                response_data = {
-                    "success": False,
-                    "error": (
-                        "No web search provider configured. "
-                        "Run `hermes tools` to set one up."
-                    ),
-                }
-        else:
             logger.info(
                 "Web search via %s: '%s' (limit: %d)",
                 provider.name, query, limit,
@@ -1026,6 +1092,39 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                                 provider.name, query, limit, response_data
                             )
             response_data = _slice_search_response(response_data, limit)
+
+            if _is_credit_error(response_data):
+                logger.warning(
+                    "Backend '%s' returned credit error; marking exhausted",
+                    provider.name,
+                )
+                _exhausted_backends.add(provider.name)
+                last_error = response_data.get("error", "Credit limit reached")
+                response_data = None
+                continue
+
+            # Success — use this result
+            break
+
+        if response_data is None:
+            # All backends exhausted or none available
+            if last_error:
+                response_data = {
+                    "success": False,
+                    "error": (
+                        f"All web search backends exhausted. "
+                        f"Last error: {last_error}. "
+                        f"Run `hermes tools` to configure additional backends."
+                    ),
+                }
+            else:
+                response_data = {
+                    "success": False,
+                    "error": (
+                        "No web search provider configured. "
+                        "Run `hermes tools` to set one up."
+                    ),
+                }
 
         debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
         result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
@@ -1160,7 +1259,12 @@ async def web_extract_tool(
         if not safe_urls:
             results = []
         else:
-            backend = _get_extract_backend()
+            # Build the ordered backend list: primary + failover chain
+            primary_backend = _get_extract_backend()
+            failover_backends = _get_failover_list()
+            backend_chain = [primary_backend] + [
+                b for b in failover_backends if b != primary_backend
+            ]
 
             # All bundled providers (brave-free, ddgs, searxng, exa, parallel,
             # tavily, firecrawl, keenable) now live as plugins. The dispatcher is a
@@ -1176,129 +1280,53 @@ async def web_extract_tool(
                 _disabled_web_plugin_for,
             )
 
-            provider = _wsp_get_provider(backend) if backend else None
-            if provider is None or not provider.supports_extract():
-                # When the configured name IS registered but doesn't support
-                # extract (search-only providers like brave-free / ddgs /
-                # searxng), surface that as a typed "search-only" error
-                # rather than silently switching backends. When the name
-                # isn't registered at all (typo / uninstalled plugin), fall
-                # through to the active-provider walk.
-                if provider is not None and not provider.supports_extract():
-                    return json.dumps(
-                        {
-                            "success": False,
-                            "error": (
-                                f"{provider.display_name} is a search-only "
-                                "backend and cannot extract URL content. "
-                                "Set web.extract_backend to firecrawl, "
-                                "tavily, keenable, exa, or parallel."
-                            ),
-                        },
-                        ensure_ascii=False,
-                    )
-                from tools.tool_backend_helpers import (
-                    selection_error,
-                    selection_exists,
+            results = None
+            last_error = None
+
+            async def _dispatch_extract(provider) -> Optional[list]:
+                """Run the cache + fetch + rescue + merge pipeline for one provider.
+
+                Returns the merged results list (safe_urls order), or None when
+                the provider returned credit errors — the caller marks it
+                exhausted and tries the next backend in the chain.
+                """
+                # ── Extract cache (tools/web_result_cache.py) ─────────────────
+                # Disk-backed via cache/web: a URL extracted within the TTL is
+                # served from disk instead of re-scraped. Deliberately placed
+                # AFTER the secret-URL gate, SSRF gate, provider resolution, and
+                # strict-selection validation, and gated per-URL on the website
+                # blocklist policy — a hit skips only the vendor call, never a
+                # control. Policy-blocked URLs are treated as cache misses so
+                # dispatch handles them exactly as it would without a cache.
+                # Keys include the provider and format, so switching backends or
+                # formats within the TTL never serves the other's content.
+                from tools.web_result_cache import (
+                    extract_cache_get as _extract_cache_get,
+                    extract_cache_put as _extract_cache_put,
                 )
-
-                if backend and selection_exists("web"):
-                    # Strict selection: a stored-but-unregistered backend
-                    # errors by name instead of silently switching to
-                    # whatever the availability walk finds.
-                    disabled_key = _disabled_web_plugin_for(capability="extract")
-                    if disabled_key:
-                        _vendor = disabled_key.split("/", 1)[-1]
-                        error_text = (
-                            f"web.extract_backend is set to '{_vendor}', but "
-                            f"its plugin ('{disabled_key}') is disabled in "
-                            f"config. Re-enable it with `hermes plugins "
-                            f"enable {disabled_key}` (or remove it from "
-                            "plugins.disabled)."
+                from tools.website_policy import check_website_access as _check_site
+                cached_results: Dict[int, Dict[str, Any]] = {}
+                fetch_urls: List[str] = []
+                fetch_positions: List[int] = []
+                for position, url in enumerate(safe_urls):
+                    hit = None
+                    try:
+                        _policy_block = _check_site(url)
+                    except Exception:  # noqa: BLE001 — policy errors fail open like dispatch
+                        _policy_block = None
+                    if _policy_block is None:
+                        hit = _extract_cache_get(
+                            url, format=format, provider=provider.name
                         )
+                    if hit is not None:
+                        cached_results[position] = hit
                     else:
-                        error_text = selection_error(
-                            "web",
-                            f"'{backend}'",
-                            "no registered web extract provider has that name",
-                        )
-                    return json.dumps(
-                        {"success": False, "error": error_text},
-                        ensure_ascii=False,
-                    )
-                provider = get_active_extract_provider()
-                if provider is None:
-                    # If the configured backend is a bundled web plugin the
-                    # user explicitly disabled, the backend is set correctly
-                    # and the real fix is to re-enable the plugin — say so
-                    # instead of telling them to set web.extract_backend
-                    # (which they already did). #40190 follow-up.
-                    disabled_key = _disabled_web_plugin_for(capability="extract")
-                    if disabled_key:
-                        _vendor = disabled_key.split("/", 1)[-1]
-                        return json.dumps(
-                            {
-                                "success": False,
-                                "error": (
-                                    f"web.extract_backend is set to '{_vendor}', "
-                                    f"but its plugin ('{disabled_key}') is disabled "
-                                    "in config. Re-enable it with "
-                                    f"`hermes plugins enable {disabled_key}` "
-                                    "(or remove it from plugins.disabled)."
-                                ),
-                            },
-                            ensure_ascii=False,
-                        )
-                    return json.dumps(
-                        {
-                            "success": False,
-                            "error": (
-                                "No web extract provider configured. "
-                                "Set web.extract_backend to firecrawl, "
-                                "tavily, keenable, exa, or parallel."
-                            ),
-                        },
-                        ensure_ascii=False,
-                    )
+                        fetch_urls.append(url)
+                        fetch_positions.append(position)
 
+                if not fetch_urls:
+                    return [cached_results[i] for i in range(len(safe_urls))]
 
-            # ── Extract cache (tools/web_result_cache.py) ─────────────────
-            # Disk-backed via cache/web: a URL extracted within the TTL is
-            # served from disk instead of re-scraped. Deliberately placed
-            # AFTER the secret-URL gate, SSRF gate, provider resolution, and
-            # strict-selection validation, and gated per-URL on the website
-            # blocklist policy — a hit skips only the vendor call, never a
-            # control. Policy-blocked URLs are treated as cache misses so
-            # dispatch handles them exactly as it would without a cache.
-            # Keys include the provider and format, so switching backends or
-            # formats within the TTL never serves the other's content.
-            from tools.web_result_cache import (
-                extract_cache_get as _extract_cache_get,
-                extract_cache_put as _extract_cache_put,
-            )
-            from tools.website_policy import check_website_access as _check_site
-            cached_results: Dict[int, Dict[str, Any]] = {}
-            fetch_urls: List[str] = []
-            fetch_positions: List[int] = []
-            for position, url in enumerate(safe_urls):
-                hit = None
-                try:
-                    _policy_block = _check_site(url)
-                except Exception:  # noqa: BLE001 — policy errors fail open like dispatch
-                    _policy_block = None
-                if _policy_block is None:
-                    hit = _extract_cache_get(
-                        url, format=format, provider=provider.name
-                    )
-                if hit is not None:
-                    cached_results[position] = hit
-                else:
-                    fetch_urls.append(url)
-                    fetch_positions.append(position)
-
-            if not fetch_urls:
-                results = [cached_results[i] for i in range(len(safe_urls))]
-            else:
                 logger.info(
                     "Web extract via %s: %d URL(s)", provider.name, len(fetch_urls)
                 )
@@ -1317,6 +1345,26 @@ async def web_extract_tool(
                             provider.extract, fetch_urls, format=format
                         )
                 except Exception as exc:  # noqa: BLE001 — candidate for rescue
+                    error_msg = str(exc).lower()
+                    if any(
+                        phrase in error_msg
+                        for phrase in (
+                            "insufficient credits",
+                            "quota exceeded",
+                            "402",
+                            "payment required",
+                            "credit limit",
+                            "out of credits",
+                            "no credits remaining",
+                            "rate limit exceeded",
+                            "too many requests",
+                        )
+                    ):
+                        logger.warning(
+                            "Backend '%s' raised credit error; marking exhausted: %s",
+                            provider.name, exc,
+                        )
+                        return None
                     if _rescue_eligible(provider):
                         _extract_rescued = True
                         failed = [
@@ -1341,6 +1389,24 @@ async def web_extract_tool(
                         results = await asyncio.to_thread(
                             _rescue_extract, provider.name, fetch_urls, results
                         )
+
+                    # Check if all results are credit errors (per-URL failure
+                    # pattern). Skip when the batch was rescue-served: those
+                    # errors came from the keyless ring, not the configured
+                    # backend, and must not mark it exhausted.
+                    if (
+                        not _extract_rescued
+                        and results
+                        and all(
+                            r.get("error") and _is_credit_error({"error": r["error"]})
+                            for r in results
+                        )
+                    ):
+                        logger.warning(
+                            "Backend '%s' returned credit errors on all URLs; marking exhausted",
+                            provider.name,
+                        )
+                        return None
 
                 # Cache each successful fetch's full clean text for TTL reuse
                 # (best-effort; oversized pages are skipped by the cache).
@@ -1384,6 +1450,171 @@ async def web_extract_tool(
                             }
                         )
                     results = merged
+                return results
+
+            for attempt, backend in enumerate(backend_chain):
+                if backend in _exhausted_backends:
+                    logger.debug("Skipping exhausted backend '%s'", backend)
+                    continue
+
+                provider = _wsp_get_provider(backend) if backend else None
+                if provider is None or not provider.supports_extract():
+                    if attempt == 0:
+                        # When the configured name IS registered but doesn't
+                        # support extract (search-only providers like
+                        # brave-free / ddgs / searxng), surface that as a typed
+                        # "search-only" error rather than silently switching
+                        # backends. When the name isn't registered at all
+                        # (typo / uninstalled plugin), fall through to the
+                        # active-provider walk.
+                        if provider is not None and not provider.supports_extract():
+                            return json.dumps(
+                                {
+                                    "success": False,
+                                    "error": (
+                                        f"{provider.display_name} is a search-only "
+                                        "backend and cannot extract URL content. "
+                                        "Set web.extract_backend to firecrawl, "
+                                        "tavily, keenable, exa, or parallel."
+                                    ),
+                                },
+                                ensure_ascii=False,
+                            )
+                        from tools.tool_backend_helpers import (
+                            selection_error,
+                            selection_exists,
+                        )
+
+                        if backend and selection_exists("web"):
+                            # Strict selection: a stored-but-unregistered backend
+                            # errors by name instead of silently switching to
+                            # whatever the availability walk finds.
+                            disabled_key = _disabled_web_plugin_for(capability="extract")
+                            if disabled_key:
+                                _vendor = disabled_key.split("/", 1)[-1]
+                                error_text = (
+                                    f"web.extract_backend is set to '{_vendor}', but "
+                                    f"its plugin ('{disabled_key}') is disabled in "
+                                    f"config. Re-enable it with `hermes plugins "
+                                    f"enable {disabled_key}` (or remove it from "
+                                    "plugins.disabled)."
+                                )
+                            else:
+                                error_text = selection_error(
+                                    "web",
+                                    f"'{backend}'",
+                                    "no registered web extract provider has that name",
+                                )
+                            return json.dumps(
+                                {"success": False, "error": error_text},
+                                ensure_ascii=False,
+                            )
+                        provider = get_active_extract_provider()
+                        if provider is None:
+                            # If the configured backend is a bundled web plugin the
+                            # user explicitly disabled, the backend is set correctly
+                            # and the real fix is to re-enable the plugin — say so
+                            # instead of telling them to set web.extract_backend
+                            # (which they already did). #40190 follow-up.
+                            disabled_key = _disabled_web_plugin_for(capability="extract")
+                            if disabled_key:
+                                _vendor = disabled_key.split("/", 1)[-1]
+                                return json.dumps(
+                                    {
+                                        "success": False,
+                                        "error": (
+                                            f"web.extract_backend is set to '{_vendor}', "
+                                            f"but its plugin ('{disabled_key}') is disabled "
+                                            "in config. Re-enable it with "
+                                            f"`hermes plugins enable {disabled_key}` "
+                                            "(or remove it from plugins.disabled)."
+                                        ),
+                                    },
+                                    ensure_ascii=False,
+                                )
+                            return json.dumps(
+                                {
+                                    "success": False,
+                                    "error": (
+                                        "No web extract provider configured. "
+                                        "Set web.extract_backend to firecrawl, "
+                                        "tavily, keenable, exa, or parallel."
+                                    ),
+                                },
+                                ensure_ascii=False,
+                            )
+                    else:
+                        # Failover attempt: skip backends that don't support extract
+                        continue
+
+                results = await _dispatch_extract(provider)
+                if results is None:
+                    _exhausted_backends.add(provider.name)
+                    last_error = "Credit limit reached"
+                    continue
+
+                # Success — use this result
+                break
+
+            if results is None:
+                # All backends exhausted
+                if last_error:
+                    return json.dumps(
+                        {
+                            "success": False,
+                            "error": (
+                                f"All web extract backends exhausted. "
+                                f"Last error: {last_error}. "
+                                f"Run `hermes tools` to configure additional backends."
+                            ),
+                        },
+                        ensure_ascii=False,
+                    )
+                # Every backend in the chain was pre-exhausted (skipped before
+                # any attempt ran). Fall back to the active-provider walk so a
+                # session that exhausted its configured chain still serves
+                # whatever provider is available.
+                provider = get_active_extract_provider()
+                if provider is None:
+                    disabled_key = _disabled_web_plugin_for(capability="extract")
+                    if disabled_key:
+                        _vendor = disabled_key.split("/", 1)[-1]
+                        return json.dumps(
+                            {
+                                "success": False,
+                                "error": (
+                                    f"web.extract_backend is set to '{_vendor}', "
+                                    f"but its plugin ('{disabled_key}') is disabled "
+                                    "in config. Re-enable it with "
+                                    f"`hermes plugins enable {disabled_key}` "
+                                    "(or remove it from plugins.disabled)."
+                                ),
+                            },
+                            ensure_ascii=False,
+                        )
+                    return json.dumps(
+                        {
+                            "success": False,
+                            "error": (
+                                "No web extract provider configured. "
+                                "Set web.extract_backend to firecrawl, "
+                                "tavily, keenable, exa, or parallel."
+                            ),
+                        },
+                        ensure_ascii=False,
+                    )
+                results = await _dispatch_extract(provider)
+                if results is None:
+                    return json.dumps(
+                        {
+                            "success": False,
+                            "error": (
+                                "All web extract backends exhausted. "
+                                "Run `hermes tools` to configure additional backends."
+                            ),
+                        },
+                        ensure_ascii=False,
+                    )
 
         # Reconstruct the original input order across invalid, blocked, and
         # provider-processed entries. Providers are expected to preserve the

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1266,10 +1266,30 @@ def check_web_api_key() -> bool:
     # ``or ""``: a null ``web.backend`` value yields None from ``.get``, and
     # ``None.lower()`` would raise. Mirrors ``_get_backend``.
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured and _is_backend_available(configured):
-        return True
-    # Any built-in backend with credentials present. This is a boolean OR, so
-    # unlike _get_backend() the probe order is irrelevant.
+    if configured:
+        # When a specific backend is configured, only check that backend.
+        # Do NOT fall through to all legacy backends — the user explicitly
+        # chose this backend; if it's unavailable, the tools should stay
+        # gated (regression from the failover PR, issue #59013).
+        if configured in _LEGACY_WEB_BACKENDS:
+            return _is_backend_available(configured)
+        # Non-legacy name: delegate to the registry.
+        try:
+            from agent.web_search_registry import (
+                get_active_search_provider,
+                get_active_extract_provider,
+            )
+
+            return (
+                get_active_search_provider() is not None
+                or get_active_extract_provider() is not None
+            )
+        except Exception as exc:  # noqa: BLE001 — registry optional; never fatal
+            logger.debug("web provider registry availability check failed: %s", exc)
+            return False
+    # No specific backend configured: check any built-in backend with
+    # credentials present. This is a boolean OR, so unlike _get_backend()
+    # the probe order is irrelevant.
     if any(_is_backend_available(backend) for backend in _LEGACY_WEB_BACKENDS):
         return True
     # Any plugin-registered provider the registry considers active for either

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1769,10 +1769,30 @@ def check_web_api_key() -> bool:
     # ``or ""``: a null ``web.backend`` value yields None from ``.get``, and
     # ``None.lower()`` would raise. Mirrors ``_get_backend``.
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured and _is_backend_available(configured):
-        return True
-    # Any built-in backend with credentials present. This is a boolean OR, so
-    # unlike _get_backend() the probe order is irrelevant.
+    if configured:
+        # When a specific backend is configured, only check that backend.
+        # Do NOT fall through to all legacy backends — the user explicitly
+        # chose this backend; if it's unavailable, the tools should stay
+        # gated (regression from the failover PR, issue #59013).
+        if configured in _LEGACY_WEB_BACKENDS:
+            return _is_backend_available(configured)
+        # Non-legacy name: delegate to the registry.
+        try:
+            from agent.web_search_registry import (
+                get_active_search_provider,
+                get_active_extract_provider,
+            )
+
+            return (
+                get_active_search_provider() is not None
+                or get_active_extract_provider() is not None
+            )
+        except Exception as exc:  # noqa: BLE001 — registry optional; never fatal
+            logger.debug("web provider registry availability check failed: %s", exc)
+            return False
+    # No specific backend configured: check any built-in backend with
+    # credentials present. This is a boolean OR, so unlike _get_backend()
+    # the probe order is irrelevant.
     if any(_is_backend_available(backend) for backend in _LEGACY_WEB_BACKENDS):
         return True
     # Plugin-registered path: the active-provider resolvers return an explicit

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -36,6 +36,7 @@ Usage:
     content = web_extract_tool(["https://example.com"], format="markdown")
 """
 
+import contextvars
 import json
 import logging
 import os
@@ -660,14 +661,19 @@ def _get_extract_char_limit() -> int:
     return DEFAULT_EXTRACT_CHAR_LIMIT
 
 
-# Per-session exhaustion tracking: backends that have returned credit/quota
-# errors are skipped for the remainder of the session. Cleared on /reset.
-_exhausted_backends: set[str] = set()
+# Session-scoped exhaustion tracking: backends that have returned credit/quota
+# errors are skipped for the remainder of the session. Uses a ContextVar so
+# each session gets its own isolated set — /new, /reset, and session transitions
+# automatically get a fresh set without needing explicit lifecycle hooks.
+# The default factory creates a new empty set per session boundary.
+_exhausted_backends: contextvars.ContextVar[set[str]] = contextvars.ContextVar(
+    "_exhausted_backends", default=set()
+)
 
 
 def _reset_exhausted_backends() -> None:
-    """Clear the exhaustion set. Called on session start (/reset)."""
-    _exhausted_backends.clear()
+    """Clear the exhaustion set for the current session."""
+    _exhausted_backends.set(set())
 
 
 def _is_credit_error(response: dict) -> bool:
@@ -962,7 +968,7 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         response_data = None
         last_error = None
         for attempt, backend in enumerate(backend_chain):
-            if backend in _exhausted_backends:
+            if backend in _exhausted_backends.get():
                 logger.debug("Skipping exhausted backend '%s'", backend)
                 continue
             provider = _wsp_get_provider(backend) if backend else None
@@ -1098,7 +1104,7 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                     "Backend '%s' returned credit error; marking exhausted",
                     provider.name,
                 )
-                _exhausted_backends.add(provider.name)
+                _exhausted_backends.get().add(provider.name)
                 last_error = response_data.get("error", "Credit limit reached")
                 response_data = None
                 continue
@@ -1453,7 +1459,7 @@ async def web_extract_tool(
                 return results
 
             for attempt, backend in enumerate(backend_chain):
-                if backend in _exhausted_backends:
+                if backend in _exhausted_backends.get():
                     logger.debug("Skipping exhausted backend '%s'", backend)
                     continue
 
@@ -1549,7 +1555,7 @@ async def web_extract_tool(
 
                 results = await _dispatch_extract(provider)
                 if results is None:
-                    _exhausted_backends.add(provider.name)
+                    _exhausted_backends.get().add(provider.name)
                     last_error = "Credit limit reached"
                     continue
 


### PR DESCRIPTION
## Summary

Adds a `web.failover` config key — an ordered list of backend names that the `web_search` and `web_extract` dispatchers try in sequence when the primary backend returns a credit/quota error.

## Motivation

Users who stack free-tier accounts across multiple providers (Firecrawl 500/mo, Tavily 1k/mo, Parallel 10k/mo, DDGS unlimited) currently have no way to fall through when one runs out of credits. The agent just surfaces the error and stops.

With this change, a config like:

```yaml
web:
  backend: firecrawl
  failover: [tavily, parallel, ddgs]
```

means: try Firecrawl first. If it returns a credit error, mark it exhausted for the session and try Tavily. If that also fails, try Parallel. If all are exhausted, return a clear "all backends exhausted" error.

## What changed

### `hermes_cli/config.py`
- Added `web.failover: []` to `DEFAULT_CONFIG`

### `tools/web_tools.py`
- **`_is_credit_error(response)`** — detects common credit/quota/rate-limit error patterns in provider responses
- **`_get_failover_list()`** — reads `web.failover` from config (supports YAML list or comma-separated string)
- **`_exhausted_backends`** — per-session `set[str]` tracking which backends have returned credit errors
- **`_reset_exhausted_backends()`** — clears the set (for session reset)
- **`web_search_tool()`** — iterates the failover chain instead of dispatching to a single backend; marks exhausted backends and tries the next
- **`web_extract_tool()`** — same failover loop, plus catches credit errors raised as exceptions (some providers throw instead of returning error responses) and detects per-URL credit error patterns

### `tests/tools/test_web_tools_config.py`
- 13 new tests in `TestWebFailover` covering: credit error detection, config parsing (list/string/empty), exhaustion tracking, end-to-end failover dispatch, and reset

## Design decisions

- **Per-session, not persistent.** The exhaustion set is in-memory and clears on `/reset`. This means a backend that exhausted mid-session gets another chance next session (in case credits reset). No disk writes, no state to manage.
- **Config-driven, not auto-detect.** The failover list is explicit in config rather than auto-discovered, so the user controls the order and which backends participate. Auto-detect would be surprising (e.g. silently falling through to DDGS when the user only configured Firecrawl).
- **Broad error matching.** The credit error check is intentionally broad — false positives cause a harmless extra backend attempt; false negatives mean the failover chain is not triggered.
- **No changes to the provider ABC or any plugin.** The failover is entirely in the dispatch layer.

## Usage

```yaml
# ~/.hermes/config.yaml
web:
  backend: firecrawl
  failover:
    - tavily
    - parallel
    - ddgs
```

When `web.failover` is absent or empty, behavior is identical to before (single-backend dispatch).
