### PR TITLE
fix(desktop): reset selectedModel on provider switch, probe empty custom providers

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -275,9 +275,30 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
   const needsSetup = !!selectedProvider && !isProviderReady(selectedProviderRow)
   const setupIsApiKey = needsSetup && selectedProviderRow?.auth_type === 'api_key' && !!selectedProviderRow?.key_env
 
-  // Clear any half-typed key when switching provider so it can't leak across.
+  // Clear any half-typed key and stale model when switching provider.
+  // Without this, switching to a custom provider whose models haven't been
+  // probed yet (empty models list) leaves the previous provider's model
+  // visible in the Select via withActive(), making it look like the model
+  // list didn't refresh.  For empty-but-authenticated providers, call
+  // with refresh=true so the backend probes the live /models endpoint.
   useEffect(() => {
     setApiKeyDraft('')
+    setSelectedModel('')
+
+    const row = providers.find(p => p.slug === selectedProvider)
+    if (row && row.authenticated !== false && (row.models?.length ?? 0) === 0) {
+      const epoch = profileEpoch.current
+      getGlobalModelOptions({ refresh: true })
+        .then(opts => {
+          if (profileEpoch.current !== epoch) return
+          setProviders(opts.providers || [])
+          const refreshed = opts.providers?.find(p => p.slug === selectedProvider)
+          if (refreshed?.models?.length) {
+            setSelectedModel(refreshed.models[0])
+          }
+        })
+        .catch(() => {})
+    }
   }, [selectedProvider])
 
   const auxDraftProviderModels = useMemo(


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in Settings → Model where switching to a custom provider (one defined under `providers:` in config.yaml with `discover_models: true` and no explicit `models:` list) kept showing the previous provider's model in the dropdown — the model list appeared not to refresh.

Two changes in `model-settings.tsx`:
1. Clears `selectedModel` when the provider changes (only `apiKeyDraft` was cleared before)
2. Auto-probes empty-but-authenticated custom providers by calling `getGlobalModelOptions({ refresh: true })`

## Related Issue

Fixes #59063

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/settings/model-settings.tsx`: Extended the existing `useEffect` on provider change to clear `selectedModel` and auto-probe authenticated providers with empty models lists via `getGlobalModelOptions({ refresh: true })`.  Respects `profileEpoch` guard so mid-flight profile switches discard stale responses.  Swallowed `.catch()` so an offline custom endpoint doesn't crash the component.

## How to Test

1. Configure a custom provider with `discover_models: true` and no explicit `models:` list
2. Open Settings → Model, note the current provider and model
3. Switch the provider dropdown to the custom provider
4. The model dropdown should clear immediately (no stale model) then populate with live models from `/v1/models`
5. Switch back to another provider — model list should follow
6. Kill the custom endpoint, switch to its provider — dropdown stays empty, no crash

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A, frontend-only TypeScript change; no Python code touched
- [ ] I've added tests for my changes — the existing test file (`model-settings.test.tsx`) has a pre-existing jsdom environment failure (`Element is not defined` in `beforeAll`).  This blocks adding a test without fixing the test infrastructure first.  Manually verified on macOS.
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
