### PR TITLE
fix(matrix): let root DM stop auto-threaded runs

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11171,6 +11171,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not hasattr(self, "_active_session_leases"):
                 self._active_session_leases = {}
             self._active_session_leases[_quick_key] = _active_session_lease
+        # Root-DM control commands may need the origin while this turn is
+        # still represented by the pending sentinel.
+        self._cache_session_source(_quick_key, source)
         self._running_agents[_quick_key] = _AGENT_PENDING_SENTINEL
         self._running_agents_ts[_quick_key] = time.time()
         self._persist_active_agents()
@@ -13551,15 +13554,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         chat_id = getattr(source, "chat_id", None)
         if not thread_id or not chat_id:
             return []
-        platform = source.platform.value
         chat_type = getattr(source, "chat_type", None) or ""
+        # The namespace is profile-aware (``agent:main`` for default,
+        # ``agent:<profile>`` for multiplexed profiles), so recover it from
+        # the caller's real session key instead of assuming ``agent:main``.
+        namespace = ":".join(own_key.split(":", 2)[:2])
         # Prefix that every per-user key in this thread shares, up to and
         # including the thread_id segment.  Matching either the exact
         # shared-thread key or any key with a further (user_id) segment
         # (prefix + ":") avoids cross-matching an unrelated thread whose id
         # merely starts with this one.
         prefix = ":".join(
-            ["agent:main", platform, chat_type, str(chat_id), str(thread_id)]
+            [namespace, source.platform.value, chat_type, str(chat_id), str(thread_id)]
         )
         matches = []
         for key, agent in list(self._running_agents.items()):
@@ -13568,6 +13574,40 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if agent is _AGENT_PENDING_SENTINEL or not agent:
                 continue
             if key == prefix or key.startswith(prefix + ":"):
+                matches.append(key)
+        return matches
+
+
+    def _sibling_dm_thread_run_keys(self, source: SessionSource, own_key: str) -> list:
+        """Find active or pending Matrix DM threads rooted in the caller's DM session."""
+        if (
+            source.platform != Platform.MATRIX
+            or getattr(source, "chat_type", None) != "dm"
+            or getattr(source, "thread_id", None)
+            or not getattr(source, "chat_id", None)
+        ):
+            return []
+
+        namespace = ":".join(own_key.split(":", 2)[:2])
+        entries = getattr(getattr(self, "session_store", None), "_entries", {})
+        matches = []
+        for key, agent in list(self._running_agents.items()):
+            if key == own_key:
+                continue
+            if not agent:
+                continue
+            entry = entries.get(key)
+            run_source = getattr(entry, "origin", None) if entry else None
+            if run_source is None:
+                run_source = self._get_cached_session_source(key)
+            if (
+                run_source is not None
+                and ":".join(key.split(":", 2)[:2]) == namespace
+                and run_source.platform == Platform.MATRIX
+                and run_source.chat_type == "dm"
+                and run_source.chat_id == source.chat_id
+                and run_source.thread_id
+            ):
                 matches.append(key)
         return matches
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1144,6 +1144,27 @@ class GatewaySlashCommandsMixin:
             )
             return EphemeralReply(t("gateway.stop.stopped"))
 
+        # Matrix DM auto-threading can give each root DM message a synthetic
+        # event-id thread. A root-level /stop is a control command for the
+        # private conversation, not a new agent topic, so let it interrupt
+        # running DM-thread sessions in the same profile and room.
+        dm_thread_keys = self._sibling_dm_thread_run_keys(source, session_key)
+        if dm_thread_keys:
+            for sibling_key in dm_thread_keys:
+                await self._interrupt_and_clear_session(
+                    sibling_key,
+                    source,
+                    interrupt_reason=_INTERRUPT_REASON_STOP,
+                    invalidation_reason="stop_command_dm_thread_sibling",
+                )
+            logger.info(
+                "STOP (DM thread sibling) by %s — interrupted %d run(s) in DM: %s",
+                session_key,
+                len(dm_thread_keys),
+                ", ".join(dm_thread_keys),
+            )
+            return EphemeralReply(t("gateway.stop.stopped"))
+
         # No running agent anywhere for this scope. A platform status
         # indicator can still be stuck — e.g. Slack's persistent
         # assistant.threads.setStatus survives a gateway restart or a turn

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -204,6 +204,26 @@ def _normalize_matrix_bang_command(text: str) -> str:
     return f"/{resolved}{match.group(2) or ''}"
 
 
+def _strip_matrix_reply_fallback(body: str, relates_to: dict) -> str:
+    """Remove Matrix plaintext reply fallback quoting from a message body."""
+    in_reply_to = relates_to.get("m.in_reply_to", {})
+    if not in_reply_to or not body.startswith("> "):
+        return body
+    lines = body.split("\n")
+    stripped = []
+    past_fallback = False
+    for line in lines:
+        if not past_fallback:
+            if line.startswith("> ") or line == ">":
+                continue
+            if line == "":
+                past_fallback = True
+                continue
+            past_fallback = True
+        stripped.append(line)
+    return "\n".join(stripped) if stripped else body
+
+
 class _MatrixHtmlSanitizer(HTMLParser):
     """Allowlist sanitizer for Matrix-compatible formatted HTML."""
 
@@ -2710,6 +2730,12 @@ class MatrixAdapter(BasePlatformAdapter):
             mentions_block.get("user_ids") if isinstance(mentions_block, dict) else None
         )
         is_mentioned = self._is_bot_mentioned(body, formatted_body, mention_user_ids)
+        command_body = _normalize_matrix_bang_command(
+            _strip_matrix_reply_fallback(body, relates_to)
+        )
+        # Keep the pre-strip form for group mention-gating below. The
+        # auto-thread policy recomputes after explicit mentions are removed.
+        is_command = command_body.startswith("/")
 
         # Require-mention gating.
         if not is_dm:
@@ -2727,7 +2753,6 @@ class MatrixAdapter(BasePlatformAdapter):
 
             is_free_room = room_id in self._free_rooms
             in_bot_thread = bool(thread_id and thread_id in self._threads)
-            is_command = body.startswith("/")
             if self._require_mention and not is_free_room and not in_bot_thread:
                 if not is_mentioned and not is_command:
                     logger.debug(
@@ -2753,20 +2778,35 @@ class MatrixAdapter(BasePlatformAdapter):
                     )
                     return None
 
-        # DM mention-thread.
-        if is_dm and not thread_id and self._dm_mention_threads and is_mentioned:
+        command_body_source = self._strip_mention(body) if is_mentioned else body
+        command_body = _normalize_matrix_bang_command(
+            _strip_matrix_reply_fallback(command_body_source, relates_to)
+        ).strip()
+        is_command = command_body.startswith("/")
+        command_parts = command_body.lower().split(maxsplit=1)
+        is_stop_command = bool(command_parts) and command_parts[0] == "/stop"
+        # Explicitly addressed control commands must reach the dispatcher even
+        # when normal mention-gating is disabled.
+        if is_mentioned and (self._require_mention or is_stop_command):
+            body = command_body_source
+
+        # DM mention-thread. Control commands must remain rooted so they can
+        # reach the command dispatcher for the private conversation.
+        if (
+            is_dm
+            and not thread_id
+            and self._dm_mention_threads
+            and is_mentioned
+            and not is_stop_command
+        ):
             thread_id = event_id
             self._threads.mark(thread_id)
-
-        # Strip mention from body (only when mention-gating is active).
-        if is_mentioned and self._require_mention:
-            body = self._strip_mention(body)
 
         # Auto-thread/session-scope policy. Real Matrix thread roots are
         # preserved above; synthetic thread roots are policy-driven.
         if not thread_id:
             if is_dm:
-                if self._dm_auto_thread:
+                if self._dm_auto_thread and not is_stop_command:
                     thread_id = event_id
                     self._threads.mark(thread_id)
             elif self._matrix_session_scope == "room":
@@ -2832,21 +2872,7 @@ class MatrixAdapter(BasePlatformAdapter):
         if in_reply_to:
             reply_to = in_reply_to.get("event_id")
 
-        # Strip reply fallback from body.
-        if reply_to and body.startswith("> "):
-            lines = body.split("\n")
-            stripped = []
-            past_fallback = False
-            for line in lines:
-                if not past_fallback:
-                    if line.startswith("> ") or line == ">":
-                        continue
-                    if line == "":
-                        past_fallback = True
-                        continue
-                    past_fallback = True
-                stripped.append(line)
-            body = "\n".join(stripped) if stripped else body
+        body = _strip_matrix_reply_fallback(body, relates_to)
 
         # Re-run bang normalization after reply-fallback stripping so a quoted
         # reply whose actual content is a bang command (e.g. ``> quoted\n\n!model``)

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -4559,6 +4559,125 @@ class TestMatrixDmAutoThread:
         assert thread_id == "$ev1"
 
     @pytest.mark.asyncio
+    async def test_dm_auto_thread_skips_slash_command(self):
+        """Root-level slash commands should not create fresh DM threads."""
+        self.adapter._dm_auto_thread = True
+
+        ctx = await self.adapter._resolve_message_context(
+            room_id="!dm:ex",
+            sender="@alice:ex",
+            event_id="$stop-event",
+            body="/stop",
+            source_content={"body": "/stop"},
+            relates_to={},
+        )
+
+        assert ctx is not None
+        _body, _is_dm, _chat_type, thread_id, _display, _source = ctx
+        assert thread_id is None
+
+    @pytest.mark.asyncio
+    async def test_dm_auto_thread_keeps_skill_command_threaded(self):
+        """Only /stop is a root-DM control command under auto-threading."""
+        self.adapter._dm_auto_thread = True
+
+        ctx = await self.adapter._resolve_message_context(
+            room_id="!dm:ex",
+            sender="@alice:ex",
+            event_id="$arxiv-event",
+            body="!arxiv cats",
+            source_content={"body": "!arxiv cats"},
+            relates_to={},
+        )
+
+        assert ctx is not None
+        _body, _is_dm, _chat_type, thread_id, _display, _source = ctx
+        assert thread_id == "$arxiv-event"
+
+    @pytest.mark.asyncio
+    async def test_dm_auto_thread_skips_reply_fallback_slash_command(self):
+        """Slash commands after Matrix reply fallback should stay flat."""
+        self.adapter._dm_auto_thread = True
+
+        ctx = await self.adapter._resolve_message_context(
+            room_id="!dm:ex",
+            sender="@alice:ex",
+            event_id="$stop-event",
+            body="> <@bob:ex> quoted\n\n/stop",
+            source_content={"body": "> <@bob:ex> quoted\n\n/stop"},
+            relates_to={"m.in_reply_to": {"event_id": "$quoted"}},
+        )
+
+        assert ctx is not None
+        _body, _is_dm, _chat_type, thread_id, _display, _source = ctx
+        assert thread_id is None
+
+    @pytest.mark.asyncio
+    async def test_dm_auto_thread_skips_mention_prefixed_slash_command(self):
+        """Mention stripping must happen before command auto-thread policy."""
+        self.adapter._dm_auto_thread = True
+        self.adapter._require_mention = True
+        self.adapter._user_id = "@hermes:ex"
+
+        ctx = await self.adapter._resolve_message_context(
+            room_id="!dm:ex",
+            sender="@alice:ex",
+            event_id="$stop-event",
+            body="@hermes:ex /stop",
+            source_content={"body": "@hermes:ex /stop"},
+            relates_to={},
+        )
+
+        assert ctx is not None
+        body, _is_dm, _chat_type, thread_id, _display, _source = ctx
+        assert body == "/stop"
+        assert thread_id is None
+
+    @pytest.mark.asyncio
+    async def test_dm_mention_thread_skips_mention_prefixed_slash_command(self):
+        """DM mention-threading must not turn a control command into a thread."""
+        self.adapter._dm_auto_thread = True
+        self.adapter._dm_mention_threads = True
+        self.adapter._require_mention = True
+        self.adapter._user_id = "@hermes:ex"
+
+        ctx = await self.adapter._resolve_message_context(
+            room_id="!dm:ex",
+            sender="@alice:ex",
+            event_id="$stop-event",
+            body="@hermes:ex /stop",
+            source_content={"body": "@hermes:ex /stop"},
+            relates_to={},
+        )
+
+        assert ctx is not None
+        body, _is_dm, _chat_type, thread_id, _display, _source = ctx
+        assert body == "/stop"
+        assert thread_id is None
+
+    @pytest.mark.asyncio
+    async def test_dm_mention_thread_recognizes_command_without_mention_gating(self):
+        """Explicit mention commands stay controls when normal mention gating is off."""
+        self.adapter._dm_auto_thread = True
+        self.adapter._dm_mention_threads = True
+        self.adapter._require_mention = False
+        self.adapter._user_id = "@hermes:ex"
+
+        ctx = await self.adapter._resolve_message_context(
+            room_id="!dm:ex",
+            sender="@alice:ex",
+            event_id="$stop-event",
+            body="@hermes:ex /stop",
+            source_content={"body": "@hermes:ex /stop"},
+            relates_to={},
+        )
+
+        assert ctx is not None
+        body, _is_dm, _chat_type, thread_id, _display, _source = ctx
+        assert body == "/stop"
+        assert thread_id is None
+
+    @pytest.mark.asyncio
     async def test_dm_auto_thread_disabled_no_thread(self):
         """When dm_auto_thread is False (default), DMs have no auto-thread."""
         self.adapter._dm_auto_thread = False

--- a/tests/gateway/test_stop_thread_sibling.py
+++ b/tests/gateway/test_stop_thread_sibling.py
@@ -29,11 +29,36 @@ def _thread_source(uid, thread_id="thr1", chat_id="chan1"):
     )
 
 
-def _per_user_key(uid, thread_id="thr1", chat_id="chan1"):
+def _per_user_key(uid, thread_id="thr1", chat_id="chan1", profile=None):
     return build_session_key(
         _thread_source(uid, thread_id, chat_id),
         thread_sessions_per_user=True,
+        profile=profile,
     )
+
+
+def _dm_source(uid="@alice:ex", thread_id=None, chat_id="!dm:ex", profile=None):
+    return SessionSource(
+        platform=Platform.MATRIX,
+        chat_type="dm",
+        chat_id=chat_id,
+        thread_id=thread_id,
+        user_id=uid,
+        profile=profile,
+    )
+
+
+def _dm_thread_key(thread_id, chat_id="!dm:ex", profile=None):
+    return build_session_key(
+        _dm_source(thread_id=thread_id, chat_id=chat_id, profile=profile), profile=profile
+    )
+
+
+def _set_dm_running_agent(runner, source, profile=None, agent=None):
+    session_key = build_session_key(source, profile=profile)
+    runner._running_agents = {session_key: agent or _FakeAgent()}
+    runner._cache_session_source(session_key, source)
+    return session_key
 
 
 # ---------------------------------------------------------------------------
@@ -87,6 +112,61 @@ def test_sibling_returns_empty_for_non_thread_source():
     )
     runner._running_agents = {grp_b: _FakeAgent()}
     assert runner._sibling_thread_run_keys(nonthread, "agent:main:discord:group:chan1:userA") == []
+
+
+def test_sibling_uses_callers_named_profile_namespace():
+    runner = object.__new__(GatewayRunner)
+    key_a = _per_user_key("userA", profile="coder")
+    key_b = _per_user_key("userB", profile="coder")
+    runner._running_agents = {key_b: _FakeAgent()}
+
+    assert runner._sibling_thread_run_keys(_thread_source("userA"), key_a) == [key_b]
+
+
+# ---------------------------------------------------------------------------
+# _sibling_dm_thread_run_keys
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("profile", [None, "coder"])
+def test_dm_sibling_finds_threaded_run_in_callers_profile(profile):
+    runner = object.__new__(GatewayRunner)
+    own_key = build_session_key(_dm_source(profile=profile), profile=profile)
+    run_source = _dm_source(thread_id="$root-event", profile=profile)
+    run_key = _set_dm_running_agent(runner, run_source, profile)
+
+    assert runner._sibling_dm_thread_run_keys(_dm_source(profile=profile), own_key) == [run_key]
+
+
+def test_dm_sibling_rejects_same_room_run_from_another_profile():
+    runner = object.__new__(GatewayRunner)
+    own_key = build_session_key(_dm_source(profile="coder"), profile="coder")
+    other_profile_key = _set_dm_running_agent(
+        runner, _dm_source(thread_id="$root-event", profile="writer"), "writer"
+    )
+
+    assert runner._sibling_dm_thread_run_keys(_dm_source(profile="coder"), own_key) == []
+
+
+def test_dm_sibling_rejects_room_id_prefix_collision():
+    runner = object.__new__(GatewayRunner)
+    stop_source = _dm_source(chat_id="!same:example.org")
+    own_key = build_session_key(stop_source)
+    _set_dm_running_agent(
+        runner,
+        _dm_source(thread_id="$root-event", chat_id="!same:example.org:8448"),
+    )
+
+    assert runner._sibling_dm_thread_run_keys(stop_source, own_key) == []
+
+
+def test_dm_sibling_ignores_threaded_stop_source():
+    runner = object.__new__(GatewayRunner)
+    stop_source = _dm_source(thread_id="$idle-thread")
+    own_key = build_session_key(stop_source)
+    runner._running_agents = {_dm_thread_key("$root-event"): _FakeAgent()}
+
+    assert runner._sibling_dm_thread_run_keys(stop_source, own_key) == []
 
 
 # ---------------------------------------------------------------------------
@@ -156,6 +236,61 @@ async def test_stop_does_not_interrupt_sibling_when_unauthorized(monkeypatch):
 
     assert interrupted == []
     assert "no active" in str(getattr(result, "text", result)).lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("profile", [None, "coder"])
+async def test_root_dm_stop_interrupts_auto_threaded_run_in_own_profile(profile):
+    runner = object.__new__(GatewayRunner)
+    stop_source = _dm_source(profile=profile)
+    stop_key = build_session_key(stop_source, profile=profile)
+    run_key = _set_dm_running_agent(
+        runner, _dm_source(thread_id="$root-event", profile=profile), profile
+    )
+    runner.session_store = _FakeStore(stop_key)
+
+    interrupted = []
+
+    async def _fake_interrupt(session_key, source, *, interrupt_reason, invalidation_reason):
+        interrupted.append((session_key, interrupt_reason, invalidation_reason))
+
+    runner._interrupt_and_clear_session = _fake_interrupt
+    runner._is_user_authorized = lambda source: False
+
+    event = MessageEvent(text="/stop", message_type=MessageType.TEXT, source=stop_source)
+    result = await runner._handle_stop_command(event)
+
+    assert interrupted == [
+        (run_key, _INTERRUPT_REASON_STOP, "stop_command_dm_thread_sibling")
+    ]
+    assert "no active" not in str(getattr(result, "text", result)).lower()
+
+
+@pytest.mark.asyncio
+async def test_root_dm_stop_clears_auto_threaded_pending_run():
+    runner = object.__new__(GatewayRunner)
+    stop_source = _dm_source()
+    stop_key = build_session_key(stop_source)
+    pending_key = _set_dm_running_agent(
+        runner, _dm_source(thread_id="$root-event"), agent=_AGENT_PENDING_SENTINEL
+    )
+    runner.session_store = _FakeStore(stop_key)
+
+    interrupted = []
+
+    async def _fake_interrupt(session_key, source, *, interrupt_reason, invalidation_reason):
+        interrupted.append((session_key, interrupt_reason, invalidation_reason))
+
+    runner._interrupt_and_clear_session = _fake_interrupt
+    runner._is_user_authorized = lambda source: False
+
+    event = MessageEvent(text="/stop", message_type=MessageType.TEXT, source=stop_source)
+    result = await runner._handle_stop_command(event)
+
+    assert interrupted == [
+        (pending_key, _INTERRUPT_REASON_STOP, "stop_command_dm_thread_sibling")
+    ]
+    assert "no active" not in str(getattr(result, "text", result)).lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes Matrix root-DM `/stop` routing when DM auto-threading is enabled.

An active DM turn can be keyed under a Matrix event thread while a later root-level `/stop` is keyed at the DM root. The old fallback could miss that run, and the previous PR head also hardcoded the `agent:main` namespace, so it was not safe for named profiles.

This rebuild derives the control namespace from the caller's real session key, matches active or pending Matrix DM runs by their stored session origin, and limits the auto-thread exemption to normalized `/stop` commands. Matching is profile-aware and requires the exact Matrix room, so a stop cannot cross profile or room boundaries.

## Related Issue

Fixes #59020

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: cache the session origin before publishing the pending sentinel and locate active/pending Matrix DM threads by exact stored origin and profile namespace.
- `gateway/slash_commands.py`: let a root-DM `/stop` interrupt matching auto-threaded runs after the existing exact-key and thread-sibling checks miss.
- `plugins/platforms/matrix/adapter.py`: keep normalized `/stop` rooted under DM auto-thread and mention-thread policies while preserving threading for skill/plugin commands such as `!arxiv`.
- `tests/gateway/test_matrix.py`: cover root, reply-fallback, mention-prefixed, mention-thread, and non-control command behavior.
- `tests/gateway/test_stop_thread_sibling.py`: cover default and named profiles, cross-profile rejection, exact-room matching, prefix collisions, pending startup, and root-vs-threaded stop behavior.

## How to Test

Reproduced on current main before the patch: a root-DM `/stop` had no matching session key for an auto-threaded child and returned `No active task to stop.` The historical PR head additionally used a literal `agent:main` prefix.

Validation on commit `d212a4ef3dc9ee487980e3c5be0c5bd466d8e796`:

```bash
scripts/run_tests.sh tests/gateway/test_matrix.py -q
# 257 passed

scripts/run_tests.sh tests/gateway/test_stop_thread_sibling.py -q
# 18 passed

scripts/run_tests.sh tests/gateway/test_command_bypass_active_session.py -q
# 40 passed

# Relevant multiplex profile suite: 28 passed

python -m ruff check gateway/run.py gateway/slash_commands.py plugins/platforms/matrix/adapter.py tests/gateway/test_matrix.py tests/gateway/test_stop_thread_sibling.py
python scripts/check-windows-footguns.py gateway/run.py gateway/slash_commands.py plugins/platforms/matrix/adapter.py tests/gateway/test_matrix.py tests/gateway/test_stop_thread_sibling.py
git diff --check upstream/main...HEAD
```

All focused, sibling, lint, portability, and whitespace checks passed. The local full-wrapper attempt began on a superseded candidate and is not claimed as final validation; GitHub CI on this draft is the final full-suite gate.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
