### PR TITLE
perf(state): batch compression-tip row fetch in list_sessions_rich

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -27,7 +27,7 @@ from pathlib import Path
 
 from agent.memory_manager import sanitize_context
 from hermes_constants import get_hermes_home
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, TypeVar
 
 logger = logging.getLogger(__name__)
 
@@ -3220,16 +3220,30 @@ class SessionDB:
         # as the live conversation. Keep the root's started_at to preserve
         # chronological ordering by original conversation start.
         if project_compression_tips and not include_children:
-            projected = []
+            # get_compression_tip() walks each root's chain individually (it's
+            # a per-session graph walk, not batchable in one query), but the
+            # tip *row* fetch afterward was previously one _get_session_rich_row()
+            # call per compression root — a separate single-row query per row
+            # on every list_sessions_rich() call. Batch that half instead: resolve
+            # every tip id first, then fetch all tip rows in a single query.
+            tip_ids_by_root: Dict[str, str] = {}
             for s in sessions:
                 if s.get("end_reason") != "compression":
-                    projected.append(s)
                     continue
                 tip_id = self.get_compression_tip(s["id"])
-                if tip_id == s["id"]:
-                    projected.append(s)
-                    continue
-                tip_row = self._get_session_rich_row(tip_id)
+                if tip_id != s["id"]:
+                    tip_ids_by_root[s["id"]] = tip_id
+
+            tip_rows = (
+                self._get_session_rich_rows_batch(set(tip_ids_by_root.values()))
+                if tip_ids_by_root
+                else {}
+            )
+
+            projected = []
+            for s in sessions:
+                tip_id = tip_ids_by_root.get(s["id"])
+                tip_row = tip_rows.get(tip_id) if tip_id else None
                 if not tip_row:
                     projected.append(s)
                     continue
@@ -3319,8 +3333,29 @@ class SessionDB:
         """Fetch a single session with the same enriched columns as
         ``list_sessions_rich`` (preview + last_active). Returns None if the
         session doesn't exist.
+
+        Thin wrapper over ``_get_session_rich_rows_batch`` so the enriched
+        SELECT lives in exactly one place.
         """
-        query = """
+        return self._get_session_rich_rows_batch([session_id]).get(session_id)
+
+    def _get_session_rich_rows_batch(
+        self, session_ids: Iterable[str]
+    ) -> Dict[str, Dict[str, Any]]:
+        """Fetch multiple sessions with the same enriched columns as
+        ``_get_session_rich_row``, in a single query.
+
+        Used by ``list_sessions_rich``'s compression-tip projection to resolve
+        every tip row for a page in one round trip instead of one query per
+        compression-root row. Returns a dict keyed by session id; ids that
+        don't exist are simply absent from the result (same as
+        ``_get_session_rich_row`` returning ``None`` for them).
+        """
+        ids = [sid for sid in session_ids if sid]
+        if not ids:
+            return {}
+        placeholders = ",".join("?" for _ in ids)
+        query = f"""
             SELECT s.*,
                 COALESCE(
                     (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
@@ -3334,21 +3369,22 @@ class SessionDB:
                     s.started_at
                 ) AS last_active
             FROM sessions s
-            WHERE s.id = ?
+            WHERE s.id IN ({placeholders})
         """
         with self._lock:
-            cursor = self._conn.execute(query, (session_id,))
-            row = cursor.fetchone()
-        if not row:
-            return None
-        s = dict(row)
-        raw = s.pop("_preview_raw", "").strip()
-        if raw:
-            text = raw[:60]
-            s["preview"] = text + ("..." if len(raw) > 60 else "")
-        else:
-            s["preview"] = ""
-        return s
+            cursor = self._conn.execute(query, ids)
+            rows = cursor.fetchall()
+        result: Dict[str, Dict[str, Any]] = {}
+        for row in rows:
+            s = dict(row)
+            raw = s.pop("_preview_raw", "").strip()
+            if raw:
+                text = raw[:60]
+                s["preview"] = text + ("..." if len(raw) > 60 else "")
+            else:
+                s["preview"] = ""
+            result[s["id"]] = s
+        return result
 
     # =========================================================================
     # Message storage

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3792,6 +3792,88 @@ class TestCompressionChainProjection:
         assert root_row["end_reason"] == "compression"
         assert "_lineage_root_id" not in root_row
 
+    def test_list_projects_multiple_independent_chains_in_one_call(self, db):
+        """Two unrelated compression chains in the same page must each
+        resolve to their own tip, not get cross-mixed by the batched tip-row
+        fetch (regression test for the single-query batch in
+        _get_session_rich_rows_batch — a wrong id->row mapping there would
+        silently swap one chain's data onto the other)."""
+        import time as _time
+
+        t0 = _time.time() - 7200
+        self._build_compression_chain(db, t0)
+
+        # Second, independent chain — same shape, different ids/content.
+        db.create_session("root2", "cli")
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0 + 100, "root2"))
+        db.append_message("root2", "user", "second conversation start")
+        db._conn.execute(
+            "UPDATE sessions SET ended_at=?, end_reason=? WHERE id=?",
+            (t0 + 200, "compression", "root2"),
+        )
+        db.create_session("tip2", "cli", parent_session_id="root2")
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0 + 201, "tip2"))
+        db.append_message("tip2", "user", "second conversation continuation")
+        db.update_session_cwd("tip2", "/tmp/workspaces/second")
+        db._conn.commit()
+
+        sessions = db.list_sessions_rich(source="cli", limit=20)
+        ids = [s["id"] for s in sessions]
+        assert "root1" not in ids and "root2" not in ids
+        assert "tip1" in ids and "tip2" in ids
+
+        tip1_row = next(s for s in sessions if s["id"] == "tip1")
+        tip2_row = next(s for s in sessions if s["id"] == "tip2")
+        assert tip1_row["_lineage_root_id"] == "root1"
+        assert tip1_row["preview"].startswith("latest message")
+        assert tip2_row["_lineage_root_id"] == "root2"
+        assert tip2_row["preview"].startswith("second conversation continuation")
+        assert tip2_row["cwd"] == "/tmp/workspaces/second"
+
+    def test_list_batches_tip_row_fetch_into_one_query(self, db, monkeypatch):
+        """Projection must resolve tip rows for a whole page in one batched
+        query, not one _get_session_rich_row() call per compression root."""
+        import time as _time
+
+        t0 = _time.time() - 7200
+        self._build_compression_chain(db, t0)
+        db.create_session("root2", "cli")
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0 + 100, "root2"))
+        db.append_message("root2", "user", "second conversation start")
+        db._conn.execute(
+            "UPDATE sessions SET ended_at=?, end_reason=? WHERE id=?",
+            (t0 + 200, "compression", "root2"),
+        )
+        db.create_session("tip2", "cli", parent_session_id="root2")
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0 + 201, "tip2"))
+        db.append_message("tip2", "user", "second continuation")
+        db._conn.commit()
+
+        batch_calls = []
+        single_calls = []
+        original_batch = db._get_session_rich_rows_batch
+        original_single = db._get_session_rich_row
+
+        def counting_batch(session_ids):
+            batch_calls.append(list(session_ids))
+            return original_batch(session_ids)
+
+        def counting_single(session_id):
+            single_calls.append(session_id)
+            return original_single(session_id)
+
+        monkeypatch.setattr(db, "_get_session_rich_rows_batch", counting_batch)
+        monkeypatch.setattr(db, "_get_session_rich_row", counting_single)
+
+        sessions = db.list_sessions_rich(source="cli", limit=20)
+        assert len(sessions) >= 2  # sanity: both chains actually surfaced
+
+        # Two compression roots resolved with exactly one batched call, and
+        # zero single-row calls — not one single-row call per root.
+        assert len(batch_calls) == 1
+        assert set(batch_calls[0]) == {"tip1", "tip2"}
+        assert single_calls == []
+
     def test_list_preserves_sort_by_started_at(self, db):
         """Chronological ordering uses the ROOT's started_at (conversation
         start), not the tip's. This keeps lineage entries stable in the list


### PR DESCRIPTION
## What does this PR do?

`SessionDB.list_sessions_rich()` projects compression-root rows forward to their live tip so a compressed-then-continued conversation shows as one entry. For each compression-root row in a page, it called `get_compression_tip()` (a chain walk, one query per hop) and then `_get_session_rich_row(tip_id)`, a full separate single-row query, in a Python loop. A page with several compression roots issues that many separate tip-row queries on every session-list render: session pickers, `/resume`, the web and TUI dashboards.

This adds `_get_session_rich_rows_batch()`, which resolves every tip id for a page in one query via `WHERE id IN (...)`, and swaps the per-row loop to call it once instead of once per root. `get_compression_tip()`'s chain walk stays untouched. It's a genuine per-session graph walk with careful handling of branch/delegate exclusion and race conditions (see its docstring), and batching that safely is a bigger change than this PR is trying to be. This only collapses the second half of the work: N single-row queries into one batched query.

## Related Issue

None filed. Found via a general efficiency pass over hot paths, not from a bug report.

## Type of Change

- [x] ♻️ Refactor (no behavior change)

(Marked refactor rather than bug fix: output is identical, this only changes the query pattern used to produce it.)

## Changes Made

- `hermes_state.py`: added `_get_session_rich_rows_batch()`; `list_sessions_rich()`'s projection step now resolves all tip ids first, batch-fetches their rows in one query, then merges, instead of calling `_get_session_rich_row()` per root.
- `tests/test_hermes_state.py`: added `test_list_projects_multiple_independent_chains_in_one_call` (two independent compression chains in a single list call, verifying rows aren't cross-mixed by the batched fetch) and `test_list_batches_tip_row_fetch_into_one_query` (asserts the batch method is called exactly once with both tip ids, and the old per-row method zero times).

## How to Test

1. Seed two sessions that each got compressed and continued (`end_reason='compression'` root, a child continuation).
2. Call `list_sessions_rich()` with both roots in the page.
3. Before this change: `_get_session_rich_row()` runs once per compression root.
4. After: `_get_session_rich_rows_batch()` runs once for the whole page, `_get_session_rich_row()` doesn't run at all from this code path.
5. `pytest tests/test_hermes_state.py -q`: 305 passed.

## Overlap with open PRs (found while searching for duplicates)

- **#42196** ("perf(dashboard): trim session list payloads") touches the exact same lines this PR does: it adds `include_system_prompt` to `_get_session_rich_row()` and threads it through the same projection call this PR replaces. The two changes optimize different axes (row width vs. row count) and aren't duplicates, but they will conflict textually. Whichever merges second needs a small rebase: if #42196 lands first, `_get_session_rich_rows_batch()` needs the same `include_system_prompt` parameter and column-list substitution; if this lands first, #42196's diff on the projection call site needs to target the batch call instead of the old per-row call.
- **#53811** ("fix(state): stable tiebreaker for default list_sessions_rich ordering") touches the same function but only the `ORDER BY` clause in the non-CTE path. No line overlap with this diff.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits (`perf(state): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate. Found #42196 and #53811, both discussed above; neither addresses the tip-row query count
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run the test suite and all relevant tests pass (`tests/test_hermes_state.py`, 305 passed)
- [x] I've added tests for my changes
- [x] Tested on: WSL2 (Ubuntu on Windows)

### Documentation & Housekeeping

- [x] N/A: no config keys, docs, or tool schemas changed
- [x] Cross-platform: pure SQL/Python change, no OS-specific calls; ran `scripts/check-windows-footguns.py` clean on the diff
