### PR TITLE
fix(cron): sanitize stale SSL_CERT_FILE before agent init

### DIFF
--- a/agent/ssl_guard.py
+++ b/agent/ssl_guard.py
@@ -84,6 +84,36 @@ def verify_ca_bundle() -> None:
     _validate_bundle_path("certifi", ca_bundle, require_substantial=True)
 
 
+def sanitize_ssl_cert_env() -> None:
+    """Sanitize ``SSL_CERT_FILE`` by clearing it when it points to a missing path.
+
+    A stale ``SSL_CERT_FILE`` env var (inherited from a Windows scheduled-task
+    context, a prior update that moved the venv, or a TLI recovery) causes
+    :func:`verify_ca_bundle` to raise ``SSLConfigurationError`` even when
+    certifi's bundled ``cacert.pem`` is intact.  This function mirrors the
+    cleanup logic in ``gateway/run.py``\u2019s ``_ensure_ssl_certs``: if the
+    variable is set and the path it references does not exist on disk, pop it
+    from the environment so subsequent CA-bundle resolution falls through to
+    certifi.
+
+    Call this **before** building an agent or making any HTTP calls that read
+    ``SSL_CERT_FILE`` from ``os.environ``, not from an already-resolved path.
+    """
+    if _skip_ssl_guard_enabled():
+        logger.debug("SSL_CERT_FILE sanitization skipped via HERMES_SKIP_SSL_GUARD")
+        return
+
+    configured_cert = os.environ.get("SSL_CERT_FILE")
+    if configured_cert:
+        if os.path.exists(configured_cert):
+            return
+        logger.warning(
+            "Ignoring stale SSL_CERT_FILE=%r because the path does not exist",
+            configured_cert,
+        )
+        os.environ.pop("SSL_CERT_FILE", None)
+
+
 def verify_ca_bundle_with_fallback() -> None:
     """Backward-compatible wrapper for older call sites.
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2443,6 +2443,15 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     # ---------------------------------------------------------------
     from run_agent import AIAgent
 
+    # Sanitize SSL_CERT_FILE before agent init. A stale env var (inherited
+    # from a Windows scheduled-task context, a prior update that moved the
+    # venv, or a TLI recovery) would otherwise cause verify_ca_bundle() to
+    # raise SSLConfigurationError even when certifi's bundle is intact.
+    # The gateway path handles this in _ensure_ssl_certs() (gateway/run.py);
+    # the cron scheduler must do the same before constructing an agent.
+    from agent.ssl_guard import sanitize_ssl_cert_env
+    sanitize_ssl_cert_env()
+
     # Initialize SQLite session store so cron job messages are persisted
     # and discoverable via session_search (same pattern as gateway/run.py).
     _session_db = None


### PR DESCRIPTION
## Problem

A stale `SSL_CERT_FILE` environment variable — inherited from a Windows scheduled-task context, a prior `hermes update` that moved the venv, or a TLI recovery — causes `verify_ca_bundle()` in `agent/ssl_guard.py` to raise `SSLConfigurationError` with "SSL_CERT_FILE points to a missing CA bundle" even when certifi's `cacert.pem` is perfectly intact on disk.

The result: every cron job fails with `RuntimeError: Failed to initialize OpenAI client` until the user manually fixes or unsets the env var.

The gateway path already handles this correctly in `_ensure_ssl_certs()` (`gateway/run.py`): it checks whether `SSL_CERT_FILE` points to a real file, and if not, pops the variable and falls back to certifi. The cron scheduler was missing this cleanup entirely.

## Fix

1. **`agent/ssl_guard.py`** — Adds `sanitize_ssl_cert_env()`, a shared function that clears `SSL_CERT_FILE` from the environment when it points to a non-existent path. Respects `HERMES_SKIP_SSL_GUARD` like the other guards in the module.

2. **`cron/scheduler.py`** — Calls `sanitize_ssl_cert_env()` in `run_job()` right after importing `AIAgent`, before any agent construction or HTTP client initialization. This mirrors the gateway's startup sequence in `_ensure_ssl_certs()`.

## Testing

- Verified that `cacert.pem` exists at `certifi.where()` path (236 KB, valid PEM)
- Verified that cron jobs no longer produce the SSL error after this fix
- The function is a no-op when `SSL_CERT_FILE` is unset or points to a valid path (the common case)

## Related

- `gateway/run.py` line 1165: `_ensure_ssl_certs()` — the gateway-side equivalent
- `agent/ssl_guard.py` line 61: `verify_ca_bundle()` — the validator that raises on stale paths
