### PR TITLE
fix(cron): reload .env before the no_agent short-circuit in run_job

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2332,6 +2332,30 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     job_id = job["id"]
     job_name = str(job.get("name") or job.get("prompt") or job_id or "cron job")
 
+    # Re-read .env + config.yaml BEFORE any branch (agent OR no_agent) so a
+    # credential/key change takes effect without a gateway restart. no_agent
+    # script jobs short-circuit and return below, so this reload MUST precede
+    # that block — it previously lived only in the agent path (#33465 covered
+    # agent jobs; the no_agent path was left running on the stale os.environ
+    # captured at gateway startup, so a script never saw freshly-added creds).
+    # Route through load_hermes_dotenv (not a bare load_dotenv) and reset the
+    # secret-source cache first: startup already applied external secrets and
+    # recorded this HERMES_HOME in _APPLIED_HOMES, so a naive reload would
+    # re-apply only the .env placeholder and never re-resolve a Bitwarden/
+    # BSM-backed secret — leaving cron jobs 401'ing on the placeholder (#33465).
+    # Clearing the cache forces the re-pull; the resolved secret overrides the
+    # placeholder only when secrets.bitwarden.override_existing is set (mirrors
+    # startup), and the Bitwarden value-cache keeps the forced re-pull off the
+    # network. load_hermes_dotenv also handles the utf-8/latin-1 encoding
+    # fallback internally. Only needs _get_hermes_home(), so it is safe to run
+    # before the per-job workdir/TERMINAL_CWD setup below. (#59030)
+    from hermes_cli.env_loader import (
+        load_hermes_dotenv,
+        reset_secret_source_cache,
+    )
+    reset_secret_source_cache()
+    load_hermes_dotenv(hermes_home=_get_hermes_home())
+
     # ---------------------------------------------------------------
     # no_agent short-circuit — the script IS the job, no LLM involvement.
     # ---------------------------------------------------------------
@@ -2601,24 +2625,10 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             os.environ["TERMINAL_CWD"] = _job_workdir
             logger.info("Job '%s': using workdir %s", job_id, _job_workdir)
 
-        # Re-read .env and config.yaml fresh every run so provider/key
-        # changes take effect without a gateway restart. Route through
-        # load_hermes_dotenv (not a bare load_dotenv) and reset the secret-
-        # source cache first: startup already applied external secrets and
-        # recorded this HERMES_HOME in _APPLIED_HOMES, so a naive reload would
-        # re-apply only the .env placeholder and never re-resolve a Bitwarden/
-        # BSM-backed secret — leaving cron jobs 401'ing on the placeholder
-        # (#33465). Clearing the cache forces the re-pull; the resolved secret
-        # overrides the placeholder only when secrets.bitwarden.override_existing
-        # is set (mirrors startup), and the Bitwarden value-cache keeps the
-        # forced re-pull off the network. load_hermes_dotenv also handles the
-        # utf-8/latin-1 encoding fallback internally.
-        from hermes_cli.env_loader import (
-            load_hermes_dotenv,
-            reset_secret_source_cache,
-        )
-        reset_secret_source_cache()
-        load_hermes_dotenv(hermes_home=_get_hermes_home())
+        # NOTE: the fresh .env + secret-source-cache reload now runs at the top
+        # of run_job(), before the no_agent short-circuit, so both branches see
+        # freshly-added credentials (#33465, #59030). It is intentionally not
+        # repeated here.
 
         delivery_target = _resolve_delivery_target(job)
         if delivery_target:

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -12,6 +12,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import os
 from unittest.mock import patch
 
 import pytest
@@ -278,6 +279,51 @@ def test_run_job_no_agent_never_invokes_aiagent(hermes_env):
         run_job(job)
 
     ai_mock.assert_not_called()
+
+
+def test_no_agent_job_reloads_env_before_short_circuit(hermes_env, monkeypatch):
+    """no_agent jobs must re-read .env before short-circuiting so a
+    freshly-added credential takes effect without a gateway restart.
+
+    Regression for #59030: the fresh-env reload used to live only in the
+    agent path, AFTER the no_agent short-circuit ``return``, so a no_agent
+    script ran against the stale ``os.environ`` captured at gateway startup.
+
+    FAIL-BEFORE: with the reload only in the agent path, the no_agent path
+    returns before any reload → the stale value survives → this assertion
+    fails. PASS-AFTER: the hoisted reload applies the on-disk .env value.
+    """
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    # Simulate a value captured at gateway startup that is now stale.
+    monkeypatch.setenv("HERMES_TEST_CRON_SECRET", "stale-startup-value")
+
+    # A newer value was written to the on-disk .env after startup (e.g. the
+    # user just added a credential) but the gateway was never restarted.
+    (hermes_env / ".env").write_text("HERMES_TEST_CRON_SECRET=fresh-from-dotenv\n")
+
+    # A trivial script — the assertion below inspects the process env directly.
+    # (The delivered stdout is passed through secret redaction, so it cannot be
+    # used to observe a credential value; os.environ is the true invariant.)
+    script_path = hermes_env / "scripts" / "noop.sh"
+    script_path.write_text("#!/bin/bash\necho tick\n")
+
+    job = create_job(
+        prompt=None,
+        schedule="every 5m",
+        script="noop.sh",
+        no_agent=True,
+        deliver="local",
+    )
+
+    success, doc, final_response, error = run_job(job)
+
+    assert success is True
+    assert error is None
+    # The reload must have applied the fresh on-disk .env value before the
+    # no_agent script ran — proving the reload precedes the short-circuit.
+    assert os.environ["HERMES_TEST_CRON_SECRET"] == "fresh-from-dotenv"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

`cron/scheduler.py::run_job()` re-reads `.env` + `config.yaml` and resets the secret-source cache every run so a credential/key change takes effect without a gateway restart. But that reload lived in the **agent path only** — after the `no_agent` short-circuit block returns.

So `no_agent=True` script jobs (the "run a bash watchdog on a timer, send stdout to Telegram" pattern) short-circuit and `return` **before** any reload runs, and therefore execute against the stale `os.environ` captured at gateway startup. A freshly-added `.env`/config credential is never seen by a no_agent script — even after a full gateway restart.

This hoists the reload to the very top of `run_job()`, before the `no_agent` branch, so **both** the agent and no_agent paths observe fresh credentials. The reload only depends on `_get_hermes_home()` (not the per-job workdir / `TERMINAL_CWD` setup that lives lower down), so running it earlier is safe; the now-redundant agent-path copy is removed. This extends the #33465 fix (which introduced the per-run reload for the agent path) to the no_agent path — the same "fresh fix leaves an adjacent path uncovered" shape.

Sibling code paths that may need the same fix: none — the reload is now the single pre-branch call covering both the agent and no_agent paths. Audited: no third execution path in `run_job()` bypasses it.

## Related Issue

Fixes #59030

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py`: Hoist the `reset_secret_source_cache()` + `load_hermes_dotenv(hermes_home=_get_hermes_home())` reload to the top of `run_job()`, before the `no_agent` short-circuit. Remove the now-redundant copy from the agent path and leave a pointer comment.
- `tests/cron/test_cron_no_agent.py`: Add `test_no_agent_job_reloads_env_before_short_circuit` — sets a stale value in `os.environ`, writes a fresh value to the on-disk `<HERMES_HOME>/.env`, runs a `no_agent=True` job, and asserts the process env reflects the fresh `.env` value.

## How to Test

1. Start the gateway, then add/change a credential in `<HERMES_HOME>/.env` without restarting.
2. Trigger a `no_agent=True` cron job whose script reads that credential.
3. Before this fix the script sees the stale startup value; after it sees the fresh `.env` value.

Regression guard (verified both directions):
- **FAIL-BEFORE** (prod hunk reverted, test kept): `assert 'stale-startup-value' == 'fresh-from-dotenv'` fails — the no_agent path never reloads.
- **PASS-AFTER**: all 19 tests in `tests/cron/test_cron_no_agent.py` pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/cron/test_cron_no_agent.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A