### PR TITLE
test: disambiguate duplicate pytest names

### DIFF
--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -394,7 +394,7 @@ class TestMattermostSend:
         assert payload["root_id"] == "root_post_123"
 
     @pytest.mark.asyncio
-    async def test_progress_send_with_invalid_thread_root_never_falls_back_flat(self):
+    async def test_progress_send_with_invalid_thread_root_status_error_never_falls_back_flat(self):
         """Tool/status/progress bubbles must stay quiet when the thread is broken."""
         self.adapter._reply_mode = "thread"
         self.adapter._api_get = AsyncMock(return_value={"id": "bad_root", "root_id": ""})

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -1390,7 +1390,7 @@ def test_save_platform_tools_clears_no_mcp_sentinel():
     assert "no_mcp" not in saved
 
 
-def test_save_platform_tools_preserves_mcp_server_names():
+def test_save_platform_tools_preserves_non_sentinel_mcp_server_names():
     """Non-sentinel passthrough entries (MCP server names) must still survive
     the save — we only clear `no_mcp`, not every non-configurable entry.
     """


### PR DESCRIPTION
## Summary
- rename duplicate pytest tests so both Mattermost thread-root cases are collected
- rename the later tools_config MCP passthrough regression to describe the non-sentinel case

## Verification
- `python3` AST duplicate test-name scan for `tests/gateway/test_mattermost.py` and `tests/hermes_cli/test_tools_config.py`
- `/Users/lee/Documents/Claude/Projects/10\ Work\ OS/projects/hermes/venv/bin/python -m pytest --collect-only tests/gateway/test_mattermost.py tests/hermes_cli/test_tools_config.py -q` → 168 tests collected
- `/Users/lee/Documents/Claude/Projects/10\ Work\ OS/projects/hermes/venv/bin/python -m pytest tests/gateway/test_mattermost.py tests/hermes_cli/test_tools_config.py -q` → 168 passed, 3 warnings
