### PR TITLE
feat(bluebubbles): group history backfill for mention-gated chats

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -71,6 +71,7 @@ _PHONE_RE = re.compile(r"\+?\d{7,15}")
 _EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.]+")
 
 _GUID_CACHE_SIZE = 500  # LRU cap for resolved chat-GUID lookups
+_CONTEXT_SEEN_MAX = 500  # LRU cap for per-chat backfill high-water marks
 
 
 def _redact(text: str) -> str:
@@ -146,11 +147,22 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             if "mention_patterns" in extra
             else os.getenv("BLUEBUBBLES_MENTION_PATTERNS")
         )
+        self.history_backfill = self._coerce_history_backfill(
+            extra.get("history_backfill"),
+            os.getenv("BLUEBUBBLES_HISTORY_BACKFILL"),
+        )
+        self.history_backfill_limit = self._coerce_history_backfill_limit(
+            extra.get("history_backfill_limit"),
+            os.getenv("BLUEBUBBLES_HISTORY_BACKFILL_LIMIT"),
+        )
         self.client: Optional[httpx.AsyncClient] = None
         self._runner = None
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
         self._guid_cache: OrderedDict[str, str] = OrderedDict()
+        # Newest message dateCreated (ms) already surfaced to the agent per
+        # group chat — the high-water mark that drives missed-message backfill.
+        self._group_context_seen: OrderedDict[str, int] = OrderedDict()
 
     # ------------------------------------------------------------------
     # API helpers
@@ -159,6 +171,120 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     def _api_url(self, path: str) -> str:
         sep = "&" if "?" in path else "?"
         return f"{self.server_url}{path}{sep}password={quote(self.password, safe='')}"
+
+    @staticmethod
+    def _coerce_history_backfill(extra_val: Any, env_val: Optional[str]) -> bool:
+        """Whether to backfill missed group messages on mention.
+
+        Defaults to **off**: surfacing un-mentioned iMessage group chatter to
+        the model is opt-in for privacy. (Discord's ``history_backfill``
+        defaults on, but iMessage groups are typically personal.)
+        """
+        raw = extra_val if extra_val is not None else env_val
+        if raw is None:
+            return False
+        return str(raw).strip().lower() in {"true", "1", "yes", "on"}
+
+    @staticmethod
+    def _coerce_history_backfill_limit(extra_val: Any, env_val: Optional[str]) -> int:
+        """Max recent group messages to scan for missed-message context."""
+        raw = extra_val if extra_val is not None else env_val
+        try:
+            n = int(raw)
+        except (TypeError, ValueError):
+            return 25
+        return n if n > 0 else 0
+
+    async def _fetch_recent_messages(
+        self, chat_guid: str, limit: int
+    ) -> List[Dict[str, Any]]:
+        """Fetch the most recent messages in a chat, returned oldest-first."""
+        try:
+            res = await self._api_get(
+                f"/api/v1/chat/{quote(chat_guid, safe='')}/message"
+                f"?limit={int(limit)}&offset=0&sort=DESC&with=handle"
+            )
+            msgs = [m for m in (res.get("data") or []) if isinstance(m, dict)]
+            msgs.sort(key=lambda m: m.get("dateCreated") or 0)
+            return msgs
+        except Exception:
+            logger.debug("[bluebubbles] history backfill fetch failed", exc_info=True)
+            return []
+
+    @staticmethod
+    def _summarize_message(m: Dict[str, Any], max_chars: int = 200) -> Optional[str]:
+        """Render one ``sender: text`` transcript line, or None if empty."""
+        body = (m.get("text") or "").strip()
+        if not body:
+            return None
+        if len(body) > max_chars:
+            body = body[:max_chars] + "…"
+        if m.get("isFromMe"):
+            sender = "you"
+        else:
+            handle = m.get("handle") or {}
+            sender = handle.get("address") or "participant"
+        return f"{sender}: {body}"
+
+    async def _build_group_backfill(
+        self, chat_guid: str, current_guid: Optional[str]
+    ) -> Optional[str]:
+        """Context block of group messages seen since the last surfaced one.
+
+        Uses a per-chat high-water mark (newest ``dateCreated`` already shown)
+        instead of scanning back to the bot's own last message, so messages
+        sent *between* two bot turns are never lost — cf. the Discord
+        ``_fetch_channel_context`` bot-message partition bug (issue #42079).
+        The bot's own messages, tapback reactions, and the triggering message
+        are excluded.
+        """
+        if self.history_backfill_limit <= 0:
+            return None
+        recent = await self._fetch_recent_messages(
+            chat_guid, self.history_backfill_limit
+        )
+        if not recent:
+            return None
+        high_water = self._group_context_seen.get(chat_guid)
+        if high_water is None:
+            # Cold start (first observation of this chat since gateway start):
+            # prime the mark from the bot's own newest message in the window.
+            # Session transcripts persist across restarts, so anything up to
+            # the bot's last reply was already seen — re-surfacing it would
+            # duplicate context. In a chat the bot has never spoken in, the
+            # mark stays 0 and the whole window (bounded by the fetch limit)
+            # is genuinely unseen.
+            high_water = max(
+                [0]
+                + [
+                    (m.get("dateCreated") or 0)
+                    for m in recent
+                    if m.get("isFromMe")
+                ]
+            )
+        tapback_codes = {**_TAPBACK_ADDED, **_TAPBACK_REMOVED}
+        missed = [
+            m
+            for m in recent
+            if not m.get("isFromMe")
+            and m.get("guid") != current_guid
+            and (m.get("dateCreated") or 0) > high_water
+            and not (
+                isinstance(m.get("associatedMessageType"), int)
+                and m.get("associatedMessageType") in tapback_codes
+            )
+        ]
+        # Advance the high-water mark to the newest message now observed.
+        self._group_context_seen[chat_guid] = max(
+            [high_water] + [(m.get("dateCreated") or 0) for m in recent]
+        )
+        self._group_context_seen.move_to_end(chat_guid)
+        while len(self._group_context_seen) > _CONTEXT_SEEN_MAX:
+            self._group_context_seen.popitem(last=False)
+        lines = [s for s in (self._summarize_message(m) for m in missed) if s]
+        if not lines:
+            return None
+        return "[group messages since you last replied:\n" + "\n".join(lines) + "\n]"
 
     @staticmethod
     def _compile_mention_patterns(raw: Any) -> List[re.Pattern]:
@@ -1003,6 +1129,20 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 )
                 return web.Response(text="ok")
             text = self._clean_mention_text(text)
+        # Mention gating drops un-mentioned group chatter, leaving the agent
+        # blind to conversation it is expected to know. When enabled, prepend
+        # the messages sent since the agent last replied here.
+        if is_group and self.history_backfill:
+            backfill = await self._build_group_backfill(
+                session_chat_id,
+                self._value(
+                    record.get("guid"),
+                    record.get("messageGuid"),
+                    record.get("id"),
+                ),
+            )
+            if backfill:
+                text = f"{backfill}\n{text}"
         source = self.build_source(
             chat_id=session_chat_id,
             chat_name=chat_identifier or sender,

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -830,3 +830,162 @@ class TestBlueBubblesWebhookRegistration:
             adapter._unregister_webhook()
         )
         assert ok is False
+
+
+class TestBlueBubblesHistoryBackfill:
+    def test_backfill_disabled_by_default(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        assert adapter.history_backfill is False
+        assert adapter.history_backfill_limit == 25
+
+    def test_backfill_enabled_via_extra(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch, history_backfill=True, history_backfill_limit=10
+        )
+        assert adapter.history_backfill is True
+        assert adapter.history_backfill_limit == 10
+
+    def test_backfill_enabled_via_env(self, monkeypatch):
+        monkeypatch.setenv("BLUEBUBBLES_HISTORY_BACKFILL", "1")
+        adapter = _make_adapter(monkeypatch)
+        assert adapter.history_backfill is True
+
+    def test_limit_invalid_falls_back_to_default(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, history_backfill_limit="not-a-number")
+        assert adapter.history_backfill_limit == 25
+
+    def test_summarize_message_formats_sender_and_text(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        assert (
+            adapter._summarize_message({"text": "hi", "handle": {"address": "+1555"}})
+            == "+1555: hi"
+        )
+        assert adapter._summarize_message({"text": "yo", "isFromMe": True}) == "you: yo"
+        assert adapter._summarize_message({"text": "   "}) is None
+
+    @pytest.mark.asyncio
+    async def test_backfill_includes_unseen_and_advances_high_water(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, history_backfill=True)
+        recent = [
+            {"guid": "m1", "text": "before bot", "dateCreated": 100, "handle": {"address": "+1"}},
+            {"guid": "bot", "text": "I replied", "dateCreated": 250, "isFromMe": True},
+            {"guid": "m2", "text": "after bot", "dateCreated": 260, "handle": {"address": "+2"}},
+            {"guid": "cur", "text": "@pookie", "dateCreated": 300, "handle": {"address": "+1"}},
+        ]
+
+        async def fake_fetch(chat_guid, limit):
+            return recent
+
+        monkeypatch.setattr(adapter, "_fetch_recent_messages", fake_fetch)
+        block = await adapter._build_group_backfill("chatA", current_guid="cur")
+        assert block is not None
+        assert "+2: after bot" in block
+        assert "I replied" not in block  # bot message excluded
+        assert "@pookie" not in block  # triggering message excluded
+        assert adapter._group_context_seen["chatA"] == 300  # advanced to newest
+
+    @pytest.mark.asyncio
+    async def test_backfill_cold_start_primes_from_bot_message(self, monkeypatch):
+        """Messages predating the bot's own last reply are not re-surfaced
+        after a gateway restart (session transcripts persist across restarts)."""
+        adapter = _make_adapter(monkeypatch, history_backfill=True)
+        recent = [
+            {"guid": "m1", "text": "old chatter", "dateCreated": 100, "handle": {"address": "+1"}},
+            {"guid": "bot", "text": "I replied", "dateCreated": 250, "isFromMe": True},
+            {"guid": "cur", "text": "@pookie", "dateCreated": 300, "handle": {"address": "+1"}},
+        ]
+
+        async def fake_fetch(chat_guid, limit):
+            return recent
+
+        monkeypatch.setattr(adapter, "_fetch_recent_messages", fake_fetch)
+        block = await adapter._build_group_backfill("chatA", current_guid="cur")
+        assert block is None  # nothing between the bot's last reply and the trigger
+
+    @pytest.mark.asyncio
+    async def test_backfill_cold_start_without_bot_message_includes_window(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, history_backfill=True)
+        recent = [
+            {"guid": "m1", "text": "hello", "dateCreated": 100, "handle": {"address": "+1"}},
+            {"guid": "cur", "text": "@pookie", "dateCreated": 300, "handle": {"address": "+1"}},
+        ]
+
+        async def fake_fetch(chat_guid, limit):
+            return recent
+
+        monkeypatch.setattr(adapter, "_fetch_recent_messages", fake_fetch)
+        block = await adapter._build_group_backfill("chatA", current_guid="cur")
+        assert block is not None and "+1: hello" in block
+
+    @pytest.mark.asyncio
+    async def test_backfill_excludes_tapback_reactions(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, history_backfill=True)
+        recent = [
+            {"guid": "m1", "text": "real message", "dateCreated": 100, "handle": {"address": "+1"}},
+            {
+                "guid": "tap",
+                "text": 'Laughed at "real message"',
+                "dateCreated": 150,
+                "handle": {"address": "+2"},
+                "associatedMessageType": 2003,
+            },
+            {"guid": "cur", "text": "@pookie", "dateCreated": 300, "handle": {"address": "+1"}},
+        ]
+
+        async def fake_fetch(chat_guid, limit):
+            return recent
+
+        monkeypatch.setattr(adapter, "_fetch_recent_messages", fake_fetch)
+        block = await adapter._build_group_backfill("chatA", current_guid="cur")
+        assert block is not None
+        assert "real message" in block
+        assert "Laughed at" not in block
+
+    @pytest.mark.asyncio
+    async def test_backfill_does_not_resurface_seen_messages(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, history_backfill=True)
+        recent = [
+            {"guid": "m1", "text": "old", "dateCreated": 100, "handle": {"address": "+1"}},
+        ]
+
+        async def fake_fetch(chat_guid, limit):
+            return recent
+
+        monkeypatch.setattr(adapter, "_fetch_recent_messages", fake_fetch)
+        adapter._group_context_seen["chatA"] = 150  # already past this message
+        block = await adapter._build_group_backfill("chatA", current_guid="cur")
+        assert block is None
+
+    @pytest.mark.asyncio
+    async def test_backfill_short_circuits_when_limit_zero(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch, history_backfill=True, history_backfill_limit=0
+        )
+        called = {"fetch": False}
+
+        async def fake_fetch(chat_guid, limit):
+            called["fetch"] = True
+            return []
+
+        monkeypatch.setattr(adapter, "_fetch_recent_messages", fake_fetch)
+        block = await adapter._build_group_backfill("chatA", "cur")
+        assert block is None
+        assert called["fetch"] is False  # never fetches when disabled
+
+    @pytest.mark.asyncio
+    async def test_backfill_high_water_cache_is_bounded(self, monkeypatch):
+        from gateway.platforms.bluebubbles import _CONTEXT_SEEN_MAX
+
+        adapter = _make_adapter(monkeypatch, history_backfill=True)
+
+        async def fake_fetch(chat_guid, limit):
+            return [{"guid": "m", "text": "x", "dateCreated": 1, "handle": {"address": "+1"}}]
+
+        monkeypatch.setattr(adapter, "_fetch_recent_messages", fake_fetch)
+        for i in range(_CONTEXT_SEEN_MAX + 25):
+            await adapter._build_group_backfill(f"chat{i}", None)
+        assert len(adapter._group_context_seen) <= _CONTEXT_SEEN_MAX

--- a/website/docs/user-guide/messaging/bluebubbles.md
+++ b/website/docs/user-guide/messaging/bluebubbles.md
@@ -63,6 +63,28 @@ platforms:
         - '(?<![\w@])@?amos\b[,:\-]?'
 ```
 
+#### Optional: Group history backfill
+
+With `require_mention: true`, the agent never sees the group messages that were
+sent *between* mentions, so it answers a mention with no idea what the group was
+discussing. Enable `history_backfill` to prepend the messages sent since the
+agent last replied in that chat (mirrors Discord's `history_backfill`):
+
+```yaml
+platforms:
+  bluebubbles:
+    extra:
+      require_mention: true
+      history_backfill: true
+      history_backfill_limit: 25   # max recent messages to scan (default 25)
+```
+
+This is **off by default** — surfacing un-mentioned group chatter is opt-in.
+The agent's own messages, tapback reactions, and the triggering message are
+excluded, and a per-chat high-water mark prevents re-surfacing messages it has
+already seen. After a gateway restart the mark is primed from the agent's own
+last reply in the chat, so persisted sessions don't receive duplicate history.
+
 ### 4. Authorize Users
 
 Choose one approach:
@@ -117,6 +139,8 @@ Hermes → BlueBubbles REST API → Messages.app → iMessage
 | `BLUEBUBBLES_ALLOW_ALL_USERS` | No | `false` | Allow all users |
 | `BLUEBUBBLES_REQUIRE_MENTION` | No | `false` | Require a mention pattern before responding in group chats |
 | `BLUEBUBBLES_MENTION_PATTERNS` | No | Hermes wake words | JSON array, newline-separated, or comma-separated regex patterns for group mention matching |
+| `BLUEBUBBLES_HISTORY_BACKFILL` | No | `false` | Prepend group messages sent since the agent last replied (context for mention-gated groups) |
+| `BLUEBUBBLES_HISTORY_BACKFILL_LIMIT` | No | `25` | Max recent group messages to scan for backfill |
 
 Auto-marking messages as read is controlled by the `send_read_receipts` key under `platforms.bluebubbles.extra` in `~/.hermes/config.yaml` (default: `true`). There is no corresponding environment variable.
 


### PR DESCRIPTION
## What does this PR do?

With `require_mention: true`, the BlueBubbles adapter drops every group message that isn't a wake-word mention. That's correct for *replying*, but it means the agent never observes the messages sent **between** mentions — so when it finally is mentioned, it answers with no idea what the group was just discussing.

This adds an opt-in `history_backfill` for BlueBubbles group chats that prepends the messages sent since the agent last replied in that chat, giving it the conversational context it was blind to. It mirrors the `history_backfill` capability already merged for Discord (#25984) and requested for WhatsApp (#42718).

**Why this approach:** rather than scanning backwards until the bot's own last message (the Discord `_fetch_channel_context` strategy, which collects zero messages between two bot turns — see #42079), this tracks a per-chat **high-water mark** of the newest `dateCreated` already surfaced. Messages newer than the mark are included; the mark then advances. Messages between bot turns are never lost, and nothing is surfaced twice. On cold start (first observation of a chat after a gateway restart) the mark is primed from the bot's own newest message in the fetch window — session transcripts persist across restarts, so re-surfacing anything older would duplicate context the session already has.

It is **off by default** — surfacing un-mentioned iMessage group chatter to the model is opt-in for privacy (iMessage groups are typically personal, unlike public Discord servers where the Discord default is on). The bot's own messages, tapback reactions, and the triggering message are excluded, and the per-chat marks are LRU-bounded (500 chats).

## Related Issue

Refs #42718 (parity with the requested WhatsApp behavior). Precedent: #25984 (Discord). Avoids the partition bug in #42079.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/platforms/bluebubbles.py`:
  - `history_backfill` / `history_backfill_limit` config (via `extra` or `BLUEBUBBLES_HISTORY_BACKFILL[_LIMIT]` env), mirroring Discord's keys; default off, limit 25.
  - `_fetch_recent_messages()` (BlueBubbles `/api/v1/chat/{guid}/message` query) and `_summarize_message()` helpers.
  - `_build_group_backfill()` — high-water-mark backfill that excludes bot + triggering messages.
  - One hook in the webhook handler: when a group message passes mention gating, prepend the backfill block.
- `tests/gateway/test_bluebubbles.py`: 12 unit tests (config coercion, exclusion rules incl. tapbacks, cold-start priming, high-water dedup, LRU bound, limit=0 short-circuit).
- `website/docs/user-guide/messaging/bluebubbles.md`: config section + env-var table rows.

## How to Test

1. Configure a BlueBubbles group with `require_mention: true` and `history_backfill: true`.
2. Send a few group messages **without** the wake word, then one **with** it.
3. The agent's context for the mention now includes a `[group messages since you last replied: …]` block containing the un-mentioned messages. Send another mention immediately — already-seen messages are not repeated (high-water mark).

Automated: `pytest tests/gateway/test_bluebubbles.py -q` → 68 passed. `ruff check` clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (no existing BlueBubbles backfill PR; Discord precedent #25984, WhatsApp request #42718)
- [x] My PR contains **only** changes related to this feature
- [x] I've run the tests and all pass (`tests/gateway/test_bluebubbles.py`: 68 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (BlueBubbles 1.9.9, live server, real 2-person group)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/.../bluebubbles.md` + docstrings)
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — **N/A**: that file has no BlueBubbles section to extend; the keys are documented in the BlueBubbles docs page instead. Happy to add a BlueBubbles block if maintainers prefer.
- [x] I've updated `CONTRIBUTING.md`/`AGENTS.md` if I changed architecture — N/A
- [x] I've considered cross-platform impact — pure-Python (datetime/dict/async http), no OS-specific calls
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Notes

Marked **draft** — opening for early visibility / CI, not yet requesting review.
