### PR TITLE
fix(gateway): scope reset banners' session info to the serving profile

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10612,7 +10612,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             f"Adjust reset timing in config.yaml under session_reset."
                         )
                         try:
-                            session_info = self._format_session_info()
+                            session_info = await asyncio.to_thread(
+                                self._reset_notice_session_info, source
+                            )
                             if session_info:
                                 notice = f"{notice}\n\n{session_info}"
                         except Exception:
@@ -11860,6 +11862,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         finally:
             # Restore session context variables to their pre-handler state
             self._clear_session_env(_session_env_tokens)
+
+    def _reset_notice_session_info(self, source: SessionSource) -> str:
+        """Session-info block for the auto-reset notice, profile-scoped.
+
+        When multiplexing, resolve model/provider/context inside the profile
+        serving ``source`` — otherwise the banner advertises the base config's
+        model while the session actually runs on the profile's (#59003).
+        Mirrors ``_run_agent``'s gating so single-profile gateways never
+        enter the scope.
+
+        Call via ``asyncio.to_thread`` from async handlers: under the scope,
+        resolution can do blocking work (credential refresh, context-length
+        HTTP probes) that must not run on the event loop. The scope is entered
+        inside this method, so contextvars behave correctly in the worker
+        thread.
+        """
+        if getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            with _profile_runtime_scope(self._resolve_profile_home_for_source(source)):
+                return self._format_session_info()
+        return self._format_session_info()
 
     def _format_session_info(self) -> str:
         """Resolve current model config and return a formatted info block.

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -231,9 +231,13 @@ class GatewaySlashCommandsMixin:
             "session_key": session_key,
         })
 
-        # Resolve session config info to surface to the user
+        # Resolve session config info to surface to the user, scoped to the
+        # profile serving this source so a multiplexed /reset //new banner
+        # reports the profile's model, not the base config's (#59003).
         try:
-            session_info = self._format_session_info()
+            session_info = await asyncio.to_thread(
+                self._reset_notice_session_info, source
+            )
         except Exception:
             session_info = ""
 

--- a/tests/gateway/test_session_info.py
+++ b/tests/gateway/test_session_info.py
@@ -107,3 +107,51 @@ class TestFormatSessionInfo:
             info = runner._format_session_info()
         assert "4K" in info
         assert "config" in info
+
+
+class TestResetNoticeSessionInfo:
+    """#59003: the auto-reset banner must report the serving profile's config,
+    not the multiplexer's base config."""
+
+    _RUNTIME = {"provider": "", "base_url": "", "api_key": ""}
+
+    def _source(self):
+        from gateway.config import Platform
+        from gateway.session import SessionSource
+        return SessionSource(
+            platform=Platform.TELEGRAM, chat_id="123", user_id="u1",
+            profile="planner",
+        )
+
+    def _homes(self, tmp_path):
+        base = tmp_path / "base"
+        profile = tmp_path / "profiles" / "planner"
+        profile.mkdir(parents=True)
+        base.mkdir()
+        base.joinpath("config.yaml").write_text(
+            "model:\n  default: base-model\n  provider: custom\n  context_length: 1000\n")
+        profile.joinpath("config.yaml").write_text(
+            "model:\n  default: profile-model\n  provider: anthropic\n  context_length: 2000\n")
+        return base, profile
+
+    def test_multiplex_uses_profile_config(self, runner, tmp_path):
+        from types import SimpleNamespace
+        base, profile = self._homes(tmp_path)
+        runner.config = SimpleNamespace(multiplex_profiles=True)
+        with patch("gateway.run._hermes_home", base), \
+             patch.object(GatewayRunner, "_resolve_profile_home_for_source", return_value=profile), \
+             patch("gateway.run._resolve_runtime_agent_kwargs", return_value=self._RUNTIME):
+            info = runner._reset_notice_session_info(self._source())
+        assert "profile-model" in info
+        assert "anthropic" in info
+        assert "base-model" not in info
+
+    def test_single_profile_uses_base_config(self, runner, tmp_path):
+        from types import SimpleNamespace
+        base, _profile = self._homes(tmp_path)
+        runner.config = SimpleNamespace(multiplex_profiles=False)
+        with patch("gateway.run._hermes_home", base), \
+             patch("gateway.run._resolve_runtime_agent_kwargs", return_value=self._RUNTIME):
+            info = runner._reset_notice_session_info(self._source())
+        assert "base-model" in info
+        assert "profile-model" not in info


### PR DESCRIPTION
## Summary

On a multiplexing gateway, the session-reset banners (the auto-reset notice and the manual `/reset` / `/new` confirmation) appended `_format_session_info()` **outside any profile scope**, so the banner advertised the **base** config's model/provider/context while the session actually ran on the serving profile's model.

## Root cause

`_format_session_info()` resolves model/provider/context via `_resolve_gateway_model()` / `_load_gateway_config()`, which honor the context-local profile home override (`_gateway_config_home()`) — but both banner call sites ran before/outside `_run_agent`'s `_profile_runtime_scope`, so the override was never set and reads fell back to the base `_hermes_home`.

## Fix

- Add `GatewayRunner._reset_notice_session_info(source)`: when `gateway.multiplex_profiles` is on, enter `_profile_runtime_scope(self._resolve_profile_home_for_source(source))` around `_format_session_info()` — mirroring `_run_agent`'s gating, so single-profile gateways never enter the scope (zero behavior change).
- Route **both** banner call sites through it: the auto-reset notice (`gateway/run.py`) and the `/reset` / `/new` confirmation (`gateway/slash_commands.py`).
- Both call sites invoke the helper via `asyncio.to_thread`: under the scope, resolution can do blocking work (credential refresh, context-length HTTP probes via `requests`) that previously failed fast when unscoped (`UnscopedSecretError`) and must not run on the event loop. The scope is entered inside the helper, so contextvars behave correctly in the worker thread.

## Tests

- `TestResetNoticeSessionInfo` (new): with `multiplex_profiles=True` and distinct base/profile `config.yaml`s, the banner reports the profile's model/provider and not the base's; with multiplexing off, the base config is used. The multiplex test fails without the scope-entering fix (verified by temporarily removing it).
- Existing `_format_session_info` tests unchanged and passing; targeted gateway reset/session suites (79 tests) and the broader affected set (530 tests) pass. The one failure in the broad set (`test_background_command.py::test_media_files_routed_by_type`) also fails on clean `main` — pre-existing and unrelated.

Fixes #59003
