### PR TITLE
fix(security): deny project-local .env/.envrc in media delivery

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -191,6 +191,17 @@ _BLOCKED_PROJECT_ENV_BASENAMES: set[str] = {
 }
 
 
+def is_project_env_basename(name: str) -> bool:
+    """True if ``name`` is a secret-bearing project env filename.
+
+    Shared by the read guard (:func:`get_read_block_error`, which blocks reading
+    these anywhere on disk) and the media-delivery denylist
+    (``gateway/platforms/base.validate_media_delivery_path``) so the delivery /
+    exfil side can't drift from the read side. Case-insensitive basename match.
+    """
+    return name.lower() in _BLOCKED_PROJECT_ENV_BASENAMES
+
+
 def get_read_block_error(path: str) -> Optional[str]:
     """Return an error message when a read targets a denied Hermes path.
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -22,6 +22,7 @@ import weakref
 from abc import ABC, abstractmethod
 from urllib.parse import urlsplit
 
+from agent.file_safety import is_project_env_basename
 from utils import normalize_proxy_url
 
 logger = logging.getLogger(__name__)
@@ -1492,6 +1493,16 @@ def validate_media_delivery_path(path: str) -> Optional[str]:
         return None
 
     if not resolved.is_file():
+        return None
+
+    # Project-local secret env files (.env, .envrc, ...) are read-blocked
+    # anywhere on disk by agent/file_safety.get_read_block_error. Mirror that on
+    # the delivery/exfil side so it can't trail the read guard (the denylist's
+    # own stated invariant, above): the per-Hermes-root ".env" entry in
+    # _media_delivery_denied_paths only covers <hermes-root>/.env, never a
+    # user's own project .env. Checked before the cache allowlist so a secret
+    # env file is never deliverable regardless of location or delivery mode.
+    if is_project_env_basename(resolved.name):
         return None
 
     # Cache / operator allowlist is always honored — these are unconditionally

--- a/tests/gateway/test_media_delivery_project_env_guard.py
+++ b/tests/gateway/test_media_delivery_project_env_guard.py
@@ -1,0 +1,103 @@
+"""Regression: a project-local ``.env`` / ``.envrc`` must not be deliverable as
+native media when the same path is read-blocked by ``agent/file_safety``.
+
+``gateway/platforms/base._media_delivery_denied_paths`` documents the invariant
+that "a credential the agent is forbidden to ... read must also never be
+auto-attached to a chat reply". ``agent/file_safety.get_read_block_error``
+read-blocks ``.env`` / ``.envrc`` anywhere on disk by basename, but the media
+denylist only enumerates ``<hermes-root>/.env``, so a user's *project* ``.env``
+(e.g. ``/home/user/app/.env``) was deliverable via a prompt-injected ``MEDIA:``
+tag in default (non-strict) single-user mode -> credential exfiltration.
+
+The gate is also only worth as much as its weakest path, so it must fail
+closed: an unavailable predicate has to deny, never skip the check.
+"""
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+import gateway.platforms.base as base
+from gateway.platforms.base import BasePlatformAdapter, validate_media_delivery_path
+from agent import file_safety
+
+
+def test_dotenv_basename_has_no_suffix():
+    # Reachability of the extensionless ``MEDIA:`` branch hinges on this pathlib
+    # fact: a leading-dot name has no suffix, so ``.env`` / ``.envrc`` are
+    # extensionless and take the branch that calls validate_media_delivery_path.
+    # Verified empirically, not from memory.
+    assert Path("/home/u/app/.env").suffix == ""
+    assert Path("/home/u/app/.envrc").suffix == ""
+    # A real extension is still detected, so ``.env.production`` is NOT
+    # extensionless and does not reach that branch (scope caveat).
+    assert Path("/home/u/app/.env.production").suffix == ".production"
+
+
+@pytest.mark.parametrize("basename", [".env", ".envrc"])
+def test_project_env_gate_mirrors_read_guard(tmp_path, monkeypatch, basename):
+    # Default single-user gateway = non-strict media delivery.
+    monkeypatch.setattr(base, "_media_delivery_strict_mode", lambda: False)
+
+    proj = tmp_path / "app"
+    proj.mkdir()
+    secret = proj / basename
+    secret.write_text("OPENAI_API_KEY=sk-live-SECRET\nDATABASE_URL=postgres://u:p@h/db\n")
+    p = str(secret.resolve())
+
+    # Precondition: the read guard blocks reading this project env file.
+    assert file_safety.get_read_block_error(p) is not None, (
+        "read guard should block the project env file (basename rule)"
+    )
+
+    # The delivery gate must mirror the read guard: a read-blocked credential
+    # must not be returned as a safe native attachment.
+    assert validate_media_delivery_path(p) is None, (
+        f"{basename} is read-blocked but validate_media_delivery_path approved "
+        "it for native attachment -> prompt-injected MEDIA: exfil"
+    )
+
+
+@pytest.mark.parametrize("basename", [".env", ".envrc"])
+def test_project_env_not_deliverable_via_media_tag(tmp_path, monkeypatch, basename):
+    # End-to-end: a prompt-injected MEDIA: tag pointing at a project env file
+    # must not surface it as a deliverable attachment.
+    monkeypatch.setattr(base, "_media_delivery_strict_mode", lambda: False)
+
+    proj = tmp_path / "app"
+    proj.mkdir()
+    secret = proj / basename
+    secret.write_text("STRIPE_SECRET_KEY=sk_live_SECRET\n")
+    p = str(secret.resolve())
+
+    reply = f"Sure, here is the file:\nMEDIA:{p}\n"
+    media, _cleaned = BasePlatformAdapter.extract_media(reply)
+    delivered_basenames = [Path(mp).name.lower() for mp, _voice in media]
+    assert basename not in delivered_basenames, (
+        f"project {basename} auto-attached for exfil via MEDIA: tag: {media}"
+    )
+
+
+def test_project_env_gate_fails_closed_on_import_failure(tmp_path, monkeypatch):
+    # The gate has to fail *closed*: an unavailable predicate must deny, never
+    # skip the check. Binding it at module import is what guarantees that, so
+    # pin the property rather than the mechanism -- a call-time import must not
+    # be able to decide whether the .env check runs at all.
+    monkeypatch.setattr(base, "_media_delivery_strict_mode", lambda: False)
+    monkeypatch.setitem(sys.modules, "agent.file_safety", None)
+
+    # Precondition: with the entry poisoned, a call-time import really fails.
+    with pytest.raises(ImportError):
+        importlib.import_module("agent.file_safety")
+
+    proj = tmp_path / "app"
+    proj.mkdir()
+    secret = proj / ".env"
+    secret.write_text("AWS_SECRET_ACCESS_KEY=SECRET\n")
+
+    assert validate_media_delivery_path(str(secret.resolve())) is None, (
+        "delivery gate fell open while agent.file_safety was unimportable at "
+        "call time -> project .env deliverable again"
+    )


### PR DESCRIPTION
## What does this PR do?

The read guard `agent/file_safety.get_read_block_error` blocks the agent from reading `.env` / `.envrc` anywhere on disk by basename (`_BLOCKED_PROJECT_ENV_BASENAMES`). The media-delivery denylist that gates auto-attachment does not mirror that rule: `_media_delivery_denied_paths` only denies `<hermes-root>/.env`, so a user's own project `.env` (e.g. `/home/user/app/.env`) passes `validate_media_delivery_path` and is delivered as a native attachment.

`_media_delivery_denied_paths` states the invariant in its own comment: a credential the agent is forbidden to read must also never be auto-attached to a chat reply. In default (non-strict) single-user mode, a prompt-injected `MEDIA:/path/.env` tag exfiltrates API keys and database passwords into the chat transport. `.env` / `.envrc` reach the delivery gate because they are extensionless (`Path(".env").suffix == ""`), so `extract_media` takes the extensionless `MEDIA:` branch that calls `validate_media_delivery_path`.

This adds a shared `is_project_env_basename()` predicate in `agent/file_safety` (single source of truth for the basename set) and rejects those basenames in `validate_media_delivery_path`, before the cache allowlist, so a secret env file is never deliverable regardless of location or mode. The delivery side now mirrors the read guard.

## Related Issue

Fixes #59044

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/file_safety.py`: add `is_project_env_basename(name)`, a case-insensitive predicate over `_BLOCKED_PROJECT_ENV_BASENAMES`, shared by the read guard and the media-delivery denylist so the two cannot drift.
- `gateway/platforms/base.py`: in `validate_media_delivery_path`, after the `is_file()` check and before the cache allowlist, reject any path whose basename is a project env file. Unconditional in both strict and non-strict mode, so the delivery side mirrors the read guard. The predicate is bound at module import, next to the existing first-party import, so the check cannot be skipped (see Review follow-up).
- `tests/gateway/test_media_delivery_project_env_guard.py` (new, 6 cases): the pathlib extensionless fact and its scope caveat (`.env.production` is not extensionless); the delivery gate mirrors the read guard for `.env`/`.envrc`; e2e that a prompt-injected `MEDIA:` tag does not surface the project env file as a deliverable attachment; and that the gate fails closed when the predicate is unavailable.

## Review follow-up

Review flagged the first cut of this gate as fail-open, and it was right. `validate_media_delivery_path` imported the predicate lazily behind `try/except Exception: is_project_env_basename = None` and then called it only `if ... is not None`, so any import failure skipped the check outright and silently reopened the exfil path the gate exists to close. A guard whose failure path allows the action is not a guard.

There was no import cycle to defer around: `agent/file_safety` imports only stdlib and never imports `gateway`, and `agent/__init__` only preloads `jiter`. The predicate is now bound at module import and called unconditionally.

`test_project_env_gate_fails_closed_on_import_failure` pins the property rather than the mechanism: it poisons `sys.modules["agent.file_safety"]`, asserts that a call-time import really raises `ImportError`, then asserts the project `.env` is still not deliverable. It discriminates: against the previous fail-open commit it fails, with `validate_media_delivery_path` returning the `.env` path instead of `None`, while the other five cases pass.

## How to Test

```
# new regression test (PR base 52a5fc0048)
pytest tests/gateway/test_media_delivery_project_env_guard.py -q
  -> 6 passed          (on the base without the fix: 5 failed, 1 passed)

# existing platform-base suite, A/B against the fix
pytest tests/gateway/test_platform_base.py -q
  -> 6 failed, 170 passed, 1 skipped   (identical with and without this change)

# lint
ruff check agent/file_safety.py gateway/platforms/base.py tests/gateway/test_media_delivery_project_env_guard.py
  -> All checks passed!
```

The 5 failures on the base are the gate-mirror and e2e-delivery assertions for `.env` / `.envrc` plus the fail-closed regression; the fix turns them green. The 6 failures in `test_platform_base.py` are pre-existing and identical with and without this change (environment-specific on Windows: recency / symlink / null-path / cache-roots), so this change adds zero regressions. The runs above are local (Windows 11, Python 3.13, cherry-picked onto current main). Full `pytest tests/` in my environment has pre-existing optional-dep collection errors unrelated to this change; the touched path is covered above and by CI.

Green ubuntu run for this head: https://github.com/cryptoyasenka/hermes-agent/actions/runs/31056695603

## Related work (not duplicates)

This continues the "delivery side cannot trail the read/write guard" line (#51055, #56163) but covers a different file class:
- #51453 denies home-root single-file stores (`~/.netrc`, `~/.pgpass`, `~/.npmrc`, `~/.pypirc`, `~/.git-credentials`).
- #47220 denies sibling-profile control files under `~/.hermes/profiles/<other>/`.
- #55796 denies home dirs (`~/.config`, `~/.gcloud`, macOS Keychains).
- #52045 casefolds the existing guards but does not add a project-env basename to the media denylist.

None of them block a user's project-local `.env`/`.envrc` (an arbitrary working-directory file the read guard already blocks by basename), which is the only path this PR changes.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(security): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (see Related work).
- [x] My PR contains only changes related to this fix
- [x] I've run the affected suites locally (see How to Test). Full `pytest tests/` has pre-existing optional-dep collection errors in my environment; the touched path is covered above and by CI.
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping
- [x] I've updated relevant documentation (N/A: internal delivery guard, no doc surface)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys (N/A: no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` (N/A)
- [x] I've considered cross-platform impact (basename logic, no OS-specific calls; the shared predicate is case-insensitive)
- [x] I've updated tool descriptions/schemas (N/A)

