### PR TITLE
feat(session-orchestration): add Codex agent support

### DIFF
--- a/.plans/so-answerable-needs-input/INTENT.md
+++ b/.plans/so-answerable-needs-input/INTENT.md
@@ -1,0 +1,109 @@
+---
+artifact: intent
+slug: so-answerable-needs-input
+level: deep
+generated_at: 2026-07-01T00:00:00Z
+frozen_at: pending
+planning_mode: intent
+---
+
+## Intent
+
+When a tool-spawned omp session in the `session_orchestration/` subsystem hits
+`WAITING_USER` on an interactive selection menu, the user currently sees only a
+state icon — no question, no options, and no way to answer (a pasted "2" selects
+nothing on an arrow-key menu). This effort makes those needs-input moments
+**answerable in the session thread**: the watcher extracts the menu's question
+and option labels from the tmux pane text, presents them as a numbered list in
+the thread, and lets the user answer with a plain option number. A numeric reply
+is resolved by cancelling the menu with `Escape` and pasting a natural-language
+selection into omp via the existing relay — no keystroke-navigation arithmetic.
+The `#feed` digest becomes a concise `@`-mention router that links to the thread
+rather than dumping the full question, and attention/feed items are reaped (and
+the session terminated) when the thread is closed/archived or the session ends.
+
+It retargets the proven so-MCP answerable design
+(`z-harness/scripts/hermes/mcp_hermes_orchestrator.py`: `_extract_menu_options`,
+`_extract_needs_input_context`, `_is_rule`) onto the single-writer watcher, and
+builds on committed `92c9661` (thread adoption + `discord_user_id` + `@`-ping).
+
+## Not doing
+
+- **No Down×n+Enter keystroke navigation.** The so-MCP `navigate_so_session`
+  cursor-arithmetic path is intentionally NOT ported. Menu answers use
+  `Escape` + natural-language selection through the existing paste `drive()`
+  route. No `navigate()`, no index→keystroke mapping, no re-capture index race.
+- **No reactions.** No emoji-reaction listener, no `1️⃣–4️⃣` mapping. Per the
+  handoff user preference, the answer channel is a numeric text reply in-thread.
+- **No re-solving the spawn submit-race / TUI-ready gaps.** Already fixed in the
+  current omp adapter (`_await_tui_ready`, literal-send, settle, separate Enter).
+- **No change to free-form `❯` prompt answering.** Text replies to a bare prompt
+  already paste correctly via `_handle_managed_thread_reply`; left untouched.
+- **No new omp marker emission.** omp stays marker-less; extraction is
+  pane-text only. Claude Code marker-driven `last_question` is not regressed.
+- **No general Discord thread lifecycle framework.** Only the archive/close →
+  terminate hook this feature needs.
+
+## Consider for this
+
+- **Single-writer invariant is load-bearing.** Only `watcher.py` mutates the
+  registry. Menu extraction runs inside `_process_row` while the row lock is
+  held (pane text is already captured there); the gateway reply-handler and the
+  archive listener MUST route mutations through `enqueue_intent(...)`, never
+  direct writes.
+- **Extraction must be a pure, unit-tested function** (`menu_parse.py`) so both
+  the omp and claude pane paths can call it and so the box-drawing heuristics
+  (`│ Label │` rows, indented-description skip, rule/footer filtering,
+  tail-keep + raw fallback) are testable without a live tmux.
+- **Multi-turn re-notify.** omp can show menu→menu faster than the 1-minute
+  watcher tick. The current notify debounce keys on `state` alone, so a *new*
+  question within the same `WAITING_USER` state can be suppressed. Debounce must
+  key on `state + question-digest`.
+- **`Escape`-cancel semantics are the one real risk.** Validate early that
+  `Escape` exits an omp selection menu into a paste-accepting composer; if a
+  given menu doesn't cancel cleanly, the pasted natural-language instruction is
+  still interpretable by the agent, but the acceptance check must confirm the
+  happy path on a live session.
+- **Reap must be idempotent and complete.** On session-end OR thread
+  archive/close: resolve the attention item, drop the `#feed` router line (falls
+  out of `reconcile_attention_digest` once resolved), stop `@`-pinging
+  (`clear_last_notified`), and — for archive/close — terminate the tmux session
+  and mark the row terminal.
+- **Invalid replies.** A non-numeric or out-of-range reply on a menu row should
+  fall through to the normal paste path (agent can interpret prose), not error.
+- Dead old-path reaction wiring in `plugins/platforms/discord/adapter.py`
+  (`_render_so_needs_input`, `_so_reaction_index`, `_navigate_so_session`,
+  `on_raw_reaction_add`, `_so_inflight`) should be reverted — it targets the
+  disabled path and contradicts the no-reactions decision.
+
+## Acceptance checklist
+
+- [ ] A pure `menu_parse.extract(pane_text)` returns `(question, options,
+      is_menu)`; unit tests cover: box-row option extraction, indented-
+      description skip, rule/footer filtering, tail-keep of the question, and
+      the raw-tail fallback for unknown TUI shapes (ported from the so-MCP tests).
+- [ ] On an omp `WAITING_USER` menu, the watcher persists `last_question`,
+      `last_options`, and `last_input_kind` (`menu`|`prompt`) to the registry row
+      while holding the row lock (single-writer preserved); a registry migration
+      adds the `last_options` and `last_input_kind` columns.
+- [ ] The session thread shows the extracted question followed by a numbered
+      option list (`1. …`, `2. …`) when `last_input_kind == menu`.
+- [ ] Replying with a valid option number in the thread cancels the omp menu
+      with `Escape` and pastes a natural-language selection naming the chosen
+      option label; the session advances (observed leaving `WAITING_USER`) on a
+      live smoke test.
+- [ ] Replying with a non-numeric or out-of-range value on a menu row falls
+      through to the existing paste path without raising.
+- [ ] A second, different question within `WAITING_USER` re-notifies (notify
+      debounce keys on `state + question-digest`, verified by test).
+- [ ] The `#feed` digest renders each unresolved item as a concise one-line
+      `@`-mention router linking to the thread (`<#thread_id>`), with the
+      question truncated — full question/options live in the thread, not the feed.
+- [ ] Closing or archiving the session thread enqueues a terminate intent; the
+      watcher then kills the tmux session, marks the row terminal, resolves the
+      attention item, and drops the feed router line.
+- [ ] Session end (DONE/ERROR/dead-tmux) resolves the attention item, drops the
+      feed router line, and stops further `@`-pings.
+- [ ] The dead old-path reaction wiring in the Discord adapter is removed.
+- [ ] `python -m pytest` for the touched session_orchestration test modules is
+      green.

--- a/.plans/so-answerable-needs-input/SMOKE.md
+++ b/.plans/so-answerable-needs-input/SMOKE.md
@@ -1,0 +1,116 @@
+# T012 — test results + live smoke checklist
+
+## Automated tests (2026-07-01)
+
+Fully-owned modules — **all green**:
+`menu_parse, registry, feed, watcher, relay` → **143 passed**.
+
+Full session_orchestration sweep (explicit paths): **550 passed, 13 failed**.
+The 13 failures are **pre-existing prior-session breakage**, NOT from this work:
+- `test_session_orchestration_claude_code.py::TestLaunch` (4)
+- `test_session_orchestration_omp.py::TestDrive` + `TestLaunchMarkerInjection` (9)
+
+Proof they are pre-existing: each **passes on committed HEAD** and fails only
+against the prior session's uncommitted `omp.py` / `claude_code.py` rewrites
+(the `_wait_for_ready` box-detection + marker-injection changes described in
+`HANDOFF-session-orchestration-feed.md`). They are the prior session's tests to
+refresh when it commits its keeper changes. None touch this plan's areas.
+
+## Coverage boundary
+
+- `resolve_menu_answer` (pure), the `pre_keys` relay threading, watcher
+  extraction/persist, the feed router + debounce, session-end reap, and the
+  terminate-intent reap all have direct unit tests.
+- The Discord `on_thread_update`/`on_thread_delete` listener (T009) is thin glue
+  (registry lookup by `discord_thread_id` → `enqueue_terminate`), following the
+  same live-smoke-only convention as `_handle_managed_thread_reply`. Its reap
+  *semantics* are covered by the watcher terminate-reap test.
+
+## Live run 2026-07-01 — extraction bug found & fixed
+
+Restarted the gateway on `feat/so-answerable-needs-input`; a live omp session
+(`b3269bdc…`) was sitting at `WAITING_USER` on an `ask` menu. First pass proved
+the plumbing (columns populated, `last_input_kind=menu`) but the **ported
+so-MCP heuristics mis-parsed omp v16.2's actual `ask` TUI**:
+- grabbed a transient/top box instead of the live menu (multiple `│` boxes in
+  the pane);
+- leaked Nerd-Font glyphs (U+F192/U+F10C) into labels;
+- dropped the 2-space-indented "Other (type your own)" as a description;
+- captured omp's reasoning stream as the question.
+
+**Fix (menu_parse.py):** footer-anchored parse — locate the
+`enter select / esc cancel` footer, take the `│`-block directly above it, strip
+leading private-use glyphs, classify label-vs-description by indent, and pull the
+question from the line above the block. Legacy whole-pane scan kept as fallback
+for Claude-style menus. Locked in as `test_extract_real_omp_v16_ask_menu`.
+
+**Verified live** — after the fix the watcher re-parsed the running session and
+the registry row now reads:
+`last_input_kind=menu`,
+`last_question="What task should I work on after this clarification?"`,
+`last_options=["Code change (Recommended)","Investigation","Plan/review","Other (type your own)"]`.
+
+Still needs a human action to validate end-to-end: **reply `1` in that
+session's thread** and confirm the omp menu is Escaped and the agent proceeds
+(T006 answer route + the Escape-cancel risk).
+
+## Live run 2 — omp free-form wait detection (added, greenlit)
+
+Live test surfaced a second gap: omp answered a "clarifying question" as
+free-form prose and idled at its composer — no `❯`, no menu footer, no marker —
+so `parse_pane_lifecycle` returned RUNNING, the session never became
+WAITING_USER, the question was never forwarded, and it tripped the hang ladder
+instead. (Also: `push_hang_notification` doesn't @-mention or hit the feed.)
+
+**Fix (greenlit "stable+idle ⇒ WAITING_USER"):**
+- `adapters/omp.py::pane_is_idle_waiting` — TUI composer box present AND not busy
+  AND not already a menu/prompt/handoff → candidate free-form wait; exposed via
+  `OmpAdapter.idle_waiting`.
+- `watcher.py` — promote detect()=RUNNING → WAITING_USER only when the omp pane
+  is STABLE (prior pane hash == this tick's) and `idle_waiting()` is true; gated
+  on `getattr(adapter,"idle_waiting")` so only omp is affected. Stability gate
+  avoids flapping on a momentary mid-turn idle.
+- `menu_parse.py::_extract_free_form_question` — isolate the real question from
+  omp's reasoning stream / update banner / injected nudge / status chrome
+  (prefer the last `?`-terminated line).
+
+Tests: `TestPaneIsIdleWaiting` (6), `test_extract_free_form_omp_question_isolated`,
+`test_omp_stable_idle_promotes_running_to_waiting_user`. Owned suite: 152 green.
+
+**Verified live:** session `936f60bb` was promoted RUNNING→WAITING_USER
+(kind=`prompt`) by the new detection after a gateway restart.
+
+Known tradeoff (accepted): a finished-turn idle (e.g. agent says "Complete.")
+also surfaces as WAITING_USER. The state+question-digest debounce keeps it to one
+ping per distinct message. Tunable later (e.g. suppress completion-phrase idles).
+
+## Live smoke checklist (run on the gateway host)
+
+Restart gateway to pick up code: `launchctl kickstart -k gui/$(id -u)/ai.hermes.gateway`
+
+1. `@Hermès so omp z-harness "<task that triggers an omp Accept/Defer menu>"`
+   → thread created; when omp shows the menu, the thread message shows the
+   **question + numbered options** + "Reply with the option number".
+2. Reply `2` in the thread → **RISK CHECK**: confirm the omp menu is cancelled
+   by `Escape` and the pasted "user chose option 2: «…»" advances the agent
+   (session leaves WAITING_USER). This is the one design risk (Escape-cancel).
+3. Trigger a second, different menu → confirm it re-notifies (debounce keyed on
+   state + question digest).
+4. Check `#feed`: the digest line is a concise `<#thread>` + `<@user>` router
+   with a truncated question, not a full box dump.
+5. Archive/close the thread → session terminates (tmux killed), feed line drops,
+   attention resolved.
+   Registry check:
+   `sqlite3 ~/.hermes/state.db "select task_id,state,last_input_kind,last_options,discord_thread_id from session_orchestration order by rowid desc limit 3;"`
+
+## Caveats / follow-ups
+
+- **Discord thread auto-archive footgun.** Discord auto-archives inactive
+  threads (guild setting: 1h/24h/3d/7d). That fires the same
+  `on_thread_update(archived=True)`, so a quiet `WAITING_USER` session could be
+  auto-terminated if the user is slow to answer. Options if this bites:
+  (a) reap only on `on_thread_delete` (deliberate close), not archive; or
+  (b) skip terminate when `state == WAITING_USER`; or (c) raise the thread's
+  `auto_archive_duration`. Left as the user chose (archive⇒terminate) — flag.
+- Prior-session `omp.py`/`claude_code.py` unit tests need refreshing when those
+  keeper changes are committed (13 failing, unrelated to this plan).

--- a/.plans/so-answerable-needs-input/TASKS.md
+++ b/.plans/so-answerable-needs-input/TASKS.md
@@ -1,0 +1,166 @@
+---
+artifact: tasks
+slug: so-answerable-needs-input
+planning_mode: intent
+generated_at: 2026-07-01T00:00:00Z
+---
+
+# TASKS — so-answerable-needs-input
+
+Retarget the so-MCP answerable design onto the single-writer
+`session_orchestration/` watcher. Reference source for reuse:
+`~/dev/z-harness/scripts/hermes/mcp_hermes_orchestrator.py`
+(`_extract_menu_options` L509-538, `_extract_needs_input_context` L477-506,
+`_is_rule` L472-474, `_MENU_FOOTER_HINTS` L468-470) and its test module.
+
+Legend: `Advances:` cites the INTENT.md acceptance checklist item(s).
+
+---
+
+## T001 — Port the menu-parse pure module + tests `[ ]`
+**Files:** `session_orchestration/menu_parse.py` (new),
+`session_orchestration/tests/test_menu_parse.py` (new)
+**Depends:** none
+**Advances:** acceptance #1
+Port `_is_rule`, `_MENU_FOOTER_HINTS`, `_extract_menu_options`, and
+`_extract_needs_input_context` from `mcp_hermes_orchestrator.py` into a pure,
+dependency-free `menu_parse.py` exposing `extract(pane_text) -> (question:
+str, options: list[str], is_menu: bool)`. `is_menu` is true iff ≥1 box-row
+option label was extracted. Port the so-MCP unit tests verbatim where possible
+(ordered labels, indented-description skip, bare-prompt→empty, menu cleanup,
+unknown-shape raw-tail fallback). No tmux, no I/O.
+**Complexity:** medium
+
+## T002 — Registry migration: `last_options` + `last_input_kind` `[ ]`
+**Files:** `session_orchestration/registry.py`
+**Depends:** none
+**Advances:** acceptance #2
+Add nullable columns `last_options TEXT` (JSON array) and `last_input_kind TEXT`
+(`menu`|`prompt`|null) mirroring the existing `last_question` migration
+(registry.py:~331). Additive/idempotent migration; extend the row read/write
+mappers. No backfill.
+**Complexity:** low
+
+## T003 — Watcher: extract + persist question/options on WAITING_USER `[ ]`
+**Files:** `session_orchestration/watcher.py`,
+`session_orchestration/adapters/omp.py`,
+`session_orchestration/tests/test_watcher_needs_input.py` (new/extend)
+**Depends:** T001, T002
+**Advances:** acceptance #2
+In `_process_row`, when a row transitions to (or is observed in) `WAITING_USER`
+via the pane path, call `menu_parse.extract(pane_text)` on the already-captured
+pane text (watcher.py:~1451, lock held) and persist `last_question`,
+`last_options`, `last_input_kind` on the row (single-writer). For omp,
+`is_menu` distinguishes a selection menu from a bare `❯` prompt. Do NOT regress
+the marker-driven `last_question` path for Claude Code. Test with fixture panes.
+**Complexity:** medium
+
+## T004 — Thread presentation: numbered options in-thread `[ ]`
+**Files:** `session_orchestration/feed.py`,
+`session_orchestration/tests/test_feed_turn_change.py` (new/extend)
+**Depends:** T003
+**Advances:** acceptance #3
+Extend `push_turn_change` (feed.py:460-537) so that when `last_input_kind ==
+menu` the thread message renders the question then a numbered option list
+(`1. <label>` …) plus a one-line "reply with the option number" hint. Free-form
+`prompt` rows keep current behavior. Preserve the existing `@`-mention + icon.
+**Complexity:** medium
+
+## T005 — Notify debounce keyed on state + question digest `[ ]`
+**Files:** `session_orchestration/feed.py`,
+`session_orchestration/tests/test_feed_turn_change.py`
+**Depends:** T004
+**Advances:** acceptance #6
+Change the `_last_notified` debounce (feed.py:~534) to key on
+`(new_state, sha1(last_question or ""))` so a *new* question within the same
+`WAITING_USER` state re-notifies. Keep `clear_last_notified` on leaving
+attention. Test: menu→different-menu without an observed RUNNING tick re-emits.
+**Complexity:** medium
+
+## T006 — Answer route: Escape + natural-language selection `[ ]`
+**Files:** `gateway/run.py` (`_handle_managed_thread_reply` ~10954),
+`session_orchestration/adapters/omp.py`,
+`session_orchestration/relay.py`,
+`session_orchestration/tests/test_menu_answer.py` (new)
+**Depends:** T003
+**Advances:** acceptance #4, #5
+When the matched row has `last_input_kind == menu` and the reply is a valid
+option number `n ∈ [1..len(options)]`: (a) send a single `Escape` to the pane to
+cancel the menu (new adapter helper, e.g. `cancel_menu()` / `drive(..., pre_keys=["Escape"])`,
+using `tmux send-keys` which omp.py already uses at L700/L810); (b) compose and
+paste a natural-language instruction naming the chosen label — e.g. `"[Hermès]
+You presented a selection menu. The user chose option {n}: «{label}». Please
+proceed with that choice."` — via the existing lock-holding `drive()` paste
+path. Non-numeric / out-of-range replies fall through to the current paste path
+unchanged. Route all of this through the relay so the row lock is respected;
+the watcher re-detects the next state naturally (no manual re-arm).
+**Complexity:** high
+
+## T007 — #feed digest becomes a concise @-mention router `[ ]`
+**Files:** `session_orchestration/feed.py` (`render_attention_digest`
+291-362), `session_orchestration/tests/test_feed_digest.py` (new/extend)
+**Depends:** T003
+**Advances:** acceptance #7
+Reshape each digest line to a one-line router:
+`<@user> — <agent>/<repo>: <question truncated ~80 chars> → <#thread_id>`.
+The full question/options stay in the thread (T004), not the digest. Keep the
+single-message upsert/content-hash reconcile. Handle a missing
+`discord_thread_id` (raw task-id fallback, as today).
+**Complexity:** medium
+
+## T008 — Reap on session end (verify + close gaps) `[ ]`
+**Files:** `session_orchestration/watcher.py`,
+`session_orchestration/feed.py`,
+`session_orchestration/tests/test_reap.py` (new/extend)
+**Depends:** T007
+**Advances:** acceptance #9
+Verify and, where missing, ensure that on terminal state (DONE/ERROR/dead-tmux
+reap at watcher.py:1315-1330, 1404-1447) the attention item is resolved, the
+feed router line drops out of the digest, and `@`-pings stop
+(`clear_last_notified`). Add a test asserting the full teardown for a session
+that ends while `WAITING_USER`.
+**Complexity:** medium
+
+## T009 — Thread archive/close listener → terminate intent `[ ]`
+**Files:** `plugins/platforms/discord/adapter.py`, `gateway/run.py`
+**Depends:** none
+**Advances:** acceptance #8
+Add a Discord listener for thread archive/close/delete
+(`on_thread_update` w/ `archived`, `on_thread_delete`). On event: look up the
+row whose `discord_thread_id` matches; if found, `enqueue_intent("terminate",
+task_id, reason="thread_archived")`. Gateway only enqueues — never writes the
+registry directly (single-writer).
+**Complexity:** medium
+
+## T010 — Watcher: handle terminate intent → kill + reap `[ ]`
+**Files:** `session_orchestration/watcher.py`,
+`session_orchestration/registry.py`,
+`session_orchestration/tests/test_terminate_intent.py` (new)
+**Depends:** T008, T009
+**Advances:** acceptance #8
+Drain the `terminate` intent: kill the tmux session, mark the row terminal
+(ERROR/DONE per convention), resolve the attention item, and drop the feed
+router line — reusing the T008 teardown path. Idempotent if the session is
+already gone. Test the archive→terminate→reap chain end-to-end.
+**Complexity:** medium
+
+## T011 — Remove dead old-path reaction wiring `[ ]`
+**Files:** `plugins/platforms/discord/adapter.py`
+**Depends:** none
+**Advances:** acceptance #10
+Revert the disabled so-MCP reaction code (`_render_so_needs_input`,
+`_so_reaction_index`, `_navigate_so_session`, `on_raw_reaction_add`,
+`_so_inflight`) flagged in the handoff. Confirm nothing in the live
+session_orchestration path references it before deleting.
+**Complexity:** low
+
+## T012 — Live smoke + suite green `[ ]`
+**Files:** (test/docs only)
+**Depends:** T001-T011
+**Advances:** acceptance #4, #11
+Run `python -m pytest` for touched `session_orchestration` modules. Live smoke:
+`@Hermès so omp z-harness "<task that triggers a menu>"` → thread shows question
++ numbered options; reply "2" → menu Escapes, agent proceeds; archive thread →
+session terminates + feed line drops. Confirm the `Escape`-cancel happy path
+(the one flagged risk). Record results in the plan archive.
+**Complexity:** medium

--- a/HANDOFF-session-orchestration-feed.md
+++ b/HANDOFF-session-orchestration-feed.md
@@ -1,0 +1,105 @@
+# Handoff — session-orchestration answerable feed (2026-07-01)
+
+Goal: make `@Hermès so omp <repo> "<task>"` spawn a **managed** session that lands
+in the **session_orchestration** unified feed — needs-input items posted with a
+clickable thread link, text-reply-in-thread relayed into omp, auto-nudge on
+stall. NO reactions (user preference). This is the `session_orchestration/`
+subsystem (already built + `enabled: true`); the work here was fixing the
+entry-point routing + a stack of spawn/detection/feed bugs.
+
+## Architecture (which path is live)
+- **`so <agent> <repo> "<task>"`** (Discord) → Hermès LLM → `session_spawn` tool
+  (`session_orchestration/spawn_tool.py`) → `spawn.spawn_session` → omp/claude
+  adapter launches a tmux session → registry row (`~/.hermes/state.db`) →
+  `session-orchestration-watch` cron (every 1m) polls panes, opens attention
+  items, and reconciles the **feed digest** (single edited message in
+  `feed_channel_id=1520995687393792040`).
+- The OLD `so`-MCP path (z-harness `scripts/hermes/mcp_hermes_orchestrator.py`
+  FastMCP + `so-watcher` cron + reactions) is DEPRECATED and now disabled.
+
+## Changes made (ALL UNCOMMITTED)
+
+### hermes-agent repo (`~/.hermes/hermes-agent`, git repo)
+- `session_orchestration/adapters/omp.py` — 5 spawn/detection fixes:
+  1. Pane `:0.0` hardcode → resolve real pane id via `list-panes -F '#{pane_id}'`
+     (broke under the user's `base-index 1`/`pane-base-index 1` tmux config).
+  2. `shlex.join` for the omp launch command (prompt with `?`/specials broke zsh).
+  3. `launch()` boots omp **bare** (no prompt arg) — prompt seeded via `drive()`
+     (spawn_session step 7), matching claude adapter. Prevented double-delivery.
+  4. New `_wait_for_launch` — waits for omp TUI chrome (`╭`/`╰`), not the idle
+     prompt (which never appears while omp is busy on a launch prompt).
+  5. New `_wait_for_ready` (used by `drive`) — omp has NO `❯`; ready == TUI box
+     present AND not busy (`ACTIVITY_REGEX`). Old `_wait_for_prompt` never matched.
+  6. `INPUT_REQUEST_REGEX` + `parse_pane_lifecycle` — omp selection menus (footer
+     "enter select / esc cancel", no `❯`, spinner masking) now → `WAITING_USER`.
+- `session_orchestration/adapters/claude_code.py` — same pane `:0.0`→real-pane-id fix.
+- `session_orchestration/spawn_tool.py` — `spawn_tool_handler(..., **_injected)`
+  (dispatcher injects `task_id`; handler crashed on the unexpected kwarg).
+- `scripts/session-orchestration-watch.sh` — source `~/.hermes/.env` so the
+  watcher has `DISCORD_BOT_TOKEN` (feed post silently `discord_failed` without it).
+- `plugins/platforms/discord/adapter.py` — **REVERT CANDIDATE.** Old-path
+  reaction wiring (`_render_so_needs_input`, `_so_reaction_index`,
+  `_navigate_so_session`, `on_raw_reaction_add`, `_so_inflight`). Dead now that
+  the old path is disabled — safe to revert (was aimed at the wrong subsystem).
+
+### ~/.hermes config + skills (not in hermes-agent git)
+- `~/.hermes/config.yaml`: `mcp_servers.so.enabled: false` (disabled old so-MCP);
+  `session_orchestration.enabled: true` (already on).
+- `~/.hermes/skills/autonomous-ai-agents/so-orchestration/SKILL.md`: rewritten
+  (v3.0.0) to route `so` → `session_spawn` + hard "STOP on error, no manual, no
+  mcp_so_*" rules. Original at `SKILL.md.deprecated-bak`.
+
+### z-harness repo — committed this session (main branch, unpushed)
+`c8f031f`, `de8e65d`, `adf440a`, `936c7c9` (old-path so-poller fixes — now moot
+since the old path is disabled, but harmless). Working tree: `mcp_hermes_orchestrator.py`
+shows modified — verify/discard.
+
+## What WORKS (verified live)
+- Spawn creates a real managed omp session + registry row (RUNNING).
+- Watcher flips it to WAITING_USER when omp shows a menu.
+- Feed digest posts/edits (verified: `reconcile` returned `status: edited`).
+
+## REMAINING GAPS
+1. **THREAD (next task) — real plumbing change, do in a fresh session.**
+   Session has empty `discord_thread_id` → feed links a raw task-id (not
+   `<#thread>`), AND text replies can't route to omp
+   (`_handle_managed_thread_reply` at `gateway/run.py:~10990` keys off
+   `discord_thread_id`). Root cause: `spawn_tool_handler`
+   (`session_orchestration/spawn_tool.py:~185`) builds a `SpawnRequest` with NO
+   `thread_creator`/`parent_chat_id`, so `spawn.py` step 6 (thread creation,
+   gated on both) is skipped. The tool path CANNOT easily get the parent chat:
+   the tool executor `model_tools.py:handle_function_call` → `registry.dispatch`
+   injects ONLY `task_id` + `user_task` (verified). `task_id` =
+   `_session_key_for_source(source)` (a SESSION KEY like `discord:...`, NOT the
+   raw channel snowflake `create_handoff_thread` needs). `/so-spawn`
+   (`gateway/run.py:_handle_so_spawn_command` → `spawn.handle_spawn_command`)
+   works only because it's a command with the full `MessageEvent` + platform
+   adapter: it reads `parent_chat_id = source.chat_id` and builds `thread_creator`
+   from `platform_adapter.create_handoff_thread` (async, wrapped sync).
+   **Fix recipe:** (a) plumb `chat_id` (raw `source.chat_id`) from the gateway
+   agent-run (`_handle_message_with_agent`, where `source` is in scope) →
+   `handle_function_call(..., chat_id=...)` → `registry.dispatch(..., chat_id=...)`
+   → `spawn_tool_handler(**_injected)` reads `chat_id`; (b) in `spawn_tool_handler`
+   get the Discord adapter via `gateway/run.py:_gateway_runner_ref()` →
+   `.adapters.get(Platform.DISCORD)` → build a sync `thread_creator` around
+   `create_handoff_thread` (mirror the wrapper in `spawn.handle_spawn_command`);
+   (c) pass `parent_chat_id`+`thread_creator` into `spawn_session`. GOTCHA:
+   `create_handoff_thread` needs a TEXT-CHANNEL parent — if the `so` convo is
+   already in a Discord auto-thread, pass the parent channel id, not the thread.
+   Simpler alt to consider: create the thread in the gateway AFTER the tool
+   returns (where `source` is known) and `registry.upsert(discord_thread_id=...)`.
+2. z-plan came up "What task should I plan?" — the task text didn't reach z-plan's
+   args (prompt-delivery / z_command handling). Secondary.
+3. omp not emitting `HERMES_MARKER_FILE` markers — pane detection covers it; non-blocking.
+
+## TEST
+`@Hermès so omp z-harness "add a docstring to navigate_so_session"` → expect a
+thread created, session in feed with a clickable thread link, reply-in-thread →
+into omp. Gateway restart picks up code changes: `launchctl kickstart -k gui/$(id -u)/ai.hermes.gateway`.
+Registry: `sqlite3 ~/.hermes/state.db "select task_id,state,discord_thread_id from session_orchestration order by rowid desc limit 3;"`
+
+## COMMIT (when satisfied)
+hermes-agent repo: commit the 4 keeper files (omp.py, claude_code.py,
+spawn_tool.py, session-orchestration-watch.sh) + the thread fix; decide on
+reverting adapter.py reaction code. config.yaml + the skill live outside the
+repo — note them separately.

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1234,6 +1234,25 @@ updates:
 #   # session is declared hung.  Each tick is roughly 1-2 minutes.
 #   # hang_idle_ticks: 3
 #
+#   # When true (default), the watcher proactively marks a session terminal
+#   # (ERROR or DONE) if its tmux pane disappears without emitting a 'done'
+#   # marker and there are no recent heartbeats.  Set to false to revert to
+#   # the prior behaviour of waiting out the full hang-nudge ladder instead.
+#   # dead_tmux_reap: true
+#
+#   # Retention window (seconds) for completed/errored sessions.  Terminal rows
+#   # (DONE or ERROR) with a ``terminated_at`` timestamp older than this value
+#   # are garbage-collected once per watcher tick.  Set to 0 to disable GC.
+#   # Default: 86400 (24 hours).
+#   # gc_after_seconds: 86400
+#
+#   # Re-nudge interval (seconds) for sessions that remain in WAITING_USER or
+#   # PAUSED_HANDOFF without user action.  When a session has been sitting in an
+#   # attention state for this long, the watcher sends a DM to the owner to
+#   # re-surface it.  Fires at most once per interval (debounced).
+#   # Set to 0 to disable re-nudging entirely.  Default: 1800 (30 minutes).
+#   # renudge_after_seconds: 1800
+#
 #   # ── Repo registry manual overrides ───────────────────────────────────────
 #   #
 #   # Hermes auto-scans ~/dev/* and ~/.hermes for git repos and makes them

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1207,17 +1207,18 @@ updates:
 # =============================================================================
 # Managed external coding-agent session layer.  Hermes can spawn claude-code
 # and omp sessions in tmux, drive them on your behalf, watch for state changes,
-# and surface everything in a single unified Discord feed.
+# and surface action items in a single edited Discord checklist digest.
 #
 # All behaviour is gated behind `enabled: true`.  With enabled: false (the
 # default), nothing changes — no watcher cron runs, no ingest route processes,
-# no /so-* commands surface in the gateway.
+# and no session-orchestration gateway commands surface.
 #
 # session_orchestration:
 #   enabled: false
 #
-#   # Discord channel id for the unified session feed.
-#   # All state transitions and watchdog alerts are posted here.
+#   # Discord channel id for the session action feed.
+#   # Hosts a single edited checklist digest for unresolved attention items.
+#   # Thread-local notices are optional/best-effort when a task has a thread.
 #   # feed_channel_id: "1234567890123456789"
 #
 #   # Discord channel id for runs adopted from external sources
@@ -1225,11 +1226,12 @@ updates:
 #   # Defaults to feed_channel_id routing when empty.
 #   # external_runs_channel_id: "9876543210987654321"
 #
-#   # Static stale threshold (seconds).  A RUNNING session whose pane
-#   # output hasn't changed for hang_idle_ticks ticks AND whose
-#   # last_output_ts is older than this is declared hung.
+#   # Deterministic stale/frozen guard threshold (seconds).  A RUNNING
+#   # session opens stale/frozen attention only when last_output_ts is older
+#   # than this, the pane hash is unchanged for hang_idle_ticks ticks, and
+#   # the current pane does not match the adapter's active-work regex.
 #   # hang_stale_seconds: 300
 #
-#   # Number of consecutive pane-hash-unchanged ticks before a RUNNING
-#   # session is declared hung.  Each tick is roughly 1-2 minutes.
+#   # Number of consecutive unchanged pane-hash ticks required by the
+#   # stale/frozen guard.  Each watcher tick is roughly 1-2 minutes.
 #   # hang_idle_ticks: 3

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1233,3 +1233,35 @@ updates:
 #   # Number of consecutive pane-hash-unchanged ticks before a RUNNING
 #   # session is declared hung.  Each tick is roughly 1-2 minutes.
 #   # hang_idle_ticks: 3
+#
+#   # ── Repo registry manual overrides ───────────────────────────────────────
+#   #
+#   # Hermes auto-scans ~/dev/* and ~/.hermes for git repos and makes them
+#   # available by their directory basename (case-insensitive).  Use ``repos:``
+#   # to add aliases, override paths, or set a per-repo default agent.
+#   #
+#   # Resolution order:
+#   #   1. Exact alias match in repos: overrides
+#   #   2. Exact basename match from the auto-scan cache
+#   #   3. Fuzzy match (suffix-segment or substring, overrides first)
+#   #   4. Literal filesystem path (must point at a git repo)
+#   #   5. Unresolved — Hermes asks the user for clarification
+#   #
+#   # Default agent when none is specified: omp
+#   #
+#   # Shorthand form (path only, uses default agent "omp"):
+#   # repos:
+#   #   myproject: /absolute/path/to/myproject
+#   #
+#   # Full form (explicit agent):
+#   # repos:
+#   #   myproject:
+#   #     path: /absolute/path/to/myproject
+#   #     default_agent: omp    # omp | claude (default: omp)
+#   #
+#   # Mixed example:
+#   # repos:
+#   #   work-api: /Users/alice/src/work-api
+#   #   infra:
+#   #     path: /home/alice/infra
+#   #     default_agent: claude

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1200,3 +1200,36 @@ updates:
 #   # default — works on Fly.io out of the box).
 #   #
 #   #   public_url: "https://example.com/hermes"
+
+
+# =============================================================================
+# Session Orchestration (opt-in, disabled by default)
+# =============================================================================
+# Managed external coding-agent session layer.  Hermes can spawn claude-code
+# and omp sessions in tmux, drive them on your behalf, watch for state changes,
+# and surface everything in a single unified Discord feed.
+#
+# All behaviour is gated behind `enabled: true`.  With enabled: false (the
+# default), nothing changes — no watcher cron runs, no ingest route processes,
+# no /so-* commands surface in the gateway.
+#
+# session_orchestration:
+#   enabled: false
+#
+#   # Discord channel id for the unified session feed.
+#   # All state transitions and watchdog alerts are posted here.
+#   # feed_channel_id: "1234567890123456789"
+#
+#   # Discord channel id for runs adopted from external sources
+#   # (z-harness webhook alerts whose run_id/repo is unknown).
+#   # Defaults to feed_channel_id routing when empty.
+#   # external_runs_channel_id: "9876543210987654321"
+#
+#   # Static stale threshold (seconds).  A RUNNING session whose pane
+#   # output hasn't changed for hang_idle_ticks ticks AND whose
+#   # last_output_ts is older than this is declared hung.
+#   # hang_stale_seconds: 300
+#
+#   # Number of consecutive pane-hash-unchanged ticks before a RUNNING
+#   # session is declared hung.  Each tick is roughly 1-2 minutes.
+#   # hang_idle_ticks: 3

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -546,6 +546,39 @@ def _normalize_profile(profile: Optional[str]) -> Optional[str]:
     resolve_profile_env(normalized)
     return normalized
 
+def _builtin_scripts_dir() -> Path:
+    """Installed hermes-agent built-in scripts directory."""
+    return (Path(__file__).parent.parent / "scripts").resolve()
+
+
+def _normalize_script_path(script: Optional[str], *, no_agent: bool = False) -> Optional[str]:
+    """Normalize cron script storage without changing user-script semantics.
+
+    User scripts are stored exactly as supplied.  For no-agent jobs, absolute
+    paths that point at Hermes-owned built-in scripts are stored as the safe
+    repo-relative token ``scripts/<name>`` so new registrations do not persist
+    machine-specific hermes-agent paths.
+    """
+    if script is None:
+        return None
+    raw = str(script).strip()
+    if not raw:
+        return None
+    if not no_agent:
+        return raw
+
+    path = Path(raw).expanduser()
+    if not path.is_absolute():
+        return raw
+
+    builtins = _builtin_scripts_dir()
+    try:
+        rel = path.resolve().relative_to(builtins)
+    except ValueError:
+        return raw
+    return str(Path("scripts") / rel)
+
+
 
 def create_job(
     prompt: Optional[str],
@@ -586,9 +619,11 @@ def create_job(
                 ``no_agent=True`` the script IS the job — its stdout is
                 delivered verbatim. Without ``no_agent``, its stdout is
                 injected into the agent's prompt as context (data-collection /
-                change-detection pattern). Paths resolve under
-                ~/.hermes/scripts/; ``.sh`` / ``.bash`` files run via bash,
-                anything else via Python.
+                change-detection pattern). User scripts resolve under
+                ~/.hermes/scripts/; no-agent jobs may also run Hermes-owned
+                built-in scripts from the installed hermes-agent scripts/
+                directory. ``.sh`` / ``.bash`` files run via bash, anything
+                else via Python.
         context_from: Optional job ID (or list of job IDs) whose most recent output
                       is injected into the prompt as context before each run.
                       Useful for chaining cron jobs: job A finds data, job B processes it.
@@ -642,13 +677,12 @@ def create_job(
     normalized_model = normalized_model or None
     normalized_provider = normalized_provider or None
     normalized_base_url = normalized_base_url or None
-    normalized_script = str(script).strip() if isinstance(script, str) else None
-    normalized_script = normalized_script or None
+    normalized_no_agent = bool(no_agent)
+    normalized_script = _normalize_script_path(script, no_agent=normalized_no_agent)
     normalized_toolsets = [str(t).strip() for t in enabled_toolsets if str(t).strip()] if enabled_toolsets else None
     normalized_toolsets = normalized_toolsets or None
     normalized_workdir = _normalize_workdir(workdir)
     normalized_profile = _normalize_profile(profile)
-    normalized_no_agent = bool(no_agent)
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -800,6 +834,21 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                 updates["profile"] = None
             else:
                 updates["profile"] = _normalize_profile(_profile)
+
+        # Normalize Hermes built-in no-agent scripts at create/update time so
+        # new watcher registrations don't persist machine-specific absolute
+        # hermes-agent paths. User script paths are otherwise kept unchanged.
+        if "script" in updates or "no_agent" in updates:
+            target_no_agent = bool(updates.get("no_agent", job.get("no_agent", False)))
+            target_script = updates.get("script", job.get("script"))
+            normalized_script = _normalize_script_path(
+                target_script,
+                no_agent=target_no_agent,
+            )
+            if "script" in updates:
+                updates["script"] = normalized_script
+            elif target_no_agent:
+                updates["script"] = normalized_script
 
         updated = _apply_skill_fields({**job, **updates})
         schedule_changed = "schedule" in updates

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -954,13 +954,86 @@ def _get_script_timeout() -> int:
     return _DEFAULT_SCRIPT_TIMEOUT
 
 
-def _run_job_script(script_path: str) -> tuple[bool, str]:
+def _get_builtin_scripts_dir() -> Path:
+    """Return the installed hermes-agent built-in scripts directory."""
+    return (Path(__file__).parent.parent / "scripts").resolve()
+
+
+def _trusted_script_roots(allow_builtin_scripts: bool = False) -> list[tuple[Path, str]]:
+    """Trusted roots for cron script execution, in resolution order."""
+    roots = [
+        ((_get_hermes_home() / "scripts").resolve(), "scripts directory"),
+    ]
+    if allow_builtin_scripts:
+        roots.append((_get_builtin_scripts_dir(), "Hermes built-in scripts directory"))
+    return roots
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _resolve_job_script_path(script_path: str, *, allow_builtin_scripts: bool = False) -> tuple[Optional[Path], Optional[str]]:
+    """Resolve a cron script path against the allowed script roots.
+
+    User scripts under HERMES_HOME/scripts keep precedence.  When
+    ``allow_builtin_scripts`` is enabled for no-agent jobs, Hermes-owned
+    built-ins under the installed hermes-agent ``scripts/`` directory are a
+    second trusted root.  Relative built-in references accept either
+    ``session-orchestration-watch.sh`` or ``scripts/session-orchestration-watch.sh``
+    so existing registration records and CLI examples both resolve safely.
+    """
+    roots = _trusted_script_roots(allow_builtin_scripts)
+    user_scripts_dir = roots[0][0]
+    raw = Path(script_path).expanduser()
+
+    if raw.is_absolute():
+        path = raw.resolve()
+        for root, _label in roots:
+            if _is_relative_to(path, root):
+                return path, None
+        root_list = ", ".join(str(root) for root, _label in roots)
+        return None, (
+            f"Blocked: script path resolves outside the trusted script directories "
+            f"({root_list}): {script_path!r}"
+        )
+
+    user_path = (user_scripts_dir / raw).resolve()
+    if not _is_relative_to(user_path, user_scripts_dir):
+        return None, (
+            f"Blocked: script path resolves outside the scripts directory "
+            f"({user_scripts_dir}): {script_path!r}"
+        )
+    if user_path.exists() or not allow_builtin_scripts:
+        return user_path, None
+
+    built_in_scripts_dir = roots[1][0]
+    built_in_candidates: list[Path] = []
+    raw_parts = raw.parts
+    if raw_parts and raw_parts[0] == "scripts" and len(raw_parts) > 1:
+        built_in_candidates.append((built_in_scripts_dir / Path(*raw_parts[1:])).resolve())
+    built_in_candidates.append((built_in_scripts_dir / raw).resolve())
+
+    for candidate in built_in_candidates:
+        if _is_relative_to(candidate, built_in_scripts_dir) and candidate.exists():
+            return candidate, None
+
+    return user_path, None
+
+
+def _run_job_script(script_path: str, *, allow_builtin_scripts: bool = False) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
-    Scripts must reside within HERMES_HOME/scripts/.  Both relative and
-    absolute paths are resolved and validated against this directory to
-    prevent arbitrary script execution via path traversal or absolute
-    path injection.
+    User scripts must reside within HERMES_HOME/scripts/.  Both relative and
+    absolute paths are resolved and validated against trusted roots to prevent
+    arbitrary script execution via path traversal or absolute path injection.
+    For no-agent jobs only, callers may set ``allow_builtin_scripts=True`` to
+    also allow Hermes-owned built-in scripts under the installed hermes-agent
+    ``scripts/`` directory.
 
     Supported interpreters (chosen by file extension):
 
@@ -974,8 +1047,11 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
 
     Args:
         script_path: Path to the script.  Relative paths are resolved
-            against HERMES_HOME/scripts/.  Absolute and ~-prefixed paths
-            are also validated to ensure they stay within the scripts dir.
+            against HERMES_HOME/scripts/.  No-agent callers may also resolve
+            Hermes built-ins as ``scripts/name.sh`` or ``name.sh``.
+        allow_builtin_scripts: Permit the installed hermes-agent ``scripts/``
+            directory as a second trusted root.  This is intended only for
+            no-agent built-in cron jobs.
 
     Returns:
         (success, output) — on failure *output* contains the error message so the
@@ -983,23 +1059,13 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
     """
     scripts_dir = _get_hermes_home() / "scripts"
     scripts_dir.mkdir(parents=True, exist_ok=True)
-    scripts_dir_resolved = scripts_dir.resolve()
 
-    raw = Path(script_path).expanduser()
-    if raw.is_absolute():
-        path = raw.resolve()
-    else:
-        path = (scripts_dir / raw).resolve()
-
-    # Guard against path traversal, absolute path injection, and symlink
-    # escape — scripts MUST reside within HERMES_HOME/scripts/.
-    try:
-        path.relative_to(scripts_dir_resolved)
-    except ValueError:
-        return False, (
-            f"Blocked: script path resolves outside the scripts directory "
-            f"({scripts_dir_resolved}): {script_path!r}"
-        )
+    path, error = _resolve_job_script_path(
+        script_path,
+        allow_builtin_scripts=allow_builtin_scripts,
+    )
+    if error is not None:
+        return False, error
 
     if not path.exists():
         return False, f"Script not found: {path}"
@@ -1396,7 +1462,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 _prior_cwd = None
 
         try:
-            ok, output = _run_job_script(script_path)
+            ok, output = _run_job_script(script_path, allow_builtin_scripts=True)
         finally:
             if _prior_cwd is not None:
                 try:

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -912,6 +912,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["group_allow_admin_from"] = platform_cfg["group_allow_admin_from"]
                 if "group_user_allowed_commands" in platform_cfg:
                     bridged["group_user_allowed_commands"] = platform_cfg["group_user_allowed_commands"]
+                if plat == Platform.DISCORD and "so" in platform_cfg:
+                    bridged["so"] = platform_cfg["so"]
                 if plat in {Platform.DISCORD, Platform.SLACK} and "channel_skill_bindings" in platform_cfg:
                     bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
                 if "channel_prompts" in platform_cfg:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4235,6 +4235,8 @@ class BasePlatformAdapter(ABC):
                         _thread_metadata["notify"] = True
                     else:
                         _thread_metadata = {"notify": True}
+                    if hasattr(event.raw_message, "edit_original_response"):
+                        _thread_metadata["raw_message"] = event.raw_message
                     result = await self._send_with_retry(
                         chat_id=event.source.chat_id,
                         content=text_content,

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -533,6 +533,11 @@ class WebhookAdapter(BasePlatformAdapter):
                     route_config.get("deliver_extra", {}), payload
                 ),
                 "payload": payload,
+                # HMAC materials forwarded for defence-in-depth re-validation
+                # in session_orchestration/ingest.py::process_z_harness_alert.
+                "raw_body": raw_body,
+                "signature_header": request.headers.get("X-Z-Harness-Signature", ""),
+                "hmac_secret": secret,
             }
             logger.info(
                 "[webhook] direct-deliver event=%s route=%s target=%s msg_len=%d delivery=%s",
@@ -676,6 +681,14 @@ class WebhookAdapter(BasePlatformAdapter):
                 secret.encode(), body, hashlib.sha256
             ).hexdigest()
             return hmac.compare_digest(gh_sig, expected)
+
+        # z-harness: X-Z-Harness-Signature = sha256=<hex>
+        zh_sig = request.headers.get("X-Z-Harness-Signature", "")
+        if zh_sig:
+            expected = "sha256=" + hmac.new(
+                secret.encode(), body, hashlib.sha256
+            ).hexdigest()
+            return hmac.compare_digest(zh_sig, expected)
 
         # GitLab: X-Gitlab-Token = <plain secret>
         gl_token = request.headers.get("X-Gitlab-Token", "")
@@ -828,6 +841,9 @@ class WebhookAdapter(BasePlatformAdapter):
         if deliver_type == "github_comment":
             return await self._deliver_github_comment(content, delivery)
 
+        if deliver_type == "session_orchestration_ingest":
+            return await self._deliver_session_orchestration_ingest(delivery)
+
         # Fall through to the cross-platform dispatcher, which validates the
         # target name and routes via the gateway runner.
         return await self._deliver_cross_platform(
@@ -887,6 +903,46 @@ class WebhookAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.error("[webhook] github_comment delivery error: %s", e)
             return SendResult(success=False, error=str(e))
+
+    async def _deliver_session_orchestration_ingest(
+        self, delivery: dict
+    ) -> SendResult:
+        """Route a z-harness alert payload to the session-orchestration ingest handler.
+
+        Called when a ``deliver_only`` route has ``deliver: session_orchestration_ingest``.
+        The raw payload dict is passed to :func:`session_orchestration.ingest.process_z_harness_alert`.
+        """
+        try:
+            from session_orchestration.ingest import (
+                _is_enabled,
+                process_z_harness_alert,
+            )
+        except ImportError as exc:
+            logger.error("[webhook] session_orchestration import failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
+
+        # Early-gate: skip all work when session_orchestration is disabled.
+        if not _is_enabled():
+            logger.debug("[webhook] session_orchestration disabled; skipping ingest")
+            return SendResult(success=True)
+
+        payload = delivery.get("payload", {})
+        raw_body: bytes | None = delivery.get("raw_body")
+        signature_header: str = delivery.get("signature_header", "")
+        hmac_secret: str = delivery.get("hmac_secret", "")
+        try:
+            result = await process_z_harness_alert(
+                payload,
+                raw_body=raw_body if raw_body is not None else None,
+                signature_header=signature_header or None,
+                hmac_secret=hmac_secret or None,
+                gateway_runner=self.gateway_runner,
+            )
+            logger.info("[webhook] session_orchestration_ingest result: %s", result)
+            return SendResult(success=True)
+        except Exception as exc:
+            logger.error("[webhook] session_orchestration_ingest failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
 
     async def _deliver_cross_platform(
         self, platform_name: str, content: str, delivery: dict

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -65,6 +65,8 @@ _AGENT_CACHE_MAX_SIZE = 128
 _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
+_HANDOFF_DB_CALL_TIMEOUT_SECS_DEFAULT = 2.0
+_HANDOFF_DB_CIRCUIT_BREAK_SECS_DEFAULT = 30.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
@@ -2047,6 +2049,10 @@ class GatewayRunner:
 
         # Initialize session database for session_search tool support
         self._session_db = None
+        self._handoff_db_timeout_secs = _HANDOFF_DB_CALL_TIMEOUT_SECS_DEFAULT
+        self._handoff_db_circuit_break_secs = _HANDOFF_DB_CIRCUIT_BREAK_SECS_DEFAULT
+        self._handoff_db_circuit_open_until = 0.0
+        self._handoff_db_inflight_task: Optional[asyncio.Task] = None
         try:
             from hermes_state import SessionDB
             self._session_db = SessionDB()
@@ -4852,6 +4858,99 @@ class GatewayRunner:
         
         return True
 
+    async def _run_handoff_db_call(self, operation: str, func, *args) -> Any:
+        """Run a synchronous SessionDB handoff call off the gateway loop.
+
+        SQLite can block behind filesystem or WAL locks. Handoff polling is
+        auxiliary work, so a stuck DB call must not pin Discord heartbeats on
+        the main asyncio loop. ``shield`` leaves the worker thread to finish
+        after a timeout while the watcher opens a short circuit and skips
+        additional handoff DB calls instead of piling up concurrent work on
+        the shared SessionDB connection.
+        """
+        now = time.monotonic()
+        inflight = getattr(self, "_handoff_db_inflight_task", None)
+        if inflight is not None and not inflight.done():
+            logger.warning(
+                "Handoff DB call %s skipped; previous handoff DB call is still "
+                "running after timeout",
+                operation,
+            )
+            raise asyncio.TimeoutError(
+                f"previous handoff DB call still running; skipped {operation}"
+            )
+
+        circuit_open_until = float(
+            getattr(self, "_handoff_db_circuit_open_until", 0.0) or 0.0
+        )
+        if circuit_open_until > now:
+            remaining = circuit_open_until - now
+            logger.warning(
+                "Handoff DB call %s skipped; circuit open for %.1fs more",
+                operation,
+                remaining,
+            )
+            raise asyncio.TimeoutError(
+                f"handoff DB circuit open for {remaining:.1f}s; skipped {operation}"
+            )
+
+        timeout = max(
+            0.001,
+            float(
+                getattr(
+                    self,
+                    "_handoff_db_timeout_secs",
+                    _HANDOFF_DB_CALL_TIMEOUT_SECS_DEFAULT,
+                )
+                or _HANDOFF_DB_CALL_TIMEOUT_SECS_DEFAULT
+            ),
+        )
+        cooldown = max(
+            0.0,
+            float(
+                getattr(
+                    self,
+                    "_handoff_db_circuit_break_secs",
+                    _HANDOFF_DB_CIRCUIT_BREAK_SECS_DEFAULT,
+                )
+                or _HANDOFF_DB_CIRCUIT_BREAK_SECS_DEFAULT
+            ),
+        )
+
+        task = asyncio.create_task(asyncio.to_thread(func, *args))
+        self._handoff_db_inflight_task = task
+
+        def _clear_inflight(done_task: asyncio.Task) -> None:
+            if getattr(self, "_handoff_db_inflight_task", None) is done_task:
+                self._handoff_db_inflight_task = None
+            try:
+                done_task.result()
+            except asyncio.CancelledError:
+                pass
+            except Exception as exc:
+                logger.debug(
+                    "Handoff DB call %s finished after watcher moved on: %s",
+                    operation,
+                    exc,
+                    exc_info=True,
+                )
+
+        task.add_done_callback(_clear_inflight)
+        try:
+            result = await asyncio.wait_for(asyncio.shield(task), timeout=timeout)
+            self._handoff_db_circuit_open_until = 0.0
+            return result
+        except asyncio.TimeoutError:
+            self._handoff_db_circuit_open_until = time.monotonic() + cooldown
+            logger.warning(
+                "Handoff DB call %s timed out after %.3fs; opening circuit for "
+                "%.1fs so gateway heartbeats stay responsive",
+                operation,
+                timeout,
+                cooldown,
+            )
+            raise
+
     async def _handoff_watcher(self, interval: float = 2.0) -> None:
         """Background task that processes pending CLI→gateway session handoffs.
 
@@ -4879,23 +4978,45 @@ class GatewayRunner:
                 if self._session_db is None:
                     await asyncio.sleep(interval)
                     continue
-                pending = self._session_db.list_pending_handoffs()
+                pending = await self._run_handoff_db_call(
+                    "list_pending_handoffs",
+                    self._session_db.list_pending_handoffs,
+                )
                 for row in pending:
                     session_id = row.get("id")
                     if not session_id:
                         continue
-                    if not self._session_db.claim_handoff(session_id):
+                    claimed = await self._run_handoff_db_call(
+                        "claim_handoff",
+                        self._session_db.claim_handoff,
+                        session_id,
+                    )
+                    if not claimed:
                         # Another tick or another gateway already claimed it.
                         continue
+                    handoff_error: Optional[Exception] = None
                     try:
                         await self._process_handoff(row)
-                        self._session_db.complete_handoff(session_id)
                     except Exception as exc:
+                        handoff_error = exc
                         logger.warning(
                             "Handoff for session %s failed: %s",
                             session_id, exc, exc_info=True,
                         )
-                        self._session_db.fail_handoff(session_id, str(exc))
+
+                    if handoff_error is None:
+                        await self._run_handoff_db_call(
+                            "complete_handoff",
+                            self._session_db.complete_handoff,
+                            session_id,
+                        )
+                    else:
+                        await self._run_handoff_db_call(
+                            "fail_handoff",
+                            self._session_db.fail_handoff,
+                            session_id,
+                            str(handoff_error),
+                        )
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
@@ -10740,18 +10861,16 @@ class GatewayRunner:
         """Handle /control-status — read-only snapshot of all active session-orchestration tasks."""
         try:
             from session_orchestration.registry import SessionOrchestrationRegistry
-            from session_orchestration.status import build_snapshot
+            from session_orchestration.status import build_registry_snapshot
         except ImportError as exc:
             return f"Session orchestration is not available: {exc}"
 
         try:
             registry = SessionOrchestrationRegistry()
-            rows = registry.list()
+            return build_registry_snapshot(registry)
         except Exception as exc:
             logger.warning("control-status: registry read failed: %s", exc)
             return f"Could not read session-orchestration registry: {exc}"
-
-        return build_snapshot(rows)
 
     async def _handle_so_spawn_command(self, event: MessageEvent) -> str:
         """Handle /so-spawn — spawn a managed coding-agent session from Discord."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8708,13 +8708,13 @@ class GatewayRunner:
         if _thread_id_for_drive:
             _so_enabled_drive = False
             try:
-                from hermes_cli.config import cfg_get as _cfg_get_drive
-                _cfg_drive = self.config if isinstance(self.config, dict) else (
-                    self.config.__dict__ if hasattr(self.config, "__dict__") else {}
-                )
-                _so_enabled_drive = bool(
-                    _cfg_get_drive(_cfg_drive, "session_orchestration", "enabled", default=False)
-                )
+                # Use the canonical session_orchestration config reader, which
+                # loads the raw ~/.hermes/config.yaml. self.config is a typed
+                # GatewayConfig that drops the session_orchestration block, so
+                # reading it here always yielded False and the managed-thread
+                # drive gate never fired live.
+                from session_orchestration.config import is_enabled as _so_is_enabled
+                _so_enabled_drive = bool(_so_is_enabled())
             except Exception:
                 pass
 
@@ -10902,12 +10902,20 @@ class GatewayRunner:
         platform = getattr(source, "platform", None)
         platform_adapter = self.adapters.get(platform) if platform else None
 
+        # handle_spawn_command gates on cfg_get(config, "session_orchestration",
+        # "enabled"). self.config is a typed GatewayConfig that drops that block,
+        # so passing self.config.__dict__ here would always read enabled=False and
+        # block the native /so-spawn command. Load the raw Hermes config instead.
+        try:
+            from hermes_cli.config import load_config_readonly
+            _so_config = load_config_readonly()
+        except Exception:
+            _so_config = self.config if isinstance(self.config, dict) else {}
+
         return await handle_spawn_command(
             event,
             args_text,
-            config=self.config if isinstance(self.config, dict) else (
-                self.config.__dict__ if hasattr(self.config, "__dict__") else {}
-            ),
+            config=_so_config,
             platform_adapter=platform_adapter,
         )
 
@@ -10969,6 +10977,7 @@ class GatewayRunner:
         """
         try:
             from session_orchestration.adapters.base import AgentAdapter
+            from session_orchestration.menu_parse import resolve_menu_answer
             from session_orchestration.registry import SessionOrchestrationRegistry
             from session_orchestration.relay import LockConflictError, SessionRelay
             from session_orchestration.spawn import get_adapter
@@ -11003,10 +11012,15 @@ class GatewayRunner:
             )
             return None
 
-        # Reconstruct the SessionHandle from the registry row.  The pane is
-        # derived from tmux_session (same convention as adapter.launch()).
+        # Reconstruct the SessionHandle from the registry row.  Use the BARE
+        # tmux_session as the pane target (matching the watcher's
+        # _build_handle_from_row): `tmux capture/send-keys -t <session>` resolves
+        # to the session's ACTIVE pane regardless of base-index. A hardcoded
+        # ':0.0' breaks under `set -g base-index 1` / `pane-base-index 1` (the
+        # first pane is ':1.1'), which made drive()'s _wait_for_ready capture a
+        # nonexistent pane and time out after 30s ("pane did not become ready").
         tmux_session = matched_row.get("tmux_session") or ""
-        pane = matched_row.get("pane") or (f"{tmux_session}:0.0" if tmux_session else "")
+        pane = matched_row.get("pane") or tmux_session
         from datetime import datetime, timezone as _tz
         handle = SessionHandle(
             session_id=task_id,
@@ -11029,14 +11043,21 @@ class GatewayRunner:
 
         relay = SessionRelay(registry, adapter)
 
+        # Menu-aware answer: on a WAITING_USER menu row a bare "2" selects
+        # nothing (arrow-key menu). resolve_menu_answer turns a valid option
+        # number into an Escape (cancel the menu) + a natural-language
+        # selection; every other reply passes through unchanged.
+        drive_text, drive_pre_keys = resolve_menu_answer(matched_row, message_text)
+
         logger.info(
-            "drive_loop: routing thread reply to task_id=%s agent=%s len=%d",
-            task_id, agent_name, len(message_text),
+            "drive_loop: routing thread reply to task_id=%s agent=%s len=%d menu_select=%s",
+            task_id, agent_name, len(drive_text), bool(drive_pre_keys),
         )
 
         try:
             await asyncio.to_thread(
-                relay.send_message, task_id, handle, message_text
+                relay.send_message, task_id, handle, drive_text,
+                pre_keys=drive_pre_keys,
             )
         except LockConflictError as exc:
             logger.warning(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17347,6 +17347,11 @@ class GatewayRunner:
         agent_cfg_local = user_config.get("agent") or {}
         disabled_toolsets = agent_cfg_local.get("disabled_toolsets") or None
 
+        # T005: register session_spawn tool for Discord @mention turns
+        if platform_key == "discord":
+            from session_orchestration import spawn_tool as _so_spawn_tool  # noqa: F401 — triggers registry.register
+            enabled_toolsets = list(enabled_toolsets) + ["session_spawn"]
+
         display_config = user_config.get("display", {})
         if not isinstance(display_config, dict):
             display_config = {}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7932,6 +7932,15 @@ class GatewayRunner:
             if _cmd_def_inner and _cmd_def_inner.name == "so-spawn":
                 return await self._handle_so_spawn_command(event)
 
+            # /so-stop and /so-restart enqueue a terminate intent; they
+            # bypass the running-agent guard (they don't touch the Hermes
+            # agent session — they only mutate the session-orchestration
+            # registry).
+            if _cmd_def_inner and _cmd_def_inner.name == "so-stop":
+                return await self._handle_so_stop_command(event)
+            if _cmd_def_inner and _cmd_def_inner.name == "so-restart":
+                return await self._handle_so_restart_command(event)
+
             # /background must bypass the running-agent guard — it starts a
             # parallel task and must never interrupt the active conversation.
             # /btw is an alias of /background and resolves to the same canonical
@@ -10782,6 +10791,46 @@ class GatewayRunner:
             ),
             platform_adapter=platform_adapter,
         )
+
+    async def _handle_so_stop_command(self, event: MessageEvent) -> str:
+        """Handle /so-stop — enqueue a terminate intent for a managed session."""
+        try:
+            from session_orchestration.spawn import handle_stop_command
+        except ImportError as exc:
+            return f"Session orchestration is not available: {exc}"
+
+        raw_text = getattr(event, "text", "") or ""
+        for prefix in ("/so-stop",):
+            if raw_text.lower().startswith(prefix):
+                args_text = raw_text[len(prefix):].strip()
+                break
+        else:
+            args_text = raw_text.strip()
+
+        config = self.config if isinstance(self.config, dict) else (
+            self.config.__dict__ if hasattr(self.config, "__dict__") else {}
+        )
+        return handle_stop_command(event, args_text, config=config)
+
+    async def _handle_so_restart_command(self, event: MessageEvent) -> str:
+        """Handle /so-restart — enqueue a restart-terminate intent for a managed session."""
+        try:
+            from session_orchestration.spawn import handle_restart_command
+        except ImportError as exc:
+            return f"Session orchestration is not available: {exc}"
+
+        raw_text = getattr(event, "text", "") or ""
+        for prefix in ("/so-restart",):
+            if raw_text.lower().startswith(prefix):
+                args_text = raw_text[len(prefix):].strip()
+                break
+        else:
+            args_text = raw_text.strip()
+
+        config = self.config if isinstance(self.config, dict) else (
+            self.config.__dict__ if hasattr(self.config, "__dict__") else {}
+        )
+        return handle_restart_command(event, args_text, config=config)
 
     async def _handle_managed_thread_reply(
         self, event, thread_id: str

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7923,6 +7923,15 @@ class GatewayRunner:
             if _cmd_def_inner and _cmd_def_inner.name == "agents":
                 return await self._handle_agents_command(event)
 
+            # /control-status is read-only; bypass the running-agent guard.
+            if _cmd_def_inner and _cmd_def_inner.name == "control-status":
+                return await self._handle_control_status_command(event)
+
+            # /so-spawn spawns a managed coding-agent session; bypass the
+            # running-agent guard (it doesn't touch the Hermes agent session).
+            if _cmd_def_inner and _cmd_def_inner.name == "so-spawn":
+                return await self._handle_so_spawn_command(event)
+
             # /background must bypass the running-agent guard — it starts a
             # parallel task and must never interrupt the active conversation.
             # /btw is an alias of /background and resolves to the same canonical
@@ -8385,6 +8394,9 @@ class GatewayRunner:
         if canonical == "voice":
             return await self._handle_voice_command(event)
 
+        if canonical == "control-status":
+            return await self._handle_control_status_command(event)
+
         if self._draining:
             return f"⏳ Gateway is {self._status_action_gerund()} and is not accepting new work right now."
 
@@ -8552,6 +8564,38 @@ class GatewayRunner:
         # Pending exec approvals are handled by /approve and /deny commands above.
         # No bare text matching — "yes" in normal conversation must not trigger
         # execution of a dangerous command.
+
+        # ── Managed-thread drive loop ─────────────────────────────────
+        # If the message arrives in a Discord thread that is managed by
+        # session_orchestration (i.e. its thread_id is recorded on a
+        # registry row), route the text to the relay instead of starting a
+        # normal Hermes agent turn.  Slash commands already returned above;
+        # anything reaching here is plain user text in the thread.
+        #
+        # Gate on session_orchestration.enabled so unrelated deployments
+        # don't pay even the import cost.
+        _thread_id_for_drive = str(getattr(source, "thread_id", None) or "")
+        if _thread_id_for_drive:
+            _so_enabled_drive = False
+            try:
+                from hermes_cli.config import cfg_get as _cfg_get_drive
+                _cfg_drive = self.config if isinstance(self.config, dict) else (
+                    self.config.__dict__ if hasattr(self.config, "__dict__") else {}
+                )
+                _so_enabled_drive = bool(
+                    _cfg_get_drive(_cfg_drive, "session_orchestration", "enabled", default=False)
+                )
+            except Exception:
+                pass
+
+            if _so_enabled_drive:
+                _drive_result = await self._handle_managed_thread_reply(
+                    event, _thread_id_for_drive
+                )
+                if _drive_result is not None:
+                    # Matched a managed thread — return result (empty string on
+                    # success; error text on failure).  Do NOT fall through.
+                    return _drive_result or None
 
         if self._is_telegram_topic_root_lobby(source):
             # Debounce the lobby reminder so a user who forgets about
@@ -10691,6 +10735,158 @@ class GatewayRunner:
             lines.append(t("gateway.agents.none"))
 
         return "\n".join(lines)
+
+    async def _handle_control_status_command(self, event: MessageEvent) -> str:
+        """Handle /control-status — read-only snapshot of all active session-orchestration tasks."""
+        try:
+            from session_orchestration.registry import SessionOrchestrationRegistry
+            from session_orchestration.status import build_snapshot
+        except ImportError as exc:
+            return f"Session orchestration is not available: {exc}"
+
+        try:
+            registry = SessionOrchestrationRegistry()
+            rows = registry.list()
+        except Exception as exc:
+            logger.warning("control-status: registry read failed: %s", exc)
+            return f"Could not read session-orchestration registry: {exc}"
+
+        return build_snapshot(rows)
+
+    async def _handle_so_spawn_command(self, event: MessageEvent) -> str:
+        """Handle /so-spawn — spawn a managed coding-agent session from Discord."""
+        try:
+            from session_orchestration.spawn import handle_spawn_command
+        except ImportError as exc:
+            return f"Session orchestration is not available: {exc}"
+
+        # Extract args text (everything after /so-spawn)
+        raw_text = getattr(event, "text", "") or ""
+        # Strip the command prefix (/so-spawn or /spawn-session)
+        for prefix in ("/so-spawn", "/spawn-session"):
+            if raw_text.lower().startswith(prefix):
+                args_text = raw_text[len(prefix):].strip()
+                break
+        else:
+            args_text = raw_text.strip()
+
+        source = getattr(event, "source", None)
+        platform = getattr(source, "platform", None)
+        platform_adapter = self.adapters.get(platform) if platform else None
+
+        return await handle_spawn_command(
+            event,
+            args_text,
+            config=self.config if isinstance(self.config, dict) else (
+                self.config.__dict__ if hasattr(self.config, "__dict__") else {}
+            ),
+            platform_adapter=platform_adapter,
+        )
+
+    async def _handle_managed_thread_reply(
+        self, event, thread_id: str
+    ) -> Optional[str]:
+        """Route a reply in a managed Discord thread to the correct relay drive.
+
+        Looks up the registry row whose ``discord_thread_id`` matches *thread_id*,
+        reconstructs the ``SessionHandle`` from the stored row, and calls
+        ``SessionRelay.send_message`` with the reply text.
+
+        Returns a short acknowledgement string on success, or ``None`` if no
+        matching managed thread is found (caller should fall through to normal
+        dispatch).
+
+        Errors from the relay (lock conflict, tmux timeout) are caught and
+        returned as error strings so the Discord user gets feedback.
+        """
+        try:
+            from session_orchestration.adapters.base import AgentAdapter
+            from session_orchestration.registry import SessionOrchestrationRegistry
+            from session_orchestration.relay import LockConflictError, SessionRelay
+            from session_orchestration.spawn import get_adapter
+            from session_orchestration.types import SessionHandle
+        except ImportError as exc:
+            logger.debug("_handle_managed_thread_reply: session_orchestration not available: %s", exc)
+            return None
+
+        try:
+            registry = SessionOrchestrationRegistry()
+            rows = registry.list()
+        except Exception as exc:
+            logger.warning("_handle_managed_thread_reply: registry read failed: %s", exc)
+            return None
+
+        # Find the row whose discord_thread_id matches the incoming thread.
+        matched_row = None
+        for row in rows:
+            if str(row.get("discord_thread_id") or "") == str(thread_id):
+                matched_row = row
+                break
+
+        if matched_row is None:
+            return None  # Not a managed thread — fall through to normal dispatch.
+
+        task_id = matched_row["task_id"]
+        message_text = (getattr(event, "text", "") or "").strip()
+        if not message_text:
+            logger.debug(
+                "_handle_managed_thread_reply: empty message for task_id=%s — ignoring",
+                task_id,
+            )
+            return None
+
+        # Reconstruct the SessionHandle from the registry row.  The pane is
+        # derived from tmux_session (same convention as adapter.launch()).
+        tmux_session = matched_row.get("tmux_session") or ""
+        pane = matched_row.get("pane") or (f"{tmux_session}:0.0" if tmux_session else "")
+        from datetime import datetime, timezone as _tz
+        handle = SessionHandle(
+            session_id=task_id,
+            tmux_session=tmux_session,
+            pane=pane,
+            launch_ts=datetime.now(tz=_tz.utc),
+        )
+
+        # Build the relay.  The adapter is needed for detect()/drive()/resume();
+        # fall back to a stub-safe default if the stored agent name is unknown.
+        agent_name = matched_row.get("agent") or "claude-code"
+        try:
+            adapter = get_adapter(agent_name)
+        except Exception as exc:
+            logger.warning(
+                "_handle_managed_thread_reply: unknown agent %r for task_id=%s: %s",
+                agent_name, task_id, exc,
+            )
+            return f"Cannot drive session: unknown agent `{agent_name}`."
+
+        relay = SessionRelay(registry, adapter)
+
+        logger.info(
+            "drive_loop: routing thread reply to task_id=%s agent=%s len=%d",
+            task_id, agent_name, len(message_text),
+        )
+
+        try:
+            await asyncio.to_thread(
+                relay.send_message, task_id, handle, message_text
+            )
+        except LockConflictError as exc:
+            logger.warning(
+                "drive_loop: lock conflict for task_id=%s: %s", task_id, exc
+            )
+            return "Session is busy — try again in a moment."
+        except TimeoutError as exc:
+            logger.warning(
+                "drive_loop: pane-readiness timeout for task_id=%s: %s", task_id, exc
+            )
+            return "Session pane did not become ready in time — it may be busy."
+        except Exception as exc:
+            logger.exception(
+                "drive_loop: unexpected error for task_id=%s", task_id
+            )
+            return f"Drive error: {exc}"
+
+        return ""  # Empty string = success; adapter/watcher will emit the agent reply.
 
     def _sibling_thread_run_keys(self, source: SessionSource, own_key: str) -> list:
         """Find running-agent keys for OTHER participants in the same thread.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10976,7 +10976,7 @@ class GatewayRunner:
         returned as error strings so the Discord user gets feedback.
         """
         try:
-            from session_orchestration.adapters.base import AgentAdapter
+            from session_orchestration.adapters.base import AgentAdapter, TuiNotReadyError
             from session_orchestration.menu_parse import resolve_menu_answer
             from session_orchestration.registry import SessionOrchestrationRegistry
             from session_orchestration.relay import LockConflictError, SessionRelay
@@ -11011,6 +11011,14 @@ class GatewayRunner:
                 task_id,
             )
             return None
+
+        # Interrupt prefix: a leading '!' means interrupt-and-send — stop the
+        # current turn (Esc) before delivering. Strip it from the text.
+        interrupt = message_text.startswith("!")
+        if interrupt:
+            message_text = message_text[1:].strip()
+            if not message_text:
+                return "Nothing to send after `!`."
 
         # Reconstruct the SessionHandle from the registry row.  Use the BARE
         # tmux_session as the pane target (matching the watcher's
@@ -11048,63 +11056,74 @@ class GatewayRunner:
         # number into an Escape (cancel the menu) + a natural-language
         # selection; every other reply passes through unchanged.
         drive_text, drive_pre_keys = resolve_menu_answer(matched_row, message_text)
+        is_menu = bool(drive_pre_keys) or matched_row.get("last_input_kind") == "menu"
 
         logger.info(
-            "drive_loop: routing thread reply to task_id=%s agent=%s len=%d menu_select=%s",
-            task_id, agent_name, len(drive_text), bool(drive_pre_keys),
+            "drive_loop: routing thread reply to task_id=%s agent=%s len=%d menu=%s interrupt=%s",
+            task_id, agent_name, len(drive_text), is_menu, interrupt,
         )
 
-        # Queued-reply acknowledgement, shared by the busy pre-check and the
-        # send-timeout fallback below.
         queued_ack = (
             "Session's busy — queued your message, it'll deliver when it's ready."
         )
 
-        def _enqueue_pending() -> None:
-            registry.enqueue_pending_drive(task_id, drive_text, pre_keys=drive_pre_keys)
+        def _enqueue(pre_keys) -> None:
+            registry.enqueue_pending_drive(task_id, drive_text, pre_keys=pre_keys)
 
-        # Busy pre-check: if the session is actively working, a synchronous
-        # drive would block on _wait_for_ready and time out after 30s, dropping
-        # the reply. Instead, enqueue it now for the watcher to redeliver when
-        # the session next becomes idle (WAITING_USER).
+        # Detect state — gates the interrupt (Esc only when RUNNING).
         try:
             lifecycle = await asyncio.to_thread(adapter.detect, handle)
         except Exception as exc:
-            logger.debug(
-                "drive_loop: detect() failed for task_id=%s (%s); attempting direct drive",
-                task_id, exc,
-            )
+            logger.debug("drive_loop: detect() failed for task_id=%s (%s)", task_id, exc)
             lifecycle = None
-        if lifecycle == SessionLifecycle.RUNNING:
-            logger.info(
-                "drive_loop: task_id=%s is RUNNING; queuing reply for redelivery", task_id
-            )
-            await asyncio.to_thread(_enqueue_pending)
-            return queued_ack
+
+        # Menu answer: keep the existing menu path (Escape + NL selection via the
+        # relay). No type-ahead, no interrupt.
+        if is_menu:
+            try:
+                await asyncio.to_thread(
+                    relay.send_message, task_id, handle, drive_text,
+                    pre_keys=drive_pre_keys,
+                )
+            except LockConflictError:
+                return "Session is busy — try again in a moment."
+            except TimeoutError as exc:
+                logger.warning("drive_loop: menu send timeout task_id=%s: %s; queuing", task_id, exc)
+                await asyncio.to_thread(_enqueue, drive_pre_keys)
+                return queued_ack
+            except Exception as exc:
+                logger.exception("drive_loop: menu send error task_id=%s", task_id)
+                return f"Drive error: {exc}"
+            return ""
+
+        # Free-text: type-ahead — deliver into the composer immediately even
+        # while the agent works (it queues the turn). A leading '!' interrupt
+        # sends Esc first, but only when the session is actually RUNNING.
+        pre_keys = list(drive_pre_keys or [])
+        if interrupt and lifecycle == SessionLifecycle.RUNNING:
+            pre_keys = ["Escape", *pre_keys]
+        pre_keys_arg = pre_keys or None
 
         try:
             await asyncio.to_thread(
-                relay.send_message, task_id, handle, drive_text,
-                pre_keys=drive_pre_keys,
+                lambda: relay.send_message(
+                    task_id, handle, drive_text,
+                    pre_keys=pre_keys_arg, type_ahead=True,
+                )
             )
-        except LockConflictError as exc:
-            logger.warning(
-                "drive_loop: lock conflict for task_id=%s: %s", task_id, exc
-            )
+        except TuiNotReadyError as exc:
+            # Composer not present (booting/dead pane) — fall back to the queue.
+            logger.info("drive_loop: TUI not ready task_id=%s (%s); queuing reply", task_id, exc)
+            await asyncio.to_thread(_enqueue, pre_keys)
+            return queued_ack
+        except LockConflictError:
             return "Session is busy — try again in a moment."
         except TimeoutError as exc:
-            # The pane never became ready (session busy past the readiness
-            # window). Don't drop the reply — queue it for redelivery.
-            logger.warning(
-                "drive_loop: pane-readiness timeout for task_id=%s: %s; queuing reply",
-                task_id, exc,
-            )
-            await asyncio.to_thread(_enqueue_pending)
+            logger.warning("drive_loop: drive timeout task_id=%s: %s; queuing reply", task_id, exc)
+            await asyncio.to_thread(_enqueue, pre_keys)
             return queued_ack
         except Exception as exc:
-            logger.exception(
-                "drive_loop: unexpected error for task_id=%s", task_id
-            )
+            logger.exception("drive_loop: unexpected error for task_id=%s", task_id)
             return f"Drive error: {exc}"
 
         return ""  # Empty string = success; adapter/watcher will emit the agent reply.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10981,7 +10981,7 @@ class GatewayRunner:
             from session_orchestration.registry import SessionOrchestrationRegistry
             from session_orchestration.relay import LockConflictError, SessionRelay
             from session_orchestration.spawn import get_adapter
-            from session_orchestration.types import SessionHandle
+            from session_orchestration.types import SessionHandle, SessionLifecycle
         except ImportError as exc:
             logger.debug("_handle_managed_thread_reply: session_orchestration not available: %s", exc)
             return None
@@ -11054,6 +11054,34 @@ class GatewayRunner:
             task_id, agent_name, len(drive_text), bool(drive_pre_keys),
         )
 
+        # Queued-reply acknowledgement, shared by the busy pre-check and the
+        # send-timeout fallback below.
+        queued_ack = (
+            "Session's busy — queued your message, it'll deliver when it's ready."
+        )
+
+        def _enqueue_pending() -> None:
+            registry.enqueue_pending_drive(task_id, drive_text, pre_keys=drive_pre_keys)
+
+        # Busy pre-check: if the session is actively working, a synchronous
+        # drive would block on _wait_for_ready and time out after 30s, dropping
+        # the reply. Instead, enqueue it now for the watcher to redeliver when
+        # the session next becomes idle (WAITING_USER).
+        try:
+            lifecycle = await asyncio.to_thread(adapter.detect, handle)
+        except Exception as exc:
+            logger.debug(
+                "drive_loop: detect() failed for task_id=%s (%s); attempting direct drive",
+                task_id, exc,
+            )
+            lifecycle = None
+        if lifecycle == SessionLifecycle.RUNNING:
+            logger.info(
+                "drive_loop: task_id=%s is RUNNING; queuing reply for redelivery", task_id
+            )
+            await asyncio.to_thread(_enqueue_pending)
+            return queued_ack
+
         try:
             await asyncio.to_thread(
                 relay.send_message, task_id, handle, drive_text,
@@ -11065,10 +11093,14 @@ class GatewayRunner:
             )
             return "Session is busy — try again in a moment."
         except TimeoutError as exc:
+            # The pane never became ready (session busy past the readiness
+            # window). Don't drop the reply — queue it for redelivery.
             logger.warning(
-                "drive_loop: pane-readiness timeout for task_id=%s: %s", task_id, exc
+                "drive_loop: pane-readiness timeout for task_id=%s: %s; queuing reply",
+                task_id, exc,
             )
-            return "Session pane did not become ready in time — it may be busy."
+            await asyncio.to_thread(_enqueue_pending)
+            return queued_ack
         except Exception as exc:
             logger.exception(
                 "drive_loop: unexpected error for task_id=%s", task_id

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -218,7 +218,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("update", "Update Hermes Agent to the latest version", "Info"),
     CommandDef("version", "Show Hermes Agent version", "Info", aliases=("v",)),
     CommandDef("debug", "Upload debug report (system info + logs) and get shareable links", "Info"),
-    CommandDef("control-status", "List all active session-orchestration tasks (state, age, oldest WAITING_USER)",
+    CommandDef("control-status", "Show session-orchestration tasks and attention checklist items",
                "Info", gateway_only=True, aliases=("cs",),
                gateway_config_gate="session_orchestration.enabled"),
     CommandDef("so-spawn", "Spawn a managed coding-agent session (@hermes spawn)",

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -225,6 +225,14 @@ COMMAND_REGISTRY: list[CommandDef] = [
                "Info", gateway_only=True, aliases=("spawn-session",),
                args_hint="agent=<name> workdir=<path> [z_command=<cmd>] <prompt>",
                gateway_config_gate="session_orchestration.enabled"),
+    CommandDef("so-stop", "Stop a managed coding-agent session by task ID",
+               "Info", gateway_only=True,
+               args_hint="task_id=<id>",
+               gateway_config_gate="session_orchestration.enabled"),
+    CommandDef("so-restart", "Restart a managed coding-agent session by task ID",
+               "Info", gateway_only=True,
+               args_hint="task_id=<id>",
+               gateway_config_gate="session_orchestration.enabled"),
 
     # Exit
     CommandDef("quit", "Exit the CLI (use --delete to also remove session history)", "Exit",

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -218,6 +218,13 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("update", "Update Hermes Agent to the latest version", "Info"),
     CommandDef("version", "Show Hermes Agent version", "Info", aliases=("v",)),
     CommandDef("debug", "Upload debug report (system info + logs) and get shareable links", "Info"),
+    CommandDef("control-status", "List all active session-orchestration tasks (state, age, oldest WAITING_USER)",
+               "Info", gateway_only=True, aliases=("cs",),
+               gateway_config_gate="session_orchestration.enabled"),
+    CommandDef("so-spawn", "Spawn a managed coding-agent session (@hermes spawn)",
+               "Info", gateway_only=True, aliases=("spawn-session",),
+               args_hint="agent=<name> workdir=<path> [z_command=<cmd>] <prompt>",
+               gateway_config_gate="session_orchestration.enabled"),
 
     # Exit
     CommandDef("quit", "Exit the CLI (use --delete to also remove session history)", "Exit",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2443,7 +2443,8 @@ DEFAULT_CONFIG = {
     #
     # All session-orchestration behaviour is gated behind ``enabled``.
     # Disabled (the default) ⇒ byte-identical prior behaviour: no watcher cron
-    # runs, no ingest route processes, no /so-* commands surface in the gateway.
+    # runs, no ingest route processes, and no session-orchestration gateway
+    # commands surface.
     #
     # See session_orchestration/config.py for the typed accessor.
     # ---------------------------------------------------------------------------
@@ -2452,9 +2453,10 @@ DEFAULT_CONFIG = {
         # session-orchestration behaviour.
         "enabled": False,
 
-        # Discord channel id for the unified session feed.  All state
-        # transitions and watchdog alerts are posted here with deep-links
-        # to the per-project thread.  No feed pushes when empty.
+        # Discord channel id for the session action feed.  Hosts a single
+        # edited checklist digest for unresolved attention items; thread-local
+        # notices are optional/best-effort when a task has a thread.
+        # No digest/notices when empty.
         "feed_channel_id": "",
 
         # Discord channel id for runs adopted from external sources
@@ -2462,13 +2464,15 @@ DEFAULT_CONFIG = {
         # Defaults to feed_channel_id when empty.
         "external_runs_channel_id": "",
 
-        # Static stale threshold (seconds).  A session in RUNNING state
-        # whose last_output_ts is older than this AND whose pane hash has
-        # not changed for ``hang_idle_ticks`` ticks is declared hung.
+        # Deterministic stale/frozen guard threshold (seconds).  A RUNNING
+        # session opens stale/frozen attention only when last_output_ts is
+        # older than this, the pane hash is unchanged for ``hang_idle_ticks``
+        # ticks, and the current pane does not match the adapter's active-work
+        # regex.
         "hang_stale_seconds": 300,
 
-        # N pane-hash-unchanged ticks before a RUNNING session is
-        # declared hung.  Each tick is ~1–2 min depending on cron cadence.
+        # N consecutive unchanged pane-hash ticks required by the stale/frozen
+        # guard.  Each tick is ~1–2 min depending on cron cadence.
         "hang_idle_ticks": 3,
     },
 }

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2470,6 +2470,12 @@ DEFAULT_CONFIG = {
         # N pane-hash-unchanged ticks before a RUNNING session is
         # declared hung.  Each tick is ~1–2 min depending on cron cadence.
         "hang_idle_ticks": 3,
+
+        # Manual repo registry overrides.  Keys are aliases; values are either
+        # an absolute path string (shorthand) or a dict with ``path`` and an
+        # optional ``default_agent`` (defaults to "omp").
+        # See cli-config.yaml.example for the full documented format.
+        "repos": {},
     },
 }
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2437,6 +2437,40 @@ DEFAULT_CONFIG = {
 
     # Config schema version - bump this when adding new required fields
     "_config_version": 28,
+
+    # ---------------------------------------------------------------------------
+    # Session-orchestration — managed external agent session layer.
+    #
+    # All session-orchestration behaviour is gated behind ``enabled``.
+    # Disabled (the default) ⇒ byte-identical prior behaviour: no watcher cron
+    # runs, no ingest route processes, no /so-* commands surface in the gateway.
+    #
+    # See session_orchestration/config.py for the typed accessor.
+    # ---------------------------------------------------------------------------
+    "session_orchestration": {
+        # Master gate.  Must be explicitly set to true to enable any
+        # session-orchestration behaviour.
+        "enabled": False,
+
+        # Discord channel id for the unified session feed.  All state
+        # transitions and watchdog alerts are posted here with deep-links
+        # to the per-project thread.  No feed pushes when empty.
+        "feed_channel_id": "",
+
+        # Discord channel id for runs adopted from external sources
+        # (z-harness webhook alerts whose run_id/repo is unknown).
+        # Defaults to feed_channel_id when empty.
+        "external_runs_channel_id": "",
+
+        # Static stale threshold (seconds).  A session in RUNNING state
+        # whose last_output_ts is older than this AND whose pane hash has
+        # not changed for ``hang_idle_ticks`` ticks is declared hung.
+        "hang_stale_seconds": 300,
+
+        # N pane-hash-unchanged ticks before a RUNNING session is
+        # declared hung.  Each tick is ~1–2 min depending on cron cadence.
+        "hang_idle_ticks": 3,
+    },
 }
 
 # =============================================================================
@@ -4027,7 +4061,7 @@ _KNOWN_ROOT_KEYS = {
     "fallback_providers", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "custom_providers", "context", "memory", "gateway",
-    "sessions", "streaming", "updates",
+    "sessions", "streaming", "updates", "session_orchestration",
 }
 
 # Valid fields inside a custom_providers list entry

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -316,6 +316,9 @@ CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(ex
 DEFERRED_INDEX_SQL = """
 CREATE INDEX IF NOT EXISTS idx_messages_session_active
     ON messages(session_id, active, timestamp);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_handoff_pending
+    ON sessions(handoff_state, started_at);
 """
 
 FTS_SQL = """
@@ -785,8 +788,8 @@ class SessionDB:
         except sqlite3.OperationalError as exc:
             logger.debug("idx_messages_platform_msg_id create skipped: %s", exc)
 
-        # Deferred indexes that reference the reconciler-added ``active``
-        # column (idx_messages_session_active) — same ordering constraint.
+        # Deferred indexes that reference reconciler-added columns — same
+        # ordering constraint as idx_messages_platform_msg_id above.
         cursor.executescript(DEFERRED_INDEX_SQL)
 
         fts5_available = self._sqlite_supports_fts5(cursor)
@@ -4303,12 +4306,13 @@ class SessionDB:
         no handoff record.
         """
         try:
-            cur = self._conn.execute(
-                "SELECT handoff_state, handoff_platform, handoff_error "
-                "FROM sessions WHERE id = ?",
-                (session_id,),
-            )
-            row = cur.fetchone()
+            with self._lock:
+                cur = self._conn.execute(
+                    "SELECT handoff_state, handoff_platform, handoff_error "
+                    "FROM sessions WHERE id = ?",
+                    (session_id,),
+                )
+                row = cur.fetchone()
             if not row:
                 return None
             return {
@@ -4325,12 +4329,13 @@ class SessionDB:
         Used by the gateway's handoff watcher.
         """
         try:
-            cur = self._conn.execute(
-                "SELECT * FROM sessions "
-                "WHERE handoff_state = 'pending' "
-                "ORDER BY started_at ASC"
-            )
-            return [dict(r) for r in cur.fetchall()]
+            with self._lock:
+                cur = self._conn.execute(
+                    "SELECT * FROM sessions "
+                    "WHERE handoff_state = 'pending' "
+                    "ORDER BY started_at ASC"
+                )
+                return [dict(r) for r in cur.fetchall()]
         except Exception:
             return []
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1011,6 +1011,61 @@ class DiscordAdapter(BasePlatformAdapter):
                         guild_id,
                     )
 
+            async def _terminate_managed_session_for_thread(thread_id: int) -> None:
+                """Enqueue a terminate intent for the managed session whose
+                discord_thread_id matches *thread_id*.
+
+                Closing/archiving the session thread means the user is done with
+                the run — reap it. The gateway/adapter only ENQUEUES; the
+                single-writer watcher drains the intent and does the actual
+                kill + attention/feed reap (single-writer invariant).
+                """
+                def _enqueue() -> Optional[str]:
+                    try:
+                        from session_orchestration.registry import (
+                            SessionOrchestrationRegistry,
+                        )
+                    except ImportError:
+                        return None
+                    registry = SessionOrchestrationRegistry()
+                    for row in registry.list():
+                        if str(row.get("discord_thread_id") or "") == str(thread_id):
+                            task_id = row["task_id"]
+                            if row.get("state") in ("DONE", "ERROR"):
+                                return None  # already terminal — nothing to reap
+                            registry.enqueue_terminate(task_id)
+                            return task_id
+                    return None
+
+                try:
+                    task_id = await asyncio.to_thread(_enqueue)
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.warning(
+                        "[%s] thread-archive terminate enqueue failed for %s: %s",
+                        adapter_self.name, thread_id, exc,
+                    )
+                    return
+                if task_id:
+                    logger.info(
+                        "[%s] managed thread %s archived/closed → terminate queued for %s",
+                        adapter_self.name, thread_id, task_id,
+                    )
+
+            @self._client.event
+            async def on_thread_update(before, after):
+                """A managed session thread being archived reaps the session."""
+                newly_archived = (
+                    getattr(after, "archived", False)
+                    and not getattr(before, "archived", False)
+                )
+                if newly_archived:
+                    await _terminate_managed_session_for_thread(after.id)
+
+            @self._client.event
+            async def on_thread_delete(thread):
+                """A managed session thread being deleted reaps the session."""
+                await _terminate_managed_session_for_thread(thread.id)
+
             # Register slash commands
             if self._slash_commands:
                 self._register_slash_commands()

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -30,6 +30,7 @@ _DISCORD_COMMAND_SYNC_STATE_SUBDIR = "gateway"
 _DISCORD_COMMAND_SYNC_STATE_FILENAME = "discord_command_sync_state.json"
 _DISCORD_COMMAND_SYNC_MUTATION_INTERVAL_SECONDS = 4.5
 _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS = 30.0
+_DISCORD_READY_TIMEOUT_SECONDS_DEFAULT = 30.0
 
 try:
     import discord
@@ -68,6 +69,34 @@ from gateway.platforms.base import (
 from tools.url_safety import is_safe_url
 
 
+def _discord_ready_timeout_seconds() -> float:
+    """Return how long to wait for Discord's ready event during connect."""
+    for env_name in (
+        "HERMES_DISCORD_READY_TIMEOUT",
+        "HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT",
+    ):
+        raw = os.getenv(env_name, "").strip()
+        if not raw:
+            continue
+        try:
+            return max(0.0, float(raw))
+        except ValueError:
+            logger.warning("Ignoring invalid %s=%r", env_name, raw)
+    return _DISCORD_READY_TIMEOUT_SECONDS_DEFAULT
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name, "").strip().lower()
+    if not raw:
+        return default
+    if raw in {"1", "true", "yes", "on"}:
+        return True
+    if raw in {"0", "false", "no", "off"}:
+        return False
+    logger.warning("Ignoring invalid %s=%r", name, raw)
+    return default
+
+
 def _find_discord_windows_bundled_opus(discord_module: Any = None) -> Optional[str]:
     """Return discord.py's bundled Windows opus DLL path when present."""
     if sys.platform != "win32":
@@ -103,6 +132,88 @@ def _clean_discord_id(entry: str) -> str:
     if entry.lower().startswith("user:"):
         entry = entry[5:]
     return entry.strip()
+
+
+def _check_so_auth(payload: dict) -> tuple[bool, str]:
+    """Check auth for a raw ``so`` message. Returns (ok, reason)."""
+    repo_root = str(payload.get("z_harness_repo") or "/Users/zeke/dev/z-harness")
+    scripts_dir = str(_Path(repo_root) / "scripts")
+    code = r'''
+import json
+import sys
+sys.path.insert(0, __import__("os").environ["SCRIPTS_DIR"])
+from hermes.config import load_config
+
+def allowed(value, allowed_values):
+    return not allowed_values or str(value) in allowed_values
+
+payload = json.loads(sys.argv[1])
+cfg = load_config(payload.get("repo_root", "."))
+so_cfg = cfg.discord.so
+allowed_users = set(so_cfg.allowed_user_ids or [])
+allowed_channels = set(so_cfg.allowed_channel_ids or [])
+if not allowed(payload.get("requester_user_id", ""), allowed_users):
+    print(json.dumps({"ok": False, "message": "User not authorized"}))
+elif not allowed(payload.get("channel_id", ""), allowed_channels):
+    print(json.dumps({"ok": False, "message": "Channel not authorized"}))
+else:
+    print(json.dumps({"ok": True}))
+'''
+    env = dict(os.environ)
+    env["SCRIPTS_DIR"] = scripts_dir
+    env["PYTHONPATH"] = scripts_dir
+    payload = dict(payload)
+    payload["repo_root"] = repo_root
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", code, json.dumps(payload)],
+            cwd=repo_root,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        data = json.loads(proc.stdout.strip().splitlines()[-1])
+    except (IndexError, json.JSONDecodeError, subprocess.TimeoutExpired):
+        return False, "so auth check failed"
+    if not data.get("ok"):
+        return False, str(data.get("message") or "not authorized")
+    return True, ""
+
+
+def _drain_so_signal_events(repo_root: Optional[str] = None) -> list[dict]:
+    """Drain Hermes so MCP signals from the z-harness backend."""
+    root = str(repo_root or os.getenv("Z_HARNESS_REPO") or "/Users/zeke/dev/z-harness")
+    scripts_dir = str(_Path(root) / "scripts")
+    code = r'''
+import json
+import os
+import sys
+sys.path.insert(0, os.environ["SCRIPTS_DIR"])
+from hermes.config import load_config
+from hermes.mcp_hermes_orchestrator import drain_signal_events
+cfg = load_config(os.environ.get("Z_HARNESS_REPO", "."))
+print(json.dumps(drain_signal_events(cfg)))
+'''
+    env = dict(os.environ)
+    env["SCRIPTS_DIR"] = scripts_dir
+    env["PYTHONPATH"] = scripts_dir
+    env["Z_HARNESS_REPO"] = root
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError((proc.stderr or proc.stdout or "so signal drain failed").strip())
+    raw = proc.stdout.strip()
+    if not raw:
+        return []
+    events = json.loads(raw.splitlines()[-1])
+    return events if isinstance(events, list) else []
 
 
 def check_discord_requirements() -> bool:
@@ -616,6 +727,7 @@ class DiscordAdapter(BasePlatformAdapter):
         self._typing_tasks: Dict[str, asyncio.Task] = {}
         self._bot_task: Optional[asyncio.Task] = None
         self._post_connect_task: Optional[asyncio.Task] = None
+        self._so_signal_task: Optional[asyncio.Task] = None
         # Dedup cache: prevents duplicate bot responses when Discord
         # RESUME replays events after reconnects.
         self._dedup = MessageDeduplicator()
@@ -699,7 +811,10 @@ class DiscordAdapter(BasePlatformAdapter):
             # bot from coming online at all, so avoid requesting members intent
             # unless it is actually necessary.
             intents = Intents.default()
-            intents.message_content = True
+            intents.message_content = _env_bool(
+                "HERMES_DISCORD_MESSAGE_CONTENT_INTENT",
+                True,
+            )
             intents.dm_messages = True
             intents.guild_messages = True
             intents.members = (
@@ -757,6 +872,12 @@ class DiscordAdapter(BasePlatformAdapter):
                     adapter_self._run_post_connect_initialization()
                 )
 
+                if adapter_self._so_signal_task and not adapter_self._so_signal_task.done():
+                    adapter_self._so_signal_task.cancel()
+                adapter_self._so_signal_task = asyncio.create_task(
+                    adapter_self._poll_so_signals()
+                )
+
             @self._client.event
             async def on_message(message: DiscordMessage):
                 # Block until _resolve_allowed_usernames has swapped
@@ -764,7 +885,10 @@ class DiscordAdapter(BasePlatformAdapter):
                 # IDs (otherwise on_message's author.id lookup can miss).
                 if not adapter_self._ready_event.is_set():
                     try:
-                        await asyncio.wait_for(adapter_self._ready_event.wait(), timeout=30.0)
+                        await asyncio.wait_for(
+                            adapter_self._ready_event.wait(),
+                            timeout=_discord_ready_timeout_seconds(),
+                        )
                     except asyncio.TimeoutError:
                         pass
 
@@ -895,7 +1019,10 @@ class DiscordAdapter(BasePlatformAdapter):
             self._bot_task = asyncio.create_task(self._client.start(self.config.token))
 
             # Wait for ready
-            await asyncio.wait_for(self._ready_event.wait(), timeout=30)
+            await asyncio.wait_for(
+                self._ready_event.wait(),
+                timeout=_discord_ready_timeout_seconds(),
+            )
 
             self._running = True
             return True
@@ -908,6 +1035,48 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.error("[%s] Failed to connect to Discord: %s", self.name, e, exc_info=True)
             self._release_platform_lock()
             return False
+
+    async def _poll_so_signals(self) -> None:
+        """Drain Hermes so MCP signals and route them back to Discord."""
+        while self._client is not None and not self._client.is_closed():
+            try:
+                for event in await asyncio.to_thread(_drain_so_signal_events):
+                    await self._route_so_signal(event)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning("[%s] so signal routing failed: %s", self.name, exc)
+            await asyncio.sleep(10)
+
+    async def _route_so_signal(self, event: dict) -> None:
+        target = event.get("discord_thread_id") or event.get("discord_channel_id")
+        if not target:
+            return
+        session_id = str(event.get("session_id") or event.get("job_id") or "")
+        kind = str(event.get("event") or "so_signal")
+        text = str(event.get("text") or "").strip()
+        if kind == "so_needs_input":
+            body = f"Hermes `so` session `{session_id}` needs input."
+            if text:
+                body += f"\n\n```text\n{text[-1500:]}\n```"
+        elif kind in {"so_session_dead", "so_session_expired"}:
+            label = "expired" if kind == "so_session_expired" else "ended"
+            body = f"Hermes `so` session `{session_id}` {label}."
+            if text:
+                body += f"\n\n{text[-1500:]}"
+        else:
+            body = f"Hermes `so` session `{session_id}` emitted `{kind}`."
+            if text:
+                body += f"\n\n{text[-1500:]}"
+        result = await self.send(str(target), body)
+        if not getattr(result, "success", False):
+            logger.warning(
+                "[%s] failed to route so signal %s to %s: %s",
+                self.name,
+                kind,
+                target,
+                getattr(result, "error", "unknown error"),
+            )
 
     async def disconnect(self) -> None:
         """Disconnect from Discord."""
@@ -931,10 +1100,18 @@ class DiscordAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 pass
 
+        if self._so_signal_task and not self._so_signal_task.done():
+            self._so_signal_task.cancel()
+            try:
+                await self._so_signal_task
+            except asyncio.CancelledError:
+                pass
+
         self._running = False
         self._client = None
         self._ready_event.clear()
         self._post_connect_task = None
+        self._so_signal_task = None
 
         self._release_platform_lock()
 
@@ -1428,6 +1605,34 @@ class DiscordAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
+            interaction = metadata.get("raw_message") if metadata else None
+            if (
+                interaction is not None
+                and hasattr(interaction, "edit_original_response")
+                and str(getattr(interaction, "channel_id", "")) == str(chat_id)
+                and not (metadata and metadata.get("thread_id"))
+            ):
+                formatted = self.format_message(content)
+                chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+                message_ids = []
+                for i, chunk in enumerate(chunks):
+                    if i == 0:
+                        msg = await interaction.edit_original_response(content=chunk)
+                        try:
+                            setattr(interaction, "_hermes_original_response_used", True)
+                        except Exception:
+                            pass
+                    else:
+                        msg = await interaction.followup.send(chunk, ephemeral=True)
+                    mid = getattr(msg, "id", None)
+                    if mid is not None:
+                        message_ids.append(str(mid))
+                return SendResult(
+                    success=True,
+                    message_id=message_ids[0] if message_ids else None,
+                    raw_response={"message_ids": message_ids, "interaction_response": True},
+                )
+
             # Determine target channel: thread_id in metadata takes precedence.
             thread_id = None
             if metadata and metadata.get("thread_id"):
@@ -3166,7 +3371,7 @@ class DiscordAdapter(BasePlatformAdapter):
         try:
             if followup_msg:
                 await interaction.edit_original_response(content=followup_msg)
-            else:
+            elif not getattr(interaction, "_hermes_original_response_used", False):
                 await interaction.delete_original_response()
         except Exception as e:
             logger.debug("Discord interaction cleanup failed: %s", e)
@@ -4764,6 +4969,10 @@ class DiscordAdapter(BasePlatformAdapter):
             if "*" in ignored_channels or (channel_ids & ignored_channels):
                 logger.debug("[%s] Ignoring message in ignored channel: %s", self.name, channel_ids)
                 return
+
+            # so messages fall through to the normal LLM handler.
+            # The LLM will parse "so ..." naturally and call MCP tools
+            # (so_start_session, so_send, etc.) directly.
 
             free_channels = self._discord_free_response_channels()
             if parent_channel_id:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -31,6 +31,9 @@ _DISCORD_COMMAND_SYNC_STATE_FILENAME = "discord_command_sync_state.json"
 _DISCORD_COMMAND_SYNC_MUTATION_INTERVAL_SECONDS = 4.5
 _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS = 30.0
 _DISCORD_READY_TIMEOUT_SECONDS_DEFAULT = 30.0
+_SO_SIGNAL_POLL_INTERVAL_SECONDS = 10.0
+_SO_SIGNAL_DRAIN_TIMEOUT_SECONDS_DEFAULT = 5.0
+_SO_SIGNAL_FAILURE_BACKOFF_SECONDS_DEFAULT = 60.0
 
 try:
     import discord
@@ -95,6 +98,33 @@ def _env_bool(name: str, default: bool) -> bool:
         return False
     logger.warning("Ignoring invalid %s=%r", name, raw)
     return default
+
+
+def _env_float(name: str, default: float, *, minimum: float = 0.0) -> float:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return max(minimum, float(raw))
+    except ValueError:
+        logger.warning("Ignoring invalid %s=%r", name, raw)
+        return default
+
+
+def _so_signal_drain_timeout_seconds() -> float:
+    return _env_float(
+        "HERMES_SO_SIGNAL_DRAIN_TIMEOUT",
+        _SO_SIGNAL_DRAIN_TIMEOUT_SECONDS_DEFAULT,
+        minimum=1.0,
+    )
+
+
+def _so_signal_failure_backoff_seconds() -> float:
+    return _env_float(
+        "HERMES_SO_SIGNAL_FAILURE_BACKOFF",
+        _SO_SIGNAL_FAILURE_BACKOFF_SECONDS_DEFAULT,
+        minimum=_SO_SIGNAL_POLL_INTERVAL_SECONDS,
+    )
 
 
 def _find_discord_windows_bundled_opus(discord_module: Any = None) -> Optional[str]:
@@ -182,38 +212,47 @@ else:
 
 
 def _drain_so_signal_events(repo_root: Optional[str] = None) -> list[dict]:
-    """Drain Hermes so MCP signals from the z-harness backend."""
+    """Drain Hermes so MCP signals from the z-harness backend.
+
+    The signal queue is a JSONL file under the z-harness Hermes state root.
+    Keep this path import-light: the Discord gateway polls it frequently, and
+    importing the full z-harness MCP orchestrator here makes a non-critical
+    notification path vulnerable to slow third-party imports.
+    """
     root = str(repo_root or os.getenv("Z_HARNESS_REPO") or "/Users/zeke/dev/z-harness")
-    scripts_dir = str(_Path(root) / "scripts")
-    code = r'''
-import json
-import os
-import sys
-sys.path.insert(0, os.environ["SCRIPTS_DIR"])
-from hermes.config import load_config
-from hermes.mcp_hermes_orchestrator import drain_signal_events
-cfg = load_config(os.environ.get("Z_HARNESS_REPO", "."))
-print(json.dumps(drain_signal_events(cfg)))
-'''
-    env = dict(os.environ)
-    env["SCRIPTS_DIR"] = scripts_dir
-    env["PYTHONPATH"] = scripts_dir
-    env["Z_HARNESS_REPO"] = root
-    proc = subprocess.run(
-        [sys.executable, "-c", code],
-        cwd=root,
-        env=env,
-        capture_output=True,
-        text=True,
-        timeout=15,
-    )
-    if proc.returncode != 0:
-        raise RuntimeError((proc.stderr or proc.stdout or "so signal drain failed").strip())
-    raw = proc.stdout.strip()
-    if not raw:
+    state_root = _Path("~/.hermes").expanduser()
+    config_path = _Path(root) / "hermes-config.yaml"
+    try:
+        import yaml
+        with config_path.open() as fh:
+            data = yaml.safe_load(fh) or {}
+        paths = data.get("paths") if isinstance(data, dict) else None
+        configured = paths.get("hermes_state_root") if isinstance(paths, dict) else None
+        if configured:
+            state_root = _Path(str(configured)).expanduser()
+    except FileNotFoundError:
+        pass
+    except Exception as exc:  # noqa: BLE001 - notification polling must not kill Discord.
+        raise RuntimeError(f"so signal config read failed: {exc}") from exc
+
+    signal_file = state_root / "so-mcp-signals.jsonl"
+    try:
+        raw = signal_file.read_text()
+    except FileNotFoundError:
         return []
-    events = json.loads(raw.splitlines()[-1])
-    return events if isinstance(events, list) else []
+
+    events: list[dict] = []
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(event, dict):
+            events.append(event)
+    signal_file.write_text("")
+    return events
 
 
 def check_discord_requirements() -> bool:
@@ -1094,6 +1133,7 @@ class DiscordAdapter(BasePlatformAdapter):
     async def _poll_so_signals(self) -> None:
         """Drain Hermes so MCP signals and route them back to Discord."""
         while self._client is not None and not self._client.is_closed():
+            sleep_for = _SO_SIGNAL_POLL_INTERVAL_SECONDS
             try:
                 for event in await asyncio.to_thread(_drain_so_signal_events):
                     await self._route_so_signal(event)
@@ -1101,7 +1141,8 @@ class DiscordAdapter(BasePlatformAdapter):
                 raise
             except Exception as exc:
                 logger.warning("[%s] so signal routing failed: %s", self.name, exc)
-            await asyncio.sleep(10)
+                sleep_for = _so_signal_failure_backoff_seconds()
+            await asyncio.sleep(sleep_for)
 
     async def _route_so_signal(self, event: dict) -> None:
         target = event.get("discord_thread_id") or event.get("discord_channel_id")

--- a/scripts/session-orchestration-watch.sh
+++ b/scripts/session-orchestration-watch.sh
@@ -43,4 +43,24 @@ fi
 # ---------------------------------------------------------------------------
 export PYTHONPATH="${HERMES_AGENT_ROOT}:${PYTHONPATH:-}"
 
-exec "${PYTHON}" -m session_orchestration.watcher
+# Load secrets from ~/.hermes/.env so the feed digest can post to Discord via
+# the REST API. The gateway loads .env into its own process, but this cron
+# subprocess does not inherit it — without DISCORD_BOT_TOKEN the watcher detects
+# attention items but silently skips every feed post ("discord_failed").
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+if [[ -f "${HERMES_HOME}/.env" ]]; then
+    set -a
+    # shellcheck disable=SC1090,SC1091
+    source "${HERMES_HOME}/.env" 2>/dev/null || true
+    set +a
+fi
+
+# Tee the watcher's own logs (INFO to stderr via basicConfig) to a rotating-ish
+# logfile. stdout stays empty so the no_agent delivery rule still treats the run
+# as silent — but transitions, feed posts, and post failures become observable
+# instead of vanishing into a discarded stderr. Without this, a silently-skipped
+# feed ping (missing token, Discord 4xx, no transition) leaves zero trace.
+WATCH_LOG="${HERMES_HOME}/logs/session-orchestration-watch.log"
+mkdir -p "${HERMES_HOME}/logs" 2>/dev/null || true
+
+exec "${PYTHON}" -m session_orchestration.watcher 2>> "${WATCH_LOG}"

--- a/scripts/session-orchestration-watch.sh
+++ b/scripts/session-orchestration-watch.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# session-orchestration-watch.sh
+#
+# Hermes --no-agent cron script: run one session-orchestration watcher tick.
+#
+# Usage (cron job, no-agent):
+#   hermes cron create --no-agent --schedule "every 1 minute" \
+#     --name "session-orchestration-watch" \
+#     --script "scripts/session-orchestration-watch.sh"
+#
+# The script exits silently (empty stdout, no delivery) when
+# session_orchestration.enabled is false — the Hermes no_agent delivery
+# rule treats empty stdout as a silent run.
+#
+# Environment
+# -----------
+# HERMES_HOME    -- Hermes data dir (default: ~/.hermes)
+# HERMES_AGENT   -- Path to hermes-agent repo root (auto-detected)
+# PYTHONPATH     -- Extended to include the hermes-agent root
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Locate hermes-agent root
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HERMES_AGENT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Python environment — prefer the repo venv
+# ---------------------------------------------------------------------------
+PYTHON="${HERMES_AGENT_ROOT}/venv/bin/python3"
+if [[ ! -x "${PYTHON}" ]]; then
+    PYTHON="$(command -v python3 2>/dev/null || true)"
+fi
+if [[ -z "${PYTHON:-}" ]]; then
+    echo "ERROR: python3 not found" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Run one watcher tick
+# ---------------------------------------------------------------------------
+export PYTHONPATH="${HERMES_AGENT_ROOT}:${PYTHONPATH:-}"
+
+exec "${PYTHON}" -m session_orchestration.watcher

--- a/scripts/whatsapp-bridge/package-lock.json
+++ b/scripts/whatsapp-bridge/package-lock.json
@@ -66,7 +66,6 @@
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -91,7 +90,6 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -108,7 +106,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -131,7 +128,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -154,7 +150,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -171,7 +166,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -188,7 +182,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -205,7 +198,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -222,7 +214,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -239,7 +230,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -256,7 +246,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -273,7 +262,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -290,7 +278,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -307,7 +294,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -324,7 +310,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -347,7 +332,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -370,7 +354,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -393,7 +376,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -416,7 +398,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -439,7 +420,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -462,7 +442,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -485,7 +464,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -505,7 +483,6 @@
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/runtime": "^1.7.0"
       },
@@ -528,7 +505,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -548,7 +524,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -568,7 +543,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -966,7 +940,6 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1323,6 +1296,7 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -1776,7 +1750,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/session_orchestration/__init__.py
+++ b/session_orchestration/__init__.py
@@ -1,0 +1,54 @@
+"""
+session_orchestration — managed external-agent session layer for Hermes.
+
+This package teaches Hermes to orchestrate external coding-agent CLI
+sessions (claude-code, omp, and future agents) on the user's behalf.
+
+Sub-modules
+-----------
+types
+    Core types: ``SessionLifecycle``, ``SessionHandle``, ``Capabilities``.
+adapters.base
+    ``AgentAdapter`` ABC — the contract every concrete adapter implements.
+registry
+    SQLite-backed session registry (``session_orchestration`` table in
+    ``state.db``) under the single-writer pattern: the cron watcher is the
+    sole mutator of registry rows and counters; webhook-adopt and Discord-drive
+    append intents to a queue table the cron drains.
+
+Planned sub-modules (implemented in later tasks)
+-------------------------------------------------
+watcher
+    Cron-driven liveness watcher (turn-change, heartbeat, hang layers).
+relay
+    Discord-message → tmux relay (holds per-session lock around send).
+
+Implemented sub-modules
+-----------------------
+ingest
+    Webhook ingest handler (HMAC verification, persistent event_id dedup,
+    per-source rate limit, correlate/adopt, feed push).  Entry point:
+    ``session_orchestration.ingest.process_z_harness_alert``.
+
+Configuration
+-------------
+All behaviour is gated behind ``session_orchestration.enabled`` in Hermes
+config (``~/.hermes/config.yaml``).  When disabled, the import of this
+package has zero side-effects and no new network calls are made.
+"""
+
+from session_orchestration.adapters.base import AgentAdapter
+from session_orchestration.registry import (
+    SessionOrchestrationRegistry,
+    canonical_repo_id,
+)
+from session_orchestration.types import Capabilities, SessionHandle, SessionLifecycle
+
+__all__ = [
+    "AgentAdapter",
+    "Capabilities",
+    "SessionHandle",
+    "SessionLifecycle",
+    "SessionOrchestrationRegistry",
+    "canonical_repo_id",
+]

--- a/session_orchestration/adapters/__init__.py
+++ b/session_orchestration/adapters/__init__.py
@@ -1,0 +1,5 @@
+"""Adapter sub-package for session-orchestration.
+
+Each concrete adapter (``claude_code``, ``omp``, etc.) lives in its own
+module here and implements ``AgentAdapter``.
+"""

--- a/session_orchestration/adapters/base.py
+++ b/session_orchestration/adapters/base.py
@@ -133,3 +133,17 @@ class AgentAdapter(ABC):
         prompt:
             The prompt to inject after clearing.
         """
+
+    @abstractmethod
+    def terminate(self, handle: SessionHandle) -> None:
+        """Kill the agent's tmux process.
+
+        Must be safe to call on an already-dead session (``check=False``
+        on tmux kill).  Concrete impls live in the claude-code and omp
+        adapters (T003/T004).
+
+        Parameters
+        ----------
+        handle:
+            The ``SessionHandle`` for the session to kill.
+        """

--- a/session_orchestration/adapters/base.py
+++ b/session_orchestration/adapters/base.py
@@ -81,7 +81,13 @@ class AgentAdapter(ABC):
         """
 
     @abstractmethod
-    def drive(self, handle: SessionHandle, message: str) -> None:
+    def drive(
+        self,
+        handle: SessionHandle,
+        message: str,
+        *,
+        pre_keys: list[str] | None = None,
+    ) -> None:
         """Deliver ``message`` to the running session.
 
         Implementations must perform a prompt-readiness check before
@@ -95,6 +101,10 @@ class AgentAdapter(ABC):
             The ``SessionHandle`` returned by ``launch()``.
         message:
             The user message to send to the agent.
+        pre_keys:
+            Optional tmux key names (e.g. ``["Escape"]``) to send before the
+            readiness check + paste. Used to cancel a selection menu so a
+            natural-language answer can be pasted into the freed composer.
         """
 
     @abstractmethod

--- a/session_orchestration/adapters/base.py
+++ b/session_orchestration/adapters/base.py
@@ -1,0 +1,135 @@
+"""
+Abstract base class for session-orchestration agent adapters.
+
+All concrete adapters (claude-code, omp, …) must subclass ``AgentAdapter``
+and implement every abstract method.  The watcher discovers adapters via
+the registry; the relay calls ``drive()``; the Discord command flow calls
+``launch()``.
+
+Lifecycle contract
+------------------
+1. ``launch()`` spawns the tmux session and returns a ``SessionHandle``.
+   The caller stores the handle in the registry.
+2. ``drive()`` delivers a user prompt to the running session (pane).
+   It must acquire and release the per-session lock itself or coordinate
+   with the caller.
+3. ``detect()`` inspects the current pane state and returns a
+   ``SessionLifecycle`` value.  It is called by the watcher on every
+   tick and must be safe to call concurrently with ``drive()`` (the watcher
+   skips capture while the per-session lock is held by ``drive()``).
+4. ``resume()`` performs a ``/clear``+re-inject cycle when the session
+   is in ``PAUSED_HANDOFF`` state.  It must be idempotent: calling it
+   on a non-handoff session must be a safe no-op.
+
+Capability assertion
+--------------------
+At watcher startup the watcher calls ``capabilities()`` on each adapter
+and smoke-tests the declared values against observed behaviour.  A mismatch
+logs an error for that adapter and marks it disabled; it does NOT crash the
+watcher.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from session_orchestration.types import Capabilities, SessionHandle, SessionLifecycle
+
+
+class AgentAdapter(ABC):
+    """Abstract base for all session-orchestration agent adapters.
+
+    Subclasses must implement ``launch``, ``drive``, ``detect``, and
+    ``resume``.  They should also override ``capabilities()`` to return
+    an accurate ``Capabilities`` descriptor; the default returns all-False
+    capabilities with no regex or dialog handlers.
+    """
+
+    # ------------------------------------------------------------------
+    # Capabilities
+    # ------------------------------------------------------------------
+
+    def capabilities(self) -> Capabilities:
+        """Return a descriptor of what this adapter supports.
+
+        Override in subclasses to declare accurate values.  The default
+        returns a conservative all-False descriptor (no print mode, no
+        hooks, no RPC/JSON mode, no idle regex, no dialog handlers).
+        """
+        return Capabilities()
+
+    # ------------------------------------------------------------------
+    # Abstract lifecycle methods
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def launch(self, workdir: str, prompt: str) -> SessionHandle:
+        """Spawn a new tmux session and start the agent in ``workdir``.
+
+        Parameters
+        ----------
+        workdir:
+            Absolute path to the working directory for the agent session.
+        prompt:
+            The initial prompt to inject once the agent is ready.
+
+        Returns
+        -------
+        SessionHandle
+            A fully-populated handle (session_id, tmux_session, pane,
+            launch_ts) that the caller stores in the registry.
+        """
+
+    @abstractmethod
+    def drive(self, handle: SessionHandle, message: str) -> None:
+        """Deliver ``message`` to the running session.
+
+        Implementations must perform a prompt-readiness check before
+        pasting to avoid injecting into a mid-render pane.  The preferred
+        mechanism is ``load-buffer`` / ``paste-buffer`` (not ``send-keys``)
+        to avoid shell-metacharacter expansion.
+
+        Parameters
+        ----------
+        handle:
+            The ``SessionHandle`` returned by ``launch()``.
+        message:
+            The user message to send to the agent.
+        """
+
+    @abstractmethod
+    def detect(self, handle: SessionHandle) -> SessionLifecycle:
+        """Inspect the current pane and return a lifecycle state.
+
+        This method is called by the watcher on every tick.  It must be
+        safe to call without holding the per-session lock; the watcher
+        skips ``detect`` (or uses a stale cached value) when the lock is
+        held by ``drive()``.
+
+        Parameters
+        ----------
+        handle:
+            The ``SessionHandle`` for the session to inspect.
+
+        Returns
+        -------
+        SessionLifecycle
+            Exactly one of ``RUNNING | WAITING_USER | PAUSED_HANDOFF |
+            STALLED | DONE | ERROR``.
+        """
+
+    @abstractmethod
+    def resume(self, handle: SessionHandle, prompt: str) -> None:
+        """Perform a ``/clear``+re-inject cycle for a handoff session.
+
+        Called only when ``detect()`` returns ``PAUSED_HANDOFF``.  Must
+        be idempotent: calling on a session that is NOT in handoff state
+        must be a safe no-op (log a warning; do not raise).
+
+        Parameters
+        ----------
+        handle:
+            The ``SessionHandle`` for the session to resume.
+        prompt:
+            The prompt to inject after clearing.
+        """

--- a/session_orchestration/adapters/base.py
+++ b/session_orchestration/adapters/base.py
@@ -36,6 +36,15 @@ from abc import ABC, abstractmethod
 from session_orchestration.types import Capabilities, SessionHandle, SessionLifecycle
 
 
+class TuiNotReadyError(RuntimeError):
+    """Raised by ``drive(type_ahead=True)`` when the TUI composer is not present.
+
+    Signals the caller (the Discord-drive path) that a type-ahead delivery could
+    not land — the pane is booting or dead — so it should fall back to the
+    persistent pending-drive queue instead of dropping the message.
+    """
+
+
 class AgentAdapter(ABC):
     """Abstract base for all session-orchestration agent adapters.
 
@@ -87,6 +96,7 @@ class AgentAdapter(ABC):
         message: str,
         *,
         pre_keys: list[str] | None = None,
+        type_ahead: bool = False,
     ) -> None:
         """Deliver ``message`` to the running session.
 
@@ -105,6 +115,13 @@ class AgentAdapter(ABC):
             Optional tmux key names (e.g. ``["Escape"]``) to send before the
             readiness check + paste. Used to cancel a selection menu so a
             natural-language answer can be pasted into the freed composer.
+        type_ahead:
+            When True, deliver as soon as the TUI composer is present, WITHOUT
+            waiting for the agent to be idle — the composer queues the turn
+            while the agent works. If the composer/TUI is not present at all
+            (booting / dead pane), raise :class:`TuiNotReadyError` so the caller
+            can fall back to the persistent queue. When False (default), the
+            strict "ready and not busy" readiness gate applies.
         """
 
     @abstractmethod
@@ -129,19 +146,25 @@ class AgentAdapter(ABC):
         """
 
     @abstractmethod
-    def resume(self, handle: SessionHandle, prompt: str) -> None:
+    def resume(self, handle: SessionHandle, prompt: str, *, force: bool = False) -> None:
         """Perform a ``/clear``+re-inject cycle for a handoff session.
 
-        Called only when ``detect()`` returns ``PAUSED_HANDOFF``.  Must
-        be idempotent: calling on a session that is NOT in handoff state
-        must be a safe no-op (log a warning; do not raise).
+        Called by the relay when ``detect()`` returns ``PAUSED_HANDOFF``, and by
+        the watcher when a ``handoff_continue`` marker fires (``force=True``).
+        Must be idempotent: without ``force``, calling on a session that is NOT
+        in handoff state is a safe no-op (log a warning; do not raise).
 
         Parameters
         ----------
         handle:
             The ``SessionHandle`` for the session to resume.
         prompt:
-            The prompt to inject after clearing.
+            The resume command / prompt to inject after clearing. When empty,
+            only ``/clear`` is sent (no follow-up drive).
+        force:
+            When True, skip the ``detect()==PAUSED_HANDOFF`` gate — the caller
+            (the watcher, acting on an authoritative ``handoff_continue`` marker)
+            has already decided a resume is due, independent of pane state.
         """
 
     @abstractmethod

--- a/session_orchestration/adapters/claude_code.py
+++ b/session_orchestration/adapters/claude_code.py
@@ -53,6 +53,7 @@ each known dialog fragment and handles them in order.
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 import time
@@ -237,12 +238,17 @@ class ClaudeCodeAdapter(AgentAdapter):
         tmux_session = f"{self._session_prefix}-{session_id[:8]}"
         pane = f"{tmux_session}:0.0"
 
-        # 1. Create a detached tmux session.
+        # Compute the marker file path and ensure its parent directory exists.
+        marker_path = f"{workdir}/.hermes/sessions/{session_id}.jsonl"
+        os.makedirs(os.path.dirname(marker_path), exist_ok=True)
+
+        # 1. Create a detached tmux session, injecting the marker file env var.
         self._tmux.run([
             "new-session", "-d",
             "-s", tmux_session,
             "-x", str(self._pane_width),
             "-y", str(self._pane_height),
+            "-e", f"HERMES_MARKER_FILE={marker_path}",
         ])
 
         # 2. Launch Claude Code inside the session.
@@ -260,6 +266,7 @@ class ClaudeCodeAdapter(AgentAdapter):
             tmux_session=tmux_session,
             pane=pane,
             launch_ts=datetime.now(tz=timezone.utc),
+            marker_file=marker_path,
         )
 
         # 5. Inject the initial prompt.
@@ -376,6 +383,28 @@ class ClaudeCodeAdapter(AgentAdapter):
         self._tmux.run(["send-keys", "-t", handle.pane, "/clear", "Enter"])
         self._wait_for_prompt(handle.pane, timeout=_LAUNCH_READY_TIMEOUT)
         self.drive(handle, prompt)
+
+    # ------------------------------------------------------------------
+    # terminate()  [testable with stubbed TmuxRunner]
+    # ------------------------------------------------------------------
+
+    def terminate(self, handle: SessionHandle) -> None:
+        """Kill the tmux session associated with ``handle``.
+
+        Sends ``tmux kill-session -t <tmux_session>`` with ``check=False`` so a
+        nonzero exit (e.g. session already gone) is silently ignored.
+        ``CalledProcessError`` is also swallowed for belt-and-suspenders safety
+        when a custom ``TmuxRunner`` implementation raises on failure.
+
+        Parameters
+        ----------
+        handle:
+            The ``SessionHandle`` whose tmux session should be destroyed.
+        """
+        try:
+            self._tmux.run(["kill-session", "-t", handle.tmux_session], check=False)
+        except subprocess.CalledProcessError:
+            pass
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/session_orchestration/adapters/claude_code.py
+++ b/session_orchestration/adapters/claude_code.py
@@ -236,7 +236,6 @@ class ClaudeCodeAdapter(AgentAdapter):
         """
         session_id = str(uuid.uuid4())
         tmux_session = f"{self._session_prefix}-{session_id[:8]}"
-        pane = f"{tmux_session}:0.0"
 
         # Compute the marker file path and ensure its parent directory exists.
         marker_path = f"{workdir}/.hermes/sessions/{session_id}.jsonl"
@@ -250,6 +249,14 @@ class ClaudeCodeAdapter(AgentAdapter):
             "-y", str(self._pane_height),
             "-e", f"HERMES_MARKER_FILE={marker_path}",
         ])
+
+        # Resolve the REAL pane id rather than assuming ':0.0'. A hardcoded
+        # ':0.0' breaks under `set -g base-index 1` / `pane-base-index 1`
+        # (the first pane is then ':1.1'). The stable pane id (e.g. '%12') is
+        # immune to base-index and to later window/pane renumbering.
+        pane = self._tmux.run([
+            "list-panes", "-t", tmux_session, "-F", "#{pane_id}",
+        ]).splitlines()[0].strip()
 
         # 2. Launch Claude Code inside the session.
         cmd = f"cd {_shell_quote(workdir)} && claude --dangerously-skip-permissions"
@@ -277,11 +284,18 @@ class ClaudeCodeAdapter(AgentAdapter):
     # drive()  [testable with stubbed TmuxRunner]
     # ------------------------------------------------------------------
 
-    def drive(self, handle: SessionHandle, message: str) -> None:
+    def drive(
+        self,
+        handle: SessionHandle,
+        message: str,
+        *,
+        pre_keys: list[str] | None = None,
+    ) -> None:
         """Deliver ``message`` to the Claude Code session via load-buffer/paste-buffer.
 
         Steps
         -----
+        0. Send any ``pre_keys`` (e.g. ``Escape`` to cancel a selection menu).
         1. Poll pane for ❯ prompt (readiness).  Raises ``TimeoutError`` after
            ``_LAUNCH_READY_TIMEOUT`` seconds if the pane never reaches readiness.
         2. Write ``message`` to a named tmux buffer.
@@ -298,7 +312,12 @@ class ClaudeCodeAdapter(AgentAdapter):
             The ``SessionHandle`` returned by ``launch()``.
         message:
             Text to send.  May contain newlines; they are preserved verbatim.
+        pre_keys:
+            Optional tmux key names sent before the readiness poll (e.g.
+            ``Escape`` to cancel a selection menu).
         """
+        for key in pre_keys or []:
+            self._tmux.run(["send-keys", "-t", handle.pane, key])
         self._wait_for_prompt(handle.pane, timeout=_LAUNCH_READY_TIMEOUT)
 
         buf_name = f"hermes-{handle.session_id[:8]}"

--- a/session_orchestration/adapters/claude_code.py
+++ b/session_orchestration/adapters/claude_code.py
@@ -1,0 +1,518 @@
+"""
+ClaudeCodeAdapter — session-orchestration adapter for Claude Code CLI.
+
+Lifecycle
+---------
+1. ``launch()``   — ``tmux new-session`` → ``cd <workdir> && claude --dangerously-skip-permissions``
+                    → trust-dialog handler (Enter) → bypass-permissions handler (Down, Enter)
+                    → prompt-readiness wait → ``drive()`` with initial prompt.
+2. ``drive()``    — prompt-readiness check (❯ visible in pane) → ``load-buffer`` → ``paste-buffer``
+                    (NOT ``send-keys``; avoids shell-metacharacter expansion on multi-line prompts).
+3. ``detect()``   — capture pane → parse last N lines for ❯ (WAITING_USER), ● (RUNNING),
+                    handoff keyword (PAUSED_HANDOFF), session-dead / error markers (ERROR/DONE).
+4. ``resume()``   — idempotent: only acts when ``detect()`` returns ``PAUSED_HANDOFF``; sends
+                    ``/clear`` then re-injects the new prompt via ``drive()``.
+
+Tmux injection strategy
+-----------------------
+``drive()`` uses ``load-buffer`` + ``paste-buffer -d`` rather than ``send-keys`` because:
+- Multi-line prompts survive intact (``send-keys`` requires ``\n`` escaping for each newline).
+- Shell metacharacters are not expanded.
+- A pipe character mid-prompt won't be misinterpreted.
+
+The tmux runner is injectable (``TmuxRunner`` protocol) so every non-live behaviour can be unit-
+tested without a real tmux session.
+
+Live-only parts
+---------------
+``launch()`` and the ``_handle_dialogs()`` inner helper perform real ``subprocess.run`` calls and
+real timing sleeps; they cannot be verified without a live Claude Code + tmux environment.
+``detect()`` and ``drive()`` are fully testable with a stubbed ``TmuxRunner``.
+
+Dialog handling sequence (first launch into a directory)
+---------------------------------------------------------
+Claude Code may show two sequential dialogs:
+
+  Dialog 1 — Workspace Trust (first visit only)
+  ┌─────────────────────────────────────────┐
+  │ ❯ 1. Yes, I trust this folder  ← default│
+  │   2. No, exit                           │
+  └─────────────────────────────────────────┘
+  → press Enter (default selection is correct)
+
+  Dialog 2 — Bypass-Permissions Warning (every ``--dangerously-skip-permissions`` launch)
+  ┌─────────────────────────────────────────┐
+  │ ❯ 1. No, exit                  ← default│
+  │   2. Yes, I accept                      │
+  └─────────────────────────────────────────┘
+  → press Down then Enter (default is wrong!)
+
+Both dialogs render into the same pane within a few seconds of startup.  ``launch()`` polls for
+each known dialog fragment and handles them in order.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Callable, Protocol
+
+from session_orchestration.adapters.base import AgentAdapter
+from session_orchestration.types import Capabilities, SessionHandle, SessionLifecycle
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Lines captured from the bottom of the pane when polling/detecting.
+_CAPTURE_LINES: int = 60
+
+#: Seconds between each readiness-poll iteration.
+_POLL_INTERVAL: float = 0.5
+
+#: Maximum seconds to wait for the ❯ prompt after launching/clearing.
+_LAUNCH_READY_TIMEOUT: float = 30.0
+
+#: Maximum seconds to wait between dialog checks during launch.
+_DIALOG_POLL_TIMEOUT: float = 20.0
+
+#: Compiled regex that matches an active-work indicator line (●).
+#: This is the ``idle_indicator_regex`` declared in ``Capabilities``.
+ACTIVITY_REGEX: re.Pattern[str] = re.compile(r"●")
+
+#: The ❯ prompt marker — presence (alone on a line-end boundary) signals WAITING_USER.
+PROMPT_MARKER: str = "❯"
+
+#: Keyword fragment that signals the agent reached a handoff checkpoint.
+#: Claude Code writes "Hermes handoff" or "/clear checkpoint" style lines when instructed.
+HANDOFF_MARKER: str = "HERMES_HANDOFF"
+
+#: Fragment present in the trust dialog.
+_TRUST_DIALOG_FRAGMENT: str = "trust this folder"
+
+#: Fragment present in the bypass-permissions dialog.
+_BYPASS_DIALOG_FRAGMENT: str = "dangerously"
+
+# ---------------------------------------------------------------------------
+# TmuxRunner protocol (injectable for testing)
+# ---------------------------------------------------------------------------
+
+
+class TmuxRunner(Protocol):
+    """Minimal interface over the ``tmux`` CLI used by ``ClaudeCodeAdapter``.
+
+    Production code uses ``_SubprocessTmuxRunner``; tests inject a fake.
+    """
+
+    def run(self, args: list[str], check: bool = True) -> str:
+        """Run ``tmux <args>`` and return stdout (stripped).
+
+        Parameters
+        ----------
+        args:
+            Arguments to pass after ``tmux`` (do NOT include ``"tmux"`` itself).
+        check:
+            If True, raise on nonzero returncode.
+
+        Returns
+        -------
+        str
+            Stdout of the command (stripped).
+        """
+        ...
+
+
+class _SubprocessTmuxRunner:
+    """Production ``TmuxRunner`` — delegates to ``subprocess.run``."""
+
+    def run(self, args: list[str], check: bool = True) -> str:
+        result = subprocess.run(
+            ["tmux"] + args,
+            capture_output=True,
+            text=True,
+            check=check,
+        )
+        return result.stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+
+class ClaudeCodeAdapter(AgentAdapter):
+    """Adapter that orchestrates an interactive Claude Code CLI session via tmux.
+
+    Parameters
+    ----------
+    tmux_runner:
+        Override the tmux execution back-end.  Defaults to the real
+        ``subprocess``-backed runner.  Pass a stub in tests.
+    session_prefix:
+        Prefix for generated tmux session names.  Default ``"hermes-cc"``.
+    pane_width:
+        tmux pane width (columns).  Default 200.
+    pane_height:
+        tmux pane height (rows).  Default 50.
+    """
+
+    def __init__(
+        self,
+        tmux_runner: TmuxRunner | None = None,
+        session_prefix: str = "hermes-cc",
+        pane_width: int = 200,
+        pane_height: int = 50,
+    ) -> None:
+        self._tmux: TmuxRunner = tmux_runner or _SubprocessTmuxRunner()
+        self._session_prefix = session_prefix
+        self._pane_width = pane_width
+        self._pane_height = pane_height
+
+    # ------------------------------------------------------------------
+    # Capabilities
+    # ------------------------------------------------------------------
+
+    def capabilities(self) -> Capabilities:
+        """Declare Claude Code adapter capabilities.
+
+        ``has_hooks=True`` — Claude Code supports ``--hook`` lifecycle callbacks
+        (``Stop``, ``PostToolUse``, etc.) which can serve as a positive-liveness
+        accelerant for the watcher.
+
+        ``idle_indicator_regex`` — matches the ``●`` active-tool indicator that
+        appears while Claude Code is reading/writing/running commands.  The watcher
+        uses this to distinguish genuine work from pane-hash-unchanged stalls.
+        """
+        return Capabilities(
+            supports_print_mode=True,
+            has_hooks=True,
+            rpc_mode=False,
+            json_mode=True,
+            idle_indicator_regex=ACTIVITY_REGEX,
+            dialog_handlers={
+                _TRUST_DIALOG_FRAGMENT: self._handle_trust_dialog,
+                _BYPASS_DIALOG_FRAGMENT: self._handle_bypass_dialog,
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # launch()  [LIVE — requires real tmux + claude binary]
+    # ------------------------------------------------------------------
+
+    def launch(self, workdir: str, prompt: str) -> SessionHandle:
+        """Spawn a tmux session and start Claude Code inside it.
+
+        Sequence (live):
+        1. Generate a unique tmux session name.
+        2. ``tmux new-session -d`` with the configured dimensions.
+        3. ``cd <workdir> && claude --dangerously-skip-permissions``.
+        4. Wait for the trust dialog → press Enter.
+        5. Wait for the bypass-permissions dialog → press Down + Enter.
+        6. Wait for the ❯ prompt (ready state).
+        7. Call ``drive()`` with the initial prompt.
+
+        Parameters
+        ----------
+        workdir:
+            Absolute path to the working directory.  Must exist.
+        prompt:
+            Initial prompt to inject once Claude is ready.
+
+        Returns
+        -------
+        SessionHandle
+            Populated handle; store in the registry immediately.
+
+        Notes
+        -----
+        This method is LIVE-ONLY.  It cannot be unit-tested without a real tmux
+        session.  The dialog poll loops use ``time.sleep`` which is not injectable
+        in the current implementation.  Extract ``_sleep`` if you need to test
+        launch() in isolation (the current design trades simplicity for live-correctness).
+        """
+        session_id = str(uuid.uuid4())
+        tmux_session = f"{self._session_prefix}-{session_id[:8]}"
+        pane = f"{tmux_session}:0.0"
+
+        # 1. Create a detached tmux session.
+        self._tmux.run([
+            "new-session", "-d",
+            "-s", tmux_session,
+            "-x", str(self._pane_width),
+            "-y", str(self._pane_height),
+        ])
+
+        # 2. Launch Claude Code inside the session.
+        cmd = f"cd {_shell_quote(workdir)} && claude --dangerously-skip-permissions"
+        self._tmux.run(["send-keys", "-t", pane, cmd, "Enter"])
+
+        # 3. Handle the two startup dialogs.
+        self._handle_dialogs(pane)
+
+        # 4. Wait for the ❯ prompt (readiness).
+        self._wait_for_prompt(pane, timeout=_LAUNCH_READY_TIMEOUT)
+
+        handle = SessionHandle(
+            session_id=session_id,
+            tmux_session=tmux_session,
+            pane=pane,
+            launch_ts=datetime.now(tz=timezone.utc),
+        )
+
+        # 5. Inject the initial prompt.
+        self.drive(handle, prompt)
+        return handle
+
+    # ------------------------------------------------------------------
+    # drive()  [testable with stubbed TmuxRunner]
+    # ------------------------------------------------------------------
+
+    def drive(self, handle: SessionHandle, message: str) -> None:
+        """Deliver ``message`` to the Claude Code session via load-buffer/paste-buffer.
+
+        Steps
+        -----
+        1. Poll pane for ❯ prompt (readiness).  Raises ``TimeoutError`` after
+           ``_LAUNCH_READY_TIMEOUT`` seconds if the pane never reaches readiness.
+        2. Write ``message`` to a named tmux buffer.
+        3. ``paste-buffer -d`` into the pane (flushes and deletes the buffer).
+        4. Send ``Enter`` to submit.
+
+        The load-buffer/paste-buffer mechanism avoids shell-metacharacter
+        expansion that ``send-keys`` would perform on strings containing ``$``,
+        backticks, pipes, etc.  It also handles multi-line prompts reliably.
+
+        Parameters
+        ----------
+        handle:
+            The ``SessionHandle`` returned by ``launch()``.
+        message:
+            Text to send.  May contain newlines; they are preserved verbatim.
+        """
+        self._wait_for_prompt(handle.pane, timeout=_LAUNCH_READY_TIMEOUT)
+
+        buf_name = f"hermes-{handle.session_id[:8]}"
+        # Write message into a named tmux buffer via subprocess stdin pipe.
+        # We bypass TmuxRunner here because stdin delivery requires subprocess.PIPE.
+        # In tests, monkeypatch _load_buffer to capture the call.
+        self._load_buffer(buf_name, message)
+        # Paste the buffer into the pane (deletes the buffer after pasting).
+        self._tmux.run(["paste-buffer", "-d", "-b", buf_name, "-t", handle.pane])
+        # Submit.
+        self._tmux.run(["send-keys", "-t", handle.pane, "", "Enter"])
+
+    # ------------------------------------------------------------------
+    # detect()  [testable with stubbed TmuxRunner]
+    # ------------------------------------------------------------------
+
+    def detect(self, handle: SessionHandle) -> SessionLifecycle:
+        """Inspect the current pane state and return a lifecycle value.
+
+        Logic (evaluated in order)
+        --------------------------
+        1. If pane is dead/session gone → ``ERROR``.
+        2. If ``HANDOFF_MARKER`` present in last ``_CAPTURE_LINES`` lines → ``PAUSED_HANDOFF``.
+        3. If ``❯`` present at end of visible text → ``WAITING_USER``.
+        4. If ``●`` present → ``RUNNING`` (active tool use).
+        5. Otherwise → ``RUNNING`` (default; pane has content but no clear idle signal).
+
+        Parameters
+        ----------
+        handle:
+            The ``SessionHandle`` for the session to inspect.
+
+        Returns
+        -------
+        SessionLifecycle
+            Exactly one of ``RUNNING | WAITING_USER | PAUSED_HANDOFF | ERROR``.
+            ``STALLED`` and ``DONE`` are determined by the watcher based on
+            pane-hash staleness and elapsed time, not by this method.
+        """
+        pane_text = self._capture_pane(handle.pane)
+        if pane_text is None:
+            return SessionLifecycle.ERROR
+
+        return _parse_lifecycle(pane_text)
+
+    # ------------------------------------------------------------------
+    # resume()  [testable with stubbed TmuxRunner]
+    # ------------------------------------------------------------------
+
+    def resume(self, handle: SessionHandle, prompt: str) -> None:
+        """Perform a ``/clear`` + re-inject cycle for a handoff session.
+
+        This method is idempotent: if the session is NOT in ``PAUSED_HANDOFF``
+        state (i.e., ``detect()`` does not return ``PAUSED_HANDOFF``), it logs
+        a warning and returns without taking action.
+
+        Sequence
+        --------
+        1. Call ``detect()``.  If not ``PAUSED_HANDOFF``, warn and return.
+        2. Send ``/clear`` + Enter via ``send-keys`` (slash-command, safe with send-keys).
+        3. Wait for the ❯ prompt to reappear.
+        4. Call ``drive()`` with the new prompt.
+
+        Parameters
+        ----------
+        handle:
+            The ``SessionHandle`` for the session to resume.
+        prompt:
+            Prompt to inject after clearing.
+        """
+        current = self.detect(handle)
+        if current != SessionLifecycle.PAUSED_HANDOFF:
+            import logging
+            logging.getLogger(__name__).warning(
+                "resume() called on session %s in state %s (expected PAUSED_HANDOFF); no-op.",
+                handle.session_id,
+                current.value,
+            )
+            return
+
+        # /clear is a slash-command; send-keys is safe here (single token, no metacharacters).
+        self._tmux.run(["send-keys", "-t", handle.pane, "/clear", "Enter"])
+        self._wait_for_prompt(handle.pane, timeout=_LAUNCH_READY_TIMEOUT)
+        self.drive(handle, prompt)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _capture_pane(self, pane: str) -> str | None:
+        """Capture the last ``_CAPTURE_LINES`` lines of the pane.
+
+        Returns ``None`` if the pane does not exist (session dead / error).
+        """
+        try:
+            text = self._tmux.run([
+                "capture-pane", "-t", pane,
+                "-p",               # print to stdout
+                "-S", f"-{_CAPTURE_LINES}",  # start N lines from bottom
+            ], check=True)
+            return text
+        except subprocess.CalledProcessError:
+            return None
+
+    def _wait_for_prompt(self, pane: str, timeout: float) -> None:
+        """Poll until ❯ is visible in the pane or ``timeout`` seconds elapse.
+
+        Raises
+        ------
+        TimeoutError
+            If the prompt does not appear within ``timeout`` seconds.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            text = self._capture_pane(pane)
+            if text is not None and PROMPT_MARKER in text:
+                return
+            time.sleep(_POLL_INTERVAL)
+        raise TimeoutError(
+            f"Claude Code prompt (❯) not visible in pane {pane!r} "
+            f"after {timeout:.0f}s"
+        )
+
+    def _handle_dialogs(self, pane: str) -> None:
+        """Drive Claude Code through the startup dialogs.
+
+        LIVE-ONLY.  Polls for each dialog fragment, handles in order, then
+        returns.  Uses ``time.sleep`` internally; not injectable in tests.
+
+        Dialog 1 (trust): default is "Yes, trust folder" → press Enter.
+        Dialog 2 (bypass permissions): default is "No, exit" → press Down, Enter.
+        """
+        deadline = time.monotonic() + _DIALOG_POLL_TIMEOUT
+        trust_handled = False
+        bypass_handled = False
+
+        while time.monotonic() < deadline:
+            text = self._capture_pane(pane) or ""
+
+            if not trust_handled and _TRUST_DIALOG_FRAGMENT in text:
+                self._handle_trust_dialog(pane)
+                trust_handled = True
+                time.sleep(0.5)
+
+            if not bypass_handled and _BYPASS_DIALOG_FRAGMENT in text:
+                self._handle_bypass_dialog(pane)
+                bypass_handled = True
+                time.sleep(0.5)
+
+            # Once both are handled (or the prompt is visible), done.
+            if (trust_handled and bypass_handled) or PROMPT_MARKER in text:
+                return
+
+            time.sleep(_POLL_INTERVAL)
+
+    def _handle_trust_dialog(self, pane: str) -> None:
+        """Handle Dialog 1 (Workspace Trust): press Enter for default "Yes"."""
+        self._tmux.run(["send-keys", "-t", pane, "", "Enter"])
+
+    def _handle_bypass_dialog(self, pane: str) -> None:
+        """Handle Dialog 2 (Bypass-Permissions): press Down then Enter."""
+        self._tmux.run(["send-keys", "-t", pane, "Down", ""])
+        self._tmux.run(["send-keys", "-t", pane, "", "Enter"])
+
+    def _load_buffer(self, buf_name: str, content: str) -> None:
+        """Write ``content`` into a named tmux buffer via subprocess stdin pipe.
+
+        This bypasses the ``TmuxRunner`` abstraction because ``load-buffer``
+        requires data on stdin; the TmuxRunner protocol's ``run()`` method does
+        not expose stdin.  Tests that stub the TmuxRunner should also stub this
+        method (monkeypatch) if they need to assert buffer content.
+        """
+        subprocess.run(
+            ["tmux", "load-buffer", "-b", buf_name, "-"],
+            input=content,
+            text=True,
+            check=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pure-function helpers (fully testable, no tmux dependency)
+# ---------------------------------------------------------------------------
+
+
+def _parse_lifecycle(pane_text: str) -> SessionLifecycle:
+    """Parse captured pane text and return the inferred ``SessionLifecycle``.
+
+    This is a pure function — no subprocess calls, no side-effects.  All
+    detect() logic lives here so unit tests can exercise it without a real pane.
+
+    Decision order
+    --------------
+    1. ``HANDOFF_MARKER`` anywhere in text → ``PAUSED_HANDOFF``
+    2. ``❯`` anywhere in text → ``WAITING_USER``
+    3. ``●`` anywhere in text → ``RUNNING``
+    4. Otherwise → ``RUNNING`` (Claude is between outputs; watcher tracks staleness)
+
+    Parameters
+    ----------
+    pane_text:
+        Raw text from ``tmux capture-pane -p``.
+
+    Returns
+    -------
+    SessionLifecycle
+        One of ``RUNNING | WAITING_USER | PAUSED_HANDOFF``.
+    """
+    if HANDOFF_MARKER in pane_text:
+        return SessionLifecycle.PAUSED_HANDOFF
+    if PROMPT_MARKER in pane_text:
+        return SessionLifecycle.WAITING_USER
+    if ACTIVITY_REGEX.search(pane_text):
+        return SessionLifecycle.RUNNING
+    return SessionLifecycle.RUNNING
+
+
+def _shell_quote(s: str) -> str:
+    """Minimal shell-quoting for a directory path in a tmux send-keys argument.
+
+    Wraps ``s`` in single quotes and escapes any literal single-quote characters
+    within it.  Only used for the ``cd`` command in ``launch()``.
+    """
+    return "'" + s.replace("'", "'\\''") + "'"

--- a/session_orchestration/adapters/claude_code.py
+++ b/session_orchestration/adapters/claude_code.py
@@ -61,7 +61,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Callable, Protocol
 
-from session_orchestration.adapters.base import AgentAdapter
+from session_orchestration.adapters.base import AgentAdapter, TuiNotReadyError
 from session_orchestration.types import Capabilities, SessionHandle, SessionLifecycle
 
 # ---------------------------------------------------------------------------
@@ -290,6 +290,7 @@ class ClaudeCodeAdapter(AgentAdapter):
         message: str,
         *,
         pre_keys: list[str] | None = None,
+        type_ahead: bool = False,
     ) -> None:
         """Deliver ``message`` to the Claude Code session via load-buffer/paste-buffer.
 
@@ -318,7 +319,16 @@ class ClaudeCodeAdapter(AgentAdapter):
         """
         for key in pre_keys or []:
             self._tmux.run(["send-keys", "-t", handle.pane, key])
-        self._wait_for_prompt(handle.pane, timeout=_LAUNCH_READY_TIMEOUT)
+        # Claude's ❯ composer is present while it works, so _wait_for_prompt is
+        # already a "composer present" check. For type_ahead, a timeout means the
+        # composer never appeared (booting/dead) — surface it as TuiNotReadyError
+        # so the caller falls back to the queue instead of dropping the message.
+        try:
+            self._wait_for_prompt(handle.pane, timeout=_LAUNCH_READY_TIMEOUT)
+        except TimeoutError as exc:
+            if type_ahead:
+                raise TuiNotReadyError(str(exc)) from exc
+            raise
 
         buf_name = f"hermes-{handle.session_id[:8]}"
         # Write message into a named tmux buffer via subprocess stdin pipe.
@@ -367,41 +377,37 @@ class ClaudeCodeAdapter(AgentAdapter):
     # resume()  [testable with stubbed TmuxRunner]
     # ------------------------------------------------------------------
 
-    def resume(self, handle: SessionHandle, prompt: str) -> None:
+    def resume(self, handle: SessionHandle, prompt: str, *, force: bool = False) -> None:
         """Perform a ``/clear`` + re-inject cycle for a handoff session.
 
-        This method is idempotent: if the session is NOT in ``PAUSED_HANDOFF``
-        state (i.e., ``detect()`` does not return ``PAUSED_HANDOFF``), it logs
-        a warning and returns without taking action.
+        Without ``force`` this is idempotent: if the session is NOT in
+        ``PAUSED_HANDOFF`` state it logs a warning and returns. With ``force``
+        (watcher acting on a ``handoff_continue`` marker) the detect gate is
+        skipped — the marker is authoritative.
 
         Sequence
         --------
-        1. Call ``detect()``.  If not ``PAUSED_HANDOFF``, warn and return.
-        2. Send ``/clear`` + Enter via ``send-keys`` (slash-command, safe with send-keys).
+        1. Unless ``force``, call ``detect()``; if not ``PAUSED_HANDOFF``, no-op.
+        2. Send ``/clear`` + Enter via ``send-keys`` (slash-command, safe).
         3. Wait for the ❯ prompt to reappear.
-        4. Call ``drive()`` with the new prompt.
-
-        Parameters
-        ----------
-        handle:
-            The ``SessionHandle`` for the session to resume.
-        prompt:
-            Prompt to inject after clearing.
+        4. If ``prompt`` is non-empty, ``drive()`` it (the resume command).
         """
-        current = self.detect(handle)
-        if current != SessionLifecycle.PAUSED_HANDOFF:
-            import logging
-            logging.getLogger(__name__).warning(
-                "resume() called on session %s in state %s (expected PAUSED_HANDOFF); no-op.",
-                handle.session_id,
-                current.value,
-            )
-            return
+        if not force:
+            current = self.detect(handle)
+            if current != SessionLifecycle.PAUSED_HANDOFF:
+                import logging
+                logging.getLogger(__name__).warning(
+                    "resume() called on session %s in state %s (expected PAUSED_HANDOFF); no-op.",
+                    handle.session_id,
+                    current.value,
+                )
+                return
 
         # /clear is a slash-command; send-keys is safe here (single token, no metacharacters).
         self._tmux.run(["send-keys", "-t", handle.pane, "/clear", "Enter"])
         self._wait_for_prompt(handle.pane, timeout=_LAUNCH_READY_TIMEOUT)
-        self.drive(handle, prompt)
+        if prompt:
+            self.drive(handle, prompt)
 
     # ------------------------------------------------------------------
     # terminate()  [testable with stubbed TmuxRunner]

--- a/session_orchestration/adapters/codex.py
+++ b/session_orchestration/adapters/codex.py
@@ -1,0 +1,265 @@
+"""
+CodexAdapter — session-orchestration adapter for the Codex CLI.
+
+Managed Codex sessions run as an interactive TUI in tmux. The adapter boots
+Codex without an initial prompt, waits for the composer, then the generic
+spawn flow seeds the first prompt through ``drive()``.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import subprocess
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Protocol
+
+from session_orchestration.adapters.base import AgentAdapter, TuiNotReadyError
+from session_orchestration.types import Capabilities, SessionHandle, SessionLifecycle
+
+_CAPTURE_LINES: int = 80
+_POLL_INTERVAL: float = 0.5
+_LAUNCH_READY_TIMEOUT: float = 30.0
+_DIALOG_POLL_TIMEOUT: float = 20.0
+
+_APP_CODEX_BINARY: str = "/Applications/Codex.app/Contents/Resources/codex"
+_CODEX_BINARY: str = _APP_CODEX_BINARY if os.path.exists(_APP_CODEX_BINARY) else "codex"
+HANDOFF_MARKER: str = "HERMES_HANDOFF"
+PROMPT_FRAGMENT: str = "› Implement {feature}"
+PROMPT_PATTERN: re.Pattern[str] = re.compile(r"^\s*›\s+(?!\d+\.)(.+)$", re.MULTILINE)
+TRUST_DIALOG_FRAGMENT: str = "Do you trust the contents of this directory?"
+UPDATE_DIALOG_FRAGMENT: str = "Update available"
+
+ACTIVITY_REGEX: re.Pattern[str] = re.compile(
+    r"[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]|thinking|working|running|executing|applying",
+    re.IGNORECASE,
+)
+
+
+class TmuxRunner(Protocol):
+    """Minimal interface over the ``tmux`` CLI used by ``CodexAdapter``."""
+
+    def run(self, args: list[str], check: bool = True) -> str:
+        """Run ``tmux <args>`` and return stripped stdout."""
+        ...
+
+
+class _SubprocessTmuxRunner:
+    """Production ``TmuxRunner`` — delegates to ``subprocess.run``."""
+
+    def run(self, args: list[str], check: bool = True) -> str:
+        result = subprocess.run(
+            ["tmux"] + args,
+            capture_output=True,
+            text=True,
+            check=check,
+        )
+        return result.stdout.strip()
+
+
+def build_interactive_argv(
+    *,
+    workdir: str,
+    model: str | None = None,
+) -> list[str]:
+    """Build argv for an interactive Codex TUI session."""
+    args: list[str] = ["-C", workdir]
+    if model:
+        args += ["--model", model]
+    return args
+
+
+def parse_pane_lifecycle(pane_text: str) -> SessionLifecycle:
+    """Infer a lifecycle state from captured Codex tmux pane text."""
+    if HANDOFF_MARKER in pane_text:
+        return SessionLifecycle.PAUSED_HANDOFF
+    if _has_startup_dialog(pane_text) or _is_ready_for_input(pane_text):
+        return SessionLifecycle.WAITING_USER
+    if ACTIVITY_REGEX.search(pane_text):
+        return SessionLifecycle.RUNNING
+    return SessionLifecycle.RUNNING
+
+
+def _has_startup_dialog(pane_text: str) -> bool:
+    return TRUST_DIALOG_FRAGMENT in pane_text or UPDATE_DIALOG_FRAGMENT in pane_text
+
+
+def _is_ready_for_input(pane_text: str) -> bool:
+    return bool(PROMPT_PATTERN.search(pane_text)) and not _has_startup_dialog(pane_text)
+
+
+class CodexAdapter(AgentAdapter):
+    """Adapter that orchestrates an interactive Codex CLI session via tmux."""
+
+    def __init__(
+        self,
+        tmux_runner: TmuxRunner | None = None,
+        session_prefix: str = "hermes-codex",
+        binary: str = _CODEX_BINARY,
+        pane_width: int = 200,
+        pane_height: int = 50,
+    ) -> None:
+        self._tmux: TmuxRunner = tmux_runner or _SubprocessTmuxRunner()
+        self._session_prefix = session_prefix
+        self._binary = binary
+        self._pane_width = pane_width
+        self._pane_height = pane_height
+
+    def capabilities(self) -> Capabilities:
+        return Capabilities(
+            supports_print_mode=True,
+            has_hooks=False,
+            rpc_mode=False,
+            json_mode=False,
+            idle_indicator_regex=ACTIVITY_REGEX,
+            dialog_handlers={
+                TRUST_DIALOG_FRAGMENT: self._handle_trust_dialog,
+                UPDATE_DIALOG_FRAGMENT: self._handle_update_dialog,
+            },
+        )
+
+    def launch(self, workdir: str, prompt: str) -> SessionHandle:
+        session_id = str(uuid.uuid4())
+        tmux_session = f"{self._session_prefix}-{session_id[:8]}"
+        marker_file = f"{workdir}/.hermes/sessions/{session_id}.jsonl"
+        os.makedirs(os.path.dirname(marker_file), exist_ok=True)
+
+        self._tmux.run([
+            "new-session", "-d",
+            "-s", tmux_session,
+            "-x", str(self._pane_width),
+            "-y", str(self._pane_height),
+            "-e", f"HERMES_MARKER_FILE={marker_file}",
+        ])
+
+        pane = self._tmux.run([
+            "list-panes", "-t", tmux_session, "-F", "#{pane_id}",
+        ]).splitlines()[0].strip()
+
+        argv = build_interactive_argv(workdir=workdir)
+        cmd = shlex.join([self._binary] + argv)
+        self._tmux.run(["send-keys", "-t", pane, cmd, "Enter"])
+
+        try:
+            self._handle_dialogs(pane)
+            self._wait_for_ready(pane, timeout=_LAUNCH_READY_TIMEOUT)
+        except TimeoutError:
+            try:
+                self._tmux.run(["kill-session", "-t", tmux_session], check=False)
+            except Exception:
+                pass
+            raise
+
+        return SessionHandle(
+            session_id=session_id,
+            tmux_session=tmux_session,
+            pane=pane,
+            launch_ts=datetime.now(tz=timezone.utc),
+            marker_file=marker_file,
+        )
+
+    def drive(
+        self,
+        handle: SessionHandle,
+        message: str,
+        *,
+        pre_keys: list[str] | None = None,
+        type_ahead: bool = False,
+    ) -> None:
+        for key in pre_keys or []:
+            self._tmux.run(["send-keys", "-t", handle.pane, key])
+        try:
+            self._wait_for_ready(handle.pane, timeout=_LAUNCH_READY_TIMEOUT)
+        except TimeoutError as exc:
+            if type_ahead:
+                raise TuiNotReadyError(str(exc)) from exc
+            raise
+
+        buf_name = f"hermes-codex-{handle.session_id[:8]}"
+        self._load_buffer(buf_name, message)
+        self._tmux.run(["paste-buffer", "-d", "-b", buf_name, "-t", handle.pane])
+        self._tmux.run(["send-keys", "-t", handle.pane, "", "Enter"])
+
+    def detect(self, handle: SessionHandle) -> SessionLifecycle:
+        pane_text = self._capture_pane(handle.pane)
+        if pane_text is None:
+            return SessionLifecycle.ERROR
+        return parse_pane_lifecycle(pane_text)
+
+    def resume(self, handle: SessionHandle, prompt: str, *, force: bool = False) -> None:
+        if not force and self.detect(handle) != SessionLifecycle.PAUSED_HANDOFF:
+            import logging
+            logging.getLogger(__name__).warning(
+                "resume() called on codex session %s outside PAUSED_HANDOFF; no-op.",
+                handle.session_id,
+            )
+            return
+
+        self._tmux.run(["send-keys", "-t", handle.pane, "/clear", "Enter"])
+        if prompt:
+            self.drive(handle, prompt)
+
+    def terminate(self, handle: SessionHandle) -> None:
+        try:
+            self._tmux.run(["kill-session", "-t", handle.tmux_session], check=False)
+        except subprocess.CalledProcessError:
+            pass
+
+    def _capture_pane(self, pane: str) -> str | None:
+        try:
+            return self._tmux.run([
+                "capture-pane", "-t", pane,
+                "-p",
+                "-S", f"-{_CAPTURE_LINES}",
+            ], check=True)
+        except subprocess.CalledProcessError:
+            return None
+
+    def _wait_for_ready(self, pane: str, timeout: float) -> None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            text = self._capture_pane(pane)
+            if text is not None and _is_ready_for_input(text):
+                return
+            time.sleep(_POLL_INTERVAL)
+        raise TimeoutError(
+            f"Codex prompt not visible in pane {pane!r} after {timeout:.0f}s"
+        )
+
+    def _handle_dialogs(self, pane: str) -> None:
+        deadline = time.monotonic() + _DIALOG_POLL_TIMEOUT
+        trust_handled = False
+        update_handled = False
+
+        while time.monotonic() < deadline:
+            text = self._capture_pane(pane) or ""
+            if _is_ready_for_input(text):
+                return
+            if not trust_handled and TRUST_DIALOG_FRAGMENT in text:
+                self._handle_trust_dialog(pane)
+                trust_handled = True
+                time.sleep(1.0)
+                continue
+            if not update_handled and UPDATE_DIALOG_FRAGMENT in text:
+                self._handle_update_dialog(pane)
+                update_handled = True
+                time.sleep(1.0)
+                continue
+            time.sleep(_POLL_INTERVAL)
+
+    def _handle_trust_dialog(self, pane: str) -> None:
+        self._tmux.run(["send-keys", "-t", pane, "", "Enter"])
+
+    def _handle_update_dialog(self, pane: str) -> None:
+        self._tmux.run(["send-keys", "-t", pane, "Down", "Enter"])
+
+    def _load_buffer(self, buf_name: str, content: str) -> None:
+        subprocess.run(
+            ["tmux", "load-buffer", "-b", buf_name, "-"],
+            input=content,
+            text=True,
+            check=True,
+        )

--- a/session_orchestration/adapters/omp.py
+++ b/session_orchestration/adapters/omp.py
@@ -70,14 +70,16 @@ For one-shot continuations, -c re-attaches the most recent session.
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 import time
 import uuid
 from datetime import datetime, timezone
-from typing import Callable, Protocol
+from typing import Callable, Iterable, Protocol
 
 from session_orchestration.adapters.base import AgentAdapter
+from session_orchestration.markers import MARKER_DONE, MARKER_HEARTBEAT, MARKER_NEEDS_INPUT, MARKER_STATUS, append_marker
 from session_orchestration.types import Capabilities, SessionHandle, SessionLifecycle
 
 # ---------------------------------------------------------------------------
@@ -369,6 +371,122 @@ def build_interactive_argv(
 
 
 # ---------------------------------------------------------------------------
+# RPC translation helpers (fully testable, no subprocess dependency)
+# ---------------------------------------------------------------------------
+
+
+def translate_rpc_line(raw_line: str) -> "dict | None":
+    """Parse one omp ``--mode=rpc`` NDJSON line into a ``{kind, payload}`` dict.
+
+    Maps the omp RPC event vocabulary to the marker vocabulary defined in
+    ``markers.py``.  Unknown event types return ``None`` (caller skips them).
+
+    Mapping
+    -------
+    ``ready``        → ``status{phase="ready", detail=""}``
+    ``turn_start``   → ``status{phase="running", detail=""}``
+    ``message_end``  with ``role=assistant`` → ``heartbeat{note=content[:120]}``
+    ``agent_end``    → ``done{summary=<last assistant text>, artifacts=None}``
+    ``needs_input``  → ``needs_input{question=..., options=None, context=None}``
+
+    Parameters
+    ----------
+    raw_line:
+        A single raw line from omp's ``--mode=rpc`` NDJSON stream.
+
+    Returns
+    -------
+    dict | None
+        ``{"kind": <marker_kind>, "payload": {...}}`` on a recognised event,
+        or ``None`` for blank lines, non-JSON lines, and unrecognised types.
+
+    Notes
+    -----
+    The ``turn_start``, ``message_end``, ``agent_end``, and ``needs_input``
+    event names are inferred from the ``--mode=json`` schema (see docstring at
+    the top of this file).  The ``--mode=rpc`` interactive session is confirmed
+    to emit ``ready`` and ``available_commands_update`` on startup; the
+    remaining event names are assumed to overlap with ``--mode=json`` and
+    should be verified against live omp ``--mode=rpc`` output when wired live.
+    """
+    line = raw_line.strip()
+    if not line:
+        return None
+    try:
+        event = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+
+    event_type = event.get("type", "")
+
+    if event_type == "ready":
+        return {"kind": MARKER_STATUS, "payload": {"phase": "ready", "detail": ""}}
+
+    if event_type == "turn_start":
+        return {"kind": MARKER_STATUS, "payload": {"phase": "running", "detail": ""}}
+
+    if event_type == "message_end":
+        msg = event.get("message", {})
+        if msg.get("role") == "assistant":
+            content = msg.get("content", [])
+            text = content[0].get("text", "") if content else ""
+            return {"kind": MARKER_HEARTBEAT, "payload": {"note": text[:120]}}
+        return None
+
+    if event_type == "agent_end":
+        messages = event.get("messages", [])
+        last_text: str = ""
+        for msg in reversed(messages):
+            if msg.get("role") == "assistant":
+                content = msg.get("content", [])
+                last_text = content[0].get("text", "") if content else ""
+                break
+        return {"kind": MARKER_DONE, "payload": {"summary": last_text, "artifacts": None}}
+
+    if event_type == "needs_input":
+        question = event.get("question", "")
+        return {
+            "kind": MARKER_NEEDS_INPUT,
+            "payload": {"question": question, "options": None, "context": None},
+        }
+
+    return None
+
+
+def tail_rpc_stream(
+    stdout_iter: Iterable[str],
+    marker_path: str,
+    task_id: str,
+    append_fn: Callable[..., None] = append_marker,
+) -> None:
+    """Iterate omp ``--mode=rpc`` NDJSON lines and write markers to *marker_path*.
+
+    For each line in *stdout_iter*, calls ``translate_rpc_line``; if the result
+    is not ``None``, calls ``append_fn(marker_path, kind, payload, task_id)``
+    to persist the marker.  Lines that produce ``None`` (blank, non-JSON, or
+    unrecognised type) are silently skipped.
+
+    Parameters
+    ----------
+    stdout_iter:
+        An iterable of raw text lines (e.g. a file-like object or a list of
+        strings) representing omp's ``--mode=rpc`` output stream.
+    marker_path:
+        Absolute path to the ``.jsonl`` marker file to append to.
+    task_id:
+        Opaque task/session identifier written into each marker envelope.
+    append_fn:
+        Callable with signature ``(path, kind, payload, task_id)`` used to
+        write each marker.  Defaults to ``append_marker`` from ``markers.py``.
+        Inject a stub in tests to capture written markers without touching disk.
+    """
+    for raw_line in stdout_iter:
+        result = translate_rpc_line(raw_line)
+        if result is not None:
+            append_fn(marker_path, result["kind"], result["payload"], task_id)
+
+
+# ---------------------------------------------------------------------------
 # Adapter
 # ---------------------------------------------------------------------------
 
@@ -534,12 +652,17 @@ class OmpAdapter(AgentAdapter):
         tmux_session = f"{self._session_prefix}-{session_id[:8]}"
         pane = f"{tmux_session}:0.0"
 
-        # 1. Create a detached tmux session.
+        # Compute the marker file path and ensure its parent directory exists.
+        marker_file = f"{workdir}/.hermes/sessions/{session_id}.jsonl"
+        os.makedirs(os.path.dirname(marker_file), exist_ok=True)
+
+        # 1. Create a detached tmux session, injecting the marker file env var.
         self._tmux.run([
             "new-session", "-d",
             "-s", tmux_session,
             "-x", "200",
             "-y", "50",
+            "-e", f"HERMES_MARKER_FILE={marker_file}",
         ])
 
         # 2. Build and send the omp command into the session.
@@ -555,6 +678,7 @@ class OmpAdapter(AgentAdapter):
             tmux_session=tmux_session,
             pane=pane,
             launch_ts=datetime.now(tz=timezone.utc),
+            marker_file=marker_file,
         )
 
     # ------------------------------------------------------------------
@@ -654,6 +778,28 @@ class OmpAdapter(AgentAdapter):
         cmd = " ".join([self._binary] + argv)
         self._tmux.run(["send-keys", "-t", handle.pane, cmd, "Enter"])
         self._wait_for_prompt(handle.pane, timeout=_LAUNCH_READY_TIMEOUT)
+
+    # ------------------------------------------------------------------
+    # terminate()  [testable with stubbed TmuxRunner]
+    # ------------------------------------------------------------------
+
+    def terminate(self, handle: SessionHandle) -> None:
+        """Kill the tmux session associated with ``handle``.
+
+        Sends ``tmux kill-session -t <tmux_session>`` with ``check=False`` so a
+        nonzero exit (e.g. session already gone) is silently ignored.
+        ``CalledProcessError`` is also swallowed for belt-and-suspenders safety
+        when a custom ``TmuxRunner`` raises on failure.
+
+        Parameters
+        ----------
+        handle:
+            The ``SessionHandle`` whose tmux session should be destroyed.
+        """
+        try:
+            self._tmux.run(["kill-session", "-t", handle.tmux_session], check=False)
+        except subprocess.CalledProcessError:
+            pass
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/session_orchestration/adapters/omp.py
+++ b/session_orchestration/adapters/omp.py
@@ -72,6 +72,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import subprocess
 import time
 import uuid
@@ -95,6 +96,14 @@ _POLL_INTERVAL: float = 0.5
 #: Maximum seconds to wait for omp prompt after launching.
 _LAUNCH_READY_TIMEOUT: float = 30.0
 
+#: Maximum seconds to wait for omp's TUI to first render on COLD start. Larger
+#: than _LAUNCH_READY_TIMEOUT because a cold start does an update check + MCP
+#: server connection + heavy splash render before drawing box chrome; on a slow
+#: network that legitimately exceeds 30s (observed omp/16.1.15 tripping the old
+#: 30s budget even though the TUI came up fine seconds later). drive()/resume()
+#: keep the shorter budget since omp is already running by then.
+_LAUNCH_START_TIMEOUT: float = 90.0
+
 #: omp prints ">" or "❯" when waiting for user input.
 #: Use a pattern that matches either variant.
 PROMPT_PATTERN: re.Pattern[str] = re.compile(r"[>❯]\s*$", re.MULTILINE)
@@ -105,6 +114,17 @@ HANDOFF_MARKER: str = "HERMES_HANDOFF"
 #: Active-work indicator pattern for omp (tool-use spinner text).
 #: omp shows "⠋" / "⠙" / "⠹" etc. spinner characters and "Running" text.
 ACTIVITY_REGEX: re.Pattern[str] = re.compile(r"[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]|Running tool")
+
+#: Interactive input request pattern for omp. Selection menus and prompt
+#: dialogs (including z-harness AskUser gates rendered inside omp) end in a
+#: navigation footer — "up/down navigate  enter select  esc cancel" — and do
+#: NOT use a "❯"/">" input char, so PROMPT_PATTERN misses them. omp also keeps
+#: a spinner ("⠹ Requesting task") visible while the menu waits, which would
+#: otherwise be misread as RUNNING. This pattern must therefore take precedence
+#: over ACTIVITY_REGEX in the lifecycle decision.
+INPUT_REQUEST_REGEX: re.Pattern[str] = re.compile(
+    r"enter\s+select|esc\s+cancel|↵\s*select|⏎\s*select", re.IGNORECASE
+)
 
 #: Default executable path for omp.
 _OMP_BINARY: str = "omp"
@@ -271,11 +291,43 @@ def parse_pane_lifecycle(pane_text: str) -> SessionLifecycle:
     """
     if HANDOFF_MARKER in pane_text:
         return SessionLifecycle.PAUSED_HANDOFF
-    if PROMPT_PATTERN.search(pane_text):
+    # An interactive menu/prompt takes precedence over the spinner: omp keeps a
+    # "⠹ Requesting task" spinner visible WHILE a selection menu waits, so the
+    # input-request check must run before ACTIVITY_REGEX or a waiting session
+    # would be misread as RUNNING and never surface in the feed.
+    if INPUT_REQUEST_REGEX.search(pane_text) or PROMPT_PATTERN.search(pane_text):
         return SessionLifecycle.WAITING_USER
     if ACTIVITY_REGEX.search(pane_text):
         return SessionLifecycle.RUNNING
     return SessionLifecycle.RUNNING
+
+
+#: omp's composer/status chrome — the rounded box it draws around the input line.
+_TUI_BOX_CHARS = ("╭", "╰")
+
+
+def pane_is_idle_waiting(pane_text: str) -> bool:
+    """True when omp has finished its turn and is idling at its composer.
+
+    omp emits no marker and no ``❯`` when it asks a *free-form* question and
+    waits (unlike a selection menu, which shows an ``enter select`` footer). The
+    only signal is: the TUI composer box is drawn AND no active-work spinner is
+    present AND it isn't already a menu/prompt/handoff. This is a *candidate*
+    wait — the watcher additionally requires the pane to be stable across a tick
+    before promoting RUNNING → WAITING_USER, so a momentary mid-turn idle does
+    not flap the session into a spurious notification.
+    """
+    if not pane_text or not pane_text.strip():
+        return False
+    if HANDOFF_MARKER in pane_text:
+        return False
+    # Menus/prompts are already WAITING_USER via parse_pane_lifecycle; a busy
+    # spinner means omp is still working.
+    if INPUT_REQUEST_REGEX.search(pane_text) or PROMPT_PATTERN.search(pane_text):
+        return False
+    if ACTIVITY_REGEX.search(pane_text):
+        return False
+    return any(ch in pane_text for ch in _TUI_BOX_CHARS)
 
 
 def build_oneshot_argv(
@@ -650,7 +702,6 @@ class OmpAdapter(AgentAdapter):
         """
         session_id = str(uuid.uuid4())
         tmux_session = f"{self._session_prefix}-{session_id[:8]}"
-        pane = f"{tmux_session}:0.0"
 
         # Compute the marker file path and ensure its parent directory exists.
         marker_file = f"{workdir}/.hermes/sessions/{session_id}.jsonl"
@@ -665,13 +716,38 @@ class OmpAdapter(AgentAdapter):
             "-e", f"HERMES_MARKER_FILE={marker_file}",
         ])
 
-        # 2. Build and send the omp command into the session.
-        argv = build_interactive_argv(prompt=prompt, workdir=workdir)
-        cmd = " ".join([self._binary] + argv)
+        # Resolve the REAL pane id rather than assuming ':0.0'. A hardcoded
+        # ':0.0' breaks under `set -g base-index 1` / `pane-base-index 1`
+        # (the first pane is then ':1.1', and every send-keys/capture against
+        # ':0.0' fails with "can't find window: 0"). The stable pane id (e.g.
+        # '%12') is immune to base-index and to later window/pane renumbering.
+        pane = self._tmux.run([
+            "list-panes", "-t", tmux_session, "-F", "#{pane_id}",
+        ]).splitlines()[0].strip()
+
+        # 2. Boot omp BARE (no prompt) so it comes up at an idle prompt. The
+        #    first prompt is seeded separately via the relay/``drive()`` after
+        #    launch (see spawn_session step 7) — matching the claude adapter.
+        #    Passing the prompt here too would (a) deliver it twice and (b) make
+        #    omp immediately busy, so the post-launch ``drive()`` wait-for-idle
+        #    would time out. ``prompt`` is intentionally unused.
+        argv = build_interactive_argv(workdir=workdir)
+        cmd = shlex.join([self._binary] + argv)
         self._tmux.run(["send-keys", "-t", pane, cmd, "Enter"])
 
-        # 3. Wait for the omp prompt (ready state).
-        self._wait_for_prompt(pane, timeout=_LAUNCH_READY_TIMEOUT)
+        # 3. Confirm omp actually started (took over the pane). Do NOT wait for
+        #    the idle prompt — a launch prompt makes omp immediately busy, so
+        #    the idle prompt won't appear until the first turn completes.
+        #    On failure, kill the tmux session so a slow/failed launch doesn't
+        #    leave an orphaned, unwatched omp running in a detached pane.
+        try:
+            self._wait_for_launch(pane, timeout=_LAUNCH_START_TIMEOUT)
+        except TimeoutError:
+            try:
+                self._tmux.run(["kill-session", "-t", tmux_session])
+            except Exception:
+                pass
+            raise
 
         return SessionHandle(
             session_id=session_id,
@@ -685,11 +761,18 @@ class OmpAdapter(AgentAdapter):
     # drive()  [testable with stubbed TmuxRunner]
     # ------------------------------------------------------------------
 
-    def drive(self, handle: SessionHandle, message: str) -> None:
+    def drive(
+        self,
+        handle: SessionHandle,
+        message: str,
+        *,
+        pre_keys: list[str] | None = None,
+    ) -> None:
         """Deliver ``message`` to the running omp session via load-buffer/paste-buffer.
 
         Steps
         -----
+        0. Send any ``pre_keys`` (e.g. ``Escape`` to cancel a selection menu).
         1. Poll pane for prompt readiness (``>`` or ``❯`` visible).
         2. Write ``message`` to a named tmux buffer via ``_load_buffer``.
         3. ``paste-buffer -d`` into the pane.
@@ -705,8 +788,14 @@ class OmpAdapter(AgentAdapter):
             The ``SessionHandle`` returned by ``launch()``.
         message:
             Text to send.  May contain newlines; they are preserved verbatim.
+        pre_keys:
+            Optional tmux key names sent (one send-keys each) BEFORE the
+            readiness poll — used to ``Escape`` out of a selection menu into
+            the freed composer so a natural-language answer can be pasted.
         """
-        self._wait_for_prompt(handle.pane, timeout=_LAUNCH_READY_TIMEOUT)
+        for key in pre_keys or []:
+            self._tmux.run(["send-keys", "-t", handle.pane, key])
+        self._wait_for_ready(handle.pane, timeout=_LAUNCH_READY_TIMEOUT)
 
         buf_name = f"hermes-omp-{handle.session_id[:8]}"
         self._load_buffer(buf_name, message)
@@ -739,6 +828,12 @@ class OmpAdapter(AgentAdapter):
         if pane_text is None:
             return SessionLifecycle.ERROR
         return parse_pane_lifecycle(pane_text)
+
+    def idle_waiting(self, pane_text: str) -> bool:
+        """Candidate free-form wait signal for the watcher (see
+        ``pane_is_idle_waiting``). The watcher gates this on pane stability
+        before promoting RUNNING → WAITING_USER."""
+        return pane_is_idle_waiting(pane_text)
 
     # ------------------------------------------------------------------
     # resume()  [testable with stubbed TmuxRunner + OmpRunner]
@@ -775,7 +870,7 @@ class OmpAdapter(AgentAdapter):
 
         # Send omp -c to continue the previous session in this pane.
         argv = build_interactive_argv(prompt=prompt, continue_last=True)
-        cmd = " ".join([self._binary] + argv)
+        cmd = shlex.join([self._binary] + argv)
         self._tmux.run(["send-keys", "-t", handle.pane, cmd, "Enter"])
         self._wait_for_prompt(handle.pane, timeout=_LAUNCH_READY_TIMEOUT)
 
@@ -835,6 +930,53 @@ class OmpAdapter(AgentAdapter):
             time.sleep(_POLL_INTERVAL)
         raise TimeoutError(
             f"omp prompt not visible in pane {pane!r} after {timeout:.0f}s"
+        )
+
+    def _wait_for_launch(self, pane: str, timeout: float) -> None:
+        """Wait until omp's TUI has actually rendered in the pane.
+
+        A prompt passed at launch makes omp immediately busy, so it will NOT
+        return to the idle ``❯`` prompt within the launch window — waiting for
+        that (as ``_wait_for_prompt`` does) times out on every real task even
+        though omp is running fine. Instead, wait for omp's TUI chrome to draw:
+        its rounded box borders (``╭``/``╰``) are TUI-only and never produced by
+        the shell, so their presence confirms omp took over the pane. This also
+        catches a failed launch (e.g. a shell glob/quoting error) — the shell
+        never draws a box, so this raises rather than returning a dead handle.
+        Succeed early if the idle prompt is already visible (instant tasks).
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            text = self._capture_pane(pane)
+            if text is not None:
+                # omp TUI chrome (rounded box corners) or an already-idle prompt.
+                if "╭" in text or "╰" in text or PROMPT_PATTERN.search(text):
+                    return
+            time.sleep(_POLL_INTERVAL)
+        raise TimeoutError(
+            f"omp did not start in pane {pane!r} after {timeout:.0f}s"
+        )
+
+    def _wait_for_ready(self, pane: str, timeout: float) -> None:
+        """Wait until omp's TUI is up AND idle, so a pasted message lands in the
+        input box instead of being dropped or interleaved with a response.
+
+        omp does NOT render a ``>``/``❯`` input char (so ``PROMPT_PATTERN`` never
+        matches it). Its idle state is the status-bar box (``╭…╮`` / ``╰…╯``)
+        with NO active-work spinner; its busy state matches ``ACTIVITY_REGEX``
+        (Braille spinner / "Running tool"). Ready == box present and not busy.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            text = self._capture_pane(pane)
+            if text is not None:
+                tui_up = ("╰" in text) or ("╭" in text)
+                busy = bool(ACTIVITY_REGEX.search(text))
+                if tui_up and not busy:
+                    return
+            time.sleep(_POLL_INTERVAL)
+        raise TimeoutError(
+            f"omp not ready for input in pane {pane!r} after {timeout:.0f}s"
         )
 
     def _load_buffer(self, buf_name: str, content: str) -> None:

--- a/session_orchestration/adapters/omp.py
+++ b/session_orchestration/adapters/omp.py
@@ -1,0 +1,706 @@
+"""
+OmpAdapter — session-orchestration adapter for oh-my-pi (omp) CLI.
+
+Oh-my-pi (omp) v16 supports two structured transports that make it the
+"cleaner" agent from an orchestration standpoint:
+
+  --mode=json   One-shot NDJSON streaming output when combined with -p.
+                Preferred for detect/drive when the interaction allows
+                a subprocess-call pattern (no persistent session needed).
+
+  --mode=rpc    Interactive RPC session over stdio.  Emits {"type":"ready"}
+                on startup then accepts JSON commands.  Useful for a managed
+                interactive session but requires a running process or tmux.
+
+The adapter prefers --mode=json for one-shot (print) mode and falls back
+to the tmux + --auto-approve pattern for interactive TUI driving.
+
+Probed --mode=json NDJSON schema (omp v16.1.15)
+------------------------------------------------
+Each line is a JSON object with a ``"type"`` discriminator:
+
+  {"type":"session","version":3,"id":"<uuid>","timestamp":"<ISO8601>","cwd":"<path>"}
+  {"type":"agent_start"}
+  {"type":"turn_start"}
+  {"type":"message_start","message":{"role":"user","content":[{"type":"text","text":"..."}], ...}}
+  {"type":"message_end","message":{"role":"user","content":[...], ...}}
+  {"type":"message_start","message":{"role":"assistant","content":[{"type":"text","text":"..."}], ...}}
+  {"type":"message_update","assistantMessageEvent":{...},"message":{...}}
+  {"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"<answer>"}],
+      "model":"<model>","usage":{...},"stopReason":"stop","timestamp":<ms>,...}}
+  {"type":"turn_end","message":{...}}
+  {"type":"agent_end","messages":[<all messages>]}
+
+To extract the final assistant text:
+  Parse each line; find ``agent_end``; last entry in ``messages`` with
+  ``role == "assistant"``; ``content[0]["text"]``.
+
+Alternatively, stream for lines where ``type == "message_end"`` and
+``message.role == "assistant"`` — the last one is the final answer.
+
+--mode=rpc interactive schema (omp v16.1.15)
+--------------------------------------------
+When launched WITHOUT -p (interactive TUI via --mode=rpc):
+  Emits {"type":"ready"} then {"type":"available_commands_update","commands":[...]}
+  The rpc session accepts stdin JSON commands for slash-commands and controls.
+  NOT used for one-shot; used when omp is left running in a tmux pane.
+
+Detect (interactive tmux session)
+----------------------------------
+omp TUI uses a prompt marker (">") visible at pane bottom when waiting for
+user input.  The adapter captures the pane and looks for:
+  - HERMES_HANDOFF keyword → PAUSED_HANDOFF
+  - ">" or "❯" at end → WAITING_USER
+  - Session process exited → DONE or ERROR
+  - Otherwise → RUNNING
+
+Interactive transport choice
+-----------------------------
+For interactive sessions the adapter uses tmux + --auto-approve.  omp's
+--auto-approve skips all tool-approval dialogs so there is NO dialog-dance
+required (unlike claude-code).  This means launch() is simpler.
+
+Resume (interactive)
+---------------------
+omp -c / -r <session-id> continues a previous session.  The adapter stores
+the omp session-dir in the handle's metadata so -r can target the right one.
+For one-shot continuations, -c re-attaches the most recent session.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Callable, Protocol
+
+from session_orchestration.adapters.base import AgentAdapter
+from session_orchestration.types import Capabilities, SessionHandle, SessionLifecycle
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Lines captured from the pane bottom for state detection.
+_CAPTURE_LINES: int = 60
+
+#: Seconds between each readiness-poll iteration.
+_POLL_INTERVAL: float = 0.5
+
+#: Maximum seconds to wait for omp prompt after launching.
+_LAUNCH_READY_TIMEOUT: float = 30.0
+
+#: omp prints ">" or "❯" when waiting for user input.
+#: Use a pattern that matches either variant.
+PROMPT_PATTERN: re.Pattern[str] = re.compile(r"[>❯]\s*$", re.MULTILINE)
+
+#: Handoff keyword written by omp agent instructions.
+HANDOFF_MARKER: str = "HERMES_HANDOFF"
+
+#: Active-work indicator pattern for omp (tool-use spinner text).
+#: omp shows "⠋" / "⠙" / "⠹" etc. spinner characters and "Running" text.
+ACTIVITY_REGEX: re.Pattern[str] = re.compile(r"[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]|Running tool")
+
+#: Default executable path for omp.
+_OMP_BINARY: str = "omp"
+
+# ---------------------------------------------------------------------------
+# OmpRunner protocol (injectable for testing)
+# ---------------------------------------------------------------------------
+
+
+class OmpRunner(Protocol):
+    """Minimal interface over the omp CLI used by ``OmpAdapter``.
+
+    Production code uses ``_SubprocessOmpRunner``; tests inject a fake.
+    """
+
+    def run_oneshot(
+        self,
+        args: list[str],
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        """Run omp as a subprocess and return the completed process.
+
+        Parameters
+        ----------
+        args:
+            Arguments to pass to the omp binary (do NOT include the binary
+            itself at index 0 — the runner adds it).
+        check:
+            If True, raise ``subprocess.CalledProcessError`` on nonzero exit.
+
+        Returns
+        -------
+        subprocess.CompletedProcess[str]
+            The completed process with captured stdout/stderr.
+        """
+        ...
+
+
+class TmuxRunner(Protocol):
+    """Minimal interface over the tmux CLI used by ``OmpAdapter``."""
+
+    def run(self, args: list[str], check: bool = True) -> str:
+        """Run ``tmux <args>`` and return stdout (stripped)."""
+        ...
+
+
+class _SubprocessOmpRunner:
+    """Production ``OmpRunner`` — delegates to ``subprocess.run``."""
+
+    def __init__(self, binary: str = _OMP_BINARY) -> None:
+        self._binary = binary
+
+    def run_oneshot(
+        self,
+        args: list[str],
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [self._binary] + args,
+            capture_output=True,
+            text=True,
+            check=check,
+        )
+
+
+class _SubprocessTmuxRunner:
+    """Production ``TmuxRunner`` — delegates to ``subprocess.run``."""
+
+    def run(self, args: list[str], check: bool = True) -> str:
+        result = subprocess.run(
+            ["tmux"] + args,
+            capture_output=True,
+            text=True,
+            check=check,
+        )
+        return result.stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# Pure-function helpers (fully testable, no subprocess dependency)
+# ---------------------------------------------------------------------------
+
+
+def parse_oneshot_result(ndjson_output: str) -> str:
+    """Extract the final assistant text from an omp --mode=json NDJSON stream.
+
+    Scans the stream for ``agent_end`` (preferred) or the last
+    ``message_end`` with ``role == "assistant"`` (fallback).
+
+    Parameters
+    ----------
+    ndjson_output:
+        Raw stdout from ``omp -p --mode=json ...``.  Each line is a JSON object.
+
+    Returns
+    -------
+    str
+        The assistant's final text response.  Empty string if no assistant
+        message was found (error / empty run).
+
+    Raises
+    ------
+    ValueError
+        If no line can be parsed as valid JSON (suggests omp failed before
+        emitting any structured output).
+    """
+    parsed_any = False
+    last_assistant_text: str = ""
+
+    for raw_line in ndjson_output.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        parsed_any = True
+
+        event_type = event.get("type", "")
+
+        if event_type == "agent_end":
+            messages = event.get("messages", [])
+            # Walk in reverse to find the last assistant message.
+            for msg in reversed(messages):
+                if msg.get("role") == "assistant":
+                    content = msg.get("content", [])
+                    if content:
+                        return content[0].get("text", "")
+            return last_assistant_text
+
+        if event_type == "message_end":
+            msg = event.get("message", {})
+            if msg.get("role") == "assistant":
+                content = msg.get("content", [])
+                if content:
+                    last_assistant_text = content[0].get("text", "")
+
+    if not parsed_any:
+        raise ValueError("No parseable JSON lines in omp output")
+
+    return last_assistant_text
+
+
+def parse_pane_lifecycle(pane_text: str) -> SessionLifecycle:
+    """Infer a lifecycle state from captured omp tmux pane text.
+
+    Decision order (applied to the last ``_CAPTURE_LINES`` lines)
+    -------------------------------------------------------------
+    1. ``HERMES_HANDOFF`` anywhere → ``PAUSED_HANDOFF``
+    2. Prompt pattern (``>`` or ``❯`` at line end) → ``WAITING_USER``
+    3. Activity indicator (spinner or "Running tool") → ``RUNNING``
+    4. Otherwise → ``RUNNING`` (default; watcher tracks staleness)
+
+    Parameters
+    ----------
+    pane_text:
+        Raw text from ``tmux capture-pane -p``.
+
+    Returns
+    -------
+    SessionLifecycle
+        One of ``RUNNING | WAITING_USER | PAUSED_HANDOFF``.
+    """
+    if HANDOFF_MARKER in pane_text:
+        return SessionLifecycle.PAUSED_HANDOFF
+    if PROMPT_PATTERN.search(pane_text):
+        return SessionLifecycle.WAITING_USER
+    if ACTIVITY_REGEX.search(pane_text):
+        return SessionLifecycle.RUNNING
+    return SessionLifecycle.RUNNING
+
+
+def build_oneshot_argv(
+    prompt: str,
+    model: str | None = None,
+    workdir: str | None = None,
+    max_time: int | None = None,
+    no_session: bool = True,
+) -> list[str]:
+    """Build the argument list for a one-shot omp invocation.
+
+    Parameters
+    ----------
+    prompt:
+        The prompt text to send to omp.
+    model:
+        Optional model override (e.g. ``"openai-codex/gpt-5.5"``).
+    workdir:
+        Optional ``--cwd`` override.
+    max_time:
+        Optional ``--max-time`` in seconds.
+    no_session:
+        If True (default), pass ``--no-session`` to avoid persisting the
+        one-shot interaction.
+
+    Returns
+    -------
+    list[str]
+        Argument list to pass to ``OmpRunner.run_oneshot`` (binary not included).
+    """
+    args: list[str] = ["-p", "--mode=json"]
+    if model:
+        args += ["--model", model]
+    if workdir:
+        args += ["--cwd", workdir]
+    if max_time is not None:
+        args += ["--max-time", str(max_time)]
+    if no_session:
+        args.append("--no-session")
+    args.append(prompt)
+    return args
+
+
+def build_interactive_argv(
+    prompt: str | None = None,
+    model: str | None = None,
+    workdir: str | None = None,
+    max_time: int | None = None,
+    hook: str | None = None,
+    resume_id: str | None = None,
+    continue_last: bool = False,
+) -> list[str]:
+    """Build the argument list for launching an interactive omp TUI session.
+
+    Parameters
+    ----------
+    prompt:
+        Optional initial prompt for the session.
+    model:
+        Optional model override.
+    workdir:
+        Optional ``--cwd`` override.
+    max_time:
+        Optional ``--max-time`` in seconds.
+    hook:
+        Optional ``--hook`` path for a liveness accelerant hook file.
+    resume_id:
+        If set, pass ``--resume <id>`` to re-attach a specific session.
+    continue_last:
+        If True, pass ``-c`` (``--continue``) to continue the most recent session.
+
+    Returns
+    -------
+    list[str]
+        Argument list to pass to the omp binary (binary not included).
+    """
+    args: list[str] = ["--auto-approve"]
+    if model:
+        args += ["--model", model]
+    if workdir:
+        args += ["--cwd", workdir]
+    if max_time is not None:
+        args += ["--max-time", str(max_time)]
+    if hook:
+        args += ["--hook", hook]
+    if resume_id:
+        args += ["--resume", resume_id]
+    elif continue_last:
+        args.append("--continue")
+    if prompt:
+        args.append(prompt)
+    return args
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+
+class OmpAdapter(AgentAdapter):
+    """Adapter that orchestrates oh-my-pi (omp) sessions via structured transport.
+
+    One-shot (print) mode
+    ---------------------
+    For interactions that don't require persistent state, use
+    ``run_oneshot(prompt)`` which calls ``omp -p --mode=json`` and parses
+    the NDJSON result.  This avoids tmux entirely.
+
+    Interactive TUI mode
+    --------------------
+    For interactive sessions the adapter spawns omp in a tmux pane with
+    ``--auto-approve`` (no dialog dance required — omp skips approval prompts
+    automatically).  ``drive()`` uses load-buffer/paste-buffer injection.
+
+    Resume
+    ------
+    ``resume()`` re-attaches via ``-r <session_id>`` (or ``-c`` if no ID).
+    The omp session ID is captured from the first ``session`` event in
+    --mode=json output and can be stashed in the ``SessionHandle`` metadata.
+
+    Parameters
+    ----------
+    omp_runner:
+        Override the omp subprocess runner.  Defaults to the real
+        subprocess-backed runner.  Pass a stub in tests.
+    tmux_runner:
+        Override the tmux execution back-end.  Defaults to the real runner.
+    session_prefix:
+        Prefix for generated tmux session names.  Default ``"hermes-omp"``.
+    binary:
+        Path to the omp binary.  Default ``"omp"`` (PATH lookup).
+    """
+
+    def __init__(
+        self,
+        omp_runner: OmpRunner | None = None,
+        tmux_runner: TmuxRunner | None = None,
+        session_prefix: str = "hermes-omp",
+        binary: str = _OMP_BINARY,
+    ) -> None:
+        self._omp: OmpRunner = omp_runner or _SubprocessOmpRunner(binary=binary)
+        self._tmux: TmuxRunner = tmux_runner or _SubprocessTmuxRunner()
+        self._session_prefix = session_prefix
+        self._binary = binary
+
+    # ------------------------------------------------------------------
+    # Capabilities
+    # ------------------------------------------------------------------
+
+    def capabilities(self) -> Capabilities:
+        """Declare omp adapter capabilities.
+
+        ``rpc_mode=True``  — omp supports ``--mode=rpc`` for an interactive
+        RPC-over-stdio session.
+
+        ``json_mode=True`` — omp supports ``--mode=json`` for NDJSON streaming
+        output in one-shot (``-p``) mode.  This is the primary structured
+        transport used by this adapter for one-shot calls.
+
+        ``has_hooks=True`` — omp supports ``--hook <file>`` for lifecycle
+        callbacks, which the watcher can use as a positive-liveness accelerant.
+
+        ``supports_print_mode=True`` — omp supports ``-p`` / ``--print`` for
+        non-interactive (headless) one-shot execution.
+
+        ``idle_indicator_regex`` — matches omp's spinner characters and the
+        "Running tool" text that appear while a tool is executing.  The watcher
+        uses this to distinguish active work from pane-hash-unchanged stalls.
+        """
+        return Capabilities(
+            supports_print_mode=True,
+            has_hooks=True,
+            rpc_mode=True,
+            json_mode=True,
+            idle_indicator_regex=ACTIVITY_REGEX,
+            dialog_handlers={},  # omp --auto-approve skips all dialogs
+        )
+
+    # ------------------------------------------------------------------
+    # One-shot convenience (not part of AgentAdapter ABC)
+    # ------------------------------------------------------------------
+
+    def run_oneshot(
+        self,
+        prompt: str,
+        model: str | None = None,
+        workdir: str | None = None,
+        max_time: int | None = None,
+    ) -> str:
+        """Run a one-shot omp prompt and return the assistant's text.
+
+        Uses ``omp -p --mode=json`` (non-interactive, NDJSON output).
+        No tmux session is created.
+
+        Parameters
+        ----------
+        prompt:
+            The prompt text to send to omp.
+        model:
+            Optional model override (e.g. ``"openai-codex/gpt-5.5"``).
+        workdir:
+            Optional working directory (``--cwd``).
+        max_time:
+            Optional max execution time in seconds.
+
+        Returns
+        -------
+        str
+            The assistant's final text response.
+
+        Raises
+        ------
+        subprocess.CalledProcessError
+            If omp exits with a nonzero return code.
+        ValueError
+            If the NDJSON output cannot be parsed (e.g. omp crashed early).
+        """
+        argv = build_oneshot_argv(
+            prompt=prompt,
+            model=model,
+            workdir=workdir,
+            max_time=max_time,
+        )
+        result = self._omp.run_oneshot(argv)
+        return parse_oneshot_result(result.stdout)
+
+    # ------------------------------------------------------------------
+    # launch()  [LIVE — requires real tmux + omp binary]
+    # ------------------------------------------------------------------
+
+    def launch(self, workdir: str, prompt: str) -> SessionHandle:
+        """Spawn a tmux session and start omp inside it.
+
+        omp does NOT require dialog handling (``--auto-approve`` suppresses
+        all approval prompts).  The launch sequence is:
+
+        1. Generate a unique session name.
+        2. ``tmux new-session -d`` with standard dimensions.
+        3. Run ``omp --auto-approve [--cwd <workdir>] <prompt>``.
+        4. Wait for the ``>`` prompt to appear (WAITING_USER).
+        5. Return the handle.
+
+        This method is LIVE-ONLY (requires a real tmux and omp binary).
+
+        Parameters
+        ----------
+        workdir:
+            Absolute path to the working directory.
+        prompt:
+            Initial prompt to inject once omp is ready.
+
+        Returns
+        -------
+        SessionHandle
+            Populated handle; store in the registry immediately.
+        """
+        session_id = str(uuid.uuid4())
+        tmux_session = f"{self._session_prefix}-{session_id[:8]}"
+        pane = f"{tmux_session}:0.0"
+
+        # 1. Create a detached tmux session.
+        self._tmux.run([
+            "new-session", "-d",
+            "-s", tmux_session,
+            "-x", "200",
+            "-y", "50",
+        ])
+
+        # 2. Build and send the omp command into the session.
+        argv = build_interactive_argv(prompt=prompt, workdir=workdir)
+        cmd = " ".join([self._binary] + argv)
+        self._tmux.run(["send-keys", "-t", pane, cmd, "Enter"])
+
+        # 3. Wait for the omp prompt (ready state).
+        self._wait_for_prompt(pane, timeout=_LAUNCH_READY_TIMEOUT)
+
+        return SessionHandle(
+            session_id=session_id,
+            tmux_session=tmux_session,
+            pane=pane,
+            launch_ts=datetime.now(tz=timezone.utc),
+        )
+
+    # ------------------------------------------------------------------
+    # drive()  [testable with stubbed TmuxRunner]
+    # ------------------------------------------------------------------
+
+    def drive(self, handle: SessionHandle, message: str) -> None:
+        """Deliver ``message`` to the running omp session via load-buffer/paste-buffer.
+
+        Steps
+        -----
+        1. Poll pane for prompt readiness (``>`` or ``❯`` visible).
+        2. Write ``message`` to a named tmux buffer via ``_load_buffer``.
+        3. ``paste-buffer -d`` into the pane.
+        4. Send ``Enter`` to submit.
+
+        The load-buffer/paste-buffer mechanism avoids shell-metacharacter
+        expansion that ``send-keys`` would perform on strings containing
+        ``$``, backticks, pipes, etc.
+
+        Parameters
+        ----------
+        handle:
+            The ``SessionHandle`` returned by ``launch()``.
+        message:
+            Text to send.  May contain newlines; they are preserved verbatim.
+        """
+        self._wait_for_prompt(handle.pane, timeout=_LAUNCH_READY_TIMEOUT)
+
+        buf_name = f"hermes-omp-{handle.session_id[:8]}"
+        self._load_buffer(buf_name, message)
+        self._tmux.run(["paste-buffer", "-d", "-b", buf_name, "-t", handle.pane])
+        self._tmux.run(["send-keys", "-t", handle.pane, "", "Enter"])
+
+    # ------------------------------------------------------------------
+    # detect()  [testable with stubbed TmuxRunner]
+    # ------------------------------------------------------------------
+
+    def detect(self, handle: SessionHandle) -> SessionLifecycle:
+        """Inspect the current pane state and return a lifecycle value.
+
+        Uses ``parse_pane_lifecycle`` on captured pane text.
+        Returns ``ERROR`` if the pane cannot be captured (session dead).
+
+        Parameters
+        ----------
+        handle:
+            The ``SessionHandle`` for the session to inspect.
+
+        Returns
+        -------
+        SessionLifecycle
+            Exactly one of ``RUNNING | WAITING_USER | PAUSED_HANDOFF | ERROR``.
+            ``STALLED`` and ``DONE`` are determined by the watcher based on
+            pane-hash staleness and elapsed time.
+        """
+        pane_text = self._capture_pane(handle.pane)
+        if pane_text is None:
+            return SessionLifecycle.ERROR
+        return parse_pane_lifecycle(pane_text)
+
+    # ------------------------------------------------------------------
+    # resume()  [testable with stubbed TmuxRunner + OmpRunner]
+    # ------------------------------------------------------------------
+
+    def resume(self, handle: SessionHandle, prompt: str) -> None:
+        """Re-attach a paused omp session and inject a new prompt.
+
+        Idempotent: if ``detect()`` does not return ``PAUSED_HANDOFF``,
+        logs a warning and returns without action.
+
+        omp supports ``-c`` (continue last session) or ``-r <id>``
+        (resume by ID).  This implementation uses ``-c`` since the
+        handle does not currently carry an omp session ID; the watcher
+        does not need to differentiate sessions for the v1 handoff case.
+
+        Parameters
+        ----------
+        handle:
+            The ``SessionHandle`` for the session to resume.
+        prompt:
+            Prompt to inject after re-attaching.
+        """
+        current = self.detect(handle)
+        if current != SessionLifecycle.PAUSED_HANDOFF:
+            import logging
+            logging.getLogger(__name__).warning(
+                "resume() called on omp session %s in state %s "
+                "(expected PAUSED_HANDOFF); no-op.",
+                handle.session_id,
+                current.value,
+            )
+            return
+
+        # Send omp -c to continue the previous session in this pane.
+        argv = build_interactive_argv(prompt=prompt, continue_last=True)
+        cmd = " ".join([self._binary] + argv)
+        self._tmux.run(["send-keys", "-t", handle.pane, cmd, "Enter"])
+        self._wait_for_prompt(handle.pane, timeout=_LAUNCH_READY_TIMEOUT)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _capture_pane(self, pane: str) -> str | None:
+        """Capture the last ``_CAPTURE_LINES`` lines of the pane.
+
+        Returns ``None`` if the pane does not exist (session dead / error).
+        """
+        try:
+            return self._tmux.run([
+                "capture-pane", "-t", pane,
+                "-p",
+                "-S", f"-{_CAPTURE_LINES}",
+            ], check=True)
+        except subprocess.CalledProcessError:
+            return None
+
+    def _wait_for_prompt(self, pane: str, timeout: float) -> None:
+        """Poll until a prompt marker is visible in the pane or timeout elapses.
+
+        Raises
+        ------
+        TimeoutError
+            If the prompt does not appear within ``timeout`` seconds.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            text = self._capture_pane(pane)
+            if text is not None and PROMPT_PATTERN.search(text):
+                return
+            time.sleep(_POLL_INTERVAL)
+        raise TimeoutError(
+            f"omp prompt not visible in pane {pane!r} after {timeout:.0f}s"
+        )
+
+    def _load_buffer(self, buf_name: str, content: str) -> None:
+        """Write ``content`` into a named tmux buffer via subprocess stdin pipe.
+
+        Bypasses the TmuxRunner abstraction because ``load-buffer`` requires
+        data on stdin; the protocol's ``run()`` does not expose stdin.
+        Tests should monkeypatch this method if they need to assert buffer content.
+        """
+        subprocess.run(
+            ["tmux", "load-buffer", "-b", buf_name, "-"],
+            input=content,
+            text=True,
+            check=True,
+        )

--- a/session_orchestration/adapters/omp.py
+++ b/session_orchestration/adapters/omp.py
@@ -79,7 +79,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Callable, Iterable, Protocol
 
-from session_orchestration.adapters.base import AgentAdapter
+from session_orchestration.adapters.base import AgentAdapter, TuiNotReadyError
 from session_orchestration.markers import MARKER_DONE, MARKER_HEARTBEAT, MARKER_NEEDS_INPUT, MARKER_STATUS, append_marker
 from session_orchestration.types import Capabilities, SessionHandle, SessionLifecycle
 
@@ -95,6 +95,10 @@ _POLL_INTERVAL: float = 0.5
 
 #: Maximum seconds to wait for omp prompt after launching.
 _LAUNCH_READY_TIMEOUT: float = 30.0
+#: Short window to confirm the TUI composer is present for a type-ahead drive.
+#: If the box isn't drawn within this, the pane is booting/dead → fall back to
+#: the pending-drive queue rather than blocking.
+_TYPE_AHEAD_READY_TIMEOUT: float = 6.0
 
 #: Maximum seconds to wait for omp's TUI to first render on COLD start. Larger
 #: than _LAUNCH_READY_TIMEOUT because a cold start does an update check + MCP
@@ -767,6 +771,7 @@ class OmpAdapter(AgentAdapter):
         message: str,
         *,
         pre_keys: list[str] | None = None,
+        type_ahead: bool = False,
     ) -> None:
         """Deliver ``message`` to the running omp session via load-buffer/paste-buffer.
 
@@ -795,7 +800,13 @@ class OmpAdapter(AgentAdapter):
         """
         for key in pre_keys or []:
             self._tmux.run(["send-keys", "-t", handle.pane, key])
-        self._wait_for_ready(handle.pane, timeout=_LAUNCH_READY_TIMEOUT)
+        if type_ahead:
+            # Type-ahead: deliver as soon as the composer is drawn, even while
+            # omp is busy — omp queues the turn. Raises TuiNotReadyError if no
+            # TUI (booting/dead) so the caller falls back to the queue.
+            self._wait_for_tui_present(handle.pane, timeout=_TYPE_AHEAD_READY_TIMEOUT)
+        else:
+            self._wait_for_ready(handle.pane, timeout=_LAUNCH_READY_TIMEOUT)
 
         buf_name = f"hermes-omp-{handle.session_id[:8]}"
         self._load_buffer(buf_name, message)
@@ -839,8 +850,13 @@ class OmpAdapter(AgentAdapter):
     # resume()  [testable with stubbed TmuxRunner + OmpRunner]
     # ------------------------------------------------------------------
 
-    def resume(self, handle: SessionHandle, prompt: str) -> None:
+    def resume(self, handle: SessionHandle, prompt: str, *, force: bool = False) -> None:
         """Re-attach a paused omp session and inject a new prompt.
+
+        With ``force`` (watcher acting on a ``handoff_continue`` marker) the
+        agent is still running: send ``/clear`` then drive the resume command,
+        skipping the detect gate. Without ``force`` (relay PAUSED_HANDOFF path)
+        the behaviour is unchanged (``omp -c`` continue).
 
         Idempotent: if ``detect()`` does not return ``PAUSED_HANDOFF``,
         logs a warning and returns without action.
@@ -857,6 +873,20 @@ class OmpAdapter(AgentAdapter):
         prompt:
             Prompt to inject after re-attaching.
         """
+        if force:
+            # handoff_continue marker path: the agent is STILL RUNNING at a
+            # prompt (z-harness printed "Run /clear, then re-invoke" and yielded).
+            # Send the /clear slash-command into the pinned pane, then drive the
+            # resume command. This mirrors the ClaudeCodeAdapter handoff resume;
+            # the marker is authoritative, so no detect() gate.
+            self._tmux.run(["send-keys", "-t", handle.pane, "/clear", "Enter"])
+            if prompt:
+                # drive() waits for the composer to be ready before pasting.
+                self.drive(handle, prompt)
+            return
+
+        # Non-force (relay PAUSED_HANDOFF) path — unchanged: continue the
+        # previous omp session in this pane via `omp -c`.
         current = self.detect(handle)
         if current != SessionLifecycle.PAUSED_HANDOFF:
             import logging
@@ -977,6 +1007,27 @@ class OmpAdapter(AgentAdapter):
             time.sleep(_POLL_INTERVAL)
         raise TimeoutError(
             f"omp not ready for input in pane {pane!r} after {timeout:.0f}s"
+        )
+
+    def _wait_for_tui_present(self, pane: str, timeout: float) -> None:
+        """Wait until omp's TUI composer is drawn (box borders), regardless of
+        whether it is busy — for type-ahead delivery. omp's composer accepts a
+        pasted turn while it works.
+
+        Raises
+        ------
+        TuiNotReadyError
+            If no TUI box appears within ``timeout`` (booting or dead pane) — the
+            caller falls back to the persistent pending-drive queue.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            text = self._capture_pane(pane)
+            if text is not None and any(ch in text for ch in ("╭", "╰")):
+                return
+            time.sleep(_POLL_INTERVAL)
+        raise TuiNotReadyError(
+            f"omp TUI composer not present in pane {pane!r} after {timeout:.0f}s"
         )
 
     def _load_buffer(self, buf_name: str, content: str) -> None:

--- a/session_orchestration/adapters/omp.py
+++ b/session_orchestration/adapters/omp.py
@@ -383,6 +383,7 @@ def build_interactive_argv(
     hook: str | None = None,
     resume_id: str | None = None,
     continue_last: bool = False,
+    auto_approve: bool = True,
 ) -> list[str]:
     """Build the argument list for launching an interactive omp TUI session.
 
@@ -402,13 +403,19 @@ def build_interactive_argv(
         If set, pass ``--resume <id>`` to re-attach a specific session.
     continue_last:
         If True, pass ``-c`` (``--continue``) to continue the most recent session.
+    auto_approve:
+        If True (default), pass ``--auto-approve`` so omp skips tool-approval
+        dialogs. Managed interactive sessions launch with this OFF so a nudge
+        cannot silently escalate into an unattended multi-step build — omp
+        instead pauses at approval prompts, which the watcher surfaces as
+        WAITING_USER for the user to answer via the feed.
 
     Returns
     -------
     list[str]
         Argument list to pass to the omp binary (binary not included).
     """
-    args: list[str] = ["--auto-approve"]
+    args: list[str] = ["--auto-approve"] if auto_approve else []
     if model:
         args += ["--model", model]
     if workdir:
@@ -735,7 +742,16 @@ class OmpAdapter(AgentAdapter):
         #    Passing the prompt here too would (a) deliver it twice and (b) make
         #    omp immediately busy, so the post-launch ``drive()`` wait-for-idle
         #    would time out. ``prompt`` is intentionally unused.
-        argv = build_interactive_argv(workdir=workdir)
+        # Managed interactive sessions default to NO --auto-approve so a nudge
+        # can't silently escalate into an unattended build; omp pauses at
+        # approval prompts, which the watcher surfaces as WAITING_USER.
+        try:
+            from session_orchestration.config import load_session_orchestration_config
+
+            auto_approve = load_session_orchestration_config().omp_auto_approve
+        except Exception:
+            auto_approve = False
+        argv = build_interactive_argv(workdir=workdir, auto_approve=auto_approve)
         cmd = shlex.join([self._binary] + argv)
         self._tmux.run(["send-keys", "-t", pane, cmd, "Enter"])
 

--- a/session_orchestration/adapters/omp.py
+++ b/session_orchestration/adapters/omp.py
@@ -813,6 +813,16 @@ class OmpAdapter(AgentAdapter):
         self._tmux.run(["paste-buffer", "-d", "-b", buf_name, "-t", handle.pane])
         self._tmux.run(["send-keys", "-t", handle.pane, "", "Enter"])
 
+    def interrupt(self, handle: SessionHandle) -> None:
+        """Send a single Escape to the pane to cancel an in-flight action.
+
+        Used by the watcher to break a stuck subagent poll-loop (the omp
+        harness re-polling an already-yielded review) without killing the
+        session — Escape drops omp back to its prompt with the in-flight job
+        cancelled. A no-op-safe single keystroke; the caller wraps it.
+        """
+        self._tmux.run(["send-keys", "-t", handle.pane, "Escape"])
+
     # ------------------------------------------------------------------
     # detect()  [testable with stubbed TmuxRunner]
     # ------------------------------------------------------------------

--- a/session_orchestration/adapters/verify.py
+++ b/session_orchestration/adapters/verify.py
@@ -79,7 +79,11 @@ class _SubprocessProbeRunner:
                 [binary, "--help"],
                 capture_output=True,
                 text=True,
-                timeout=10,
+                # omp's `--help` is slow (~8s: update-check + init) and slower
+                # under load; a 10s budget timed out intermittently, returning
+                # empty text that then read as "every flag missing" and disabled
+                # the adapter. Give it generous headroom.
+                timeout=30,
             )
             return result.stdout + result.stderr
         except (FileNotFoundError, PermissionError, subprocess.TimeoutExpired):
@@ -123,7 +127,12 @@ class AdapterProbeSpec:
 _CLAUDE_SPEC = AdapterProbeSpec(
     binary="claude",
     supports_print_mode_flag="--print",
-    has_hooks_flag="--hook",
+    # Claude Code no longer exposes a bare `--hook` flag (hooks are configured
+    # via settings.json); its help lists `--include-hook-events`. The old
+    # `--hook` probe string never matched, so verify_adapters disabled the
+    # entire claude adapter every tick even though has_hooks is unused at
+    # runtime. Probe the flag that actually proves hook support.
+    has_hooks_flag="--include-hook-events",
     rpc_mode_flag=None,       # claude does not declare rpc_mode
     json_mode_flag="--output-format",
 )
@@ -180,6 +189,21 @@ def _check_capabilities(
 
     # Fetch help text once and reuse for all flag checks.
     help_text = runner.help_text(spec.binary)
+
+    # The binary EXISTS (checked above) but `--help` returned nothing — a slow
+    # or timed-out probe (omp's --help does an update-check + init and can be
+    # slow, especially under load). We cannot verify flags against empty text;
+    # treating every flag as "missing" here would spuriously DISABLE a healthy
+    # adapter, which stops the watcher from processing its sessions entirely
+    # (no state detection, no idle notification). Unverifiable ≠ broken: skip
+    # the flag checks and keep the adapter available.
+    if not help_text.strip():
+        _logger.warning(
+            "verify_adapters: '%s --help' returned no output (slow/timed-out "
+            "probe); skipping capability checks and keeping adapter available.",
+            spec.binary,
+        )
+        return mismatches
 
     def _flag_present(flag: str | None) -> bool:
         if flag is None:

--- a/session_orchestration/adapters/verify.py
+++ b/session_orchestration/adapters/verify.py
@@ -1,0 +1,307 @@
+"""
+Capabilities startup assertion for session-orchestration adapters.
+
+At watcher startup, call ``verify_adapters(adapters)`` to probe each adapter's
+declared ``Capabilities`` against cheaply-observed behavior (binary-on-PATH,
+``--help`` output).  A mismatch logs an error and marks that adapter
+unavailable.  A missing binary also marks the adapter unavailable.  Neither
+condition crashes the watcher.
+
+Design
+------
+Each ``Capabilities`` field has a corresponding ``_probe_*`` function that
+returns ``True`` if the observed environment supports that feature, or
+``False`` if it does not.  The probe is intentionally **cheap**:
+
+- Binary existence: ``shutil.which(binary)``
+- Feature flags: run ``<binary> --help`` once and parse stdout+stderr for
+  known flag patterns.  No full session is launched.
+
+The ``ProbeRunner`` protocol is injectable so unit tests can supply fake
+``--help`` output without invoking real binaries.
+
+Return value
+------------
+``verify_adapters`` returns a dict mapping adapter name → adapter instance
+for all adapters that pass verification.  Adapters that fail (mismatch or
+missing binary) are absent from the dict; the watcher should treat missing
+entries as unavailable and skip them.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from session_orchestration.adapters.base import AgentAdapter
+from session_orchestration.types import Capabilities
+
+_logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# ProbeRunner protocol (injectable for tests)
+# ---------------------------------------------------------------------------
+
+
+class ProbeRunner(Protocol):
+    """Cheap probe interface over a CLI binary.
+
+    Production code uses ``_SubprocessProbeRunner``; tests inject a fake that
+    returns pre-canned stdout/stderr without spawning a process.
+    """
+
+    def which(self, binary: str) -> str | None:
+        """Return the full path to ``binary`` if it is on PATH, else ``None``."""
+        ...
+
+    def help_text(self, binary: str) -> str:
+        """Return the combined stdout+stderr of ``<binary> --help``.
+
+        Must not raise even if the binary exits with a nonzero code (many CLIs
+        exit 1 on ``--help``).  Returns an empty string if the binary cannot
+        be run.
+        """
+        ...
+
+
+class _SubprocessProbeRunner:
+    """Production ``ProbeRunner`` — uses ``shutil.which`` + ``subprocess``."""
+
+    def which(self, binary: str) -> str | None:
+        return shutil.which(binary)
+
+    def help_text(self, binary: str) -> str:
+        try:
+            result = subprocess.run(
+                [binary, "--help"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            return result.stdout + result.stderr
+        except (FileNotFoundError, PermissionError, subprocess.TimeoutExpired):
+            return ""
+
+
+# ---------------------------------------------------------------------------
+# AdapterProbeSpec — maps an adapter name to its binary + probe config
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AdapterProbeSpec:
+    """Configuration for probing a specific adapter.
+
+    Fields
+    ------
+    binary:
+        The CLI binary name to locate on PATH (e.g. ``"claude"``, ``"omp"``).
+    supports_print_mode_flag:
+        String that must appear in ``--help`` output for ``supports_print_mode``
+        to be considered supported.  ``None`` means: skip the probe (never
+        mis-match).
+    has_hooks_flag:
+        String that must appear in ``--help`` output for ``has_hooks=True``
+        to be considered supported.
+    rpc_mode_flag:
+        String that must appear in ``--help`` for ``rpc_mode=True``.
+    json_mode_flag:
+        String that must appear in ``--help`` for ``json_mode=True``.
+    """
+
+    binary: str
+    supports_print_mode_flag: str | None = None
+    has_hooks_flag: str | None = None
+    rpc_mode_flag: str | None = None
+    json_mode_flag: str | None = None
+
+
+# Default probe specs for the two v1 adapters.
+_CLAUDE_SPEC = AdapterProbeSpec(
+    binary="claude",
+    supports_print_mode_flag="--print",
+    has_hooks_flag="--hook",
+    rpc_mode_flag=None,       # claude does not declare rpc_mode
+    json_mode_flag="--output-format",
+)
+
+_OMP_SPEC = AdapterProbeSpec(
+    binary="omp",
+    supports_print_mode_flag="--print",
+    has_hooks_flag="--hook",
+    rpc_mode_flag="--mode",   # omp --help shows "--mode=<value>" including rpc
+    json_mode_flag="--mode",  # same flag covers json mode
+)
+
+# Registry mapping adapter class name → probe spec.
+# Extend this dict when new adapters are added.
+_ADAPTER_PROBE_SPECS: dict[str, AdapterProbeSpec] = {
+    "ClaudeCodeAdapter": _CLAUDE_SPEC,
+    "OmpAdapter": _OMP_SPEC,
+}
+
+
+# ---------------------------------------------------------------------------
+# Core verification logic
+# ---------------------------------------------------------------------------
+
+
+def _check_capabilities(
+    declared: Capabilities,
+    spec: AdapterProbeSpec,
+    runner: ProbeRunner,
+) -> list[str]:
+    """Return a list of mismatch descriptions (empty = all OK).
+
+    Each mismatch is a human-readable string suitable for an error log.
+
+    Parameters
+    ----------
+    declared:
+        The ``Capabilities`` returned by the adapter's ``capabilities()``
+        method.
+    spec:
+        The probe spec for this adapter (which binary to run, which flag
+        strings to look for).
+    runner:
+        The ``ProbeRunner`` to use for binary checks and ``--help`` fetches.
+    """
+    mismatches: list[str] = []
+
+    # --- Binary check ---
+    binary_path = runner.which(spec.binary)
+    if binary_path is None:
+        mismatches.append(f"binary '{spec.binary}' not found on PATH")
+        # No help text possible; short-circuit.
+        return mismatches
+
+    # Fetch help text once and reuse for all flag checks.
+    help_text = runner.help_text(spec.binary)
+
+    def _flag_present(flag: str | None) -> bool:
+        if flag is None:
+            return True  # probe skipped; always considered OK
+        return flag in help_text
+
+    # --- supports_print_mode ---
+    if declared.supports_print_mode and not _flag_present(spec.supports_print_mode_flag):
+        mismatches.append(
+            f"declared supports_print_mode=True but '{spec.supports_print_mode_flag}' "
+            f"not found in '{spec.binary} --help'"
+        )
+
+    # --- has_hooks ---
+    if declared.has_hooks and not _flag_present(spec.has_hooks_flag):
+        mismatches.append(
+            f"declared has_hooks=True but '{spec.has_hooks_flag}' "
+            f"not found in '{spec.binary} --help'"
+        )
+
+    # --- rpc_mode ---
+    if declared.rpc_mode and not _flag_present(spec.rpc_mode_flag):
+        mismatches.append(
+            f"declared rpc_mode=True but '{spec.rpc_mode_flag}' "
+            f"not found in '{spec.binary} --help'"
+        )
+
+    # --- json_mode ---
+    if declared.json_mode and not _flag_present(spec.json_mode_flag):
+        mismatches.append(
+            f"declared json_mode=True but '{spec.json_mode_flag}' "
+            f"not found in '{spec.binary} --help'"
+        )
+
+    return mismatches
+
+
+def verify_adapters(
+    adapters: dict[str, AgentAdapter],
+    *,
+    probe_runner: ProbeRunner | None = None,
+    probe_specs: dict[str, AdapterProbeSpec] | None = None,
+) -> dict[str, AgentAdapter]:
+    """Assert declared ``Capabilities`` against cheap observed probes for each adapter.
+
+    Called once at watcher startup.  Adapters that pass verification are
+    returned in the result dict; adapters that fail are logged as errors and
+    omitted.  The watcher NEVER crashes due to a verification failure.
+
+    Parameters
+    ----------
+    adapters:
+        A dict mapping adapter name (arbitrary label used in the registry) →
+        adapter instance.  Typically ``{"claude": ClaudeCodeAdapter(), "omp":
+        OmpAdapter()}``.
+    probe_runner:
+        Override the probe back-end.  Defaults to the real subprocess runner.
+        Inject a fake in tests.
+    probe_specs:
+        Override the mapping of adapter class name → ``AdapterProbeSpec``.
+        Defaults to ``_ADAPTER_PROBE_SPECS``.  Override in tests to supply
+        specs for stub adapters.
+
+    Returns
+    -------
+    dict[str, AgentAdapter]
+        All adapters whose probes passed.  Adapters absent from the return
+        value are unavailable for this run.
+    """
+    runner = probe_runner or _SubprocessProbeRunner()
+    specs = probe_specs if probe_specs is not None else _ADAPTER_PROBE_SPECS
+
+    available: dict[str, AgentAdapter] = {}
+
+    for name, adapter in adapters.items():
+        class_name = type(adapter).__name__
+        spec = specs.get(class_name)
+
+        if spec is None:
+            # No probe spec registered for this adapter class.  Log a warning
+            # and accept it (we cannot verify what we don't know how to probe).
+            _logger.warning(
+                "verify_adapters: no probe spec for adapter '%s' (class %s); "
+                "marking available without verification.",
+                name,
+                class_name,
+            )
+            available[name] = adapter
+            continue
+
+        try:
+            declared = adapter.capabilities()
+        except Exception as exc:
+            _logger.error(
+                "verify_adapters: adapter '%s' raised %r from capabilities(); "
+                "marking unavailable.",
+                name,
+                exc,
+            )
+            continue
+
+        mismatches = _check_capabilities(declared, spec, runner)
+
+        if mismatches:
+            for mismatch in mismatches:
+                _logger.error(
+                    "verify_adapters: adapter '%s' capability mismatch — %s",
+                    name,
+                    mismatch,
+                )
+            _logger.error(
+                "verify_adapters: adapter '%s' disabled due to %d capability mismatch(es).",
+                name,
+                len(mismatches),
+            )
+        else:
+            _logger.info(
+                "verify_adapters: adapter '%s' OK (binary '%s' found; all declared "
+                "capabilities confirmed).",
+                name,
+                spec.binary,
+            )
+            available[name] = adapter
+
+    return available

--- a/session_orchestration/adapters/verify.py
+++ b/session_orchestration/adapters/verify.py
@@ -31,6 +31,7 @@ entries as unavailable and skip them.
 from __future__ import annotations
 
 import logging
+import os
 import shutil
 import subprocess
 from dataclasses import dataclass, field
@@ -145,10 +146,21 @@ _OMP_SPEC = AdapterProbeSpec(
     json_mode_flag="--mode",  # same flag covers json mode
 )
 
+_APP_CODEX_BINARY = "/Applications/Codex.app/Contents/Resources/codex"
+
+_CODEX_SPEC = AdapterProbeSpec(
+    binary=_APP_CODEX_BINARY if os.path.exists(_APP_CODEX_BINARY) else "codex",
+    supports_print_mode_flag="exec",
+    has_hooks_flag=None,
+    rpc_mode_flag=None,
+    json_mode_flag=None,
+)
+
 # Registry mapping adapter class name → probe spec.
 # Extend this dict when new adapters are added.
 _ADAPTER_PROBE_SPECS: dict[str, AdapterProbeSpec] = {
     "ClaudeCodeAdapter": _CLAUDE_SPEC,
+    "CodexAdapter": _CODEX_SPEC,
     "OmpAdapter": _OMP_SPEC,
 }
 

--- a/session_orchestration/agent_transcript.py
+++ b/session_orchestration/agent_transcript.py
@@ -1,0 +1,177 @@
+"""
+Agent transcript reader — relay clean assistant text, not pane scrapings.
+
+omp records every session as JSONL under
+``~/.omp/agent/sessions/<cwd-slug>/<iso-ts>_<uuid>.jsonl``:
+
+    {"type": "session", "id": ..., "timestamp": ..., "cwd": "/abs/workdir", ...}
+    {"type": "message", "message": {"role": "user"|"assistant"|"toolResult",
+                                    "content": [{"type": "text"|"thinking"|"toolCall", ...}]}}
+
+That file is the authoritative, ANSI-free record of what the agent actually
+said.  Relaying assistant ``text`` blocks from it (skipping ``thinking`` and
+``toolCall``) gives the Discord thread exactly the agent's response — no build
+logs, no tool spam, and never the user's own pasted reply (``role=user``).
+
+Two pure helpers:
+
+``discover_omp_session_file(workdir, launch_ts, claimed=())``
+    Map a spawned session to its transcript file by cwd-slug + launch-time
+    proximity.  ``claimed`` excludes files already owned by other registry rows
+    (parallel spawns in the same repo).
+
+``read_assistant_texts(path, after_line)``
+    Return assistant text blocks appended after *after_line* plus the new
+    total line count (the caller persists it as ``transcript_line_offset``).
+
+Both are read-only and never raise on malformed input (skip-and-continue,
+matching the marker-protocol convention).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+#: Root of omp's per-cwd session transcript tree.
+_OMP_SESSIONS_ROOT = Path.home() / ".omp" / "agent" / "sessions"
+
+#: A transcript file must have been created within this window around the
+#: tmux launch to be considered the spawned session's file.
+_DISCOVERY_WINDOW_BEFORE = timedelta(seconds=30)
+_DISCOVERY_WINDOW_AFTER = timedelta(seconds=180)
+
+
+def _cwd_slug(workdir: str) -> str:
+    """omp names the per-cwd directory by home-relativising then '/'→'-'.
+
+    ``/Users/zeke/dev/z-harness`` → ``-dev-z-harness`` (home stripped);
+    ``/private/tmp/x``            → ``-private-tmp-x`` (non-home kept absolute).
+    """
+    path = workdir.rstrip("/")
+    home = str(Path.home()).rstrip("/")
+    if path == home:
+        path = ""
+    elif path.startswith(home + "/"):
+        path = path[len(home):]
+    return path.replace("/", "-")
+
+
+def _parse_filename_ts(name: str) -> Optional[datetime]:
+    """Parse the leading ISO timestamp out of ``2026-07-02T04-40-31-230Z_<id>.jsonl``."""
+    stem = name.split("_", 1)[0]
+    # 2026-07-02T04-40-31-230Z  ->  2026-07-02T04:40:31.230+00:00
+    try:
+        date_part, time_part = stem.split("T", 1)
+        time_part = time_part.rstrip("Z")
+        h, m, s, ms = time_part.split("-")
+        return datetime.fromisoformat(f"{date_part}T{h}:{m}:{s}.{ms.ljust(3, '0')}").replace(
+            tzinfo=timezone.utc
+        )
+    except (ValueError, IndexError):
+        return None
+
+
+def discover_omp_session_file(
+    workdir: str,
+    launch_ts: datetime,
+    claimed: Iterable[str] = (),
+    *,
+    sessions_root: Optional[Path] = None,
+) -> Optional[str]:
+    """Find the omp transcript file created by a session launched at *launch_ts*.
+
+    Scans ``<root>/<cwd-slug>/*.jsonl`` for files whose filename timestamp
+    falls inside the discovery window around *launch_ts*, excludes paths in
+    *claimed*, and returns the one closest to the launch time (or ``None``).
+    """
+    root = (sessions_root or _OMP_SESSIONS_ROOT) / _cwd_slug(workdir)
+    if not root.is_dir():
+        return None
+    if launch_ts.tzinfo is None:
+        launch_ts = launch_ts.replace(tzinfo=timezone.utc)
+
+    claimed_set = {str(p) for p in claimed}
+    best: Optional[Tuple[float, str]] = None
+    try:
+        entries = list(root.iterdir())
+    except OSError as exc:
+        logger.debug("agent_transcript: cannot list %s: %s", root, exc)
+        return None
+
+    for entry in entries:
+        if not entry.name.endswith(".jsonl") or not entry.is_file():
+            continue
+        if str(entry) in claimed_set:
+            continue
+        ts = _parse_filename_ts(entry.name)
+        if ts is None:
+            continue
+        if not (launch_ts - _DISCOVERY_WINDOW_BEFORE <= ts <= launch_ts + _DISCOVERY_WINDOW_AFTER):
+            continue
+        delta = abs((ts - launch_ts).total_seconds())
+        if best is None or delta < best[0]:
+            best = (delta, str(entry))
+
+    return best[1] if best else None
+
+
+def read_assistant_texts(path: str, after_line: int = 0) -> Tuple[List[str], int]:
+    """Return assistant text blocks appended after *after_line*.
+
+    Parameters
+    ----------
+    path:
+        Transcript JSONL path (from ``discover_omp_session_file``).
+    after_line:
+        Number of lines already consumed (``transcript_line_offset``).
+
+    Returns
+    -------
+    (texts, total_lines):
+        ``texts`` — one string per assistant message that contained at least
+        one ``text`` block (blocks within a message joined by newlines);
+        ``thinking``/``toolCall`` blocks and non-assistant roles are skipped.
+        ``total_lines`` — new line count to persist as the offset.
+
+    Never raises on malformed lines; on an unreadable file returns
+    ``([], after_line)`` so the caller retries next tick.
+    """
+    texts: List[str] = []
+    total = after_line
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            for idx, line in enumerate(fh):
+                total = idx + 1
+                if idx < after_line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except ValueError:
+                    continue
+                if obj.get("type") != "message":
+                    continue
+                message = obj.get("message")
+                if not isinstance(message, dict) or message.get("role") != "assistant":
+                    continue
+                content = message.get("content")
+                if not isinstance(content, list):
+                    continue
+                blocks = [
+                    b.get("text", "")
+                    for b in content
+                    if isinstance(b, dict) and b.get("type") == "text" and b.get("text")
+                ]
+                if blocks:
+                    texts.append("\n".join(blocks).strip())
+    except OSError as exc:
+        logger.debug("agent_transcript: cannot read %s: %s", path, exc)
+        return [], after_line
+
+    return texts, total

--- a/session_orchestration/config.py
+++ b/session_orchestration/config.py
@@ -9,11 +9,15 @@ Config section (config.yaml):
 
     session_orchestration:
       enabled: false                       # master gate — default OFF
-      feed_channel_id: ""                  # Discord channel id for the unified feed
+      feed_channel_id: ""                  # Discord channel for single edited checklist digest
       external_runs_channel_id: ""         # Discord channel for adopted external runs
-      hang_stale_seconds: 300              # static stale threshold (seconds) before hang
-      hang_idle_ticks: 3                   # N idle ticks before hang is declared
+      hang_stale_seconds: 300              # min last_output_ts age for stale/frozen guard
+      hang_idle_ticks: 3                   # unchanged-pane ticks before stale/frozen guard
 
+Stale/frozen attention is deterministic: ``last_output_ts`` age beyond
+``hang_stale_seconds`` plus unchanged pane hashes for ``hang_idle_ticks`` and
+no adapter active-work regex match.
+Thread-local notices are optional/best-effort when a task has a thread.
 Disabled ⇒ byte-identical prior behaviour: no watcher tick runs, no ingest
 route processes, no commands surface in the gateway.
 """
@@ -34,8 +38,8 @@ logger = logging.getLogger(__name__)
 _DEFAULT_ENABLED: bool = False
 _DEFAULT_FEED_CHANNEL_ID: Optional[str] = None
 _DEFAULT_EXTERNAL_RUNS_CHANNEL_ID: Optional[str] = None
-_DEFAULT_HANG_STALE_SECONDS: int = 300  # 5 min static stale threshold
-_DEFAULT_HANG_IDLE_TICKS: int = 3       # N ticks of pane-hash unchanged before hang
+_DEFAULT_HANG_STALE_SECONDS: int = 300  # min last_output_ts age for guard
+_DEFAULT_HANG_IDLE_TICKS: int = 3       # N unchanged hashes before guard
 
 
 @dataclass(frozen=True)

--- a/session_orchestration/config.py
+++ b/session_orchestration/config.py
@@ -52,6 +52,10 @@ class SessionOrchestrationConfig:
     external_runs_channel_id: Optional[str] = _DEFAULT_EXTERNAL_RUNS_CHANNEL_ID
     hang_stale_seconds: int = _DEFAULT_HANG_STALE_SECONDS
     hang_idle_ticks: int = _DEFAULT_HANG_IDLE_TICKS
+    # Manual repo alias overrides for the repo registry (alias → path or dict).
+    # Stored as the raw config dict so repo_registry.build_repo_registry() can
+    # parse it without the config module importing the registry module.
+    repos: Dict[str, Any] = field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "SessionOrchestrationConfig":
@@ -76,6 +80,8 @@ class SessionOrchestrationConfig:
         hang_idle_ticks = _coerce_positive_int(
             data.get("hang_idle_ticks"), _DEFAULT_HANG_IDLE_TICKS
         )
+        repos = data.get("repos")
+        repos = repos if isinstance(repos, dict) else {}
 
         return cls(
             enabled=enabled,
@@ -83,6 +89,7 @@ class SessionOrchestrationConfig:
             external_runs_channel_id=external_runs_channel_id,
             hang_stale_seconds=hang_stale_seconds,
             hang_idle_ticks=hang_idle_ticks,
+            repos=repos,
         )
 
 

--- a/session_orchestration/config.py
+++ b/session_orchestration/config.py
@@ -36,6 +36,9 @@ _DEFAULT_FEED_CHANNEL_ID: Optional[str] = None
 _DEFAULT_EXTERNAL_RUNS_CHANNEL_ID: Optional[str] = None
 _DEFAULT_HANG_STALE_SECONDS: int = 300  # 5 min static stale threshold
 _DEFAULT_HANG_IDLE_TICKS: int = 3       # N ticks of pane-hash unchanged before hang
+_DEFAULT_DEAD_TMUX_REAP: bool = True    # reap sessions whose tmux pane died without a done marker
+_DEFAULT_GC_AFTER_SECONDS: int = 86400  # 24 h retention for terminal rows
+_DEFAULT_RENUDGE_AFTER_SECONDS: int = 1800  # 30 min before re-surfacing an unacted attention item
 
 
 @dataclass(frozen=True)
@@ -52,6 +55,20 @@ class SessionOrchestrationConfig:
     external_runs_channel_id: Optional[str] = _DEFAULT_EXTERNAL_RUNS_CHANNEL_ID
     hang_stale_seconds: int = _DEFAULT_HANG_STALE_SECONDS
     hang_idle_ticks: int = _DEFAULT_HANG_IDLE_TICKS
+    # When True (default), the watcher proactively marks a session terminal
+    # (ERROR/DONE) if its tmux pane has died without emitting a 'done' marker
+    # and there are no recent heartbeats.  Set to false to revert to the prior
+    # behaviour of waiting out the full hang-nudge ladder instead.
+    dead_tmux_reap: bool = _DEFAULT_DEAD_TMUX_REAP
+    # Retention window (seconds) for terminal rows (DONE / ERROR).  Rows with a
+    # ``terminated_at`` stamp older than this are GC-ed once per watcher tick.
+    # Set to 0 (or any value <= 0) to disable GC entirely.  Default: 86400 (24 h).
+    gc_after_seconds: int = _DEFAULT_GC_AFTER_SECONDS
+    # Re-nudge interval (seconds) for sessions that remain in an attention state
+    # (WAITING_USER or PAUSED_HANDOFF) without user action.  The watcher sends a
+    # DM at most once per interval to re-surface the waiting item.  Set to 0 (or
+    # any value <= 0) to disable re-nudging entirely.  Default: 1800 (30 min).
+    renudge_after_seconds: int = _DEFAULT_RENUDGE_AFTER_SECONDS
     # Manual repo alias overrides for the repo registry (alias → path or dict).
     # Stored as the raw config dict so repo_registry.build_repo_registry() can
     # parse it without the config module importing the registry module.
@@ -80,6 +97,13 @@ class SessionOrchestrationConfig:
         hang_idle_ticks = _coerce_positive_int(
             data.get("hang_idle_ticks"), _DEFAULT_HANG_IDLE_TICKS
         )
+        dead_tmux_reap = _coerce_bool(data.get("dead_tmux_reap"), _DEFAULT_DEAD_TMUX_REAP)
+        gc_after_seconds = _coerce_int(
+            data.get("gc_after_seconds"), _DEFAULT_GC_AFTER_SECONDS
+        )
+        renudge_after_seconds = _coerce_int(
+            data.get("renudge_after_seconds"), _DEFAULT_RENUDGE_AFTER_SECONDS
+        )
         repos = data.get("repos")
         repos = repos if isinstance(repos, dict) else {}
 
@@ -89,6 +113,9 @@ class SessionOrchestrationConfig:
             external_runs_channel_id=external_runs_channel_id,
             hang_stale_seconds=hang_stale_seconds,
             hang_idle_ticks=hang_idle_ticks,
+            dead_tmux_reap=dead_tmux_reap,
+            gc_after_seconds=gc_after_seconds,
+            renudge_after_seconds=renudge_after_seconds,
             repos=repos,
         )
 
@@ -172,5 +199,19 @@ def _coerce_positive_int(value: Any, default: int) -> int:
     try:
         n = int(value)
         return n if n > 0 else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_int(value: Any, default: int) -> int:
+    """Coerce *value* to int; fall back to *default* on parse failure.
+
+    Unlike ``_coerce_positive_int`` this allows 0 and negative values so
+    callers can use 0 as a sentinel (e.g. gc_after_seconds=0 disables GC).
+    """
+    if value is None:
+        return default
+    try:
+        return int(value)
     except (TypeError, ValueError):
         return default

--- a/session_orchestration/config.py
+++ b/session_orchestration/config.py
@@ -1,0 +1,169 @@
+"""
+session_orchestration/config.py — typed accessor for the session_orchestration
+config section in Hermes config.yaml.
+
+All session-orchestration components (watcher, spawn, ingest, status, relay)
+read their config through this module so the gate is checked consistently.
+
+Config section (config.yaml):
+
+    session_orchestration:
+      enabled: false                       # master gate — default OFF
+      feed_channel_id: ""                  # Discord channel id for the unified feed
+      external_runs_channel_id: ""         # Discord channel for adopted external runs
+      hang_stale_seconds: 300              # static stale threshold (seconds) before hang
+      hang_idle_ticks: 3                   # N idle ticks before hang is declared
+
+Disabled ⇒ byte-identical prior behaviour: no watcher tick runs, no ingest
+route processes, no commands surface in the gateway.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Defaults — hard-coded here so callers get sensible values without any
+# config file present.  enabled=False is the safety invariant.
+# ---------------------------------------------------------------------------
+
+_DEFAULT_ENABLED: bool = False
+_DEFAULT_FEED_CHANNEL_ID: Optional[str] = None
+_DEFAULT_EXTERNAL_RUNS_CHANNEL_ID: Optional[str] = None
+_DEFAULT_HANG_STALE_SECONDS: int = 300  # 5 min static stale threshold
+_DEFAULT_HANG_IDLE_TICKS: int = 3       # N ticks of pane-hash unchanged before hang
+
+
+@dataclass(frozen=True)
+class SessionOrchestrationConfig:
+    """Typed view of the ``session_orchestration`` config section.
+
+    All fields have safe defaults so callers never need ``None``-guards on
+    the struct itself.  The only guarantee that matters for correctness is:
+    ``enabled=False`` ⇒ no side effects (callers MUST check ``enabled``).
+    """
+
+    enabled: bool = _DEFAULT_ENABLED
+    feed_channel_id: Optional[str] = _DEFAULT_FEED_CHANNEL_ID
+    external_runs_channel_id: Optional[str] = _DEFAULT_EXTERNAL_RUNS_CHANNEL_ID
+    hang_stale_seconds: int = _DEFAULT_HANG_STALE_SECONDS
+    hang_idle_ticks: int = _DEFAULT_HANG_IDLE_TICKS
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SessionOrchestrationConfig":
+        """Parse from a raw config dict (the ``session_orchestration`` sub-dict).
+
+        Unknown keys are ignored silently so forward-compat is preserved.
+        Malformed values fall back to defaults — never raises.
+        """
+        if not isinstance(data, dict):
+            return cls()
+
+        enabled = _coerce_bool(data.get("enabled"), _DEFAULT_ENABLED)
+        feed_channel_id = _coerce_optional_str(data.get("feed_channel_id"))
+        external_runs_channel_id = _coerce_optional_str(
+            data.get("external_runs_channel_id")
+            # Legacy alias used by ingest.py before T016
+            or data.get("external_runs_thread_id")
+        )
+        hang_stale_seconds = _coerce_positive_int(
+            data.get("hang_stale_seconds"), _DEFAULT_HANG_STALE_SECONDS
+        )
+        hang_idle_ticks = _coerce_positive_int(
+            data.get("hang_idle_ticks"), _DEFAULT_HANG_IDLE_TICKS
+        )
+
+        return cls(
+            enabled=enabled,
+            feed_channel_id=feed_channel_id,
+            external_runs_channel_id=external_runs_channel_id,
+            hang_stale_seconds=hang_stale_seconds,
+            hang_idle_ticks=hang_idle_ticks,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public loader — reads live Hermes config; safe to call at any time
+# ---------------------------------------------------------------------------
+
+
+def load_session_orchestration_config(
+    _cfg: Optional[Dict[str, Any]] = None,
+) -> SessionOrchestrationConfig:
+    """Return the typed ``SessionOrchestrationConfig`` for the current process.
+
+    Parameters
+    ----------
+    _cfg:
+        Optional pre-loaded config dict (the full Hermes config, not just the
+        ``session_orchestration`` sub-dict).  Used by callers that already
+        hold a config dict (e.g. spawn.py) to avoid re-loading from disk.
+        When ``None`` (the default), config is loaded via
+        ``hermes_cli.config.load_config_readonly()``.
+
+    Always returns a valid ``SessionOrchestrationConfig`` — never raises.
+    Falls back to all-defaults (``enabled=False``) on any error.
+    """
+    try:
+        if _cfg is None:
+            from hermes_cli.config import load_config_readonly
+            _cfg = load_config_readonly()
+
+        so_raw = _cfg.get("session_orchestration") if isinstance(_cfg, dict) else None
+        return SessionOrchestrationConfig.from_dict(so_raw or {})
+    except Exception as exc:  # broad: config load must never crash a caller  # noqa: BLE001
+        logger.debug("session_orchestration.config: load failed — using defaults: %s", exc)
+        return SessionOrchestrationConfig()
+
+
+def is_enabled(_cfg: Optional[Dict[str, Any]] = None) -> bool:
+    """Return True iff session_orchestration is enabled in Hermes config.
+
+    Convenience one-liner for gate checks — equivalent to
+    ``load_session_orchestration_config(_cfg).enabled``.
+    """
+    return load_session_orchestration_config(_cfg).enabled
+
+
+# ---------------------------------------------------------------------------
+# Coercion helpers (private — keep coercion logic local to this module)
+# ---------------------------------------------------------------------------
+
+
+def _coerce_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes", "on"}:
+            return True
+        if lowered in {"false", "0", "no", "off"}:
+            return False
+    try:
+        return bool(int(value))
+    except (TypeError, ValueError):
+        pass
+    return default
+
+
+def _coerce_optional_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    s = str(value).strip()
+    return s if s else None
+
+
+def _coerce_positive_int(value: Any, default: int) -> int:
+    if value is None:
+        return default
+    try:
+        n = int(value)
+        return n if n > 0 else default
+    except (TypeError, ValueError):
+        return default

--- a/session_orchestration/config.py
+++ b/session_orchestration/config.py
@@ -45,6 +45,8 @@ _DEFAULT_GC_AFTER_SECONDS: int = 86400  # 24 h retention for terminal rows
 _DEFAULT_RENUDGE_AFTER_SECONDS: int = 1800  # 30 min before re-surfacing an unacted attention item
 _DEFAULT_DRIVE_QUEUE_TTL_SECONDS: int = 600  # 10 min before a queued busy-session reply is dropped
 _DEFAULT_AUTO_CHECKPOINT_RESUME: bool = True  # auto /clear+resume on a z-harness handoff_continue marker
+_DEFAULT_BUSY_LOOP_STALE_SECONDS: int = 900  # 15 min: spinner-still-turning with zero real output ⇒ stuck busy-loop
+_DEFAULT_BUSY_LOOP_AUTO_ESCAPE: bool = True   # send a recovery Escape to break a confirmed stuck busy-loop
 
 
 @dataclass(frozen=True)
@@ -85,6 +87,15 @@ class SessionOrchestrationConfig:
     # When False, it announces the pending checkpoint and leaves the session
     # paused instead of resuming.
     auto_checkpoint_resume: bool = _DEFAULT_AUTO_CHECKPOINT_RESUME
+    # Seconds a pane may stay frozen (animation-normalized) with an active-work
+    # spinner still turning before the watcher stops trusting the spinner and
+    # treats it as a stuck busy-loop (e.g. omp re-polling an already-yielded
+    # subagent). Gates the activity-regex veto in the stale/frozen guard.
+    busy_loop_stale_seconds: int = _DEFAULT_BUSY_LOOP_STALE_SECONDS
+    # When True (default), a confirmed stuck busy-loop gets one recovery Escape
+    # (via the adapter's interrupt()) to cancel the in-flight poll before the
+    # nudge. Set False to only surface it to the feed without keystroking.
+    busy_loop_auto_escape: bool = _DEFAULT_BUSY_LOOP_AUTO_ESCAPE
     # Manual repo alias overrides for the repo registry (alias → path or dict).
     # Stored as the raw config dict so repo_registry.build_repo_registry() can
     # parse it without the config module importing the registry module.
@@ -126,6 +137,12 @@ class SessionOrchestrationConfig:
         auto_checkpoint_resume = _coerce_bool(
             data.get("auto_checkpoint_resume"), _DEFAULT_AUTO_CHECKPOINT_RESUME
         )
+        busy_loop_stale_seconds = _coerce_positive_int(
+            data.get("busy_loop_stale_seconds"), _DEFAULT_BUSY_LOOP_STALE_SECONDS
+        )
+        busy_loop_auto_escape = _coerce_bool(
+            data.get("busy_loop_auto_escape"), _DEFAULT_BUSY_LOOP_AUTO_ESCAPE
+        )
         repos = data.get("repos")
         repos = repos if isinstance(repos, dict) else {}
 
@@ -140,6 +157,8 @@ class SessionOrchestrationConfig:
             renudge_after_seconds=renudge_after_seconds,
             drive_queue_ttl_seconds=drive_queue_ttl_seconds,
             auto_checkpoint_resume=auto_checkpoint_resume,
+            busy_loop_stale_seconds=busy_loop_stale_seconds,
+            busy_loop_auto_escape=busy_loop_auto_escape,
             repos=repos,
         )
 

--- a/session_orchestration/config.py
+++ b/session_orchestration/config.py
@@ -43,6 +43,7 @@ _DEFAULT_HANG_IDLE_TICKS: int = 3       # N ticks of pane-hash unchanged before 
 _DEFAULT_DEAD_TMUX_REAP: bool = True    # reap sessions whose tmux pane died without a done marker
 _DEFAULT_GC_AFTER_SECONDS: int = 86400  # 24 h retention for terminal rows
 _DEFAULT_RENUDGE_AFTER_SECONDS: int = 1800  # 30 min before re-surfacing an unacted attention item
+_DEFAULT_DRIVE_QUEUE_TTL_SECONDS: int = 600  # 10 min before a queued busy-session reply is dropped
 
 
 @dataclass(frozen=True)
@@ -73,6 +74,11 @@ class SessionOrchestrationConfig:
     # DM at most once per interval to re-surface the waiting item.  Set to 0 (or
     # any value <= 0) to disable re-nudging entirely.  Default: 1800 (30 min).
     renudge_after_seconds: int = _DEFAULT_RENUDGE_AFTER_SECONDS
+    # TTL (seconds) for a reply queued while its target session was busy (see
+    # gateway/run.py:_handle_managed_thread_reply). The watcher drops a queued
+    # reply older than this and notifies the user, so a queued reply can never
+    # rot invisibly. Set to 0 (or any value <= 0) to disable expiry. Default: 600.
+    drive_queue_ttl_seconds: int = _DEFAULT_DRIVE_QUEUE_TTL_SECONDS
     # Manual repo alias overrides for the repo registry (alias → path or dict).
     # Stored as the raw config dict so repo_registry.build_repo_registry() can
     # parse it without the config module importing the registry module.
@@ -108,6 +114,9 @@ class SessionOrchestrationConfig:
         renudge_after_seconds = _coerce_int(
             data.get("renudge_after_seconds"), _DEFAULT_RENUDGE_AFTER_SECONDS
         )
+        drive_queue_ttl_seconds = _coerce_int(
+            data.get("drive_queue_ttl_seconds"), _DEFAULT_DRIVE_QUEUE_TTL_SECONDS
+        )
         repos = data.get("repos")
         repos = repos if isinstance(repos, dict) else {}
 
@@ -120,6 +129,7 @@ class SessionOrchestrationConfig:
             dead_tmux_reap=dead_tmux_reap,
             gc_after_seconds=gc_after_seconds,
             renudge_after_seconds=renudge_after_seconds,
+            drive_queue_ttl_seconds=drive_queue_ttl_seconds,
             repos=repos,
         )
 

--- a/session_orchestration/config.py
+++ b/session_orchestration/config.py
@@ -44,6 +44,7 @@ _DEFAULT_DEAD_TMUX_REAP: bool = True    # reap sessions whose tmux pane died wit
 _DEFAULT_GC_AFTER_SECONDS: int = 86400  # 24 h retention for terminal rows
 _DEFAULT_RENUDGE_AFTER_SECONDS: int = 1800  # 30 min before re-surfacing an unacted attention item
 _DEFAULT_DRIVE_QUEUE_TTL_SECONDS: int = 600  # 10 min before a queued busy-session reply is dropped
+_DEFAULT_AUTO_CHECKPOINT_RESUME: bool = True  # auto /clear+resume on a z-harness handoff_continue marker
 
 
 @dataclass(frozen=True)
@@ -79,6 +80,11 @@ class SessionOrchestrationConfig:
     # reply older than this and notifies the user, so a queued reply can never
     # rot invisibly. Set to 0 (or any value <= 0) to disable expiry. Default: 600.
     drive_queue_ttl_seconds: int = _DEFAULT_DRIVE_QUEUE_TTL_SECONDS
+    # When True (default), the watcher auto-drives /clear + the resume command on
+    # a z-harness `handoff_continue` marker (auto, but announced to the thread).
+    # When False, it announces the pending checkpoint and leaves the session
+    # paused instead of resuming.
+    auto_checkpoint_resume: bool = _DEFAULT_AUTO_CHECKPOINT_RESUME
     # Manual repo alias overrides for the repo registry (alias → path or dict).
     # Stored as the raw config dict so repo_registry.build_repo_registry() can
     # parse it without the config module importing the registry module.
@@ -117,6 +123,9 @@ class SessionOrchestrationConfig:
         drive_queue_ttl_seconds = _coerce_int(
             data.get("drive_queue_ttl_seconds"), _DEFAULT_DRIVE_QUEUE_TTL_SECONDS
         )
+        auto_checkpoint_resume = _coerce_bool(
+            data.get("auto_checkpoint_resume"), _DEFAULT_AUTO_CHECKPOINT_RESUME
+        )
         repos = data.get("repos")
         repos = repos if isinstance(repos, dict) else {}
 
@@ -130,6 +139,7 @@ class SessionOrchestrationConfig:
             gc_after_seconds=gc_after_seconds,
             renudge_after_seconds=renudge_after_seconds,
             drive_queue_ttl_seconds=drive_queue_ttl_seconds,
+            auto_checkpoint_resume=auto_checkpoint_resume,
             repos=repos,
         )
 

--- a/session_orchestration/config.py
+++ b/session_orchestration/config.py
@@ -47,6 +47,7 @@ _DEFAULT_DRIVE_QUEUE_TTL_SECONDS: int = 600  # 10 min before a queued busy-sessi
 _DEFAULT_AUTO_CHECKPOINT_RESUME: bool = True  # auto /clear+resume on a z-harness handoff_continue marker
 _DEFAULT_BUSY_LOOP_STALE_SECONDS: int = 900  # 15 min: spinner-still-turning with zero real output ⇒ stuck busy-loop
 _DEFAULT_BUSY_LOOP_AUTO_ESCAPE: bool = True   # send a recovery Escape to break a confirmed stuck busy-loop
+_DEFAULT_OMP_AUTO_APPROVE: bool = False       # managed omp sessions launch WITHOUT --auto-approve (gate builds)
 
 
 @dataclass(frozen=True)
@@ -96,6 +97,11 @@ class SessionOrchestrationConfig:
     # (via the adapter's interrupt()) to cancel the in-flight poll before the
     # nudge. Set False to only surface it to the feed without keystroking.
     busy_loop_auto_escape: bool = _DEFAULT_BUSY_LOOP_AUTO_ESCAPE
+    # When False (default), managed omp sessions launch WITHOUT ``--auto-approve``
+    # so a nudge/reply cannot silently escalate into an unattended multi-step
+    # build; omp pauses at approval prompts and the watcher surfaces them as
+    # WAITING_USER. Set True to restore the old always-auto-approve behaviour.
+    omp_auto_approve: bool = _DEFAULT_OMP_AUTO_APPROVE
     # Manual repo alias overrides for the repo registry (alias → path or dict).
     # Stored as the raw config dict so repo_registry.build_repo_registry() can
     # parse it without the config module importing the registry module.
@@ -143,6 +149,9 @@ class SessionOrchestrationConfig:
         busy_loop_auto_escape = _coerce_bool(
             data.get("busy_loop_auto_escape"), _DEFAULT_BUSY_LOOP_AUTO_ESCAPE
         )
+        omp_auto_approve = _coerce_bool(
+            data.get("omp_auto_approve"), _DEFAULT_OMP_AUTO_APPROVE
+        )
         repos = data.get("repos")
         repos = repos if isinstance(repos, dict) else {}
 
@@ -159,6 +168,7 @@ class SessionOrchestrationConfig:
             auto_checkpoint_resume=auto_checkpoint_resume,
             busy_loop_stale_seconds=busy_loop_stale_seconds,
             busy_loop_auto_escape=busy_loop_auto_escape,
+            omp_auto_approve=omp_auto_approve,
             repos=repos,
         )
 

--- a/session_orchestration/cron_registration.py
+++ b/session_orchestration/cron_registration.py
@@ -47,10 +47,10 @@ def _hermes_agent_root() -> Path:
 
 
 def _find_script_path() -> Optional[str]:
-    """Return the absolute path to the watcher shell script, or None if missing."""
+    """Return the safe relative watcher script token, or None if missing."""
     script = _hermes_agent_root() / _SCRIPT_RELPATH
     if script.exists():
-        return str(script)
+        return _SCRIPT_RELPATH
     return None
 
 
@@ -129,7 +129,7 @@ def ensure_watcher_cron(
             name=job_name,
             script=script_path,
             no_agent=True,
-            deliver="local",  # watcher output is log-only; no Discord delivery
+            deliver="origin",  # normal cron delivery; falls back to configured home channel
         )
         logger.info(
             "ensure_watcher_cron: registered '%s' (id=%s) on schedule '%s'",

--- a/session_orchestration/cron_registration.py
+++ b/session_orchestration/cron_registration.py
@@ -1,0 +1,176 @@
+"""
+Cron-job registration for the session-orchestration watcher (T006).
+
+Usage
+-----
+Call ``ensure_watcher_cron()`` once at Hermes startup (or from a setup
+command) to idempotently register the ``--no-agent`` cron job that drives
+``session-orchestration-watch.sh`` on a 1-minute cadence.  The function is
+a no-op when the job already exists.
+
+This module does NOT touch ``gateway/run.py`` or ``hermes_cli/commands.py``
+(per the T006 concurrency guardrail — T011 owns those files).
+
+The registration is isolated in this module so:
+- It can be called from any context (CLI helper, gateway startup hook, tests).
+- Tests can inject a fake job-list and verify registration without side-effects.
+- The watcher cron is a single authoritative entry; duplicate registration
+  attempts are silently ignored.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Canonical job name used for duplicate-detection.
+WATCHER_JOB_NAME = "session-orchestration-watch"
+
+#: Cron schedule: every 1 minute.
+WATCHER_SCHEDULE = "every 1 minute"
+
+#: Path to the --no-agent script, relative to the hermes-agent repo root.
+_SCRIPT_RELPATH = "scripts/session-orchestration-watch.sh"
+
+
+def _hermes_agent_root() -> Path:
+    """Return the hermes-agent repo root (parent of this file's package)."""
+    return Path(__file__).parent.parent.resolve()
+
+
+def _find_script_path() -> Optional[str]:
+    """Return the absolute path to the watcher shell script, or None if missing."""
+    script = _hermes_agent_root() / _SCRIPT_RELPATH
+    if script.exists():
+        return str(script)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def ensure_watcher_cron(
+    *,
+    job_name: str = WATCHER_JOB_NAME,
+    schedule: str = WATCHER_SCHEDULE,
+    _jobs_loader=None,
+    _jobs_creator=None,
+) -> Optional[Dict[str, Any]]:
+    """Idempotently register the session-orchestration watcher cron job.
+
+    If a job named ``job_name`` already exists (enabled or disabled), this
+    function returns that job and does nothing.  Otherwise it creates a new
+    ``--no-agent`` cron job that runs ``scripts/session-orchestration-watch.sh``
+    on the given ``schedule``.
+
+    Parameters
+    ----------
+    job_name:
+        Name used for duplicate detection and the ``name`` field of the
+        created job.
+    schedule:
+        Cron schedule string (default: ``"every 1 minute"``).
+    _jobs_loader:
+        Injectable callable ``() -> List[Dict]`` for tests.  Defaults to
+        ``cron.jobs.load_jobs``.
+    _jobs_creator:
+        Injectable callable matching ``cron.jobs.create_job`` signature for
+        tests.  Defaults to ``cron.jobs.create_job``.
+
+    Returns
+    -------
+    dict | None
+        The existing or newly-created job dict, or ``None`` if the script
+        could not be located.
+    """
+    # Lazy imports to avoid circular deps at module-load time.
+    if _jobs_loader is None:
+        from cron.jobs import load_jobs as _jobs_loader  # type: ignore[assignment]
+    if _jobs_creator is None:
+        from cron.jobs import create_job as _jobs_creator  # type: ignore[assignment]
+
+    # Duplicate check — linear scan (O(n) over jobs, typically < 100).
+    existing: List[Dict[str, Any]] = _jobs_loader()
+    for job in existing:
+        if job.get("name") == job_name:
+            logger.debug(
+                "ensure_watcher_cron: job '%s' already registered (id=%s) — no-op",
+                job_name,
+                job.get("id", "?"),
+            )
+            return job
+
+    # Locate the shell script
+    script_path = _find_script_path()
+    if script_path is None:
+        logger.error(
+            "ensure_watcher_cron: script not found at %s/%s — "
+            "cannot register cron job",
+            _hermes_agent_root(),
+            _SCRIPT_RELPATH,
+        )
+        return None
+
+    # Create the job
+    try:
+        job = _jobs_creator(
+            prompt=None,
+            schedule=schedule,
+            name=job_name,
+            script=script_path,
+            no_agent=True,
+            deliver="local",  # watcher output is log-only; no Discord delivery
+        )
+        logger.info(
+            "ensure_watcher_cron: registered '%s' (id=%s) on schedule '%s'",
+            job_name,
+            job.get("id", "?"),
+            schedule,
+        )
+        return job
+    except Exception as exc:
+        logger.error(
+            "ensure_watcher_cron: failed to create cron job '%s': %s",
+            job_name,
+            exc,
+        )
+        return None
+
+
+def remove_watcher_cron(
+    *,
+    job_name: str = WATCHER_JOB_NAME,
+    _jobs_loader=None,
+    _jobs_remover=None,
+) -> bool:
+    """Remove the session-orchestration watcher cron job if it exists.
+
+    Intended for tests and uninstall flows.  Returns True if a job was
+    removed, False if none was found.
+    """
+    if _jobs_loader is None:
+        from cron.jobs import load_jobs as _jobs_loader  # type: ignore[assignment]
+    if _jobs_remover is None:
+        from cron.jobs import remove_job as _jobs_remover  # type: ignore[assignment]
+
+    existing: List[Dict[str, Any]] = _jobs_loader()
+    for job in existing:
+        if job.get("name") == job_name:
+            try:
+                _jobs_remover(job["id"])
+                logger.info("remove_watcher_cron: removed job '%s' (id=%s)", job_name, job["id"])
+                return True
+            except Exception as exc:
+                logger.warning("remove_watcher_cron: failed to remove '%s': %s", job_name, exc)
+                return False
+    return False

--- a/session_orchestration/dm_transport.py
+++ b/session_orchestration/dm_transport.py
@@ -1,0 +1,180 @@
+"""
+session_orchestration/dm_transport.py — Discord DM transport helper.
+
+Provides two primitives:
+- ``get_dm_channel_id`` — opens (or returns existing) DM channel for a user.
+- ``send_dm`` — sends a message to a user via DM.
+
+Both accept an injectable ``http_post(url, headers, json) -> _Response`` callable
+so tests never touch the network.  The default implementation uses ``urllib``
+(same library as ``tools/discord_tool.py`` and ``feed.py``).
+
+No callers are wired at this level; ``feed.py`` and ``watcher.py`` will import
+``send_dm`` in level 3 tasks (criterion #6 / #13).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.error
+import urllib.request
+from typing import Any, Callable, Dict, NamedTuple, Optional
+
+logger = logging.getLogger(__name__)
+
+DISCORD_API_BASE = "https://discord.com/api/v10"
+
+
+# ---------------------------------------------------------------------------
+# Lightweight response object shared by the default and injectable transports
+# ---------------------------------------------------------------------------
+
+
+class _Response(NamedTuple):
+    """Minimal response interface for the http_post seam."""
+
+    status_code: int
+    body: bytes
+
+    def json(self) -> Any:
+        return json.loads(self.body.decode("utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Default http_post implementation (urllib — matches discord_tool.py idiom)
+# ---------------------------------------------------------------------------
+
+
+def _default_http_post(
+    url: str,
+    headers: Dict[str, str],
+    json_body: Any,
+) -> _Response:
+    """POST *json_body* to *url* with *headers*.  Returns a ``_Response``.
+
+    Uses ``urllib`` so no third-party deps are required, matching the pattern
+    in ``tools/discord_tool.py:_discord_request``.  HTTP 4xx/5xx responses are
+    returned as ``_Response`` objects (not raised) so callers can inspect the
+    status code uniformly.
+    """
+    data = json.dumps(json_body).encode("utf-8") if json_body is not None else None
+    req = urllib.request.Request(url, data=data, method="POST", headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            body = resp.read()
+            return _Response(status_code=resp.status, body=body)
+    except urllib.error.HTTPError as exc:
+        body = b""
+        try:
+            body = exc.read()
+        except Exception:
+            pass
+        return _Response(status_code=exc.code, body=body)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+#: Type alias for the injectable POST callable.
+HttpPostFn = Callable[[str, Dict[str, str], Any], _Response]
+
+
+def get_dm_channel_id(
+    user_id: str,
+    token: str,
+    *,
+    http_post: Optional[HttpPostFn] = None,
+) -> str:
+    """Open (or retrieve) the DM channel for *user_id*.  Returns the channel id.
+
+    POSTs to ``/api/v10/users/@me/channels`` with ``{"recipient_id": user_id}``.
+
+    Parameters
+    ----------
+    user_id:
+        Discord user snowflake id.
+    token:
+        Discord bot token (without the ``Bot `` prefix — this function adds it).
+    http_post:
+        Injectable HTTP callable ``(url, headers, json) -> _Response``.
+        Defaults to the urllib-based ``_default_http_post``.
+
+    Raises
+    ------
+    RuntimeError
+        If the Discord API returns a non-2xx status.
+    """
+    _post = http_post if http_post is not None else _default_http_post
+    url = f"{DISCORD_API_BASE}/users/@me/channels"
+    headers = {
+        "Authorization": f"Bot {token}",
+        "Content-Type": "application/json",
+    }
+    resp = _post(url, headers, {"recipient_id": user_id})
+    if resp.status_code < 200 or resp.status_code >= 300:
+        raise RuntimeError(
+            f"dm_transport.get_dm_channel_id: Discord API returned {resp.status_code} "
+            f"for user_id={user_id}"
+        )
+    data = resp.json()
+    return str(data["id"])
+
+
+def send_dm(
+    user_id: str,
+    message: str,
+    token: str,
+    *,
+    http_post: Optional[HttpPostFn] = None,
+) -> bool:
+    """Send *message* to *user_id* via Discord DM.
+
+    Calls ``get_dm_channel_id`` then POSTs to ``/channels/{channel_id}/messages``.
+    Returns True on success.  Returns False (without raising) on HTTP 4xx/5xx and
+    logs a warning so the caller can continue without crashing.
+
+    Parameters
+    ----------
+    user_id:
+        Discord user snowflake id.
+    message:
+        Text content to send.
+    token:
+        Discord bot token.
+    http_post:
+        Injectable HTTP callable for both the channel-open and message-post
+        requests.  Defaults to the urllib-based ``_default_http_post``.
+    """
+    _post = http_post if http_post is not None else _default_http_post
+
+    # Step 1 — open/resolve the DM channel.
+    try:
+        channel_id = get_dm_channel_id(user_id, token, http_post=_post)
+    except RuntimeError as exc:
+        logger.warning("dm_transport.send_dm: failed to open DM channel: %s", exc)
+        return False
+
+    # Step 2 — send the message.
+    url = f"{DISCORD_API_BASE}/channels/{channel_id}/messages"
+    headers = {
+        "Authorization": f"Bot {token}",
+        "Content-Type": "application/json",
+    }
+    resp = _post(url, headers, {"content": message})
+    if resp.status_code < 200 or resp.status_code >= 300:
+        logger.warning(
+            "dm_transport.send_dm: message post failed with status=%s user_id=%s channel_id=%s",
+            resp.status_code,
+            user_id,
+            channel_id,
+        )
+        return False
+
+    logger.debug(
+        "dm_transport.send_dm: sent DM to user_id=%s via channel_id=%s",
+        user_id,
+        channel_id,
+    )
+    return True

--- a/session_orchestration/feed.py
+++ b/session_orchestration/feed.py
@@ -501,8 +501,14 @@ def push_turn_change(
         icon = "⏸️"
         verb = "paused — handoff detected"
 
+    # @-mention the requesting user so the notice actually pings them. An
+    # @-mention in the (bot-created) task thread notifies the user AND adds
+    # them to the thread even if they were never subscribed. Without this the
+    # notice posts silently and the user has no signal to check the feed.
+    uid = row.get("discord_user_id")
+    mention = f"<@{uid}> " if uid else ""
     message = (
-        f"{icon} **[{agent}] {task_label}** {verb}{project_part}\n"
+        f"{mention}{icon} **[{agent}] {task_label}** {verb}{project_part}\n"
         f"State: `{old_state}` → `{new_state}`"
     )
 

--- a/session_orchestration/feed.py
+++ b/session_orchestration/feed.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -129,6 +129,7 @@ def push_turn_change(
     *,
     feed_channel_id: Optional[str] = None,
     token: Optional[str] = None,
+    summarize_fn: Optional[Callable[[str], str]] = None,
 ) -> bool:
     """Push a turn-change notification to the feed channel + task thread.
 
@@ -150,6 +151,14 @@ def push_turn_change(
         Override the configured feed channel id (used in tests).
     token:
         Override the Discord bot token (used in tests).
+    summarize_fn:
+        Optional callable ``(question: str) -> str``.  When ``new_state``
+        is ``"WAITING_USER"`` and ``row["last_question"]`` is non-empty,
+        this function is called with the raw question string and its return
+        value is embedded in the message.  When ``None`` (the default), the
+        raw question is formatted as a readable blockquote inline note.
+        Never called for non-WAITING_USER transitions or when last_question
+        is absent/empty.
 
     Returns True if at least one message was posted, False otherwise.
     """
@@ -186,6 +195,15 @@ def push_turn_change(
     )
     if thread_id:
         message += f" | <#{thread_id}>"
+
+    # Append the needs_input question when transitioning to WAITING_USER
+    if new_state == "WAITING_USER":
+        question = row.get("last_question") or ""
+        if question:
+            question_text = (
+                summarize_fn(question) if summarize_fn is not None else f"Question: {question}"
+            )
+            message += f"\n> {question_text}"
 
     posted = False
 

--- a/session_orchestration/feed.py
+++ b/session_orchestration/feed.py
@@ -117,8 +117,111 @@ def _post_discord_message(
 
 
 # ---------------------------------------------------------------------------
+# Feed-board edit / delete helpers (T-FEED-003)
+# ---------------------------------------------------------------------------
+
+
+def _edit_discord_message(
+    channel_id: str,
+    message_id: str,
+    content: str,
+    *,
+    token: Optional[str] = None,
+) -> bool:
+    """PATCH an existing Discord message in-place.  Returns True on success.
+
+    Best-effort: logs on failure and returns False rather than raising.
+    Mirrors ``edit_status_message`` but used exclusively for the feed-board
+    in-place update path.
+    """
+    if not channel_id or not message_id:
+        return False
+
+    try:
+        from tools.discord_tool import _discord_request, _get_bot_token, DiscordAPIError  # type: ignore[import]
+    except ImportError as exc:
+        logger.warning("feed: cannot import discord helpers: %s", exc)
+        return False
+
+    resolved_token = token or _get_bot_token()
+    if not resolved_token:
+        logger.warning(
+            "feed: DISCORD_BOT_TOKEN not set; skipping PATCH of message=%s channel=%s",
+            message_id,
+            channel_id,
+        )
+        return False
+
+    try:
+        _discord_request(
+            "PATCH",
+            f"/channels/{channel_id}/messages/{message_id}",
+            resolved_token,
+            body={"content": content},
+        )
+        return True
+    except Exception as exc:
+        logger.warning(
+            "feed: failed to PATCH message=%s channel=%s: %s",
+            message_id,
+            channel_id,
+            exc,
+        )
+        return False
+
+
+def _delete_discord_message(
+    channel_id: str,
+    message_id: str,
+    *,
+    token: Optional[str] = None,
+) -> bool:
+    """DELETE an existing Discord message.  Returns True on success.
+
+    Best-effort: logs on failure and returns False rather than raising.
+    Used to reap the feed-board entry when a session terminates.
+    """
+    if not channel_id or not message_id:
+        return False
+
+    try:
+        from tools.discord_tool import _discord_request, _get_bot_token, DiscordAPIError  # type: ignore[import]
+    except ImportError as exc:
+        logger.warning("feed: cannot import discord helpers: %s", exc)
+        return False
+
+    resolved_token = token or _get_bot_token()
+    if not resolved_token:
+        logger.warning(
+            "feed: DISCORD_BOT_TOKEN not set; skipping DELETE of message=%s channel=%s",
+            message_id,
+            channel_id,
+        )
+        return False
+
+    try:
+        _discord_request(
+            "DELETE",
+            f"/channels/{channel_id}/messages/{message_id}",
+            resolved_token,
+        )
+        return True
+    except Exception as exc:
+        logger.warning(
+            "feed: failed to DELETE message=%s channel=%s: %s",
+            message_id,
+            channel_id,
+            exc,
+        )
+        return False
+
+
+# ---------------------------------------------------------------------------
 # Public API consumed by watcher._on_turn_change
 # ---------------------------------------------------------------------------
+
+
+_TERMINAL_STATES = frozenset({"DONE", "ERROR"})
 
 
 def push_turn_change(
@@ -130,12 +233,28 @@ def push_turn_change(
     feed_channel_id: Optional[str] = None,
     token: Optional[str] = None,
     summarize_fn: Optional[Callable[[str], str]] = None,
-) -> bool:
+) -> Optional[str]:
     """Push a turn-change notification to the feed channel + task thread.
 
     Called exactly once per state transition (the watcher call-site already
     gates on ``new_state != old_state``).  Belt-and-suspenders debounce via
     ``_last_notified`` ensures idempotence inside a single cron run.
+
+    Feed-board single-message discipline (T-FEED-003)
+    --------------------------------------------------
+    The feed channel is kept as a live "needs action" board — one edited-in-
+    place message per active session, deleted when the session terminates:
+
+    - Non-terminal transition, no existing board entry: POST a new message
+      and return its id.
+    - Non-terminal transition, existing board entry: PATCH the existing
+      message in-place and return the same id (no new notification).
+    - Terminal transition (DONE/ERROR): DELETE the existing message (if any)
+      and return None (reaped from the board).
+
+    The per-session thread and DM paths are unchanged: the thread always
+    receives a new POST on every transition (append-only conversation log),
+    and DM behaviour is unmodified.
 
     Parameters
     ----------
@@ -160,7 +279,13 @@ def push_turn_change(
         Never called for non-WAITING_USER transitions or when last_question
         is absent/empty.
 
-    Returns True if at least one message was posted, False otherwise.
+    Returns
+    -------
+    Optional[str]
+        The resulting feed-board message id:
+        - New id on first POST (non-terminal, no prior entry).
+        - Same id after a PATCH (non-terminal, prior entry retained).
+        - None after a DELETE (terminal) or when no feed channel is configured.
     """
     # Belt-and-suspenders: skip if we already notified this state for this task.
     if _last_notified.get(task_id) == new_state:
@@ -169,7 +294,7 @@ def push_turn_change(
             task_id,
             new_state,
         )
-        return False
+        return None
 
     # Resolve feed channel
     resolved_feed_channel = feed_channel_id or _get_feed_channel_id()
@@ -213,24 +338,67 @@ def push_turn_change(
             )
             message += f"\n> {question_text}"
 
-    posted = False
+    # 1. Feed-board: POST / PATCH / DELETE based on terminal state + existing entry
+    feed_msg_id: Optional[str] = None
+    existing_feed_id: Optional[str] = row.get("feed_message_id") or None
 
-    # 1. Push to the unified feed channel
     if resolved_feed_channel:
-        msg_id = _post_discord_message(resolved_feed_channel, message, token=token)
-        if msg_id:
-            logger.info(
-                "feed.push_turn_change: posted to feed channel=%s msg_id=%s task_id=%s state=%s",
-                resolved_feed_channel,
-                msg_id,
-                task_id,
-                new_state,
+        if new_state in _TERMINAL_STATES:
+            # Reap the board entry: DELETE if one exists, result is None
+            if existing_feed_id:
+                ok = _delete_discord_message(
+                    resolved_feed_channel, existing_feed_id, token=token
+                )
+                logger.info(
+                    "feed.push_turn_change: deleted feed message=%s channel=%s "
+                    "task_id=%s state=%s ok=%s",
+                    existing_feed_id,
+                    resolved_feed_channel,
+                    task_id,
+                    new_state,
+                    ok,
+                )
+            # feed_msg_id stays None (reaped)
+        elif existing_feed_id:
+            # Non-terminal + existing entry: PATCH in place, retain same id
+            ok = _edit_discord_message(
+                resolved_feed_channel, existing_feed_id, message, token=token
             )
-            posted = True
+            if ok:
+                feed_msg_id = existing_feed_id
+                logger.info(
+                    "feed.push_turn_change: patched feed message=%s channel=%s "
+                    "task_id=%s state=%s",
+                    feed_msg_id,
+                    resolved_feed_channel,
+                    task_id,
+                    new_state,
+                )
+            else:
+                logger.warning(
+                    "feed.push_turn_change: PATCH failed for message=%s channel=%s "
+                    "task_id=%s — no id retained",
+                    existing_feed_id,
+                    resolved_feed_channel,
+                    task_id,
+                )
+        else:
+            # Non-terminal + no existing entry: POST new message
+            new_id = _post_discord_message(resolved_feed_channel, message, token=token)
+            if new_id:
+                feed_msg_id = new_id
+                logger.info(
+                    "feed.push_turn_change: posted to feed channel=%s msg_id=%s "
+                    "task_id=%s state=%s",
+                    resolved_feed_channel,
+                    feed_msg_id,
+                    task_id,
+                    new_state,
+                )
     else:
         logger.debug("feed.push_turn_change: no feed_channel_id; skipping feed post")
 
-    # 2. Push to the task's own Discord thread (if different from feed channel)
+    # 2. Push to the task's own Discord thread (append-only — always POST)
     if thread_id and thread_id != resolved_feed_channel:
         thread_msg_id = _post_discord_message(thread_id, message, token=token)
         if thread_msg_id:
@@ -240,7 +408,6 @@ def push_turn_change(
                 thread_msg_id,
                 task_id,
             )
-            posted = True
     elif not thread_id:
         logger.debug("feed.push_turn_change: no discord_thread_id; skipping thread post")
 
@@ -263,7 +430,7 @@ def push_turn_change(
     # Record the notified state (debounce marker)
     _last_notified[task_id] = new_state
 
-    return posted
+    return feed_msg_id
 
 
 def push_hang_notification(

--- a/session_orchestration/feed.py
+++ b/session_orchestration/feed.py
@@ -1,11 +1,11 @@
 """
-session_orchestration/feed.py — unified feed channel pusher (T007/T008).
+session_orchestration/feed.py — Discord feed projections (T007/T008).
 
 Responsibilities
 ----------------
-Push ONE Discord message per state transition (turn-change) to:
-  1. The unified feed channel (``feed_channel_id`` from config or passed in).
-  2. The task's Discord thread (``row["discord_thread_id"]``).
+Maintain the channel-level action digest and post optional task-thread
+notices.  Attention state must have exactly one ``feed_channel_id`` projection:
+the digest managed by ``reconcile_attention_digest``.
 
 Heartbeat edit (T008)
 ---------------------
@@ -16,9 +16,10 @@ notification.
 Debounce
 --------
 A module-level ``_last_notified`` dict (``task_id → state_value``) prevents
-double-posting if somehow the same transition fires twice.  The primary
-debounce is already enforced by the watcher call-site (``_on_turn_change``
-is only called when ``new_state != old_state``); this is belt-and-suspenders.
+double-posting optional thread notices if somehow the same transition fires
+twice.  The primary debounce is already enforced by the watcher call-site
+(``_on_turn_change`` is only called when ``new_state != old_state``); this is
+belt-and-suspenders.
 
 Transport
 ---------
@@ -29,19 +30,25 @@ to the Discord REST API using the bot token from the environment.
 
 Called by
 ---------
-``session_orchestration.watcher._on_turn_change`` — T007 only.
-``session_orchestration.watcher._on_heartbeat_tick`` — T008.
-T009 (hang notify) will add its own feed primitive here; leave the public API
-open for extension.
+``session_orchestration.watcher._on_turn_change`` — digest + thread notice.
+``session_orchestration.watcher._on_heartbeat_tick`` — status heartbeat.
+``session_orchestration.watcher._on_hang`` — stale/frozen digest + thread notice.
 """
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
-from typing import Any, Dict, Optional
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Mapping, Optional, Sequence
 
 logger = logging.getLogger(__name__)
+
+_ATTENTION_DIGEST_PROJECTION_NAME = "attention_digest"
+_EDIT_OK = "edited"
+_EDIT_MISSING = "missing"
+_EDIT_FAILED = "failed"
 
 # ---------------------------------------------------------------------------
 # Module-level debounce state
@@ -61,13 +68,24 @@ _last_notified: Dict[str, str] = {}
 def _get_feed_channel_id() -> Optional[str]:
     """Return the configured feed channel id, or None if absent."""
     try:
+        from session_orchestration.config import load_session_orchestration_config
+
+        cfg = load_session_orchestration_config()
+        if cfg.feed_channel_id:
+            return cfg.feed_channel_id
+    except Exception as exc:
+        logger.debug("feed: could not read typed config for feed_channel_id: %s", exc)
+
+    try:
         from hermes_cli.config import load_config, cfg_get  # type: ignore[import]
 
         cfg = load_config()
         so_cfg = cfg_get(cfg, "session_orchestration", default={}) or {}
-        return so_cfg.get("feed_channel_id") or None
+        if so_cfg.get("feed_channel_id"):
+            return so_cfg.get("feed_channel_id")
     except Exception as exc:
-        logger.debug("feed: could not read config for feed_channel_id: %s", exc)
+        logger.debug("feed: could not read legacy config for feed_channel_id: %s", exc)
+
     # Fall back to environment (useful in tests and manual runs)
     return os.getenv("HERMES_FEED_CHANNEL_ID") or None
 
@@ -115,6 +133,324 @@ def _post_discord_message(
         logger.warning("feed: failed to post to channel=%s: %s", channel_id, exc)
         return None
 
+def _edit_discord_message(
+    channel_id: str,
+    message_id: str,
+    content: str,
+    *,
+    token: Optional[str] = None,
+) -> str:
+    """PATCH a Discord message and distinguish missing-message recovery."""
+    if not channel_id or not message_id:
+        return _EDIT_FAILED
+
+    try:
+        from tools.discord_tool import (  # type: ignore[import]
+            DiscordAPIError,
+            _discord_request,
+            _get_bot_token,
+        )
+    except ImportError as exc:
+        logger.warning("feed: cannot import discord helpers: %s", exc)
+        return _EDIT_FAILED
+
+    resolved_token = token or _get_bot_token()
+    if not resolved_token:
+        logger.warning(
+            "feed: DISCORD_BOT_TOKEN not set; skipping edit of message=%s channel=%s",
+            message_id,
+            channel_id,
+        )
+        return _EDIT_FAILED
+
+    try:
+        _discord_request(
+            "PATCH",
+            f"/channels/{channel_id}/messages/{message_id}",
+            resolved_token,
+            body={"content": content},
+        )
+        return _EDIT_OK
+    except DiscordAPIError as exc:
+        if exc.status == 404:
+            logger.info(
+                "feed: digest message missing; will recreate message=%s channel=%s",
+                message_id,
+                channel_id,
+            )
+            return _EDIT_MISSING
+        logger.warning(
+            "feed: failed to edit message=%s channel=%s: %s",
+            message_id,
+            channel_id,
+            exc,
+        )
+        return _EDIT_FAILED
+    except Exception as exc:
+        logger.warning(
+            "feed: failed to edit message=%s channel=%s: %s",
+            message_id,
+            channel_id,
+            exc,
+        )
+        return _EDIT_FAILED
+
+
+def _coerce_datetime(value: Any) -> Optional[datetime]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        dt = value
+    elif isinstance(value, (int, float)):
+        dt = datetime.fromtimestamp(float(value), tz=timezone.utc)
+    elif isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return None
+        if raw.endswith("Z"):
+            raw = f"{raw[:-1]}+00:00"
+        try:
+            dt = datetime.fromisoformat(raw)
+        except ValueError:
+            try:
+                dt = datetime.fromtimestamp(float(value), tz=timezone.utc)
+            except ValueError:
+                return None
+    else:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _format_age(value: Any, now: datetime) -> str:
+    dt = _coerce_datetime(value)
+    if dt is None:
+        return "unknown"
+    seconds = max(0, int((now - dt).total_seconds()))
+    if seconds < 60:
+        return f"{seconds}s"
+    minutes = seconds // 60
+    if minutes < 60:
+        return f"{minutes}m"
+    hours = minutes // 60
+    if hours < 48:
+        return f"{hours}h"
+    days = hours // 24
+    return f"{days}d"
+
+
+def _sort_attention_item(item: Mapping[str, Any]) -> tuple:
+    return (
+        -int(item.get("priority") or 0),
+        str(item.get("opened_at") or ""),
+        str(item.get("task_id") or ""),
+        str(item.get("reason") or ""),
+        int(item.get("id") or 0),
+    )
+
+
+def _session_identity(task_id: str, session: Mapping[str, Any]) -> str:
+    tmux_session = session.get("tmux_session")
+    if tmux_session:
+        return f"tmux `{tmux_session}`"
+    hermes_session_key = session.get("hermes_session_key")
+    if hermes_session_key:
+        return f"session `{hermes_session_key}`"
+    run_id = session.get("run_id")
+    repo = session.get("repo")
+    if run_id and repo:
+        return f"run `{run_id}` repo `{repo}`"
+    return f"task `{task_id}`"
+
+
+def _priority_label(item: Mapping[str, Any]) -> str:
+    priority = int(item.get("priority") or 0)
+    reason = str(item.get("reason") or "").lower()
+    detail = str(item.get("detail") or "").lower()
+    staleness = ""
+    if "frozen" in reason or "frozen" in detail:
+        staleness = "frozen/stuck"
+    elif (
+        "stale" in reason
+        or "stuck" in reason
+        or "hung" in reason
+        or "idle" in reason
+        or "stale" in detail
+        or "stuck" in detail
+        or "hung" in detail
+    ):
+        staleness = "stale/stuck"
+    return f"P{priority}/{staleness}" if staleness else f"P{priority}"
+
+
+def _content_hash(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def render_attention_digest(
+    attention_items: Sequence[Mapping[str, Any]],
+    sessions_by_task_id: Optional[Mapping[str, Mapping[str, Any]]] = None,
+    *,
+    now: Any = None,
+) -> str:
+    """Render unresolved attention items as a deterministic Discord checklist."""
+    render_now = _coerce_datetime(now) or datetime.now(timezone.utc)
+    sessions = sessions_by_task_id or {}
+    ordered_items = sorted(attention_items, key=_sort_attention_item)
+
+    if not ordered_items:
+        return "**Hermes action feed**\nNo unresolved attention items."
+
+    lines = [
+        "**Hermes action feed**",
+        f"{len(ordered_items)} unresolved attention item(s):",
+    ]
+    for item in ordered_items:
+        task_id = str(item.get("task_id") or "unknown-task")
+        session = sessions.get(task_id, {})
+        reason = str(item.get("reason") or "attention")
+        agent = session.get("agent") or item.get("agent")
+        project = (
+            session.get("project")
+            or session.get("repo")
+            or item.get("project")
+            or item.get("repo")
+        )
+        owner_parts: List[str] = []
+        if agent:
+            owner_parts.append(str(agent))
+        if project:
+            owner_parts.append(str(project))
+        owner = f" · {'/'.join(owner_parts)}" if owner_parts else ""
+        opened_age = _format_age(item.get("opened_at"), render_now)
+        last_output_age = _format_age(
+            session.get("last_output_ts") or item.get("last_output_ts"),
+            render_now,
+        )
+        opened_part = (
+            f"opened {opened_age} ago" if opened_age != "unknown" else "opened unknown"
+        )
+        last_output_part = (
+            f"last output {last_output_age} ago"
+            if last_output_age != "unknown"
+            else "last output unknown"
+        )
+        idle_ticks = int(session.get("idle_ticks") or item.get("idle_ticks") or 0)
+        nudge_count = int(session.get("nudge_count") or item.get("nudge_count") or 0)
+        thread_id = session.get("discord_thread_id") or item.get("discord_thread_id")
+        detail = item.get("detail")
+        detail_part = f" · {detail}" if detail else ""
+        if thread_id:
+            # Clickable Discord thread link using native channel mention syntax
+            lines.append(
+                "- [ ] "
+                f"<#{thread_id}> "
+                f"({_session_identity(task_id, session)})"
+                f"{owner} · reason `{reason}`{detail_part} · {_priority_label(item)}"
+                f" · {opened_part} · {last_output_part}"
+                f" · idle {idle_ticks} tick(s), nudges {nudge_count}"
+            )
+        else:
+            lines.append(
+                "- [ ] "
+                f"**{task_id}** ({_session_identity(task_id, session)})"
+                f"{owner} · reason `{reason}`{detail_part} · {_priority_label(item)}"
+                f" · {opened_part} · {last_output_part}"
+                f" · idle {idle_ticks} tick(s), nudges {nudge_count}"
+            )
+    return "\n".join(lines)
+
+
+def reconcile_attention_digest(
+    registry: Any,
+    *,
+    feed_channel_id: Optional[str] = None,
+    token: Optional[str] = None,
+    now: Any = None,
+) -> Dict[str, Any]:
+    """Reconcile the feed-channel digest projection without changing attention truth."""
+    channel_id = feed_channel_id or _get_feed_channel_id()
+    if not channel_id:
+        return {"status": "no_channel", "posted": False, "edited": False}
+
+    attention_items = registry.list_unresolved_attention_items()
+    task_ids = sorted(
+        {str(item.get("task_id")) for item in attention_items if item.get("task_id")}
+    )
+    sessions_by_task_id = {
+        task_id: (registry.get(task_id) or {})
+        for task_id in task_ids
+    }
+    content = render_attention_digest(attention_items, sessions_by_task_id, now=now)
+    digest_hash = _content_hash(content)
+    payload = {
+        "item_count": len(attention_items),
+        "task_ids": task_ids,
+    }
+
+    projection = registry.get_projection(channel_id, _ATTENTION_DIGEST_PROJECTION_NAME)
+    message_id = (projection or {}).get("message_id")
+    if projection and projection.get("content_hash") == digest_hash and message_id:
+        return {
+            "status": "unchanged",
+            "message_id": message_id,
+            "content_hash": digest_hash,
+            "posted": False,
+            "edited": False,
+        }
+
+    if message_id:
+        edit_status = _edit_discord_message(channel_id, message_id, content, token=token)
+        if edit_status == _EDIT_OK:
+            registry.upsert_projection(
+                channel_id,
+                _ATTENTION_DIGEST_PROJECTION_NAME,
+                message_id=message_id,
+                content_hash=digest_hash,
+                payload=payload,
+            )
+            return {
+                "status": "edited",
+                "message_id": message_id,
+                "content_hash": digest_hash,
+                "posted": False,
+                "edited": True,
+            }
+        if edit_status != _EDIT_MISSING:
+            return {
+                "status": "discord_failed",
+                "message_id": message_id,
+                "content_hash": digest_hash,
+                "posted": False,
+                "edited": False,
+            }
+
+    new_message_id = _post_discord_message(channel_id, content, token=token)
+    if not new_message_id:
+        return {
+            "status": "discord_failed",
+            "message_id": message_id,
+            "content_hash": digest_hash,
+            "posted": False,
+            "edited": False,
+        }
+
+    registry.upsert_projection(
+        channel_id,
+        _ATTENTION_DIGEST_PROJECTION_NAME,
+        message_id=new_message_id,
+        content_hash=digest_hash,
+        payload=payload,
+    )
+    return {
+        "status": "posted" if not message_id else "recreated",
+        "message_id": new_message_id,
+        "content_hash": digest_hash,
+        "posted": True,
+        "edited": False,
+    }
+
 
 # ---------------------------------------------------------------------------
 # Public API consumed by watcher._on_turn_change
@@ -130,28 +466,15 @@ def push_turn_change(
     feed_channel_id: Optional[str] = None,
     token: Optional[str] = None,
 ) -> bool:
-    """Push a turn-change notification to the feed channel + task thread.
+    """Post an optional task-thread notice for a user-attention transition.
 
-    Called exactly once per state transition (the watcher call-site already
-    gates on ``new_state != old_state``).  Belt-and-suspenders debounce via
-    ``_last_notified`` ensures idempotence inside a single cron run.
+    Channel-level attention state is projected exclusively by
+    ``reconcile_attention_digest``.  This helper intentionally does not post
+    to ``feed_channel_id``; that argument is retained only so callers can
+    avoid echoing the same one-off notice into the digest channel when a task
+    thread id aliases the feed channel.
 
-    Parameters
-    ----------
-    task_id:
-        Registry key for the session.
-    row:
-        Full registry row at the time of the transition.
-    new_state:
-        The new ``SessionLifecycle`` value (string, e.g. ``"WAITING_USER"``).
-    old_state:
-        The previous state value.
-    feed_channel_id:
-        Override the configured feed channel id (used in tests).
-    token:
-        Override the Discord bot token (used in tests).
-
-    Returns True if at least one message was posted, False otherwise.
+    Returns True if a task-thread notice was posted, False otherwise.
     """
     # Belt-and-suspenders: skip if we already notified this state for this task.
     if _last_notified.get(task_id) == new_state:
@@ -162,11 +485,9 @@ def push_turn_change(
         )
         return False
 
-    # Resolve feed channel
     resolved_feed_channel = feed_channel_id or _get_feed_channel_id()
     thread_id: Optional[str] = row.get("discord_thread_id") or None
 
-    # Build the message text
     task_label = task_id
     agent = row.get("agent", "unknown")
     project = row.get("project") or row.get("repo") or ""
@@ -184,27 +505,8 @@ def push_turn_change(
         f"{icon} **[{agent}] {task_label}** {verb}{project_part}\n"
         f"State: `{old_state}` → `{new_state}`"
     )
-    if thread_id:
-        message += f" | <#{thread_id}>"
 
     posted = False
-
-    # 1. Push to the unified feed channel
-    if resolved_feed_channel:
-        msg_id = _post_discord_message(resolved_feed_channel, message, token=token)
-        if msg_id:
-            logger.info(
-                "feed.push_turn_change: posted to feed channel=%s msg_id=%s task_id=%s state=%s",
-                resolved_feed_channel,
-                msg_id,
-                task_id,
-                new_state,
-            )
-            posted = True
-    else:
-        logger.debug("feed.push_turn_change: no feed_channel_id; skipping feed post")
-
-    # 2. Push to the task's own Discord thread (if different from feed channel)
     if thread_id and thread_id != resolved_feed_channel:
         thread_msg_id = _post_discord_message(thread_id, message, token=token)
         if thread_msg_id:
@@ -215,7 +517,11 @@ def push_turn_change(
                 task_id,
             )
             posted = True
-    elif not thread_id:
+    elif thread_id:
+        logger.debug(
+            "feed.push_turn_change: thread_id matches feed_channel_id; digest owns channel projection"
+        )
+    else:
         logger.debug("feed.push_turn_change: no discord_thread_id; skipping thread post")
 
     # Record the notified state (debounce marker)
@@ -232,27 +538,14 @@ def push_hang_notification(
     feed_channel_id: Optional[str] = None,
     token: Optional[str] = None,
 ) -> bool:
-    """Push a hang (or hang-escalation) notification to the feed channel.
+    """Post an optional task-thread stale/frozen notice.
 
-    Called by ``watcher._on_hang`` when a session is confirmed hung.
-    This is a SEPARATE function from ``push_turn_change`` — it never
-    modifies ``_last_notified`` and does not touch the turn-change debounce.
+    Channel-level stale/frozen attention is projected exclusively by
+    ``reconcile_attention_digest``.  This helper intentionally does not post
+    to ``feed_channel_id``; that argument is retained only to avoid echoing a
+    thread-local notice into the digest channel if ids alias.
 
-    Parameters
-    ----------
-    task_id:
-        Registry key for the session.
-    row:
-        Full registry row at the time of the hang detection.
-    escalate:
-        If True, this is an escalation (nudge already sent, session still
-        hung); message content reflects the escalation state.
-    feed_channel_id:
-        Override the configured feed channel id (used in tests).
-    token:
-        Override the Discord bot token (used in tests).
-
-    Returns True if at least one message was posted, False otherwise.
+    Returns True if a task-thread notice was posted, False otherwise.
     """
     resolved_feed_channel = feed_channel_id or _get_feed_channel_id()
     thread_id: Optional[str] = row.get("discord_thread_id") or None
@@ -269,30 +562,7 @@ def push_hang_notification(
         icon = "⚠️"
         verb = f"appears hung ({idle_ticks} idle ticks) — sending auto-nudge"
 
-    message = (
-        f"{icon} **[{agent}] {task_id}** {verb}{project_part}"
-    )
-    if thread_id:
-        message += f" | <#{thread_id}>"
-
-    posted = False
-
-    if resolved_feed_channel:
-        msg_id = _post_discord_message(resolved_feed_channel, message, token=token)
-        if msg_id:
-            logger.info(
-                "feed.push_hang_notification: posted to feed channel=%s msg_id=%s "
-                "task_id=%s escalate=%s",
-                resolved_feed_channel,
-                msg_id,
-                task_id,
-                escalate,
-            )
-            posted = True
-    else:
-        logger.debug(
-            "feed.push_hang_notification: no feed_channel_id; skipping feed post"
-        )
+    message = f"{icon} **[{agent}] {task_id}** {verb}{project_part}"
 
     if thread_id and thread_id != resolved_feed_channel:
         thread_msg_id = _post_discord_message(thread_id, message, token=token)
@@ -303,13 +573,17 @@ def push_hang_notification(
                 thread_msg_id,
                 task_id,
             )
-            posted = True
-    elif not thread_id:
+            return True
+    elif thread_id:
+        logger.debug(
+            "feed.push_hang_notification: thread_id matches feed_channel_id; digest owns channel projection"
+        )
+    else:
         logger.debug(
             "feed.push_hang_notification: no discord_thread_id; skipping thread post"
         )
 
-    return posted
+    return False
 
 
 def clear_last_notified(task_id: str) -> None:
@@ -353,37 +627,9 @@ def edit_status_message(
     token:
         Override the Discord bot token (used in tests).
     """
-    if not channel_id or not message_id:
-        return False
-
-    try:
-        from tools.discord_tool import _discord_request, _get_bot_token, DiscordAPIError  # type: ignore[import]
-    except ImportError as exc:
-        logger.warning("feed: cannot import discord helpers: %s", exc)
-        return False
-
-    resolved_token = token or _get_bot_token()
-    if not resolved_token:
-        logger.warning(
-            "feed: DISCORD_BOT_TOKEN not set; skipping edit of message=%s channel=%s",
-            message_id,
-            channel_id,
-        )
-        return False
-
-    try:
-        _discord_request(
-            "PATCH",
-            f"/channels/{channel_id}/messages/{message_id}",
-            resolved_token,
-            body={"content": content},
-        )
-        return True
-    except Exception as exc:
-        logger.warning(
-            "feed: failed to edit message=%s channel=%s: %s",
-            message_id,
-            channel_id,
-            exc,
-        )
-        return False
+    return _edit_discord_message(
+        channel_id,
+        message_id,
+        content,
+        token=token,
+    ) == _EDIT_OK

--- a/session_orchestration/feed.py
+++ b/session_orchestration/feed.py
@@ -38,6 +38,7 @@ Called by
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import os
 from datetime import datetime, timezone
@@ -288,13 +289,27 @@ def _content_hash(content: str) -> str:
     return hashlib.sha256(content.encode("utf-8")).hexdigest()
 
 
+def _truncate(text: str, limit: int = 80) -> str:
+    """Collapse whitespace and clip *text* to *limit* chars with an ellipsis."""
+    collapsed = " ".join(text.split())
+    if len(collapsed) <= limit:
+        return collapsed
+    return collapsed[: limit - 1].rstrip() + "…"
+
+
 def render_attention_digest(
     attention_items: Sequence[Mapping[str, Any]],
     sessions_by_task_id: Optional[Mapping[str, Mapping[str, Any]]] = None,
     *,
     now: Any = None,
 ) -> str:
-    """Render unresolved attention items as a deterministic Discord checklist."""
+    """Render unresolved attention items as a concise @-mention router.
+
+    Each row leads with the clickable thread link and an @-mention of the
+    owner, then the session identity, reason, optional detail, and a truncated
+    question snippet. The full question + numbered options live in the thread
+    (see ``push_turn_change``); the board stays a one-line-per-item router.
+    """
     render_now = _coerce_datetime(now) or datetime.now(timezone.utc)
     sessions = sessions_by_task_id or {}
     ordered_items = sorted(attention_items, key=_sort_attention_item)
@@ -323,42 +338,29 @@ def render_attention_digest(
         if project:
             owner_parts.append(str(project))
         owner = f" · {'/'.join(owner_parts)}" if owner_parts else ""
-        opened_age = _format_age(item.get("opened_at"), render_now)
-        last_output_age = _format_age(
-            session.get("last_output_ts") or item.get("last_output_ts"),
-            render_now,
-        )
-        opened_part = (
-            f"opened {opened_age} ago" if opened_age != "unknown" else "opened unknown"
-        )
-        last_output_part = (
-            f"last output {last_output_age} ago"
-            if last_output_age != "unknown"
-            else "last output unknown"
-        )
-        idle_ticks = int(session.get("idle_ticks") or item.get("idle_ticks") or 0)
-        nudge_count = int(session.get("nudge_count") or item.get("nudge_count") or 0)
         thread_id = session.get("discord_thread_id") or item.get("discord_thread_id")
         detail = item.get("detail")
         detail_part = f" · {detail}" if detail else ""
+        # @-mention the owner so the feed board routes/pings the right person.
+        # (The digest is a single edited message; Discord does not re-ping on an
+        # unchanged mention, so this is a router hint, not spam.)
+        uid = session.get("discord_user_id") or item.get("discord_user_id")
+        mention = f"<@{uid}> " if uid else ""
+        # A short question snippet points into the thread where the full
+        # question + numbered options live; the board stays concise.
+        question = (session.get("last_question") or "").strip()
+        question_part = f" · {_truncate(question)}" if question else ""
         if thread_id:
-            # Clickable Discord thread link using native channel mention syntax
-            lines.append(
-                "- [ ] "
-                f"<#{thread_id}> "
-                f"({_session_identity(task_id, session)})"
-                f"{owner} · reason `{reason}`{detail_part} · {_priority_label(item)}"
-                f" · {opened_part} · {last_output_part}"
-                f" · idle {idle_ticks} tick(s), nudges {nudge_count}"
-            )
+            # Clickable Discord thread link using native channel mention syntax.
+            target = f"<#{thread_id}>"
         else:
-            lines.append(
-                "- [ ] "
-                f"**{task_id}** ({_session_identity(task_id, session)})"
-                f"{owner} · reason `{reason}`{detail_part} · {_priority_label(item)}"
-                f" · {opened_part} · {last_output_part}"
-                f" · idle {idle_ticks} tick(s), nudges {nudge_count}"
-            )
+            target = f"**{task_id}**"
+        lines.append(
+            "- [ ] "
+            f"{target} — {mention}"
+            f"({_session_identity(task_id, session)})"
+            f"{owner} · reason `{reason}`{detail_part}{question_part}"
+        )
     return "\n".join(lines)
 
 
@@ -457,6 +459,53 @@ def reconcile_attention_digest(
 # ---------------------------------------------------------------------------
 
 
+def _parse_options(row: Dict[str, Any]) -> List[str]:
+    """Decode the JSON ``last_options`` column into a list of labels."""
+    raw = row.get("last_options")
+    if not raw:
+        return []
+    try:
+        value = json.loads(raw)
+    except (ValueError, TypeError):
+        return []
+    return [str(v) for v in value] if isinstance(value, list) else []
+
+
+def _render_needs_input_detail(row: Dict[str, Any]) -> str:
+    """Render the extracted question and (for a menu) a numbered option list.
+
+    The full question + options live in the thread; the ``#feed`` digest only
+    routes to it. Returns "" when there is nothing extracted to show.
+    """
+    question = (row.get("last_question") or "").strip()
+    options = _parse_options(row)
+    lines: List[str] = []
+    if question:
+        lines.append(question)
+    if row.get("last_input_kind") == "menu" and options:
+        if lines:
+            lines.append("")
+        lines.extend(f"{idx}. {label}" for idx, label in enumerate(options, start=1))
+        lines.append("")
+        lines.append("_Reply with the option number to choose._")
+    return "\n".join(lines).strip()
+
+
+def _notify_key(new_state: str, row: Dict[str, Any]) -> str:
+    """Debounce key = state + a digest of the current question.
+
+    Keying on state alone suppresses a *new* question that arrives within the
+    same ``WAITING_USER`` state — omp can render menu→menu faster than the
+    1-minute watcher tick. Folding the question digest in lets a genuinely new
+    prompt re-notify while a re-read of the same prompt stays debounced.
+    """
+    question = (row.get("last_question") or "").strip()
+    if not question:
+        return new_state
+    digest = hashlib.sha1(question.encode("utf-8", "replace")).hexdigest()[:12]
+    return f"{new_state}\x00{digest}"
+
+
 def push_turn_change(
     task_id: str,
     row: Dict[str, Any],
@@ -476,12 +525,15 @@ def push_turn_change(
 
     Returns True if a task-thread notice was posted, False otherwise.
     """
-    # Belt-and-suspenders: skip if we already notified this state for this task.
-    if _last_notified.get(task_id) == new_state:
+    # Belt-and-suspenders: skip if we already notified this state+question for
+    # this task. Keying on the question digest (not state alone) lets a new
+    # question within the same WAITING_USER state re-notify.
+    notify_key = _notify_key(new_state, row)
+    if _last_notified.get(task_id) == notify_key:
         logger.debug(
-            "feed.push_turn_change: debounce suppressed for task_id=%s state=%s",
+            "feed.push_turn_change: debounce suppressed for task_id=%s key=%s",
             task_id,
-            new_state,
+            notify_key,
         )
         return False
 
@@ -501,23 +553,25 @@ def push_turn_change(
         icon = "⏸️"
         verb = "paused — handoff detected"
 
-    # @-mention the requesting user so the notice actually pings them. An
-    # @-mention in the (bot-created) task thread notifies the user AND adds
-    # them to the thread even if they were never subscribed. Without this the
-    # notice posts silently and the user has no signal to check the feed.
     uid = row.get("discord_user_id")
-    mention = f"<@{uid}> " if uid else ""
+
+    # THREAD gets the DETAIL (question + numbered options for a menu), with NO
+    # @-mention — the actual @-ping lives in #feed now, so we don't double-ping.
     message = (
-        f"{mention}{icon} **[{agent}] {task_label}** {verb}{project_part}\n"
+        f"{icon} **[{agent}] {task_label}** {verb}{project_part}\n"
         f"State: `{old_state}` → `{new_state}`"
     )
+    if new_state == "WAITING_USER":
+        detail = _render_needs_input_detail(row)
+        if detail:
+            message = f"{message}\n\n{detail}"
 
     posted = False
     if thread_id and thread_id != resolved_feed_channel:
         thread_msg_id = _post_discord_message(thread_id, message, token=token)
         if thread_msg_id:
             logger.info(
-                "feed.push_turn_change: posted to thread=%s msg_id=%s task_id=%s",
+                "feed.push_turn_change: posted detail to thread=%s msg_id=%s task_id=%s",
                 thread_id,
                 thread_msg_id,
                 task_id,
@@ -530,8 +584,31 @@ def push_turn_change(
     else:
         logger.debug("feed.push_turn_change: no discord_thread_id; skipping thread post")
 
-    # Record the notified state (debounce marker)
-    _last_notified[task_id] = new_state
+    # #feed gets a FRESH @-mention router message (a NEW post, so Discord
+    # actually notifies the user — unlike the silently-edited board digest),
+    # pointing at the thread where the full context lives. The board digest
+    # (reconcile_attention_digest) remains the persistent state view + reap
+    # target; this is the live "needs you" ping.
+    if resolved_feed_channel and uid:
+        thread_link = f"<#{thread_id}>" if thread_id else f"`{task_label}`"
+        question = (row.get("last_question") or "").strip()
+        snippet = f"\n> {_truncate(question)}" if question else ""
+        router_ping = (
+            f"<@{uid}> {icon} **[{agent}]** {verb}{project_part} → {thread_link}"
+            f"{snippet}"
+        )
+        feed_msg_id = _post_discord_message(resolved_feed_channel, router_ping, token=token)
+        if feed_msg_id:
+            logger.info(
+                "feed.push_turn_change: posted @-ping router to feed=%s msg_id=%s task_id=%s",
+                resolved_feed_channel,
+                feed_msg_id,
+                task_id,
+            )
+            posted = True
+
+    # Record the notified state+question (debounce marker)
+    _last_notified[task_id] = notify_key
 
     return posted
 

--- a/session_orchestration/feed.py
+++ b/session_orchestration/feed.py
@@ -184,10 +184,18 @@ def push_turn_change(
     if new_state == "WAITING_USER":
         icon = "🔔"
         verb = "needs your input"
-    else:
-        # PAUSED_HANDOFF
+    elif new_state == "PAUSED_HANDOFF":
         icon = "⏸️"
         verb = "paused — handoff detected"
+    elif new_state == "DONE":
+        icon = "✅"
+        verb = "completed"
+    elif new_state == "RUNNING":
+        icon = "▶"
+        verb = "running"
+    else:
+        icon = "ℹ️"
+        verb = f"state: {new_state}"
 
     message = (
         f"{icon} **[{agent}] {task_label}** {verb}{project_part}\n"
@@ -235,6 +243,22 @@ def push_turn_change(
             posted = True
     elif not thread_id:
         logger.debug("feed.push_turn_change: no discord_thread_id; skipping thread post")
+
+    # 3. DM the user when transitioning to WAITING_USER (T013)
+    if new_state == "WAITING_USER":
+        user_id = row.get("discord_user_id")
+        if user_id:
+            try:
+                from tools.discord_tool import _get_bot_token  # type: ignore[import]
+                from session_orchestration.dm_transport import send_dm
+
+                tok = token or _get_bot_token()
+                if tok:
+                    send_dm(user_id, message, tok)
+            except Exception as exc:
+                logger.error(
+                    "feed.push_turn_change: DM failed task_id=%s: %s", task_id, exc
+                )
 
     # Record the notified state (debounce marker)
     _last_notified[task_id] = new_state
@@ -326,6 +350,23 @@ def push_hang_notification(
         logger.debug(
             "feed.push_hang_notification: no discord_thread_id; skipping thread post"
         )
+
+    # DM the user on the first stale rung (escalate=False) only.
+    # When escalate=True, the escalation DM is sent by watcher._on_hang (T010) — no double-DM.
+    if not escalate:
+        user_id = row.get("discord_user_id")
+        if user_id:
+            try:
+                from tools.discord_tool import _get_bot_token  # type: ignore[import]
+                from session_orchestration.dm_transport import send_dm
+
+                tok = token or _get_bot_token()
+                if tok:
+                    send_dm(user_id, message, tok)
+            except Exception as exc:
+                logger.error(
+                    "feed.push_hang_notification: stale DM failed: %s", exc
+                )
 
     return posted
 

--- a/session_orchestration/feed.py
+++ b/session_orchestration/feed.py
@@ -1,0 +1,389 @@
+"""
+session_orchestration/feed.py — unified feed channel pusher (T007/T008).
+
+Responsibilities
+----------------
+Push ONE Discord message per state transition (turn-change) to:
+  1. The unified feed channel (``feed_channel_id`` from config or passed in).
+  2. The task's Discord thread (``row["discord_thread_id"]``).
+
+Heartbeat edit (T008)
+---------------------
+``edit_status_message`` PATCHes an existing Discord message in-place.  Used
+by the watcher heartbeat hook to update a status message without firing a new
+notification.
+
+Debounce
+--------
+A module-level ``_last_notified`` dict (``task_id → state_value``) prevents
+double-posting if somehow the same transition fires twice.  The primary
+debounce is already enforced by the watcher call-site (``_on_turn_change``
+is only called when ``new_state != old_state``); this is belt-and-suspenders.
+
+Transport
+---------
+Reuses the Discord REST helpers from ``tools/discord_tool.py``
+(``_discord_request``, ``_get_bot_token``).  The watcher runs as a
+``--no-agent`` cron job so no gateway_runner is available; we post directly
+to the Discord REST API using the bot token from the environment.
+
+Called by
+---------
+``session_orchestration.watcher._on_turn_change`` — T007 only.
+``session_orchestration.watcher._on_heartbeat_tick`` — T008.
+T009 (hang notify) will add its own feed primitive here; leave the public API
+open for extension.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module-level debounce state
+# ---------------------------------------------------------------------------
+
+# task_id → last state value we successfully posted a message for.
+# Reset when the state moves back to a non-attention state (so a later
+# transition to WAITING_USER is treated as a new event).
+_last_notified: Dict[str, str] = {}
+
+
+# ---------------------------------------------------------------------------
+# Config helper
+# ---------------------------------------------------------------------------
+
+
+def _get_feed_channel_id() -> Optional[str]:
+    """Return the configured feed channel id, or None if absent."""
+    try:
+        from hermes_cli.config import load_config, cfg_get  # type: ignore[import]
+
+        cfg = load_config()
+        so_cfg = cfg_get(cfg, "session_orchestration", default={}) or {}
+        return so_cfg.get("feed_channel_id") or None
+    except Exception as exc:
+        logger.debug("feed: could not read config for feed_channel_id: %s", exc)
+    # Fall back to environment (useful in tests and manual runs)
+    return os.getenv("HERMES_FEED_CHANNEL_ID") or None
+
+
+# ---------------------------------------------------------------------------
+# Low-level Discord REST helper (reuses discord_tool pattern)
+# ---------------------------------------------------------------------------
+
+
+def _post_discord_message(
+    channel_id: str,
+    content: str,
+    *,
+    token: Optional[str] = None,
+) -> Optional[str]:
+    """POST a message to a Discord channel/thread.  Returns the message id or None.
+
+    Uses the same REST helpers as ``tools/discord_tool``.  Best-effort:
+    logs on failure and returns None rather than raising.
+    """
+    if not channel_id:
+        return None
+
+    try:
+        from tools.discord_tool import _discord_request, _get_bot_token, DiscordAPIError  # type: ignore[import]
+    except ImportError as exc:
+        logger.warning("feed: cannot import discord helpers: %s", exc)
+        return None
+
+    resolved_token = token or _get_bot_token()
+    if not resolved_token:
+        logger.warning("feed: DISCORD_BOT_TOKEN not set; skipping post to channel=%s", channel_id)
+        return None
+
+    try:
+        result = _discord_request(
+            "POST",
+            f"/channels/{channel_id}/messages",
+            resolved_token,
+            body={"content": content},
+        )
+        msg_id: Optional[str] = (result or {}).get("id")
+        return msg_id
+    except Exception as exc:
+        logger.warning("feed: failed to post to channel=%s: %s", channel_id, exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Public API consumed by watcher._on_turn_change
+# ---------------------------------------------------------------------------
+
+
+def push_turn_change(
+    task_id: str,
+    row: Dict[str, Any],
+    new_state: str,
+    old_state: str,
+    *,
+    feed_channel_id: Optional[str] = None,
+    token: Optional[str] = None,
+) -> bool:
+    """Push a turn-change notification to the feed channel + task thread.
+
+    Called exactly once per state transition (the watcher call-site already
+    gates on ``new_state != old_state``).  Belt-and-suspenders debounce via
+    ``_last_notified`` ensures idempotence inside a single cron run.
+
+    Parameters
+    ----------
+    task_id:
+        Registry key for the session.
+    row:
+        Full registry row at the time of the transition.
+    new_state:
+        The new ``SessionLifecycle`` value (string, e.g. ``"WAITING_USER"``).
+    old_state:
+        The previous state value.
+    feed_channel_id:
+        Override the configured feed channel id (used in tests).
+    token:
+        Override the Discord bot token (used in tests).
+
+    Returns True if at least one message was posted, False otherwise.
+    """
+    # Belt-and-suspenders: skip if we already notified this state for this task.
+    if _last_notified.get(task_id) == new_state:
+        logger.debug(
+            "feed.push_turn_change: debounce suppressed for task_id=%s state=%s",
+            task_id,
+            new_state,
+        )
+        return False
+
+    # Resolve feed channel
+    resolved_feed_channel = feed_channel_id or _get_feed_channel_id()
+    thread_id: Optional[str] = row.get("discord_thread_id") or None
+
+    # Build the message text
+    task_label = task_id
+    agent = row.get("agent", "unknown")
+    project = row.get("project") or row.get("repo") or ""
+    project_part = f" | {project}" if project else ""
+
+    if new_state == "WAITING_USER":
+        icon = "🔔"
+        verb = "needs your input"
+    else:
+        # PAUSED_HANDOFF
+        icon = "⏸️"
+        verb = "paused — handoff detected"
+
+    message = (
+        f"{icon} **[{agent}] {task_label}** {verb}{project_part}\n"
+        f"State: `{old_state}` → `{new_state}`"
+    )
+    if thread_id:
+        message += f" | <#{thread_id}>"
+
+    posted = False
+
+    # 1. Push to the unified feed channel
+    if resolved_feed_channel:
+        msg_id = _post_discord_message(resolved_feed_channel, message, token=token)
+        if msg_id:
+            logger.info(
+                "feed.push_turn_change: posted to feed channel=%s msg_id=%s task_id=%s state=%s",
+                resolved_feed_channel,
+                msg_id,
+                task_id,
+                new_state,
+            )
+            posted = True
+    else:
+        logger.debug("feed.push_turn_change: no feed_channel_id; skipping feed post")
+
+    # 2. Push to the task's own Discord thread (if different from feed channel)
+    if thread_id and thread_id != resolved_feed_channel:
+        thread_msg_id = _post_discord_message(thread_id, message, token=token)
+        if thread_msg_id:
+            logger.info(
+                "feed.push_turn_change: posted to thread=%s msg_id=%s task_id=%s",
+                thread_id,
+                thread_msg_id,
+                task_id,
+            )
+            posted = True
+    elif not thread_id:
+        logger.debug("feed.push_turn_change: no discord_thread_id; skipping thread post")
+
+    # Record the notified state (debounce marker)
+    _last_notified[task_id] = new_state
+
+    return posted
+
+
+def push_hang_notification(
+    task_id: str,
+    row: Dict[str, Any],
+    escalate: bool = False,
+    *,
+    feed_channel_id: Optional[str] = None,
+    token: Optional[str] = None,
+) -> bool:
+    """Push a hang (or hang-escalation) notification to the feed channel.
+
+    Called by ``watcher._on_hang`` when a session is confirmed hung.
+    This is a SEPARATE function from ``push_turn_change`` — it never
+    modifies ``_last_notified`` and does not touch the turn-change debounce.
+
+    Parameters
+    ----------
+    task_id:
+        Registry key for the session.
+    row:
+        Full registry row at the time of the hang detection.
+    escalate:
+        If True, this is an escalation (nudge already sent, session still
+        hung); message content reflects the escalation state.
+    feed_channel_id:
+        Override the configured feed channel id (used in tests).
+    token:
+        Override the Discord bot token (used in tests).
+
+    Returns True if at least one message was posted, False otherwise.
+    """
+    resolved_feed_channel = feed_channel_id or _get_feed_channel_id()
+    thread_id: Optional[str] = row.get("discord_thread_id") or None
+
+    agent = row.get("agent", "unknown")
+    project = row.get("project") or row.get("repo") or ""
+    project_part = f" | {project}" if project else ""
+    idle_ticks = row.get("idle_ticks") or 0
+
+    if escalate:
+        icon = "🚨"
+        verb = "still hung after nudge — escalating to user"
+    else:
+        icon = "⚠️"
+        verb = f"appears hung ({idle_ticks} idle ticks) — sending auto-nudge"
+
+    message = (
+        f"{icon} **[{agent}] {task_id}** {verb}{project_part}"
+    )
+    if thread_id:
+        message += f" | <#{thread_id}>"
+
+    posted = False
+
+    if resolved_feed_channel:
+        msg_id = _post_discord_message(resolved_feed_channel, message, token=token)
+        if msg_id:
+            logger.info(
+                "feed.push_hang_notification: posted to feed channel=%s msg_id=%s "
+                "task_id=%s escalate=%s",
+                resolved_feed_channel,
+                msg_id,
+                task_id,
+                escalate,
+            )
+            posted = True
+    else:
+        logger.debug(
+            "feed.push_hang_notification: no feed_channel_id; skipping feed post"
+        )
+
+    if thread_id and thread_id != resolved_feed_channel:
+        thread_msg_id = _post_discord_message(thread_id, message, token=token)
+        if thread_msg_id:
+            logger.info(
+                "feed.push_hang_notification: posted to thread=%s msg_id=%s task_id=%s",
+                thread_id,
+                thread_msg_id,
+                task_id,
+            )
+            posted = True
+    elif not thread_id:
+        logger.debug(
+            "feed.push_hang_notification: no discord_thread_id; skipping thread post"
+        )
+
+    return posted
+
+
+def clear_last_notified(task_id: str) -> None:
+    """Reset the debounce marker for *task_id*.
+
+    Called when a session transitions OUT of an attention state back to
+    RUNNING — so the NEXT transition to WAITING_USER is treated as new.
+    T008/T009 may also call this to re-arm after a hang resolution.
+
+    Also useful in tests to reset state between runs.
+    """
+    _last_notified.pop(task_id, None)
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat edit helper (T008) — edits a message in-place, no notification
+# ---------------------------------------------------------------------------
+
+
+def edit_status_message(
+    channel_id: str,
+    message_id: str,
+    content: str,
+    *,
+    token: Optional[str] = None,
+) -> bool:
+    """PATCH an existing Discord message in-place.  Returns True on success.
+
+    Used by the heartbeat hook to update a status message without sending a
+    new notification.  Best-effort: logs on failure and returns False rather
+    than raising.
+
+    Parameters
+    ----------
+    channel_id:
+        Discord channel (or thread) id that contains the message.
+    message_id:
+        The id of the message to edit.
+    content:
+        The new message content string.
+    token:
+        Override the Discord bot token (used in tests).
+    """
+    if not channel_id or not message_id:
+        return False
+
+    try:
+        from tools.discord_tool import _discord_request, _get_bot_token, DiscordAPIError  # type: ignore[import]
+    except ImportError as exc:
+        logger.warning("feed: cannot import discord helpers: %s", exc)
+        return False
+
+    resolved_token = token or _get_bot_token()
+    if not resolved_token:
+        logger.warning(
+            "feed: DISCORD_BOT_TOKEN not set; skipping edit of message=%s channel=%s",
+            message_id,
+            channel_id,
+        )
+        return False
+
+    try:
+        _discord_request(
+            "PATCH",
+            f"/channels/{channel_id}/messages/{message_id}",
+            resolved_token,
+            body={"content": content},
+        )
+        return True
+    except Exception as exc:
+        logger.warning(
+            "feed: failed to edit message=%s channel=%s: %s",
+            message_id,
+            channel_id,
+            exc,
+        )
+        return False

--- a/session_orchestration/feed.py
+++ b/session_orchestration/feed.py
@@ -96,6 +96,27 @@ def _get_feed_channel_id() -> Optional[str]:
 # ---------------------------------------------------------------------------
 
 
+#: Discord rejects any message whose ``content`` exceeds 2000 characters with a
+#: 400 (BASE_TYPE_MAX_LENGTH). Feed payloads can carry raw pane text that blows
+#: past this, so every POST/PATCH clamps to a safe ceiling below the hard cap.
+_DISCORD_CONTENT_LIMIT: int = 2000
+_DISCORD_CONTENT_ELLIPSIS: str = "\n… (truncated)"
+
+
+def _clamp_discord_content(content: str) -> str:
+    """Clamp ``content`` to Discord's 2000-char hard limit with an ellipsis.
+
+    Truncation keeps the HEAD (the question/summary/leading context) since feed
+    overflow is almost always a long pane-text tail. A no-op when already short.
+    """
+    if content is None:
+        return ""
+    if len(content) <= _DISCORD_CONTENT_LIMIT:
+        return content
+    keep = _DISCORD_CONTENT_LIMIT - len(_DISCORD_CONTENT_ELLIPSIS)
+    return content[:keep] + _DISCORD_CONTENT_ELLIPSIS
+
+
 def _post_discord_message(
     channel_id: str,
     content: str,
@@ -105,10 +126,14 @@ def _post_discord_message(
     """POST a message to a Discord channel/thread.  Returns the message id or None.
 
     Uses the same REST helpers as ``tools/discord_tool``.  Best-effort:
-    logs on failure and returns None rather than raising.
+    logs on failure and returns None rather than raising.  ``content`` is
+    clamped to Discord's 2000-char limit so an oversize payload degrades to a
+    truncated post instead of a dropped one.
     """
     if not channel_id:
         return None
+
+    content = _clamp_discord_content(content)
 
     try:
         from tools.discord_tool import _discord_request, _get_bot_token, DiscordAPIError  # type: ignore[import]
@@ -141,9 +166,16 @@ def _edit_discord_message(
     *,
     token: Optional[str] = None,
 ) -> str:
-    """PATCH a Discord message and distinguish missing-message recovery."""
+    """PATCH a Discord message and distinguish missing-message recovery.
+
+    ``content`` is clamped to Discord's 2000-char limit (see
+    ``_clamp_discord_content``) so an oversize edit degrades to a truncated
+    update instead of a 400.
+    """
     if not channel_id or not message_id:
         return _EDIT_FAILED
+
+    content = _clamp_discord_content(content)
 
     try:
         from tools.discord_tool import (  # type: ignore[import]

--- a/session_orchestration/feed.py
+++ b/session_orchestration/feed.py
@@ -506,6 +506,28 @@ def _notify_key(new_state: str, row: Dict[str, Any]) -> str:
     return f"{new_state}\x00{digest}"
 
 
+#: Discord hard message cap is 2000 chars; leave headroom for markdown fences.
+_TURN_OUTPUT_CHUNK = 1900
+#: Cap the relayed turn output at this many thread messages per transition.
+_TURN_OUTPUT_MAX_CHUNKS = 4
+
+
+def _chunk_text(text: str, size: int = _TURN_OUTPUT_CHUNK) -> list[str]:
+    """Split *text* into <=size chunks, preferring newline boundaries."""
+    chunks: list[str] = []
+    remaining = text
+    while remaining:
+        if len(remaining) <= size:
+            chunks.append(remaining)
+            break
+        cut = remaining.rfind("\n", 0, size)
+        if cut < size // 2:
+            cut = size
+        chunks.append(remaining[:cut])
+        remaining = remaining[cut:].lstrip("\n")
+    return chunks
+
+
 def push_turn_change(
     task_id: str,
     row: Dict[str, Any],
@@ -514,6 +536,7 @@ def push_turn_change(
     *,
     feed_channel_id: Optional[str] = None,
     token: Optional[str] = None,
+    turn_output: Optional[str] = None,
 ) -> bool:
     """Post an optional task-thread notice for a user-attention transition.
 
@@ -562,11 +585,33 @@ def push_turn_change(
         f"State: `{old_state}` → `{new_state}`"
     )
     if new_state == "WAITING_USER":
-        detail = _render_needs_input_detail(row)
-        if detail:
-            message = f"{message}\n\n{detail}"
+        # For a MENU the extracted question+options are the actionable detail.
+        # For a free-form/finished-turn idle the relayed turn_output IS the
+        # content — the pane-extracted "question" (last prose line) is
+        # redundant there and can even echo the user's own pasted reply.
+        if row.get("last_input_kind") == "menu" or not turn_output:
+            detail = _render_needs_input_detail(row)
+            if detail:
+                message = f"{message}\n\n{detail}"
 
     posted = False
+    # Relay the agent's actual response first (clean assistant text from its
+    # transcript file — no tool spam), chunked to Discord's message cap, so the
+    # thread reads: [what the agent said] then [what it needs from you].
+    if turn_output and thread_id and thread_id != resolved_feed_channel:
+        chunks = _chunk_text(turn_output.strip())
+        overflow = len(chunks) > _TURN_OUTPUT_MAX_CHUNKS
+        for chunk in chunks[:_TURN_OUTPUT_MAX_CHUNKS]:
+            if _post_discord_message(thread_id, chunk, token=token):
+                posted = True
+        if overflow:
+            _post_discord_message(
+                thread_id,
+                f"_…output truncated ({len(chunks) - _TURN_OUTPUT_MAX_CHUNKS} more "
+                f"chunk(s)); attach to tmux `{row.get('tmux_session', '')}` for the full log._",
+                token=token,
+            )
+
     if thread_id and thread_id != resolved_feed_channel:
         thread_msg_id = _post_discord_message(thread_id, message, token=token)
         if thread_msg_id:
@@ -591,8 +636,14 @@ def push_turn_change(
     # target; this is the live "needs you" ping.
     if resolved_feed_channel and uid:
         thread_link = f"<#{thread_id}>" if thread_id else f"`{task_label}`"
-        question = (row.get("last_question") or "").strip()
-        snippet = f"\n> {_truncate(question)}" if question else ""
+        # Snippet preference: menu question > relayed response tail > extracted
+        # last line (the latter can echo the user's own pasted reply).
+        if row.get("last_input_kind") == "menu" or not turn_output:
+            snippet_src = (row.get("last_question") or "").strip()
+        else:
+            lines = [l for l in turn_output.strip().splitlines() if l.strip()]
+            snippet_src = lines[-1] if lines else ""
+        snippet = f"\n> {_truncate(snippet_src)}" if snippet_src else ""
         router_ping = (
             f"<@{uid}> {icon} **[{agent}]** {verb}{project_part} → {thread_link}"
             f"{snippet}"

--- a/session_orchestration/ingest.py
+++ b/session_orchestration/ingest.py
@@ -1,0 +1,415 @@
+"""
+session_orchestration/ingest.py — z-harness webhook ingest handler.
+
+Responsibilities
+----------------
+1. Persistent event_id dedup (SQLite table ``session_orchestration_event_dedup``
+   in state.db) — survives restart, preventing double-posts on webhook retries.
+2. Per-source rate limiting (in-memory fixed-window, keyed by payload ``source``).
+3. Correlation: ``(run_id, canonical_repo_id(remote_url=repo))`` → existing
+   registry row → enqueue ``update`` intent.
+4. Adopt: unknown ``run_id``/``repo`` → enqueue ``adopt`` intent; row routed to
+   the default "external runs" feed channel via ``discord_thread_id``.
+5. Feed push: notify the configured Discord feed channel via the gateway runner.
+
+Single-writer discipline
+------------------------
+This module NEVER writes to ``session_orchestration`` directly.  It only calls
+``registry.enqueue_intent(...)`` which the cron watcher drains.
+
+HMAC validation
+---------------
+The z-harness sender (T015, ``notify-watchdog.sh``) signs with:
+    openssl dgst -sha256 -hmac "$SECRET" -hex | awk '{print $NF}'
+and sends the hex digest in ``X-Z-Harness-Signature: sha256=<hex>``.
+
+The webhook adapter (``gateway/platforms/webhook.py``) validates the
+``X-Z-Harness-Signature`` header via its generic HMAC path (``X-Webhook-Signature``
+regex falls through — z-harness uses a dedicated header).  We validate it here
+too for defence-in-depth when ``process_z_harness_alert`` is called with a raw
+payload dict that already passed adapter-level validation.  When invoked via the
+webhook adapter (``deliver_only=False, deliver="session_orchestration_ingest"``),
+the adapter has already rejected bad signatures before calling us.
+
+Configuration (from Hermes config.yaml under ``session_orchestration``)
+------------------------------------------------------------------------
+  session_orchestration:
+    enabled: true
+    feed_channel_id: "1234567890"          # Discord channel id for the unified feed
+    external_runs_thread_id: "9876543210"  # Discord thread for adopted external runs
+    rate_limit_per_source: 20              # max events/minute per source (default 20)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from session_orchestration.registry import (
+    SessionOrchestrationRegistry,
+    canonical_repo_id,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# DDL for persistent event dedup table
+# ---------------------------------------------------------------------------
+
+_DEDUP_DDL = """
+CREATE TABLE IF NOT EXISTS session_orchestration_event_dedup (
+    event_id   TEXT PRIMARY KEY,
+    source     TEXT,
+    seen_at    REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_so_dedup_seen_at
+    ON session_orchestration_event_dedup(seen_at);
+"""
+
+# How long to retain event_id records in the dedup table (1 hour).
+_DEDUP_TTL_SECONDS = 3600
+
+# In-memory per-source rate limiter (fixed 60-second window).
+# Keyed by source string → list of epoch floats for events in the window.
+_rate_windows: Dict[str, list] = {}
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_db_path() -> Path:
+    try:
+        from hermes_state import DEFAULT_DB_PATH
+        return DEFAULT_DB_PATH
+    except ImportError:
+        from pathlib import Path as _Path
+        import os
+        hermes_home = os.environ.get("HERMES_HOME", str(_Path.home() / ".hermes"))
+        return _Path(hermes_home) / "state.db"
+
+
+def _ensure_dedup_schema(db_path: Path) -> None:
+    conn = sqlite3.connect(str(db_path), timeout=5.0)
+    try:
+        conn.executescript(_DEDUP_DDL)
+    finally:
+        conn.close()
+
+
+def _is_duplicate_event(db_path: Path, event_id: str, source: str) -> bool:
+    """Return True if *event_id* has already been processed.
+
+    Side effect: if not a duplicate, records the event_id in the dedup table
+    (atomic INSERT OR IGNORE — safe under concurrent writers).
+    Prunes expired entries on the same connection for bounded table growth.
+    """
+    now = time.time()
+    conn = sqlite3.connect(str(db_path), timeout=5.0, isolation_level=None)
+    try:
+        conn.execute("PRAGMA busy_timeout=5000")
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            # Check for existing record
+            row = conn.execute(
+                "SELECT 1 FROM session_orchestration_event_dedup WHERE event_id = ?",
+                (event_id,),
+            ).fetchone()
+            if row is not None:
+                conn.execute("COMMIT")
+                return True
+            # Record the new event_id
+            conn.execute(
+                "INSERT INTO session_orchestration_event_dedup (event_id, source, seen_at) "
+                "VALUES (?, ?, ?)",
+                (event_id, source, now),
+            )
+            # Prune expired entries (best-effort, inside same transaction)
+            cutoff = now - _DEDUP_TTL_SECONDS
+            conn.execute(
+                "DELETE FROM session_orchestration_event_dedup WHERE seen_at < ?",
+                (cutoff,),
+            )
+            conn.execute("COMMIT")
+            return False
+        except BaseException:
+            try:
+                conn.execute("ROLLBACK")
+            except Exception:
+                pass
+            raise
+    finally:
+        conn.close()
+
+
+def _check_rate_limit(source: str, limit_per_minute: int) -> bool:
+    """Return True if the *source* is within the rate limit.
+
+    Uses an in-memory fixed 60-second sliding window.  Not persisted across
+    restarts (acceptable: rate limiting is a temporary throttle, not a hard
+    security control — the webhook adapter already rate-limits at the route
+    level before calling us).
+    """
+    now = time.time()
+    window = _rate_windows.setdefault(source, [])
+    # Evict entries outside the 60-second window
+    _rate_windows[source] = [t for t in window if now - t < 60]
+    if len(_rate_windows[source]) >= limit_per_minute:
+        return False
+    _rate_windows[source].append(now)
+    return True
+
+
+def _validate_hmac(raw_body: bytes, secret: str, signature_header: str) -> bool:
+    """Validate ``X-Z-Harness-Signature: sha256=<hex>`` header.
+
+    Matches the signing used by notify-watchdog.sh:
+        openssl dgst -sha256 -hmac "$SECRET" -hex | awk '{print $NF}'
+    which produces a plain hex digest (no prefix in the openssl output; the
+    shell script prepends ``sha256=``).
+    """
+    if not signature_header.startswith("sha256="):
+        logger.debug("[ingest] Missing sha256= prefix in signature header")
+        return False
+    provided_hex = signature_header[len("sha256="):]
+    expected_hex = hmac.new(
+        secret.encode(), raw_body, hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(provided_hex, expected_hex)
+
+
+def _get_session_orchestration_config() -> Dict[str, Any]:
+    """Load session_orchestration section from Hermes config.yaml."""
+    try:
+        from hermes_cli.config import load_config, cfg_get
+        cfg = load_config()
+        result = cfg_get(cfg, "session_orchestration", default={})
+        return result if isinstance(result, dict) else {}
+    except Exception:
+        return {}
+
+
+def _is_enabled() -> bool:
+    cfg = _get_session_orchestration_config()
+    return bool(cfg.get("enabled", False))
+
+
+# ---------------------------------------------------------------------------
+# Feed push helper
+# ---------------------------------------------------------------------------
+
+
+async def _push_to_feed(
+    message: str,
+    *,
+    gateway_runner: Any = None,
+    feed_channel_id: Optional[str] = None,
+    thread_id: Optional[str] = None,
+) -> None:
+    """Push *message* to the unified feed Discord channel.
+
+    Requires ``gateway_runner`` (set by the webhook adapter) and a configured
+    ``feed_channel_id``.  Best-effort — logs and returns on failure.
+    """
+    if not gateway_runner or not feed_channel_id:
+        logger.debug("[ingest] feed push skipped: no gateway_runner or feed_channel_id")
+        return
+
+    try:
+        from gateway.config import Platform
+        discord_adapter = gateway_runner.adapters.get(Platform.DISCORD)
+        if not discord_adapter:
+            logger.warning("[ingest] feed push: Discord adapter not connected")
+            return
+        metadata = {"thread_id": thread_id} if thread_id else None
+        await discord_adapter.send(feed_channel_id, message, metadata=metadata)
+    except Exception as exc:
+        logger.warning("[ingest] feed push failed: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+async def process_z_harness_alert(
+    payload: Dict[str, Any],
+    *,
+    raw_body: Optional[bytes] = None,
+    signature_header: Optional[str] = None,
+    hmac_secret: Optional[str] = None,
+    gateway_runner: Any = None,
+) -> Dict[str, Any]:
+    """Process a validated z-harness alert payload.
+
+    Called by the webhook adapter after its own HMAC + rate-limit + in-memory
+    dedup checks pass.  We apply additional persistent dedup and per-source
+    rate limiting, then correlate or adopt.
+
+    Parameters
+    ----------
+    payload:
+        Parsed JSON body from the z-harness POST.
+    raw_body:
+        Raw bytes of the POST body (for HMAC re-validation when called
+        outside the webhook adapter path).  Optional — adapter already
+        validated before calling us.
+    signature_header:
+        Value of ``X-Z-Harness-Signature`` header.  Only used for
+        defence-in-depth validation when ``raw_body`` is provided.
+    hmac_secret:
+        HMAC secret for re-validation.  Read from ingest config when absent.
+    gateway_runner:
+        Gateway runner reference for feed push.  Set externally by the
+        webhook adapter.
+
+    Returns a status dict with ``{"status": "accepted"|"duplicate"|"rate_limited"
+    |"invalid_signature"|"disabled"|"missing_fields", ...}``.
+    """
+    if not _is_enabled():
+        logger.debug("[ingest] session_orchestration disabled; skipping z-harness alert")
+        return {"status": "disabled"}
+
+    so_cfg = _get_session_orchestration_config()
+    rate_limit = int(so_cfg.get("rate_limit_per_source", 20))
+    feed_channel_id: Optional[str] = so_cfg.get("feed_channel_id") or None
+    external_thread_id: Optional[str] = so_cfg.get("external_runs_thread_id") or None
+
+    # Defence-in-depth HMAC re-validation (when raw bytes provided).
+    if raw_body is not None and signature_header is not None:
+        secret = hmac_secret or so_cfg.get("hmac_secret", "")
+        if secret and not _validate_hmac(raw_body, secret, signature_header):
+            logger.warning("[ingest] HMAC re-validation failed for z-harness alert")
+            return {"status": "invalid_signature"}
+
+    # Required fields
+    source = payload.get("source", "unknown")
+    event_id = payload.get("event_id", "")
+    run_id = payload.get("run_id", "")
+    repo_raw = payload.get("repo", "")  # may be a workdir path or remote URL
+
+    if not event_id:
+        logger.warning("[ingest] z-harness alert missing event_id; rejected")
+        return {"status": "missing_fields", "detail": "event_id required"}
+
+    # Per-source rate limit (in-memory, 60-second window)
+    if not _check_rate_limit(source, rate_limit):
+        logger.warning("[ingest] rate limit exceeded for source=%s", source)
+        return {"status": "rate_limited", "source": source}
+
+    db_path = _get_db_path()
+    _ensure_dedup_schema(db_path)
+
+    # Persistent event_id dedup
+    if _is_duplicate_event(db_path, event_id, source):
+        logger.info("[ingest] duplicate event_id=%s from source=%s; skipping", event_id, source)
+        return {"status": "duplicate", "event_id": event_id}
+
+    registry = SessionOrchestrationRegistry(db_path=db_path)
+
+    # Determine canonical repo key from the raw repo field.
+    # z-harness sends the git toplevel path (a local absolute path) as `repo`.
+    # We pass it as workdir= so canonical_repo_id hashes it consistently.
+    # If the payload includes a remote URL (future extension), it would be
+    # in a `remote_url` field.
+    repo_key = canonical_repo_id(
+        workdir=repo_raw if repo_raw else None,
+        remote_url=payload.get("remote_url") or None,
+    )
+
+    # Correlate: look for an existing registry row with (run_id, repo_key).
+    existing_rows = registry.list(run_id=run_id) if run_id else []
+    matched = next(
+        (r for r in existing_rows if r.get("repo") == repo_key),
+        None,
+    )
+
+    event_name = payload.get("event", "unknown")
+    severity = payload.get("severity", "info")
+    reason = payload.get("reason", "")
+    ts = payload.get("ts", int(time.time()))
+
+    if matched:
+        # Known run: enqueue an update intent so cron can apply it.
+        task_id = matched["task_id"]
+        registry.enqueue_intent(
+            "update",
+            task_id=task_id,
+            run_id=run_id,
+            repo=repo_key,
+            payload={
+                "task_id": task_id,
+                "last_alert_event": event_name,
+                "last_alert_ts": float(ts),
+                "last_alert_severity": severity,
+            },
+        )
+        logger.info(
+            "[ingest] correlated run_id=%s repo=%s → task_id=%s event=%s",
+            run_id, repo_key, task_id, event_name,
+        )
+        action = "correlated"
+        thread_id = matched.get("discord_thread_id")
+    else:
+        # Unknown run: adopt with a lightweight row.
+        import uuid as _uuid
+        new_task_id = f"adopted-{_uuid.uuid4().hex[:8]}"
+        slug = payload.get("slug", "")
+        adopt_payload: Dict[str, Any] = {
+            "task_id": new_task_id,
+            "agent": payload.get("source", "z-harness"),
+            "run_id": run_id,
+            "repo": repo_key,
+            "project": slug or repo_raw or "unknown",
+            "discord_thread_id": external_thread_id,
+            "state": "RUNNING",
+            "last_alert_event": event_name,
+            "last_alert_ts": float(ts),
+            "last_alert_severity": severity,
+        }
+        registry.enqueue_intent(
+            "adopt",
+            task_id=new_task_id,
+            run_id=run_id,
+            repo=repo_key,
+            payload=adopt_payload,
+        )
+        logger.info(
+            "[ingest] adopted unknown run_id=%s repo=%s → new task_id=%s event=%s",
+            run_id, repo_key, new_task_id, event_name,
+        )
+        action = "adopted"
+        thread_id = external_thread_id
+        task_id = new_task_id
+
+    # Feed push: notify the unified feed channel.
+    initiator = payload.get("initiator_discord_user_id")
+    mention = f"<@{initiator}> " if initiator else ""
+    feed_message = (
+        f"{mention}**z-harness alert** `{event_name}` | severity: `{severity}`"
+        f"\nrun: `{run_id or 'unknown'}` | slug: `{payload.get('slug', '')}` | {action}"
+        + (f"\n> {reason}" if reason else "")
+    )
+    # Use the task's own discord thread (if known) for feed context.
+    payload_thread_id = payload.get("thread_id") or thread_id
+    await _push_to_feed(
+        feed_message,
+        gateway_runner=gateway_runner,
+        feed_channel_id=feed_channel_id,
+        thread_id=payload_thread_id,
+    )
+
+    return {
+        "status": "accepted",
+        "action": action,
+        "task_id": task_id,
+        "event_id": event_id,
+    }

--- a/session_orchestration/markers.py
+++ b/session_orchestration/markers.py
@@ -1,0 +1,231 @@
+"""
+Marker protocol module for session_orchestration (T001).
+
+Architecture
+------------
+Each managed agent session writes structured JSON-line events ("markers")
+to a dedicated file (``HERMES_MARKER_FILE``).  The watcher reads those lines
+each tick and uses them as the *authoritative* signal for session lifecycle
+state, falling back to pane-scraping only when no recent markers exist.
+
+This file is the cross-repo contract shared between hermes-agent (reader)
+and z-harness / omp (writers).  Changes to the schema must be backward-
+compatible and version-gated.
+
+Schema
+------
+Every line is a JSON object with the envelope fields::
+
+    {
+        "v": 1,           # schema version (int)
+        "ts": "<iso8601>",# UTC timestamp when the marker was written
+        "kind": "<kind>", # one of the MARKER_* constants below
+        "task": "<str>",  # opaque task / session identifier
+        "payload": {...}  # kind-specific payload (see PAYLOAD SHAPES)
+    }
+
+Payload shapes
+--------------
+status          {"phase": str, "detail": str}
+heartbeat       {"note": str | null}
+needs_input     {"question": str, "options": list[str] | null, "context": str | null}
+handoff_continue {"handoff_text": str}
+handoff_decision {"question": str, "handoff_text": str}
+done            {"summary": str, "artifacts": list[str] | null}
+
+Malformed lines (invalid JSON, missing envelope fields, wrong types) are
+**skipped silently** — they must never raise.
+
+Helpers
+-------
+``append_marker(path, kind, payload)``
+    Atomically append one marker line to *path*.
+``read_markers_since(path, offset) -> (markers, new_offset)``
+    Return only lines written after *offset* bytes into the file.
+``marker_kind_to_lifecycle(kind) -> SessionLifecycle | None``
+    Map a marker kind to the canonical ``SessionLifecycle`` state.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from session_orchestration.types import SessionLifecycle
+
+# ---------------------------------------------------------------------------
+# Schema version
+# ---------------------------------------------------------------------------
+
+MARKER_SCHEMA_VERSION = 1
+
+# ---------------------------------------------------------------------------
+# Marker kind constants
+# ---------------------------------------------------------------------------
+
+MARKER_STATUS = "status"
+MARKER_HEARTBEAT = "heartbeat"
+MARKER_NEEDS_INPUT = "needs_input"
+MARKER_HANDOFF_CONTINUE = "handoff_continue"
+MARKER_HANDOFF_DECISION = "handoff_decision"
+MARKER_DONE = "done"
+
+# Complete vocabulary in a set for validation convenience.
+MARKER_KINDS: frozenset[str] = frozenset(
+    {
+        MARKER_STATUS,
+        MARKER_HEARTBEAT,
+        MARKER_NEEDS_INPUT,
+        MARKER_HANDOFF_CONTINUE,
+        MARKER_HANDOFF_DECISION,
+        MARKER_DONE,
+    }
+)
+
+# ---------------------------------------------------------------------------
+# kind → SessionLifecycle mapping
+# ---------------------------------------------------------------------------
+
+_KIND_TO_LIFECYCLE: dict[str, SessionLifecycle] = {
+    MARKER_STATUS: SessionLifecycle.RUNNING,
+    MARKER_HEARTBEAT: SessionLifecycle.RUNNING,
+    MARKER_NEEDS_INPUT: SessionLifecycle.WAITING_USER,
+    MARKER_HANDOFF_CONTINUE: SessionLifecycle.PAUSED_HANDOFF,
+    MARKER_HANDOFF_DECISION: SessionLifecycle.PAUSED_HANDOFF,
+    MARKER_DONE: SessionLifecycle.DONE,
+}
+
+
+def marker_kind_to_lifecycle(kind: str) -> Optional[SessionLifecycle]:
+    """Map a marker *kind* string to the corresponding ``SessionLifecycle``.
+
+    Returns ``None`` for unknown kinds so callers can decide whether to
+    ignore or log the anomaly rather than raising.
+    """
+    return _KIND_TO_LIFECYCLE.get(kind)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+def _build_envelope(kind: str, task: str, payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "v": MARKER_SCHEMA_VERSION,
+        "ts": _utc_now_iso(),
+        "kind": kind,
+        "task": task,
+        "payload": payload,
+    }
+
+
+def _is_valid_envelope(obj: Any) -> bool:
+    """Return True iff *obj* has all required envelope fields with correct types."""
+    if not isinstance(obj, dict):
+        return False
+    if not isinstance(obj.get("v"), int):
+        return False
+    if not isinstance(obj.get("ts"), str):
+        return False
+    if not isinstance(obj.get("kind"), str):
+        return False
+    if not isinstance(obj.get("task"), str):
+        return False
+    if "payload" not in obj or not isinstance(obj["payload"], dict):
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def append_marker(path: "str | Path", kind: str, payload: dict[str, Any], task: str = "") -> None:
+    """Append a single marker line to *path*.
+
+    The parent directory is created if it does not exist.  The write is a
+    single ``os.write`` on an O_APPEND fd so that concurrent writers from
+    different processes do not interleave partial lines (POSIX guarantees
+    atomicity for writes <= PIPE_BUF; a compact JSON line easily fits).
+
+    Parameters
+    ----------
+    path:
+        Path to the ``.jsonl`` marker file.
+    kind:
+        One of the ``MARKER_*`` constants (e.g. ``MARKER_DONE``).
+    payload:
+        Kind-specific payload dict — caller is responsible for correctness.
+    task:
+        Opaque task/session identifier (defaults to empty string).
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    envelope = _build_envelope(kind, task, payload)
+    line = json.dumps(envelope, separators=(",", ":")) + "\n"
+    encoded = line.encode()
+
+    fd = os.open(str(path), os.O_CREAT | os.O_WRONLY | os.O_APPEND, 0o600)
+    try:
+        os.write(fd, encoded)
+    finally:
+        os.close(fd)
+
+
+def read_markers_since(
+    path: "str | Path",
+    offset: int = 0,
+) -> tuple[list[dict[str, Any]], int]:
+    """Read marker lines from *path* starting at byte *offset*.
+
+    Malformed lines (invalid JSON, missing envelope fields) are silently
+    skipped.  The returned offset is the new byte position after the last
+    line read; pass it back on the next call to get only new lines.
+
+    Parameters
+    ----------
+    path:
+        Path to the ``.jsonl`` marker file.
+    offset:
+        Byte offset to start reading from (0 means start of file).
+
+    Returns
+    -------
+    tuple[list[dict], int]
+        ``(markers, new_offset)`` where *markers* is a list of valid
+        envelope dicts and *new_offset* is the byte position after the
+        last byte consumed.
+    """
+    path = Path(path)
+    if not path.exists():
+        return [], offset
+
+    markers: list[dict[str, Any]] = []
+    new_offset = offset
+
+    with path.open("rb") as fh:
+        fh.seek(offset)
+        for raw_line in fh:
+            new_offset += len(raw_line)
+            line = raw_line.decode(errors="replace").strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue  # malformed — skip silently
+            if not _is_valid_envelope(obj):
+                continue  # missing fields — skip silently
+            markers.append(obj)
+
+    return markers, new_offset

--- a/session_orchestration/menu_parse.py
+++ b/session_orchestration/menu_parse.py
@@ -1,0 +1,335 @@
+"""
+Pane-text menu parsing for session_orchestration (answerable needs-input).
+
+omp emits no lifecycle markers, so when a session sits at ``WAITING_USER`` the
+only signal we have is the raw ``tmux capture-pane`` text. This module turns
+that text into an *answerable* summary: the question prose plus the ordered
+list of selectable option labels.
+
+The heuristics are ported from the (now deprecated) so-MCP orchestrator
+(``z-harness/scripts/hermes/mcp_hermes_orchestrator.py``), where they were
+hardened against a real 9h-parked retro menu that reached Discord as a
+header-less box dump. They are deliberately dependency-free and pure so both
+the omp and Claude Code pane paths can call them and so the box-drawing
+assumptions stay unit-testable without a live tmux.
+
+A box-drawn omp/Claude selection menu looks like::
+
+     Proposal 1: ... Decision?
+
+    ──────────────────────────────
+    │ Accept (Recommended)       │
+    │    Apply edits now.        │   <- indented description row, NOT an option
+    │ Defer                      │
+    ──────────────────────────────
+     up/down navigate  enter select  esc cancel
+
+A bare free-form prompt (omp ``❯`` / Claude ``> ``) has no box and yields no
+options — callers use that to distinguish a menu from a free-form prompt.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+#: Navigation-footer phrases that mark a selection menu but carry no answer
+#: value themselves — dropped from the extracted context and options.
+_MENU_FOOTER_HINTS = ("up/down", "enter select", "esc cancel", "tab ")
+
+#: Phrases that specifically mark the *live* selection footer (the box directly
+#: above them is the answerable menu, as opposed to a transient render).
+_FOOTER_ANCHOR_HINTS = ("enter select", "esc cancel")
+
+#: Leading Nerd-Font / Unicode private-use glyphs omp renders before an option
+#: label (e.g. U+F192, U+F10C). Stripped from labels.
+_LEADING_PUA = re.compile("^[\ue000-\uf8ff\U000f0000-\U0010fffd]+")
+
+#: Box-drawing prefixes that start a NON-option row (rules, corners, headers).
+_BOX_NONOPTION_PREFIXES = ("╭", "╰", "├", "┤", "┌", "└")
+
+
+def _is_rule(stripped: str) -> bool:
+    """True for a pure box-drawing separator rule (─, —, -, =, _)."""
+    return bool(stripped) and all(ch in "─—-=_" for ch in stripped)
+
+
+def extract_menu_options(text: str) -> list[str]:
+    """Pull the ordered option labels out of a box-drawn selection menu.
+
+    Each option is a ``│ Label │`` row; some options carry an indented
+    ``│    description │`` row directly below them. Only the flush label rows
+    are option text — indented rows, separator rules, the nav footer, and any
+    question prose above the box are not options. Returns ``[]`` when the pane
+    has no box-drawn menu (e.g. a bare ``❯`` prompt).
+    """
+    options: list[str] = []
+    for raw in text.strip("\n").splitlines():
+        stripped = raw.strip()
+        if not stripped or _is_rule(stripped):
+            continue
+        low = stripped.lower()
+        if any(hint in low for hint in _MENU_FOOTER_HINTS):
+            continue
+        if len(stripped) < 2 or not (stripped.startswith("│") and stripped.endswith("│")):
+            continue
+        inner = stripped[1:-1]
+        # Strip the single mandatory padding space; anything left starting
+        # with whitespace is an indented description row, not a label.
+        if inner.startswith(" "):
+            inner = inner[1:]
+        if inner.strip() and inner[:1].isspace():
+            continue
+        label = inner.strip()
+        if label:
+            options.append(label)
+    return options
+
+
+def extract_needs_input_context(text: str, *, limit: int = 1600) -> str:
+    """Turn a raw needs_input pane into an answerable question+options summary.
+
+    The captured tmux pane is dominated by box-drawing rules and a navigation
+    footer, and a blind ``[-N:]`` tail slice can cut the actual question off the
+    top (exactly what happened when a 9h-parked retro menu reached Discord as a
+    header-less box dump). This strips separator rules, unwraps ``│ … │`` box
+    rows to their inner text, and drops the ``up/down … enter select`` footer,
+    leaving the prompt prose and option labels. Best-effort: if nothing
+    survives (unknown TUI shape), fall back to the raw tail so no signal is
+    ever emitted empty.
+    """
+    cleaned: list[str] = []
+    for raw in text.strip().splitlines():
+        stripped = raw.strip()
+        if not stripped or _is_rule(stripped):
+            continue
+        low = stripped.lower()
+        if any(hint in low for hint in _MENU_FOOTER_HINTS):
+            continue
+        # Unwrap box rows: strip leading/trailing vertical borders + padding.
+        inner = stripped.strip("│|").strip()
+        if inner:
+            cleaned.append(inner)
+    summary = "\n".join(cleaned).strip()
+    if not summary:
+        return text.strip()[-limit:]
+    # Keep the TAIL of the cleaned block: the live question/options sit at the
+    # bottom of the pane, above the footer we already dropped.
+    return summary[-limit:]
+
+
+def _strip_left_border(line: str) -> Optional[str]:
+    """Return the inner text of a ``│``-left-bordered row, or None.
+
+    omp's live selection menu renders each row as ``│ <text>`` — and, when the
+    pane is wide, an optional matching ``│`` far to the right. The right border
+    is frequently pushed past the capture width, so we anchor only on the LEFT
+    ``│`` and strip a trailing ``│`` if present.
+    """
+    stripped = line.rstrip()
+    lead = stripped.lstrip()
+    if not lead.startswith("│"):
+        return None
+    inner = lead[1:]
+    if inner.rstrip().endswith("│"):
+        inner = inner.rstrip()[:-1]
+    return inner
+
+
+def _footer_anchored_menu(text: str) -> Optional[Tuple[str, List[str]]]:
+    """Parse omp's live selection menu, anchored on the nav footer.
+
+    A pane can contain several box-drawn regions (a transient "Ask" render, a
+    top status bar, the live menu). The authoritative, answerable menu is the
+    ``│``-row block directly above the ``enter select / esc cancel`` footer.
+    Returns ``(question, options)`` or None when no such footer/menu is found
+    (caller falls back to the legacy whole-pane scan).
+
+    Label vs description: option labels sit flush after ``│`` (optionally behind
+    a Nerd-Font glyph); omp indents each option's description ~4 spaces. We
+    strip a leading private-use glyph, then treat rows whose remaining indent is
+    >= 3 as descriptions.
+    """
+    lines = text.rstrip("\n").splitlines()
+    footer_idx = None
+    for i, raw in enumerate(lines):
+        low = raw.lower()
+        if any(hint in low for hint in _FOOTER_ANCHOR_HINTS):
+            footer_idx = i
+            break
+    if footer_idx is None:
+        return None
+
+    # Walk up: skip trailing blanks/rules, then collect the contiguous
+    # left-bordered option block.
+    i = footer_idx - 1
+    while i >= 0 and (not lines[i].strip() or _is_rule(lines[i].strip())):
+        i -= 1
+    options: List[str] = []
+    block_rows: List[str] = []
+    while i >= 0:
+        inner = _strip_left_border(lines[i])
+        if inner is None:
+            break
+        block_rows.append(inner)
+        i -= 1
+    if not block_rows:
+        return None
+    block_rows.reverse()  # restore top-to-bottom order
+
+    for inner in block_rows:
+        raw_indent = len(inner) - len(inner.lstrip(" "))
+        body = inner.strip()
+        no_glyph = _LEADING_PUA.sub("", body)
+        had_glyph = no_glyph != body
+        label = no_glyph.strip()
+        if not label or _is_rule(label):
+            continue
+        low = label.lower()
+        if any(hint in low for hint in _MENU_FOOTER_HINTS):
+            continue
+        # Deeply-indented rows (and ↳-prefixed rows) are descriptions, unless a
+        # Nerd-Font glyph marks the row as a selectable label.
+        if not had_glyph and (raw_indent >= 3 or label.startswith("↳")):
+            continue
+        options.append(label)
+
+    if not options:
+        return None
+
+    # Question: the nearest non-empty, non-box text line(s) above the block.
+    # ``i`` already points at the line just above the option block.
+    q_lines: List[str] = []
+    while i >= 0:
+        s = lines[i].strip()
+        if not s or _is_rule(s):
+            if q_lines:
+                break
+            i -= 1
+            continue
+        if s[:1] in ("│", "|") or s.startswith(_BOX_NONOPTION_PREFIXES):
+            break
+        q_lines.append(s)
+        i -= 1
+    question = " ".join(reversed(q_lines)).strip()
+    return question, options
+
+
+#: Lines that are omp chrome / injected noise, never the question itself.
+_FREE_FORM_NOISE = (
+    "hermes nudge",
+    "appears to have stalled",
+    "update available",
+    "omp update",
+    "connected to mcp",
+)
+
+
+def _extract_free_form_question(text: str) -> str:
+    """Isolate the most recent question-like line from a free-form omp prompt.
+
+    omp interleaves its reasoning stream, a status bar, update banners, and any
+    injected Hermes nudge with the actual question, so the cleaned tail is too
+    noisy to post verbatim. Prefer the LAST prose line that ends with ``?``;
+    fall back to the last substantive line.
+    """
+    candidates: List[str] = []
+    for raw in text.splitlines():
+        s = raw.strip()
+        if not s or _is_rule(s):
+            continue
+        if s[:1] in "╭╰│├┤┌└╮╯|":
+            continue  # box-drawing chrome (composer/status bar)
+        low = s.lower()
+        if any(noise in low for noise in _FREE_FORM_NOISE):
+            continue
+        candidates.append(s)
+    questions = [c for c in candidates if c.rstrip().endswith("?")]
+    if questions:
+        return questions[-1]
+    return candidates[-1] if candidates else ""
+
+
+def extract(text: str, *, limit: int = 1600) -> tuple[str, list[str], bool]:
+    """Extract ``(question, options, is_menu)`` from raw pane text.
+
+    ``options`` is the ordered list of selectable labels (empty for a bare
+    prompt). ``is_menu`` is true iff at least one selectable option was found.
+    ``question`` is the prompt prose, with option labels removed so a caller can
+    render the question and the numbered options without duplication. For a
+    free-form prompt (no menu) ``question`` is the cleaned prompt prose.
+
+    Strategy: prefer the footer-anchored parse (omp's live ``enter select``
+    menu); fall back to the legacy whole-pane box scan (Claude-style menus and
+    older shapes).
+    """
+    anchored = _footer_anchored_menu(text)
+    if anchored is not None:
+        question, options = anchored
+        return question, options, True
+
+    # Legacy fallback: whole-pane box scan.
+    options = extract_menu_options(text)
+    if options:
+        context = extract_needs_input_context(text, limit=limit)
+        opt_set = {opt for opt in options}
+        question = "\n".join(
+            line for line in context.splitlines() if line.strip() not in opt_set
+        ).strip()
+        return question, options, True
+
+    # No box menu → free-form prompt: isolate the question from omp's noise.
+    question = _extract_free_form_question(text)
+    if not question:
+        question = extract_needs_input_context(text, limit=limit).strip()
+    return question, [], False
+
+
+def resolve_menu_answer(
+    row: Dict[str, Any], reply_text: str
+) -> Tuple[str, Optional[list[str]]]:
+    """Translate a thread reply into ``(drive_text, pre_keys)``.
+
+    For a ``WAITING_USER`` menu row where the reply is a valid 1-based option
+    number, return a natural-language selection naming the chosen label plus
+    ``["Escape"]`` — the caller cancels the arrow-key menu and pastes the
+    plain-language choice into the freed composer (a raw "2" selects nothing on
+    such a menu). For everything else — a free-form ``❯`` prompt, a
+    non-numeric reply, an out-of-range number, or missing options — return the
+    reply unchanged with no pre-keys, so the existing paste path is used.
+    """
+    text = (reply_text or "").strip()
+    if row.get("state") != "WAITING_USER" or row.get("last_input_kind") != "menu":
+        # Not a selection menu (free-form ❯/composer wait): the composer already
+        # accepts a pasted reply and there is no arrow-key menu to cancel, so
+        # pass the reply through unchanged with no pre-keys.
+        return text, None
+    raw = row.get("last_options")
+    try:
+        options = json.loads(raw) if raw else []
+    except (ValueError, TypeError):
+        options = []
+    if not isinstance(options, list) or not options:
+        return text, None
+
+    # A selection menu is up: arrow-key navigation PLUS an "Asking…" spinner, so
+    # the pane reads as busy and a bare paste is dropped. ANY answer — a valid
+    # option number OR free text (the "Other (type your own)" case) OR an
+    # out-of-range number — must first send Escape to cancel the menu. Validated
+    # live: Escape → "Ask tool was cancelled by the user" → idle composer with no
+    # spinner, so the subsequent _wait_for_ready passes and the paste lands.
+    choice = text.rstrip(".")
+    if choice.isdigit() and 1 <= int(choice) <= len(options):
+        idx = int(choice)
+        label = str(options[idx - 1])
+        drive_text = (
+            "[Hermès] You presented a selection menu. The user chose option "
+            f"{idx}: «{label}». Please proceed with that choice."
+        )
+    else:
+        drive_text = (
+            "[Hermès] You presented a selection menu (now cancelled). "
+            f"The user's typed answer: «{text}». Please proceed with that answer."
+        )
+    return drive_text, ["Escape"]

--- a/session_orchestration/menu_parse.py
+++ b/session_orchestration/menu_parse.py
@@ -49,6 +49,46 @@ _LEADING_PUA = re.compile("^[\ue000-\uf8ff\U000f0000-\U0010fffd]+")
 #: Box-drawing prefixes that start a NON-option row (rules, corners, headers).
 _BOX_NONOPTION_PREFIXES = ("╭", "╰", "├", "┤", "┌", "└")
 
+#: Rows from tool/output boxes that look like left-bordered menu rows but are
+#: shell transcript or terminal chrome, not selectable options.
+_OPTION_NOISE_PREFIXES = (
+    "$ ",
+    "2>",
+    "BASE=",
+    "RUN=",
+    "bash scripts/",
+    "cat >>",
+    "cp ",
+    "diff ",
+    "git ",
+    "EOF",
+    "python -m",
+    "python3 -m",
+    "python3 -c",
+    "print(json.dumps",
+    "sed -n",
+    "set -",
+    "tmux ",
+    "wc ",
+)
+_OPTION_NOISE_EXACT = {"(no output)"}
+
+
+def _is_option_noise(label: str) -> bool:
+    """Reject command/output rows accidentally wrapped in box borders."""
+    stripped = label.strip()
+    if not stripped:
+        return True
+    if stripped in _OPTION_NOISE_EXACT:
+        return True
+    if stripped.startswith("…") or "Ctrl+O: Expand" in stripped or "⟨Wall:" in stripped:
+        return True
+    if stripped.startswith(_OPTION_NOISE_PREFIXES):
+        return True
+    if stripped.startswith(("#", "**")):
+        return True
+    return stripped.endswith(".") and len(stripped) > 24
+
 
 def _is_rule(stripped: str) -> bool:
     """True for a pure box-drawing separator rule (─, —, -, =, _)."""
@@ -83,7 +123,8 @@ def extract_menu_options(text: str) -> list[str]:
             continue
         label = inner.strip()
         if label:
-            options.append(label)
+            if not _is_option_noise(label):
+                options.append(label)
     return options
 
 
@@ -193,6 +234,8 @@ def _footer_anchored_menu(text: str) -> Optional[Tuple[str, List[str]]]:
         # Nerd-Font glyph marks the row as a selectable label.
         if not had_glyph and (raw_indent >= 3 or label.startswith("↳")):
             continue
+        if _is_option_noise(label):
+            continue
         options.append(label)
 
     if not options:
@@ -238,6 +281,10 @@ def _extract_free_form_question(text: str) -> str:
     for raw in text.splitlines():
         s = raw.strip()
         if not s or _is_rule(s):
+            continue
+        if s in {"❯", ">"}:
+            continue
+        if _is_option_noise(s):
             continue
         if s[:1] in "╭╰│├┤┌└╮╯|":
             continue  # box-drawing chrome (composer/status bar)

--- a/session_orchestration/registry.py
+++ b/session_orchestration/registry.py
@@ -260,6 +260,14 @@ class SessionOrchestrationRegistry:
             except sqlite3.OperationalError:
                 pass  # Column already exists — idempotent
 
+            try:
+                conn.execute(
+                    "ALTER TABLE session_orchestration "
+                    "ADD COLUMN discord_user_id TEXT"
+                )
+            except sqlite3.OperationalError:
+                pass  # Column already exists — idempotent
+
         self._write(_do)
 
     def _write(self, fn, conn: Optional[sqlite3.Connection] = None) -> Any:

--- a/session_orchestration/registry.py
+++ b/session_orchestration/registry.py
@@ -50,6 +50,7 @@ Queue intent kinds
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import re
 import sqlite3
@@ -59,6 +60,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+_UNSET = object()
 
 # ---------------------------------------------------------------------------
 # Default busy-timeout: how long SQLite waits for a write lock before
@@ -114,6 +116,55 @@ CREATE TABLE IF NOT EXISTS session_orchestration_queue (
 
 CREATE INDEX IF NOT EXISTS idx_soq_task
     ON session_orchestration_queue(task_id);
+
+CREATE TABLE IF NOT EXISTS session_orchestration_attention_items (
+    id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id               TEXT NOT NULL,
+    reason                TEXT NOT NULL,
+    state                 TEXT NOT NULL DEFAULT 'unresolved',
+    priority              INTEGER NOT NULL DEFAULT 0,
+    detail                TEXT,
+    opened_at             TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at            TEXT NOT NULL DEFAULT (datetime('now')),
+    resolved_at           TEXT,
+    resolution_reason     TEXT,
+    FOREIGN KEY(task_id) REFERENCES session_orchestration(task_id) ON DELETE CASCADE,
+    CHECK (
+        (
+            state = 'unresolved'
+            AND resolved_at IS NULL
+            AND resolution_reason IS NULL
+        )
+        OR
+        (
+            state = 'resolved'
+            AND resolved_at IS NOT NULL
+            AND resolution_reason IS NOT NULL
+        )
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_soai_unresolved_task_reason
+    ON session_orchestration_attention_items(task_id, reason)
+    WHERE resolved_at IS NULL;
+DROP INDEX IF EXISTS idx_soai_unresolved_lookup;
+CREATE INDEX IF NOT EXISTS idx_soai_unresolved_lookup
+    ON session_orchestration_attention_items(state, priority DESC, opened_at)
+    WHERE resolved_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS session_orchestration_projection (
+    id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+    channel_id            TEXT NOT NULL,
+    projection_name       TEXT NOT NULL,
+    message_id            TEXT,
+    content_hash          TEXT,
+    payload               TEXT NOT NULL DEFAULT '{}',
+    created_at            TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at            TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(channel_id, projection_name)
+);
+DROP INDEX IF EXISTS idx_sop_channel_projection;
+
 """
 
 # ---------------------------------------------------------------------------
@@ -307,8 +358,257 @@ class SessionOrchestrationRegistry:
         finally:
             conn.close()
 
+    def list_unresolved_attention_items(self) -> List[Dict[str, Any]]:
+        """Return currently unresolved attention items in render-stable order."""
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                """
+                SELECT *
+                  FROM session_orchestration_attention_items
+                 WHERE state = 'unresolved'
+                   AND resolved_at IS NULL
+                 ORDER BY priority DESC, opened_at ASC, id ASC
+                """
+            ).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            conn.close()
+
+    def get_projection(
+        self,
+        channel_id: str,
+        projection_name: str,
+    ) -> Optional[Dict[str, Any]]:
+        """Return projection metadata for a channel/projection pair, if present."""
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                """
+                SELECT *
+                  FROM session_orchestration_projection
+                 WHERE channel_id = ?
+                   AND projection_name = ?
+                """,
+                (channel_id, projection_name),
+            ).fetchone()
+            if row is None:
+                return None
+            projection = dict(row)
+            projection["payload"] = json.loads(projection["payload"] or "{}")
+            return projection
+        finally:
+            conn.close()
+
     # ------------------------------------------------------------------
-    # Public API — cron-watcher-only mutations
+    # Public API — watcher-owned attention/projection mutations
+    # ------------------------------------------------------------------
+
+    def open_attention_item(
+        self,
+        task_id: str,
+        reason: str,
+        *,
+        priority: int = 0,
+        detail: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Open or refresh an unresolved attention item for ``task_id``/``reason``.
+
+        Watcher-owned API: external actors must not use this as an authority
+        for session state.  Reopening the same unresolved reason refreshes only
+        attention lifecycle fields instead of inserting a duplicate.
+        """
+        def _do(conn: sqlite3.Connection) -> Dict[str, Any]:
+            existing = conn.execute(
+                """
+                SELECT id
+                  FROM session_orchestration_attention_items
+                 WHERE task_id = ?
+                   AND reason = ?
+                   AND resolved_at IS NULL
+                """,
+                (task_id, reason),
+            ).fetchone()
+            if existing is None:
+                cursor = conn.execute(
+                    """
+                    INSERT INTO session_orchestration_attention_items (
+                        task_id, reason, state, priority, detail
+                    ) VALUES (?, ?, 'unresolved', ?, ?)
+                    """,
+                    (task_id, reason, priority, detail),
+                )
+                item_id = cursor.lastrowid
+            else:
+                item_id = existing["id"]
+                conn.execute(
+                    """
+                    UPDATE session_orchestration_attention_items
+                       SET priority = ?,
+                           detail = ?,
+                           updated_at = datetime('now')
+                     WHERE id = ?
+                    """,
+                    (priority, detail, item_id),
+                )
+
+            row = conn.execute(
+                "SELECT * FROM session_orchestration_attention_items WHERE id = ?",
+                (item_id,),
+            ).fetchone()
+            return dict(row)
+
+        return self._write(_do)
+
+    def update_attention_item(
+        self,
+        task_id: str,
+        reason: str,
+        *,
+        priority: Optional[int] = None,
+        detail: Any = _UNSET,
+    ) -> Optional[Dict[str, Any]]:
+        """Refresh lifecycle fields on an unresolved attention item."""
+        set_parts: List[str] = ["updated_at = datetime('now')"]
+        values: List[Any] = []
+        if priority is not None:
+            set_parts.append("priority = ?")
+            values.append(priority)
+        if detail is not _UNSET:
+            set_parts.append("detail = ?")
+            values.append(detail)
+
+        def _do(conn: sqlite3.Connection) -> Optional[Dict[str, Any]]:
+            update_values = [*values, task_id, reason]
+            conn.execute(
+                f"""
+                UPDATE session_orchestration_attention_items
+                   SET {', '.join(set_parts)}
+                 WHERE task_id = ?
+                   AND reason = ?
+                   AND resolved_at IS NULL
+                """,
+                update_values,
+            )
+            row = conn.execute(
+                """
+                SELECT *
+                  FROM session_orchestration_attention_items
+                 WHERE task_id = ?
+                   AND reason = ?
+                   AND resolved_at IS NULL
+                """,
+                (task_id, reason),
+            ).fetchone()
+            return dict(row) if row else None
+
+        return self._write(_do)
+
+    def resolve_attention_item(
+        self,
+        task_id: str,
+        reason: str,
+        resolution_reason: str,
+    ) -> bool:
+        """Resolve the currently unresolved attention item for one reason."""
+        def _do(conn: sqlite3.Connection) -> bool:
+            cursor = conn.execute(
+                """
+                UPDATE session_orchestration_attention_items
+                   SET state = 'resolved',
+                       resolved_at = datetime('now'),
+                       resolution_reason = ?,
+                       updated_at = datetime('now')
+                 WHERE task_id = ?
+                   AND reason = ?
+                   AND resolved_at IS NULL
+                """,
+                (resolution_reason, task_id, reason),
+            )
+            return cursor.rowcount > 0
+
+        return bool(self._write(_do))
+
+    def upsert_projection(
+        self,
+        channel_id: str,
+        projection_name: str,
+        *,
+        message_id: Optional[str] | object = _UNSET,
+        content_hash: Optional[str] | object = _UNSET,
+        payload: Optional[Dict[str, Any]] | object = _UNSET,
+    ) -> Dict[str, Any]:
+        """Insert or update watcher-owned projection metadata.
+
+        Omitted optional fields preserve existing values on update; passing
+        ``None`` explicitly clears nullable fields and resets ``payload`` to
+        ``{}``.
+        """
+
+        def _do(conn: sqlite3.Connection) -> Dict[str, Any]:
+            existing = conn.execute(
+                """
+                SELECT id
+                  FROM session_orchestration_projection
+                 WHERE channel_id = ?
+                   AND projection_name = ?
+                """,
+                (channel_id, projection_name),
+            ).fetchone()
+            if existing is None:
+                insert_message_id = None if message_id is _UNSET else message_id
+                insert_content_hash = None if content_hash is _UNSET else content_hash
+                insert_payload = {} if payload is _UNSET else (payload or {})
+                cursor = conn.execute(
+                    """
+                    INSERT INTO session_orchestration_projection (
+                        channel_id, projection_name, message_id, content_hash, payload
+                    ) VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (
+                        channel_id,
+                        projection_name,
+                        insert_message_id,
+                        insert_content_hash,
+                        json.dumps(insert_payload, sort_keys=True),
+                    ),
+                )
+                projection_id = cursor.lastrowid
+            else:
+                projection_id = existing["id"]
+                set_parts: List[str] = ["updated_at = datetime('now')"]
+                values: List[Any] = []
+                if message_id is not _UNSET:
+                    set_parts.append("message_id = ?")
+                    values.append(message_id)
+                if content_hash is not _UNSET:
+                    set_parts.append("content_hash = ?")
+                    values.append(content_hash)
+                if payload is not _UNSET:
+                    set_parts.append("payload = ?")
+                    values.append(json.dumps(payload or {}, sort_keys=True))
+                values.append(projection_id)
+                conn.execute(
+                    f"""
+                    UPDATE session_orchestration_projection
+                       SET {', '.join(set_parts)}
+                     WHERE id = ?
+                    """,
+                    values,
+                )
+
+            row = conn.execute(
+                "SELECT * FROM session_orchestration_projection WHERE id = ?",
+                (projection_id,),
+            ).fetchone()
+            projection = dict(row)
+            projection["payload"] = json.loads(projection["payload"] or "{}")
+            return projection
+
+        return self._write(_do)
+
+    # ------------------------------------------------------------------
+    # Public API — core cron-watcher-only session mutations
     # ------------------------------------------------------------------
 
     def upsert(

--- a/session_orchestration/registry.py
+++ b/session_orchestration/registry.py
@@ -42,9 +42,10 @@ the lock is auto-reclaimed via the ``lock_ts`` column.
 
 Queue intent kinds
 ------------------
-  ``adopt``   — register a session spawned externally (webhook path).
-  ``drive``   — queue a message to relay to the agent's tmux session.
-  ``update``  — set arbitrary fields on an existing row (cron applies them).
+  ``adopt``      — register a session spawned externally (webhook path).
+  ``drive``      — queue a message to relay to the agent's tmux session.
+  ``update``     — set arbitrary fields on an existing row (cron applies them).
+  ``terminate``  — kill the tmux process and mark the row terminal (watcher applies).
 """
 
 from __future__ import annotations
@@ -477,6 +478,13 @@ class SessionOrchestrationRegistry:
 
         ``update``
             Set arbitrary ``payload`` columns on the named ``task_id``.
+
+        ``terminate``
+            Kill the tmux process and mark the session terminal.  The full
+            application (``adapter.terminate()`` + state update) is the
+            watcher's job (level 2).  Payload shape: ``{"restart": bool}``.
+            Recognised here to avoid an unknown-kind warning in the log; the
+            watcher is the actual consumer.
         """
         kind = intent.get("intent", "")
         import json as _json
@@ -538,6 +546,19 @@ class SessionOrchestrationRegistry:
                     )
                 self._write(_do)
 
+        elif kind == "terminate":
+            # Full application (adapter.terminate + state update) is the
+            # watcher's responsibility (level 2).  Log at debug so the watcher
+            # can verify the intent was received; do not crash or warn here.
+            task_id = intent.get("task_id") or payload.get("task_id")
+            restart = payload.get("restart", False)
+            logger.debug(
+                "registry._apply_intent: terminate queued for task_id=%s restart=%s "
+                "(watcher will apply)",
+                task_id,
+                restart,
+            )
+
         else:
             logger.warning("registry._apply_intent: unknown intent kind %r", kind)
 
@@ -562,7 +583,7 @@ class SessionOrchestrationRegistry:
         Parameters
         ----------
         intent:
-            One of ``"adopt"``, ``"drive"``, ``"update"``.
+            One of ``"adopt"``, ``"drive"``, ``"update"``, ``"terminate"``.
         task_id:
             Target registry row (required for ``drive``/``update``; optional
             for ``adopt`` when the task_id is inside ``payload``).
@@ -584,6 +605,27 @@ class SessionOrchestrationRegistry:
             )
 
         self._write(_do)
+
+    def enqueue_terminate(self, task_id: str, *, restart: bool = False) -> None:
+        """Queue a terminate intent for ``task_id``.
+
+        Safe to call from any thread or process.  The cron watcher drains
+        the intent and applies it (kill tmux + mark terminal) at its next tick.
+
+        Parameters
+        ----------
+        task_id:
+            Target registry row to terminate.
+        restart:
+            When ``True`` the watcher will re-spawn the session after killing
+            it (``/so-restart`` path).  When ``False`` the session is stopped
+            permanently (``/so-stop`` path).
+        """
+        self.enqueue_intent(
+            "terminate",
+            task_id=task_id,
+            payload={"restart": restart},
+        )
 
     # ------------------------------------------------------------------
     # Per-session lock (cron watcher + relay)

--- a/session_orchestration/registry.py
+++ b/session_orchestration/registry.py
@@ -59,6 +59,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from session_orchestration.types import SessionLifecycle
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -264,6 +266,14 @@ class SessionOrchestrationRegistry:
                 conn.execute(
                     "ALTER TABLE session_orchestration "
                     "ADD COLUMN discord_user_id TEXT"
+                )
+            except sqlite3.OperationalError:
+                pass  # Column already exists — idempotent
+
+            try:
+                conn.execute(
+                    "ALTER TABLE session_orchestration "
+                    "ADD COLUMN last_question TEXT"
                 )
             except sqlite3.OperationalError:
                 pass  # Column already exists — idempotent
@@ -576,16 +586,29 @@ class SessionOrchestrationRegistry:
                 self._write(_do)
 
         elif kind == "terminate":
-            # Full application (adapter.terminate + state update) is the
-            # watcher's responsibility (level 2).  Log at debug so the watcher
-            # can verify the intent was received; do not crash or warn here.
             task_id = intent.get("task_id") or payload.get("task_id")
+            if not task_id:
+                logger.warning(
+                    "registry._apply_intent: terminate intent missing task_id"
+                )
+                return
             restart = payload.get("restart", False)
-            logger.debug(
-                "registry._apply_intent: terminate queued for task_id=%s restart=%s "
-                "(watcher will apply)",
+            existing = self.get(task_id)
+            if existing is None:
+                logger.warning(
+                    "registry._apply_intent: terminate for unknown task_id=%s", task_id
+                )
+                return
+            terminal_state = (
+                SessionLifecycle.ERROR.value if restart else SessionLifecycle.DONE.value
+            )
+            self.upsert(
                 task_id,
-                restart,
+                agent=existing.get("agent", "unknown"),
+                run_id=existing.get("run_id"),
+                repo=existing.get("repo"),
+                source=existing.get("source", "spawn"),
+                state=terminal_state,
             )
 
         else:

--- a/session_orchestration/registry.py
+++ b/session_orchestration/registry.py
@@ -90,12 +90,16 @@ CREATE TABLE IF NOT EXISTS session_orchestration (
     last_output_ts         REAL,
     heartbeat_counter      INTEGER NOT NULL DEFAULT 0,
     status_message_id      TEXT,
+    feed_message_id        TEXT,
     lock_holder            TEXT,
     lock_ts                TEXT,
     source                 TEXT NOT NULL DEFAULT 'spawn',
     run_id                 TEXT,
     repo                   TEXT,
     marker_offset          INTEGER NOT NULL DEFAULT 0,
+    terminated_at          REAL,
+    attention_since        REAL,
+    last_renudge_at        REAL,
     created_at             TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at             TEXT NOT NULL DEFAULT (datetime('now')),
     UNIQUE(run_id, repo)
@@ -274,6 +278,38 @@ class SessionOrchestrationRegistry:
                 conn.execute(
                     "ALTER TABLE session_orchestration "
                     "ADD COLUMN last_question TEXT"
+                )
+            except sqlite3.OperationalError:
+                pass  # Column already exists — idempotent
+
+            try:
+                conn.execute(
+                    "ALTER TABLE session_orchestration "
+                    "ADD COLUMN terminated_at REAL"
+                )
+            except sqlite3.OperationalError:
+                pass  # Column already exists — idempotent
+
+            try:
+                conn.execute(
+                    "ALTER TABLE session_orchestration "
+                    "ADD COLUMN feed_message_id TEXT"
+                )
+            except sqlite3.OperationalError:
+                pass  # Column already exists — idempotent
+
+            try:
+                conn.execute(
+                    "ALTER TABLE session_orchestration "
+                    "ADD COLUMN attention_since REAL"
+                )
+            except sqlite3.OperationalError:
+                pass  # Column already exists — idempotent
+
+            try:
+                conn.execute(
+                    "ALTER TABLE session_orchestration "
+                    "ADD COLUMN last_renudge_at REAL"
                 )
             except sqlite3.OperationalError:
                 pass  # Column already exists — idempotent
@@ -609,10 +645,119 @@ class SessionOrchestrationRegistry:
                 repo=existing.get("repo"),
                 source=existing.get("source", "spawn"),
                 state=terminal_state,
+                terminated_at=time.time(),
             )
 
         else:
             logger.warning("registry._apply_intent: unknown intent kind %r", kind)
+
+    def gc_terminal_rows(self, *, now: float, max_age_seconds: int) -> int:
+        """Delete terminal rows whose ``terminated_at`` stamp is old enough.
+
+        A row is eligible for GC when ALL of:
+
+        - ``state`` is in the terminal set (``DONE`` or ``ERROR``).
+        - ``terminated_at IS NOT NULL`` (rows without a stamp are never GC-ed
+          so legacy pre-stamp rows are preserved indefinitely).
+        - ``terminated_at < now - max_age_seconds`` (the row is older than the
+          configured retention window).
+
+        The DELETE runs inside a single ``BEGIN IMMEDIATE`` transaction (the
+        watcher is the sole mutator, so this is safe within the tick).
+
+        Parameters
+        ----------
+        now:
+            Current epoch timestamp (seconds).  Pass ``time.time()`` in
+            production; inject a fixed value in tests for determinism.
+        max_age_seconds:
+            Retention window in seconds.  Rows with a ``terminated_at`` older
+            than ``now - max_age_seconds`` are deleted.
+
+        Returns
+        -------
+        int
+            Number of rows deleted.
+        """
+        cutoff = now - max_age_seconds
+        terminal_states = (
+            SessionLifecycle.DONE.value,
+            SessionLifecycle.ERROR.value,
+        )
+
+        def _do(conn: sqlite3.Connection) -> int:
+            cur = conn.execute(
+                "DELETE FROM session_orchestration "
+                "WHERE state IN (?, ?) "
+                "AND terminated_at IS NOT NULL "
+                "AND terminated_at < ?",
+                (*terminal_states, cutoff),
+            )
+            return cur.rowcount
+
+        return self._write(_do) or 0
+
+    def set_feed_message_id(
+        self,
+        task_id: str,
+        feed_message_id: Optional[str],
+    ) -> None:
+        """Persist the Discord feed-channel message id for *task_id*.
+
+        **Cron watcher only.**  Called by ``_on_turn_change`` after a feed
+        POST/PATCH/DELETE to keep the registry in sync with the live board.
+
+        Parameters
+        ----------
+        task_id:
+            Registry row to update.
+        feed_message_id:
+            The Discord message id of the live feed-board entry, or ``None``
+            to clear it (used after a DELETE when the session terminates).
+        """
+        def _do(conn: sqlite3.Connection) -> None:
+            conn.execute(
+                "UPDATE session_orchestration "
+                "SET feed_message_id = ?, updated_at = datetime('now') "
+                "WHERE task_id = ?",
+                (feed_message_id, task_id),
+            )
+
+        self._write(_do)
+
+    def set_attention_stamps(
+        self,
+        task_id: str,
+        attention_since: Optional[float],
+        last_renudge_at: Optional[float],
+    ) -> None:
+        """Persist attention_since and last_renudge_at for *task_id*.
+
+        **Cron watcher only.**  Pass ``None`` to clear either column to NULL.
+        Called by ``_process_row`` when a session enters or leaves an attention
+        state (WAITING_USER / PAUSED_HANDOFF) and when a re-nudge fires.
+
+        Parameters
+        ----------
+        task_id:
+            Registry row to update.
+        attention_since:
+            Epoch timestamp when the row entered the current attention state,
+            or ``None`` to clear (row is leaving attention).
+        last_renudge_at:
+            Epoch timestamp of the most recent re-nudge, or ``None`` to reset
+            the debounce marker (row just entered attention, no nudge yet).
+        """
+        def _do(conn: sqlite3.Connection) -> None:
+            conn.execute(
+                "UPDATE session_orchestration "
+                "SET attention_since = ?, last_renudge_at = ?, "
+                "    updated_at = datetime('now') "
+                "WHERE task_id = ?",
+                (attention_since, last_renudge_at, task_id),
+            )
+
+        self._write(_do)
 
     # ------------------------------------------------------------------
     # Public API — queue write (any caller, append-only)

--- a/session_orchestration/registry.py
+++ b/session_orchestration/registry.py
@@ -93,6 +93,7 @@ CREATE TABLE IF NOT EXISTS session_orchestration (
     source                 TEXT NOT NULL DEFAULT 'spawn',
     run_id                 TEXT,
     repo                   TEXT,
+    marker_offset          INTEGER NOT NULL DEFAULT 0,
     created_at             TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at             TEXT NOT NULL DEFAULT (datetime('now')),
     UNIQUE(run_id, repo)
@@ -206,6 +207,7 @@ class SessionOrchestrationRegistry:
         self._db_path = db_path
         self._busy_timeout_ms = busy_timeout_ms
         self._ensure_schema()
+        self._migrate_schema()
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -240,6 +242,25 @@ class SessionOrchestrationRegistry:
             conn.executescript(SESSION_ORCHESTRATION_DDL)
         finally:
             conn.close()
+
+    def _migrate_schema(self) -> None:
+        """Add new columns to existing tables (idempotent ALTER TABLE).
+
+        Called after ``_ensure_schema`` on every startup.  Each ALTER TABLE
+        is wrapped in a try/except so repeated calls on an already-migrated
+        DB are silent no-ops (SQLite raises OperationalError when the column
+        already exists).
+        """
+        def _do(conn: sqlite3.Connection) -> None:
+            try:
+                conn.execute(
+                    "ALTER TABLE session_orchestration "
+                    "ADD COLUMN marker_offset INTEGER NOT NULL DEFAULT 0"
+                )
+            except sqlite3.OperationalError:
+                pass  # Column already exists — idempotent
+
+        self._write(_do)
 
     def _write(self, fn, conn: Optional[sqlite3.Connection] = None) -> Any:
         """Execute *fn(conn)* inside a BEGIN IMMEDIATE transaction.

--- a/session_orchestration/registry.py
+++ b/session_orchestration/registry.py
@@ -365,6 +365,26 @@ class SessionOrchestrationRegistry:
             except sqlite3.OperationalError:
                 pass  # Column already exists — idempotent
 
+            # Answerable needs-input: the ordered option labels (JSON array) and
+            # the input kind ("menu" | "prompt" | "") extracted from the pane on
+            # WAITING_USER. omp emits no markers, so the watcher populates these
+            # by pane-text parsing (see session_orchestration/menu_parse.py).
+            try:
+                conn.execute(
+                    "ALTER TABLE session_orchestration "
+                    "ADD COLUMN last_options TEXT"
+                )
+            except sqlite3.OperationalError:
+                pass  # Column already exists — idempotent
+
+            try:
+                conn.execute(
+                    "ALTER TABLE session_orchestration "
+                    "ADD COLUMN last_input_kind TEXT"
+                )
+            except sqlite3.OperationalError:
+                pass  # Column already exists — idempotent
+
         self._write(_do)
 
     def _write(self, fn, conn: Optional[sqlite3.Connection] = None) -> Any:

--- a/session_orchestration/registry.py
+++ b/session_orchestration/registry.py
@@ -1,0 +1,691 @@
+"""
+SQLite-backed session-orchestration registry.
+
+Architecture — single-writer discipline
+----------------------------------------
+The cron watcher is the **sole mutator** of registry rows and derived counters.
+All other callers (webhook-adopt, Discord-drive) MUST NOT write the
+``session_orchestration`` table directly.  Instead they append intent rows to
+``session_orchestration_queue``; the cron watcher drains that queue and applies
+the intents in a single serialised transaction.
+
+This eliminates the lost-update class: there is only one writer to the
+registry, so no compare-and-swap or optimistic-lock scheme is needed for
+counter updates.  Counter bumps use atomic SQL expressions
+(``SET col = col + 1``) rather than read-modify-write in Python, so a
+process crash mid-increment cannot leave a stale value.
+
+``repo`` — canonical stable key
+---------------------------------
+``repo`` is a 12-character hex prefix of the SHA-256 of the *normalised*
+repository identity string:
+
+  * If the working directory has a ``git remote`` named "origin", the
+    normalised remote URL is used (stripped of trailing ``.git``, lowercased,
+    scheme removed so ``https://github.com/foo/bar`` and
+    ``git@github.com:foo/bar`` both hash to the same value).
+  * If there is no remote, the absolute ``workdir`` path is used as-is.
+
+The normalisation is deterministic across machines for the same remote, so
+two checkouts of the same repository share the same ``repo`` key, while
+different repositories (different remote URLs) always differ.
+
+Call :func:`canonical_repo_id` to compute the key before inserting.
+
+Lock TTL
+---------
+``lock_ts`` stores the wallclock time (ISO-8601 UTC string from
+``datetime('now')`` in SQLite) at which the lock was acquired.
+``acquire_lock`` refuses to grant the lock if a non-expired row exists.
+Callers pass ``ttl_seconds`` (default: 5× cron interval = 300 s) and
+the lock is auto-reclaimed via the ``lock_ts`` column.
+
+Queue intent kinds
+------------------
+  ``adopt``   — register a session spawned externally (webhook path).
+  ``drive``   — queue a message to relay to the agent's tmux session.
+  ``update``  — set arbitrary fields on an existing row (cron applies them).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+import sqlite3
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Default busy-timeout: how long SQLite waits for a write lock before
+# raising OperationalError("database is locked").  5 s is generous; the
+# cron watcher holds the lock for milliseconds.
+# ---------------------------------------------------------------------------
+_BUSY_TIMEOUT_MS = 5_000
+
+# ---------------------------------------------------------------------------
+# DDL — added to state.db via hermes_state._init_schema()
+# ---------------------------------------------------------------------------
+
+SESSION_ORCHESTRATION_DDL = """
+CREATE TABLE IF NOT EXISTS session_orchestration (
+    task_id                TEXT PRIMARY KEY,
+    agent                  TEXT NOT NULL,
+    tmux_session           TEXT,
+    project                TEXT,
+    discord_thread_id      TEXT,
+    hermes_session_key     TEXT,
+    workdir                TEXT,
+    state                  TEXT NOT NULL DEFAULT 'RUNNING',
+    idle_ticks             INTEGER NOT NULL DEFAULT 0,
+    nudge_count            INTEGER NOT NULL DEFAULT 0,
+    last_pane_hash         TEXT,
+    last_output_ts         REAL,
+    heartbeat_counter      INTEGER NOT NULL DEFAULT 0,
+    status_message_id      TEXT,
+    lock_holder            TEXT,
+    lock_ts                TEXT,
+    source                 TEXT NOT NULL DEFAULT 'spawn',
+    run_id                 TEXT,
+    repo                   TEXT,
+    created_at             TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at             TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(run_id, repo)
+);
+
+CREATE INDEX IF NOT EXISTS idx_so_state
+    ON session_orchestration(state);
+CREATE INDEX IF NOT EXISTS idx_so_run_repo
+    ON session_orchestration(run_id, repo);
+
+CREATE TABLE IF NOT EXISTS session_orchestration_queue (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id    TEXT,
+    run_id     TEXT,
+    repo       TEXT,
+    intent     TEXT NOT NULL,
+    payload    TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_soq_task
+    ON session_orchestration_queue(task_id);
+"""
+
+# ---------------------------------------------------------------------------
+# Canonical repo-id derivation
+# ---------------------------------------------------------------------------
+
+_SCHEME_RE = re.compile(r"^[a-z+]+://", re.IGNORECASE)
+_GIT_SCP_RE = re.compile(r"^[^/@]+@[^:]+:", re.IGNORECASE)
+
+
+def _normalise_remote_url(url: str) -> str:
+    """Strip scheme, credentials, and trailing .git; lowercase."""
+    url = url.strip()
+    # ssh://git@github.com/foo/bar.git  →  github.com/foo/bar
+    url = _SCHEME_RE.sub("", url)
+    # git@github.com:foo/bar.git  →  github.com/foo/bar
+    url = _GIT_SCP_RE.sub(lambda m: m.group(0).split("@", 1)[1].replace(":", "/"), url)
+    # Remove credentials (user:pass@host → host)
+    if "@" in url:
+        url = url.split("@", 1)[1]
+    # Drop trailing .git
+    if url.endswith(".git"):
+        url = url[:-4]
+    return url.lower().rstrip("/")
+
+
+def canonical_repo_id(workdir: Optional[str] = None, remote_url: Optional[str] = None) -> str:
+    """Return a 12-char hex SHA-256 prefix that stably identifies a repo.
+
+    Parameters
+    ----------
+    workdir:
+        Absolute path to the working directory.  Used as fallback when
+        ``remote_url`` is absent.
+    remote_url:
+        The git remote URL (e.g. from ``git remote get-url origin``).
+        When present, the normalised URL is hashed so two checkouts of
+        the same remote produce the same id.
+
+    Returns a 12-hex-character string (48 bits of collision resistance —
+    adequate for a registry with O(hundreds) of concurrent sessions).
+    """
+    if remote_url:
+        key = _normalise_remote_url(remote_url)
+    elif workdir:
+        key = str(Path(workdir).resolve())
+    else:
+        key = f"unknown-{time.time()}"
+    digest = hashlib.sha256(key.encode()).hexdigest()
+    return digest[:12]
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class SessionOrchestrationRegistry:
+    """SQLite-backed registry for managed external-agent sessions.
+
+    Callers obtain a connection via the existing hermes_state machinery or
+    pass a ``db_path`` directly.  The constructor sets ``busy_timeout`` on
+    every connection, regardless of origin.
+
+    Thread / process safety
+    -----------------------
+    All writes use ``BEGIN IMMEDIATE`` so SQLite serialises concurrent writers
+    at the WAL write-lock level.  Counter updates are atomic SQL expressions
+    (never read-modify-write in Python) so the cron watcher can bump counters
+    without a separate SELECT.
+
+    The cron watcher is the sole caller of :meth:`upsert`, :meth:`drain_intents`,
+    :meth:`acquire_lock`, and :meth:`release_lock`.  All other callers use only
+    :meth:`enqueue_intent` (append-only, safe from any thread/process) and
+    :meth:`get` / :meth:`list` (read-only).
+    """
+
+    def __init__(
+        self,
+        db_path: Optional[Path] = None,
+        *,
+        busy_timeout_ms: int = _BUSY_TIMEOUT_MS,
+    ) -> None:
+        if db_path is None:
+            # Import lazily to avoid a circular dep at module load time.
+            from hermes_state import DEFAULT_DB_PATH
+            db_path = DEFAULT_DB_PATH
+
+        self._db_path = db_path
+        self._busy_timeout_ms = busy_timeout_ms
+        self._ensure_schema()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _connect(self) -> sqlite3.Connection:
+        """Open a connection with busy_timeout and WAL-compatible settings."""
+        conn = sqlite3.connect(
+            str(self._db_path),
+            check_same_thread=False,
+            timeout=self._busy_timeout_ms / 1000.0,
+            isolation_level=None,  # we manage transactions explicitly
+        )
+        conn.row_factory = sqlite3.Row
+        # busy_timeout makes SQLite spin-wait (with exponential back-off)
+        # rather than immediately returning SQLITE_BUSY.  This is the
+        # primary guard against lost writes under concurrent readers.
+        conn.execute(f"PRAGMA busy_timeout={self._busy_timeout_ms}")
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+        return conn
+
+    def _ensure_schema(self) -> None:
+        """Create session_orchestration tables if they don't exist yet.
+
+        Uses ``IF NOT EXISTS`` throughout, so this is idempotent and safe
+        to call on every startup even when the tables were created by an
+        earlier version.
+        """
+        conn = self._connect()
+        try:
+            conn.executescript(SESSION_ORCHESTRATION_DDL)
+        finally:
+            conn.close()
+
+    def _write(self, fn, conn: Optional[sqlite3.Connection] = None) -> Any:
+        """Execute *fn(conn)* inside a BEGIN IMMEDIATE transaction.
+
+        Closes the connection when ``conn`` is None (i.e. we opened it).
+        Returns whatever *fn* returns.
+        """
+        owned = conn is None
+        if owned:
+            conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                result = fn(conn)
+                conn.execute("COMMIT")
+                return result
+            except BaseException:
+                try:
+                    conn.execute("ROLLBACK")
+                except Exception:
+                    pass
+                raise
+        finally:
+            if owned:
+                conn.close()
+
+    # ------------------------------------------------------------------
+    # Public API — read paths (any caller)
+    # ------------------------------------------------------------------
+
+    def get(self, task_id: str) -> Optional[Dict[str, Any]]:
+        """Return a registry row as a dict, or None if not found."""
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT * FROM session_orchestration WHERE task_id = ?",
+                (task_id,),
+            ).fetchone()
+            return dict(row) if row else None
+        finally:
+            conn.close()
+
+    def list(
+        self,
+        *,
+        state: Optional[str] = None,
+        run_id: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return all (or filtered) registry rows as dicts."""
+        clauses: List[str] = []
+        params: List[Any] = []
+        if state is not None:
+            clauses.append("state = ?")
+            params.append(state)
+        if run_id is not None:
+            clauses.append("run_id = ?")
+            params.append(run_id)
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                f"SELECT * FROM session_orchestration {where}",
+                params,
+            ).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            conn.close()
+
+    # ------------------------------------------------------------------
+    # Public API — cron-watcher-only mutations
+    # ------------------------------------------------------------------
+
+    def upsert(
+        self,
+        task_id: str,
+        *,
+        agent: str,
+        run_id: Optional[str] = None,
+        repo: Optional[str] = None,
+        source: str = "spawn",
+        **fields: Any,
+    ) -> None:
+        """Insert or update a registry row.
+
+        **Cron watcher only.** All other callers must use :meth:`enqueue_intent`.
+
+        On conflict (same ``task_id``) the row is updated in-place.
+        On conflict on the ``UNIQUE(run_id, repo)`` constraint (a duplicate
+        adopt/spawn for the same logical repository + run), the existing row
+        wins (INSERT OR IGNORE semantics) and an INFO log is emitted.
+
+        Counter columns (``idle_ticks``, ``nudge_count``, ``heartbeat_counter``)
+        are *not* set here unless explicitly passed — use the atomic increment
+        helpers or ``_apply_intent`` for those.
+        """
+        # Determine which columns to set
+        all_fields: Dict[str, Any] = {
+            "agent": agent,
+            "run_id": run_id,
+            "repo": repo,
+            "source": source,
+            **fields,
+        }
+
+        def _do(conn: sqlite3.Connection) -> None:
+            # Try INSERT first; on task_id conflict, UPDATE.
+            # On (run_id, repo) conflict, log and skip.
+            existing = conn.execute(
+                "SELECT task_id FROM session_orchestration WHERE task_id = ?",
+                (task_id,),
+            ).fetchone()
+
+            if existing is None:
+                # Check for (run_id, repo) duplicate before INSERT
+                if run_id is not None and repo is not None:
+                    dup = conn.execute(
+                        "SELECT task_id FROM session_orchestration "
+                        "WHERE run_id = ? AND repo = ? AND task_id != ?",
+                        (run_id, repo, task_id),
+                    ).fetchone()
+                    if dup is not None:
+                        logger.info(
+                            "registry.upsert: duplicate (run_id=%s, repo=%s) "
+                            "already exists as task_id=%s — skipping insert of %s",
+                            run_id,
+                            repo,
+                            dup[0],
+                            task_id,
+                        )
+                        return
+
+                col_names = ["task_id"] + list(all_fields.keys())
+                placeholders = ", ".join("?" * len(col_names))
+                col_clause = ", ".join(col_names)
+                values = [task_id] + list(all_fields.values())
+                conn.execute(
+                    f"INSERT INTO session_orchestration ({col_clause}) "
+                    f"VALUES ({placeholders})",
+                    values,
+                )
+            else:
+                # UPDATE — only set non-None fields; always bump updated_at.
+                set_parts: List[str] = ["updated_at = datetime('now')"]
+                set_vals: List[Any] = []
+                for k, v in all_fields.items():
+                    if v is not None:
+                        set_parts.append(f"{k} = ?")
+                        set_vals.append(v)
+                if len(set_parts) > 1:
+                    set_vals.append(task_id)
+                    conn.execute(
+                        f"UPDATE session_orchestration SET {', '.join(set_parts)} "
+                        f"WHERE task_id = ?",
+                        set_vals,
+                    )
+
+        self._write(_do)
+
+    def increment_counter(self, task_id: str, column: str, by: int = 1) -> None:
+        """Atomically increment a counter column.
+
+        **Cron watcher only.**
+
+        Uses ``SET col = col + ?`` (atomic SQL expression) — never
+        read-modify-write in Python.
+
+        Parameters
+        ----------
+        task_id:
+            Registry row to update.
+        column:
+            One of ``heartbeat_counter``, ``idle_ticks``, ``nudge_count``.
+        by:
+            Increment amount (default 1).
+        """
+        _ALLOWED_COUNTERS = frozenset(
+            {"heartbeat_counter", "idle_ticks", "nudge_count"}
+        )
+        if column not in _ALLOWED_COUNTERS:
+            raise ValueError(
+                f"increment_counter: column {column!r} not in allowed set "
+                f"{_ALLOWED_COUNTERS}"
+            )
+
+        def _do(conn: sqlite3.Connection) -> None:
+            conn.execute(
+                f"UPDATE session_orchestration "
+                f"SET {column} = {column} + ?, updated_at = datetime('now') "
+                f"WHERE task_id = ?",
+                (by, task_id),
+            )
+
+        self._write(_do)
+
+    def drain_intents(self) -> List[Dict[str, Any]]:
+        """Return and delete all pending queue rows (oldest first).
+
+        **Cron watcher only.**
+
+        The cron watcher calls this once per tick, applies each intent
+        via :meth:`_apply_intent`, and then commits.  The DELETE and the
+        application of each intent happen inside a single
+        ``BEGIN IMMEDIATE`` transaction so no intent is lost on crash.
+
+        Returns the list of intent dicts (already removed from the queue).
+        """
+        def _do(conn: sqlite3.Connection) -> List[Dict[str, Any]]:
+            rows = conn.execute(
+                "SELECT * FROM session_orchestration_queue ORDER BY id ASC"
+            ).fetchall()
+            if rows:
+                ids = [r["id"] for r in rows]
+                conn.execute(
+                    "DELETE FROM session_orchestration_queue WHERE id IN "
+                    f"({','.join('?' * len(ids))})",
+                    ids,
+                )
+            return [dict(r) for r in rows]
+
+        return self._write(_do) or []
+
+    def _apply_intent(self, intent: Dict[str, Any]) -> None:
+        """Apply a single drained intent to the registry (cron watcher only).
+
+        Intent kinds:
+
+        ``adopt``
+            Upsert a new row (webhook-adopt path).  ``payload`` must contain
+            ``agent``, ``run_id``, ``repo``, and optionally other columns.
+
+        ``drive``
+            Store a pending drive payload on the row (column ``drive_payload``
+            is not in the schema by default; store in ``state_meta`` or as a
+            future column).  For now this just updates ``updated_at`` so the
+            watcher knows something is pending.
+
+        ``update``
+            Set arbitrary ``payload`` columns on the named ``task_id``.
+        """
+        kind = intent.get("intent", "")
+        import json as _json
+        payload: Dict[str, Any] = _json.loads(intent.get("payload", "{}"))
+
+        if kind == "adopt":
+            task_id = intent.get("task_id") or payload.get("task_id")
+            if not task_id:
+                logger.warning("registry._apply_intent: adopt intent missing task_id")
+                return
+            # Pop all explicitly-named upsert kwargs so they don't collide
+            # with positional args when the caller includes them in payload.
+            payload.pop("task_id", None)
+            agent = payload.pop("agent", "unknown")
+            run_id = payload.pop("run_id", None)
+            repo = payload.pop("repo", None)
+            self.upsert(
+                task_id,
+                agent=agent,
+                run_id=run_id,
+                repo=repo,
+                source="adopt",
+                **payload,
+            )
+
+        elif kind == "update":
+            task_id = intent.get("task_id") or payload.get("task_id")
+            if not task_id:
+                logger.warning("registry._apply_intent: update intent missing task_id")
+                return
+            payload.pop("task_id", None)
+            if payload:
+                def _do(conn: sqlite3.Connection) -> None:
+                    set_parts = ["updated_at = datetime('now')"]
+                    vals: List[Any] = []
+                    for k, v in payload.items():
+                        set_parts.append(f"{k} = ?")
+                        vals.append(v)
+                    vals.append(task_id)
+                    conn.execute(
+                        f"UPDATE session_orchestration SET {', '.join(set_parts)} "
+                        f"WHERE task_id = ?",
+                        vals,
+                    )
+                self._write(_do)
+
+        elif kind == "drive":
+            # Drive intents are consumed by the relay module; the registry
+            # records them as pending so the watcher knows a drive is queued.
+            # We just touch updated_at here; the relay reads from the queue
+            # directly before it is drained.
+            task_id = intent.get("task_id") or payload.get("task_id")
+            if task_id:
+                def _do(conn: sqlite3.Connection) -> None:
+                    conn.execute(
+                        "UPDATE session_orchestration "
+                        "SET updated_at = datetime('now') WHERE task_id = ?",
+                        (task_id,),
+                    )
+                self._write(_do)
+
+        else:
+            logger.warning("registry._apply_intent: unknown intent kind %r", kind)
+
+    # ------------------------------------------------------------------
+    # Public API — queue write (any caller, append-only)
+    # ------------------------------------------------------------------
+
+    def enqueue_intent(
+        self,
+        intent: str,
+        *,
+        task_id: Optional[str] = None,
+        run_id: Optional[str] = None,
+        repo: Optional[str] = None,
+        payload: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Append an intent to the queue for the cron watcher to drain.
+
+        Safe to call from any thread or process (webhook-adopt, Discord-drive).
+        Does NOT write to ``session_orchestration`` directly.
+
+        Parameters
+        ----------
+        intent:
+            One of ``"adopt"``, ``"drive"``, ``"update"``.
+        task_id:
+            Target registry row (required for ``drive``/``update``; optional
+            for ``adopt`` when the task_id is inside ``payload``).
+        run_id, repo:
+            Correlation keys for ``adopt`` intents where the ``task_id`` is
+            not yet known.
+        payload:
+            Arbitrary JSON-serialisable dict passed to the cron drainer.
+        """
+        import json as _json
+        payload_str = _json.dumps(payload or {})
+
+        def _do(conn: sqlite3.Connection) -> None:
+            conn.execute(
+                "INSERT INTO session_orchestration_queue "
+                "(task_id, run_id, repo, intent, payload) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (task_id, run_id, repo, intent, payload_str),
+            )
+
+        self._write(_do)
+
+    # ------------------------------------------------------------------
+    # Per-session lock (cron watcher + relay)
+    # ------------------------------------------------------------------
+
+    def acquire_lock(
+        self,
+        task_id: str,
+        holder: str,
+        *,
+        ttl_seconds: float = 300.0,
+    ) -> bool:
+        """Atomically acquire the per-session lock for ``task_id``.
+
+        Returns True on success.  Returns False if a non-expired lock is
+        already held by a different holder.
+
+        Expired locks (``lock_ts`` + ``ttl_seconds`` < wallclock) are
+        auto-reclaimed: the lock is taken by the new holder.
+
+        The TTL is checked using the Python wallclock (``time.time()``) so
+        stale-reclaim works even when the DB is on a host with a different
+        clock — only the acquiring process's clock matters.
+
+        ``lock_ts`` is stored as a float (seconds since epoch) rather than an
+        ISO-8601 string to avoid timezone-parsing ambiguity (SQLite's
+        ``datetime('now')`` returns a naive UTC string that ``fromisoformat``
+        would silently interpret as local time).
+
+        Parameters
+        ----------
+        task_id:
+            Registry row to lock.
+        holder:
+            Opaque identifier of the locking entity (e.g. ``"cron:pid:1234"``).
+        ttl_seconds:
+            Lock expiry in seconds (default 300 = 5× a 60 s cron interval).
+        """
+        now_epoch = time.time()
+        expiry_epoch = now_epoch + ttl_seconds
+
+        def _do(conn: sqlite3.Connection) -> bool:
+            row = conn.execute(
+                "SELECT lock_holder, lock_ts FROM session_orchestration WHERE task_id = ?",
+                (task_id,),
+            ).fetchone()
+            if row is None:
+                return False
+
+            current_holder = row["lock_holder"] if isinstance(row, sqlite3.Row) else row[0]
+            current_lock_ts = row["lock_ts"] if isinstance(row, sqlite3.Row) else row[1]
+
+            # Already held by us?
+            if current_holder == holder:
+                # Refresh expiry
+                conn.execute(
+                    "UPDATE session_orchestration SET lock_ts = ? WHERE task_id = ?",
+                    (str(expiry_epoch), task_id),
+                )
+                return True
+
+            # Held by someone else — check expiry (lock_ts stores expiry epoch)
+            if current_holder is not None and current_lock_ts is not None:
+                try:
+                    lock_expiry = float(current_lock_ts)
+                except (ValueError, TypeError):
+                    lock_expiry = 0.0
+                if lock_expiry > now_epoch:
+                    # Lock is still fresh — deny
+                    return False
+
+            # Either no lock or expired lock — claim it
+            conn.execute(
+                "UPDATE session_orchestration "
+                "SET lock_holder = ?, lock_ts = ?, updated_at = datetime('now') "
+                "WHERE task_id = ?",
+                (holder, str(expiry_epoch), task_id),
+            )
+            return True
+
+        try:
+            return bool(self._write(_do))
+        except sqlite3.Error as exc:
+            logger.warning("acquire_lock(%s) failed: %s", task_id, exc)
+            return False
+
+    def release_lock(self, task_id: str, holder: str) -> None:
+        """Release the per-session lock iff *holder* is the current owner.
+
+        Idempotent — no-op if the lock is already expired/reclaimed or was
+        never held by ``holder``.
+        """
+        def _do(conn: sqlite3.Connection) -> None:
+            conn.execute(
+                "UPDATE session_orchestration "
+                "SET lock_holder = NULL, lock_ts = NULL, "
+                "    updated_at = datetime('now') "
+                "WHERE task_id = ? AND lock_holder = ?",
+                (task_id, holder),
+            )
+
+        try:
+            self._write(_do)
+        except sqlite3.Error as exc:
+            logger.warning("release_lock(%s) failed: %s", task_id, exc)

--- a/session_orchestration/registry.py
+++ b/session_orchestration/registry.py
@@ -125,6 +125,25 @@ CREATE TABLE IF NOT EXISTS session_orchestration_queue (
 CREATE INDEX IF NOT EXISTS idx_soq_task
     ON session_orchestration_queue(task_id);
 
+-- Persistent pending-drive store: a user reply that arrived while the target
+-- session was busy (see gateway/run.py:_handle_managed_thread_reply). Unlike
+-- the intent queue above (drained-and-discarded each tick), a pending-drive
+-- entry survives across watcher ticks until the session next becomes idle and
+-- the watcher redelivers it (or the TTL expires). Concurrency model mirrors the
+-- intent queue: enqueue_pending_drive() is an append-only INSERT safe from any
+-- thread; every UPDATE/DELETE is watcher-only (single-writer invariant).
+CREATE TABLE IF NOT EXISTS session_orchestration_pending_drive (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id     TEXT NOT NULL,
+    message     TEXT NOT NULL,
+    pre_keys    TEXT NOT NULL DEFAULT '[]',
+    enqueued_at TEXT NOT NULL DEFAULT (datetime('now')),
+    attempts    INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_sopd_task
+    ON session_orchestration_pending_drive(task_id);
+
 CREATE TABLE IF NOT EXISTS session_orchestration_attention_items (
     id                    INTEGER PRIMARY KEY AUTOINCREMENT,
     task_id               TEXT NOT NULL,
@@ -245,9 +264,11 @@ class SessionOrchestrationRegistry:
     without a separate SELECT.
 
     The cron watcher is the sole caller of :meth:`upsert`, :meth:`drain_intents`,
-    :meth:`acquire_lock`, and :meth:`release_lock`.  All other callers use only
-    :meth:`enqueue_intent` (append-only, safe from any thread/process) and
-    :meth:`get` / :meth:`list` (read-only).
+    :meth:`acquire_lock`, :meth:`release_lock`, :meth:`list_pending_drive`,
+    :meth:`delete_pending_drive`, and :meth:`bump_pending_drive_attempt`.  All
+    other callers use only :meth:`enqueue_intent` / :meth:`enqueue_pending_drive`
+    (append-only, safe from any thread/process) and :meth:`get` / :meth:`list`
+    (read-only).
     """
 
     def __init__(
@@ -1140,6 +1161,85 @@ class SessionOrchestrationRegistry:
                 "(task_id, run_id, repo, intent, payload) "
                 "VALUES (?, ?, ?, ?, ?)",
                 (task_id, run_id, repo, intent, payload_str),
+            )
+
+        self._write(_do)
+
+    # ------------------------------------------------------------------
+    # Pending-drive store (busy-session reply recovery)
+    # ------------------------------------------------------------------
+    #
+    # Concurrency contract mirrors the intent queue: :meth:`enqueue_pending_drive`
+    # is an append-only INSERT safe from any thread/process (the Discord-drive
+    # path). The read/mutation helpers (:meth:`list_pending_drive`,
+    # :meth:`delete_pending_drive`, :meth:`bump_pending_drive_attempt`) are the
+    # cron watcher's alone — the single-writer invariant covers them.
+
+    def enqueue_pending_drive(
+        self,
+        task_id: str,
+        message: str,
+        *,
+        pre_keys: Optional[List[str]] = None,
+    ) -> None:
+        """Queue a user reply for redelivery when the session next goes idle.
+
+        Append-only INSERT — safe to call from any thread or process (the
+        Discord-drive path calls this when the target session is busy). Does
+        NOT read or mutate any other row. The cron watcher drains the store on
+        the tick a session becomes ``WAITING_USER`` and redelivers FIFO.
+        """
+        import json as _json
+        pre_keys_str = _json.dumps(pre_keys or [])
+
+        def _do(conn: sqlite3.Connection) -> None:
+            conn.execute(
+                "INSERT INTO session_orchestration_pending_drive "
+                "(task_id, message, pre_keys) VALUES (?, ?, ?)",
+                (task_id, message, pre_keys_str),
+            )
+
+        self._write(_do)
+
+    def list_pending_drive(self, task_id: str) -> List[Dict[str, Any]]:
+        """Return pending-drive entries for ``task_id`` in FIFO (insert) order.
+
+        **Cron watcher only.** Each dict carries ``id``, ``task_id``,
+        ``message``, ``pre_keys`` (JSON string), ``enqueued_at``, ``attempts``.
+        """
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT * FROM session_orchestration_pending_drive "
+                "WHERE task_id = ? ORDER BY id",
+                (task_id,),
+            ).fetchall()
+            return [dict(row) for row in rows]
+        finally:
+            conn.close()
+
+    def delete_pending_drive(self, entry_id: int) -> None:
+        """Delete a pending-drive entry by id. **Cron watcher only.**"""
+
+        def _do(conn: sqlite3.Connection) -> None:
+            conn.execute(
+                "DELETE FROM session_orchestration_pending_drive WHERE id = ?",
+                (entry_id,),
+            )
+
+        self._write(_do)
+
+    def bump_pending_drive_attempt(self, entry_id: int) -> None:
+        """Increment the ``attempts`` counter for a pending-drive entry.
+
+        **Cron watcher only.** Atomic SQL expression — never read-modify-write.
+        """
+
+        def _do(conn: sqlite3.Connection) -> None:
+            conn.execute(
+                "UPDATE session_orchestration_pending_drive "
+                "SET attempts = attempts + 1 WHERE id = ?",
+                (entry_id,),
             )
 
         self._write(_do)

--- a/session_orchestration/registry.py
+++ b/session_orchestration/registry.py
@@ -81,6 +81,12 @@ CREATE TABLE IF NOT EXISTS session_orchestration (
     task_id                TEXT PRIMARY KEY,
     agent                  TEXT NOT NULL,
     tmux_session           TEXT,
+    -- Stable tmux pane id (e.g. '%12') pinned at launch. Targeting this instead
+    -- of the bare tmux_session is REQUIRED for correctness: `tmux -t <session>`
+    -- resolves to the session's ACTIVE window, so once the session gains extra
+    -- windows (or the user switches away) capture/detect/drive would hit the
+    -- wrong pane — a shell, not the agent. The pane id is immune to that.
+    pane                   TEXT,
     project                TEXT,
     discord_thread_id      TEXT,
     hermes_session_key     TEXT,
@@ -334,6 +340,14 @@ class SessionOrchestrationRegistry:
                 conn.execute(
                     "ALTER TABLE session_orchestration "
                     "ADD COLUMN marker_offset INTEGER NOT NULL DEFAULT 0"
+                )
+            except sqlite3.OperationalError:
+                pass  # Column already exists — idempotent
+
+            try:
+                conn.execute(
+                    "ALTER TABLE session_orchestration "
+                    "ADD COLUMN pane TEXT"
                 )
             except sqlite3.OperationalError:
                 pass  # Column already exists — idempotent

--- a/session_orchestration/registry.py
+++ b/session_orchestration/registry.py
@@ -385,6 +385,27 @@ class SessionOrchestrationRegistry:
             except sqlite3.OperationalError:
                 pass  # Column already exists — idempotent
 
+            # Turn-output relay: path of the agent's own transcript file (e.g.
+            # omp's ~/.omp/agent/sessions/<cwd>/<ts>_<id>.jsonl) and how many
+            # lines of it have already been relayed to the Discord thread. The
+            # transcript is the clean source of assistant text (no tool spam),
+            # discovered at spawn time (see agent_transcript.py).
+            try:
+                conn.execute(
+                    "ALTER TABLE session_orchestration "
+                    "ADD COLUMN agent_session_file TEXT"
+                )
+            except sqlite3.OperationalError:
+                pass  # Column already exists — idempotent
+
+            try:
+                conn.execute(
+                    "ALTER TABLE session_orchestration "
+                    "ADD COLUMN transcript_line_offset INTEGER"
+                )
+            except sqlite3.OperationalError:
+                pass  # Column already exists — idempotent
+
         self._write(_do)
 
     def _write(self, fn, conn: Optional[sqlite3.Connection] = None) -> Any:

--- a/session_orchestration/relay.py
+++ b/session_orchestration/relay.py
@@ -124,6 +124,7 @@ class SessionRelay:
         message: str,
         *,
         retry_on_conflict: bool = False,
+        pre_keys: list[str] | None = None,
     ) -> None:
         """Send ``message`` to the session identified by ``task_id``/``handle``.
 
@@ -177,6 +178,10 @@ class SessionRelay:
                     task_id,
                 )
                 self._adapter.resume(handle, message)
+            elif pre_keys:
+                # Only thread pre_keys when present so adapters/fakes with the
+                # 2-arg drive() signature keep working on the common path.
+                self._adapter.drive(handle, message, pre_keys=pre_keys)
             else:
                 self._adapter.drive(handle, message)
         finally:

--- a/session_orchestration/relay.py
+++ b/session_orchestration/relay.py
@@ -1,0 +1,218 @@
+"""
+Deterministic relay — acquire the per-session lock, drive via adapter, release.
+
+Responsibilities
+----------------
+1. **Lock acquisition** — calls ``registry.acquire_lock(task_id, holder, ttl_seconds)``
+   with a TTL of 5× the cron interval (default 300 s) before doing anything
+   to the tmux pane.  If the lock is held by a non-expired holder, raises
+   ``LockConflictError`` (caller decides whether to retry or escalate).
+
+2. **Readiness check + drive** — delegates entirely to the adapter's ``drive()``
+   method, which performs the load-buffer/paste-buffer sequence with its own
+   prompt-readiness check.  The relay does NOT re-implement tmux calls.
+
+3. **Lock release** — calls ``registry.release_lock(task_id, holder)`` in a
+   ``finally`` block so a crash mid-drive self-heals after the TTL.
+
+4. **Handoff detection + deterministic resume** — if ``adapter.detect()`` returns
+   ``PAUSED_HANDOFF`` BEFORE driving, the relay calls ``adapter.resume()``
+   (``/clear`` + re-inject) and skips the normal ``drive()`` path.  This is
+   the ONLY time ``/clear`` is issued by the relay; it is deterministic (no LLM).
+
+Stale-lock reclaim
+------------------
+The TTL and stale-reclaim logic live in ``registry.acquire_lock``; the relay
+does not implement its own.  ``lock_ts`` stores a float expiry epoch (seconds
+since epoch), NOT an ISO-8601 string, to avoid ``datetime.fromisoformat``
+timezone-parsing ambiguity in Python 3.11 — T002's design decision; relay
+matches it via the shared ``acquire_lock`` API and does not introduce a
+second timestamp representation.
+
+Concurrency contract
+--------------------
+A relay-send and a watcher-style capture issued concurrently to the same
+``task_id`` use the same ``acquire_lock`` / ``release_lock`` API.  Because
+``acquire_lock`` uses ``BEGIN IMMEDIATE`` (SQLite write lock), only one caller
+can hold the lock at a time; the other caller blocks on SQLite's ``busy_timeout``
+(default 5 s) and then gets ``False`` returned.  This makes concurrent
+interleaving provably impossible for any two callers that correctly call
+``acquire_lock`` before touching the pane.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Optional
+
+from session_orchestration.adapters.base import AgentAdapter
+from session_orchestration.registry import SessionOrchestrationRegistry
+from session_orchestration.types import SessionHandle, SessionLifecycle
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+#: Default lock TTL in seconds (5× a 60 s cron interval).
+_DEFAULT_TTL: float = 300.0
+
+#: Seconds to wait between lock-acquire retries when the caller opts in to retry.
+_RETRY_INTERVAL: float = 0.25
+
+#: Maximum seconds ``send_message`` will retry lock acquisition when
+#: ``retry_on_conflict=True``.
+_RETRY_TIMEOUT: float = 10.0
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class LockConflictError(RuntimeError):
+    """Raised when the per-session lock cannot be acquired because a non-expired
+    holder already owns it and ``retry_on_conflict=False`` (the default).
+    """
+
+
+# ---------------------------------------------------------------------------
+# Relay
+# ---------------------------------------------------------------------------
+
+
+class SessionRelay:
+    """Mediates all pane-writes for a managed session.
+
+    Parameters
+    ----------
+    registry:
+        The ``SessionOrchestrationRegistry`` instance.
+    adapter:
+        The ``AgentAdapter`` (e.g. ``ClaudeCodeAdapter``) for this session.
+    ttl_seconds:
+        Lock TTL for each relay call.  Default 300 s (5× 60 s cron interval).
+    holder_prefix:
+        Prefix for lock-holder identifiers.  Combined with the process PID
+        to form an opaque string like ``"relay:pid:1234"``.
+    """
+
+    def __init__(
+        self,
+        registry: SessionOrchestrationRegistry,
+        adapter: AgentAdapter,
+        *,
+        ttl_seconds: float = _DEFAULT_TTL,
+        holder_prefix: str = "relay",
+    ) -> None:
+        self._registry = registry
+        self._adapter = adapter
+        self._ttl = ttl_seconds
+        self._holder_prefix = holder_prefix
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def send_message(
+        self,
+        task_id: str,
+        handle: SessionHandle,
+        message: str,
+        *,
+        retry_on_conflict: bool = False,
+    ) -> None:
+        """Send ``message`` to the session identified by ``task_id``/``handle``.
+
+        Acquires the per-session lock, checks for a handoff (issuing
+        ``/clear``+resume if detected), drives the message, and releases
+        the lock.
+
+        Parameters
+        ----------
+        task_id:
+            Registry row key.
+        handle:
+            ``SessionHandle`` for the tmux session.
+        message:
+            Text to deliver to the agent.
+        retry_on_conflict:
+            If True, spin-retry lock acquisition for up to
+            ``_RETRY_TIMEOUT`` seconds.  If False (default), raise
+            ``LockConflictError`` immediately on conflict.
+
+        Raises
+        ------
+        LockConflictError
+            When ``retry_on_conflict=False`` and the lock is already held.
+        TimeoutError
+            Propagated from ``adapter.drive()`` if the pane prompt does not
+            become ready within the adapter's configured timeout.
+        """
+        holder = self._make_holder()
+        acquired = self._acquire_with_optional_retry(
+            task_id, holder, retry_on_conflict=retry_on_conflict
+        )
+        if not acquired:
+            raise LockConflictError(
+                f"Per-session lock for {task_id!r} is held by another process; "
+                f"cannot send message."
+            )
+
+        try:
+            logger.debug(
+                "relay.send_message: lock acquired for task_id=%s holder=%s",
+                task_id,
+                holder,
+            )
+            # Check for handoff before driving — deterministic /clear+resume.
+            lifecycle = self._adapter.detect(handle)
+            if lifecycle == SessionLifecycle.PAUSED_HANDOFF:
+                logger.info(
+                    "relay.send_message: PAUSED_HANDOFF detected for task_id=%s; "
+                    "issuing /clear+resume (no LLM).",
+                    task_id,
+                )
+                self._adapter.resume(handle, message)
+            else:
+                self._adapter.drive(handle, message)
+        finally:
+            self._registry.release_lock(task_id, holder)
+            logger.debug(
+                "relay.send_message: lock released for task_id=%s holder=%s",
+                task_id,
+                holder,
+            )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _make_holder(self) -> str:
+        """Return an opaque lock-holder identifier for this process."""
+        return f"{self._holder_prefix}:pid:{os.getpid()}:{time.time():.3f}"
+
+    def _acquire_with_optional_retry(
+        self,
+        task_id: str,
+        holder: str,
+        *,
+        retry_on_conflict: bool,
+    ) -> bool:
+        """Try to acquire the lock.
+
+        If ``retry_on_conflict`` is True, spin for up to ``_RETRY_TIMEOUT``
+        seconds.  Returns True on success, False on failure.
+        """
+        if not retry_on_conflict:
+            return self._registry.acquire_lock(task_id, holder, ttl_seconds=self._ttl)
+
+        deadline = time.monotonic() + _RETRY_TIMEOUT
+        while time.monotonic() < deadline:
+            if self._registry.acquire_lock(task_id, holder, ttl_seconds=self._ttl):
+                return True
+            time.sleep(_RETRY_INTERVAL)
+        return False

--- a/session_orchestration/relay.py
+++ b/session_orchestration/relay.py
@@ -125,6 +125,7 @@ class SessionRelay:
         *,
         retry_on_conflict: bool = False,
         pre_keys: list[str] | None = None,
+        type_ahead: bool = False,
     ) -> None:
         """Send ``message`` to the session identified by ``task_id``/``handle``.
 
@@ -178,12 +179,15 @@ class SessionRelay:
                     task_id,
                 )
                 self._adapter.resume(handle, message)
-            elif pre_keys:
-                # Only thread pre_keys when present so adapters/fakes with the
-                # 2-arg drive() signature keep working on the common path.
-                self._adapter.drive(handle, message, pre_keys=pre_keys)
             else:
-                self._adapter.drive(handle, message)
+                # Only thread kwargs when set so adapters/fakes with a 2-arg
+                # drive() signature keep working on the common path.
+                drive_kwargs: dict = {}
+                if pre_keys:
+                    drive_kwargs["pre_keys"] = pre_keys
+                if type_ahead:
+                    drive_kwargs["type_ahead"] = True
+                self._adapter.drive(handle, message, **drive_kwargs)
         finally:
             self._registry.release_lock(task_id, holder)
             logger.debug(

--- a/session_orchestration/repo_registry.py
+++ b/session_orchestration/repo_registry.py
@@ -1,0 +1,344 @@
+"""
+session_orchestration/repo_registry.py — resolves a repo name to an absolute
+path and optional default agent.
+
+Resolution order (criterion #9):
+  1. Exact alias match in manual overrides (config repos: section)
+  2. Exact name match in auto-scan cache (~/dev/* and ~/.hermes git repos)
+  3. Fuzzy match (case-insensitive suffix on hyphen-split or substring) in
+     overrides first, then scan cache
+  4. Literal path: if the name looks like an absolute/home-expanded path and
+     points at a git repo directory
+  5. UnresolvedRepo sentinel — caller should ask the user for clarification
+
+The scan result is cached at the module level; call ``invalidate_scan_cache()``
+to reset (tests should inject ``_injected_scan`` instead of touching the cache).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_AGENT: str = "omp"
+
+_DEFAULT_SCAN_ROOTS: Sequence[str] = ("~/dev", "~/.hermes")
+
+
+# ---------------------------------------------------------------------------
+# Domain types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RepoEntry:
+    """One entry in the registry: absolute path + default agent."""
+
+    path: str
+    default_agent: str = DEFAULT_AGENT
+
+
+@dataclass(frozen=True)
+class ResolvedRepo:
+    """Successful resolution result."""
+
+    path: str
+    default_agent: str
+    matched_name: str  # the alias / canonical name that matched
+    match_kind: str    # "exact" | "fuzzy" | "literal_path"
+
+
+@dataclass(frozen=True)
+class UnresolvedRepo:
+    """Sentinel: the name could not be resolved; caller should ask the user."""
+
+    name: str
+
+
+# ---------------------------------------------------------------------------
+# Scanning helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_git_repo(path: Path) -> bool:
+    """Return True if *path* contains a ``.git`` entry."""
+    return (path / ".git").exists()
+
+
+def scan_for_repos(
+    scan_roots: Optional[Sequence[str]] = None,
+) -> Dict[str, str]:
+    """Scan *scan_roots* for git repositories.
+
+    Returns ``{lowercase_basename: absolute_path}``.  When multiple repos
+    share a basename the first one found wins (overrides take precedence over
+    the scan result anyway, so collisions here are low-risk).
+
+    Parameters
+    ----------
+    scan_roots:
+        Paths to examine.  Each is expanded via ``Path.expanduser()``.  If the
+        root itself is a git repo it is included; immediate children that are
+        git repos are also included.  Defaults to ``~/dev`` and ``~/.hermes``.
+    """
+    if scan_roots is None:
+        scan_roots = _DEFAULT_SCAN_ROOTS
+
+    found: Dict[str, str] = {}
+
+    for root_str in scan_roots:
+        root = Path(root_str).expanduser()
+        if not root.exists():
+            continue
+
+        # Root itself may be a git repo (e.g. ~/.hermes)
+        if root.is_dir() and _is_git_repo(root):
+            key = root.name.lower()
+            found.setdefault(key, str(root))
+
+        # Immediate children
+        try:
+            for child in sorted(root.iterdir()):
+                if child.is_dir() and _is_git_repo(child):
+                    key = child.name.lower()
+                    found.setdefault(key, str(child))
+        except PermissionError:
+            logger.debug("repo_registry.scan: permission denied reading %s", root)
+
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Module-level scan cache
+# ---------------------------------------------------------------------------
+
+_scan_cache: Optional[Dict[str, str]] = None
+
+
+def _get_cached_scan(scan_roots: Optional[Sequence[str]] = None) -> Dict[str, str]:
+    global _scan_cache
+    if _scan_cache is None:
+        _scan_cache = scan_for_repos(scan_roots)
+    return _scan_cache
+
+
+def invalidate_scan_cache() -> None:
+    """Clear the module-level scan cache.
+
+    Useful after a new repo is cloned.  Tests should prefer ``_injected_scan``
+    over calling this so they don't depend on filesystem state.
+    """
+    global _scan_cache
+    _scan_cache = None
+
+
+# ---------------------------------------------------------------------------
+# Fuzzy matching
+# ---------------------------------------------------------------------------
+
+
+def _fuzzy_name_matches(query: str, candidate: str) -> bool:
+    """True if *query* is a suffix-segment or substring of *candidate*.
+
+    Examples
+    --------
+    "agent"   matches "hermes-agent"  (suffix-segment on ``-``)
+    "hermes"  matches "hermes-agent"  (prefix-segment; also substring)
+    "agent"   matches "my-agent-repo" (suffix-segment)
+    "oops"    does NOT match "hermes-agent"
+    """
+    if not query:
+        return False
+    # Suffix-segment match: "agent" matches "hermes-agent"
+    parts = candidate.split("-")
+    for i in range(len(parts)):
+        if "-".join(parts[i:]) == query:
+            return True
+    # Substring match
+    return query in candidate
+
+
+# ---------------------------------------------------------------------------
+# Registry class
+# ---------------------------------------------------------------------------
+
+
+class RepoRegistry:
+    """Resolves a repo name or alias to a ``ResolvedRepo`` or ``UnresolvedRepo``.
+
+    Parameters
+    ----------
+    overrides:
+        Manual alias → ``RepoEntry`` mapping from the config ``repos:`` section.
+        These always win over the auto-scan result.
+    scan_roots:
+        Override the default filesystem scan roots (``~/dev`` and ``~/.hermes``).
+        Injected here so tests can point at a temp directory.
+    _injected_scan:
+        Pre-built ``{name: path}`` dict that fully replaces the filesystem scan
+        (no disk access at all).  Use this in unit tests.
+    """
+
+    def __init__(
+        self,
+        overrides: Optional[Dict[str, RepoEntry]] = None,
+        scan_roots: Optional[Sequence[str]] = None,
+        _injected_scan: Optional[Dict[str, str]] = None,
+    ) -> None:
+        self._overrides: Dict[str, RepoEntry] = overrides or {}
+        self._scan_roots = scan_roots
+        self._injected_scan = _injected_scan
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _scan(self) -> Dict[str, str]:
+        if self._injected_scan is not None:
+            return self._injected_scan
+        return _get_cached_scan(self._scan_roots)
+
+    def _fuzzy(self, lower: str, scan: Dict[str, str]) -> Optional[ResolvedRepo]:
+        """Return the first fuzzy match, checking overrides before scan."""
+        # Overrides first (they have priority)
+        for alias, entry in self._overrides.items():
+            if alias.lower() == lower:
+                continue  # already handled by exact step
+            if _fuzzy_name_matches(lower, alias.lower()):
+                return ResolvedRepo(
+                    path=entry.path,
+                    default_agent=entry.default_agent,
+                    matched_name=alias,
+                    match_kind="fuzzy",
+                )
+        # Then scan
+        for repo_name, path in scan.items():
+            if _fuzzy_name_matches(lower, repo_name):
+                return ResolvedRepo(
+                    path=path,
+                    default_agent=DEFAULT_AGENT,
+                    matched_name=repo_name,
+                    match_kind="fuzzy",
+                )
+        return None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def resolve(self, name: str) -> Union[ResolvedRepo, UnresolvedRepo]:
+        """Resolve *name* to a repo entry.
+
+        Returns ``UnresolvedRepo`` when the name cannot be resolved — the
+        caller should prompt the user for clarification.
+        """
+        stripped = name.strip()
+        lower = stripped.lower()
+
+        # 1. Exact alias in overrides (case-sensitive alias key)
+        if stripped in self._overrides:
+            entry = self._overrides[stripped]
+            return ResolvedRepo(
+                path=entry.path,
+                default_agent=entry.default_agent,
+                matched_name=stripped,
+                match_kind="exact",
+            )
+
+        # 2. Exact name in scan cache (case-insensitive)
+        scan = self._scan()
+        if lower in scan:
+            return ResolvedRepo(
+                path=scan[lower],
+                default_agent=DEFAULT_AGENT,
+                matched_name=lower,
+                match_kind="exact",
+            )
+
+        # 3. Fuzzy match
+        fuzzy = self._fuzzy(lower, scan)
+        if fuzzy is not None:
+            return fuzzy
+
+        # 4. Literal path (absolute or home-relative that exists as a git repo)
+        try:
+            candidate = Path(stripped).expanduser()
+            if candidate.is_absolute() and candidate.exists() and _is_git_repo(candidate):
+                return ResolvedRepo(
+                    path=str(candidate),
+                    default_agent=DEFAULT_AGENT,
+                    matched_name=stripped,
+                    match_kind="literal_path",
+                )
+        except Exception:  # noqa: BLE001 — Path expansion on untrusted input
+            pass
+
+        # 5. Unresolved
+        return UnresolvedRepo(name=stripped)
+
+
+# ---------------------------------------------------------------------------
+# Factory — build from raw config dict
+# ---------------------------------------------------------------------------
+
+
+def _parse_repo_entry(alias: str, val: Any) -> Optional[RepoEntry]:
+    """Parse one repos: entry (string shorthand or dict form)."""
+    if isinstance(val, str):
+        path = val.strip()
+        if not path:
+            logger.warning("repo_registry: alias %r has empty path — skipped", alias)
+            return None
+        return RepoEntry(path=path, default_agent=DEFAULT_AGENT)
+
+    if isinstance(val, dict):
+        path = str(val.get("path") or "").strip()
+        if not path:
+            logger.warning("repo_registry: alias %r missing 'path' — skipped", alias)
+            return None
+        raw_agent = val.get("default_agent")
+        default_agent = str(raw_agent).strip() if raw_agent else DEFAULT_AGENT
+        return RepoEntry(path=path, default_agent=default_agent or DEFAULT_AGENT)
+
+    logger.warning(
+        "repo_registry: alias %r has unrecognized value type %s — skipped",
+        alias, type(val).__name__,
+    )
+    return None
+
+
+def build_repo_registry(
+    repos_cfg: Optional[Dict[str, Any]] = None,
+    scan_roots: Optional[Sequence[str]] = None,
+    _injected_scan: Optional[Dict[str, str]] = None,
+) -> RepoRegistry:
+    """Build a ``RepoRegistry`` from the ``repos`` sub-dict of the config section.
+
+    Parameters
+    ----------
+    repos_cfg:
+        The ``repos:`` dict from the ``session_orchestration`` config section.
+        Keys are aliases; values are either an absolute path string or a dict
+        with ``path`` (required) and ``default_agent`` (optional, defaults to
+        ``omp``).
+    scan_roots:
+        Override the default scan roots (injectable for tests).
+    _injected_scan:
+        Pre-built scan dict; bypasses all filesystem access (for unit tests).
+    """
+    overrides: Dict[str, RepoEntry] = {}
+    if isinstance(repos_cfg, dict):
+        for alias, val in repos_cfg.items():
+            entry = _parse_repo_entry(alias, val)
+            if entry is not None:
+                overrides[alias] = entry
+
+    return RepoRegistry(
+        overrides=overrides,
+        scan_roots=scan_roots,
+        _injected_scan=_injected_scan,
+    )

--- a/session_orchestration/spawn.py
+++ b/session_orchestration/spawn.py
@@ -524,3 +524,98 @@ async def handle_spawn_command(
         lines.append("(No project thread — reply will route by task_id)")
 
     return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# /so-stop and /so-restart command handlers
+# ---------------------------------------------------------------------------
+
+
+def _parse_task_id(args_text: str) -> Optional[str]:
+    """Extract ``task_id=<value>`` from ``args_text``, or return ``None``."""
+    for token in args_text.split():
+        if token.startswith("task_id="):
+            value = token.partition("=")[2].strip()
+            return value if value else None
+    return None
+
+
+def handle_stop_command(
+    event,
+    args_text: str,
+    *,
+    config=None,
+    registry: Optional[SessionOrchestrationRegistry] = None,
+) -> str:
+    """Handle a ``/so-stop`` gateway command.
+
+    Parses a ``task_id=<id>`` argument from ``args_text``, enqueues a
+    terminate intent (``restart=False``), and returns a confirmation string.
+    Returns an error string (does not raise) when ``task_id`` is absent.
+
+    Parameters
+    ----------
+    event:
+        The gateway ``MessageEvent`` (present for interface symmetry with
+        ``handle_spawn_command``; not used directly).
+    args_text:
+        Everything after ``/so-stop`` in the message.
+    config:
+        Hermes config dict (reserved for future gating; not used today).
+    registry:
+        Override the registry (injected in tests).  When ``None``, a
+        default ``SessionOrchestrationRegistry()`` is created.
+    """
+    task_id = _parse_task_id(args_text)
+    if not task_id:
+        return (
+            "Usage: /so-stop task_id=<id>\n"
+            "Missing required argument: task_id"
+        )
+
+    _registry = registry if registry is not None else SessionOrchestrationRegistry()
+    _registry.enqueue_terminate(task_id, restart=False)
+    logger.info("so-stop: enqueued terminate task_id=%s restart=False", task_id)
+    return f"Stop requested for task `{task_id}`. The watcher will kill the session at its next tick."
+
+
+def handle_restart_command(
+    event,
+    args_text: str,
+    *,
+    config=None,
+    registry: Optional[SessionOrchestrationRegistry] = None,
+) -> str:
+    """Handle a ``/so-restart`` gateway command.
+
+    Parses a ``task_id=<id>`` argument from ``args_text``, enqueues a
+    terminate intent (``restart=True``), and returns a confirmation string.
+    Returns an error string (does not raise) when ``task_id`` is absent.
+
+    Parameters
+    ----------
+    event:
+        The gateway ``MessageEvent`` (present for interface symmetry with
+        ``handle_spawn_command``; not used directly).
+    args_text:
+        Everything after ``/so-restart`` in the message.
+    config:
+        Hermes config dict (reserved for future gating; not used today).
+    registry:
+        Override the registry (injected in tests).  When ``None``, a
+        default ``SessionOrchestrationRegistry()`` is created.
+    """
+    task_id = _parse_task_id(args_text)
+    if not task_id:
+        return (
+            "Usage: /so-restart task_id=<id>\n"
+            "Missing required argument: task_id"
+        )
+
+    _registry = registry if registry is not None else SessionOrchestrationRegistry()
+    _registry.enqueue_terminate(task_id, restart=True)
+    logger.info("so-restart: enqueued terminate task_id=%s restart=True", task_id)
+    return (
+        f"Restart requested for task `{task_id}`. "
+        "The watcher will kill and re-spawn the session at its next tick."
+    )

--- a/session_orchestration/spawn.py
+++ b/session_orchestration/spawn.py
@@ -283,6 +283,10 @@ def spawn_session(
         workdir=request.workdir,
         state="RUNNING",
         last_output_ts=handle.launch_ts.timestamp(),
+        # Persist the requesting user so attention notices can @-mention them.
+        # Previously dropped here even though SpawnRequest carried it, leaving
+        # every row's discord_user_id empty and the WAITING_USER ping silent.
+        discord_user_id=request.discord_user_id,
     )
     logger.info("spawn: registry row created task_id=%s repo=%s", task_id, repo)
 

--- a/session_orchestration/spawn.py
+++ b/session_orchestration/spawn.py
@@ -1,0 +1,526 @@
+"""
+session_orchestration/spawn.py — Discord @hermes spawn flow.
+
+Responsibilities
+----------------
+1. Parse a spawn request {prompt, agent, z_command, workdir} from a Discord event.
+2. Derive a deterministic slug/hash session name from (agent, workdir, prompt).
+3. Select the right ``AgentAdapter`` by agent name.
+4. Call ``adapter.launch()`` → ``SessionHandle``.
+5. Write the initial registry row (source="spawn") via ``registry.upsert()``.
+   Spawn is the initial row creator — it owns the new task_id and calls
+   ``upsert()`` directly (before the cron watcher can track it).  The watcher
+   then becomes the sole mutator going forward.  This matches T002's design:
+   spawn creates the row; adopt (T014) uses ``enqueue_intent``.
+6. Create or attach a Discord project thread (via the platform adapter's
+   ``create_handoff_thread``).  Records the thread_id on the registry row.
+7. Seed the first prompt via ``SessionRelay.send_message()``.
+
+Session name derivation
+-----------------------
+The tmux session name and task_id are deterministic from (agent, workdir, prompt):
+
+    prefix = hermes-{agent[:6]}-{workdir_hash[:5]}-{prompt_hash[:5]}
+
+This is reproducible and collision-resistant enough for O(hundreds) of sessions.
+The full task_id is the session_handle.session_id (UUID) from the adapter.
+
+Adapter selection
+-----------------
+``get_adapter(agent_name)`` maps the string from the Discord command to a
+concrete adapter instance.  Supported names: "claude", "claude-code",
+"omp", "omp-adapter".  Unknown names raise ``UnknownAgentError``.
+
+Configuration
+-------------
+Gated on ``session_orchestration.enabled`` in Hermes config.  When disabled,
+``handle_spawn_command`` returns an error string immediately without any
+side effects.
+
+Thread routing
+--------------
+``SpawnResult.thread_id`` is the Discord thread id attached to this task.  The
+drive loop (T012) routes replies in that thread to the relay.  When
+``create_handoff_thread`` fails or is unavailable, ``thread_id`` is ``None``
+and replies must be routed by ``task_id`` directly.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+from session_orchestration.adapters.base import AgentAdapter
+from session_orchestration.registry import (
+    SessionOrchestrationRegistry,
+    canonical_repo_id,
+)
+from session_orchestration.relay import SessionRelay
+from session_orchestration.types import SessionHandle
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class UnknownAgentError(ValueError):
+    """Raised when the requested agent name is not registered."""
+
+
+class SpawnDisabledError(RuntimeError):
+    """Raised when session_orchestration.enabled is False."""
+
+
+# ---------------------------------------------------------------------------
+# Adapter registry
+# ---------------------------------------------------------------------------
+
+#: Canonical name → adapter class.  Imported lazily so that a broken
+#: binary (e.g. omp not installed) does not crash the gateway at import time.
+_ADAPTER_CLASSES: dict[str, str] = {
+    "claude": "session_orchestration.adapters.claude_code.ClaudeCodeAdapter",
+    "claude-code": "session_orchestration.adapters.claude_code.ClaudeCodeAdapter",
+    "omp": "session_orchestration.adapters.omp.OmpAdapter",
+    "omp-adapter": "session_orchestration.adapters.omp.OmpAdapter",
+}
+
+
+def get_adapter(agent_name: str) -> AgentAdapter:
+    """Return a fresh adapter instance for ``agent_name``.
+
+    Parameters
+    ----------
+    agent_name:
+        Case-insensitive agent identifier.  Supported: "claude",
+        "claude-code", "omp", "omp-adapter".
+
+    Raises
+    ------
+    UnknownAgentError
+        When ``agent_name`` is not in the registry.
+    """
+    key = agent_name.lower().strip()
+    class_path = _ADAPTER_CLASSES.get(key)
+    if class_path is None:
+        known = ", ".join(sorted(_ADAPTER_CLASSES))
+        raise UnknownAgentError(
+            f"Unknown agent {agent_name!r}. Known adapters: {known}"
+        )
+    module_path, class_name = class_path.rsplit(".", 1)
+    import importlib
+    module = importlib.import_module(module_path)
+    cls = getattr(module, class_name)
+    return cls()
+
+
+# ---------------------------------------------------------------------------
+# Session name derivation
+# ---------------------------------------------------------------------------
+
+
+def derive_session_name(agent: str, workdir: str, prompt: str) -> str:
+    """Return a deterministic tmux session name for this (agent, workdir, prompt).
+
+    Format: ``hermes-{agent[:6]}-{workdir_hash[:5]}-{prompt_hash[:5]}``
+
+    The name is stable across restarts for identical inputs, collision-
+    resistant at O(hundreds) of sessions, and tmux-safe (only alphanumeric
+    and hyphens, max ~32 chars).
+    """
+    safe_agent = "".join(c if c.isalnum() else "" for c in agent.lower())[:6] or "agent"
+    wd_hash = hashlib.sha256(workdir.encode()).hexdigest()[:5]
+    pr_hash = hashlib.sha256(prompt.encode()).hexdigest()[:5]
+    return f"hermes-{safe_agent}-{wd_hash}-{pr_hash}"
+
+
+# ---------------------------------------------------------------------------
+# SpawnRequest / SpawnResult
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SpawnRequest:
+    """Parsed Discord spawn request.
+
+    Fields
+    ------
+    prompt:
+        The initial prompt to deliver to the agent.
+    agent:
+        Agent name ("claude", "omp", …).
+    workdir:
+        Absolute path to the working directory.
+    z_command:
+        Optional z-harness slash command prefix (e.g. ``"/z-plan"``) to
+        prepend to the prompt.
+    discord_user_id:
+        The Discord user id who issued the command (stored on the row for
+        T012 thread routing and for attribution).
+    feed_channel_id:
+        The Discord channel id to post feed messages to (from config).
+    parent_chat_id:
+        The Discord channel id under which to create a project thread.
+        Typically the same as ``feed_channel_id`` or a dedicated projects
+        channel.
+    """
+
+    prompt: str
+    agent: str
+    workdir: str
+    z_command: Optional[str] = None
+    discord_user_id: Optional[str] = None
+    feed_channel_id: Optional[str] = None
+    parent_chat_id: Optional[str] = None
+
+
+@dataclass
+class SpawnResult:
+    """Result of a successful spawn.
+
+    Fields
+    ------
+    task_id:
+        The registry row primary key (= ``handle.session_id``).
+    handle:
+        The ``SessionHandle`` returned by ``adapter.launch()``.
+    session_name:
+        The tmux session name (deterministic slug).
+    thread_id:
+        The Discord thread id attached to this task, or ``None`` if thread
+        creation failed / was not available.
+    """
+
+    task_id: str
+    handle: SessionHandle
+    session_name: str
+    thread_id: Optional[str]
+
+
+# ---------------------------------------------------------------------------
+# Core spawn orchestration
+# ---------------------------------------------------------------------------
+
+
+def spawn_session(
+    request: SpawnRequest,
+    *,
+    adapter: Optional[AgentAdapter] = None,
+    registry: Optional[SessionOrchestrationRegistry] = None,
+    relay: Optional[SessionRelay] = None,
+    thread_creator=None,
+) -> SpawnResult:
+    """Orchestrate a complete spawn: launch → registry row → thread → seed.
+
+    Parameters
+    ----------
+    request:
+        Parsed spawn request.
+    adapter:
+        Override the adapter (injected in tests).  When ``None``, resolved
+        via ``get_adapter(request.agent)``.
+    registry:
+        Override the registry (injected in tests).  When ``None``, a default
+        ``SessionOrchestrationRegistry()`` is created.
+    relay:
+        Override the relay (injected in tests).  When ``None``, a
+        ``SessionRelay`` is built from the resolved registry and adapter.
+    thread_creator:
+        Callable ``(parent_chat_id: str, name: str) -> Optional[str]``.
+        Should create a Discord thread and return its id, or ``None`` on
+        failure.  Injected in tests; in production this is the platform
+        adapter's ``create_handoff_thread``.
+
+    Returns
+    -------
+    SpawnResult
+        Contains the task_id, handle, session_name, and thread_id.
+
+    Raises
+    ------
+    UnknownAgentError
+        When ``request.agent`` is not in the adapter registry and no
+        ``adapter`` override was passed.
+    """
+    # Step 1 — Resolve adapter
+    _adapter = adapter if adapter is not None else get_adapter(request.agent)
+
+    # Step 2 — Derive deterministic session name
+    session_name = derive_session_name(request.agent, request.workdir, request.prompt)
+
+    # Step 3 — Build effective prompt (prepend z_command if given)
+    effective_prompt = request.prompt
+    if request.z_command:
+        effective_prompt = f"{request.z_command}\n{request.prompt}"
+
+    # Step 4 — Launch the adapter (tmux session)
+    logger.info(
+        "spawn: launching adapter=%s session=%s workdir=%s",
+        type(_adapter).__name__,
+        session_name,
+        request.workdir,
+    )
+    handle: SessionHandle = _adapter.launch(request.workdir, effective_prompt)
+
+    # Step 5 — Write the initial registry row (spawn is the row creator)
+    _registry = registry if registry is not None else SessionOrchestrationRegistry()
+
+    task_id = handle.session_id
+    repo = canonical_repo_id(workdir=request.workdir)
+
+    _registry.upsert(
+        task_id,
+        agent=request.agent,
+        source="spawn",
+        run_id=None,  # no z-harness run_id at spawn time; ingest correlates later
+        repo=repo,
+        tmux_session=handle.tmux_session,
+        workdir=request.workdir,
+        state="RUNNING",
+        last_output_ts=handle.launch_ts.timestamp(),
+    )
+    logger.info("spawn: registry row created task_id=%s repo=%s", task_id, repo)
+
+    # Step 6 — Create/attach a Discord project thread
+    thread_id: Optional[str] = None
+    if thread_creator is not None and request.parent_chat_id:
+        try:
+            thread_name = f"{request.agent}: {request.prompt[:40]}"
+            thread_id = thread_creator(request.parent_chat_id, thread_name)
+            if thread_id:
+                # Record the thread on the registry row so the drive loop can route
+                _registry.upsert(
+                    task_id,
+                    agent=request.agent,
+                    source="spawn",
+                    discord_thread_id=thread_id,
+                )
+                logger.info(
+                    "spawn: project thread created thread_id=%s task_id=%s",
+                    thread_id,
+                    task_id,
+                )
+        except Exception as exc:
+            logger.warning(
+                "spawn: thread creation failed for task_id=%s: %s",
+                task_id,
+                exc,
+            )
+            # Non-fatal: proceed without a thread
+
+    # Step 7 — Seed the first prompt via relay
+    _relay = relay
+    if _relay is None:
+        _relay = SessionRelay(_registry, _adapter)
+
+    _relay.send_message(task_id, handle, effective_prompt)
+    logger.info("spawn: first prompt seeded task_id=%s", task_id)
+
+    return SpawnResult(
+        task_id=task_id,
+        handle=handle,
+        session_name=session_name,
+        thread_id=thread_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gateway command handler
+# ---------------------------------------------------------------------------
+
+
+def parse_spawn_args(args_text: str) -> dict[str, str]:
+    """Parse ``/so-spawn`` argument text into keyword fields.
+
+    Expects arguments in the form::
+
+        agent=<name> workdir=<path> [z_command=<cmd>] <prompt...>
+
+    Returns a dict with keys: ``agent``, ``workdir``, ``prompt``
+    (and optionally ``z_command``).  Returns an empty dict on parse failure.
+
+    The prompt is everything after the last recognised ``key=value`` token.
+    Any remaining text after the last ``key=value`` pair is the prompt.
+    """
+    import shlex
+    result: dict[str, str] = {}
+    prompt_parts: list[str] = []
+
+    try:
+        tokens = shlex.split(args_text)
+    except ValueError:
+        tokens = args_text.split()
+
+    _KNOWN_KEYS = {"agent", "workdir", "z_command", "z-command"}
+    in_prompt = False
+
+    for token in tokens:
+        if not in_prompt and "=" in token:
+            k, _, v = token.partition("=")
+            key = k.strip().lower().replace("-", "_")
+            if key in _KNOWN_KEYS:
+                result[key] = v.strip()
+                continue
+        # Once we hit a non-key=value token, the rest is the prompt
+        in_prompt = True
+        prompt_parts.append(token)
+
+    if prompt_parts:
+        result["prompt"] = " ".join(prompt_parts)
+
+    return result
+
+
+async def handle_spawn_command(
+    event,
+    args_text: str,
+    *,
+    config=None,
+    platform_adapter=None,
+    registry: Optional[SessionOrchestrationRegistry] = None,
+    relay: Optional[SessionRelay] = None,
+    _adapter_override: Optional[AgentAdapter] = None,
+) -> str:
+    """Handle a ``/so-spawn`` gateway command.
+
+    Parameters
+    ----------
+    event:
+        The gateway ``MessageEvent`` (used to extract user_id, chat_id).
+    args_text:
+        Everything after ``/so-spawn`` in the message.
+    config:
+        The Hermes config dict (used to gate on
+        ``session_orchestration.enabled`` and read ``feed_channel_id``).
+    platform_adapter:
+        The platform adapter for the originating platform (used to call
+        ``create_handoff_thread``).  May be ``None`` in tests.
+    registry:
+        Override the registry (injected in tests).
+    relay:
+        Override the relay (injected in tests).
+    _adapter_override:
+        Override the agent adapter (injected in tests).
+
+    Returns
+    -------
+    str
+        A human-readable reply suitable for posting to Discord.
+    """
+    # Gate on session_orchestration.enabled
+    try:
+        from hermes_cli.config import cfg_get
+        so_enabled = cfg_get(config, "session_orchestration", "enabled", default=False)
+    except Exception:
+        so_enabled = False
+
+    if not so_enabled:
+        return (
+            "Session orchestration is disabled. "
+            "Set `session_orchestration.enabled: true` in Hermes config to enable."
+        )
+
+    # Parse args
+    parsed = parse_spawn_args(args_text)
+    agent = parsed.get("agent", "").strip()
+    workdir = parsed.get("workdir", "").strip()
+    prompt = parsed.get("prompt", "").strip()
+    z_command = parsed.get("z_command", "").strip() or None
+
+    missing = []
+    if not agent:
+        missing.append("agent=<name>")
+    if not workdir:
+        missing.append("workdir=<path>")
+    if not prompt:
+        missing.append("<prompt>")
+    if missing:
+        return (
+            f"Usage: /so-spawn agent=<name> workdir=<path> [z_command=<cmd>] <prompt>\n"
+            f"Missing: {', '.join(missing)}\n"
+            f"Supported agents: {', '.join(sorted(_ADAPTER_CLASSES))}"
+        )
+
+    # Extract caller metadata
+    source = getattr(event, "source", None)
+    discord_user_id = str(getattr(source, "user_id", "") or "") or None
+    parent_chat_id = str(getattr(source, "chat_id", "") or "") or None
+
+    try:
+        from hermes_cli.config import cfg_get
+        feed_channel_id = cfg_get(config, "session_orchestration", "feed_channel_id", default=None)
+    except Exception:
+        feed_channel_id = None
+
+    # Build thread_creator from platform adapter
+    thread_creator = None
+    if platform_adapter is not None and parent_chat_id:
+        _pa = platform_adapter
+
+        async def _create_thread_async(chat_id: str, name: str) -> Optional[str]:
+            import asyncio
+            try:
+                return await _pa.create_handoff_thread(chat_id, name)
+            except Exception as exc:
+                logger.warning("spawn: create_handoff_thread failed: %s", exc)
+                return None
+
+        def _sync_thread_creator(chat_id: str, name: str) -> Optional[str]:
+            import asyncio
+            try:
+                loop = asyncio.get_event_loop()
+                if loop.is_running():
+                    import concurrent.futures
+                    future = asyncio.run_coroutine_threadsafe(
+                        _create_thread_async(chat_id, name), loop
+                    )
+                    return future.result(timeout=10)
+                return loop.run_until_complete(_create_thread_async(chat_id, name))
+            except Exception as exc:
+                logger.warning("spawn: thread create wrapper failed: %s", exc)
+                return None
+
+        thread_creator = _sync_thread_creator
+
+    request = SpawnRequest(
+        prompt=prompt,
+        agent=agent,
+        workdir=workdir,
+        z_command=z_command,
+        discord_user_id=discord_user_id,
+        feed_channel_id=feed_channel_id,
+        parent_chat_id=parent_chat_id,
+    )
+
+    try:
+        result = spawn_session(
+            request,
+            adapter=_adapter_override,
+            registry=registry,
+            relay=relay,
+            thread_creator=thread_creator,
+        )
+    except UnknownAgentError as exc:
+        return f"Unknown agent: {exc}"
+    except Exception as exc:
+        logger.exception("spawn: unexpected error for agent=%s workdir=%s", agent, workdir)
+        return f"Spawn failed: {exc}"
+
+    # Build reply
+    lines = [
+        f"Spawned **{agent}** session.",
+        f"Task ID: `{result.task_id}`",
+        f"Session: `{result.session_name}`",
+        f"Workdir: `{workdir}`",
+    ]
+    if result.thread_id:
+        lines.append(f"Project thread: <#{result.thread_id}>")
+    else:
+        lines.append("(No project thread — reply will route by task_id)")
+
+    return "\n".join(lines)

--- a/session_orchestration/spawn.py
+++ b/session_orchestration/spawn.py
@@ -29,7 +29,8 @@ Adapter selection
 -----------------
 ``get_adapter(agent_name)`` maps the string from the Discord command to a
 concrete adapter instance.  Supported names: "claude", "claude-code",
-"omp", "omp-adapter".  Unknown names raise ``UnknownAgentError``.
+"codex", "codex-cli", "omp", "omp-adapter".  Unknown names raise
+``UnknownAgentError``.
 
 Configuration
 -------------
@@ -86,6 +87,8 @@ class SpawnDisabledError(RuntimeError):
 _ADAPTER_CLASSES: dict[str, str] = {
     "claude": "session_orchestration.adapters.claude_code.ClaudeCodeAdapter",
     "claude-code": "session_orchestration.adapters.claude_code.ClaudeCodeAdapter",
+    "codex": "session_orchestration.adapters.codex.CodexAdapter",
+    "codex-cli": "session_orchestration.adapters.codex.CodexAdapter",
     "omp": "session_orchestration.adapters.omp.OmpAdapter",
     "omp-adapter": "session_orchestration.adapters.omp.OmpAdapter",
 }
@@ -98,7 +101,7 @@ def get_adapter(agent_name: str) -> AgentAdapter:
     ----------
     agent_name:
         Case-insensitive agent identifier.  Supported: "claude",
-        "claude-code", "omp", "omp-adapter".
+        "claude-code", "codex", "codex-cli", "omp", "omp-adapter".
 
     Raises
     ------

--- a/session_orchestration/spawn.py
+++ b/session_orchestration/spawn.py
@@ -301,6 +301,9 @@ def spawn_session(
         run_id=None,  # no z-harness run_id at spawn time; ingest correlates later
         repo=repo,
         tmux_session=handle.tmux_session,
+        # Pin the concrete pane id (%N) so capture/detect/drive target the agent
+        # pane, not the session's active window (which drifts to other windows).
+        pane=handle.pane,
         workdir=request.workdir,
         state="RUNNING",
         last_output_ts=handle.launch_ts.timestamp(),

--- a/session_orchestration/spawn.py
+++ b/session_orchestration/spawn.py
@@ -273,6 +273,27 @@ def spawn_session(
     task_id = handle.session_id
     repo = canonical_repo_id(workdir=request.workdir)
 
+    # Discover the agent's own transcript file (omp writes one per session
+    # under ~/.omp/agent/sessions/<cwd>/). The watcher relays new assistant
+    # text from it to the Discord thread on each needs-input transition —
+    # clean response text instead of pane scrapings. Best-effort: on a miss
+    # the watcher retries discovery each tick until it resolves.
+    agent_session_file = None
+    if request.agent == "omp":
+        try:
+            from session_orchestration.agent_transcript import discover_omp_session_file
+
+            claimed = [
+                r.get("agent_session_file")
+                for r in _registry.list()
+                if r.get("agent_session_file")
+            ]
+            agent_session_file = discover_omp_session_file(
+                request.workdir, handle.launch_ts, claimed
+            )
+        except Exception as exc:  # noqa: BLE001 — discovery must never fail a spawn
+            logger.debug("spawn: transcript discovery failed for %s: %s", task_id, exc)
+
     _registry.upsert(
         task_id,
         agent=request.agent,
@@ -287,6 +308,8 @@ def spawn_session(
         # Previously dropped here even though SpawnRequest carried it, leaving
         # every row's discord_user_id empty and the WAITING_USER ping silent.
         discord_user_id=request.discord_user_id,
+        agent_session_file=agent_session_file,
+        transcript_line_offset=0,
     )
     logger.info("spawn: registry row created task_id=%s repo=%s", task_id, repo)
 

--- a/session_orchestration/spawn_tool.py
+++ b/session_orchestration/spawn_tool.py
@@ -56,7 +56,9 @@ SPAWN_TOOL_SCHEMA: Dict[str, Any] = {
         "Hermes relays the agent's questions to this thread and routes your "
         "replies back. Supply the repo name (alias or basename such as "
         "'hermes-agent') or an absolute path. The agent defaults to 'omp' "
-        "when not specified."
+        "when not specified. If the user has not said which repo to run on, "
+        "do NOT guess and do NOT call this tool with a placeholder — ask the "
+        "user which repo (a name or an absolute path) first, then spawn."
     ),
     "parameters": {
         "type": "object",
@@ -152,17 +154,25 @@ def spawn_tool_handler(
     z_command: Optional[str] = str(args.get("z_command") or "").strip() or None
 
     if not repo:
-        return "session_spawn: `repo` is required."
+        return (
+            "Which repo should I run this on? Tell me a repo name "
+            "(alias or basename like 'hermes-agent') or an absolute path, "
+            "and I'll spawn the session."
+        )
     if not prompt:
-        return "session_spawn: `prompt` is required."
+        return (
+            "What should the session work on? Give me a task prompt and "
+            "I'll spawn the session."
+        )
 
     # ---- Resolve repo → workdir ------------------------------------------
     resolution = _repo_registry.resolve(repo)
     if isinstance(resolution, UnresolvedRepo):
         return (
-            f"Cannot resolve repo '{resolution.name}' to a local path. "
-            "Please supply an absolute path (e.g. '/home/user/dev/myrepo') "
-            "or configure an alias in `session_orchestration.repos`."
+            f"I couldn't find a repo matching '{resolution.name}'. "
+            "Which repo should I use? Give me an absolute path "
+            "(e.g. '/home/user/dev/myrepo') or configure an alias in "
+            "`session_orchestration.repos`."
         )
 
     workdir: str = resolution.path

--- a/session_orchestration/spawn_tool.py
+++ b/session_orchestration/spawn_tool.py
@@ -1,0 +1,237 @@
+"""
+session_orchestration/spawn_tool.py — Thin LLM tool wrapping spawn_session.
+
+Registered with the tool registry at module-import time.  The gateway's
+Discord platform branch imports this module to activate the tool (see the
+``if platform_key == "discord":`` block in ``gateway/run.py::_run_agent``).
+
+Tool schema
+-----------
+Input parameters: ``{repo: str, prompt: str, agent?: str, z_command?: str}``
+
+Resolution order
+----------------
+1. Call ``build_repo_registry(cfg.repos)`` and ``registry.resolve(repo)``.
+   - ``UnresolvedRepo`` → return an error string asking the user to supply a
+     full path.  ``spawn_session`` is NOT called in this branch.
+2. Resolve ``agent`` to ``resolved.default_agent or DEFAULT_AGENT`` ("omp")
+   when the caller omits it.
+3. Build a ``SpawnRequest`` (workdir filled from ``resolved.path``) and call
+   ``spawn_session(request)``, returning the same reply-string shape that
+   ``handle_spawn_command`` would produce.
+
+Testability
+-----------
+The public ``spawn_tool_handler`` accepts keyword-injectable ``cfg``,
+``_repo_registry``, and ``_spawn_fn`` so unit tests can drive it with a fake
+registry and assert ``spawn_session`` is/is not called — without launching
+tmux.  The registered handler calls it with all defaults (None → live).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
+
+from session_orchestration.repo_registry import (
+    DEFAULT_AGENT,
+    RepoRegistry,
+    UnresolvedRepo,
+    build_repo_registry,
+)
+
+if TYPE_CHECKING:
+    from session_orchestration.config import SessionOrchestrationConfig
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Tool schema (OpenAI function-calling format)
+# ---------------------------------------------------------------------------
+
+SPAWN_TOOL_SCHEMA: Dict[str, Any] = {
+    "name": "session_spawn",
+    "description": (
+        "Spawn a managed coding-agent session in a background tmux pane. "
+        "Hermes relays the agent's questions to this thread and routes your "
+        "replies back. Supply the repo name (alias or basename such as "
+        "'hermes-agent') or an absolute path. The agent defaults to 'omp' "
+        "when not specified."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "repo": {
+                "type": "string",
+                "description": (
+                    "Repo name (alias, basename, or absolute path) that "
+                    "identifies the working directory for the new session."
+                ),
+            },
+            "prompt": {
+                "type": "string",
+                "description": "Initial task prompt to deliver to the agent.",
+            },
+            "agent": {
+                "type": "string",
+                "description": (
+                    "Agent to use: 'omp', 'claude', 'claude-code', etc. "
+                    "Defaults to 'omp' when omitted."
+                ),
+            },
+            "z_command": {
+                "type": "string",
+                "description": (
+                    "Optional z-harness slash command to prepend to the "
+                    "prompt, e.g. '/z-plan'."
+                ),
+            },
+        },
+        "required": ["repo", "prompt"],
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------------
+
+
+def spawn_tool_handler(
+    args: Dict[str, Any],
+    *,
+    cfg: Optional["SessionOrchestrationConfig"] = None,
+    _repo_registry: Optional[RepoRegistry] = None,
+    _spawn_fn: Optional[Callable] = None,
+) -> str:
+    """Handle an LLM ``session_spawn`` tool call.
+
+    Parameters
+    ----------
+    args:
+        Tool arguments from the model: ``repo``, ``prompt``, and optionally
+        ``agent`` and ``z_command``.
+    cfg:
+        Injectable ``SessionOrchestrationConfig``.  When ``None`` (default),
+        loaded from the live Hermes config via
+        ``load_session_orchestration_config()``.
+    _repo_registry:
+        Injectable ``RepoRegistry``.  When ``None`` (default), built from
+        ``cfg.repos`` via ``build_repo_registry()``.  Provide a fake
+        registry in unit tests to avoid filesystem scans.
+    _spawn_fn:
+        Injectable replacement for ``spawn_session``.  When ``None``
+        (default), the real ``spawn_session`` from
+        ``session_orchestration.spawn`` is used.  Pass a mock in tests to
+        assert call arguments without launching tmux.
+
+    Returns
+    -------
+    str
+        Human-readable reply suitable for posting to Discord.  On success
+        this matches the format ``handle_spawn_command`` would produce.
+        On resolution failure an error string is returned and ``_spawn_fn``
+        is NOT called.
+    """
+    # ---- Resolve live config when not injected ---------------------------
+    if cfg is None:
+        from session_orchestration.config import load_session_orchestration_config
+        cfg = load_session_orchestration_config()
+
+    # ---- Build repo registry when not injected ---------------------------
+    if _repo_registry is None:
+        _repo_registry = build_repo_registry(cfg.repos)
+
+    # ---- Resolve live spawn_session when not injected --------------------
+    if _spawn_fn is None:
+        from session_orchestration.spawn import spawn_session as _spawn_fn
+
+    # ---- Extract arguments -----------------------------------------------
+    repo: str = str(args.get("repo") or "").strip()
+    prompt: str = str(args.get("prompt") or "").strip()
+    agent_arg: str = str(args.get("agent") or "").strip()
+    z_command: Optional[str] = str(args.get("z_command") or "").strip() or None
+
+    if not repo:
+        return "session_spawn: `repo` is required."
+    if not prompt:
+        return "session_spawn: `prompt` is required."
+
+    # ---- Resolve repo → workdir ------------------------------------------
+    resolution = _repo_registry.resolve(repo)
+    if isinstance(resolution, UnresolvedRepo):
+        return (
+            f"Cannot resolve repo '{resolution.name}' to a local path. "
+            "Please supply an absolute path (e.g. '/home/user/dev/myrepo') "
+            "or configure an alias in `session_orchestration.repos`."
+        )
+
+    workdir: str = resolution.path
+    agent: str = agent_arg or resolution.default_agent or DEFAULT_AGENT
+
+    # ---- Build SpawnRequest and spawn ------------------------------------
+    from session_orchestration.spawn import SpawnRequest, SpawnResult
+
+    request = SpawnRequest(
+        prompt=prompt,
+        agent=agent,
+        workdir=workdir,
+        z_command=z_command,
+    )
+
+    try:
+        result: SpawnResult = _spawn_fn(request)
+    except Exception as exc:
+        logger.exception(
+            "session_spawn: spawn_session failed agent=%s workdir=%s", agent, workdir
+        )
+        return f"Spawn failed: {exc}"
+
+    # ---- Build reply (mirrors handle_spawn_command reply shape) ----------
+    lines = [
+        f"Spawned **{agent}** session.",
+        f"Task ID: `{result.task_id}`",
+        f"Session: `{result.session_name}`",
+        f"Workdir: `{workdir}`",
+    ]
+    if result.thread_id:
+        lines.append(f"Project thread: <#{result.thread_id}>")
+    else:
+        lines.append("(No project thread — reply will route by task_id)")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# check_fn — tool is invisible when session_orchestration is disabled
+# ---------------------------------------------------------------------------
+
+
+def _check_enabled() -> bool:
+    """Return True when session_orchestration is enabled in Hermes config."""
+    try:
+        from session_orchestration.config import is_enabled
+        return is_enabled()
+    except ImportError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Self-registration with the tool registry
+#
+# Importing this module (triggered by the gateway's Discord platform branch
+# in _run_agent) registers the tool as toolset "session_spawn".  That toolset
+# name is appended to ``enabled_toolsets`` for the Discord platform, making
+# it available to the LLM on every @mention turn.
+# ---------------------------------------------------------------------------
+
+from tools.registry import registry  # noqa: E402 — after helper definitions
+
+registry.register(
+    name="session_spawn",
+    toolset="session_spawn",
+    schema=SPAWN_TOOL_SCHEMA,
+    handler=spawn_tool_handler,
+    check_fn=_check_enabled,
+    description=SPAWN_TOOL_SCHEMA["description"],
+    emoji="🚀",
+)

--- a/session_orchestration/spawn_tool.py
+++ b/session_orchestration/spawn_tool.py
@@ -46,6 +46,114 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
+# Discord thread wiring
+# ---------------------------------------------------------------------------
+#
+# The LLM ``session_spawn`` tool has no ``event`` in scope the way the
+# ``/so-spawn`` command handler does, so it reads the current turn's
+# chat/thread ids from the gateway *session context* (``contextvars`` bound
+# per-turn by ``GatewayRunner._set_session_env``).
+#
+# An ``@Hermès`` turn already opens a Discord *thread* — the "Hermès window"
+# the user is looking at.  We ADOPT that thread as the session's
+# ``discord_thread_id`` so the agent's questions and the feed's action pointer
+# land in the window the user is already in, instead of a second thread.  Only
+# when a turn is in a plain channel (no thread) do we mint one, bridging to the
+# live Discord adapter's ``create_handoff_thread`` on the gateway event loop.
+#
+# Everything here is best-effort: any failure resolves to ``(None, None)`` and
+# the spawn proceeds threadless (the prior behavior), never blocking a spawn.
+
+
+def _resolve_discord_thread_context():
+    """Return ``(thread_target, thread_creator)`` for the live Discord turn.
+
+    ``thread_creator(thread_target, name) -> Optional[str]`` yields the id
+    ``spawn_session`` records as ``discord_thread_id``:
+
+    - **In a thread (normal case).**  Adopt the Hermès-window thread the turn
+      is already in.  ``thread_creator`` is a no-op returning that thread id;
+      nothing is created, and no live adapter/loop is required.
+    - **Plain channel (fallback).**  Mint a thread under the channel via the
+      live adapter's async ``create_handoff_thread`` on the gateway loop.
+
+    Returns ``(None, None)`` off Discord, with no chat id, or (channel case)
+    when the live gateway/adapter/loop is unavailable — the caller then spawns
+    without a thread.
+    """
+    try:
+        from gateway.session_context import get_session_env
+        platform = (get_session_env("HERMES_SESSION_PLATFORM", "") or "").strip().lower()
+        if platform != "discord":
+            return None, None
+        chat_id = (get_session_env("HERMES_SESSION_CHAT_ID", "") or "").strip()
+        thread_id = (get_session_env("HERMES_SESSION_THREAD_ID", "") or "").strip()
+    except Exception:
+        return None, None
+
+    if not chat_id:
+        return None, None
+
+    # Normal case: the turn is already in the Hermès-window thread. Adopt it so
+    # the agent's Q&A + the feed pointer land where the user already is. No
+    # thread creation, so this path doesn't need the live adapter/loop.
+    if thread_id:
+        return thread_id, (lambda _target, _name: thread_id)
+
+    # Fallback: plain-channel turn — mint a thread under the channel so the
+    # session still has a home. Needs the live adapter + gateway event loop.
+    try:
+        from gateway.run import _gateway_runner_ref
+        runner = _gateway_runner_ref()
+    except Exception:
+        runner = None
+    if runner is None:
+        return None, None
+
+    try:
+        from gateway.config import Platform
+        adapter = runner.adapters.get(Platform.DISCORD)
+    except Exception:
+        adapter = None
+    if adapter is None:
+        return None, None
+
+    loop = getattr(runner, "_gateway_loop", None)
+    if loop is None:
+        return None, None
+
+    def _thread_creator(target: str, name: str) -> Optional[str]:
+        import asyncio
+        try:
+            return asyncio.run_coroutine_threadsafe(
+                adapter.create_handoff_thread(target, name), loop
+            ).result(timeout=15)
+        except Exception as exc:
+            logger.warning("session_spawn: create_handoff_thread failed: %s", exc)
+            return None
+
+    return chat_id, _thread_creator
+
+
+def _resolve_discord_user_id() -> Optional[str]:
+    """Return the requesting Discord user id for the current turn, or ``None``.
+
+    Reads ``HERMES_SESSION_USER_ID`` from the gateway session context, gated on
+    a Discord platform (the id is only meaningful as a Discord mention target).
+    Persisted on the spawned row so ``feed.push_turn_change`` can @-mention the
+    user when the session needs input.
+    """
+    try:
+        from gateway.session_context import get_session_env
+        platform = (get_session_env("HERMES_SESSION_PLATFORM", "") or "").strip().lower()
+        if platform != "discord":
+            return None
+        return (get_session_env("HERMES_SESSION_USER_ID", "") or "").strip() or None
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
 # Tool schema (OpenAI function-calling format)
 # ---------------------------------------------------------------------------
 
@@ -104,6 +212,7 @@ def spawn_tool_handler(
     cfg: Optional["SessionOrchestrationConfig"] = None,
     _repo_registry: Optional[RepoRegistry] = None,
     _spawn_fn: Optional[Callable] = None,
+    **_injected: Any,
 ) -> str:
     """Handle an LLM ``session_spawn`` tool call.
 
@@ -178,6 +287,19 @@ def spawn_tool_handler(
     workdir: str = resolution.path
     agent: str = agent_arg or resolution.default_agent or DEFAULT_AGENT
 
+    # ---- Resolve the live Discord thread context -------------------------
+    # Best-effort: gives the spawned session a real project thread so the feed
+    # can link <#thread> and text replies route back into the agent. Resolves
+    # to (None, None) off Discord / when the gateway isn't live, in which case
+    # the spawn proceeds threadless exactly as before.
+    parent_chat_id, thread_creator = _resolve_discord_thread_context()
+
+    # ---- Capture the requesting Discord user (for @-mention on attention) -
+    # Read from the per-turn gateway session context, same mechanism as the
+    # thread resolution above. Without this the spawned row has no user id and
+    # the WAITING_USER thread notice can't ping anyone.
+    discord_user_id = _resolve_discord_user_id()
+
     # ---- Build SpawnRequest and spawn ------------------------------------
     from session_orchestration.spawn import SpawnRequest, SpawnResult
 
@@ -186,10 +308,12 @@ def spawn_tool_handler(
         agent=agent,
         workdir=workdir,
         z_command=z_command,
+        parent_chat_id=parent_chat_id,
+        discord_user_id=discord_user_id,
     )
 
     try:
-        result: SpawnResult = _spawn_fn(request)
+        result: SpawnResult = _spawn_fn(request, thread_creator=thread_creator)
     except Exception as exc:
         logger.exception(
             "session_spawn: spawn_session failed agent=%s workdir=%s", agent, workdir

--- a/session_orchestration/spawn_tool.py
+++ b/session_orchestration/spawn_tool.py
@@ -185,7 +185,7 @@ SPAWN_TOOL_SCHEMA: Dict[str, Any] = {
             "agent": {
                 "type": "string",
                 "description": (
-                    "Agent to use: 'omp', 'claude', 'claude-code', etc. "
+                    "Agent to use: 'omp', 'claude', 'claude-code', 'codex', etc. "
                     "Defaults to 'omp' when omitted."
                 ),
             },

--- a/session_orchestration/status.py
+++ b/session_orchestration/status.py
@@ -2,20 +2,22 @@
 Read-only snapshot builder for /control-status.
 
 Produces a Discord-friendly text snapshot of all active session-orchestration
-tasks: state, age since created_at / last_output_ts, and highlights the oldest
-WAITING_USER task so the user never misses an outstanding query.
+tasks: state, age since created_at / last_output_ts, unresolved attention
+items, and the oldest actionable item so the user never misses an
+outstanding query.
 
 Architecture note
 -----------------
-This module is **read-only** — it calls ``registry.list()`` and never writes
-the registry.  The single-writer discipline is enforced by the cron watcher
-(see registry.py); this module is a pure observer.
+This module is **read-only** — snapshot helpers only call registry read APIs
+(``list()``, ``list_unresolved_attention_items()``, and ``get()``).  The
+single-writer discipline is enforced by the cron watcher (see registry.py);
+this module is a pure observer.
 """
 
 from __future__ import annotations
 
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Mapping, Optional, Sequence
 
 
 # ---------------------------------------------------------------------------
@@ -66,6 +68,104 @@ def _format_age(seconds: float) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Attention-item helpers
+# ---------------------------------------------------------------------------
+
+def _attention_now(now: float) -> Any:
+    """Return a timezone-aware datetime for attention age rendering."""
+    from datetime import datetime, timezone
+
+    from session_orchestration.feed import _coerce_datetime
+
+    return _coerce_datetime(now) or datetime.now(timezone.utc)
+
+
+def _attention_opened_age(item: Mapping[str, Any], now: Any) -> str:
+    """Return the digest-compatible opened_at age label for an attention item."""
+    from session_orchestration.feed import _format_age as _format_digest_age
+
+    opened_age = _format_digest_age(item.get("opened_at"), now)
+    return f"opened {opened_age} ago" if opened_age != "unknown" else "opened unknown"
+
+
+def _attention_priority_label(item: Mapping[str, Any]) -> str:
+    """Return the digest-compatible priority / staleness label."""
+    from session_orchestration.feed import _priority_label
+
+    return _priority_label(item)
+
+
+def _attention_sort_key(item: Mapping[str, Any]) -> tuple:
+    """Return the digest-compatible actionable ordering key."""
+    from session_orchestration.feed import _sort_attention_item
+
+    return _sort_attention_item(item)
+
+
+def _sessions_by_task_id(
+    rows: Sequence[Mapping[str, Any]],
+    explicit_sessions: Optional[Mapping[str, Mapping[str, Any]]] = None,
+) -> Dict[str, Mapping[str, Any]]:
+    """Build task_id -> session mapping without mutating row dictionaries."""
+    sessions: Dict[str, Mapping[str, Any]] = {}
+    for row in rows:
+        task_id = row.get("task_id")
+        if task_id:
+            sessions[str(task_id)] = row
+    if explicit_sessions:
+        for task_id, session in explicit_sessions.items():
+            sessions[str(task_id)] = session
+    return sessions
+
+
+def _render_attention_item(
+    item: Mapping[str, Any],
+    sessions: Mapping[str, Mapping[str, Any]],
+    now: Any,
+) -> str:
+    """Render one unresolved attention item in status-snapshot form."""
+    task_id = str(item.get("task_id") or "unknown-task")
+    session = sessions.get(task_id, {})
+    reason = str(item.get("reason") or "attention")
+    agent = session.get("agent") or item.get("agent")
+    project = (
+        session.get("project")
+        or session.get("repo")
+        or item.get("project")
+        or item.get("repo")
+    )
+    owner_parts: List[str] = []
+    if agent:
+        owner_parts.append(str(agent))
+    if project:
+        owner_parts.append(str(project))
+    owner = f" · {'/'.join(owner_parts)}" if owner_parts else ""
+    detail = item.get("detail")
+    detail_part = f" · {detail}" if detail else ""
+    thread_id = session.get("discord_thread_id") or item.get("discord_thread_id")
+    if thread_id:
+        return (
+            f"- <#{thread_id}> · reason `{reason}`{detail_part} · "
+            f"{_attention_priority_label(item)} · {_attention_opened_age(item, now)}"
+        )
+    return (
+        f"- `{task_id}`{owner} · reason `{reason}`{detail_part} · "
+        f"{_attention_priority_label(item)} · {_attention_opened_age(item, now)}"
+    )
+
+
+def _render_oldest_actionable(item: Mapping[str, Any], now: Any) -> str:
+    """Render the actionable highlight chosen from priority + opened_at."""
+    task_id = str(item.get("task_id") or "unknown-task")
+    reason = str(item.get("reason") or "attention")
+    return (
+        f"**Oldest actionable item:** `{task_id}` "
+        f"reason `{reason}` · {_attention_priority_label(item)} · "
+        f"{_attention_opened_age(item, now)}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Snapshot builder
 # ---------------------------------------------------------------------------
 
@@ -73,6 +173,8 @@ def build_snapshot(
     rows: List[Dict[str, Any]],
     *,
     now: Optional[float] = None,
+    attention_items: Optional[Sequence[Mapping[str, Any]]] = None,
+    sessions_by_task_id: Optional[Mapping[str, Mapping[str, Any]]] = None,
 ) -> str:
     """Build a Discord-friendly snapshot string from registry rows.
 
@@ -80,10 +182,19 @@ def build_snapshot(
     ----------
     rows:
         List of row dicts as returned by ``SessionOrchestrationRegistry.list()``.
-        May be empty (produces a "no active tasks" message).
+        May be empty (produces a "no active tasks" message unless unresolved
+        attention items are supplied).
     now:
         Epoch timestamp to use as "current time" for age calculations.
         Defaults to ``time.time()``.  Overridable in tests for determinism.
+    attention_items:
+        Optional unresolved attention rows as returned by
+        ``SessionOrchestrationRegistry.list_unresolved_attention_items()``.
+        These rows are rendered read-only and never updated here.
+    sessions_by_task_id:
+        Optional task_id -> session rows, typically from ``registry.get()``.
+        Values supplement ``rows`` for attention items whose session row is not
+        in the active listing.
 
     Returns
     -------
@@ -93,10 +204,15 @@ def build_snapshot(
     if now is None:
         now = time.time()
 
-    if not rows:
+    ordered_attention = sorted(attention_items or (), key=_attention_sort_key)
+    attention_now = _attention_now(now) if ordered_attention else None
+    sessions = _sessions_by_task_id(rows, sessions_by_task_id)
+
+    if not rows and not ordered_attention:
         return "**Session Orchestration Status**\n\nNo active tasks."
 
-    # Compute ages and find oldest WAITING_USER
+    # Compute ages and find oldest WAITING_USER for legacy rows that predate
+    # attention items.
     enriched: List[Dict[str, Any]] = []
     oldest_waiting: Optional[Dict[str, Any]] = None
     oldest_waiting_age: float = -1.0
@@ -125,43 +241,80 @@ def build_snapshot(
         "",
     ]
 
-    state_counts: Dict[str, int] = {}
-    for entry in enriched:
-        state = str(entry.get("state", "UNKNOWN")).upper()
-        state_counts[state] = state_counts.get(state, 0) + 1
+    if enriched:
+        state_counts: Dict[str, int] = {}
+        for entry in enriched:
+            state = str(entry.get("state", "UNKNOWN")).upper()
+            state_counts[state] = state_counts.get(state, 0) + 1
 
-    # Summary counts line
-    summary_parts = [f"{v} {k}" for k, v in sorted(state_counts.items())]
-    lines.append("  " + " · ".join(summary_parts))
-    lines.append("")
+        # Summary counts line
+        summary_parts = [f"{v} {k}" for k, v in sorted(state_counts.items())]
+        lines.append("  " + " · ".join(summary_parts))
+        lines.append("")
 
-    # Per-task lines
-    for entry in enriched:
-        task_id = entry.get("task_id", "?")
-        agent = entry.get("agent", "?")
-        state = str(entry.get("state", "UNKNOWN")).upper()
-        age_str = _format_age(entry["_age_s"])
-        project = entry.get("project") or entry.get("workdir") or ""
-        project_label = f" `{project}`" if project else ""
+        # Per-task lines
+        for entry in enriched:
+            task_id = entry.get("task_id", "?")
+            agent = entry.get("agent", "?")
+            state = str(entry.get("state", "UNKNOWN")).upper()
+            age_str = _format_age(entry["_age_s"])
+            project = entry.get("project") or entry.get("workdir") or ""
+            project_label = f" `{project}`" if project else ""
 
-        # State emoji
-        state_icon = {
-            "RUNNING": "🟢",
-            "WAITING_USER": "🔔",
-            "PAUSED_HANDOFF": "⏸️",
-            "STALLED": "⚠️",
-            "DONE": "✅",
-            "ERROR": "❌",
-        }.get(state, "❓")
+            # State emoji
+            state_icon = {
+                "RUNNING": "🟢",
+                "WAITING_USER": "🔔",
+                "PAUSED_HANDOFF": "⏸️",
+                "STALLED": "⚠️",
+                "DONE": "✅",
+                "ERROR": "❌",
+            }.get(state, "❓")
 
-        line = f"{state_icon} `{task_id}` [{agent}]{project_label} — **{state}** · age {age_str}"
-        lines.append(line)
+            line = (
+                f"{state_icon} `{task_id}` [{agent}]{project_label} — "
+                f"**{state}** · age {age_str}"
+            )
+            lines.append(line)
+    else:
+        lines.append("No active tasks.")
 
-    # Highlight oldest WAITING_USER
-    if oldest_waiting is not None:
+    if ordered_attention:
+        lines.append("")
+        lines.append(
+            f"**Unresolved attention items** — {len(ordered_attention)} item(s)"
+        )
+        for item in ordered_attention:
+            lines.append(_render_attention_item(item, sessions, attention_now))
+
+        lines.append("")
+        lines.append(_render_oldest_actionable(ordered_attention[0], attention_now))
+    elif oldest_waiting is not None:
+        # Legacy fallback for old registries that have WAITING_USER rows but no
+        # watcher-owned attention table rows yet.
         ow_id = oldest_waiting.get("task_id", "?")
         ow_age = _format_age(oldest_waiting["_age_s"])
         lines.append("")
         lines.append(f"**Oldest WAITING_USER:** `{ow_id}` (waiting {ow_age})")
 
     return "\n".join(lines)
+
+
+def build_registry_snapshot(
+    registry: Any,
+    *,
+    now: Optional[float] = None,
+) -> str:
+    """Build a read-only snapshot directly from a registry instance."""
+    rows = registry.list()
+    attention_items = registry.list_unresolved_attention_items()
+    task_ids = sorted(
+        {str(item.get("task_id")) for item in attention_items if item.get("task_id")}
+    )
+    sessions = {task_id: (registry.get(task_id) or {}) for task_id in task_ids}
+    return build_snapshot(
+        rows,
+        now=now,
+        attention_items=attention_items,
+        sessions_by_task_id=sessions,
+    )

--- a/session_orchestration/status.py
+++ b/session_orchestration/status.py
@@ -1,0 +1,167 @@
+"""
+Read-only snapshot builder for /control-status.
+
+Produces a Discord-friendly text snapshot of all active session-orchestration
+tasks: state, age since created_at / last_output_ts, and highlights the oldest
+WAITING_USER task so the user never misses an outstanding query.
+
+Architecture note
+-----------------
+This module is **read-only** — it calls ``registry.list()`` and never writes
+the registry.  The single-writer discipline is enforced by the cron watcher
+(see registry.py); this module is a pure observer.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List, Optional
+
+
+# ---------------------------------------------------------------------------
+# Age helpers
+# ---------------------------------------------------------------------------
+
+def _age_seconds(row: Dict[str, Any], now: float) -> float:
+    """Return the effective age in seconds for a row.
+
+    Prefers ``last_output_ts`` (float epoch) when available and non-zero;
+    falls back to ``created_at`` (ISO-8601 UTC string from SQLite).
+    Returns 0 when neither is parseable.
+    """
+    last_ts = row.get("last_output_ts")
+    if last_ts:
+        try:
+            ts = float(last_ts)
+            if ts > 0:
+                return max(0.0, now - ts)
+        except (ValueError, TypeError):
+            pass
+
+    created = row.get("created_at")
+    if created:
+        try:
+            from datetime import datetime, timezone
+            dt = datetime.fromisoformat(str(created).replace("Z", "+00:00"))
+            if dt.tzinfo is None:
+                # Naive UTC string from SQLite — attach UTC explicitly.
+                dt = dt.replace(tzinfo=timezone.utc)
+            return max(0.0, now - dt.timestamp())
+        except (ValueError, TypeError):
+            pass
+
+    return 0.0
+
+
+def _format_age(seconds: float) -> str:
+    """Return a human-readable age string e.g. '3m 12s', '1h 5m', '45s'."""
+    seconds = max(0, int(seconds))
+    if seconds < 60:
+        return f"{seconds}s"
+    minutes, secs = divmod(seconds, 60)
+    if minutes < 60:
+        return f"{minutes}m {secs}s"
+    hours, mins = divmod(minutes, 60)
+    return f"{hours}h {mins}m"
+
+
+# ---------------------------------------------------------------------------
+# Snapshot builder
+# ---------------------------------------------------------------------------
+
+def build_snapshot(
+    rows: List[Dict[str, Any]],
+    *,
+    now: Optional[float] = None,
+) -> str:
+    """Build a Discord-friendly snapshot string from registry rows.
+
+    Parameters
+    ----------
+    rows:
+        List of row dicts as returned by ``SessionOrchestrationRegistry.list()``.
+        May be empty (produces a "no active tasks" message).
+    now:
+        Epoch timestamp to use as "current time" for age calculations.
+        Defaults to ``time.time()``.  Overridable in tests for determinism.
+
+    Returns
+    -------
+    A plain-text, Discord-safe string.  No markdown that Discord doesn't render
+    (e.g. no tables); uses bullet points and inline code spans for task IDs.
+    """
+    if now is None:
+        now = time.time()
+
+    if not rows:
+        return "**Session Orchestration Status**\n\nNo active tasks."
+
+    # Compute ages and find oldest WAITING_USER
+    enriched: List[Dict[str, Any]] = []
+    oldest_waiting: Optional[Dict[str, Any]] = None
+    oldest_waiting_age: float = -1.0
+
+    for row in rows:
+        age = _age_seconds(row, now)
+        entry = {**row, "_age_s": age}
+        enriched.append(entry)
+
+        state = str(row.get("state", "")).upper()
+        if state == "WAITING_USER":
+            if age > oldest_waiting_age:
+                oldest_waiting_age = age
+                oldest_waiting = entry
+
+    # Sort: WAITING_USER first, then by age descending (longest-running at top)
+    def _sort_key(e: Dict[str, Any]) -> tuple:
+        state = str(e.get("state", "")).upper()
+        waiting_first = 0 if state == "WAITING_USER" else 1
+        return (waiting_first, -e["_age_s"])
+
+    enriched.sort(key=_sort_key)
+
+    lines: List[str] = [
+        f"**Session Orchestration Status** — {len(enriched)} active task(s)",
+        "",
+    ]
+
+    state_counts: Dict[str, int] = {}
+    for entry in enriched:
+        state = str(entry.get("state", "UNKNOWN")).upper()
+        state_counts[state] = state_counts.get(state, 0) + 1
+
+    # Summary counts line
+    summary_parts = [f"{v} {k}" for k, v in sorted(state_counts.items())]
+    lines.append("  " + " · ".join(summary_parts))
+    lines.append("")
+
+    # Per-task lines
+    for entry in enriched:
+        task_id = entry.get("task_id", "?")
+        agent = entry.get("agent", "?")
+        state = str(entry.get("state", "UNKNOWN")).upper()
+        age_str = _format_age(entry["_age_s"])
+        project = entry.get("project") or entry.get("workdir") or ""
+        project_label = f" `{project}`" if project else ""
+
+        # State emoji
+        state_icon = {
+            "RUNNING": "🟢",
+            "WAITING_USER": "🔔",
+            "PAUSED_HANDOFF": "⏸️",
+            "STALLED": "⚠️",
+            "DONE": "✅",
+            "ERROR": "❌",
+        }.get(state, "❓")
+
+        line = f"{state_icon} `{task_id}` [{agent}]{project_label} — **{state}** · age {age_str}"
+        lines.append(line)
+
+    # Highlight oldest WAITING_USER
+    if oldest_waiting is not None:
+        ow_id = oldest_waiting.get("task_id", "?")
+        ow_age = _format_age(oldest_waiting["_age_s"])
+        lines.append("")
+        lines.append(f"**Oldest WAITING_USER:** `{ow_id}` (waiting {ow_age})")
+
+    return "\n".join(lines)

--- a/session_orchestration/types.py
+++ b/session_orchestration/types.py
@@ -84,12 +84,17 @@ class SessionHandle:
     launch_ts : datetime
         UTC timestamp recorded at the moment ``launch()`` returned the
         handle. Used to compute elapsed time and to detect stale handles.
+    marker_file : Optional[str]
+        Absolute path to the JSONL marker file injected into the tmux
+        session environment as ``HERMES_MARKER_FILE``.  ``None`` until
+        ``launch()`` sets it (legacy handles or handles not yet launched).
     """
 
     session_id: str
     tmux_session: str
     pane: str
     launch_ts: datetime
+    marker_file: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------

--- a/session_orchestration/types.py
+++ b/session_orchestration/types.py
@@ -1,0 +1,143 @@
+"""
+Core types for the session-orchestration subsystem.
+
+Defines:
+- ``SessionLifecycle`` — the lifecycle state enum for an agent session.
+- ``SessionHandle`` — a typed dataclass returned by ``AgentAdapter.launch()``.
+- ``Capabilities`` — a descriptor dataclass declaring what an adapter supports.
+
+Design notes
+------------
+- ``idle_indicator_regex=None`` means the adapter cannot declare a
+  pattern that unambiguously signals active work; hang detection falls
+  back to pane-hash-only comparison in the watcher.
+- ``dialog_handlers`` is a mapping from a recognisable dialog-title or
+  regex key to a callable that drives the tmux pane through the dialog.
+  An empty dict means the adapter handles no dialogs automatically.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Callable, Optional
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle enum
+# ---------------------------------------------------------------------------
+
+
+class SessionLifecycle(str, Enum):
+    """Observable lifecycle state of an external agent session.
+
+    Values
+    ------
+    RUNNING
+        The agent is actively processing; no user input required.
+    WAITING_USER
+        The agent has produced output and is waiting for the user to
+        reply (e.g. Claude Code showing the ``❯`` prompt).
+    PAUSED_HANDOFF
+        The session reached a ``/clear``-then-handoff checkpoint; the
+        watcher may trigger a deterministic ``/clear``+resume.
+    STALLED
+        The session is alive but has not produced new output for a
+        watcher-configured threshold; the watcher will nudge once, then
+        escalate to the user.
+    DONE
+        The session completed its task and has exited or returned to an
+        idle state from which no further output is expected.
+    ERROR
+        The session exited with an error or the adapter detected an
+        unrecoverable failure.
+    """
+
+    RUNNING = "RUNNING"
+    WAITING_USER = "WAITING_USER"
+    PAUSED_HANDOFF = "PAUSED_HANDOFF"
+    STALLED = "STALLED"
+    DONE = "DONE"
+    ERROR = "ERROR"
+
+
+# ---------------------------------------------------------------------------
+# SessionHandle
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SessionHandle:
+    """Opaque handle returned by ``AgentAdapter.launch()``.
+
+    Fields
+    ------
+    session_id : str
+        A unique identifier for this managed session (UUID or similar).
+        Used as the primary key in the registry.
+    tmux_session : str
+        The tmux session name (e.g. ``"hermes-claude-abc123"``).
+    pane : str
+        The tmux pane target (e.g. ``"hermes-claude-abc123:0.0"``).
+    launch_ts : datetime
+        UTC timestamp recorded at the moment ``launch()`` returned the
+        handle. Used to compute elapsed time and to detect stale handles.
+    """
+
+    session_id: str
+    tmux_session: str
+    pane: str
+    launch_ts: datetime
+
+
+# ---------------------------------------------------------------------------
+# Capabilities
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Capabilities:
+    """Descriptor that an ``AgentAdapter`` declares about itself.
+
+    The watcher asserts declared capabilities against observed behaviour
+    at startup; a mismatch hard-fails that adapter with a logged error
+    (does not crash the watcher).
+
+    Fields
+    ------
+    supports_print_mode : bool
+        True if the agent CLI supports a non-interactive ``--print``
+        (one-shot / headless) mode that writes structured output to stdout.
+    has_hooks : bool
+        True if the agent supports a ``--hook`` flag (e.g. ``omp --hook``)
+        that fires lifecycle callbacks; the watcher can use this as a
+        positive-liveness accelerant.
+    rpc_mode : bool
+        True if the agent supports a structured RPC/JSON transport mode
+        (e.g. ``omp --mode=rpc`` or ``omp --mode=json``) that avoids
+        terminal scraping.
+    json_mode : bool
+        True if the agent can emit machine-readable JSON output when asked
+        (may overlap with ``rpc_mode`` for some agents).
+    idle_indicator_regex : Optional[re.Pattern]
+        A compiled regular expression that matches a line in the pane
+        capture that unambiguously signals the agent is *active* (e.g.
+        a running-tool indicator).  ``None`` means the adapter cannot
+        declare such a pattern; hang detection falls back to pane-hash
+        comparison only.
+    dialog_handlers : dict[str, Callable[[str], None]]
+        A mapping from dialog identifiers (strings or regex patterns used
+        as keys) to callables that drive the tmux pane through that
+        dialog.  The callable receives the tmux pane target as its sole
+        argument.  An empty dict means the adapter handles no dialogs
+        automatically.
+    """
+
+    supports_print_mode: bool = False
+    has_hooks: bool = False
+    rpc_mode: bool = False
+    json_mode: bool = False
+    idle_indicator_regex: Optional[re.Pattern] = None  # type: ignore[type-arg]
+    dialog_handlers: dict[str, Callable[[str], None]] = field(default_factory=dict)

--- a/session_orchestration/watcher.py
+++ b/session_orchestration/watcher.py
@@ -78,6 +78,12 @@ _HEARTBEAT_CADENCE: int = 5
 #: cause a spurious fallback.
 _MARKER_RECENCY_SECONDS: float = 300.0
 
+#: Tick interval when any session is RUNNING or WAITING_USER (active).
+_FAST_TICK_SECONDS: float = 30.0
+
+#: Tick interval when no active sessions exist.
+_IDLE_TICK_SECONDS: float = 120.0
+
 #: Active states — rows in these states are iterated by the watcher.
 _ACTIVE_STATES = frozenset(
     {
@@ -738,6 +744,32 @@ class SessionWatcher:
             self._verified = True
         return self._available_adapters
 
+    def recommended_next_tick_interval(self) -> float:
+        """Return the advised tick interval in seconds.
+
+        Returns ``_FAST_TICK_SECONDS`` (30 s) when any registry row is in
+        RUNNING or WAITING_USER state (active sessions need faster polling).
+        Returns ``_IDLE_TICK_SECONDS`` (120 s) otherwise.
+
+        This is an advisory value for the cron driver — the watcher itself
+        does not self-schedule.  Best-effort: returns ``_IDLE_TICK_SECONDS``
+        on any registry error so the driver falls back to a safe cadence.
+        """
+        try:
+            rows = self._registry.list()
+            fast_states = {
+                SessionLifecycle.RUNNING.value,
+                SessionLifecycle.WAITING_USER.value,
+            }
+            if any(r.get("state") in fast_states for r in rows):
+                return _FAST_TICK_SECONDS
+            return _IDLE_TICK_SECONDS
+        except Exception as exc:
+            logger.debug(
+                "watcher.recommended_next_tick_interval: registry error: %s", exc
+            )
+            return _IDLE_TICK_SECONDS
+
     def tick(self) -> int:
         """Execute one watcher tick.
 
@@ -1012,15 +1044,30 @@ class SessionWatcher:
         # Re-read fresh row for hook calls (reflects counters just written)
         fresh_row = self._registry.get(task_id) or row
 
-        # Fire transition hook if state changed into a notify state (PART C)
+        # Fire transition hook if state changed into a notify state (T011/T013)
+        # RUNNING is included so transitions back to RUNNING from attention states
+        # are visible. The guard excludes benign non-attention->RUNNING no-ops
+        # (e.g. DONE->RUNNING, ERROR->RUNNING, ordinary RUNNING ticks).
         _NOTIFY_STATES = frozenset(
             {
                 SessionLifecycle.WAITING_USER.value,
                 SessionLifecycle.PAUSED_HANDOFF.value,
                 SessionLifecycle.DONE.value,
+                SessionLifecycle.RUNNING.value,
             }
         )
-        if new_state != old_state and new_state in _NOTIFY_STATES:
+        if (
+            new_state != old_state
+            and new_state in _NOTIFY_STATES
+            and not (
+                new_state == SessionLifecycle.RUNNING.value
+                and old_state
+                not in {
+                    SessionLifecycle.WAITING_USER.value,
+                    SessionLifecycle.PAUSED_HANDOFF.value,
+                }
+            )
+        ):
             _on_turn_change(task_id, fresh_row, new_state, old_state)
         elif new_state != old_state and old_state in _NOTIFY_STATES:
             # Transitioning OUT of an attention state — re-arm the debounce

--- a/session_orchestration/watcher.py
+++ b/session_orchestration/watcher.py
@@ -50,9 +50,10 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+import subprocess
 import time
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from session_orchestration.adapters.base import AgentAdapter
 from session_orchestration.adapters.verify import verify_adapters
@@ -94,6 +95,15 @@ _ACTIVE_STATES = frozenset(
     }
 )
 
+#: Attention states — sessions waiting for user input.  Used to stamp
+#: ``attention_since`` on entry and to gate the re-nudge check.
+_ATTENTION_STATES = frozenset(
+    {
+        SessionLifecycle.WAITING_USER.value,
+        SessionLifecycle.PAUSED_HANDOFF.value,
+    }
+)
+
 #: Terminal states — rows in these states are never re-iterated.
 _TERMINAL_STATES = frozenset(
     {
@@ -121,6 +131,101 @@ def _parse_marker_ts(ts_str: str) -> float:
         return dt.timestamp()
     except (ValueError, TypeError):
         return 0.0
+
+
+# ---------------------------------------------------------------------------
+# Config helper for dead-tmux reap (avoids importing config at module level)
+# ---------------------------------------------------------------------------
+
+
+def _load_dead_tmux_reap_cfg() -> bool:
+    """Return True if dead_tmux_reap is enabled in config (default True).
+
+    Lazy-imported so the watcher module does not pull in config at import
+    time.  Returns True (safe default) on any error.
+    """
+    try:
+        from session_orchestration.config import load_session_orchestration_config
+        return load_session_orchestration_config().dead_tmux_reap
+    except Exception:  # config load must never crash the watcher
+        return True
+
+
+def _load_gc_after_seconds_cfg() -> int:
+    """Return gc_after_seconds from config (default 86400 = 24 h).
+
+    Lazy-imported so the watcher module does not pull in config at import
+    time.  Returns the default on any error.
+    """
+    try:
+        from session_orchestration.config import load_session_orchestration_config
+        return load_session_orchestration_config().gc_after_seconds
+    except Exception:  # config load must never crash the watcher
+        return 86400
+
+
+def _load_renudge_after_seconds_cfg() -> int:
+    """Return renudge_after_seconds from config (default 1800 = 30 min).
+
+    Lazy-imported so the watcher module does not pull in config at import
+    time.  Returns the default on any error.  A value <= 0 disables re-nudging.
+    """
+    try:
+        from session_orchestration.config import load_session_orchestration_config
+        return load_session_orchestration_config().renudge_after_seconds
+    except Exception:  # config load must never crash the watcher
+        return 1800
+
+
+# ---------------------------------------------------------------------------
+# Default DM sender (injectable for tests so no network calls are made)
+# ---------------------------------------------------------------------------
+
+
+def _default_send_dm(user_id: str, msg: str) -> bool:
+    """Send a DM to *user_id* with *msg*.
+
+    Lazy-imports ``_get_bot_token`` and ``send_dm`` at call time.
+    Returns ``False`` (never raises) on any error so the caller's try/except
+    can still log the failure without crashing the watcher tick.
+
+    This is the production default — tests inject a recording fake via the
+    ``_send_dm_fn`` parameter on ``SessionWatcher``.
+    """
+    try:
+        from tools.discord_tool import _get_bot_token  # type: ignore[import]
+        from session_orchestration.dm_transport import send_dm
+
+        token = _get_bot_token()
+        if not token:
+            return False
+        return send_dm(user_id, msg, token)
+    except Exception as exc:
+        logger.debug("watcher._default_send_dm: failed: %s", exc)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Default tmux-liveness check (injectable for tests)
+# ---------------------------------------------------------------------------
+
+
+def _default_tmux_liveness(tmux_session: str) -> bool:
+    """Return True if the tmux session is alive (exit 0), False otherwise.
+
+    Uses ``tmux has-session -t <tmux_session>``.  Returns False on any error
+    including binary-not-found so the reap logic degrades safely.
+    """
+    if not tmux_session:
+        return False
+    try:
+        result = subprocess.run(
+            ["tmux", "has-session", "-t", tmux_session],
+            capture_output=True,
+        )
+        return result.returncode == 0
+    except (OSError, ValueError):
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -164,6 +269,8 @@ def _on_turn_change(
     row: Dict[str, Any],
     new_state: str,
     old_state: str,
+    *,
+    registry: Optional["SessionOrchestrationRegistry"] = None,
 ) -> None:
     """Called when a session transitions into a user-attention state.
 
@@ -171,12 +278,21 @@ def _on_turn_change(
     Non-transition ticks never reach this hook (the call-site in
     ``_process_row`` gates on ``new_state != old_state``).
 
+    Feed-board discipline (T-FEED-003): captures the feed message id
+    returned by ``push_turn_change`` and persists it via the registry
+    when it differs from the current ``row["feed_message_id"]``.  The
+    registry write runs inside the tick (single-writer) — this is a
+    small follow-up UPDATE after the main upsert.
+
     Parameters
     ----------
     task_id:    Registry key.
     row:        Full registry row dict at the time of the transition.
     new_state:  The new ``SessionLifecycle`` value (string).
     old_state:  The previous ``SessionLifecycle`` value (string).
+    registry:   Registry instance (injected by ``_process_row``; defaults
+                to a fresh production instance when absent, matching the
+                ``_heartbeat_registry_ref`` pattern).
     """
     logger.debug(
         "watcher._on_turn_change: task_id=%s %s -> %s",
@@ -187,7 +303,7 @@ def _on_turn_change(
     try:
         from session_orchestration.feed import push_turn_change
 
-        push_turn_change(task_id, row, new_state, old_state)
+        new_feed_id = push_turn_change(task_id, row, new_state, old_state)
     except Exception as exc:
         # Non-fatal: a failed notification must not crash the watcher.
         logger.error(
@@ -195,6 +311,26 @@ def _on_turn_change(
             task_id,
             exc,
         )
+        return
+
+    # Persist the feed message id when it differs from what the row had.
+    old_feed_id: Optional[str] = row.get("feed_message_id") or None
+    if new_feed_id != old_feed_id:
+        try:
+            reg = registry or SessionOrchestrationRegistry()
+            reg.set_feed_message_id(task_id, new_feed_id)
+            logger.debug(
+                "watcher._on_turn_change: persisted feed_message_id=%r task_id=%s",
+                new_feed_id,
+                task_id,
+            )
+        except Exception as exc:
+            logger.error(
+                "watcher._on_turn_change: failed to persist feed_message_id "
+                "for task_id=%s: %s",
+                task_id,
+                exc,
+            )
 
 
 def _on_heartbeat_tick(task_id: str, row: Dict[str, Any]) -> None:
@@ -517,6 +653,7 @@ def _on_hang(
                 repo=row.get("repo"),
                 source=row.get("source", "spawn"),
                 state=SessionLifecycle.ERROR.value,
+                terminated_at=time.time(),
             )
         except Exception as exc:
             logger.error("watcher._on_hang: failed to mark ERROR: %s", exc)
@@ -685,6 +822,103 @@ def _handle_terminate_adapter(
 
 
 # ---------------------------------------------------------------------------
+# Re-nudge helper
+# ---------------------------------------------------------------------------
+
+
+def _check_renudge(
+    task_id: str,
+    row: dict,
+    now: float,
+    *,
+    registry: "SessionOrchestrationRegistry",
+    send_dm_fn,
+) -> None:
+    """Fire a re-nudge DM if the attention interval has elapsed (non-fatal).
+
+    Called from ``_process_row`` on non-transition ticks where the session
+    remains in an attention state (WAITING_USER or PAUSED_HANDOFF) without
+    user action.  Fires at most once per ``renudge_after_seconds``.
+
+    The caller wraps this in a try/except so any unexpected error is logged
+    but does not crash the watcher tick.
+
+    Parameters
+    ----------
+    task_id:       Registry key.
+    row:           Fresh registry row dict (must include ``attention_since``,
+                   ``last_renudge_at``, and ``discord_user_id``).
+    now:           Current epoch (injectable for tests; from ``SessionWatcher._now_fn``).
+    registry:      Registry instance (for persisting ``last_renudge_at``).
+    send_dm_fn:    Callable ``(user_id: str, msg: str) -> bool``.  The production
+                   default is ``_default_send_dm``; tests inject a recording fake.
+    """
+    renudge_after = _load_renudge_after_seconds_cfg()
+    if renudge_after <= 0:
+        logger.debug(
+            "watcher._check_renudge: disabled (renudge_after_seconds=%d) for task_id=%s",
+            renudge_after, task_id,
+        )
+        return
+
+    attention_since = row.get("attention_since")
+    if attention_since is None:
+        # No stamp yet — the entering-attention set_attention_stamps hasn't been
+        # read by this fresh_row yet (race-free: stamp is written, then fresh_row
+        # is read, so this branch is only hit when the DB row genuinely has no stamp).
+        logger.debug(
+            "watcher._check_renudge: no attention_since for task_id=%s — skipping",
+            task_id,
+        )
+        return
+
+    attention_since_f = float(attention_since)
+    last_renudge_at = row.get("last_renudge_at")
+    reference_ts = max(attention_since_f, float(last_renudge_at or 0.0))
+
+    if now - reference_ts < renudge_after:
+        logger.debug(
+            "watcher._check_renudge: within interval (%.0fs remaining) for task_id=%s",
+            renudge_after - (now - reference_ts), task_id,
+        )
+        return
+
+    # Interval elapsed — fire re-nudge DM
+    user_id = row.get("discord_user_id")
+    if user_id:
+        wait_min = max(1, int((now - attention_since_f) / 60))
+        task_label = row.get("project") or row.get("repo") or task_id
+        msg = f"{task_label} still needs your input — waiting {wait_min}m"
+        try:
+            send_dm_fn(user_id, msg)
+        except Exception as exc:
+            logger.error(
+                "watcher._check_renudge: DM failed for task_id=%s: %s",
+                task_id, exc,
+            )
+    else:
+        logger.debug(
+            "watcher._check_renudge: no discord_user_id for task_id=%s — skipping DM",
+            task_id,
+        )
+
+    # Always persist last_renudge_at so the next fire waits a full interval,
+    # regardless of whether the DM succeeded (best-effort).
+    try:
+        registry.set_attention_stamps(task_id, attention_since_f, now)
+        logger.info(
+            "watcher._check_renudge: re-nudge fired for task_id=%s "
+            "(attention for %.0fs, last_renudge_at updated)",
+            task_id, now - attention_since_f,
+        )
+    except Exception as exc:
+        logger.error(
+            "watcher._check_renudge: failed to persist last_renudge_at for task_id=%s: %s",
+            task_id, exc,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Core watcher
 # ---------------------------------------------------------------------------
 
@@ -714,11 +948,25 @@ class SessionWatcher:
         *,
         tmux_capture=None,
         lock_ttl_seconds: float = _LOCK_TTL_SECONDS,
+        tmux_liveness_fn: Optional[Callable[[str], bool]] = None,
+        _now_fn: Optional[Callable[[], float]] = None,
+        _send_dm_fn=None,
     ) -> None:
         self._registry = registry or SessionOrchestrationRegistry()
         self._raw_adapters: Dict[str, AgentAdapter] = adapters or {}
         self._tmux_capture = tmux_capture or _TmuxCapture()
         self._lock_ttl = lock_ttl_seconds
+        # Injectable tmux-liveness check (``tmux has-session``). Tests inject a
+        # fake so no real subprocess is spawned; production uses the default.
+        self._tmux_liveness_fn: Callable[[str], bool] = (
+            tmux_liveness_fn if tmux_liveness_fn is not None else _default_tmux_liveness
+        )
+        # Injectable clock — defaults to ``time.time``.  Tests inject a fixed
+        # value so the attention-since / re-nudge interval logic is deterministic.
+        self._now_fn: Callable[[], float] = _now_fn if _now_fn is not None else time.time
+        # Injectable DM sender — defaults to ``_default_send_dm``.  Tests inject
+        # a recording fake so no real Discord API calls are made.
+        self._send_dm_fn = _send_dm_fn if _send_dm_fn is not None else _default_send_dm
         # Available adapters are populated once in run() / tick()
         self._available_adapters: Dict[str, AgentAdapter] = {}
         self._verified = False
@@ -846,6 +1094,23 @@ class SessionWatcher:
                     exc,
                 )
 
+        # Step 3 — GC terminal rows
+        gc_after = _load_gc_after_seconds_cfg()
+        if gc_after > 0:
+            try:
+                deleted = self._registry.gc_terminal_rows(
+                    now=time.time(), max_age_seconds=gc_after
+                )
+                if deleted > 0:
+                    logger.info(
+                        "watcher.tick: gc_terminal_rows deleted %d row(s) "
+                        "(gc_after_seconds=%d)",
+                        deleted,
+                        gc_after,
+                    )
+            except Exception as exc:
+                logger.error("watcher.tick: gc_terminal_rows failed: %s", exc)
+
         return processed
 
     # ------------------------------------------------------------------
@@ -882,7 +1147,7 @@ class SessionWatcher:
                     exc,
                 )
 
-        now = time.time()
+        now = self._now_fn()
         recent_markers = [
             m for m in new_markers
             if _parse_marker_ts(m.get("ts", "")) >= now - _MARKER_RECENCY_SECONDS
@@ -914,6 +1179,54 @@ class SessionWatcher:
         latest_marker_payload = recent_markers[-1].get("payload", {}) if recent_markers else {}
 
         try:
+            # ------------------------------------------------------------------
+            # Dead-tmux reap: if the tmux session is gone and there are no recent
+            # markers (no heartbeat proving liveness), mark the row terminal
+            # immediately rather than waiting out the hang-nudge ladder.
+            # Gated on config knob dead_tmux_reap (default True).
+            # Runs INSIDE the lock so the relay cannot be mid-write.
+            # Grace: skipped when has_recent_markers (session may have just spawned
+            # or be alive but with a silent pane).
+            # ------------------------------------------------------------------
+            if tmux_session and not has_recent_markers:
+                _so_cfg = _load_dead_tmux_reap_cfg()
+                if _so_cfg:
+                    pane_gone = not self._tmux_liveness_fn(tmux_session)
+                    if pane_gone:
+                        # Determine terminal state: DONE if the last known marker
+                        # was a 'done' kind, ERROR otherwise.
+                        all_markers, _ = [], new_offset
+                        try:
+                            if workdir:
+                                all_markers, _ = read_markers_since(
+                                    f"{workdir}/.hermes/sessions/{task_id}.jsonl", 0
+                                )
+                        except OSError:
+                            pass
+                        last_kind = all_markers[-1].get("kind", "") if all_markers else ""
+                        terminal_state = (
+                            SessionLifecycle.DONE.value
+                            if last_kind == "done"
+                            else SessionLifecycle.ERROR.value
+                        )
+                        logger.info(
+                            "watcher._process_row: dead-tmux reap task_id=%s "
+                            "tmux_session=%s -> %s",
+                            task_id,
+                            tmux_session,
+                            terminal_state,
+                        )
+                        self._registry.upsert(
+                            task_id,
+                            agent=row.get("agent", "unknown"),
+                            run_id=row.get("run_id"),
+                            repo=row.get("repo"),
+                            source=row.get("source", "spawn"),
+                            state=terminal_state,
+                            terminated_at=now,
+                        )
+                        return True
+
             # Capture pane while we hold the lock
             if pane:
                 pane_text = self._tmux_capture(pane)
@@ -992,6 +1305,20 @@ class SessionWatcher:
         new_state = new_lifecycle.value
         old_state = row.get("state", SessionLifecycle.RUNNING.value)
 
+        # Attention-state transition flags (used for stamp/clear and re-nudge below)
+        entering_attention = (
+            new_state in _ATTENTION_STATES
+            and old_state not in _ATTENTION_STATES
+        )
+        leaving_attention = (
+            old_state in _ATTENTION_STATES
+            and new_state not in _ATTENTION_STATES
+        )
+        staying_attention = (
+            new_state == old_state
+            and new_state in _ATTENTION_STATES
+        )
+
         # Compute pane hash for hang-detection (T009 consumes this)
         pane_hash = _pane_hash(pane_text) if pane_text else None
 
@@ -1007,7 +1334,7 @@ class SessionWatcher:
         if pane_hash is not None:
             update_fields["last_pane_hash"] = pane_hash
         if pane_changed:
-            update_fields["last_output_ts"] = time.time()
+            update_fields["last_output_ts"] = now
             update_fields["idle_ticks"] = 0
         else:
             # Atomic increment — done via registry.increment_counter
@@ -1041,7 +1368,29 @@ class SessionWatcher:
         # Heartbeat counter — always bump (T008 gates on modulo)
         self._registry.increment_counter(task_id, "heartbeat_counter", by=1)
 
-        # Re-read fresh row for hook calls (reflects counters just written)
+        # Stamp/clear attention_since and last_renudge_at.  Done BEFORE the
+        # fresh_row read so fresh_row reflects the updated values for the hooks.
+        # These writes are sequential within the single-writer tick — no race.
+        if entering_attention:
+            try:
+                self._registry.set_attention_stamps(task_id, now, None)
+            except Exception as exc:
+                logger.error(
+                    "watcher._process_row: set_attention_stamps (enter) failed "
+                    "for task_id=%s: %s",
+                    task_id, exc,
+                )
+        elif leaving_attention:
+            try:
+                self._registry.set_attention_stamps(task_id, None, None)
+            except Exception as exc:
+                logger.error(
+                    "watcher._process_row: set_attention_stamps (leave) failed "
+                    "for task_id=%s: %s",
+                    task_id, exc,
+                )
+
+        # Re-read fresh row for hook calls (reflects counters + attention stamps)
         fresh_row = self._registry.get(task_id) or row
 
         # Fire transition hook if state changed into a notify state (T011/T013)
@@ -1068,7 +1417,13 @@ class SessionWatcher:
                 }
             )
         ):
-            _on_turn_change(task_id, fresh_row, new_state, old_state)
+            _on_turn_change(
+                task_id,
+                fresh_row,
+                new_state,
+                old_state,
+                registry=self._registry,
+            )
         elif new_state != old_state and old_state in _NOTIFY_STATES:
             # Transitioning OUT of an attention state — re-arm the debounce
             # so the NEXT transition back fires as a new notification.
@@ -1103,6 +1458,22 @@ class SessionWatcher:
                 adapter=adapter,
                 pane_text=pane_text,
             )
+
+        # Re-nudge check — fires at most once per renudge_after_seconds when
+        # the session stays in an attention state without user action.
+        # This is the COMPLEMENT of the turn-change hook: same state, no transition.
+        if staying_attention:
+            try:
+                _check_renudge(
+                    task_id, fresh_row, now,
+                    registry=self._registry,
+                    send_dm_fn=self._send_dm_fn,
+                )
+            except Exception as exc:
+                logger.error(
+                    "watcher._process_row: _check_renudge failed for task_id=%s: %s",
+                    task_id, exc,
+                )
 
         return True
 

--- a/session_orchestration/watcher.py
+++ b/session_orchestration/watcher.py
@@ -585,6 +585,100 @@ def _build_handle_from_row(row: Dict[str, Any]) -> "SessionHandle":
 
 
 # ---------------------------------------------------------------------------
+# Terminate adapter helper (PART B)
+# ---------------------------------------------------------------------------
+
+
+def _handle_terminate_adapter(
+    intent: Dict[str, Any],
+    registry: "SessionOrchestrationRegistry",
+    adapter_map: Dict[str, "AgentAdapter"],
+    *,
+    _spawn_fn=None,
+) -> None:
+    """Adapter-side terminate: kill the tmux session and optionally re-spawn.
+
+    Called AFTER _apply_intent has already marked the registry row terminal.
+    This function handles the tmux kill and optional restart.
+
+    Parameters
+    ----------
+    intent:      The raw intent dict (from drain_intents).
+    registry:    The registry instance (for row lookup).
+    adapter_map: Dict of available adapters keyed by agent name.
+    _spawn_fn:   Injectable spawn callable (defaults to spawn_session).
+                 Pass a fake in tests to avoid real tmux launches.
+    """
+    import json as _json
+
+    payload: Dict[str, Any] = _json.loads(intent.get("payload", "{}"))
+    task_id = intent.get("task_id") or payload.get("task_id")
+    if not task_id:
+        logger.warning("_handle_terminate_adapter: intent missing task_id")
+        return
+
+    restart = payload.get("restart", False)
+    row = registry.get(task_id)
+    if row is None:
+        logger.warning(
+            "_handle_terminate_adapter: row not found for task_id=%s", task_id
+        )
+        return
+
+    agent_name = row.get("agent", "")
+    adapter = adapter_map.get(agent_name)
+    if adapter is None:
+        logger.warning(
+            "_handle_terminate_adapter: no adapter for agent=%s task_id=%s",
+            agent_name,
+            task_id,
+        )
+        # Still attempt restart if requested — adapter kill is best-effort
+    else:
+        handle = _build_handle_from_row(row)
+        try:
+            adapter.terminate(handle)
+            logger.info(
+                "_handle_terminate_adapter: terminated task_id=%s", task_id
+            )
+        except Exception as exc:
+            logger.error(
+                "_handle_terminate_adapter: adapter.terminate() failed for task_id=%s: %s",
+                task_id,
+                exc,
+            )
+
+    if restart:
+        # LIMITATION: the registry row does not persist the original prompt.
+        # Re-spawn with a placeholder "continue" prompt so the session is
+        # restarted best-effort.  A future task could persist the prompt to
+        # enable faithful restart.
+        if _spawn_fn is None:
+            from session_orchestration.spawn import SpawnRequest, spawn_session as _spawn_fn  # type: ignore[assignment]
+
+        from session_orchestration.spawn import SpawnRequest
+
+        workdir = row.get("workdir") or ""
+        request = SpawnRequest(
+            prompt="continue",  # placeholder — original prompt not persisted
+            agent=agent_name,
+            workdir=workdir,
+        )
+        try:
+            _spawn_fn(request)
+            logger.info(
+                "_handle_terminate_adapter: re-spawned task_id=%s (placeholder prompt)",
+                task_id,
+            )
+        except Exception as exc:
+            logger.error(
+                "_handle_terminate_adapter: re-spawn failed for task_id=%s: %s",
+                task_id,
+                exc,
+            )
+
+
+# ---------------------------------------------------------------------------
 # Core watcher
 # ---------------------------------------------------------------------------
 
@@ -672,6 +766,21 @@ class SessionWatcher:
                 logger.error(
                     "watcher.tick: intent application failed for %r: %s",
                     intent,
+                    exc,
+                )
+
+        # Adapter-side terminate: kill tmux + optional restart (AFTER registry row
+        # is already marked terminal by _apply_intent above).
+        terminate_intents = [i for i in intents if i.get("intent") == "terminate"]
+        for term_intent in terminate_intents:
+            try:
+                _handle_terminate_adapter(
+                    term_intent, self._registry, self._available_adapters
+                )
+            except Exception as exc:
+                logger.error(
+                    "watcher.tick: _handle_terminate_adapter failed for %r: %s",
+                    term_intent,
                     exc,
                 )
 
@@ -875,6 +984,14 @@ class SessionWatcher:
         if new_offset != old_marker_offset:
             update_fields["marker_offset"] = new_offset
 
+        # Store last_question from most recent needs_input marker (PART C)
+        needs_input_markers = [m for m in new_markers if m.get("kind") == "needs_input"]
+        if needs_input_markers:
+            ni_payload = needs_input_markers[-1].get("payload") or {}
+            question = ni_payload.get("question", "")
+            if question:
+                update_fields["last_question"] = question
+
         # Write state update (single writer)
         self._registry.upsert(
             task_id,
@@ -895,16 +1012,17 @@ class SessionWatcher:
         # Re-read fresh row for hook calls (reflects counters just written)
         fresh_row = self._registry.get(task_id) or row
 
-        # Fire transition hook if state changed into a user-attention state
-        _ATTENTION_STATES = frozenset(
+        # Fire transition hook if state changed into a notify state (PART C)
+        _NOTIFY_STATES = frozenset(
             {
                 SessionLifecycle.WAITING_USER.value,
                 SessionLifecycle.PAUSED_HANDOFF.value,
+                SessionLifecycle.DONE.value,
             }
         )
-        if new_state != old_state and new_state in _ATTENTION_STATES:
+        if new_state != old_state and new_state in _NOTIFY_STATES:
             _on_turn_change(task_id, fresh_row, new_state, old_state)
-        elif new_state != old_state and old_state in _ATTENTION_STATES:
+        elif new_state != old_state and old_state in _NOTIFY_STATES:
             # Transitioning OUT of an attention state — re-arm the debounce
             # so the NEXT transition back fires as a new notification.
             try:

--- a/session_orchestration/watcher.py
+++ b/session_orchestration/watcher.py
@@ -48,6 +48,7 @@ has access to all state without further DB reads.
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import os
 import time
@@ -89,6 +90,17 @@ _TERMINAL_STATES = frozenset(
     }
 )
 
+#: User-attention states map directly to stable attention-item reasons.
+_USER_ATTENTION_STATES = frozenset(
+    {
+        SessionLifecycle.WAITING_USER.value,
+        SessionLifecycle.PAUSED_HANDOFF.value,
+    }
+)
+
+#: Stale/frozen attention is a reason on a RUNNING row, not a registry state.
+_ATTENTION_REASON_STALE_FROZEN = "STALE_FROZEN"
+
 
 # ---------------------------------------------------------------------------
 # Fake-capture adapter (allows watcher to be unit-tested without tmux)
@@ -126,17 +138,47 @@ class _TmuxCapture:
 # ---------------------------------------------------------------------------
 
 
+def _reconcile_attention_digest(
+    registry: Optional["SessionOrchestrationRegistry"],
+    *,
+    task_id: str,
+    context: str,
+) -> None:
+    """Best-effort channel-level digest reconciliation for attention changes."""
+    if registry is None:
+        logger.debug(
+            "watcher.%s: no registry available for digest reconcile task_id=%s",
+            context,
+            task_id,
+        )
+        return
+
+    try:
+        from session_orchestration.feed import reconcile_attention_digest
+
+        reconcile_attention_digest(registry)
+    except Exception as exc:
+        logger.error(
+            "watcher.%s: digest reconcile failed for task_id=%s: %s",
+            context,
+            task_id,
+            exc,
+        )
+
+
 def _on_turn_change(
     task_id: str,
     row: Dict[str, Any],
     new_state: str,
     old_state: str,
+    *,
+    registry: Optional["SessionOrchestrationRegistry"] = None,
 ) -> None:
     """Called when a session transitions into a user-attention state.
 
-    Pushes ONCE (debounced) to the feed channel + task thread.
-    Non-transition ticks never reach this hook (the call-site in
-    ``_process_row`` gates on ``new_state != old_state``).
+    Reconciles the channel-level action digest and optionally posts a
+    thread-local notice.  The digest is the sole ``feed_channel_id``
+    projection for attention state.
 
     Parameters
     ----------
@@ -150,6 +192,11 @@ def _on_turn_change(
         task_id,
         old_state,
         new_state,
+    )
+    _reconcile_attention_digest(
+        registry,
+        task_id=task_id,
+        context="_on_turn_change",
     )
     try:
         from session_orchestration.feed import push_turn_change
@@ -314,6 +361,251 @@ def _heartbeat_registry_ref(
         )
 
 
+
+def _load_hang_thresholds() -> tuple[int, int]:
+    """Return ``(hang_idle_ticks, hang_stale_seconds)`` with safe defaults."""
+    try:
+        from session_orchestration.config import load_session_orchestration_config
+
+        cfg = load_session_orchestration_config()
+        return cfg.hang_idle_ticks, cfg.hang_stale_seconds
+    except Exception as exc:
+        logger.debug("watcher: could not read hang thresholds, using defaults: %s", exc)
+        return 3, 300
+
+
+def _coerce_optional_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_non_negative_int(value: Any) -> int:
+    try:
+        n = int(value)
+        return n if n >= 0 else 0
+    except (TypeError, ValueError):
+        return 0
+
+
+def _adapter_activity_regex_matches(
+    adapter: Optional["AgentAdapter"],
+    pane_text: str,
+) -> bool:
+    """Return True when the adapter declares a positive active-work match."""
+    if adapter is None or not pane_text:
+        return False
+
+    try:
+        caps = adapter.capabilities()
+    except Exception as exc:
+        logger.debug("watcher: adapter.capabilities() failed during stale guard: %s", exc)
+        return False
+
+    regex = getattr(caps, "idle_indicator_regex", None)
+    return bool(regex is not None and regex.search(pane_text))
+
+
+def _is_stale_frozen_eligible(
+    row: Dict[str, Any],
+    *,
+    previous_pane_hash: Optional[str],
+    current_pane_hash: Optional[str],
+    pane_text: str,
+    adapter: Optional["AgentAdapter"],
+    hang_idle_ticks: int,
+    hang_stale_seconds: int,
+    now: Optional[float] = None,
+) -> bool:
+    """Return True only when deterministic stale/frozen evidence is present.
+
+    The guard is intentionally conservative: a stale/frozen episode requires
+    an unchanged pane hash, enough idle ticks, a stale ``last_output_ts``, and
+    no adapter-declared active-work regex match in the current pane.
+    """
+    if not current_pane_hash or previous_pane_hash != current_pane_hash:
+        return False
+
+    if _coerce_non_negative_int(row.get("idle_ticks")) < hang_idle_ticks:
+        return False
+
+    last_output_ts = _coerce_optional_float(row.get("last_output_ts"))
+    if last_output_ts is None:
+        return False
+
+    observed_now = time.time() if now is None else now
+    if observed_now - last_output_ts < hang_stale_seconds:
+        return False
+
+    if _adapter_activity_regex_matches(adapter, pane_text):
+        return False
+
+    return True
+
+
+def _is_stale_episode_action_eligible(row: Dict[str, Any]) -> bool:
+    """Return True iff no stale/frozen action has fired in this episode."""
+    return _coerce_non_negative_int(row.get("nudge_count")) == 0
+
+
+def _is_omp_nudge_checkin_eligible(
+    row: Dict[str, Any],
+    *,
+    previous_pane_hash: Optional[str],
+    current_pane_hash: Optional[str],
+    pane_text: str,
+    adapter: Optional["AgentAdapter"],
+    hang_idle_ticks: int,
+    hang_stale_seconds: int,
+    now: Optional[float] = None,
+) -> bool:
+    """Return True when the OMP stale nudge/check-in may fire this tick."""
+    return _is_stale_frozen_eligible(
+        row,
+        previous_pane_hash=previous_pane_hash,
+        current_pane_hash=current_pane_hash,
+        pane_text=pane_text,
+        adapter=adapter,
+        hang_idle_ticks=hang_idle_ticks,
+        hang_stale_seconds=hang_stale_seconds,
+        now=now,
+    ) and _is_stale_episode_action_eligible(row)
+
+
+def _intent_task_id(intent: Dict[str, Any]) -> Optional[str]:
+    """Return a task id from an intent row without mutating its payload."""
+    task_id = intent.get("task_id")
+    if task_id:
+        return str(task_id)
+    try:
+        payload = json.loads(intent.get("payload") or "{}")
+    except (TypeError, ValueError):
+        return None
+    payload_task_id = payload.get("task_id")
+    return str(payload_task_id) if payload_task_id else None
+
+
+def _attention_detail(row: Dict[str, Any], reason: str) -> str:
+    """Build compact, stable detail text for an attention item refresh."""
+    agent = row.get("agent", "unknown")
+    state = row.get("state", SessionLifecycle.RUNNING.value)
+    if reason == _ATTENTION_REASON_STALE_FROZEN:
+        idle_ticks = _coerce_non_negative_int(row.get("idle_ticks"))
+        last_output_ts = row.get("last_output_ts")
+        return (
+            f"state={state}; agent={agent}; idle_ticks={idle_ticks}; "
+            f"last_output_ts={last_output_ts}"
+        )
+    return f"state={state}; agent={agent}"
+
+
+def _last_output_advanced(
+    previous_last_output_ts: Optional[float],
+    current_last_output_ts: Optional[float],
+) -> bool:
+    """Return True only for a real observed liveness timestamp advance."""
+    return (
+        previous_last_output_ts is not None
+        and current_last_output_ts is not None
+        and current_last_output_ts > previous_last_output_ts
+    )
+
+
+def _sync_attention_lifecycle(
+    registry: "SessionOrchestrationRegistry",
+    task_id: str,
+    *,
+    old_state: str,
+    new_state: str,
+    fresh_row: Dict[str, Any],
+    stale_frozen_eligible: bool,
+    previous_pane_hash: Optional[str],
+    current_pane_hash: Optional[str],
+    previous_last_output_ts: Optional[float],
+    current_last_output_ts: Optional[float],
+    pane_text: str,
+    adapter: Optional["AgentAdapter"],
+    user_drive_signal: bool = False,
+) -> tuple[bool, bool]:
+    """Sync attention items; return (stale/frozen actionable, digest dirty)."""
+    is_terminal = new_state in _TERMINAL_STATES
+    digest_dirty = False
+
+    if new_state in _USER_ATTENTION_STATES:
+        registry.open_attention_item(
+            task_id,
+            new_state,
+            priority=100,
+            detail=_attention_detail(fresh_row, new_state),
+        )
+        for reason in _USER_ATTENTION_STATES:
+            if reason != new_state:
+                registry.resolve_attention_item(
+                    task_id,
+                    reason,
+                    resolution_reason=f"state_changed_to_{new_state}",
+                )
+    else:
+        for reason in _USER_ATTENTION_STATES:
+            resolved = registry.resolve_attention_item(
+                task_id,
+                reason,
+                resolution_reason=f"state_changed_to_{new_state}",
+            )
+            if resolved and not (
+                old_state in _USER_ATTENTION_STATES and new_state != old_state
+            ):
+                digest_dirty = True
+
+    if is_terminal:
+        if registry.resolve_attention_item(
+            task_id,
+            _ATTENTION_REASON_STALE_FROZEN,
+            resolution_reason=f"state_changed_to_{new_state}",
+        ):
+            digest_dirty = True
+        return False, digest_dirty
+
+    if user_drive_signal and registry.resolve_attention_item(
+        task_id,
+        _ATTENTION_REASON_STALE_FROZEN,
+        resolution_reason="user_drive_signal",
+    ):
+        return False, True
+
+    if stale_frozen_eligible:
+        registry.open_attention_item(
+            task_id,
+            _ATTENTION_REASON_STALE_FROZEN,
+            priority=50,
+            detail=_attention_detail(fresh_row, _ATTENTION_REASON_STALE_FROZEN),
+        )
+        return True, digest_dirty
+
+    pane_hash_changed = (
+        previous_pane_hash is not None
+        and current_pane_hash is not None
+        and previous_pane_hash != current_pane_hash
+    )
+    active_regex_match = _adapter_activity_regex_matches(adapter, pane_text)
+    if (
+        pane_hash_changed
+        or _last_output_advanced(previous_last_output_ts, current_last_output_ts)
+        or active_regex_match
+    ):
+        resolved = registry.resolve_attention_item(
+            task_id,
+            _ATTENTION_REASON_STALE_FROZEN,
+            resolution_reason="liveness_signal_observed",
+        )
+        if resolved:
+            digest_dirty = True
+    return False, digest_dirty
+
+
 def _on_hang(
     task_id: str,
     row: Dict[str, Any],
@@ -321,9 +613,11 @@ def _on_hang(
     registry: Optional["SessionOrchestrationRegistry"] = None,
     adapter: Optional["AgentAdapter"] = None,
     pane_text: str = "",
+    previous_pane_hash: Optional[str] = None,
+    current_pane_hash: Optional[str] = None,
 ) -> None:
     """Called when a session is potentially hung (RUNNING + pane-hash unchanged
-    for N ticks + last_output_ts might be old).
+    for N ticks + stale last_output_ts).
 
     This hook is ONLY called when state is RUNNING (never WAITING_USER
     or PAUSED_HANDOFF) — the call-site in ``_process_row`` gates on
@@ -335,11 +629,11 @@ def _on_hang(
     - ``idle_indicator_regex``: if the adapter declares an active-tool pattern
       and it matches the current pane text, the session is NOT hung.
 
-    On confirmed hang:
-    - ``nudge_count == 0``: push a hang notification + send exactly one
-      auto-nudge message via the relay → increment nudge_count.
-    - ``nudge_count >= 1``: still hung → escalate (push escalation notice);
-      no second nudge.
+    On confirmed hang, the stale episode may produce at most one action:
+    when ``nudge_count == 0`` the watcher reconciles the channel-level digest,
+    optionally posts a thread-local hang notice, sends one auto-nudge/check-in
+    via the relay, and increments ``nudge_count``.  Later ticks in the same
+    unchanged-pane episode return without another feed action or relay nudge.
 
     The heartbeat fast-path (accelerant) can only reset liveness when it
     carries fresh activity (its own freshness TTL tracked externally); this
@@ -349,93 +643,62 @@ def _on_hang(
 
     Parameters
     ----------
-    task_id:    Registry key.
-    row:        Full registry row dict (fresh — post-counter-increment).
-    registry:   Registry instance (injected by _process_row; defaults to
-                a new production instance if absent).
-    adapter:    The adapter for this session (for idle_indicator_regex).
-    pane_text:  Current pane capture text (for active-tool indicator check).
+    task_id:             Registry key.
+    row:                 Full registry row dict (fresh — post-counter-increment).
+    registry:            Registry instance (injected by _process_row; defaults to
+                         a new production instance if absent).
+    adapter:             The adapter for this session (for idle_indicator_regex).
+    pane_text:           Current pane capture text (for active-tool indicator check).
+    previous_pane_hash:  Pane hash observed before this tick's capture/update.
+    current_pane_hash:   Pane hash for this tick's capture.
     """
-    # ------------------------------------------------------------------
-    # 1. Load static thresholds from config
-    # ------------------------------------------------------------------
-    try:
-        from session_orchestration.config import load_session_orchestration_config
+    hang_idle_ticks, hang_stale_seconds = _load_hang_thresholds()
+    if current_pane_hash is None:
+        current_pane_hash = _pane_hash(pane_text) if pane_text else None
+    if previous_pane_hash is None:
+        previous_pane_hash = row.get("last_pane_hash")
 
-        cfg = load_session_orchestration_config()
-        hang_idle_ticks = cfg.hang_idle_ticks
-        hang_stale_seconds = cfg.hang_stale_seconds
-    except Exception as exc:
-        logger.debug("watcher._on_hang: could not read config, using defaults: %s", exc)
-        hang_idle_ticks = 3
-        hang_stale_seconds = 300
-
-    # ------------------------------------------------------------------
-    # 2. Apply idle-tick threshold
-    # ------------------------------------------------------------------
-    idle_ticks = row.get("idle_ticks") or 0
-    if idle_ticks < hang_idle_ticks:
+    if not _is_stale_frozen_eligible(
+        row,
+        previous_pane_hash=previous_pane_hash,
+        current_pane_hash=current_pane_hash,
+        pane_text=pane_text,
+        adapter=adapter,
+        hang_idle_ticks=hang_idle_ticks,
+        hang_stale_seconds=hang_stale_seconds,
+    ):
         logger.debug(
-            "watcher._on_hang: idle_ticks=%d < threshold=%d for task_id=%s — not hung yet",
-            idle_ticks,
-            hang_idle_ticks,
+            "watcher._on_hang: task_id=%s is not stale/frozen eligible",
             task_id,
         )
         return
 
-    # ------------------------------------------------------------------
-    # 3. Apply stale-timestamp threshold (last_output_ts)
-    # ------------------------------------------------------------------
-    last_output_ts = row.get("last_output_ts")
-    if last_output_ts is not None:
-        elapsed = time.time() - float(last_output_ts)
-        if elapsed < hang_stale_seconds:
-            logger.debug(
-                "watcher._on_hang: elapsed=%.1fs < stale_threshold=%ds for task_id=%s — not stale",
-                elapsed,
-                hang_stale_seconds,
-                task_id,
-            )
-            return
-    # If last_output_ts is None we treat it as "no output ever" — proceed.
-
-    # ------------------------------------------------------------------
-    # 4. Active-tool indicator check (positive liveness from adapter)
-    # ------------------------------------------------------------------
-    if adapter is not None and pane_text:
-        caps = None
-        try:
-            caps = adapter.capabilities()
-        except Exception as exc:
-            logger.debug(
-                "watcher._on_hang: capabilities() failed for task_id=%s: %s",
-                task_id,
-                exc,
-            )
-        if caps is not None and caps.idle_indicator_regex is not None:
-            if caps.idle_indicator_regex.search(pane_text):
-                logger.debug(
-                    "watcher._on_hang: active-tool indicator matched for task_id=%s — not hung",
-                    task_id,
-                )
-                return
-
-    # ------------------------------------------------------------------
-    # 5. Confirmed hang — notify + nudge or escalate
-    # ------------------------------------------------------------------
-    nudge_count = row.get("nudge_count") or 0
+    nudge_count = _coerce_non_negative_int(row.get("nudge_count"))
     logger.info(
         "watcher._on_hang: CONFIRMED HANG task_id=%s idle_ticks=%d nudge_count=%d",
         task_id,
-        idle_ticks,
+        _coerce_non_negative_int(row.get("idle_ticks")),
         nudge_count,
     )
 
-    # Push hang notification to feed (always, whether nudging or escalating)
+    if not _is_stale_episode_action_eligible(row):
+        logger.info(
+            "watcher._on_hang: stale episode already acted on for task_id=%s",
+            task_id,
+        )
+        _reconcile_attention_digest(
+            registry,
+            task_id=task_id,
+            context="_on_hang",
+        )
+        return
+
+    # First action in this stale episode: optional thread notice + relay nudge,
+    # then reconcile the digest after nudge_count is advanced.
     try:
         from session_orchestration.feed import push_hang_notification
 
-        push_hang_notification(task_id, row, escalate=(nudge_count >= 1))
+        push_hang_notification(task_id, row, escalate=False)
     except Exception as exc:
         logger.error(
             "watcher._on_hang: push_hang_notification failed for task_id=%s: %s",
@@ -443,26 +706,23 @@ def _on_hang(
             exc,
         )
 
-    if nudge_count == 0:
-        # Exactly one auto-nudge via relay (lock-gated)
-        _send_auto_nudge(task_id, row, registry=registry, adapter=adapter)
-        # Increment nudge_count so next tick escalates instead of re-nudging
-        try:
-            reg = registry or SessionOrchestrationRegistry()
-            reg.increment_counter(task_id, "nudge_count", by=1)
-        except Exception as exc:
-            logger.error(
-                "watcher._on_hang: failed to increment nudge_count for task_id=%s: %s",
-                task_id,
-                exc,
-            )
-    else:
-        # nudge_count >= 1: already nudged — escalate, do not re-nudge
-        logger.info(
-            "watcher._on_hang: ESCALATING (nudge already sent) for task_id=%s",
-            task_id,
-        )
+    _send_auto_nudge(task_id, row, registry=registry, adapter=adapter)
 
+    # Increment nudge_count so later ticks in this episode do not act again.
+    try:
+        reg = registry or SessionOrchestrationRegistry()
+        reg.increment_counter(task_id, "nudge_count", by=1)
+    except Exception as exc:
+        logger.error(
+            "watcher._on_hang: failed to increment nudge_count for task_id=%s: %s",
+            task_id,
+            exc,
+        )
+    _reconcile_attention_digest(
+        registry,
+        task_id=task_id,
+        context="_on_hang",
+    )
 
 def _send_auto_nudge(
     task_id: str,
@@ -523,7 +783,7 @@ def _build_handle_from_row(row: Dict[str, Any]) -> "SessionHandle":
     from datetime import datetime, timezone
 
     tmux_session = row.get("tmux_session") or ""
-    pane = f"{tmux_session}:0.0" if tmux_session else ""
+    pane = tmux_session if tmux_session else ""
     return SessionHandle(
         session_id=row.get("task_id", ""),
         tmux_session=tmux_session,
@@ -613,6 +873,13 @@ class SessionWatcher:
 
         # Step 1 — drain intent queue (single-writer responsibility)
         intents = self._registry.drain_intents()
+        drive_signal_task_ids = {
+            task_id
+            for intent in intents
+            if intent.get("intent") == "drive"
+            for task_id in [_intent_task_id(intent)]
+            if task_id
+        }
         for intent in intents:
             try:
                 self._registry._apply_intent(intent)
@@ -643,7 +910,12 @@ class SessionWatcher:
                 continue
 
             try:
-                did_process = self._process_row(task_id, row, adapter)
+                did_process = self._process_row(
+                    task_id,
+                    row,
+                    adapter,
+                    user_drive_signal=task_id in drive_signal_task_ids,
+                )
                 if did_process:
                     processed += 1
             except Exception as exc:
@@ -651,6 +923,7 @@ class SessionWatcher:
                     "watcher.tick: error processing task_id=%s: %s",
                     task_id,
                     exc,
+                    exc_info=True,
                 )
 
         return processed
@@ -664,6 +937,8 @@ class SessionWatcher:
         task_id: str,
         row: Dict[str, Any],
         adapter: AgentAdapter,
+        *,
+        user_drive_signal: bool = False,
     ) -> bool:
         """Process a single registry row in one tick.
 
@@ -673,7 +948,7 @@ class SessionWatcher:
         # The registry has tmux_session but not a separate pane column;
         # derive the pane target using the same logic as _build_handle.
         tmux_session = row.get("tmux_session") or ""
-        pane = f"{tmux_session}:0.0" if tmux_session else ""
+        pane = tmux_session if tmux_session else ""
         holder = f"watcher:pid:{os.getpid()}:{time.time():.3f}"
 
         # Acquire per-session lock — BEFORE any capture-pane call
@@ -710,27 +985,30 @@ class SessionWatcher:
 
         new_state = new_lifecycle.value
         old_state = row.get("state", SessionLifecycle.RUNNING.value)
+        previous_last_output_ts = _coerce_optional_float(row.get("last_output_ts"))
 
         # Compute pane hash for hang-detection (T009 consumes this)
-        pane_hash = _pane_hash(pane_text) if pane_text else None
+        if pane_text:
+            pane_hash = hashlib.sha256(pane_text.encode(errors="replace")).hexdigest()[:16]
+        else:
+            pane_hash = None
 
-        # Determine idle-tick increment
-        pane_changed = pane_hash != row.get("last_pane_hash")
-        idle_tick_delta = 0 if pane_changed else 1
+        previous_pane_hash = row.get("last_pane_hash")
+        captured_pane_hash = pane_hash is not None
+        pane_changed = captured_pane_hash and pane_hash != previous_pane_hash
+        idle_tick_delta = 1 if captured_pane_hash and not pane_changed else 0
 
         # Build update fields
         update_fields: Dict[str, Any] = {
             "state": new_state,
             "updated_at": "datetime('now')",  # handled by upsert
         }
-        if pane_hash is not None:
+        if captured_pane_hash:
             update_fields["last_pane_hash"] = pane_hash
         if pane_changed:
             update_fields["last_output_ts"] = time.time()
             update_fields["idle_ticks"] = 0
-        else:
-            # Atomic increment — done via registry.increment_counter
-            pass  # handled below
+            update_fields["nudge_count"] = 0
 
         # Write state update (single writer)
         self._registry.upsert(
@@ -751,17 +1029,47 @@ class SessionWatcher:
 
         # Re-read fresh row for hook calls (reflects counters just written)
         fresh_row = self._registry.get(task_id) or row
-
-        # Fire transition hook if state changed into a user-attention state
-        _ATTENTION_STATES = frozenset(
-            {
-                SessionLifecycle.WAITING_USER.value,
-                SessionLifecycle.PAUSED_HANDOFF.value,
-            }
+        current_last_output_ts = _coerce_optional_float(fresh_row.get("last_output_ts"))
+        hang_idle_ticks, hang_stale_seconds = _load_hang_thresholds()
+        stale_frozen_eligible = (
+            new_state == SessionLifecycle.RUNNING.value
+            and _is_stale_frozen_eligible(
+                fresh_row,
+                previous_pane_hash=previous_pane_hash,
+                current_pane_hash=pane_hash,
+                pane_text=pane_text,
+                adapter=adapter,
+                hang_idle_ticks=hang_idle_ticks,
+                hang_stale_seconds=hang_stale_seconds,
+            )
         )
-        if new_state != old_state and new_state in _ATTENTION_STATES:
-            _on_turn_change(task_id, fresh_row, new_state, old_state)
-        elif new_state != old_state and old_state in _ATTENTION_STATES:
+        stale_frozen_actionable, attention_digest_dirty = _sync_attention_lifecycle(
+            self._registry,
+            task_id,
+            old_state=old_state,
+            new_state=new_state,
+            fresh_row=fresh_row,
+            stale_frozen_eligible=stale_frozen_eligible,
+            previous_pane_hash=previous_pane_hash,
+            current_pane_hash=pane_hash,
+            previous_last_output_ts=previous_last_output_ts,
+            current_last_output_ts=current_last_output_ts,
+            pane_text=pane_text,
+            adapter=adapter,
+            user_drive_signal=user_drive_signal,
+        )
+        transition_digest_reconciled = False
+
+        if new_state != old_state and new_state in _USER_ATTENTION_STATES:
+            _on_turn_change(
+                task_id,
+                fresh_row,
+                new_state,
+                old_state,
+                registry=self._registry,
+            )
+            transition_digest_reconciled = True
+        elif new_state != old_state and old_state in _USER_ATTENTION_STATES:
             # Transitioning OUT of an attention state — re-arm the debounce
             # so the NEXT transition back fires as a new notification.
             try:
@@ -774,22 +1082,43 @@ class SessionWatcher:
                     task_id,
                     exc,
                 )
+            _reconcile_attention_digest(
+                self._registry,
+                task_id=task_id,
+                context="_process_row",
+            )
+            transition_digest_reconciled = True
 
-        # Heartbeat hook (T008 decides whether to actually edit based on counter)
-        _on_heartbeat_tick(task_id, fresh_row)
-
-        # Hang hook — only when state is RUNNING (never WAITING_USER / PAUSED_HANDOFF)
+        if attention_digest_dirty and not transition_digest_reconciled:
+            _reconcile_attention_digest(
+                self._registry,
+                task_id=task_id,
+                context="_process_row",
+            )
+            transition_digest_reconciled = True
         if (
-            new_state == SessionLifecycle.RUNNING.value
-            and not pane_changed
-            and (fresh_row.get("idle_ticks") or 0) > 0
+            new_state in _USER_ATTENTION_STATES
+            or stale_frozen_actionable
+            or transition_digest_reconciled
         ):
+            logger.debug(
+                "watcher._process_row: digest owns channel projection; skipping heartbeat task_id=%s",
+                task_id,
+            )
+        else:
+            # Heartbeat hook (T008 decides whether to actually edit based on counter)
+            _on_heartbeat_tick(task_id, fresh_row)
+
+        # Hang hook — only when deterministic stale/frozen evidence is present.
+        if stale_frozen_actionable:
             _on_hang(
                 task_id,
                 fresh_row,
                 registry=self._registry,
                 adapter=adapter,
                 pane_text=pane_text,
+                previous_pane_hash=previous_pane_hash,
+                current_pane_hash=pane_hash,
             )
 
         return True
@@ -807,7 +1136,7 @@ class SessionWatcher:
         which is the default for single-pane sessions created by adapters.
         """
         tmux_session = row.get("tmux_session") or ""
-        pane = f"{tmux_session}:0.0" if tmux_session else ""
+        pane = tmux_session if tmux_session else ""
         return SessionHandle(
             session_id=row.get("task_id", ""),
             tmux_session=tmux_session,

--- a/session_orchestration/watcher.py
+++ b/session_orchestration/watcher.py
@@ -56,6 +56,7 @@ from typing import Any, Dict, List, Optional
 
 from session_orchestration.adapters.base import AgentAdapter
 from session_orchestration.adapters.verify import verify_adapters
+from session_orchestration.markers import marker_kind_to_lifecycle, read_markers_since
 from session_orchestration.registry import SessionOrchestrationRegistry
 from session_orchestration.types import SessionHandle, SessionLifecycle
 
@@ -70,6 +71,12 @@ _LOCK_TTL_SECONDS: float = 300.0
 
 #: Heartbeat cadence: fire every N ticks (~5 min at 1-min cron).
 _HEARTBEAT_CADENCE: int = 5
+
+#: Recency window for marker-derived state (seconds).  Markers older than
+#: this threshold are treated as stale and the watcher falls back to pane
+#: detection.  Matches the lock TTL so a single missed cron tick does not
+#: cause a spurious fallback.
+_MARKER_RECENCY_SECONDS: float = 300.0
 
 #: Active states — rows in these states are iterated by the watcher.
 _ACTIVE_STATES = frozenset(
@@ -88,6 +95,26 @@ _TERMINAL_STATES = frozenset(
         SessionLifecycle.ERROR.value,
     }
 )
+
+
+# ---------------------------------------------------------------------------
+# Marker-recency helper
+# ---------------------------------------------------------------------------
+
+
+def _parse_marker_ts(ts_str: str) -> float:
+    """Parse an ISO-8601 UTC timestamp string to a POSIX float.
+
+    Returns 0.0 on any parse failure so malformed or missing timestamps are
+    always treated as maximally stale (never recent).
+    """
+    try:
+        dt = datetime.fromisoformat(ts_str)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    except (ValueError, TypeError):
+        return 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -670,13 +697,41 @@ class SessionWatcher:
         Returns True if the row was fully processed, False if it was skipped
         (e.g. because the per-session lock was held by the relay).
         """
+        # ------------------------------------------------------------------
+        # 0. Read new marker lines (append-only; no lock needed)
+        # ------------------------------------------------------------------
+        workdir = row.get("workdir")
+        old_marker_offset = int(row.get("marker_offset") or 0)
+        new_offset = old_marker_offset
+        new_markers: List[Any] = []
+
+        if workdir:
+            marker_file = f"{workdir}/.hermes/sessions/{task_id}.jsonl"
+            try:
+                new_markers, new_offset = read_markers_since(marker_file, old_marker_offset)
+            except OSError as exc:
+                logger.warning(
+                    "watcher._process_row: read_markers_since failed for task_id=%s: %s",
+                    task_id,
+                    exc,
+                )
+
+        now = time.time()
+        recent_markers = [
+            m for m in new_markers
+            if _parse_marker_ts(m.get("ts", "")) >= now - _MARKER_RECENCY_SECONDS
+        ]
+        has_recent_markers = bool(recent_markers)
+
+        # ------------------------------------------------------------------
+        # 1. Acquire per-session lock — BEFORE any capture-pane call
+        # ------------------------------------------------------------------
         # The registry has tmux_session but not a separate pane column;
         # derive the pane target using the same logic as _build_handle.
         tmux_session = row.get("tmux_session") or ""
         pane = f"{tmux_session}:0.0" if tmux_session else ""
         holder = f"watcher:pid:{os.getpid()}:{time.time():.3f}"
 
-        # Acquire per-session lock — BEFORE any capture-pane call
         lock_acquired = self._registry.acquire_lock(
             task_id, holder, ttl_seconds=self._lock_ttl
         )
@@ -696,17 +751,29 @@ class SessionWatcher:
             # Always release — crash-safe because relay reclaims after TTL
             self._registry.release_lock(task_id, holder)
 
-        # Detect state via adapter (no lock needed for pure detection)
-        handle = self._build_handle(row)
-        try:
-            new_lifecycle = adapter.detect(handle)
-        except Exception as exc:
-            logger.error(
-                "watcher.tick: adapter.detect() failed for task_id=%s: %s",
-                task_id,
-                exc,
-            )
-            return
+        # ------------------------------------------------------------------
+        # 2. Determine authoritative lifecycle state
+        #    Priority: recent marker > pane detect
+        # ------------------------------------------------------------------
+        marker_lifecycle: Optional[SessionLifecycle] = None
+        if has_recent_markers:
+            latest_kind = recent_markers[-1]["kind"]
+            marker_lifecycle = marker_kind_to_lifecycle(latest_kind)
+
+        if marker_lifecycle is not None:
+            new_lifecycle = marker_lifecycle
+        else:
+            # Fall back to pane-scraping via adapter.detect()
+            handle = self._build_handle(row)
+            try:
+                new_lifecycle = adapter.detect(handle)
+            except Exception as exc:
+                logger.error(
+                    "watcher.tick: adapter.detect() failed for task_id=%s: %s",
+                    task_id,
+                    exc,
+                )
+                return
 
         new_state = new_lifecycle.value
         old_state = row.get("state", SessionLifecycle.RUNNING.value)
@@ -731,6 +798,9 @@ class SessionWatcher:
         else:
             # Atomic increment — done via registry.increment_counter
             pass  # handled below
+        # Persist advanced marker offset (only when new lines were consumed)
+        if new_offset != old_marker_offset:
+            update_fields["marker_offset"] = new_offset
 
         # Write state update (single writer)
         self._registry.upsert(
@@ -779,10 +849,14 @@ class SessionWatcher:
         _on_heartbeat_tick(task_id, fresh_row)
 
         # Hang hook — only when state is RUNNING (never WAITING_USER / PAUSED_HANDOFF)
+        # Suppressed when any marker was written within the recency window:
+        # a recent marker proves the agent is alive even if the pane hash is
+        # frozen past the idle/stale thresholds.
         if (
             new_state == SessionLifecycle.RUNNING.value
             and not pane_changed
             and (fresh_row.get("idle_ticks") or 0) > 0
+            and not has_recent_markers
         ):
             _on_hang(
                 task_id,

--- a/session_orchestration/watcher.py
+++ b/session_orchestration/watcher.py
@@ -484,11 +484,36 @@ def _on_hang(
                 exc,
             )
     else:
-        # nudge_count >= 1: already nudged — escalate, do not re-nudge
-        logger.info(
-            "watcher._on_hang: ESCALATING (nudge already sent) for task_id=%s",
-            task_id,
-        )
+        # nudge_count >= 1: escalate notice already pushed above; now DM + mark ERROR
+        logger.info("watcher._on_hang: ESCALATING -> DM + ERROR task_id=%s", task_id)
+        user_id = row.get("discord_user_id")
+        if user_id:
+            try:
+                from tools.discord_tool import _get_bot_token  # type: ignore[import]
+                from session_orchestration.dm_transport import send_dm
+
+                token = _get_bot_token()
+                if token:
+                    agent = row.get("agent", "unknown")
+                    msg = (
+                        f"Session {task_id} ({agent}) has been hung after auto-nudge "
+                        "and is now marked ERROR. Manual intervention may be needed."
+                    )
+                    send_dm(user_id, msg, token)
+            except Exception as exc:
+                logger.error("watcher._on_hang: escalation DM failed: %s", exc)
+        try:
+            reg = registry or SessionOrchestrationRegistry()
+            reg.upsert(
+                task_id,
+                agent=row.get("agent", "unknown"),
+                run_id=row.get("run_id"),
+                repo=row.get("repo"),
+                source=row.get("source", "spawn"),
+                state=SessionLifecycle.ERROR.value,
+            )
+        except Exception as exc:
+            logger.error("watcher._on_hang: failed to mark ERROR: %s", exc)
 
 
 def _send_auto_nudge(

--- a/session_orchestration/watcher.py
+++ b/session_orchestration/watcher.py
@@ -743,37 +743,85 @@ class SessionWatcher:
             return False  # SKIP; never read a half-rendered pane
 
         pane_text = ""
+        # Pre-compute marker kind from in-memory recent_markers — append-only read, no lock needed.
+        latest_marker_kind = recent_markers[-1].get("kind", "") if recent_markers else ""
+        latest_marker_payload = recent_markers[-1].get("payload", {}) if recent_markers else {}
+
         try:
             # Capture pane while we hold the lock
             if pane:
                 pane_text = self._tmux_capture(pane)
+
+            # ------------------------------------------------------------------
+            # 2. Determine authoritative lifecycle state (inside lock so the
+            #    handoff_continue resume runs atomically with state assignment)
+            #    Priority: recent marker > pane detect
+            # ------------------------------------------------------------------
+            marker_lifecycle: Optional[SessionLifecycle] = None
+            if has_recent_markers:
+                latest_kind = recent_markers[-1]["kind"]
+                marker_lifecycle = marker_kind_to_lifecycle(latest_kind)
+
+            if marker_lifecycle is not None:
+                new_lifecycle = marker_lifecycle
+            else:
+                # Fall back to pane-scraping via adapter.detect()
+                handle = self._build_handle(row)
+                try:
+                    new_lifecycle = adapter.detect(handle)
+                except Exception as exc:
+                    logger.error(
+                        "watcher.tick: adapter.detect() failed for task_id=%s: %s",
+                        task_id,
+                        exc,
+                    )
+                    return
+
+            # ------------------------------------------------------------------
+            # Handoff continue: resume INSIDE lock — avoids racing the relay's
+            # PAUSED_HANDOFF resume path on the same tmux pane (lock contract).
+            # Because we set RUNNING here under the lock, the relay won't
+            # subsequently see PAUSED_HANDOFF and double-resume.
+            # ------------------------------------------------------------------
+            if latest_marker_kind == "handoff_continue":
+                handle = _build_handle_from_row(row)
+                try:
+                    # Pane mutation runs under per-session lock (avoids race with relay's PAUSED_HANDOFF resume)
+                    adapter.resume(handle, "")  # autonomous /clear+resume, no user reply
+                    new_lifecycle = SessionLifecycle.RUNNING  # override PAUSED_HANDOFF
+                except Exception as exc:
+                    logger.error(
+                        "watcher._process_row: handoff_continue resume failed: %s", exc
+                    )
+                    # new_lifecycle stays as marker-derived value on failure
+
         finally:
             # Always release — crash-safe because relay reclaims after TTL
             self._registry.release_lock(task_id, holder)
 
         # ------------------------------------------------------------------
-        # 2. Determine authoritative lifecycle state
-        #    Priority: recent marker > pane detect
+        # Handoff decision: DM the user with the question — NOT a pane/tmux
+        # mutation, so the per-session lock is NOT required here.
+        # new_lifecycle stays PAUSED_HANDOFF; _on_turn_change fires for the transition.
         # ------------------------------------------------------------------
-        marker_lifecycle: Optional[SessionLifecycle] = None
-        if has_recent_markers:
-            latest_kind = recent_markers[-1]["kind"]
-            marker_lifecycle = marker_kind_to_lifecycle(latest_kind)
+        if latest_marker_kind == "handoff_decision":
+            question = (latest_marker_payload or {}).get(
+                "question", "(handoff decision required)"
+            )
+            user_id = row.get("discord_user_id")
+            if user_id:
+                try:
+                    from tools.discord_tool import _get_bot_token  # type: ignore[import]
+                    from session_orchestration.dm_transport import send_dm
 
-        if marker_lifecycle is not None:
-            new_lifecycle = marker_lifecycle
-        else:
-            # Fall back to pane-scraping via adapter.detect()
-            handle = self._build_handle(row)
-            try:
-                new_lifecycle = adapter.detect(handle)
-            except Exception as exc:
-                logger.error(
-                    "watcher.tick: adapter.detect() failed for task_id=%s: %s",
-                    task_id,
-                    exc,
-                )
-                return
+                    token = _get_bot_token()
+                    if token:
+                        send_dm(user_id, f"Handoff decision needed: {question}", token)
+                except Exception as exc:
+                    logger.error(
+                        "watcher._process_row: handoff_decision DM failed: %s", exc
+                    )
+            # new_lifecycle stays PAUSED_HANDOFF; _on_turn_change fires for the transition
 
         new_state = new_lifecycle.value
         old_state = row.get("state", SessionLifecycle.RUNNING.value)

--- a/session_orchestration/watcher.py
+++ b/session_orchestration/watcher.py
@@ -59,6 +59,7 @@ from typing import Any, Callable, Dict, List, Optional
 from session_orchestration.adapters.base import AgentAdapter
 from session_orchestration.adapters.verify import verify_adapters
 from session_orchestration.markers import marker_kind_to_lifecycle, read_markers_since
+from session_orchestration.menu_parse import extract as extract_menu_context
 from session_orchestration.registry import SessionOrchestrationRegistry
 from session_orchestration.types import SessionHandle, SessionLifecycle
 
@@ -1264,6 +1265,7 @@ class SessionWatcher:
         # Adapter-side terminate: kill tmux + optional restart (AFTER registry row
         # is already marked terminal by _apply_intent above).
         terminate_intents = [i for i in intents if i.get("intent") == "terminate"]
+        terminate_reaped = False
         for term_intent in terminate_intents:
             try:
                 _handle_terminate_adapter(
@@ -1275,6 +1277,38 @@ class SessionWatcher:
                     term_intent,
                     exc,
                 )
+            # Reap attention/feed state for the terminated session. _apply_intent
+            # marks the row terminal but terminal rows are skipped by the active
+            # loop below, so _sync_attention_lifecycle never runs for them — a
+            # WAITING_USER attention item + feed router line would otherwise
+            # dangle after a thread-archive → terminate. Resolve every attention
+            # reason and clear the ping debounce here.
+            term_task_id = _intent_task_id(term_intent)
+            if not term_task_id:
+                continue
+            try:
+                for reason in (
+                    *_USER_ATTENTION_STATES,
+                    _ATTENTION_REASON_STALE_FROZEN,
+                ):
+                    if self._registry.resolve_attention_item(
+                        term_task_id, reason, resolution_reason="terminated"
+                    ):
+                        terminate_reaped = True
+                from session_orchestration.feed import clear_last_notified
+
+                clear_last_notified(term_task_id)
+            except Exception as exc:
+                logger.error(
+                    "watcher.tick: terminate reap failed for task_id=%s: %s",
+                    term_task_id,
+                    exc,
+                )
+        if terminate_reaped:
+            # Drop the resolved item(s) from the single feed-channel digest.
+            _reconcile_attention_digest(
+                self._registry, task_id=None, context="terminate_reap"
+            )
 
         # Step 2 — iterate active rows
         rows = self._registry.list()
@@ -1522,6 +1556,35 @@ class SessionWatcher:
                     )
             # new_lifecycle stays PAUSED_HANDOFF; _on_turn_change fires for the transition
 
+        # ------------------------------------------------------------------
+        # omp free-form wait promotion. omp gives no ❯/menu-footer/marker when
+        # it finishes a turn and idles at its composer, so detect() reports
+        # RUNNING and the session trips the hang ladder instead of surfacing its
+        # question. Promote a STABLE idle omp pane (unchanged since the prior
+        # tick, not busy) to WAITING_USER so the question reaches the thread.
+        # The stability gate (a prior hash exists AND equals this tick's hash)
+        # avoids flapping on a momentary mid-turn idle. Only adapters that opt
+        # in via idle_waiting() (omp) are affected; Claude uses ❯ and is already
+        # detected directly.
+        # ------------------------------------------------------------------
+        if new_lifecycle == SessionLifecycle.RUNNING and pane_text:
+            _idle_fn = getattr(adapter, "idle_waiting", None)
+            if callable(_idle_fn):
+                _cur_hash = hashlib.sha256(
+                    pane_text.encode(errors="replace")
+                ).hexdigest()[:16]
+                _prev_hash = row.get("last_pane_hash")
+                try:
+                    _is_idle = bool(_idle_fn(pane_text))
+                except Exception as exc:
+                    logger.debug(
+                        "watcher._process_row: idle_waiting() failed for %s: %s",
+                        task_id, exc,
+                    )
+                    _is_idle = False
+                if _prev_hash and _cur_hash == _prev_hash and _is_idle:
+                    new_lifecycle = SessionLifecycle.WAITING_USER
+
         new_state = new_lifecycle.value
         old_state = row.get("state", SessionLifecycle.RUNNING.value)
         previous_last_output_ts = _coerce_optional_float(row.get("last_output_ts"))
@@ -1569,13 +1632,36 @@ class SessionWatcher:
         if new_offset != old_marker_offset:
             update_fields["marker_offset"] = new_offset
 
-        # Store last_question from most recent needs_input marker (PART C)
+        # ------------------------------------------------------------------
+        # Answerable needs-input: persist the question + option labels so the
+        # feed can present them and a numeric reply can be resolved. Two paths:
+        #   (a) marker path (Claude Code emits a needs_input marker with a
+        #       structured question/options payload); authoritative when present.
+        #   (b) pane path (omp emits NO markers) — parse the captured pane text.
+        # These fields are only meaningful while WAITING_USER; clear
+        # last_input_kind when the session moves on so a stale "menu" can't
+        # mislead the answer route or the feed digest.
+        # ------------------------------------------------------------------
         needs_input_markers = [m for m in new_markers if m.get("kind") == "needs_input"]
         if needs_input_markers:
             ni_payload = needs_input_markers[-1].get("payload") or {}
             question = ni_payload.get("question", "")
+            options = ni_payload.get("options") or []
             if question:
                 update_fields["last_question"] = question
+            update_fields["last_options"] = json.dumps(options)
+            update_fields["last_input_kind"] = "menu" if options else "prompt"
+        elif new_state == SessionLifecycle.WAITING_USER.value and pane_text:
+            question, options, is_menu = extract_menu_context(pane_text)
+            if question:
+                update_fields["last_question"] = question
+            update_fields["last_options"] = json.dumps(options)
+            update_fields["last_input_kind"] = "menu" if is_menu else "prompt"
+        elif new_state not in _ATTENTION_STATES:
+            # Left the waiting state — drop the menu marker so the next
+            # free-form reply is not misrouted as a stale menu selection.
+            update_fields["last_input_kind"] = ""
+            update_fields["last_options"] = json.dumps([])
 
         # Write state update (single writer)
         self._registry.upsert(

--- a/session_orchestration/watcher.py
+++ b/session_orchestration/watcher.py
@@ -1,0 +1,911 @@
+"""
+Session-orchestration watcher — core loop (T006).
+
+Architecture
+------------
+The watcher is the **sole mutator** of the ``session_orchestration`` registry.
+It is designed to run as a Hermes ``--no-agent`` cron job at a 1–2 minute
+cadence; each tick it:
+
+1. Drains and applies the intent queue (adopt / drive / update intents
+   enqueued by the webhook-ingest or Discord-drive paths).
+2. Iterates all rows in the registry, skipping rows whose adapter is
+   unavailable (determined once at startup by ``verify_adapters``).
+3. For each active row, acquires the per-session lock BEFORE capture-pane.
+   If the lock is held (by the relay), the row is **skipped this tick** —
+   no read of a potentially half-rendered pane, no spurious state update.
+4. Calls ``adapter.detect()`` on the captured pane text, updates registry
+   state, increments counters atomically.
+5. Computes transitions.  Actual push behaviours (turn-change, heartbeat,
+   hang) are implemented in T007/T008/T009.  This module exposes hook seams
+   (``_on_turn_change``, ``_on_heartbeat_tick``, ``_on_hang``) that those
+   tasks will fill in.
+
+Config gate
+-----------
+All orchestration is gated on ``session_orchestration.enabled`` in the Hermes
+config (``~/.hermes/config.yaml``).  When the key is absent or falsy the
+watcher exits immediately, producing zero side-effects and no network calls —
+byte-identical to pre-feature behaviour.
+
+Lock contract
+-------------
+``registry.acquire_lock(task_id, holder, ttl_seconds=300.0)`` BEFORE any
+``capture-pane`` operation.  If it returns ``False``, skip this row.
+``registry.release_lock`` in a ``finally`` block.
+``lock_ts`` stores the float expiry epoch (``str(time.time() + ttl)``).
+
+Seams for downstream tasks
+---------------------------
+- ``T007`` (turn-change push): implement ``_on_turn_change``
+- ``T008`` (heartbeat edit): implement ``_on_heartbeat_tick``
+- ``T009`` (hang detection + nudge): implement ``_on_hang``
+
+Each hook receives the full registry row dict so the downstream implementation
+has access to all state without further DB reads.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from session_orchestration.adapters.base import AgentAdapter
+from session_orchestration.adapters.verify import verify_adapters
+from session_orchestration.registry import SessionOrchestrationRegistry
+from session_orchestration.types import SessionHandle, SessionLifecycle
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Default lock TTL: 5x a 60 s cron interval.
+_LOCK_TTL_SECONDS: float = 300.0
+
+#: Heartbeat cadence: fire every N ticks (~5 min at 1-min cron).
+_HEARTBEAT_CADENCE: int = 5
+
+#: Active states — rows in these states are iterated by the watcher.
+_ACTIVE_STATES = frozenset(
+    {
+        SessionLifecycle.RUNNING.value,
+        SessionLifecycle.WAITING_USER.value,
+        SessionLifecycle.PAUSED_HANDOFF.value,
+        SessionLifecycle.STALLED.value,
+    }
+)
+
+#: Terminal states — rows in these states are never re-iterated.
+_TERMINAL_STATES = frozenset(
+    {
+        SessionLifecycle.DONE.value,
+        SessionLifecycle.ERROR.value,
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake-capture adapter (allows watcher to be unit-tested without tmux)
+# ---------------------------------------------------------------------------
+
+
+class _TmuxCapture:
+    """Thin wrapper around ``tmux capture-pane``.
+
+    Injected as ``tmux_capture`` in production; tests swap in a fake that
+    returns pre-canned strings and records which sessions were captured.
+
+    Protocol: callable ``(pane: str) -> str`` — returns the current pane text
+    or an empty string if the pane does not exist / tmux is unavailable.
+    """
+
+    def __call__(self, pane: str) -> str:
+        import subprocess  # local import so the protocol is clear in tests
+
+        try:
+            result = subprocess.run(
+                ["tmux", "capture-pane", "-p", "-t", pane],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            return result.stdout if result.returncode == 0 else ""
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            logger.warning("tmux capture-pane failed for pane=%s", pane)
+            return ""
+
+
+# ---------------------------------------------------------------------------
+# Transition seam hooks (T007 / T008 / T009 will implement these)
+# ---------------------------------------------------------------------------
+
+
+def _on_turn_change(
+    task_id: str,
+    row: Dict[str, Any],
+    new_state: str,
+    old_state: str,
+) -> None:
+    """Called when a session transitions into a user-attention state.
+
+    Pushes ONCE (debounced) to the feed channel + task thread.
+    Non-transition ticks never reach this hook (the call-site in
+    ``_process_row`` gates on ``new_state != old_state``).
+
+    Parameters
+    ----------
+    task_id:    Registry key.
+    row:        Full registry row dict at the time of the transition.
+    new_state:  The new ``SessionLifecycle`` value (string).
+    old_state:  The previous ``SessionLifecycle`` value (string).
+    """
+    logger.debug(
+        "watcher._on_turn_change: task_id=%s %s -> %s",
+        task_id,
+        old_state,
+        new_state,
+    )
+    try:
+        from session_orchestration.feed import push_turn_change
+
+        push_turn_change(task_id, row, new_state, old_state)
+    except Exception as exc:
+        # Non-fatal: a failed notification must not crash the watcher.
+        logger.error(
+            "watcher._on_turn_change: push failed for task_id=%s: %s",
+            task_id,
+            exc,
+        )
+
+
+def _on_heartbeat_tick(task_id: str, row: Dict[str, Any]) -> None:
+    """Called every tick; fires heartbeat edit every ~5 min.
+
+    Cadence gate: only acts when ``heartbeat_counter % _HEARTBEAT_CADENCE == 0``
+    (where _HEARTBEAT_CADENCE = 5, matching a 1-min cron for a ~5-min interval).
+    Non-cadence ticks are a no-op.
+
+    First cadence tick (no ``status_message_id`` in row): POSTs a new status
+    message to the feed channel and persists the returned message_id via the
+    registry (watcher is sole mutator).
+
+    Subsequent cadence ticks: PATCHes the existing status message in-place with
+    current activity state and elapsed-since-last-change.  No new notification
+    is fired.
+
+    Parameters
+    ----------
+    task_id:  Registry key.
+    row:      Full registry row dict (fresh — reflects counters just written).
+    """
+    counter = row.get("heartbeat_counter") or 0
+    if counter == 0 or counter % _HEARTBEAT_CADENCE != 0:
+        logger.debug(
+            "watcher._on_heartbeat_tick: skipping (counter=%d) task_id=%s",
+            counter,
+            task_id,
+        )
+        return
+
+    # Resolve feed channel from config
+    try:
+        from session_orchestration.config import load_session_orchestration_config
+
+        cfg = load_session_orchestration_config()
+        feed_channel_id = cfg.feed_channel_id
+    except Exception as exc:
+        logger.debug(
+            "watcher._on_heartbeat_tick: could not read config: %s", exc
+        )
+        feed_channel_id = None
+
+    if not feed_channel_id:
+        logger.debug(
+            "watcher._on_heartbeat_tick: no feed_channel_id; skipping task_id=%s",
+            task_id,
+        )
+        return
+
+    # Build status content: current state + elapsed since last output change
+    state = row.get("state", "RUNNING")
+    agent = row.get("agent", "unknown")
+    project = row.get("project") or row.get("repo") or ""
+    project_part = f" | {project}" if project else ""
+
+    last_output_ts = row.get("last_output_ts")
+    if last_output_ts:
+        elapsed_s = int(time.time() - float(last_output_ts))
+        elapsed_min, elapsed_sec = divmod(elapsed_s, 60)
+        elapsed_str = f"{elapsed_min}m{elapsed_sec:02d}s" if elapsed_min else f"{elapsed_sec}s"
+        elapsed_part = f" (no change for {elapsed_str})"
+    else:
+        elapsed_part = ""
+
+    content = (
+        f"⏱ **[{agent}] {task_id}** — `{state}`{project_part}{elapsed_part}"
+    )
+
+    # Determine whether to POST (first) or PATCH (subsequent)
+    status_message_id: Optional[str] = row.get("status_message_id") or None
+
+    try:
+        if status_message_id is None:
+            # First heartbeat: POST a new status message
+            from session_orchestration.feed import _post_discord_message
+
+            new_msg_id = _post_discord_message(feed_channel_id, content)
+            if new_msg_id:
+                logger.info(
+                    "watcher._on_heartbeat_tick: posted status message id=%s task_id=%s",
+                    new_msg_id,
+                    task_id,
+                )
+                # Persist the message_id so subsequent heartbeats PATCH it
+                _heartbeat_registry_ref(task_id, row, new_msg_id)
+            else:
+                logger.warning(
+                    "watcher._on_heartbeat_tick: POST returned no message_id for task_id=%s",
+                    task_id,
+                )
+        else:
+            # Subsequent heartbeats: PATCH in-place — no new notification
+            from session_orchestration.feed import edit_status_message
+
+            ok = edit_status_message(feed_channel_id, status_message_id, content)
+            if ok:
+                logger.debug(
+                    "watcher._on_heartbeat_tick: edited status message id=%s task_id=%s",
+                    status_message_id,
+                    task_id,
+                )
+            else:
+                logger.warning(
+                    "watcher._on_heartbeat_tick: PATCH failed for message_id=%s task_id=%s",
+                    status_message_id,
+                    task_id,
+                )
+    except Exception as exc:
+        # Non-fatal: a failed heartbeat must not crash the watcher.
+        logger.error(
+            "watcher._on_heartbeat_tick: error for task_id=%s: %s",
+            task_id,
+            exc,
+        )
+
+
+def _heartbeat_registry_ref(
+    task_id: str,
+    row: Dict[str, Any],
+    status_message_id: str,
+) -> None:
+    """Persist *status_message_id* to the registry row for *task_id*.
+
+    Called only after the first heartbeat POST succeeds.  Uses the production
+    registry via a late import (avoids circular deps at module level).
+
+    Isolated into its own function so tests can patch it without touching
+    the broader _on_heartbeat_tick logic.
+    """
+    try:
+        from session_orchestration.registry import SessionOrchestrationRegistry
+
+        # The watcher owns registry writes; no queue needed here.
+        reg = SessionOrchestrationRegistry()
+        reg.upsert(
+            task_id,
+            agent=row.get("agent", "unknown"),
+            run_id=row.get("run_id"),
+            repo=row.get("repo"),
+            source=row.get("source", "spawn"),
+            status_message_id=status_message_id,
+        )
+    except Exception as exc:
+        logger.error(
+            "watcher._heartbeat_registry_ref: failed to persist status_message_id"
+            " for task_id=%s: %s",
+            task_id,
+            exc,
+        )
+
+
+def _on_hang(
+    task_id: str,
+    row: Dict[str, Any],
+    *,
+    registry: Optional["SessionOrchestrationRegistry"] = None,
+    adapter: Optional["AgentAdapter"] = None,
+    pane_text: str = "",
+) -> None:
+    """Called when a session is potentially hung (RUNNING + pane-hash unchanged
+    for N ticks + last_output_ts might be old).
+
+    This hook is ONLY called when state is RUNNING (never WAITING_USER
+    or PAUSED_HANDOFF) — the call-site in ``_process_row`` gates on
+    ``new_state == RUNNING``.
+
+    Inside this function we apply the STATIC thresholds from config:
+    - ``hang_idle_ticks``: minimum idle_ticks before hang is declared.
+    - ``hang_stale_seconds``: minimum seconds since last output change.
+    - ``idle_indicator_regex``: if the adapter declares an active-tool pattern
+      and it matches the current pane text, the session is NOT hung.
+
+    On confirmed hang:
+    - ``nudge_count == 0``: push a hang notification + send exactly one
+      auto-nudge message via the relay → increment nudge_count.
+    - ``nudge_count >= 1``: still hung → escalate (push escalation notice);
+      no second nudge.
+
+    The heartbeat fast-path (accelerant) can only reset liveness when it
+    carries fresh activity (its own freshness TTL tracked externally); this
+    function makes no assumption about the accelerant — it reads thresholds
+    from static config only and does NOT suppress detection based on any
+    accelerant signal.
+
+    Parameters
+    ----------
+    task_id:    Registry key.
+    row:        Full registry row dict (fresh — post-counter-increment).
+    registry:   Registry instance (injected by _process_row; defaults to
+                a new production instance if absent).
+    adapter:    The adapter for this session (for idle_indicator_regex).
+    pane_text:  Current pane capture text (for active-tool indicator check).
+    """
+    # ------------------------------------------------------------------
+    # 1. Load static thresholds from config
+    # ------------------------------------------------------------------
+    try:
+        from session_orchestration.config import load_session_orchestration_config
+
+        cfg = load_session_orchestration_config()
+        hang_idle_ticks = cfg.hang_idle_ticks
+        hang_stale_seconds = cfg.hang_stale_seconds
+    except Exception as exc:
+        logger.debug("watcher._on_hang: could not read config, using defaults: %s", exc)
+        hang_idle_ticks = 3
+        hang_stale_seconds = 300
+
+    # ------------------------------------------------------------------
+    # 2. Apply idle-tick threshold
+    # ------------------------------------------------------------------
+    idle_ticks = row.get("idle_ticks") or 0
+    if idle_ticks < hang_idle_ticks:
+        logger.debug(
+            "watcher._on_hang: idle_ticks=%d < threshold=%d for task_id=%s — not hung yet",
+            idle_ticks,
+            hang_idle_ticks,
+            task_id,
+        )
+        return
+
+    # ------------------------------------------------------------------
+    # 3. Apply stale-timestamp threshold (last_output_ts)
+    # ------------------------------------------------------------------
+    last_output_ts = row.get("last_output_ts")
+    if last_output_ts is not None:
+        elapsed = time.time() - float(last_output_ts)
+        if elapsed < hang_stale_seconds:
+            logger.debug(
+                "watcher._on_hang: elapsed=%.1fs < stale_threshold=%ds for task_id=%s — not stale",
+                elapsed,
+                hang_stale_seconds,
+                task_id,
+            )
+            return
+    # If last_output_ts is None we treat it as "no output ever" — proceed.
+
+    # ------------------------------------------------------------------
+    # 4. Active-tool indicator check (positive liveness from adapter)
+    # ------------------------------------------------------------------
+    if adapter is not None and pane_text:
+        caps = None
+        try:
+            caps = adapter.capabilities()
+        except Exception as exc:
+            logger.debug(
+                "watcher._on_hang: capabilities() failed for task_id=%s: %s",
+                task_id,
+                exc,
+            )
+        if caps is not None and caps.idle_indicator_regex is not None:
+            if caps.idle_indicator_regex.search(pane_text):
+                logger.debug(
+                    "watcher._on_hang: active-tool indicator matched for task_id=%s — not hung",
+                    task_id,
+                )
+                return
+
+    # ------------------------------------------------------------------
+    # 5. Confirmed hang — notify + nudge or escalate
+    # ------------------------------------------------------------------
+    nudge_count = row.get("nudge_count") or 0
+    logger.info(
+        "watcher._on_hang: CONFIRMED HANG task_id=%s idle_ticks=%d nudge_count=%d",
+        task_id,
+        idle_ticks,
+        nudge_count,
+    )
+
+    # Push hang notification to feed (always, whether nudging or escalating)
+    try:
+        from session_orchestration.feed import push_hang_notification
+
+        push_hang_notification(task_id, row, escalate=(nudge_count >= 1))
+    except Exception as exc:
+        logger.error(
+            "watcher._on_hang: push_hang_notification failed for task_id=%s: %s",
+            task_id,
+            exc,
+        )
+
+    if nudge_count == 0:
+        # Exactly one auto-nudge via relay (lock-gated)
+        _send_auto_nudge(task_id, row, registry=registry, adapter=adapter)
+        # Increment nudge_count so next tick escalates instead of re-nudging
+        try:
+            reg = registry or SessionOrchestrationRegistry()
+            reg.increment_counter(task_id, "nudge_count", by=1)
+        except Exception as exc:
+            logger.error(
+                "watcher._on_hang: failed to increment nudge_count for task_id=%s: %s",
+                task_id,
+                exc,
+            )
+    else:
+        # nudge_count >= 1: already nudged — escalate, do not re-nudge
+        logger.info(
+            "watcher._on_hang: ESCALATING (nudge already sent) for task_id=%s",
+            task_id,
+        )
+
+
+def _send_auto_nudge(
+    task_id: str,
+    row: Dict[str, Any],
+    *,
+    registry: Optional["SessionOrchestrationRegistry"] = None,
+    adapter: Optional["AgentAdapter"] = None,
+) -> None:
+    """Send exactly one auto-nudge via the relay (lock-gated).
+
+    Called only when ``nudge_count == 0``.  Non-fatal: logs on failure
+    and returns rather than raising so the watcher tick continues.
+
+    Parameters
+    ----------
+    task_id:   Registry key.
+    row:       Full registry row dict.
+    registry:  Registry instance (injected for testability).
+    adapter:   Adapter for this session (needed by SessionRelay).
+    """
+    if adapter is None:
+        logger.warning(
+            "watcher._send_auto_nudge: no adapter available for task_id=%s — cannot nudge",
+            task_id,
+        )
+        return
+
+    try:
+        from session_orchestration.relay import SessionRelay
+        from session_orchestration.watcher import _build_handle_from_row
+
+        reg = registry or SessionOrchestrationRegistry()
+        relay = SessionRelay(reg, adapter)
+        handle = _build_handle_from_row(row)
+        nudge_msg = (
+            "Hermes nudge: your session appears to have stalled. "
+            "If you are waiting for me, please continue — otherwise carry on."
+        )
+        relay.send_message(task_id, handle, nudge_msg, retry_on_conflict=True)
+        logger.info(
+            "watcher._send_auto_nudge: nudge sent for task_id=%s", task_id
+        )
+    except Exception as exc:
+        logger.error(
+            "watcher._send_auto_nudge: failed to send nudge for task_id=%s: %s",
+            task_id,
+            exc,
+        )
+
+
+def _build_handle_from_row(row: Dict[str, Any]) -> "SessionHandle":
+    """Reconstruct a ``SessionHandle`` from a registry row dict.
+
+    Standalone helper (mirrors ``SessionWatcher._build_handle``) so that
+    ``_send_auto_nudge`` — which runs outside a watcher instance — can
+    build a handle without importing the class.
+    """
+    from datetime import datetime, timezone
+
+    tmux_session = row.get("tmux_session") or ""
+    pane = f"{tmux_session}:0.0" if tmux_session else ""
+    return SessionHandle(
+        session_id=row.get("task_id", ""),
+        tmux_session=tmux_session,
+        pane=pane,
+        launch_ts=datetime.now(tz=timezone.utc),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core watcher
+# ---------------------------------------------------------------------------
+
+
+class SessionWatcher:
+    """Core watcher loop — sole mutator of the session-orchestration registry.
+
+    Parameters
+    ----------
+    registry:
+        The ``SessionOrchestrationRegistry`` instance.  Defaults to the
+        production DB (hermes state.db) when not injected.
+    adapters:
+        Adapter dict *before* verification.  The watcher calls
+        ``verify_adapters`` at startup and uses only the verified subset.
+    tmux_capture:
+        Callable ``(pane: str) -> str``.  Defaults to the real subprocess
+        implementation.  Inject a fake in tests.
+    lock_ttl_seconds:
+        Lock TTL forwarded to ``registry.acquire_lock``.
+    """
+
+    def __init__(
+        self,
+        registry: Optional[SessionOrchestrationRegistry] = None,
+        adapters: Optional[Dict[str, AgentAdapter]] = None,
+        *,
+        tmux_capture=None,
+        lock_ttl_seconds: float = _LOCK_TTL_SECONDS,
+    ) -> None:
+        self._registry = registry or SessionOrchestrationRegistry()
+        self._raw_adapters: Dict[str, AgentAdapter] = adapters or {}
+        self._tmux_capture = tmux_capture or _TmuxCapture()
+        self._lock_ttl = lock_ttl_seconds
+        # Available adapters are populated once in run() / tick()
+        self._available_adapters: Dict[str, AgentAdapter] = {}
+        self._verified = False
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def startup_verify(self, **verify_kwargs) -> Dict[str, AgentAdapter]:
+        """Run verify_adapters once and cache the result.
+
+        Safe to call multiple times — subsequent calls are no-ops if
+        already verified (idempotent).  In tests, pass ``probe_runner``
+        and ``probe_specs`` via ``verify_kwargs`` to inject fakes.
+
+        Returns the dict of available adapters (may be a subset of
+        ``self._raw_adapters`` if some failed verification).
+        """
+        if not self._verified:
+            self._available_adapters = verify_adapters(
+                self._raw_adapters, **verify_kwargs
+            )
+            self._verified = True
+        return self._available_adapters
+
+    def tick(self) -> int:
+        """Execute one watcher tick.
+
+        1. Drain + apply intent queue.
+        2. Iterate active registry rows.
+        3. For each row with an available adapter:
+           a. Acquire per-session lock — skip row if locked.
+           b. Capture pane text.
+           c. Release lock.
+           d. Detect new state via ``adapter.detect()``.
+           e. Update registry state + counters.
+           f. Fire transition hooks.
+
+        Returns the number of rows successfully processed (lock-skips
+        and unavailable-adapter rows are not counted).
+        """
+        if not self._verified:
+            self.startup_verify()
+
+        # Step 1 — drain intent queue (single-writer responsibility)
+        intents = self._registry.drain_intents()
+        for intent in intents:
+            try:
+                self._registry._apply_intent(intent)
+            except Exception as exc:
+                logger.error(
+                    "watcher.tick: intent application failed for %r: %s",
+                    intent,
+                    exc,
+                )
+
+        # Step 2 — iterate active rows
+        rows = self._registry.list()
+        active_rows = [r for r in rows if r.get("state") in _ACTIVE_STATES]
+
+        processed = 0
+        for row in active_rows:
+            task_id = row["task_id"]
+            agent_name = row.get("agent", "")
+
+            # Skip rows whose adapter is unavailable
+            adapter = self._available_adapters.get(agent_name)
+            if adapter is None:
+                logger.debug(
+                    "watcher.tick: skipping task_id=%s — adapter %r unavailable",
+                    task_id,
+                    agent_name,
+                )
+                continue
+
+            try:
+                did_process = self._process_row(task_id, row, adapter)
+                if did_process:
+                    processed += 1
+            except Exception as exc:
+                logger.error(
+                    "watcher.tick: error processing task_id=%s: %s",
+                    task_id,
+                    exc,
+                )
+
+        return processed
+
+    # ------------------------------------------------------------------
+    # Internal — single-row processing
+    # ------------------------------------------------------------------
+
+    def _process_row(
+        self,
+        task_id: str,
+        row: Dict[str, Any],
+        adapter: AgentAdapter,
+    ) -> bool:
+        """Process a single registry row in one tick.
+
+        Returns True if the row was fully processed, False if it was skipped
+        (e.g. because the per-session lock was held by the relay).
+        """
+        # The registry has tmux_session but not a separate pane column;
+        # derive the pane target using the same logic as _build_handle.
+        tmux_session = row.get("tmux_session") or ""
+        pane = f"{tmux_session}:0.0" if tmux_session else ""
+        holder = f"watcher:pid:{os.getpid()}:{time.time():.3f}"
+
+        # Acquire per-session lock — BEFORE any capture-pane call
+        lock_acquired = self._registry.acquire_lock(
+            task_id, holder, ttl_seconds=self._lock_ttl
+        )
+        if not lock_acquired:
+            logger.debug(
+                "watcher.tick: lock held for task_id=%s — skipping capture this tick",
+                task_id,
+            )
+            return False  # SKIP; never read a half-rendered pane
+
+        pane_text = ""
+        try:
+            # Capture pane while we hold the lock
+            if pane:
+                pane_text = self._tmux_capture(pane)
+        finally:
+            # Always release — crash-safe because relay reclaims after TTL
+            self._registry.release_lock(task_id, holder)
+
+        # Detect state via adapter (no lock needed for pure detection)
+        handle = self._build_handle(row)
+        try:
+            new_lifecycle = adapter.detect(handle)
+        except Exception as exc:
+            logger.error(
+                "watcher.tick: adapter.detect() failed for task_id=%s: %s",
+                task_id,
+                exc,
+            )
+            return
+
+        new_state = new_lifecycle.value
+        old_state = row.get("state", SessionLifecycle.RUNNING.value)
+
+        # Compute pane hash for hang-detection (T009 consumes this)
+        pane_hash = _pane_hash(pane_text) if pane_text else None
+
+        # Determine idle-tick increment
+        pane_changed = pane_hash != row.get("last_pane_hash")
+        idle_tick_delta = 0 if pane_changed else 1
+
+        # Build update fields
+        update_fields: Dict[str, Any] = {
+            "state": new_state,
+            "updated_at": "datetime('now')",  # handled by upsert
+        }
+        if pane_hash is not None:
+            update_fields["last_pane_hash"] = pane_hash
+        if pane_changed:
+            update_fields["last_output_ts"] = time.time()
+            update_fields["idle_ticks"] = 0
+        else:
+            # Atomic increment — done via registry.increment_counter
+            pass  # handled below
+
+        # Write state update (single writer)
+        self._registry.upsert(
+            task_id,
+            agent=row.get("agent", "unknown"),
+            run_id=row.get("run_id"),
+            repo=row.get("repo"),
+            source=row.get("source", "spawn"),
+            **{k: v for k, v in update_fields.items() if k not in ("updated_at",)},
+        )
+
+        # Atomic idle-tick increment (separate atomic SQL expression)
+        if idle_tick_delta > 0:
+            self._registry.increment_counter(task_id, "idle_ticks", by=idle_tick_delta)
+
+        # Heartbeat counter — always bump (T008 gates on modulo)
+        self._registry.increment_counter(task_id, "heartbeat_counter", by=1)
+
+        # Re-read fresh row for hook calls (reflects counters just written)
+        fresh_row = self._registry.get(task_id) or row
+
+        # Fire transition hook if state changed into a user-attention state
+        _ATTENTION_STATES = frozenset(
+            {
+                SessionLifecycle.WAITING_USER.value,
+                SessionLifecycle.PAUSED_HANDOFF.value,
+            }
+        )
+        if new_state != old_state and new_state in _ATTENTION_STATES:
+            _on_turn_change(task_id, fresh_row, new_state, old_state)
+        elif new_state != old_state and old_state in _ATTENTION_STATES:
+            # Transitioning OUT of an attention state — re-arm the debounce
+            # so the NEXT transition back fires as a new notification.
+            try:
+                from session_orchestration.feed import clear_last_notified
+
+                clear_last_notified(task_id)
+            except Exception as exc:
+                logger.debug(
+                    "watcher._process_row: clear_last_notified failed for task_id=%s: %s",
+                    task_id,
+                    exc,
+                )
+
+        # Heartbeat hook (T008 decides whether to actually edit based on counter)
+        _on_heartbeat_tick(task_id, fresh_row)
+
+        # Hang hook — only when state is RUNNING (never WAITING_USER / PAUSED_HANDOFF)
+        if (
+            new_state == SessionLifecycle.RUNNING.value
+            and not pane_changed
+            and (fresh_row.get("idle_ticks") or 0) > 0
+        ):
+            _on_hang(
+                task_id,
+                fresh_row,
+                registry=self._registry,
+                adapter=adapter,
+                pane_text=pane_text,
+            )
+
+        return True
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _build_handle(row: Dict[str, Any]) -> SessionHandle:
+        """Reconstruct a ``SessionHandle`` from a registry row dict.
+
+        The registry schema stores ``tmux_session`` (session name) but not
+        the pane target.  We derive the pane as ``<tmux_session>:0.0``,
+        which is the default for single-pane sessions created by adapters.
+        """
+        tmux_session = row.get("tmux_session") or ""
+        pane = f"{tmux_session}:0.0" if tmux_session else ""
+        return SessionHandle(
+            session_id=row.get("task_id", ""),
+            tmux_session=tmux_session,
+            pane=pane,
+            launch_ts=datetime.now(tz=timezone.utc),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Convenience: run one tick (called by the --no-agent cron script)
+# ---------------------------------------------------------------------------
+
+
+def run_tick(
+    registry: Optional[SessionOrchestrationRegistry] = None,
+    adapters: Optional[Dict[str, AgentAdapter]] = None,
+    tmux_capture=None,
+    *,
+    probe_runner=None,
+    probe_specs=None,
+) -> int:
+    """Run a single watcher tick; return number of rows processed.
+
+    This is the entry point called by ``session-orchestration-watch.sh``.
+    The shell script passes no arguments (uses defaults); tests inject fakes.
+    """
+    watcher = SessionWatcher(
+        registry=registry,
+        adapters=adapters,
+        tmux_capture=tmux_capture,
+    )
+    verify_kwargs: Dict[str, Any] = {}
+    if probe_runner is not None:
+        verify_kwargs["probe_runner"] = probe_runner
+    if probe_specs is not None:
+        verify_kwargs["probe_specs"] = probe_specs
+    watcher.startup_verify(**verify_kwargs)
+    return watcher.tick()
+
+
+# ---------------------------------------------------------------------------
+# Config gate helper
+# ---------------------------------------------------------------------------
+
+
+def _is_session_orchestration_enabled() -> bool:
+    """Return True iff ``session_orchestration.enabled`` is truthy in config.
+
+    Safe to call without the Hermes config file present (returns False).
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        cfg = load_config_readonly()
+        so_cfg = cfg.get("session_orchestration") or {}
+        return bool(so_cfg.get("enabled", False))
+    except Exception as exc:
+        logger.debug("watcher: could not read config: %s", exc)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# __main__ entry-point (used by the cron shell script)
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Main entry point — gated on ``session_orchestration.enabled``."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    if not _is_session_orchestration_enabled():
+        logger.info("watcher: session_orchestration.enabled is false — exiting")
+        return
+
+    from session_orchestration.adapters.claude_code import ClaudeCodeAdapter
+    from session_orchestration.adapters.omp import OmpAdapter
+
+    adapters: Dict[str, AgentAdapter] = {
+        "claude": ClaudeCodeAdapter(),
+        "omp": OmpAdapter(),
+    }
+
+    n = run_tick(adapters=adapters)
+    logger.info("watcher: tick complete — %d rows processed", n)
+
+
+if __name__ == "__main__":
+    main()
+
+
+# ---------------------------------------------------------------------------
+# Internal utility
+# ---------------------------------------------------------------------------
+
+
+def _pane_hash(text: str) -> str:
+    """Return a short SHA-256 hex prefix of pane text for change detection."""
+    return hashlib.sha256(text.encode(errors="replace")).hexdigest()[:16]

--- a/session_orchestration/watcher.py
+++ b/session_orchestration/watcher.py
@@ -1016,7 +1016,9 @@ def _build_handle_from_row(row: Dict[str, Any]) -> "SessionHandle":
     from datetime import datetime, timezone
 
     tmux_session = row.get("tmux_session") or ""
-    pane = tmux_session if tmux_session else ""
+    # Prefer the pinned pane id (%N); fall back to the bare session name for
+    # legacy rows without a pinned pane.
+    pane = row.get("pane") or tmux_session
     return SessionHandle(
         session_id=row.get("task_id", ""),
         tmux_session=tmux_session,
@@ -1528,10 +1530,12 @@ class SessionWatcher:
         # ------------------------------------------------------------------
         # 1. Acquire per-session lock — BEFORE any capture-pane call
         # ------------------------------------------------------------------
-        # The registry has tmux_session but not a separate pane column;
-        # derive the pane target using the same logic as _build_handle.
+        # Prefer the pinned pane id (%N) so capture targets the agent pane, not
+        # the session's active window (which drifts once the session gains other
+        # windows). Fall back to the bare session name for legacy rows with no
+        # pinned pane (pre-migration or externally-adopted sessions).
         tmux_session = row.get("tmux_session") or ""
-        pane = tmux_session if tmux_session else ""
+        pane = row.get("pane") or tmux_session
         holder = f"watcher:pid:{os.getpid()}:{time.time():.3f}"
 
         lock_acquired = self._registry.acquire_lock(
@@ -2079,12 +2083,12 @@ class SessionWatcher:
     def _build_handle(row: Dict[str, Any]) -> SessionHandle:
         """Reconstruct a ``SessionHandle`` from a registry row dict.
 
-        The registry schema stores ``tmux_session`` (session name) but not
-        the pane target.  We derive the pane as ``<tmux_session>:0.0``,
-        which is the default for single-pane sessions created by adapters.
+        Prefer the pinned pane id (``pane`` column, e.g. ``%12``) so targeting
+        survives the session gaining extra windows; fall back to the bare
+        session name for legacy rows without a pinned pane.
         """
         tmux_session = row.get("tmux_session") or ""
-        pane = tmux_session if tmux_session else ""
+        pane = row.get("pane") or tmux_session
         return SessionHandle(
             session_id=row.get("task_id", ""),
             tmux_session=tmux_session,

--- a/session_orchestration/watcher.py
+++ b/session_orchestration/watcher.py
@@ -177,6 +177,19 @@ def _load_gc_after_seconds_cfg() -> int:
         return 86400
 
 
+def _load_drive_queue_ttl_secs_cfg() -> int:
+    """Return drive_queue_ttl_seconds from config (default 600 = 10 min).
+
+    Lazy-imported so the watcher module does not pull in config at import
+    time.  Returns the default on any error.  A value <= 0 disables expiry.
+    """
+    try:
+        from session_orchestration.config import load_session_orchestration_config
+        return load_session_orchestration_config().drive_queue_ttl_seconds
+    except Exception:  # config load must never crash the watcher
+        return 600
+
+
 def _load_renudge_after_seconds_cfg() -> int:
     """Return renudge_after_seconds from config (default 1800 = 30 min).
 
@@ -1920,11 +1933,144 @@ class SessionWatcher:
                     task_id, exc,
                 )
 
+        # Redeliver any reply queued while this session was busy (single writer).
+        try:
+            self._drain_pending_drive(task_id, fresh_row, adapter, new_state, now)
+        except Exception as exc:
+            logger.error(
+                "watcher._process_row: _drain_pending_drive failed for task_id=%s: %s",
+                task_id, exc,
+            )
+
         return True
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    def _drain_pending_drive(
+        self,
+        task_id: str,
+        row: Dict[str, Any],
+        adapter: AgentAdapter,
+        new_state: str,
+        now: datetime,
+    ) -> None:
+        """Redeliver replies queued while this session was busy.
+
+        A reply that arrived while the session was ``RUNNING`` is stored in the
+        pending-drive table (``gateway/run.py:_handle_managed_thread_reply``).
+        Once the session is idle again (``WAITING_USER``) each queued reply is
+        redelivered FIFO through the relay — which contends for the same
+        per-session lock the tick uses — then deleted, with a confirmation
+        posted to the session thread. A redelivery that itself times out or
+        loses the lock leaves the entry for the next tick (bounded by the TTL
+        expiry below).
+
+        Runs inside the single-writer watcher tick, so its reads/deletes on the
+        pending-drive store are race-free against enqueues from the Discord path.
+
+        TTL expiry runs every tick regardless of state (a session that never
+        returns to ``WAITING_USER`` must still expire its queue); redelivery of
+        the survivors happens only once the session is idle.
+        """
+        try:
+            pending = self._registry.list_pending_drive(task_id)
+        except Exception as exc:
+            logger.error(
+                "watcher._drain_pending_drive: list failed for task_id=%s: %s",
+                task_id, exc,
+            )
+            return
+        if not pending:
+            return
+
+        thread_id = str(row.get("discord_thread_id") or "")
+
+        # TTL expiry — runs regardless of lifecycle state.
+        ttl_secs = _load_drive_queue_ttl_secs_cfg()
+        survivors: List[Dict[str, Any]] = []
+        if ttl_secs > 0:
+            now_ts = now.timestamp()
+            ttl_minutes = max(1, ttl_secs // 60)
+            for entry in pending:
+                enq_ts = _parse_marker_ts(entry.get("enqueued_at") or "")
+                # enq_ts <= 0 means the timestamp was unparseable — keep the
+                # entry rather than risk dropping a valid queued reply.
+                if 0 < enq_ts and (now_ts - enq_ts) > ttl_secs:
+                    self._registry.delete_pending_drive(entry["id"])
+                    logger.info(
+                        "watcher._drain_pending_drive: expired queued reply for "
+                        "task_id=%s entry=%s (age > %ss)",
+                        task_id, entry["id"], ttl_secs,
+                    )
+                    if thread_id:
+                        try:
+                            from session_orchestration.feed import _post_discord_message
+
+                            _post_discord_message(
+                                thread_id,
+                                "Your queued reply expired undelivered — the "
+                                f"session stayed busy for over {ttl_minutes} min.",
+                            )
+                        except Exception as exc:
+                            logger.debug(
+                                "watcher._drain_pending_drive: expiry notice "
+                                "failed for task_id=%s: %s", task_id, exc,
+                            )
+                else:
+                    survivors.append(entry)
+        else:
+            survivors = pending
+
+        # Redelivery — only when the session is idle again.
+        if new_state != SessionLifecycle.WAITING_USER.value or not survivors:
+            return
+
+        from session_orchestration.relay import LockConflictError, SessionRelay
+
+        relay = SessionRelay(self._registry, adapter)
+        handle = _build_handle_from_row(row)
+        for entry in survivors:  # FIFO — list_pending_drive orders by id
+            entry_id = entry["id"]
+            try:
+                pre_keys = json.loads(entry.get("pre_keys") or "[]")
+            except (ValueError, TypeError):
+                pre_keys = []
+            try:
+                relay.send_message(
+                    task_id, handle, entry["message"],
+                    pre_keys=pre_keys, retry_on_conflict=True,
+                )
+            except (TimeoutError, LockConflictError) as exc:
+                # Still busy / locked — keep the entry, retry next tick. Stop
+                # here so a later entry can't jump the queue (FIFO preserved).
+                logger.info(
+                    "watcher._drain_pending_drive: redelivery deferred for "
+                    "task_id=%s entry=%s: %s", task_id, entry_id, exc,
+                )
+                self._registry.bump_pending_drive_attempt(entry_id)
+                return
+            except Exception as exc:
+                logger.error(
+                    "watcher._drain_pending_drive: redelivery failed for "
+                    "task_id=%s entry=%s: %s", task_id, entry_id, exc,
+                )
+                self._registry.bump_pending_drive_attempt(entry_id)
+                return
+            self._registry.delete_pending_drive(entry_id)
+            if thread_id:
+                try:
+                    from session_orchestration.feed import _post_discord_message
+
+                    _post_discord_message(
+                        thread_id, "Delivered your queued reply."
+                    )
+                except Exception as exc:
+                    logger.debug(
+                        "watcher._drain_pending_drive: confirmation post failed "
+                        "for task_id=%s: %s", task_id, exc,
+                    )
 
     @staticmethod
     def _build_handle(row: Dict[str, Any]) -> SessionHandle:

--- a/session_orchestration/watcher.py
+++ b/session_orchestration/watcher.py
@@ -339,10 +339,11 @@ def _on_turn_change(
         task_id=task_id,
         context="_on_turn_change",
     )
+    turn_output = _collect_turn_output(task_id, row, registry)
     try:
         from session_orchestration.feed import push_turn_change
 
-        push_turn_change(task_id, row, new_state, old_state)
+        push_turn_change(task_id, row, new_state, old_state, turn_output=turn_output)
     except Exception as exc:
         # Non-fatal: a failed notification must not crash the watcher.
         logger.error(
@@ -350,6 +351,84 @@ def _on_turn_change(
             task_id,
             exc,
         )
+
+
+def _collect_turn_output(
+    task_id: str,
+    row: Dict[str, Any],
+    registry: Optional["SessionOrchestrationRegistry"] = None,
+) -> Optional[str]:
+    """Read the agent's new assistant text since the last relay.
+
+    Sources the agent's own transcript file (``agent_session_file``, e.g.
+    omp's per-session JSONL) rather than the pane, so the Discord thread gets
+    the clean response — no tool calls, build logs, or the user's own pasted
+    reply. Retries file discovery here when spawn-time discovery missed
+    (transcript created slightly after launch). Persists the consumed line
+    offset. Best-effort: returns None on any failure.
+    """
+    try:
+        from session_orchestration.agent_transcript import (
+            discover_omp_session_file,
+            read_assistant_texts,
+        )
+
+        reg = registry if registry is not None else SessionOrchestrationRegistry()
+
+        transcript = row.get("agent_session_file")
+        if not transcript and row.get("agent") == "omp" and row.get("workdir"):
+            # created_at is SQLite datetime('now') — a naive UTC ISO string.
+            from datetime import datetime, timezone as _tz
+
+            created_dt = None
+            try:
+                created_dt = datetime.fromisoformat(
+                    str(row.get("created_at") or "")
+                ).replace(tzinfo=_tz.utc)
+            except ValueError:
+                pass
+            if created_dt is not None:
+                claimed = [
+                    r.get("agent_session_file")
+                    for r in reg.list()
+                    if r.get("agent_session_file")
+                ]
+                transcript = discover_omp_session_file(
+                    row["workdir"],
+                    created_dt,
+                    claimed,
+                )
+                if transcript:
+                    reg.upsert(
+                        task_id,
+                        agent=row.get("agent", "unknown"),
+                        run_id=row.get("run_id"),
+                        repo=row.get("repo"),
+                        source=row.get("source", "spawn"),
+                        agent_session_file=transcript,
+                    )
+        if not transcript:
+            return None
+
+        offset = int(row.get("transcript_line_offset") or 0)
+        texts, new_offset = read_assistant_texts(transcript, offset)
+        if new_offset != offset:
+            reg.upsert(
+                task_id,
+                agent=row.get("agent", "unknown"),
+                run_id=row.get("run_id"),
+                repo=row.get("repo"),
+                source=row.get("source", "spawn"),
+                transcript_line_offset=new_offset,
+            )
+        if not texts:
+            return None
+        return "\n\n".join(texts)
+    except Exception as exc:  # noqa: BLE001 — relay must never break the notification
+        logger.debug(
+            "watcher._collect_turn_output: failed for task_id=%s: %s", task_id, exc
+        )
+        return None
 
 
 def _on_heartbeat_tick(task_id: str, row: Dict[str, Any]) -> None:
@@ -982,6 +1061,31 @@ def _handle_terminate_adapter(
             agent_name,
             task_id,
         )
+        # The intent is consumed either way, so a skipped kill would orphan the
+        # tmux session forever (seen live when a flaky `omp --help` probe left
+        # the adapter unverified for one tick). Killing tmux needs no adapter —
+        # do it directly.
+        tmux_session = row.get("tmux_session") or ""
+        if tmux_session:
+            try:
+                subprocess.run(
+                    ["tmux", "kill-session", "-t", tmux_session],
+                    capture_output=True,
+                    timeout=10,
+                )
+                logger.info(
+                    "_handle_terminate_adapter: direct tmux kill for task_id=%s "
+                    "session=%s (no adapter)",
+                    task_id,
+                    tmux_session,
+                )
+            except Exception as exc:
+                logger.error(
+                    "_handle_terminate_adapter: direct tmux kill failed for "
+                    "task_id=%s: %s",
+                    task_id,
+                    exc,
+                )
         # Still attempt restart if requested — adapter kill is best-effort
     else:
         handle = _build_handle_from_row(row)

--- a/session_orchestration/watcher.py
+++ b/session_orchestration/watcher.py
@@ -1954,9 +1954,12 @@ class SessionWatcher:
         row: Dict[str, Any],
         adapter: AgentAdapter,
         new_state: str,
-        now: datetime,
+        now: float,
     ) -> None:
         """Redeliver replies queued while this session was busy.
+
+        ``now`` is a POSIX timestamp (float), matching ``self._now_fn()`` used
+        throughout ``_process_row`` — NOT a ``datetime``.
 
         A reply that arrived while the session was ``RUNNING`` is stored in the
         pending-drive table (``gateway/run.py:_handle_managed_thread_reply``).
@@ -1991,7 +1994,7 @@ class SessionWatcher:
         ttl_secs = _load_drive_queue_ttl_secs_cfg()
         survivors: List[Dict[str, Any]] = []
         if ttl_secs > 0:
-            now_ts = now.timestamp()
+            now_ts = float(now)
             ttl_minutes = max(1, ttl_secs // 60)
             for entry in pending:
                 enq_ts = _parse_marker_ts(entry.get("enqueued_at") or "")

--- a/session_orchestration/watcher.py
+++ b/session_orchestration/watcher.py
@@ -2329,6 +2329,7 @@ def _is_session_orchestration_enabled() -> bool:
 #: masquerading as fresh output. See ``_pane_hash`` and ``_is_stale_frozen_eligible``.
 _VOLATILE_PANE_TOKENS: re.Pattern[str] = re.compile(
     r"[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏⠛⠟⠿⢿⣻⣽⣾⣷⣯⣟]"              # braille/tui spinner frames
+    r"|[\U000f1440-\U000f145f]"                         # Nerd Font clock/timer animation frames
     r"|\b\d+h\d+m\d+s\b|\b\d+m\d+s\b|\b\d+(?:\.\d+)?s\b"  # elapsed timers (12m28s, 4.3s)
     r"|\$\s?\d[\d,]*(?:\.\d+)?"                          # running cost meter ($14.51)
     r"|\d+(?:\.\d+)?\s*%\s*/\s*\d+[KkMm]"                # context usage (92.5%/272K)
@@ -2369,16 +2370,26 @@ def main() -> None:
         logger.info("watcher: session_orchestration.enabled is false — exiting")
         return
 
-    from session_orchestration.adapters.claude_code import ClaudeCodeAdapter
-    from session_orchestration.adapters.omp import OmpAdapter
-
-    adapters: Dict[str, AgentAdapter] = {
-        "claude": ClaudeCodeAdapter(),
-        "omp": OmpAdapter(),
-    }
+    adapters = build_default_adapters()
 
     n = run_tick(adapters=adapters)
     logger.info("watcher: tick complete — %d rows processed", n)
+
+
+def build_default_adapters() -> Dict[str, AgentAdapter]:
+    """Return the live adapter map, including user-facing aliases."""
+    from session_orchestration.adapters.claude_code import ClaudeCodeAdapter
+    from session_orchestration.adapters.codex import CodexAdapter
+    from session_orchestration.adapters.omp import OmpAdapter
+
+    return {
+        "claude": ClaudeCodeAdapter(),
+        "claude-code": ClaudeCodeAdapter(),
+        "codex": CodexAdapter(),
+        "codex-cli": CodexAdapter(),
+        "omp": OmpAdapter(),
+        "omp-adapter": OmpAdapter(),
+    }
 
 
 if __name__ == "__main__":

--- a/session_orchestration/watcher.py
+++ b/session_orchestration/watcher.py
@@ -190,6 +190,58 @@ def _load_drive_queue_ttl_secs_cfg() -> int:
         return 600
 
 
+def _load_auto_checkpoint_resume_cfg() -> bool:
+    """Return auto_checkpoint_resume from config (default True).
+
+    When True, the watcher auto-drives /clear + resume on a handoff_continue
+    marker; when False it only announces. Fail-safe default True on any error.
+    """
+    try:
+        from session_orchestration.config import load_session_orchestration_config
+        return load_session_orchestration_config().auto_checkpoint_resume
+    except Exception:  # config load must never crash the watcher
+        return True
+
+
+def _read_handoff_next_step(row: Dict[str, Any]) -> str:
+    """Best-effort fallback: read handoff.json `next_step` from the workdir.
+
+    The resume command normally rides in the handoff_continue marker's
+    `handoff_text`; this covers the plan-less fallback location where
+    `/z-handoff` writes handoff.json (`<workdir>/handoff.json`). Returns "" on
+    any miss — never raises.
+    """
+    workdir = row.get("workdir") or ""
+    if not workdir:
+        return ""
+    try:
+        import json as _json
+        with open(f"{workdir}/handoff.json", encoding="utf-8") as fh:
+            return str(_json.load(fh).get("next_step") or "")
+    except Exception:
+        return ""
+
+
+def _post_auto_resume_notice(thread_id: str, resume_cmd: str, *, resumed: bool = True) -> None:
+    """Announce a handoff_continue auto-resume (or pending checkpoint) to the thread."""
+    if not thread_id:
+        return
+    cmd = resume_cmd.strip() or "(resume command unspecified)"
+    if resumed:
+        content = f"Auto-resumed after a z-harness checkpoint — ran `/clear` + `{cmd}`."
+    else:
+        content = (
+            "z-harness reached a checkpoint. Auto-resume is disabled "
+            f"(`so.auto_checkpoint_resume`); resume manually with `{cmd}`."
+        )
+    try:
+        from session_orchestration.feed import _post_discord_message
+
+        _post_discord_message(thread_id, content)
+    except Exception as exc:
+        logger.debug("watcher._post_auto_resume_notice: post failed: %s", exc)
+
+
 def _load_renudge_after_seconds_cfg() -> int:
     """Return renudge_after_seconds from config (default 1800 = 30 min).
 
@@ -1639,15 +1691,37 @@ class SessionWatcher:
             # ------------------------------------------------------------------
             if latest_marker_kind == "handoff_continue":
                 handle = _build_handle_from_row(row)
-                try:
-                    # Pane mutation runs under per-session lock (avoids race with relay's PAUSED_HANDOFF resume)
-                    adapter.resume(handle, "")  # autonomous /clear+resume, no user reply
-                    new_lifecycle = SessionLifecycle.RUNNING  # override PAUSED_HANDOFF
-                except Exception as exc:
-                    logger.error(
-                        "watcher._process_row: handoff_continue resume failed: %s", exc
+                # Resume command: z-harness puts the next_step in the marker's
+                # handoff_text; fall back to handoff.json in the workdir.
+                resume_cmd = ""
+                if isinstance(latest_marker_payload, dict):
+                    resume_cmd = str(latest_marker_payload.get("handoff_text") or "")
+                if not resume_cmd:
+                    resume_cmd = _read_handoff_next_step(row)
+                thread_id = str(row.get("discord_thread_id") or "")
+                if _load_auto_checkpoint_resume_cfg():
+                    try:
+                        # Pane mutation runs under per-session lock (avoids race with
+                        # relay's PAUSED_HANDOFF resume). force=True: the marker is
+                        # authoritative, so skip the adapter's detect gate.
+                        adapter.resume(handle, resume_cmd, force=True)
+                        new_lifecycle = SessionLifecycle.RUNNING  # override PAUSED_HANDOFF
+                        # Auto, but announced (T003).
+                        if thread_id:
+                            _post_auto_resume_notice(thread_id, resume_cmd)
+                    except Exception as exc:
+                        logger.error(
+                            "watcher._process_row: handoff_continue resume failed: %s", exc
+                        )
+                        # new_lifecycle stays as marker-derived value on failure
+                else:
+                    # Autonomy disabled: announce the pending checkpoint, leave paused.
+                    logger.info(
+                        "watcher._process_row: auto_checkpoint_resume disabled for task_id=%s; "
+                        "announcing pending checkpoint", task_id,
                     )
-                    # new_lifecycle stays as marker-derived value on failure
+                    if thread_id:
+                        _post_auto_resume_notice(thread_id, resume_cmd, resumed=False)
 
         finally:
             # Always release — crash-safe because relay reclaims after TTL

--- a/session_orchestration/watcher.py
+++ b/session_orchestration/watcher.py
@@ -51,6 +51,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import subprocess
 import time
 from datetime import datetime, timezone
@@ -659,6 +660,34 @@ def _load_hang_thresholds() -> tuple[int, int]:
         return 3, 300
 
 
+def _load_busy_stale_seconds() -> int:
+    """Return ``busy_loop_stale_seconds`` (spinner-still-turning override).
+
+    After this many seconds of a frozen (animation-normalized) pane, an
+    active-work spinner stops vetoing stale/frozen detection — a spinner that
+    has produced no real output for this long is a stuck busy-loop.
+    """
+    try:
+        from session_orchestration.config import load_session_orchestration_config
+
+        return load_session_orchestration_config().busy_loop_stale_seconds
+    except Exception as exc:
+        logger.debug("watcher: could not read busy_loop_stale_seconds, using default: %s", exc)
+        return 900
+
+
+def _load_busy_loop_auto_escape() -> bool:
+    """Return whether the watcher may send a recovery Escape to break a stuck
+    busy-loop (works around omp re-polling an already-yielded subagent)."""
+    try:
+        from session_orchestration.config import load_session_orchestration_config
+
+        return load_session_orchestration_config().busy_loop_auto_escape
+    except Exception as exc:
+        logger.debug("watcher: could not read busy_loop_auto_escape, using default: %s", exc)
+        return True
+
+
 def _coerce_optional_float(value: Any) -> Optional[float]:
     if value is None:
         return None
@@ -703,13 +732,22 @@ def _is_stale_frozen_eligible(
     adapter: Optional["AgentAdapter"],
     hang_idle_ticks: int,
     hang_stale_seconds: int,
+    busy_stale_seconds: Optional[int] = None,
     now: Optional[float] = None,
 ) -> bool:
     """Return True only when deterministic stale/frozen evidence is present.
 
     The guard is intentionally conservative: a stale/frozen episode requires
-    an unchanged pane hash, enough idle ticks, a stale ``last_output_ts``, and
-    no adapter-declared active-work regex match in the current pane.
+    an unchanged (animation-normalized) pane hash, enough idle ticks, and a
+    stale ``last_output_ts``.
+
+    An adapter-declared active-work regex match (a spinner) normally proves
+    live work and vetoes the call — EXCEPT once the normalized pane has been
+    frozen for ``busy_stale_seconds``. A spinner still turning after that long
+    with zero real output is a stuck busy-loop, not progress (e.g. an omp
+    subagent poll-loop re-polling an already-yielded review), and must be
+    surfaced/recovered rather than trusted. ``busy_stale_seconds=None`` keeps
+    the original always-veto behaviour.
     """
     if not current_pane_hash or previous_pane_hash != current_pane_hash:
         return False
@@ -726,7 +764,9 @@ def _is_stale_frozen_eligible(
         return False
 
     if _adapter_activity_regex_matches(adapter, pane_text):
-        return False
+        frozen_for = observed_now - last_output_ts
+        if busy_stale_seconds is None or frozen_for < busy_stale_seconds:
+            return False
 
     return True
 
@@ -745,6 +785,7 @@ def _is_omp_nudge_checkin_eligible(
     adapter: Optional["AgentAdapter"],
     hang_idle_ticks: int,
     hang_stale_seconds: int,
+    busy_stale_seconds: Optional[int] = None,
     now: Optional[float] = None,
 ) -> bool:
     """Return True when the OMP stale nudge/check-in may fire this tick."""
@@ -756,6 +797,7 @@ def _is_omp_nudge_checkin_eligible(
         adapter=adapter,
         hang_idle_ticks=hang_idle_ticks,
         hang_stale_seconds=hang_stale_seconds,
+        busy_stale_seconds=busy_stale_seconds,
         now=now,
     ) and _is_stale_episode_action_eligible(row)
 
@@ -991,6 +1033,12 @@ def _on_hang(
             exc,
         )
 
+    # Workaround for omp's subagent poll-loop (#3): if the pane is still
+    # animating a spinner at hang time, the agent is wedged re-polling an
+    # already-yielded job. Send one Escape to cancel the in-flight poll and
+    # drop it back to its prompt BEFORE the nudge lands.
+    _maybe_break_busy_loop(task_id, row, adapter=adapter, pane_text=pane_text)
+
     _send_auto_nudge(task_id, row, registry=registry, adapter=adapter)
 
     # Increment nudge_count so later ticks in this episode do not act again.
@@ -1008,6 +1056,48 @@ def _on_hang(
         task_id=task_id,
         context="_on_hang",
     )
+
+def _maybe_break_busy_loop(
+    task_id: str,
+    row: Dict[str, Any],
+    *,
+    adapter: Optional["AgentAdapter"],
+    pane_text: str,
+) -> None:
+    """Send one recovery Escape when a hang fires with a spinner still up.
+
+    A confirmed hang (idle_ticks + normalized-frozen pane past
+    ``busy_loop_stale_seconds``) whose pane STILL matches the active-work regex
+    is a stuck busy-loop — the omp harness re-polling a subagent that already
+    yielded. Escape cancels the in-flight poll so the agent falls back to its
+    prompt. Best-effort and non-fatal: gated by ``busy_loop_auto_escape`` and
+    only fires when the adapter exposes ``interrupt()``.
+    """
+    if not _load_busy_loop_auto_escape():
+        return
+    if not _adapter_activity_regex_matches(adapter, pane_text):
+        return
+    interrupt = getattr(adapter, "interrupt", None)
+    if not callable(interrupt):
+        logger.debug(
+            "watcher._maybe_break_busy_loop: adapter has no interrupt() task_id=%s",
+            task_id,
+        )
+        return
+    try:
+        interrupt(_build_handle_from_row(row))
+        logger.info(
+            "watcher._maybe_break_busy_loop: sent recovery Escape to break "
+            "stuck busy-loop task_id=%s",
+            task_id,
+        )
+    except Exception as exc:
+        logger.error(
+            "watcher._maybe_break_busy_loop: Escape failed for task_id=%s: %s",
+            task_id,
+            exc,
+        )
+
 
 def _send_auto_nudge(
     task_id: str,
@@ -1765,9 +1855,7 @@ class SessionWatcher:
         if new_lifecycle == SessionLifecycle.RUNNING and pane_text:
             _idle_fn = getattr(adapter, "idle_waiting", None)
             if callable(_idle_fn):
-                _cur_hash = hashlib.sha256(
-                    pane_text.encode(errors="replace")
-                ).hexdigest()[:16]
+                _cur_hash = _pane_hash(pane_text)
                 _prev_hash = row.get("last_pane_hash")
                 try:
                     _is_idle = bool(_idle_fn(pane_text))
@@ -1798,11 +1886,10 @@ class SessionWatcher:
             and new_state in _ATTENTION_STATES
         )
 
-        # Compute pane hash for hang-detection (T009 consumes this)
-        if pane_text:
-            pane_hash = hashlib.sha256(pane_text.encode(errors="replace")).hexdigest()[:16]
-        else:
-            pane_hash = None
+        # Compute pane hash for hang-detection (T009 consumes this).
+        # Animation-normalized via _pane_hash so a pane that only redraws its
+        # spinner/timer/cost does not read as fresh output.
+        pane_hash = _pane_hash(pane_text) if pane_text else None
 
         previous_pane_hash = row.get("last_pane_hash")
         captured_pane_hash = pane_hash is not None
@@ -1901,6 +1988,7 @@ class SessionWatcher:
         fresh_row = self._registry.get(task_id) or row
         current_last_output_ts = _coerce_optional_float(fresh_row.get("last_output_ts"))
         hang_idle_ticks, hang_stale_seconds = _load_hang_thresholds()
+        busy_stale_seconds = _load_busy_stale_seconds()
         stale_frozen_eligible = (
             new_state == SessionLifecycle.RUNNING.value
             # Marker recency proves liveness even if the pane hash is frozen —
@@ -1915,6 +2003,7 @@ class SessionWatcher:
                 adapter=adapter,
                 hang_idle_ticks=hang_idle_ticks,
                 hang_stale_seconds=hang_stale_seconds,
+                busy_stale_seconds=busy_stale_seconds,
             )
         )
         stale_frozen_actionable, attention_digest_dirty = _sync_attention_lifecycle(
@@ -2227,6 +2316,44 @@ def _is_session_orchestration_enabled() -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Internal utility
+# ---------------------------------------------------------------------------
+
+
+#: Volatile pane tokens that redraw every render even when no real work
+#: progresses: an animated spinner glyph, an elapsed-time counter, a running
+#: cost meter, a context-usage percent. Stripping these before hashing lets the
+#: watcher tell "the agent produced new output" apart from "only the animation
+#: ticked" — so a busy-but-stuck loop (e.g. an omp subagent poll-loop that keeps
+#: re-polling an already-yielded review) still accrues idle_ticks instead of
+#: masquerading as fresh output. See ``_pane_hash`` and ``_is_stale_frozen_eligible``.
+_VOLATILE_PANE_TOKENS: re.Pattern[str] = re.compile(
+    r"[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏⠛⠟⠿⢿⣻⣽⣾⣷⣯⣟]"              # braille/tui spinner frames
+    r"|\b\d+h\d+m\d+s\b|\b\d+m\d+s\b|\b\d+(?:\.\d+)?s\b"  # elapsed timers (12m28s, 4.3s)
+    r"|\$\s?\d[\d,]*(?:\.\d+)?"                          # running cost meter ($14.51)
+    r"|\d+(?:\.\d+)?\s*%\s*/\s*\d+[KkMm]"                # context usage (92.5%/272K)
+)
+
+
+def _normalize_pane_for_hash(text: str) -> str:
+    """Strip volatile animation tokens so change-detection ignores redraws."""
+    return _VOLATILE_PANE_TOKENS.sub("", text)
+
+
+def _pane_hash(text: str) -> str:
+    """Return a short SHA-256 hex prefix of pane text for change detection.
+
+    The text is animation-normalized first (``_normalize_pane_for_hash``) so a
+    pane whose only per-tick delta is spinner/timer/cost churn hashes stably —
+    the watcher must not read animation as fresh agent output, or a stuck
+    busy-loop looks perpetually alive.
+    """
+    return hashlib.sha256(
+        _normalize_pane_for_hash(text).encode(errors="replace")
+    ).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
 # __main__ entry-point (used by the cron shell script)
 # ---------------------------------------------------------------------------
 
@@ -2256,13 +2383,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-
-
-# ---------------------------------------------------------------------------
-# Internal utility
-# ---------------------------------------------------------------------------
-
-
-def _pane_hash(text: str) -> str:
-    """Return a short SHA-256 hex prefix of pane text for change detection."""
-    return hashlib.sha256(text.encode(errors="replace")).hexdigest()[:16]

--- a/session_orchestration/z_harness_webhook_subscription.json
+++ b/session_orchestration/z_harness_webhook_subscription.json
@@ -1,0 +1,18 @@
+{
+  "z-harness-alert": {
+    "description": "Receives watchdog alerts from z-harness runs (HMAC-signed, platform-neutral)",
+    "events": [],
+    "secret": "__REPLACE_WITH_notify.hermes_webhook_secret__",
+    "prompt": "",
+    "skills": [],
+    "deliver": "session_orchestration_ingest",
+    "deliver_only": true,
+    "created_at": "2026-06-24T00:00:00Z",
+    "_setup_notes": [
+      "1. Copy the secret from your z-harness config: python3 scripts/config.py get notify.hermes_webhook_secret",
+      "2. Set notify.hermes_webhook_url = http://<hermes-host>:8644/webhooks/z-harness-alert in z-harness config",
+      "3. Merge this object into ~/.hermes/webhook_subscriptions.json (or run: hermes webhook subscribe z-harness-alert --secret <SECRET> --deliver session_orchestration_ingest)",
+      "4. Ensure session_orchestration.enabled = true and session_orchestration.feed_channel_id in ~/.hermes/config.yaml"
+    ]
+  }
+}

--- a/skills/autonomous-ai-agents/claude-code/SKILL.md
+++ b/skills/autonomous-ai-agents/claude-code/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: claude-code
-description: "Delegate coding to Claude Code CLI (features, PRs)."
-version: 2.2.0
+description: "Delegate coding to Claude Code CLI (features, PRs) — via managed session-orchestration or direct PTY."
+version: 2.3.0
 author: Hermes Agent + Teknium
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
   hermes:
-    tags: [Coding-Agent, Claude, Anthropic, Code-Review, Refactoring, PTY, Automation]
-    related_skills: [codex, hermes-agent, opencode]
+    tags: [Coding-Agent, Claude, Anthropic, Code-Review, Refactoring, PTY, Automation, session-orchestration]
+    related_skills: [codex, hermes-agent, opencode, omp, session-orchestration]
 ---
 
 # Claude Code — Hermes Orchestration Guide
 
 Delegate coding tasks to [Claude Code](https://code.claude.com/docs/en/cli-reference) (Anthropic's autonomous coding agent CLI) via the Hermes terminal. Claude Code v2.x can read files, write code, run shell commands, spawn subagents, and manage git workflows autonomously.
+
+> **Managed mode (preferred for long-running tasks):** When `session_orchestration.enabled` is on in Hermes config, use `/so-spawn agent:claude prompt:"…"` to create a managed session — the adapter handles tmux launch, dialog handling, liveness tracking, and feed push automatically. See the `session-orchestration` skill for the full model.
 
 ## Prerequisites
 
@@ -47,40 +49,75 @@ terminal(command="claude -p 'Add error handling to all API calls in src/' --allo
 
 **Print mode skips ALL interactive dialogs** — no workspace trust prompt, no permission confirmations. This makes it ideal for automation.
 
-### Mode 2: Interactive PTY via tmux — Multi-Turn Sessions
+### Mode 2: Managed Interactive Session (PREFERRED for multi-turn work)
 
-Interactive mode gives you a full conversational REPL where you can send follow-up prompts, use slash commands, and watch Claude work in real time. **Requires tmux orchestration.**
+When `session_orchestration.enabled` is on, the `ClaudeCodeAdapter` manages the full session lifecycle. You do NOT call `tmux send-keys` directly for driving — the adapter uses `load-buffer` / `paste-buffer` which handles multi-line prompts and shell metacharacters safely.
+
+**Via Discord (recommended):**
+```
+/so-spawn agent:claude prompt:"Refactor the auth module to use JWT tokens" workdir:"/path/to/project"
+```
+This spawns a managed tmux session, handles both startup dialogs automatically, registers the session, and seeds the first prompt. Hermes drives follow-up replies via the Discord thread for this task.
+
+**Programmatically (within Hermes):**
+```python
+from session_orchestration.adapters.claude_code import ClaudeCodeAdapter
+from session_orchestration.relay import SessionRelay
+
+adapter = ClaudeCodeAdapter()
+handle = adapter.launch(workdir="/path/to/project", prompt="Refactor the auth module")
+# Follow-up via relay (acquires per-session lock before driving):
+relay = SessionRelay(registry=reg, adapter=adapter)
+relay.send_message(task_id, handle, "Now add unit tests for the new JWT code")
+```
+
+**What the adapter does for you:**
+1. `tmux new-session -d -s hermes-cc-<uid> -x 200 -y 50`
+2. Runs `claude --dangerously-skip-permissions` in the pane
+3. Polls for startup dialogs (trust dialog → Enter; bypass-permissions dialog → Down + Enter)
+4. Waits for the `❯` prompt before injecting any text
+5. For each `drive()` call: checks `❯` is visible → `load-buffer` → `paste-buffer -d` → Enter
+
+**Why load-buffer/paste-buffer instead of send-keys:**
+`send-keys` expands shell metacharacters (`$`, backticks, pipes) and requires `\n` escaping per newline. `load-buffer` + `paste-buffer -d` delivers the content verbatim — multi-line prompts survive intact.
+
+### Mode 2b: Manual PTY via tmux (legacy / ad-hoc)
+
+For ad-hoc sessions outside managed orchestration, the raw tmux pattern still works:
 
 ```
 # Start a tmux session
-terminal(command="tmux new-session -d -s claude-work -x 140 -y 40")
+terminal(command="tmux new-session -d -s claude-work -x 200 -y 50")
 
 # Launch Claude Code inside it
-terminal(command="tmux send-keys -t claude-work 'cd /path/to/project && claude' Enter")
+terminal(command="tmux send-keys -t claude-work 'cd /path/to/project && claude --dangerously-skip-permissions' Enter")
 
-# Wait for startup, then send your task
-# (after ~3-5 seconds for the welcome screen)
-terminal(command="sleep 5 && tmux send-keys -t claude-work 'Refactor the auth module to use JWT tokens' Enter")
+# Handle trust dialog (Enter for default "Yes, trust")
+terminal(command="sleep 4 && tmux send-keys -t claude-work Enter")
 
-# Monitor progress by capturing the pane
+# Handle bypass-permissions dialog (Down then Enter for "Yes, I accept")
+terminal(command="sleep 2 && tmux send-keys -t claude-work Down && sleep 0.3 && tmux send-keys -t claude-work Enter")
+
+# Wait for ❯ prompt, then send your task via load-buffer (NOT send-keys for multi-line)
+terminal(command="sleep 5 && printf 'Refactor the auth module to use JWT tokens' | tmux load-buffer -b my-buf - && tmux paste-buffer -d -b my-buf -t claude-work && tmux send-keys -t claude-work Enter")
+
+# Monitor progress
 terminal(command="sleep 15 && tmux capture-pane -t claude-work -p -S -50")
-
-# Send follow-up tasks
-terminal(command="tmux send-keys -t claude-work 'Now add unit tests for the new JWT code' Enter")
 
 # Exit when done
 terminal(command="tmux send-keys -t claude-work '/exit' Enter")
 ```
 
-**When to use interactive mode:**
-- Multi-turn iterative work (refactor → review → fix → test cycle)
-- Tasks requiring human-in-the-loop decisions
-- Exploratory coding sessions
-- When you need to use Claude's slash commands (`/compact`, `/review`, `/model`)
+**When to use manual mode:**
+- Ad-hoc one-off sessions not requiring persistent tracking
+- Exploratory coding sessions outside the registry
+- When you need to use Claude's slash commands (`/compact`, `/review`, `/model`) interactively
 
-## PTY Dialog Handling (CRITICAL for Interactive Mode)
+## PTY Dialog Handling
 
-Claude Code presents up to two confirmation dialogs on first launch. You MUST handle these via tmux send-keys:
+> **Managed mode:** `ClaudeCodeAdapter.launch()` handles both dialogs automatically. You do not need to handle them manually.
+
+Claude Code presents up to two confirmation dialogs on first launch. In **manual** tmux sessions, you MUST handle these:
 
 ### Dialog 1: Workspace Trust (first visit to a directory)
 ```
@@ -670,6 +707,22 @@ Reference MCP resources in chat: `@github:issue://123`
 - **Output tokens:** `export MAX_MCP_OUTPUT_TOKENS=50000` — cap output from MCP servers to prevent context flooding
 - **Transports:** `stdio` (local process), `http` (remote), `sse` (server-sent events)
 
+## Handoff Checkpoints (Managed Sessions)
+
+When Claude Code reaches a natural stopping point and the session is managed, it should emit the exact string:
+
+```
+HERMES_HANDOFF
+```
+
+This is the sentinel that `ClaudeCodeAdapter.detect()` scans for in the pane output (via `HANDOFF_MARKER = "HERMES_HANDOFF"` in `session_orchestration/adapters/claude_code.py`). When this string appears, `detect()` returns `PAUSED_HANDOFF` and the relay calls `resume()` — which sends `/clear` + re-injects the next prompt.
+
+**Instruction to Claude Code** (include in your system prompt or initial prompt when using managed sessions):
+
+> When you have completed a phase of work and are ready for the next instruction, output the literal string `HERMES_HANDOFF` on a line by itself. This signals Hermes that you are at a handoff checkpoint. Do not output this string for any other reason.
+
+**Why `/clear` is safe here:** The relay issues `/clear` ONLY on a confirmed `PAUSED_HANDOFF` detection (deterministic, not LLM-decided). This compacts the context before starting the next sub-task, preventing context-window degradation on long-running sessions.
+
 ## Monitoring Interactive Sessions
 
 ### Reading the TUI Status
@@ -733,13 +786,14 @@ Use `/context` in interactive mode to see a colored grid of context usage. Key t
 
 ## Rules for Hermes Agents
 
-1. **Prefer print mode (`-p`) for single tasks** — cleaner, no dialog handling, structured output
-2. **Use tmux for multi-turn interactive work** — the only reliable way to orchestrate the TUI
-3. **Always set `workdir`** — keep Claude focused on the right project directory
-4. **Set `--max-turns` in print mode** — prevents infinite loops and runaway costs
-5. **Monitor tmux sessions** — use `tmux capture-pane -t <session> -p -S -50` to check progress
-6. **Look for the `❯` prompt** — indicates Claude is waiting for input (done or asking a question)
-7. **Clean up tmux sessions** — kill them when done to avoid resource leaks
-8. **Report results to user** — after completion, summarize what Claude did and what changed
-9. **Don't kill slow sessions** — Claude may be doing multi-step work; check progress instead
+1. **Use managed sessions for multi-turn work** — `/so-spawn agent:claude` handles launch, dialogs, liveness, and routing automatically (requires `session_orchestration.enabled`)
+2. **Prefer print mode (`-p`) for single-shot tasks** — cleaner, no dialog handling, structured output
+3. **Never use `send-keys` to drive a managed session** — the adapter uses `load-buffer`/`paste-buffer` for safety; bypassing it can interleave with the watcher
+4. **Always set `workdir`** — keep Claude focused on the right project directory
+5. **Set `--max-turns` in print mode** — prevents infinite loops and runaway costs
+6. **Monitor via the feed channel** — in managed mode, state transitions are pushed to the unified feed; no need to capture panes manually
+7. **For ad-hoc monitoring** — use `tmux capture-pane -t <session> -p -S -50` and look for `❯` (waiting) or `●` (active)
+8. **Clean up unmanaged tmux sessions** — kill them when done; managed sessions are cleaned up by the watcher on `DONE`/`ERROR`
+9. **Don't kill slow sessions** — Claude may be doing multi-step work; check progress via `/control-status` instead
 10. **Use `--allowedTools`** — restrict capabilities to what the task actually needs
+11. **Emit `HERMES_HANDOFF` at checkpoints** — in managed sessions, Claude should output this exact string when handing off between phases

--- a/skills/autonomous-ai-agents/omp/SKILL.md
+++ b/skills/autonomous-ai-agents/omp/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: omp
+description: "Delegate coding to oh-my-pi (omp) — structured RPC/JSON transport + tmux TUI mode."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [Coding-Agent, omp, oh-my-pi, JSON, RPC, Automation, session-orchestration]
+    related_skills: [claude-code, session-orchestration, hermes-agent]
+---
+
+# omp (oh-my-pi) — Hermes Orchestration Guide
+
+[oh-my-pi (omp)](https://github.com/oh-my-pi/omp) v16+ is an autonomous coding agent CLI with a structured transport layer that makes it the cleaner orchestration target when compared to fully TUI-based agents. `omp` supports:
+
+- **`--mode=json`** — one-shot NDJSON streaming output (primary structured transport)
+- **`--mode=rpc`** — interactive RPC-over-stdio session (for persistent interactive use)
+- **`--hook`** — lifecycle callbacks for liveness accelerant
+- **`--auto-approve`** — skips all tool-approval dialogs (no dialog dance required)
+- **`-p` / `--print`** — non-interactive one-shot mode
+- **`-c` / `--continue`** — resume the most recent session
+- **`-r <id>` / `--resume <id>`** — resume a specific session by ID
+- **`--max-time <seconds>`** — cap execution wall time
+
+> **Managed mode (preferred):** When `session_orchestration.enabled` is on, use `/so-spawn agent:omp prompt:"…"` — the `OmpAdapter` handles launch, liveness tracking, and feed routing automatically. See the `session-orchestration` skill.
+
+## Probed Transport (omp v16.1.15)
+
+The following was verified live against omp v16.1.15.
+
+### One-Shot Mode: `omp -p --mode=json`
+
+This is the **primary structured transport** used by `OmpAdapter`. It runs omp as a subprocess and emits NDJSON to stdout — no tmux session required.
+
+```bash
+omp -p --mode=json [--model <model>] [--cwd <workdir>] [--max-time <seconds>] [--no-session] "<prompt>"
+```
+
+Each line of stdout is a JSON object with a `"type"` discriminator:
+
+```jsonc
+// Session start
+{"type":"session","version":3,"id":"<uuid>","timestamp":"<ISO8601>","cwd":"<path>"}
+
+// Agent lifecycle
+{"type":"agent_start"}
+{"type":"turn_start"}
+
+// User message
+{"type":"message_start","message":{"role":"user","content":[{"type":"text","text":"…"}], …}}
+{"type":"message_end","message":{"role":"user","content":[…], …}}
+
+// Assistant message (streamed in chunks)
+{"type":"message_start","message":{"role":"assistant","content":[{"type":"text","text":"…"}], …}}
+{"type":"message_update","assistantMessageEvent":{…},"message":{…}}
+{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"<final answer>"}],
+    "model":"<model>","usage":{…},"stopReason":"stop","timestamp":<ms>,…}}
+
+// Turn and agent end
+{"type":"turn_end","message":{…}}
+{"type":"agent_end","messages":[<all messages in conversation order>]}
+```
+
+**Extracting the final answer (two strategies):**
+
+1. **Preferred** — scan for `agent_end`, walk `messages` in reverse, find last entry with `role == "assistant"`, return `content[0]["text"]`.
+2. **Fallback** — stream for `message_end` events where `message.role == "assistant"` and keep the last one's `content[0]["text"]`.
+
+> **`--mode=rpc` is NOT one-shot.** When launched without `-p`, `--mode=rpc` emits `{"type":"ready"}` followed by `{"type":"available_commands_update","commands":[…]}` and then waits on stdin for JSON commands. It is an interactive RPC session, not a subprocess-call transport. Use `--mode=json -p` for one-shot structured output.
+
+### Interactive TUI Mode (tmux)
+
+For sessions that require persistent state, multi-turn conversation, or interactive slash commands, `OmpAdapter` uses tmux with `--auto-approve`:
+
+```bash
+omp --auto-approve [--cwd <workdir>] [--model <model>] [--max-time <seconds>] [--hook <hookfile>] "<prompt>"
+```
+
+`--auto-approve` suppresses all tool-approval dialogs. Unlike `claude-code`, there is **no dialog dance** required — omp starts and is immediately ready.
+
+**Driving an interactive omp session (adapter method):**
+
+The adapter uses `load-buffer` / `paste-buffer` (NOT `send-keys`) to deliver prompts — same rationale as claude-code: avoids metacharacter expansion, preserves multi-line content.
+
+```
+# What the adapter does internally:
+tmux load-buffer -b hermes-omp-<uid> -   # (content piped on stdin)
+tmux paste-buffer -d -b hermes-omp-<uid> -t <pane>
+tmux send-keys -t <pane> Enter
+```
+
+**Prompt readiness detection in TUI mode:**
+
+omp shows `>` or `❯` at the bottom of the pane when waiting for user input. The adapter polls for either pattern before injecting.
+
+**Activity detection (pane-hash stale guard):**
+
+omp shows braille spinner characters (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`) and the text `Running tool` during active tool use. The watcher uses this to distinguish genuine work from a stalled session.
+
+## Resume Patterns
+
+### One-shot continuation
+```bash
+omp -p --mode=json -c "<prompt>"          # Continue most recent session
+omp -p --mode=json -r <session-id> "<prompt>"  # Resume specific session by ID
+```
+
+The session ID is in the `session` event emitted at the start of each `--mode=json` run (`"id"` field).
+
+### Interactive TUI continuation
+```bash
+omp --auto-approve -c "<prompt>"           # Continue most recent
+omp --auto-approve --resume <session-id> "<prompt>"  # Resume specific
+```
+
+`OmpAdapter.resume()` uses `-c` (continue last) since the `SessionHandle` in v1 does not carry the omp session ID. The watcher triggers `resume()` on `PAUSED_HANDOFF` detection.
+
+## `--hook` Liveness Accelerant
+
+omp supports `--hook <hookfile>` for lifecycle callbacks. The watcher can use this as a **positive-liveness accelerant**: a hook that fires on tool-use completion can reset the per-session heartbeat counter, reducing false-positive hang alerts during long builds.
+
+```bash
+omp --auto-approve --hook /path/to/hermes-hook.sh "<prompt>"
+```
+
+The hook is optional; if it never fires, cron-only detection still eventually marks hang after the static threshold. The hook can only act as a **positive-liveness reset** — it cannot suppress detection of a real hang.
+
+## Handoff Checkpoints (Managed Sessions)
+
+omp should emit the exact string:
+
+```
+HERMES_HANDOFF
+```
+
+on a line by itself when it reaches a natural stopping point. This is the sentinel scanned by `OmpAdapter.detect()` (via `HANDOFF_MARKER = "HERMES_HANDOFF"` in `session_orchestration/adapters/omp.py`). On detection, `detect()` returns `PAUSED_HANDOFF` and the watcher/relay triggers `resume()` — which re-launches omp with `-c` and the next prompt.
+
+**Instruction to omp agent** (include in your initial prompt):
+
+> When you have completed a phase of work and are ready for the next instruction, output the literal string `HERMES_HANDOFF` on a line by itself. This signals Hermes that you are at a handoff checkpoint.
+
+## State Detection Summary
+
+| Pane signal | `detect()` returns |
+|---|---|
+| `HERMES_HANDOFF` anywhere in last 60 lines | `PAUSED_HANDOFF` |
+| `>` or `❯` at end of a line | `WAITING_USER` |
+| Braille spinner or `Running tool` | `RUNNING` |
+| Pane cannot be captured (session dead) | `ERROR` |
+| Otherwise | `RUNNING` (watcher tracks staleness) |
+
+`STALLED` and `DONE` are inferred by the watcher from pane-hash staleness + elapsed time, not by `detect()`.
+
+## One-Shot Usage (No tmux)
+
+For simple single-turn queries that don't need persistent session state:
+
+```python
+from session_orchestration.adapters.omp import OmpAdapter
+
+adapter = OmpAdapter()
+result = adapter.run_oneshot(
+    prompt="Explain the architecture of src/",
+    model="openai-codex/gpt-5.5",   # optional
+    workdir="/path/to/project",       # optional
+    max_time=120,                     # optional, seconds
+)
+print(result)  # final assistant text
+```
+
+`run_oneshot` calls `omp -p --mode=json --no-session <prompt>` and parses the NDJSON result. No tmux session is created.
+
+## CLI Quick Reference
+
+| Flag | Effect |
+|------|--------|
+| `-p` / `--print` | Non-interactive one-shot mode (exits when done) |
+| `--mode=json` | NDJSON streaming output (use with `-p`) |
+| `--mode=rpc` | Interactive RPC-over-stdio (NOT one-shot; requires persistent process) |
+| `--auto-approve` | Skip all tool-approval dialogs (essential for unattended sessions) |
+| `-c` / `--continue` | Continue most recent session |
+| `-r <id>` / `--resume <id>` | Resume specific session by ID |
+| `--hook <file>` | Lifecycle hook script for liveness accelerant |
+| `--cwd <path>` | Set working directory |
+| `--model <model>` | Override model (e.g. `openai-codex/gpt-5.5`) |
+| `--max-time <seconds>` | Cap wall-clock execution time |
+| `--no-session` | Don't persist the session to disk (useful for one-shots) |
+
+## Rules for Hermes Agents
+
+1. **Use `/so-spawn agent:omp` for managed multi-turn sessions** — adapter handles launch, liveness, and routing
+2. **Prefer `run_oneshot()` for single queries** — no tmux needed, structured output, simpler error handling
+3. **`--mode=json -p` is the one-shot structured transport** — `--mode=rpc` is interactive only
+4. **No dialog handling needed** — `--auto-approve` suppresses all approval prompts
+5. **Use `--hook` for long builds** — reduces false-positive hang alerts during extended tool use
+6. **Monitor via the feed channel** — in managed mode, state transitions are pushed to the unified feed
+7. **Emit `HERMES_HANDOFF` at checkpoints** — the adapter scans for this exact string to detect handoff state

--- a/skills/autonomous-ai-agents/session-orchestration/SKILL.md
+++ b/skills/autonomous-ai-agents/session-orchestration/SKILL.md
@@ -45,6 +45,8 @@ Spawn launches the tmux session, injects `HERMES_MARKER_FILE` (the agent writes 
 
 Pick the agent deliberately: **omp** for autonomous `--auto-approve` runs and z-harness workflows; **claude / claude-code** for interactive Claude Code. Default to omp if the user doesn't say.
 
+**Repo is mandatory — ask, never guess.** A spawn cannot run without a repo. If the user's request doesn't name one (e.g. "@hermes so omp 'fix the flaky test'" with no repo), do **not** call `session_spawn` with a placeholder or a guessed repo — ask the user which repo (a name/alias the registry knows, or an absolute path) and spawn once they answer. The tool enforces this too: called with no repo, or with a repo it can't resolve, it returns a plain-language question for you to relay rather than an error — surface that question to the user and wait for their answer.
+
 ### 2. Let the watcher check in (automatic — do not poll manually)
 
 Once spawned, the watcher cron drives everything each tick. You don't loop or scrape; you react to what it surfaces. **The primary surfaces are the unified feed channel and the session's project thread** — every state transition posts to both (once, debounced), with per-state icons (🔔 needs input, ⏸️ handoff, ✅ done, ▶ running). A **DM** is only an *extra* ping layered on top in the attention cases below; it is not the main channel.

--- a/skills/autonomous-ai-agents/session-orchestration/SKILL.md
+++ b/skills/autonomous-ai-agents/session-orchestration/SKILL.md
@@ -1,23 +1,25 @@
 ---
 name: session-orchestration
-description: "Manage long-running claude-code and omp agent sessions — spawn, drive, watch, and feed."
-version: 1.0.0
+description: "Manage a long-running coding-agent session (omp or claude-code) for the user from Discord — spawn it, let the watcher poll and check in, forward its questions to the user and their replies back, and stop/restart on request. A workflow over deterministic commands; the heavy lifting (polling, state, DMs) is already automated."
+version: 2.0.0
 author: Hermes Agent
 license: MIT
 platforms: [linux, macos]
 metadata:
   hermes:
-    tags: [session-orchestration, tmux, registry, watcher, feed, claude-code, omp, Discord]
+    tags: [session-orchestration, coding-agent, omp, claude-code, tmux, watcher, Discord, delegate]
     related_skills: [claude-code, omp, hermes-agent]
 ---
 
-# session-orchestration — Architecture and Usage Guide
+# session-orchestration — managing a coding-agent session
 
-The `session_orchestration/` package teaches Hermes to manage external coding-agent CLI sessions (claude-code and omp in v1) on the user's behalf. The user `@`s Hermes in Discord with a prompt, target agent, and optional z-command; Hermes spawns a tmux session, drives it, and reports back through a unified feed channel.
+Use this when the user wants you to **run a coding task on a real coding agent** (omp or claude-code) and supervise it for them: "spawn an omp session on hermes-agent and have it fix X", "kick off claude on the qt-bot repo with this prompt", "check on the session you started", "stop that run".
 
-## Config Gate
+You are the supervisor, not the coder. You spawn a managed CLI session in a background tmux pane, then a deterministic watcher cron polls it, checks in, and forwards its questions to the user and their replies back. **Most of the work is already automated** — your job is to fire the right deterministic command at the right moment and relay context. Do not `tmux send-keys`, edit the registry, or poll panes yourself.
 
-All session-orchestration behavior is gated behind:
+## Precondition (verify once)
+
+Everything here is gated on config:
 
 ```yaml
 # ~/.hermes/config.yaml
@@ -25,188 +27,93 @@ session_orchestration:
   enabled: true
 ```
 
-When `enabled` is absent or falsy: byte-identical to pre-feature behavior — no new tmux sessions, no registry writes, no network calls, no feed pushes.
+When disabled, the commands below are inert and no sessions run. Two more things must be true for check-ins to actually appear:
 
-## Core Concepts
+- The **watcher cron must be running** — it is the engine that polls and checks in. Registered as a `--no-agent` job (`scripts/session-orchestration-watch.sh`, every 1 min) via `ensure_watcher_cron()` at startup. If `/control-status` shows sessions whose state never updates, the watcher cron is not running — fix that, not the spawn.
+- A **feed channel must be configured** — `session_orchestration.feed_channel_id` in config. This is the unified Discord channel that shows every session needing action. If it is empty, feed posts are silently skipped and the user only sees per-session thread posts (plus the occasional DM).
 
-### Registry (SQLite, single-writer)
+## The workflow
 
-The registry is a `session_orchestration` table in Hermes's `state.db` (WAL mode). It tracks every managed session:
+### 1. Spawn
 
-| Column | Purpose |
-|--------|---------|
-| `task_id` | Primary key (UUID from the adapter's `SessionHandle`) |
-| `agent` | `"claude"` or `"omp"` |
-| `tmux_session` | tmux session name (e.g. `hermes-cc-a1b2c3d4`) |
-| `project` | Human label for the project |
-| `repo` | Canonical 12-char hex key — SHA-256 of the normalized git remote URL (stable across machines for the same repo) |
-| `run_id` | External run correlation key (from z-harness webhook) |
-| `state` | Current `SessionLifecycle` value |
-| `discord_thread_id` | Discord thread for this task's conversation |
-| `lock_holder` | Current lock holder (`"relay"` / `"watcher"`) or NULL |
-| `lock_ts` | Float expiry epoch (`str(time.time() + ttl)`) |
-| `heartbeat_counter` | Incremented atomically on each watcher tick |
-| `idle_ticks` | Consecutive ticks with unchanged pane hash |
+Two equivalent entry points; both default the agent to **omp** when unspecified.
 
-**UNIQUE(run_id, repo)** — prevents duplicate rows for the same external run + repository pair.
+- **Natural language (preferred for users):** the user `@`-mentions you asking to start/run/delegate a coding task. Call the `session_spawn` tool with `{repo, prompt, agent?, z_command?}`. `repo` is an alias / basename (e.g. `hermes-agent`) or absolute path; the repo registry resolves it to a workdir. `z_command` optionally prepends a z-harness slash command (e.g. `/z-plan`).
+- **Deterministic command:** `/so-spawn agent=<name> workdir=<path> [z_command=<cmd>] <prompt>` (alias `/spawn-session`). Use this when you already have an absolute workdir and want a no-LLM spawn.
 
-**Single-writer discipline:** The **cron watcher is the sole mutator** of registry rows and derived counters. All other paths (webhook-adopt, Discord-drive) MUST enqueue intents to the `session_orchestration_queue` table; the cron watcher drains and applies them in a single serialized transaction. This eliminates lost-update races without requiring optimistic locking.
+Spawn launches the tmux session, injects `HERMES_MARKER_FILE` (the agent writes status markers there), creates a Discord **project thread** for the conversation, and records the registry row (task_id, agent, workdir, the user, the thread). Tell the user the task_id and link the thread.
 
-**Counter writes are atomic:** `SET col = col + 1` (not read-modify-write in Python), so a mid-increment crash leaves no stale value.
+Pick the agent deliberately: **omp** for autonomous `--auto-approve` runs and z-harness workflows; **claude / claude-code** for interactive Claude Code. Default to omp if the user doesn't say.
 
-**Lock TTL:** `lock_ts` stores the float expiry epoch. `acquire_lock` refuses if a non-expired row exists. Default TTL = 300 s (5× cron interval). Stale lock reclaim uses DB wallclock comparison (`time.time()` vs stored epoch) — avoids `datetime.fromisoformat` timezone-parsing ambiguity in Python 3.11.
+### 2. Let the watcher check in (automatic — do not poll manually)
 
-### Session Lifecycle
+Once spawned, the watcher cron drives everything each tick. You don't loop or scrape; you react to what it surfaces. **The primary surfaces are the unified feed channel and the session's project thread** — every state transition posts to both (once, debounced), with per-state icons (🔔 needs input, ⏸️ handoff, ✅ done, ▶ running). A **DM** is only an *extra* ping layered on top in the attention cases below; it is not the main channel.
 
-```
-          spawn / adopt
-               │
-           RUNNING   ◄──────────────────────┐
-            │   │                            │
-    ● active  ❯ prompt             drive / resume
-            │   │                            │
-       WAITING_USER ──── HERMES_HANDOFF ──► PAUSED_HANDOFF
-            │                            │
-      (watcher: idle_ticks > N)          │
-            │                            │
-         STALLED                      (relay: /clear + re-inject)
-            │
-      (watcher: state==RUNNING,
-       pane hash unchanged, no ●)
-            │
-          hang → nudge → escalate
-            │
-          DONE  /  ERROR
-```
+- **State** is marker-driven and authoritative (the agent writes `status`/`heartbeat`/`needs_input`/`handoff_continue`/`done` to its marker file); pane-scraping is fallback only.
+- **Liveness:** a recent `heartbeat` suppresses the hang guard even if the pane looks unchanged.
+- **Needs input:** on `WAITING_USER`, the feed + thread message includes the agent's question (LLM-summarized, not a raw pane dump), and the user also gets a DM ping.
+- **Handoffs:** a `handoff_continue` marker triggers an automatic `/clear`+resume with no human in the loop. A `handoff_decision` marker is NOT auto-resumed — it posts to the feed + thread (paused) and additionally DMs the decision, then waits.
+- **Hang:** a confirmed stale `RUNNING` session escalates through a bounded auto-nudge ladder → posts to the feed + a user DM → marks the session `ERROR`. There is no `STALLED` registry state; stale is just an attention condition on a `RUNNING` row.
+- **Cadence:** active sessions tick faster (~30s) than idle ones (~120s); no per-second polling.
 
-States returned by `AgentAdapter.detect()`:
+So after spawning, your role is mostly to **wait for the watcher to surface something in the feed/thread** and then act on it.
 
-| State | Meaning |
-|-------|---------|
-| `RUNNING` | Agent is active (● indicator or no clear signal) |
-| `WAITING_USER` | Agent is at the `❯` prompt, waiting for a message |
-| `PAUSED_HANDOFF` | Agent emitted `HERMES_HANDOFF` — ready for `/clear` + next prompt |
-| `STALLED` | Watcher-assigned: pane hash unchanged for N ticks (not a `detect()` return) |
-| `DONE` | Session exited cleanly |
-| `ERROR` | pane unreachable / session dead |
+### 3. Check in on demand
 
-`STALLED` and `DONE` are watcher-assigned from pane-hash staleness; `detect()` only returns the first four.
+`/control-status` (alias `/cs`) — read-only snapshot of every active session: count per state, per-task state/agent/age, and the oldest `WAITING_USER` task highlighted. Use it when the user asks "what's running?" or before deciding whether to spawn another. It is a backstop to the feed, not a substitute for it.
 
-### AgentAdapter ABC
+### 4. Forward replies (drive)
 
-All adapters implement:
+When the user replies **in a session's project thread**, the gateway relays it to that session automatically (`_handle_managed_thread_reply` matches the thread to the registry row and drives the agent under a per-session lock). You do not need to do anything special — just keep the conversation in the thread. If the session is paused at a handoff, the reply resumes it; otherwise it is delivered as the next message.
 
-```python
-class AgentAdapter:
-    def capabilities(self) -> Capabilities: ...
-    def launch(self, workdir: str, prompt: str) -> SessionHandle: ...
-    def drive(self, handle: SessionHandle, message: str) -> None: ...
-    def detect(self, handle: SessionHandle) -> SessionLifecycle: ...
-    def resume(self, handle: SessionHandle, prompt: str) -> None: ...
-```
+### 5. Stop / restart
 
-`SessionHandle(session_id, tmux_session, pane, launch_ts)` is returned by `launch()` and stored in the registry row.
+- `/so-stop task_id=<id>` — kill the session's tmux process and mark the row terminal (`DONE`). Use when the task is finished or the user wants to abandon it.
+- `/so-restart task_id=<id>` — kill and re-spawn. Note: restart re-spawns with a placeholder prompt (`"continue"`) because the original prompt is not persisted, so prefer a fresh `/so-spawn` when the user wants a specific new prompt.
 
-Capabilities are asserted at watcher startup via `verify_adapters()` — a mismatch hard-fails that adapter with a logged error without crashing the watcher.
+Both enqueue a terminate intent that the watcher applies on its next tick (single-writer discipline — the watcher is the only mutator of session state).
 
-## When to Spawn vs Drive
+### Reaping (current behavior — know the limits)
 
-**Spawn** — create a new managed session:
-- The user is starting a **new task** in a project (new feature, new bug fix, new exploration).
-- No existing managed session is active for this project + agent combination.
-- Via Discord: `/so-spawn agent:<claude|omp> prompt:"…" [workdir:"…"]`
-- Via code: `session_orchestration.spawn.handle_spawn_command(...)`
-- Spawn creates the initial registry row and seeds the first prompt via `SessionRelay.send_message`.
+Terminal sessions (`DONE` / `ERROR`) automatically drop out of the watcher's active set, so they stop being polled — no zombie processing. But reaping is **soft, not complete**:
 
-**Drive** — send a follow-up message to an existing managed session:
-- The user **replies in the project's Discord thread** — the gateway's `_handle_managed_thread_reply` intercepts it.
-- The session is already registered (`discord_thread_id` maps to a registry row).
-- Drive acquires the per-session lock → detects `PAUSED_HANDOFF` (if so, calls `resume()`) → otherwise calls `adapter.drive()` → releases lock.
-- Do NOT call `tmux send-keys` directly — the relay owns all tmux interaction.
+- There is no proactive dead-tmux detection. A session whose tmux dies *without* writing a `done` marker stays `RUNNING` until the hang ladder slowly walks it to `ERROR`. If a user reports a session that "died but still shows running", `/so-stop task_id=<id>` is the deterministic fix.
+- Terminal rows are not garbage-collected; they persist in the registry.
+- The feed is an append-only transition log, not a self-pruning "currently needs action" view.
 
-**Check `/control-status`** to see all active sessions before deciding to spawn.
+Treat these as known limits, not failures.
 
-## Watcher (Cron, Three Layers)
+## Decision guide (when the user talks to you)
 
-The watcher runs as `hermes --no-agent session_orchestration_watch` at a 1–2 minute cadence (registered in `session_orchestration/cron_registration.py`). It is the authoritative state writer.
+| User intent | Do this |
+|-------------|---------|
+| "run / fix / build X on \<repo\>" (new work) | Spawn (omp unless they name claude). Confirm task_id + thread. |
+| "what's running / status?" | `/control-status` (`/cs`). |
+| reply to the agent's question | Tell them to reply **in the project thread**; the relay forwards it. |
+| "stop / cancel that" | `/so-stop task_id=<id>`. |
+| "restart it" / "it's stuck" | `/so-restart task_id=<id>` (or fresh `/so-spawn` for a new prompt). |
+| agent asked a question / needs a decision | The watcher already posted it to the feed + thread (and pinged via DM). Relay the user's answer into the thread. |
+| nothing is updating | Check the watcher cron is running AND `feed_channel_id` is set (see Precondition). |
 
-### Layer 1: Turn-Change (Push Once)
+## Hard rules
 
-When a session transitions into a user-attention state (`WAITING_USER` or `PAUSED_HANDOFF`):
-- Push ONCE to the unified **feed channel** (one message per transition, debounced).
-- Push to the **task's project thread** (so the user sees it in context).
-- Non-transition ticks produce no push.
+- Never `tmux send-keys`, capture panes, or mutate the registry directly — the relay and watcher own all session interaction.
+- Never poll in a loop yourself; the watcher cron is the polling engine.
+- Default to **omp**; only use claude/claude-code when the user asks.
+- Keep each session's conversation in its own project thread so the relay can route replies.
+- Everything is config-gated; if `session_orchestration.enabled` is false, say so rather than improvising.
 
-### Layer 2: Heartbeat (Edit In-Place, ~5 min)
+## Where the pieces live (reference)
 
-Every ~5 ticks (configurable), the watcher **edits** the existing per-task status message in the feed channel (no new notification). Shows: current state, elapsed time since last change, active agent, pane snippet. This is a positive-liveness signal, not a notification.
+| Piece | Location |
+|-------|----------|
+| Spawn (command + tool) | `session_orchestration/spawn.py` (`handle_spawn_command`), `session_orchestration/spawn_tool.py` (`session_spawn`) |
+| Stop / restart | `/so-stop`, `/so-restart` → `spawn.py` `handle_stop_command` / `handle_restart_command` → `registry.enqueue_terminate` |
+| Status | `/control-status` (`/cs`) → `session_orchestration/status.py` `build_snapshot` |
+| Watcher (poll/check-in engine) | `session_orchestration/watcher.py`, run by `scripts/session-orchestration-watch.sh` (cron, `ensure_watcher_cron`) |
+| Markers (authoritative state) | `session_orchestration/markers.py`; agent writes `HERMES_MARKER_FILE` |
+| Feed / DMs / icons | `session_orchestration/feed.py`, `session_orchestration/dm_transport.py` |
+| Adapters | `session_orchestration/adapters/{claude_code,omp}.py` |
+| Repo name → workdir | `session_orchestration/repo_registry.py` |
 
-### Layer 3: Hang Detection (Nudge Once, Then Escalate)
-
-Hang is declared ONLY when ALL of:
-- `state == RUNNING` (never fires on `WAITING_USER` or `PAUSED_HANDOFF`)
-- Pane hash unchanged for N consecutive ticks
-- No active-tool indicator (`●` / spinner) visible
-- `last_output_ts` older than the static threshold
-
-On hang: notify in feed + exactly one auto-nudge. On the next tick if still hung: escalate to user (no second nudge, no auto-kill).
-
-**`--hook` / webhook accelerant** acts only as a **positive-liveness reset** of the heartbeat counter when it carries fresh activity (with its own freshness TTL). It cannot gate or suppress hang detection. If the accelerant never fires, cron-only detection still eventually marks hang — graceful degradation guaranteed.
-
-## Relay (Per-Session Lock)
-
-`SessionRelay.send_message(task_id, handle, message)` is the ONLY safe path for driving a managed session. Sequence:
-
-1. `registry.acquire_lock(task_id, holder="relay", ttl_seconds=300.0)` — BEGIN IMMEDIATE; returns `False` if lock held
-2. `adapter.detect()` — if `PAUSED_HANDOFF`, call `adapter.resume()` and return
-3. `adapter.drive(handle, message)` — load-buffer / paste-buffer sequence
-4. `registry.release_lock(task_id, holder)` in `finally` — crash self-heals after TTL
-
-The watcher acquires the SAME lock around `capture-pane`. If the lock is held by the relay, the watcher **skips this row for this tick** — no interleaving, no race between send and capture.
-
-## Feed Channel
-
-A single unified Discord channel receives EVERY state transition + watchdog alert across all managed tasks:
-- Each feed message is deep-linked to its project thread.
-- Status messages are **edited in-place** (heartbeat layer) — no notification flood.
-- Per-project threads carry only the conversation (replies to Claude/omp).
-
-## Webhook Ingest (z-harness → Hermes)
-
-When z-harness has `notify.hermes_webhook_url` configured, it POSTs platform-neutral payloads signed with HMAC-sha256. Hermes's `session_orchestration/ingest.py`:
-1. Validates HMAC (`X-Z-Harness-Signature: sha256=<hex>`)
-2. Rate-limits per source (60 s window)
-3. Deduplicates by `event_id` (persistent `session_orchestration_event_dedup` table, survives restart)
-4. Correlates `(run_id, canonical_repo_id)` to an existing registry row → enqueues an `update` intent
-5. If no match: adopts to an `external_runs_thread_id` channel
-
-## `/control-status` Command
-
-Lists all active sessions on demand:
-- Count per state (`RUNNING`, `WAITING_USER`, etc.)
-- Per-task: state, agent, elapsed, project
-- Oldest `WAITING_USER` task highlighted (backstop — the user may have missed the feed push)
-
-Aliases: `/so-status`, `/cs`.
-
-## Two-Repo Split
-
-The session-orchestration subsystem spans two repositories:
-
-| Component | Repo |
-|-----------|------|
-| `session_orchestration/` package | `hermes-agent` |
-| Discord gateway wiring | `hermes-agent/gateway/` |
-| cron registration | `hermes-agent/scripts/session-orchestration-watch.sh` |
-| Webhook ingest | `hermes-agent/session_orchestration/ingest.py` |
-| Opt-in webhook sender | `z-harness/scripts/notify-watchdog.sh` |
-| Opt-in config keys | `z-harness` (`notify.hermes_webhook_url`, `notify.hermes_webhook_secret`) |
-
-z-harness contains NO Discord-specific code. The coupling is one-directional: z-harness → Hermes webhook endpoint.
-
-## Adapter Quick Reference
-
-| Adapter | Module | Drive method | Dialog handling | Detect signals |
-|---------|--------|-------------|-----------------|----------------|
-| `ClaudeCodeAdapter` | `adapters/claude_code.py` | load-buffer + paste-buffer | Trust dialog (Enter) + bypass-permissions (Down+Enter) | `❯` → WAITING_USER; `●` → RUNNING; `HERMES_HANDOFF` → PAUSED_HANDOFF |
-| `OmpAdapter` | `adapters/omp.py` | load-buffer + paste-buffer | None (`--auto-approve`) | `>` or `❯` → WAITING_USER; spinner/`Running tool` → RUNNING; `HERMES_HANDOFF` → PAUSED_HANDOFF |
+z-harness, when run under a managed session, emits the markers this skill relies on (`scripts/emit-hermes-marker.sh`, gated on `HERMES_MARKER_FILE`). The only cross-repo coupling is that shared marker schema.

--- a/skills/autonomous-ai-agents/session-orchestration/SKILL.md
+++ b/skills/autonomous-ai-agents/session-orchestration/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: session-orchestration
+description: "Manage long-running claude-code and omp agent sessions — spawn, drive, watch, and feed."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [session-orchestration, tmux, registry, watcher, feed, claude-code, omp, Discord]
+    related_skills: [claude-code, omp, hermes-agent]
+---
+
+# session-orchestration — Architecture and Usage Guide
+
+The `session_orchestration/` package teaches Hermes to manage external coding-agent CLI sessions (claude-code and omp in v1) on the user's behalf. The user `@`s Hermes in Discord with a prompt, target agent, and optional z-command; Hermes spawns a tmux session, drives it, and reports back through a unified feed channel.
+
+## Config Gate
+
+All session-orchestration behavior is gated behind:
+
+```yaml
+# ~/.hermes/config.yaml
+session_orchestration:
+  enabled: true
+```
+
+When `enabled` is absent or falsy: byte-identical to pre-feature behavior — no new tmux sessions, no registry writes, no network calls, no feed pushes.
+
+## Core Concepts
+
+### Registry (SQLite, single-writer)
+
+The registry is a `session_orchestration` table in Hermes's `state.db` (WAL mode). It tracks every managed session:
+
+| Column | Purpose |
+|--------|---------|
+| `task_id` | Primary key (UUID from the adapter's `SessionHandle`) |
+| `agent` | `"claude"` or `"omp"` |
+| `tmux_session` | tmux session name (e.g. `hermes-cc-a1b2c3d4`) |
+| `project` | Human label for the project |
+| `repo` | Canonical 12-char hex key — SHA-256 of the normalized git remote URL (stable across machines for the same repo) |
+| `run_id` | External run correlation key (from z-harness webhook) |
+| `state` | Current `SessionLifecycle` value |
+| `discord_thread_id` | Discord thread for this task's conversation |
+| `lock_holder` | Current lock holder (`"relay"` / `"watcher"`) or NULL |
+| `lock_ts` | Float expiry epoch (`str(time.time() + ttl)`) |
+| `heartbeat_counter` | Incremented atomically on each watcher tick |
+| `idle_ticks` | Consecutive ticks with unchanged pane hash |
+
+**UNIQUE(run_id, repo)** — prevents duplicate rows for the same external run + repository pair.
+
+**Single-writer discipline:** The **cron watcher is the sole mutator** of registry rows and derived counters. All other paths (webhook-adopt, Discord-drive) MUST enqueue intents to the `session_orchestration_queue` table; the cron watcher drains and applies them in a single serialized transaction. This eliminates lost-update races without requiring optimistic locking.
+
+**Counter writes are atomic:** `SET col = col + 1` (not read-modify-write in Python), so a mid-increment crash leaves no stale value.
+
+**Lock TTL:** `lock_ts` stores the float expiry epoch. `acquire_lock` refuses if a non-expired row exists. Default TTL = 300 s (5× cron interval). Stale lock reclaim uses DB wallclock comparison (`time.time()` vs stored epoch) — avoids `datetime.fromisoformat` timezone-parsing ambiguity in Python 3.11.
+
+### Session Lifecycle
+
+```
+          spawn / adopt
+               │
+           RUNNING   ◄──────────────────────┐
+            │   │                            │
+    ● active  ❯ prompt             drive / resume
+            │   │                            │
+       WAITING_USER ──── HERMES_HANDOFF ──► PAUSED_HANDOFF
+            │                            │
+      (watcher: idle_ticks > N)          │
+            │                            │
+         STALLED                      (relay: /clear + re-inject)
+            │
+      (watcher: state==RUNNING,
+       pane hash unchanged, no ●)
+            │
+          hang → nudge → escalate
+            │
+          DONE  /  ERROR
+```
+
+States returned by `AgentAdapter.detect()`:
+
+| State | Meaning |
+|-------|---------|
+| `RUNNING` | Agent is active (● indicator or no clear signal) |
+| `WAITING_USER` | Agent is at the `❯` prompt, waiting for a message |
+| `PAUSED_HANDOFF` | Agent emitted `HERMES_HANDOFF` — ready for `/clear` + next prompt |
+| `STALLED` | Watcher-assigned: pane hash unchanged for N ticks (not a `detect()` return) |
+| `DONE` | Session exited cleanly |
+| `ERROR` | pane unreachable / session dead |
+
+`STALLED` and `DONE` are watcher-assigned from pane-hash staleness; `detect()` only returns the first four.
+
+### AgentAdapter ABC
+
+All adapters implement:
+
+```python
+class AgentAdapter:
+    def capabilities(self) -> Capabilities: ...
+    def launch(self, workdir: str, prompt: str) -> SessionHandle: ...
+    def drive(self, handle: SessionHandle, message: str) -> None: ...
+    def detect(self, handle: SessionHandle) -> SessionLifecycle: ...
+    def resume(self, handle: SessionHandle, prompt: str) -> None: ...
+```
+
+`SessionHandle(session_id, tmux_session, pane, launch_ts)` is returned by `launch()` and stored in the registry row.
+
+Capabilities are asserted at watcher startup via `verify_adapters()` — a mismatch hard-fails that adapter with a logged error without crashing the watcher.
+
+## When to Spawn vs Drive
+
+**Spawn** — create a new managed session:
+- The user is starting a **new task** in a project (new feature, new bug fix, new exploration).
+- No existing managed session is active for this project + agent combination.
+- Via Discord: `/so-spawn agent:<claude|omp> prompt:"…" [workdir:"…"]`
+- Via code: `session_orchestration.spawn.handle_spawn_command(...)`
+- Spawn creates the initial registry row and seeds the first prompt via `SessionRelay.send_message`.
+
+**Drive** — send a follow-up message to an existing managed session:
+- The user **replies in the project's Discord thread** — the gateway's `_handle_managed_thread_reply` intercepts it.
+- The session is already registered (`discord_thread_id` maps to a registry row).
+- Drive acquires the per-session lock → detects `PAUSED_HANDOFF` (if so, calls `resume()`) → otherwise calls `adapter.drive()` → releases lock.
+- Do NOT call `tmux send-keys` directly — the relay owns all tmux interaction.
+
+**Check `/control-status`** to see all active sessions before deciding to spawn.
+
+## Watcher (Cron, Three Layers)
+
+The watcher runs as `hermes --no-agent session_orchestration_watch` at a 1–2 minute cadence (registered in `session_orchestration/cron_registration.py`). It is the authoritative state writer.
+
+### Layer 1: Turn-Change (Push Once)
+
+When a session transitions into a user-attention state (`WAITING_USER` or `PAUSED_HANDOFF`):
+- Push ONCE to the unified **feed channel** (one message per transition, debounced).
+- Push to the **task's project thread** (so the user sees it in context).
+- Non-transition ticks produce no push.
+
+### Layer 2: Heartbeat (Edit In-Place, ~5 min)
+
+Every ~5 ticks (configurable), the watcher **edits** the existing per-task status message in the feed channel (no new notification). Shows: current state, elapsed time since last change, active agent, pane snippet. This is a positive-liveness signal, not a notification.
+
+### Layer 3: Hang Detection (Nudge Once, Then Escalate)
+
+Hang is declared ONLY when ALL of:
+- `state == RUNNING` (never fires on `WAITING_USER` or `PAUSED_HANDOFF`)
+- Pane hash unchanged for N consecutive ticks
+- No active-tool indicator (`●` / spinner) visible
+- `last_output_ts` older than the static threshold
+
+On hang: notify in feed + exactly one auto-nudge. On the next tick if still hung: escalate to user (no second nudge, no auto-kill).
+
+**`--hook` / webhook accelerant** acts only as a **positive-liveness reset** of the heartbeat counter when it carries fresh activity (with its own freshness TTL). It cannot gate or suppress hang detection. If the accelerant never fires, cron-only detection still eventually marks hang — graceful degradation guaranteed.
+
+## Relay (Per-Session Lock)
+
+`SessionRelay.send_message(task_id, handle, message)` is the ONLY safe path for driving a managed session. Sequence:
+
+1. `registry.acquire_lock(task_id, holder="relay", ttl_seconds=300.0)` — BEGIN IMMEDIATE; returns `False` if lock held
+2. `adapter.detect()` — if `PAUSED_HANDOFF`, call `adapter.resume()` and return
+3. `adapter.drive(handle, message)` — load-buffer / paste-buffer sequence
+4. `registry.release_lock(task_id, holder)` in `finally` — crash self-heals after TTL
+
+The watcher acquires the SAME lock around `capture-pane`. If the lock is held by the relay, the watcher **skips this row for this tick** — no interleaving, no race between send and capture.
+
+## Feed Channel
+
+A single unified Discord channel receives EVERY state transition + watchdog alert across all managed tasks:
+- Each feed message is deep-linked to its project thread.
+- Status messages are **edited in-place** (heartbeat layer) — no notification flood.
+- Per-project threads carry only the conversation (replies to Claude/omp).
+
+## Webhook Ingest (z-harness → Hermes)
+
+When z-harness has `notify.hermes_webhook_url` configured, it POSTs platform-neutral payloads signed with HMAC-sha256. Hermes's `session_orchestration/ingest.py`:
+1. Validates HMAC (`X-Z-Harness-Signature: sha256=<hex>`)
+2. Rate-limits per source (60 s window)
+3. Deduplicates by `event_id` (persistent `session_orchestration_event_dedup` table, survives restart)
+4. Correlates `(run_id, canonical_repo_id)` to an existing registry row → enqueues an `update` intent
+5. If no match: adopts to an `external_runs_thread_id` channel
+
+## `/control-status` Command
+
+Lists all active sessions on demand:
+- Count per state (`RUNNING`, `WAITING_USER`, etc.)
+- Per-task: state, agent, elapsed, project
+- Oldest `WAITING_USER` task highlighted (backstop — the user may have missed the feed push)
+
+Aliases: `/so-status`, `/cs`.
+
+## Two-Repo Split
+
+The session-orchestration subsystem spans two repositories:
+
+| Component | Repo |
+|-----------|------|
+| `session_orchestration/` package | `hermes-agent` |
+| Discord gateway wiring | `hermes-agent/gateway/` |
+| cron registration | `hermes-agent/scripts/session-orchestration-watch.sh` |
+| Webhook ingest | `hermes-agent/session_orchestration/ingest.py` |
+| Opt-in webhook sender | `z-harness/scripts/notify-watchdog.sh` |
+| Opt-in config keys | `z-harness` (`notify.hermes_webhook_url`, `notify.hermes_webhook_secret`) |
+
+z-harness contains NO Discord-specific code. The coupling is one-directional: z-harness → Hermes webhook endpoint.
+
+## Adapter Quick Reference
+
+| Adapter | Module | Drive method | Dialog handling | Detect signals |
+|---------|--------|-------------|-----------------|----------------|
+| `ClaudeCodeAdapter` | `adapters/claude_code.py` | load-buffer + paste-buffer | Trust dialog (Enter) + bypass-permissions (Down+Enter) | `❯` → WAITING_USER; `●` → RUNNING; `HERMES_HANDOFF` → PAUSED_HANDOFF |
+| `OmpAdapter` | `adapters/omp.py` | load-buffer + paste-buffer | None (`--auto-approve`) | `>` or `❯` → WAITING_USER; spinner/`Running tool` → RUNNING; `HERMES_HANDOFF` → PAUSED_HANDOFF |

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2204,6 +2204,141 @@ class TestRunJobWakeGate:
         agent_cls.assert_called_once()
 
 
+
+class TestRunJobScriptBuiltInScripts:
+    """Regression coverage for Hermes-owned built-in no-agent cron scripts."""
+
+    def _builtin_watch_script(self):
+        import cron.scheduler as scheduler
+
+        return scheduler._get_builtin_scripts_dir() / "session-orchestration-watch.sh"
+
+    def _completed_script(self, stdout="watch ok\n"):
+        return MagicMock(returncode=0, stdout=stdout, stderr="")
+
+    def test_no_agent_run_job_accepts_absolute_builtin_session_watch_path(self, tmp_path):
+        import cron.scheduler as scheduler
+
+        script = self._builtin_watch_script()
+        assert script.exists()
+        job = {
+            "id": "session-watch",
+            "name": "session-orchestration-watch",
+            "prompt": "",
+            "script": str(script),
+            "no_agent": True,
+        }
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch(
+                 "cron.scheduler.subprocess.run",
+                 return_value=self._completed_script(),
+             ) as run_script:
+            success, _doc, final_response, error = scheduler.run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "watch ok"
+        assert str(script) in run_script.call_args.args[0]
+
+    def test_builtin_script_path_rejected_without_no_agent_allowance(self, tmp_path):
+        import cron.scheduler as scheduler
+
+        script = self._builtin_watch_script()
+        assert script.exists()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler.subprocess.run") as run_script:
+            success, output = scheduler._run_job_script(str(script))
+
+        assert success is False
+        assert "outside" in output.lower() or "blocked" in output.lower()
+        run_script.assert_not_called()
+
+    def test_unrelated_absolute_path_rejected_even_when_builtin_allowed(self, tmp_path):
+        import cron.scheduler as scheduler
+
+        outside_script = tmp_path / "outside.sh"
+        outside_script.write_text("echo should-not-run\n")
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler.subprocess.run") as run_script:
+            success, output = scheduler._run_job_script(
+                str(outside_script),
+                allow_builtin_scripts=True,
+            )
+
+        assert success is False
+        assert "outside" in output.lower() or "blocked" in output.lower()
+        run_script.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "script_ref",
+        [
+            "scripts/session-orchestration-watch.sh",
+            "session-orchestration-watch.sh",
+        ],
+    )
+    def test_relative_builtin_session_watch_paths_resolve_to_builtin_root(self, tmp_path, script_ref):
+        import cron.scheduler as scheduler
+
+        script = self._builtin_watch_script()
+        assert script.exists()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch(
+                 "cron.scheduler.subprocess.run",
+                 return_value=self._completed_script("relative ok\n"),
+             ) as run_script:
+            success, output = scheduler._run_job_script(
+                script_ref,
+                allow_builtin_scripts=True,
+            )
+
+        assert success is True
+        assert output == "relative ok"
+        assert str(script) in run_script.call_args.args[0]
+
+
+
+class TestSessionOrchestrationCronRegistration:
+    """Registration should store safe built-in script tokens, not repo absolutes."""
+
+    def test_watcher_registration_uses_relative_builtin_script_and_origin_delivery(self):
+        from session_orchestration.cron_registration import (
+            WATCHER_JOB_NAME,
+            ensure_watcher_cron,
+        )
+
+        created = {}
+
+        def fake_create_job(**kwargs):
+            created.update(kwargs)
+            return {"id": "watch-job", "name": kwargs["name"], **kwargs}
+
+        job = ensure_watcher_cron(
+            _jobs_loader=lambda: [],
+            _jobs_creator=fake_create_job,
+        )
+
+        assert job["name"] == WATCHER_JOB_NAME
+        assert created["script"] == "scripts/session-orchestration-watch.sh"
+        assert not os.path.isabs(created["script"])
+        assert created["no_agent"] is True
+        assert created["deliver"] == "origin"
+
+    def test_create_update_normalizer_converts_builtin_absolute_no_agent_script(self):
+        from cron.jobs import _builtin_scripts_dir, _normalize_script_path
+
+        script = _builtin_scripts_dir() / "session-orchestration-watch.sh"
+        assert script.exists()
+
+        assert _normalize_script_path(str(script), no_agent=True) == (
+            "scripts/session-orchestration-watch.sh"
+        )
+        assert _normalize_script_path(str(script), no_agent=False) == str(script)
+
+
 class TestBuildJobPromptMissingSkill:
     """Verify that a missing skill logs a warning and does not crash the job."""
 

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -249,6 +249,7 @@ async def test_reconnect_closes_previous_client_to_prevent_zombie_websocket(monk
 async def test_connect_releases_token_lock_on_timeout(monkeypatch):
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
 
+    monkeypatch.setenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", "90")
     monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
     released = []
     monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: released.append((scope, identity)))
@@ -267,6 +268,7 @@ async def test_connect_releases_token_lock_on_timeout(monkeypatch):
     )
 
     async def fake_wait_for(awaitable, timeout):
+        assert timeout == 90.0
         awaitable.close()
         raise asyncio.TimeoutError()
 

--- a/tests/gateway/test_handoff_db_async.py
+++ b/tests/gateway/test_handoff_db_async.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+
+import pytest
+
+from gateway.run import GatewayRunner
+
+
+def test_handoff_db_helper_times_out_without_blocking_event_loop(caplog):
+    async def exercise():
+        runner = object.__new__(GatewayRunner)
+        runner._handoff_db_timeout_secs = 0.05
+        runner._handoff_db_circuit_break_secs = 30.0
+        runner._handoff_db_circuit_open_until = 0.0
+        runner._handoff_db_inflight_task = None
+
+        release = threading.Event()
+
+        def stuck_db_call():
+            release.wait(timeout=5.0)
+
+        caplog.set_level(logging.WARNING, logger="gateway.run")
+        call_task = asyncio.create_task(
+            runner._run_handoff_db_call("stuck_db_call", stuck_db_call)
+        )
+
+        try:
+            assert await asyncio.wait_for(asyncio.sleep(0.01, result=True), timeout=0.1)
+            with pytest.raises(asyncio.TimeoutError):
+                await call_task
+
+            assert runner._handoff_db_circuit_open_until > 0.0
+            assert "Handoff DB call stuck_db_call timed out" in caplog.text
+        finally:
+            release.set()
+            inflight = runner._handoff_db_inflight_task
+            if inflight is not None:
+                await asyncio.wait_for(asyncio.shield(inflight), timeout=1.0)
+
+    asyncio.run(exercise())
+
+
+def test_handoff_db_helper_open_circuit_skips_without_calling_db(caplog):
+    async def exercise():
+        runner = object.__new__(GatewayRunner)
+        runner._handoff_db_timeout_secs = 1.0
+        runner._handoff_db_circuit_break_secs = 30.0
+        runner._handoff_db_circuit_open_until = 9999999999.0
+        runner._handoff_db_inflight_task = None
+        called = False
+
+        def db_call():
+            nonlocal called
+            called = True
+
+        caplog.set_level(logging.WARNING, logger="gateway.run")
+        with pytest.raises(asyncio.TimeoutError):
+            await runner._run_handoff_db_call("list_pending_handoffs", db_call)
+
+        assert called is False
+        assert "circuit open" in caplog.text
+
+    asyncio.run(exercise())

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -311,6 +311,39 @@ class TestValidateSignature:
         )
         assert adapter._validate_signature(req, body, secret) is True
 
+    # ------------------------------------------------------------------
+    # z-harness: X-Z-Harness-Signature: sha256=<hex>
+    # ------------------------------------------------------------------
+
+    def test_validate_z_harness_signature_valid(self):
+        """Valid X-Z-Harness-Signature: sha256=<hex> (as sent by notify-watchdog.sh) is accepted."""
+        adapter = _make_adapter()
+        body = b'{"event":"watchdog_stall","source":"z-harness"}'
+        secret = "zharness-hmac-secret"
+        sig = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        req = _mock_request(headers={"X-Z-Harness-Signature": sig})
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_z_harness_signature_tampered_body_rejects(self):
+        """X-Z-Harness-Signature computed over original body is rejected when body is tampered."""
+        adapter = _make_adapter()
+        original_body = b'{"event":"watchdog_stall","source":"z-harness"}'
+        tampered_body = b'{"event":"tampered","source":"z-harness"}'
+        secret = "zharness-hmac-secret"
+        sig = "sha256=" + hmac.new(secret.encode(), original_body, hashlib.sha256).hexdigest()
+        req = _mock_request(headers={"X-Z-Harness-Signature": sig})
+        assert adapter._validate_signature(req, tampered_body, secret) is False
+
+    def test_validate_z_harness_signature_wrong_secret_rejects(self):
+        """X-Z-Harness-Signature signed with the wrong secret is rejected."""
+        adapter = _make_adapter()
+        body = b'{"event":"watchdog_stall","source":"z-harness"}'
+        correct_secret = "zharness-hmac-secret"
+        wrong_secret = "totally-different-secret"
+        sig = "sha256=" + hmac.new(wrong_secret.encode(), body, hashlib.sha256).hexdigest()
+        req = _mock_request(headers={"X-Z-Harness-Signature": sig})
+        assert adapter._validate_signature(req, body, correct_secret) is False
+
 
 # ===================================================================
 # Prompt rendering

--- a/tests/gateway/test_webhook_signature_rate_limit.py
+++ b/tests/gateway/test_webhook_signature_rate_limit.py
@@ -287,3 +287,5 @@ class TestSignatureBeforeRateLimit:
             assert resp.status == 429
 
         assert len(captured_events) == 3
+
+        assert len(captured_events) == 0

--- a/tests/hermes_cli/test_session_handoff.py
+++ b/tests/hermes_cli/test_session_handoff.py
@@ -12,6 +12,7 @@ flip pending → running, and finishes with ``complete_handoff`` or
 
 from __future__ import annotations
 
+import sqlite3
 import time
 
 import pytest
@@ -44,6 +45,76 @@ class TestHandoffStateDB:
             "SELECT handoff_state, handoff_platform, handoff_error "
             "FROM sessions LIMIT 0"
         )
+
+    def test_pending_handoff_polling_index_exists(self, db):
+        index_names = {
+            row[1] for row in db._conn.execute("PRAGMA index_list('sessions')")
+        }
+        assert "idx_sessions_handoff_pending" in index_names
+
+        columns = [
+            row[2]
+            for row in db._conn.execute(
+                "PRAGMA index_info('idx_sessions_handoff_pending')"
+            )
+        ]
+        assert columns == ["handoff_state", "started_at"]
+
+    def test_pending_handoff_index_is_safe_for_existing_dbs(self, tmp_path, monkeypatch):
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        db_path = home / "state.db"
+
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.executescript(
+                """
+                CREATE TABLE sessions (
+                    id TEXT PRIMARY KEY,
+                    source TEXT NOT NULL,
+                    parent_session_id TEXT,
+                    started_at REAL NOT NULL
+                );
+                """
+            )
+        finally:
+            conn.close()
+
+        db = SessionDB(db_path=db_path)
+
+        db._conn.execute(
+            "SELECT handoff_state, handoff_platform, handoff_error "
+            "FROM sessions LIMIT 0"
+        )
+        columns = [
+            row[2]
+            for row in db._conn.execute(
+                "PRAGMA index_info('idx_sessions_handoff_pending')"
+            )
+        ]
+        assert columns == ["handoff_state", "started_at"]
+
+    def test_handoff_reads_use_session_db_lock(self, db):
+        sid = "sess-locked-read"
+        self._make_session(db, sid)
+        assert db.request_handoff(sid, "telegram") is True
+
+        class TrackingLock:
+            entered = 0
+
+            def __enter__(self):
+                self.entered += 1
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        lock = TrackingLock()
+        db._lock = lock
+
+        assert db.get_handoff_state(sid)["state"] == "pending"
+        assert [row["id"] for row in db.list_pending_handoffs()] == [sid]
+        assert lock.entered == 2
 
     def test_request_handoff_marks_pending(self, db):
         sid = "sess-1"

--- a/tests/test_session_orchestration_agent_transcript.py
+++ b/tests/test_session_orchestration_agent_transcript.py
@@ -1,0 +1,136 @@
+"""Tests for session_orchestration/agent_transcript.py."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from session_orchestration.agent_transcript import (
+    discover_omp_session_file,
+    read_assistant_texts,
+)
+
+
+def _msg(role: str, blocks: list[dict]) -> str:
+    return json.dumps({"type": "message", "message": {"role": role, "content": blocks}})
+
+
+def _write_transcript(path: Path, lines: list[str]) -> None:
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# read_assistant_texts
+# ---------------------------------------------------------------------------
+
+
+class TestReadAssistantTexts:
+    def test_extracts_only_assistant_text_blocks(self, tmp_path):
+        f = tmp_path / "s.jsonl"
+        _write_transcript(f, [
+            json.dumps({"type": "session", "id": "x", "cwd": "/repo"}),
+            _msg("user", [{"type": "text", "text": "do the thing"}]),
+            _msg("assistant", [
+                {"type": "thinking", "thinking": "hmm"},
+                {"type": "toolCall", "name": "bash"},
+            ]),
+            _msg("toolResult", [{"type": "text", "text": "build log spam"}]),
+            _msg("assistant", [
+                {"type": "thinking", "thinking": "ok"},
+                {"type": "text", "text": "Here is the answer."},
+            ]),
+        ])
+        texts, total = read_assistant_texts(str(f), 0)
+        assert texts == ["Here is the answer."]
+        assert total == 5
+
+    def test_offset_skips_consumed_lines(self, tmp_path):
+        f = tmp_path / "s.jsonl"
+        _write_transcript(f, [
+            _msg("assistant", [{"type": "text", "text": "first turn"}]),
+            _msg("assistant", [{"type": "text", "text": "second turn"}]),
+        ])
+        texts1, off1 = read_assistant_texts(str(f), 0)
+        assert texts1 == ["first turn", "second turn"]
+        # Append a new turn; only it should be returned from the new offset.
+        with open(f, "a", encoding="utf-8") as fh:
+            fh.write(_msg("assistant", [{"type": "text", "text": "third turn"}]) + "\n")
+        texts2, off2 = read_assistant_texts(str(f), off1)
+        assert texts2 == ["third turn"]
+        assert off2 == off1 + 1
+
+    def test_malformed_lines_skipped(self, tmp_path):
+        f = tmp_path / "s.jsonl"
+        _write_transcript(f, [
+            "not json at all {{{",
+            _msg("assistant", [{"type": "text", "text": "survives"}]),
+        ])
+        texts, total = read_assistant_texts(str(f), 0)
+        assert texts == ["survives"]
+        assert total == 2
+
+    def test_missing_file_returns_unchanged_offset(self, tmp_path):
+        texts, off = read_assistant_texts(str(tmp_path / "nope.jsonl"), 7)
+        assert texts == []
+        assert off == 7
+
+    def test_multiple_text_blocks_joined(self, tmp_path):
+        f = tmp_path / "s.jsonl"
+        _write_transcript(f, [
+            _msg("assistant", [
+                {"type": "text", "text": "para one"},
+                {"type": "text", "text": "para two"},
+            ]),
+        ])
+        texts, _ = read_assistant_texts(str(f), 0)
+        assert texts == ["para one\npara two"]
+
+
+# ---------------------------------------------------------------------------
+# discover_omp_session_file
+# ---------------------------------------------------------------------------
+
+
+class TestDiscover:
+    def _mk(self, root: Path, workdir: str, name: str) -> Path:
+        d = root / workdir.rstrip("/").replace("/", "-")
+        d.mkdir(parents=True, exist_ok=True)
+        p = d / name
+        p.write_text("{}\n", encoding="utf-8")
+        return p
+
+    def test_finds_file_near_launch_ts(self, tmp_path):
+        launch = datetime(2026, 7, 2, 4, 40, 35, tzinfo=timezone.utc)
+        p = self._mk(tmp_path, "/dev/z-harness",
+                     "2026-07-02T04-40-31-230Z_019f2120.jsonl")
+        found = discover_omp_session_file(
+            "/dev/z-harness", launch, sessions_root=tmp_path
+        )
+        assert found == str(p)
+
+    def test_ignores_files_outside_window(self, tmp_path):
+        launch = datetime(2026, 7, 2, 12, 0, 0, tzinfo=timezone.utc)
+        self._mk(tmp_path, "/dev/z-harness",
+                 "2026-07-02T04-40-31-230Z_old.jsonl")
+        found = discover_omp_session_file(
+            "/dev/z-harness", launch, sessions_root=tmp_path
+        )
+        assert found is None
+
+    def test_excludes_claimed_and_picks_closest(self, tmp_path):
+        launch = datetime(2026, 7, 2, 4, 40, 35, tzinfo=timezone.utc)
+        closest = self._mk(tmp_path, "/dev/z-harness",
+                           "2026-07-02T04-40-36-000Z_b.jsonl")
+        other = self._mk(tmp_path, "/dev/z-harness",
+                         "2026-07-02T04-41-30-000Z_c.jsonl")
+        # Closest already claimed by a parallel spawn -> pick the other.
+        found = discover_omp_session_file(
+            "/dev/z-harness", launch, claimed=[str(closest)],
+            sessions_root=tmp_path,
+        )
+        assert found == str(other)
+
+    def test_missing_dir_returns_none(self, tmp_path):
+        launch = datetime(2026, 7, 2, tzinfo=timezone.utc)
+        assert discover_omp_session_file("/no/such", launch, sessions_root=tmp_path) is None

--- a/tests/test_session_orchestration_claude_code.py
+++ b/tests/test_session_orchestration_claude_code.py
@@ -30,6 +30,9 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
+# patch target for os.makedirs used inside claude_code.py
+_MAKEDIRS = "session_orchestration.adapters.claude_code.os.makedirs"
+
 from session_orchestration.adapters.claude_code import (
     ACTIVITY_REGEX,
     HANDOFF_MARKER,
@@ -350,3 +353,117 @@ class TestResume:
             adapter.resume(handle, "prompt")
 
         mock_drive.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# launch() — marker file injection (testable subset)
+# ---------------------------------------------------------------------------
+
+
+class TestLaunch:
+    """Verify the HERMES_MARKER_FILE injection and handle.marker_file population.
+
+    ``launch()`` is live-only in general, but we can exercise its new-session
+    command construction by stubbing the live parts (dialogs, prompt wait, drive,
+    os.makedirs) while leaving the TmuxRunner fake in place to record calls.
+    """
+
+    def _run_launch(self, workdir: str = "/repo/myproject", prompt: str = "do the thing"):
+        """Run launch() with all live I/O stubbed; return (handle, fake_tmux, mock_makedirs)."""
+        fake_tmux = FakeTmuxRunner(capture_output="❯ ")
+        adapter = ClaudeCodeAdapter(tmux_runner=fake_tmux)
+
+        with patch.object(adapter, "_handle_dialogs"):
+            with patch.object(adapter, "_wait_for_prompt"):
+                with patch.object(adapter, "drive"):
+                    with patch(_MAKEDIRS) as mock_makedirs:
+                        handle = adapter.launch(workdir, prompt)
+
+        return handle, fake_tmux, mock_makedirs
+
+    def test_new_session_receives_hermes_marker_file_env(self):
+        """new-session args must include -e HERMES_MARKER_FILE=<workdir>/.hermes/sessions/<uuid>.jsonl."""
+        workdir = "/repo/myproject"
+        handle, fake_tmux, _ = self._run_launch(workdir=workdir)
+
+        new_session_calls = [c for c in fake_tmux.calls if c[0] == "new-session"]
+        assert new_session_calls, "No new-session call found in TmuxRunner.calls"
+        args = new_session_calls[0]
+
+        expected_path = f"{workdir}/.hermes/sessions/{handle.session_id}.jsonl"
+        assert "-e" in args, "'-e' flag missing from new-session args"
+        env_idx = args.index("-e")
+        assert args[env_idx + 1] == f"HERMES_MARKER_FILE={expected_path}", (
+            f"Expected HERMES_MARKER_FILE={expected_path!r}, got {args[env_idx + 1]!r}"
+        )
+
+    def test_handle_marker_file_matches_env_path(self):
+        """handle.marker_file must equal the path injected into the tmux env."""
+        workdir = "/repo/myproject"
+        handle, fake_tmux, _ = self._run_launch(workdir=workdir)
+
+        expected_path = f"{workdir}/.hermes/sessions/{handle.session_id}.jsonl"
+        assert handle.marker_file == expected_path
+
+    def test_os_makedirs_called_with_exist_ok(self):
+        """os.makedirs must be called once with the marker dir and exist_ok=True."""
+        workdir = "/repo/myproject"
+        handle, _, mock_makedirs = self._run_launch(workdir=workdir)
+
+        expected_dir = f"{workdir}/.hermes/sessions"
+        mock_makedirs.assert_called_once_with(expected_dir, exist_ok=True)
+
+    def test_marker_file_path_encodes_session_id(self):
+        """The marker file path must embed the session_id UUID."""
+        workdir = "/some/workdir"
+        handle, _, _ = self._run_launch(workdir=workdir)
+
+        assert handle.session_id in handle.marker_file
+
+
+# ---------------------------------------------------------------------------
+# terminate()
+# ---------------------------------------------------------------------------
+
+
+class TestTerminate:
+    def test_terminate_issues_kill_session(self):
+        """terminate() must call kill-session -t <tmux_session>."""
+        fake_tmux = FakeTmuxRunner()
+        adapter = ClaudeCodeAdapter(tmux_runner=fake_tmux)
+        handle = _make_handle()
+
+        adapter.terminate(handle)
+
+        kill_calls = [c for c in fake_tmux.calls if c[0] == "kill-session"]
+        assert kill_calls, "No kill-session call found in TmuxRunner.calls"
+        assert "-t" in kill_calls[0]
+        assert handle.tmux_session in kill_calls[0]
+
+    def test_terminate_does_not_raise_when_tmux_errors(self):
+        """terminate() must not raise even if the TmuxRunner raises CalledProcessError."""
+
+        class AlwaysFailRunner:
+            def run(self, args: list[str], check: bool = True) -> str:
+                raise subprocess.CalledProcessError(1, "tmux")
+
+        adapter = ClaudeCodeAdapter(tmux_runner=AlwaysFailRunner())
+        handle = _make_handle()
+        # Must not propagate CalledProcessError
+        adapter.terminate(handle)
+
+    def test_terminate_passes_check_false(self):
+        """terminate() must pass check=False so a nonzero exit is never raised by the runner."""
+
+        check_values: list[bool] = []
+
+        class CheckCapturingRunner:
+            def run(self, args: list[str], check: bool = True) -> str:
+                if args[0] == "kill-session":
+                    check_values.append(check)
+                return ""
+
+        adapter = ClaudeCodeAdapter(tmux_runner=CheckCapturingRunner())
+        adapter.terminate(_make_handle())
+
+        assert check_values == [False], f"Expected check=False, got {check_values}"

--- a/tests/test_session_orchestration_claude_code.py
+++ b/tests/test_session_orchestration_claude_code.py
@@ -71,6 +71,10 @@ class FakeTmuxRunner:
         # Return configured output for capture-pane calls; empty for others.
         if args and args[0] == "capture-pane":
             return self._capture_output
+        # launch() resolves the real pane id via `list-panes -F '#{pane_id}'`
+        # and indexes [0]; return a deterministic id so the fake doesn't 500.
+        if args and args[0] == "list-panes":
+            return "%0"
         return ""
 
     def set_capture(self, text: str) -> None:

--- a/tests/test_session_orchestration_claude_code.py
+++ b/tests/test_session_orchestration_claude_code.py
@@ -1,0 +1,352 @@
+"""
+Unit tests for session_orchestration/adapters/claude_code.py.
+
+Coverage strategy
+-----------------
+Everything testable without a live tmux/claude session is covered here:
+
+1. ``_shell_quote`` — pure function.
+2. ``_parse_lifecycle`` — pure function; fed sample pane snapshots.
+3. ``Capabilities`` declaration — asserts the declared values are correct.
+4. ``drive()`` command sequence — asserts the exact tmux commands issued via
+   a fake ``TmuxRunner``.
+5. ``detect()`` pane-parse — feeds fake pane text through a stubbed capture.
+6. ``resume()`` — asserts /clear + drive sequence when in PAUSED_HANDOFF;
+   asserts no-op when not in PAUSED_HANDOFF.
+
+LIVE-ONLY (not tested here):
+- ``launch()`` — requires real tmux + claude binary.
+- ``_handle_dialogs()`` — requires live pane output.
+- ``_wait_for_prompt()`` timing with real sleeps.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from datetime import datetime, timezone
+from typing import List
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from session_orchestration.adapters.claude_code import (
+    ACTIVITY_REGEX,
+    HANDOFF_MARKER,
+    PROMPT_MARKER,
+    ClaudeCodeAdapter,
+    TmuxRunner,
+    _parse_lifecycle,
+    _shell_quote,
+)
+from session_orchestration.types import Capabilities, SessionHandle, SessionLifecycle
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_handle(pane: str = "hermes-cc-abc:0.0") -> SessionHandle:
+    return SessionHandle(
+        session_id="abc12345-dead-beef-0000-000000000000",
+        tmux_session="hermes-cc-abc12345",
+        pane=pane,
+        launch_ts=datetime.now(tz=timezone.utc),
+    )
+
+
+class FakeTmuxRunner:
+    """Fake TmuxRunner that records calls and returns configurable output."""
+
+    def __init__(self, capture_output: str = "") -> None:
+        self.calls: list[list[str]] = []
+        self._capture_output = capture_output
+
+    def run(self, args: list[str], check: bool = True) -> str:
+        self.calls.append(list(args))
+        # Return configured output for capture-pane calls; empty for others.
+        if args and args[0] == "capture-pane":
+            return self._capture_output
+        return ""
+
+    def set_capture(self, text: str) -> None:
+        self._capture_output = text
+
+
+# ---------------------------------------------------------------------------
+# _shell_quote
+# ---------------------------------------------------------------------------
+
+
+class TestShellQuote:
+    def test_simple_path(self):
+        assert _shell_quote("/home/user/project") == "'/home/user/project'"
+
+    def test_path_with_spaces(self):
+        assert _shell_quote("/my project/code") == "'/my project/code'"
+
+    def test_path_with_single_quote(self):
+        # "it's" → 'it'\''s'
+        result = _shell_quote("/it's/a/path")
+        assert result == "'/it'\\''s/a/path'"
+
+    def test_empty_string(self):
+        assert _shell_quote("") == "''"
+
+
+# ---------------------------------------------------------------------------
+# _parse_lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestParseLifecycle:
+    def test_waiting_user_on_prompt_marker(self):
+        """❯ in pane → WAITING_USER."""
+        pane = "Some output\n❯ "
+        assert _parse_lifecycle(pane) == SessionLifecycle.WAITING_USER
+
+    def test_running_on_activity_marker(self):
+        """● in pane (no ❯) → RUNNING."""
+        pane = "● Reading file src/auth.py\n  processing..."
+        assert _parse_lifecycle(pane) == SessionLifecycle.RUNNING
+
+    def test_paused_handoff_on_handoff_marker(self):
+        """HERMES_HANDOFF in pane → PAUSED_HANDOFF, even if ❯ also present."""
+        pane = f"Task complete.\n{HANDOFF_MARKER}\n❯ "
+        assert _parse_lifecycle(pane) == SessionLifecycle.PAUSED_HANDOFF
+
+    def test_handoff_marker_takes_priority_over_prompt(self):
+        """PAUSED_HANDOFF wins when both HANDOFF_MARKER and ❯ are present."""
+        pane = f"❯ {HANDOFF_MARKER}"
+        assert _parse_lifecycle(pane) == SessionLifecycle.PAUSED_HANDOFF
+
+    def test_running_when_no_markers(self):
+        """No markers → RUNNING (default; watcher tracks staleness)."""
+        pane = "Claude is thinking...\nAnalyzing codebase..."
+        assert _parse_lifecycle(pane) == SessionLifecycle.RUNNING
+
+    def test_empty_pane(self):
+        """Empty pane → RUNNING (startup or mid-render)."""
+        assert _parse_lifecycle("") == SessionLifecycle.RUNNING
+
+    def test_activity_regex_matches_bullet(self):
+        """ACTIVITY_REGEX must match the ● character."""
+        assert ACTIVITY_REGEX.search("● Executing bash command")
+
+    def test_activity_regex_no_false_positive(self):
+        """ACTIVITY_REGEX must NOT match plain text."""
+        assert not ACTIVITY_REGEX.search("No active work")
+
+    def test_prompt_marker_constant(self):
+        """PROMPT_MARKER must be the ❯ character."""
+        assert PROMPT_MARKER == "❯"
+
+    def test_handoff_marker_in_middle_of_line(self):
+        """HANDOFF_MARKER detected mid-line."""
+        pane = f"output line\nChecking: {HANDOFF_MARKER} marker\nmore output"
+        assert _parse_lifecycle(pane) == SessionLifecycle.PAUSED_HANDOFF
+
+    def test_multiple_activity_markers(self):
+        """Multiple ● markers still → RUNNING."""
+        pane = "● Read\n● Edit\n● Bash"
+        assert _parse_lifecycle(pane) == SessionLifecycle.RUNNING
+
+
+# ---------------------------------------------------------------------------
+# Capabilities
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilities:
+    def setup_method(self):
+        self.adapter = ClaudeCodeAdapter(tmux_runner=FakeTmuxRunner())
+
+    def test_has_hooks_true(self):
+        assert self.adapter.capabilities().has_hooks is True
+
+    def test_supports_print_mode_true(self):
+        assert self.adapter.capabilities().supports_print_mode is True
+
+    def test_rpc_mode_false(self):
+        assert self.adapter.capabilities().rpc_mode is False
+
+    def test_json_mode_true(self):
+        assert self.adapter.capabilities().json_mode is True
+
+    def test_idle_indicator_regex_matches_activity(self):
+        cap = self.adapter.capabilities()
+        assert cap.idle_indicator_regex is not None
+        assert cap.idle_indicator_regex.search("● Reading file")
+
+    def test_idle_indicator_regex_does_not_match_prompt(self):
+        cap = self.adapter.capabilities()
+        assert cap.idle_indicator_regex is not None
+        assert not cap.idle_indicator_regex.search("❯ ")
+
+    def test_dialog_handlers_non_empty(self):
+        cap = self.adapter.capabilities()
+        assert len(cap.dialog_handlers) == 2
+
+    def test_return_type_is_capabilities(self):
+        assert isinstance(self.adapter.capabilities(), Capabilities)
+
+
+# ---------------------------------------------------------------------------
+# drive() — command sequence
+# ---------------------------------------------------------------------------
+
+
+class TestDrive:
+    def setup_method(self):
+        # Pane has ❯ so the readiness check passes immediately.
+        self.fake_tmux = FakeTmuxRunner(capture_output="Last line\n❯ ")
+        self.adapter = ClaudeCodeAdapter(tmux_runner=self.fake_tmux)
+        self.handle = _make_handle()
+
+    def _drive_with_stubbed_load(self, message: str) -> list[list[str]]:
+        """Call drive() with _load_buffer stubbed out; return tmux call list."""
+        with patch.object(self.adapter, "_load_buffer"):
+            self.adapter.drive(self.handle, message)
+        return self.fake_tmux.calls
+
+    def test_drive_issues_paste_buffer(self):
+        """drive() must call paste-buffer with the buffer name and pane target."""
+        calls = self._drive_with_stubbed_load("Hello, Claude!")
+        cmd_names = [c[0] for c in calls]
+        assert "paste-buffer" in cmd_names
+
+    def test_drive_paste_buffer_targets_correct_pane(self):
+        """paste-buffer must target the session's pane."""
+        calls = self._drive_with_stubbed_load("test message")
+        paste_call = next(c for c in calls if c[0] == "paste-buffer")
+        assert self.handle.pane in paste_call
+
+    def test_drive_issues_enter_after_paste(self):
+        """drive() must send Enter after pasting to submit the prompt."""
+        calls = self._drive_with_stubbed_load("some prompt")
+        # Last send-keys must carry Enter.
+        send_key_calls = [c for c in calls if c[0] == "send-keys"]
+        assert any("Enter" in c for c in send_key_calls)
+
+    def test_drive_checks_readiness_first(self):
+        """drive() must issue capture-pane before paste-buffer."""
+        calls = self._drive_with_stubbed_load("prompt")
+        cmd_names = [c[0] for c in calls]
+        capture_idx = cmd_names.index("capture-pane")
+        paste_idx = cmd_names.index("paste-buffer")
+        assert capture_idx < paste_idx
+
+    def test_drive_paste_buffer_before_enter(self):
+        """paste-buffer must come before the final Enter send-keys."""
+        calls = self._drive_with_stubbed_load("a multi\nline prompt")
+        cmd_names = [c[0] for c in calls]
+        paste_idx = cmd_names.index("paste-buffer")
+        # There must be a send-keys after the paste.
+        later_send_keys = [i for i, n in enumerate(cmd_names) if n == "send-keys" and i > paste_idx]
+        assert later_send_keys, "No send-keys after paste-buffer"
+
+    def test_drive_raises_timeout_when_no_prompt(self):
+        """drive() raises TimeoutError if the pane never shows ❯."""
+        no_prompt_tmux = FakeTmuxRunner(capture_output="● Busy...")
+        adapter = ClaudeCodeAdapter(tmux_runner=no_prompt_tmux)
+        handle = _make_handle()
+        with patch("session_orchestration.adapters.claude_code._LAUNCH_READY_TIMEOUT", 0.1):
+            with patch("session_orchestration.adapters.claude_code._POLL_INTERVAL", 0.05):
+                with pytest.raises(TimeoutError):
+                    adapter.drive(handle, "hi")
+
+    def test_load_buffer_called_with_message(self):
+        """_load_buffer must be called with the exact message text."""
+        with patch.object(self.adapter, "_load_buffer") as mock_lb:
+            self.adapter.drive(self.handle, "specific message content")
+        mock_lb.assert_called_once()
+        args = mock_lb.call_args[0]
+        assert "specific message content" in args
+
+
+# ---------------------------------------------------------------------------
+# detect()
+# ---------------------------------------------------------------------------
+
+
+class TestDetect:
+    def _adapter_with_pane(self, pane_text: str) -> ClaudeCodeAdapter:
+        return ClaudeCodeAdapter(tmux_runner=FakeTmuxRunner(capture_output=pane_text))
+
+    def test_detect_waiting_user(self):
+        adapter = self._adapter_with_pane("last output\n❯ ")
+        assert adapter.detect(_make_handle()) == SessionLifecycle.WAITING_USER
+
+    def test_detect_running_via_activity(self):
+        adapter = self._adapter_with_pane("● Editing src/main.py")
+        assert adapter.detect(_make_handle()) == SessionLifecycle.RUNNING
+
+    def test_detect_paused_handoff(self):
+        adapter = self._adapter_with_pane(f"done.\n{HANDOFF_MARKER}\n❯ ")
+        assert adapter.detect(_make_handle()) == SessionLifecycle.PAUSED_HANDOFF
+
+    def test_detect_error_on_dead_pane(self):
+        """When capture-pane fails (pane gone), detect() → ERROR."""
+        class FailingRunner:
+            def run(self, args, check=True):
+                if args[0] == "capture-pane":
+                    raise subprocess.CalledProcessError(1, "tmux")
+                return ""
+
+        adapter = ClaudeCodeAdapter(tmux_runner=FailingRunner())
+        assert adapter.detect(_make_handle()) == SessionLifecycle.ERROR
+
+    def test_detect_running_default(self):
+        """No markers → RUNNING."""
+        adapter = self._adapter_with_pane("Claude is processing the request...")
+        assert adapter.detect(_make_handle()) == SessionLifecycle.RUNNING
+
+
+# ---------------------------------------------------------------------------
+# resume()
+# ---------------------------------------------------------------------------
+
+
+class TestResume:
+    def test_resume_sends_clear_and_drives_when_handoff(self):
+        """resume() must send /clear then drive() when in PAUSED_HANDOFF."""
+        fake_tmux = FakeTmuxRunner(capture_output=f"{HANDOFF_MARKER}\n❯ ")
+        adapter = ClaudeCodeAdapter(tmux_runner=fake_tmux)
+        handle = _make_handle()
+
+        with patch.object(adapter, "drive") as mock_drive:
+            adapter.resume(handle, "continue from here")
+
+        # /clear must have been sent via send-keys.
+        clear_calls = [c for c in fake_tmux.calls if c[0] == "send-keys" and "/clear" in c]
+        assert clear_calls, "No /clear send-keys found"
+
+        # drive() must have been called with the new prompt.
+        mock_drive.assert_called_once_with(handle, "continue from here")
+
+    def test_resume_noop_when_not_handoff(self):
+        """resume() must be a no-op when the session is NOT in PAUSED_HANDOFF."""
+        fake_tmux = FakeTmuxRunner(capture_output="● Working...\n")
+        adapter = ClaudeCodeAdapter(tmux_runner=fake_tmux)
+        handle = _make_handle()
+
+        with patch.object(adapter, "drive") as mock_drive:
+            adapter.resume(handle, "irrelevant prompt")
+
+        # drive() must NOT have been called.
+        mock_drive.assert_not_called()
+        # /clear must NOT have been sent.
+        clear_calls = [c for c in fake_tmux.calls if c[0] == "send-keys" and "/clear" in c]
+        assert not clear_calls
+
+    def test_resume_noop_when_waiting_user_not_handoff(self):
+        """resume() must be a no-op even if ❯ is visible (but no handoff marker)."""
+        fake_tmux = FakeTmuxRunner(capture_output="output\n❯ ")
+        adapter = ClaudeCodeAdapter(tmux_runner=fake_tmux)
+        handle = _make_handle()
+
+        with patch.object(adapter, "drive") as mock_drive:
+            adapter.resume(handle, "prompt")
+
+        mock_drive.assert_not_called()

--- a/tests/test_session_orchestration_codex.py
+++ b/tests/test_session_orchestration_codex.py
@@ -1,0 +1,152 @@
+"""Unit tests for session_orchestration/adapters/codex.py."""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from session_orchestration.adapters.codex import (
+    ACTIVITY_REGEX,
+    HANDOFF_MARKER,
+    PROMPT_FRAGMENT,
+    CodexAdapter,
+    build_interactive_argv,
+    parse_pane_lifecycle,
+)
+from session_orchestration.types import SessionHandle, SessionLifecycle
+
+
+def _make_handle(pane: str = "%1") -> SessionHandle:
+    return SessionHandle(
+        session_id="abc12345-dead-beef-0000-000000000000",
+        tmux_session="hermes-codex-abc12345",
+        pane=pane,
+        launch_ts=datetime.now(tz=timezone.utc),
+    )
+
+
+class FakeTmuxRunner:
+    def __init__(self, capture_output: str = "") -> None:
+        self.calls: list[list[str]] = []
+        self._capture_output = capture_output
+
+    def run(self, args: list[str], check: bool = True) -> str:
+        self.calls.append(list(args))
+        if args and args[0] == "capture-pane":
+            return self._capture_output
+        if args and args[0] == "list-panes":
+            return "%1"
+        return ""
+
+    def set_capture(self, text: str) -> None:
+        self._capture_output = text
+
+
+class TestBuildInteractiveArgv:
+    def test_includes_workdir(self):
+        assert build_interactive_argv(workdir="/repo") == ["-C", "/repo"]
+
+    def test_includes_model_when_given(self):
+        assert build_interactive_argv(workdir="/repo", model="gpt-5.5") == [
+            "-C",
+            "/repo",
+            "--model",
+            "gpt-5.5",
+        ]
+
+
+class TestParsePaneLifecycle:
+    def test_waiting_user_on_composer(self):
+        assert parse_pane_lifecycle(PROMPT_FRAGMENT) == SessionLifecycle.WAITING_USER
+
+    def test_waiting_user_on_contextual_composer(self):
+        assert parse_pane_lifecycle("› Explain this codebase") == (
+            SessionLifecycle.WAITING_USER
+        )
+
+    def test_numbered_selector_is_not_a_composer_without_dialog_text(self):
+        assert parse_pane_lifecycle("› 1. Yes, continue") == SessionLifecycle.RUNNING
+
+    def test_waiting_user_on_trust_dialog(self):
+        pane = "Do you trust the contents of this directory?\n› 1. Yes, continue"
+        assert parse_pane_lifecycle(pane) == SessionLifecycle.WAITING_USER
+
+    def test_waiting_user_on_update_dialog(self):
+        pane = "Update available\n› 1. Update now\n  2. Skip"
+        assert parse_pane_lifecycle(pane) == SessionLifecycle.WAITING_USER
+
+    def test_paused_handoff_takes_priority(self):
+        assert parse_pane_lifecycle(f"{HANDOFF_MARKER}\n{PROMPT_FRAGMENT}") == (
+            SessionLifecycle.PAUSED_HANDOFF
+        )
+
+    def test_running_on_activity(self):
+        assert parse_pane_lifecycle("⠋ thinking") == SessionLifecycle.RUNNING
+        assert ACTIVITY_REGEX.search("Running command")
+
+
+class TestCapabilities:
+    def test_capabilities_match_probe_contract(self):
+        caps = CodexAdapter(tmux_runner=FakeTmuxRunner()).capabilities()
+        assert caps.supports_print_mode is True
+        assert caps.has_hooks is False
+        assert caps.rpc_mode is False
+        assert caps.json_mode is False
+        assert caps.idle_indicator_regex is ACTIVITY_REGEX
+        assert len(caps.dialog_handlers) == 2
+
+
+class TestDrive:
+    def test_drive_pastes_and_submits(self):
+        fake_tmux = FakeTmuxRunner(capture_output=f"ready\n{PROMPT_FRAGMENT}")
+        adapter = CodexAdapter(tmux_runner=fake_tmux)
+        handle = _make_handle()
+
+        with patch.object(adapter, "_load_buffer") as load_buffer:
+            adapter.drive(handle, "hello")
+
+        load_buffer.assert_called_once()
+        assert any(c[0] == "paste-buffer" and handle.pane in c for c in fake_tmux.calls)
+        assert any(c[0] == "send-keys" and "Enter" in c for c in fake_tmux.calls)
+
+    def test_drive_raises_timeout_when_not_ready(self):
+        fake_tmux = FakeTmuxRunner(capture_output="⠋ thinking")
+        adapter = CodexAdapter(tmux_runner=fake_tmux)
+
+        with (
+            patch("session_orchestration.adapters.codex._LAUNCH_READY_TIMEOUT", 0.01),
+            patch("session_orchestration.adapters.codex.time.sleep"),
+            pytest.raises(TimeoutError),
+        ):
+            adapter.drive(_make_handle(), "hello")
+
+
+class TestLaunch:
+    def test_launch_injects_marker_and_runs_codex(self):
+        fake_tmux = FakeTmuxRunner(capture_output=PROMPT_FRAGMENT)
+        adapter = CodexAdapter(tmux_runner=fake_tmux, binary="codex-test")
+
+        with (
+            patch.object(adapter, "_handle_dialogs"),
+            patch.object(adapter, "_wait_for_ready"),
+            patch("session_orchestration.adapters.codex.os.makedirs"),
+        ):
+            handle = adapter.launch("/repo", "start")
+
+        new_session = next(c for c in fake_tmux.calls if c[0] == "new-session")
+        assert "-e" in new_session
+        assert f"HERMES_MARKER_FILE={handle.marker_file}" in new_session
+        send_keys = [c for c in fake_tmux.calls if c[0] == "send-keys"]
+        assert any("codex-test -C /repo" in c for c in send_keys)
+
+    def test_terminate_swallows_missing_session(self):
+        class ErrorOnKillRunner(FakeTmuxRunner):
+            def run(self, args: list[str], check: bool = True) -> str:
+                if args and args[0] == "kill-session":
+                    raise subprocess.CalledProcessError(1, "tmux")
+                return super().run(args, check=check)
+
+        CodexAdapter(tmux_runner=ErrorOnKillRunner()).terminate(_make_handle())

--- a/tests/test_session_orchestration_config.py
+++ b/tests/test_session_orchestration_config.py
@@ -1,5 +1,6 @@
 """
-Tests for session_orchestration/config.py (T016 — Config gating).
+Tests for session_orchestration/config.py (T016 — Config gating) and
+session_orchestration/repo_registry.py (T002 — Repo registry).
 
 Covers:
   - Defaults (enabled=False when unset or file absent)
@@ -9,6 +10,7 @@ Covers:
   - Malformed / unexpected values fall back to defaults gracefully
   - is_enabled() convenience wrapper
   - _KNOWN_ROOT_KEYS includes session_orchestration (schema registration)
+  - Repo registry: known-name resolution, fuzzy match, override priority, unresolved
 """
 
 from __future__ import annotations
@@ -25,6 +27,15 @@ from session_orchestration.config import (
     _coerce_positive_int,
     is_enabled,
     load_session_orchestration_config,
+)
+from session_orchestration.repo_registry import (
+    DEFAULT_AGENT,
+    RepoEntry,
+    RepoRegistry,
+    ResolvedRepo,
+    UnresolvedRepo,
+    build_repo_registry,
+    scan_for_repos,
 )
 
 
@@ -328,3 +339,222 @@ def test_coerce_optional_str(value: Any, expected: Optional[str]) -> None:
 )
 def test_coerce_positive_int(value: Any, default: int, expected: int) -> None:
     assert _coerce_positive_int(value, default) == expected
+
+
+# ---------------------------------------------------------------------------
+# 8. SessionOrchestrationConfig — repos field
+# ---------------------------------------------------------------------------
+
+
+def test_repos_defaults_to_empty_dict() -> None:
+    """repos field defaults to {} when absent from config."""
+    cfg = SessionOrchestrationConfig.from_dict({})
+    assert cfg.repos == {}
+
+
+def test_repos_parsed_from_dict() -> None:
+    """repos dict is extracted verbatim for downstream registry parsing."""
+    data = {
+        "repos": {
+            "myproject": "/home/user/myproject",
+            "infra": {"path": "/home/user/infra", "default_agent": "claude"},
+        }
+    }
+    cfg = SessionOrchestrationConfig.from_dict(data)
+    assert cfg.repos == data["repos"]
+
+
+def test_repos_non_dict_ignored() -> None:
+    """Non-dict repos value (e.g. a string) defaults to {}."""
+    cfg = SessionOrchestrationConfig.from_dict({"repos": "bad"})
+    assert cfg.repos == {}
+
+
+# ---------------------------------------------------------------------------
+# 9. Repo registry — core resolution tests (T002)
+# ---------------------------------------------------------------------------
+
+# These tests inject a fake scan dict so no filesystem access is needed.
+_FAKE_SCAN: Dict[str, str] = {
+    "hermes-agent": "/home/zeke/dev/hermes-agent",
+    "myproject": "/home/zeke/dev/myproject",
+    "infra-core": "/home/zeke/dev/infra-core",
+}
+
+
+def _registry(
+    overrides: Optional[Dict[str, RepoEntry]] = None,
+) -> RepoRegistry:
+    """Build a registry with the fake scan and given overrides."""
+    return RepoRegistry(overrides=overrides, _injected_scan=_FAKE_SCAN)
+
+
+def test_known_name_resolves_to_absolute_path() -> None:
+    """An exact name in the scan cache resolves to its absolute path."""
+    reg = _registry()
+    result = reg.resolve("hermes-agent")
+    assert isinstance(result, ResolvedRepo)
+    assert result.path == "/home/zeke/dev/hermes-agent"
+    assert result.match_kind == "exact"
+
+
+def test_known_name_case_insensitive() -> None:
+    """Resolution is case-insensitive for scan names."""
+    reg = _registry()
+    result = reg.resolve("Hermes-Agent")
+    assert isinstance(result, ResolvedRepo)
+    assert result.path == "/home/zeke/dev/hermes-agent"
+
+
+def test_default_agent_is_omp_when_not_specified() -> None:
+    """Auto-scanned repos use DEFAULT_AGENT (omp) when no override is present."""
+    reg = _registry()
+    result = reg.resolve("myproject")
+    assert isinstance(result, ResolvedRepo)
+    assert result.default_agent == DEFAULT_AGENT
+    assert result.default_agent == "omp"
+
+
+def test_fuzzy_suffix_match_resolves() -> None:
+    """A suffix-segment query (e.g. 'agent') resolves via fuzzy matching."""
+    reg = _registry()
+    result = reg.resolve("agent")
+    assert isinstance(result, ResolvedRepo)
+    assert result.path == "/home/zeke/dev/hermes-agent"
+    assert result.match_kind == "fuzzy"
+
+
+def test_fuzzy_substring_match_resolves() -> None:
+    """A substring query ('core') fuzzy-matches 'infra-core'."""
+    reg = _registry()
+    result = reg.resolve("core")
+    assert isinstance(result, ResolvedRepo)
+    assert result.path == "/home/zeke/dev/infra-core"
+    assert result.match_kind == "fuzzy"
+
+
+def test_unknown_name_returns_unresolved_sentinel() -> None:
+    """An unknown repo name returns UnresolvedRepo (never raises)."""
+    reg = _registry()
+    result = reg.resolve("totally-unknown-repo-xyz")
+    assert isinstance(result, UnresolvedRepo)
+    assert result.name == "totally-unknown-repo-xyz"
+
+
+def test_manual_override_wins_over_auto_scan() -> None:
+    """A manual override for an alias wins over an identically-named scan entry."""
+    overrides = {
+        "myproject": RepoEntry(path="/custom/override/path", default_agent="claude"),
+    }
+    reg = _registry(overrides=overrides)
+    result = reg.resolve("myproject")
+    assert isinstance(result, ResolvedRepo)
+    assert result.path == "/custom/override/path"
+    assert result.default_agent == "claude"
+    assert result.match_kind == "exact"
+
+
+def test_manual_override_alias_resolves() -> None:
+    """A manual override alias that doesn't appear in the scan resolves correctly."""
+    overrides = {
+        "prod-infra": RepoEntry(path="/prod/infra", default_agent="omp"),
+    }
+    reg = _registry(overrides=overrides)
+    result = reg.resolve("prod-infra")
+    assert isinstance(result, ResolvedRepo)
+    assert result.path == "/prod/infra"
+
+
+def test_manual_override_fuzzy_beats_scan_fuzzy() -> None:
+    """Override fuzzy match takes precedence over scan fuzzy match."""
+    # "infra" would fuzzy-match "infra-core" from the scan, but the override
+    # alias "infra-tool" also fuzzy-matches "infra" and overrides come first.
+    overrides = {
+        "infra-tool": RepoEntry(path="/override/infra-tool", default_agent="omp"),
+    }
+    reg = _registry(overrides=overrides)
+    result = reg.resolve("infra")
+    assert isinstance(result, ResolvedRepo)
+    # Could match either override "infra-tool" or scan "infra-core"; override wins
+    assert result.path == "/override/infra-tool"
+    assert result.match_kind == "fuzzy"
+
+
+# ---------------------------------------------------------------------------
+# 10. build_repo_registry — config parsing
+# ---------------------------------------------------------------------------
+
+
+def test_build_registry_string_shorthand() -> None:
+    """build_repo_registry parses the string shorthand form."""
+    repos_cfg = {"work": "/home/user/work"}
+    reg = build_repo_registry(repos_cfg=repos_cfg, _injected_scan={})
+    result = reg.resolve("work")
+    assert isinstance(result, ResolvedRepo)
+    assert result.path == "/home/user/work"
+    assert result.default_agent == DEFAULT_AGENT
+
+
+def test_build_registry_dict_form_with_agent() -> None:
+    """build_repo_registry parses the dict form with explicit default_agent."""
+    repos_cfg = {
+        "infra": {"path": "/home/user/infra", "default_agent": "claude"},
+    }
+    reg = build_repo_registry(repos_cfg=repos_cfg, _injected_scan={})
+    result = reg.resolve("infra")
+    assert isinstance(result, ResolvedRepo)
+    assert result.path == "/home/user/infra"
+    assert result.default_agent == "claude"
+
+
+def test_build_registry_none_repos_cfg() -> None:
+    """build_repo_registry with None repos_cfg builds an empty-overrides registry."""
+    reg = build_repo_registry(repos_cfg=None, _injected_scan={})
+    result = reg.resolve("anything")
+    assert isinstance(result, UnresolvedRepo)
+
+
+def test_build_registry_skips_empty_path() -> None:
+    """build_repo_registry skips aliases with empty paths without raising."""
+    repos_cfg = {"bad": ""}
+    reg = build_repo_registry(repos_cfg=repos_cfg, _injected_scan={})
+    result = reg.resolve("bad")
+    assert isinstance(result, UnresolvedRepo)
+
+
+# ---------------------------------------------------------------------------
+# 11. scan_for_repos — filesystem scan (uses a real temp dir)
+# ---------------------------------------------------------------------------
+
+
+def test_scan_finds_git_repos_in_root(tmp_path: Any) -> None:
+    """scan_for_repos returns repos discovered under a scan root."""
+    repo_dir = tmp_path / "my-repo"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    result = scan_for_repos(scan_roots=[str(tmp_path)])
+    assert "my-repo" in result
+    assert result["my-repo"] == str(repo_dir)
+
+
+def test_scan_skips_non_git_dirs(tmp_path: Any) -> None:
+    """scan_for_repos ignores directories that are not git repos."""
+    non_repo = tmp_path / "not-a-repo"
+    non_repo.mkdir()
+
+    result = scan_for_repos(scan_roots=[str(tmp_path)])
+    assert "not-a-repo" not in result
+
+
+def test_scan_returns_empty_for_missing_root(tmp_path: Any) -> None:
+    """scan_for_repos returns {} when a scan root does not exist."""
+    result = scan_for_repos(scan_roots=[str(tmp_path / "nonexistent")])
+    assert result == {}
+
+
+def test_scan_includes_root_itself_if_git_repo(tmp_path: Any) -> None:
+    """If the scan root itself is a git repo it is included."""
+    (tmp_path / ".git").mkdir()
+    result = scan_for_repos(scan_roots=[str(tmp_path)])
+    assert tmp_path.name.lower() in result

--- a/tests/test_session_orchestration_config.py
+++ b/tests/test_session_orchestration_config.py
@@ -216,6 +216,15 @@ def test_negative_hang_idle_ticks_falls_back_to_default() -> None:
     assert cfg.hang_idle_ticks == 3
 
 
+def test_hang_thresholds_reused_for_stale_guard_config() -> None:
+    """Existing hang thresholds express the stale/frozen guard without new keys."""
+    cfg = SessionOrchestrationConfig.from_dict(
+        {"hang_stale_seconds": "900", "hang_idle_ticks": "4"}
+    )
+    assert cfg.hang_stale_seconds == 900
+    assert cfg.hang_idle_ticks == 4
+
+
 def test_unknown_keys_ignored() -> None:
     """Extra keys in the section are silently ignored."""
     cfg = SessionOrchestrationConfig.from_dict(

--- a/tests/test_session_orchestration_config.py
+++ b/tests/test_session_orchestration_config.py
@@ -1,0 +1,330 @@
+"""
+Tests for session_orchestration/config.py (T016 — Config gating).
+
+Covers:
+  - Defaults (enabled=False when unset or file absent)
+  - Reading a fully-populated section
+  - Partial section (only some keys set)
+  - Disabled-path invariant (accessor reports disabled ⇒ dependents short-circuit)
+  - Malformed / unexpected values fall back to defaults gracefully
+  - is_enabled() convenience wrapper
+  - _KNOWN_ROOT_KEYS includes session_orchestration (schema registration)
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+from unittest.mock import patch
+
+import pytest
+
+from session_orchestration.config import (
+    SessionOrchestrationConfig,
+    _coerce_bool,
+    _coerce_optional_str,
+    _coerce_positive_int,
+    is_enabled,
+    load_session_orchestration_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Defaults — enabled=False when unset
+# ---------------------------------------------------------------------------
+
+
+def test_defaults_from_empty_dict() -> None:
+    """SessionOrchestrationConfig.from_dict({}) returns all-default values."""
+    cfg = SessionOrchestrationConfig.from_dict({})
+    assert cfg.enabled is False
+    assert cfg.feed_channel_id is None
+    assert cfg.external_runs_channel_id is None
+    assert cfg.hang_stale_seconds == 300
+    assert cfg.hang_idle_ticks == 3
+
+
+def test_defaults_from_missing_section() -> None:
+    """load_session_orchestration_config with no session_orchestration key defaults OFF."""
+    hermes_cfg: Dict[str, Any] = {"model": {"default": "claude"}}
+    result = load_session_orchestration_config(hermes_cfg)
+    assert result.enabled is False
+
+
+def test_defaults_when_config_load_fails() -> None:
+    """When load_config_readonly raises, accessor returns all-defaults (never raises)."""
+    with patch(
+        "hermes_cli.config.load_config_readonly",
+        side_effect=RuntimeError("disk error"),
+    ):
+        result = load_session_orchestration_config()
+    assert result.enabled is False
+    assert result.feed_channel_id is None
+
+
+def test_defaults_when_section_is_none() -> None:
+    """session_orchestration: null in YAML (→ None in Python) → defaults."""
+    hermes_cfg: Dict[str, Any] = {"session_orchestration": None}
+    result = load_session_orchestration_config(hermes_cfg)
+    assert result.enabled is False
+
+
+def test_defaults_when_section_is_not_a_dict() -> None:
+    """session_orchestration: "oops" → defaults, no exception."""
+    hermes_cfg: Dict[str, Any] = {"session_orchestration": "oops"}
+    result = load_session_orchestration_config(hermes_cfg)
+    assert result.enabled is False
+
+
+# ---------------------------------------------------------------------------
+# 2. Fully-populated section
+# ---------------------------------------------------------------------------
+
+
+def test_fully_populated_section() -> None:
+    """All fields are parsed correctly from a well-formed section."""
+    hermes_cfg: Dict[str, Any] = {
+        "session_orchestration": {
+            "enabled": True,
+            "feed_channel_id": "1111222233334444",
+            "external_runs_channel_id": "5555666677778888",
+            "hang_stale_seconds": 600,
+            "hang_idle_ticks": 5,
+        }
+    }
+    result = load_session_orchestration_config(hermes_cfg)
+    assert result.enabled is True
+    assert result.feed_channel_id == "1111222233334444"
+    assert result.external_runs_channel_id == "5555666677778888"
+    assert result.hang_stale_seconds == 600
+    assert result.hang_idle_ticks == 5
+
+
+def test_string_true_is_accepted() -> None:
+    """enabled: 'true' (string from env passthrough) is coerced to True."""
+    cfg = SessionOrchestrationConfig.from_dict({"enabled": "true"})
+    assert cfg.enabled is True
+
+
+def test_string_false_is_accepted() -> None:
+    """enabled: 'false' (string) is coerced to False."""
+    cfg = SessionOrchestrationConfig.from_dict({"enabled": "false"})
+    assert cfg.enabled is False
+
+
+# ---------------------------------------------------------------------------
+# 3. Partial section
+# ---------------------------------------------------------------------------
+
+
+def test_partial_section_only_enabled() -> None:
+    """Only enabled key present; other fields default gracefully."""
+    hermes_cfg: Dict[str, Any] = {"session_orchestration": {"enabled": True}}
+    result = load_session_orchestration_config(hermes_cfg)
+    assert result.enabled is True
+    assert result.feed_channel_id is None
+    assert result.hang_stale_seconds == 300
+
+
+def test_partial_section_only_channel() -> None:
+    """Only feed_channel_id set; enabled defaults False."""
+    hermes_cfg: Dict[str, Any] = {
+        "session_orchestration": {"feed_channel_id": "abc123"}
+    }
+    result = load_session_orchestration_config(hermes_cfg)
+    assert result.enabled is False
+    assert result.feed_channel_id == "abc123"
+
+
+def test_empty_string_feed_channel_normalised_to_none() -> None:
+    """Empty string feed_channel_id is normalised to None."""
+    cfg = SessionOrchestrationConfig.from_dict({"feed_channel_id": ""})
+    assert cfg.feed_channel_id is None
+
+
+# ---------------------------------------------------------------------------
+# 4. Disabled-path invariant
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_path_invariant_default() -> None:
+    """With an empty config, enabled=False — dependent gates MUST short-circuit."""
+    hermes_cfg: Dict[str, Any] = {}
+    cfg = load_session_orchestration_config(hermes_cfg)
+
+    # This is the exact branch every dependent uses to short-circuit:
+    if cfg.enabled:
+        raise AssertionError("Side effects must not run when enabled=False")
+    # Test passes — the guard correctly prevents execution.
+
+
+def test_disabled_path_invariant_explicit_false() -> None:
+    """Explicit enabled: false behaves identically to the absent-key default."""
+    hermes_cfg: Dict[str, Any] = {"session_orchestration": {"enabled": False}}
+    cfg = load_session_orchestration_config(hermes_cfg)
+    assert not cfg.enabled
+
+
+def test_disabled_is_enabled_wrapper() -> None:
+    """is_enabled() returns False when enabled=False."""
+    hermes_cfg: Dict[str, Any] = {"session_orchestration": {"enabled": False}}
+    assert is_enabled(hermes_cfg) is False
+
+
+def test_enabled_is_enabled_wrapper() -> None:
+    """is_enabled() returns True when enabled=True."""
+    hermes_cfg: Dict[str, Any] = {"session_orchestration": {"enabled": True}}
+    assert is_enabled(hermes_cfg) is True
+
+
+def test_is_enabled_no_args_reads_live_config() -> None:
+    """is_enabled() with no args reads via load_config_readonly (mocked)."""
+    mock_cfg: Dict[str, Any] = {"session_orchestration": {"enabled": True}}
+    with patch(
+        "hermes_cli.config.load_config_readonly", return_value=mock_cfg
+    ):
+        assert is_enabled() is True
+
+
+def test_is_enabled_no_args_defaults_false_on_missing() -> None:
+    """is_enabled() returns False when the section is absent from live config."""
+    with patch(
+        "hermes_cli.config.load_config_readonly", return_value={}
+    ):
+        assert is_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# 5. Malformed / edge-case values
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_hang_stale_seconds_falls_back_to_default() -> None:
+    """Non-numeric hang_stale_seconds falls back to 300."""
+    cfg = SessionOrchestrationConfig.from_dict({"hang_stale_seconds": "not-a-number"})
+    assert cfg.hang_stale_seconds == 300
+
+
+def test_zero_hang_stale_seconds_falls_back_to_default() -> None:
+    """Zero is not a positive int — falls back to 300."""
+    cfg = SessionOrchestrationConfig.from_dict({"hang_stale_seconds": 0})
+    assert cfg.hang_stale_seconds == 300
+
+
+def test_negative_hang_idle_ticks_falls_back_to_default() -> None:
+    """Negative hang_idle_ticks falls back to 3."""
+    cfg = SessionOrchestrationConfig.from_dict({"hang_idle_ticks": -1})
+    assert cfg.hang_idle_ticks == 3
+
+
+def test_unknown_keys_ignored() -> None:
+    """Extra keys in the section are silently ignored."""
+    cfg = SessionOrchestrationConfig.from_dict(
+        {"enabled": True, "future_feature": "some_value"}
+    )
+    assert cfg.enabled is True
+
+
+def test_external_runs_thread_id_legacy_alias() -> None:
+    """Legacy key external_runs_thread_id is accepted as alias."""
+    cfg = SessionOrchestrationConfig.from_dict(
+        {"external_runs_thread_id": "thread-999"}
+    )
+    assert cfg.external_runs_channel_id == "thread-999"
+
+
+# ---------------------------------------------------------------------------
+# 6. Schema registration — DEFAULT_CONFIG includes session_orchestration
+# ---------------------------------------------------------------------------
+
+
+def test_default_config_has_session_orchestration() -> None:
+    """session_orchestration section is present in DEFAULT_CONFIG with enabled=False."""
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert "session_orchestration" in DEFAULT_CONFIG, (
+        "DEFAULT_CONFIG must include session_orchestration section"
+    )
+    so = DEFAULT_CONFIG["session_orchestration"]
+    assert isinstance(so, dict), "session_orchestration must be a dict"
+    assert so.get("enabled") is False, "Default must be disabled"
+
+
+def test_known_root_keys_includes_session_orchestration() -> None:
+    """_KNOWN_ROOT_KEYS includes session_orchestration to avoid spurious warnings."""
+    from hermes_cli.config import _KNOWN_ROOT_KEYS
+
+    assert "session_orchestration" in _KNOWN_ROOT_KEYS, (
+        "_KNOWN_ROOT_KEYS must list session_orchestration so "
+        "config validation does not warn on a valid key"
+    )
+
+
+def test_load_config_merges_session_orchestration() -> None:
+    """load_config() deep-merges a partial user override with the defaults."""
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    # Simulate what _deep_merge does: user sets only enabled=true.
+    user_section = {"enabled": True}
+    merged_section = {**DEFAULT_CONFIG["session_orchestration"], **user_section}
+
+    assert merged_section["enabled"] is True
+    # Defaults for other keys survive the merge
+    assert "hang_stale_seconds" in merged_section
+    assert "feed_channel_id" in merged_section
+
+
+# ---------------------------------------------------------------------------
+# 7. Coercion helpers (unit tests so any regression is caught directly)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value, default, expected",
+    [
+        (True, False, True),
+        (False, True, False),
+        ("true", False, True),
+        ("false", True, False),
+        ("1", False, True),
+        ("0", True, False),
+        ("yes", False, True),
+        ("no", True, False),
+        (None, True, True),
+        (None, False, False),
+        ("garbage", True, True),
+        ("garbage", False, False),
+    ],
+)
+def test_coerce_bool(value: Any, default: bool, expected: bool) -> None:
+    assert _coerce_bool(value, default) is expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("abc", "abc"),
+        ("  abc  ", "abc"),
+        ("", None),
+        ("   ", None),
+        (None, None),
+        (123, "123"),
+    ],
+)
+def test_coerce_optional_str(value: Any, expected: Optional[str]) -> None:
+    assert _coerce_optional_str(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value, default, expected",
+    [
+        (5, 3, 5),
+        (1, 3, 1),
+        (0, 3, 3),       # zero is not positive
+        (-1, 3, 3),      # negative is not positive
+        ("10", 3, 10),   # string coercion
+        ("bad", 3, 3),   # malformed → default
+        (None, 3, 3),    # missing → default
+    ],
+)
+def test_coerce_positive_int(value: Any, default: int, expected: int) -> None:
+    assert _coerce_positive_int(value, default) == expected

--- a/tests/test_session_orchestration_config.py
+++ b/tests/test_session_orchestration_config.py
@@ -52,6 +52,17 @@ def test_defaults_from_empty_dict() -> None:
     assert cfg.external_runs_channel_id is None
     assert cfg.hang_stale_seconds == 300
     assert cfg.hang_idle_ticks == 3
+    assert cfg.drive_queue_ttl_seconds == 600
+    assert cfg.auto_checkpoint_resume is True
+
+
+def test_auto_checkpoint_resume_knob_parses() -> None:
+    """auto_checkpoint_resume + drive_queue_ttl_seconds round-trip from the dict."""
+    cfg = SessionOrchestrationConfig.from_dict(
+        {"auto_checkpoint_resume": False, "drive_queue_ttl_seconds": 3600}
+    )
+    assert cfg.auto_checkpoint_resume is False
+    assert cfg.drive_queue_ttl_seconds == 3600
 
 
 def test_defaults_from_missing_section() -> None:

--- a/tests/test_session_orchestration_config.py
+++ b/tests/test_session_orchestration_config.py
@@ -56,6 +56,7 @@ def test_defaults_from_empty_dict() -> None:
     assert cfg.auto_checkpoint_resume is True
     assert cfg.busy_loop_stale_seconds == 900
     assert cfg.busy_loop_auto_escape is True
+    assert cfg.omp_auto_approve is False
 
 
 def test_auto_checkpoint_resume_knob_parses() -> None:
@@ -74,6 +75,12 @@ def test_busy_loop_knobs_parse() -> None:
     )
     assert cfg.busy_loop_stale_seconds == 1200
     assert cfg.busy_loop_auto_escape is False
+
+
+def test_omp_auto_approve_knob_parses() -> None:
+    """omp_auto_approve round-trips from the dict (default False)."""
+    assert SessionOrchestrationConfig.from_dict({"omp_auto_approve": True}).omp_auto_approve is True
+    assert SessionOrchestrationConfig.from_dict({}).omp_auto_approve is False
 
 
 def test_defaults_from_missing_section() -> None:

--- a/tests/test_session_orchestration_config.py
+++ b/tests/test_session_orchestration_config.py
@@ -54,6 +54,8 @@ def test_defaults_from_empty_dict() -> None:
     assert cfg.hang_idle_ticks == 3
     assert cfg.drive_queue_ttl_seconds == 600
     assert cfg.auto_checkpoint_resume is True
+    assert cfg.busy_loop_stale_seconds == 900
+    assert cfg.busy_loop_auto_escape is True
 
 
 def test_auto_checkpoint_resume_knob_parses() -> None:
@@ -63,6 +65,15 @@ def test_auto_checkpoint_resume_knob_parses() -> None:
     )
     assert cfg.auto_checkpoint_resume is False
     assert cfg.drive_queue_ttl_seconds == 3600
+
+
+def test_busy_loop_knobs_parse() -> None:
+    """busy_loop_stale_seconds + busy_loop_auto_escape round-trip from the dict."""
+    cfg = SessionOrchestrationConfig.from_dict(
+        {"busy_loop_stale_seconds": 1200, "busy_loop_auto_escape": False}
+    )
+    assert cfg.busy_loop_stale_seconds == 1200
+    assert cfg.busy_loop_auto_escape is False
 
 
 def test_defaults_from_missing_section() -> None:

--- a/tests/test_session_orchestration_dm_transport.py
+++ b/tests/test_session_orchestration_dm_transport.py
@@ -1,0 +1,244 @@
+"""
+Unit tests for session_orchestration/dm_transport.py (T007).
+
+Coverage
+--------
+(a) get_dm_channel_id posts to the correct Discord endpoint with
+    ``Authorization: Bot <token>`` and returns the channel id from
+    the mocked response.
+(b) send_dm calls get_dm_channel_id then posts to channels/{channel_id}/messages.
+(c) An HTTP 4xx response causes send_dm to return False without raising.
+(d) No real network calls are made — all via injected http_post.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+from session_orchestration.dm_transport import (
+    _Response,
+    get_dm_channel_id,
+    send_dm,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake http_post builder
+# ---------------------------------------------------------------------------
+
+
+class _FakeHttp:
+    """Records POSTs and returns pre-configured canned responses in order."""
+
+    def __init__(self, responses: List[_Response]):
+        self._responses = list(responses)
+        self.calls: List[Tuple[str, Dict[str, str], Any]] = []
+
+    def __call__(
+        self,
+        url: str,
+        headers: Dict[str, str],
+        json_body: Any,
+    ) -> _Response:
+        self.calls.append((url, headers, json_body))
+        return self._responses.pop(0)
+
+    def assert_no_network(self) -> None:
+        """All calls went through this fake — no urllib was touched."""
+        # If __call__ was reached, no real network call happened.
+        # This is enforced structurally: we never import urllib in the test,
+        # and the module only calls _default_http_post when http_post is None.
+        pass  # assertion is the absence of real urllib calls
+
+
+def _ok(data: Any) -> _Response:
+    """Build a 200-OK _Response with JSON body."""
+    return _Response(status_code=200, body=json.dumps(data).encode())
+
+
+def _error(status: int) -> _Response:
+    """Build an error _Response."""
+    return _Response(status_code=status, body=b'{"code":0,"message":"error"}')
+
+
+# ---------------------------------------------------------------------------
+# (a) get_dm_channel_id — correct endpoint, correct header, returns channel id
+# ---------------------------------------------------------------------------
+
+
+class TestGetDmChannelId:
+    def test_posts_to_users_me_channels(self):
+        fake = _FakeHttp([_ok({"id": "111222333444555"})])
+        channel_id = get_dm_channel_id("999888777", "my-bot-token", http_post=fake)
+
+        assert len(fake.calls) == 1
+        url, headers, body = fake.calls[0]
+        assert url.endswith("/users/@me/channels"), f"unexpected url: {url}"
+
+    def test_authorization_header_is_bot_token(self):
+        fake = _FakeHttp([_ok({"id": "111222333444555"})])
+        get_dm_channel_id("999888777", "my-bot-token", http_post=fake)
+
+        _, headers, _ = fake.calls[0]
+        assert headers.get("Authorization") == "Bot my-bot-token"
+
+    def test_returns_channel_id_from_response(self):
+        expected_channel = "111222333444555"
+        fake = _FakeHttp([_ok({"id": expected_channel, "type": 1})])
+        result = get_dm_channel_id("999888777", "tok", http_post=fake)
+        assert result == expected_channel
+
+    def test_recipient_id_in_request_body(self):
+        fake = _FakeHttp([_ok({"id": "chan1"})])
+        get_dm_channel_id("user-abc", "tok", http_post=fake)
+        _, _, body = fake.calls[0]
+        assert body == {"recipient_id": "user-abc"}
+
+    def test_no_real_network(self):
+        fake = _FakeHttp([_ok({"id": "chan1"})])
+        get_dm_channel_id("user-abc", "tok", http_post=fake)
+        fake.assert_no_network()
+
+    def test_raises_on_4xx(self):
+        fake = _FakeHttp([_error(403)])
+        with pytest.raises(RuntimeError):
+            get_dm_channel_id("bad-user", "tok", http_post=fake)
+
+
+# ---------------------------------------------------------------------------
+# (b) send_dm — calls get_dm_channel_id then posts to channels/{id}/messages
+# ---------------------------------------------------------------------------
+
+
+class TestSendDm:
+    def test_posts_to_correct_channel_messages_url(self):
+        channel_id = "777666555444"
+        fake = _FakeHttp([
+            _ok({"id": channel_id}),             # DM channel open
+            _ok({"id": "msg-001", "content": "hello"}),  # message POST
+        ])
+        result = send_dm("user-123", "hello", "bot-tok", http_post=fake)
+
+        assert result is True
+        assert len(fake.calls) == 2
+        msg_url, _, msg_body = fake.calls[1]
+        assert f"/channels/{channel_id}/messages" in msg_url
+        assert msg_body == {"content": "hello"}
+
+    def test_authorization_header_on_message_post(self):
+        fake = _FakeHttp([
+            _ok({"id": "chan99"}),
+            _ok({"id": "msg-002"}),
+        ])
+        send_dm("u", "hi", "secret-token", http_post=fake)
+        _, headers, _ = fake.calls[1]
+        assert headers.get("Authorization") == "Bot secret-token"
+
+    def test_first_call_opens_dm_channel(self):
+        """The first http_post goes to /users/@me/channels (get_dm_channel_id)."""
+        fake = _FakeHttp([
+            _ok({"id": "chan-dm"}),
+            _ok({"id": "m1"}),
+        ])
+        send_dm("uid", "msg", "tok", http_post=fake)
+        first_url, _, _ = fake.calls[0]
+        assert "/users/@me/channels" in first_url
+
+    def test_no_real_network(self):
+        fake = _FakeHttp([
+            _ok({"id": "c1"}),
+            _ok({"id": "m1"}),
+        ])
+        send_dm("uid", "msg", "tok", http_post=fake)
+        fake.assert_no_network()
+
+
+# ---------------------------------------------------------------------------
+# (c) HTTP 4xx response causes send_dm to return False without raising
+# ---------------------------------------------------------------------------
+
+
+class TestSendDmErrorHandling:
+    def test_returns_false_on_message_post_4xx(self):
+        """400 on the message post: returns False, does not raise."""
+        fake = _FakeHttp([
+            _ok({"id": "chan1"}),   # DM channel opened OK
+            _error(400),            # message POST fails
+        ])
+        result = send_dm("user", "hello", "tok", http_post=fake)
+        assert result is False
+
+    def test_returns_false_on_403(self):
+        fake = _FakeHttp([
+            _ok({"id": "chan1"}),
+            _error(403),
+        ])
+        result = send_dm("user", "hello", "tok", http_post=fake)
+        assert result is False
+
+    def test_returns_false_on_5xx(self):
+        fake = _FakeHttp([
+            _ok({"id": "chan1"}),
+            _error(500),
+        ])
+        result = send_dm("user", "hello", "tok", http_post=fake)
+        assert result is False
+
+    def test_returns_false_when_channel_open_fails(self):
+        """If get_dm_channel_id raises, send_dm returns False without raising."""
+        fake = _FakeHttp([_error(403)])  # channel open fails
+        result = send_dm("bad-user", "hello", "tok", http_post=fake)
+        assert result is False
+
+    def test_no_second_post_when_channel_open_fails(self):
+        """If channel open fails, no message post is attempted."""
+        fake = _FakeHttp([_error(403)])
+        send_dm("bad-user", "hello", "tok", http_post=fake)
+        assert len(fake.calls) == 1  # only the channel-open attempt
+
+    def test_does_not_raise_on_4xx(self):
+        """4xx must not propagate as an exception — just return False."""
+        fake = _FakeHttp([
+            _ok({"id": "chan1"}),
+            _error(429),
+        ])
+        try:
+            result = send_dm("user", "hello", "tok", http_post=fake)
+        except Exception as exc:
+            pytest.fail(f"send_dm raised unexpectedly: {exc}")
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# (d) Confirm no real network calls (structural guard)
+# ---------------------------------------------------------------------------
+
+
+class TestNoRealNetwork:
+    def test_get_dm_channel_id_uses_only_injected_http(self, monkeypatch):
+        """Patching urllib.request.urlopen to fail proves it is never called."""
+        import urllib.request as urllib_req
+
+        def _boom(*args, **kwargs):
+            pytest.fail("urllib.request.urlopen was called — real network hit!")
+
+        monkeypatch.setattr(urllib_req, "urlopen", _boom)
+
+        fake = _FakeHttp([_ok({"id": "safe-chan"})])
+        result = get_dm_channel_id("u1", "tok", http_post=fake)
+        assert result == "safe-chan"
+
+    def test_send_dm_uses_only_injected_http(self, monkeypatch):
+        import urllib.request as urllib_req
+
+        def _boom(*args, **kwargs):
+            pytest.fail("urllib.request.urlopen was called — real network hit!")
+
+        monkeypatch.setattr(urllib_req, "urlopen", _boom)
+
+        fake = _FakeHttp([_ok({"id": "c1"}), _ok({"id": "m1"})])
+        result = send_dm("u1", "hi", "tok", http_post=fake)
+        assert result is True

--- a/tests/test_session_orchestration_drive_loop.py
+++ b/tests/test_session_orchestration_drive_loop.py
@@ -70,6 +70,9 @@ class _FakeAdapter(AgentAdapter):
     def resume(self, handle: SessionHandle, message: str) -> None:
         self.resume_calls.append(message)
 
+    def terminate(self, handle: SessionHandle) -> None:
+        raise NotImplementedError
+
 
 def _make_event(text: str, thread_id: Optional[str] = None) -> MagicMock:
     """Build a minimal fake MessageEvent."""

--- a/tests/test_session_orchestration_drive_loop.py
+++ b/tests/test_session_orchestration_drive_loop.py
@@ -1,0 +1,367 @@
+"""
+Tests for the T012 drive loop — managed-thread reply → relay drive.
+
+Coverage
+--------
+1. Happy path: a reply in a managed thread (discord_thread_id matches a
+   registry row) calls relay.send_message with the correct task_id and
+   message text.
+2. Unmanaged thread: a reply whose thread_id does NOT match any registry
+   row falls through (returns None from _handle_managed_thread_reply) and
+   does NOT call relay.send_message.
+3. Gating: when session_orchestration.enabled is False the drive intercept
+   is skipped entirely (relay not called even for a matching thread_id).
+4. Empty text: a thread reply with empty/whitespace text is ignored (relay
+   not called, returns None).
+5. Lock conflict: LockConflictError from relay is caught and returned as a
+   user-facing error string (not re-raised).
+6. Unknown agent: a registry row with an unknown agent name returns an error
+   string without raising.
+
+All tests use fakes — no live tmux, no live Discord, no real SQLite on the
+network.  Async tests use asyncio.run() following the repo convention
+(no pytest-asyncio dependency).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from session_orchestration.adapters.base import AgentAdapter
+from session_orchestration.registry import SessionOrchestrationRegistry
+from session_orchestration.relay import LockConflictError, SessionRelay
+from session_orchestration.types import Capabilities, SessionHandle, SessionLifecycle
+
+
+# ---------------------------------------------------------------------------
+# Fakes / helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeAdapter(AgentAdapter):
+    """Stub adapter that records drive/resume calls without touching tmux."""
+
+    def __init__(self, lifecycle: SessionLifecycle = SessionLifecycle.WAITING_USER):
+        self._lifecycle = lifecycle
+        self.drive_calls: List[str] = []
+        self.resume_calls: List[str] = []
+        self.detect_calls: int = 0
+
+    def capabilities(self) -> Capabilities:
+        return Capabilities()
+
+    def launch(self, workdir: str, prompt: str) -> SessionHandle:
+        raise NotImplementedError
+
+    def detect(self, handle: SessionHandle) -> SessionLifecycle:
+        self.detect_calls += 1
+        return self._lifecycle
+
+    def drive(self, handle: SessionHandle, message: str) -> None:
+        self.drive_calls.append(message)
+
+    def resume(self, handle: SessionHandle, message: str) -> None:
+        self.resume_calls.append(message)
+
+
+def _make_event(text: str, thread_id: Optional[str] = None) -> MagicMock:
+    """Build a minimal fake MessageEvent."""
+    event = MagicMock()
+    event.text = text
+    event.internal = False
+    source = MagicMock()
+    source.thread_id = thread_id
+    event.source = source
+    event.get_command.return_value = None
+    return event
+
+
+def _seed_registry_row(
+    registry: SessionOrchestrationRegistry,
+    task_id: str,
+    *,
+    agent: str = "claude-code",
+    tmux_session: str = "hermes-test-sess",
+    discord_thread_id: Optional[str] = None,
+) -> None:
+    """Insert a minimal RUNNING row with an optional discord_thread_id."""
+    registry.upsert(
+        task_id,
+        agent=agent,
+        tmux_session=tmux_session,
+        state="RUNNING",
+        discord_thread_id=discord_thread_id,
+    )
+
+
+# Import the method under test (unbound).
+from gateway.run import GatewayRunner as _GW  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "state.db"
+
+
+@pytest.fixture()
+def registry(db_path: Path) -> SessionOrchestrationRegistry:
+    return SessionOrchestrationRegistry(db_path=db_path)
+
+
+# ---------------------------------------------------------------------------
+# 1. Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_managed_thread_reply_routes_to_relay(
+    db_path: Path, registry: SessionOrchestrationRegistry
+):
+    """Happy path: reply in managed thread → relay.send_message called with correct args."""
+    task_id = str(uuid.uuid4())
+    thread_id = "discord-thread-123"
+    _seed_registry_row(registry, task_id, discord_thread_id=thread_id)
+
+    adapter = _FakeAdapter()
+    relay = SessionRelay(registry, adapter)
+
+    calls: List[tuple] = []
+
+    def _fake_send(tid, handle, message, **kw):
+        calls.append((tid, handle, message))
+
+    relay.send_message = _fake_send
+
+    event = _make_event("hello from discord", thread_id=thread_id)
+
+    async def _run():
+        with (
+            patch(
+                "session_orchestration.registry.SessionOrchestrationRegistry",
+                return_value=registry,
+            ),
+            patch("session_orchestration.spawn.get_adapter", return_value=adapter),
+            patch("session_orchestration.relay.SessionRelay", return_value=relay),
+        ):
+            stub = MagicMock()
+            stub.config = {}
+            return await _GW._handle_managed_thread_reply(stub, event, thread_id)
+
+    result = asyncio.run(_run())
+
+    # The method should return empty string (success sentinel) — NOT an error string.
+    assert result == "" or result is None, f"Unexpected result: {result!r}"
+
+    # Relay was called with the correct task_id and message.
+    assert len(calls) == 1, f"Expected 1 relay call, got {len(calls)}"
+    called_task_id, _handle, called_msg = calls[0]
+    assert called_task_id == task_id, f"Wrong task_id: {called_task_id!r}"
+    assert called_msg == "hello from discord", f"Wrong message: {called_msg!r}"
+
+
+# ---------------------------------------------------------------------------
+# 2. Unmanaged thread is ignored
+# ---------------------------------------------------------------------------
+
+
+def test_unmanaged_thread_is_ignored(
+    db_path: Path, registry: SessionOrchestrationRegistry
+):
+    """A reply in an UNmanaged thread returns None — relay not called."""
+    task_id = str(uuid.uuid4())
+    _seed_registry_row(registry, task_id, discord_thread_id="managed-thread-999")
+
+    event = _make_event("hello", thread_id="unmanaged-thread-000")
+
+    relay_mock = MagicMock()
+
+    async def _run():
+        with (
+            patch(
+                "session_orchestration.registry.SessionOrchestrationRegistry",
+                return_value=registry,
+            ),
+            patch("session_orchestration.relay.SessionRelay", return_value=relay_mock),
+        ):
+            stub = MagicMock()
+            stub.config = {}
+            return await _GW._handle_managed_thread_reply(stub, event, "unmanaged-thread-000")
+
+    result = asyncio.run(_run())
+
+    assert result is None, f"Expected None for unmanaged thread, got {result!r}"
+    relay_mock.send_message.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 3. Gating on session_orchestration.enabled
+# ---------------------------------------------------------------------------
+
+
+def test_drive_loop_gated_off_when_so_disabled(
+    db_path: Path, registry: SessionOrchestrationRegistry
+):
+    """When session_orchestration.enabled is False, the intercept must be skipped."""
+    # Verify that cfg_get returns False for the disabled config.
+    config_disabled: Dict[str, Any] = {"session_orchestration": {"enabled": False}}
+    try:
+        from hermes_cli.config import cfg_get
+        result = cfg_get(config_disabled, "session_orchestration", "enabled", default=False)
+    except Exception:
+        result = False
+
+    assert not result, "session_orchestration.enabled should be False with disabled config"
+
+    # Verify cfg_get returns True for an enabled config.
+    config_enabled: Dict[str, Any] = {"session_orchestration": {"enabled": True}}
+    try:
+        from hermes_cli.config import cfg_get  # type: ignore[no-redef]
+        result_enabled = cfg_get(config_enabled, "session_orchestration", "enabled", default=False)
+    except Exception:
+        result_enabled = False
+
+    assert result_enabled, "session_orchestration.enabled should be True with enabled config"
+
+    # Confirm that when disabled, relay is never called even for a matching thread.
+    task_id = str(uuid.uuid4())
+    thread_id = "discord-thread-gated"
+    _seed_registry_row(registry, task_id, discord_thread_id=thread_id)
+
+    event = _make_event("should be ignored", thread_id=thread_id)
+    relay_mock = MagicMock()
+
+    # When _so_enabled is False, the gateway code does NOT call
+    # _handle_managed_thread_reply at all.  We verify the gating logic itself.
+    _so_enabled = False  # same branch as the gateway's gating block
+    if _so_enabled:
+        asyncio.run(
+            _GW._handle_managed_thread_reply(MagicMock(), event, thread_id)
+        )
+
+    relay_mock.send_message.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 4. Empty message is ignored
+# ---------------------------------------------------------------------------
+
+
+def test_empty_message_is_ignored(
+    db_path: Path, registry: SessionOrchestrationRegistry
+):
+    """A managed-thread reply with empty/whitespace text is silently ignored."""
+    task_id = str(uuid.uuid4())
+    thread_id = "discord-thread-empty"
+    _seed_registry_row(registry, task_id, discord_thread_id=thread_id)
+
+    event = _make_event("   ", thread_id=thread_id)  # whitespace only
+
+    relay_mock = MagicMock()
+
+    async def _run():
+        with (
+            patch(
+                "session_orchestration.registry.SessionOrchestrationRegistry",
+                return_value=registry,
+            ),
+            patch("session_orchestration.relay.SessionRelay", return_value=relay_mock),
+        ):
+            stub = MagicMock()
+            stub.config = {}
+            return await _GW._handle_managed_thread_reply(stub, event, thread_id)
+
+    result = asyncio.run(_run())
+
+    assert result is None, f"Expected None for empty message, got {result!r}"
+    relay_mock.send_message.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 5. Lock conflict returns user-facing error
+# ---------------------------------------------------------------------------
+
+
+def test_lock_conflict_returns_user_error(
+    db_path: Path, registry: SessionOrchestrationRegistry
+):
+    """LockConflictError from relay is caught and returned as a user-facing string."""
+    task_id = str(uuid.uuid4())
+    thread_id = "discord-thread-locked"
+    _seed_registry_row(registry, task_id, discord_thread_id=thread_id)
+
+    adapter = _FakeAdapter()
+    relay_mock = MagicMock()
+    relay_mock.send_message.side_effect = LockConflictError("test lock conflict")
+
+    event = _make_event("message while locked", thread_id=thread_id)
+
+    async def _run():
+        with (
+            patch(
+                "session_orchestration.registry.SessionOrchestrationRegistry",
+                return_value=registry,
+            ),
+            patch("session_orchestration.spawn.get_adapter", return_value=adapter),
+            patch("session_orchestration.relay.SessionRelay", return_value=relay_mock),
+        ):
+            stub = MagicMock()
+            stub.config = {}
+            return await _GW._handle_managed_thread_reply(stub, event, thread_id)
+
+    result = asyncio.run(_run())
+
+    assert result is not None, "Expected error string, got None"
+    # Must contain a user-friendly message about the session being busy.
+    assert any(
+        kw in result.lower() for kw in ("busy", "conflict", "moment", "try again")
+    ), f"Expected busy/conflict message, got: {result!r}"
+
+
+# ---------------------------------------------------------------------------
+# 6. Unknown agent returns error string (does not raise)
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_agent_returns_error(
+    db_path: Path, registry: SessionOrchestrationRegistry
+):
+    """A registry row with an unknown agent name returns an error string without raising."""
+    task_id = str(uuid.uuid4())
+    thread_id = "discord-thread-badagent"
+    registry.upsert(
+        task_id,
+        agent="nonexistent-agent-xyz",
+        tmux_session="hermes-test",
+        state="RUNNING",
+        discord_thread_id=thread_id,
+    )
+
+    event = _make_event("some message", thread_id=thread_id)
+
+    async def _run():
+        # Do NOT patch get_adapter — let it raise UnknownAgentError naturally.
+        with patch(
+            "session_orchestration.registry.SessionOrchestrationRegistry",
+            return_value=registry,
+        ):
+            stub = MagicMock()
+            stub.config = {}
+            return await _GW._handle_managed_thread_reply(stub, event, thread_id)
+
+    result = asyncio.run(_run())
+
+    assert result is not None, "Expected error string, got None"
+    assert any(
+        kw in result.lower() for kw in ("agent", "unknown", "cannot", "drive")
+    ), f"Expected agent error message, got: {result!r}"

--- a/tests/test_session_orchestration_drive_queue.py
+++ b/tests/test_session_orchestration_drive_queue.py
@@ -1,0 +1,389 @@
+"""
+Tests for the busy-session drive-queue recovery path (drive-queue-recovery).
+
+A reply sent to a managed session that is busy (RUNNING) must not be dropped:
+it is enqueued into the persistent pending-drive store and redelivered by the
+watcher once the session next becomes idle (WAITING_USER), or expired after a
+TTL with a user notification.
+
+Coverage
+--------
+Registry (T001, single-writer invariant):
+  * enqueue_pending_drive is a plain append-only INSERT usable without a
+    session_orchestration row or any lock.
+  * list_pending_drive returns entries FIFO; delete/bump mutate correctly.
+
+Gateway drive loop (T002):
+  * A RUNNING session enqueues the reply (relay NOT driven) + queued ack.
+  * A TimeoutError from send_message enqueues rather than dropping.
+
+Watcher (T003 redelivery, T004 TTL):
+  * Redelivery on WAITING_USER drives FIFO, deletes entries, posts confirmation.
+  * A failed (TimeoutError) redelivery keeps the entry and bumps attempts.
+  * A TTL-expired entry is dropped with a notice; a fresh entry is kept.
+  * TTL expiry runs even when the session is not WAITING_USER.
+
+Async tests use asyncio.run() following the repo convention.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import List, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from session_orchestration.adapters.base import AgentAdapter
+from session_orchestration.registry import SessionOrchestrationRegistry
+from session_orchestration.relay import LockConflictError
+from session_orchestration.types import Capabilities, SessionHandle, SessionLifecycle
+from session_orchestration.watcher import SessionWatcher
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / fakes
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "state.db"
+
+
+@pytest.fixture()
+def registry(db_path: Path) -> SessionOrchestrationRegistry:
+    return SessionOrchestrationRegistry(db_path=db_path)
+
+
+class _FakeAdapter(AgentAdapter):
+    """Stub adapter recording drive calls; drive may be made to raise."""
+
+    def __init__(
+        self,
+        lifecycle: SessionLifecycle = SessionLifecycle.WAITING_USER,
+        drive_exc: Optional[BaseException] = None,
+    ):
+        self._lifecycle = lifecycle
+        self._drive_exc = drive_exc
+        self.drive_calls: List[str] = []
+
+    def capabilities(self) -> Capabilities:
+        return Capabilities()
+
+    def launch(self, workdir: str, prompt: str) -> SessionHandle:
+        raise NotImplementedError
+
+    def detect(self, handle: SessionHandle) -> SessionLifecycle:
+        return self._lifecycle
+
+    def drive(self, handle: SessionHandle, message: str, *, pre_keys=None) -> None:
+        if self._drive_exc is not None:
+            raise self._drive_exc
+        self.drive_calls.append(message)
+
+    def resume(self, handle: SessionHandle, message: str) -> None:
+        raise NotImplementedError
+
+    def terminate(self, handle: SessionHandle) -> None:
+        raise NotImplementedError
+
+
+def _seed_row(
+    registry: SessionOrchestrationRegistry,
+    task_id: str,
+    *,
+    tmux_session: str = "hermes-test-sess",
+    discord_thread_id: Optional[str] = None,
+) -> dict:
+    registry.upsert(
+        task_id,
+        agent="omp",
+        tmux_session=tmux_session,
+        state="RUNNING",
+        discord_thread_id=discord_thread_id,
+    )
+    return registry.get(task_id)
+
+
+def _make_event(text: str, thread_id: Optional[str] = None) -> MagicMock:
+    event = MagicMock()
+    event.text = text
+    event.internal = False
+    source = MagicMock()
+    source.thread_id = thread_id
+    event.source = source
+    event.get_command.return_value = None
+    return event
+
+
+# ===========================================================================
+# T001 — registry pending-drive store (single-writer invariant)
+# ===========================================================================
+
+
+def test_enqueue_pending_drive_is_append_only_without_row_or_lock(registry):
+    """enqueue works with no session_orchestration row and no lock held."""
+    task_id = str(uuid.uuid4())
+    # No _seed_row, no acquire_lock — a pure append from any thread.
+    registry.enqueue_pending_drive(task_id, "queued msg", pre_keys=["Escape"])
+
+    entries = registry.list_pending_drive(task_id)
+    assert len(entries) == 1
+    assert entries[0]["message"] == "queued msg"
+    assert entries[0]["pre_keys"] == '["Escape"]'
+    assert entries[0]["attempts"] == 0
+
+
+def test_list_pending_drive_is_fifo_and_delete_bump_work(registry):
+    task_id = str(uuid.uuid4())
+    registry.enqueue_pending_drive(task_id, "first")
+    registry.enqueue_pending_drive(task_id, "second")
+    registry.enqueue_pending_drive(task_id, "third")
+
+    entries = registry.list_pending_drive(task_id)
+    assert [e["message"] for e in entries] == ["first", "second", "third"]
+
+    registry.bump_pending_drive_attempt(entries[0]["id"])
+    registry.bump_pending_drive_attempt(entries[0]["id"])
+    registry.delete_pending_drive(entries[1]["id"])
+
+    remaining = registry.list_pending_drive(task_id)
+    assert [e["message"] for e in remaining] == ["first", "third"]
+    assert remaining[0]["attempts"] == 2
+
+
+def test_pending_drive_is_scoped_by_task_id(registry):
+    registry.enqueue_pending_drive("task-a", "a1")
+    registry.enqueue_pending_drive("task-b", "b1")
+    assert [e["message"] for e in registry.list_pending_drive("task-a")] == ["a1"]
+    assert [e["message"] for e in registry.list_pending_drive("task-b")] == ["b1"]
+
+
+# ===========================================================================
+# T002 — gateway enqueue-on-busy
+# ===========================================================================
+
+from gateway.run import GatewayRunner as _GW  # noqa: E402
+
+
+def test_running_session_enqueues_reply_and_acks(registry):
+    """A RUNNING session enqueues the reply instead of driving it."""
+    task_id = str(uuid.uuid4())
+    thread_id = "discord-thread-busy"
+    _seed_row(registry, task_id, discord_thread_id=thread_id)
+
+    adapter = _FakeAdapter(lifecycle=SessionLifecycle.RUNNING)
+    relay_mock = MagicMock()
+    event = _make_event("reply while busy", thread_id=thread_id)
+
+    async def _run():
+        with (
+            patch(
+                "session_orchestration.registry.SessionOrchestrationRegistry",
+                return_value=registry,
+            ),
+            patch("session_orchestration.spawn.get_adapter", return_value=adapter),
+            patch("session_orchestration.relay.SessionRelay", return_value=relay_mock),
+        ):
+            stub = MagicMock()
+            stub.config = {}
+            return await _GW._handle_managed_thread_reply(stub, event, thread_id)
+
+    result = asyncio.run(_run())
+
+    # User is told it was queued; relay was NOT driven.
+    assert result is not None and "queued" in result.lower()
+    relay_mock.send_message.assert_not_called()
+    # The reply is persisted for redelivery.
+    entries = registry.list_pending_drive(task_id)
+    assert [e["message"] for e in entries] == ["reply while busy"]
+
+
+def test_send_timeout_enqueues_instead_of_dropping(registry):
+    """A TimeoutError from send_message queues the reply, not the dead-end error."""
+    task_id = str(uuid.uuid4())
+    thread_id = "discord-thread-timeout"
+    _seed_row(registry, task_id, discord_thread_id=thread_id)
+
+    # Idle on pre-check so we reach send_message, which then times out.
+    adapter = _FakeAdapter(lifecycle=SessionLifecycle.WAITING_USER)
+    relay_mock = MagicMock()
+    relay_mock.send_message.side_effect = TimeoutError("pane not ready")
+    event = _make_event("reply that times out", thread_id=thread_id)
+
+    async def _run():
+        with (
+            patch(
+                "session_orchestration.registry.SessionOrchestrationRegistry",
+                return_value=registry,
+            ),
+            patch("session_orchestration.spawn.get_adapter", return_value=adapter),
+            patch("session_orchestration.relay.SessionRelay", return_value=relay_mock),
+        ):
+            stub = MagicMock()
+            stub.config = {}
+            return await _GW._handle_managed_thread_reply(stub, event, thread_id)
+
+    result = asyncio.run(_run())
+
+    assert result is not None and "queued" in result.lower()
+    # It must NOT be the old dead-end message.
+    assert "did not become ready" not in result
+    entries = registry.list_pending_drive(task_id)
+    assert [e["message"] for e in entries] == ["reply that times out"]
+
+
+def test_lock_conflict_still_returns_busy_error_unchanged(registry):
+    """LockConflictError path is unchanged — not enqueued, returns busy error."""
+    task_id = str(uuid.uuid4())
+    thread_id = "discord-thread-lock"
+    _seed_row(registry, task_id, discord_thread_id=thread_id)
+
+    adapter = _FakeAdapter(lifecycle=SessionLifecycle.WAITING_USER)
+    relay_mock = MagicMock()
+    relay_mock.send_message.side_effect = LockConflictError("held")
+    event = _make_event("reply", thread_id=thread_id)
+
+    async def _run():
+        with (
+            patch(
+                "session_orchestration.registry.SessionOrchestrationRegistry",
+                return_value=registry,
+            ),
+            patch("session_orchestration.spawn.get_adapter", return_value=adapter),
+            patch("session_orchestration.relay.SessionRelay", return_value=relay_mock),
+        ):
+            stub = MagicMock()
+            stub.config = {}
+            return await _GW._handle_managed_thread_reply(stub, event, thread_id)
+
+    result = asyncio.run(_run())
+    assert result is not None and "try again" in result.lower()
+    # Lock conflict is transient — the reply is NOT queued.
+    assert registry.list_pending_drive(task_id) == []
+
+
+# ===========================================================================
+# T003 — watcher redelivery on WAITING_USER
+# ===========================================================================
+
+
+def _watcher(registry) -> SessionWatcher:
+    return SessionWatcher(registry=registry, adapters={})
+
+
+def test_redelivery_fifo_deletes_and_confirms(registry):
+    task_id = str(uuid.uuid4())
+    thread_id = "thread-redeliver"
+    row = _seed_row(registry, task_id, discord_thread_id=thread_id)
+    registry.enqueue_pending_drive(task_id, "first queued")
+    registry.enqueue_pending_drive(task_id, "second queued")
+
+    adapter = _FakeAdapter(lifecycle=SessionLifecycle.WAITING_USER)
+    posts: List[str] = []
+    now = datetime.now(tz=timezone.utc)
+
+    with patch(
+        "session_orchestration.feed._post_discord_message",
+        side_effect=lambda ch, content, **kw: posts.append((ch, content)),
+    ):
+        _watcher(registry)._drain_pending_drive(
+            task_id, row, adapter, SessionLifecycle.WAITING_USER.value, now
+        )
+
+    # Both delivered FIFO, both removed, one confirmation each.
+    assert adapter.drive_calls == ["first queued", "second queued"]
+    assert registry.list_pending_drive(task_id) == []
+    assert len(posts) == 2
+    assert all(ch == thread_id for ch, _ in posts)
+
+
+def test_no_redelivery_when_not_waiting_user(registry):
+    task_id = str(uuid.uuid4())
+    row = _seed_row(registry, task_id)
+    registry.enqueue_pending_drive(task_id, "still queued")
+
+    adapter = _FakeAdapter(lifecycle=SessionLifecycle.RUNNING)
+    now = datetime.now(tz=timezone.utc)
+
+    _watcher(registry)._drain_pending_drive(
+        task_id, row, adapter, SessionLifecycle.RUNNING.value, now
+    )
+
+    assert adapter.drive_calls == []
+    # Entry survives (still busy) — not dropped, since it is within TTL.
+    assert [e["message"] for e in registry.list_pending_drive(task_id)] == ["still queued"]
+
+
+def test_failed_redelivery_keeps_entry_and_bumps_attempt(registry):
+    task_id = str(uuid.uuid4())
+    row = _seed_row(registry, task_id)
+    registry.enqueue_pending_drive(task_id, "will fail")
+    registry.enqueue_pending_drive(task_id, "behind it")
+
+    # drive raises TimeoutError → send_message propagates it → entry retained.
+    adapter = _FakeAdapter(
+        lifecycle=SessionLifecycle.WAITING_USER, drive_exc=TimeoutError("busy")
+    )
+    now = datetime.now(tz=timezone.utc)
+
+    _watcher(registry)._drain_pending_drive(
+        task_id, row, adapter, SessionLifecycle.WAITING_USER.value, now
+    )
+
+    entries = registry.list_pending_drive(task_id)
+    # FIFO preserved: the stuck head is kept (attempt bumped), the tail not skipped.
+    assert [e["message"] for e in entries] == ["will fail", "behind it"]
+    assert entries[0]["attempts"] == 1
+    assert entries[1]["attempts"] == 0
+
+
+# ===========================================================================
+# T004 — TTL expiry + notification
+# ===========================================================================
+
+
+def test_ttl_expires_old_entry_with_notice(registry):
+    task_id = str(uuid.uuid4())
+    thread_id = "thread-ttl"
+    row = _seed_row(registry, task_id, discord_thread_id=thread_id)
+    registry.enqueue_pending_drive(task_id, "stale reply")
+
+    adapter = _FakeAdapter(lifecycle=SessionLifecycle.RUNNING)
+    posts: List[str] = []
+    # Evaluate "now" one hour in the future so the just-enqueued entry is
+    # older than the default 600s TTL.
+    future = datetime.now(tz=timezone.utc) + timedelta(hours=1)
+
+    with patch(
+        "session_orchestration.feed._post_discord_message",
+        side_effect=lambda ch, content, **kw: posts.append((ch, content)),
+    ):
+        _watcher(registry)._drain_pending_drive(
+            task_id, row, adapter, SessionLifecycle.RUNNING.value, future
+        )
+
+    # Dropped + user notified, even though the session never went idle.
+    assert registry.list_pending_drive(task_id) == []
+    assert adapter.drive_calls == []
+    assert len(posts) == 1
+    assert "expired" in posts[0][1].lower()
+
+
+def test_ttl_keeps_fresh_entry(registry):
+    task_id = str(uuid.uuid4())
+    row = _seed_row(registry, task_id)
+    registry.enqueue_pending_drive(task_id, "fresh reply")
+
+    adapter = _FakeAdapter(lifecycle=SessionLifecycle.RUNNING)
+    now = datetime.now(tz=timezone.utc)  # age ~0 < TTL
+
+    _watcher(registry)._drain_pending_drive(
+        task_id, row, adapter, SessionLifecycle.RUNNING.value, now
+    )
+
+    assert [e["message"] for e in registry.list_pending_drive(task_id)] == ["fresh reply"]

--- a/tests/test_session_orchestration_drive_queue.py
+++ b/tests/test_session_orchestration_drive_queue.py
@@ -170,15 +170,8 @@ def test_pending_drive_is_scoped_by_task_id(registry):
 from gateway.run import GatewayRunner as _GW  # noqa: E402
 
 
-def test_running_session_enqueues_reply_and_acks(registry):
-    """A RUNNING session enqueues the reply instead of driving it."""
-    task_id = str(uuid.uuid4())
-    thread_id = "discord-thread-busy"
-    _seed_row(registry, task_id, discord_thread_id=thread_id)
-
-    adapter = _FakeAdapter(lifecycle=SessionLifecycle.RUNNING)
-    relay_mock = MagicMock()
-    event = _make_event("reply while busy", thread_id=thread_id)
+def _drive_reply(registry, adapter, relay_mock, text, thread_id):
+    event = _make_event(text, thread_id=thread_id)
 
     async def _run():
         with (
@@ -193,14 +186,78 @@ def test_running_session_enqueues_reply_and_acks(registry):
             stub.config = {}
             return await _GW._handle_managed_thread_reply(stub, event, thread_id)
 
-    result = asyncio.run(_run())
+    return asyncio.run(_run())
 
-    # User is told it was queued; relay was NOT driven.
+
+def test_running_session_type_aheads_not_queued(registry):
+    """A RUNNING session with a live composer is delivered immediately (type-ahead),
+    NOT held in the queue — the composer queues the turn itself."""
+    task_id = str(uuid.uuid4())
+    thread_id = "discord-thread-busy"
+    _seed_row(registry, task_id, discord_thread_id=thread_id)
+
+    adapter = _FakeAdapter(lifecycle=SessionLifecycle.RUNNING)
+    relay_mock = MagicMock()
+    result = _drive_reply(registry, adapter, relay_mock, "reply while busy", thread_id)
+
+    # Delivered (empty success sentinel), not the "queued" ack.
+    assert result == "" or result is None
+    relay_mock.send_message.assert_called_once()
+    _, kwargs = relay_mock.send_message.call_args
+    assert kwargs.get("type_ahead") is True
+    # NOT queued.
+    assert registry.list_pending_drive(task_id) == []
+
+
+def test_tui_not_ready_falls_back_to_queue(registry):
+    """When the composer isn't present (TuiNotReadyError), fall back to the queue."""
+    from session_orchestration.adapters.base import TuiNotReadyError
+
+    task_id = str(uuid.uuid4())
+    thread_id = "discord-thread-boot"
+    _seed_row(registry, task_id, discord_thread_id=thread_id)
+
+    adapter = _FakeAdapter(lifecycle=SessionLifecycle.RUNNING)
+    relay_mock = MagicMock()
+    relay_mock.send_message.side_effect = TuiNotReadyError("no TUI")
+    result = _drive_reply(registry, adapter, relay_mock, "reply while booting", thread_id)
+
     assert result is not None and "queued" in result.lower()
-    relay_mock.send_message.assert_not_called()
-    # The reply is persisted for redelivery.
-    entries = registry.list_pending_drive(task_id)
-    assert [e["message"] for e in entries] == ["reply while busy"]
+    assert [e["message"] for e in registry.list_pending_drive(task_id)] == ["reply while booting"]
+
+
+def test_interrupt_prefix_sends_escape_when_running(registry):
+    """A leading '!' interrupts (Esc pre-key) when the session is RUNNING."""
+    task_id = str(uuid.uuid4())
+    thread_id = "discord-thread-int"
+    _seed_row(registry, task_id, discord_thread_id=thread_id)
+
+    adapter = _FakeAdapter(lifecycle=SessionLifecycle.RUNNING)
+    relay_mock = MagicMock()
+    result = _drive_reply(registry, adapter, relay_mock, "!stop and do this", thread_id)
+
+    assert result == "" or result is None
+    _, kwargs = relay_mock.send_message.call_args
+    assert kwargs.get("type_ahead") is True
+    assert "Escape" in (kwargs.get("pre_keys") or [])
+    # The '!' is stripped from the delivered text.
+    args, _ = relay_mock.send_message.call_args
+    assert args[2] == "stop and do this"
+
+
+def test_interrupt_prefix_no_escape_when_idle(registry):
+    """'!' at an idle (WAITING_USER) session delivers without Esc."""
+    task_id = str(uuid.uuid4())
+    thread_id = "discord-thread-int2"
+    _seed_row(registry, task_id, discord_thread_id=thread_id)
+
+    adapter = _FakeAdapter(lifecycle=SessionLifecycle.WAITING_USER)
+    relay_mock = MagicMock()
+    result = _drive_reply(registry, adapter, relay_mock, "!go", thread_id)
+
+    assert result == "" or result is None
+    _, kwargs = relay_mock.send_message.call_args
+    assert "Escape" not in (kwargs.get("pre_keys") or [])
 
 
 def test_send_timeout_enqueues_instead_of_dropping(registry):

--- a/tests/test_session_orchestration_drive_queue.py
+++ b/tests/test_session_orchestration_drive_queue.py
@@ -374,6 +374,27 @@ def test_ttl_expires_old_entry_with_notice(registry):
     assert "expired" in posts[0][1].lower()
 
 
+def test_handle_targets_pinned_pane_not_active_window(registry):
+    """_build_handle_from_row targets the pinned pane id, not the bare session.
+
+    Regression: with only tmux_session, capture/drive resolve to the session's
+    ACTIVE window — a shell once the session gains other windows. The pinned
+    pane id (%N) is immune to that.
+    """
+    from session_orchestration.watcher import _build_handle_from_row
+
+    pinned = _build_handle_from_row(
+        {"task_id": "t1", "tmux_session": "hermes-omp-abc", "pane": "%50"}
+    )
+    assert pinned.pane == "%50"
+
+    # Legacy row without a pinned pane falls back to the session name.
+    legacy = _build_handle_from_row(
+        {"task_id": "t2", "tmux_session": "hermes-omp-xyz", "pane": None}
+    )
+    assert legacy.pane == "hermes-omp-xyz"
+
+
 def test_ttl_keeps_fresh_entry(registry):
     task_id = str(uuid.uuid4())
     row = _seed_row(registry, task_id)

--- a/tests/test_session_orchestration_drive_queue.py
+++ b/tests/test_session_orchestration_drive_queue.py
@@ -29,8 +29,8 @@ Async tests use asyncio.run() following the repo convention.
 from __future__ import annotations
 
 import asyncio
+import time
 import uuid
-from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import List, Optional
 from unittest.mock import MagicMock, patch
@@ -285,7 +285,7 @@ def test_redelivery_fifo_deletes_and_confirms(registry):
 
     adapter = _FakeAdapter(lifecycle=SessionLifecycle.WAITING_USER)
     posts: List[str] = []
-    now = datetime.now(tz=timezone.utc)
+    now = time.time()
 
     with patch(
         "session_orchestration.feed._post_discord_message",
@@ -308,7 +308,7 @@ def test_no_redelivery_when_not_waiting_user(registry):
     registry.enqueue_pending_drive(task_id, "still queued")
 
     adapter = _FakeAdapter(lifecycle=SessionLifecycle.RUNNING)
-    now = datetime.now(tz=timezone.utc)
+    now = time.time()
 
     _watcher(registry)._drain_pending_drive(
         task_id, row, adapter, SessionLifecycle.RUNNING.value, now
@@ -329,7 +329,7 @@ def test_failed_redelivery_keeps_entry_and_bumps_attempt(registry):
     adapter = _FakeAdapter(
         lifecycle=SessionLifecycle.WAITING_USER, drive_exc=TimeoutError("busy")
     )
-    now = datetime.now(tz=timezone.utc)
+    now = time.time()
 
     _watcher(registry)._drain_pending_drive(
         task_id, row, adapter, SessionLifecycle.WAITING_USER.value, now
@@ -356,8 +356,8 @@ def test_ttl_expires_old_entry_with_notice(registry):
     adapter = _FakeAdapter(lifecycle=SessionLifecycle.RUNNING)
     posts: List[str] = []
     # Evaluate "now" one hour in the future so the just-enqueued entry is
-    # older than the default 600s TTL.
-    future = datetime.now(tz=timezone.utc) + timedelta(hours=1)
+    # older than the default 600s TTL. (POSIX float, matching self._now_fn.)
+    future = time.time() + 3600
 
     with patch(
         "session_orchestration.feed._post_discord_message",
@@ -380,7 +380,7 @@ def test_ttl_keeps_fresh_entry(registry):
     registry.enqueue_pending_drive(task_id, "fresh reply")
 
     adapter = _FakeAdapter(lifecycle=SessionLifecycle.RUNNING)
-    now = datetime.now(tz=timezone.utc)  # age ~0 < TTL
+    now = time.time()  # age ~0 < TTL
 
     _watcher(registry)._drain_pending_drive(
         task_id, row, adapter, SessionLifecycle.RUNNING.value, now

--- a/tests/test_session_orchestration_feed.py
+++ b/tests/test_session_orchestration_feed.py
@@ -385,3 +385,169 @@ class TestPushTurnChangeSummarizeFn:
         )
         for _, content in tracker.calls:
             assert "SHOULD_NOT_APPEAR" not in content
+
+
+# ---------------------------------------------------------------------------
+# T013 — DONE/RUNNING icons, WAITING_USER DM, hang stale DM
+# ---------------------------------------------------------------------------
+
+
+class TestPushTurnChangeIcons:
+    """T013: DONE and RUNNING states render distinct icons in the posted message."""
+
+    def test_done_icon_in_message(self):
+        """new_state=DONE must produce a message containing '✅'."""
+        tracker = _FakePostTracker()
+        row = _make_row(task_id="t-done-icon", thread_id=None)
+
+        with patch.object(feed_mod, "_post_discord_message", tracker):
+            result = push_turn_change(
+                "t-done-icon",
+                row,
+                new_state="DONE",
+                old_state="RUNNING",
+                feed_channel_id="feed-ch-done",
+            )
+
+        assert result is True
+        assert tracker.calls, "at least one post expected"
+        for _, content in tracker.calls:
+            assert "✅" in content, f"DONE icon '✅' not in message: {content!r}"
+
+    def test_running_icon_in_message(self):
+        """new_state=RUNNING must produce a message containing '▶'."""
+        tracker = _FakePostTracker()
+        row = _make_row(task_id="t-running-icon", thread_id=None)
+
+        with patch.object(feed_mod, "_post_discord_message", tracker):
+            result = push_turn_change(
+                "t-running-icon",
+                row,
+                new_state="RUNNING",
+                old_state="WAITING_USER",
+                feed_channel_id="feed-ch-running",
+            )
+
+        assert result is True
+        assert tracker.calls, "at least one post expected"
+        for _, content in tracker.calls:
+            assert "▶" in content, f"RUNNING icon '▶' not in message: {content!r}"
+
+
+class TestPushTurnChangeWaitingUserDM:
+    """T013: push_turn_change sends a DM when new_state=WAITING_USER and user_id present."""
+
+    def test_waiting_user_sends_dm(self, monkeypatch):
+        """WAITING_USER + discord_user_id -> send_dm called with the message."""
+        tracker = _FakePostTracker()
+        dm_calls: list = []
+
+        monkeypatch.setattr(
+            "tools.discord_tool._get_bot_token",
+            lambda: "fake-bot-token",
+        )
+        monkeypatch.setattr(
+            "session_orchestration.dm_transport.send_dm",
+            lambda user_id, message, token, **kw: dm_calls.append((user_id, message, token)),
+        )
+
+        row = _make_row(task_id="t-dm-wu-001", thread_id=None)
+        row["discord_user_id"] = "user-dm-001"
+
+        with patch.object(feed_mod, "_post_discord_message", tracker):
+            push_turn_change(
+                "t-dm-wu-001",
+                row,
+                new_state="WAITING_USER",
+                old_state="RUNNING",
+                feed_channel_id="feed-ch-dm",
+            )
+
+        assert len(dm_calls) == 1, "send_dm must be called exactly once"
+        user_id_sent, message, token = dm_calls[0]
+        assert user_id_sent == "user-dm-001"
+        assert token == "fake-bot-token"
+
+    def test_waiting_user_no_dm_when_no_user_id(self, monkeypatch):
+        """WAITING_USER without discord_user_id: send_dm must NOT be called."""
+        tracker = _FakePostTracker()
+        dm_calls: list = []
+
+        monkeypatch.setattr(
+            "session_orchestration.dm_transport.send_dm",
+            lambda *a, **kw: dm_calls.append(a),
+        )
+
+        row = _make_row(task_id="t-dm-wu-noid", thread_id=None)
+        # No discord_user_id key in row
+
+        with patch.object(feed_mod, "_post_discord_message", tracker):
+            push_turn_change(
+                "t-dm-wu-noid",
+                row,
+                new_state="WAITING_USER",
+                old_state="RUNNING",
+                feed_channel_id="feed-ch-dm-noid",
+            )
+
+        assert dm_calls == [], "send_dm must NOT be called when discord_user_id absent"
+
+
+class TestPushHangNotificationDM:
+    """T013: push_hang_notification sends a DM on the first stale rung only."""
+
+    def test_hang_stale_sends_dm(self, monkeypatch):
+        """escalate=False + discord_user_id -> send_dm called once."""
+        from session_orchestration.feed import push_hang_notification
+
+        dm_calls: list = []
+        monkeypatch.setattr("tools.discord_tool._get_bot_token", lambda: "tok-hang")
+        monkeypatch.setattr(
+            "session_orchestration.dm_transport.send_dm",
+            lambda user_id, message, token, **kw: dm_calls.append((user_id, message, token)),
+        )
+
+        tracker = _FakePostTracker()
+        row = _make_row(task_id="t-hang-stale-dm", thread_id=None)
+        row["discord_user_id"] = "user-hang-001"
+        row["idle_ticks"] = 5
+
+        with patch.object(feed_mod, "_post_discord_message", tracker):
+            push_hang_notification(
+                "t-hang-stale-dm",
+                row,
+                escalate=False,
+                feed_channel_id="feed-ch-hang",
+            )
+
+        assert len(dm_calls) == 1, "send_dm must be called exactly once for stale rung"
+        user_id_sent, _msg, token = dm_calls[0]
+        assert user_id_sent == "user-hang-001"
+        assert token == "tok-hang"
+
+    def test_hang_escalate_no_stale_dm(self, monkeypatch):
+        """escalate=True: push_hang_notification must NOT call send_dm (T010 handles it)."""
+        from session_orchestration.feed import push_hang_notification
+
+        dm_calls: list = []
+        monkeypatch.setattr(
+            "session_orchestration.dm_transport.send_dm",
+            lambda *a, **kw: dm_calls.append(a),
+        )
+
+        tracker = _FakePostTracker()
+        row = _make_row(task_id="t-hang-esc-nodm", thread_id=None)
+        row["discord_user_id"] = "user-hang-esc"
+        row["idle_ticks"] = 5
+
+        with patch.object(feed_mod, "_post_discord_message", tracker):
+            push_hang_notification(
+                "t-hang-esc-nodm",
+                row,
+                escalate=True,
+                feed_channel_id="feed-ch-hang-esc",
+            )
+
+        assert dm_calls == [], (
+            "send_dm must NOT be called by push_hang_notification when escalate=True"
+        )

--- a/tests/test_session_orchestration_feed.py
+++ b/tests/test_session_orchestration_feed.py
@@ -174,6 +174,31 @@ class TestPushTurnChange:
             )
         ]
 
+    def test_waiting_user_notice_at_mentions_requesting_user(self):
+        """When the row carries discord_user_id, the thread notice must lead
+        with an <@uid> mention so the user is actually pinged."""
+        tracker = _FakePostTracker()
+        row = _make_row(task_id="t-mention", thread_id="thread-333")
+        row["discord_user_id"] = "555000111"
+
+        with patch.object(feed_mod, "_post_discord_message", tracker):
+            result = push_turn_change(
+                "t-mention",
+                row,
+                new_state="WAITING_USER",
+                old_state="RUNNING",
+                feed_channel_id="feed-ch-001",
+            )
+
+        assert result is True
+        assert tracker.calls == [
+            (
+                "thread-333",
+                "<@555000111> 🔔 **[claude] t-mention** needs your input | my-project\n"
+                "State: `RUNNING` → `WAITING_USER`",
+            )
+        ], "notice must be prefixed with the user mention"
+
     def test_transition_to_paused_handoff_posts_once_to_thread(self):
         tracker = _FakePostTracker()
         row = _make_row(task_id="t-002", thread_id="thread-222")

--- a/tests/test_session_orchestration_feed.py
+++ b/tests/test_session_orchestration_feed.py
@@ -1,5 +1,5 @@
 """
-Unit tests for session_orchestration/feed.py (T007).
+Unit tests for session_orchestration/feed.py (T007 / T-FEED-003).
 
 Coverage
 --------
@@ -11,13 +11,25 @@ Coverage
    push fires again.
 4. Missing feed_channel_id: only thread message is posted (not feed channel).
 5. Missing discord_thread_id: only feed channel message is posted.
-6. Both absent: no messages posted, returns False.
+6. Both absent: no messages posted, returns None.
+
+T-FEED-003 coverage (self-pruning feed-board):
+(a) First non-terminal transition: POST to feed → returns new id.
+(b) Second non-terminal transition with existing feed_message_id: PATCH same
+    id → returns same id (no new POST).
+(c) Terminal transition (DONE/ERROR) with existing feed_message_id: DELETE
+    feed message → returns None.
+(d) Per-session THREAD always receives a POST on every transition (append-only
+    unchanged) even when feed uses PATCH or DELETE.
+(e) feed_message_id column migration is idempotent (registry schema test).
 
 All tests use fakes — no live Discord calls.
 """
 
 from __future__ import annotations
 
+import tempfile
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import patch
 
@@ -31,7 +43,7 @@ from session_orchestration.feed import (
 
 
 # ---------------------------------------------------------------------------
-# Fake Discord post helper
+# Fake Discord transport helpers
 # ---------------------------------------------------------------------------
 
 
@@ -54,6 +66,41 @@ class _FakePostTracker:
         return f"fake-msg-id-{self._call_count}"
 
 
+class _FakeEditTracker:
+    """Records calls to _edit_discord_message; always returns True."""
+
+    def __init__(self):
+        self.calls: List[Tuple[str, str, str]] = []  # [(channel_id, msg_id, content)]
+
+    def __call__(
+        self,
+        channel_id: str,
+        message_id: str,
+        content: str,
+        *,
+        token: Optional[str] = None,
+    ) -> bool:
+        self.calls.append((channel_id, message_id, content))
+        return True
+
+
+class _FakeDeleteTracker:
+    """Records calls to _delete_discord_message; always returns True."""
+
+    def __init__(self):
+        self.calls: List[Tuple[str, str]] = []  # [(channel_id, msg_id)]
+
+    def __call__(
+        self,
+        channel_id: str,
+        message_id: str,
+        *,
+        token: Optional[str] = None,
+    ) -> bool:
+        self.calls.append((channel_id, message_id))
+        return True
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -64,6 +111,7 @@ def _make_row(
     agent: str = "claude",
     thread_id: Optional[str] = "thread-999",
     project: str = "my-project",
+    feed_message_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     return {
         "task_id": task_id,
@@ -71,6 +119,7 @@ def _make_row(
         "discord_thread_id": thread_id,
         "project": project,
         "state": "RUNNING",
+        "feed_message_id": feed_message_id,
     }
 
 
@@ -108,7 +157,9 @@ class TestPushTurnChange:
                 feed_channel_id="feed-ch-001",
             )
 
-        assert result is True, "should report at least one message posted"
+        # Returns the new feed message id (non-None = success)
+        assert result is not None, "should return a feed message id when posted"
+        assert isinstance(result, str), "feed message id must be a string"
         # Expect two posts: feed channel + task thread
         channel_ids = [c for c, _ in tracker.calls]
         assert "feed-ch-001" in channel_ids, "must post to feed channel"
@@ -128,7 +179,7 @@ class TestPushTurnChange:
                 feed_channel_id="feed-ch-002",
             )
 
-        assert result is True
+        assert result is not None
         assert len(tracker.calls) == 2  # feed + thread
 
     def test_same_state_second_call_is_suppressed(self):
@@ -154,8 +205,8 @@ class TestPushTurnChange:
                 feed_channel_id="feed-ch-003",
             )
 
-        assert r1 is True, "first call should post"
-        assert r2 is False, "second call (same state) must be suppressed"
+        assert r1 is not None, "first call should return a feed message id"
+        assert r2 is None, "second call (same state) must be suppressed → None"
         # Only 2 posts from the first call
         assert len(tracker.calls) == 2
 
@@ -187,12 +238,15 @@ class TestPushTurnChange:
                 feed_channel_id="feed-ch-004",
             )
 
-        assert r3 is True, "re-armed notification should post"
+        assert r3 is not None, "re-armed notification should return a feed message id"
         # 2 posts per transition × 2 transitions = 4 posts total
         assert len(tracker.calls) == count_after_first * 2
 
     def test_no_feed_channel_only_thread_posts(self):
-        """When no feed_channel_id is configured, only the thread is posted."""
+        """When no feed_channel_id is configured, only the thread is posted.
+
+        Return value is None (no feed message id) since no feed post was made.
+        """
         tracker = _FakePostTracker()
         row = _make_row(task_id="t-005", thread_id="thread-555")
 
@@ -211,8 +265,8 @@ class TestPushTurnChange:
         channel_ids = [c for c, _ in tracker.calls]
         assert "feed-ch-005" not in channel_ids
         assert "thread-555" in channel_ids
-        # Returns True because thread post succeeded
-        assert result is True
+        # Returns None because no feed channel post was made
+        assert result is None
 
     def test_no_thread_id_only_feed_posts(self):
         """When row has no discord_thread_id, only the feed channel is posted."""
@@ -231,10 +285,12 @@ class TestPushTurnChange:
         channel_ids = [c for c, _ in tracker.calls]
         assert "feed-ch-006" in channel_ids
         assert len(tracker.calls) == 1  # only feed
-        assert result is True
+        # Returns the feed message id
+        assert result is not None
+        assert isinstance(result, str)
 
-    def test_no_feed_channel_no_thread_returns_false(self):
-        """Both absent: no posts, returns False."""
+    def test_no_feed_channel_no_thread_returns_none(self):
+        """Both absent: no posts, returns None."""
         tracker = _FakePostTracker()
         row = _make_row(task_id="t-007", thread_id=None)
 
@@ -248,7 +304,7 @@ class TestPushTurnChange:
                     feed_channel_id=None,
                 )
 
-        assert result is False
+        assert result is None
         assert tracker.calls == []
 
 
@@ -292,7 +348,7 @@ class TestPushTurnChangeSummarizeFn:
                 feed_channel_id="feed-ch-q01",
             )
 
-        assert result is True
+        assert result is not None, "should return a feed message id"
         # Both feed and thread messages should contain the question
         for _, content in tracker.calls:
             assert "What should the output format be?" in content, (
@@ -355,7 +411,7 @@ class TestPushTurnChangeSummarizeFn:
 
         assert fn_calls == [], f"summarize_fn must not be called when no question; got: {fn_calls}"
         # Post still succeeds (no question note appended, but message is valid)
-        assert result is True
+        assert result is not None, "must return a feed message id even when no question present"
         for _, content in tracker.calls:
             assert "SHOULD_NOT_APPEAR" not in content
 
@@ -396,11 +452,25 @@ class TestPushTurnChangeIcons:
     """T013: DONE and RUNNING states render distinct icons in the posted message."""
 
     def test_done_icon_in_message(self):
-        """new_state=DONE must produce a message containing '✅'."""
-        tracker = _FakePostTracker()
-        row = _make_row(task_id="t-done-icon", thread_id=None)
+        """new_state=DONE must produce a message containing '✅'.
 
-        with patch.object(feed_mod, "_post_discord_message", tracker):
+        DONE is terminal so the feed channel receives a DELETE (not a POST).
+        We verify icon content via the thread POST, which is always append-only.
+        """
+        post_tracker = _FakePostTracker()
+        delete_tracker = _FakeDeleteTracker()
+        # Give the row a thread so we can read the posted message content,
+        # and an existing feed_message_id so the DELETE path fires.
+        row = _make_row(
+            task_id="t-done-icon",
+            thread_id="thread-done-icon",
+            feed_message_id="existing-feed-msg",
+        )
+
+        with (
+            patch.object(feed_mod, "_post_discord_message", post_tracker),
+            patch.object(feed_mod, "_delete_discord_message", delete_tracker),
+        ):
             result = push_turn_change(
                 "t-done-icon",
                 row,
@@ -409,9 +479,12 @@ class TestPushTurnChangeIcons:
                 feed_channel_id="feed-ch-done",
             )
 
-        assert result is True
-        assert tracker.calls, "at least one post expected"
-        for _, content in tracker.calls:
+        # Terminal state → feed message deleted, result is None
+        assert result is None, "DONE is terminal; feed message id must be None"
+        assert len(delete_tracker.calls) == 1, "feed message must be DELETEd"
+        # Thread still receives a new POST (append-only)
+        assert post_tracker.calls, "thread POST must fire even for DONE"
+        for _, content in post_tracker.calls:
             assert "✅" in content, f"DONE icon '✅' not in message: {content!r}"
 
     def test_running_icon_in_message(self):
@@ -428,7 +501,7 @@ class TestPushTurnChangeIcons:
                 feed_channel_id="feed-ch-running",
             )
 
-        assert result is True
+        assert result is not None, "RUNNING is non-terminal; must return a feed message id"
         assert tracker.calls, "at least one post expected"
         for _, content in tracker.calls:
             assert "▶" in content, f"RUNNING icon '▶' not in message: {content!r}"
@@ -551,3 +624,255 @@ class TestPushHangNotificationDM:
         assert dm_calls == [], (
             "send_dm must NOT be called by push_hang_notification when escalate=True"
         )
+
+
+# ---------------------------------------------------------------------------
+# T-FEED-003 — self-pruning feed board
+# ---------------------------------------------------------------------------
+
+
+class TestFeedBoardSingleMessage:
+    """T-FEED-003: feed channel uses POST / PATCH / DELETE for a single board entry."""
+
+    def test_first_transition_posts_to_feed_returns_new_id(self):
+        """(a) First non-terminal transition: POST to feed → returns a new message id."""
+        post_tracker = _FakePostTracker()
+        edit_tracker = _FakeEditTracker()
+        delete_tracker = _FakeDeleteTracker()
+        # Row has no existing feed_message_id (fresh session)
+        row = _make_row(task_id="t-fb-001", thread_id="thread-fb-001", feed_message_id=None)
+
+        with (
+            patch.object(feed_mod, "_post_discord_message", post_tracker),
+            patch.object(feed_mod, "_edit_discord_message", edit_tracker),
+            patch.object(feed_mod, "_delete_discord_message", delete_tracker),
+        ):
+            result = push_turn_change(
+                "t-fb-001",
+                row,
+                new_state="WAITING_USER",
+                old_state="RUNNING",
+                feed_channel_id="feed-ch-fb",
+            )
+
+        # Must POST (not PATCH or DELETE) to the feed channel
+        feed_posts = [ch for ch, _ in post_tracker.calls if ch == "feed-ch-fb"]
+        assert len(feed_posts) == 1, "exactly one POST to feed channel on first transition"
+        assert result is not None, "must return a non-None feed message id"
+        assert isinstance(result, str), "feed message id must be a string"
+        # No PATCH or DELETE should have been called
+        assert edit_tracker.calls == [], "no PATCH on first POST"
+        assert delete_tracker.calls == [], "no DELETE on first POST"
+
+    def test_second_transition_patches_same_id(self):
+        """(b) Second non-terminal transition with existing feed_message_id: PATCH, no new POST."""
+        post_tracker = _FakePostTracker()
+        edit_tracker = _FakeEditTracker()
+        delete_tracker = _FakeDeleteTracker()
+        existing_id = "existing-feed-msg-42"
+        row = _make_row(
+            task_id="t-fb-002",
+            thread_id="thread-fb-002",
+            feed_message_id=existing_id,
+        )
+
+        with (
+            patch.object(feed_mod, "_post_discord_message", post_tracker),
+            patch.object(feed_mod, "_edit_discord_message", edit_tracker),
+            patch.object(feed_mod, "_delete_discord_message", delete_tracker),
+        ):
+            result = push_turn_change(
+                "t-fb-002",
+                row,
+                new_state="PAUSED_HANDOFF",
+                old_state="RUNNING",
+                feed_channel_id="feed-ch-fb2",
+            )
+
+        # Feed channel must NOT receive a new POST (existing id retained)
+        feed_posts = [ch for ch, _ in post_tracker.calls if ch == "feed-ch-fb2"]
+        assert feed_posts == [], "no new POST to feed channel when existing id present"
+        # Must PATCH the existing message
+        assert len(edit_tracker.calls) == 1, "exactly one PATCH"
+        patched_ch, patched_id, _ = edit_tracker.calls[0]
+        assert patched_ch == "feed-ch-fb2"
+        assert patched_id == existing_id, "PATCH must target the existing message id"
+        # Return value must be the SAME id (retained)
+        assert result == existing_id, "PATCH must return the same feed_message_id"
+        # No DELETE
+        assert delete_tracker.calls == [], "no DELETE on non-terminal PATCH"
+
+    def test_terminal_transition_deletes_feed_message_returns_none(self):
+        """(c) Terminal transition (DONE) with existing feed_message_id: DELETE → returns None."""
+        post_tracker = _FakePostTracker()
+        edit_tracker = _FakeEditTracker()
+        delete_tracker = _FakeDeleteTracker()
+        existing_id = "board-msg-to-reap"
+        row = _make_row(
+            task_id="t-fb-003",
+            thread_id="thread-fb-003",
+            feed_message_id=existing_id,
+        )
+
+        with (
+            patch.object(feed_mod, "_post_discord_message", post_tracker),
+            patch.object(feed_mod, "_edit_discord_message", edit_tracker),
+            patch.object(feed_mod, "_delete_discord_message", delete_tracker),
+        ):
+            result = push_turn_change(
+                "t-fb-003",
+                row,
+                new_state="DONE",
+                old_state="RUNNING",
+                feed_channel_id="feed-ch-fb3",
+            )
+
+        # Must DELETE the existing feed message
+        assert len(delete_tracker.calls) == 1, "exactly one DELETE"
+        del_ch, del_id = delete_tracker.calls[0]
+        assert del_ch == "feed-ch-fb3"
+        assert del_id == existing_id, "DELETE must target the existing message id"
+        # Must return None (reaped)
+        assert result is None, "terminal transition must return None"
+        # No new POST or PATCH
+        feed_posts = [ch for ch, _ in post_tracker.calls if ch == "feed-ch-fb3"]
+        assert feed_posts == [], "no new POST on terminal transition"
+        assert edit_tracker.calls == [], "no PATCH on terminal transition"
+
+    def test_error_state_also_deletes_feed_message(self):
+        """(c) ERROR is also terminal: DELETE existing feed entry → returns None."""
+        post_tracker = _FakePostTracker()
+        edit_tracker = _FakeEditTracker()
+        delete_tracker = _FakeDeleteTracker()
+        existing_id = "board-msg-error-reap"
+        row = _make_row(
+            task_id="t-fb-004",
+            thread_id="thread-fb-004",
+            feed_message_id=existing_id,
+        )
+
+        with (
+            patch.object(feed_mod, "_post_discord_message", post_tracker),
+            patch.object(feed_mod, "_edit_discord_message", edit_tracker),
+            patch.object(feed_mod, "_delete_discord_message", delete_tracker),
+        ):
+            result = push_turn_change(
+                "t-fb-004",
+                row,
+                new_state="ERROR",
+                old_state="RUNNING",
+                feed_channel_id="feed-ch-fb4",
+            )
+
+        assert len(delete_tracker.calls) == 1
+        assert result is None
+
+    def test_thread_always_receives_post_on_every_transition(self):
+        """(d) Thread always receives a new POST regardless of PATCH/DELETE on feed."""
+        post_tracker = _FakePostTracker()
+        edit_tracker = _FakeEditTracker()
+        delete_tracker = _FakeDeleteTracker()
+        existing_id = "board-msg-patch-path"
+        thread_id = "thread-fb-append-only"
+        row = _make_row(
+            task_id="t-fb-005",
+            thread_id=thread_id,
+            feed_message_id=existing_id,
+        )
+
+        with (
+            patch.object(feed_mod, "_post_discord_message", post_tracker),
+            patch.object(feed_mod, "_edit_discord_message", edit_tracker),
+            patch.object(feed_mod, "_delete_discord_message", delete_tracker),
+        ):
+            # Non-terminal: PATCH on feed, POST on thread
+            push_turn_change(
+                "t-fb-005",
+                row,
+                new_state="WAITING_USER",
+                old_state="RUNNING",
+                feed_channel_id="feed-ch-fb5",
+            )
+
+        # Feed was PATCHed (no new post to feed channel)
+        feed_posts = [ch for ch, _ in post_tracker.calls if ch == "feed-ch-fb5"]
+        assert feed_posts == [], "feed channel must not receive a new POST on PATCH path"
+        # Thread must still have received a new POST (append-only)
+        thread_posts = [ch for ch, _ in post_tracker.calls if ch == thread_id]
+        assert len(thread_posts) == 1, "thread must always receive a new POST"
+
+        # Now verify DELETE path also keeps thread append-only
+        feed_mod._last_notified.clear()
+        row2 = _make_row(
+            task_id="t-fb-005b",
+            thread_id=thread_id,
+            feed_message_id=existing_id,
+        )
+        post_tracker.calls.clear()
+        edit_tracker.calls.clear()
+        delete_tracker.calls.clear()
+
+        with (
+            patch.object(feed_mod, "_post_discord_message", post_tracker),
+            patch.object(feed_mod, "_edit_discord_message", edit_tracker),
+            patch.object(feed_mod, "_delete_discord_message", delete_tracker),
+        ):
+            push_turn_change(
+                "t-fb-005b",
+                row2,
+                new_state="DONE",
+                old_state="RUNNING",
+                feed_channel_id="feed-ch-fb5",
+            )
+
+        # Feed was DELETEd
+        assert len(delete_tracker.calls) == 1
+        # Thread still received a new POST (append-only, even on terminal)
+        thread_posts_terminal = [ch for ch, _ in post_tracker.calls if ch == thread_id]
+        assert len(thread_posts_terminal) == 1, (
+            "thread must receive a new POST even on terminal (DONE/ERROR) transitions"
+        )
+
+
+class TestFeedMessageIdMigration:
+    """(e) feed_message_id column migration is idempotent."""
+
+    def test_migration_is_idempotent(self):
+        """Calling _migrate_schema twice on the same DB must not raise."""
+        from session_orchestration.registry import SessionOrchestrationRegistry
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test_state.db"
+            # First instantiation: creates schema + runs migration
+            reg1 = SessionOrchestrationRegistry(db_path=db_path)
+            # Second instantiation: migration is idempotent (ALTER TABLE must
+            # catch OperationalError when column already exists)
+            reg2 = SessionOrchestrationRegistry(db_path=db_path)
+            # Verify the column exists by inserting a row with feed_message_id
+            reg1.upsert(
+                "t-migrate-001",
+                agent="claude",
+                feed_message_id="test-msg-id",
+            )
+            row = reg1.get("t-migrate-001")
+            assert row is not None
+            assert row.get("feed_message_id") == "test-msg-id"
+
+    def test_set_feed_message_id_updates_and_clears(self):
+        """set_feed_message_id sets and clears the feed_message_id column."""
+        from session_orchestration.registry import SessionOrchestrationRegistry
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test_state2.db"
+            reg = SessionOrchestrationRegistry(db_path=db_path)
+            reg.upsert("t-sfmi-001", agent="claude")
+
+            # Set a value
+            reg.set_feed_message_id("t-sfmi-001", "msg-id-abc")
+            row = reg.get("t-sfmi-001")
+            assert row["feed_message_id"] == "msg-id-abc"
+
+            # Clear it (None)
+            reg.set_feed_message_id("t-sfmi-001", None)
+            row = reg.get("t-sfmi-001")
+            assert row["feed_message_id"] is None

--- a/tests/test_session_orchestration_feed.py
+++ b/tests/test_session_orchestration_feed.py
@@ -19,6 +19,7 @@ All tests use fakes — no live Discord calls.
 
 from __future__ import annotations
 
+import json
 from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import patch
 
@@ -174,12 +175,14 @@ class TestPushTurnChange:
             )
         ]
 
-    def test_waiting_user_notice_at_mentions_requesting_user(self):
-        """When the row carries discord_user_id, the thread notice must lead
-        with an <@uid> mention so the user is actually pinged."""
+    def test_at_mention_ping_goes_to_feed_thread_gets_detail(self):
+        """The @-ping lives in #feed (a fresh router post that links to the
+        thread); the thread message carries the detail with NO @-mention (so
+        the user isn't double-pinged)."""
         tracker = _FakePostTracker()
         row = _make_row(task_id="t-mention", thread_id="thread-333")
         row["discord_user_id"] = "555000111"
+        row["last_question"] = "What should I do next?"
 
         with patch.object(feed_mod, "_post_discord_message", tracker):
             result = push_turn_change(
@@ -191,13 +194,30 @@ class TestPushTurnChange:
             )
 
         assert result is True
-        assert tracker.calls == [
-            (
-                "thread-333",
-                "<@555000111> 🔔 **[claude] t-mention** needs your input | my-project\n"
-                "State: `RUNNING` → `WAITING_USER`",
+        channels = [c for c, _ in tracker.calls]
+        assert channels == ["thread-333", "feed-ch-001"], "thread detail + feed ping"
+
+        thread_body = dict(tracker.calls)["thread-333"]
+        feed_body = dict(tracker.calls)["feed-ch-001"]
+        # Thread: detail, NO @-mention.
+        assert "<@555000111>" not in thread_body
+        # Feed: the @-ping router linking to the thread, with a question snippet.
+        assert feed_body.startswith("<@555000111> ")
+        assert "<#thread-333>" in feed_body
+        assert "What should I do next?" in feed_body
+
+    def test_no_feed_ping_without_user_id(self):
+        """No discord_user_id → no feed router ping (only the thread detail)."""
+        tracker = _FakePostTracker()
+        row = _make_row(task_id="t-nouid", thread_id="thread-777")
+
+        with patch.object(feed_mod, "_post_discord_message", tracker):
+            push_turn_change(
+                "t-nouid", row, new_state="WAITING_USER", old_state="RUNNING",
+                feed_channel_id="feed-ch-001",
             )
-        ], "notice must be prefixed with the user mention"
+
+        assert [c for c, _ in tracker.calls] == ["thread-777"]
 
     def test_transition_to_paused_handoff_posts_once_to_thread(self):
         tracker = _FakePostTracker()
@@ -267,6 +287,56 @@ class TestPushTurnChange:
             "thread-444",
             "thread-444",
         ]
+
+    def test_menu_renders_question_and_numbered_options(self):
+        """A WAITING_USER menu row renders the question + numbered options."""
+        tracker = _FakePostTracker()
+        row = _make_row(task_id="t-menu", thread_id="thread-menu")
+        row["last_question"] = "Apply the proposed edit?"
+        row["last_input_kind"] = "menu"
+        row["last_options"] = json.dumps(["Accept", "Defer", "Reject"])
+
+        with patch.object(feed_mod, "_post_discord_message", tracker):
+            push_turn_change(
+                "t-menu", row, new_state="WAITING_USER", old_state="RUNNING",
+                feed_channel_id="feed-ch",
+            )
+
+        assert len(tracker.calls) == 1
+        _, body = tracker.calls[0]
+        assert "Apply the proposed edit?" in body
+        assert "1. Accept" in body
+        assert "2. Defer" in body
+        assert "3. Reject" in body
+        assert "Reply with the option number" in body
+
+    def test_new_question_within_waiting_user_renotifies(self):
+        """A different question in the same WAITING_USER state re-notifies
+        (debounce keys on state + question digest, not state alone)."""
+        tracker = _FakePostTracker()
+        row = _make_row(task_id="t-multi", thread_id="thread-multi")
+        row["last_input_kind"] = "menu"
+
+        with patch.object(feed_mod, "_post_discord_message", tracker):
+            row["last_question"] = "First question?"
+            row["last_options"] = json.dumps(["A", "B"])
+            r1 = push_turn_change(
+                "t-multi", row, new_state="WAITING_USER", old_state="RUNNING",
+            )
+            # Same state, SAME question — suppressed.
+            r2 = push_turn_change(
+                "t-multi", row, new_state="WAITING_USER", old_state="WAITING_USER",
+            )
+            # Same state, NEW question — must re-notify.
+            row["last_question"] = "Second, different question?"
+            row["last_options"] = json.dumps(["C", "D"])
+            r3 = push_turn_change(
+                "t-multi", row, new_state="WAITING_USER", old_state="WAITING_USER",
+            )
+
+        assert r1 is True
+        assert r2 is False
+        assert r3 is True
 
     def test_no_feed_channel_only_thread_posts(self):
         """When no feed_channel_id is configured, the task thread may still post."""
@@ -415,7 +485,10 @@ class TestAttentionDigestRenderer:
         assert content.index("task-high-earlier") < content.index("task-high-later")
         assert content.index("task-high-later") < content.index("task-low")
 
-    def test_renderer_includes_required_row_fields(self):
+    def test_renderer_is_concise_at_mention_router(self):
+        """Each row is a one-line router: thread link + @-mention + identity +
+        reason + detail + a truncated question snippet. Verbose telemetry
+        (age / idle / nudges / priority prose) lives in the thread, not here."""
         now = "2026-06-29T02:00:00+00:00"
         items = [
             {
@@ -433,6 +506,8 @@ class TestAttentionDigestRenderer:
                 "project": "hermes-agent",
                 "tmux_session": "sess-1",
                 "discord_thread_id": "thread-1",
+                "discord_user_id": "555000",
+                "last_question": "Which migration strategy should I use?",
                 "last_output_ts": "2026-06-29T01:45:00+00:00",
                 "idle_ticks": 4,
                 "nudge_count": 2,
@@ -441,15 +516,29 @@ class TestAttentionDigestRenderer:
 
         content = render_attention_digest(items, sessions, now=now)
 
+        # Router essentials present.
+        assert "<#thread-1>" in content
+        assert "<@555000>" in content
         assert "tmux `sess-1`" in content
         assert "claude/hermes-agent" in content
         assert "reason `FROZEN_STALE`" in content
         assert "pane hash unchanged" in content
-        assert "P9/frozen/stuck" in content
-        assert "opened 30m ago" in content
-        assert "last output 15m ago" in content
-        assert "idle 4 tick(s), nudges 2" in content
-        assert "<#thread-1>" in content
+        assert "Which migration strategy should I use?" in content
+        # Verbose telemetry moved to the thread — kept off the board.
+        assert "opened 30m ago" not in content
+        assert "idle 4 tick(s)" not in content
+        assert "P9/frozen/stuck" not in content
+
+    def test_renderer_truncates_long_question(self):
+        now = "2026-06-29T02:00:00+00:00"
+        items = [{"id": 1, "task_id": "task-1", "reason": "WAITING_USER"}]
+        long_q = "word " * 60
+        sessions = {"task-1": {"agent": "omp", "discord_thread_id": "t-9",
+                               "last_question": long_q}}
+        content = render_attention_digest(items, sessions, now=now)
+        assert "…" in content
+        # No single rendered line should carry the full 300-char question.
+        assert long_q.strip() not in content
 
 
 class TestAttentionDigestReconciler:

--- a/tests/test_session_orchestration_feed.py
+++ b/tests/test_session_orchestration_feed.py
@@ -263,3 +263,125 @@ class TestClearLastNotified:
         feed_mod._last_notified["task-x"] = "WAITING_USER"
         clear_last_notified("task-x")
         assert "task-x" not in feed_mod._last_notified
+
+
+# ---------------------------------------------------------------------------
+# T012 — summarize_fn / last_question tests
+# ---------------------------------------------------------------------------
+
+
+class TestPushTurnChangeSummarizeFn:
+    """Tests for the summarize_fn / last_question feature (T012)."""
+
+    def _row_with_question(self, question: str) -> Dict[str, Any]:
+        row = _make_row(task_id="t-q01", thread_id="thread-q01")
+        row["last_question"] = question
+        return row
+
+    def test_push_turn_change_waiting_user_includes_question(self):
+        """WAITING_USER + last_question: message contains the question text."""
+        tracker = _FakePostTracker()
+        row = self._row_with_question("What should the output format be?")
+
+        with patch.object(feed_mod, "_post_discord_message", tracker):
+            result = push_turn_change(
+                "t-q01",
+                row,
+                new_state="WAITING_USER",
+                old_state="RUNNING",
+                feed_channel_id="feed-ch-q01",
+            )
+
+        assert result is True
+        # Both feed and thread messages should contain the question
+        for _, content in tracker.calls:
+            assert "What should the output format be?" in content, (
+                f"question not found in message: {content!r}"
+            )
+        # Must be a readable blockquote, not a raw JSON dump
+        for _, content in tracker.calls:
+            assert content.count("{") == 0, "message must not contain raw JSON braces"
+
+    def test_push_turn_change_summarize_fn_called(self):
+        """When summarize_fn is provided it is called with last_question and its result is embedded."""
+        tracker = _FakePostTracker()
+        question_received: list = []
+
+        def fake_summarize(q: str) -> str:
+            question_received.append(q)
+            return "SUMMARY"
+
+        row = self._row_with_question("Should I use tabs or spaces?")
+
+        with patch.object(feed_mod, "_post_discord_message", tracker):
+            push_turn_change(
+                "t-q01",
+                row,
+                new_state="WAITING_USER",
+                old_state="RUNNING",
+                feed_channel_id="feed-ch-q01",
+                summarize_fn=fake_summarize,
+            )
+
+        # fn must have been called exactly once with the question string
+        assert question_received == ["Should I use tabs or spaces?"], (
+            f"summarize_fn not called correctly; got calls: {question_received}"
+        )
+        # Both posted messages must contain the fn's return value
+        for _, content in tracker.calls:
+            assert "SUMMARY" in content, f"summary not in message: {content!r}"
+
+    def test_push_turn_change_no_question_no_summarize_fn_call(self):
+        """When last_question is absent/empty, summarize_fn is NOT called."""
+        tracker = _FakePostTracker()
+        fn_calls: list = []
+
+        def recording_fn(q: str) -> str:
+            fn_calls.append(q)
+            return "SHOULD_NOT_APPEAR"
+
+        # Row with no last_question key
+        row = _make_row(task_id="t-q02", thread_id="thread-q02")
+
+        with patch.object(feed_mod, "_post_discord_message", tracker):
+            result = push_turn_change(
+                "t-q02",
+                row,
+                new_state="WAITING_USER",
+                old_state="RUNNING",
+                feed_channel_id="feed-ch-q02",
+                summarize_fn=recording_fn,
+            )
+
+        assert fn_calls == [], f"summarize_fn must not be called when no question; got: {fn_calls}"
+        # Post still succeeds (no question note appended, but message is valid)
+        assert result is True
+        for _, content in tracker.calls:
+            assert "SHOULD_NOT_APPEAR" not in content
+
+    def test_push_turn_change_non_waiting_state_no_summarize_fn_call(self):
+        """When new_state != WAITING_USER, summarize_fn is NOT called even if last_question present."""
+        tracker = _FakePostTracker()
+        fn_calls: list = []
+
+        def recording_fn(q: str) -> str:
+            fn_calls.append(q)
+            return "SHOULD_NOT_APPEAR"
+
+        row = self._row_with_question("Is this a good stopping point?")
+
+        with patch.object(feed_mod, "_post_discord_message", tracker):
+            push_turn_change(
+                "t-q01",
+                row,
+                new_state="PAUSED_HANDOFF",
+                old_state="RUNNING",
+                feed_channel_id="feed-ch-q01",
+                summarize_fn=recording_fn,
+            )
+
+        assert fn_calls == [], (
+            f"summarize_fn must not be called for non-WAITING_USER state; got: {fn_calls}"
+        )
+        for _, content in tracker.calls:
+            assert "SHOULD_NOT_APPEAR" not in content

--- a/tests/test_session_orchestration_feed.py
+++ b/tests/test_session_orchestration_feed.py
@@ -1,17 +1,18 @@
 """
-Unit tests for session_orchestration/feed.py (T007).
+Unit tests for session_orchestration/feed.py.
 
 Coverage
 --------
-1. A transition into WAITING_USER pushes exactly one message to feed channel
-   + task thread.
-2. A repeat call with the same state (steady-state tick scenario) pushes
-   nothing (debounce).
-3. A transition back to RUNNING then back to WAITING_USER re-arms — next
-   push fires again.
-4. Missing feed_channel_id: only thread message is posted (not feed channel).
-5. Missing discord_thread_id: only feed channel message is posted.
-6. Both absent: no messages posted, returns False.
+1. Optional task-thread notices for user attention and stale/frozen hooks never
+   duplicate the channel-level feed digest.
+2. The action digest renders deterministic checklist rows with reason,
+   priority/staleness, opened age, last-output age, idle/nudge status, and
+   thread links.
+3. Digest reconciliation posts the first digest, skips unchanged hashes, edits
+   existing messages, recreates missing messages, renders empty state, and
+   avoids registry mutation on Discord failure.
+4. Debounce/re-arm behavior keeps thread-local notices from repeating while the
+   digest remains the sole feed_channel_id attention projection.
 
 All tests use fakes — no live Discord calls.
 """
@@ -27,6 +28,8 @@ import session_orchestration.feed as feed_mod
 from session_orchestration.feed import (
     clear_last_notified,
     push_turn_change,
+    reconcile_attention_digest,
+    render_attention_digest,
 )
 
 
@@ -74,6 +77,60 @@ def _make_row(
     }
 
 
+class _FakeRegistry:
+    def __init__(
+        self,
+        *,
+        attention_items: List[Dict[str, Any]],
+        sessions: Optional[Dict[str, Dict[str, Any]]] = None,
+        projection: Optional[Dict[str, Any]] = None,
+    ):
+        self.attention_items = attention_items
+        self.sessions = sessions or {}
+        self.projection = projection
+        self.upserts: List[Dict[str, Any]] = []
+
+    def list_unresolved_attention_items(self) -> List[Dict[str, Any]]:
+        return [dict(item) for item in self.attention_items]
+
+    def get(self, task_id: str) -> Optional[Dict[str, Any]]:
+        row = self.sessions.get(task_id)
+        return dict(row) if row else None
+
+    def get_projection(
+        self,
+        channel_id: str,
+        projection_name: str,
+    ) -> Optional[Dict[str, Any]]:
+        if self.projection is None:
+            return None
+        if (
+            self.projection.get("channel_id") == channel_id
+            and self.projection.get("projection_name") == projection_name
+        ):
+            return dict(self.projection)
+        return None
+
+    def upsert_projection(
+        self,
+        channel_id: str,
+        projection_name: str,
+        *,
+        message_id: Optional[str] = None,
+        content_hash: Optional[str] = None,
+        payload: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        self.projection = {
+            "channel_id": channel_id,
+            "projection_name": projection_name,
+            "message_id": message_id,
+            "content_hash": content_hash,
+            "payload": payload or {},
+        }
+        self.upserts.append(dict(self.projection))
+        return dict(self.projection)
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -93,9 +150,9 @@ def reset_debounce():
 
 
 class TestPushTurnChange:
-    """push_turn_change posts to feed + thread on a transition."""
+    """push_turn_change posts only optional task-thread notices."""
 
-    def test_transition_to_waiting_user_posts_to_feed_and_thread(self):
+    def test_transition_to_waiting_user_posts_only_to_thread(self):
         tracker = _FakePostTracker()
         row = _make_row(task_id="t-001", thread_id="thread-111")
 
@@ -108,14 +165,16 @@ class TestPushTurnChange:
                 feed_channel_id="feed-ch-001",
             )
 
-        assert result is True, "should report at least one message posted"
-        # Expect two posts: feed channel + task thread
-        channel_ids = [c for c, _ in tracker.calls]
-        assert "feed-ch-001" in channel_ids, "must post to feed channel"
-        assert "thread-111" in channel_ids, "must post to task thread"
-        assert len(tracker.calls) == 2
+        assert result is True, "should report the task-thread notice"
+        assert tracker.calls == [
+            (
+                "thread-111",
+                "🔔 **[claude] t-001** needs your input | my-project\n"
+                "State: `RUNNING` → `WAITING_USER`",
+            )
+        ]
 
-    def test_transition_to_paused_handoff_posts_once(self):
+    def test_transition_to_paused_handoff_posts_once_to_thread(self):
         tracker = _FakePostTracker()
         row = _make_row(task_id="t-002", thread_id="thread-222")
 
@@ -129,7 +188,7 @@ class TestPushTurnChange:
             )
 
         assert result is True
-        assert len(tracker.calls) == 2  # feed + thread
+        assert [channel_id for channel_id, _ in tracker.calls] == ["thread-222"]
 
     def test_same_state_second_call_is_suppressed(self):
         """Repeat call with the same state pushes nothing (debounce)."""
@@ -137,7 +196,6 @@ class TestPushTurnChange:
         row = _make_row(task_id="t-003", thread_id="thread-333")
 
         with patch.object(feed_mod, "_post_discord_message", tracker):
-            # First call: state transition → should post
             r1 = push_turn_change(
                 "t-003",
                 row,
@@ -145,7 +203,6 @@ class TestPushTurnChange:
                 old_state="RUNNING",
                 feed_channel_id="feed-ch-003",
             )
-            # Second call: same state → debounce suppresses
             r2 = push_turn_change(
                 "t-003",
                 row,
@@ -154,10 +211,9 @@ class TestPushTurnChange:
                 feed_channel_id="feed-ch-003",
             )
 
-        assert r1 is True, "first call should post"
+        assert r1 is True, "first call should post to the thread"
         assert r2 is False, "second call (same state) must be suppressed"
-        # Only 2 posts from the first call
-        assert len(tracker.calls) == 2
+        assert [channel_id for channel_id, _ in tracker.calls] == ["thread-333"]
 
     def test_rearm_after_transition_back(self):
         """Transition back to RUNNING then back to WAITING_USER re-arms."""
@@ -165,7 +221,6 @@ class TestPushTurnChange:
         row = _make_row(task_id="t-004", thread_id="thread-444")
 
         with patch.object(feed_mod, "_post_discord_message", tracker):
-            # First transition: RUNNING → WAITING_USER
             push_turn_change(
                 "t-004",
                 row,
@@ -173,12 +228,7 @@ class TestPushTurnChange:
                 old_state="RUNNING",
                 feed_channel_id="feed-ch-004",
             )
-            count_after_first = len(tracker.calls)
-
-            # Session goes back to RUNNING (clear debounce marker)
             clear_last_notified("t-004")
-
-            # Second transition: RUNNING → WAITING_USER again
             r3 = push_turn_change(
                 "t-004",
                 row,
@@ -187,16 +237,17 @@ class TestPushTurnChange:
                 feed_channel_id="feed-ch-004",
             )
 
-        assert r3 is True, "re-armed notification should post"
-        # 2 posts per transition × 2 transitions = 4 posts total
-        assert len(tracker.calls) == count_after_first * 2
+        assert r3 is True, "re-armed thread notice should post"
+        assert [channel_id for channel_id, _ in tracker.calls] == [
+            "thread-444",
+            "thread-444",
+        ]
 
     def test_no_feed_channel_only_thread_posts(self):
-        """When no feed_channel_id is configured, only the thread is posted."""
+        """When no feed_channel_id is configured, the task thread may still post."""
         tracker = _FakePostTracker()
         row = _make_row(task_id="t-005", thread_id="thread-555")
 
-        # Patch config reader to return None
         with patch.object(feed_mod, "_get_feed_channel_id", return_value=None):
             with patch.object(feed_mod, "_post_discord_message", tracker):
                 result = push_turn_change(
@@ -204,18 +255,14 @@ class TestPushTurnChange:
                     row,
                     new_state="WAITING_USER",
                     old_state="RUNNING",
-                    feed_channel_id=None,  # not passed explicitly either
+                    feed_channel_id=None,
                 )
 
-        # Only thread post
-        channel_ids = [c for c, _ in tracker.calls]
-        assert "feed-ch-005" not in channel_ids
-        assert "thread-555" in channel_ids
-        # Returns True because thread post succeeded
         assert result is True
+        assert [channel_id for channel_id, _ in tracker.calls] == ["thread-555"]
 
-    def test_no_thread_id_only_feed_posts(self):
-        """When row has no discord_thread_id, only the feed channel is posted."""
+    def test_no_thread_id_does_not_post_feed_channel_message(self):
+        """When row has no discord_thread_id, digest owns the feed channel."""
         tracker = _FakePostTracker()
         row = _make_row(task_id="t-006", thread_id=None)
 
@@ -228,10 +275,8 @@ class TestPushTurnChange:
                 feed_channel_id="feed-ch-006",
             )
 
-        channel_ids = [c for c, _ in tracker.calls]
-        assert "feed-ch-006" in channel_ids
-        assert len(tracker.calls) == 1  # only feed
-        assert result is True
+        assert result is False
+        assert tracker.calls == []
 
     def test_no_feed_channel_no_thread_returns_false(self):
         """Both absent: no posts, returns False."""
@@ -251,6 +296,54 @@ class TestPushTurnChange:
         assert result is False
         assert tracker.calls == []
 
+    def test_thread_aliasing_feed_channel_is_not_posted_as_one_off(self):
+        tracker = _FakePostTracker()
+        row = _make_row(task_id="t-008", thread_id="feed-ch-008")
+
+        with patch.object(feed_mod, "_post_discord_message", tracker):
+            result = push_turn_change(
+                "t-008",
+                row,
+                new_state="WAITING_USER",
+                old_state="RUNNING",
+                feed_channel_id="feed-ch-008",
+            )
+
+        assert result is False
+        assert tracker.calls == []
+
+
+class TestPushHangNotification:
+    """push_hang_notification posts only optional task-thread notices."""
+
+    def test_hang_notice_posts_only_to_thread(self):
+        tracker = _FakePostTracker()
+        row = _make_row(task_id="t-hang-001", thread_id="thread-hang")
+        row["idle_ticks"] = 4
+
+        with patch.object(feed_mod, "_post_discord_message", tracker):
+            result = feed_mod.push_hang_notification(
+                "t-hang-001",
+                row,
+                feed_channel_id="feed-hang",
+            )
+
+        assert result is True
+        assert [channel_id for channel_id, _ in tracker.calls] == ["thread-hang"]
+
+    def test_hang_notice_never_posts_to_feed_channel_alias(self):
+        tracker = _FakePostTracker()
+        row = _make_row(task_id="t-hang-002", thread_id="feed-hang")
+
+        with patch.object(feed_mod, "_post_discord_message", tracker):
+            result = feed_mod.push_hang_notification(
+                "t-hang-002",
+                row,
+                feed_channel_id="feed-hang",
+            )
+
+        assert result is False
+        assert tracker.calls == []
 
 class TestClearLastNotified:
     """clear_last_notified re-arms the debounce for a task_id."""
@@ -263,3 +356,279 @@ class TestClearLastNotified:
         feed_mod._last_notified["task-x"] = "WAITING_USER"
         clear_last_notified("task-x")
         assert "task-x" not in feed_mod._last_notified
+
+
+class TestAttentionDigestRenderer:
+    def test_renderer_orders_deterministically(self):
+        now = "2026-06-29T02:00:00+00:00"
+        items = [
+            {
+                "id": 3,
+                "task_id": "task-low",
+                "reason": "WAITING_USER",
+                "priority": 1,
+                "opened_at": "2026-06-29T01:10:00+00:00",
+            },
+            {
+                "id": 2,
+                "task_id": "task-high-later",
+                "reason": "STALE",
+                "priority": 5,
+                "opened_at": "2026-06-29T01:30:00+00:00",
+            },
+            {
+                "id": 1,
+                "task_id": "task-high-earlier",
+                "reason": "STALE",
+                "priority": 5,
+                "opened_at": "2026-06-29T01:00:00+00:00",
+            },
+        ]
+
+        content = render_attention_digest(items, now=now)
+
+        assert content.index("task-high-earlier") < content.index("task-high-later")
+        assert content.index("task-high-later") < content.index("task-low")
+
+    def test_renderer_includes_required_row_fields(self):
+        now = "2026-06-29T02:00:00+00:00"
+        items = [
+            {
+                "id": 1,
+                "task_id": "task-1",
+                "reason": "FROZEN_STALE",
+                "priority": 9,
+                "detail": "pane hash unchanged",
+                "opened_at": "2026-06-29T01:30:00+00:00",
+            }
+        ]
+        sessions = {
+            "task-1": {
+                "agent": "claude",
+                "project": "hermes-agent",
+                "tmux_session": "sess-1",
+                "discord_thread_id": "thread-1",
+                "last_output_ts": "2026-06-29T01:45:00+00:00",
+                "idle_ticks": 4,
+                "nudge_count": 2,
+            }
+        }
+
+        content = render_attention_digest(items, sessions, now=now)
+
+        assert "tmux `sess-1`" in content
+        assert "claude/hermes-agent" in content
+        assert "reason `FROZEN_STALE`" in content
+        assert "pane hash unchanged" in content
+        assert "P9/frozen/stuck" in content
+        assert "opened 30m ago" in content
+        assert "last output 15m ago" in content
+        assert "idle 4 tick(s), nudges 2" in content
+        assert "<#thread-1>" in content
+
+
+class TestAttentionDigestReconciler:
+    def test_reconciler_first_post_records_projection(self):
+        registry = _FakeRegistry(attention_items=[])
+        calls: List[Tuple[str, str]] = []
+
+        def fake_post(
+            channel_id: str,
+            content: str,
+            *,
+            token: Optional[str] = None,
+        ) -> Optional[str]:
+            calls.append((channel_id, content))
+            return "msg-1"
+
+        with patch.object(feed_mod, "_post_discord_message", fake_post):
+            result = reconcile_attention_digest(
+                registry,
+                feed_channel_id="feed-1",
+                now="2026-06-29T02:00:00+00:00",
+            )
+
+        assert result["status"] == "posted"
+        assert result["message_id"] == "msg-1"
+        assert calls == [
+            ("feed-1", "**Hermes action feed**\nNo unresolved attention items.")
+        ]
+        assert registry.upserts[0]["message_id"] == "msg-1"
+        assert registry.upserts[0]["payload"] == {"item_count": 0, "task_ids": []}
+
+    def test_reconciler_skips_unchanged_hash(self):
+        now = "2026-06-29T02:00:00+00:00"
+        content = render_attention_digest([], now=now)
+        registry = _FakeRegistry(
+            attention_items=[],
+            projection={
+                "channel_id": "feed-1",
+                "projection_name": feed_mod._ATTENTION_DIGEST_PROJECTION_NAME,
+                "message_id": "msg-1",
+                "content_hash": feed_mod._content_hash(content),
+                "payload": {"item_count": 0, "task_ids": []},
+            },
+        )
+
+        with patch.object(feed_mod, "_post_discord_message") as post:
+            with patch.object(feed_mod, "_edit_discord_message") as edit:
+                result = reconcile_attention_digest(
+                    registry,
+                    feed_channel_id="feed-1",
+                    now=now,
+                )
+
+        assert result["status"] == "unchanged"
+        post.assert_not_called()
+        edit.assert_not_called()
+        assert registry.upserts == []
+
+    def test_reconciler_edits_existing_message(self):
+        registry = _FakeRegistry(
+            attention_items=[
+                {
+                    "id": 1,
+                    "task_id": "task-1",
+                    "reason": "WAITING_USER",
+                    "priority": 3,
+                    "opened_at": "2026-06-29T01:55:00+00:00",
+                }
+            ],
+            projection={
+                "channel_id": "feed-1",
+                "projection_name": feed_mod._ATTENTION_DIGEST_PROJECTION_NAME,
+                "message_id": "msg-1",
+                "content_hash": "old-hash",
+                "payload": {},
+            },
+        )
+
+        with patch.object(
+            feed_mod,
+            "_edit_discord_message",
+            return_value=feed_mod._EDIT_OK,
+        ) as edit:
+            with patch.object(feed_mod, "_post_discord_message") as post:
+                result = reconcile_attention_digest(
+                    registry,
+                    feed_channel_id="feed-1",
+                    now="2026-06-29T02:00:00+00:00",
+                )
+
+        assert result["status"] == "edited"
+        edit.assert_called_once()
+        post.assert_not_called()
+        assert registry.upserts[0]["message_id"] == "msg-1"
+        assert registry.upserts[0]["payload"] == {
+            "item_count": 1,
+            "task_ids": ["task-1"],
+        }
+
+    def test_reconciler_recreates_missing_message(self):
+        registry = _FakeRegistry(
+            attention_items=[
+                {
+                    "id": 1,
+                    "task_id": "task-1",
+                    "reason": "WAITING_USER",
+                    "priority": 100,
+                    "opened_at": "2026-06-29T01:55:00+00:00",
+                }
+            ],
+            projection={
+                "channel_id": "feed-1",
+                "projection_name": feed_mod._ATTENTION_DIGEST_PROJECTION_NAME,
+                "message_id": "missing-msg",
+                "content_hash": "old-hash",
+                "payload": {},
+            },
+        )
+
+        with patch.object(
+            feed_mod,
+            "_edit_discord_message",
+            return_value=feed_mod._EDIT_MISSING,
+        ) as edit:
+            with patch.object(
+                feed_mod,
+                "_post_discord_message",
+                return_value="msg-2",
+            ) as post:
+                result = reconcile_attention_digest(
+                    registry,
+                    feed_channel_id="feed-1",
+                    now="2026-06-29T02:00:00+00:00",
+                )
+
+        assert result["status"] == "recreated"
+        edit.assert_called_once()
+        post.assert_called_once()
+        assert registry.upserts[0]["message_id"] == "msg-2"
+        assert "task-1" in post.call_args.args[1]
+        assert "reason `WAITING_USER`" in post.call_args.args[1]
+        assert registry.upserts[0]["payload"] == {
+            "item_count": 1,
+            "task_ids": ["task-1"],
+        }
+
+    def test_reconciler_posts_empty_state_render(self):
+        registry = _FakeRegistry(attention_items=[])
+        posted: List[str] = []
+
+        def fake_post(
+            channel_id: str,
+            content: str,
+            *,
+            token: Optional[str] = None,
+        ) -> Optional[str]:
+            posted.append(content)
+            return "msg-empty"
+
+        with patch.object(feed_mod, "_post_discord_message", fake_post):
+            result = reconcile_attention_digest(
+                registry,
+                feed_channel_id="feed-1",
+                now="2026-06-29T02:00:00+00:00",
+            )
+
+        assert result["status"] == "posted"
+        assert posted == ["**Hermes action feed**\nNo unresolved attention items."]
+        assert registry.projection is not None
+
+    def test_reconciler_discord_failure_does_not_mutate_registry(self):
+        original_projection = {
+            "channel_id": "feed-1",
+            "projection_name": feed_mod._ATTENTION_DIGEST_PROJECTION_NAME,
+            "message_id": "msg-1",
+            "content_hash": "old-hash",
+            "payload": {"item_count": 99},
+        }
+        registry = _FakeRegistry(
+            attention_items=[
+                {
+                    "id": 1,
+                    "task_id": "task-1",
+                    "reason": "WAITING_USER",
+                    "priority": 3,
+                    "opened_at": "2026-06-29T01:55:00+00:00",
+                }
+            ],
+            projection=dict(original_projection),
+        )
+        original_attention_items = [dict(item) for item in registry.attention_items]
+
+        with patch.object(
+            feed_mod,
+            "_edit_discord_message",
+            return_value=feed_mod._EDIT_FAILED,
+        ):
+            result = reconcile_attention_digest(
+                registry,
+                feed_channel_id="feed-1",
+                now="2026-06-29T02:00:00+00:00",
+            )
+
+        assert result["status"] == "discord_failed"
+        assert registry.upserts == []
+        assert registry.projection == original_projection
+        assert registry.attention_items == original_attention_items

--- a/tests/test_session_orchestration_feed.py
+++ b/tests/test_session_orchestration_feed.py
@@ -1,0 +1,265 @@
+"""
+Unit tests for session_orchestration/feed.py (T007).
+
+Coverage
+--------
+1. A transition into WAITING_USER pushes exactly one message to feed channel
+   + task thread.
+2. A repeat call with the same state (steady-state tick scenario) pushes
+   nothing (debounce).
+3. A transition back to RUNNING then back to WAITING_USER re-arms — next
+   push fires again.
+4. Missing feed_channel_id: only thread message is posted (not feed channel).
+5. Missing discord_thread_id: only feed channel message is posted.
+6. Both absent: no messages posted, returns False.
+
+All tests use fakes — no live Discord calls.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+from unittest.mock import patch
+
+import pytest
+
+import session_orchestration.feed as feed_mod
+from session_orchestration.feed import (
+    clear_last_notified,
+    push_turn_change,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake Discord post helper
+# ---------------------------------------------------------------------------
+
+
+class _FakePostTracker:
+    """Records calls to _post_discord_message and returns a fake message id."""
+
+    def __init__(self):
+        self.calls: List[Tuple[str, str]] = []  # [(channel_id, content), ...]
+        self._call_count = 0
+
+    def __call__(
+        self,
+        channel_id: str,
+        content: str,
+        *,
+        token: Optional[str] = None,
+    ) -> Optional[str]:
+        self.calls.append((channel_id, content))
+        self._call_count += 1
+        return f"fake-msg-id-{self._call_count}"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_row(
+    task_id: str = "task-001",
+    agent: str = "claude",
+    thread_id: Optional[str] = "thread-999",
+    project: str = "my-project",
+) -> Dict[str, Any]:
+    return {
+        "task_id": task_id,
+        "agent": agent,
+        "discord_thread_id": thread_id,
+        "project": project,
+        "state": "RUNNING",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_debounce():
+    """Clear module-level debounce state before + after every test."""
+    feed_mod._last_notified.clear()
+    yield
+    feed_mod._last_notified.clear()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestPushTurnChange:
+    """push_turn_change posts to feed + thread on a transition."""
+
+    def test_transition_to_waiting_user_posts_to_feed_and_thread(self):
+        tracker = _FakePostTracker()
+        row = _make_row(task_id="t-001", thread_id="thread-111")
+
+        with patch.object(feed_mod, "_post_discord_message", tracker):
+            result = push_turn_change(
+                "t-001",
+                row,
+                new_state="WAITING_USER",
+                old_state="RUNNING",
+                feed_channel_id="feed-ch-001",
+            )
+
+        assert result is True, "should report at least one message posted"
+        # Expect two posts: feed channel + task thread
+        channel_ids = [c for c, _ in tracker.calls]
+        assert "feed-ch-001" in channel_ids, "must post to feed channel"
+        assert "thread-111" in channel_ids, "must post to task thread"
+        assert len(tracker.calls) == 2
+
+    def test_transition_to_paused_handoff_posts_once(self):
+        tracker = _FakePostTracker()
+        row = _make_row(task_id="t-002", thread_id="thread-222")
+
+        with patch.object(feed_mod, "_post_discord_message", tracker):
+            result = push_turn_change(
+                "t-002",
+                row,
+                new_state="PAUSED_HANDOFF",
+                old_state="RUNNING",
+                feed_channel_id="feed-ch-002",
+            )
+
+        assert result is True
+        assert len(tracker.calls) == 2  # feed + thread
+
+    def test_same_state_second_call_is_suppressed(self):
+        """Repeat call with the same state pushes nothing (debounce)."""
+        tracker = _FakePostTracker()
+        row = _make_row(task_id="t-003", thread_id="thread-333")
+
+        with patch.object(feed_mod, "_post_discord_message", tracker):
+            # First call: state transition → should post
+            r1 = push_turn_change(
+                "t-003",
+                row,
+                new_state="WAITING_USER",
+                old_state="RUNNING",
+                feed_channel_id="feed-ch-003",
+            )
+            # Second call: same state → debounce suppresses
+            r2 = push_turn_change(
+                "t-003",
+                row,
+                new_state="WAITING_USER",
+                old_state="RUNNING",
+                feed_channel_id="feed-ch-003",
+            )
+
+        assert r1 is True, "first call should post"
+        assert r2 is False, "second call (same state) must be suppressed"
+        # Only 2 posts from the first call
+        assert len(tracker.calls) == 2
+
+    def test_rearm_after_transition_back(self):
+        """Transition back to RUNNING then back to WAITING_USER re-arms."""
+        tracker = _FakePostTracker()
+        row = _make_row(task_id="t-004", thread_id="thread-444")
+
+        with patch.object(feed_mod, "_post_discord_message", tracker):
+            # First transition: RUNNING → WAITING_USER
+            push_turn_change(
+                "t-004",
+                row,
+                new_state="WAITING_USER",
+                old_state="RUNNING",
+                feed_channel_id="feed-ch-004",
+            )
+            count_after_first = len(tracker.calls)
+
+            # Session goes back to RUNNING (clear debounce marker)
+            clear_last_notified("t-004")
+
+            # Second transition: RUNNING → WAITING_USER again
+            r3 = push_turn_change(
+                "t-004",
+                row,
+                new_state="WAITING_USER",
+                old_state="RUNNING",
+                feed_channel_id="feed-ch-004",
+            )
+
+        assert r3 is True, "re-armed notification should post"
+        # 2 posts per transition × 2 transitions = 4 posts total
+        assert len(tracker.calls) == count_after_first * 2
+
+    def test_no_feed_channel_only_thread_posts(self):
+        """When no feed_channel_id is configured, only the thread is posted."""
+        tracker = _FakePostTracker()
+        row = _make_row(task_id="t-005", thread_id="thread-555")
+
+        # Patch config reader to return None
+        with patch.object(feed_mod, "_get_feed_channel_id", return_value=None):
+            with patch.object(feed_mod, "_post_discord_message", tracker):
+                result = push_turn_change(
+                    "t-005",
+                    row,
+                    new_state="WAITING_USER",
+                    old_state="RUNNING",
+                    feed_channel_id=None,  # not passed explicitly either
+                )
+
+        # Only thread post
+        channel_ids = [c for c, _ in tracker.calls]
+        assert "feed-ch-005" not in channel_ids
+        assert "thread-555" in channel_ids
+        # Returns True because thread post succeeded
+        assert result is True
+
+    def test_no_thread_id_only_feed_posts(self):
+        """When row has no discord_thread_id, only the feed channel is posted."""
+        tracker = _FakePostTracker()
+        row = _make_row(task_id="t-006", thread_id=None)
+
+        with patch.object(feed_mod, "_post_discord_message", tracker):
+            result = push_turn_change(
+                "t-006",
+                row,
+                new_state="WAITING_USER",
+                old_state="RUNNING",
+                feed_channel_id="feed-ch-006",
+            )
+
+        channel_ids = [c for c, _ in tracker.calls]
+        assert "feed-ch-006" in channel_ids
+        assert len(tracker.calls) == 1  # only feed
+        assert result is True
+
+    def test_no_feed_channel_no_thread_returns_false(self):
+        """Both absent: no posts, returns False."""
+        tracker = _FakePostTracker()
+        row = _make_row(task_id="t-007", thread_id=None)
+
+        with patch.object(feed_mod, "_get_feed_channel_id", return_value=None):
+            with patch.object(feed_mod, "_post_discord_message", tracker):
+                result = push_turn_change(
+                    "t-007",
+                    row,
+                    new_state="WAITING_USER",
+                    old_state="RUNNING",
+                    feed_channel_id=None,
+                )
+
+        assert result is False
+        assert tracker.calls == []
+
+
+class TestClearLastNotified:
+    """clear_last_notified re-arms the debounce for a task_id."""
+
+    def test_clear_unknown_task_is_noop(self):
+        """Clearing a task that was never notified should not raise."""
+        clear_last_notified("task-never-seen")  # must not raise
+
+    def test_clear_resets_marker(self):
+        feed_mod._last_notified["task-x"] = "WAITING_USER"
+        clear_last_notified("task-x")
+        assert "task-x" not in feed_mod._last_notified

--- a/tests/test_session_orchestration_feed.py
+++ b/tests/test_session_orchestration_feed.py
@@ -813,3 +813,23 @@ class TestAttentionDigestReconciler:
         assert registry.upserts == []
         assert registry.projection == original_projection
         assert registry.attention_items == original_attention_items
+
+
+class TestClampDiscordContent:
+    """_clamp_discord_content keeps posts within Discord's 2000-char hard cap."""
+
+    def test_short_content_unchanged(self):
+        assert feed_mod._clamp_discord_content("hello") == "hello"
+
+    def test_none_becomes_empty(self):
+        assert feed_mod._clamp_discord_content(None) == ""
+
+    def test_oversize_content_clamped_to_limit(self):
+        clamped = feed_mod._clamp_discord_content("x" * 5000)
+        assert len(clamped) <= 2000
+        assert clamped.endswith("… (truncated)")
+        assert clamped.startswith("x")
+
+    def test_exactly_at_limit_unchanged(self):
+        exact = "y" * 2000
+        assert feed_mod._clamp_discord_content(exact) == exact

--- a/tests/test_session_orchestration_feed.py
+++ b/tests/test_session_orchestration_feed.py
@@ -219,6 +219,73 @@ class TestPushTurnChange:
 
         assert [c for c, _ in tracker.calls] == ["thread-777"]
 
+    def test_turn_output_relayed_to_thread_before_detail(self):
+        """turn_output (clean assistant text) posts to the thread first; for a
+        prompt-kind idle the redundant extracted 'question' line is dropped."""
+        tracker = _FakePostTracker()
+        row = _make_row(task_id="t-out", thread_id="thread-out")
+        row["discord_user_id"] = "555000111"
+        row["last_input_kind"] = "prompt"
+        row["last_question"] = "stale last line (would echo)"
+
+        with patch.object(feed_mod, "_post_discord_message", tracker):
+            push_turn_change(
+                "t-out", row, new_state="WAITING_USER", old_state="RUNNING",
+                feed_channel_id="feed-ch-001",
+                turn_output="Here is the full z-explain answer.\nSecond line.",
+            )
+
+        channels = [c for c, _ in tracker.calls]
+        assert channels[0] == "thread-out"  # response chunk first
+        bodies = [b for _, b in tracker.calls]
+        assert "Here is the full z-explain answer." in bodies[0]
+        # Prompt-kind: the extracted last-line 'question' is NOT re-rendered.
+        assert all("stale last line" not in b for b in bodies)
+        # Feed snippet quotes the response tail, not the stale extraction.
+        feed_body = [b for c, b in tracker.calls if c == "feed-ch-001"][0]
+        assert "Second line." in feed_body
+
+    def test_turn_output_chunked_and_capped(self):
+        """Oversized turn_output splits at ~1900 chars and caps with a
+        truncation notice."""
+        tracker = _FakePostTracker()
+        row = _make_row(task_id="t-big", thread_id="thread-big")
+        big = "\n".join(f"line {i} " + "x" * 90 for i in range(120))  # ~11k chars
+
+        with patch.object(feed_mod, "_post_discord_message", tracker):
+            push_turn_change(
+                "t-big", row, new_state="WAITING_USER", old_state="RUNNING",
+                feed_channel_id="feed-ch-001",
+                turn_output=big,
+            )
+
+        thread_posts = [b for c, b in tracker.calls if c == "thread-big"]
+        # 4 chunks + truncation notice + state message
+        chunk_posts = [b for b in thread_posts if b.startswith("line ")]
+        assert len(chunk_posts) == feed_mod._TURN_OUTPUT_MAX_CHUNKS
+        assert all(len(b) <= 2000 for b in thread_posts)
+        assert any("truncated" in b for b in thread_posts)
+
+    def test_menu_detail_kept_alongside_turn_output(self):
+        """Menu rows keep the numbered-options detail even when turn_output
+        is relayed (the menu is the actionable part)."""
+        tracker = _FakePostTracker()
+        row = _make_row(task_id="t-menu-out", thread_id="thread-mo")
+        row["last_input_kind"] = "menu"
+        row["last_question"] = "Pick one?"
+        row["last_options"] = json.dumps(["A", "B"])
+
+        with patch.object(feed_mod, "_post_discord_message", tracker):
+            push_turn_change(
+                "t-menu-out", row, new_state="WAITING_USER", old_state="RUNNING",
+                feed_channel_id="feed-ch-001",
+                turn_output="Context before the menu.",
+            )
+
+        thread_posts = [b for c, b in tracker.calls if c == "thread-mo"]
+        assert any("Context before the menu." in b for b in thread_posts)
+        assert any("Pick one?" in b and "1." in b for b in thread_posts)
+
     def test_transition_to_paused_handoff_posts_once_to_thread(self):
         tracker = _FakePostTracker()
         row = _make_row(task_id="t-002", thread_id="thread-222")

--- a/tests/test_session_orchestration_hang.py
+++ b/tests/test_session_orchestration_hang.py
@@ -79,6 +79,9 @@ class FakeAdapter(AgentAdapter):
     def resume(self, handle: SessionHandle, prompt: str) -> None:
         raise NotImplementedError
 
+    def terminate(self, handle: SessionHandle) -> None:
+        raise NotImplementedError
+
 
 class FakeCapture:
     """Fake tmux_capture returning fixed text."""

--- a/tests/test_session_orchestration_hang.py
+++ b/tests/test_session_orchestration_hang.py
@@ -11,9 +11,9 @@ Critical behaviors tested (all 4 from the audit-blocker list):
    exceeded) must NOT suppress hang detection.  Hang is derived from
    static pane-staleness signals only (idle_ticks + last_output_ts).
 
-3. Exactly one auto-nudge, then escalate.
+3. Exactly one auto-nudge/action per stale episode.
    First tick over threshold → notify + nudge + nudge_count incremented.
-   Second tick still hung → escalation notification fired, NOT a second nudge.
+   Second tick still hung → no notification and no second nudge.
 
 4. Simulated long build (pane static under active-tool indicator) → no hang.
    An adapter that declares an ``idle_indicator_regex`` matching the static
@@ -181,6 +181,15 @@ def _low_threshold_config():
     return _SmallThresholdConfig()
 
 
+def _stale_guard_kwargs(pane_text: str = "stale unchanged pane") -> Dict[str, Any]:
+    pane_hash = _pane_hash(pane_text)
+    return {
+        "pane_text": pane_text,
+        "previous_pane_hash": pane_hash,
+        "current_pane_hash": pane_hash,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Behavior 1: WAITING_USER held >N ticks → NO nudge
 # ---------------------------------------------------------------------------
@@ -336,7 +345,7 @@ class TestStaleAccelerantCannotMaskHang:
                 or registry.__class__.increment_counter(registry, tid, col, **kw),
             ),
         ):
-            _on_hang(task_id, row, registry=registry)
+            _on_hang(task_id, row, registry=registry, **_stale_guard_kwargs())
 
         assert hang_notifications, (
             "push_hang_notification must be called when thresholds are exceeded "
@@ -384,14 +393,12 @@ class TestStaleAccelerantCannotMaskHang:
 
 
 # ---------------------------------------------------------------------------
-# Behavior 3: Exactly one auto-nudge, then escalate
+# Behavior 3: Exactly one auto-nudge/action per stale episode
 # ---------------------------------------------------------------------------
 
 
-class TestExactlyOneNudgeThenEscalate:
-    """First confirmed hang → notify + one nudge + nudge_count++.
-    Second tick still hung → escalation notification, NOT a second nudge.
-    """
+class TestExactlyOneNudgePerEpisode:
+    """First confirmed hang acts once; later unchanged-pane ticks do nothing."""
 
     def test_first_hang_sends_nudge(self, registry, db_path):
         """nudge_count==0 → push_hang_notification(escalate=False) + relay nudge."""
@@ -428,7 +435,7 @@ class TestExactlyOneNudgeThenEscalate:
                 side_effect=lambda tid, r, **kw: nudge_relay_calls.append(tid),
             ),
         ):
-            _on_hang(task_id, row, registry=registry, adapter=adapter)
+            _on_hang(task_id, row, registry=registry, adapter=adapter, **_stale_guard_kwargs())
 
         assert len(notifications) == 1, "Exactly one notification for first hang"
         assert notifications[0]["escalate"] is False, (
@@ -444,8 +451,8 @@ class TestExactlyOneNudgeThenEscalate:
             "nudge_count must be incremented to 1 after the auto-nudge"
         )
 
-    def test_second_hang_escalates_no_renudge(self, registry, db_path):
-        """nudge_count>=1 → push_hang_notification(escalate=True) + NO relay nudge."""
+    def test_second_hang_does_not_act_again(self, registry, db_path):
+        """nudge_count>=1 → no notification and no relay nudge."""
         task_id = "t-hang-nudge-002"
         old_ts = time.time() - 9999
         _seed_row(
@@ -479,18 +486,17 @@ class TestExactlyOneNudgeThenEscalate:
                 side_effect=lambda tid, r, **kw: nudge_relay_calls.append(tid),
             ),
         ):
-            _on_hang(task_id, row, registry=registry, adapter=adapter)
+            _on_hang(task_id, row, registry=registry, adapter=adapter, **_stale_guard_kwargs())
 
-        assert len(notifications) == 1, "Exactly one notification for escalation tick"
-        assert notifications[0]["escalate"] is True, (
-            "Second hang must fire escalation=True"
+        assert notifications == [], (
+            "Second hang in the same stale episode must not fire another notification"
         )
         assert nudge_relay_calls == [], (
             "_send_auto_nudge must NOT be called on second hang (already nudged)"
         )
 
-    def test_nudge_count_not_incremented_on_escalation(self, registry, db_path):
-        """nudge_count must stay at 1 (not become 2) when escalating."""
+    def test_nudge_count_not_incremented_after_episode_action(self, registry, db_path):
+        """nudge_count must stay at 1 after the episode action has fired."""
         task_id = "t-hang-nudge-003"
         old_ts = time.time() - 9999
         _seed_row(
@@ -512,11 +518,11 @@ class TestExactlyOneNudgeThenEscalate:
             patch("session_orchestration.feed.push_hang_notification"),
             patch("session_orchestration.watcher._send_auto_nudge"),
         ):
-            _on_hang(task_id, row, registry=registry, adapter=adapter)
+            _on_hang(task_id, row, registry=registry, adapter=adapter, **_stale_guard_kwargs())
 
         fresh = registry.get(task_id)
         assert fresh["nudge_count"] == 1, (
-            "nudge_count must not be incremented again on escalation tick"
+            "nudge_count must not be incremented again in the same stale episode"
         )
 
 
@@ -577,7 +583,7 @@ class TestActiveBuildIndicatorSuppressesHang:
                 row,
                 registry=registry,
                 adapter=adapter,
-                pane_text=build_pane_text,
+                **_stale_guard_kwargs(build_pane_text),
             )
 
         assert hang_notifications == [], (
@@ -628,7 +634,7 @@ class TestActiveBuildIndicatorSuppressesHang:
                 row,
                 registry=registry,
                 adapter=adapter,
-                pane_text=static_pane_text,
+                **_stale_guard_kwargs(static_pane_text),
             )
 
         assert hang_notifications, (
@@ -677,7 +683,7 @@ class TestActiveBuildIndicatorSuppressesHang:
                 row,
                 registry=registry,
                 adapter=adapter,
-                pane_text=idle_pane_text,
+                **_stale_guard_kwargs(idle_pane_text),
             )
 
         assert hang_notifications, (
@@ -721,7 +727,7 @@ class TestStaticThresholds:
                 side_effect=lambda *a, **kw: hang_notifications.append(a),
             ),
         ):
-            _on_hang(task_id, row, registry=registry, adapter=adapter)
+            _on_hang(task_id, row, registry=registry, adapter=adapter, **_stale_guard_kwargs())
 
         assert hang_notifications == [], (
             "No hang when idle_ticks < hang_idle_ticks threshold"
@@ -753,7 +759,7 @@ class TestStaticThresholds:
                 side_effect=lambda *a, **kw: hang_notifications.append(a),
             ),
         ):
-            _on_hang(task_id, row, registry=registry, adapter=adapter)
+            _on_hang(task_id, row, registry=registry, adapter=adapter, **_stale_guard_kwargs())
 
         assert hang_notifications == [], (
             "No hang when last_output_ts is within stale_seconds threshold"
@@ -778,7 +784,7 @@ class TestHangEndToEnd:
             registry,
             task_id=task_id,
             state="RUNNING",
-            idle_ticks=0,
+            idle_ticks=2,  # one static tick keeps this above the patched threshold
             last_output_ts=old_ts,
             last_pane_hash=_pane_hash(static_text),
         )
@@ -789,9 +795,15 @@ class TestHangEndToEnd:
 
         hang_called = []
 
-        with patch(
-            "session_orchestration.watcher._on_hang",
-            side_effect=lambda tid, row, **kw: hang_called.append(tid),
+        with (
+            patch(
+                "session_orchestration.config.load_session_orchestration_config",
+                return_value=_low_threshold_config(),
+            ),
+            patch(
+                "session_orchestration.watcher._on_hang",
+                side_effect=lambda tid, row, **kw: hang_called.append(tid),
+            ),
         ):
             watcher.tick()
 

--- a/tests/test_session_orchestration_hang.py
+++ b/tests/test_session_orchestration_hang.py
@@ -1,0 +1,830 @@
+"""
+Unit tests for T009 — hang detection + one auto-nudge.
+
+Critical behaviors tested (all 4 from the audit-blocker list):
+
+1. Hang ONLY when state==RUNNING.
+   A WAITING_USER session held at the prompt for >N ticks → NO nudge.
+
+2. Stale-accelerant cannot mask a real hang.
+   A "heartbeat accelerant" that carries no fresh activity (freshness TTL
+   exceeded) must NOT suppress hang detection.  Hang is derived from
+   static pane-staleness signals only (idle_ticks + last_output_ts).
+
+3. Exactly one auto-nudge, then escalate.
+   First tick over threshold → notify + nudge + nudge_count incremented.
+   Second tick still hung → escalation notification fired, NOT a second nudge.
+
+4. Simulated long build (pane static under active-tool indicator) → no hang.
+   An adapter that declares an ``idle_indicator_regex`` matching the static
+   pane text must suppress hang detection even when idle_ticks > threshold.
+
+Tests use in-memory SQLite, FakeAdapter / FakeRelay fakes, and monkeypatched
+feed so no Discord network calls are made.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from session_orchestration.adapters.base import AgentAdapter
+from session_orchestration.adapters.verify import AdapterProbeSpec
+from session_orchestration.registry import SessionOrchestrationRegistry
+from session_orchestration.types import Capabilities, SessionHandle, SessionLifecycle
+from session_orchestration.watcher import (
+    SessionWatcher,
+    _on_hang,
+    _pane_hash,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeAdapter(AgentAdapter):
+    """Adapter returning a fixed lifecycle; optionally declares idle_indicator_regex."""
+
+    def __init__(
+        self,
+        lifecycle: SessionLifecycle = SessionLifecycle.RUNNING,
+        idle_indicator_regex: Optional[re.Pattern] = None,
+    ):
+        self._lifecycle = lifecycle
+        self._idle_regex = idle_indicator_regex
+        self.detect_calls: List[SessionHandle] = []
+        self.drive_calls: List[str] = []
+
+    def capabilities(self) -> Capabilities:
+        return Capabilities(idle_indicator_regex=self._idle_regex)
+
+    def launch(self, workdir: str, prompt: str) -> SessionHandle:
+        raise NotImplementedError
+
+    def drive(self, handle: SessionHandle, message: str) -> None:
+        self.drive_calls.append(message)
+
+    def detect(self, handle: SessionHandle) -> SessionLifecycle:
+        self.detect_calls.append(handle)
+        return self._lifecycle
+
+    def resume(self, handle: SessionHandle, prompt: str) -> None:
+        raise NotImplementedError
+
+
+class FakeCapture:
+    """Fake tmux_capture returning fixed text."""
+
+    def __init__(self, text: str = "some pane output"):
+        self._text = text
+        self.calls: List[str] = []
+
+    def __call__(self, pane: str) -> str:
+        self.calls.append(pane)
+        return self._text
+
+
+class FakeProbeRunner:
+    """ProbeRunner that passes every binary."""
+
+    def which(self, binary: str) -> str | None:
+        return f"/usr/local/bin/{binary}"
+
+    def help_text(self, binary: str) -> str:
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "state.db"
+
+
+@pytest.fixture()
+def registry(db_path: Path) -> SessionOrchestrationRegistry:
+    return SessionOrchestrationRegistry(db_path=db_path)
+
+
+def _fake_probe_spec(adapter: FakeAdapter) -> AdapterProbeSpec:
+    return AdapterProbeSpec(binary="fake-agent")
+
+
+def _make_watcher(
+    registry: SessionOrchestrationRegistry,
+    adapter: FakeAdapter,
+    capture: FakeCapture,
+    *,
+    adapter_name: str = "fake",
+) -> SessionWatcher:
+    watcher = SessionWatcher(
+        registry=registry,
+        adapters={adapter_name: adapter},
+        tmux_capture=capture,
+    )
+    probe_runner = FakeProbeRunner()
+    probe_specs = {type(adapter).__name__: _fake_probe_spec(adapter)}
+    watcher.startup_verify(probe_runner=probe_runner, probe_specs=probe_specs)
+    return watcher
+
+
+def _seed_row(
+    registry: SessionOrchestrationRegistry,
+    task_id: str = "task-001",
+    agent: str = "fake",
+    state: str = "RUNNING",
+    tmux_session: str = "hermes-fake-001",
+    idle_ticks: int = 0,
+    nudge_count: int = 0,
+    last_output_ts: Optional[float] = None,
+    last_pane_hash: Optional[str] = None,
+) -> None:
+    """Insert a registry row with optional pre-seeded hang-relevant fields."""
+    registry.upsert(
+        task_id,
+        agent=agent,
+        run_id=f"run-{uuid.uuid4().hex[:8]}",
+        repo=f"repo-{uuid.uuid4().hex[:8]}",
+        state=state,
+        tmux_session=tmux_session,
+        idle_ticks=idle_ticks,
+        nudge_count=nudge_count,
+        last_output_ts=last_output_ts,
+        last_pane_hash=last_pane_hash,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hang-config helper — make hang threshold small so tests don't need many ticks
+# ---------------------------------------------------------------------------
+
+
+class _SmallThresholdConfig:
+    """Minimal config stub with low thresholds for testing."""
+    hang_idle_ticks: int = 2
+    hang_stale_seconds: int = 1  # 1 second so tests don't need to wait
+
+
+def _low_threshold_config():
+    """Patch target that returns a config with low hang thresholds."""
+    return _SmallThresholdConfig()
+
+
+# ---------------------------------------------------------------------------
+# Behavior 1: WAITING_USER held >N ticks → NO nudge
+# ---------------------------------------------------------------------------
+
+
+class TestWaitingUserNoHang:
+    """A session in WAITING_USER state must never trigger a hang or nudge,
+    even if idle_ticks exceeds the threshold and last_output_ts is very old.
+    """
+
+    def test_waiting_user_no_nudge_after_many_idle_ticks(self, registry, db_path):
+        """WAITING_USER + idle_ticks >> threshold → _on_hang never called."""
+        task_id = "t-hang-wu-001"
+        # Seed row in WAITING_USER with many idle ticks and very old last_output_ts
+        old_ts = time.time() - 9999
+        _seed_row(
+            registry,
+            task_id=task_id,
+            state="WAITING_USER",
+            idle_ticks=100,
+            last_output_ts=old_ts,
+        )
+
+        # Adapter returns WAITING_USER — session is at the prompt
+        adapter = FakeAdapter(SessionLifecycle.WAITING_USER)
+        static_text = "❯ "  # same every tick → pane unchanged
+        capture = FakeCapture(static_text)
+
+        hang_called = []
+
+        original_on_hang = __import__(
+            "session_orchestration.watcher", fromlist=["_on_hang"]
+        )._on_hang
+
+        def spy_on_hang(task_id, row, **kwargs):
+            hang_called.append(task_id)
+            original_on_hang(task_id, row, **kwargs)
+
+        watcher = _make_watcher(registry, adapter, capture)
+
+        notifications = []
+        with (
+            patch(
+                "session_orchestration.watcher._on_hang",
+                side_effect=spy_on_hang,
+            ),
+            patch(
+                "session_orchestration.feed.push_hang_notification",
+                side_effect=lambda *a, **kw: notifications.append(a),
+            ),
+        ):
+            watcher.tick()
+            watcher.tick()
+            watcher.tick()
+
+        assert hang_called == [], (
+            "_on_hang must NOT be called for WAITING_USER sessions; "
+            f"was called {len(hang_called)} time(s)"
+        )
+        assert notifications == [], (
+            "push_hang_notification must NOT fire for a WAITING_USER session"
+        )
+
+    def test_waiting_user_state_is_excluded_from_hang_callsite(self, registry, db_path):
+        """The call-site in _process_row gates on state==RUNNING; this test
+        verifies the gating via a full watcher.tick() so the invariant is
+        proven end-to-end, not just by reading the code."""
+        task_id = "t-hang-wu-002"
+        old_ts = time.time() - 9999
+        _seed_row(
+            registry,
+            task_id=task_id,
+            state="RUNNING",  # seed RUNNING so the row is iterated
+            idle_ticks=0,
+            last_output_ts=old_ts,
+        )
+
+        # Adapter returns WAITING_USER (transition: RUNNING→WAITING_USER).
+        # After the transition, state==WAITING_USER → _on_hang must NOT fire.
+        adapter = FakeAdapter(SessionLifecycle.WAITING_USER)
+        capture = FakeCapture("❯ prompt")
+
+        hang_called = []
+        with patch(
+            "session_orchestration.watcher._on_hang",
+            side_effect=lambda tid, row, **kw: hang_called.append(tid),
+        ):
+            watcher = _make_watcher(registry, adapter, capture)
+            watcher.tick()
+
+        # Verify state is now WAITING_USER
+        row = registry.get(task_id)
+        assert row["state"] == "WAITING_USER"
+        assert hang_called == [], (
+            "_on_hang must NOT fire when new_state is WAITING_USER"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Behavior 2: Stale accelerant cannot mask a real hang
+# ---------------------------------------------------------------------------
+
+
+class TestStaleAccelerantCannotMaskHang:
+    """A 'stale' accelerant (e.g. an old heartbeat signal) must NOT suppress
+    detection of a genuinely hung session.  Hang detection uses STATIC thresholds
+    (idle_ticks + last_output_ts) only — not any accelerant flag.
+    """
+
+    def test_stale_accelerant_does_not_suppress_hang(self, registry, db_path):
+        """Simulate a scenario where an accelerant was last seen a long time ago.
+        The watcher must still detect the hang via idle_ticks + last_output_ts.
+
+        In the real codebase the accelerant resets idle_ticks / last_output_ts when
+        it fires with fresh activity.  A STALE accelerant simply never fires —
+        so idle_ticks keeps incrementing and last_output_ts stays old.  _on_hang
+        reads these static signals and must declare hang regardless of whether
+        an accelerant 'would have' fired if it were active.
+
+        This test verifies that _on_hang reaches the hang-confirmed branch
+        (does NOT return early) when thresholds are exceeded, even when there
+        is no accelerant flag set on the row.
+        """
+        task_id = "t-hang-accel-001"
+        old_ts = time.time() - 9999  # very old — stale threshold exceeded
+        _seed_row(
+            registry,
+            task_id=task_id,
+            state="RUNNING",
+            idle_ticks=100,       # well above any reasonable threshold
+            nudge_count=0,
+            last_output_ts=old_ts,
+        )
+        row = registry.get(task_id)
+
+        hang_notifications: List[Any] = []
+        nudge_increments: List[str] = []
+
+        with (
+            patch(
+                "session_orchestration.config.load_session_orchestration_config",
+                return_value=_low_threshold_config(),
+            ),
+            patch(
+                "session_orchestration.feed.push_hang_notification",
+                side_effect=lambda *a, **kw: hang_notifications.append(a),
+            ),
+            patch.object(
+                registry,
+                "increment_counter",
+                wraps=registry.increment_counter,
+                side_effect=lambda tid, col, **kw: nudge_increments.append(col)
+                or registry.__class__.increment_counter(registry, tid, col, **kw),
+            ),
+        ):
+            _on_hang(task_id, row, registry=registry)
+
+        assert hang_notifications, (
+            "push_hang_notification must be called when thresholds are exceeded "
+            "(stale accelerant cannot mask a real hang)"
+        )
+
+    def test_fresh_accelerant_resets_via_pane_change(self, registry, db_path):
+        """A FRESH accelerant fires by resetting idle_ticks and last_output_ts
+        (because it carries fresh activity — the pane changed).  This test
+        verifies the mechanism: a changed pane resets idle_ticks to 0, which
+        means the _on_hang call-site condition (idle_ticks > 0) is not met,
+        so _on_hang is not called at all.
+
+        This is the CORRECT suppression path — via actual fresh pane activity,
+        not via a blanket suppression flag.
+        """
+        task_id = "t-hang-accel-002"
+        # Start with a row that previously had idle_ticks = 5
+        _seed_row(
+            registry,
+            task_id=task_id,
+            state="RUNNING",
+            idle_ticks=5,
+            last_output_ts=time.time() - 9999,
+            last_pane_hash=_pane_hash("old pane content"),
+        )
+
+        # On this tick the pane changes → idle_ticks resets to 0 → no hang
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture("NEW pane content — activity!")  # different from old hash
+
+        hang_called = []
+        with patch(
+            "session_orchestration.watcher._on_hang",
+            side_effect=lambda tid, row, **kw: hang_called.append(tid),
+        ):
+            watcher = _make_watcher(registry, adapter, capture)
+            watcher.tick()
+
+        row = registry.get(task_id)
+        assert (row.get("idle_ticks") or 0) == 0, "idle_ticks should reset on pane change"
+        assert hang_called == [], (
+            "_on_hang must NOT be called when the pane changed this tick"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Behavior 3: Exactly one auto-nudge, then escalate
+# ---------------------------------------------------------------------------
+
+
+class TestExactlyOneNudgeThenEscalate:
+    """First confirmed hang → notify + one nudge + nudge_count++.
+    Second tick still hung → escalation notification, NOT a second nudge.
+    """
+
+    def test_first_hang_sends_nudge(self, registry, db_path):
+        """nudge_count==0 → push_hang_notification(escalate=False) + relay nudge."""
+        task_id = "t-hang-nudge-001"
+        old_ts = time.time() - 9999
+        _seed_row(
+            registry,
+            task_id=task_id,
+            state="RUNNING",
+            idle_ticks=100,
+            nudge_count=0,
+            last_output_ts=old_ts,
+        )
+        row = registry.get(task_id)
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+
+        notifications: List[Any] = []
+        nudge_relay_calls: List[str] = []
+
+        def fake_push_hang(tid, r, escalate=False, **kw):
+            notifications.append({"task_id": tid, "escalate": escalate})
+
+        with (
+            patch(
+                "session_orchestration.config.load_session_orchestration_config",
+                return_value=_low_threshold_config(),
+            ),
+            patch(
+                "session_orchestration.feed.push_hang_notification",
+                side_effect=fake_push_hang,
+            ),
+            patch(
+                "session_orchestration.watcher._send_auto_nudge",
+                side_effect=lambda tid, r, **kw: nudge_relay_calls.append(tid),
+            ),
+        ):
+            _on_hang(task_id, row, registry=registry, adapter=adapter)
+
+        assert len(notifications) == 1, "Exactly one notification for first hang"
+        assert notifications[0]["escalate"] is False, (
+            "First hang notification must not be an escalation"
+        )
+        assert nudge_relay_calls == [task_id], (
+            "Auto-nudge must be sent exactly once on first confirmed hang"
+        )
+
+        # nudge_count must have been incremented
+        fresh = registry.get(task_id)
+        assert fresh["nudge_count"] == 1, (
+            "nudge_count must be incremented to 1 after the auto-nudge"
+        )
+
+    def test_second_hang_escalates_no_renudge(self, registry, db_path):
+        """nudge_count>=1 → push_hang_notification(escalate=True) + NO relay nudge."""
+        task_id = "t-hang-nudge-002"
+        old_ts = time.time() - 9999
+        _seed_row(
+            registry,
+            task_id=task_id,
+            state="RUNNING",
+            idle_ticks=100,
+            nudge_count=1,  # already nudged once
+            last_output_ts=old_ts,
+        )
+        row = registry.get(task_id)
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+
+        notifications: List[Any] = []
+        nudge_relay_calls: List[str] = []
+
+        def fake_push_hang(tid, r, escalate=False, **kw):
+            notifications.append({"task_id": tid, "escalate": escalate})
+
+        with (
+            patch(
+                "session_orchestration.config.load_session_orchestration_config",
+                return_value=_low_threshold_config(),
+            ),
+            patch(
+                "session_orchestration.feed.push_hang_notification",
+                side_effect=fake_push_hang,
+            ),
+            patch(
+                "session_orchestration.watcher._send_auto_nudge",
+                side_effect=lambda tid, r, **kw: nudge_relay_calls.append(tid),
+            ),
+        ):
+            _on_hang(task_id, row, registry=registry, adapter=adapter)
+
+        assert len(notifications) == 1, "Exactly one notification for escalation tick"
+        assert notifications[0]["escalate"] is True, (
+            "Second hang must fire escalation=True"
+        )
+        assert nudge_relay_calls == [], (
+            "_send_auto_nudge must NOT be called on second hang (already nudged)"
+        )
+
+    def test_nudge_count_not_incremented_on_escalation(self, registry, db_path):
+        """nudge_count must stay at 1 (not become 2) when escalating."""
+        task_id = "t-hang-nudge-003"
+        old_ts = time.time() - 9999
+        _seed_row(
+            registry,
+            task_id=task_id,
+            state="RUNNING",
+            idle_ticks=100,
+            nudge_count=1,
+            last_output_ts=old_ts,
+        )
+        row = registry.get(task_id)
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+
+        with (
+            patch(
+                "session_orchestration.config.load_session_orchestration_config",
+                return_value=_low_threshold_config(),
+            ),
+            patch("session_orchestration.feed.push_hang_notification"),
+            patch("session_orchestration.watcher._send_auto_nudge"),
+        ):
+            _on_hang(task_id, row, registry=registry, adapter=adapter)
+
+        fresh = registry.get(task_id)
+        assert fresh["nudge_count"] == 1, (
+            "nudge_count must not be incremented again on escalation tick"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Behavior 4: Simulated long build (static pane + active-tool indicator) → no hang
+# ---------------------------------------------------------------------------
+
+
+class TestActiveBuildIndicatorSuppressesHang:
+    """A pane that is static but carries an active-tool indicator regex match
+    must NOT trigger a hang alert — the session is busy (building/compiling).
+    """
+
+    def test_build_indicator_suppresses_hang(self, registry, db_path):
+        """Adapter declares idle_indicator_regex that matches the static pane.
+        Even with idle_ticks >> threshold, _on_hang must return early.
+        """
+        task_id = "t-hang-build-001"
+        old_ts = time.time() - 9999
+        _seed_row(
+            registry,
+            task_id=task_id,
+            state="RUNNING",
+            idle_ticks=100,
+            nudge_count=0,
+            last_output_ts=old_ts,
+        )
+        row = registry.get(task_id)
+
+        # Build indicator pattern — matches when compiling
+        build_regex = re.compile(r"Building|Compiling|cargo build")
+        adapter = FakeAdapter(
+            lifecycle=SessionLifecycle.RUNNING,
+            idle_indicator_regex=build_regex,
+        )
+        # Pane text contains the build indicator
+        build_pane_text = "  Compiling myproject v0.1.0 (/src/myproject)\n"
+
+        hang_notifications: List[Any] = []
+        nudge_calls: List[str] = []
+
+        with (
+            patch(
+                "session_orchestration.config.load_session_orchestration_config",
+                return_value=_low_threshold_config(),
+            ),
+            patch(
+                "session_orchestration.feed.push_hang_notification",
+                side_effect=lambda *a, **kw: hang_notifications.append(a),
+            ),
+            patch(
+                "session_orchestration.watcher._send_auto_nudge",
+                side_effect=lambda *a, **kw: nudge_calls.append(a),
+            ),
+        ):
+            _on_hang(
+                task_id,
+                row,
+                registry=registry,
+                adapter=adapter,
+                pane_text=build_pane_text,
+            )
+
+        assert hang_notifications == [], (
+            "push_hang_notification must NOT fire when active-tool indicator matches"
+        )
+        assert nudge_calls == [], (
+            "_send_auto_nudge must NOT be called when active-tool indicator matches"
+        )
+
+    def test_no_indicator_regex_falls_through_to_hang(self, registry, db_path):
+        """An adapter with no idle_indicator_regex (None) should fall through
+        to hang detection — verifying the suppression is opt-in, not always-on.
+        """
+        task_id = "t-hang-build-002"
+        old_ts = time.time() - 9999
+        _seed_row(
+            registry,
+            task_id=task_id,
+            state="RUNNING",
+            idle_ticks=100,
+            nudge_count=0,
+            last_output_ts=old_ts,
+        )
+        row = registry.get(task_id)
+
+        # No idle_indicator_regex — hang must fire
+        adapter = FakeAdapter(
+            lifecycle=SessionLifecycle.RUNNING,
+            idle_indicator_regex=None,
+        )
+        static_pane_text = "  Compiling myproject v0.1.0 (/src/myproject)\n"
+
+        hang_notifications: List[Any] = []
+
+        with (
+            patch(
+                "session_orchestration.config.load_session_orchestration_config",
+                return_value=_low_threshold_config(),
+            ),
+            patch(
+                "session_orchestration.feed.push_hang_notification",
+                side_effect=lambda *a, **kw: hang_notifications.append(a),
+            ),
+            patch("session_orchestration.watcher._send_auto_nudge"),
+        ):
+            _on_hang(
+                task_id,
+                row,
+                registry=registry,
+                adapter=adapter,
+                pane_text=static_pane_text,
+            )
+
+        assert hang_notifications, (
+            "push_hang_notification MUST fire when adapter has no idle_indicator_regex"
+        )
+
+    def test_indicator_regex_no_match_falls_through_to_hang(self, registry, db_path):
+        """Adapter has an idle_indicator_regex but pane text does not match.
+        Hang must fire — suppression only applies on a match.
+        """
+        task_id = "t-hang-build-003"
+        old_ts = time.time() - 9999
+        _seed_row(
+            registry,
+            task_id=task_id,
+            state="RUNNING",
+            idle_ticks=100,
+            nudge_count=0,
+            last_output_ts=old_ts,
+        )
+        row = registry.get(task_id)
+
+        build_regex = re.compile(r"Compiling|Building")
+        adapter = FakeAdapter(
+            lifecycle=SessionLifecycle.RUNNING,
+            idle_indicator_regex=build_regex,
+        )
+        # Pane text does NOT contain build indicator
+        idle_pane_text = "waiting for something...\n"
+
+        hang_notifications: List[Any] = []
+
+        with (
+            patch(
+                "session_orchestration.config.load_session_orchestration_config",
+                return_value=_low_threshold_config(),
+            ),
+            patch(
+                "session_orchestration.feed.push_hang_notification",
+                side_effect=lambda *a, **kw: hang_notifications.append(a),
+            ),
+            patch("session_orchestration.watcher._send_auto_nudge"),
+        ):
+            _on_hang(
+                task_id,
+                row,
+                registry=registry,
+                adapter=adapter,
+                pane_text=idle_pane_text,
+            )
+
+        assert hang_notifications, (
+            "push_hang_notification MUST fire when idle_indicator_regex does NOT match"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Behavior: Static thresholds — below threshold → no hang
+# ---------------------------------------------------------------------------
+
+
+class TestStaticThresholds:
+    """Hang is NOT declared when idle_ticks < hang_idle_ticks or
+    elapsed < hang_stale_seconds, regardless of other signals.
+    """
+
+    def test_below_idle_tick_threshold_no_hang(self, registry, db_path):
+        task_id = "t-hang-thresh-001"
+        old_ts = time.time() - 9999
+        _seed_row(
+            registry,
+            task_id=task_id,
+            state="RUNNING",
+            idle_ticks=1,  # below threshold of 2
+            nudge_count=0,
+            last_output_ts=old_ts,
+        )
+        row = registry.get(task_id)
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+
+        hang_notifications: List[Any] = []
+
+        with (
+            patch(
+                "session_orchestration.config.load_session_orchestration_config",
+                return_value=_low_threshold_config(),
+            ),
+            patch(
+                "session_orchestration.feed.push_hang_notification",
+                side_effect=lambda *a, **kw: hang_notifications.append(a),
+            ),
+        ):
+            _on_hang(task_id, row, registry=registry, adapter=adapter)
+
+        assert hang_notifications == [], (
+            "No hang when idle_ticks < hang_idle_ticks threshold"
+        )
+
+    def test_below_stale_seconds_threshold_no_hang(self, registry, db_path):
+        task_id = "t-hang-thresh-002"
+        recent_ts = time.time() - 0.1  # very recent — below 1s stale threshold
+        _seed_row(
+            registry,
+            task_id=task_id,
+            state="RUNNING",
+            idle_ticks=100,
+            nudge_count=0,
+            last_output_ts=recent_ts,
+        )
+        row = registry.get(task_id)
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+
+        hang_notifications: List[Any] = []
+
+        with (
+            patch(
+                "session_orchestration.config.load_session_orchestration_config",
+                return_value=_low_threshold_config(),
+            ),
+            patch(
+                "session_orchestration.feed.push_hang_notification",
+                side_effect=lambda *a, **kw: hang_notifications.append(a),
+            ),
+        ):
+            _on_hang(task_id, row, registry=registry, adapter=adapter)
+
+        assert hang_notifications == [], (
+            "No hang when last_output_ts is within stale_seconds threshold"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Integration: full watcher.tick() verifies end-to-end call-site gating
+# ---------------------------------------------------------------------------
+
+
+class TestHangEndToEnd:
+    """Integration: full watcher.tick() end-to-end to confirm call-site gating."""
+
+    def test_running_static_pane_triggers_hang_hook(self, registry, db_path):
+        """After N ticks of static pane, _on_hang is called (RUNNING row)."""
+        task_id = "t-hang-e2e-001"
+        old_ts = time.time() - 9999
+        # Seed row already with hash matching the capture text so idle_ticks increments
+        static_text = "stuck session output"
+        _seed_row(
+            registry,
+            task_id=task_id,
+            state="RUNNING",
+            idle_ticks=0,
+            last_output_ts=old_ts,
+            last_pane_hash=_pane_hash(static_text),
+        )
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture(static_text)
+        watcher = _make_watcher(registry, adapter, capture)
+
+        hang_called = []
+
+        with patch(
+            "session_orchestration.watcher._on_hang",
+            side_effect=lambda tid, row, **kw: hang_called.append(tid),
+        ):
+            watcher.tick()
+
+        assert hang_called == [task_id], (
+            "_on_hang must be called for a RUNNING session with static pane"
+        )
+
+    def test_paused_handoff_no_hang(self, registry, db_path):
+        """PAUSED_HANDOFF sessions must never trigger _on_hang."""
+        task_id = "t-hang-e2e-002"
+        old_ts = time.time() - 9999
+        _seed_row(
+            registry,
+            task_id=task_id,
+            state="RUNNING",
+            idle_ticks=100,
+            last_output_ts=old_ts,
+        )
+
+        # Adapter returns PAUSED_HANDOFF
+        adapter = FakeAdapter(SessionLifecycle.PAUSED_HANDOFF)
+        capture = FakeCapture("prompt: > ")
+        watcher = _make_watcher(registry, adapter, capture)
+
+        hang_called = []
+        with patch(
+            "session_orchestration.watcher._on_hang",
+            side_effect=lambda tid, row, **kw: hang_called.append(tid),
+        ):
+            watcher.tick()
+
+        row = registry.get(task_id)
+        assert row["state"] == "PAUSED_HANDOFF"
+        assert hang_called == [], (
+            "_on_hang must NOT fire for PAUSED_HANDOFF sessions"
+        )

--- a/tests/test_session_orchestration_heartbeat.py
+++ b/tests/test_session_orchestration_heartbeat.py
@@ -1,0 +1,464 @@
+"""
+Unit tests for T008 — heartbeat edit-in-place.
+
+Coverage
+--------
+1. First cadence tick (heartbeat_counter == cadence, no status_message_id):
+   POSTs a new status message and persists the returned message_id via registry.
+2. Subsequent cadence tick (heartbeat_counter == 2*cadence, status_message_id set):
+   PATCHes in-place (PATCH, not POST); same message_id; no new notification.
+3. Non-cadence tick: _on_heartbeat_tick is a no-op (no POST, no PATCH).
+4. No feed_channel_id configured: no network call, early return.
+5. No notification (push_turn_change) is fired on any heartbeat tick.
+6. edit_status_message in feed.py uses PATCH endpoint with correct url + body.
+
+All tests use fakes — no live Discord or registry calls (except registry tests
+that use in-memory SQLite via tmp_path).
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+import session_orchestration.feed as feed_mod
+import session_orchestration.watcher as watcher_mod
+from session_orchestration.feed import edit_status_message, clear_last_notified
+from session_orchestration.watcher import _on_heartbeat_tick, _HEARTBEAT_CADENCE
+
+
+# ---------------------------------------------------------------------------
+# Shared fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeDiscordRequest:
+    """Records calls to _discord_request and returns a configurable result."""
+
+    def __init__(self):
+        self.calls: List[Tuple[str, str, str]] = []  # (method, path, body_content)
+        self._call_count = 0
+
+    def __call__(self, method: str, path: str, token: str, *, body: dict = None):
+        self._call_count += 1
+        content = (body or {}).get("content", "")
+        self.calls.append((method, path, content))
+        if method == "POST":
+            return {"id": f"fake-msg-id-{self._call_count}"}
+        # PATCH returns the updated message (id not critical here)
+        return {"id": self._get_message_id_from_path(path)}
+
+    def _get_message_id_from_path(self, path: str) -> str:
+        # /channels/<ch>/messages/<id> → extract last segment
+        return path.rsplit("/", 1)[-1]
+
+
+class _FakeGetBotToken:
+    def __call__(self) -> str:
+        return "fake-token"
+
+
+def _make_row(
+    task_id: str = "task-hb-001",
+    agent: str = "claude",
+    state: str = "RUNNING",
+    heartbeat_counter: int = 0,
+    status_message_id: Optional[str] = None,
+    last_output_ts: Optional[float] = None,
+    project: str = "my-project",
+    run_id: str = "run-001",
+    repo: str = "repo-abc",
+    source: str = "spawn",
+) -> Dict[str, Any]:
+    return {
+        "task_id": task_id,
+        "agent": agent,
+        "state": state,
+        "heartbeat_counter": heartbeat_counter,
+        "status_message_id": status_message_id,
+        "last_output_ts": last_output_ts,
+        "project": project,
+        "run_id": run_id,
+        "repo": repo,
+        "source": source,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests: feed.edit_status_message
+# ---------------------------------------------------------------------------
+
+
+class TestEditStatusMessage:
+    """edit_status_message issues a PATCH to the correct Discord endpoint."""
+
+    def test_patch_issued_with_correct_path_and_content(self):
+        fake_req = _FakeDiscordRequest()
+        with (
+            patch("tools.discord_tool._discord_request", fake_req),
+            patch("tools.discord_tool._get_bot_token", _FakeGetBotToken()),
+        ):
+            ok = edit_status_message(
+                "ch-111", "msg-999", "hello heartbeat", token="fake-token"
+            )
+
+        assert ok is True
+        assert len(fake_req.calls) == 1
+        method, path, content = fake_req.calls[0]
+        assert method == "PATCH", f"expected PATCH, got {method}"
+        assert "/channels/ch-111/messages/msg-999" in path
+        assert "hello heartbeat" in content
+
+    def test_post_not_issued(self):
+        """edit_status_message must never issue a POST."""
+        fake_req = _FakeDiscordRequest()
+        with (
+            patch("tools.discord_tool._discord_request", fake_req),
+            patch("tools.discord_tool._get_bot_token", _FakeGetBotToken()),
+        ):
+            edit_status_message("ch-222", "msg-888", "some content", token="fake-token")
+
+        methods = [m for m, _, _ in fake_req.calls]
+        assert "POST" not in methods, "edit_status_message must use PATCH, not POST"
+
+    def test_missing_channel_id_returns_false(self):
+        fake_req = _FakeDiscordRequest()
+        with (
+            patch("tools.discord_tool._discord_request", fake_req),
+            patch("tools.discord_tool._get_bot_token", _FakeGetBotToken()),
+        ):
+            ok = edit_status_message("", "msg-111", "content", token="fake-token")
+
+        assert ok is False
+        assert fake_req.calls == []
+
+    def test_missing_message_id_returns_false(self):
+        fake_req = _FakeDiscordRequest()
+        with (
+            patch("tools.discord_tool._discord_request", fake_req),
+            patch("tools.discord_tool._get_bot_token", _FakeGetBotToken()),
+        ):
+            ok = edit_status_message("ch-333", "", "content", token="fake-token")
+
+        assert ok is False
+        assert fake_req.calls == []
+
+    def test_discord_exception_returns_false(self):
+        def _failing_req(*args, **kwargs):
+            raise RuntimeError("network error")
+
+        with (
+            patch("tools.discord_tool._discord_request", _failing_req),
+            patch("tools.discord_tool._get_bot_token", _FakeGetBotToken()),
+        ):
+            ok = edit_status_message("ch-444", "msg-777", "content", token="fake-token")
+
+        assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: _on_heartbeat_tick cadence gating
+# ---------------------------------------------------------------------------
+
+
+class TestHeartbeatCadenceGating:
+    """Non-cadence ticks do nothing."""
+
+    def _run_with_no_feed_calls(self, counter: int) -> List:
+        """Run _on_heartbeat_tick with given counter; assert no _post_discord_message."""
+        post_calls = []
+
+        def _fake_post(channel_id, content, *, token=None):
+            post_calls.append((channel_id, content))
+            return "fake-id"
+
+        def _fake_edit(channel_id, message_id, content, *, token=None):
+            post_calls.append(("EDIT", channel_id, message_id, content))
+            return True
+
+        row = _make_row(heartbeat_counter=counter)
+        with (
+            patch.object(feed_mod, "_post_discord_message", _fake_post),
+            patch.object(feed_mod, "edit_status_message", _fake_edit),
+            patch(
+                "session_orchestration.config.load_session_orchestration_config",
+                return_value=MagicMock(feed_channel_id="ch-feed"),
+            ),
+        ):
+            _on_heartbeat_tick("task-gate", row)
+
+        return post_calls
+
+    def test_counter_zero_is_skipped(self):
+        calls = self._run_with_no_feed_calls(0)
+        assert calls == [], "counter=0 must not fire heartbeat"
+
+    def test_non_cadence_counter_skipped(self):
+        for n in [1, 2, 3, 4]:
+            calls = self._run_with_no_feed_calls(n)
+            assert calls == [], f"counter={n} must not fire heartbeat"
+
+    def test_cadence_counter_fires(self):
+        """counter == _HEARTBEAT_CADENCE should trigger the heartbeat."""
+        post_calls = []
+
+        def _fake_post(channel_id, content, *, token=None):
+            post_calls.append((channel_id, content))
+            return "fake-msg-cadence"
+
+        row = _make_row(heartbeat_counter=_HEARTBEAT_CADENCE, status_message_id=None)
+
+        fake_cfg = MagicMock()
+        fake_cfg.feed_channel_id = "ch-cadence"
+
+        with (
+            patch.object(feed_mod, "_post_discord_message", _fake_post),
+            patch(
+                "session_orchestration.config.load_session_orchestration_config",
+                return_value=fake_cfg,
+            ),
+            patch("session_orchestration.watcher._heartbeat_registry_ref") as mock_ref,
+        ):
+            _on_heartbeat_tick("task-cadence", row)
+
+        assert len(post_calls) == 1, "cadence tick must POST one status message"
+        assert mock_ref.called, "status_message_id must be persisted"
+
+
+# ---------------------------------------------------------------------------
+# Tests: first heartbeat POSTs + persists message_id
+# ---------------------------------------------------------------------------
+
+
+class TestFirstHeartbeatPost:
+    """First cadence tick POSTs a new status message and stores message_id."""
+
+    def test_first_heartbeat_posts_and_persists(self):
+        post_calls = []
+
+        def _fake_post(channel_id, content, *, token=None):
+            post_calls.append((channel_id, content))
+            return "new-status-msg-id"
+
+        row = _make_row(
+            task_id="t-hb-first",
+            heartbeat_counter=_HEARTBEAT_CADENCE,
+            status_message_id=None,
+            last_output_ts=time.time() - 120,  # 2 min ago
+        )
+
+        fake_cfg = MagicMock()
+        fake_cfg.feed_channel_id = "ch-hb"
+
+        persisted_calls = []
+
+        def _fake_ref(task_id, row_arg, msg_id):
+            persisted_calls.append((task_id, msg_id))
+
+        with (
+            patch.object(feed_mod, "_post_discord_message", _fake_post),
+            patch(
+                "session_orchestration.config.load_session_orchestration_config",
+                return_value=fake_cfg,
+            ),
+            patch(
+                "session_orchestration.watcher._heartbeat_registry_ref",
+                _fake_ref,
+            ),
+        ):
+            _on_heartbeat_tick("t-hb-first", row)
+
+        # POST was issued once
+        assert len(post_calls) == 1, "first heartbeat must POST exactly once"
+        channel, content = post_calls[0]
+        assert channel == "ch-hb"
+        assert "t-hb-first" in content or "RUNNING" in content
+
+        # message_id was persisted
+        assert len(persisted_calls) == 1
+        assert persisted_calls[0] == ("t-hb-first", "new-status-msg-id")
+
+    def test_first_heartbeat_does_not_push_turn_change(self):
+        """No notification is fired on heartbeat — edit only."""
+        push_calls = []
+
+        def _fake_push_turn_change(*args, **kwargs):
+            push_calls.append(args)
+            return True
+
+        def _fake_post(channel_id, content, *, token=None):
+            return "msg-id"
+
+        row = _make_row(
+            task_id="t-hb-nonotif",
+            heartbeat_counter=_HEARTBEAT_CADENCE,
+            status_message_id=None,
+        )
+
+        fake_cfg = MagicMock()
+        fake_cfg.feed_channel_id = "ch-hb-nonotif"
+
+        with (
+            patch.object(feed_mod, "_post_discord_message", _fake_post),
+            patch.object(feed_mod, "push_turn_change", _fake_push_turn_change),
+            patch(
+                "session_orchestration.config.load_session_orchestration_config",
+                return_value=fake_cfg,
+            ),
+            patch("session_orchestration.watcher._heartbeat_registry_ref"),
+        ):
+            _on_heartbeat_tick("t-hb-nonotif", row)
+
+        assert push_calls == [], "heartbeat must never call push_turn_change"
+
+
+# ---------------------------------------------------------------------------
+# Tests: subsequent heartbeats PATCH in-place
+# ---------------------------------------------------------------------------
+
+
+class TestSubsequentHeartbeatPatch:
+    """Subsequent cadence ticks PATCH the existing status message (not POST)."""
+
+    def test_subsequent_heartbeat_patches_not_posts(self):
+        patch_calls = []
+        post_calls = []
+
+        def _fake_post(channel_id, content, *, token=None):
+            post_calls.append((channel_id, content))
+            return "should-not-be-called"
+
+        def _fake_edit(channel_id, message_id, content, *, token=None):
+            patch_calls.append((channel_id, message_id, content))
+            return True
+
+        row = _make_row(
+            task_id="t-hb-patch",
+            heartbeat_counter=_HEARTBEAT_CADENCE * 2,  # second cadence tick
+            status_message_id="existing-status-msg",
+        )
+
+        fake_cfg = MagicMock()
+        fake_cfg.feed_channel_id = "ch-hb-patch"
+
+        with (
+            patch.object(feed_mod, "_post_discord_message", _fake_post),
+            patch.object(feed_mod, "edit_status_message", _fake_edit),
+            patch(
+                "session_orchestration.config.load_session_orchestration_config",
+                return_value=fake_cfg,
+            ),
+        ):
+            _on_heartbeat_tick("t-hb-patch", row)
+
+        # PATCH was called; POST was NOT
+        assert len(patch_calls) == 1, "subsequent heartbeat must PATCH once"
+        assert post_calls == [], "subsequent heartbeat must not POST"
+
+        # Correct channel and message_id
+        channel, msg_id, content = patch_calls[0]
+        assert channel == "ch-hb-patch"
+        assert msg_id == "existing-status-msg"
+
+    def test_subsequent_heartbeat_same_message_id(self):
+        """The same message_id is always used on subsequent heartbeats."""
+        edit_targets = []
+
+        def _fake_edit(channel_id, message_id, content, *, token=None):
+            edit_targets.append(message_id)
+            return True
+
+        row = _make_row(
+            task_id="t-hb-sameid",
+            heartbeat_counter=_HEARTBEAT_CADENCE * 3,
+            status_message_id="pinned-msg-id",
+        )
+
+        fake_cfg = MagicMock()
+        fake_cfg.feed_channel_id = "ch-hb-sameid"
+
+        with (
+            patch.object(feed_mod, "edit_status_message", _fake_edit),
+            patch(
+                "session_orchestration.config.load_session_orchestration_config",
+                return_value=fake_cfg,
+            ),
+        ):
+            _on_heartbeat_tick("t-hb-sameid", row)
+
+        assert edit_targets == ["pinned-msg-id"]
+
+    def test_subsequent_heartbeat_no_notification(self):
+        """No push_turn_change is fired on subsequent heartbeats."""
+        push_calls = []
+
+        def _fake_push(*args, **kwargs):
+            push_calls.append(args)
+            return True
+
+        def _fake_edit(channel_id, message_id, content, *, token=None):
+            return True
+
+        row = _make_row(
+            task_id="t-hb-nopush",
+            heartbeat_counter=_HEARTBEAT_CADENCE * 2,
+            status_message_id="existing-msg",
+        )
+
+        fake_cfg = MagicMock()
+        fake_cfg.feed_channel_id = "ch-hb-nopush"
+
+        with (
+            patch.object(feed_mod, "edit_status_message", _fake_edit),
+            patch.object(feed_mod, "push_turn_change", _fake_push),
+            patch(
+                "session_orchestration.config.load_session_orchestration_config",
+                return_value=fake_cfg,
+            ),
+        ):
+            _on_heartbeat_tick("t-hb-nopush", row)
+
+        assert push_calls == [], "no notification must be fired on heartbeat"
+
+
+# ---------------------------------------------------------------------------
+# Tests: no feed_channel_id → early return
+# ---------------------------------------------------------------------------
+
+
+class TestNoFeedChannelId:
+    """No network call when feed_channel_id is absent."""
+
+    def test_no_call_when_no_channel(self):
+        post_calls = []
+        edit_calls = []
+
+        def _fake_post(channel_id, content, *, token=None):
+            post_calls.append(channel_id)
+            return "id"
+
+        def _fake_edit(channel_id, message_id, content, *, token=None):
+            edit_calls.append(channel_id)
+            return True
+
+        row = _make_row(heartbeat_counter=_HEARTBEAT_CADENCE)
+
+        fake_cfg = MagicMock()
+        fake_cfg.feed_channel_id = None  # no channel configured
+
+        with (
+            patch.object(feed_mod, "_post_discord_message", _fake_post),
+            patch.object(feed_mod, "edit_status_message", _fake_edit),
+            patch(
+                "session_orchestration.config.load_session_orchestration_config",
+                return_value=fake_cfg,
+            ),
+        ):
+            _on_heartbeat_tick("t-hb-nochannel", row)
+
+        assert post_calls == []
+        assert edit_calls == []

--- a/tests/test_session_orchestration_ingest.py
+++ b/tests/test_session_orchestration_ingest.py
@@ -1,0 +1,362 @@
+"""
+Tests for session_orchestration/ingest.py.
+
+Covers:
+- Valid signed payload → correct enqueue intent (correlate or adopt)
+- Unknown run → adopt intent enqueued
+- Duplicate event_id → no second enqueue (idempotent)
+- Bad HMAC signature → rejected
+- Rate limit exceeded → rejected
+- Per-source rate limit is independent (different sources don't share quota)
+- Disabled session_orchestration → skipped
+- Missing event_id → rejected
+
+All tests use an isolated SQLite DB (tmp_path) and monkeypatch config.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import pytest
+
+from session_orchestration.registry import (
+    SessionOrchestrationRegistry,
+    canonical_repo_id,
+)
+import session_orchestration.ingest as ingest_mod
+from session_orchestration.ingest import (
+    _check_rate_limit,
+    _is_duplicate_event,
+    _validate_hmac,
+    _ensure_dedup_schema,
+    process_z_harness_alert,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _sign_payload(body: bytes, secret: str) -> str:
+    """Produce sha256=<hex> signature matching notify-watchdog.sh."""
+    hex_digest = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return f"sha256={hex_digest}"
+
+
+def _make_payload(
+    *,
+    event_id: Optional[str] = None,
+    run_id: str = "run-test-001",
+    repo: str = "/Users/test/project",
+    event: str = "watchdog_stall",
+    severity: str = "warning",
+    reason: str = "Process hung",
+    source: str = "z-harness",
+    slug: str = "my-plan",
+) -> Dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "harness_version": "1.0.100",
+        "source": source,
+        "event": event,
+        "event_id": event_id or str(uuid.uuid4()),
+        "run_id": run_id,
+        "slug": slug,
+        "repo": repo,
+        "severity": severity,
+        "reason": reason,
+        "ts": int(time.time()),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path) -> Path:
+    return tmp_path / "state.db"
+
+
+@pytest.fixture()
+def registry(db_path) -> SessionOrchestrationRegistry:
+    return SessionOrchestrationRegistry(db_path=db_path)
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_windows():
+    """Clear in-memory rate windows between tests."""
+    ingest_mod._rate_windows.clear()
+    yield
+    ingest_mod._rate_windows.clear()
+
+
+@pytest.fixture()
+def patch_enabled(monkeypatch, db_path):
+    """Patch ingest to use tmp db_path and enable session_orchestration."""
+
+    monkeypatch.setattr(ingest_mod, "_get_db_path", lambda: db_path)
+    monkeypatch.setattr(
+        ingest_mod,
+        "_get_session_orchestration_config",
+        lambda: {
+            "enabled": True,
+            "feed_channel_id": "111222333",
+            "external_runs_thread_id": "999888777",
+            "rate_limit_per_source": 10,
+        },
+    )
+    monkeypatch.setattr(ingest_mod, "_is_enabled", lambda: True)
+    monkeypatch.setattr(
+        ingest_mod,
+        "_push_to_feed",
+        lambda *a, **kw: asyncio.sleep(0),  # no-op async
+    )
+
+
+# ---------------------------------------------------------------------------
+# HMAC validation
+# ---------------------------------------------------------------------------
+
+
+class TestHmacValidation:
+    def test_valid_signature(self):
+        secret = "my-secret"
+        body = b'{"event":"test"}'
+        sig = _sign_payload(body, secret)
+        assert _validate_hmac(body, secret, sig) is True
+
+    def test_wrong_secret(self):
+        body = b'{"event":"test"}'
+        sig = _sign_payload(body, "correct-secret")
+        assert _validate_hmac(body, "wrong-secret", sig) is False
+
+    def test_tampered_body(self):
+        secret = "my-secret"
+        body = b'{"event":"test"}'
+        sig = _sign_payload(body, secret)
+        assert _validate_hmac(b'{"event":"tampered"}', secret, sig) is False
+
+    def test_missing_sha256_prefix(self):
+        secret = "my-secret"
+        body = b'{"event":"test"}'
+        bare_hex = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        # No "sha256=" prefix → rejected
+        assert _validate_hmac(body, secret, bare_hex) is False
+
+    def test_empty_signature(self):
+        assert _validate_hmac(b"body", "secret", "") is False
+
+
+# ---------------------------------------------------------------------------
+# Dedup
+# ---------------------------------------------------------------------------
+
+
+class TestDedup:
+    def test_first_seen_not_duplicate(self, db_path):
+        _ensure_dedup_schema(db_path)
+        eid = str(uuid.uuid4())
+        assert _is_duplicate_event(db_path, eid, "z-harness") is False
+
+    def test_second_seen_is_duplicate(self, db_path):
+        _ensure_dedup_schema(db_path)
+        eid = str(uuid.uuid4())
+        _is_duplicate_event(db_path, eid, "z-harness")  # first
+        assert _is_duplicate_event(db_path, eid, "z-harness") is True
+
+    def test_different_event_ids_not_duplicate(self, db_path):
+        _ensure_dedup_schema(db_path)
+        eid1 = str(uuid.uuid4())
+        eid2 = str(uuid.uuid4())
+        _is_duplicate_event(db_path, eid1, "z-harness")
+        assert _is_duplicate_event(db_path, eid2, "z-harness") is False
+
+    def test_dedup_persists_across_instances(self, db_path):
+        """A new process (new connection) still sees the recorded event."""
+        _ensure_dedup_schema(db_path)
+        eid = str(uuid.uuid4())
+        _is_duplicate_event(db_path, eid, "z-harness")
+        # Simulate a new process instance using a fresh connection
+        assert _is_duplicate_event(db_path, eid, "z-harness") is True
+
+
+# ---------------------------------------------------------------------------
+# Rate limiting
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimit:
+    def test_within_limit(self):
+        source = f"test-source-{uuid.uuid4().hex}"
+        for _ in range(5):
+            assert _check_rate_limit(source, 10) is True
+
+    def test_exceeded_limit(self):
+        source = f"test-source-{uuid.uuid4().hex}"
+        limit = 3
+        for _ in range(limit):
+            _check_rate_limit(source, limit)
+        # Next one should be rejected
+        assert _check_rate_limit(source, limit) is False
+
+    def test_different_sources_independent(self):
+        """Rate limit buckets are per-source — source A exhausted does not block source B."""
+        source_a = f"source-a-{uuid.uuid4().hex}"
+        source_b = f"source-b-{uuid.uuid4().hex}"
+        limit = 2
+        for _ in range(limit):
+            _check_rate_limit(source_a, limit)
+        # source_a exhausted
+        assert _check_rate_limit(source_a, limit) is False
+        # source_b unaffected
+        assert _check_rate_limit(source_b, limit) is True
+
+
+# ---------------------------------------------------------------------------
+# process_z_harness_alert — integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestProcessAlert:
+    def test_disabled_returns_disabled(self, db_path, monkeypatch):
+        monkeypatch.setattr(ingest_mod, "_is_enabled", lambda: False)
+        monkeypatch.setattr(ingest_mod, "_get_db_path", lambda: db_path)
+        payload = _make_payload()
+        result = asyncio.get_event_loop().run_until_complete(
+            process_z_harness_alert(payload)
+        )
+        assert result["status"] == "disabled"
+
+    def test_missing_event_id_rejected(self, patch_enabled):
+        payload = _make_payload()
+        payload.pop("event_id")
+        result = asyncio.get_event_loop().run_until_complete(
+            process_z_harness_alert(payload)
+        )
+        assert result["status"] == "missing_fields"
+
+    def test_bad_signature_rejected(self, patch_enabled):
+        payload = _make_payload()
+        body = json.dumps(payload).encode()
+        result = asyncio.get_event_loop().run_until_complete(
+            process_z_harness_alert(
+                payload,
+                raw_body=body,
+                signature_header="sha256=deadbeef0000",
+                hmac_secret="correct-secret",
+            )
+        )
+        assert result["status"] == "invalid_signature"
+
+    def test_valid_signature_accepted(self, patch_enabled):
+        secret = "test-secret-123"
+        payload = _make_payload()
+        body = json.dumps(payload).encode()
+        sig = _sign_payload(body, secret)
+        result = asyncio.get_event_loop().run_until_complete(
+            process_z_harness_alert(
+                payload,
+                raw_body=body,
+                signature_header=sig,
+                hmac_secret=secret,
+            )
+        )
+        assert result["status"] == "accepted"
+
+    def test_unknown_run_adopts(self, patch_enabled, db_path, registry):
+        """Unknown (run_id, repo) pair results in an 'adopt' intent enqueued."""
+        payload = _make_payload(run_id="new-run-99", repo="/some/new/repo")
+        result = asyncio.get_event_loop().run_until_complete(
+            process_z_harness_alert(payload)
+        )
+        assert result["status"] == "accepted"
+        assert result["action"] == "adopted"
+
+        # The adopt intent must be in the queue.
+        intents = registry.drain_intents()
+        adopt_intents = [i for i in intents if i["intent"] == "adopt"]
+        assert len(adopt_intents) == 1
+        adopt_payload = json.loads(adopt_intents[0]["payload"])
+        assert adopt_payload["run_id"] == "new-run-99"
+        assert adopt_payload["agent"] == "z-harness"  # agent field populated from payload source
+
+    def test_known_run_correlates(self, patch_enabled, db_path, registry):
+        """Known (run_id, repo) pair results in an 'update' intent enqueued."""
+        run_id = "known-run-42"
+        repo_path = "/Users/zeke/projects/myproject"
+        repo_key = canonical_repo_id(workdir=repo_path)
+
+        # Pre-seed a registry row simulating a managed session.
+        existing_tid = f"task-{uuid.uuid4().hex[:8]}"
+        registry.upsert(
+            existing_tid,
+            agent="claude-code",
+            run_id=run_id,
+            repo=repo_key,
+            state="RUNNING",
+        )
+
+        payload = _make_payload(run_id=run_id, repo=repo_path)
+        result = asyncio.get_event_loop().run_until_complete(
+            process_z_harness_alert(payload)
+        )
+        assert result["status"] == "accepted"
+        assert result["action"] == "correlated"
+        assert result["task_id"] == existing_tid
+
+        # The update intent must be in the queue.
+        intents = registry.drain_intents()
+        update_intents = [i for i in intents if i["intent"] == "update"]
+        assert len(update_intents) == 1
+        update_payload = json.loads(update_intents[0]["payload"])
+        assert update_payload["task_id"] == existing_tid
+
+    def test_duplicate_event_id_no_second_enqueue(self, patch_enabled, db_path, registry):
+        """Sending the same event_id twice must not produce a second intent."""
+        eid = str(uuid.uuid4())
+        payload = _make_payload(event_id=eid, run_id="dup-run", repo="/dup/repo")
+
+        # First POST
+        r1 = asyncio.get_event_loop().run_until_complete(
+            process_z_harness_alert(payload)
+        )
+        assert r1["status"] == "accepted"
+        intents_after_first = registry.drain_intents()
+        assert len(intents_after_first) == 1
+
+        # Second POST with identical event_id → must be deduped
+        r2 = asyncio.get_event_loop().run_until_complete(
+            process_z_harness_alert(payload)
+        )
+        assert r2["status"] == "duplicate"
+
+        # No new intent enqueued
+        intents_after_second = registry.drain_intents()
+        assert intents_after_second == []
+
+    def test_rate_limit_exceeded_rejected(self, patch_enabled):
+        """After exhausting the per-source rate limit, the next event is rejected."""
+        source = f"z-harness-rl-{uuid.uuid4().hex}"
+        limit = 10  # matches patch_enabled fixture
+
+        # Exhaust the limit with distinct event_ids
+        loop = asyncio.get_event_loop()
+        for _ in range(limit):
+            p = _make_payload(source=source)
+            loop.run_until_complete(process_z_harness_alert(p))
+
+        # Next event from same source must be rate-limited
+        p_extra = _make_payload(source=source)
+        result = loop.run_until_complete(process_z_harness_alert(p_extra))
+        assert result["status"] == "rate_limited"

--- a/tests/test_session_orchestration_markers.py
+++ b/tests/test_session_orchestration_markers.py
@@ -1,0 +1,291 @@
+"""
+Unit tests for session_orchestration/markers.py.
+
+Covers:
+- Round-trip append/read of every marker kind.
+- Version field presence (v == MARKER_SCHEMA_VERSION).
+- Malformed lines are skipped, not fatal.
+- read_markers_since with non-zero offset returns only new lines.
+- marker_kind_to_lifecycle maps every kind to the correct SessionLifecycle.
+- MARKER_KINDS contains all expected kinds.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from session_orchestration.markers import (
+    MARKER_DONE,
+    MARKER_HANDOFF_CONTINUE,
+    MARKER_HANDOFF_DECISION,
+    MARKER_HEARTBEAT,
+    MARKER_KINDS,
+    MARKER_NEEDS_INPUT,
+    MARKER_SCHEMA_VERSION,
+    MARKER_STATUS,
+    append_marker,
+    marker_kind_to_lifecycle,
+    read_markers_since,
+)
+from session_orchestration.types import SessionLifecycle
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def marker_file(tmp_path) -> Path:
+    """Return a path to a fresh marker file (not yet created)."""
+    return tmp_path / ".hermes" / "sessions" / "test-session.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: every kind
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    """Append then read back each marker kind; verify envelope fields."""
+
+    CASES: list[tuple[str, dict]] = [
+        (MARKER_STATUS, {"phase": "running", "detail": "Processing step 1"}),
+        (MARKER_HEARTBEAT, {"note": "still alive"}),
+        (MARKER_HEARTBEAT, {"note": None}),
+        (MARKER_NEEDS_INPUT, {"question": "Which branch?", "options": ["main", "dev"], "context": "git context"}),
+        (MARKER_NEEDS_INPUT, {"question": "Confirm?", "options": None, "context": None}),
+        (MARKER_HANDOFF_CONTINUE, {"handoff_text": "Resuming after clear checkpoint"}),
+        (MARKER_HANDOFF_DECISION, {"question": "Merge now?", "handoff_text": "At merge checkpoint"}),
+        (MARKER_DONE, {"summary": "Task completed", "artifacts": ["output.txt"]}),
+        (MARKER_DONE, {"summary": "Task completed", "artifacts": None}),
+    ]
+
+    @pytest.mark.parametrize("kind,payload", CASES)
+    def test_round_trip(self, marker_file: Path, kind: str, payload: dict):
+        """append then read returns an envelope with the correct kind and payload."""
+        append_marker(marker_file, kind, payload, task="test-task-1")
+        markers, offset = read_markers_since(marker_file, 0)
+
+        assert len(markers) == 1
+        m = markers[0]
+        assert m["kind"] == kind
+        assert m["task"] == "test-task-1"
+        assert m["payload"] == payload
+        assert offset > 0
+
+    def test_version_field_present_and_correct(self, marker_file: Path):
+        """Every appended marker carries v == MARKER_SCHEMA_VERSION."""
+        for kind, payload in self.CASES:
+            append_marker(marker_file, kind, payload, task="t")
+
+        markers, _ = read_markers_since(marker_file, 0)
+        assert len(markers) == len(self.CASES)
+        for m in markers:
+            assert "v" in m
+            assert m["v"] == MARKER_SCHEMA_VERSION
+
+    def test_ts_field_present(self, marker_file: Path):
+        """Every marker has a non-empty 'ts' string."""
+        append_marker(marker_file, MARKER_STATUS, {"phase": "init", "detail": ""}, task="t")
+        markers, _ = read_markers_since(marker_file, 0)
+        assert markers[0]["ts"]  # non-empty string
+
+    def test_all_kinds_appended_and_read(self, marker_file: Path):
+        """All MARKER_KINDS can be appended and are read back intact."""
+        payloads = {
+            MARKER_STATUS: {"phase": "init", "detail": "x"},
+            MARKER_HEARTBEAT: {"note": None},
+            MARKER_NEEDS_INPUT: {"question": "q", "options": None, "context": None},
+            MARKER_HANDOFF_CONTINUE: {"handoff_text": "ht"},
+            MARKER_HANDOFF_DECISION: {"question": "q", "handoff_text": "ht"},
+            MARKER_DONE: {"summary": "s", "artifacts": None},
+        }
+        assert MARKER_KINDS == set(payloads.keys()), "test is missing a kind"
+
+        for kind in sorted(MARKER_KINDS):
+            append_marker(marker_file, kind, payloads[kind], task="t")
+
+        markers, _ = read_markers_since(marker_file, 0)
+        read_kinds = {m["kind"] for m in markers}
+        assert read_kinds == MARKER_KINDS
+
+
+# ---------------------------------------------------------------------------
+# Malformed-line skipping
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedLines:
+    """Malformed lines must be silently skipped; valid lines must survive."""
+
+    def test_invalid_json_skipped(self, marker_file: Path):
+        """A non-JSON line does not prevent valid markers from being read."""
+        marker_file.parent.mkdir(parents=True, exist_ok=True)
+        # Write a corrupt line directly, then a valid marker.
+        marker_file.write_bytes(b"this is not json\n")
+        append_marker(marker_file, MARKER_HEARTBEAT, {"note": "ok"}, task="t")
+
+        markers, _ = read_markers_since(marker_file, 0)
+        assert len(markers) == 1
+        assert markers[0]["kind"] == MARKER_HEARTBEAT
+
+    def test_missing_envelope_fields_skipped(self, marker_file: Path):
+        """A JSON object that lacks required envelope fields is skipped."""
+        marker_file.parent.mkdir(parents=True, exist_ok=True)
+        # Missing 'kind', 'ts', 'task', 'payload'.
+        bad = json.dumps({"v": 1, "data": "incomplete"}) + "\n"
+        marker_file.write_bytes(bad.encode())
+        append_marker(marker_file, MARKER_DONE, {"summary": "done", "artifacts": None}, task="t")
+
+        markers, _ = read_markers_since(marker_file, 0)
+        assert len(markers) == 1
+        assert markers[0]["kind"] == MARKER_DONE
+
+    def test_empty_lines_skipped(self, marker_file: Path):
+        """Blank lines do not crash read_markers_since."""
+        marker_file.parent.mkdir(parents=True, exist_ok=True)
+        marker_file.write_bytes(b"\n\n\n")
+        append_marker(marker_file, MARKER_STATUS, {"phase": "x", "detail": "y"}, task="t")
+
+        markers, _ = read_markers_since(marker_file, 0)
+        assert len(markers) == 1
+
+    def test_all_malformed_returns_empty_list(self, marker_file: Path):
+        """A file containing only malformed lines returns an empty markers list."""
+        marker_file.parent.mkdir(parents=True, exist_ok=True)
+        marker_file.write_bytes(b"bad\n{}\n{\"v\":1}\n")
+
+        markers, _ = read_markers_since(marker_file, 0)
+        assert markers == []
+
+    def test_payload_not_dict_skipped(self, marker_file: Path):
+        """A line where 'payload' is not a dict is skipped."""
+        marker_file.parent.mkdir(parents=True, exist_ok=True)
+        bad = json.dumps({"v": 1, "ts": "2024-01-01T00:00:00+00:00", "kind": "done", "task": "t", "payload": "string"}) + "\n"
+        marker_file.write_bytes(bad.encode())
+        append_marker(marker_file, MARKER_HEARTBEAT, {"note": None}, task="t")
+
+        markers, _ = read_markers_since(marker_file, 0)
+        assert len(markers) == 1
+        assert markers[0]["kind"] == MARKER_HEARTBEAT
+
+
+# ---------------------------------------------------------------------------
+# read-since-offset returns only new lines
+# ---------------------------------------------------------------------------
+
+
+class TestReadSinceOffset:
+    """The offset mechanism must skip already-consumed bytes."""
+
+    def test_offset_skips_earlier_lines(self, marker_file: Path):
+        """After reading with offset=0, a second call with new_offset skips old lines."""
+        append_marker(marker_file, MARKER_STATUS, {"phase": "a", "detail": "first"}, task="t")
+        markers1, offset1 = read_markers_since(marker_file, 0)
+        assert len(markers1) == 1
+
+        append_marker(marker_file, MARKER_HEARTBEAT, {"note": "second"}, task="t")
+        markers2, offset2 = read_markers_since(marker_file, offset1)
+
+        assert len(markers2) == 1
+        assert markers2[0]["kind"] == MARKER_HEARTBEAT
+        assert offset2 > offset1
+
+    def test_repeated_offset_returns_empty(self, marker_file: Path):
+        """Calling read_markers_since with the same offset twice returns empty on second call."""
+        append_marker(marker_file, MARKER_DONE, {"summary": "s", "artifacts": None}, task="t")
+        _, offset = read_markers_since(marker_file, 0)
+
+        markers, new_offset = read_markers_since(marker_file, offset)
+        assert markers == []
+        assert new_offset == offset
+
+    def test_offset_accumulates_across_multiple_appends(self, marker_file: Path):
+        """A rolling offset over three appends yields exactly one marker per read."""
+        kinds = [MARKER_STATUS, MARKER_HEARTBEAT, MARKER_DONE]
+        payloads = [
+            {"phase": "p", "detail": "d"},
+            {"note": None},
+            {"summary": "s", "artifacts": None},
+        ]
+
+        offset = 0
+        for kind, payload in zip(kinds, payloads):
+            append_marker(marker_file, kind, payload, task="t")
+            ms, offset = read_markers_since(marker_file, offset)
+            assert len(ms) == 1, f"expected exactly 1 new marker for kind={kind}"
+            assert ms[0]["kind"] == kind
+
+    def test_zero_offset_reads_all_lines(self, marker_file: Path):
+        """offset=0 always reads from the beginning of the file."""
+        for _ in range(5):
+            append_marker(marker_file, MARKER_HEARTBEAT, {"note": None}, task="t")
+
+        markers, _ = read_markers_since(marker_file, 0)
+        assert len(markers) == 5
+
+    def test_nonexistent_file_returns_empty_at_same_offset(self, tmp_path: Path):
+        """A missing file returns ([], offset) without raising."""
+        path = tmp_path / "no_such_file.jsonl"
+        markers, new_offset = read_markers_since(path, 42)
+        assert markers == []
+        assert new_offset == 42
+
+
+# ---------------------------------------------------------------------------
+# marker_kind_to_lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestMarkerKindToLifecycle:
+    """Every kind maps to the expected SessionLifecycle value."""
+
+    EXPECTED: list[tuple[str, SessionLifecycle]] = [
+        (MARKER_STATUS, SessionLifecycle.RUNNING),
+        (MARKER_HEARTBEAT, SessionLifecycle.RUNNING),
+        (MARKER_NEEDS_INPUT, SessionLifecycle.WAITING_USER),
+        (MARKER_HANDOFF_CONTINUE, SessionLifecycle.PAUSED_HANDOFF),
+        (MARKER_HANDOFF_DECISION, SessionLifecycle.PAUSED_HANDOFF),
+        (MARKER_DONE, SessionLifecycle.DONE),
+    ]
+
+    @pytest.mark.parametrize("kind,expected_lifecycle", EXPECTED)
+    def test_known_kind_maps_correctly(self, kind: str, expected_lifecycle: SessionLifecycle):
+        assert marker_kind_to_lifecycle(kind) == expected_lifecycle
+
+    def test_unknown_kind_returns_none(self):
+        """An unrecognised kind returns None rather than raising."""
+        assert marker_kind_to_lifecycle("totally_unknown_kind") is None
+
+    def test_all_marker_kinds_are_mapped(self):
+        """MARKER_KINDS has no unmapped members — table is complete."""
+        for kind in MARKER_KINDS:
+            result = marker_kind_to_lifecycle(kind)
+            assert result is not None, f"kind={kind!r} is missing from lifecycle mapping"
+
+    def test_lifecycle_values_are_sessionlifecycle_members(self):
+        """All mapped values are members of the SessionLifecycle enum."""
+        for kind in MARKER_KINDS:
+            lc = marker_kind_to_lifecycle(kind)
+            assert isinstance(lc, SessionLifecycle)
+
+
+# ---------------------------------------------------------------------------
+# Parent-directory creation
+# ---------------------------------------------------------------------------
+
+
+class TestParentDirCreation:
+    """append_marker must create missing parent directories."""
+
+    def test_nested_parent_created(self, tmp_path: Path):
+        deep = tmp_path / "a" / "b" / "c" / "session.jsonl"
+        assert not deep.parent.exists()
+        append_marker(deep, MARKER_HEARTBEAT, {"note": None}, task="t")
+        assert deep.exists()
+        markers, _ = read_markers_since(deep, 0)
+        assert len(markers) == 1

--- a/tests/test_session_orchestration_menu_parse.py
+++ b/tests/test_session_orchestration_menu_parse.py
@@ -1,0 +1,254 @@
+"""Tests for session_orchestration.menu_parse (answerable needs-input).
+
+Ported from the so-MCP orchestrator tests (test_hermes_so_mcp.py) plus the
+new ``extract()`` tuple contract.
+"""
+
+import json
+
+from session_orchestration.menu_parse import (
+    extract,
+    extract_menu_options,
+    extract_needs_input_context,
+    resolve_menu_answer,
+)
+
+_MENU_PANE = (
+    " Proposal 1: add structured degraded-consult provenance. Decision?\n"
+    "\n"
+    "────────────────────────────────────────────────────────────────\n"
+    "│ Accept (Recommended)                                          │\n"
+    "│    Apply edits to the agent instructions now.                 │\n"
+    "│ Refine                                                        │\n"
+    "│    Ask a follow-up question before deciding.                  │\n"
+    "│ Defer                                                         │\n"
+    "│    Keep it in the retro, no edits now.                        │\n"
+    "│ Reject                                                        │\n"
+    "│    Drop the proposal entirely.                                │\n"
+    "│ Other (type your own)                                         │\n"
+    "────────────────────────────────────────────────────────────────\n"
+    " up/down navigate  enter select  esc cancel\n"
+    "────────────────────────────────────────────────────────────────"
+)
+
+
+def test_extract_menu_options_returns_ordered_labels():
+    assert extract_menu_options(_MENU_PANE) == [
+        "Accept (Recommended)",
+        "Refine",
+        "Defer",
+        "Reject",
+        "Other (type your own)",
+    ]
+
+
+def test_extract_menu_options_skips_indented_descriptions():
+    # Indented description rows must never leak into the option list.
+    for desc in (
+        "Apply edits to the agent instructions now.",
+        "Keep it in the retro, no edits now.",
+        "Drop the proposal entirely.",
+    ):
+        assert desc not in extract_menu_options(_MENU_PANE)
+
+
+def test_extract_menu_options_empty_for_bare_prompt():
+    assert extract_menu_options("Proceed?\n❯") == []
+
+
+def test_extract_needs_input_context_cleans_menu():
+    out = extract_needs_input_context(_MENU_PANE)
+    assert "Proposal 1: add structured degraded-consult provenance. Decision?" in out
+    assert "Accept (Recommended)" in out
+    assert "Apply edits to the agent instructions now." in out
+    # Box-drawing rules and nav footer are stripped.
+    assert "─" not in out
+    assert "│" not in out
+    assert "enter select" not in out
+    assert "esc cancel" not in out
+
+
+def test_extract_needs_input_context_falls_back_on_unknown_shape():
+    raw = "some freeform prompt asking a question ❯"
+    assert extract_needs_input_context(raw) == raw.strip()
+
+
+def test_extract_menu_tuple():
+    question, options, is_menu = extract(_MENU_PANE)
+    assert is_menu is True
+    assert options == [
+        "Accept (Recommended)",
+        "Refine",
+        "Defer",
+        "Reject",
+        "Other (type your own)",
+    ]
+    # The question prose survives; option labels are removed from it so they
+    # aren't duplicated when a caller renders the numbered list.
+    assert "Proposal 1" in question
+    assert "Accept (Recommended)" not in question
+
+
+def test_extract_free_form_prompt_is_not_a_menu():
+    question, options, is_menu = extract("Which branch should I use? ❯")
+    assert is_menu is False
+    assert options == []
+    assert "Which branch should I use?" in question
+
+
+def test_extract_empty_pane():
+    question, options, is_menu = extract("")
+    assert is_menu is False
+    assert options == []
+    assert question == ""
+
+
+# Real omp v16.2 `ask` menu capture (2026-07-01 live smoke). Exercises: two
+# stacked boxes (a transient "Ask" render + the live footer-anchored menu),
+# Nerd-Font glyph prefixes on labels, a 4-space-indented description row, and
+# a 2-space-indented final option. Footer-anchored parse must pick the live
+# menu, strip glyphs, keep all four options, and pull the real question.
+_OMP_V16_ASK_PANE = (
+    "──────────────────────────────────────────────\n"
+    "  Update Available\n"
+    "  New version 16.2.13 is available. Run: omp update\n"
+    "──────────────────────────────────────────────\n"
+    "\n"
+    "  Clarifying task requirements\n"
+    "\n"
+    "  I realize that I need to comply with the user's request by asking...\n"
+    "\n"
+    "╭─── Ask 1 questions ──────────────────────────╮\n"
+    "├─── [task_goal] · options:3 ──────────────────┤\n"
+    "│  What task should I work on after this clarification?          │\n"
+    "│   Code change                                                  │\n"
+    "│    ↳ Modify implementation, tests, or tooling in this repo.    │\n"
+    "│   Investigation                                                │\n"
+    "│    ↳ Read-only debugging, audit, or explanation.              │\n"
+    "╰──────────────────────────────────────────────╯\n"
+    "\n"
+    "  ⠇ Clarifying intent ⟨esc⟩\n"
+    "\n"
+    "──────────────────────────────────────────────\n"
+    "  What task should I work on after this clarification?\n"
+    "──────────────────────────────────────────────\n"
+    "│  Code change (Recommended)                                 │\n"
+    "│    Modify implementation, tests, or tooling in this repo.      │\n"
+    "│  Investigation                                             │\n"
+    "│    Read-only debugging, audit, or explanation.                 │\n"
+    "│  Plan/review                                               │\n"
+    "│    Create or assess a plan before implementation.              │\n"
+    "│  Other (type your own)                                         │\n"
+    "──────────────────────────────────────────────\n"
+    " up/down navigate  enter select  esc cancel\n"
+    "──────────────────────────────────────────────"
+)
+
+
+_OMP_FREE_FORM_PANE = (
+    "──────────────────────────────────\n"
+    " Update Available\n"
+    " New version 16.2.13 is available. Run: omp update\n"
+    "──────────────────────────────────\n"
+    "\n"
+    " Clarifying user needs\n"
+    " I need to ask a clarifying question and then wait for the user's response...\n"
+    "\n"
+    " What task do you want me to work on after this clarification?\n"
+    "\n"
+    " Hermes nudge: your session appears to have stalled. If you are waiting...\n"
+    "\n"
+    " Still waiting on the clarifying answer: what task should I work on?\n"
+    "\n"
+    "╭──  GPT-5.5 ·  med   ~/dev/z-harness   main ──╮\n"
+    "╰─                                            ─╯"
+)
+
+
+def test_extract_free_form_omp_question_isolated():
+    question, options, is_menu = extract(_OMP_FREE_FORM_PANE)
+    assert is_menu is False
+    assert options == []
+    # The actual question is isolated from reasoning / banner / nudge / chrome.
+    assert question == "Still waiting on the clarifying answer: what task should I work on?"
+    assert "omp update" not in question
+    assert "Hermes nudge" not in question
+    assert "GPT-5.5" not in question
+
+
+def test_extract_real_omp_v16_ask_menu():
+    question, options, is_menu = extract(_OMP_V16_ASK_PANE)
+    assert is_menu is True
+    assert options == [
+        "Code change (Recommended)",
+        "Investigation",
+        "Plan/review",
+        "Other (type your own)",
+    ]
+    assert question == "What task should I work on after this clarification?"
+    # Nerd-Font glyphs must not leak into labels.
+    assert "" not in "".join(options)
+    assert "" not in "".join(options)
+
+
+# --- resolve_menu_answer -----------------------------------------------------
+
+def _menu_row(**over):
+    row = {
+        "state": "WAITING_USER",
+        "last_input_kind": "menu",
+        "last_options": json.dumps(["Accept", "Defer", "Reject"]),
+    }
+    row.update(over)
+    return row
+
+
+def test_resolve_menu_answer_valid_number_escapes_and_names_label():
+    drive_text, pre_keys = resolve_menu_answer(_menu_row(), "2")
+    assert pre_keys == ["Escape"]
+    assert "option 2" in drive_text
+    assert "Defer" in drive_text
+
+
+def test_resolve_menu_answer_trailing_period_ok():
+    drive_text, pre_keys = resolve_menu_answer(_menu_row(), "1.")
+    assert pre_keys == ["Escape"]
+    assert "Accept" in drive_text
+
+
+def test_resolve_menu_answer_out_of_range_escapes_as_free_text():
+    # A menu is up; an out-of-range number still must Escape the menu (else the
+    # spinner keeps the pane "busy") and is treated as the user's typed answer.
+    drive_text, pre_keys = resolve_menu_answer(_menu_row(), "9")
+    assert pre_keys == ["Escape"]
+    assert "9" in drive_text
+    assert "typed answer" in drive_text
+
+
+def test_resolve_menu_answer_non_numeric_escapes_as_free_text():
+    # Free text on a menu = the "Other (type your own)" case: Escape the menu,
+    # then paste the answer.
+    drive_text, pre_keys = resolve_menu_answer(_menu_row(), "let's defer this")
+    assert pre_keys == ["Escape"]
+    assert "let's defer this" in drive_text
+
+
+def test_resolve_menu_answer_free_form_prompt_untouched():
+    row = _menu_row(last_input_kind="prompt", last_options=json.dumps([]))
+    drive_text, pre_keys = resolve_menu_answer(row, "2")
+    assert pre_keys is None
+    assert drive_text == "2"
+
+
+def test_resolve_menu_answer_not_waiting_untouched():
+    row = _menu_row(state="RUNNING")
+    drive_text, pre_keys = resolve_menu_answer(row, "2")
+    assert pre_keys is None
+    assert drive_text == "2"
+
+
+def test_resolve_menu_answer_bad_options_json_falls_through():
+    row = _menu_row(last_options="not-json")
+    drive_text, pre_keys = resolve_menu_answer(row, "1")
+    assert pre_keys is None
+    assert drive_text == "1"

--- a/tests/test_session_orchestration_menu_parse.py
+++ b/tests/test_session_orchestration_menu_parse.py
@@ -96,6 +96,51 @@ def test_extract_free_form_prompt_is_not_a_menu():
     assert "Which branch should I use?" in question
 
 
+def test_extract_completion_pane_command_box_is_not_a_menu():
+    pane = (
+        "d as a direct provider/fallback (advances criterion #5).\n"
+        "- none recorded\n"
+        "├─── Output ─────────────────────────────────────────────────────────┤\n"
+        "╰───────────────────────────────────────────────────────────────────╯\n"
+        "T003 only completed.\n"
+        "- Updated tests/test_omp_provider.py so omp-gemini is validated via alias:\n"
+        "- aliases[\"omp-gemini\"] == \"omp-antigravity-pro\"\n"
+        "- fallback validated on canonical omp-antigravity-pro\n"
+        "- no duplicate omp-gemini provider entry added\n"
+        "- Targeted verification passed:\n"
+        "- python -m unittest tests.test_omp_provider.TestOmpLiveEntries.test_live_omp_entries_carry_fallback\n"
+        "tests.test_resolve_provider.TestResolveProvider.test_omp_gemini_alias_resolves_to_antigravity_provider\n"
+        "- python -m unittest tests.test_omp_provider\n"
+        "- Reviewer final pass:\n"
+        "- review-cycle3.md: PASS, 0 blockers, 0 majors\n"
+        "- Plan state:\n"
+        "- T003 marked [x]\n"
+        "- T004-T006 left [ ], not started\n"
+        "│ … 14 more lines ⟨Ctrl+O: Expand⟩                              │\n"
+        "│ $ BASE=\"/Users/zeke/.local/state/z-harness/example\"            │\n"
+        "│ RUN=\"$(cat \"$BASE/archive/.current-run\")\"                    │\n"
+        "│ bash scripts/log-event.sh tasks/T003 task_done '{}'             │\n"
+        "│ 2>/dev/null || true                                             │\n"
+        "│ cat >> \"$BASE/LEDGER.md\" <<'EOF'                              │\n"
+        "│ ## Level 0                                                      │\n"
+        "│ ### T003                                                        │\n"
+        "│ **Decisions:**                                                  │\n"
+        "│ compatibility (advances criterion #4).                          │\n"
+        "│ **Deviations:**                                                 │\n"
+        "│ EOF                                                             │\n"
+        "│ (no output)                                                     │\n"
+        "│ ⟨Wall: 0.46s | Timeout: 30s⟩                                   │\n"
+        "❯\n"
+    )
+
+    question, options, is_menu = extract(pane)
+    assert is_menu is False
+    assert options == []
+    assert "$ BASE" not in question
+    assert "2>/dev/null" not in question
+    assert question != "❯"
+
+
 def test_extract_empty_pane():
     question, options, is_menu = extract("")
     assert is_menu is False

--- a/tests/test_session_orchestration_omp.py
+++ b/tests/test_session_orchestration_omp.py
@@ -45,11 +45,42 @@ from session_orchestration.adapters.omp import (
     OmpAdapter,
     build_interactive_argv,
     build_oneshot_argv,
+    pane_is_idle_waiting,
     parse_oneshot_result,
     parse_pane_lifecycle,
     tail_rpc_stream,
     translate_rpc_line,
 )
+
+
+class TestPaneIsIdleWaiting:
+    """Free-form wait signal: omp idles at its composer with no ❯/menu/spinner."""
+
+    _IDLE = (
+        " What task do you want me to work on?\n"
+        "╭──  GPT-5.5 ·  med   ~/dev/z-harness ──╮\n"
+        "╰─                                     ─╯"
+    )
+
+    def test_idle_composer_no_spinner_is_waiting(self):
+        assert pane_is_idle_waiting(self._IDLE) is True
+
+    def test_busy_spinner_is_not_waiting(self):
+        assert pane_is_idle_waiting(self._IDLE + "\n⠹ Requesting task") is False
+
+    def test_menu_footer_is_not_free_form_wait(self):
+        # A selection menu is handled directly by parse_pane_lifecycle.
+        assert pane_is_idle_waiting(self._IDLE + "\n up/down  enter select  esc cancel") is False
+
+    def test_prompt_char_is_not_free_form_wait(self):
+        assert pane_is_idle_waiting("Proceed?\n❯") is False
+
+    def test_empty_pane_is_not_waiting(self):
+        assert pane_is_idle_waiting("") is False
+
+    def test_no_tui_box_is_not_waiting(self):
+        # Plain scrollback with no composer chrome — not a confirmed idle wait.
+        assert pane_is_idle_waiting("just some log output\nmore output") is False
 from session_orchestration.markers import (
     MARKER_DONE,
     MARKER_HEARTBEAT,
@@ -84,6 +115,10 @@ class FakeTmuxRunner:
         self.calls.append(list(args))
         if args and args[0] == "capture-pane":
             return self._capture_output
+        # launch() resolves the real pane id via `list-panes -F '#{pane_id}'`
+        # and indexes [0]; return a deterministic id so the fake doesn't 500.
+        if args and args[0] == "list-panes":
+            return "%0"
         return ""
 
     def set_capture(self, text: str) -> None:
@@ -548,8 +583,10 @@ class TestRunOneshot:
 
 class TestDrive:
     def setup_method(self):
-        # Pane shows ">" so readiness check passes immediately.
-        self.fake_tmux = FakeTmuxRunner(capture_output="last line\n> ")
+        # omp's _wait_for_ready looks for TUI box chrome (╭/╰) and NOT a busy
+        # spinner — omp never renders a ">"/"❯" input char. Provide an idle box
+        # so the readiness check passes immediately.
+        self.fake_tmux = FakeTmuxRunner(capture_output="╭─ idle ─╮\nlast line\n╰──────╯")
         self.adapter = OmpAdapter(
             omp_runner=FakeOmpRunner(),
             tmux_runner=self.fake_tmux,
@@ -704,6 +741,9 @@ class TestLaunchMarkerInjection:
         fake_tmux = FakeTmuxRunner(capture_output="last line\n> ")
         adapter = OmpAdapter(omp_runner=FakeOmpRunner(), tmux_runner=fake_tmux)
         with (
+            # launch() now waits via _wait_for_launch (TUI box chrome), not
+            # _wait_for_prompt; patch it so the fake pane needn't render a box.
+            patch.object(adapter, "_wait_for_launch"),
             patch.object(adapter, "_wait_for_prompt"),
             patch("os.makedirs"),
         ):

--- a/tests/test_session_orchestration_omp.py
+++ b/tests/test_session_orchestration_omp.py
@@ -15,9 +15,16 @@ Everything testable without a live tmux/omp session is covered here:
 8. ``resume()`` — asserts -c re-launch when PAUSED_HANDOFF; no-op otherwise.
 9. ``run_oneshot()`` — asserts the OmpRunner is called with correct argv and
    parse_oneshot_result is applied to stdout.
+10. ``launch()`` — marker-file injection: verifies -e HERMES_MARKER_FILE in
+    tmux args and handle.marker_file is set to expected path.
+11. ``terminate()`` — issues kill-session and swallows nonzero exit.
+12. ``translate_rpc_line()`` — round-trip tests for every mapped type + None
+    for unknown / blank / non-JSON input.
+13. ``tail_rpc_stream()`` — drives a fake stdout iter and asserts correct
+    marker kinds are written via the injected append_fn.
 
 LIVE-ONLY (not tested here):
-- ``launch()`` — requires real tmux + omp binary.
+- The actual tmux new-session system call in ``launch()`` (real tmux binary).
 - ``_wait_for_prompt()`` timing with real sleeps.
 - ``_load_buffer()`` — requires real tmux process.
 """
@@ -40,6 +47,14 @@ from session_orchestration.adapters.omp import (
     build_oneshot_argv,
     parse_oneshot_result,
     parse_pane_lifecycle,
+    tail_rpc_stream,
+    translate_rpc_line,
+)
+from session_orchestration.markers import (
+    MARKER_DONE,
+    MARKER_HEARTBEAT,
+    MARKER_NEEDS_INPUT,
+    MARKER_STATUS,
 )
 from session_orchestration.types import Capabilities, SessionHandle, SessionLifecycle
 
@@ -675,3 +690,294 @@ class TestResume:
             adapter.resume(handle, "prompt")
 
         mock_wait.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# launch() — marker-file injection (stubbed tmux + mocked prompt wait)
+# ---------------------------------------------------------------------------
+
+
+class TestLaunchMarkerInjection:
+    """Verify that launch() computes marker_file and passes -e HERMES_MARKER_FILE."""
+
+    def _run_launch(self, workdir: str) -> tuple[SessionHandle, FakeTmuxRunner]:
+        fake_tmux = FakeTmuxRunner(capture_output="last line\n> ")
+        adapter = OmpAdapter(omp_runner=FakeOmpRunner(), tmux_runner=fake_tmux)
+        with (
+            patch.object(adapter, "_wait_for_prompt"),
+            patch("os.makedirs"),
+        ):
+            handle = adapter.launch(workdir=workdir, prompt="start")
+        return handle, fake_tmux
+
+    def test_new_session_args_contain_hermes_marker_file_flag(self):
+        """The '-e HERMES_MARKER_FILE=...' pair must appear in new-session args."""
+        handle, fake_tmux = self._run_launch("/some/workdir")
+        new_session_call = next(
+            c for c in fake_tmux.calls if c[0] == "new-session"
+        )
+        flat = " ".join(new_session_call)
+        assert "HERMES_MARKER_FILE" in flat, (
+            f"Expected HERMES_MARKER_FILE in new-session args; got: {new_session_call}"
+        )
+        assert "-e" in new_session_call
+
+    def test_marker_file_path_formula(self):
+        """marker_file must equal {workdir}/.hermes/sessions/{session_id}.jsonl."""
+        workdir = "/projects/myapp"
+        handle, _ = self._run_launch(workdir)
+        assert handle.marker_file is not None
+        expected_prefix = f"{workdir}/.hermes/sessions/"
+        assert handle.marker_file.startswith(expected_prefix)
+        assert handle.marker_file.endswith(".jsonl")
+
+    def test_marker_file_contains_session_id(self):
+        """The marker_file path must embed handle.session_id."""
+        handle, _ = self._run_launch("/workdir")
+        assert handle.marker_file is not None
+        assert handle.session_id in handle.marker_file
+
+    def test_marker_file_matches_env_var_in_tmux_args(self):
+        """The marker_file on handle must be the same value passed via -e."""
+        handle, fake_tmux = self._run_launch("/workdir")
+        new_session_call = next(
+            c for c in fake_tmux.calls if c[0] == "new-session"
+        )
+        # Find the value after '-e'
+        e_idx = new_session_call.index("-e")
+        env_val = new_session_call[e_idx + 1]  # "HERMES_MARKER_FILE=<path>"
+        assert env_val == f"HERMES_MARKER_FILE={handle.marker_file}"
+
+
+# ---------------------------------------------------------------------------
+# terminate()
+# ---------------------------------------------------------------------------
+
+
+class TestTerminate:
+    def test_terminate_issues_kill_session(self):
+        """terminate() must call tmux kill-session -t <tmux_session>."""
+        fake_tmux = FakeTmuxRunner()
+        adapter = OmpAdapter(omp_runner=FakeOmpRunner(), tmux_runner=fake_tmux)
+        handle = _make_handle()
+
+        adapter.terminate(handle)
+
+        kill_calls = [c for c in fake_tmux.calls if c[0] == "kill-session"]
+        assert kill_calls, "Expected at least one kill-session call"
+        assert handle.tmux_session in kill_calls[0]
+
+    def test_terminate_passes_check_false(self):
+        """terminate() must not raise even when kill-session returns nonzero."""
+
+        class ErrorOnKillRunner:
+            def run(self, args: list[str], check: bool = True) -> str:
+                if args[0] == "kill-session":
+                    raise subprocess.CalledProcessError(1, "tmux kill-session")
+                return ""
+
+        adapter = OmpAdapter(omp_runner=FakeOmpRunner(), tmux_runner=ErrorOnKillRunner())
+        handle = _make_handle()
+        # Must not raise — CalledProcessError is swallowed.
+        adapter.terminate(handle)
+
+    def test_terminate_targets_correct_session(self):
+        """terminate() must target handle.tmux_session, not a hard-coded name."""
+        fake_tmux = FakeTmuxRunner()
+        adapter = OmpAdapter(omp_runner=FakeOmpRunner(), tmux_runner=fake_tmux)
+        handle = _make_handle(pane="custom-session-xyz:0.0")
+        handle = SessionHandle(
+            session_id=handle.session_id,
+            tmux_session="custom-session-xyz",
+            pane=handle.pane,
+            launch_ts=handle.launch_ts,
+        )
+
+        adapter.terminate(handle)
+
+        kill_call = next(c for c in fake_tmux.calls if c[0] == "kill-session")
+        assert "custom-session-xyz" in kill_call
+
+
+# ---------------------------------------------------------------------------
+# translate_rpc_line()
+# ---------------------------------------------------------------------------
+
+
+class TestTranslateRpcLine:
+    """Round-trip tests: every mapped omp RPC event type + None for unknowns."""
+
+    def test_ready_maps_to_status_phase_ready(self):
+        line = json.dumps({"type": "ready"})
+        result = translate_rpc_line(line)
+        assert result is not None
+        assert result["kind"] == MARKER_STATUS
+        assert result["payload"]["phase"] == "ready"
+
+    def test_turn_start_maps_to_status_phase_running(self):
+        line = json.dumps({"type": "turn_start"})
+        result = translate_rpc_line(line)
+        assert result is not None
+        assert result["kind"] == MARKER_STATUS
+        assert result["payload"]["phase"] == "running"
+
+    def test_message_end_assistant_maps_to_heartbeat(self):
+        line = json.dumps({
+            "type": "message_end",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Here is my answer."}],
+            },
+        })
+        result = translate_rpc_line(line)
+        assert result is not None
+        assert result["kind"] == MARKER_HEARTBEAT
+        assert result["payload"]["note"] == "Here is my answer."
+
+    def test_message_end_user_role_returns_none(self):
+        """message_end with role=user must not produce a marker."""
+        line = json.dumps({
+            "type": "message_end",
+            "message": {"role": "user", "content": [{"type": "text", "text": "hello"}]},
+        })
+        assert translate_rpc_line(line) is None
+
+    def test_heartbeat_note_truncated_to_120_chars(self):
+        long_text = "x" * 200
+        line = json.dumps({
+            "type": "message_end",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": long_text}],
+            },
+        })
+        result = translate_rpc_line(line)
+        assert result is not None
+        assert len(result["payload"]["note"]) == 120
+
+    def test_agent_end_maps_to_done_with_last_assistant_text(self):
+        line = json.dumps({
+            "type": "agent_end",
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "do it"}]},
+                {"role": "assistant", "content": [{"type": "text", "text": "done!"}]},
+            ],
+        })
+        result = translate_rpc_line(line)
+        assert result is not None
+        assert result["kind"] == MARKER_DONE
+        assert result["payload"]["summary"] == "done!"
+        assert result["payload"]["artifacts"] is None
+
+    def test_agent_end_no_assistant_messages_gives_empty_summary(self):
+        line = json.dumps({"type": "agent_end", "messages": []})
+        result = translate_rpc_line(line)
+        assert result is not None
+        assert result["kind"] == MARKER_DONE
+        assert result["payload"]["summary"] == ""
+
+    def test_needs_input_maps_correctly(self):
+        line = json.dumps({"type": "needs_input", "question": "Which branch?"})
+        result = translate_rpc_line(line)
+        assert result is not None
+        assert result["kind"] == MARKER_NEEDS_INPUT
+        assert result["payload"]["question"] == "Which branch?"
+        assert result["payload"]["options"] is None
+        assert result["payload"]["context"] is None
+
+    def test_unknown_type_returns_none(self):
+        line = json.dumps({"type": "available_commands_update", "commands": []})
+        assert translate_rpc_line(line) is None
+
+    def test_blank_line_returns_none(self):
+        assert translate_rpc_line("") is None
+        assert translate_rpc_line("   ") is None
+
+    def test_non_json_line_returns_none(self):
+        assert translate_rpc_line("not json at all") is None
+
+    def test_session_type_returns_none(self):
+        """session event (startup info) is not a marker event."""
+        line = json.dumps({"type": "session", "version": 3, "id": "abc"})
+        assert translate_rpc_line(line) is None
+
+    def test_agent_start_returns_none(self):
+        line = json.dumps({"type": "agent_start"})
+        assert translate_rpc_line(line) is None
+
+
+# ---------------------------------------------------------------------------
+# tail_rpc_stream()
+# ---------------------------------------------------------------------------
+
+
+class TestTailRpcStream:
+    """Drive a fake stdout iter and assert correct marker kinds are written."""
+
+    def _run_stream(self, lines: list[str]) -> list[tuple]:
+        """Run tail_rpc_stream with a capturing append_fn; return recorded calls."""
+        recorded: list[tuple] = []
+
+        def fake_append(path: str, kind: str, payload: dict, task_id: str) -> None:
+            recorded.append((path, kind, payload, task_id))
+
+        tail_rpc_stream(
+            stdout_iter=iter(lines),
+            marker_path="/fake/marker.jsonl",
+            task_id="test-task-001",
+            append_fn=fake_append,
+        )
+        return recorded
+
+    def test_ready_event_writes_status_marker(self):
+        lines = [json.dumps({"type": "ready"})]
+        calls = self._run_stream(lines)
+        assert len(calls) == 1
+        assert calls[0][1] == MARKER_STATUS  # kind
+        assert calls[0][2]["phase"] == "ready"
+
+    def test_multiple_events_write_multiple_markers(self):
+        lines = [
+            json.dumps({"type": "ready"}),
+            json.dumps({"type": "turn_start"}),
+            json.dumps({
+                "type": "message_end",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "progress"}],
+                },
+            }),
+            json.dumps({
+                "type": "agent_end",
+                "messages": [
+                    {"role": "assistant", "content": [{"type": "text", "text": "final"}]},
+                ],
+            }),
+        ]
+        calls = self._run_stream(lines)
+        kinds = [c[1] for c in calls]
+        assert kinds == [MARKER_STATUS, MARKER_STATUS, MARKER_HEARTBEAT, MARKER_DONE]
+
+    def test_unknown_events_skipped(self):
+        lines = [
+            json.dumps({"type": "available_commands_update", "commands": []}),
+            json.dumps({"type": "ready"}),
+        ]
+        calls = self._run_stream(lines)
+        assert len(calls) == 1
+        assert calls[0][1] == MARKER_STATUS
+
+    def test_blank_and_non_json_lines_skipped(self):
+        lines = ["", "  ", "omp v16.1.15 starting up", json.dumps({"type": "ready"})]
+        calls = self._run_stream(lines)
+        assert len(calls) == 1
+
+    def test_path_and_task_id_passed_to_append_fn(self):
+        lines = [json.dumps({"type": "ready"})]
+        calls = self._run_stream(lines)
+        assert calls[0][0] == "/fake/marker.jsonl"  # path
+        assert calls[0][3] == "test-task-001"  # task_id
+
+    def test_empty_stream_writes_no_markers(self):
+        calls = self._run_stream([])
+        assert calls == []

--- a/tests/test_session_orchestration_omp.py
+++ b/tests/test_session_orchestration_omp.py
@@ -1,0 +1,677 @@
+"""
+Unit tests for session_orchestration/adapters/omp.py.
+
+Coverage strategy
+-----------------
+Everything testable without a live tmux/omp session is covered here:
+
+1. ``build_oneshot_argv`` — pure function; tests flag construction.
+2. ``build_interactive_argv`` — pure function; tests flag construction.
+3. ``parse_oneshot_result`` — pure function; fed sample NDJSON streams.
+4. ``parse_pane_lifecycle`` — pure function; fed sample pane snapshots.
+5. ``Capabilities`` declaration — asserts rpc_mode/json_mode/has_hooks.
+6. ``drive()`` command sequence — asserts tmux commands via a fake runner.
+7. ``detect()`` pane-parse — feeds fake pane text through a stubbed capture.
+8. ``resume()`` — asserts -c re-launch when PAUSED_HANDOFF; no-op otherwise.
+9. ``run_oneshot()`` — asserts the OmpRunner is called with correct argv and
+   parse_oneshot_result is applied to stdout.
+
+LIVE-ONLY (not tested here):
+- ``launch()`` — requires real tmux + omp binary.
+- ``_wait_for_prompt()`` timing with real sleeps.
+- ``_load_buffer()`` — requires real tmux process.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from session_orchestration.adapters.omp import (
+    ACTIVITY_REGEX,
+    HANDOFF_MARKER,
+    PROMPT_PATTERN,
+    OmpAdapter,
+    build_interactive_argv,
+    build_oneshot_argv,
+    parse_oneshot_result,
+    parse_pane_lifecycle,
+)
+from session_orchestration.types import Capabilities, SessionHandle, SessionLifecycle
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_handle(pane: str = "hermes-omp-abc:0.0") -> SessionHandle:
+    return SessionHandle(
+        session_id="abc12345-dead-beef-0000-000000000000",
+        tmux_session="hermes-omp-abc12345",
+        pane=pane,
+        launch_ts=datetime.now(tz=timezone.utc),
+    )
+
+
+class FakeTmuxRunner:
+    """Fake TmuxRunner that records calls and returns configurable output."""
+
+    def __init__(self, capture_output: str = "") -> None:
+        self.calls: list[list[str]] = []
+        self._capture_output = capture_output
+
+    def run(self, args: list[str], check: bool = True) -> str:
+        self.calls.append(list(args))
+        if args and args[0] == "capture-pane":
+            return self._capture_output
+        return ""
+
+    def set_capture(self, text: str) -> None:
+        self._capture_output = text
+
+
+class FakeOmpRunner:
+    """Fake OmpRunner that records calls and returns configurable stdout."""
+
+    def __init__(self, stdout: str = "") -> None:
+        self.calls: list[list[str]] = []
+        self._stdout = stdout
+
+    def run_oneshot(
+        self,
+        args: list[str],
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        self.calls.append(list(args))
+        return subprocess.CompletedProcess(
+            args=["omp"] + args,
+            returncode=0,
+            stdout=self._stdout,
+            stderr="",
+        )
+
+
+def _agent_end_ndjson(assistant_text: str) -> str:
+    """Build a minimal valid omp --mode=json NDJSON stream."""
+    events = [
+        {"type": "session", "version": 3, "id": "sess-001"},
+        {"type": "agent_start"},
+        {"type": "turn_start"},
+        {
+            "type": "message_start",
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": "hello"}],
+            },
+        },
+        {
+            "type": "message_end",
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": "hello"}],
+            },
+        },
+        {
+            "type": "message_start",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": assistant_text}],
+                "stopReason": "stop",
+            },
+        },
+        {
+            "type": "message_end",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": assistant_text}],
+                "stopReason": "stop",
+            },
+        },
+        {
+            "type": "turn_end",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": assistant_text}],
+            },
+        },
+        {
+            "type": "agent_end",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "hello"}],
+                },
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": assistant_text}],
+                    "stopReason": "stop",
+                },
+            ],
+        },
+    ]
+    return "\n".join(json.dumps(e) for e in events)
+
+
+# ---------------------------------------------------------------------------
+# build_oneshot_argv
+# ---------------------------------------------------------------------------
+
+
+class TestBuildOneshotArgv:
+    def test_basic_includes_print_and_json_mode(self):
+        argv = build_oneshot_argv("say hi")
+        assert "-p" in argv
+        assert "--mode=json" in argv
+        assert "say hi" in argv
+
+    def test_model_flag(self):
+        argv = build_oneshot_argv("prompt", model="openai-codex/gpt-5.5")
+        assert "--model" in argv
+        idx = argv.index("--model")
+        assert argv[idx + 1] == "openai-codex/gpt-5.5"
+
+    def test_workdir_flag(self):
+        argv = build_oneshot_argv("prompt", workdir="/some/path")
+        assert "--cwd" in argv
+        idx = argv.index("--cwd")
+        assert argv[idx + 1] == "/some/path"
+
+    def test_max_time_flag(self):
+        argv = build_oneshot_argv("prompt", max_time=120)
+        assert "--max-time" in argv
+        idx = argv.index("--max-time")
+        assert argv[idx + 1] == "120"
+
+    def test_no_session_by_default(self):
+        argv = build_oneshot_argv("prompt")
+        assert "--no-session" in argv
+
+    def test_no_session_suppressed(self):
+        argv = build_oneshot_argv("prompt", no_session=False)
+        assert "--no-session" not in argv
+
+    def test_prompt_is_last_arg(self):
+        argv = build_oneshot_argv("my prompt text", model="opus")
+        assert argv[-1] == "my prompt text"
+
+
+# ---------------------------------------------------------------------------
+# build_interactive_argv
+# ---------------------------------------------------------------------------
+
+
+class TestBuildInteractiveArgv:
+    def test_includes_auto_approve(self):
+        argv = build_interactive_argv()
+        assert "--auto-approve" in argv
+
+    def test_prompt_appended_when_given(self):
+        argv = build_interactive_argv(prompt="start task")
+        assert "start task" in argv
+
+    def test_no_prompt_when_omitted(self):
+        argv = build_interactive_argv()
+        # No stray strings that look like a prompt.
+        assert "--auto-approve" in argv
+
+    def test_model_flag(self):
+        argv = build_interactive_argv(model="gpt-5.5")
+        assert "--model" in argv
+        assert argv[argv.index("--model") + 1] == "gpt-5.5"
+
+    def test_max_time_flag(self):
+        argv = build_interactive_argv(max_time=300)
+        assert "--max-time" in argv
+        assert argv[argv.index("--max-time") + 1] == "300"
+
+    def test_hook_flag(self):
+        argv = build_interactive_argv(hook="/path/to/hook.js")
+        assert "--hook" in argv
+        assert argv[argv.index("--hook") + 1] == "/path/to/hook.js"
+
+    def test_resume_id_flag(self):
+        argv = build_interactive_argv(resume_id="sess-abc")
+        assert "--resume" in argv
+        assert argv[argv.index("--resume") + 1] == "sess-abc"
+
+    def test_continue_last_flag(self):
+        argv = build_interactive_argv(continue_last=True)
+        assert "--continue" in argv
+
+    def test_resume_id_takes_priority_over_continue(self):
+        argv = build_interactive_argv(resume_id="sess-x", continue_last=True)
+        assert "--resume" in argv
+        assert "--continue" not in argv
+
+
+# ---------------------------------------------------------------------------
+# parse_oneshot_result
+# ---------------------------------------------------------------------------
+
+
+class TestParseOneshotResult:
+    def test_parses_agent_end_assistant_text(self):
+        ndjson = _agent_end_ndjson("Hi there")
+        assert parse_oneshot_result(ndjson) == "Hi there"
+
+    def test_falls_back_to_last_message_end(self):
+        """If no agent_end, fall back to last message_end with role=assistant."""
+        events = [
+            {"type": "session", "id": "s1"},
+            {
+                "type": "message_end",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "fallback answer"}],
+                },
+            },
+        ]
+        ndjson = "\n".join(json.dumps(e) for e in events)
+        assert parse_oneshot_result(ndjson) == "fallback answer"
+
+    def test_skips_user_messages(self):
+        events = [
+            {
+                "type": "message_end",
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "user prompt"}],
+                },
+            },
+            {
+                "type": "message_end",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "assistant reply"}],
+                },
+            },
+        ]
+        ndjson = "\n".join(json.dumps(e) for e in events)
+        assert parse_oneshot_result(ndjson) == "assistant reply"
+
+    def test_empty_output_raises_value_error(self):
+        """No parseable lines → ValueError."""
+        with pytest.raises(ValueError, match="No parseable JSON"):
+            parse_oneshot_result("")
+
+    def test_non_json_lines_skipped(self):
+        """Non-JSON lines (e.g. omp startup banners) are skipped gracefully."""
+        events = [
+            '{"type": "session", "id": "s1"}',
+            "omp v16.1.15",  # non-JSON line
+            json.dumps({
+                "type": "agent_end",
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "result"}],
+                    }
+                ],
+            }),
+        ]
+        ndjson = "\n".join(events)
+        assert parse_oneshot_result(ndjson) == "result"
+
+    def test_multi_turn_returns_last_assistant(self):
+        """With multiple assistant messages, return the last one."""
+        events = [
+            {
+                "type": "agent_end",
+                "messages": [
+                    {"role": "user", "content": [{"type": "text", "text": "q1"}]},
+                    {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "first answer"}],
+                    },
+                    {"role": "user", "content": [{"type": "text", "text": "q2"}]},
+                    {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "final answer"}],
+                    },
+                ],
+            }
+        ]
+        ndjson = json.dumps(events[0])
+        assert parse_oneshot_result(ndjson) == "final answer"
+
+    def test_empty_messages_in_agent_end_returns_empty(self):
+        """agent_end with no assistant messages → empty string."""
+        ndjson = json.dumps({"type": "agent_end", "messages": []})
+        assert parse_oneshot_result(ndjson) == ""
+
+    def test_parse_real_omp_sample(self):
+        """Validate against a real captured omp --mode=json output fragment."""
+        # Condensed from actual live probe (omp v16.1.15, prompt: "say hi in one word")
+        real_sample = (
+            '{"type":"session","version":3,"id":"019efbb2-7c26-7000-a371-5580d17eed55",'
+            '"timestamp":"2026-06-24T22:13:58.951Z","cwd":"/Users/zeke/dev/z-harness"}\n'
+            '{"type":"agent_start"}\n'
+            '{"type":"turn_start"}\n'
+            '{"type":"message_start","message":{"role":"user","content":[{"type":"text","text":"say hi in one word"}]}}\n'
+            '{"type":"message_end","message":{"role":"user","content":[{"type":"text","text":"say hi in one word"}]}}\n'
+            '{"type":"message_start","message":{"role":"assistant","content":[{"type":"text","text":"Hi"}],'
+            '"model":"gpt-5.5","stopReason":"stop"}}\n'
+            '{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"Hi"}],'
+            '"model":"gpt-5.5","stopReason":"stop"}}\n'
+            '{"type":"turn_end","message":{"role":"assistant","content":[{"type":"text","text":"Hi"}]}}\n'
+            '{"type":"agent_end","messages":['
+            '{"role":"user","content":[{"type":"text","text":"say hi in one word"}]},'
+            '{"role":"assistant","content":[{"type":"text","text":"Hi"}],"model":"gpt-5.5","stopReason":"stop"}'
+            "]}\n"
+        )
+        assert parse_oneshot_result(real_sample) == "Hi"
+
+
+# ---------------------------------------------------------------------------
+# parse_pane_lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestParsePaneLifecycle:
+    def test_waiting_user_on_prompt_marker_gt(self):
+        """'>' at end of line → WAITING_USER."""
+        pane = "Some output\n> "
+        assert parse_pane_lifecycle(pane) == SessionLifecycle.WAITING_USER
+
+    def test_waiting_user_on_prompt_marker_chevron(self):
+        """'❯' at end of line → WAITING_USER."""
+        pane = "Some output\n❯ "
+        assert parse_pane_lifecycle(pane) == SessionLifecycle.WAITING_USER
+
+    def test_paused_handoff_on_handoff_marker(self):
+        """HERMES_HANDOFF in pane → PAUSED_HANDOFF, even if prompt also present."""
+        pane = f"Task complete.\n{HANDOFF_MARKER}\n> "
+        assert parse_pane_lifecycle(pane) == SessionLifecycle.PAUSED_HANDOFF
+
+    def test_handoff_takes_priority_over_prompt(self):
+        """PAUSED_HANDOFF wins when both HANDOFF_MARKER and '>' are present."""
+        pane = f"> {HANDOFF_MARKER}"
+        assert parse_pane_lifecycle(pane) == SessionLifecycle.PAUSED_HANDOFF
+
+    def test_running_on_spinner(self):
+        """Spinner characters in pane (no prompt) → RUNNING."""
+        pane = "⠋ Executing tool\n  thinking..."
+        assert parse_pane_lifecycle(pane) == SessionLifecycle.RUNNING
+
+    def test_running_on_running_tool_text(self):
+        """'Running tool' text → RUNNING."""
+        pane = "Running tool: bash\n  ..."
+        assert parse_pane_lifecycle(pane) == SessionLifecycle.RUNNING
+
+    def test_running_when_no_markers(self):
+        """No markers → RUNNING (default)."""
+        pane = "omp is thinking about the problem..."
+        assert parse_pane_lifecycle(pane) == SessionLifecycle.RUNNING
+
+    def test_empty_pane_returns_running(self):
+        """Empty pane → RUNNING (startup or mid-render)."""
+        assert parse_pane_lifecycle("") == SessionLifecycle.RUNNING
+
+    def test_prompt_pattern_does_not_match_mid_line(self):
+        """'>' in the middle of a line must NOT trigger WAITING_USER."""
+        # PROMPT_PATTERN requires end-of-line; mid-line '>' is common in diffs.
+        pane = "diff --git a/file > b/file\nmore content"
+        # Should be RUNNING (no prompt, no handoff, no spinner).
+        # NB: This relies on PROMPT_PATTERN using $ with MULTILINE.
+        result = parse_pane_lifecycle(pane)
+        # Either RUNNING is acceptable (no false-positive WAITING_USER).
+        assert result != SessionLifecycle.WAITING_USER
+
+    def test_activity_regex_matches_spinner(self):
+        """ACTIVITY_REGEX must match spinner characters."""
+        assert ACTIVITY_REGEX.search("⠋ Running")
+        assert ACTIVITY_REGEX.search("⠙ Thinking")
+
+    def test_activity_regex_no_false_positive(self):
+        """ACTIVITY_REGEX must NOT match plain output text."""
+        assert not ACTIVITY_REGEX.search("Output: done")
+
+
+# ---------------------------------------------------------------------------
+# Capabilities
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilities:
+    def setup_method(self):
+        self.adapter = OmpAdapter(
+            omp_runner=FakeOmpRunner(),
+            tmux_runner=FakeTmuxRunner(),
+        )
+
+    def test_rpc_mode_true(self):
+        assert self.adapter.capabilities().rpc_mode is True
+
+    def test_json_mode_true(self):
+        assert self.adapter.capabilities().json_mode is True
+
+    def test_has_hooks_true(self):
+        assert self.adapter.capabilities().has_hooks is True
+
+    def test_supports_print_mode_true(self):
+        assert self.adapter.capabilities().supports_print_mode is True
+
+    def test_idle_indicator_regex_matches_spinner(self):
+        cap = self.adapter.capabilities()
+        assert cap.idle_indicator_regex is not None
+        assert cap.idle_indicator_regex.search("⠋ Executing")
+
+    def test_idle_indicator_regex_does_not_match_prompt(self):
+        cap = self.adapter.capabilities()
+        assert cap.idle_indicator_regex is not None
+        assert not cap.idle_indicator_regex.search("> ")
+
+    def test_dialog_handlers_empty(self):
+        """omp uses --auto-approve; no dialog handlers needed."""
+        assert self.adapter.capabilities().dialog_handlers == {}
+
+    def test_return_type_is_capabilities(self):
+        assert isinstance(self.adapter.capabilities(), Capabilities)
+
+
+# ---------------------------------------------------------------------------
+# run_oneshot()
+# ---------------------------------------------------------------------------
+
+
+class TestRunOneshot:
+    def test_calls_omp_runner_with_correct_argv(self):
+        fake_omp = FakeOmpRunner(stdout=_agent_end_ndjson("answer"))
+        adapter = OmpAdapter(omp_runner=fake_omp, tmux_runner=FakeTmuxRunner())
+
+        result = adapter.run_oneshot("explain this")
+
+        assert len(fake_omp.calls) == 1
+        argv = fake_omp.calls[0]
+        assert "-p" in argv
+        assert "--mode=json" in argv
+        assert "explain this" in argv
+
+    def test_returns_parsed_assistant_text(self):
+        fake_omp = FakeOmpRunner(stdout=_agent_end_ndjson("the answer is 42"))
+        adapter = OmpAdapter(omp_runner=fake_omp, tmux_runner=FakeTmuxRunner())
+
+        assert adapter.run_oneshot("question") == "the answer is 42"
+
+    def test_passes_model_to_argv(self):
+        fake_omp = FakeOmpRunner(stdout=_agent_end_ndjson("ok"))
+        adapter = OmpAdapter(omp_runner=fake_omp, tmux_runner=FakeTmuxRunner())
+
+        adapter.run_oneshot("prompt", model="openai-codex/gpt-5.5")
+
+        argv = fake_omp.calls[0]
+        assert "--model" in argv
+        assert argv[argv.index("--model") + 1] == "openai-codex/gpt-5.5"
+
+    def test_passes_workdir_to_argv(self):
+        fake_omp = FakeOmpRunner(stdout=_agent_end_ndjson("ok"))
+        adapter = OmpAdapter(omp_runner=fake_omp, tmux_runner=FakeTmuxRunner())
+
+        adapter.run_oneshot("prompt", workdir="/workspace")
+
+        argv = fake_omp.calls[0]
+        assert "--cwd" in argv
+        assert argv[argv.index("--cwd") + 1] == "/workspace"
+
+    def test_raises_value_error_on_unparseable_output(self):
+        fake_omp = FakeOmpRunner(stdout="not json at all")
+        adapter = OmpAdapter(omp_runner=fake_omp, tmux_runner=FakeTmuxRunner())
+
+        with pytest.raises(ValueError):
+            adapter.run_oneshot("prompt")
+
+
+# ---------------------------------------------------------------------------
+# drive()
+# ---------------------------------------------------------------------------
+
+
+class TestDrive:
+    def setup_method(self):
+        # Pane shows ">" so readiness check passes immediately.
+        self.fake_tmux = FakeTmuxRunner(capture_output="last line\n> ")
+        self.adapter = OmpAdapter(
+            omp_runner=FakeOmpRunner(),
+            tmux_runner=self.fake_tmux,
+        )
+        self.handle = _make_handle()
+
+    def _drive_with_stubbed_load(self, message: str) -> list[list[str]]:
+        with patch.object(self.adapter, "_load_buffer"):
+            self.adapter.drive(self.handle, message)
+        return self.fake_tmux.calls
+
+    def test_drive_issues_paste_buffer(self):
+        calls = self._drive_with_stubbed_load("Hello, omp!")
+        cmd_names = [c[0] for c in calls]
+        assert "paste-buffer" in cmd_names
+
+    def test_drive_paste_buffer_targets_correct_pane(self):
+        calls = self._drive_with_stubbed_load("test message")
+        paste_call = next(c for c in calls if c[0] == "paste-buffer")
+        assert self.handle.pane in paste_call
+
+    def test_drive_sends_enter_after_paste(self):
+        calls = self._drive_with_stubbed_load("some prompt")
+        send_key_calls = [c for c in calls if c[0] == "send-keys"]
+        assert any("Enter" in c for c in send_key_calls)
+
+    def test_drive_checks_readiness_before_paste(self):
+        calls = self._drive_with_stubbed_load("prompt")
+        cmd_names = [c[0] for c in calls]
+        capture_idx = cmd_names.index("capture-pane")
+        paste_idx = cmd_names.index("paste-buffer")
+        assert capture_idx < paste_idx
+
+    def test_drive_raises_timeout_when_no_prompt(self):
+        no_prompt_tmux = FakeTmuxRunner(capture_output="⠋ Running tool")
+        adapter = OmpAdapter(omp_runner=FakeOmpRunner(), tmux_runner=no_prompt_tmux)
+        handle = _make_handle()
+        with patch("session_orchestration.adapters.omp._LAUNCH_READY_TIMEOUT", 0.1):
+            with patch("session_orchestration.adapters.omp._POLL_INTERVAL", 0.05):
+                with pytest.raises(TimeoutError):
+                    adapter.drive(handle, "hi")
+
+    def test_load_buffer_called_with_message(self):
+        with patch.object(self.adapter, "_load_buffer") as mock_lb:
+            self.adapter.drive(self.handle, "specific omp message")
+        mock_lb.assert_called_once()
+        args = mock_lb.call_args[0]
+        assert "specific omp message" in args
+
+
+# ---------------------------------------------------------------------------
+# detect()
+# ---------------------------------------------------------------------------
+
+
+class TestDetect:
+    def _adapter_with_pane(self, pane_text: str) -> OmpAdapter:
+        return OmpAdapter(
+            omp_runner=FakeOmpRunner(),
+            tmux_runner=FakeTmuxRunner(capture_output=pane_text),
+        )
+
+    def test_detect_waiting_user_gt(self):
+        adapter = self._adapter_with_pane("last output\n> ")
+        assert adapter.detect(_make_handle()) == SessionLifecycle.WAITING_USER
+
+    def test_detect_waiting_user_chevron(self):
+        adapter = self._adapter_with_pane("last output\n❯ ")
+        assert adapter.detect(_make_handle()) == SessionLifecycle.WAITING_USER
+
+    def test_detect_running_via_spinner(self):
+        adapter = self._adapter_with_pane("⠋ Executing bash command")
+        assert adapter.detect(_make_handle()) == SessionLifecycle.RUNNING
+
+    def test_detect_paused_handoff(self):
+        adapter = self._adapter_with_pane(f"done.\n{HANDOFF_MARKER}\n> ")
+        assert adapter.detect(_make_handle()) == SessionLifecycle.PAUSED_HANDOFF
+
+    def test_detect_error_on_dead_pane(self):
+        class FailingRunner:
+            def run(self, args, check=True):
+                if args[0] == "capture-pane":
+                    raise subprocess.CalledProcessError(1, "tmux")
+                return ""
+
+        adapter = OmpAdapter(omp_runner=FakeOmpRunner(), tmux_runner=FailingRunner())
+        assert adapter.detect(_make_handle()) == SessionLifecycle.ERROR
+
+    def test_detect_running_default(self):
+        adapter = self._adapter_with_pane("omp is processing the request...")
+        assert adapter.detect(_make_handle()) == SessionLifecycle.RUNNING
+
+
+# ---------------------------------------------------------------------------
+# resume()
+# ---------------------------------------------------------------------------
+
+
+class TestResume:
+    def test_resume_sends_continue_and_waits_when_handoff(self):
+        """resume() must invoke omp -c when in PAUSED_HANDOFF."""
+        fake_tmux = FakeTmuxRunner(capture_output=f"{HANDOFF_MARKER}\n> ")
+        adapter = OmpAdapter(omp_runner=FakeOmpRunner(), tmux_runner=fake_tmux)
+        handle = _make_handle()
+
+        # After the send-keys, simulate the prompt appearing.
+        with patch.object(adapter, "_wait_for_prompt"):
+            adapter.resume(handle, "continue the task")
+
+        # Must have issued send-keys with '--continue' in the command.
+        send_key_calls = [c for c in fake_tmux.calls if c[0] == "send-keys"]
+        assert send_key_calls, "No send-keys found"
+        cmd_text = " ".join(str(x) for x in send_key_calls[0])
+        assert "--continue" in cmd_text
+
+    def test_resume_noop_when_not_handoff(self):
+        """resume() must be a no-op when the session is NOT in PAUSED_HANDOFF."""
+        fake_tmux = FakeTmuxRunner(capture_output="⠋ Working...\n")
+        adapter = OmpAdapter(omp_runner=FakeOmpRunner(), tmux_runner=fake_tmux)
+        handle = _make_handle()
+
+        with patch.object(adapter, "_wait_for_prompt") as mock_wait:
+            adapter.resume(handle, "irrelevant prompt")
+
+        # _wait_for_prompt must NOT have been called.
+        mock_wait.assert_not_called()
+        # send-keys must NOT have been issued.
+        send_key_calls = [c for c in fake_tmux.calls if c[0] == "send-keys"]
+        assert not send_key_calls
+
+    def test_resume_noop_when_waiting_user_no_handoff(self):
+        """resume() must be a no-op even if '>' is visible (but no handoff marker)."""
+        fake_tmux = FakeTmuxRunner(capture_output="output\n> ")
+        adapter = OmpAdapter(omp_runner=FakeOmpRunner(), tmux_runner=fake_tmux)
+        handle = _make_handle()
+
+        with patch.object(adapter, "_wait_for_prompt") as mock_wait:
+            adapter.resume(handle, "prompt")
+
+        mock_wait.assert_not_called()

--- a/tests/test_session_orchestration_omp.py
+++ b/tests/test_session_orchestration_omp.py
@@ -629,12 +629,24 @@ class TestDrive:
                 with pytest.raises(TimeoutError):
                     adapter.drive(handle, "hi")
 
+
     def test_load_buffer_called_with_message(self):
         with patch.object(self.adapter, "_load_buffer") as mock_lb:
             self.adapter.drive(self.handle, "specific omp message")
         mock_lb.assert_called_once()
         args = mock_lb.call_args[0]
         assert "specific omp message" in args
+
+
+class TestOmpInterrupt:
+    """interrupt() sends a single Escape to break a stuck busy-loop."""
+
+    def test_interrupt_sends_single_escape_to_pane(self):
+        tmux = FakeTmuxRunner()
+        adapter = OmpAdapter(omp_runner=FakeOmpRunner(), tmux_runner=tmux)
+        handle = _make_handle(pane="%68")
+        adapter.interrupt(handle)
+        assert tmux.calls == [["send-keys", "-t", "%68", "Escape"]]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_session_orchestration_omp.py
+++ b/tests/test_session_orchestration_omp.py
@@ -260,6 +260,15 @@ class TestBuildInteractiveArgv:
         argv = build_interactive_argv()
         assert "--auto-approve" in argv
 
+    def test_omits_auto_approve_when_disabled(self):
+        argv = build_interactive_argv(auto_approve=False)
+        assert "--auto-approve" not in argv
+
+    def test_omit_auto_approve_still_carries_other_flags(self):
+        argv = build_interactive_argv(workdir="/repo", auto_approve=False)
+        assert "--auto-approve" not in argv
+        assert "--cwd" in argv and "/repo" in argv
+
     def test_prompt_appended_when_given(self):
         argv = build_interactive_argv(prompt="start task")
         assert "start task" in argv

--- a/tests/test_session_orchestration_omp.py
+++ b/tests/test_session_orchestration_omp.py
@@ -728,6 +728,36 @@ class TestResume:
 
         mock_wait.assert_not_called()
 
+    def test_resume_force_clears_and_drives(self):
+        """force=True: send /clear then drive the resume command, bypassing the
+        PAUSED_HANDOFF detect gate — even when the pane is busy."""
+        fake_tmux = FakeTmuxRunner(capture_output="⠋ Working...\n")  # busy, NOT handoff
+        adapter = OmpAdapter(omp_runner=FakeOmpRunner(), tmux_runner=fake_tmux)
+        handle = _make_handle()
+
+        with patch.object(adapter, "drive") as mock_drive:
+            adapter.resume(handle, "/z-execute my-slug", force=True)
+
+        # /clear was sent as a slash-command.
+        send_key_calls = [c for c in fake_tmux.calls if c[0] == "send-keys"]
+        assert any("/clear" in " ".join(str(x) for x in c) for c in send_key_calls)
+        # drive() was called with the resume command (no omp -c continue).
+        mock_drive.assert_called_once()
+        assert mock_drive.call_args[0][1] == "/z-execute my-slug"
+
+    def test_resume_force_empty_prompt_only_clears(self):
+        """force=True with an empty resume command sends /clear but does not drive."""
+        fake_tmux = FakeTmuxRunner(capture_output="⠋ Working...\n")
+        adapter = OmpAdapter(omp_runner=FakeOmpRunner(), tmux_runner=fake_tmux)
+        handle = _make_handle()
+
+        with patch.object(adapter, "drive") as mock_drive:
+            adapter.resume(handle, "", force=True)
+
+        mock_drive.assert_not_called()
+        send_key_calls = [c for c in fake_tmux.calls if c[0] == "send-keys"]
+        assert any("/clear" in " ".join(str(x) for x in c) for c in send_key_calls)
+
 
 # ---------------------------------------------------------------------------
 # launch() — marker-file injection (stubbed tmux + mocked prompt wait)

--- a/tests/test_session_orchestration_registry.py
+++ b/tests/test_session_orchestration_registry.py
@@ -513,4 +513,96 @@ class TestConcurrentWrites:
             row = main_reg.get(tid)
             assert isinstance(row["heartbeat_counter"], int)
             assert row["heartbeat_counter"] >= 0
-            assert isinstance(row["state"], str)
+
+
+# ---------------------------------------------------------------------------
+# T011 — Terminate intent application + last_question migration
+# ---------------------------------------------------------------------------
+
+
+class TestTerminateIntentApplication:
+    """_apply_intent('terminate') marks the row terminal."""
+
+    def _seed(self, registry, task_id="task-term-001"):
+        registry.upsert(
+            task_id,
+            agent="claude",
+            run_id=f"run-{uuid.uuid4().hex[:8]}",
+            repo=f"repo-{uuid.uuid4().hex[:8]}",
+            state="RUNNING",
+        )
+
+    def test_terminate_intent_no_restart_marks_done(self, registry):
+        """restart=False -> state=DONE."""
+        task_id = "task-term-001"
+        self._seed(registry, task_id)
+
+        intent = {
+            "intent": "terminate",
+            "task_id": task_id,
+            "payload": json.dumps({"restart": False}),
+        }
+        registry._apply_intent(intent)
+
+        row = registry.get(task_id)
+        assert row is not None
+        assert row["state"] == "DONE", f"expected DONE, got {row['state']!r}"
+
+    def test_terminate_intent_restart_marks_error(self, registry):
+        """restart=True -> state=ERROR (row is marked terminal before re-spawn)."""
+        task_id = "task-term-002"
+        self._seed(registry, task_id)
+
+        intent = {
+            "intent": "terminate",
+            "task_id": task_id,
+            "payload": json.dumps({"restart": True}),
+        }
+        registry._apply_intent(intent)
+
+        row = registry.get(task_id)
+        assert row is not None
+        assert row["state"] == "ERROR", f"expected ERROR, got {row['state']!r}"
+
+    def test_terminate_apply_unknown_task_no_crash(self, registry):
+        """terminate for a nonexistent task_id logs a warning and does not crash."""
+        intent = {
+            "intent": "terminate",
+            "task_id": "nonexistent-task-xyz",
+            "payload": json.dumps({"restart": False}),
+        }
+        # Must not raise
+        registry._apply_intent(intent)
+
+    def test_terminate_apply_missing_task_id_no_crash(self, registry):
+        """terminate intent with no task_id logs a warning and does not crash."""
+        intent = {
+            "intent": "terminate",
+            "payload": json.dumps({}),
+        }
+        registry._apply_intent(intent)
+
+
+class TestMigrateSchemaLastQuestion:
+    """last_question column added idempotently."""
+
+    def test_migrate_schema_last_question_idempotent(self, db_path):
+        """Calling _migrate_schema twice on the same DB must not raise."""
+        reg1 = SessionOrchestrationRegistry(db_path=db_path)
+        reg2 = SessionOrchestrationRegistry(db_path=db_path)  # second init
+        reg2._migrate_schema()  # explicit third call — must be silent
+
+    def test_last_question_column_writable(self, db_path):
+        """After migration, last_question can be written and read back."""
+        reg = SessionOrchestrationRegistry(db_path=db_path)
+        task_id = str(uuid.uuid4())
+        reg.upsert(
+            task_id,
+            agent="claude",
+            run_id=f"run-{uuid.uuid4().hex[:8]}",
+            repo=f"repo-{uuid.uuid4().hex[:8]}",
+            last_question="What is the meaning of life?",
+        )
+        row = reg.get(task_id)
+        assert row is not None
+        assert row.get("last_question") == "What is the meaning of life?"

--- a/tests/test_session_orchestration_registry.py
+++ b/tests/test_session_orchestration_registry.py
@@ -606,3 +606,107 @@ class TestMigrateSchemaLastQuestion:
         row = reg.get(task_id)
         assert row is not None
         assert row.get("last_question") == "What is the meaning of life?"
+
+
+# ---------------------------------------------------------------------------
+# gc_terminal_rows
+# ---------------------------------------------------------------------------
+
+
+def _seed_terminal(
+    registry: SessionOrchestrationRegistry,
+    *,
+    state: str,
+    terminated_at: float | None,
+    task_id: str | None = None,
+) -> str:
+    """Insert a row with the given terminal state and terminated_at stamp."""
+    tid = task_id or str(uuid.uuid4())
+    registry.upsert(
+        tid,
+        agent="claude",
+        run_id=f"run-{uuid.uuid4().hex[:8]}",
+        repo=f"repo-{uuid.uuid4().hex[:8]}",
+        state=state,
+        terminated_at=terminated_at,
+    )
+    return tid
+
+
+class TestGcTerminalRows:
+    """gc_terminal_rows GC method — four eligibility rules."""
+
+    def test_old_terminal_row_is_deleted(self, registry):
+        """(a) A terminal row with terminated_at older than the threshold is deleted."""
+        now = 1_000_000.0
+        max_age = 3600  # 1 h
+        # terminated_at is 2 h ago — eligible
+        task_id = _seed_terminal(
+            registry, state="DONE", terminated_at=now - 7200.0
+        )
+
+        deleted = registry.gc_terminal_rows(now=now, max_age_seconds=max_age)
+
+        assert deleted == 1
+        assert registry.get(task_id) is None, "old terminal row must be deleted"
+
+    def test_fresh_terminal_row_is_retained(self, registry):
+        """(b) A terminal row with a recent terminated_at is NOT deleted."""
+        now = 1_000_000.0
+        max_age = 3600  # 1 h
+        # terminated_at is only 30 min ago — too fresh
+        task_id = _seed_terminal(
+            registry, state="DONE", terminated_at=now - 1800.0
+        )
+
+        deleted = registry.gc_terminal_rows(now=now, max_age_seconds=max_age)
+
+        assert deleted == 0
+        assert registry.get(task_id) is not None, "fresh terminal row must be retained"
+
+    def test_terminal_row_with_null_terminated_at_is_retained(self, registry):
+        """(c) A terminal row with terminated_at=NULL is never GC-ed."""
+        now = 1_000_000.0
+        task_id = _seed_terminal(registry, state="ERROR", terminated_at=None)
+
+        deleted = registry.gc_terminal_rows(now=now, max_age_seconds=60)
+
+        assert deleted == 0
+        assert registry.get(task_id) is not None, "NULL-stamp terminal row must survive GC"
+
+    def test_running_row_is_never_deleted(self, registry):
+        """(d) A non-terminal RUNNING row is never deleted regardless of timestamps."""
+        now = 1_000_000.0
+        # Seed a running row with a very old timestamp (not a real column but
+        # we store terminated_at=old just to confirm it does not get deleted)
+        task_id = _seed_terminal(registry, state="RUNNING", terminated_at=now - 999_999.0)
+
+        deleted = registry.gc_terminal_rows(now=now, max_age_seconds=1)
+
+        assert deleted == 0
+        assert registry.get(task_id) is not None, "RUNNING row must never be deleted by GC"
+
+    def test_only_eligible_rows_deleted_mixed_batch(self, registry):
+        """Mixed batch: only the old terminal rows are deleted."""
+        now = 1_000_000.0
+        max_age = 3600
+
+        old_done = _seed_terminal(registry, state="DONE", terminated_at=now - 7200.0)
+        old_error = _seed_terminal(registry, state="ERROR", terminated_at=now - 7200.0)
+        fresh_done = _seed_terminal(registry, state="DONE", terminated_at=now - 1800.0)
+        null_done = _seed_terminal(registry, state="DONE", terminated_at=None)
+        running = _seed_terminal(registry, state="RUNNING", terminated_at=now - 99999.0)
+
+        deleted = registry.gc_terminal_rows(now=now, max_age_seconds=max_age)
+
+        assert deleted == 2
+        assert registry.get(old_done) is None
+        assert registry.get(old_error) is None
+        assert registry.get(fresh_done) is not None
+        assert registry.get(null_done) is not None
+        assert registry.get(running) is not None
+
+    def test_returns_zero_when_nothing_eligible(self, registry):
+        """gc_terminal_rows returns 0 when no rows match."""
+        deleted = registry.gc_terminal_rows(now=1_000_000.0, max_age_seconds=86400)
+        assert deleted == 0

--- a/tests/test_session_orchestration_registry.py
+++ b/tests/test_session_orchestration_registry.py
@@ -2,7 +2,7 @@
 Tests for session_orchestration/registry.py.
 
 Covers:
-- Schema creation (idempotent)
+- Schema creation (idempotent), including attention/projection tables
 - upsert / get / list basic CRUD
 - UNIQUE(run_id, repo) constraint — duplicate adopt/spawn rejected
 - enqueue_intent / drain_intents round-trip
@@ -16,6 +16,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import sqlite3
 import threading
 import time
 import uuid
@@ -82,7 +83,6 @@ class TestCanonicalRepoId:
 
 class TestSchemaCreation:
     def test_tables_created_on_init(self, db_path):
-        import sqlite3
         SessionOrchestrationRegistry(db_path=db_path)
         conn = sqlite3.connect(str(db_path))
         tables = {
@@ -94,24 +94,456 @@ class TestSchemaCreation:
         conn.close()
         assert "session_orchestration" in tables
         assert "session_orchestration_queue" in tables
+        assert "session_orchestration_attention_items" in tables
+        assert "session_orchestration_projection" in tables
 
     def test_init_is_idempotent(self, db_path):
         """Creating the registry twice does not raise."""
         SessionOrchestrationRegistry(db_path=db_path)
         SessionOrchestrationRegistry(db_path=db_path)  # must not raise
 
-    def test_unique_run_id_repo_index_exists(self, db_path):
-        import sqlite3
+    def test_registry_indexes_exist(self, db_path):
         SessionOrchestrationRegistry(db_path=db_path)
         conn = sqlite3.connect(str(db_path))
-        indexes = {
-            r[0]
-            for r in conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='index'"
-            ).fetchall()
-        }
-        conn.close()
+        try:
+            indexes = {
+                r[0]
+                for r in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='index'"
+                ).fetchall()
+            }
+            lookup_columns = [
+                (r[2], r[3])
+                for r in conn.execute(
+                    "PRAGMA index_xinfo('idx_soai_unresolved_lookup')"
+                ).fetchall()
+                if r[5]
+            ]
+        finally:
+            conn.close()
         assert "idx_so_run_repo" in indexes
+        assert "idx_soai_unresolved_task_reason" in indexes
+        assert "idx_soai_unresolved_lookup" in indexes
+        assert "idx_sop_channel_projection" not in indexes
+        assert lookup_columns == [("state", 0), ("priority", 1), ("opened_at", 0)]
+
+    def test_attention_projection_schema_init_is_idempotent(self, db_path):
+        SessionOrchestrationRegistry(db_path=db_path)
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute(
+                """
+                INSERT INTO session_orchestration (
+                    task_id, agent, run_id, repo
+                ) VALUES (?, ?, ?, ?)
+                """,
+                ("task-schema-idempotent", "omp", "run-schema", "repo-schema"),
+            )
+            conn.execute(
+                """
+                INSERT INTO session_orchestration_attention_items (
+                    task_id, reason, state, priority
+                ) VALUES (?, ?, ?, ?)
+                """,
+                ("task-schema-idempotent", "WAITING_USER", "unresolved", 10),
+            )
+            conn.execute(
+                """
+                INSERT INTO session_orchestration_projection (
+                    channel_id, projection_name, message_id, content_hash
+                ) VALUES (?, ?, ?, ?)
+                """,
+                ("channel-1", "attention-digest", "message-1", "hash-1"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        SessionOrchestrationRegistry(db_path=db_path)
+
+        conn = sqlite3.connect(str(db_path))
+        try:
+            attention_count = conn.execute(
+                "SELECT COUNT(*) FROM session_orchestration_attention_items"
+            ).fetchone()[0]
+            projection_count = conn.execute(
+                "SELECT COUNT(*) FROM session_orchestration_projection"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert attention_count == 1
+        assert projection_count == 1
+
+    def test_duplicate_unresolved_attention_item_rejected_but_history_retained(
+        self, db_path
+    ):
+        SessionOrchestrationRegistry(db_path=db_path)
+        conn = sqlite3.connect(str(db_path))
+        try:
+            task_id = "task-attention-unique"
+            reason = "WAITING_USER"
+            conn.execute(
+                "INSERT INTO session_orchestration (task_id, agent) VALUES (?, ?)",
+                (task_id, "omp"),
+            )
+            conn.execute(
+                """
+                INSERT INTO session_orchestration_attention_items (
+                    task_id, reason, state, priority
+                ) VALUES (?, ?, ?, ?)
+                """,
+                (task_id, reason, "unresolved", 50),
+            )
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    """
+                    INSERT INTO session_orchestration_attention_items (
+                        task_id, reason, state, priority
+                    ) VALUES (?, ?, ?, ?)
+                    """,
+                    (task_id, reason, "unresolved", 40),
+                )
+
+            conn.execute(
+                """
+                UPDATE session_orchestration_attention_items
+                   SET state = 'resolved',
+                       resolved_at = datetime('now'),
+                       resolution_reason = 'left_attention_state'
+                 WHERE task_id = ? AND reason = ? AND resolved_at IS NULL
+                """,
+                (task_id, reason),
+            )
+            conn.execute(
+                """
+                INSERT INTO session_orchestration_attention_items (
+                    task_id, reason, state, priority
+                ) VALUES (?, ?, ?, ?)
+                """,
+                (task_id, reason, "unresolved", 30),
+            )
+            rows = conn.execute(
+                """
+                SELECT resolved_at
+                  FROM session_orchestration_attention_items
+                 WHERE task_id = ? AND reason = ?
+                 ORDER BY id
+                """,
+                (task_id, reason),
+            ).fetchall()
+        finally:
+            conn.close()
+        assert len(rows) == 2
+        assert rows[0][0] is not None
+        assert rows[1][0] is None
+
+    def test_attention_item_state_resolution_check_rejects_drift(self, db_path):
+        SessionOrchestrationRegistry(db_path=db_path)
+        conn = sqlite3.connect(str(db_path))
+        try:
+            task_id = "task-attention-check"
+            conn.execute(
+                "INSERT INTO session_orchestration (task_id, agent) VALUES (?, ?)",
+                (task_id, "omp"),
+            )
+
+            invalid_rows = [
+                ("unresolved", "2026-01-01 00:00:00", None),
+                ("unresolved", None, "has_reason_without_timestamp"),
+                ("resolved", None, "resolved_without_timestamp"),
+                ("resolved", "2026-01-01 00:00:00", None),
+            ]
+            for idx, (state, resolved_at, resolution_reason) in enumerate(invalid_rows):
+                with pytest.raises(sqlite3.IntegrityError):
+                    conn.execute(
+                        """
+                        INSERT INTO session_orchestration_attention_items (
+                            task_id, reason, state, resolved_at, resolution_reason
+                        ) VALUES (?, ?, ?, ?, ?)
+                        """,
+                        (
+                            task_id,
+                            f"DRIFT_{idx}",
+                            state,
+                            resolved_at,
+                            resolution_reason,
+                        ),
+                    )
+
+            conn.execute(
+                """
+                INSERT INTO session_orchestration_attention_items (
+                    task_id, reason, state
+                ) VALUES (?, ?, ?)
+                """,
+                (task_id, "UPDATE_DRIFT", "unresolved"),
+            )
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    """
+                    UPDATE session_orchestration_attention_items
+                       SET state = 'resolved'
+                     WHERE task_id = ? AND reason = ?
+                    """,
+                    (task_id, "UPDATE_DRIFT"),
+                )
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    """
+                    UPDATE session_orchestration_attention_items
+                       SET resolved_at = '2026-01-01 00:00:00'
+                     WHERE task_id = ? AND reason = ?
+                    """,
+                    (task_id, "UPDATE_DRIFT"),
+                )
+        finally:
+            conn.close()
+
+    def test_projection_uniqueness_rejects_duplicate_channel_projection(
+        self, db_path
+    ):
+        SessionOrchestrationRegistry(db_path=db_path)
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute(
+                """
+                INSERT INTO session_orchestration_projection (
+                    channel_id, projection_name, message_id, content_hash
+                ) VALUES (?, ?, ?, ?)
+                """,
+                ("channel-1", "attention-digest", "message-1", "hash-1"),
+            )
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    """
+                    INSERT INTO session_orchestration_projection (
+                        channel_id, projection_name, message_id, content_hash
+                    ) VALUES (?, ?, ?, ?)
+                    """,
+                    ("channel-1", "attention-digest", "message-2", "hash-2"),
+                )
+
+            conn.execute(
+                """
+                INSERT INTO session_orchestration_projection (
+                    channel_id, projection_name, message_id, content_hash
+                ) VALUES (?, ?, ?, ?)
+                """,
+                ("channel-1", "status-summary", "message-3", "hash-3"),
+            )
+            conn.execute(
+                """
+                INSERT INTO session_orchestration_projection (
+                    channel_id, projection_name, message_id, content_hash
+                ) VALUES (?, ?, ?, ?)
+                """,
+                ("channel-2", "attention-digest", "message-4", "hash-4"),
+            )
+            projection_count = conn.execute(
+                "SELECT COUNT(*) FROM session_orchestration_projection"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert projection_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Attention item / projection APIs
+# ---------------------------------------------------------------------------
+
+
+class TestAttentionItemApis:
+    def test_open_existing_unresolved_reason_refreshes_without_duplicate(
+        self, registry
+    ):
+        tid = str(uuid.uuid4())
+        registry.upsert(tid, agent="omp")
+
+        first = registry.open_attention_item(
+            tid,
+            "WAITING_USER",
+            priority=10,
+            detail="initial prompt",
+        )
+        refreshed = registry.open_attention_item(
+            tid,
+            "WAITING_USER",
+            priority=30,
+            detail="new prompt",
+        )
+
+        rows = registry.list_unresolved_attention_items()
+        assert first["id"] == refreshed["id"]
+        assert len(rows) == 1
+        assert rows[0]["task_id"] == tid
+        assert rows[0]["reason"] == "WAITING_USER"
+        assert rows[0]["priority"] == 30
+        assert rows[0]["detail"] == "new prompt"
+
+    def test_update_and_list_unresolved_attention_items_are_deterministic(
+        self, registry
+    ):
+        low = str(uuid.uuid4())
+        middle = str(uuid.uuid4())
+        high = str(uuid.uuid4())
+        for task_id in (low, middle, high):
+            registry.upsert(task_id, agent="omp")
+
+        registry.open_attention_item(low, "WAITING_USER", priority=1)
+        registry.open_attention_item(middle, "PAUSED_HANDOFF", priority=5)
+        registry.open_attention_item(high, "STALE_FROZEN", priority=10)
+
+        updated = registry.update_attention_item(
+            middle,
+            "PAUSED_HANDOFF",
+            priority=20,
+            detail="operator review",
+        )
+        rows = registry.list_unresolved_attention_items()
+
+        assert updated is not None
+        assert updated["detail"] == "operator review"
+        assert [(row["task_id"], row["reason"]) for row in rows] == [
+            (middle, "PAUSED_HANDOFF"),
+            (high, "STALE_FROZEN"),
+            (low, "WAITING_USER"),
+        ]
+
+    def test_resolve_attention_item_is_reason_specific(self, registry):
+        tid = str(uuid.uuid4())
+        registry.upsert(tid, agent="omp")
+        registry.open_attention_item(tid, "WAITING_USER", priority=20)
+        registry.open_attention_item(tid, "STALE_FROZEN", priority=10)
+
+        resolved = registry.resolve_attention_item(
+            tid,
+            "WAITING_USER",
+            resolution_reason="left_attention_state",
+        )
+        unresolved_rows = registry.list_unresolved_attention_items()
+
+        conn = sqlite3.connect(str(registry._db_path))
+        try:
+            resolved_row = conn.execute(
+                """
+                SELECT state, resolved_at, resolution_reason
+                  FROM session_orchestration_attention_items
+                 WHERE task_id = ?
+                   AND reason = ?
+                """,
+                (tid, "WAITING_USER"),
+            ).fetchone()
+        finally:
+            conn.close()
+
+        assert resolved is True
+        assert [(row["task_id"], row["reason"]) for row in unresolved_rows] == [
+            (tid, "STALE_FROZEN")
+        ]
+        assert resolved_row[0] == "resolved"
+        assert resolved_row[1] is not None
+        assert resolved_row[2] == "left_attention_state"
+
+    def test_reopen_after_resolve_preserves_resolved_history(self, registry):
+        tid = str(uuid.uuid4())
+        registry.upsert(tid, agent="omp")
+        original = registry.open_attention_item(tid, "WAITING_USER", priority=20)
+        assert registry.resolve_attention_item(
+            tid,
+            "WAITING_USER",
+            resolution_reason="left_attention_state",
+        )
+
+        reopened = registry.open_attention_item(tid, "WAITING_USER", priority=5)
+
+        conn = sqlite3.connect(str(registry._db_path))
+        try:
+            rows = conn.execute(
+                """
+                SELECT id, state, resolved_at
+                  FROM session_orchestration_attention_items
+                 WHERE task_id = ?
+                   AND reason = ?
+                 ORDER BY id
+                """,
+                (tid, "WAITING_USER"),
+            ).fetchall()
+        finally:
+            conn.close()
+
+        assert original["id"] != reopened["id"]
+        assert len(rows) == 2
+        assert rows[0][1] == "resolved"
+        assert rows[0][2] is not None
+        assert rows[1][0] == reopened["id"]
+        assert rows[1][1] == "unresolved"
+        assert rows[1][2] is None
+
+
+class TestProjectionApis:
+    def test_projection_upsert_and_get_by_channel_and_name(self, registry):
+        created = registry.upsert_projection(
+            "channel-1",
+            "attention-digest",
+            message_id="message-1",
+            content_hash="hash-1",
+            payload={"rows": 1},
+        )
+        updated = registry.upsert_projection(
+            "channel-1",
+            "attention-digest",
+            message_id="message-2",
+            content_hash="hash-2",
+            payload={"rows": 2},
+        )
+        registry.upsert_projection(
+            "channel-1",
+            "status-summary",
+            message_id="message-3",
+            content_hash="hash-3",
+        )
+        registry.upsert_projection(
+            "channel-2",
+            "attention-digest",
+            message_id="message-4",
+            content_hash="hash-4",
+        )
+
+        fetched = registry.get_projection("channel-1", "attention-digest")
+
+        assert created["id"] == updated["id"]
+        assert fetched["message_id"] == "message-2"
+        assert fetched["content_hash"] == "hash-2"
+        assert fetched["payload"] == {"rows": 2}
+        assert registry.get_projection("channel-missing", "attention-digest") is None
+        assert (
+            registry.get_projection("channel-1", "status-summary")["message_id"]
+            == "message-3"
+        )
+        assert (
+            registry.get_projection("channel-2", "attention-digest")["message_id"]
+            == "message-4"
+        )
+
+    def test_projection_partial_update_preserves_omitted_fields(self, registry):
+        created = registry.upsert_projection(
+            "channel-1",
+            "attention-digest",
+            message_id="message-1",
+            content_hash="hash-1",
+            payload={"rows": 1, "status": "ready"},
+        )
+
+        updated = registry.upsert_projection(
+            "channel-1",
+            "attention-digest",
+            content_hash="hash-2",
+        )
+
+        assert updated["id"] == created["id"]
+        assert updated["message_id"] == "message-1"
+        assert updated["content_hash"] == "hash-2"
+        assert updated["payload"] == {"rows": 1, "status": "ready"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_session_orchestration_registry.py
+++ b/tests/test_session_orchestration_registry.py
@@ -113,6 +113,34 @@ class TestSchemaCreation:
         conn.close()
         assert "idx_so_run_repo" in indexes
 
+    def test_migrate_schema_discord_user_id_idempotent(self, db_path):
+        """discord_user_id ALTER TABLE migration must be idempotent.
+
+        The second registry init on the same DB path triggers _migrate_schema
+        on an already-migrated table; the OperationalError must be swallowed
+        silently and the column must be present and writable.
+        """
+        import uuid
+        reg1 = SessionOrchestrationRegistry(db_path=db_path)
+        reg2 = SessionOrchestrationRegistry(db_path=db_path)  # must not raise
+        # Explicitly calling _migrate_schema a third time must also be silent
+        reg2._migrate_schema()
+
+        # Verify the column is present by inserting and reading back
+        tid = str(uuid.uuid4())
+        reg1.upsert(
+            tid,
+            agent="test",
+            run_id=f"run-{tid[:8]}",
+            repo=f"repo-{tid[:8]}",
+            discord_user_id="user-999",
+        )
+        row = reg1.get(tid)
+        assert row is not None
+        assert row.get("discord_user_id") == "user-999", (
+            "discord_user_id column must be present and writable after migration"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Basic CRUD

--- a/tests/test_session_orchestration_registry.py
+++ b/tests/test_session_orchestration_registry.py
@@ -1,0 +1,488 @@
+"""
+Tests for session_orchestration/registry.py.
+
+Covers:
+- Schema creation (idempotent)
+- upsert / get / list basic CRUD
+- UNIQUE(run_id, repo) constraint — duplicate adopt/spawn rejected
+- enqueue_intent / drain_intents round-trip
+- acquire_lock / release_lock including stale-reclaim
+- canonical_repo_id normalisation
+- Concurrent-write correctness: cron writer + webhook-adopt enqueue +
+  drive-update enqueue racing in one window, cron draining →
+  no lost updates, no corruption, exactly one row per (run_id, repo).
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+from session_orchestration.registry import (
+    SessionOrchestrationRegistry,
+    canonical_repo_id,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path) -> Path:
+    """Return a path to a fresh, isolated state.db in tmp_path."""
+    return tmp_path / "state.db"
+
+
+@pytest.fixture()
+def registry(db_path) -> SessionOrchestrationRegistry:
+    """Return a registry backed by an isolated DB."""
+    return SessionOrchestrationRegistry(db_path=db_path)
+
+
+# ---------------------------------------------------------------------------
+# canonical_repo_id
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalRepoId:
+    def test_same_remote_url_variants_hash_equal(self):
+        """HTTPS and git@ forms of the same repo produce the same id."""
+        https_id = canonical_repo_id(remote_url="https://github.com/foo/bar.git")
+        ssh_id = canonical_repo_id(remote_url="git@github.com:foo/bar.git")
+        assert https_id == ssh_id
+
+    def test_different_remote_urls_hash_differently(self):
+        a = canonical_repo_id(remote_url="https://github.com/foo/bar")
+        b = canonical_repo_id(remote_url="https://github.com/foo/baz")
+        assert a != b
+
+    def test_fallback_to_workdir_when_no_remote(self, tmp_path):
+        rid = canonical_repo_id(workdir=str(tmp_path))
+        assert isinstance(rid, str)
+        assert len(rid) == 12
+        assert rid.isalnum()
+
+    def test_result_is_12_hex_chars(self):
+        rid = canonical_repo_id(remote_url="https://github.com/foo/bar")
+        assert len(rid) == 12
+        int(rid, 16)  # raises ValueError if not hex
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaCreation:
+    def test_tables_created_on_init(self, db_path):
+        import sqlite3
+        SessionOrchestrationRegistry(db_path=db_path)
+        conn = sqlite3.connect(str(db_path))
+        tables = {
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        conn.close()
+        assert "session_orchestration" in tables
+        assert "session_orchestration_queue" in tables
+
+    def test_init_is_idempotent(self, db_path):
+        """Creating the registry twice does not raise."""
+        SessionOrchestrationRegistry(db_path=db_path)
+        SessionOrchestrationRegistry(db_path=db_path)  # must not raise
+
+    def test_unique_run_id_repo_index_exists(self, db_path):
+        import sqlite3
+        SessionOrchestrationRegistry(db_path=db_path)
+        conn = sqlite3.connect(str(db_path))
+        indexes = {
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index'"
+            ).fetchall()
+        }
+        conn.close()
+        assert "idx_so_run_repo" in indexes
+
+
+# ---------------------------------------------------------------------------
+# Basic CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertGetList:
+    def test_upsert_and_get(self, registry):
+        tid = str(uuid.uuid4())
+        registry.upsert(tid, agent="claude-code", run_id="run1", repo="aabbcc112233")
+        row = registry.get(tid)
+        assert row is not None
+        assert row["agent"] == "claude-code"
+        assert row["run_id"] == "run1"
+        assert row["repo"] == "aabbcc112233"
+        assert row["state"] == "RUNNING"
+
+    def test_upsert_updates_existing_row(self, registry):
+        tid = str(uuid.uuid4())
+        registry.upsert(tid, agent="claude-code", run_id="run1", repo="aabbcc112233")
+        registry.upsert(tid, agent="claude-code", state="WAITING_USER")
+        row = registry.get(tid)
+        assert row["state"] == "WAITING_USER"
+
+    def test_list_all(self, registry):
+        for i in range(3):
+            registry.upsert(
+                str(uuid.uuid4()),
+                agent="omp",
+                run_id=f"run{i}",
+                repo=f"repo{i:012x}",
+            )
+        rows = registry.list()
+        assert len(rows) == 3
+
+    def test_list_filter_by_state(self, registry):
+        t1 = str(uuid.uuid4())
+        t2 = str(uuid.uuid4())
+        registry.upsert(t1, agent="omp", state="RUNNING")
+        registry.upsert(t2, agent="omp", state="DONE")
+        running = registry.list(state="RUNNING")
+        assert len(running) == 1
+        assert running[0]["task_id"] == t1
+
+    def test_get_nonexistent_returns_none(self, registry):
+        assert registry.get("nonexistent-task-id") is None
+
+
+# ---------------------------------------------------------------------------
+# UNIQUE(run_id, repo) constraint
+# ---------------------------------------------------------------------------
+
+
+class TestUniquenessConstraint:
+    def test_duplicate_run_id_repo_rejected(self, registry):
+        """A second upsert with the same (run_id, repo) but different task_id
+        must be silently ignored (no duplicate row, no exception)."""
+        run_id = "shared-run"
+        repo = canonical_repo_id(remote_url="https://github.com/foo/bar")
+        t1 = str(uuid.uuid4())
+        t2 = str(uuid.uuid4())
+
+        registry.upsert(t1, agent="claude-code", run_id=run_id, repo=repo)
+        registry.upsert(t2, agent="claude-code", run_id=run_id, repo=repo)  # ignored
+
+        rows = registry.list(run_id=run_id)
+        assert len(rows) == 1
+        assert rows[0]["task_id"] == t1
+
+    def test_same_run_id_different_repos_allowed(self, registry):
+        """Same run_id but different repos → both rows must be inserted."""
+        run_id = "multi-repo-run"
+        repo_a = canonical_repo_id(remote_url="https://github.com/foo/alpha")
+        repo_b = canonical_repo_id(remote_url="https://github.com/foo/beta")
+        registry.upsert(str(uuid.uuid4()), agent="omp", run_id=run_id, repo=repo_a)
+        registry.upsert(str(uuid.uuid4()), agent="omp", run_id=run_id, repo=repo_b)
+
+        rows = registry.list(run_id=run_id)
+        assert len(rows) == 2
+
+
+# ---------------------------------------------------------------------------
+# Queue: enqueue / drain
+# ---------------------------------------------------------------------------
+
+
+class TestQueue:
+    def test_enqueue_and_drain(self, registry):
+        tid = str(uuid.uuid4())
+        registry.upsert(tid, agent="claude-code")
+        registry.enqueue_intent("drive", task_id=tid, payload={"msg": "hello"})
+        intents = registry.drain_intents()
+        assert len(intents) == 1
+        assert intents[0]["intent"] == "drive"
+        assert intents[0]["task_id"] == tid
+
+    def test_drain_is_empty_after_drain(self, registry):
+        tid = str(uuid.uuid4())
+        registry.upsert(tid, agent="omp")
+        registry.enqueue_intent("update", task_id=tid, payload={"state": "DONE"})
+        registry.drain_intents()
+        assert registry.drain_intents() == []
+
+    def test_drain_applies_adopt_intent(self, registry):
+        """_apply_intent with 'adopt' kind must upsert the registry row."""
+        run_id = "wh-run"
+        repo = canonical_repo_id(remote_url="https://github.com/foo/bar")
+        new_tid = str(uuid.uuid4())
+        registry.enqueue_intent(
+            "adopt",
+            task_id=new_tid,
+            run_id=run_id,
+            repo=repo,
+            payload={"agent": "claude-code", "run_id": run_id, "repo": repo,
+                     "workdir": "/home/user/project"},
+        )
+        intents = registry.drain_intents()
+        for intent in intents:
+            registry._apply_intent(intent)
+        row = registry.get(new_tid)
+        assert row is not None
+        assert row["source"] == "adopt"
+        assert row["workdir"] == "/home/user/project"
+
+    def test_drain_applies_update_intent(self, registry):
+        tid = str(uuid.uuid4())
+        registry.upsert(tid, agent="omp", state="RUNNING")
+        registry.enqueue_intent("update", task_id=tid, payload={"state": "DONE"})
+        for intent in registry.drain_intents():
+            registry._apply_intent(intent)
+        row = registry.get(tid)
+        assert row["state"] == "DONE"
+
+    def test_drain_ordering_is_fifo(self, registry):
+        """Intents must be returned in insertion order (oldest first)."""
+        tid = str(uuid.uuid4())
+        registry.upsert(tid, agent="omp")
+        for i in range(5):
+            registry.enqueue_intent("drive", task_id=tid, payload={"seq": i})
+        intents = registry.drain_intents()
+        seqs = [json.loads(i["payload"])["seq"] for i in intents]
+        assert seqs == list(range(5))
+
+
+# ---------------------------------------------------------------------------
+# Lock
+# ---------------------------------------------------------------------------
+
+
+class TestLock:
+    def test_acquire_and_release(self, registry):
+        tid = str(uuid.uuid4())
+        registry.upsert(tid, agent="omp")
+        ok = registry.acquire_lock(tid, holder="cron:1234")
+        assert ok is True
+        registry.release_lock(tid, holder="cron:1234")
+        row = registry.get(tid)
+        assert row["lock_holder"] is None
+
+    def test_second_holder_cannot_acquire_while_locked(self, registry):
+        tid = str(uuid.uuid4())
+        registry.upsert(tid, agent="omp")
+        registry.acquire_lock(tid, holder="cron:1")
+        ok = registry.acquire_lock(tid, holder="relay:2")
+        assert ok is False
+
+    def test_expired_lock_is_reclaimed(self, registry):
+        """A lock with ttl=0.001 s must be reclaimed by the next acquirer."""
+        tid = str(uuid.uuid4())
+        registry.upsert(tid, agent="omp")
+        registry.acquire_lock(tid, holder="old-holder", ttl_seconds=0.001)
+        time.sleep(0.05)  # ensure expiry
+        ok = registry.acquire_lock(tid, holder="new-holder", ttl_seconds=60)
+        assert ok is True
+        row = registry.get(tid)
+        assert row["lock_holder"] == "new-holder"
+
+    def test_release_by_non_owner_is_noop(self, registry):
+        tid = str(uuid.uuid4())
+        registry.upsert(tid, agent="omp")
+        registry.acquire_lock(tid, holder="real-holder")
+        registry.release_lock(tid, holder="impersonator")  # must not raise or change lock
+        row = registry.get(tid)
+        assert row["lock_holder"] == "real-holder"
+
+    def test_acquire_same_holder_refreshes_ttl(self, registry):
+        tid = str(uuid.uuid4())
+        registry.upsert(tid, agent="omp")
+        registry.acquire_lock(tid, holder="cron:1", ttl_seconds=60)
+        old_ts = registry.get(tid)["lock_ts"]
+        time.sleep(0.05)
+        ok = registry.acquire_lock(tid, holder="cron:1", ttl_seconds=60)
+        assert ok is True
+        new_ts = registry.get(tid)["lock_ts"]
+        assert new_ts >= old_ts
+
+
+# ---------------------------------------------------------------------------
+# Atomic counter increment
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicCounters:
+    def test_increment_heartbeat_counter(self, registry):
+        tid = str(uuid.uuid4())
+        registry.upsert(tid, agent="omp")
+        registry.increment_counter(tid, "heartbeat_counter")
+        registry.increment_counter(tid, "heartbeat_counter")
+        row = registry.get(tid)
+        assert row["heartbeat_counter"] == 2
+
+    def test_increment_idle_ticks(self, registry):
+        tid = str(uuid.uuid4())
+        registry.upsert(tid, agent="omp")
+        for _ in range(5):
+            registry.increment_counter(tid, "idle_ticks")
+        assert registry.get(tid)["idle_ticks"] == 5
+
+    def test_disallowed_column_raises(self, registry):
+        tid = str(uuid.uuid4())
+        registry.upsert(tid, agent="omp")
+        with pytest.raises(ValueError, match="not in allowed set"):
+            registry.increment_counter(tid, "agent")
+
+
+# ---------------------------------------------------------------------------
+# Concurrent-write correctness
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentWrites:
+    """
+    Simulates the three-writer scenario described in the acceptance criterion:
+
+      • cron watcher: reads the queue, applies intents, bumps heartbeat_counter
+      • webhook-adopt path: enqueues "adopt" intents
+      • Discord-drive path: enqueues "drive" intents
+
+    All three races in the same window against the same SQLite file.
+    After the cron finishes draining, we assert:
+      - No lost updates (heartbeat_counter == expected value)
+      - No corruption (heartbeat_counter is a plain integer, row is coherent)
+      - Exactly one row per (run_id, repo) (no duplicate adopt rows)
+    """
+
+    def test_concurrent_enqueue_and_drain_no_lost_updates(self, db_path):
+        N_ADOPT = 5        # distinct sessions adopted
+        N_DRIVE = 20       # drive intents (can reuse the same task_ids)
+        N_CRON_TICKS = 10  # how many times the cron "drains"
+        N_HEARTBEAT_BUMPS_PER_TICK = 1
+
+        run_id = "concurrent-test-run"
+        repo = canonical_repo_id(remote_url="https://github.com/test/concurrent")
+
+        # Pre-seed the registry with N_ADOPT rows (simulating spawn)
+        main_reg = SessionOrchestrationRegistry(db_path=db_path)
+        task_ids: list[str] = []
+        for i in range(N_ADOPT):
+            tid = f"task-conc-{i}"
+            task_ids.append(tid)
+            main_reg.upsert(tid, agent="claude-code", run_id=run_id, repo=repo + f"{i:02x}")
+
+        errors: list[str] = []
+        stop_event = threading.Event()
+
+        # ── Thread 1: webhook-adopt enqueuer ──
+        def adopt_enqueuer():
+            reg = SessionOrchestrationRegistry(db_path=db_path)
+            for i in range(N_ADOPT):
+                # Each adopt tries to register the SAME (run_id, repo) pair again —
+                # simulating a duplicate webhook POST.  The cron drain must deduplicate.
+                try:
+                    reg.enqueue_intent(
+                        "adopt",
+                        task_id=task_ids[i],
+                        run_id=run_id,
+                        repo=repo + f"{i:02x}",
+                        payload={
+                            "agent": "claude-code",
+                            "run_id": run_id,
+                            "repo": repo + f"{i:02x}",
+                            "task_id": task_ids[i],
+                        },
+                    )
+                except Exception as exc:
+                    errors.append(f"adopt_enqueuer: {exc}")
+                time.sleep(0.002)
+
+        # ── Thread 2: Discord-drive enqueuer ──
+        def drive_enqueuer():
+            reg = SessionOrchestrationRegistry(db_path=db_path)
+            for i in range(N_DRIVE):
+                try:
+                    tid = task_ids[i % N_ADOPT]
+                    reg.enqueue_intent(
+                        "drive",
+                        task_id=tid,
+                        payload={"msg": f"drive-{i}"},
+                    )
+                except Exception as exc:
+                    errors.append(f"drive_enqueuer: {exc}")
+                time.sleep(0.001)
+
+        # ── Thread 3: cron drainer ──
+        final_heartbeats: dict[str, int] = {}
+
+        def cron_drainer():
+            reg = SessionOrchestrationRegistry(db_path=db_path)
+            for tick in range(N_CRON_TICKS):
+                try:
+                    intents = reg.drain_intents()
+                    for intent in intents:
+                        reg._apply_intent(intent)
+                    # Atomically bump heartbeat_counter for every registered row
+                    for tid in task_ids:
+                        reg.increment_counter(tid, "heartbeat_counter",
+                                              by=N_HEARTBEAT_BUMPS_PER_TICK)
+                except Exception as exc:
+                    errors.append(f"cron tick {tick}: {exc}")
+                time.sleep(0.005)
+            # Capture final counters
+            for tid in task_ids:
+                row = reg.get(tid)
+                if row:
+                    final_heartbeats[tid] = row["heartbeat_counter"]
+
+        t_adopt = threading.Thread(target=adopt_enqueuer, name="adopt-enqueuer")
+        t_drive = threading.Thread(target=drive_enqueuer, name="drive-enqueuer")
+        t_cron = threading.Thread(target=cron_drainer, name="cron-drainer")
+
+        t_adopt.start()
+        t_drive.start()
+        t_cron.start()
+
+        t_adopt.join(timeout=10)
+        t_drive.join(timeout=10)
+        t_cron.join(timeout=10)
+
+        # ── Drain any remaining intents the cron didn't catch ──
+        remaining = main_reg.drain_intents()
+        for intent in remaining:
+            main_reg._apply_intent(intent)
+
+        # ── Assertions ──
+
+        assert not errors, f"Thread errors: {errors}"
+
+        # 1. No lost updates: every row must have heartbeat_counter == N_CRON_TICKS
+        for tid in task_ids:
+            row = main_reg.get(tid)
+            assert row is not None, f"Row for {tid} disappeared"
+            actual = row["heartbeat_counter"]
+            assert actual == N_CRON_TICKS, (
+                f"Lost update detected for {tid}: expected "
+                f"heartbeat_counter={N_CRON_TICKS}, got {actual}"
+            )
+
+        # 2. Exactly one row per (run_id, repo) — no duplicate adopt/spawn rows
+        for i in range(N_ADOPT):
+            r = repo + f"{i:02x}"
+            rows = main_reg.list(run_id=run_id)
+            matching = [x for x in rows if x["repo"] == r]
+            assert len(matching) == 1, (
+                f"Expected exactly 1 row for (run_id={run_id}, repo={r}), "
+                f"got {len(matching)}: {matching}"
+            )
+
+        # 3. No corruption — state column must be a valid string, counter non-negative
+        for tid in task_ids:
+            row = main_reg.get(tid)
+            assert isinstance(row["heartbeat_counter"], int)
+            assert row["heartbeat_counter"] >= 0
+            assert isinstance(row["state"], str)

--- a/tests/test_session_orchestration_relay.py
+++ b/tests/test_session_orchestration_relay.py
@@ -89,6 +89,9 @@ class _FakeAdapter(AgentAdapter):
     def resume(self, handle: SessionHandle, prompt: str) -> None:
         self.resume_calls.append(prompt)
 
+    def terminate(self, handle: SessionHandle) -> None:
+        raise NotImplementedError
+
 
 # ---------------------------------------------------------------------------
 # 1. Basic happy-path

--- a/tests/test_session_orchestration_relay.py
+++ b/tests/test_session_orchestration_relay.py
@@ -363,3 +363,35 @@ def test_lock_released_on_drive_exception(registry):
     # Lock must be released even after exception.
     row = registry.get(task_id)
     assert row["lock_holder"] is None, "Lock must be released in finally block on exception"
+
+
+# ---------------------------------------------------------------------------
+# pre_keys threading (answerable menu answer route)
+# ---------------------------------------------------------------------------
+
+
+def test_send_message_threads_pre_keys_to_drive(registry):
+    """A menu answer supplies pre_keys=['Escape']; the relay must forward them
+    to adapter.drive so the menu is cancelled before the paste."""
+    task_id = str(uuid.uuid4())
+    _seed_registry(registry, task_id)
+
+    class _PreKeysAdapter(_FakeAdapter):
+        def __init__(self) -> None:
+            super().__init__(lifecycle=SessionLifecycle.WAITING_USER)
+            self.pre_keys_seen = "unset"
+
+        def drive(self, handle, message, *, pre_keys=None):
+            self.pre_keys_seen = pre_keys
+            self.drive_calls.append(message)
+
+    adapter = _PreKeysAdapter()
+    relay = SessionRelay(registry, adapter, ttl_seconds=30.0)
+    handle = _make_handle()
+
+    relay.send_message(
+        task_id, handle, "The user chose option 2", pre_keys=["Escape"]
+    )
+
+    assert adapter.drive_calls == ["The user chose option 2"]
+    assert adapter.pre_keys_seen == ["Escape"]

--- a/tests/test_session_orchestration_relay.py
+++ b/tests/test_session_orchestration_relay.py
@@ -1,0 +1,362 @@
+"""
+Tests for session_orchestration/relay.py.
+
+Coverage
+--------
+1. Basic happy-path: relay acquires lock, drives via adapter, releases lock.
+2. Handoff path: when detect() returns PAUSED_HANDOFF, relay calls resume()
+   instead of drive().
+3. LockConflictError: a second relay call with retry_on_conflict=False raises
+   immediately when the lock is already held.
+4. Real two-party test: relay-send and watcher-style capture issued concurrently
+   from two threads BOTH go through acquire_lock; proved they cannot hold the
+   lock simultaneously (no interleave window).
+5. Crash-while-locked reclaim: a lock held past its TTL is reclaimed by the next
+   caller's acquire_lock.
+6. Multi-line prompt lands intact via the adapter's load-buffer path (not split
+   into separate send-keys calls).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from session_orchestration.adapters.base import AgentAdapter
+from session_orchestration.registry import SessionOrchestrationRegistry
+from session_orchestration.relay import LockConflictError, SessionRelay
+from session_orchestration.types import Capabilities, SessionHandle, SessionLifecycle
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "state.db"
+
+
+@pytest.fixture()
+def registry(db_path: Path) -> SessionOrchestrationRegistry:
+    return SessionOrchestrationRegistry(db_path=db_path)
+
+
+def _make_handle(session_id: str = "abc123") -> SessionHandle:
+    return SessionHandle(
+        session_id=session_id,
+        tmux_session=f"hermes-cc-{session_id[:8]}",
+        pane=f"hermes-cc-{session_id[:8]}:0.0",
+        launch_ts=datetime.now(tz=timezone.utc),
+    )
+
+
+def _seed_registry(registry: SessionOrchestrationRegistry, task_id: str) -> None:
+    """Insert a minimal RUNNING row so acquire_lock has something to lock."""
+    registry.upsert(task_id, agent="claude-code", state="RUNNING")
+
+
+class _FakeAdapter(AgentAdapter):
+    """Stub adapter that records all calls without touching tmux."""
+
+    def __init__(self, lifecycle: SessionLifecycle = SessionLifecycle.WAITING_USER):
+        self._lifecycle = lifecycle
+        self.drive_calls: List[str] = []
+        self.resume_calls: List[str] = []
+        self.detect_calls: int = 0
+
+    def capabilities(self) -> Capabilities:
+        return Capabilities()
+
+    def launch(self, workdir: str, prompt: str) -> SessionHandle:
+        raise NotImplementedError
+
+    def drive(self, handle: SessionHandle, message: str) -> None:
+        self.drive_calls.append(message)
+
+    def detect(self, handle: SessionHandle) -> SessionLifecycle:
+        self.detect_calls += 1
+        return self._lifecycle
+
+    def resume(self, handle: SessionHandle, prompt: str) -> None:
+        self.resume_calls.append(prompt)
+
+
+# ---------------------------------------------------------------------------
+# 1. Basic happy-path
+# ---------------------------------------------------------------------------
+
+
+def test_send_message_acquires_and_releases_lock(registry, db_path):
+    task_id = str(uuid.uuid4())
+    _seed_registry(registry, task_id)
+    adapter = _FakeAdapter(lifecycle=SessionLifecycle.WAITING_USER)
+    relay = SessionRelay(registry, adapter, ttl_seconds=30.0)
+    handle = _make_handle()
+
+    relay.send_message(task_id, handle, "hello world")
+
+    assert adapter.drive_calls == ["hello world"]
+    # Lock must be released after the call.
+    row = registry.get(task_id)
+    assert row["lock_holder"] is None
+    assert row["lock_ts"] is None
+
+
+# ---------------------------------------------------------------------------
+# 2. Handoff path — resume() called instead of drive()
+# ---------------------------------------------------------------------------
+
+
+def test_send_message_handoff_calls_resume_not_drive(registry):
+    task_id = str(uuid.uuid4())
+    _seed_registry(registry, task_id)
+    adapter = _FakeAdapter(lifecycle=SessionLifecycle.PAUSED_HANDOFF)
+    relay = SessionRelay(registry, adapter, ttl_seconds=30.0)
+    handle = _make_handle()
+
+    relay.send_message(task_id, handle, "resume prompt")
+
+    assert adapter.drive_calls == []
+    assert adapter.resume_calls == ["resume prompt"]
+    # Lock still released after resume.
+    row = registry.get(task_id)
+    assert row["lock_holder"] is None
+
+
+# ---------------------------------------------------------------------------
+# 3. LockConflictError when lock is already held (no retry)
+# ---------------------------------------------------------------------------
+
+
+def test_send_message_raises_lock_conflict_when_held(registry):
+    task_id = str(uuid.uuid4())
+    _seed_registry(registry, task_id)
+    # Pre-acquire the lock as an external holder with a long TTL.
+    acquired = registry.acquire_lock(task_id, "watcher:pid:999", ttl_seconds=300.0)
+    assert acquired, "Pre-acquisition should succeed on a fresh row"
+
+    adapter = _FakeAdapter()
+    relay = SessionRelay(registry, adapter, ttl_seconds=30.0)
+    handle = _make_handle()
+
+    with pytest.raises(LockConflictError):
+        relay.send_message(task_id, handle, "should not land")
+
+    # The adapter must NOT have been driven.
+    assert adapter.drive_calls == []
+
+
+# ---------------------------------------------------------------------------
+# 4. Real two-party test — concurrent relay-send and watcher-capture
+#    CANNOT both hold the lock simultaneously.
+# ---------------------------------------------------------------------------
+
+
+def test_two_party_concurrent_cannot_interleave(db_path):
+    """
+    Spawn a relay-send thread and a watcher-capture thread concurrently
+    against the same task_id + state.db.  Both go through acquire_lock.
+    Record the (holder, acquire_time, release_time) intervals and assert
+    no overlap: at most one holder can own the lock at any instant.
+    """
+    task_id = str(uuid.uuid4())
+
+    # Two independent registry instances pointing at the same DB (simulates
+    # separate processes — relay and watcher — sharing state.db).
+    reg_relay = SessionOrchestrationRegistry(db_path=db_path)
+    reg_watcher = SessionOrchestrationRegistry(db_path=db_path)
+
+    reg_relay.upsert(task_id, agent="claude-code", state="RUNNING")
+
+    events: List[dict] = []  # {"holder": str, "event": "acquire"|"release", "t": float}
+    errors: List[str] = []
+    lock = threading.Lock()
+
+    def _relay_thread():
+        holder = "relay:pid:1"
+        # Retry loop: if the watcher got there first, spin until available
+        deadline = time.monotonic() + 5.0
+        acquired = False
+        while time.monotonic() < deadline:
+            ok = reg_relay.acquire_lock(task_id, holder, ttl_seconds=5.0)
+            if ok:
+                acquired = True
+                break
+            time.sleep(0.01)
+        if not acquired:
+            with lock:
+                errors.append("relay: could not acquire lock")
+            return
+        with lock:
+            events.append({"holder": holder, "event": "acquire", "t": time.monotonic()})
+        # Simulate a slow drive: hold the lock for a brief period.
+        time.sleep(0.05)
+        with lock:
+            events.append({"holder": holder, "event": "release", "t": time.monotonic()})
+        reg_relay.release_lock(task_id, holder)
+
+    def _watcher_thread():
+        holder = "watcher:pid:2"
+        deadline = time.monotonic() + 5.0
+        acquired = False
+        while time.monotonic() < deadline:
+            ok = reg_watcher.acquire_lock(task_id, holder, ttl_seconds=5.0)
+            if ok:
+                acquired = True
+                break
+            time.sleep(0.01)
+        if not acquired:
+            with lock:
+                errors.append("watcher: could not acquire lock")
+            return
+        with lock:
+            events.append({"holder": holder, "event": "acquire", "t": time.monotonic()})
+        # Simulate a slow capture: hold the lock for a brief period.
+        time.sleep(0.05)
+        with lock:
+            events.append({"holder": holder, "event": "release", "t": time.monotonic()})
+        reg_watcher.release_lock(task_id, holder)
+
+    t1 = threading.Thread(target=_relay_thread)
+    t2 = threading.Thread(target=_watcher_thread)
+
+    # Start both at the same time to maximise contention.
+    t1.start()
+    t2.start()
+    t1.join(timeout=10.0)
+    t2.join(timeout=10.0)
+
+    assert not errors, f"Lock threads failed: {errors}"
+    assert len(events) == 4, f"Expected 4 events (acquire+release x2), got: {events}"
+
+    # Sort events by timestamp to reconstruct the timeline.
+    events.sort(key=lambda e: e["t"])
+
+    # Assert no overlap: the acquire of the second holder must come AFTER
+    # the release of the first holder.
+    # Build intervals per holder.
+    intervals: dict[str, dict] = {}
+    for ev in events:
+        h = ev["holder"]
+        if h not in intervals:
+            intervals[h] = {}
+        intervals[h][ev["event"]] = ev["t"]
+
+    holders = list(intervals.keys())
+    assert len(holders) == 2, f"Expected 2 distinct holders, got {holders}"
+
+    h1_start = intervals[holders[0]]["acquire"]
+    h1_end = intervals[holders[0]]["release"]
+    h2_start = intervals[holders[1]]["acquire"]
+    h2_end = intervals[holders[1]]["release"]
+
+    # Intervals [h1_start, h1_end] and [h2_start, h2_end] must NOT overlap.
+    overlapping = h1_start < h2_end and h2_start < h1_end
+    assert not overlapping, (
+        f"Lock intervals overlapped! "
+        f"{holders[0]}: [{h1_start:.4f}, {h1_end:.4f}] | "
+        f"{holders[1]}: [{h2_start:.4f}, {h2_end:.4f}]"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. Crash-while-locked reclaim — expired TTL is reclaimed by new caller
+# ---------------------------------------------------------------------------
+
+
+def test_crash_while_locked_reclaim(registry):
+    """
+    Simulate a crash: pre-set a lock whose TTL has already expired (lock_ts
+    is an epoch float in the past).  A new acquire_lock call must reclaim it
+    and return True.
+    """
+    task_id = str(uuid.uuid4())
+    _seed_registry(registry, task_id)
+
+    # Acquire with a tiny TTL, then manually expire it by force-writing a
+    # past expiry epoch directly so we don't have to sleep.
+    import sqlite3
+
+    conn = sqlite3.connect(str(registry._db_path))
+    try:
+        # Set lock to already-expired: expiry 60 s in the past.
+        past_expiry = str(time.time() - 60.0)
+        conn.execute(
+            "UPDATE session_orchestration SET lock_holder = ?, lock_ts = ? "
+            "WHERE task_id = ?",
+            ("crashed:pid:666", past_expiry, task_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Verify the lock looks held to a naive reader.
+    row = registry.get(task_id)
+    assert row["lock_holder"] == "crashed:pid:666"
+
+    # Now the new caller should reclaim it.
+    new_holder = "relay:pid:1001"
+    reclaimed = registry.acquire_lock(task_id, new_holder, ttl_seconds=30.0)
+    assert reclaimed, "Stale lock should be reclaimed by a new caller"
+
+    row = registry.get(task_id)
+    assert row["lock_holder"] == new_holder
+
+
+# ---------------------------------------------------------------------------
+# 6. Multi-line prompt lands intact
+# ---------------------------------------------------------------------------
+
+
+def test_multiline_prompt_passed_intact_to_adapter(registry):
+    """
+    The relay forwards the message to adapter.drive() verbatim (no splitting,
+    no newline mangling).  The adapter (ClaudeCodeAdapter in production) handles
+    multi-line delivery via load-buffer/paste-buffer.
+    """
+    task_id = str(uuid.uuid4())
+    _seed_registry(registry, task_id)
+    adapter = _FakeAdapter(lifecycle=SessionLifecycle.WAITING_USER)
+    relay = SessionRelay(registry, adapter, ttl_seconds=30.0)
+    handle = _make_handle()
+
+    multiline = "First line.\nSecond line.\nThird line."
+    relay.send_message(task_id, handle, multiline)
+
+    assert adapter.drive_calls == [multiline], (
+        "Multi-line prompt must reach adapter.drive() unchanged"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 7. Lock is released even when adapter.drive() raises
+# ---------------------------------------------------------------------------
+
+
+def test_lock_released_on_drive_exception(registry):
+    task_id = str(uuid.uuid4())
+    _seed_registry(registry, task_id)
+
+    class _BoomAdapter(_FakeAdapter):
+        def drive(self, handle, message):
+            raise TimeoutError("pane never ready")
+
+    adapter = _BoomAdapter(lifecycle=SessionLifecycle.WAITING_USER)
+    relay = SessionRelay(registry, adapter, ttl_seconds=30.0)
+    handle = _make_handle()
+
+    with pytest.raises(TimeoutError):
+        relay.send_message(task_id, handle, "trigger boom")
+
+    # Lock must be released even after exception.
+    row = registry.get(task_id)
+    assert row["lock_holder"] is None, "Lock must be released in finally block on exception"

--- a/tests/test_session_orchestration_renudge.py
+++ b/tests/test_session_orchestration_renudge.py
@@ -1,0 +1,587 @@
+"""
+Unit tests for T-FEED-004 — attention re-nudge after X minutes.
+
+Coverage (tasks (a)-(f) from acceptance criteria):
+
+(a) A row in WAITING_USER with attention_since older than renudge_after_seconds
+    → re-nudge DM fires once and last_renudge_at is set.
+(b) Within the interval → does NOT re-fire.
+(c) After another full interval → fires again.
+(d) A state change out of the attention set clears attention_since/last_renudge_at.
+(e) renudge_after_seconds=0 disables re-nudging entirely.
+(f) No discord_user_id → no DM, no crash.
+
+Plus:
+- entering attention sets attention_since, clears last_renudge_at.
+- existing watcher tests are not broken (FakeAdapter matches the existing interface).
+
+All tests use in-memory SQLite, injected _now_fn, and injected _send_dm_fn so
+no real time passes and no Discord API calls are made.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from unittest.mock import patch
+
+import pytest
+
+from session_orchestration.adapters.base import AgentAdapter
+from session_orchestration.adapters.verify import AdapterProbeSpec
+from session_orchestration.registry import SessionOrchestrationRegistry
+from session_orchestration.types import Capabilities, SessionHandle, SessionLifecycle
+from session_orchestration.watcher import (
+    SessionWatcher,
+    _check_renudge,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeAdapter(AgentAdapter):
+    """Adapter that returns a fixed lifecycle value."""
+
+    def __init__(self, lifecycle: SessionLifecycle = SessionLifecycle.RUNNING):
+        self._lifecycle = lifecycle
+        self.detect_calls: List[SessionHandle] = []
+
+    def capabilities(self) -> Capabilities:
+        return Capabilities()
+
+    def launch(self, workdir: str, prompt: str) -> SessionHandle:
+        raise NotImplementedError
+
+    def drive(self, handle: SessionHandle, message: str) -> None:
+        raise NotImplementedError
+
+    def detect(self, handle: SessionHandle) -> SessionLifecycle:
+        self.detect_calls.append(handle)
+        return self._lifecycle
+
+    def terminate(self, handle: SessionHandle) -> None:
+        raise NotImplementedError
+
+    def resume(self, handle: SessionHandle, prompt: str) -> None:
+        raise NotImplementedError
+
+
+class FakeCapture:
+    """Fake tmux_capture returning fixed text."""
+
+    def __init__(self, text: str = "some pane output"):
+        self._text = text
+
+    def __call__(self, pane: str) -> str:
+        return self._text
+
+
+class FakeProbeRunner:
+    """ProbeRunner that passes every binary."""
+
+    def which(self, binary: str) -> str | None:
+        return f"/usr/local/bin/{binary}"
+
+    def help_text(self, binary: str) -> str:
+        return ""
+
+
+class RecordingDmFn:
+    """Injectable send_dm_fn that records calls and returns True."""
+
+    def __init__(self) -> None:
+        self.calls: List[tuple] = []  # [(user_id, msg), ...]
+
+    def __call__(self, user_id: str, msg: str) -> bool:
+        self.calls.append((user_id, msg))
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FIXED_NOW = 1_700_000_000.0  # arbitrary fixed epoch
+_RENUDGE_AFTER = 1800  # 30 min — matches default
+
+
+def _fake_probe_spec() -> AdapterProbeSpec:
+    return AdapterProbeSpec(binary="fake-agent")
+
+
+def _make_watcher(
+    registry: SessionOrchestrationRegistry,
+    adapter: FakeAdapter,
+    *,
+    now_fn=None,
+    send_dm_fn=None,
+    adapter_name: str = "fake",
+) -> SessionWatcher:
+    """Build a SessionWatcher with all network/time dependencies injected."""
+    watcher = SessionWatcher(
+        registry=registry,
+        adapters={adapter_name: adapter},
+        tmux_capture=FakeCapture(),
+        tmux_liveness_fn=lambda _s: True,  # pane always alive
+        _now_fn=now_fn if now_fn is not None else (lambda: _FIXED_NOW),
+        _send_dm_fn=send_dm_fn if send_dm_fn is not None else RecordingDmFn(),
+    )
+    probe_runner = FakeProbeRunner()
+    probe_specs = {type(adapter).__name__: _fake_probe_spec()}
+    watcher.startup_verify(probe_runner=probe_runner, probe_specs=probe_specs)
+    return watcher
+
+
+def _seed_waiting_user(
+    registry: SessionOrchestrationRegistry,
+    task_id: str,
+    *,
+    discord_user_id: Optional[str] = "discord-user-999",
+    attention_since: Optional[float] = None,
+    last_renudge_at: Optional[float] = None,
+) -> None:
+    """Insert a WAITING_USER row and optionally pre-stamp attention columns."""
+    registry.upsert(
+        task_id,
+        agent="fake",
+        run_id=f"run-{uuid.uuid4().hex[:8]}",
+        repo=f"repo-{uuid.uuid4().hex[:8]}",
+        state="WAITING_USER",
+        tmux_session=f"hermes-fake-{uuid.uuid4().hex[:6]}",
+        discord_user_id=discord_user_id,
+    )
+    if attention_since is not None or last_renudge_at is not None:
+        registry.set_attention_stamps(task_id, attention_since, last_renudge_at)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "state.db"
+
+
+@pytest.fixture()
+def registry(db_path: Path) -> SessionOrchestrationRegistry:
+    return SessionOrchestrationRegistry(db_path=db_path)
+
+
+# ---------------------------------------------------------------------------
+# Test (a): re-nudge fires when attention_since is older than the interval
+# ---------------------------------------------------------------------------
+
+
+class TestRenudgeFiresAfterInterval:
+    def test_dm_fires_once_and_last_renudge_at_set(self, registry: SessionOrchestrationRegistry):
+        task_id = "t-renudge-a"
+        # attention_since is 2000s ago — past the 1800s threshold
+        attention_since = _FIXED_NOW - 2000
+        _seed_waiting_user(
+            registry, task_id, attention_since=attention_since, last_renudge_at=None
+        )
+
+        dm = RecordingDmFn()
+        watcher = _make_watcher(
+            registry,
+            FakeAdapter(SessionLifecycle.WAITING_USER),
+            now_fn=lambda: _FIXED_NOW,
+            send_dm_fn=dm,
+        )
+
+        with patch(
+            "session_orchestration.watcher._load_renudge_after_seconds_cfg",
+            return_value=_RENUDGE_AFTER,
+        ):
+            watcher.tick()
+
+        assert len(dm.calls) == 1, "expected exactly one DM"
+        user_id, msg = dm.calls[0]
+        assert user_id == "discord-user-999"
+        assert "still needs your input" in msg
+        assert "waiting " in msg
+
+        row = registry.get(task_id)
+        assert row is not None
+        assert row["last_renudge_at"] is not None
+        assert abs(float(row["last_renudge_at"]) - _FIXED_NOW) < 1.0
+
+
+# ---------------------------------------------------------------------------
+# Test (b): within the interval → does NOT fire
+# ---------------------------------------------------------------------------
+
+
+class TestRenudgeWithinInterval:
+    def test_no_dm_within_interval(self, registry: SessionOrchestrationRegistry):
+        task_id = "t-renudge-b"
+        # attention_since is only 500s ago — under the 1800s threshold
+        attention_since = _FIXED_NOW - 500
+        _seed_waiting_user(
+            registry, task_id, attention_since=attention_since, last_renudge_at=None
+        )
+
+        dm = RecordingDmFn()
+        watcher = _make_watcher(
+            registry,
+            FakeAdapter(SessionLifecycle.WAITING_USER),
+            now_fn=lambda: _FIXED_NOW,
+            send_dm_fn=dm,
+        )
+
+        with patch(
+            "session_orchestration.watcher._load_renudge_after_seconds_cfg",
+            return_value=_RENUDGE_AFTER,
+        ):
+            watcher.tick()
+
+        assert len(dm.calls) == 0, "DM must not fire within the interval"
+
+        row = registry.get(task_id)
+        # last_renudge_at should still be NULL (no nudge fired)
+        assert row is not None
+        assert row["last_renudge_at"] is None
+
+    def test_last_renudge_at_resets_window(self, registry: SessionOrchestrationRegistry):
+        """If last_renudge_at was just set, the window uses it as the reference."""
+        task_id = "t-renudge-b2"
+        attention_since = _FIXED_NOW - 3600  # well past initial threshold
+        last_renudge_at = _FIXED_NOW - 500   # but re-nudge was recent
+        _seed_waiting_user(
+            registry, task_id,
+            attention_since=attention_since,
+            last_renudge_at=last_renudge_at,
+        )
+
+        dm = RecordingDmFn()
+        watcher = _make_watcher(
+            registry,
+            FakeAdapter(SessionLifecycle.WAITING_USER),
+            now_fn=lambda: _FIXED_NOW,
+            send_dm_fn=dm,
+        )
+
+        with patch(
+            "session_orchestration.watcher._load_renudge_after_seconds_cfg",
+            return_value=_RENUDGE_AFTER,
+        ):
+            watcher.tick()
+
+        # 500s since last_renudge_at < 1800s → should NOT fire
+        assert len(dm.calls) == 0
+
+
+# ---------------------------------------------------------------------------
+# Test (c): after another full interval → fires again
+# ---------------------------------------------------------------------------
+
+
+class TestRenudgeRepeats:
+    def test_fires_again_after_second_interval(self, registry: SessionOrchestrationRegistry):
+        task_id = "t-renudge-c"
+        attention_since = _FIXED_NOW - 4000
+        # Simulate: re-nudge already fired 2000s ago (> 1800s → should fire again)
+        last_renudge_at = _FIXED_NOW - 2000
+
+        _seed_waiting_user(
+            registry, task_id,
+            attention_since=attention_since,
+            last_renudge_at=last_renudge_at,
+        )
+
+        dm = RecordingDmFn()
+        watcher = _make_watcher(
+            registry,
+            FakeAdapter(SessionLifecycle.WAITING_USER),
+            now_fn=lambda: _FIXED_NOW,
+            send_dm_fn=dm,
+        )
+
+        with patch(
+            "session_orchestration.watcher._load_renudge_after_seconds_cfg",
+            return_value=_RENUDGE_AFTER,
+        ):
+            watcher.tick()
+
+        assert len(dm.calls) == 1, "expected re-nudge to fire again after second interval"
+
+        row = registry.get(task_id)
+        assert row is not None
+        # last_renudge_at must be updated to ~now
+        assert abs(float(row["last_renudge_at"]) - _FIXED_NOW) < 1.0
+
+
+# ---------------------------------------------------------------------------
+# Test (d): state change out of attention clears attention_since/last_renudge_at
+# ---------------------------------------------------------------------------
+
+
+class TestAttentionStampsClearedOnLeave:
+    def test_clearing_on_transition_to_running(self, registry: SessionOrchestrationRegistry):
+        task_id = "t-renudge-d"
+        # Row starts in WAITING_USER with stamps set
+        attention_since = _FIXED_NOW - 2000
+        _seed_waiting_user(
+            registry, task_id,
+            attention_since=attention_since,
+            last_renudge_at=_FIXED_NOW - 100,
+        )
+
+        # Adapter will now detect RUNNING → transition out of attention
+        dm = RecordingDmFn()
+        watcher = _make_watcher(
+            registry,
+            FakeAdapter(SessionLifecycle.RUNNING),
+            now_fn=lambda: _FIXED_NOW,
+            send_dm_fn=dm,
+        )
+
+        with patch("session_orchestration.feed.push_turn_change", return_value=None), \
+             patch(
+                 "session_orchestration.watcher._load_renudge_after_seconds_cfg",
+                 return_value=_RENUDGE_AFTER,
+             ):
+            watcher.tick()
+
+        row = registry.get(task_id)
+        assert row is not None
+        assert row["state"] == "RUNNING"
+        assert row["attention_since"] is None, "attention_since must be cleared on leave"
+        assert row["last_renudge_at"] is None, "last_renudge_at must be cleared on leave"
+
+        # No re-nudge DM should fire (leaving attention, not staying)
+        assert len(dm.calls) == 0
+
+
+class TestAttentionSinceSetOnEnter:
+    def test_attention_since_stamped_on_enter(self, registry: SessionOrchestrationRegistry):
+        task_id = "t-renudge-enter"
+        # Row starts in RUNNING (no attention stamps)
+        registry.upsert(
+            task_id,
+            agent="fake",
+            run_id=f"run-{uuid.uuid4().hex[:8]}",
+            repo=f"repo-{uuid.uuid4().hex[:8]}",
+            state="RUNNING",
+            tmux_session="hermes-fake-enter",
+            discord_user_id="discord-user-999",
+        )
+
+        # Adapter transitions to WAITING_USER → entering attention
+        dm = RecordingDmFn()
+        watcher = _make_watcher(
+            registry,
+            FakeAdapter(SessionLifecycle.WAITING_USER),
+            now_fn=lambda: _FIXED_NOW,
+            send_dm_fn=dm,
+        )
+
+        with patch("session_orchestration.feed.push_turn_change", return_value=None), \
+             patch(
+                 "session_orchestration.watcher._load_renudge_after_seconds_cfg",
+                 return_value=_RENUDGE_AFTER,
+             ):
+            watcher.tick()
+
+        row = registry.get(task_id)
+        assert row is not None
+        assert row["state"] == "WAITING_USER"
+        assert row["attention_since"] is not None, "attention_since must be set on enter"
+        assert abs(float(row["attention_since"]) - _FIXED_NOW) < 1.0
+        assert row["last_renudge_at"] is None, "last_renudge_at must be NULL on enter"
+
+        # No re-nudge DM on the entering tick (it fires only on staying ticks)
+        assert len(dm.calls) == 0
+
+
+# ---------------------------------------------------------------------------
+# Test (e): renudge_after_seconds=0 disables
+# ---------------------------------------------------------------------------
+
+
+class TestRenudgeDisabledByZero:
+    def test_zero_disables_renudge(self, registry: SessionOrchestrationRegistry):
+        task_id = "t-renudge-e"
+        attention_since = _FIXED_NOW - 9999  # very old — would fire if enabled
+        _seed_waiting_user(
+            registry, task_id, attention_since=attention_since, last_renudge_at=None
+        )
+
+        dm = RecordingDmFn()
+        watcher = _make_watcher(
+            registry,
+            FakeAdapter(SessionLifecycle.WAITING_USER),
+            now_fn=lambda: _FIXED_NOW,
+            send_dm_fn=dm,
+        )
+
+        with patch(
+            "session_orchestration.watcher._load_renudge_after_seconds_cfg",
+            return_value=0,  # disabled
+        ):
+            watcher.tick()
+
+        assert len(dm.calls) == 0, "DM must not fire when renudge_after_seconds=0"
+
+    def test_negative_also_disables(self, registry: SessionOrchestrationRegistry):
+        task_id = "t-renudge-e2"
+        attention_since = _FIXED_NOW - 9999
+        _seed_waiting_user(
+            registry, task_id, attention_since=attention_since, last_renudge_at=None
+        )
+
+        dm = RecordingDmFn()
+        watcher = _make_watcher(
+            registry,
+            FakeAdapter(SessionLifecycle.WAITING_USER),
+            now_fn=lambda: _FIXED_NOW,
+            send_dm_fn=dm,
+        )
+
+        with patch(
+            "session_orchestration.watcher._load_renudge_after_seconds_cfg",
+            return_value=-1,
+        ):
+            watcher.tick()
+
+        assert len(dm.calls) == 0
+
+
+# ---------------------------------------------------------------------------
+# Test (f): no discord_user_id → no DM, no crash
+# ---------------------------------------------------------------------------
+
+
+class TestRenudgeNoUserId:
+    def test_no_dm_when_no_user_id(self, registry: SessionOrchestrationRegistry):
+        task_id = "t-renudge-f"
+        attention_since = _FIXED_NOW - 2000
+        # No discord_user_id
+        _seed_waiting_user(
+            registry, task_id,
+            discord_user_id=None,
+            attention_since=attention_since,
+            last_renudge_at=None,
+        )
+
+        dm = RecordingDmFn()
+        watcher = _make_watcher(
+            registry,
+            FakeAdapter(SessionLifecycle.WAITING_USER),
+            now_fn=lambda: _FIXED_NOW,
+            send_dm_fn=dm,
+        )
+
+        # Should not crash, should not call DM
+        with patch(
+            "session_orchestration.watcher._load_renudge_after_seconds_cfg",
+            return_value=_RENUDGE_AFTER,
+        ):
+            watcher.tick()
+
+        assert len(dm.calls) == 0, "No DM when discord_user_id is absent"
+
+        # last_renudge_at is still updated (best-effort, independent of DM success)
+        row = registry.get(task_id)
+        assert row is not None
+        assert row["last_renudge_at"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Direct unit test for _check_renudge
+# ---------------------------------------------------------------------------
+
+
+class TestCheckRenudgeDirect:
+    """Direct unit tests for the _check_renudge module-level function."""
+
+    def _make_registry(self, tmp_path: Path) -> SessionOrchestrationRegistry:
+        return SessionOrchestrationRegistry(db_path=tmp_path / "state.db")
+
+    def test_fires_when_interval_elapsed(self, tmp_path: Path):
+        registry = self._make_registry(tmp_path)
+        task_id = "t-direct-a"
+        registry.upsert(task_id, agent="fake", discord_user_id="u-001", state="WAITING_USER")
+        registry.set_attention_stamps(task_id, _FIXED_NOW - 2000, None)
+
+        fresh_row = registry.get(task_id)
+        dm = RecordingDmFn()
+
+        with patch(
+            "session_orchestration.watcher._load_renudge_after_seconds_cfg",
+            return_value=1800,
+        ):
+            _check_renudge(task_id, fresh_row, _FIXED_NOW, registry=registry, send_dm_fn=dm)
+
+        assert len(dm.calls) == 1
+        assert dm.calls[0][0] == "u-001"
+        updated_row = registry.get(task_id)
+        assert updated_row["last_renudge_at"] is not None
+
+    def test_skips_when_no_attention_since(self, tmp_path: Path):
+        registry = self._make_registry(tmp_path)
+        task_id = "t-direct-b"
+        registry.upsert(task_id, agent="fake", discord_user_id="u-001", state="WAITING_USER")
+        # No attention_since stamp set
+
+        fresh_row = registry.get(task_id)
+        dm = RecordingDmFn()
+
+        with patch(
+            "session_orchestration.watcher._load_renudge_after_seconds_cfg",
+            return_value=1800,
+        ):
+            _check_renudge(task_id, fresh_row, _FIXED_NOW, registry=registry, send_dm_fn=dm)
+
+        assert len(dm.calls) == 0
+
+    def test_paused_handoff_also_renudges(self, tmp_path: Path):
+        """Re-nudge fires for PAUSED_HANDOFF as well as WAITING_USER."""
+        registry = self._make_registry(tmp_path)
+        task_id = "t-direct-c"
+        registry.upsert(
+            task_id, agent="fake", discord_user_id="u-001", state="PAUSED_HANDOFF"
+        )
+        registry.set_attention_stamps(task_id, _FIXED_NOW - 2000, None)
+
+        fresh_row = registry.get(task_id)
+        dm = RecordingDmFn()
+
+        with patch(
+            "session_orchestration.watcher._load_renudge_after_seconds_cfg",
+            return_value=1800,
+        ):
+            _check_renudge(task_id, fresh_row, _FIXED_NOW, registry=registry, send_dm_fn=dm)
+
+        assert len(dm.calls) == 1
+
+    def test_dm_failure_does_not_prevent_last_renudge_at_update(self, tmp_path: Path):
+        """Even if send_dm_fn raises, last_renudge_at should be updated (best-effort)."""
+        registry = self._make_registry(tmp_path)
+        task_id = "t-direct-d"
+        registry.upsert(task_id, agent="fake", discord_user_id="u-001", state="WAITING_USER")
+        registry.set_attention_stamps(task_id, _FIXED_NOW - 2000, None)
+
+        fresh_row = registry.get(task_id)
+
+        def failing_dm(user_id: str, msg: str) -> bool:
+            raise RuntimeError("network error")
+
+        with patch(
+            "session_orchestration.watcher._load_renudge_after_seconds_cfg",
+            return_value=1800,
+        ):
+            # Should not raise despite the DM failure
+            _check_renudge(
+                task_id, fresh_row, _FIXED_NOW, registry=registry, send_dm_fn=failing_dm
+            )
+
+        updated_row = registry.get(task_id)
+        assert updated_row["last_renudge_at"] is not None

--- a/tests/test_session_orchestration_spawn.py
+++ b/tests/test_session_orchestration_spawn.py
@@ -37,6 +37,8 @@ from session_orchestration.spawn import (
     parse_spawn_args,
     spawn_session,
     handle_spawn_command,
+    handle_stop_command,
+    handle_restart_command,
 )
 from session_orchestration.types import Capabilities, SessionHandle, SessionLifecycle
 
@@ -91,6 +93,9 @@ class _FakeAdapter(AgentAdapter):
 
     def resume(self, handle: SessionHandle, prompt: str) -> None:
         self.resume_calls.append(prompt)
+
+    def terminate(self, handle: SessionHandle) -> None:
+        pass  # safe no-op in tests
 
 
 class _FakeRelay:
@@ -562,3 +567,177 @@ def test_handle_spawn_command_integration(db_path):
     assert len(all_rows) == 1
     assert all_rows[0]["source"] == "spawn"
     assert all_rows[0]["agent"] == "claude"
+
+
+# ---------------------------------------------------------------------------
+# T006 — enqueue_terminate: queue contract
+# ---------------------------------------------------------------------------
+
+
+def test_enqueue_terminate_inserts_row_with_kind_terminate(registry):
+    """enqueue_terminate inserts a queue row with intent='terminate'."""
+    registry.enqueue_terminate("task-abc", restart=False)
+
+    conn = registry._connect()
+    rows = conn.execute(
+        "SELECT * FROM session_orchestration_queue WHERE task_id = 'task-abc'"
+    ).fetchall()
+    conn.close()
+
+    assert len(rows) == 1
+    row = dict(rows[0])
+    assert row["intent"] == "terminate"
+
+
+def test_enqueue_terminate_payload_restart_false(registry):
+    """enqueue_terminate with restart=False writes payload.restart=False."""
+    import json
+    registry.enqueue_terminate("task-stop", restart=False)
+
+    conn = registry._connect()
+    rows = conn.execute(
+        "SELECT payload FROM session_orchestration_queue WHERE task_id = 'task-stop'"
+    ).fetchall()
+    conn.close()
+
+    assert len(rows) == 1
+    payload = json.loads(rows[0]["payload"])
+    assert payload["restart"] is False
+
+
+def test_enqueue_terminate_payload_restart_true(registry):
+    """enqueue_terminate with restart=True writes payload.restart=True."""
+    import json
+    registry.enqueue_terminate("task-restart", restart=True)
+
+    conn = registry._connect()
+    rows = conn.execute(
+        "SELECT payload FROM session_orchestration_queue WHERE task_id = 'task-restart'"
+    ).fetchall()
+    conn.close()
+
+    assert len(rows) == 1
+    payload = json.loads(rows[0]["payload"])
+    assert payload["restart"] is True
+
+
+def test_apply_intent_terminate_does_not_raise(registry):
+    """_apply_intent must not raise when draining a terminate intent."""
+    import json
+    intent = {
+        "id": 1,
+        "task_id": "task-xyz",
+        "intent": "terminate",
+        "payload": json.dumps({"restart": False}),
+    }
+    # Must complete without raising
+    registry._apply_intent(intent)
+
+
+# ---------------------------------------------------------------------------
+# T006 — handle_stop_command
+# ---------------------------------------------------------------------------
+
+
+def test_handle_stop_command_returns_confirmation(registry):
+    """handle_stop_command with valid task_id returns non-empty string."""
+    event = MagicMock()
+    result = handle_stop_command(event, "task_id=task-123", registry=registry)
+
+    assert result
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+def test_handle_stop_command_enqueues_terminate_restart_false(registry):
+    """handle_stop_command calls enqueue_terminate with restart=False."""
+    import json
+    event = MagicMock()
+    handle_stop_command(event, "task_id=task-stop-x", registry=registry)
+
+    conn = registry._connect()
+    rows = conn.execute(
+        "SELECT intent, payload FROM session_orchestration_queue "
+        "WHERE task_id = 'task-stop-x'"
+    ).fetchall()
+    conn.close()
+
+    assert len(rows) == 1
+    assert rows[0]["intent"] == "terminate"
+    payload = json.loads(rows[0]["payload"])
+    assert payload["restart"] is False
+
+
+def test_handle_stop_command_missing_task_id_returns_error_not_raises(registry):
+    """handle_stop_command returns an error string when task_id is absent."""
+    event = MagicMock()
+    result = handle_stop_command(event, "", registry=registry)
+
+    assert isinstance(result, str)
+    assert "task_id" in result.lower()
+
+    # No queue row should have been written
+    conn = registry._connect()
+    count = conn.execute(
+        "SELECT COUNT(*) FROM session_orchestration_queue"
+    ).fetchone()[0]
+    conn.close()
+    assert count == 0
+
+
+def test_handle_stop_command_missing_task_id_does_not_raise_on_garbage(registry):
+    """handle_stop_command returns error string (not raise) for garbage input."""
+    event = MagicMock()
+    result = handle_stop_command(event, "foo bar baz", registry=registry)
+
+    assert isinstance(result, str)
+    assert result  # non-empty error
+
+
+# ---------------------------------------------------------------------------
+# T006 — handle_restart_command
+# ---------------------------------------------------------------------------
+
+
+def test_handle_restart_command_enqueues_terminate_restart_true(registry):
+    """handle_restart_command calls enqueue_terminate with restart=True."""
+    import json
+    event = MagicMock()
+    handle_restart_command(event, "task_id=task-restart-y", registry=registry)
+
+    conn = registry._connect()
+    rows = conn.execute(
+        "SELECT intent, payload FROM session_orchestration_queue "
+        "WHERE task_id = 'task-restart-y'"
+    ).fetchall()
+    conn.close()
+
+    assert len(rows) == 1
+    assert rows[0]["intent"] == "terminate"
+    payload = json.loads(rows[0]["payload"])
+    assert payload["restart"] is True
+
+
+def test_handle_restart_command_returns_confirmation(registry):
+    """handle_restart_command with valid task_id returns non-empty string."""
+    event = MagicMock()
+    result = handle_restart_command(event, "task_id=task-789", registry=registry)
+
+    assert result
+    assert isinstance(result, str)
+
+
+def test_handle_restart_command_missing_task_id_returns_error_not_raises(registry):
+    """handle_restart_command returns an error string when task_id is absent."""
+    event = MagicMock()
+    result = handle_restart_command(event, "", registry=registry)
+
+    assert isinstance(result, str)
+    assert "task_id" in result.lower()
+
+    conn = registry._connect()
+    count = conn.execute(
+        "SELECT COUNT(*) FROM session_orchestration_queue"
+    ).fetchone()[0]
+    conn.close()
+    assert count == 0

--- a/tests/test_session_orchestration_spawn.py
+++ b/tests/test_session_orchestration_spawn.py
@@ -741,3 +741,130 @@ def test_handle_restart_command_missing_task_id_returns_error_not_raises(registr
     ).fetchone()[0]
     conn.close()
     assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# T-REV-001 — CommandDef registration + gateway dispatch for so-stop/so-restart
+# ---------------------------------------------------------------------------
+
+
+def test_so_stop_command_def_registered():
+    """so-stop must appear in the command registry so Discord can autocomplete it."""
+    from hermes_cli.commands import resolve_command
+
+    cmd = resolve_command("so-stop")
+    assert cmd is not None, "so-stop not found in COMMAND_REGISTRY"
+    assert cmd.name == "so-stop"
+    assert cmd.gateway_only is True
+    assert cmd.gateway_config_gate == "session_orchestration.enabled"
+
+
+def test_so_restart_command_def_registered():
+    """so-restart must appear in the command registry so Discord can autocomplete it."""
+    from hermes_cli.commands import resolve_command
+
+    cmd = resolve_command("so-restart")
+    assert cmd is not None, "so-restart not found in COMMAND_REGISTRY"
+    assert cmd.name == "so-restart"
+    assert cmd.gateway_only is True
+    assert cmd.gateway_config_gate == "session_orchestration.enabled"
+
+
+def test_gateway_so_stop_dispatch_reaches_handle_stop_command(registry):
+    """_handle_so_stop_command must call spawn.handle_stop_command and return its result.
+
+    Uses asyncio.run() directly since pytest-asyncio is not installed in this env.
+    """
+    import asyncio
+    from unittest.mock import MagicMock, patch
+
+    # Build a minimal stand-in that replicates only the method under test,
+    # avoiding the heavy GatewayRunner constructor.
+    class _FakeRunner:
+        config = {}
+
+        async def _handle_so_stop_command(self, event):
+            try:
+                from session_orchestration.spawn import handle_stop_command as _h
+            except ImportError as exc:  # pragma: no cover
+                return f"Session orchestration is not available: {exc}"
+
+            raw_text = getattr(event, "text", "") or ""
+            for prefix in ("/so-stop",):
+                if raw_text.lower().startswith(prefix):
+                    args_text = raw_text[len(prefix):].strip()
+                    break
+            else:
+                args_text = raw_text.strip()
+
+            cfg = self.config if isinstance(self.config, dict) else (
+                self.config.__dict__ if hasattr(self.config, "__dict__") else {}
+            )
+            return _h(event, args_text, config=cfg)
+
+    event = MagicMock()
+    event.text = "/so-stop task_id=task-abc"
+
+    with patch(
+        "session_orchestration.spawn.handle_stop_command",
+        wraps=lambda ev, args, **kw: handle_stop_command(ev, args, registry=registry),
+    ) as mock_stop:
+        runner = _FakeRunner()
+        result = asyncio.run(runner._handle_so_stop_command(event))
+
+    mock_stop.assert_called_once()
+    call_args = mock_stop.call_args
+    assert call_args[0][1] == "task_id=task-abc", (
+        "args_text must be the text after '/so-stop'"
+    )
+    assert isinstance(result, str)
+    assert "task-abc" in result
+
+
+def test_gateway_so_restart_dispatch_reaches_handle_restart_command(registry):
+    """_handle_so_restart_command must call spawn.handle_restart_command and return its result.
+
+    Uses asyncio.run() directly since pytest-asyncio is not installed in this env.
+    """
+    import asyncio
+    from unittest.mock import MagicMock, patch
+
+    class _FakeRunner:
+        config = {}
+
+        async def _handle_so_restart_command(self, event):
+            try:
+                from session_orchestration.spawn import handle_restart_command as _h
+            except ImportError as exc:  # pragma: no cover
+                return f"Session orchestration is not available: {exc}"
+
+            raw_text = getattr(event, "text", "") or ""
+            for prefix in ("/so-restart",):
+                if raw_text.lower().startswith(prefix):
+                    args_text = raw_text[len(prefix):].strip()
+                    break
+            else:
+                args_text = raw_text.strip()
+
+            cfg = self.config if isinstance(self.config, dict) else (
+                self.config.__dict__ if hasattr(self.config, "__dict__") else {}
+            )
+            return _h(event, args_text, config=cfg)
+
+    event = MagicMock()
+    event.text = "/so-restart task_id=task-xyz"
+
+    with patch(
+        "session_orchestration.spawn.handle_restart_command",
+        wraps=lambda ev, args, **kw: handle_restart_command(ev, args, registry=registry),
+    ) as mock_restart:
+        runner = _FakeRunner()
+        result = asyncio.run(runner._handle_so_restart_command(event))
+
+    mock_restart.assert_called_once()
+    call_args = mock_restart.call_args
+    assert call_args[0][1] == "task_id=task-xyz", (
+        "args_text must be the text after '/so-restart'"
+    )
+    assert isinstance(result, str)
+    assert "task-xyz" in result

--- a/tests/test_session_orchestration_spawn.py
+++ b/tests/test_session_orchestration_spawn.py
@@ -278,6 +278,28 @@ def test_spawn_session_writes_registry_row_source_spawn(registry):
     assert row["tmux_session"] is not None
 
 
+def test_spawn_session_persists_discord_user_id(registry):
+    """spawn_session must write discord_user_id onto the row so attention
+    notices can @-mention the requesting user."""
+    adapter = _FakeAdapter()
+    relay = _FakeRelay()
+
+    request = SpawnRequest(
+        prompt="do the thing",
+        agent="omp",
+        workdir="/tmp/project",
+        discord_user_id="555000111",
+    )
+
+    result = spawn_session(request, adapter=adapter, registry=registry, relay=relay)
+
+    row = registry.get(result.task_id)
+    assert row is not None
+    assert row["discord_user_id"] == "555000111", (
+        "discord_user_id must be persisted on the spawned row"
+    )
+
+
 def test_spawn_session_registry_row_has_correct_task_id(registry):
     fixed_id = str(uuid.uuid4())
     adapter = _FakeAdapter(fixed_session_id=fixed_id)

--- a/tests/test_session_orchestration_spawn.py
+++ b/tests/test_session_orchestration_spawn.py
@@ -1,0 +1,564 @@
+"""
+Tests for session_orchestration/spawn.py.
+
+Coverage
+--------
+1. derive_session_name: deterministic, stable, tmux-safe.
+2. get_adapter: resolves all known names; raises UnknownAgentError for unknown.
+3. parse_spawn_args: parses key=value tokens + trailing prompt; handles edge cases.
+4. spawn_session (happy path): launch called, registry row written (source=spawn,
+   correct fields), thread creator called, relay seeded — all via fakes.
+5. spawn_session: registry row has source="spawn" (not "adopt").
+6. spawn_session: thread creator failure is non-fatal; SpawnResult.thread_id=None.
+7. spawn_session: z_command is prepended to prompt when present.
+8. handle_spawn_command: returns disabled message when so_enabled=False.
+9. handle_spawn_command: returns usage message when required args are missing.
+10. handle_spawn_command (integration): calls spawn_session with correct request.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from session_orchestration.adapters.base import AgentAdapter
+from session_orchestration.registry import SessionOrchestrationRegistry
+from session_orchestration.relay import SessionRelay
+from session_orchestration.spawn import (
+    SpawnRequest,
+    UnknownAgentError,
+    derive_session_name,
+    get_adapter,
+    parse_spawn_args,
+    spawn_session,
+    handle_spawn_command,
+)
+from session_orchestration.types import Capabilities, SessionHandle, SessionLifecycle
+
+
+# ---------------------------------------------------------------------------
+# Fixtures & helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "state.db"
+
+
+@pytest.fixture()
+def registry(db_path: Path) -> SessionOrchestrationRegistry:
+    return SessionOrchestrationRegistry(db_path=db_path)
+
+
+def _make_handle(session_id: Optional[str] = None) -> SessionHandle:
+    sid = session_id or str(uuid.uuid4())
+    return SessionHandle(
+        session_id=sid,
+        tmux_session=f"hermes-cc-{sid[:8]}",
+        pane=f"hermes-cc-{sid[:8]}:0.0",
+        launch_ts=datetime.now(tz=timezone.utc),
+    )
+
+
+class _FakeAdapter(AgentAdapter):
+    """Stub adapter that records calls without touching tmux."""
+
+    def __init__(self, fixed_session_id: Optional[str] = None):
+        self._session_id = fixed_session_id or str(uuid.uuid4())
+        self.launch_calls: List[tuple] = []
+        self.drive_calls: List[str] = []
+        self.resume_calls: List[str] = []
+        self.detect_returns = SessionLifecycle.WAITING_USER
+
+    def capabilities(self) -> Capabilities:
+        return Capabilities()
+
+    def launch(self, workdir: str, prompt: str) -> SessionHandle:
+        self.launch_calls.append((workdir, prompt))
+        return _make_handle(session_id=self._session_id)
+
+    def drive(self, handle: SessionHandle, message: str) -> None:
+        self.drive_calls.append(message)
+
+    def detect(self, handle: SessionHandle) -> SessionLifecycle:
+        return self.detect_returns
+
+    def resume(self, handle: SessionHandle, prompt: str) -> None:
+        self.resume_calls.append(prompt)
+
+
+class _FakeRelay:
+    """Stub relay that records send_message calls."""
+
+    def __init__(self):
+        self.calls: List[tuple] = []
+
+    def send_message(
+        self,
+        task_id: str,
+        handle: SessionHandle,
+        message: str,
+        *,
+        retry_on_conflict: bool = False,
+    ) -> None:
+        self.calls.append((task_id, message))
+
+
+# ---------------------------------------------------------------------------
+# 1. derive_session_name: deterministic + stable
+# ---------------------------------------------------------------------------
+
+
+def test_derive_session_name_is_deterministic():
+    name1 = derive_session_name("claude", "/home/zeke/project", "fix the bug")
+    name2 = derive_session_name("claude", "/home/zeke/project", "fix the bug")
+    assert name1 == name2
+
+
+def test_derive_session_name_differs_on_different_inputs():
+    a = derive_session_name("claude", "/home/zeke/project", "fix the bug")
+    b = derive_session_name("omp", "/home/zeke/project", "fix the bug")
+    c = derive_session_name("claude", "/home/other/project", "fix the bug")
+    d = derive_session_name("claude", "/home/zeke/project", "different prompt")
+    assert len({a, b, c, d}) == 4
+
+
+def test_derive_session_name_is_tmux_safe():
+    name = derive_session_name("claude-code", "/home/zeke/project", "hello world")
+    # tmux session names must not contain colons or dots per convention
+    assert ":" not in name
+    assert len(name) <= 40
+    # Only alphanumeric and hyphens
+    import re
+    assert re.fullmatch(r"[a-zA-Z0-9\-]+", name)
+
+
+def test_derive_session_name_starts_with_hermes():
+    name = derive_session_name("omp", "/tmp/x", "prompt")
+    assert name.startswith("hermes-")
+
+
+# ---------------------------------------------------------------------------
+# 2. get_adapter: resolves known names; raises on unknown
+# ---------------------------------------------------------------------------
+
+
+def test_get_adapter_resolves_claude():
+    from session_orchestration.adapters.claude_code import ClaudeCodeAdapter
+    adapter = get_adapter("claude")
+    assert isinstance(adapter, ClaudeCodeAdapter)
+
+
+def test_get_adapter_resolves_claude_code():
+    from session_orchestration.adapters.claude_code import ClaudeCodeAdapter
+    adapter = get_adapter("claude-code")
+    assert isinstance(adapter, ClaudeCodeAdapter)
+
+
+def test_get_adapter_resolves_omp():
+    from session_orchestration.adapters.omp import OmpAdapter
+    adapter = get_adapter("omp")
+    assert isinstance(adapter, OmpAdapter)
+
+
+def test_get_adapter_raises_for_unknown():
+    with pytest.raises(UnknownAgentError, match="not-a-real-agent"):
+        get_adapter("not-a-real-agent")
+
+
+def test_get_adapter_case_insensitive():
+    from session_orchestration.adapters.claude_code import ClaudeCodeAdapter
+    adapter = get_adapter("Claude")
+    assert isinstance(adapter, ClaudeCodeAdapter)
+
+
+# ---------------------------------------------------------------------------
+# 3. parse_spawn_args
+# ---------------------------------------------------------------------------
+
+
+def test_parse_spawn_args_basic():
+    result = parse_spawn_args("agent=claude workdir=/tmp/foo fix the bug in auth.py")
+    assert result["agent"] == "claude"
+    assert result["workdir"] == "/tmp/foo"
+    assert result["prompt"] == "fix the bug in auth.py"
+
+
+def test_parse_spawn_args_with_z_command():
+    result = parse_spawn_args("agent=omp workdir=/tmp/x z_command=/z-plan the feature")
+    assert result["agent"] == "omp"
+    assert result["z_command"] == "/z-plan"
+    assert result["prompt"] == "the feature"
+
+
+def test_parse_spawn_args_missing_prompt_returns_no_prompt_key():
+    result = parse_spawn_args("agent=claude workdir=/tmp/foo")
+    assert "prompt" not in result or not result.get("prompt")
+
+
+def test_parse_spawn_args_empty_string():
+    result = parse_spawn_args("")
+    assert result == {}
+
+
+def test_parse_spawn_args_workdir_with_spaces():
+    result = parse_spawn_args('agent=claude workdir="/tmp/my project" fix it')
+    assert result["workdir"] == "/tmp/my project"
+
+
+# ---------------------------------------------------------------------------
+# 4. spawn_session happy path: launch, registry row, thread, relay seed
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_session_calls_launch(registry):
+    adapter = _FakeAdapter()
+    relay = _FakeRelay()
+    thread_creator_calls: List[tuple] = []
+
+    def thread_creator(chat_id: str, name: str) -> str:
+        thread_creator_calls.append((chat_id, name))
+        return "thread-123"
+
+    request = SpawnRequest(
+        prompt="fix the auth bug",
+        agent="claude",
+        workdir="/tmp/project",
+        parent_chat_id="chan-456",
+    )
+
+    result = spawn_session(
+        request,
+        adapter=adapter,
+        registry=registry,
+        relay=relay,
+        thread_creator=thread_creator,
+    )
+
+    # launch was called with correct workdir and prompt
+    assert len(adapter.launch_calls) == 1
+    assert adapter.launch_calls[0][0] == "/tmp/project"
+    assert "fix the auth bug" in adapter.launch_calls[0][1]
+
+
+def test_spawn_session_writes_registry_row_source_spawn(registry):
+    adapter = _FakeAdapter()
+    relay = _FakeRelay()
+
+    request = SpawnRequest(
+        prompt="implement feature X",
+        agent="omp",
+        workdir="/tmp/project",
+    )
+
+    result = spawn_session(
+        request,
+        adapter=adapter,
+        registry=registry,
+        relay=relay,
+    )
+
+    row = registry.get(result.task_id)
+    assert row is not None
+    assert row["source"] == "spawn"
+    assert row["agent"] == "omp"
+    assert row["workdir"] == "/tmp/project"
+    assert row["state"] == "RUNNING"
+    assert row["tmux_session"] is not None
+
+
+def test_spawn_session_registry_row_has_correct_task_id(registry):
+    fixed_id = str(uuid.uuid4())
+    adapter = _FakeAdapter(fixed_session_id=fixed_id)
+    relay = _FakeRelay()
+
+    request = SpawnRequest(
+        prompt="hello",
+        agent="claude",
+        workdir="/tmp/x",
+    )
+
+    result = spawn_session(request, adapter=adapter, registry=registry, relay=relay)
+
+    assert result.task_id == fixed_id
+    row = registry.get(fixed_id)
+    assert row is not None
+
+
+def test_spawn_session_creates_thread(registry):
+    adapter = _FakeAdapter()
+    relay = _FakeRelay()
+    thread_calls: List[tuple] = []
+
+    def thread_creator(chat_id: str, name: str) -> str:
+        thread_calls.append((chat_id, name))
+        return "thread-999"
+
+    request = SpawnRequest(
+        prompt="do something",
+        agent="claude",
+        workdir="/tmp/p",
+        parent_chat_id="chan-123",
+    )
+
+    result = spawn_session(
+        request,
+        adapter=adapter,
+        registry=registry,
+        relay=relay,
+        thread_creator=thread_creator,
+    )
+
+    assert result.thread_id == "thread-999"
+    assert len(thread_calls) == 1
+    assert thread_calls[0][0] == "chan-123"
+
+    # thread_id must be persisted in the registry row
+    row = registry.get(result.task_id)
+    assert row["discord_thread_id"] == "thread-999"
+
+
+def test_spawn_session_seeds_first_prompt_via_relay(registry):
+    adapter = _FakeAdapter()
+    relay = _FakeRelay()
+
+    request = SpawnRequest(
+        prompt="write tests for auth.py",
+        agent="claude",
+        workdir="/tmp/proj",
+    )
+
+    result = spawn_session(request, adapter=adapter, registry=registry, relay=relay)
+
+    assert len(relay.calls) == 1
+    seeded_task_id, seeded_msg = relay.calls[0]
+    assert seeded_task_id == result.task_id
+    assert "write tests for auth.py" in seeded_msg
+
+
+# ---------------------------------------------------------------------------
+# 5. source="spawn" not "adopt" (contract for single-writer discipline)
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_session_row_source_is_spawn_not_adopt(registry):
+    adapter = _FakeAdapter()
+    relay = _FakeRelay()
+
+    result = spawn_session(
+        SpawnRequest(prompt="p", agent="claude", workdir="/tmp/x"),
+        adapter=adapter,
+        registry=registry,
+        relay=relay,
+    )
+
+    row = registry.get(result.task_id)
+    assert row["source"] == "spawn"
+    assert row["source"] != "adopt"
+
+
+# ---------------------------------------------------------------------------
+# 6. Thread creator failure is non-fatal
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_session_thread_failure_is_non_fatal(registry):
+    adapter = _FakeAdapter()
+    relay = _FakeRelay()
+
+    def failing_thread_creator(chat_id: str, name: str) -> Optional[str]:
+        raise RuntimeError("Discord API failed")
+
+    request = SpawnRequest(
+        prompt="do work",
+        agent="claude",
+        workdir="/tmp/p",
+        parent_chat_id="chan-x",
+    )
+
+    result = spawn_session(
+        request,
+        adapter=adapter,
+        registry=registry,
+        relay=relay,
+        thread_creator=failing_thread_creator,
+    )
+
+    # Should succeed despite thread failure
+    assert result.task_id is not None
+    assert result.thread_id is None
+    # Registry row should exist
+    row = registry.get(result.task_id)
+    assert row is not None
+
+
+def test_spawn_session_no_thread_when_no_parent_chat_id(registry):
+    adapter = _FakeAdapter()
+    relay = _FakeRelay()
+    thread_calls: List[tuple] = []
+
+    def thread_creator(chat_id: str, name: str) -> str:
+        thread_calls.append((chat_id, name))
+        return "thread-123"
+
+    # No parent_chat_id → thread creator should NOT be called
+    request = SpawnRequest(
+        prompt="work",
+        agent="claude",
+        workdir="/tmp/p",
+        parent_chat_id=None,  # no parent
+    )
+
+    result = spawn_session(
+        request,
+        adapter=adapter,
+        registry=registry,
+        relay=relay,
+        thread_creator=thread_creator,
+    )
+
+    assert result.thread_id is None
+    assert thread_calls == []
+
+
+# ---------------------------------------------------------------------------
+# 7. z_command is prepended to prompt
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_session_prepends_z_command(registry):
+    adapter = _FakeAdapter()
+    relay = _FakeRelay()
+
+    request = SpawnRequest(
+        prompt="implement the feature",
+        agent="claude",
+        workdir="/tmp/p",
+        z_command="/z-plan",
+    )
+
+    spawn_session(request, adapter=adapter, registry=registry, relay=relay)
+
+    launched_prompt = adapter.launch_calls[0][1]
+    assert launched_prompt.startswith("/z-plan")
+    assert "implement the feature" in launched_prompt
+
+    seeded_msg = relay.calls[0][1]
+    assert seeded_msg.startswith("/z-plan")
+
+
+# ---------------------------------------------------------------------------
+# 8. handle_spawn_command: disabled when so_enabled=False
+# ---------------------------------------------------------------------------
+
+
+def test_handle_spawn_command_disabled():
+    import asyncio
+
+    event = MagicMock()
+    event.text = "/so-spawn agent=claude workdir=/tmp/x do work"
+    event.source = MagicMock()
+    event.source.user_id = "u1"
+    event.source.chat_id = "c1"
+
+    # config with session_orchestration.enabled=False
+    config = {"session_orchestration": {"enabled": False}}
+
+    result = asyncio.run(
+        handle_spawn_command(event, "agent=claude workdir=/tmp/x do work", config=config)
+    )
+
+    assert "disabled" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# 9. handle_spawn_command: missing args returns usage
+# ---------------------------------------------------------------------------
+
+
+def test_handle_spawn_command_missing_agent():
+    import asyncio
+
+    event = MagicMock()
+    event.text = "/so-spawn workdir=/tmp/x do work"
+    event.source = MagicMock()
+    event.source.user_id = "u1"
+    event.source.chat_id = "c1"
+
+    config = {"session_orchestration": {"enabled": True}}
+
+    result = asyncio.run(
+        handle_spawn_command(event, "workdir=/tmp/x do work", config=config)
+    )
+
+    assert "Usage" in result or "Missing" in result
+    assert "agent" in result.lower()
+
+
+def test_handle_spawn_command_missing_workdir():
+    import asyncio
+
+    event = MagicMock()
+    event.source = MagicMock()
+    event.source.user_id = "u1"
+    event.source.chat_id = "c1"
+
+    config = {"session_orchestration": {"enabled": True}}
+
+    result = asyncio.run(
+        handle_spawn_command(event, "agent=claude do work", config=config)
+    )
+
+    assert "workdir" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# 10. handle_spawn_command integration: calls spawn_session with correct request
+# ---------------------------------------------------------------------------
+
+
+def test_handle_spawn_command_integration(db_path):
+    import asyncio
+
+    registry = SessionOrchestrationRegistry(db_path=db_path)
+    adapter = _FakeAdapter()
+    relay = _FakeRelay()
+
+    event = MagicMock()
+    event.text = "/so-spawn agent=claude workdir=/tmp/myproject fix the bug"
+    event.source = MagicMock()
+    event.source.user_id = "user-123"
+    event.source.chat_id = "chan-456"
+    event.source.platform = "discord"
+
+    config = {"session_orchestration": {"enabled": True, "feed_channel_id": "feed-789"}}
+
+    result = asyncio.run(
+        handle_spawn_command(
+            event,
+            "agent=claude workdir=/tmp/myproject fix the bug",
+            config=config,
+            platform_adapter=None,
+            registry=registry,
+            relay=relay,
+            _adapter_override=adapter,
+        )
+    )
+
+    # Reply should contain the task_id
+    assert "Task ID" in result
+    # launch was called
+    assert len(adapter.launch_calls) == 1
+    # relay was seeded
+    assert len(relay.calls) == 1
+    # registry has the row
+    all_rows = registry.list()
+    assert len(all_rows) == 1
+    assert all_rows[0]["source"] == "spawn"
+    assert all_rows[0]["agent"] == "claude"

--- a/tests/test_session_orchestration_spawn.py
+++ b/tests/test_session_orchestration_spawn.py
@@ -166,6 +166,18 @@ def test_get_adapter_resolves_claude_code():
     assert isinstance(adapter, ClaudeCodeAdapter)
 
 
+def test_get_adapter_resolves_codex():
+    from session_orchestration.adapters.codex import CodexAdapter
+    adapter = get_adapter("codex")
+    assert isinstance(adapter, CodexAdapter)
+
+
+def test_get_adapter_resolves_codex_cli():
+    from session_orchestration.adapters.codex import CodexAdapter
+    adapter = get_adapter("codex-cli")
+    assert isinstance(adapter, CodexAdapter)
+
+
 def test_get_adapter_resolves_omp():
     from session_orchestration.adapters.omp import OmpAdapter
     adapter = get_adapter("omp")

--- a/tests/test_session_orchestration_spawn_tool.py
+++ b/tests/test_session_orchestration_spawn_tool.py
@@ -321,6 +321,163 @@ def test_reply_missing_required_fields():
 
 
 # ---------------------------------------------------------------------------
+# Discord thread wiring (gap #1)
+# ---------------------------------------------------------------------------
+
+
+def test_thread_context_threaded_into_spawn(monkeypatch):
+    """When a live Discord turn resolves a thread context, the handler must set
+    ``parent_chat_id`` on the SpawnRequest and pass ``thread_creator`` to
+    spawn_session — so spawn.py step 6 creates the project thread."""
+    import session_orchestration.spawn_tool as st
+
+    sentinel_creator = lambda pcid, name: "thread-123"  # noqa: E731
+
+    monkeypatch.setattr(
+        st, "_resolve_discord_thread_context",
+        lambda: ("channel-999", sentinel_creator),
+    )
+
+    captured = {}
+
+    def mock_spawn(request: SpawnRequest, **kw) -> SpawnResult:
+        captured["request"] = request
+        captured["kw"] = kw
+        return _make_fake_spawn_result(thread_id="thread-123")
+
+    registry = _make_fake_registry(_make_resolved_repo())
+
+    reply = st.spawn_tool_handler(
+        {"repo": "myrepo", "prompt": "do stuff"},
+        _repo_registry=registry,
+        _spawn_fn=mock_spawn,
+    )
+
+    assert captured["request"].parent_chat_id == "channel-999", (
+        "resolved parent chat id must be set on the SpawnRequest"
+    )
+    assert captured["kw"].get("thread_creator") is sentinel_creator, (
+        "resolved thread_creator must be forwarded to spawn_session"
+    )
+    # The reply should surface the created thread link.
+    assert "thread-123" in reply
+
+
+def test_thread_context_absent_spawns_threadless(monkeypatch):
+    """Off Discord / no live gateway, the resolver returns (None, None); the
+    handler must still spawn, with parent_chat_id=None and thread_creator=None
+    (prior behavior — never block a spawn on thread wiring)."""
+    import session_orchestration.spawn_tool as st
+
+    monkeypatch.setattr(st, "_resolve_discord_thread_context", lambda: (None, None))
+
+    captured = {}
+
+    def mock_spawn(request: SpawnRequest, **kw) -> SpawnResult:
+        captured["request"] = request
+        captured["kw"] = kw
+        return _make_fake_spawn_result(thread_id=None)
+
+    registry = _make_fake_registry(_make_resolved_repo())
+
+    reply = st.spawn_tool_handler(
+        {"repo": "myrepo", "prompt": "do stuff"},
+        _repo_registry=registry,
+        _spawn_fn=mock_spawn,
+    )
+
+    assert captured["request"].parent_chat_id is None
+    assert captured["kw"].get("thread_creator") is None
+    assert "No project thread" in reply
+
+
+def test_resolver_is_discord_gated(monkeypatch):
+    """_resolve_discord_thread_context must short-circuit to (None, None) for a
+    non-Discord platform without touching the gateway runner."""
+    import session_orchestration.spawn_tool as st
+    from gateway import session_context as sc
+
+    monkeypatch.setattr(
+        sc, "get_session_env",
+        lambda name, default="": "telegram" if name == "HERMES_SESSION_PLATFORM" else default,
+    )
+    # If gating fails, this would blow up rather than return cleanly.
+    assert st._resolve_discord_thread_context() == (None, None)
+
+
+def test_resolver_adopts_existing_thread(monkeypatch):
+    """When the Discord turn is already in a thread (the Hermès window), the
+    resolver must ADOPT that thread — return it as the target and a no-op
+    creator that yields the same id — without creating a new thread or needing
+    the live gateway/adapter."""
+    import session_orchestration.spawn_tool as st
+    from gateway import session_context as sc
+
+    def fake_env(name, default=""):
+        return {
+            "HERMES_SESSION_PLATFORM": "discord",
+            "HERMES_SESSION_CHAT_ID": "1521983360040304871",
+            "HERMES_SESSION_THREAD_ID": "1521983360040304871",
+        }.get(name, default)
+
+    monkeypatch.setattr(sc, "get_session_env", fake_env)
+    # Guard: if the adopt path wrongly fell through to creation it would call
+    # _gateway_runner_ref; make that explode so the test fails loudly instead.
+    import gateway.run as gr
+    monkeypatch.setattr(
+        gr, "_gateway_runner_ref",
+        lambda: (_ for _ in ()).throw(AssertionError("must not reach create path")),
+    )
+
+    target, creator = st._resolve_discord_thread_context()
+    assert target == "1521983360040304871", "must adopt the window thread as target"
+    assert creator("ignored-parent", "ignored-name") == "1521983360040304871", (
+        "adopt creator must return the existing thread id, not create a new one"
+    )
+
+
+def test_discord_user_id_captured_onto_request(monkeypatch):
+    """The handler must read HERMES_SESSION_USER_ID (Discord turn) and set it as
+    discord_user_id on the SpawnRequest, so the row can @-mention the user."""
+    import session_orchestration.spawn_tool as st
+
+    monkeypatch.setattr(st, "_resolve_discord_thread_context", lambda: (None, None))
+    monkeypatch.setattr(st, "_resolve_discord_user_id", lambda: "555000111")
+
+    captured = {}
+
+    def mock_spawn(request: SpawnRequest, **kw) -> SpawnResult:
+        captured["request"] = request
+        return _make_fake_spawn_result()
+
+    registry = _make_fake_registry(_make_resolved_repo())
+
+    st.spawn_tool_handler(
+        {"repo": "myrepo", "prompt": "do stuff"},
+        _repo_registry=registry,
+        _spawn_fn=mock_spawn,
+    )
+
+    assert captured["request"].discord_user_id == "555000111"
+
+
+def test_user_id_resolver_is_discord_gated(monkeypatch):
+    """_resolve_discord_user_id must return None off Discord even if a user id
+    is present in the session context."""
+    import session_orchestration.spawn_tool as st
+    from gateway import session_context as sc
+
+    def fake_env(name, default=""):
+        return {
+            "HERMES_SESSION_PLATFORM": "telegram",
+            "HERMES_SESSION_USER_ID": "999",
+        }.get(name, default)
+
+    monkeypatch.setattr(sc, "get_session_env", fake_env)
+    assert st._resolve_discord_user_id() is None
+
+
+# ---------------------------------------------------------------------------
 # Tool registration smoke-test
 # ---------------------------------------------------------------------------
 

--- a/tests/test_session_orchestration_spawn_tool.py
+++ b/tests/test_session_orchestration_spawn_tool.py
@@ -129,6 +129,32 @@ def test_unresolved_repo_returns_error_without_calling_spawn():
 
 
 # ---------------------------------------------------------------------------
+# (b2) Missing repo → asks for a repo, spawn_session NOT called
+# ---------------------------------------------------------------------------
+
+
+def test_missing_repo_asks_for_repo_without_calling_spawn():
+    """No repo supplied (e.g. "so omp 'fix blah'") must return a plain-language
+    ask for a repo and must NOT call spawn_session — never break, just ask."""
+    spawn_called = []
+
+    def mock_spawn(request: SpawnRequest, **_kw) -> SpawnResult:
+        spawn_called.append(request)
+        return _make_fake_spawn_result()
+
+    # repo key absent entirely; a valid prompt is present
+    result = spawn_tool_handler(
+        {"prompt": "fix the flaky test", "agent": "omp"},
+        _repo_registry=_make_fake_registry(_make_resolved_repo()),
+        _spawn_fn=mock_spawn,
+    )
+
+    assert spawn_called == [], "spawn_session must NOT be called when repo is missing"
+    assert "repo" in result.lower(), "ask should mention 'repo'"
+    assert "?" in result, "ask should be phrased as a question, not an error"
+
+
+# ---------------------------------------------------------------------------
 # (c) agent defaults to DEFAULT_AGENT ("omp") when omitted
 # ---------------------------------------------------------------------------
 

--- a/tests/test_session_orchestration_spawn_tool.py
+++ b/tests/test_session_orchestration_spawn_tool.py
@@ -1,0 +1,311 @@
+"""
+tests/test_session_orchestration_spawn_tool.py — Unit tests for the
+session_spawn LLM tool defined in session_orchestration/spawn_tool.py.
+
+Acceptance criteria covered
+----------------------------
+(a) Resolved repo fills workdir in the SpawnRequest.
+(b) Unresolved repo returns an error string WITHOUT calling spawn_session.
+(c) agent defaults to "omp" when omitted from args (DEFAULT_AGENT).
+(d) spawn_session is called with the correct SpawnRequest when repo resolves.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from session_orchestration.repo_registry import (
+    DEFAULT_AGENT,
+    RepoEntry,
+    RepoRegistry,
+    ResolvedRepo,
+    UnresolvedRepo,
+    build_repo_registry,
+)
+from session_orchestration.spawn import SpawnRequest, SpawnResult
+from session_orchestration.spawn_tool import spawn_tool_handler
+from session_orchestration.types import SessionHandle
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+_FAKE_WORKDIR = "/home/user/dev/myrepo"
+_FAKE_TASK_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+_FAKE_SESSION = "hermes-omp-abc12-def34"
+
+
+def _make_resolved_repo(path: str = _FAKE_WORKDIR, agent: str = DEFAULT_AGENT) -> ResolvedRepo:
+    return ResolvedRepo(
+        path=path,
+        default_agent=agent,
+        matched_name="myrepo",
+        match_kind="exact",
+    )
+
+
+def _make_fake_registry(resolved) -> RepoRegistry:
+    """Build a RepoRegistry whose resolve() always returns *resolved*."""
+    class _FakeRegistry:
+        def resolve(self, name: str):
+            return resolved
+
+    return _FakeRegistry()  # type: ignore[return-value]
+
+
+def _make_fake_spawn_result(**overrides) -> SpawnResult:
+    from datetime import datetime, timezone
+
+    defaults = dict(
+        task_id=_FAKE_TASK_ID,
+        handle=SessionHandle(
+            session_id=_FAKE_TASK_ID,
+            tmux_session=_FAKE_SESSION,
+            pane=f"{_FAKE_SESSION}:0.0",
+            launch_ts=datetime.now(tz=timezone.utc),
+        ),
+        session_name=_FAKE_SESSION,
+        thread_id=None,
+    )
+    defaults.update(overrides)
+    return SpawnResult(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# (a) Resolved repo fills workdir
+# ---------------------------------------------------------------------------
+
+
+def test_resolved_repo_fills_workdir():
+    """When repo resolves, the SpawnRequest workdir must equal resolved.path."""
+    captured: list[SpawnRequest] = []
+
+    def mock_spawn(request: SpawnRequest, **_kw) -> SpawnResult:
+        captured.append(request)
+        return _make_fake_spawn_result()
+
+    registry = _make_fake_registry(_make_resolved_repo(path="/srv/code/projectX"))
+
+    spawn_tool_handler(
+        {"repo": "projectX", "prompt": "Do the thing"},
+        _repo_registry=registry,
+        _spawn_fn=mock_spawn,
+    )
+
+    assert len(captured) == 1
+    assert captured[0].workdir == "/srv/code/projectX", (
+        "workdir should be set to the resolved repo path"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (b) Unresolved repo → error string, spawn_session NOT called
+# ---------------------------------------------------------------------------
+
+
+def test_unresolved_repo_returns_error_without_calling_spawn():
+    """UnresolvedRepo must return an error string; spawn_session must not be called."""
+    spawn_called = []
+
+    def mock_spawn(request: SpawnRequest, **_kw) -> SpawnResult:
+        spawn_called.append(request)
+        return _make_fake_spawn_result()
+
+    registry = _make_fake_registry(UnresolvedRepo(name="nosuchrepo"))
+
+    result = spawn_tool_handler(
+        {"repo": "nosuchrepo", "prompt": "something"},
+        _repo_registry=registry,
+        _spawn_fn=mock_spawn,
+    )
+
+    assert spawn_called == [], "spawn_session must NOT be called for an unresolved repo"
+    assert "nosuchrepo" in result, "error message should mention the unresolved name"
+    # Must ask the user to supply a full path or configure an alias
+    assert "path" in result.lower() or "alias" in result.lower(), (
+        "error should guide the user toward a full path or alias"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (c) agent defaults to DEFAULT_AGENT ("omp") when omitted
+# ---------------------------------------------------------------------------
+
+
+def test_agent_defaults_to_omp_when_omitted():
+    """When 'agent' is absent from args and resolved repo has no default, agent must be 'omp'."""
+    captured: list[SpawnRequest] = []
+
+    def mock_spawn(request: SpawnRequest, **_kw) -> SpawnResult:
+        captured.append(request)
+        return _make_fake_spawn_result()
+
+    # Resolved repo with default_agent=DEFAULT_AGENT (matches the fallback)
+    registry = _make_fake_registry(_make_resolved_repo(agent=DEFAULT_AGENT))
+
+    spawn_tool_handler(
+        # "agent" key absent — must default to DEFAULT_AGENT
+        {"repo": "myrepo", "prompt": "run tests"},
+        _repo_registry=registry,
+        _spawn_fn=mock_spawn,
+    )
+
+    assert len(captured) == 1
+    assert captured[0].agent == DEFAULT_AGENT, (
+        f"agent should default to '{DEFAULT_AGENT}' (DEFAULT_AGENT) when omitted"
+    )
+
+
+def test_agent_defaults_to_omp_when_resolved_repo_has_no_agent():
+    """Even if resolved.default_agent is empty, the final agent must be DEFAULT_AGENT."""
+    captured: list[SpawnRequest] = []
+
+    def mock_spawn(request: SpawnRequest, **_kw) -> SpawnResult:
+        captured.append(request)
+        return _make_fake_spawn_result()
+
+    # Resolved repo with an empty default_agent to exercise the fallback chain
+    resolved = ResolvedRepo(
+        path=_FAKE_WORKDIR,
+        default_agent="",  # empty → must fall back to DEFAULT_AGENT
+        matched_name="myrepo",
+        match_kind="exact",
+    )
+    registry = _make_fake_registry(resolved)
+
+    spawn_tool_handler(
+        {"repo": "myrepo", "prompt": "run tests"},
+        _repo_registry=registry,
+        _spawn_fn=mock_spawn,
+    )
+
+    assert len(captured) == 1
+    assert captured[0].agent == DEFAULT_AGENT, (
+        f"agent must fall back to DEFAULT_AGENT ('{DEFAULT_AGENT}') "
+        "when resolved.default_agent is empty and arg is absent"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (d) spawn_session called with correct SpawnRequest
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_session_called_with_correct_request():
+    """spawn_session must receive a SpawnRequest with the right fields."""
+    captured: list[SpawnRequest] = []
+
+    def mock_spawn(request: SpawnRequest, **_kw) -> SpawnResult:
+        captured.append(request)
+        return _make_fake_spawn_result()
+
+    registry = _make_fake_registry(_make_resolved_repo(path=_FAKE_WORKDIR, agent="claude"))
+
+    spawn_tool_handler(
+        {
+            "repo": "myrepo",
+            "prompt": "implement feature X",
+            "agent": "claude",
+            "z_command": "/z-plan",
+        },
+        _repo_registry=registry,
+        _spawn_fn=mock_spawn,
+    )
+
+    assert len(captured) == 1
+    req = captured[0]
+    assert req.prompt == "implement feature X"
+    assert req.agent == "claude"
+    assert req.workdir == _FAKE_WORKDIR
+    assert req.z_command == "/z-plan"
+
+
+def test_spawn_session_called_with_resolved_agent_over_registry_default():
+    """When arg 'agent' is explicit, it must win over resolved.default_agent."""
+    captured: list[SpawnRequest] = []
+
+    def mock_spawn(request: SpawnRequest, **_kw) -> SpawnResult:
+        captured.append(request)
+        return _make_fake_spawn_result()
+
+    # resolved.default_agent is "omp" but caller explicitly asks for "claude"
+    registry = _make_fake_registry(_make_resolved_repo(agent="omp"))
+
+    spawn_tool_handler(
+        {"repo": "myrepo", "prompt": "some task", "agent": "claude"},
+        _repo_registry=registry,
+        _spawn_fn=mock_spawn,
+    )
+
+    assert len(captured) == 1
+    assert captured[0].agent == "claude", (
+        "explicit 'agent' arg must override resolved.default_agent"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reply string shape
+# ---------------------------------------------------------------------------
+
+
+def test_reply_contains_task_id_and_session():
+    """On success the reply string must include task_id and session_name."""
+
+    def mock_spawn(request: SpawnRequest, **_kw) -> SpawnResult:
+        return _make_fake_spawn_result(
+            task_id="test-task-id",
+            session_name="hermes-omp-xxxxx-yyyyy",
+        )
+
+    registry = _make_fake_registry(_make_resolved_repo())
+
+    reply = spawn_tool_handler(
+        {"repo": "myrepo", "prompt": "do stuff"},
+        _repo_registry=registry,
+        _spawn_fn=mock_spawn,
+    )
+
+    assert "test-task-id" in reply
+    assert "hermes-omp-xxxxx-yyyyy" in reply
+
+
+def test_reply_missing_required_fields():
+    """Missing 'repo' or 'prompt' must return an error without calling spawn."""
+    spawn_called = []
+
+    def mock_spawn(request: SpawnRequest, **_kw) -> SpawnResult:
+        spawn_called.append(request)
+        return _make_fake_spawn_result()
+
+    registry = _make_fake_registry(_make_resolved_repo())
+
+    for bad_args in [
+        {},
+        {"repo": "myrepo"},
+        {"prompt": "something"},
+        {"repo": "", "prompt": "something"},
+        {"repo": "myrepo", "prompt": ""},
+    ]:
+        result = spawn_tool_handler(bad_args, _repo_registry=registry, _spawn_fn=mock_spawn)
+        assert spawn_called == [], f"spawn must not be called for args={bad_args!r}"
+        assert "required" in result.lower() or "repo" in result or "prompt" in result, (
+            f"expected an error message for args={bad_args!r}, got: {result!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tool registration smoke-test
+# ---------------------------------------------------------------------------
+
+
+def test_tool_registered_in_registry():
+    """session_spawn must appear in the tool registry after module import."""
+    import session_orchestration.spawn_tool  # noqa: F401 — triggers registry.register
+
+    from tools.registry import registry as tool_registry
+
+    entry = tool_registry.get_entry("session_spawn")
+    assert entry is not None, "session_spawn must be registered in the tool registry"
+    assert entry.toolset == "session_spawn"
+    assert entry.handler is not None

--- a/tests/test_session_orchestration_status.py
+++ b/tests/test_session_orchestration_status.py
@@ -12,6 +12,7 @@ Verifies the snapshot builder against a seeded in-memory/temp registry:
 
 from __future__ import annotations
 
+import sqlite3
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -20,7 +21,12 @@ from typing import Any, Dict, List
 import pytest
 
 from session_orchestration.registry import SessionOrchestrationRegistry
-from session_orchestration.status import _age_seconds, _format_age, build_snapshot
+from session_orchestration.status import (
+    _age_seconds,
+    _format_age,
+    build_registry_snapshot,
+    build_snapshot,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -230,6 +236,152 @@ class TestBuildSnapshotOrdering:
         # WAITING_USER rows sort before RUNNING rows
         assert pos_waiting < pos_running
 
+# ---------------------------------------------------------------------------
+# build_snapshot — unresolved attention items
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSnapshotAttentionItems:
+    def test_attention_items_include_reason_priority_and_age(self) -> None:
+        now_dt = datetime(2026, 6, 29, 2, 0, tzinfo=timezone.utc)
+        now = now_dt.timestamp()
+        rows: List[Dict[str, Any]] = [
+            {
+                "task_id": "task-1",
+                "agent": "claude",
+                "state": "RUNNING",
+                "project": "hermes-agent",
+                "last_output_ts": now - 60,
+            }
+        ]
+        attention_items: List[Dict[str, Any]] = [
+            {
+                "id": 1,
+                "task_id": "task-1",
+                "reason": "FROZEN_STALE",
+                "priority": 9,
+                "detail": "pane hash unchanged",
+                "opened_at": "2026-06-29T01:30:00+00:00",
+            }
+        ]
+
+        snapshot = build_snapshot(rows, now=now, attention_items=attention_items)
+
+        assert "Unresolved attention items" in snapshot
+        assert "task-1" in snapshot
+        assert "reason `FROZEN_STALE`" in snapshot
+        assert "pane hash unchanged" in snapshot
+        assert "P9/frozen/stuck" in snapshot
+        assert "opened 30m ago" in snapshot
+
+    def test_oldest_actionable_uses_priority_then_opened_at_not_waiting_rows(self) -> None:
+        now_dt = datetime(2026, 6, 29, 2, 0, tzinfo=timezone.utc)
+        now = now_dt.timestamp()
+        rows: List[Dict[str, Any]] = [
+            {
+                "task_id": "task-waiting-old",
+                "agent": "omp",
+                "state": "WAITING_USER",
+                "last_output_ts": now - 7200,
+            }
+        ]
+        attention_items: List[Dict[str, Any]] = [
+            {
+                "id": 1,
+                "task_id": "task-low-oldest",
+                "reason": "WAITING_USER",
+                "priority": 1,
+                "opened_at": "2026-06-29T00:30:00+00:00",
+            },
+            {
+                "id": 2,
+                "task_id": "task-high-later",
+                "reason": "STALE",
+                "priority": 5,
+                "opened_at": "2026-06-29T01:30:00+00:00",
+            },
+            {
+                "id": 3,
+                "task_id": "task-high-earlier",
+                "reason": "STALE",
+                "priority": 5,
+                "opened_at": "2026-06-29T01:00:00+00:00",
+            },
+        ]
+
+        snapshot = build_snapshot(rows, now=now, attention_items=attention_items)
+
+        assert "Oldest WAITING_USER" not in snapshot
+        highlight = snapshot.split("**Oldest actionable item:**", 1)[1]
+        assert "task-high-earlier" in highlight
+        assert "task-high-later" not in highlight
+        assert "task-low-oldest" not in highlight
+        assert "task-waiting-old" not in highlight
+
+    def test_empty_rows_with_attention_items_render_safely(self) -> None:
+        now_dt = datetime(2026, 6, 29, 2, 0, tzinfo=timezone.utc)
+        snapshot = build_snapshot(
+            [],
+            now=now_dt.timestamp(),
+            attention_items=[
+                {
+                    "id": 1,
+                    "task_id": "task-attn",
+                    "reason": "WAITING_USER",
+                    "priority": 1,
+                    "opened_at": "2026-06-29T01:59:00+00:00",
+                }
+            ],
+        )
+
+        assert "No active tasks." in snapshot
+        assert "task-attn" in snapshot
+        assert "reason `WAITING_USER`" in snapshot
+        assert "opened 1m ago" in snapshot
+
+
+class TestBuildRegistrySnapshotAttentionItems:
+    def test_registry_snapshot_reads_attention_without_mutating(
+        self, registry: SessionOrchestrationRegistry
+    ) -> None:
+        now_dt = datetime(2026, 6, 29, 2, 0, tzinfo=timezone.utc)
+        now = now_dt.timestamp()
+        registry.upsert(
+            "task-reg",
+            agent="claude",
+            state="RUNNING",
+            project="hermes-agent",
+            last_output_ts=now - 120,
+        )
+        registry.open_attention_item(
+            "task-reg",
+            "STALE_FROZEN",
+            priority=50,
+            detail="pane hash unchanged",
+        )
+        conn = sqlite3.connect(str(registry._db_path))
+        try:
+            conn.execute(
+                """
+                UPDATE session_orchestration_attention_items
+                   SET opened_at = ?
+                 WHERE task_id = ? AND reason = ?
+                """,
+                ("2026-06-29T01:00:00+00:00", "task-reg", "STALE_FROZEN"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        before = registry.list_unresolved_attention_items()
+
+        snapshot = build_registry_snapshot(registry, now=now)
+
+        assert registry.list_unresolved_attention_items() == before
+        assert "task-reg" in snapshot
+        assert "claude/hermes-agent" in snapshot
+        assert "reason `STALE_FROZEN`" in snapshot
+        assert "P50/frozen/stuck" in snapshot
+        assert "opened 1h ago" in snapshot
 
 # ---------------------------------------------------------------------------
 # Integration: registry → build_snapshot round-trip

--- a/tests/test_session_orchestration_status.py
+++ b/tests/test_session_orchestration_status.py
@@ -1,0 +1,263 @@
+"""
+Unit tests for session_orchestration/status.py.
+
+Verifies the snapshot builder against a seeded in-memory/temp registry:
+- Empty registry produces a "no active tasks" message.
+- Per-task lines contain state, age, task_id.
+- Summary counts reflect actual states.
+- Oldest WAITING_USER task is correctly identified and highlighted.
+- Age falls back to created_at when last_output_ts is absent.
+- Rows are ordered WAITING_USER first, then by age descending.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from session_orchestration.registry import SessionOrchestrationRegistry
+from session_orchestration.status import _age_seconds, _format_age, build_snapshot
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "state.db"
+
+
+@pytest.fixture()
+def registry(db_path: Path) -> SessionOrchestrationRegistry:
+    return SessionOrchestrationRegistry(db_path=db_path)
+
+
+# ---------------------------------------------------------------------------
+# _format_age
+# ---------------------------------------------------------------------------
+
+
+class TestFormatAge:
+    def test_seconds_only(self) -> None:
+        assert _format_age(45) == "45s"
+
+    def test_minutes_and_seconds(self) -> None:
+        assert _format_age(3 * 60 + 12) == "3m 12s"
+
+    def test_hours_and_minutes(self) -> None:
+        assert _format_age(65 * 60 + 3) == "1h 5m"
+
+    def test_zero(self) -> None:
+        assert _format_age(0) == "0s"
+
+    def test_negative_clamped(self) -> None:
+        # Negative ages (clock skew) clamp to zero seconds.
+        assert _format_age(-10) == "0s"
+
+
+# ---------------------------------------------------------------------------
+# _age_seconds
+# ---------------------------------------------------------------------------
+
+
+class TestAgeSeconds:
+    def test_uses_last_output_ts_when_present(self) -> None:
+        now = time.time()
+        row: Dict[str, Any] = {"last_output_ts": now - 120.0}
+        age = _age_seconds(row, now)
+        assert 119.0 <= age <= 121.0
+
+    def test_falls_back_to_created_at(self) -> None:
+        now = time.time()
+        # Use a created_at 5 minutes ago as an ISO UTC string (SQLite format).
+        created = datetime.fromtimestamp(now - 300.0, tz=timezone.utc).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+        row: Dict[str, Any] = {"created_at": created}
+        age = _age_seconds(row, now)
+        assert 299.0 <= age <= 301.0
+
+    def test_bad_timestamps_return_zero(self) -> None:
+        row: Dict[str, Any] = {"last_output_ts": "not-a-number", "created_at": "bad"}
+        assert _age_seconds(row, time.time()) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# build_snapshot — empty registry
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSnapshotEmpty:
+    def test_empty_registry_no_active_tasks(self, registry: SessionOrchestrationRegistry) -> None:
+        rows = registry.list()
+        snapshot = build_snapshot(rows)
+        assert "No active tasks" in snapshot
+
+    def test_empty_list_directly(self) -> None:
+        snapshot = build_snapshot([])
+        assert "No active tasks" in snapshot
+
+
+# ---------------------------------------------------------------------------
+# build_snapshot — seeded registry
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSnapshotSeeded:
+    def _seed(self, registry: SessionOrchestrationRegistry) -> float:
+        """Insert 3 rows: one RUNNING, two WAITING_USER with different ages."""
+        now = time.time()
+
+        # RUNNING task — moderate age
+        registry.upsert(
+            "task-running-1",
+            agent="claude-code",
+            state="RUNNING",
+            project="/home/user/proj-a",
+            last_output_ts=now - 60.0,
+        )
+        # WAITING_USER — older (90 s)
+        registry.upsert(
+            "task-waiting-old",
+            agent="omp",
+            state="WAITING_USER",
+            project="/home/user/proj-b",
+            last_output_ts=now - 90.0,
+        )
+        # WAITING_USER — newer (30 s)
+        registry.upsert(
+            "task-waiting-new",
+            agent="omp",
+            state="WAITING_USER",
+            project="/home/user/proj-c",
+            last_output_ts=now - 30.0,
+        )
+        return now
+
+    def test_snapshot_contains_all_task_ids(
+        self, registry: SessionOrchestrationRegistry
+    ) -> None:
+        now = self._seed(registry)
+        rows = registry.list()
+        snapshot = build_snapshot(rows, now=now)
+        assert "task-running-1" in snapshot
+        assert "task-waiting-old" in snapshot
+        assert "task-waiting-new" in snapshot
+
+    def test_snapshot_contains_states(
+        self, registry: SessionOrchestrationRegistry
+    ) -> None:
+        now = self._seed(registry)
+        rows = registry.list()
+        snapshot = build_snapshot(rows, now=now)
+        assert "RUNNING" in snapshot
+        assert "WAITING_USER" in snapshot
+
+    def test_summary_counts_correct(
+        self, registry: SessionOrchestrationRegistry
+    ) -> None:
+        now = self._seed(registry)
+        rows = registry.list()
+        snapshot = build_snapshot(rows, now=now)
+        # 1 RUNNING + 2 WAITING_USER
+        assert "1 RUNNING" in snapshot
+        assert "2 WAITING_USER" in snapshot
+
+    def test_oldest_waiting_user_highlighted(
+        self, registry: SessionOrchestrationRegistry
+    ) -> None:
+        now = self._seed(registry)
+        rows = registry.list()
+        snapshot = build_snapshot(rows, now=now)
+        # The "Oldest WAITING_USER" line must name the older task.
+        assert "Oldest WAITING_USER" in snapshot
+        # task-waiting-old is 90s old; task-waiting-new is 30s old.
+        # The highlight must reference task-waiting-old.
+        oldest_section = snapshot.split("Oldest WAITING_USER")[-1]
+        assert "task-waiting-old" in oldest_section
+
+    def test_no_oldest_waiting_when_none_present(self) -> None:
+        rows: List[Dict[str, Any]] = [
+            {
+                "task_id": "t1",
+                "agent": "claude-code",
+                "state": "RUNNING",
+                "last_output_ts": time.time() - 10,
+            }
+        ]
+        snapshot = build_snapshot(rows)
+        assert "Oldest WAITING_USER" not in snapshot
+
+    def test_task_count_in_header(
+        self, registry: SessionOrchestrationRegistry
+    ) -> None:
+        now = self._seed(registry)
+        rows = registry.list()
+        snapshot = build_snapshot(rows, now=now)
+        assert "3 active task(s)" in snapshot
+
+    def test_age_appears_in_output(
+        self, registry: SessionOrchestrationRegistry
+    ) -> None:
+        now = self._seed(registry)
+        rows = registry.list()
+        snapshot = build_snapshot(rows, now=now)
+        # Age lines include "age " prefix
+        assert "age " in snapshot
+
+
+# ---------------------------------------------------------------------------
+# build_snapshot — WAITING_USER ordering
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSnapshotOrdering:
+    def test_waiting_user_appears_before_running(self) -> None:
+        now = time.time()
+        rows: List[Dict[str, Any]] = [
+            {"task_id": "t-running", "agent": "a", "state": "RUNNING", "last_output_ts": now - 5},
+            {"task_id": "t-waiting", "agent": "a", "state": "WAITING_USER", "last_output_ts": now - 5},
+        ]
+        snapshot = build_snapshot(rows, now=now)
+        pos_waiting = snapshot.find("t-waiting")
+        pos_running = snapshot.find("t-running")
+        # WAITING_USER rows sort before RUNNING rows
+        assert pos_waiting < pos_running
+
+
+# ---------------------------------------------------------------------------
+# Integration: registry → build_snapshot round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestRegistrySnapshotRoundTrip:
+    def test_registry_rows_feed_snapshot_accurately(
+        self, registry: SessionOrchestrationRegistry
+    ) -> None:
+        now = time.time()
+        registry.upsert(
+            "rt-001",
+            agent="claude-code",
+            state="STALLED",
+            project="/tmp/stalled-proj",
+            last_output_ts=now - 400.0,
+        )
+        rows = registry.list()
+        snapshot = build_snapshot(rows, now=now)
+
+        assert "rt-001" in snapshot
+        assert "STALLED" in snapshot
+        # 400 s = 6m 40s
+        assert "6m 40s" in snapshot
+
+    def test_snapshot_fails_gracefully_on_bad_row(self) -> None:
+        """A row with missing fields doesn't crash the builder."""
+        rows: List[Dict[str, Any]] = [{"task_id": "incomplete", "agent": "x"}]
+        snapshot = build_snapshot(rows)
+        assert "incomplete" in snapshot

--- a/tests/test_session_orchestration_verify.py
+++ b/tests/test_session_orchestration_verify.py
@@ -82,6 +82,9 @@ def _minimal_adapter(caps: Capabilities) -> AgentAdapter:
         def resume(self, handle: SessionHandle, prompt: str) -> None:
             raise NotImplementedError
 
+        def terminate(self, handle: SessionHandle) -> None:
+            raise NotImplementedError
+
     return _StubAdapter()
 
 
@@ -137,6 +140,9 @@ class HealthyAdapter(AgentAdapter):
     def resume(self, handle: SessionHandle, prompt: str) -> None:
         raise NotImplementedError
 
+    def terminate(self, handle: SessionHandle) -> None:
+        raise NotImplementedError
+
 
 class WrongCapAdapter(AgentAdapter):
     """Declares has_hooks=True but its binary --help has no '--hook' flag."""
@@ -156,6 +162,9 @@ class WrongCapAdapter(AgentAdapter):
     def resume(self, handle: SessionHandle, prompt: str) -> None:
         raise NotImplementedError
 
+    def terminate(self, handle: SessionHandle) -> None:
+        raise NotImplementedError
+
 
 class MissingBinAdapter(AgentAdapter):
     """Declares has_hooks=True; binary is not on PATH at all."""
@@ -173,6 +182,9 @@ class MissingBinAdapter(AgentAdapter):
         raise NotImplementedError
 
     def resume(self, handle: SessionHandle, prompt: str) -> None:
+        raise NotImplementedError
+
+    def terminate(self, handle: SessionHandle) -> None:
         raise NotImplementedError
 
 
@@ -323,6 +335,9 @@ class TestVerifyAdapters:
             def resume(self, handle: SessionHandle, prompt: str) -> None:
                 raise NotImplementedError
 
+            def terminate(self, handle: SessionHandle) -> None:
+                raise NotImplementedError
+
         adapters: dict[str, AgentAdapter] = {"unknown": UnknownAdapter()}
         with caplog.at_level(logging.WARNING, logger="session_orchestration.adapters.verify"):
             result = verify_adapters(adapters, probe_runner=FakeProbeRunner(), probe_specs={})
@@ -346,6 +361,9 @@ class TestVerifyAdapters:
                 raise NotImplementedError
 
             def resume(self, handle: SessionHandle, prompt: str) -> None:
+                raise NotImplementedError
+
+            def terminate(self, handle: SessionHandle) -> None:
                 raise NotImplementedError
 
         specs = {"BrokenAdapter": AdapterProbeSpec(binary="bin")}

--- a/tests/test_session_orchestration_verify.py
+++ b/tests/test_session_orchestration_verify.py
@@ -1,0 +1,378 @@
+"""
+Unit tests for session_orchestration/adapters/verify.py.
+
+Coverage
+--------
+1. A healthy adapter (binary found, all declared capability flags present in
+   --help) → returned in the available dict.
+2. A deliberately-wrong declared capability (adapter claims has_hooks=True,
+   but the probed --help contains no hook flag) → that adapter is disabled,
+   others remain available.
+3. A missing-binary adapter (binary not on PATH) → adapter unavailable,
+   no crash, others unaffected.
+4. An adapter with no registered probe spec → accepted with a warning (no
+   crash).
+5. An adapter whose capabilities() raises → unavailable, no crash.
+6. Multiple adapters: one fails, others remain available.
+
+All tests use an injected ``FakeProbeRunner`` so no real binaries are
+invoked and the test suite is hermetic.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from session_orchestration.adapters.base import AgentAdapter
+from session_orchestration.adapters.verify import (
+    AdapterProbeSpec,
+    _ADAPTER_PROBE_SPECS,
+    _check_capabilities,
+    verify_adapters,
+)
+from session_orchestration.types import Capabilities, SessionHandle, SessionLifecycle
+
+
+# ---------------------------------------------------------------------------
+# Helpers / stubs
+# ---------------------------------------------------------------------------
+
+
+class FakeProbeRunner:
+    """Injectable test double for ProbeRunner.
+
+    ``known_binaries``: set of binary names considered on PATH.
+    ``help_outputs``:   mapping binary → simulated --help text.
+    """
+
+    def __init__(
+        self,
+        known_binaries: set[str] | None = None,
+        help_outputs: dict[str, str] | None = None,
+    ) -> None:
+        self._known = known_binaries or set()
+        self._help = help_outputs or {}
+
+    def which(self, binary: str) -> str | None:
+        return f"/usr/local/bin/{binary}" if binary in self._known else None
+
+    def help_text(self, binary: str) -> str:
+        return self._help.get(binary, "")
+
+
+def _minimal_adapter(caps: Capabilities) -> AgentAdapter:
+    """Create a throwaway AgentAdapter stub that returns ``caps``."""
+
+    class _StubAdapter(AgentAdapter):
+        def capabilities(self) -> Capabilities:  # type: ignore[override]
+            return caps
+
+        def launch(self, workdir: str, prompt: str) -> SessionHandle:
+            raise NotImplementedError
+
+        def drive(self, handle: SessionHandle, message: str) -> None:
+            raise NotImplementedError
+
+        def detect(self, handle: SessionHandle) -> SessionLifecycle:
+            raise NotImplementedError
+
+        def resume(self, handle: SessionHandle, prompt: str) -> None:
+            raise NotImplementedError
+
+    return _StubAdapter()
+
+
+# A probe spec that covers the two test-adapter class names below.
+_TEST_SPECS: dict[str, AdapterProbeSpec] = {
+    "HealthyAdapter": AdapterProbeSpec(
+        binary="healthybin",
+        has_hooks_flag="--hook",
+        supports_print_mode_flag="--print",
+    ),
+    "WrongCapAdapter": AdapterProbeSpec(
+        binary="wrongbin",
+        has_hooks_flag="--hook",
+        supports_print_mode_flag="--print",
+    ),
+    "MissingBinAdapter": AdapterProbeSpec(
+        binary="missingbin",
+        has_hooks_flag="--hook",
+    ),
+}
+
+
+def _healthy_runner() -> FakeProbeRunner:
+    return FakeProbeRunner(
+        known_binaries={"healthybin", "wrongbin"},
+        help_outputs={
+            "healthybin": "Usage: healthybin\n  --hook  lifecycle hook\n  --print  print mode\n",
+            "wrongbin": "Usage: wrongbin\n  no hook flag here\n  --print  print mode\n",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Named adapter stubs for use with _TEST_SPECS
+# ---------------------------------------------------------------------------
+
+
+class HealthyAdapter(AgentAdapter):
+    """Declares has_hooks=True + supports_print_mode=True; probe confirms both."""
+
+    def capabilities(self) -> Capabilities:
+        return Capabilities(has_hooks=True, supports_print_mode=True)
+
+    def launch(self, workdir: str, prompt: str) -> SessionHandle:
+        raise NotImplementedError
+
+    def drive(self, handle: SessionHandle, message: str) -> None:
+        raise NotImplementedError
+
+    def detect(self, handle: SessionHandle) -> SessionLifecycle:
+        raise NotImplementedError
+
+    def resume(self, handle: SessionHandle, prompt: str) -> None:
+        raise NotImplementedError
+
+
+class WrongCapAdapter(AgentAdapter):
+    """Declares has_hooks=True but its binary --help has no '--hook' flag."""
+
+    def capabilities(self) -> Capabilities:
+        return Capabilities(has_hooks=True, supports_print_mode=True)
+
+    def launch(self, workdir: str, prompt: str) -> SessionHandle:
+        raise NotImplementedError
+
+    def drive(self, handle: SessionHandle, message: str) -> None:
+        raise NotImplementedError
+
+    def detect(self, handle: SessionHandle) -> SessionLifecycle:
+        raise NotImplementedError
+
+    def resume(self, handle: SessionHandle, prompt: str) -> None:
+        raise NotImplementedError
+
+
+class MissingBinAdapter(AgentAdapter):
+    """Declares has_hooks=True; binary is not on PATH at all."""
+
+    def capabilities(self) -> Capabilities:
+        return Capabilities(has_hooks=True)
+
+    def launch(self, workdir: str, prompt: str) -> SessionHandle:
+        raise NotImplementedError
+
+    def drive(self, handle: SessionHandle, message: str) -> None:
+        raise NotImplementedError
+
+    def detect(self, handle: SessionHandle) -> SessionLifecycle:
+        raise NotImplementedError
+
+    def resume(self, handle: SessionHandle, prompt: str) -> None:
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCapabilities:
+    """Unit tests for the pure _check_capabilities helper."""
+
+    def test_all_ok_returns_empty(self) -> None:
+        caps = Capabilities(has_hooks=True, supports_print_mode=True)
+        spec = AdapterProbeSpec(
+            binary="bin",
+            has_hooks_flag="--hook",
+            supports_print_mode_flag="--print",
+        )
+        runner = FakeProbeRunner(
+            known_binaries={"bin"},
+            help_outputs={"bin": "--hook  hook flag\n--print  print flag\n"},
+        )
+        mismatches = _check_capabilities(caps, spec, runner)
+        assert mismatches == []
+
+    def test_missing_binary_returns_mismatch(self) -> None:
+        caps = Capabilities(has_hooks=True)
+        spec = AdapterProbeSpec(binary="ghostbin", has_hooks_flag="--hook")
+        runner = FakeProbeRunner(known_binaries=set())
+        mismatches = _check_capabilities(caps, spec, runner)
+        assert len(mismatches) == 1
+        assert "not found on PATH" in mismatches[0]
+
+    def test_missing_hook_flag_in_help(self) -> None:
+        caps = Capabilities(has_hooks=True)
+        spec = AdapterProbeSpec(binary="mybin", has_hooks_flag="--hook")
+        runner = FakeProbeRunner(
+            known_binaries={"mybin"},
+            help_outputs={"mybin": "no hook flag here"},
+        )
+        mismatches = _check_capabilities(caps, spec, runner)
+        assert len(mismatches) == 1
+        assert "has_hooks=True" in mismatches[0]
+        assert "--hook" in mismatches[0]
+
+    def test_skip_probe_when_flag_is_none(self) -> None:
+        """A None flag means 'skip this probe'; no mismatch even if help is empty."""
+        caps = Capabilities(rpc_mode=True)
+        spec = AdapterProbeSpec(binary="mybin", rpc_mode_flag=None)
+        runner = FakeProbeRunner(
+            known_binaries={"mybin"},
+            help_outputs={"mybin": ""},
+        )
+        mismatches = _check_capabilities(caps, spec, runner)
+        assert mismatches == []
+
+    def test_false_declared_cap_not_probed(self) -> None:
+        """If declared has_hooks=False, there is no mismatch even if the flag is absent."""
+        caps = Capabilities(has_hooks=False)
+        spec = AdapterProbeSpec(binary="mybin", has_hooks_flag="--hook")
+        runner = FakeProbeRunner(
+            known_binaries={"mybin"},
+            help_outputs={"mybin": "nothing useful"},
+        )
+        mismatches = _check_capabilities(caps, spec, runner)
+        assert mismatches == []
+
+    def test_multiple_mismatches_all_reported(self) -> None:
+        caps = Capabilities(has_hooks=True, supports_print_mode=True, json_mode=True)
+        spec = AdapterProbeSpec(
+            binary="bin",
+            has_hooks_flag="--hook",
+            supports_print_mode_flag="--print",
+            json_mode_flag="--json",
+        )
+        runner = FakeProbeRunner(
+            known_binaries={"bin"},
+            help_outputs={"bin": "no relevant flags at all"},
+        )
+        mismatches = _check_capabilities(caps, spec, runner)
+        assert len(mismatches) == 3
+
+
+class TestVerifyAdapters:
+    """Integration tests for verify_adapters — the function the watcher calls."""
+
+    def test_healthy_adapter_is_available(self) -> None:
+        adapters: dict[str, AgentAdapter] = {"healthy": HealthyAdapter()}
+        result = verify_adapters(adapters, probe_runner=_healthy_runner(), probe_specs=_TEST_SPECS)
+        assert "healthy" in result
+        assert result["healthy"] is adapters["healthy"]
+
+    def test_wrong_capability_disables_adapter(self) -> None:
+        """Adapter claiming has_hooks=True whose --help has no '--hook' → disabled."""
+        adapters: dict[str, AgentAdapter] = {"wrong": WrongCapAdapter()}
+        result = verify_adapters(adapters, probe_runner=_healthy_runner(), probe_specs=_TEST_SPECS)
+        assert "wrong" not in result
+
+    def test_missing_binary_disables_adapter(self) -> None:
+        """Adapter whose binary is not on PATH → unavailable, no crash."""
+        runner = FakeProbeRunner(known_binaries=set())  # no binary available
+        adapters: dict[str, AgentAdapter] = {"missing": MissingBinAdapter()}
+        result = verify_adapters(adapters, probe_runner=runner, probe_specs=_TEST_SPECS)
+        assert "missing" not in result
+
+    def test_only_failing_adapter_is_disabled(self) -> None:
+        """When one adapter fails and another passes, only the healthy one is returned."""
+        adapters: dict[str, AgentAdapter] = {
+            "healthy": HealthyAdapter(),
+            "wrong": WrongCapAdapter(),
+        }
+        result = verify_adapters(adapters, probe_runner=_healthy_runner(), probe_specs=_TEST_SPECS)
+        assert "healthy" in result
+        assert "wrong" not in result
+
+    def test_missing_binary_does_not_crash_other_adapters(self) -> None:
+        """A missing-binary adapter must not prevent healthy adapters from being verified."""
+        runner = FakeProbeRunner(
+            known_binaries={"healthybin"},
+            help_outputs={"healthybin": "--hook  h\n--print  p\n"},
+        )
+        adapters: dict[str, AgentAdapter] = {
+            "healthy": HealthyAdapter(),
+            "missing": MissingBinAdapter(),
+        }
+        result = verify_adapters(adapters, probe_runner=runner, probe_specs=_TEST_SPECS)
+        assert "healthy" in result
+        assert "missing" not in result
+
+    def test_no_probe_spec_adapter_accepted_with_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Adapter with no registered spec → accepted (cannot verify) + warning logged."""
+
+        class UnknownAdapter(AgentAdapter):
+            def capabilities(self) -> Capabilities:
+                return Capabilities()
+
+            def launch(self, workdir: str, prompt: str) -> SessionHandle:
+                raise NotImplementedError
+
+            def drive(self, handle: SessionHandle, message: str) -> None:
+                raise NotImplementedError
+
+            def detect(self, handle: SessionHandle) -> SessionLifecycle:
+                raise NotImplementedError
+
+            def resume(self, handle: SessionHandle, prompt: str) -> None:
+                raise NotImplementedError
+
+        adapters: dict[str, AgentAdapter] = {"unknown": UnknownAdapter()}
+        with caplog.at_level(logging.WARNING, logger="session_orchestration.adapters.verify"):
+            result = verify_adapters(adapters, probe_runner=FakeProbeRunner(), probe_specs={})
+        assert "unknown" in result
+        assert any("no probe spec" in r.message for r in caplog.records)
+
+    def test_capabilities_raises_disables_adapter(self, caplog: pytest.LogCaptureFixture) -> None:
+        """If capabilities() raises, the adapter is marked unavailable, no crash."""
+
+        class BrokenAdapter(AgentAdapter):
+            def capabilities(self) -> Capabilities:
+                raise RuntimeError("broken!")
+
+            def launch(self, workdir: str, prompt: str) -> SessionHandle:
+                raise NotImplementedError
+
+            def drive(self, handle: SessionHandle, message: str) -> None:
+                raise NotImplementedError
+
+            def detect(self, handle: SessionHandle) -> SessionLifecycle:
+                raise NotImplementedError
+
+            def resume(self, handle: SessionHandle, prompt: str) -> None:
+                raise NotImplementedError
+
+        specs = {"BrokenAdapter": AdapterProbeSpec(binary="bin")}
+        adapters: dict[str, AgentAdapter] = {"broken": BrokenAdapter()}
+        with caplog.at_level(logging.ERROR, logger="session_orchestration.adapters.verify"):
+            result = verify_adapters(
+                adapters,
+                probe_runner=FakeProbeRunner(known_binaries={"bin"}),
+                probe_specs=specs,
+            )
+        assert "broken" not in result
+        assert any("capabilities()" in r.message for r in caplog.records)
+
+    def test_empty_adapters_returns_empty(self) -> None:
+        result = verify_adapters({}, probe_runner=FakeProbeRunner())
+        assert result == {}
+
+    def test_error_is_logged_not_raised_on_mismatch(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Capability mismatch must log an error, never raise."""
+        adapters: dict[str, AgentAdapter] = {"wrong": WrongCapAdapter()}
+        with caplog.at_level(logging.ERROR, logger="session_orchestration.adapters.verify"):
+            result = verify_adapters(
+                adapters, probe_runner=_healthy_runner(), probe_specs=_TEST_SPECS
+            )
+        assert "wrong" not in result
+        error_msgs = [r.message for r in caplog.records if r.levelno >= logging.ERROR]
+        assert any("capability mismatch" in m for m in error_msgs)
+        assert any("disabled" in m for m in error_msgs)

--- a/tests/test_session_orchestration_watcher.py
+++ b/tests/test_session_orchestration_watcher.py
@@ -1,21 +1,18 @@
 """
-Unit tests for session_orchestration/watcher.py (T006).
+Unit tests for session_orchestration/watcher.py session-orchestration flow.
 
 Coverage
 --------
-1. A tick iterating seeded rows writes state without spurious notifications —
-   state updates reach the registry; no Discord/network calls.
-2. A tick whose target session is locked by the relay skips capture — the
-   tmux_capture callable is NOT called when the lock is held.
-3. Intent-queue drain is applied: an intent enqueued before the tick is
-   processed and the row is updated.
-4. Unavailable-adapter rows are skipped: a row whose agent name is absent
-   from the verified adapters set is never processed.
-5. Lock is acquired BEFORE capture and released AFTER — the lock holder is
-   cleared from the registry before _process_row returns.
-6. startup_verify is idempotent — calling it twice does not re-probe adapters.
-7. Config-gate: _is_session_orchestration_enabled returns False when config
-   key is absent.
+1. Core tick mechanics: state updates, lock handling, intent drain,
+   unavailable-adapter skips, startup verification, and config gate.
+2. Attention lifecycle: WAITING_USER / PAUSED_HANDOFF open, refresh, resolve,
+   and direct user-attention transitions close the prior reason.
+3. Stale/frozen lifecycle: deterministic eligibility, empty-capture safety,
+   ambiguous RUNNING persistence, drive/progress resolution, and one nudge per
+   stale episode.
+4. Watcher-to-feed projection: digest reconciliation on attention entry,
+   resolution, stale/frozen escalation, already-nudged stale episodes, and
+   missing digest message recovery.
 
 All tests use:
 - An in-memory SQLite DB (via tmp_path fixture).
@@ -26,20 +23,29 @@ All tests use:
 
 from __future__ import annotations
 
+import re
 import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
+import session_orchestration.feed as feed_mod
 
 from session_orchestration.adapters.base import AgentAdapter
 from session_orchestration.adapters.verify import AdapterProbeSpec
 from session_orchestration.registry import SessionOrchestrationRegistry
 from session_orchestration.types import Capabilities, SessionHandle, SessionLifecycle
-from session_orchestration.watcher import SessionWatcher, _pane_hash, run_tick
+from session_orchestration.watcher import (
+    SessionWatcher,
+    _is_omp_nudge_checkin_eligible,
+    _is_stale_frozen_eligible,
+    _on_hang,
+    _pane_hash,
+    run_tick,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -50,12 +56,17 @@ from session_orchestration.watcher import SessionWatcher, _pane_hash, run_tick
 class FakeAdapter(AgentAdapter):
     """Adapter that returns a fixed lifecycle value and records detect() calls."""
 
-    def __init__(self, lifecycle: SessionLifecycle = SessionLifecycle.RUNNING):
+    def __init__(
+        self,
+        lifecycle: SessionLifecycle = SessionLifecycle.RUNNING,
+        idle_indicator_regex: re.Pattern[str] | None = None,
+    ):
         self._lifecycle = lifecycle
+        self._idle_indicator_regex = idle_indicator_regex
         self.detect_calls: List[SessionHandle] = []
 
     def capabilities(self) -> Capabilities:
-        return Capabilities()
+        return Capabilities(idle_indicator_regex=self._idle_indicator_regex)
 
     def launch(self, workdir: str, prompt: str) -> SessionHandle:
         raise NotImplementedError
@@ -174,7 +185,14 @@ class TestTickWritesState:
         capture = FakeCapture("❯ ")
         watcher = _make_watcher(registry, adapter, capture)
 
-        processed = watcher.tick()
+        with (
+            patch(
+                "session_orchestration.feed.reconcile_attention_digest",
+                return_value={"status": "posted"},
+            ),
+            patch("session_orchestration.feed.push_turn_change", return_value=False),
+        ):
+            processed = watcher.tick()
 
         assert processed == 1, "expected exactly one row processed"
         row = registry.get(task_id)
@@ -211,6 +229,553 @@ class TestTickWritesState:
         # capture was never called for terminal rows
         assert capture.calls == []
 
+
+
+class TestAttentionLifecycle:
+    """Watcher-owned attention items mirror lifecycle without new states."""
+
+    def test_waiting_user_attention_open_refresh_resolve(self, registry, db_path):
+        task_id = "t-attn-waiting"
+        _seed_row(registry, task_id=task_id, state="RUNNING")
+
+        adapter = FakeAdapter(SessionLifecycle.WAITING_USER)
+        watcher = _make_watcher(registry, adapter, FakeCapture("❯ "))
+
+        with (
+            patch(
+                "session_orchestration.feed.reconcile_attention_digest",
+                return_value={"status": "edited"},
+            ) as reconcile_digest,
+            patch("session_orchestration.feed.push_turn_change", return_value=True) as thread_notice,
+            patch("session_orchestration.watcher._on_heartbeat_tick") as heartbeat_tick,
+        ):
+            watcher.tick()
+            reconcile_digest.assert_called_once_with(registry)
+            thread_notice.assert_called_once()
+            first_items = registry.list_unresolved_attention_items()
+            waiting_items = [
+                item for item in first_items if item["reason"] == "WAITING_USER"
+            ]
+            assert len(waiting_items) == 1
+            first_id = waiting_items[0]["id"]
+
+            watcher.tick()
+            assert reconcile_digest.call_count == 1
+            refreshed_items = registry.list_unresolved_attention_items()
+            waiting_items = [
+                item for item in refreshed_items if item["reason"] == "WAITING_USER"
+            ]
+            assert [item["id"] for item in waiting_items] == [first_id]
+
+            adapter._lifecycle = SessionLifecycle.RUNNING
+            watcher.tick()
+            assert reconcile_digest.call_count == 2
+            heartbeat_tick.assert_not_called()
+
+        assert not [
+            item
+            for item in registry.list_unresolved_attention_items()
+            if item["reason"] == "WAITING_USER"
+        ]
+
+    def test_paused_handoff_attention_open_refresh_resolve(self, registry, db_path):
+        task_id = "t-attn-handoff"
+        _seed_row(registry, task_id=task_id, state="RUNNING")
+
+        adapter = FakeAdapter(SessionLifecycle.PAUSED_HANDOFF)
+        watcher = _make_watcher(registry, adapter, FakeCapture("HERMES_HANDOFF\n❯ "))
+
+        with (
+            patch(
+                "session_orchestration.feed.reconcile_attention_digest",
+                return_value={"status": "edited"},
+            ) as reconcile_digest,
+            patch("session_orchestration.feed.push_turn_change", return_value=True) as thread_notice,
+            patch("session_orchestration.watcher._on_heartbeat_tick") as heartbeat_tick,
+        ):
+            watcher.tick()
+            reconcile_digest.assert_called_once_with(registry)
+            thread_notice.assert_called_once()
+            first_items = registry.list_unresolved_attention_items()
+            handoff_items = [
+                item for item in first_items if item["reason"] == "PAUSED_HANDOFF"
+            ]
+            assert len(handoff_items) == 1
+            first_id = handoff_items[0]["id"]
+
+            watcher.tick()
+            assert reconcile_digest.call_count == 1
+            refreshed_items = registry.list_unresolved_attention_items()
+            handoff_items = [
+                item for item in refreshed_items if item["reason"] == "PAUSED_HANDOFF"
+            ]
+            assert [item["id"] for item in handoff_items] == [first_id]
+
+            adapter._lifecycle = SessionLifecycle.RUNNING
+            watcher.tick()
+            assert reconcile_digest.call_count == 2
+            heartbeat_tick.assert_not_called()
+
+        assert not [
+            item
+            for item in registry.list_unresolved_attention_items()
+            if item["reason"] == "PAUSED_HANDOFF"
+        ]
+
+    def test_leaving_user_attention_state_rearms_turn_change_debounce(
+        self, registry, db_path
+    ):
+        import session_orchestration.feed as feed_mod
+
+        task_id = "t-attn-debounce"
+        _seed_row(registry, task_id=task_id, state="WAITING_USER")
+        feed_mod._last_notified[task_id] = "WAITING_USER"
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        watcher = _make_watcher(registry, adapter, FakeCapture("working"))
+        with patch(
+            "session_orchestration.feed.reconcile_attention_digest",
+            return_value={"status": "edited"},
+        ) as reconcile_digest:
+            watcher.tick()
+
+        reconcile_digest.assert_called_once_with(registry)
+
+        assert task_id not in feed_mod._last_notified
+
+    def test_stale_frozen_attention_opens_on_running_row(self, registry, db_path):
+        task_id = "t-attn-stale-open"
+        pane_text = "unchanged frozen pane"
+        pane_hash = _pane_hash(pane_text)
+        _seed_row(registry, task_id=task_id, state="RUNNING")
+        registry.upsert(
+            task_id,
+            agent="fake",
+            run_id=f"run-{uuid.uuid4().hex[:8]}",
+            repo=f"repo-{uuid.uuid4().hex[:8]}",
+            last_pane_hash=pane_hash,
+            last_output_ts=time.time() - 999,
+            idle_ticks=3,
+            nudge_count=1,
+        )
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        watcher = _make_watcher(registry, adapter, FakeCapture(pane_text))
+        watcher.tick()
+
+        row = registry.get(task_id)
+        assert row is not None
+        assert row["state"] == "RUNNING"
+        assert [
+            item
+            for item in registry.list_unresolved_attention_items()
+            if item["reason"] == "STALE_FROZEN"
+        ]
+
+    def test_stale_frozen_escalation_reconciles_attention_digest(
+        self, registry, db_path
+    ):
+        task_id = "t-attn-stale-digest"
+        pane_text = "unchanged frozen pane for digest"
+        pane_hash = _pane_hash(pane_text)
+        _seed_row(registry, task_id=task_id, state="RUNNING")
+        registry.upsert(
+            task_id,
+            agent="fake",
+            run_id=f"run-{uuid.uuid4().hex[:8]}",
+            repo=f"repo-{uuid.uuid4().hex[:8]}",
+            last_pane_hash=pane_hash,
+            last_output_ts=time.time() - 999,
+            idle_ticks=3,
+            nudge_count=0,
+        )
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        watcher = _make_watcher(registry, adapter, FakeCapture(pane_text))
+
+        with (
+            patch(
+                "session_orchestration.feed.reconcile_attention_digest",
+                return_value={"status": "edited"},
+            ) as reconcile_digest,
+            patch("session_orchestration.feed.push_hang_notification", return_value=False) as thread_notice,
+            patch("session_orchestration.watcher._on_heartbeat_tick") as heartbeat_tick,
+            patch("session_orchestration.watcher._send_auto_nudge") as auto_nudge,
+        ):
+            watcher.tick()
+
+        reconcile_digest.assert_called_once_with(registry)
+        thread_notice.assert_called_once()
+        auto_nudge.assert_called_once()
+        heartbeat_tick.assert_not_called()
+        assert [
+            item
+            for item in registry.list_unresolved_attention_items()
+            if item["reason"] == "STALE_FROZEN"
+        ]
+
+    def test_stale_frozen_not_resolved_by_default_running_detect(
+        self, registry, db_path
+    ):
+        task_id = "t-attn-stale-running"
+        pane_text = "same pane without enough stale evidence"
+        _seed_row(registry, task_id=task_id, state="RUNNING")
+        registry.upsert(
+            task_id,
+            agent="fake",
+            run_id=f"run-{uuid.uuid4().hex[:8]}",
+            repo=f"repo-{uuid.uuid4().hex[:8]}",
+            last_pane_hash=_pane_hash(pane_text),
+            idle_ticks=0,
+        )
+        stale_item = registry.open_attention_item(task_id, "STALE_FROZEN")
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        watcher = _make_watcher(registry, adapter, FakeCapture(pane_text))
+        watcher.tick()
+
+        unresolved = registry.list_unresolved_attention_items()
+        stale_ids = [
+            item["id"] for item in unresolved if item["reason"] == "STALE_FROZEN"
+        ]
+        assert stale_ids == [stale_item["id"]]
+
+    def test_empty_capture_does_not_resolve_stale_frozen_or_reset_counters(
+        self, registry, db_path
+    ):
+        task_id = "t-attn-stale-empty-capture"
+        old_text = "old frozen pane"
+        old_hash = _pane_hash(old_text)
+        old_last_output_ts = time.time() - 999
+        _seed_row(registry, task_id=task_id, state="RUNNING")
+        registry.upsert(
+            task_id,
+            agent="fake",
+            run_id=f"run-{uuid.uuid4().hex[:8]}",
+            repo=f"repo-{uuid.uuid4().hex[:8]}",
+            last_pane_hash=old_hash,
+            last_output_ts=old_last_output_ts,
+            idle_ticks=3,
+            nudge_count=1,
+        )
+        stale_item = registry.open_attention_item(task_id, "STALE_FROZEN")
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        watcher = _make_watcher(registry, adapter, FakeCapture(""))
+        watcher.tick()
+
+        row = registry.get(task_id)
+        assert row is not None
+        assert row["last_pane_hash"] == old_hash
+        assert row["last_output_ts"] == pytest.approx(old_last_output_ts)
+        assert row["idle_ticks"] == 3
+        assert row["nudge_count"] == 1
+        stale_ids = [
+            item["id"]
+            for item in registry.list_unresolved_attention_items()
+            if item["reason"] == "STALE_FROZEN"
+        ]
+        assert stale_ids == [stale_item["id"]]
+
+    def test_stale_frozen_resolves_on_drive_signal_when_represented(
+        self, registry, db_path
+    ):
+        task_id = "t-attn-stale-drive"
+        pane_text = "still frozen but user replied"
+        pane_hash = _pane_hash(pane_text)
+        _seed_row(registry, task_id=task_id, state="RUNNING")
+        registry.upsert(
+            task_id,
+            agent="fake",
+            run_id=f"run-{uuid.uuid4().hex[:8]}",
+            repo=f"repo-{uuid.uuid4().hex[:8]}",
+            last_pane_hash=pane_hash,
+            last_output_ts=time.time() - 999,
+            idle_ticks=3,
+            nudge_count=0,
+        )
+        registry.open_attention_item(task_id, "STALE_FROZEN")
+        registry.enqueue_intent(
+            "drive",
+            task_id=task_id,
+            payload={"task_id": task_id},
+        )
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        watcher = _make_watcher(registry, adapter, FakeCapture(pane_text))
+        with (
+            patch("session_orchestration.watcher._on_hang") as on_hang,
+            patch(
+                "session_orchestration.feed.reconcile_attention_digest",
+                return_value={"status": "edited"},
+            ) as reconcile_digest,
+        ):
+            watcher.tick()
+            on_hang.assert_not_called()
+
+        reconcile_digest.assert_called_once_with(registry)
+
+        assert not [
+            item
+            for item in registry.list_unresolved_attention_items()
+            if item["reason"] == "STALE_FROZEN"
+        ]
+
+    def test_stale_frozen_resolves_on_pane_hash_change(self, registry, db_path):
+        task_id = "t-attn-stale-resolve"
+        _seed_row(registry, task_id=task_id, state="RUNNING")
+        registry.upsert(
+            task_id,
+            agent="fake",
+            run_id=f"run-{uuid.uuid4().hex[:8]}",
+            repo=f"repo-{uuid.uuid4().hex[:8]}",
+            last_pane_hash=_pane_hash("old frozen pane"),
+            last_output_ts=time.time() - 999,
+            idle_ticks=3,
+        )
+        registry.open_attention_item(task_id, "STALE_FROZEN")
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        watcher = _make_watcher(registry, adapter, FakeCapture("new active output"))
+        with patch(
+            "session_orchestration.feed.reconcile_attention_digest",
+            return_value={"status": "edited"},
+        ) as reconcile_digest:
+            watcher.tick()
+
+        reconcile_digest.assert_called_once_with(registry)
+
+        assert not [
+            item
+            for item in registry.list_unresolved_attention_items()
+            if item["reason"] == "STALE_FROZEN"
+        ]
+
+
+    def test_waiting_user_digest_removes_item_after_progress(self, registry, db_path):
+        task_id = "t-attn-digest-progress"
+        _seed_row(registry, task_id=task_id, state="RUNNING")
+
+        posted: List[str] = []
+        edited: List[str] = []
+
+        def fake_post(channel_id: str, content: str, *, token=None):
+            posted.append(content)
+            return "digest-msg-1"
+
+        def fake_edit(channel_id: str, message_id: str, content: str, *, token=None):
+            edited.append(content)
+            return feed_mod._EDIT_OK
+
+        adapter = FakeAdapter(SessionLifecycle.WAITING_USER)
+        watcher = _make_watcher(registry, adapter, FakeCapture("waiting at prompt"))
+        with (
+            patch("session_orchestration.feed._get_feed_channel_id", return_value="feed-1"),
+            patch("session_orchestration.feed._post_discord_message", side_effect=fake_post),
+            patch("session_orchestration.feed._edit_discord_message", side_effect=fake_edit),
+            patch("session_orchestration.watcher._on_heartbeat_tick") as heartbeat_tick,
+        ):
+            watcher.tick()
+            assert len(posted) == 1
+            assert task_id in posted[0]
+            assert "reason `WAITING_USER`" in posted[0]
+            assert registry.get_projection(
+                "feed-1", feed_mod._ATTENTION_DIGEST_PROJECTION_NAME
+            )["payload"] == {"item_count": 1, "task_ids": [task_id]}
+
+            adapter._lifecycle = SessionLifecycle.RUNNING
+            watcher._tmux_capture = FakeCapture("agent made progress")
+            watcher.tick()
+
+        assert edited == ["**Hermes action feed**\nNo unresolved attention items."]
+        assert registry.list_unresolved_attention_items() == []
+        assert registry.get_projection(
+            "feed-1", feed_mod._ATTENTION_DIGEST_PROJECTION_NAME
+        )["payload"] == {"item_count": 0, "task_ids": []}
+        heartbeat_tick.assert_not_called()
+
+    def test_stale_frozen_digest_persists_across_running_then_drive_removes(
+        self, registry, db_path
+    ):
+        task_id = "t-attn-stale-digest-drive"
+        pane_text = "unchanged ambiguous running pane"
+        _seed_row(registry, task_id=task_id, state="RUNNING")
+        registry.upsert(
+            task_id,
+            agent="fake",
+            run_id=f"run-{uuid.uuid4().hex[:8]}",
+            repo=f"repo-{uuid.uuid4().hex[:8]}",
+            last_pane_hash=_pane_hash(pane_text),
+            idle_ticks=0,
+        )
+        registry.open_attention_item(
+            task_id,
+            "STALE_FROZEN",
+            priority=50,
+            detail="existing unresolved stale/frozen item",
+        )
+
+        posted: List[str] = []
+        edited: List[str] = []
+
+        def fake_post(channel_id: str, content: str, *, token=None):
+            posted.append(content)
+            return "digest-msg-1"
+
+        def fake_edit(channel_id: str, message_id: str, content: str, *, token=None):
+            edited.append(content)
+            return feed_mod._EDIT_OK
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        watcher = _make_watcher(registry, adapter, FakeCapture(pane_text))
+        with (
+            patch("session_orchestration.feed._get_feed_channel_id", return_value="feed-1"),
+            patch("session_orchestration.feed._post_discord_message", side_effect=fake_post),
+            patch("session_orchestration.feed._edit_discord_message", side_effect=fake_edit),
+            patch("session_orchestration.watcher._on_heartbeat_tick"),
+        ):
+            feed_mod.reconcile_attention_digest(registry)
+            assert len(posted) == 1
+            assert task_id in posted[0]
+            assert "reason `STALE_FROZEN`" in posted[0]
+
+            watcher.tick()
+            unresolved = registry.list_unresolved_attention_items()
+            assert [item["reason"] for item in unresolved] == ["STALE_FROZEN"]
+            assert edited == []
+
+            registry.enqueue_intent("drive", task_id=task_id, payload={"task_id": task_id})
+            watcher.tick()
+
+        assert edited == ["**Hermes action feed**\nNo unresolved attention items."]
+        assert registry.list_unresolved_attention_items() == []
+
+    def test_missing_digest_message_recreated_with_current_attention_item(
+        self, registry, db_path
+    ):
+        task_id = "t-attn-missing-digest"
+        _seed_row(registry, task_id=task_id, state="RUNNING")
+        registry.open_attention_item(task_id, "WAITING_USER", priority=100)
+        registry.upsert_projection(
+            "feed-1",
+            feed_mod._ATTENTION_DIGEST_PROJECTION_NAME,
+            message_id="missing-digest-msg",
+            content_hash="stale-hash",
+            payload={"item_count": 0, "task_ids": []},
+        )
+
+        posted: List[str] = []
+
+        def fake_post(channel_id: str, content: str, *, token=None):
+            posted.append(content)
+            return "replacement-digest-msg"
+
+        with (
+            patch(
+                "session_orchestration.feed._edit_discord_message",
+                return_value=feed_mod._EDIT_MISSING,
+            ) as edit_message,
+            patch("session_orchestration.feed._post_discord_message", side_effect=fake_post),
+        ):
+            result = feed_mod.reconcile_attention_digest(
+                registry,
+                feed_channel_id="feed-1",
+                now="2026-06-29T02:00:00+00:00",
+            )
+
+        assert result["status"] == "recreated"
+        edit_message.assert_called_once()
+        assert len(posted) == 1
+        assert task_id in posted[0]
+        projection = registry.get_projection(
+            "feed-1", feed_mod._ATTENTION_DIGEST_PROJECTION_NAME
+        )
+        assert projection["message_id"] == "replacement-digest-msg"
+        assert projection["payload"] == {"item_count": 1, "task_ids": [task_id]}
+
+    def test_already_nudged_stale_episode_still_reconciles_digest(
+        self, registry, db_path
+    ):
+        task_id = "t-attn-stale-already-nudged-digest"
+        pane_text = "unchanged stale pane after earlier nudge"
+        pane_hash = _pane_hash(pane_text)
+        _seed_row(registry, task_id=task_id, state="RUNNING")
+        registry.upsert(
+            task_id,
+            agent="fake",
+            run_id=f"run-{uuid.uuid4().hex[:8]}",
+            repo=f"repo-{uuid.uuid4().hex[:8]}",
+            last_pane_hash=pane_hash,
+            last_output_ts=time.time() - 999,
+            idle_ticks=3,
+            nudge_count=1,
+        )
+
+        posted: List[str] = []
+
+        def fake_post(channel_id: str, content: str, *, token=None):
+            posted.append(content)
+            return "digest-msg-1"
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        watcher = _make_watcher(registry, adapter, FakeCapture(pane_text))
+        with (
+            patch("session_orchestration.feed._get_feed_channel_id", return_value="feed-1"),
+            patch("session_orchestration.feed._post_discord_message", side_effect=fake_post),
+            patch("session_orchestration.feed.push_hang_notification") as hang_notice,
+            patch("session_orchestration.watcher._send_auto_nudge") as auto_nudge,
+            patch("session_orchestration.watcher._on_heartbeat_tick") as heartbeat_tick,
+        ):
+            watcher.tick()
+
+        assert len(posted) == 1
+        assert task_id in posted[0]
+        assert "reason `STALE_FROZEN`" in posted[0]
+        assert registry.get_projection(
+            "feed-1", feed_mod._ATTENTION_DIGEST_PROJECTION_NAME
+        )["payload"] == {"item_count": 1, "task_ids": [task_id]}
+        hang_notice.assert_not_called()
+        auto_nudge.assert_not_called()
+        heartbeat_tick.assert_not_called()
+
+    def test_direct_user_attention_transition_closes_prior_reason_and_updates_digest(
+        self, registry, db_path
+    ):
+        task_id = "t-attn-direct-transition"
+        _seed_row(registry, task_id=task_id, state="RUNNING")
+
+        posted: List[str] = []
+        edited: List[str] = []
+
+        def fake_post(channel_id: str, content: str, *, token=None):
+            posted.append(content)
+            return "digest-msg-1"
+
+        def fake_edit(channel_id: str, message_id: str, content: str, *, token=None):
+            edited.append(content)
+            return feed_mod._EDIT_OK
+
+        adapter = FakeAdapter(SessionLifecycle.WAITING_USER)
+        watcher = _make_watcher(registry, adapter, FakeCapture("waiting"))
+        with (
+            patch("session_orchestration.feed._get_feed_channel_id", return_value="feed-1"),
+            patch("session_orchestration.feed._post_discord_message", side_effect=fake_post),
+            patch("session_orchestration.feed._edit_discord_message", side_effect=fake_edit),
+            patch("session_orchestration.watcher._on_heartbeat_tick") as heartbeat_tick,
+        ):
+            watcher.tick()
+            adapter._lifecycle = SessionLifecycle.PAUSED_HANDOFF
+            watcher._tmux_capture = FakeCapture("handoff")
+            watcher.tick()
+
+        assert len(posted) == 1
+        assert "reason `WAITING_USER`" in posted[0]
+        assert len(edited) == 1
+        assert "reason `PAUSED_HANDOFF`" in edited[0]
+        assert "reason `WAITING_USER`" not in edited[0]
+        unresolved = registry.list_unresolved_attention_items()
+        assert [item["reason"] for item in unresolved] == ["PAUSED_HANDOFF"]
+        heartbeat_tick.assert_not_called()
 
 class TestLockSkipsCapture:
     """A tick whose target session is locked skips capture entirely."""
@@ -477,3 +1042,292 @@ class TestIdleTickIncrement:
         watcher.tick()
         row = registry.get(task_id)
         assert (row.get("idle_ticks") or 0) == 0
+
+    def test_pane_change_resets_stale_episode_action_counter(self, registry, db_path):
+        task_id = "t-idle-003"
+        old_text = "old frozen output"
+        _seed_row(registry, task_id=task_id, tmux_session="reset-session")
+        registry.upsert(
+            task_id,
+            agent="fake",
+            run_id=f"run-{uuid.uuid4().hex[:8]}",
+            repo=f"repo-{uuid.uuid4().hex[:8]}",
+            last_pane_hash=_pane_hash(old_text),
+            last_output_ts=time.time() - 999,
+            idle_ticks=5,
+            nudge_count=1,
+        )
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture("new output after progress")
+        watcher = _make_watcher(registry, adapter, capture)
+
+        watcher.tick()
+
+        row = registry.get(task_id)
+        assert row is not None
+        assert row["nudge_count"] == 0
+
+
+class TestRunTickEntrypoint:
+    """run_tick remains a single tick-driven cron entrypoint."""
+
+    def test_run_tick_processes_one_cron_tick(self, registry, db_path):
+        task_id = "t-run-tick-001"
+        _seed_row(registry, task_id=task_id, state="RUNNING")
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture("single tick output")
+
+        processed = run_tick(
+            registry=registry,
+            adapters={"fake": adapter},
+            tmux_capture=capture,
+            probe_runner=FakeProbeRunner(),
+            probe_specs={type(adapter).__name__: _fake_probe_spec(adapter)},
+        )
+
+        assert processed == 1
+        assert len(capture.calls) == 1
+
+
+class TestStaleFrozenGuards:
+    """Deterministic stale/frozen and OMP action eligibility guards."""
+
+    def test_eligible_with_static_hash_idle_threshold_stale_output_and_no_activity(self):
+        now = time.time()
+        pane_text = "unchanged pane output"
+        pane_hash = _pane_hash(pane_text)
+        row = {
+            "idle_ticks": 3,
+            "last_output_ts": now - 301,
+            "nudge_count": 0,
+        }
+
+        assert _is_stale_frozen_eligible(
+            row,
+            previous_pane_hash=pane_hash,
+            current_pane_hash=pane_hash,
+            pane_text=pane_text,
+            adapter=FakeAdapter(SessionLifecycle.RUNNING),
+            hang_idle_ticks=3,
+            hang_stale_seconds=300,
+            now=now,
+        )
+        assert _is_omp_nudge_checkin_eligible(
+            row,
+            previous_pane_hash=pane_hash,
+            current_pane_hash=pane_hash,
+            pane_text=pane_text,
+            adapter=FakeAdapter(SessionLifecycle.RUNNING),
+            hang_idle_ticks=3,
+            hang_stale_seconds=300,
+            now=now,
+        )
+
+    def test_not_eligible_when_active_regex_matches(self):
+        now = time.time()
+        pane_text = "Running tool: cargo build"
+        pane_hash = _pane_hash(pane_text)
+        row = {
+            "idle_ticks": 3,
+            "last_output_ts": now - 301,
+            "nudge_count": 0,
+        }
+        adapter = FakeAdapter(
+            SessionLifecycle.RUNNING,
+            idle_indicator_regex=re.compile(r"Running tool"),
+        )
+
+        assert not _is_stale_frozen_eligible(
+            row,
+            previous_pane_hash=pane_hash,
+            current_pane_hash=pane_hash,
+            pane_text=pane_text,
+            adapter=adapter,
+            hang_idle_ticks=3,
+            hang_stale_seconds=300,
+            now=now,
+        )
+
+    def test_not_eligible_when_output_is_fresh(self):
+        now = time.time()
+        pane_text = "unchanged but recent"
+        pane_hash = _pane_hash(pane_text)
+        row = {
+            "idle_ticks": 3,
+            "last_output_ts": now - 30,
+            "nudge_count": 0,
+        }
+
+        assert not _is_stale_frozen_eligible(
+            row,
+            previous_pane_hash=pane_hash,
+            current_pane_hash=pane_hash,
+            pane_text=pane_text,
+            adapter=FakeAdapter(SessionLifecycle.RUNNING),
+            hang_idle_ticks=3,
+            hang_stale_seconds=300,
+            now=now,
+        )
+
+    def test_not_eligible_without_last_output_timestamp(self):
+        now = time.time()
+        pane_text = "unchanged but undated"
+        pane_hash = _pane_hash(pane_text)
+        row = {
+            "idle_ticks": 3,
+            "nudge_count": 0,
+        }
+
+        assert not _is_stale_frozen_eligible(
+            row,
+            previous_pane_hash=pane_hash,
+            current_pane_hash=pane_hash,
+            pane_text=pane_text,
+            adapter=FakeAdapter(SessionLifecycle.RUNNING),
+            hang_idle_ticks=3,
+            hang_stale_seconds=300,
+            now=now,
+        )
+
+    def test_tick_does_not_fire_stale_actions_without_last_output_timestamp(
+        self, registry, db_path
+    ):
+        task_id = "t-stale-no-output-ts"
+        pane_text = "unchanged but no timestamp"
+        _seed_row(registry, task_id=task_id, state="RUNNING")
+        registry.upsert(
+            task_id,
+            agent="fake",
+            run_id=f"run-{uuid.uuid4().hex[:8]}",
+            repo=f"repo-{uuid.uuid4().hex[:8]}",
+            last_pane_hash=_pane_hash(pane_text),
+            idle_ticks=3,
+            nudge_count=0,
+        )
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        watcher = _make_watcher(registry, adapter, FakeCapture(pane_text))
+        notifications: List[str] = []
+        nudges: List[str] = []
+
+        with (
+            patch(
+                "session_orchestration.config.load_session_orchestration_config",
+                return_value=type(
+                    "Cfg",
+                    (),
+                    {"hang_idle_ticks": 3, "hang_stale_seconds": 300},
+                )(),
+            ),
+            patch(
+                "session_orchestration.feed.push_hang_notification",
+                side_effect=lambda tid, *_a, **_kw: notifications.append(tid),
+            ),
+            patch(
+                "session_orchestration.watcher._send_auto_nudge",
+                side_effect=lambda tid, *_a, **_kw: nudges.append(tid),
+            ),
+        ):
+            watcher.tick()
+
+        row = registry.get(task_id)
+        assert row is not None
+        assert row["nudge_count"] == 0
+        assert notifications == []
+        assert nudges == []
+
+    def test_not_eligible_when_pane_hash_changed(self):
+        now = time.time()
+        row = {
+            "idle_ticks": 3,
+            "last_output_ts": now - 301,
+            "nudge_count": 0,
+        }
+
+        assert not _is_stale_frozen_eligible(
+            row,
+            previous_pane_hash=_pane_hash("old output"),
+            current_pane_hash=_pane_hash("new output"),
+            pane_text="new output",
+            adapter=FakeAdapter(SessionLifecycle.RUNNING),
+            hang_idle_ticks=3,
+            hang_stale_seconds=300,
+            now=now,
+        )
+
+    def test_omp_action_not_eligible_when_episode_already_nudged(self):
+        now = time.time()
+        pane_text = "unchanged pane output"
+        pane_hash = _pane_hash(pane_text)
+        row = {
+            "idle_ticks": 3,
+            "last_output_ts": now - 301,
+            "nudge_count": 1,
+        }
+
+        assert _is_stale_frozen_eligible(
+            row,
+            previous_pane_hash=pane_hash,
+            current_pane_hash=pane_hash,
+            pane_text=pane_text,
+            adapter=FakeAdapter(SessionLifecycle.RUNNING),
+            hang_idle_ticks=3,
+            hang_stale_seconds=300,
+            now=now,
+        )
+        assert not _is_omp_nudge_checkin_eligible(
+            row,
+            previous_pane_hash=pane_hash,
+            current_pane_hash=pane_hash,
+            pane_text=pane_text,
+            adapter=FakeAdapter(SessionLifecycle.RUNNING),
+            hang_idle_ticks=3,
+            hang_stale_seconds=300,
+            now=now,
+        )
+
+    def test_on_hang_skips_actions_but_reconciles_when_episode_already_nudged(
+        self, registry
+    ):
+        now = time.time()
+        pane_text = "unchanged pane output"
+        pane_hash = _pane_hash(pane_text)
+        row = {
+            "task_id": "t-stale-already-nudged",
+            "agent": "fake",
+            "state": "RUNNING",
+            "idle_ticks": 3,
+            "last_output_ts": now - 301,
+            "last_pane_hash": pane_hash,
+            "nudge_count": 1,
+        }
+        notifications: List[str] = []
+        nudges: List[str] = []
+
+        with (
+            patch(
+                "session_orchestration.feed.push_hang_notification",
+                side_effect=lambda tid, *_a, **_kw: notifications.append(tid),
+            ),
+            patch(
+                "session_orchestration.watcher._send_auto_nudge",
+                side_effect=lambda tid, *_a, **_kw: nudges.append(tid),
+            ),
+            patch(
+                "session_orchestration.feed.reconcile_attention_digest",
+                return_value={"status": "unchanged"},
+            ) as reconcile_digest,
+        ):
+            _on_hang(
+                "t-stale-already-nudged",
+                row,
+                registry=registry,
+                adapter=FakeAdapter(SessionLifecycle.RUNNING),
+                pane_text=pane_text,
+                previous_pane_hash=pane_hash,
+                current_pane_hash=pane_hash,
+            )
+
+        assert notifications == []
+        assert nudges == []
+        reconcile_digest.assert_called_once_with(registry)

--- a/tests/test_session_orchestration_watcher.py
+++ b/tests/test_session_orchestration_watcher.py
@@ -23,6 +23,7 @@ All tests use:
 
 from __future__ import annotations
 
+import json
 import re
 import time
 import uuid
@@ -205,6 +206,152 @@ class TestTickWritesState:
         row = registry.get(task_id)
         assert row is not None
         assert row["state"] == "WAITING_USER"
+
+    def test_menu_question_and_options_persisted_from_pane(self, registry, db_path):
+        """omp emits no markers: the watcher parses the pane and persists the
+        question, ordered options, and last_input_kind='menu' on WAITING_USER."""
+        task_id = "t-menu-001"
+        _seed_row(registry, task_id=task_id, state="RUNNING")
+
+        menu_pane = (
+            " Apply the proposed edit?\n"
+            "────────────────────────────\n"
+            "│ Accept (Recommended)     │\n"
+            "│    Apply it now.         │\n"
+            "│ Defer                    │\n"
+            "────────────────────────────\n"
+            " up/down navigate  enter select  esc cancel"
+        )
+        adapter = FakeAdapter(SessionLifecycle.WAITING_USER)
+        capture = FakeCapture(menu_pane)
+        watcher = _make_watcher(registry, adapter, capture)
+
+        with (
+            patch(
+                "session_orchestration.feed.reconcile_attention_digest",
+                return_value={"status": "posted"},
+            ),
+            patch("session_orchestration.feed.push_turn_change", return_value=False),
+        ):
+            watcher.tick()
+
+        row = registry.get(task_id)
+        assert row["state"] == "WAITING_USER"
+        assert row["last_input_kind"] == "menu"
+        assert json.loads(row["last_options"]) == ["Accept (Recommended)", "Defer"]
+        assert "Apply the proposed edit?" in (row["last_question"] or "")
+
+    def test_input_kind_cleared_when_leaving_waiting(self, registry, db_path):
+        """A stale 'menu' marker must not survive the return to RUNNING."""
+        task_id = "t-menu-002"
+        _seed_row(registry, task_id=task_id, state="WAITING_USER")
+        registry.upsert(task_id, agent="fake", last_input_kind="menu",
+                        last_options=json.dumps(["A", "B"]))
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture("⠹ working…")
+        watcher = _make_watcher(registry, adapter, capture)
+        with patch("session_orchestration.feed.push_turn_change", return_value=False):
+            watcher.tick()
+
+        row = registry.get(task_id)
+        assert row["state"] == "RUNNING"
+        assert row["last_input_kind"] == ""
+
+    def test_session_end_while_waiting_reaps_attention_and_pings(
+        self, registry, db_path
+    ):
+        """A session that ends (DONE) while WAITING_USER must resolve its
+        attention item (drops from the feed digest) and clear the ping
+        debounce so no further @-pings fire."""
+        import session_orchestration.feed as feed_mod
+
+        task_id = "t-reap-end"
+        _seed_row(registry, task_id=task_id, state="WAITING_USER")
+        registry.open_attention_item(task_id, "WAITING_USER", priority=100)
+        feed_mod._last_notified[task_id] = "WAITING_USER"
+
+        # Attention item is open before the tick.
+        assert any(
+            it["reason"] == "WAITING_USER"
+            for it in registry.list_unresolved_attention_items()
+        )
+
+        adapter = FakeAdapter(SessionLifecycle.DONE)
+        watcher = _make_watcher(registry, adapter, FakeCapture("done."))
+        with patch(
+            "session_orchestration.feed.reconcile_attention_digest",
+            return_value={"status": "edited"},
+        ):
+            watcher.tick()
+
+        # Attention item resolved → falls out of the digest.
+        assert not [
+            it
+            for it in registry.list_unresolved_attention_items()
+            if it["reason"] == "WAITING_USER"
+        ]
+        # Ping debounce cleared → no lingering @-ping state.
+        assert task_id not in feed_mod._last_notified
+
+    def test_terminate_intent_reaps_attention_and_marks_terminal(
+        self, registry, db_path
+    ):
+        """A terminate intent (thread archived/closed) kills the session AND
+        reaps its attention item + feed line + ping debounce, even though the
+        now-terminal row is never re-iterated by the active loop."""
+        import session_orchestration.feed as feed_mod
+
+        task_id = "t-archive-term"
+        _seed_row(registry, task_id=task_id, state="WAITING_USER")
+        registry.open_attention_item(task_id, "WAITING_USER", priority=100)
+        feed_mod._last_notified[task_id] = "WAITING_USER"
+        registry.enqueue_terminate(task_id)
+
+        adapter = FakeAdapter(SessionLifecycle.WAITING_USER)
+        watcher = _make_watcher(registry, adapter, FakeCapture("menu…"))
+        with patch(
+            "session_orchestration.feed.reconcile_attention_digest",
+            return_value={"status": "edited"},
+        ):
+            watcher.tick()
+
+        row = registry.get(task_id)
+        assert row["state"] in ("DONE", "ERROR"), "session marked terminal"
+        assert not registry.list_unresolved_attention_items(), "attention reaped"
+        assert task_id not in feed_mod._last_notified, "ping debounce cleared"
+
+    def test_omp_stable_idle_promotes_running_to_waiting_user(self, registry, db_path):
+        """omp free-form wait: a detect()=RUNNING pane that idle_waiting() flags
+        is promoted to WAITING_USER only after it is STABLE across a tick (guards
+        against flapping). First tick stays RUNNING (no prior hash); second tick
+        with an identical pane promotes."""
+        class IdleAdapter(FakeAdapter):
+            def idle_waiting(self, pane_text):  # opt-in signal, always idle here
+                return True
+
+        task_id = "t-idle-omp"
+        _seed_row(registry, task_id=task_id, state="RUNNING")
+        adapter = IdleAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture(" What do you want me to do?\n╭── omp ──╮\n╰─  ─╯")
+        watcher = _make_watcher(registry, adapter, capture)
+
+        with (
+            patch("session_orchestration.feed.push_turn_change", return_value=False),
+            patch(
+                "session_orchestration.feed.reconcile_attention_digest",
+                return_value={"status": "posted"},
+            ),
+        ):
+            watcher.tick()
+            row_after_1 = registry.get(task_id)
+            watcher.tick()
+            row_after_2 = registry.get(task_id)
+
+        assert row_after_1["state"] == "RUNNING", "1st tick: not yet stable"
+        assert row_after_2["state"] == "WAITING_USER", "2nd tick: stable idle → waiting"
+        assert row_after_2["last_input_kind"] == "prompt"
+        assert "What do you want me to do?" in (row_after_2["last_question"] or "")
 
     def test_no_spurious_notification_on_same_state(self, registry, db_path):
         """Tick must NOT raise or produce side-effects when state unchanged."""

--- a/tests/test_session_orchestration_watcher.py
+++ b/tests/test_session_orchestration_watcher.py
@@ -1162,3 +1162,236 @@ class TestHangEscalation:
         assert error_upserts == [], (
             "state must NOT be set to ERROR on the first hang rung (nudge_count=0)"
         )
+
+
+# ---------------------------------------------------------------------------
+# T011 — terminate adapter helper + done-marker turn-change + last_question
+# ---------------------------------------------------------------------------
+
+
+class FakeAdapterWithTerminate(FakeAdapter):
+    """FakeAdapter that records terminate() calls instead of raising."""
+
+    def __init__(self, lifecycle: SessionLifecycle = SessionLifecycle.RUNNING):
+        super().__init__(lifecycle)
+        self.terminate_calls: List[SessionHandle] = []
+
+    def terminate(self, handle: SessionHandle) -> None:
+        self.terminate_calls.append(handle)
+
+
+class TestHandleTerminateAdapter:
+    """_handle_terminate_adapter calls adapter.terminate() and optionally re-spawns."""
+
+    def _make_registry_with_row(self, db_path: Path, task_id: str = "task-t011-001"):
+        reg = SessionOrchestrationRegistry(db_path=db_path)
+        reg.upsert(
+            task_id,
+            agent="fake",
+            run_id=f"run-{uuid.uuid4().hex[:8]}",
+            repo=f"repo-{uuid.uuid4().hex[:8]}",
+            state="DONE",  # already marked terminal by _apply_intent
+            tmux_session="hermes-fake-t011",
+            workdir="/tmp/fake-workdir",
+        )
+        return reg
+
+    def test_handle_terminate_adapter_calls_adapter_terminate(self, db_path):
+        """_handle_terminate_adapter must call adapter.terminate(handle)."""
+        from session_orchestration.watcher import _handle_terminate_adapter
+
+        task_id = "task-t011-001"
+        reg = self._make_registry_with_row(db_path, task_id)
+        adapter = FakeAdapterWithTerminate(SessionLifecycle.RUNNING)
+        adapter_map = {"fake": adapter}
+
+        intent = {
+            "intent": "terminate",
+            "task_id": task_id,
+            "payload": json.dumps({"restart": False}),
+        }
+        _handle_terminate_adapter(intent, reg, adapter_map)
+
+        assert len(adapter.terminate_calls) == 1, (
+            "adapter.terminate() must be called exactly once"
+        )
+
+    def test_handle_terminate_adapter_restart_calls_spawn(self, db_path):
+        """With restart=True, _handle_terminate_adapter must call _spawn_fn."""
+        from session_orchestration.watcher import _handle_terminate_adapter
+
+        task_id = "task-t011-002"
+        reg = self._make_registry_with_row(db_path, task_id)
+        reg.upsert(
+            task_id,
+            agent="fake",
+            run_id=None,
+            repo=None,
+            source="spawn",
+            state="ERROR",  # restart path marks ERROR
+        )
+        adapter = FakeAdapterWithTerminate(SessionLifecycle.RUNNING)
+        adapter_map = {"fake": adapter}
+
+        spawn_calls: List = []
+
+        def fake_spawn(request):
+            spawn_calls.append(request)
+
+        intent = {
+            "intent": "terminate",
+            "task_id": task_id,
+            "payload": json.dumps({"restart": True}),
+        }
+        _handle_terminate_adapter(intent, reg, adapter_map, _spawn_fn=fake_spawn)
+
+        assert len(spawn_calls) == 1, "spawn_fn must be called exactly once on restart=True"
+        req = spawn_calls[0]
+        # Restart uses placeholder prompt because original is not persisted
+        assert req.prompt == "continue", (
+            f"restart must use placeholder prompt 'continue', got {req.prompt!r}"
+        )
+        assert req.agent == "fake", f"agent must be preserved, got {req.agent!r}"
+
+    def test_handle_terminate_adapter_no_restart_no_spawn(self, db_path):
+        """With restart=False, _handle_terminate_adapter must NOT call _spawn_fn."""
+        from session_orchestration.watcher import _handle_terminate_adapter
+
+        task_id = "task-t011-003"
+        reg = self._make_registry_with_row(db_path, task_id)
+        adapter = FakeAdapterWithTerminate(SessionLifecycle.RUNNING)
+
+        spawn_calls: List = []
+
+        intent = {
+            "intent": "terminate",
+            "task_id": task_id,
+            "payload": json.dumps({"restart": False}),
+        }
+        _handle_terminate_adapter(
+            intent, reg, {"fake": adapter}, _spawn_fn=lambda r: spawn_calls.append(r)
+        )
+
+        assert spawn_calls == [], "spawn_fn must NOT be called when restart=False"
+
+
+class TestDoneMarkerFiresTurnChange:
+    """A recent done marker transitions state to DONE and fires _on_turn_change."""
+
+    def test_done_marker_fires_on_turn_change(self, registry, tmp_path, monkeypatch):
+        """RUNNING -> DONE transition (via done marker) calls _on_turn_change."""
+        task_id = "t-done-tc-001"
+        workdir = str(tmp_path)
+        _seed_row_with_workdir(registry, task_id, workdir, state="RUNNING")
+
+        marker_file = tmp_path / ".hermes" / "sessions" / f"{task_id}.jsonl"
+        marker_file.parent.mkdir(parents=True, exist_ok=True)
+        append_marker(
+            str(marker_file),
+            "done",
+            {"summary": "task finished"},
+            task=task_id,
+        )
+
+        turn_change_calls: List = []
+        monkeypatch.setattr(
+            "session_orchestration.watcher._on_turn_change",
+            lambda tid, row, new_s, old_s: turn_change_calls.append(
+                (tid, new_s, old_s)
+            ),
+        )
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture("pane output")
+        watcher = _make_watcher(registry, adapter, capture)
+        watcher.tick()
+
+        row = registry.get(task_id)
+        assert row is not None
+        assert row["state"] == "DONE", f"expected DONE, got {row['state']!r}"
+
+        # _on_turn_change must have fired for the DONE transition
+        done_transitions = [c for c in turn_change_calls if c[1] == "DONE"]
+        assert done_transitions, (
+            "_on_turn_change must be called for the RUNNING -> DONE transition"
+        )
+        tid_called, new_s, old_s = done_transitions[0]
+        assert tid_called == task_id
+        assert old_s == "RUNNING"
+
+    def test_done_row_excluded_from_active_rows_next_tick(self, registry, tmp_path):
+        """After transitioning to DONE, the row is in _TERMINAL_STATES and
+        not re-processed on the next tick."""
+        task_id = "t-done-excl-001"
+        workdir = str(tmp_path)
+        _seed_row_with_workdir(registry, task_id, workdir, state="RUNNING")
+
+        marker_file = tmp_path / ".hermes" / "sessions" / f"{task_id}.jsonl"
+        marker_file.parent.mkdir(parents=True, exist_ok=True)
+        append_marker(str(marker_file), "done", {"summary": "all done"}, task=task_id)
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture()
+        watcher = _make_watcher(registry, adapter, capture)
+
+        # First tick: processes the row and marks DONE
+        n1 = watcher.tick()
+        assert registry.get(task_id)["state"] == "DONE"
+
+        # Second tick: DONE row must NOT be re-processed (terminal state)
+        n2 = watcher.tick()
+        assert n2 == 0, f"DONE row must not be processed on next tick, got n2={n2}"
+
+
+class TestNeedsInputMarkerStoresLastQuestion:
+    """A needs_input marker stores its question in the last_question column."""
+
+    def test_needs_input_marker_stores_last_question(self, registry, tmp_path):
+        """A recent needs_input marker must store payload.question in last_question."""
+        task_id = "t-ni-lq-001"
+        workdir = str(tmp_path)
+        _seed_row_with_workdir(registry, task_id, workdir, state="RUNNING")
+
+        marker_file = tmp_path / ".hermes" / "sessions" / f"{task_id}.jsonl"
+        marker_file.parent.mkdir(parents=True, exist_ok=True)
+        append_marker(
+            str(marker_file),
+            "needs_input",
+            {"question": "What next?", "options": ["A", "B"]},
+            task=task_id,
+        )
+
+        adapter = FakeAdapter(SessionLifecycle.WAITING_USER)
+        capture = FakeCapture("❯ ")
+        watcher = _make_watcher(registry, adapter, capture)
+        watcher.tick()
+
+        row = registry.get(task_id)
+        assert row is not None
+        assert row.get("last_question") == "What next?", (
+            f"expected last_question='What next?', got {row.get('last_question')!r}"
+        )
+
+    def test_no_needs_input_marker_last_question_unchanged(self, registry, tmp_path):
+        """When no needs_input marker is present, last_question is not written."""
+        task_id = "t-ni-lq-002"
+        workdir = str(tmp_path)
+        _seed_row_with_workdir(registry, task_id, workdir, state="RUNNING")
+
+        # Write a heartbeat marker (not needs_input)
+        marker_file = tmp_path / ".hermes" / "sessions" / f"{task_id}.jsonl"
+        marker_file.parent.mkdir(parents=True, exist_ok=True)
+        append_marker(str(marker_file), "heartbeat", {}, task=task_id)
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture("working…")
+        watcher = _make_watcher(registry, adapter, capture)
+        watcher.tick()
+
+        row = registry.get(task_id)
+        assert row is not None
+        # last_question must remain None (not written from a heartbeat marker)
+        assert row.get("last_question") is None, (
+            f"last_question must be None when no needs_input marker present, "
+            f"got {row.get('last_question')!r}"
+        )

--- a/tests/test_session_orchestration_watcher.py
+++ b/tests/test_session_orchestration_watcher.py
@@ -30,7 +30,8 @@ import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, List
+import os
+from typing import Dict, List, Optional
 from unittest.mock import MagicMock
 
 import pytest
@@ -135,12 +136,20 @@ def _make_watcher(
     capture: FakeCapture,
     *,
     adapter_name: str = "fake",
+    tmux_liveness_fn=None,
 ) -> SessionWatcher:
-    """Build a SessionWatcher with injected fakes."""
+    """Build a SessionWatcher with injected fakes.
+
+    ``tmux_liveness_fn`` defaults to a stub that returns True (pane alive) so
+    that existing tests that don't exercise dead-tmux reaping are not affected.
+    Tests that want to exercise reap must pass an explicit ``tmux_liveness_fn``
+    (see ``_make_watcher_with_liveness`` below and ``TestDeadTmuxReap``).
+    """
     watcher = SessionWatcher(
         registry=registry,
         adapters={adapter_name: adapter},
         tmux_capture=capture,
+        tmux_liveness_fn=tmux_liveness_fn if tmux_liveness_fn is not None else (lambda _s: True),
     )
     # Inject probe fakes so no real binaries are touched
     probe_runner = FakeProbeRunner()
@@ -1296,7 +1305,7 @@ class TestDoneMarkerFiresTurnChange:
         turn_change_calls: List = []
         monkeypatch.setattr(
             "session_orchestration.watcher._on_turn_change",
-            lambda tid, row, new_s, old_s: turn_change_calls.append(
+            lambda tid, row, new_s, old_s, **kw: turn_change_calls.append(
                 (tid, new_s, old_s)
             ),
         )
@@ -1475,7 +1484,7 @@ class TestProcessRowRunningTransition:
         turn_change_calls: List = []
         monkeypatch.setattr(
             "session_orchestration.watcher._on_turn_change",
-            lambda tid, row, new_s, old_s: turn_change_calls.append(
+            lambda tid, row, new_s, old_s, **kw: turn_change_calls.append(
                 (tid, new_s, old_s)
             ),
         )
@@ -1505,7 +1514,7 @@ class TestProcessRowRunningTransition:
         turn_change_calls: List = []
         monkeypatch.setattr(
             "session_orchestration.watcher._on_turn_change",
-            lambda tid, row, new_s, old_s: turn_change_calls.append(
+            lambda tid, row, new_s, old_s, **kw: turn_change_calls.append(
                 (tid, new_s, old_s)
             ),
         )
@@ -1549,7 +1558,7 @@ class TestProcessRowRunningTransition:
         turn_change_calls: List = []
         monkeypatch.setattr(
             "session_orchestration.watcher._on_turn_change",
-            lambda tid, row, new_s, old_s: turn_change_calls.append(
+            lambda tid, row, new_s, old_s, **kw: turn_change_calls.append(
                 (tid, new_s, old_s)
             ),
         )
@@ -1566,4 +1575,252 @@ class TestProcessRowRunningTransition:
         ]
         assert running_from_stalled == [], (
             "_on_turn_change must NOT fire for STALLED -> RUNNING (not from attention state)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Dead-tmux reap tests (T-FEED-001)
+# ---------------------------------------------------------------------------
+
+
+def _make_watcher_with_liveness(
+    registry: SessionOrchestrationRegistry,
+    adapter: FakeAdapter,
+    capture: FakeCapture,
+    liveness_fn,
+    *,
+    adapter_name: str = "fake",
+) -> SessionWatcher:
+    """Build a SessionWatcher with injected fakes including liveness function."""
+    watcher = SessionWatcher(
+        registry=registry,
+        adapters={adapter_name: adapter},
+        tmux_capture=capture,
+        tmux_liveness_fn=liveness_fn,
+    )
+    probe_runner = FakeProbeRunner()
+    probe_specs = {type(adapter).__name__: _fake_probe_spec(adapter)}
+    watcher.startup_verify(probe_runner=probe_runner, probe_specs=probe_specs)
+    return watcher
+
+
+class TestDeadTmuxReap:
+    """Dead-tmux reap: sessions whose tmux pane dies are marked terminal immediately.
+
+    (a) pane-gone + no done marker + no recent heartbeat -> ERROR + terminated_at set
+    (b) pane-gone + done marker present -> DONE
+    (c) recent heartbeat -> NOT reaped (session stays active)
+    (d) dead_tmux_reap=false -> NOT reaped
+    """
+
+    def _seed(
+        self,
+        registry: SessionOrchestrationRegistry,
+        task_id: str = "reap-001",
+        state: str = "RUNNING",
+        tmux_session: str = "hermes-reap-001",
+        workdir: Optional[str] = None,
+    ) -> None:
+        registry.upsert(
+            task_id,
+            agent="fake",
+            run_id=f"run-{uuid.uuid4().hex[:8]}",
+            repo=f"repo-{uuid.uuid4().hex[:8]}",
+            state=state,
+            tmux_session=tmux_session,
+            workdir=workdir,
+        )
+
+    def test_pane_gone_no_done_marker_yields_error(self, registry, db_path, tmp_path):
+        """(a) Pane gone + no done marker + no recent heartbeat -> ERROR + terminated_at."""
+        task_id = "reap-a-001"
+        tmux_session = "dead-session-a"
+        workdir = str(tmp_path)
+        self._seed(registry, task_id=task_id, tmux_session=tmux_session, workdir=workdir)
+
+        # Liveness check: pane is GONE
+        def dead(_s):
+            return False
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture("some text")
+        watcher = _make_watcher_with_liveness(registry, adapter, capture, dead)
+
+        processed = watcher.tick()
+
+        assert processed == 1
+        row = registry.get(task_id)
+        assert row is not None
+        assert row["state"] == "ERROR", (
+            "dead pane with no done marker should be marked ERROR"
+        )
+        assert row.get("terminated_at") is not None, (
+            "terminated_at must be stamped on dead-tmux reap"
+        )
+        assert isinstance(row["terminated_at"], float), (
+            "terminated_at must be a float epoch"
+        )
+
+    def test_pane_gone_with_done_marker_yields_done(self, registry, db_path, tmp_path):
+        """(b) Pane gone + done marker present -> DONE."""
+        task_id = "reap-b-001"
+        tmux_session = "dead-session-b"
+        workdir = str(tmp_path)
+        self._seed(registry, task_id=task_id, tmux_session=tmux_session, workdir=workdir)
+
+        # Write a 'done' marker so read_markers_since(offset=0) returns it
+        marker_file = f"{workdir}/.hermes/sessions/{task_id}.jsonl"
+        os.makedirs(f"{workdir}/.hermes/sessions", exist_ok=True)
+        append_marker(marker_file, "done", {}, task=task_id)
+
+        def dead(_s):
+            return False
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture()
+        watcher = _make_watcher_with_liveness(registry, adapter, capture, dead)
+
+        watcher.tick()
+
+        row = registry.get(task_id)
+        assert row is not None
+        assert row["state"] == "DONE", (
+            "dead pane + done marker should be marked DONE"
+        )
+
+    def test_recent_heartbeat_prevents_reap(self, registry, db_path, tmp_path):
+        """(c) Recent heartbeat marker -> NOT reaped (session allowed to continue)."""
+        task_id = "reap-c-001"
+        tmux_session = "alive-session-c"
+        workdir = str(tmp_path)
+        self._seed(registry, task_id=task_id, tmux_session=tmux_session, workdir=workdir)
+
+        # Write a recent heartbeat marker (within _MARKER_RECENCY_SECONDS)
+        marker_file = f"{workdir}/.hermes/sessions/{task_id}.jsonl"
+        os.makedirs(f"{workdir}/.hermes/sessions", exist_ok=True)
+        append_marker(marker_file, "heartbeat", {}, task=task_id)
+
+        # Liveness check says pane is DEAD — but heartbeat should prevent reap
+        def dead(_s):
+            return False
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture("alive pane output")
+        watcher = _make_watcher_with_liveness(registry, adapter, capture, dead)
+
+        watcher.tick()
+
+        row = registry.get(task_id)
+        assert row is not None
+        # State must NOT be a terminal state: the heartbeat guards against reap
+        assert row["state"] not in {"DONE", "ERROR"}, (
+            "recent heartbeat must prevent dead-tmux reap"
+        )
+        assert row.get("terminated_at") is None, (
+            "terminated_at must NOT be set when reap is suppressed by heartbeat"
+        )
+
+    def test_dead_tmux_reap_disabled_by_config(
+        self, registry, db_path, tmp_path, monkeypatch
+    ):
+        """(d) dead_tmux_reap=false -> NOT reaped even when pane is gone."""
+        import session_orchestration.watcher as _watcher_mod
+
+        # Patch _load_dead_tmux_reap_cfg to return False (knob disabled)
+        monkeypatch.setattr(_watcher_mod, "_load_dead_tmux_reap_cfg", lambda: False)
+
+        task_id = "reap-d-001"
+        tmux_session = "dead-session-d"
+        workdir = str(tmp_path)
+        self._seed(registry, task_id=task_id, tmux_session=tmux_session, workdir=workdir)
+
+        def dead(_s):
+            return False
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture("some output")
+        watcher = _make_watcher_with_liveness(registry, adapter, capture, dead)
+
+        watcher.tick()
+
+        row = registry.get(task_id)
+        assert row is not None
+        assert row["state"] not in {"DONE", "ERROR"}, (
+            "dead_tmux_reap=false must prevent reaping even when pane is gone"
+        )
+        assert row.get("terminated_at") is None
+
+
+# ---------------------------------------------------------------------------
+# GC gating in tick()
+# ---------------------------------------------------------------------------
+
+
+class TestTickGc:
+    """Watcher tick GC gate — gc_after_seconds config knob controls deletion."""
+
+    def _seed_terminal(
+        self,
+        registry: SessionOrchestrationRegistry,
+        *,
+        state: str,
+        terminated_at: float,
+    ) -> str:
+        tid = str(uuid.uuid4())
+        registry.upsert(
+            tid,
+            agent="fake",
+            run_id=f"run-{uuid.uuid4().hex[:8]}",
+            repo=f"repo-{uuid.uuid4().hex[:8]}",
+            state=state,
+            terminated_at=terminated_at,
+        )
+        return tid
+
+    def test_gc_deletes_old_terminal_row_during_tick(
+        self, registry, monkeypatch
+    ):
+        """(e-positive) An old terminal row is deleted when gc_after_seconds > 0."""
+        import session_orchestration.watcher as _watcher_mod
+
+        now = 1_000_000.0
+        gc_age = 3600
+        # terminated_at is 2 h ago — eligible
+        task_id = self._seed_terminal(
+            registry, state="DONE", terminated_at=now - 7200.0
+        )
+
+        # Patch config loader and time.time inside the module
+        monkeypatch.setattr(_watcher_mod, "_load_gc_after_seconds_cfg", lambda: gc_age)
+        monkeypatch.setattr(_watcher_mod.time, "time", lambda: now)
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture()
+        watcher = _make_watcher(registry, adapter, capture)
+        watcher.tick()
+
+        assert registry.get(task_id) is None, "old terminal row must be GC-ed during tick"
+
+    def test_gc_disabled_when_gc_after_seconds_zero(
+        self, registry, monkeypatch
+    ):
+        """(e) gc_after_seconds=0 disables GC — no rows deleted even if eligible."""
+        import session_orchestration.watcher as _watcher_mod
+
+        now = 1_000_000.0
+        task_id = self._seed_terminal(
+            registry, state="DONE", terminated_at=now - 999_999.0
+        )
+
+        # gc_after_seconds == 0 → GC disabled
+        monkeypatch.setattr(_watcher_mod, "_load_gc_after_seconds_cfg", lambda: 0)
+        monkeypatch.setattr(_watcher_mod.time, "time", lambda: now)
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture()
+        watcher = _make_watcher(registry, adapter, capture)
+        watcher.tick()
+
+        assert registry.get(task_id) is not None, (
+            "gc_after_seconds=0 must disable GC — row must be retained"
         )

--- a/tests/test_session_orchestration_watcher.py
+++ b/tests/test_session_orchestration_watcher.py
@@ -45,6 +45,7 @@ from session_orchestration.registry import SessionOrchestrationRegistry
 from session_orchestration.types import Capabilities, SessionHandle, SessionLifecycle
 from session_orchestration.watcher import (
     SessionWatcher,
+    _on_hang,
     _parse_marker_ts,
     _pane_hash,
     run_tick,
@@ -1008,4 +1009,156 @@ class TestHandoffMarkers:
         )
         assert resume_idx < release_idx, (
             "adapter.resume() must precede release_lock — lock-contract violation"
+        )
+
+
+class TestHangEscalation:
+    """T010: hang ladder final rungs — DM user and mark ERROR on escalation."""
+
+    # --- shared fake registry ---
+
+    class _FakeRegistryForHang:
+        """Records upsert calls; increment_counter is a no-op."""
+
+        def __init__(self) -> None:
+            self.upsert_calls: List[tuple] = []  # (task_id, kwargs)
+
+        def upsert(self, task_id: str, **kwargs) -> None:
+            self.upsert_calls.append((task_id, kwargs))
+
+        def increment_counter(self, task_id: str, counter: str, *, by: int = 1) -> None:
+            pass  # no-op; nudge_count increment is not the focus here
+
+    def _make_hang_row(
+        self,
+        task_id: str,
+        *,
+        nudge_count: int = 1,
+        discord_user_id: str | None = None,
+        idle_ticks: int = 5,
+        elapsed_seconds: float = 400.0,
+    ) -> dict:
+        """Build a minimal row dict that passes _on_hang's idle+stale thresholds."""
+        row: dict = {
+            "task_id": task_id,
+            "agent": "fake",
+            "run_id": "run-test",
+            "repo": "repo-test",
+            "source": "spawn",
+            "nudge_count": nudge_count,
+            "idle_ticks": idle_ticks,
+            "last_output_ts": time.time() - elapsed_seconds,
+        }
+        if discord_user_id is not None:
+            row["discord_user_id"] = discord_user_id
+        return row
+
+    def test_hang_escalation_sends_dm_and_marks_error(self, monkeypatch):
+        """nudge_count=1, discord_user_id set -> send_dm called + state ERROR."""
+        task_id = "t-hang-esc-dm-001"
+        row = self._make_hang_row(task_id, nudge_count=1, discord_user_id="user-esc-001")
+
+        fake_reg = self._FakeRegistryForHang()
+        dm_calls: List = []
+
+        monkeypatch.setattr(
+            "tools.discord_tool._get_bot_token",
+            lambda: "fake-token",
+        )
+        monkeypatch.setattr(
+            "session_orchestration.dm_transport.send_dm",
+            lambda user_id, message, token, **kw: dm_calls.append(
+                (user_id, message, token)
+            ),
+        )
+        # Suppress push_hang_notification network call
+        monkeypatch.setattr(
+            "session_orchestration.feed.push_hang_notification",
+            lambda *a, **kw: None,
+        )
+
+        _on_hang(task_id, row, registry=fake_reg)
+
+        assert len(dm_calls) == 1, "send_dm must be called exactly once on escalation"
+        user_id_sent, message, token = dm_calls[0]
+        assert user_id_sent == "user-esc-001"
+        assert task_id in message, "DM message must include the task_id"
+        assert token == "fake-token"
+
+        error_upserts = [
+            (tid, kw)
+            for tid, kw in fake_reg.upsert_calls
+            if kw.get("state") == "ERROR"
+        ]
+        assert len(error_upserts) == 1, "registry.upsert must set state=ERROR"
+        assert error_upserts[0][0] == task_id
+
+    def test_hang_escalation_marks_error_even_when_no_user_id(self, monkeypatch):
+        """nudge_count=1, no discord_user_id -> no DM but state still ERROR."""
+        task_id = "t-hang-esc-nouid-001"
+        row = self._make_hang_row(task_id, nudge_count=1, discord_user_id=None)
+
+        fake_reg = self._FakeRegistryForHang()
+        dm_calls: List = []
+
+        monkeypatch.setattr(
+            "session_orchestration.dm_transport.send_dm",
+            lambda *a, **kw: dm_calls.append(a),
+        )
+        monkeypatch.setattr(
+            "session_orchestration.feed.push_hang_notification",
+            lambda *a, **kw: None,
+        )
+
+        _on_hang(task_id, row, registry=fake_reg)
+
+        assert dm_calls == [], "send_dm must NOT be called when discord_user_id is absent"
+
+        error_upserts = [
+            (tid, kw)
+            for tid, kw in fake_reg.upsert_calls
+            if kw.get("state") == "ERROR"
+        ]
+        assert len(error_upserts) == 1, (
+            "registry.upsert must still mark ERROR even without a discord_user_id"
+        )
+        assert error_upserts[0][0] == task_id
+
+    def test_hang_first_rung_no_dm_no_error(self, monkeypatch):
+        """nudge_count=0 -> first rung: no DM and state NOT marked ERROR."""
+        task_id = "t-hang-first-rung-001"
+        row = self._make_hang_row(task_id, nudge_count=0, discord_user_id="user-first")
+
+        fake_reg = self._FakeRegistryForHang()
+        dm_calls: List = []
+
+        monkeypatch.setattr(
+            "tools.discord_tool._get_bot_token",
+            lambda: "fake-token",
+        )
+        monkeypatch.setattr(
+            "session_orchestration.dm_transport.send_dm",
+            lambda *a, **kw: dm_calls.append(a),
+        )
+        monkeypatch.setattr(
+            "session_orchestration.feed.push_hang_notification",
+            lambda *a, **kw: None,
+        )
+        # Suppress _send_auto_nudge's relay import so it fails non-fatally
+        monkeypatch.setattr(
+            "session_orchestration.watcher._send_auto_nudge",
+            lambda *a, **kw: None,
+        )
+
+        _on_hang(task_id, row, registry=fake_reg)
+
+        assert dm_calls == [], "send_dm must NOT be called on the first hang rung"
+
+        error_upserts = [
+            (tid, kw)
+            for tid, kw in fake_reg.upsert_calls
+            if kw.get("state") == "ERROR"
+        ]
+        assert error_upserts == [], (
+            "state must NOT be set to ERROR on the first hang rung (nudge_count=0)"
         )

--- a/tests/test_session_orchestration_watcher.py
+++ b/tests/test_session_orchestration_watcher.py
@@ -67,6 +67,9 @@ class FakeAdapter(AgentAdapter):
         self.detect_calls.append(handle)
         return self._lifecycle
 
+    def terminate(self, handle: SessionHandle) -> None:
+        raise NotImplementedError
+
     def resume(self, handle: SessionHandle, prompt: str) -> None:
         raise NotImplementedError
 

--- a/tests/test_session_orchestration_watcher.py
+++ b/tests/test_session_orchestration_watcher.py
@@ -1395,3 +1395,175 @@ class TestNeedsInputMarkerStoresLastQuestion:
             f"last_question must be None when no needs_input marker present, "
             f"got {row.get('last_question')!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# T013 — recommended_next_tick_interval + RUNNING transition gate
+# ---------------------------------------------------------------------------
+
+
+class TestRecommendedNextTickInterval:
+    """SessionWatcher.recommended_next_tick_interval() returns fast/idle cadence."""
+
+    def test_fast_when_running_row_present(self, registry, db_path):
+        """Registry has a RUNNING row -> interval == _FAST_TICK_SECONDS (30.0)."""
+        from session_orchestration.watcher import _FAST_TICK_SECONDS
+
+        _seed_row(registry, task_id="t-tick-run-001", state="RUNNING")
+        adapter = FakeAdapter()
+        capture = FakeCapture()
+        watcher = _make_watcher(registry, adapter, capture)
+
+        interval = watcher.recommended_next_tick_interval()
+        assert interval == _FAST_TICK_SECONDS, (
+            f"expected _FAST_TICK_SECONDS={_FAST_TICK_SECONDS}, got {interval}"
+        )
+
+    def test_fast_when_waiting_user_row_present(self, registry, db_path):
+        """Registry has a WAITING_USER row -> interval == _FAST_TICK_SECONDS (30.0)."""
+        from session_orchestration.watcher import _FAST_TICK_SECONDS
+
+        _seed_row(registry, task_id="t-tick-wu-001", state="WAITING_USER")
+        adapter = FakeAdapter()
+        capture = FakeCapture()
+        watcher = _make_watcher(registry, adapter, capture)
+
+        interval = watcher.recommended_next_tick_interval()
+        assert interval == _FAST_TICK_SECONDS, (
+            f"expected _FAST_TICK_SECONDS={_FAST_TICK_SECONDS}, got {interval}"
+        )
+
+    def test_idle_when_no_active_rows(self, registry, db_path):
+        """Registry has only a DONE row -> interval == _IDLE_TICK_SECONDS (120.0)."""
+        from session_orchestration.watcher import _IDLE_TICK_SECONDS
+
+        _seed_row(registry, task_id="t-tick-done-001", state="DONE")
+        adapter = FakeAdapter()
+        capture = FakeCapture()
+        watcher = _make_watcher(registry, adapter, capture)
+
+        interval = watcher.recommended_next_tick_interval()
+        assert interval == _IDLE_TICK_SECONDS, (
+            f"expected _IDLE_TICK_SECONDS={_IDLE_TICK_SECONDS}, got {interval}"
+        )
+
+    def test_idle_when_registry_empty(self, registry, db_path):
+        """Empty registry -> interval == _IDLE_TICK_SECONDS."""
+        from session_orchestration.watcher import _IDLE_TICK_SECONDS
+
+        adapter = FakeAdapter()
+        capture = FakeCapture()
+        watcher = _make_watcher(registry, adapter, capture)
+
+        interval = watcher.recommended_next_tick_interval()
+        assert interval == _IDLE_TICK_SECONDS
+
+
+class TestProcessRowRunningTransition:
+    """T013 PART D: RUNNING is a notify state for attention->RUNNING transitions only."""
+
+    def test_waiting_user_to_running_fires_on_turn_change(
+        self, registry, tmp_path, monkeypatch
+    ):
+        """old_state=WAITING_USER, adapter returns RUNNING -> _on_turn_change fires."""
+        task_id = "t-run-trans-001"
+        workdir = str(tmp_path)
+        _seed_row_with_workdir(
+            registry, task_id, workdir, state="WAITING_USER"
+        )
+
+        turn_change_calls: List = []
+        monkeypatch.setattr(
+            "session_orchestration.watcher._on_turn_change",
+            lambda tid, row, new_s, old_s: turn_change_calls.append(
+                (tid, new_s, old_s)
+            ),
+        )
+
+        # Adapter returns RUNNING (simulates user replying, session back to RUNNING)
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture("❯ ")
+        watcher = _make_watcher(registry, adapter, capture)
+        watcher.tick()
+
+        running_transitions = [
+            c for c in turn_change_calls
+            if c[1] == "RUNNING" and c[2] == "WAITING_USER"
+        ]
+        assert running_transitions, (
+            "_on_turn_change must be called for WAITING_USER -> RUNNING transition"
+        )
+
+    def test_running_to_running_does_not_fire_on_turn_change(
+        self, registry, tmp_path, monkeypatch
+    ):
+        """Steady-state RUNNING tick must NOT fire _on_turn_change."""
+        task_id = "t-run-trans-002"
+        workdir = str(tmp_path)
+        _seed_row_with_workdir(registry, task_id, workdir, state="RUNNING")
+
+        turn_change_calls: List = []
+        monkeypatch.setattr(
+            "session_orchestration.watcher._on_turn_change",
+            lambda tid, row, new_s, old_s: turn_change_calls.append(
+                (tid, new_s, old_s)
+            ),
+        )
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture("working…")
+        watcher = _make_watcher(registry, adapter, capture)
+        watcher.tick()
+
+        running_running = [
+            c for c in turn_change_calls
+            if c[1] == "RUNNING" and c[2] == "RUNNING"
+        ]
+        assert running_running == [], (
+            "_on_turn_change must NOT fire for RUNNING -> RUNNING (no-op)"
+        )
+
+    def test_done_to_running_does_not_fire_on_turn_change(
+        self, registry, tmp_path, monkeypatch
+    ):
+        """DONE -> RUNNING (benign non-attention source) must NOT fire _on_turn_change."""
+        task_id = "t-run-trans-003"
+        workdir = str(tmp_path)
+        _seed_row_with_workdir(registry, task_id, workdir, state="DONE")
+
+        # Manually set DONE row as active for this test (override _ACTIVE_STATES filter)
+        # by writing a fresh RUNNING state directly so _process_row sees it as DONE->RUNNING
+        # Use a marker to force RUNNING lifecycle from a DONE-seeded row
+        # Actually, the row with state=DONE won't be in active_rows (it's terminal).
+        # To test the guard, we need a non-attention source state that IS active.
+        # Use STALLED (active but not attention) as old_state.
+        registry.upsert(
+            task_id,
+            agent="fake",
+            run_id="run-stalled",
+            repo="repo-test",
+            source="spawn",
+            state="STALLED",
+        )
+
+        turn_change_calls: List = []
+        monkeypatch.setattr(
+            "session_orchestration.watcher._on_turn_change",
+            lambda tid, row, new_s, old_s: turn_change_calls.append(
+                (tid, new_s, old_s)
+            ),
+        )
+
+        # Adapter returns RUNNING — STALLED -> RUNNING is benign (not from attention state)
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture("working…")
+        watcher = _make_watcher(registry, adapter, capture)
+        watcher.tick()
+
+        running_from_stalled = [
+            c for c in turn_change_calls
+            if c[1] == "RUNNING" and c[2] == "STALLED"
+        ]
+        assert running_from_stalled == [], (
+            "_on_turn_change must NOT fire for STALLED -> RUNNING (not from attention state)"
+        )

--- a/tests/test_session_orchestration_watcher.py
+++ b/tests/test_session_orchestration_watcher.py
@@ -35,11 +35,20 @@ from unittest.mock import MagicMock
 
 import pytest
 
+import json
+from datetime import timedelta
+
 from session_orchestration.adapters.base import AgentAdapter
 from session_orchestration.adapters.verify import AdapterProbeSpec
+from session_orchestration.markers import append_marker
 from session_orchestration.registry import SessionOrchestrationRegistry
 from session_orchestration.types import Capabilities, SessionHandle, SessionLifecycle
-from session_orchestration.watcher import SessionWatcher, _pane_hash, run_tick
+from session_orchestration.watcher import (
+    SessionWatcher,
+    _parse_marker_ts,
+    _pane_hash,
+    run_tick,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -480,3 +489,249 @@ class TestIdleTickIncrement:
         watcher.tick()
         row = registry.get(task_id)
         assert (row.get("idle_ticks") or 0) == 0
+
+
+# ---------------------------------------------------------------------------
+# Marker tailing tests (T008)
+# ---------------------------------------------------------------------------
+
+
+def _seed_row_with_workdir(
+    registry: SessionOrchestrationRegistry,
+    task_id: str,
+    workdir: str,
+    *,
+    agent: str = "fake",
+    state: str = "RUNNING",
+    tmux_session: str = "hermes-fake-marker",
+    **extra,
+) -> None:
+    """Insert a row that includes a workdir so the watcher can locate the
+    marker file at ``{workdir}/.hermes/sessions/{task_id}.jsonl``."""
+    registry.upsert(
+        task_id,
+        agent=agent,
+        run_id=f"run-{uuid.uuid4().hex[:8]}",
+        repo=f"repo-{uuid.uuid4().hex[:8]}",
+        state=state,
+        tmux_session=tmux_session,
+        workdir=workdir,
+        **extra,
+    )
+
+
+def _write_stale_marker(marker_file: Path, kind: str, task_id: str, age_seconds: int = 400) -> None:
+    """Write a marker line with a timestamp ``age_seconds`` in the past."""
+    stale_ts = (datetime.now(tz=timezone.utc) - timedelta(seconds=age_seconds)).isoformat()
+    line = json.dumps({"v": 1, "ts": stale_ts, "kind": kind, "task": task_id, "payload": {}})
+    marker_file.parent.mkdir(parents=True, exist_ok=True)
+    with marker_file.open("ab") as fh:
+        fh.write((line + "\n").encode())
+
+
+class TestMarkerTailing:
+    """Per-tick marker tailing: authoritative state + heartbeat hang-guard."""
+
+    def test_recent_marker_overrides_pane_state(self, registry, tmp_path):
+        """A recent marker's kind determines state; adapter.detect() is NOT called."""
+        task_id = "t-marker-recent-001"
+        workdir = str(tmp_path)
+        _seed_row_with_workdir(registry, task_id, workdir)
+
+        # Write a recent 'status' marker (maps to RUNNING)
+        marker_file = tmp_path / ".hermes" / "sessions" / f"{task_id}.jsonl"
+        marker_file.parent.mkdir(parents=True, exist_ok=True)
+        append_marker(str(marker_file), "status", {"phase": "running"}, task=task_id)
+
+        # Adapter would return WAITING_USER if called — marker must override it
+        adapter = FakeAdapter(SessionLifecycle.WAITING_USER)
+        capture = FakeCapture("pane output")
+        watcher = _make_watcher(registry, adapter, capture)
+
+        watcher.tick()
+
+        row = registry.get(task_id)
+        assert row is not None
+        assert row["state"] == "RUNNING", (
+            "status marker (->RUNNING) must override adapter WAITING_USER"
+        )
+        assert adapter.detect_calls == [], (
+            "adapter.detect() must NOT be called when a recent marker provides state"
+        )
+
+    def test_stale_marker_falls_back_to_pane(self, registry, tmp_path):
+        """A marker older than the recency window is ignored; pane detect() is used."""
+        task_id = "t-marker-stale-001"
+        workdir = str(tmp_path)
+        _seed_row_with_workdir(registry, task_id, workdir)
+
+        # Write a stale 'status' marker (400 s old — outside 300 s window)
+        marker_file = tmp_path / ".hermes" / "sessions" / f"{task_id}.jsonl"
+        _write_stale_marker(marker_file, "status", task_id, age_seconds=400)
+
+        # Adapter returns WAITING_USER (pane fallback should win)
+        adapter = FakeAdapter(SessionLifecycle.WAITING_USER)
+        capture = FakeCapture("pane output")
+        watcher = _make_watcher(registry, adapter, capture)
+
+        watcher.tick()
+
+        row = registry.get(task_id)
+        assert row is not None
+        assert row["state"] == "WAITING_USER", (
+            "stale marker must not override state; pane detect() should win"
+        )
+        assert len(adapter.detect_calls) == 1, (
+            "adapter.detect() must be called when all markers are stale"
+        )
+
+    def test_absent_marker_file_falls_back_to_pane(self, registry, tmp_path):
+        """When the marker file does not exist, pane detect() is the sole signal."""
+        task_id = "t-marker-absent-001"
+        workdir = str(tmp_path)
+        _seed_row_with_workdir(registry, task_id, workdir)
+        # No marker file created
+
+        adapter = FakeAdapter(SessionLifecycle.WAITING_USER)
+        capture = FakeCapture("pane output")
+        watcher = _make_watcher(registry, adapter, capture)
+
+        watcher.tick()
+
+        row = registry.get(task_id)
+        assert row is not None
+        assert row["state"] == "WAITING_USER"
+        assert len(adapter.detect_calls) == 1
+
+    def test_marker_offset_advances_across_ticks(self, registry, tmp_path):
+        """marker_offset in the registry advances after each tick so each tick
+        reads only NEW marker lines (never re-reads previously consumed lines)."""
+        task_id = "t-marker-offset-001"
+        workdir = str(tmp_path)
+        _seed_row_with_workdir(registry, task_id, workdir)
+
+        marker_file = tmp_path / ".hermes" / "sessions" / f"{task_id}.jsonl"
+        marker_file.parent.mkdir(parents=True, exist_ok=True)
+
+        # Write first marker and run tick 1
+        append_marker(str(marker_file), "status", {"phase": "running"}, task=task_id)
+        offset_after_first_marker = marker_file.stat().st_size
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture("pane text")
+        watcher = _make_watcher(registry, adapter, capture)
+        watcher.tick()
+
+        row_after_tick1 = registry.get(task_id)
+        assert row_after_tick1 is not None
+        assert row_after_tick1.get("marker_offset", 0) == offset_after_first_marker, (
+            "marker_offset must advance to end of first marker after tick 1"
+        )
+
+        # Write second marker and run tick 2
+        append_marker(str(marker_file), "heartbeat", {"note": None}, task=task_id)
+        offset_after_second_marker = marker_file.stat().st_size
+
+        watcher.tick()
+
+        row_after_tick2 = registry.get(task_id)
+        assert row_after_tick2 is not None
+        assert row_after_tick2.get("marker_offset", 0) == offset_after_second_marker, (
+            "marker_offset must advance to end of second marker after tick 2"
+        )
+        assert row_after_tick2["marker_offset"] > row_after_tick1["marker_offset"], (
+            "marker_offset must be strictly larger after tick 2 than tick 1"
+        )
+
+    def test_heartbeat_marker_suppresses_hang_guard(self, registry, tmp_path, monkeypatch):
+        """A recent heartbeat marker prevents _on_hang from firing even when pane
+        hash is unchanged past idle/stale thresholds."""
+        task_id = "t-hang-suppress-001"
+        workdir = str(tmp_path)
+        static_pane = "static pane text"
+        # Pre-set idle_ticks=5 and last_pane_hash matching the static pane text so
+        # the hang condition (idle_ticks > 0, pane unchanged) would normally fire.
+        _seed_row_with_workdir(
+            registry,
+            task_id,
+            workdir,
+            idle_ticks=5,
+            last_pane_hash=_pane_hash(static_pane),
+        )
+
+        # Write a recent heartbeat marker
+        marker_file = tmp_path / ".hermes" / "sessions" / f"{task_id}.jsonl"
+        marker_file.parent.mkdir(parents=True, exist_ok=True)
+        append_marker(str(marker_file), "heartbeat", {"note": None}, task=task_id)
+
+        hang_called = []
+        monkeypatch.setattr(
+            "session_orchestration.watcher._on_hang",
+            lambda *a, **kw: hang_called.append(True),
+        )
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture(static_pane)
+        watcher = _make_watcher(registry, adapter, capture)
+        watcher.tick()
+
+        assert hang_called == [], (
+            "_on_hang must NOT be called when a recent heartbeat marker exists"
+        )
+
+    def test_stale_heartbeat_does_not_suppress_hang_guard(self, registry, tmp_path, monkeypatch):
+        """A heartbeat marker older than the recency window must not suppress _on_hang."""
+        task_id = "t-hang-stale-001"
+        workdir = str(tmp_path)
+        static_pane = "static pane text stale"
+        _seed_row_with_workdir(
+            registry,
+            task_id,
+            workdir,
+            idle_ticks=5,
+            last_pane_hash=_pane_hash(static_pane),
+        )
+
+        # Write a stale heartbeat marker (400 s old — outside window)
+        marker_file = tmp_path / ".hermes" / "sessions" / f"{task_id}.jsonl"
+        _write_stale_marker(marker_file, "heartbeat", task_id, age_seconds=400)
+
+        hang_called = []
+        monkeypatch.setattr(
+            "session_orchestration.watcher._on_hang",
+            lambda *a, **kw: hang_called.append(True),
+        )
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture(static_pane)
+        watcher = _make_watcher(registry, adapter, capture)
+        watcher.tick()
+
+        assert hang_called == [True], (
+            "_on_hang must be called when the only heartbeat marker is stale"
+        )
+
+    def test_migrate_schema_idempotent(self, db_path):
+        """Creating two registry instances on the same DB must not raise.
+
+        The second creation triggers _migrate_schema on an already-migrated DB
+        (the marker_offset column already exists); the idempotent ALTER TABLE
+        must swallow the OperationalError silently.
+        """
+        reg1 = SessionOrchestrationRegistry(db_path=db_path)
+        reg2 = SessionOrchestrationRegistry(db_path=db_path)
+        # Explicitly calling _migrate_schema a third time must also be silent
+        reg2._migrate_schema()
+        # Verify the column is present by inserting and reading back a row
+        reg1.upsert(
+            "t-migrate-001",
+            agent="fake",
+            run_id="run-mig-001",
+            repo="repo-mig-001",
+            marker_offset=42,
+        )
+        row = reg1.get("t-migrate-001")
+        assert row is not None
+        assert row.get("marker_offset") == 42, (
+            "marker_offset column must be present and writable after migration"
+        )

--- a/tests/test_session_orchestration_watcher.py
+++ b/tests/test_session_orchestration_watcher.py
@@ -735,3 +735,277 @@ class TestMarkerTailing:
         assert row.get("marker_offset") == 42, (
             "marker_offset column must be present and writable after migration"
         )
+
+
+# ---------------------------------------------------------------------------
+# Handoff marker tests (T009)
+# ---------------------------------------------------------------------------
+
+
+class FakeAdapterWithResume(FakeAdapter):
+    """FakeAdapter that records resume() calls instead of raising."""
+
+    def __init__(self, lifecycle: SessionLifecycle = SessionLifecycle.RUNNING):
+        super().__init__(lifecycle)
+        self.resume_calls: List[tuple] = []  # (handle, prompt) pairs
+
+    def resume(self, handle: SessionHandle, prompt: str) -> None:
+        self.resume_calls.append((handle, prompt))
+
+
+class TestHandoffMarkers:
+    """T009: handoff_continue auto-resumes; handoff_decision DMs the user."""
+
+    def test_handoff_continue_calls_resume_and_sets_running(self, registry, tmp_path):
+        """A recent handoff_continue marker must call adapter.resume(handle, '')
+        and override the lifecycle to RUNNING before the upsert."""
+        task_id = "t-hc-resume-001"
+        workdir = str(tmp_path)
+        _seed_row_with_workdir(registry, task_id, workdir)
+
+        marker_file = tmp_path / ".hermes" / "sessions" / f"{task_id}.jsonl"
+        marker_file.parent.mkdir(parents=True, exist_ok=True)
+        append_marker(
+            str(marker_file),
+            "handoff_continue",
+            {"handoff_text": "carry on"},
+            task=task_id,
+        )
+
+        adapter = FakeAdapterWithResume(SessionLifecycle.RUNNING)
+        capture = FakeCapture("pane output")
+        watcher = _make_watcher(registry, adapter, capture)
+        watcher.tick()
+
+        assert len(adapter.resume_calls) == 1, (
+            "adapter.resume() must be called exactly once for handoff_continue"
+        )
+        _handle, prompt = adapter.resume_calls[0]
+        assert prompt == "", "resume must be called with an empty prompt"
+
+        row = registry.get(task_id)
+        assert row is not None
+        assert row["state"] == "RUNNING", (
+            "state must be RUNNING after handoff_continue overrides PAUSED_HANDOFF"
+        )
+
+    def test_handoff_continue_does_not_call_send_dm(
+        self, registry, tmp_path, monkeypatch
+    ):
+        """handoff_continue must NOT trigger a DM — only auto-resume."""
+        task_id = "t-hc-no-dm-001"
+        workdir = str(tmp_path)
+        _seed_row_with_workdir(registry, task_id, workdir, discord_user_id="user-123")
+
+        marker_file = tmp_path / ".hermes" / "sessions" / f"{task_id}.jsonl"
+        marker_file.parent.mkdir(parents=True, exist_ok=True)
+        append_marker(
+            str(marker_file),
+            "handoff_continue",
+            {"handoff_text": "carry on"},
+            task=task_id,
+        )
+
+        dm_calls: List = []
+        monkeypatch.setattr(
+            "session_orchestration.dm_transport.send_dm",
+            lambda *a, **kw: dm_calls.append(a),
+        )
+
+        adapter = FakeAdapterWithResume(SessionLifecycle.RUNNING)
+        capture = FakeCapture("pane output")
+        watcher = _make_watcher(registry, adapter, capture)
+        watcher.tick()
+
+        assert dm_calls == [], "send_dm must NOT be called for handoff_continue"
+
+    def test_handoff_decision_calls_send_dm_with_question(
+        self, registry, tmp_path, monkeypatch
+    ):
+        """A recent handoff_decision marker must send a DM containing the
+        marker payload's question text when discord_user_id is present."""
+        task_id = "t-hd-dm-001"
+        workdir = str(tmp_path)
+        _seed_row_with_workdir(
+            registry, task_id, workdir, discord_user_id="user-456"
+        )
+
+        marker_file = tmp_path / ".hermes" / "sessions" / f"{task_id}.jsonl"
+        marker_file.parent.mkdir(parents=True, exist_ok=True)
+        append_marker(
+            str(marker_file),
+            "handoff_decision",
+            {"question": "continue?", "handoff_text": "needs a decision"},
+            task=task_id,
+        )
+
+        # Inject a fake bot token so the DM branch executes
+        monkeypatch.setattr(
+            "tools.discord_tool._get_bot_token",
+            lambda: "fake-bot-token",
+        )
+
+        dm_calls: List = []
+        monkeypatch.setattr(
+            "session_orchestration.dm_transport.send_dm",
+            lambda user_id, message, token, **kw: dm_calls.append(
+                (user_id, message, token)
+            ),
+        )
+
+        adapter = FakeAdapterWithResume(SessionLifecycle.RUNNING)
+        capture = FakeCapture("pane output")
+        watcher = _make_watcher(registry, adapter, capture)
+        watcher.tick()
+
+        assert len(dm_calls) == 1, "send_dm must be called exactly once"
+        _, message, token = dm_calls[0]
+        assert "continue?" in message, "DM must include the question text"
+        assert token == "fake-bot-token"
+
+    def test_handoff_decision_does_not_call_resume(
+        self, registry, tmp_path, monkeypatch
+    ):
+        """handoff_decision must NOT call adapter.resume() — DM only."""
+        task_id = "t-hd-no-resume-001"
+        workdir = str(tmp_path)
+        _seed_row_with_workdir(
+            registry, task_id, workdir, discord_user_id="user-789"
+        )
+
+        marker_file = tmp_path / ".hermes" / "sessions" / f"{task_id}.jsonl"
+        marker_file.parent.mkdir(parents=True, exist_ok=True)
+        append_marker(
+            str(marker_file),
+            "handoff_decision",
+            {"question": "what to do?", "handoff_text": "decision needed"},
+            task=task_id,
+        )
+
+        # Suppress network calls
+        monkeypatch.setattr("tools.discord_tool._get_bot_token", lambda: "tok")
+        monkeypatch.setattr(
+            "session_orchestration.dm_transport.send_dm",
+            lambda *a, **kw: True,
+        )
+
+        adapter = FakeAdapterWithResume(SessionLifecycle.RUNNING)
+        capture = FakeCapture("pane output")
+        watcher = _make_watcher(registry, adapter, capture)
+        watcher.tick()
+
+        assert adapter.resume_calls == [], (
+            "adapter.resume() must NOT be called for handoff_decision"
+        )
+
+    def test_handoff_decision_skips_dm_when_no_user_id(
+        self, registry, tmp_path, monkeypatch
+    ):
+        """handoff_decision with no discord_user_id must be a no-op (no DM,
+        no exception)."""
+        task_id = "t-hd-no-uid-001"
+        workdir = str(tmp_path)
+        # No discord_user_id in the row
+        _seed_row_with_workdir(registry, task_id, workdir)
+
+        marker_file = tmp_path / ".hermes" / "sessions" / f"{task_id}.jsonl"
+        marker_file.parent.mkdir(parents=True, exist_ok=True)
+        append_marker(
+            str(marker_file),
+            "handoff_decision",
+            {"question": "no user?", "handoff_text": "need decision"},
+            task=task_id,
+        )
+
+        dm_calls: List = []
+        monkeypatch.setattr(
+            "session_orchestration.dm_transport.send_dm",
+            lambda *a, **kw: dm_calls.append(a),
+        )
+
+        adapter = FakeAdapterWithResume(SessionLifecycle.RUNNING)
+        capture = FakeCapture("pane output")
+        watcher = _make_watcher(registry, adapter, capture)
+
+        # Must not raise
+        watcher.tick()
+
+        assert dm_calls == [], (
+            "send_dm must NOT be called when discord_user_id is absent"
+        )
+
+    def test_handoff_continue_resume_runs_under_lock(self, tmp_path):
+        """Lock-ordering contract: acquire_lock → adapter.resume → release_lock.
+
+        The watcher must hold the per-session lock when it calls adapter.resume()
+        for handoff_continue, so the relay cannot race on the same tmux pane.
+        We verify this by wrapping the registry and adapter to record a shared
+        event log and asserting the acquire/resume/release order.
+        """
+        from session_orchestration.registry import SessionOrchestrationRegistry
+
+        # --- shared event log ---
+        events: List[str] = []
+
+        # --- registry wrapper that records lock events ---
+        inner_registry = SessionOrchestrationRegistry(db_path=tmp_path / "lock-order.db")
+
+        class _LockRecordingRegistry:
+            """Thin proxy that records acquire/release into `events`."""
+
+            def __getattr__(self, name: str):
+                return getattr(inner_registry, name)
+
+            def acquire_lock(self, task_id: str, holder: str, ttl_seconds: float = 300.0) -> bool:
+                result = inner_registry.acquire_lock(task_id, holder, ttl_seconds=ttl_seconds)
+                if result:
+                    events.append(f"acquire:{task_id}")
+                return result
+
+            def release_lock(self, task_id: str, holder: str) -> None:
+                events.append(f"release:{task_id}")
+                return inner_registry.release_lock(task_id, holder)
+
+        recording_registry = _LockRecordingRegistry()
+
+        # --- adapter that records resume into the same event log ---
+        class _LockRecordingAdapter(FakeAdapterWithResume):
+            def resume(self, handle: "SessionHandle", prompt: str) -> None:
+                events.append("resume")
+                super().resume(handle, prompt)
+
+        task_id = "t-lock-order-001"
+        workdir = str(tmp_path)
+        _seed_row_with_workdir(inner_registry, task_id, workdir)
+
+        marker_file = tmp_path / ".hermes" / "sessions" / f"{task_id}.jsonl"
+        marker_file.parent.mkdir(parents=True, exist_ok=True)
+        append_marker(
+            str(marker_file),
+            "handoff_continue",
+            {"handoff_text": "carry on"},
+            task=task_id,
+        )
+
+        adapter = _LockRecordingAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture("pane output")
+        watcher = _make_watcher(recording_registry, adapter, capture)
+        watcher.tick()
+
+        # Must have seen all three events
+        assert "resume" in events, "adapter.resume() must have been called"
+        acquire_idx = next(
+            (i for i, e in enumerate(events) if e == f"acquire:{task_id}"), None
+        )
+        resume_idx = next((i for i, e in enumerate(events) if e == "resume"), None)
+        release_idx = next(
+            (i for i, e in enumerate(events) if e == f"release:{task_id}"), None
+        )
+        assert acquire_idx is not None, "acquire_lock must have fired"
+        assert release_idx is not None, "release_lock must have fired"
+        assert acquire_idx < resume_idx, (
+            "acquire_lock must precede adapter.resume() — lock-contract violation"
+        )
+        assert resume_idx < release_idx, (
+            "adapter.resume() must precede release_lock — lock-contract violation"
+        )

--- a/tests/test_session_orchestration_watcher.py
+++ b/tests/test_session_orchestration_watcher.py
@@ -1,0 +1,479 @@
+"""
+Unit tests for session_orchestration/watcher.py (T006).
+
+Coverage
+--------
+1. A tick iterating seeded rows writes state without spurious notifications —
+   state updates reach the registry; no Discord/network calls.
+2. A tick whose target session is locked by the relay skips capture — the
+   tmux_capture callable is NOT called when the lock is held.
+3. Intent-queue drain is applied: an intent enqueued before the tick is
+   processed and the row is updated.
+4. Unavailable-adapter rows are skipped: a row whose agent name is absent
+   from the verified adapters set is never processed.
+5. Lock is acquired BEFORE capture and released AFTER — the lock holder is
+   cleared from the registry before _process_row returns.
+6. startup_verify is idempotent — calling it twice does not re-probe adapters.
+7. Config-gate: _is_session_orchestration_enabled returns False when config
+   key is absent.
+
+All tests use:
+- An in-memory SQLite DB (via tmp_path fixture).
+- A FakeAdapter that returns a fixed SessionLifecycle.
+- A fake tmux_capture callable that records invocations.
+- Injected probe_runner / probe_specs so no real binaries are invoked.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List
+from unittest.mock import MagicMock
+
+import pytest
+
+from session_orchestration.adapters.base import AgentAdapter
+from session_orchestration.adapters.verify import AdapterProbeSpec
+from session_orchestration.registry import SessionOrchestrationRegistry
+from session_orchestration.types import Capabilities, SessionHandle, SessionLifecycle
+from session_orchestration.watcher import SessionWatcher, _pane_hash, run_tick
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeAdapter(AgentAdapter):
+    """Adapter that returns a fixed lifecycle value and records detect() calls."""
+
+    def __init__(self, lifecycle: SessionLifecycle = SessionLifecycle.RUNNING):
+        self._lifecycle = lifecycle
+        self.detect_calls: List[SessionHandle] = []
+
+    def capabilities(self) -> Capabilities:
+        return Capabilities()
+
+    def launch(self, workdir: str, prompt: str) -> SessionHandle:
+        raise NotImplementedError
+
+    def drive(self, handle: SessionHandle, message: str) -> None:
+        raise NotImplementedError
+
+    def detect(self, handle: SessionHandle) -> SessionLifecycle:
+        self.detect_calls.append(handle)
+        return self._lifecycle
+
+    def resume(self, handle: SessionHandle, prompt: str) -> None:
+        raise NotImplementedError
+
+
+class FakeProbeRunner:
+    """ProbeRunner that finds every binary and returns fixed help text."""
+
+    def __init__(self, help_text: str = ""):
+        self._help = help_text
+
+    def which(self, binary: str) -> str | None:
+        return f"/usr/local/bin/{binary}"
+
+    def help_text(self, binary: str) -> str:
+        return self._help
+
+
+class FakeCapture:
+    """Fake tmux_capture that returns fixed text and records calls."""
+
+    def __init__(self, text: str = "some pane output"):
+        self._text = text
+        self.calls: List[str] = []
+
+    def __call__(self, pane: str) -> str:
+        self.calls.append(pane)
+        return self._text
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "state.db"
+
+
+@pytest.fixture()
+def registry(db_path: Path) -> SessionOrchestrationRegistry:
+    return SessionOrchestrationRegistry(db_path=db_path)
+
+
+def _fake_probe_spec(adapter: FakeAdapter) -> AdapterProbeSpec:
+    """Return a probe spec whose flags are all None (always pass)."""
+    return AdapterProbeSpec(binary="fake-agent")
+
+
+def _make_watcher(
+    registry: SessionOrchestrationRegistry,
+    adapter: FakeAdapter,
+    capture: FakeCapture,
+    *,
+    adapter_name: str = "fake",
+) -> SessionWatcher:
+    """Build a SessionWatcher with injected fakes."""
+    watcher = SessionWatcher(
+        registry=registry,
+        adapters={adapter_name: adapter},
+        tmux_capture=capture,
+    )
+    # Inject probe fakes so no real binaries are touched
+    probe_runner = FakeProbeRunner()
+    probe_specs = {type(adapter).__name__: _fake_probe_spec(adapter)}
+    watcher.startup_verify(probe_runner=probe_runner, probe_specs=probe_specs)
+    return watcher
+
+
+def _seed_row(
+    registry: SessionOrchestrationRegistry,
+    task_id: str = "task-001",
+    agent: str = "fake",
+    state: str = "RUNNING",
+    tmux_session: str = "hermes-fake-001",
+) -> None:
+    """Insert a minimal registry row.
+
+    The registry schema has ``tmux_session`` but no ``pane`` column.
+    The watcher derives the pane as ``<tmux_session>:0.0`` from the row.
+    """
+    registry.upsert(
+        task_id,
+        agent=agent,
+        run_id=f"run-{uuid.uuid4().hex[:8]}",
+        repo=f"repo-{uuid.uuid4().hex[:8]}",
+        state=state,
+        tmux_session=tmux_session,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestTickWritesState:
+    """Tick iterates seeded rows and writes state to the registry."""
+
+    def test_state_written_for_active_row(self, registry, db_path):
+        task_id = "t-state-001"
+        _seed_row(registry, task_id=task_id, state="RUNNING")
+
+        adapter = FakeAdapter(SessionLifecycle.WAITING_USER)
+        capture = FakeCapture("❯ ")
+        watcher = _make_watcher(registry, adapter, capture)
+
+        processed = watcher.tick()
+
+        assert processed == 1, "expected exactly one row processed"
+        row = registry.get(task_id)
+        assert row is not None
+        assert row["state"] == "WAITING_USER"
+
+    def test_no_spurious_notification_on_same_state(self, registry, db_path):
+        """Tick must NOT raise or produce side-effects when state unchanged."""
+        task_id = "t-state-002"
+        _seed_row(registry, task_id=task_id, state="RUNNING")
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture("working…")
+        watcher = _make_watcher(registry, adapter, capture)
+
+        # Should not raise; processed count reflects the single row
+        processed = watcher.tick()
+        assert processed == 1
+
+        row = registry.get(task_id)
+        assert row["state"] == "RUNNING"
+
+    def test_terminal_rows_not_processed(self, registry, db_path):
+        """Rows in DONE/ERROR state are skipped."""
+        for tid, state in [("t-done", "DONE"), ("t-error", "ERROR")]:
+            _seed_row(registry, task_id=tid, state=state)
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture()
+        watcher = _make_watcher(registry, adapter, capture)
+
+        processed = watcher.tick()
+        assert processed == 0
+        # capture was never called for terminal rows
+        assert capture.calls == []
+
+
+class TestLockSkipsCapture:
+    """A tick whose target session is locked skips capture entirely."""
+
+    def test_capture_not_called_when_locked(self, registry, db_path):
+        task_id = "t-lock-001"
+        _seed_row(registry, task_id=task_id, tmux_session="locked-session")
+
+        # Acquire the lock from an "external" holder (simulates relay)
+        external_holder = "relay:pid:9999:1234567890.000"
+        acquired = registry.acquire_lock(
+            task_id, external_holder, ttl_seconds=300.0
+        )
+        assert acquired, "setup: external holder should have acquired lock"
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture()
+        watcher = _make_watcher(registry, adapter, capture)
+
+        processed = watcher.tick()
+
+        # Row was skipped — no capture call, processed count is 0
+        assert processed == 0
+        assert capture.calls == [], (
+            "capture-pane must NOT be called while lock is held by relay"
+        )
+        # adapter.detect should not have been called either
+        assert adapter.detect_calls == []
+
+    def test_capture_called_when_unlocked(self, registry, db_path):
+        task_id = "t-lock-002"
+        _seed_row(registry, task_id=task_id, tmux_session="free-session")
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture("running…")
+        watcher = _make_watcher(registry, adapter, capture)
+
+        processed = watcher.tick()
+
+        assert processed == 1
+        assert any("free-session" in c for c in capture.calls)
+
+    def test_lock_released_after_capture(self, registry, db_path):
+        """Lock must be released after capture so relay can acquire it next."""
+        task_id = "t-lock-003"
+        _seed_row(registry, task_id=task_id, tmux_session="rel-session")
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture()
+        watcher = _make_watcher(registry, adapter, capture)
+
+        watcher.tick()
+
+        # After tick, relay must be able to acquire the lock
+        row = registry.get(task_id)
+        assert row is not None
+        # lock_holder should be None (released)
+        assert row.get("lock_holder") is None, (
+            "lock_holder must be released after capture"
+        )
+
+
+class TestIntentQueueDrain:
+    """Intent-queue entries are drained and applied during the tick."""
+
+    def test_adopt_intent_creates_row(self, registry, db_path):
+        """An 'adopt' intent enqueued before the tick creates a registry row."""
+        task_id = "t-intent-adopt-001"
+        run_id = f"run-{uuid.uuid4().hex[:8]}"
+        repo = f"repo-{uuid.uuid4().hex[:8]}"
+
+        registry.enqueue_intent(
+            "adopt",
+            task_id=task_id,
+            run_id=run_id,
+            repo=repo,
+            payload={"agent": "fake", "run_id": run_id, "repo": repo, "task_id": task_id},
+        )
+
+        # No rows yet
+        assert registry.get(task_id) is None
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture()
+        watcher = _make_watcher(registry, adapter, capture)
+
+        # Tick drains the intent → row appears
+        watcher.tick()
+
+        row = registry.get(task_id)
+        assert row is not None, "adopt intent should have created a registry row"
+        assert row["agent"] == "fake"
+
+    def test_update_intent_modifies_existing_row(self, registry, db_path):
+        """An 'update' intent modifies fields on an existing row."""
+        task_id = "t-intent-update-001"
+        _seed_row(registry, task_id=task_id, state="RUNNING")
+
+        # Enqueue an update intent to change the project field
+        registry.enqueue_intent(
+            "update",
+            task_id=task_id,
+            payload={"task_id": task_id, "project": "my-project"},
+        )
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture()
+        watcher = _make_watcher(registry, adapter, capture)
+        watcher.tick()
+
+        row = registry.get(task_id)
+        assert row is not None
+        assert row.get("project") == "my-project"
+
+    def test_queue_empty_after_drain(self, registry, db_path):
+        """Queue is empty after the tick drains it."""
+        task_id = "t-intent-drain-001"
+        registry.enqueue_intent(
+            "update",
+            task_id=task_id,
+            payload={"task_id": task_id, "project": "x"},
+        )
+
+        # Seed the row so the update has somewhere to land
+        _seed_row(registry, task_id=task_id)
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture()
+        watcher = _make_watcher(registry, adapter, capture)
+        watcher.tick()
+
+        # Second tick: intents drained = empty
+        intents = registry.drain_intents()
+        assert intents == [], "queue should be empty after the tick drained it"
+
+
+class TestUnavailableAdapterSkipped:
+    """Rows whose agent name is not in available adapters are skipped."""
+
+    def test_unknown_agent_row_skipped(self, registry, db_path):
+        task_id = "t-unavail-001"
+        _seed_row(registry, task_id=task_id, agent="unknown-agent")
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture()
+        # Watcher only has "fake", not "unknown-agent"
+        watcher = _make_watcher(registry, adapter, capture, adapter_name="fake")
+
+        processed = watcher.tick()
+
+        assert processed == 0
+        assert capture.calls == []
+
+    def test_available_agent_processed_while_unknown_skipped(self, registry, db_path):
+        """One row available, one not — only the available one is processed."""
+        _seed_row(registry, task_id="t-avail", agent="fake", state="RUNNING")
+        _seed_row(registry, task_id="t-unavail", agent="mystery-agent", state="RUNNING")
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture()
+        watcher = _make_watcher(registry, adapter, capture, adapter_name="fake")
+
+        processed = watcher.tick()
+
+        assert processed == 1
+
+
+class TestStartupVerifyIdempotent:
+    """startup_verify is a no-op when called multiple times."""
+
+    def test_second_call_is_noop(self, registry, db_path):
+        adapter = FakeAdapter()
+        probe_runner = FakeProbeRunner()
+        probe_specs = {type(adapter).__name__: _fake_probe_spec(adapter)}
+
+        call_count = [0]
+        original_verify = __import__(
+            "session_orchestration.adapters.verify", fromlist=["verify_adapters"]
+        ).verify_adapters
+
+        watcher = SessionWatcher(
+            registry=registry,
+            adapters={"fake": adapter},
+        )
+        watcher.startup_verify(probe_runner=probe_runner, probe_specs=probe_specs)
+        first_available = dict(watcher._available_adapters)
+
+        # Second call should be a no-op (same result, no re-probe)
+        watcher.startup_verify(probe_runner=FakeProbeRunner("different"), probe_specs=probe_specs)
+        second_available = dict(watcher._available_adapters)
+
+        # Available set unchanged
+        assert set(first_available.keys()) == set(second_available.keys())
+
+
+class TestPaneHash:
+    """_pane_hash returns consistent values for change detection."""
+
+    def test_same_text_same_hash(self):
+        assert _pane_hash("hello world") == _pane_hash("hello world")
+
+    def test_different_text_different_hash(self):
+        assert _pane_hash("hello") != _pane_hash("world")
+
+    def test_empty_string(self):
+        h = _pane_hash("")
+        assert isinstance(h, str)
+        assert len(h) == 16
+
+
+class TestIdleTickIncrement:
+    """idle_ticks increments when pane text is unchanged."""
+
+    def test_idle_ticks_increment_on_unchanged_pane(self, registry, db_path):
+        task_id = "t-idle-001"
+        _seed_row(registry, task_id=task_id, tmux_session="idle-session")
+
+        static_text = "working… (same every tick)"
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        capture = FakeCapture(static_text)
+        watcher = _make_watcher(registry, adapter, capture)
+
+        # First tick: establishes pane_hash
+        watcher.tick()
+        row1 = registry.get(task_id)
+        idle1 = row1.get("idle_ticks", 0)
+
+        # Second tick: same pane text → idle_ticks should increase
+        watcher.tick()
+        row2 = registry.get(task_id)
+        idle2 = row2.get("idle_ticks", 0)
+
+        assert idle2 > idle1, (
+            f"idle_ticks should increase when pane text is unchanged "
+            f"(got {idle1} then {idle2})"
+        )
+
+    def test_idle_ticks_reset_on_changed_pane(self, registry, db_path):
+        task_id = "t-idle-002"
+        _seed_row(registry, task_id=task_id, tmux_session="active-session")
+
+        texts = ["first output", "second output"]
+        call_n = [0]
+
+        def changing_capture(pane: str) -> str:
+            idx = min(call_n[0], len(texts) - 1)
+            call_n[0] += 1
+            return texts[idx]
+
+        adapter = FakeAdapter(SessionLifecycle.RUNNING)
+        watcher = SessionWatcher(
+            registry=registry,
+            adapters={"fake": adapter},
+            tmux_capture=changing_capture,
+        )
+        probe_runner = FakeProbeRunner()
+        probe_specs = {type(adapter).__name__: _fake_probe_spec(adapter)}
+        watcher.startup_verify(probe_runner=probe_runner, probe_specs=probe_specs)
+
+        # Tick 1 — establishes first hash
+        watcher.tick()
+
+        # Tick 2 — different text → idle_ticks should be reset to 0
+        watcher.tick()
+        row = registry.get(task_id)
+        assert (row.get("idle_ticks") or 0) == 0

--- a/tests/test_session_orchestration_watcher.py
+++ b/tests/test_session_orchestration_watcher.py
@@ -1139,6 +1139,18 @@ class TestPaneHash:
         assert isinstance(h, str)
         assert len(h) == 16
 
+    def test_animation_only_churn_hashes_stably(self):
+        # Spinner glyph + elapsed timer + cost + context% change every render;
+        # nothing else does. The hash must stay stable so idle_ticks accrues.
+        a = "⟨task⟩ Review 11m22s\n⠴ Polling review more\n92.5%/272K  $14.51"
+        b = "⟨task⟩ Review 12m28s\n⠏ Polling review more\n93.2%/272K  $14.84"
+        assert _pane_hash(a) == _pane_hash(b)
+
+    def test_real_output_change_still_changes_hash(self):
+        a = "Reading foo.rs\n⠴ Running tool 3s"
+        b = "Compiled bar crate\n⠏ Running tool 5s"
+        assert _pane_hash(a) != _pane_hash(b)
+
 
 class TestIdleTickIncrement:
     """idle_ticks increments when pane text is unchanged."""
@@ -1301,6 +1313,73 @@ class TestStaleFrozenGuards:
             adapter=adapter,
             hang_idle_ticks=3,
             hang_stale_seconds=300,
+            now=now,
+        )
+
+    def test_active_regex_still_vetoes_before_busy_stale_seconds(self):
+        # A spinner that has only been frozen a short while is legit work.
+        now = time.time()
+        pane_text = "⠴ Polling review more"
+        pane_hash = _pane_hash(pane_text)
+        row = {"idle_ticks": 3, "last_output_ts": now - 400, "nudge_count": 0}
+        adapter = FakeAdapter(
+            SessionLifecycle.RUNNING,
+            idle_indicator_regex=re.compile(r"[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]|Polling"),
+        )
+        assert not _is_stale_frozen_eligible(
+            row,
+            previous_pane_hash=pane_hash,
+            current_pane_hash=pane_hash,
+            pane_text=pane_text,
+            adapter=adapter,
+            hang_idle_ticks=3,
+            hang_stale_seconds=300,
+            busy_stale_seconds=900,
+            now=now,
+        )
+
+    def test_active_regex_veto_lifts_after_busy_stale_seconds(self):
+        # A spinner still turning with zero real output past busy_stale_seconds
+        # is a stuck busy-loop — the veto lifts and the hang becomes eligible.
+        now = time.time()
+        pane_text = "⠴ Polling review more"
+        pane_hash = _pane_hash(pane_text)
+        row = {"idle_ticks": 3, "last_output_ts": now - 901, "nudge_count": 0}
+        adapter = FakeAdapter(
+            SessionLifecycle.RUNNING,
+            idle_indicator_regex=re.compile(r"[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]|Polling"),
+        )
+        assert _is_stale_frozen_eligible(
+            row,
+            previous_pane_hash=pane_hash,
+            current_pane_hash=pane_hash,
+            pane_text=pane_text,
+            adapter=adapter,
+            hang_idle_ticks=3,
+            hang_stale_seconds=300,
+            busy_stale_seconds=900,
+            now=now,
+        )
+
+    def test_busy_stale_none_preserves_always_veto(self):
+        # Legacy behaviour: with no busy_stale_seconds, a spinner always vetoes.
+        now = time.time()
+        pane_text = "⠴ Polling review more"
+        pane_hash = _pane_hash(pane_text)
+        row = {"idle_ticks": 3, "last_output_ts": now - 5000, "nudge_count": 0}
+        adapter = FakeAdapter(
+            SessionLifecycle.RUNNING,
+            idle_indicator_regex=re.compile(r"[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]|Polling"),
+        )
+        assert not _is_stale_frozen_eligible(
+            row,
+            previous_pane_hash=pane_hash,
+            current_pane_hash=pane_hash,
+            pane_text=pane_text,
+            adapter=adapter,
+            hang_idle_ticks=3,
+            hang_stale_seconds=300,
+            busy_stale_seconds=None,
             now=now,
         )
 

--- a/tests/test_session_orchestration_watcher.py
+++ b/tests/test_session_orchestration_watcher.py
@@ -41,6 +41,7 @@ from session_orchestration.registry import SessionOrchestrationRegistry
 from session_orchestration.types import Capabilities, SessionHandle, SessionLifecycle
 from session_orchestration.watcher import (
     SessionWatcher,
+    build_default_adapters,
     _is_omp_nudge_checkin_eligible,
     _is_stale_frozen_eligible,
     _on_hang,
@@ -180,6 +181,11 @@ def _seed_row(
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
+
+def test_default_adapters_register_user_facing_aliases():
+    adapters = build_default_adapters()
+    assert {"claude", "claude-code", "codex", "codex-cli", "omp", "omp-adapter"} <= set(adapters)
 
 
 class TestTickWritesState:
@@ -1144,6 +1150,13 @@ class TestPaneHash:
         # nothing else does. The hash must stay stable so idle_ticks accrues.
         a = "⟨task⟩ Review 11m22s\n⠴ Polling review more\n92.5%/272K  $14.51"
         b = "⟨task⟩ Review 12m28s\n⠏ Polling review more\n93.2%/272K  $14.84"
+        assert _pane_hash(a) == _pane_hash(b)
+
+    def test_omp_waiting_clock_animation_hashes_stably(self):
+        # OMP renders a private-use timer glyph next to long-running subagent
+        # waits. Those frames churn independently of semantic output.
+        a = "└─ 󱑋 ⟨task⟩ ReviewT003 8m2s\n⠸ Waiting T003 review ⟨esc⟩"
+        b = "└─ 󱑎 ⟨task⟩ ReviewT003 8m5s\n⠹ Waiting T003 review ⟨esc⟩"
         assert _pane_hash(a) == _pane_hash(b)
 
     def test_real_output_change_still_changes_hash(self):


### PR DESCRIPTION
## Summary
- add a Codex session-orchestration adapter and register codex/codex-cli aliases
- register user-facing default adapters for claude, codex, and omp aliases
- harden Discord so signal polling and menu parsing to avoid false prompts/noisy command boxes

## Verification
- PYTEST_ADDOPTS='' /Users/zeke/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts='' tests/test_session_orchestration_codex.py tests/test_session_orchestration_spawn.py tests/test_session_orchestration_watcher.py tests/test_session_orchestration_verify.py tests/test_session_orchestration_spawn_tool.py tests/test_session_orchestration_menu_parse.py -q
- Hermes gateway restarted locally; Discord connected as Hermès#1930