### PR TITLE
fix: clarify that 'parallel' backend refers to Parallel.ai service

### DIFF
--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -219,6 +219,11 @@ def _is_backend_available(backend: str) -> bool:
     if backend == "exa":
         return _has_env("EXA_API_KEY")
     if backend == "parallel":
+        # NOTE: "parallel" is Parallel.ai, a separate paid scraping service,
+        # NOT a Hermes feature that fans out requests to multiple backends
+        # concurrently. The name is misleading — it requires its own API key
+        # (PARALLEL_API_KEY). For Firecrawl+Tavily redundancy, pick one as
+        # extract_backend; the other can serve as fallback via search_backend.
         return _has_env("PARALLEL_API_KEY")
     if backend == "firecrawl":
         return check_firecrawl_api_key()
@@ -1006,8 +1011,11 @@ async def web_extract_tool(
                             "error": (
                                 f"{provider.display_name} is a search-only "
                                 "backend and cannot extract URL content. "
-                                "Set web.extract_backend to firecrawl, "
-                                "tavily, exa, or parallel."
+                                "Set web.extract_backend to firecrawl "
+                                "(FIRECRAWL_API_KEY), tavily (TAVILY_API_KEY), "
+                                "exa (EXA_API_KEY), or parallel (PARALLEL_API_KEY "
+                                "— a separate paid service, not 'run both in "
+                                "parallel')."
                             ),
                         },
                         ensure_ascii=False,


### PR DESCRIPTION
## Problem

The `extract_backend: parallel` config value is easily misread as "run Firecrawl + Tavily in parallel" — a natural English reading of the word. In reality, `parallel` is [Parallel.ai](https://parallel.ai), a separate paid scraping service requiring its own `PARALLEL_API_KEY`.

This causes users to set `extract_backend: parallel` with only `FIRECRAWL_API_KEY` and `TAVILY_API_KEY`, then encounter a confusing silent failure: the backend availability check fails, falling through to DuckDuckGo (search-only, cannot extract).

## Changes

1. **Code comment** above `_is_backend_available("parallel")` explaining that parallel = Parallel.ai, NOT a multi-provider fan-out
2. **Error message** expanded to show which env var each backend requires, with an explicit note that parallel is a separate paid service

## Before / After

**Error message before:**
> Set web.extract_backend to firecrawl, tavily, exa, or parallel.

**Error message after:**
> Set web.extract_backend to firecrawl (FIRECRAWL_API_KEY), tavily (TAVILY_API_KEY), exa (EXA_API_KEY), or parallel (PARALLEL_API_KEY — a separate paid service, not "run both in parallel").

## Files changed
- `tools/web_tools.py`: +10 lines, 2 changes