### PR TITLE
fix(telegram): redact proxy credentials in INFO log line (#58994)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3067,7 +3067,8 @@ class TelegramAdapter(BasePlatformAdapter):
                     ),
                 )
             elif proxy_url:
-                logger.info("[%s] Proxy detected; passing explicitly to HTTPXRequest: %s", self.name, proxy_url)
+                safe_url = re.sub(r'://[^@]+@', '://***@', proxy_url)
+                logger.info("[%s] Proxy detected; passing explicitly to HTTPXRequest: %s", self.name, safe_url)
                 request = HTTPXRequest(
                     **request_kwargs, proxy=proxy_url, httpx_kwargs=_with_limits()
                 )


### PR DESCRIPTION
## Problem

Closes #58994.

When `HTTPS_PROXY` is set (e.g. to an Infisical Agent Vault MITM at `http://<token>:hermes@host:14322`), the Telegram adapter logs the full URL at INFO on every gateway start:

```
[Telegram] Proxy detected; passing explicitly to HTTPXRequest: http://<token>:hermes@host:14322
```

The userinfo part contains the agent-vault bearer token, leaking credentials into `gateway.log`.

## Fix

Redact the userinfo segment in the log line only — the actual proxy URL passed to HTTPXRequest remains unchanged:

```diff
- logger.info("[%s] Proxy detected; passing explicitly to HTTPXRequest: %s", self.name, proxy_url)
+ safe_url = re.sub(r'://[^@]+@', '://***@', proxy_url)
+ logger.info("[%s] Proxy detected; passing explicitly to HTTPXRequest: %s", self.name, safe_url)
```

`re` is already imported at the top of the file.

## Changes

| File | Δ |
|------|---|
| `plugins/platforms/telegram/adapter.py` | +2/-1 (redact proxy URL in log) |