### PR TITLE
fix(cron): suppress chat alert for transient failure on recurring "silence-by-default" jobs

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1084,6 +1084,7 @@ def create_job(
     workdir: Optional[str] = None,
     no_agent: bool = False,
     attach_to_session: Optional[bool] = None,
+    alert_on_transient_failure: Optional[bool] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -1160,6 +1161,7 @@ def create_job(
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
+    normalized_alert = alert_on_transient_failure if isinstance(alert_on_transient_failure, bool) else None
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -1255,6 +1257,8 @@ def create_job(
     # global cron.mirror_delivery config, default off).
     if normalized_attach is not None:
         job["attach_to_session"] = normalized_attach
+    if normalized_alert is not None:
+        job["alert_on_transient_failure"] = normalized_alert
 
     with _jobs_lock():
         jobs = load_jobs()

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -140,6 +140,110 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     return f"⚠️ Cron '{job_name}' failed: {cleaned}"
 
 
+# Substrings that mark a cron failure as a *transient* infrastructure blip —
+# the kind that self-recovers on the next scheduled run and carries no signal
+# for the operator (provider stalls, idle-kills, rate limits, transient network
+# errors). These are distinct from a real defect (bad script, auth misconfig,
+# a bug in the job's prompt) which recurs every fire and DOES warrant an alert.
+# Matched case-insensitively as substrings of the failure text.
+_CRON_TRANSIENT_FAILURE_MARKERS = (
+    "idle for",            # cron inactivity watchdog killed a stalled first API call
+    "readtimeout",
+    "read timeout",
+    "timed out",
+    "timeout",
+    "rate limit",
+    "usage limit",
+    "429",
+    "502",
+    "503",
+    "504",
+    "overloaded",
+    "temporarily unavailable",
+    "service unavailable",
+    "connection reset",
+    "connection aborted",
+    "connection error",
+    "connectionerror",
+    "remote end closed",
+    "econnreset",
+    "fallback chain was exhausted",
+    "all retries exhausted",
+    "provider timeout",
+)
+
+
+def _is_transient_cron_failure(error: str | None) -> bool:
+    """True when a cron failure looks like a self-recovering infrastructure blip.
+
+    Used to decide whether a *recurring* job's failure should page the operator.
+    A one-off provider stall / idle-kill / rate-limit on a job whose previous run
+    succeeded is noise: the next tick recovers on its own. A genuine defect (bad
+    script path, auth error, a bug in the prompt) is NOT transient — it recurs on
+    every fire — and is surfaced via the consecutive-failure escalation instead.
+    """
+    if not error:
+        return False
+    lower = str(error).lower()
+    return any(marker in lower for marker in _CRON_TRANSIENT_FAILURE_MARKERS)
+
+
+def _suppress_transient_cron_failure_alert(job: dict, error: str | None,
+                                           cfg: Optional[dict] = None) -> bool:
+    """Whether a failed *recurring* cron run should suppress its chat alert.
+
+    Design (issue: ambient/watchdog jobs paging on self-recovering blips):
+    a job whose contract is "silence is the default" (ambient sense engine,
+    watchdog pollers) must not fire a chat alert every time a provider stalls
+    for one tick. We suppress the alert when ALL of:
+
+      1. The global/per-job knob is enabled (default ON — the historically
+         noisy behaviour was never intentional for recurring jobs).
+      2. The schedule is recurring (cron/interval). One-shot jobs always alert
+         on failure — there is no "next run" to recover, so the user must know.
+      3. The failure is transient (``_is_transient_cron_failure``).
+      4. The PREVIOUS run of this job succeeded (``last_status`` == "ok" or is
+         unset/new). This is the escalation gate: a first transient failure is
+         swallowed, but a SECOND consecutive failure — where last_status is
+         already "error" — pages through, because a blip that does not
+         self-recover is a real outage.
+
+    Output is still saved to the cron output dir and logs in every case; only
+    the chat delivery of the failure summary is suppressed.
+
+    Knob precedence (first decisive value wins):
+      1. Per-job ``alert_on_transient_failure`` (bool) — lets one critical job
+         opt back into always-alerting without flipping global behaviour.
+      2. Global ``cron.suppress_transient_failure_alerts`` (bool) in config.yaml.
+      3. True (default: suppress the noise).
+    """
+    schedule_kind = (job.get("schedule", {}) or {}).get("kind")
+    if schedule_kind not in {"cron", "interval"}:
+        return False  # one-shot / unknown: always alert on failure
+
+    if not _is_transient_cron_failure(error):
+        return False  # real defect: alert
+
+    # Escalation gate: only suppress the FIRST failure. If the previous run was
+    # already an error, the blip is not self-recovering — page through.
+    prev_status = job.get("last_status")
+    if prev_status not in (None, "ok"):
+        return False
+
+    # Knob resolution (default ON — suppress).
+    per_job = job.get("alert_on_transient_failure")
+    if isinstance(per_job, bool):
+        return not per_job  # alert_on_transient_failure=True => do NOT suppress
+    try:
+        if cfg is None:
+            cfg = load_config() or {}
+        return bool(
+            (cfg.get("cron", {}) or {}).get("suppress_transient_failure_alerts", True)
+        )
+    except Exception:
+        return True
+
+
 class CronPromptInjectionBlocked(Exception):
     """Raised by _build_job_prompt when the fully-assembled prompt trips the
     injection scanner. Caught in run_job so the operator sees a clean
@@ -3813,6 +3917,21 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             # tolerance the cron contract relies on.
             if should_deliver and success and _is_cron_silence_response(deliver_content):
                 logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
+                should_deliver = False
+
+            # Transient-failure alert suppression — a recurring job whose contract is
+            # "silence is the default" (ambient sense engine, watchdog pollers) must
+            # not page the operator every time a provider stalls for one tick. When
+            # the failure is transient AND the previous run succeeded, swallow the
+            # chat alert (output is still saved). A SECOND consecutive failure pages
+            # through via the escalation gate inside the helper. Real defects (bad
+            # script, auth error) are never transient and always alert.
+            if should_deliver and not success and _suppress_transient_cron_failure_alert(job, error):
+                logger.info(
+                    "Job '%s': transient failure after a successful run — suppressing "
+                    "chat alert (output saved). Error: %s",
+                    job["id"], (error or "")[:200],
+                )
                 should_deliver = False
 
             if should_deliver:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -221,6 +221,12 @@ def _suppress_transient_cron_failure_alert(job: dict, error: str | None,
     if schedule_kind not in {"cron", "interval"}:
         return False  # one-shot / unknown: always alert on failure
 
+    # Script-only watchdogs must always page when they fail. Their timeout or
+    # exit-error text can contain transient markers, but the watchdog contract
+    # requires alerting regardless of suppression settings.
+    if job.get("no_agent"):
+        return False
+
     if not _is_transient_cron_failure(error):
         return False  # real defect: alert
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2757,6 +2757,18 @@ DEFAULT_CONFIG = {
         # mid-loop, never mutating the cached system prompt). Only the origin
         # chat is ever touched — fan-out / broadcast targets are never mirrored.
         "mirror_delivery": False,
+        # Suppress the chat alert when a RECURRING job fails on a transient,
+        # self-recovering infrastructure blip (provider stall, idle-kill, rate
+        # limit, transient network error) AND its previous run succeeded. These
+        # jobs (ambient sense engine, watchdog pollers) are "silence by default"
+        # and paging on a one-tick blip is pure noise — the next scheduled run
+        # recovers on its own. A SECOND consecutive failure escalates and pages
+        # through, so a real (non-recovering) outage is never hidden. One-shot
+        # jobs always alert on failure. Output is saved to the cron output dir in
+        # every case; only the chat delivery of the failure summary is dropped.
+        # Per-job `alert_on_transient_failure: true` opts a critical job back
+        # into always-alerting without flipping this global default.
+        "suppress_transient_failure_alerts": True,
         # Maximum number of due jobs to run in parallel per tick.
         # null/0 = unbounded (limited only by thread count).
         # 1 = serial (pre-v0.9 behaviour).

--- a/tests/cron/test_transient_failure_suppression.py
+++ b/tests/cron/test_transient_failure_suppression.py
@@ -157,3 +157,18 @@ def test_run_one_job_delivers_real_defect(monkeypatch):
     s.run_one_job(_job("interval", "ok"))
 
     assert "deliver" in [c[0] for c in calls]
+
+
+def test_no_agent_watchdog_timeout_always_delivers(monkeypatch):
+    monkeypatch.setattr(s, "load_config", lambda: _CFG_DEFAULT)
+    calls = _patch_pipeline(monkeypatch, success=False, error="script timed out after 3600s")
+
+    s.run_one_job(_job("interval", "ok", no_agent=True, script="watchdog.sh"))
+
+    assert "deliver" in [c[0] for c in calls]
+
+
+def test_schema_exposes_alert_on_transient_failure():
+    from tools.cronjob_tools import CRONJOB_SCHEMA
+
+    assert "alert_on_transient_failure" in CRONJOB_SCHEMA["parameters"]["properties"]

--- a/tests/cron/test_transient_failure_suppression.py
+++ b/tests/cron/test_transient_failure_suppression.py
@@ -1,0 +1,159 @@
+"""Behavior contract for transient-failure alert suppression on recurring cron jobs.
+
+A recurring job whose contract is "silence is the default" (ambient sense engine,
+watchdog pollers) must not page the operator every time a provider stalls for a
+single tick. When a recurring job fails on a *transient* infrastructure blip
+(idle-kill, provider stall, rate limit, transient network error) AND its previous
+run succeeded, the chat alert is suppressed — the next scheduled run recovers on
+its own. Escalation: a SECOND consecutive failure pages through, so a real (non-
+recovering) outage is never hidden. One-shot jobs always alert on failure.
+
+These assert INVARIANTS (which class of failure suppresses vs pages), not frozen
+values, so they survive marker-list edits.
+"""
+import cron.scheduler as s
+
+
+# ---------------------------------------------------------------------------
+# _is_transient_cron_failure — the classifier
+# ---------------------------------------------------------------------------
+
+def test_classifier_matches_idle_kill():
+    assert s._is_transient_cron_failure(
+        "TimeoutError: Cron job 'x' idle for 602s (limit 600s) — last activity: initializing"
+    ) is True
+
+
+def test_classifier_matches_provider_stalls_and_rate_limits():
+    for err in (
+        "Fallback chain was exhausted or unavailable",
+        "Error 429 weekly usage limit exceeded",
+        "503 model overloaded, please retry",
+        "httpx.ReadTimeout: timed out",
+        "ConnectionResetError: [Errno 54] Connection reset by peer",
+        "provider timeout",
+    ):
+        assert s._is_transient_cron_failure(err) is True, err
+
+
+def test_classifier_rejects_real_defects():
+    for err in (
+        "Script exited with code 1: FileNotFoundError",
+        "KeyError: 'foo' in prompt template",
+        "agent reported failure",
+        "provider authentication error (401)",
+    ):
+        assert s._is_transient_cron_failure(err) is False, err
+
+
+def test_classifier_handles_none_and_empty():
+    assert s._is_transient_cron_failure(None) is False
+    assert s._is_transient_cron_failure("") is False
+
+
+# ---------------------------------------------------------------------------
+# _suppress_transient_cron_failure_alert — the decision
+# ---------------------------------------------------------------------------
+
+_CFG_DEFAULT = {"cron": {}}  # suppress default ON
+
+
+def _job(kind="interval", last_status: object = "ok", **extra):
+    j = {"id": "j", "name": "n", "schedule": {"kind": kind}, "last_status": last_status}
+    j.update(extra)
+    return j
+
+
+def test_recurring_transient_after_success_is_suppressed():
+    assert s._suppress_transient_cron_failure_alert(
+        _job("interval", "ok"), "idle for 602s", _CFG_DEFAULT
+    ) is True
+
+
+def test_second_consecutive_failure_escalates():
+    # last_status already "error" => not self-recovering => page through.
+    assert s._suppress_transient_cron_failure_alert(
+        _job("interval", "error"), "idle for 602s", _CFG_DEFAULT
+    ) is False
+
+
+def test_brand_new_job_none_prev_status_is_suppressed():
+    assert s._suppress_transient_cron_failure_alert(
+        _job("interval", None), "provider timeout", _CFG_DEFAULT
+    ) is True
+
+
+def test_one_shot_always_alerts_even_when_transient():
+    assert s._suppress_transient_cron_failure_alert(
+        _job("once", "ok"), "idle for 602s", _CFG_DEFAULT
+    ) is False
+
+
+def test_real_defect_always_alerts():
+    assert s._suppress_transient_cron_failure_alert(
+        _job("interval", "ok"), "Script exited with code 1", _CFG_DEFAULT
+    ) is False
+
+
+def test_per_job_opt_out_forces_alert():
+    assert s._suppress_transient_cron_failure_alert(
+        _job("interval", "ok", alert_on_transient_failure=True),
+        "idle for 602s", _CFG_DEFAULT,
+    ) is False
+
+
+def test_global_knob_off_forces_alert():
+    assert s._suppress_transient_cron_failure_alert(
+        _job("interval", "ok"),
+        "idle for 602s",
+        {"cron": {"suppress_transient_failure_alerts": False}},
+    ) is False
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through run_one_job: the suppressed transient failure must still
+# SAVE output and MARK the run, but must NOT deliver.
+# ---------------------------------------------------------------------------
+
+def _patch_pipeline(monkeypatch, *, success, error):
+    calls = []
+
+    def fake_run_job(job, *, defer_agent_teardown=None):
+        return (success, "out", "" if not success else "final", error)
+
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(s, "save_job_output", lambda jid, out: calls.append(("save", jid)) or f"/tmp/{jid}.txt")
+    monkeypatch.setattr(s, "_deliver_result", lambda job, content, adapters=None, loop=None: calls.append(("deliver", job["id"])))
+    monkeypatch.setattr(s, "mark_job_run", lambda jid, ok, err=None, delivery_error=None: calls.append(("mark", jid, ok)))
+    return calls
+
+
+def test_run_one_job_suppresses_transient_failure_delivery(monkeypatch):
+    monkeypatch.setattr(s, "load_config", lambda: _CFG_DEFAULT)
+    calls = _patch_pipeline(monkeypatch, success=False, error="idle for 602s — last activity: initializing")
+
+    ok = s.run_one_job(_job("interval", "ok"))
+
+    kinds = [c[0] for c in calls]
+    assert "save" in kinds          # output still saved
+    assert "mark" in kinds          # run still recorded
+    assert "deliver" not in kinds   # but no chat page
+    assert ok is True
+
+
+def test_run_one_job_delivers_transient_failure_on_second_strike(monkeypatch):
+    monkeypatch.setattr(s, "load_config", lambda: _CFG_DEFAULT)
+    calls = _patch_pipeline(monkeypatch, success=False, error="idle for 602s")
+
+    s.run_one_job(_job("interval", "error"))  # prev already error => escalate
+
+    assert "deliver" in [c[0] for c in calls]
+
+
+def test_run_one_job_delivers_real_defect(monkeypatch):
+    monkeypatch.setattr(s, "load_config", lambda: _CFG_DEFAULT)
+    calls = _patch_pipeline(monkeypatch, success=False, error="Script exited with code 1")
+
+    s.run_one_job(_job("interval", "ok"))
+
+    assert "deliver" in [c[0] for c in calls]

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -677,6 +677,7 @@ def cronjob(
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
     attach_to_session: Optional[bool] = None,
+    alert_on_transient_failure: Optional[bool] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -750,6 +751,7 @@ def cronjob(
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
                 attach_to_session=attach_to_session,
+                alert_on_transient_failure=alert_on_transient_failure,
             )
             _notify_provider_jobs_changed_safe()
             _create_message = f"Cron job '{job['name']}' created."
@@ -923,6 +925,8 @@ def cronjob(
                 updates["enabled_toolsets"] = enabled_toolsets or None
             if attach_to_session is not None:
                 updates["attach_to_session"] = bool(attach_to_session)
+            if alert_on_transient_failure is not None:
+                updates["alert_on_transient_failure"] = bool(alert_on_transient_failure)
             if workdir is not None:
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
@@ -1085,6 +1089,10 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "boolean",
                 "description": "When True, this job becomes CONTINUABLE: the user can reply to its delivery and the agent has the brief in context instead of asking 'what is that?'. On thread-capable platforms (Telegram topics, Discord/Slack threads) a dedicated thread is opened for the job and its replies; on DM-only platforms (WhatsApp/Signal) the brief is mirrored into the origin DM session. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. Only the origin chat is touched (never fan-out targets); no effect when deliver='local'."
             },
+            "alert_on_transient_failure": {
+                "type": "boolean",
+                "description": "When True, always deliver the first transient failure for this recurring job instead of suppressing it. Script-only/no_agent watchdog failures always alert regardless of suppression settings."
+            },
         },
         "required": ["action"]
     }
@@ -1140,6 +1148,7 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        alert_on_transient_failure=args.get("alert_on_transient_failure"),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -413,7 +413,7 @@ Check if nginx is running. If everything is healthy, respond with only [SILENT].
 Otherwise, report the issue.
 ```
 
-Failed jobs always deliver regardless of the `[SILENT]` marker — only successful runs can be silenced. For quiet monitoring jobs, prompt the agent to reply with only `[SILENT]` when there is nothing to report.
+Failed jobs normally deliver regardless of the `[SILENT]` marker — only successful runs can be silenced. For recurring LLM jobs, a first transient infrastructure failure after a successful run may be suppressed and the output is still saved; a second consecutive failure escalates and delivers. Set `alert_on_transient_failure: true` to always deliver those first transient failures. Script-only (`no_agent`) watchdog failures, including script timeouts and non-zero exits, always deliver so a broken watchdog cannot fail silently. For quiet monitoring jobs, prompt the agent to reply with only `[SILENT]` when there is nothing to report.
 
 ## Script timeout
 


### PR DESCRIPTION
## Problem

Recurring cron jobs whose contract is "silence is the default" — an ambient/proactive engine, watchdog pollers — page the operator on **every** failure, including one-tick transient infrastructure blips that self-recover on the next scheduled run. A single provider stall / idle-kill / rate-limit produces a chat alert with no actionable signal, and the very next tick succeeds. For a job running every 20 minutes, one flaky provider moment becomes an interrupt.

Concretely: an ambient job that runs `every 20m` failed once with
`TimeoutError: Cron job idle for 602s (limit 600s) — last activity: initializing`
(the cron inactivity watchdog killing a stalled first API call) and delivered
`⚠️ Cron '…' failed: provider timeout. Fallback chain was exhausted or unavailable.`
The next run recovered on its own. 1 failure in 66 runs — pure noise.

## Root cause

`_process_job` in `cron/scheduler.py` delivers `_summarize_cron_failure_for_delivery` on **any** failure (`deliver_content = final_response if success else _summarize_cron_failure_for_delivery(...)`, "Failed jobs always deliver"), with:

- no distinction between a transient blip and a real defect, and
- no consideration of whether the **previous** run succeeded.

`_summarize_cron_failure_for_delivery` also stamps "Fallback chain was exhausted" onto any error text containing `timeout`, which mislabels an inactivity idle-kill as a provider-exhaustion event.

## Fix

Classify transient infrastructure failures (idle-kill, provider stall, rate limit, transient network errors — `_is_transient_cron_failure`). For **recurring** jobs whose previous run succeeded, suppress the chat alert while still **saving output** to the cron output dir and **recording the run** (`mark_job_run`).

Escalation gate: a **second consecutive** failure (previous run already `error`) pages through, so a real non-recovering outage is never hidden. One-shot jobs always alert on failure — there is no next run to recover. Real defects (bad script, auth error, prompt bug) are not transient and always alert.

## Controls (behavioral config in `config.yaml`, not env)

- Global `cron.suppress_transient_failure_alerts` (default `True`).
- Per-job `alert_on_transient_failure: true` opts a critical job back into always-alerting without flipping the global default.

## Tests

`tests/cron/test_transient_failure_suppression.py` — asserts the **invariant** (which failure class suppresses vs pages), not frozen values, so it survives marker-list edits. Covers the classifier, the decision matrix (recurring/one-shot × transient/defect × prev-ok/prev-error × knob on/off/per-job), and the end-to-end `run_one_job` path (a suppressed transient failure still saves + marks, never delivers).

```
tests/cron/test_transient_failure_suppression.py  16 passed
tests/cron/test_run_one_job.py                     5 passed
tests/cron/{test_scheduler,test_cron_inactivity_timeout,test_cronjob_schema}.py  226 passed
```

No behavior change for one-shot jobs, real defects, or the first failure of a job with the knob disabled.
