### PR TITLE
fix(gateway): report the routed profile's model in the auto-reset banner

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10612,7 +10612,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             f"Adjust reset timing in config.yaml under session_reset."
                         )
                         try:
-                            session_info = self._format_session_info()
+                            # Pass the source so the banner reports the routed
+                            # profile's model/provider, not the base config (#59003).
+                            session_info = self._format_session_info(source)
                             if session_info:
                                 notice = f"{notice}\n\n{session_info}"
                         except Exception:
@@ -11861,13 +11863,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Restore session context variables to their pre-handler state
             self._clear_session_env(_session_env_tokens)
 
-    def _format_session_info(self) -> str:
+    def _format_session_info(self, source: "Optional[SessionSource]" = None) -> str:
         """Resolve current model config and return a formatted info block.
 
         Surfaces model, provider, context length, and endpoint so gateway
         users can immediately see if context detection went wrong (e.g.
         local models falling to the 128K default).
+
+        When *source* is provided, model/provider/context are resolved under
+        that source's profile scope, so a multiplexed profile's banner reports
+        its own config instead of the base config.yaml (#59003). Without a
+        source the ambient scope is used (unchanged behavior).
         """
+        if source is not None:
+            with _profile_runtime_scope(self._resolve_profile_home_for_source(source)):
+                return self._format_session_info_impl()
+        return self._format_session_info_impl()
+
+    def _format_session_info_impl(self) -> str:
+        """Build the model/provider info block under the ambient HERMES_HOME scope."""
         from agent.model_metadata import get_model_context_length, DEFAULT_FALLBACK_CONTEXT
 
         model = _resolve_gateway_model()

--- a/tests/gateway/test_multiplex_phase0.py
+++ b/tests/gateway/test_multiplex_phase0.py
@@ -166,6 +166,43 @@ class TestMultiplexConfigFlag:
         assert scoped_config["display"]["tool_progress"] is False
         assert scoped_config["display"]["interim_assistant_messages"] is False
 
+    def test_format_session_info_honors_profile_runtime_scope(self, tmp_path, monkeypatch):
+        """The auto-reset banner must report the routed profile's model, not the
+        base config's (#59003)."""
+        import gateway.run as gateway_run
+
+        root_home = tmp_path / "root"
+        profile_home = tmp_path / "profiles" / "planner"
+        root_home.mkdir(parents=True)
+        profile_home.mkdir(parents=True)
+
+        (root_home / "config.yaml").write_text(
+            yaml.safe_dump({"model": {
+                "default": "base-model-xyz", "provider": "custom",
+                "context_length": 128000,
+            }}),
+            encoding="utf-8",
+        )
+        (profile_home / "config.yaml").write_text(
+            yaml.safe_dump({"model": {
+                "default": "planner-model-abc", "provider": "anthropic",
+                "context_length": 200000,
+            }}),
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", root_home)
+        runner = object.__new__(gateway_run.GatewayRunner)
+        runner._resolve_profile_home_for_source = lambda source: profile_home
+
+        # No source → base config (unchanged behavior).
+        assert "base-model-xyz" in runner._format_session_info()
+
+        # With a source → resolved under that source's profile scope.
+        scoped_info = runner._format_session_info(object())
+        assert "planner-model-abc" in scoped_info
+        assert "base-model-xyz" not in scoped_info
+
 
 class TestSessionStoreProfileResolution:
     """SessionStore._generate_session_key honors the flag: legacy namespace


### PR DESCRIPTION
## What

The gateway auto-reset banner now reports the routed profile's model / provider / context, not the base `config.yaml`.

## Why

The reset notice builds its info block via `_format_session_info()`, which resolves the model through `_resolve_gateway_model()` / `_load_gateway_config()` — both read the base `~/.hermes/config.yaml` with no notion of the per-source profile. On a multiplexed gateway serving a profile whose config overrides `model` / `provider`, the banner advertised the base model even though the live session ran the profile's model. Cosmetic, but misleading when base and profile diverge.

## Change

`_format_session_info()` takes an optional `source`. When given, it resolves the config reads inside `_profile_runtime_scope(self._resolve_profile_home_for_source(source))` — the same contextvar scope the inbound turn path already uses — so `_load_gateway_config()` picks up the profile's home. The reset-notice site passes its `source`; callers without one keep the ambient-scope behavior unchanged.

## Tests

`tests/gateway/test_multiplex_phase0.py` — `_format_session_info(source)` reports the profile's model, while the no-source call still reports the base model.

Closes #59003