### PR TITLE
fix(cron): guard finally block against double-close of lock_fd in tick()

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3471,17 +3471,18 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
 
         return sum(_results)
     finally:
-        if fcntl:
-            try:
-                fcntl.flock(lock_fd, fcntl.LOCK_UN)
-            except (OSError, IOError):
-                pass
-        elif msvcrt:
-            try:
-                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
-            except (OSError, IOError):
-                pass
-        lock_fd.close()
+        if lock_fd is not None and not lock_fd.closed:
+            if fcntl:
+                try:
+                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                except (OSError, IOError):
+                    pass
+            elif msvcrt:
+                try:
+                    msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
+                except (OSError, IOError):
+                    pass
+            lock_fd.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fix an uncaught ValueError crash on the lock-contention path in tick().

## Problem

When tick() fails to acquire the cross-process file lock (another instance already holds it), the except block at line 3300 closes lock_fd and returns 0. However, the finally block at line 3473 still runs and unconditionally calls fcntl.flock(lock_fd, LOCK_UN) and lock_fd.close() on the already-closed file descriptor.

This raises ValueError: I/O operation on closed file, which is **not** caught by the except (OSError, IOError) handlers in the finally block, causing an unhandled crash on every lock-contention scenario.

## Fix

Add a guard if lock_fd is not None and not lock_fd.closed: around the finally cleanup logic. This is a 1-line guard addition — all existing behavior is preserved, but the double-close crash path is eliminated.

## Testing
- Syntax check passed (py_compile)
- Behavior verified