### PR TITLE
fix(desktop): stop stale auto-speak playback on session switch

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.test.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.test.ts
@@ -1,0 +1,110 @@
+import { act, renderHook } from '@testing-library/react'
+import { atom } from 'nanostores'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const stopVoicePlayback = vi.fn()
+const playSpeechText = vi.fn().mockResolvedValue(true)
+const notifyError = vi.fn()
+
+vi.mock('@/lib/voice-playback', () => ({
+  playSpeechText: (...args: unknown[]) => playSpeechText(...args),
+  stopVoicePlayback: (...args: unknown[]) => stopVoicePlayback(...args)
+}))
+vi.mock('@/store/notifications', () => ({ notifyError: (...args: unknown[]) => notifyError(...args) }))
+
+// Mutable stores — tests swap .set() to simulate session switches.
+const $messages = atom<Array<{ id: string; role: string; hidden?: boolean }>>([])
+const $voicePlayback = atom<{ status: string }>({ status: 'idle' })
+const $autoSpeakReplies = atom(false)
+
+vi.mock('@/store/session', () => ({ $messages }))
+vi.mock('@/store/voice-playback', () => ({ $voicePlayback }))
+vi.mock('@/store/voice-prefs', () => ({ $autoSpeakReplies }))
+
+import { useAutoSpeakReplies } from './use-auto-speak-replies'
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+function renderAutoSpeak(overrides: Partial<Parameters<typeof useAutoSpeakReplies>[0]> = {}) {
+  const markSpoken = vi.fn()
+  let currentSessionMessages = $messages.get()
+  const pendingReply = () => {
+    const msgs = $messages.get()
+    const last = msgs.findLast(m => m.role === 'assistant' && !m.hidden)
+    if (!last) return null
+    return { id: last.id, pending: false, text: `text-${last.id}` }
+  }
+
+  const props = {
+    conversationActive: false,
+    failureLabel: 'TTS failed',
+    markSpoken,
+    pendingReply,
+    sessionId: 'session-A' as string | null | undefined,
+    ...overrides
+  }
+
+  return renderHook(
+    ({ sessionId }) => useAutoSpeakReplies({ ...props, sessionId }),
+    { initialProps: { sessionId: props.sessionId } }
+  )
+}
+
+describe('useAutoSpeakReplies', () => {
+  it('calls stopVoicePlayback on effect cleanup when sessionId changes', () => {
+    $autoSpeakReplies.set(true)
+    $messages.set([{ id: 'a1', role: 'assistant' }])
+
+    const { rerender } = renderAutoSpeak()
+
+    // Switch session — triggers old effect cleanup + new effect setup
+    act(() => {
+      $messages.set([{ id: 'b1', role: 'assistant' }])
+      rerender({ sessionId: 'session-B' })
+    })
+
+    // stopVoicePlayback must be called during cleanup to silence any playback
+    // that slipped through from the stale subscription.
+    expect(stopVoicePlayback).toHaveBeenCalled()
+  })
+
+  it('stops stale playback when a session switch triggers speakLatest before cleanup', () => {
+    $autoSpeakReplies.set(true)
+
+    // Start with session A having a reply
+    $messages.set([{ id: 'a1', role: 'assistant' }])
+    const { rerender } = renderAutoSpeak()
+
+    // Simulate the race: $messages is updated synchronously (by the session
+    // switch handler) BEFORE React runs effect cleanup.  The stale
+    // subscription fires, starts playback, then cleanup stops it.
+    act(() => {
+      // This triggers $messages subscribers synchronously — the stale
+      // speakLatest sees session B's reply and calls playSpeechText.
+      $messages.set([{ id: 'b1', role: 'assistant' }])
+
+      // React re-renders with new sessionId → old effect cleanup runs
+      // → stopVoicePlayback() silences the stale playback.
+      rerender({ sessionId: 'session-B' })
+    })
+
+    expect(stopVoicePlayback).toHaveBeenCalled()
+  })
+
+  it('does not call stopVoicePlayback when enabled is false', () => {
+    $autoSpeakReplies.set(false)
+    $messages.set([{ id: 'a1', role: 'assistant' }])
+
+    const { rerender } = renderAutoSpeak()
+
+    act(() => {
+      $messages.set([{ id: 'b1', role: 'assistant' }])
+      rerender({ sessionId: 'session-B' })
+    })
+
+    // Effect returns early when disabled — no cleanup to run
+    expect(stopVoicePlayback).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.ts
@@ -1,7 +1,7 @@
 import { useStore } from '@nanostores/react'
 import { useEffect, useRef } from 'react'
 
-import { playSpeechText } from '@/lib/voice-playback'
+import { playSpeechText, stopVoicePlayback } from '@/lib/voice-playback'
 import { notifyError } from '@/store/notifications'
 import { $messages } from '@/store/session'
 import { $voicePlayback } from '@/store/voice-playback'
@@ -74,6 +74,14 @@ export function useAutoSpeakReplies({
     // ($voicePlayback → idle), which frees us to read the next held reply.
     const stops = [$messages.subscribe(speakLatest), $voicePlayback.listen(speakLatest)]
 
-    return () => stops.forEach(f => f())
+    return () => {
+      stops.forEach(f => f())
+      // Stop any playback that was triggered by a stale subscription during a
+      // session switch — $messages.set() fires synchronously before React runs
+      // effect cleanup, so a stale speakLatest can start playback for the wrong
+      // session.  Unsubscribing above prevents future callbacks; stopping
+      // playback here silences the one that already slipped through.
+      stopVoicePlayback()
+    }
   }, [enabled, sessionId])
 }


### PR DESCRIPTION
## What does this PR do?

Stops the auto-speak hook from playing the wrong session's last reply when the user switches chat sessions with "Read replies aloud" enabled.

**Root cause**: `$messages.set()` fires synchronously during session switch, triggering the stale nanostore subscription's `speakLatest` callback *before* React runs effect cleanup. The callback reads the new session's messages via `$messages.get()` and starts playback for the wrong session.

**Fix**: Call `stopVoicePlayback()` in the effect cleanup. When React commits the session change, the old effect's cleanup stops any audio that was incorrectly started by the stale subscription.

## Related Issue

Fixes #59014

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.ts` — import `stopVoicePlayback` and call it in the effect cleanup after unsubscribing, to silence any playback triggered by a stale subscription during session switch
- `apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.test.ts` — regression tests verifying `stopVoicePlayback` is called when `sessionId` changes while auto-speak is enabled

## How to Test

1. Enable "Read replies aloud" in the desktop composer (speaker icon toggle)
2. Send a message in Session A → reply gets read aloud normally
3. Switch to Session B (with existing replies) via the sidebar
4. Observed result: Session B's last reply should NOT be read aloud (silent switch)
5. `npx vitest run apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.test.ts` should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

The race condition timeline:

```
1. User clicks Session B
2. $messages.set(sessionBMessages) → fires ALL subscribers synchronously
3. Old effect's speakLatest() → reads new session's messages → starts playback ← BUG
4. React commits → old effect cleanup → stopVoicePlayback() ← FIX stops the audio
5. New effect subscribes for session B
```
