### PR TITLE
fix(bootstrap): retry venv removal with exponential backoff on Windows

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1709,12 +1709,20 @@ function Install-Venv {
                 Write-Warn "Old venv parked at $staleName (a process still holds files in it); it will be cleaned up on the next install"
             }
         } else {
+            # Rename failed — fall back to in-place delete with retries.
+            # A killed process can take a moment to release its file handles,
+            # so the first Remove-Item may still hit a locked .pyd. Retry
+            # with exponential backoff before giving up.
             Remove-Item -Recurse -Force "venv" -ErrorAction SilentlyContinue
-            # A killed process can take a moment to release its file handles, so a
-            # first Remove-Item may still hit a locked .pyd. Retry once after a short
-            # pause before giving up and letting the stage fail loudly.
+            $retryDelay = 2
+            for ($retry = 0; $retry -lt 3; $retry++) {
+                if (-not (Test-Path "venv")) { break }
+                Write-Info "  venv still locked (attempt $($retry + 1)/3); waiting ${retryDelay}s..."
+                Start-Sleep -Seconds $retryDelay
+                Remove-Item -Recurse -Force "venv" -ErrorAction SilentlyContinue
+                $retryDelay *= 2
+            }
             if (Test-Path "venv") {
-                Start-Sleep -Seconds 2
                 Remove-Item -Recurse -Force "venv"
             }
         }


### PR DESCRIPTION
## Problem

On Windows, native Python extensions (`.pyd` files like `davey.cp311-win_amd64.pyd`) are loaded as DLLs by the running Hermes process. Windows denies deletion of in-use DLLs. When `hermes update` runs, the `install.ps1` script correctly:

1. Kills `hermes.exe` and any process whose executable lives under the venv
2. Tries `Rename-Item` on the venv directory (which succeeds even with mapped DLLs)
3. Falls back to `Remove-Item -Recurse -Force` when rename fails

However, on this user's machine the gateway autostart (Windows Scheduled Task) respawned the gateway between the kill sweep and the remove attempt, and the single 2-second retry was insufficient. The update failed with:

```
venv FAILED: Das Element ...davey.cp311-win_amd64.pyd kann nicht entfernt werden: Der Zugriff auf den Pfad "davey.cp311-win_amd64.pyd" wurde verweigert.
```

The user had to restore the installation via TLI.

## Fix

Replace the single 2-second retry in the fallback in-place delete path with a loop of up to 3 retries using exponential backoff (2s, 4s, 8s = 14s window):

- Each intermediate attempt uses `-ErrorAction SilentlyContinue` so a transient lock releases on its own
- Only the final attempt after exhaustion propagates the error
- A log line (`Write-Info`) on each retry tells the operator what's happening

This gives Windows file handles up to ~14 seconds to release, which covers common race conditions: scheduled-task respawn, slow process exit, antivirus scan locking, etc.

The Rename-Item path (which succeeds even on locked files) is untouched — this only affects the fallback when rename itself fails (rare, but happens when a handle is held on the directory itself).

## Testing

- Verified the loop logic: 2s, 4s, 8s delays, 3 total attempts, early exit on success
- The change is on the fallback path only — the common case (Rename-Item succeeds) is unchanged
- Existing tests in `scripts/tests/test-install-ps1-longpath.ps1` are not affected
