### PR TITLE
fix(whatsapp): resolve bridge dir type hints

### DIFF
--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -35,6 +35,7 @@ import json
 import logging
 import os
 import re
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 

--- a/tests/gateway/test_whatsapp_bridge_dir_resolution.py
+++ b/tests/gateway/test_whatsapp_bridge_dir_resolution.py
@@ -6,11 +6,19 @@ with EACCES. The resolver must detect the read-only install dir and mirror the
 bridge source into a writable HERMES_HOME location instead.
 """
 import importlib
+import typing
 from pathlib import Path
 
 import pytest
 
 from gateway.platforms import whatsapp_common
+
+
+def test_resolve_whatsapp_bridge_dir_type_hints_are_resolvable():
+    """Runtime introspection should resolve the public return annotation."""
+    hints = typing.get_type_hints(whatsapp_common.resolve_whatsapp_bridge_dir)
+
+    assert hints["return"] is Path
 
 
 def _seed_install_tree(install_bridge: Path) -> None:


### PR DESCRIPTION
## Summary
- import `Path` at module scope so `resolve_whatsapp_bridge_dir()`'s public return annotation can be resolved by runtime introspection
- add a regression test for `typing.get_type_hints(resolve_whatsapp_bridge_dir)`

## Verification
- `/Users/lee/Documents/Claude/Projects/10\ Work\ OS/projects/hermes/venv/bin/python -m pytest tests/gateway/test_whatsapp_bridge_dir_resolution.py::test_resolve_whatsapp_bridge_dir_type_hints_are_resolvable -q` → 1 passed, 1 warning
- `/Users/lee/Documents/Claude/Projects/10\ Work\ OS/projects/hermes/venv/bin/python -m pytest tests/gateway/test_whatsapp_bridge_dir_resolution.py -q` → 4 passed, 1 warning
- direct smoke: `typing.get_type_hints(whatsapp_common.resolve_whatsapp_bridge_dir)` → `{'return': <class 'pathlib.Path'>}`
- `git diff --check`
