### PR TITLE
fix: add FEISHU_APP_ID env fallback to _is_connected

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -5574,7 +5574,7 @@ def _is_connected(config) -> bool:
     """Feishu is connected when app_id is configured. Mirrors the legacy
     _PLATFORM_CONNECTED_CHECKERS[Platform.FEISHU] = lambda cfg: bool(app_id)."""
     extra = getattr(config, "extra", {}) or {}
-    return bool(extra.get("app_id"))
+    return bool(extra.get("app_id") or os.getenv("FEISHU_APP_ID"))
 
 
 def _build_adapter(config):


### PR DESCRIPTION
## Problem

The gateway setup wizard shows Feishu/Lark as "not configured" even when `FEISHU_APP_ID` and `FEISHU_APP_SECRET` are correctly set in `.env` and the runtime gateway is connected and processing messages fine.

## Root Cause

The plugin's `_is_connected()` check (used by the wizard's platform status display) only checks `config.extra['app_id']`, ignoring the env var. When the wizard creates a synthetic `PlatformConfig` to test, `extra` is empty → returns `False` → shows "not configured".

Meanwhile, the actual adapter init (`FeishuAdapterSettings`, line 1529) correctly uses `extra.get("app_id") **or** os.getenv("FEISHU_APP_ID")`.

## Fix

Add `or os.getenv("FEISHU_APP_ID")` to `_is_connected()`, matching the pattern already used by the runtime adapter.

Diff:
```diff
-    return bool(extra.get("app_id"))
+    return bool(extra.get("app_id") or os.getenv("FEISHU_APP_ID"))
```

## Verification

- Existing tests (`test_setup_feishu.py`, `test_plugin_platform_interface.py`) — 21/21 pass
- Manual: `hermes gateway setup` now shows `(configured)` when env vars are set