### PR TITLE
fix(dashboard): move CORSMiddleware outermost so OPTIONS preflight bypasses auth

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -282,17 +282,6 @@ _reveal_timestamps: List[float] = []
 _REVEAL_MAX_PER_WINDOW = 5
 _REVEAL_WINDOW_SECONDS = 30
 
-# CORS: restrict to localhost origins only.  The web UI is intended to run
-# locally; binding to 0.0.0.0 with allow_origins=["*"] would let any website
-# read/modify config and secrets.
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
-
 # ---------------------------------------------------------------------------
 # Endpoints that do NOT require the session token.  Everything else under
 # /api/ is gated by the auth middleware below.
@@ -599,6 +588,21 @@ async def _token_auth_seam(request: Request, call_next):
     from hermes_cli.dashboard_auth.token_auth import token_auth_middleware
     return await token_auth_middleware(request, call_next)
 
+
+# CORS: restrict to localhost origins only.  The web UI is intended to run
+# locally; binding to 0.0.0.0 with allow_origins=["*"] would let any website
+# read/modify config and secrets.
+#
+# Registered AFTER all ``@app.middleware("http")`` decorators so it is the
+# *outermost* middleware (Starlette's onion: last-added runs first).
+# Without this, an OPTIONS preflight from a cross-origin SPA hits the auth
+# middlewares before CORS can answer, producing 401 instead of 204 + headers.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 # ---------------------------------------------------------------------------
 # Config schema — auto-generated from DEFAULT_CONFIG

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -360,16 +360,6 @@ _DASHBOARD_EMBEDDED_CHAT_ENABLED = True
 # uvicorn's 16 MiB default rejects files under the 256 MiB raw attach cap.
 _DESKTOP_ATTACHMENT_WS_MAX_BYTES = 384 * 1024 * 1024
 
-
-# CORS: localhost origins only — allow_origins=["*"] on 0.0.0.0 would let any
-# website read/modify config and secrets.
-app.add_middleware(
-    CORSMiddleware,
-    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
-
 # Endpoints that do NOT require the session token; everything else under /api/
 # is gated below. Shared with the OAuth gate so the two allowlists cannot
 # drift (/api/status once 401'd under the OAuth gate, breaking the portal probe).
@@ -709,7 +699,7 @@ DASHBOARD_HEALTH = DashboardHealth()
 
 @app.middleware("http")
 async def _dashboard_health_middleware(request: Request, call_next):
-    """Outermost middleware (registered last): count unhandled exceptions and 5xx; re-raises, never alters."""
+    """Outermost non-CORS middleware: count unhandled exceptions and 5xx; re-raises, never alters."""
     try:
         response = await call_next(request)
     except Exception as exc:
@@ -718,6 +708,22 @@ async def _dashboard_health_middleware(request: Request, call_next):
     if response.status_code >= 500:
         DASHBOARD_HEALTH.record_error(f"http_{response.status_code}", request.url.path)
     return response
+
+
+# CORS: restrict to localhost origins only.  The web UI is intended to run
+# locally; binding to 0.0.0.0 with allow_origins=["*"] would let any website
+# read/modify config and secrets.
+#
+# Registered AFTER all ``@app.middleware("http")`` decorators so it is the
+# *outermost* middleware (Starlette's onion: last-added runs first).
+# Without this, an OPTIONS preflight from a cross-origin SPA hits the auth
+# middlewares before CORS can answer, producing 401 instead of 204 + headers.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 # Authenticated-route self-test: one in-process request per minute against a

--- a/tests/hermes_cli/test_web_server_cors_preflight.py
+++ b/tests/hermes_cli/test_web_server_cors_preflight.py
@@ -1,0 +1,95 @@
+"""Tests for CORS preflight ordering on the dashboard web server.
+
+Regression: ``CORSMiddleware`` was registered *before* the
+``@app.middleware("http")`` auth decorators, making it the innermost
+layer in Starlette's onion model.  A cross-origin ``OPTIONS`` preflight
+hit the auth middleware first → 401, and the CORS headers were never
+sent.  Moving the ``add_middleware(CORSMiddleware, …)`` call *after*
+all ``@app.middleware("http")`` registrations makes CORS outermost so
+preflights are answered before auth runs.
+
+See: https://github.com/NousResearch/hermes-agent/issues/59052
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli import web_server
+
+pytest.importorskip("starlette.testclient")
+from starlette.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    return TestClient(web_server.app)
+
+
+# ---- CORS preflight (OPTIONS) must not be blocked by auth ------------
+
+
+def test_options_preflight_returns_cors_headers(client):
+    """OPTIONS with Origin + Access-Control-Request-Method → 200 + CORS."""
+    resp = client.options(
+        "/api/skills",
+        headers={
+            "Origin": "http://127.0.0.1:8092",
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "x-hermes-session-token",
+        },
+    )
+    assert resp.status_code == 200
+    assert "access-control-allow-origin" in resp.headers
+    assert resp.headers["access-control-allow-origin"] == "http://127.0.0.1:8092"
+    assert "access-control-allow-methods" in resp.headers
+
+
+def test_options_preflight_allows_localhost_origin(client):
+    """Preflight from a different localhost port is allowed."""
+    resp = client.options(
+        "/api/status",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.headers.get("access-control-allow-origin") == "http://localhost:3000"
+
+
+def test_options_preflight_rejects_disallowed_origin(client):
+    """Preflight from a non-localhost origin is rejected (no CORS headers)."""
+    resp = client.options(
+        "/api/skills",
+        headers={
+            "Origin": "http://evil.example.com",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    # Starlette CORSMiddleware returns 400 for disallowed origins on preflight
+    assert resp.status_code == 400
+    assert "access-control-allow-origin" not in resp.headers
+
+
+def test_get_without_origin_has_no_cors_headers(client):
+    """A same-origin GET (no Origin header) has no CORS headers."""
+    resp = client.get(
+        "/api/status",
+        headers={web_server._SESSION_HEADER_NAME: web_server._SESSION_TOKEN},
+    )
+    assert resp.status_code == 200
+    assert "access-control-allow-origin" not in resp.headers
+
+
+def test_get_with_matching_origin_has_cors_headers(client):
+    """A cross-origin GET from an allowed origin has CORS headers."""
+    resp = client.get(
+        "/api/status",
+        headers={
+            "Origin": "http://127.0.0.1:8092",
+            web_server._SESSION_HEADER_NAME: web_server._SESSION_TOKEN,
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.headers.get("access-control-allow-origin") == "http://127.0.0.1:8092"


### PR DESCRIPTION
## What does this PR do?

Moves the `CORSMiddleware` registration in `hermes_cli/web_server.py` from before the `@app.middleware("http")` auth decorators to after them. In Starlette's onion model, the last-added middleware is the outermost (runs first). Previously, CORS was innermost — an `OPTIONS` preflight from a cross-origin SPA hit the auth middlewares first, which returned 401 before CORS could answer with the proper `Access-Control-Allow-*` headers.

## Related Issue

Fixes #59052

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py` — Moved `app.add_middleware(CORSMiddleware, …)` from line 289 (before `@app.middleware("http")` registrations) to after the last `@app.middleware("http")` decorator (`_token_auth_seam`), making CORS the outermost middleware. Added comment explaining the ordering rationale.
- `tests/hermes_cli/test_web_server_cors_preflight.py` (new) — 5 regression tests verifying OPTIONS preflight returns CORS headers, allowed/disallowed origin handling, and same-origin requests are unaffected.

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_web_server_cors_preflight.py -v` — all 5 tests should pass.
2. Run `python -m pytest tests/hermes_cli/ -v` — all existing dashboard tests should still pass (auth tests verify 401 for unauthenticated non-OPTIONS requests is unchanged).
3. Manual verification (optional): start `hermes dashboard`, then from a different localhost port:
   ```
   curl -i -X OPTIONS \
     -H 'Origin: http://127.0.0.1:8092' \
     -H 'Access-Control-Request-Method: GET' \
     -H 'Access-Control-Request-Headers: x-hermes-session-token' \
     http://127.0.0.1:9119/api/skills
   ```
   Expected: `HTTP/1.1 200 OK` with `Access-Control-Allow-Origin: http://127.0.0.1:8092`. Before this fix: `HTTP/1.1 401 Unauthorized`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
