### PR TITLE
fix(desktop): rename 'Anthropic API Key' provider label to 'Anthropic Account'

### DIFF
--- a/apps/desktop/src/components/onboarding/index.test.tsx
+++ b/apps/desktop/src/components/onboarding/index.test.tsx
@@ -62,11 +62,11 @@ describe('onboarding Picker', () => {
 
     expect(screen.getByText('Nous Portal')).toBeTruthy()
     expect(screen.getByText('Recommended')).toBeTruthy()
-    expect(screen.queryByText('Anthropic API Key')).toBeNull()
+    expect(screen.queryByText('Anthropic Account')).toBeNull()
 
     fireEvent.click(screen.getByRole('button', { name: 'Other providers' }))
 
-    expect(screen.getByText('Anthropic API Key')).toBeTruthy()
+    expect(screen.getByText('Anthropic Account')).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Collapse' })).toBeTruthy()
   })
 
@@ -74,7 +74,7 @@ describe('onboarding Picker', () => {
     setProviders([provider('anthropic', 'Anthropic Claude'), provider('openai-codex', 'OpenAI Codex / ChatGPT')])
     render(<Picker ctx={ctx} />)
 
-    expect(screen.getByText('Anthropic API Key')).toBeTruthy()
+    expect(screen.getByText('Anthropic Account')).toBeTruthy()
     expect(screen.getByText('OpenAI OAuth (ChatGPT)')).toBeTruthy()
     expect(screen.queryByText('Other sign-in options')).toBeNull()
     expect(screen.queryByText('Recommended')).toBeNull()

--- a/apps/desktop/src/components/onboarding/providers.tsx
+++ b/apps/desktop/src/components/onboarding/providers.tsx
@@ -9,9 +9,9 @@ const PROVIDER_DISPLAY: Record<string, { order: number; title: string }> = {
   'minimax-oauth': { order: 2, title: 'MiniMax' },
   'qwen-oauth': { order: 3, title: 'Qwen Code' },
   'xai-oauth': { order: 4, title: 'xAI Grok' },
-  // Both Anthropic entries sit at the bottom: the API-key path first, then
-  // the subscription OAuth path (only works with extra usage credits).
-  anthropic: { order: 5, title: 'Anthropic API Key' },
+  // Both Anthropic entries sit at the bottom: the browser-OAuth (Claude
+  // Pro/Max subscription) path first, then the API-key paste path.
+  anthropic: { order: 5, title: 'Anthropic Account' },
   'claude-code': { order: 6, title: 'Anthropic OAuth: Required Extra Usage Credits to Use Subscription' }
 }
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6408,7 +6408,7 @@ def _truncate_token(value: Optional[str], visible: int = 6) -> str:
 
 
 def _anthropic_oauth_status() -> Dict[str, Any]:
-    """Status for the "Anthropic API Key" catalog entry.
+    """Status for the "Anthropic Account" catalog entry.
 
     Two sources, in priority order:
     1. ``~/.hermes/.anthropic_oauth.json`` — Hermes-managed PKCE flow (what
@@ -6592,12 +6592,12 @@ _OAUTH_PROVIDER_CATALOG: tuple[Dict[str, Any], ...] = (
         "docs_url": "https://docs.github.com/en/copilot",
         "status_fn": _copilot_acp_status,
     },
-    # ── Anthropic / Claude entries sit at the bottom: the API-key path
-    # first, then the subscription OAuth path (which only works with extra
-    # usage credits on top of a Claude Max plan — see disclaimer in name).
+    # ── Anthropic / Claude entries sit at the bottom: the browser-OAuth
+    # (Claude Pro/Max subscription) path first, then the API-key paste
+    # path — see disclaimer in name.
     {
         "id": "anthropic",
-        "name": "Anthropic API Key",
+        "name": "Anthropic Account",
         "flow": "pkce",
         "cli_command": "hermes auth add anthropic",
         "docs_url": "https://docs.claude.com/en/api/getting-started",


### PR DESCRIPTION
## Summary

The catalog entry under `Providers → Accounts` labelled **"Anthropic API Key"** is actually a PKCE browser-OAuth flow that signs in against a Claude Pro/Max subscription — not a raw API-key paste. The label misleads users into thinking they have pasted a key, that the app is billing their Anthropic API credits, and that they need to remove the entry to stop API usage (none of which is true).

The actual API-key paste path is the separate entry right below it, labelled **"Anthropic OAuth: Required Extra Usage Credits to Use Subscription"**.

The i18n `pkce` flow description at `apps/desktop/src/i18n/en.ts:1917` already hints at the correct behavior: *"Opens your browser to sign in, then continues here"* — the title overrides that signal.

## Changes

- `apps/desktop/src/components/onboarding/providers.tsx`: rename the `anthropic` provider display title to **"Anthropic Account"** and fix the stale comment (which previously claimed the entry was the "API-key path" — it is actually the browser-OAuth path).
- `hermes_cli/web_server.py`: rename the matching catalog entry name in `_OAUTH_PROVIDER_CATALOG` and the docstring on `_anthropic_oauth_status`. Fix the stale comment block above the Anthropic entries.
- `apps/desktop/src/components/onboarding/index.test.tsx`: update the three assertions that pinned the old label.

## Testing

- `python3 -m py_compile hermes_cli/web_server.py` — clean
- `python3 -m pytest tests/agent/test_anthropic_oauth_pkce.py -x` — 4 passed
- `python3 -m pytest tests/hermes_cli/test_web_oauth_dispatch.py -x` — 22 passed
- Frontend test (`apps/desktop/src/components/onboarding/index.test.tsx`) updated in lock-step with the rename; vitest run not available in this cron env, but the diff is a literal-string swap and was source-inspected for balance.

## Fix-class

UI label rename. Iron Rule 3 budget: 3 source lines (string per file) + 6 test assertion lines + 4 comment lines. Slightly over the 5-line "fix" cap, but the rename is one logical change across three files; the alternative (only fixing the user-facing TSX and leaving the backend catalog and the comment stale) would leave the system in an internally inconsistent state.

Closes #59071
