### PR TITLE
fix(plugins/langfuse): declare pip_dependencies and warn when SDK missing with credentials configured

### DIFF
--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -162,6 +162,19 @@ def _get_langfuse() -> Optional[Langfuse]:
         return _LANGFUSE_CLIENT
 
     if Langfuse is None:
+        # Warn if real credentials are configured but SDK is missing — the
+        # plugin is fail-open so this produces a silent no-op otherwise
+        # (e.g. after a venv refresh removes the langfuse package).
+        # Skip the warning for placeholder/template credentials — those
+        # already get a separate "look like placeholders" warning below.
+        pk = _env("HERMES_LANGFUSE_PUBLIC_KEY") or _env("LANGFUSE_PUBLIC_KEY")
+        sk = _env("HERMES_LANGFUSE_SECRET_KEY") or _env("LANGFUSE_SECRET_KEY")
+        if pk and sk and pk.startswith("pk-lf-") and sk.startswith("sk-lf-"):
+            logger.warning(
+                "Langfuse plugin: credentials are configured but the 'langfuse' "
+                "SDK is not installed — tracing is a silent no-op. "
+                "Install with: pip install langfuse"
+            )
         _LANGFUSE_CLIENT = _INIT_FAILED
         return None
 

--- a/plugins/observability/langfuse/plugin.yaml
+++ b/plugins/observability/langfuse/plugin.yaml
@@ -2,6 +2,8 @@ name: langfuse
 version: "1.0.0"
 description: "Optional Langfuse observability for Hermes — traces conversations, LLM calls, and tool usage. Opt-in via `hermes plugins enable observability/langfuse` or `hermes tools → Langfuse Observability`."
 author: NousResearch
+pip_dependencies:
+  - "langfuse>=2.0"
 requires_env:
   - HERMES_LANGFUSE_PUBLIC_KEY
   - HERMES_LANGFUSE_SECRET_KEY

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -38,6 +38,10 @@ class TestManifest:
         # Required env vars are the user-facing HERMES_ prefixed keys.
         assert "HERMES_LANGFUSE_PUBLIC_KEY" in data["requires_env"]
         assert "HERMES_LANGFUSE_SECRET_KEY" in data["requires_env"]
+        # pip_dependencies declares the langfuse SDK so that dependency
+        # management tools can discover it after venv refresh.
+        assert "pip_dependencies" in data
+        assert any("langfuse" in d for d in data["pip_dependencies"])
 
 
 # ---------------------------------------------------------------------------
@@ -90,6 +94,34 @@ class TestRuntimeGate:
 
         langfuse_plugin = self._fresh_plugin()
         assert langfuse_plugin._get_langfuse() is None
+
+    def test_warns_when_sdk_missing_but_credentials_present(
+        self, monkeypatch, caplog
+    ):
+        """When the langfuse SDK is absent but credentials are configured,
+        _get_langfuse() must log a warning so the operator sees the silent
+        no-op instead of wondering why tracing stopped."""
+        for k in (
+            "HERMES_LANGFUSE_PUBLIC_KEY", "HERMES_LANGFUSE_SECRET_KEY",
+            "LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY",
+        ):
+            monkeypatch.delenv(k, raising=False)
+
+        # Simulate configured credentials.
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-test123")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-test456")
+
+        langfuse_plugin = self._fresh_plugin()
+        # Force Langfuse to None (SDK not installed).
+        langfuse_plugin.Langfuse = None
+
+        with caplog.at_level(logging.WARNING):
+            assert langfuse_plugin._get_langfuse() is None
+
+        assert any(
+            "langfuse" in r.message.lower() and "not installed" in r.message.lower()
+            for r in caplog.records
+        ), f"Expected SDK-missing warning, got: {caplog.records}"
 
     def test_get_langfuse_caches_failure_no_config_load(self, monkeypatch):
         """A miss must be cached — no per-hook config.yaml reads, no env re-reads."""


### PR DESCRIPTION
## What does this PR do?

Declares the `langfuse` SDK as a `pip_dependencies` entry in the bundled Langfuse plugin manifest, and adds a runtime warning when the SDK is missing but Langfuse credentials are configured. Previously, a venv refresh (e.g. via `hermes update`) could silently remove the `langfuse` package while the plugin remained enabled and credentials stayed configured — making observability go dark with no visible signal.

## Related Issue

Fixes #59026

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/observability/langfuse/plugin.yaml`: Added `pip_dependencies: ["langfuse>=2.0"]` so dependency management tools can discover and reinstall the SDK after venv refresh. Consistent with how all 6 bundled memory plugins declare their pip dependencies.
- `plugins/observability/langfuse/__init__.py`: Added a `logger.warning()` in `_get_langfuse()` when the SDK is absent but real (non-placeholder) Langfuse credentials are configured. The plugin remains fail-open — the warning is purely informational and does not affect the agent loop.
- `tests/plugins/test_langfuse_plugin.py`: Added manifest `pip_dependencies` assertion in `test_manifest_fields` and a new `test_warns_when_sdk_missing_but_credentials_present` test covering the warning path.

## How to Test

1. Run `pytest tests/plugins/test_langfuse_plugin.py -v` — all 49 tests should pass, including the new `test_warns_when_sdk_missing_but_credentials_present`.
2. Verify the manifest change: `grep pip_dependencies plugins/observability/langfuse/plugin.yaml` should show `langfuse>=2.0`.
3. Verify the warning path manually: with `langfuse` uninstalled, set `HERMES_LANGFUSE_PUBLIC_KEY=pk-lf-test` and `HERMES_LANGFUSE_SECRET_KEY=sk-lf-test`, then call `_get_langfuse()` — a warning should appear in the log.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
WARNING  plugins.observability.langfuse:__init__.py:171 Langfuse plugin: credentials are configured but the 'langfuse' SDK is not installed — tracing is a silent no-op. Install with: pip install langfuse
```
