### PR TITLE
fix(desktop): show messaging platform status across all profiles

### DIFF
--- a/apps/desktop/src/app/messaging/index.test.tsx
+++ b/apps/desktop/src/app/messaging/index.test.tsx
@@ -3,14 +3,21 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { MessagingPlatformInfo } from '@/types/hermes'
+import type { MessagingPlatformInfo, ProfileInfo } from '@/types/hermes'
 
 const getMessagingPlatforms = vi.fn()
 const updateMessagingPlatform = vi.fn()
+const getProfiles = vi.fn()
 const openExternalLink = vi.fn()
 
 vi.mock('@/hermes', () => ({
-  getMessagingPlatforms: () => getMessagingPlatforms(),
+  // getProfiles/setApiRequestProfile are required so @/store/profile's
+  // module-level $activeGatewayProfile subscription (imported by
+  // messaging/index.tsx for the cross-profile rail) doesn't crash without
+  // window.hermesDesktop — see profile.test.ts for the same pattern.
+  getProfiles: () => getProfiles(),
+  setApiRequestProfile: vi.fn(),
+  getMessagingPlatforms: (profile?: null | string) => getMessagingPlatforms(profile),
   updateMessagingPlatform: (id: string, body: unknown) => updateMessagingPlatform(id, body)
 }))
 
@@ -42,8 +49,24 @@ function platform(patch: Partial<MessagingPlatformInfo> = {}): MessagingPlatform
   }
 }
 
+function profileInfo(patch: Partial<ProfileInfo> = {}): ProfileInfo {
+  return {
+    gateway_running: true,
+    has_env: false,
+    is_default: false,
+    model: null,
+    name: 'default',
+    path: '/tmp/hermes',
+    provider: null,
+    skill_count: 0,
+    ...patch
+  }
+}
+
 beforeEach(() => {
   updateMessagingPlatform.mockResolvedValue({ ok: true, platform: 'teams' })
+  // Single-profile baseline: no rail, same behavior as before this feature.
+  getProfiles.mockResolvedValue({ profiles: [] })
 })
 
 afterEach(() => {
@@ -85,5 +108,68 @@ describe('MessagingView setup-guide link', () => {
     fireEvent.click(link)
 
     await waitFor(() => expect(openExternalLink).toHaveBeenCalledWith(docsUrl))
+  })
+})
+
+describe('MessagingView cross-profile rail', () => {
+  it('does not render a rail with a single profile (default, unaffected behavior)', async () => {
+    getProfiles.mockResolvedValue({ profiles: [profileInfo({ name: 'default' })] })
+    getMessagingPlatforms.mockResolvedValue({ platforms: [platform()] })
+
+    await renderMessaging()
+
+    await screen.findAllByText('Microsoft Teams')
+    expect(screen.queryByRole('button', { name: 'default' })).toBeNull()
+    // Resolved to the concrete profile name, never an ambiguous null/current —
+    // see the regression test below for why that distinction matters.
+    expect(getMessagingPlatforms).toHaveBeenCalledWith('default')
+  })
+
+  it('re-scopes the page to another profile on click, without switching the app-wide active profile', async () => {
+    getProfiles.mockResolvedValue({
+      profiles: [
+        profileInfo({ name: 'default', is_default: true, gateway_running: true }),
+        profileInfo({ name: 'health', gateway_running: false })
+      ]
+    })
+    getMessagingPlatforms.mockImplementation(async (profile?: null | string) =>
+      profile === 'health'
+        ? { platforms: [platform({ enabled: true, id: 'wechat', name: 'WeChat', state: 'fatal' })] }
+        : { platforms: [platform()] }
+    )
+
+    await renderMessaging()
+
+    await screen.findAllByText('Microsoft Teams')
+    expect(getMessagingPlatforms).toHaveBeenCalledWith('default')
+
+    fireEvent.click(await screen.findByRole('button', { name: 'health' }))
+
+    await waitFor(() => expect(getMessagingPlatforms).toHaveBeenCalledWith('health'))
+    expect((await screen.findAllByText('WeChat')).length).toBeGreaterThan(0)
+  })
+
+  it('regression: writes always carry the resolved profile, never an ambiguous null/current', async () => {
+    // _profile_scope(None/""/"current") on the backend resolves to whatever
+    // profile the PRIMARY BACKEND PROCESS happens to be running as — which
+    // can drift from $activeGatewayProfile (e.g. a chat-session gateway
+    // swap moves it without restarting the primary backend). Toggling a
+    // platform while viewing "default" must send profile: 'default'
+    // explicitly, or the write can silently land in whatever profile the
+    // backend process itself is bound to instead (#59011 follow-up).
+    getProfiles.mockResolvedValue({
+      profiles: [profileInfo({ name: 'default' }), profileInfo({ name: 'health' })]
+    })
+    getMessagingPlatforms.mockResolvedValue({ platforms: [platform({ enabled: false })] })
+
+    await renderMessaging()
+    await screen.findAllByText('Microsoft Teams')
+
+    const toggle = await screen.findByRole('switch')
+    fireEvent.click(toggle)
+
+    await waitFor(() =>
+      expect(updateMessagingPlatform).toHaveBeenCalledWith('teams', { enabled: true, profile: 'default' })
+    )
   })
 })

--- a/apps/desktop/src/app/messaging/index.tsx
+++ b/apps/desktop/src/app/messaging/index.tsx
@@ -1,3 +1,4 @@
+import { useStore } from '@nanostores/react'
 import type * as React from 'react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
@@ -20,7 +21,9 @@ import { ExternalLink, Save, Trash2 } from '@/lib/icons'
 import { normalize } from '@/lib/text'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
+import { $activeGatewayProfile, $profiles, normalizeProfileKey, refreshProfiles } from '@/store/profile'
 import { runGatewayRestart } from '@/store/system-actions'
+import type { ProfileInfo } from '@/types/hermes'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
 import { useRouteEnumParam } from '../hooks/use-route-enum-param'
@@ -112,6 +115,27 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
   const platformIds = useMemo(() => platforms?.map(p => p.id) ?? [], [platforms])
   const [selectedId, setSelectedId] = useRouteEnumParam('platform', platformIds, platformIds[0] ?? '')
 
+  // Which profile's platforms this page is showing. null just means "the
+  // rail hasn't been touched, defer to $activeGatewayProfile for display" —
+  // it drives ONLY the rail's highlighted pill, never a request directly.
+  // Every actual read/write below uses effectiveScope, the resolved name,
+  // never `scope` itself: an implicit/empty profile on the backend means
+  // "whatever the primary backend process happens to be", which can drift
+  // from what this page displays as selected (e.g. a chat-session gateway
+  // swap moves $activeGatewayProfile without restarting the primary
+  // backend) — sending the resolved name instead avoids that class of bug.
+  // Non-default values are a page-local view only: this does NOT call
+  // selectProfile()/switch the app's active profile, same idea as
+  // GatewaySettings' scope.
+  const [scope, setScope] = useState<null | string>(null)
+  const profiles = useStore($profiles)
+  const activeGatewayProfile = useStore($activeGatewayProfile)
+  const effectiveScope = scope ?? normalizeProfileKey(activeGatewayProfile)
+
+  useEffect(() => {
+    void refreshProfiles()
+  }, [])
+
   const refreshPlatforms = useCallback(
     async (silent = false) => {
       if (!silent) {
@@ -119,7 +143,17 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
       }
 
       try {
-        const result = await getMessagingPlatforms()
+        // Always send the resolved profile name, never scope directly.
+        // _profile_scope(None/""/"current") on the backend means "whatever
+        // profile the PRIMARY BACKEND PROCESS happens to be running as" —
+        // NOT necessarily the profile this page is displaying as selected.
+        // Those two can drift apart (e.g. a chat-session gateway swap moves
+        // $activeGatewayProfile without restarting the primary backend), so
+        // an implicit "current" can silently read/write the wrong profile's
+        // config. Passing the explicit name resolves unambiguously via
+        // _resolve_profile_dir() regardless of what the backend process
+        // itself is bound to.
+        const result = await getMessagingPlatforms(effectiveScope)
         setPlatforms(result.platforms)
       } catch (err) {
         if (!silent) {
@@ -131,7 +165,7 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
         }
       }
     },
-    [m]
+    [m, effectiveScope]
   )
 
   useRefreshHotkey(() => void refreshPlatforms())
@@ -142,6 +176,10 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
 
   // Auto-poll while the user is on the messaging page so connection status
   // updates without a manual "check" click. Pause when the tab is hidden.
+  // Only the selected profile is polled this way — the other profiles' pills
+  // show their last-known gateway_running state from $profiles, which is
+  // already being fetched for the profile switcher elsewhere in the app, so
+  // it costs nothing extra and doesn't multiply this poll across profiles.
   useEffect(() => {
     let cancelled = false
 
@@ -191,7 +229,7 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
     setSaving(`enabled:${platform.id}`)
 
     try {
-      await updateMessagingPlatform(platform.id, { enabled })
+      await updateMessagingPlatform(platform.id, { enabled, profile: effectiveScope })
       setPlatforms(
         current =>
           current?.map(row =>
@@ -227,7 +265,7 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
     setSaving(`env:${platform.id}`)
 
     try {
-      await updateMessagingPlatform(platform.id, { env })
+      await updateMessagingPlatform(platform.id, { env, profile: effectiveScope })
       setEdits(current => ({ ...current, [platform.id]: {} }))
       await refreshPlatforms()
       notify({
@@ -247,7 +285,7 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
     setSaving(`clear:${key}`)
 
     try {
-      await updateMessagingPlatform(platform.id, { clear_env: [key] })
+      await updateMessagingPlatform(platform.id, { clear_env: [key], profile: effectiveScope })
       setEdits(current => ({
         ...current,
         [platform.id]: {
@@ -267,6 +305,16 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
   return (
     <PageSearchShell
       {...props}
+      filters={
+        profiles.length > 1 ? (
+          <ProfileRail
+            effectiveScope={effectiveScope}
+            onSelect={name => setScope(normalizeProfileKey(name) === normalizeProfileKey(activeGatewayProfile) ? null : name)}
+            platforms={platforms}
+            profiles={profiles}
+          />
+        ) : null
+      }
       onSearchChange={setQuery}
       searchHidden={(platforms?.length ?? 0) === 0}
       searchHints={platforms?.slice(0, 5).map(platform => t.common.tryHint(platform.name.toLowerCase()))}
@@ -325,6 +373,58 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
         </MasterDetail>
       )}
     </PageSearchShell>
+  )
+}
+
+// One pill per profile. Clicking re-scopes this page (not the app's active
+// profile — no global switch, no gateway swap) to that profile's platforms.
+// Only the selected pill's dot reflects real, just-fetched platform state;
+// every other pill shows gateway_running from $profiles (already loaded for
+// the profile switcher elsewhere, so this is free) — coarser, since a
+// running gateway can still have one dead platform inside it, but it never
+// claims health it hasn't actually checked.
+function ProfileRail({
+  effectiveScope,
+  onSelect,
+  platforms,
+  profiles
+}: {
+  effectiveScope: string
+  onSelect: (name: string) => void
+  platforms: MessagingPlatformInfo[] | null
+  profiles: ProfileInfo[]
+}) {
+  return (
+    <>
+      {profiles.map(profile => {
+        const isSelected = normalizeProfileKey(profile.name) === effectiveScope
+
+        const tone: StatusTone = isSelected
+          ? (platforms ?? []).some(p => p.enabled && ['bad', 'warn'].includes(stateTone(p)))
+            ? 'bad'
+            : 'good'
+          : profile.gateway_running
+            ? 'good'
+            : 'bad'
+
+        return (
+          <button
+            className={cn(
+              'flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[length:var(--conversation-caption-font-size)] transition',
+              isSelected
+                ? 'border-(--ui-stroke-secondary) bg-(--ui-bg-tertiary) text-foreground'
+                : 'border-(--ui-stroke-tertiary) bg-(--ui-bg-quinary) text-(--ui-text-tertiary) hover:bg-(--chrome-action-hover)'
+            )}
+            key={profile.name}
+            onClick={() => onSelect(profile.name)}
+            type="button"
+          >
+            <StatusDot tone={tone} />
+            {profile.name}
+          </button>
+        )
+      })}
+    </>
   )
 }
 

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -723,9 +723,17 @@ export function grantComputerUsePermissions(): Promise<ActionResponse> {
   })
 }
 
-export function getMessagingPlatforms(): Promise<MessagingPlatformsResponse> {
+// `profile` is baked into the query string only — deliberately NOT passed as
+// the api() call's routing field. That field triggers Electron's
+// ensureBackend() pool-spawn routing (see hermes:api in main.cjs); this
+// endpoint doesn't need that because the backend already reads any other
+// profile's on-disk state directly via _profile_scope(), so every profile's
+// status can be read from the one already-running primary backend.
+export function getMessagingPlatforms(profile?: null | string): Promise<MessagingPlatformsResponse> {
+  const suffix = profile ? `?profile=${encodeURIComponent(profile)}` : ''
+
   return window.hermesDesktop.api<MessagingPlatformsResponse>({
-    path: '/api/messaging/platforms'
+    path: `/api/messaging/platforms${suffix}`
   })
 }
 

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -24,6 +24,7 @@ const { queryClient } = await import('@/lib/query-client')
 const { getProfiles } = await import('@/hermes')
 
 const profile = (name: string, isDefault = false): ProfileInfo => ({
+  gateway_running: false,
   has_env: false,
   is_default: isDefault,
   model: null,

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -188,6 +188,8 @@ export interface MessagingPlatformUpdate {
   clear_env?: string[]
   enabled?: boolean
   env?: Record<string, string>
+  /** Target a specific profile's env instead of the dashboard's own. */
+  profile?: string
 }
 
 export interface MessagingPlatformTestResponse {
@@ -592,6 +594,7 @@ export interface ProfileCreatePayload {
 }
 
 export interface ProfileInfo {
+  gateway_running: boolean
   has_env: boolean
   is_default: boolean
   model: null | string

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1877,6 +1877,7 @@ AUTHOR_MAP = {
     "yosapol@jitrak.dev": "Eji4h",  # direct email match
     "kiljadn@gmail.com": "designnotdrum",  # PR #56480 salvage (toolset static-inference fix)
     "lavya@loom.local": "LavyaTandel",  # PR #57893 salvage local git identity (envelope-layout cache markers on tool/empty-assistant messages; #57845)
+    "arjunbharadwaj94@gmail.com": "prudentprogrammer",  # desktop: cross-profile messaging status (#59011)
 }
 
 


### PR DESCRIPTION
## What changed and why

The messaging tab in the desktop app only showed platform status for whatever profile the primary backend happened to be running as. There was no way to check another profile's Telegram, WeChat, etc. status without fully switching into it, so if a platform silently disconnected in a profile you weren't looking at, nothing surfaced it.

The backend endpoint (`GET /api/messaging/platforms`) already accepts an optional `?profile=` param and scopes the read via `_profile_scope()` against that profile's on-disk state, so no extra backend process is needed. The frontend just never passed it.

This adds a profile rail above the platform list. It only shows up when there's more than one profile, so single-profile users won't see any change. Clicking a profile re-scopes this page's view, not the app's active profile, so there's no gateway swap involved, and it polls live every 6 seconds just like today. Every other profile's pill only shows `gateway_running` from `$profiles`, which is already loaded for the profile switcher elsewhere in the app, so it's free to show and doesn't claim full platform health it hasn't actually checked.

While testing this, I ran into a real bug. Reads and writes were passing the raw nullable scope state instead of the resolved profile name. On the backend, an empty or "current" profile means "whatever profile the primary backend process happens to be running as," which isn't always the same as the profile this page shows as selected (a chat session's gateway swap can move `$activeGatewayProfile` without restarting the primary backend). I confirmed this with a real repro, toggling a platform while viewing "default" wrote into a different profile's config.yaml instead. This codebase has hit this same bug class before, so the fix follows the same pattern already used for the Skills & Tools endpoints: always send the resolved profile name, never rely on an implicit "current."

Also fixed two backend/frontend type gaps found along the way. `MessagingPlatformUpdate` was missing the `profile` field the backend already accepts, and `ProfileInfo` was missing `gateway_running`, which the backend always sends.

## How to test

1. `hermes profile create work` (or any second profile)
2. `hermes desktop`
3. Open the Messaging tab. With 2+ profiles, a row of profile pills shows up above the platform list. With just 1 profile, nothing changes.
4. Click a different profile's pill. The list re-fetches and shows that profile's platforms without switching the app's active profile anywhere else (sidebar, chat, etc. all stay put).
5. Toggle a platform on while viewing one profile, then switch to another profile and confirm it's untouched.
6. `cd apps/desktop && npx vitest run src/app/messaging src/store/profile.test.ts`, 12/12 passing.

## Test Plan

- [x] Default profile: enable Webhooks, confirm the toggle shows on and the config write lands in `~/.hermes/config.yaml`.
- [x] Work profile: switch to it via the rail, confirm Webhooks shows off there and hasn't leaked over from the default profile.

Confirmed on disk after the test, each profile's own `config.yaml`:

`~/.hermes/config.yaml` (default):
```yaml
platforms:
  webhook:
    enabled: true
```

`~/.hermes/profiles/work/config.yaml` (work):
```yaml
# no platforms section at all, webhook stays off, nothing leaked from default
```

**Default profile, Webhooks on:**

<img width="1201" height="792" alt="Screenshot 2026-07-05 at 3 06 59 PM" src="https://github.com/user-attachments/assets/dbfbf464-c5ce-4cf9-86ce-4f2e80221645" />


**Work profile, Webhooks off:**

<img width="1206" height="789" alt="Screenshot 2026-07-05 at 3 07 13 PM" src="https://github.com/user-attachments/assets/d6ea9e14-1567-46ef-803d-67d73d189c31" />



## What platforms tested

macOS only so far.

Fixes #59011

🤖 Generated with [Claude Code](https://claude.com/claude-code)