### PR TITLE
fix(desktop): restart gateway after backend update

### DIFF
--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -34,11 +34,13 @@ vi.mock('@/store/notifications', () => ({
 const checkHermesUpdateSpy = vi.fn()
 const updateHermesSpy = vi.fn()
 const getActionStatusSpy = vi.fn()
+const restartGatewaySpy = vi.fn()
 
 vi.mock('@/hermes', () => ({
   checkHermesUpdate: (...args: unknown[]) => checkHermesUpdateSpy(...args),
   updateHermes: (...args: unknown[]) => updateHermesSpy(...args),
-  getActionStatus: (...args: unknown[]) => getActionStatusSpy(...args)
+  getActionStatus: (...args: unknown[]) => getActionStatusSpy(...args),
+  restartGateway: (...args: unknown[]) => restartGatewaySpy(...args)
 }))
 
 const {
@@ -373,6 +375,8 @@ describe('applyBackendUpdate recovery', () => {
     checkHermesUpdateSpy.mockReset()
     updateHermesSpy.mockReset()
     getActionStatusSpy.mockReset()
+    restartGatewaySpy.mockReset()
+    restartGatewaySpy.mockResolvedValue({ ok: true, name: 'gateway-restart', pid: 2 })
     $backendUpdateApply.set({
       applying: false,
       stage: 'idle',
@@ -407,6 +411,7 @@ describe('applyBackendUpdate recovery', () => {
     const result = await promise
 
     expect(result.ok).toBe(true)
+    expect(restartGatewaySpy).toHaveBeenCalledTimes(1)
     expect($backendUpdateApply.get().stage).toBe('idle')
     expect($backendUpdateApply.get().applying).toBe(false)
   })
@@ -443,6 +448,57 @@ describe('applyBackendUpdate recovery', () => {
 
     await vi.advanceTimersByTimeAsync(5000)
     await promise
+    expect(restartGatewaySpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('queues a gateway restart after a successful backend update action before clearing the overlay', async () => {
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'update', pid: 1 })
+    getActionStatusSpy.mockResolvedValue({
+      exit_code: 0,
+      lines: ['Update complete'],
+      name: 'update',
+      pid: 1,
+      running: false
+    })
+    checkHermesUpdateSpy.mockResolvedValue({
+      install_method: 'git',
+      current_version: '0.16.0',
+      behind: 0,
+      update_available: false,
+      can_apply: true,
+      update_command: 'hermes update',
+      message: null
+    })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(3000)
+    const result = await promise
+
+    expect(result.ok).toBe(true)
+    expect(restartGatewaySpy).toHaveBeenCalledTimes(1)
+    expect($backendUpdateApply.get().stage).toBe('idle')
+    expect($backendUpdateApply.get().applying).toBe(false)
+  })
+
+  it('surfaces an error when the gateway restart cannot be queued after update', async () => {
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'update', pid: 1 })
+    getActionStatusSpy.mockResolvedValue({
+      exit_code: 0,
+      lines: ['Update complete'],
+      name: 'update',
+      pid: 1,
+      running: false
+    })
+    restartGatewaySpy.mockResolvedValue({ ok: false, message: 'gateway restart unavailable' })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(1500)
+    const result = await promise
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toBe('gateway-restart-failed')
+    expect($backendUpdateApply.get().stage).toBe('error')
+    expect($backendUpdateApply.get().message).toBe('gateway restart unavailable')
   })
 
   it('surfaces an error when the backend never comes back after the restart', async () => {

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -13,7 +13,7 @@ import type {
   DesktopUpdateStatus,
   DesktopVersionInfo
 } from '@/global'
-import { checkHermesUpdate, getActionStatus, updateHermes } from '@/hermes'
+import { checkHermesUpdate, getActionStatus, restartGateway, updateHermes } from '@/hermes'
 import { translateNow } from '@/i18n'
 import { persistString, storedString } from '@/lib/storage'
 import { dismissNotification, notify } from '@/store/notifications'
@@ -464,6 +464,74 @@ function finishBackendApply(returned: boolean): DesktopUpdateApplyResult {
   return { ok: false, error: 'apply-failed', message: 'Backend did not come back online.' }
 }
 
+async function restartGatewayAfterBackendUpdate(): Promise<DesktopUpdateApplyResult | null> {
+  $backendUpdateApply.set({
+    ...$backendUpdateApply.get(),
+    applying: true,
+    stage: 'restart',
+    message: translateNow('updates.applyStatus.restarting')
+  })
+
+  try {
+    const restarted = await restartGateway()
+
+    if (!restarted.ok) {
+      const message = (restarted as { message?: string }).message || 'Gateway restart could not be started.'
+
+      return { ok: false, error: 'gateway-restart-failed', message }
+    }
+
+    return null
+  } catch {
+    // The updated backend can drop the dashboard API while the action status
+    // flips from update to restart. Wait for it once, then retry the explicit
+    // gateway restart so messaging channels are not left on the old process.
+    const returned = await waitForBackendReturn()
+
+    if (!returned) {
+      return { ok: false, error: 'apply-failed', message: 'Backend did not come back online.' }
+    }
+
+    try {
+      const restarted = await restartGateway()
+
+      if (!restarted.ok) {
+        const message = (restarted as { message?: string }).message || 'Gateway restart could not be started.'
+
+        return { ok: false, error: 'gateway-restart-failed', message }
+      }
+
+      return null
+    } catch (retryError) {
+      const message = retryError instanceof Error ? retryError.message : String(retryError)
+
+      return { ok: false, error: 'gateway-restart-failed', message }
+    }
+  }
+}
+
+async function finishBackendApplyWithGatewayRestart(returned: boolean): Promise<DesktopUpdateApplyResult> {
+  if (!returned) {
+    return finishBackendApply(false)
+  }
+
+  const restartFailure = await restartGatewayAfterBackendUpdate()
+
+  if (restartFailure) {
+    $backendUpdateApply.set({
+      ...$backendUpdateApply.get(),
+      applying: false,
+      stage: 'error',
+      error: restartFailure.error ?? 'gateway-restart-failed',
+      message: restartFailure.message ?? translateNow('updates.applyStatus.failed')
+    })
+
+    return restartFailure
+  }
+
+  return finishBackendApply(await waitForBackendReturn())
+}
+
 function ingestBackendActionStatus(status: Awaited<ReturnType<typeof getActionStatus>>): void {
   const current = $backendUpdateApply.get()
 
@@ -529,7 +597,7 @@ export async function applyBackendUpdate(): Promise<DesktopUpdateApplyResult> {
           message: translateNow('updates.applyStatus.restarting')
         })
 
-        return finishBackendApply(await waitForBackendReturn())
+        return finishBackendApplyWithGatewayRestart(await waitForBackendReturn())
       }
 
       if (last && !last.running) {
@@ -540,14 +608,7 @@ export async function applyBackendUpdate(): Promise<DesktopUpdateApplyResult> {
     const ok = !!last && (last.exit_code ?? 1) === 0
 
     if (ok) {
-      $backendUpdateApply.set({
-        ...$backendUpdateApply.get(),
-        applying: true,
-        stage: 'restart',
-        message: translateNow('updates.applyStatus.restarting')
-      })
-
-      return finishBackendApply(await waitForBackendReturn())
+      return finishBackendApplyWithGatewayRestart(true)
     }
 
     $backendUpdateApply.set({


### PR DESCRIPTION
## What does this PR do?

Desktop backend updates now explicitly queue a messaging gateway restart before the update overlay clears, retrying once if the backend API briefly drops during the update/restart handoff.

## Related Issue

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Shared root cause

- The Desktop backend update flow waited for the dashboard API to come back, but did not make the messaging gateway restart part of the same completion contract. If the backend API dropped with ECONNREFUSED during update handoff, the UI could remain in recovery behavior while messaging channels were left dependent on manual restart.

## How this fixes each issue

- #37775: routes the transient ECONNREFUSED/backend-return branch through the same bounded recovery helper, so the update flow retries after the backend returns and finishes in either a clear success or visible error state instead of silently hanging.
- #38134: after a successful backend update action, the Desktop update flow calls the existing `/api/gateway/restart` action before clearing the overlay, so Telegram/Discord/other gateway channels are restarted as part of update completion.

## Changes Made

- `apps/desktop/src/store/updates.ts`: adds a shared backend-update completion helper that starts the gateway restart action, retries once after a transient backend API drop, and surfaces gateway restart failures in the overlay.
- `apps/desktop/src/store/updates.test.ts`: extends update recovery tests to assert the restart is queued on successful update and that restart queue failures are shown as errors.

## How to Test

1. Trigger a Desktop backend update from the update overlay.
2. Confirm the update action completes, the gateway restart action is queued, and the overlay clears only after the backend API is reachable again.
3. Simulate `/api/gateway/restart` returning `ok: false` and confirm the update overlay lands on an error state instead of closing silently.

Local checks attempted:
- `git diff --check` passed.
- Changed-file Ruff check reported no changed Python files.
- `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh` failed during collection before reaching changed code because this environment lacks `fastapi` and the lazy dashboard dependency install is blocked by the externally managed Python environment (PEP 668).
- `npm --workspace apps/desktop run test:ui -- src/store/updates.test.ts` could not run because this worktree has no `node_modules`/`vitest` installed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched the relevant source paths for existing update/gateway handling
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — blocked locally by missing dashboard Python dependencies
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS on darwin-arm64 (static checks only; JS/Python dependency gaps noted above)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A

## What platforms tested on

- macOS on darwin-arm64 (local)

---
_This coordinated PR bundles a fix that spans several issues. Happy to split it back into focused per-issue PRs if you'd prefer to review them separately._

Refs #37775
Refs #38134

<!-- autocontrib:worker-id=pr-spanning-d76b36b8 kind=pr-open -->