### PR TITLE
fix(gateway): write restart-notification marker in all restart paths (launchd + systemd CLI + systemd direct)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20017,6 +20017,14 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             # marker first, land in the `planned_stop` branch above, and
             # leave this flag False so they DO persist "stopped".
             runner._signal_initiated_shutdown = True
+            # systemd SIGTERM: when INVOCATION_ID is set the signal came
+            # from the service manager (Restart=always or systemctl restart),
+            # not an external kill. Treat it as a planned service restart so
+            # the gateway writes .restart_pending.json and exits 0 instead
+            # of triggering an additional restart cycle.
+            if os.environ.get("INVOCATION_ID"):
+                runner._restart_requested = True
+                runner._restart_via_service = True
             logger.info(
                 "Received %s — initiating shutdown",
                 _shutdown_ctx["signal"] if _shutdown_ctx else "SIGTERM/SIGINT",

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3257,6 +3257,11 @@ def systemd_restart(system: bool = False):
             if _systemd_service_is_start_limited(system=system):
                 return
 
+        # SIGUSR1 timed out — the gateway didn't exit gracefully in time.
+        # Write the planned-restart marker so the next startup sends the
+        # "♻️ Gateway online" home-channel notification.  (On the graceful
+        # path the gateway writes this itself; here it didn't complete.)
+        _write_planned_restart_marker()
         print(
             f"⚠ Graceful restart did not complete within {int(drain_timeout + 5)}s; "
             "forcing a service restart..."
@@ -3289,6 +3294,10 @@ def systemd_restart(system: bool = False):
     if _recover_pending_systemd_restart(system=system, previous_pid=pid):
         return
 
+    # No running PID and no pending restart to recover — this is a cold
+    # `systemctl restart` with no gateway running.  Write the marker so the
+    # freshly started gateway sends the "♻️ Gateway online" notification.
+    _write_planned_restart_marker()
     _run_systemctl(
         ["reset-failed", get_service_name()],
         system=system,
@@ -4249,11 +4258,14 @@ def _wait_for_gateway_exit(
 
 
 def _write_planned_restart_marker() -> None:
-    """Write the .restart_pending.json marker so the next gateway startup
-    sends the \"♻️ Gateway online\" notification to home channels.
+    """Write .restart_pending.json so the next gateway startup sends the
+    "♻️ Gateway online" notification to home channels.
 
     Mirrors the marker written by the graceful SIGUSR1 path inside the
-    gateway process (gateway/run.py ~line 5925).
+    gateway process (gateway/run.py, ``_planned_restart_notification_path``).
+    Called from the SIGTERM fallback paths in ``launchd_restart()`` and
+    ``systemd_restart()`` where the gateway process cannot write the marker
+    itself because ``_restart_requested`` is never set.
     """
     try:
         marker = get_hermes_home() / ".restart_pending.json"
@@ -4279,10 +4291,10 @@ def launchd_restart():
             print("✓ Service restart requested")
             _clear_launchd_unsupported_marker()
             return
-        # SIGUSR1 path failed (terminal is not a gateway child) or no PID found.
-        # Write the planned-restart marker so the next gateway startup sends
-        # "♻️ Gateway online" — mirroring what the graceful SIGUSR1 path does
-        # inside the gateway process (gateway/run.py ~line 5925).
+        # SIGUSR1 path failed (terminal is not a gateway child) or no PID was
+        # found.  Write the planned-restart marker now so the next gateway
+        # startup sends "♻️ Gateway online" to home channels — mirroring what
+        # the graceful SIGUSR1 path does inside the gateway process.
         _write_planned_restart_marker()
         if pid is not None:
             # Announce the drain BEFORE waiting on it. This wait can run for

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4248,6 +4248,25 @@ def _wait_for_gateway_exit(
     return True
 
 
+def _write_planned_restart_marker() -> None:
+    """Write the .restart_pending.json marker so the next gateway startup
+    sends the \"♻️ Gateway online\" notification to home channels.
+
+    Mirrors the marker written by the graceful SIGUSR1 path inside the
+    gateway process (gateway/run.py ~line 5925).
+    """
+    try:
+        marker = get_hermes_home() / ".restart_pending.json"
+        data = {
+            "requested_at": time.time(),
+            "via_service": True,
+            "detached": False,
+        }
+        marker.write_text(json.dumps(data, indent=None), encoding="utf-8")
+    except Exception as e:
+        print(f"⚠ Failed to write restart notification marker: {e}")
+
+
 def launchd_restart():
     label = get_launchd_label()
     target = f"{_launchd_domain()}/{label}"
@@ -4260,6 +4279,11 @@ def launchd_restart():
             print("✓ Service restart requested")
             _clear_launchd_unsupported_marker()
             return
+        # SIGUSR1 path failed (terminal is not a gateway child) or no PID found.
+        # Write the planned-restart marker so the next gateway startup sends
+        # "♻️ Gateway online" — mirroring what the graceful SIGUSR1 path does
+        # inside the gateway process (gateway/run.py ~line 5925).
+        _write_planned_restart_marker()
         if pid is not None:
             # Announce the drain BEFORE waiting on it. This wait can run for
             # the full drain budget (180s by default) while the old gateway


### PR DESCRIPTION
## fix(gateway): write restart-notification marker in all restart paths

This PR merges the fix from #43199 (by @emarrero) with our two additional commits that cover the systemd direct-restart path, giving complete coverage of all restart scenarios.

### Problem

The `♻️ Gateway online` restart notification was only sent reliably on the graceful SIGUSR1 path. Three other paths were broken:

1. **CLI launchd fallback** — when SIGUSR1 fails, `launchd_restart()` force-kills via `launchctl kickstart -k` without writing the marker
2. **CLI systemd fallback** — same for `systemd_restart()` when SIGUSR1 times out or no PID is found
3. **Direct `systemctl restart`** — bypasses the CLI entirely; the gateway receives SIGTERM but never sets `_restart_requested=True`, so `_stop_impl()` does not write the marker

### Solution — three commits, three paths covered

| Path | Fix | Source |
|------|-----|--------|
| CLI `hermes gateway restart` → SIGUSR1 fails → launchd force-kill | CLI writes marker before `launchctl kickstart -k` | #43199 (emarrero, original author preserved) |
| CLI `hermes gateway restart` → SIGUSR1 timeout → systemd force-restart | CLI writes marker in both early-exit and cold-start branches | this PR |
| `systemctl restart` (direct, no CLI) | Gateway detects `INVOCATION_ID` env var → sets `_restart_requested=True` → `_stop_impl()` writes marker normally | this PR |

### Commits

1. `fix(launchd): write restart-notification marker in fallback kill path` — cherry-picked from #43199, author @emarrero preserved
2. `fix(gateway): detect systemd SIGTERM via INVOCATION_ID for planned restart` — gateway process self-detects planned systemd restart
3. `fix(gateway): write restart-notification marker in all SIGTERM fallback paths` — CLI-side coverage for systemd restart paths

### References

- Fixes #47179
- Supersedes #43199, #52565