### PR TITLE
feat(skillopt): add staged self-improvement loops

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -164,7 +164,15 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
         try:
             compressor.update_from_response(usage_dict)
             context_window = getattr(turn, "model_context_window", None)
-            if isinstance(context_window, int) and context_window > 0:
+            config_context_length = getattr(agent, "_config_context_length", None)
+            has_config_context_length = (
+                isinstance(config_context_length, int) and config_context_length > 0
+            )
+            if (
+                isinstance(context_window, int)
+                and context_window > 0
+                and not has_config_context_length
+            ):
                 compressor.context_length = context_window
         except Exception:
             logger.debug("codex app-server usage update failed", exc_info=True)

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -108,10 +108,11 @@ SUPPORTED_POOL_STRATEGIES = {
 
 # Cooldown before retrying an exhausted credential.
 # Transient 401 auth failures cool down briefly so single-key setups can recover.
-# 429 (rate-limited), 402 (billing/quota), and other failures cool down after 1 hour.
+# 429 (rate-limited) cools down after 60 seconds for transient NIM rate limits.
+# 402 (billing/quota) and other failures cool down after 1 hour.
 # Provider-supplied reset_at timestamps override these defaults.
 EXHAUSTED_TTL_401_SECONDS = 5 * 60           # 5 minutes
-EXHAUSTED_TTL_429_SECONDS = 60 * 60          # 1 hour
+EXHAUSTED_TTL_429_SECONDS = 60               # 60 seconds
 EXHAUSTED_TTL_DEFAULT_SECONDS = 60 * 60      # 1 hour
 
 # Pool key prefix for custom OpenAI-compatible endpoints.

--- a/agent/learning_graph.py
+++ b/agent/learning_graph.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from hermes_constants import get_hermes_home
+from agent.memory_wiki import build_memory_wiki_index
 
 
 @dataclass
@@ -191,32 +192,34 @@ def density_stats(nodes: dict[str, SkillNode], edges: list[tuple[str, str]]) -> 
 
 
 def _memory_cards() -> list[dict[str, Any]]:
-    """Freeform memory as readable cards.
+    """Structured memory-wiki entries as readable graph cards.
 
-    ``MEMORY.md`` / ``USER.md`` are prose split on bare ``§`` separators; each
-    chunk becomes one card. Every chunk is surfaced — the graph shows everything.
+    The memory wiki parser is the single source for splitting, categorization,
+    keywords, and provenance. ``source`` preserves the legacy graph API
+    (``USER.md`` appears as ``profile``), while ``wikiSource`` exposes the raw
+    memory-wiki source for callers that want exact provenance.
     """
-    base = get_hermes_home() / "memories"
+    index = build_memory_wiki_index()
     cards: list[dict[str, Any]] = []
-    for fname, source in (("MEMORY.md", "memory"), ("USER.md", "profile")):
-        path = base / fname
-        try:
-            text = path.read_text(encoding="utf-8").strip()
-            file_ts = _to_int_ts(path.stat().st_mtime)
-        except OSError:
+    for entry in index.get("entries") or []:
+        if not isinstance(entry, dict):
             continue
-        for chunk_idx, chunk in enumerate(c.strip() for c in text.split("\n§\n")):
-            if not chunk:
-                continue
-            first = chunk.splitlines()[0].strip().lstrip("# ").strip()
-            cards.append(
-                {
-                    "source": source,
-                    "timestamp": file_ts + chunk_idx if file_ts is not None else None,
-                    "title": (first[:80] + "…") if len(first) > 80 else first,
-                    "body": chunk[:1200],
-                }
-            )
+        wiki_source = str(entry.get("source") or "memory")
+        legacy_source = "profile" if wiki_source == "user" else wiki_source
+        body = str(entry.get("text") or "")
+        cards.append(
+            {
+                "id": entry.get("id"),
+                "source": legacy_source,
+                "wikiSource": wiki_source,
+                "timestamp": entry.get("timestamp"),
+                "title": entry.get("title") or "(untitled memory)",
+                "body": body[:1200],
+                "category": entry.get("category") or "memory",
+                "keywords": list(entry.get("keywords") or []),
+                "provenance": dict(entry.get("provenance") or {}),
+            }
+        )
     return cards
 
 
@@ -298,11 +301,14 @@ def build_learning_graph() -> dict[str, Any]:
                 "kind": "memory",
                 "memorySource": card["source"],
                 "timestamp": card.get("timestamp"),
-                "category": "memory",
+                "category": card.get("category", "memory"),
                 "useCount": 0,
                 "state": "active",
                 "createdBy": "memory",
                 "pinned": False,
+                "memoryCategory": card.get("category"),
+                "wikiSource": card.get("wikiSource"),
+                "provenance": card.get("provenance"),
             }
         )
 

--- a/agent/loop_detector.py
+++ b/agent/loop_detector.py
@@ -1,0 +1,94 @@
+"""Context-aware repeated tool-call loop detector."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import deque
+from dataclasses import dataclass
+from typing import Any
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+", re.IGNORECASE)
+_LOW_INFORMATION_MARKERS = {"", "no results", "not found", "none", "[]", "{}"}
+
+
+@dataclass(frozen=True)
+class ToolCallRecord:
+    tool_name: str
+    args_key: str
+    tokens: frozenset[str]
+    low_information: bool
+
+
+def _tokens(value: Any) -> frozenset[str]:
+    if isinstance(value, dict):
+        text = " ".join(str(v) for v in value.values())
+    else:
+        text = str(value)
+    normalized = []
+    for token in _TOKEN_RE.findall(text):
+        token = token.lower()
+        if len(token) > 3 and token.endswith("s"):
+            token = token[:-1]
+        if len(token) > 1:
+            normalized.append(token)
+    return frozenset(normalized)
+
+
+def _args_key(arguments: Any) -> str:
+    try:
+        return json.dumps(arguments, ensure_ascii=False, sort_keys=True)
+    except TypeError:
+        return str(arguments)
+
+
+def _similarity(a: frozenset[str], b: frozenset[str]) -> float:
+    if not a or not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+def _low_info(result_summary: str | None) -> bool:
+    if result_summary is None:
+        return False
+    text = str(result_summary).strip().lower()
+    return text in _LOW_INFORMATION_MARKERS or len(text) < 12
+
+
+class ToolLoopDetector:
+    """Detect repeated exact/similar calls and recommend a strategy switch."""
+
+    def __init__(self, *, max_window: int = 10, repeat_threshold: int = 3, similarity_threshold: float = 0.85) -> None:
+        self.max_window = max(1, int(max_window))
+        self.repeat_threshold = max(2, int(repeat_threshold))
+        self.similarity_threshold = float(similarity_threshold)
+        self._records: deque[ToolCallRecord] = deque(maxlen=self.max_window)
+
+    def record(self, tool_name: str, arguments: Any, *, result_summary: str | None = None) -> dict[str, Any] | None:
+        record = ToolCallRecord(
+            tool_name=str(tool_name),
+            args_key=_args_key(arguments),
+            tokens=_tokens(arguments),
+            low_information=_low_info(result_summary),
+        )
+        self._records.append(record)
+        recent = list(self._records)[-self.repeat_threshold:]
+        if len(recent) < self.repeat_threshold:
+            return None
+        same_tool = all(r.tool_name == record.tool_name for r in recent)
+        if not same_tool:
+            return None
+        if all(r.args_key == record.args_key for r in recent):
+            return self._warning("repeated_tool_call", record.tool_name, recent)
+        similarities = [_similarity(recent[i - 1].tokens, recent[i].tokens) for i in range(1, len(recent))]
+        if all(s >= self.similarity_threshold for s in similarities) and any(r.low_information for r in recent):
+            return self._warning("low_information_loop", record.tool_name, recent)
+        return None
+
+    def _warning(self, kind: str, tool_name: str, recent: list[ToolCallRecord]) -> dict[str, Any]:
+        return {
+            "kind": kind,
+            "tool_name": tool_name,
+            "repeat_count": len(recent),
+            "recommendation": "Stop repeating this tool call; switch strategy, inspect a primary source, or ask for missing context.",
+        }

--- a/agent/memory_benchmarker.py
+++ b/agent/memory_benchmarker.py
@@ -1,0 +1,133 @@
+"""Local memory linting and retrieval benchmark helpers.
+
+These helpers are deliberately LLM-free and read-only. They give Hermes a cheap
+quality gate for prompt-injected MEMORY.md/USER.md entries before any heavier
+memory optimization loop is considered.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, Iterable
+
+from hermes_constants import get_hermes_home
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+", re.IGNORECASE)
+_STALE_RE = re.compile(r"\b(PR|issue|commit|phase|submitted|registered|fixed|done|completed|yesterday|today)\b", re.IGNORECASE)
+_SKILL_LIKE_RE = re.compile(r"\b(run|execute|use|always|never|first|then|after)\b.+\b(pytest|git|commit|command|script|workflow|steps?)\b", re.IGNORECASE)
+
+
+def _entries() -> list[dict[str, Any]]:
+    mem_dir = get_hermes_home() / "memories"
+    rows: list[dict[str, Any]] = []
+    for filename, target in (("MEMORY.md", "memory"), ("USER.md", "user")):
+        path = mem_dir / filename
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        for idx, part in enumerate(text.split("§")):
+            entry = part.strip()
+            if entry:
+                rows.append({"target": target, "path": str(path), "index": idx, "text": entry})
+    return rows
+
+
+def _normalize_token(token: str) -> str:
+    token = token.lower()
+    if len(token) > 3 and token.endswith("s"):
+        token = token[:-1]
+    return token
+
+
+def _tokens(text: str) -> set[str]:
+    return {_normalize_token(t) for t in _TOKEN_RE.findall(str(text)) if len(t) > 1}
+
+
+def _jaccard(a: str, b: str) -> float:
+    ta = _tokens(a)
+    tb = _tokens(b)
+    if not ta or not tb:
+        return 0.0
+    return len(ta & tb) / len(ta | tb)
+
+
+def lint_memory_entries(*, duplicate_threshold: float = 0.6) -> list[dict[str, Any]]:
+    """Return memory quality findings without mutating memory files."""
+
+    rows = _entries()
+    findings: list[dict[str, Any]] = []
+    prior: list[dict[str, Any]] = []
+    for row in rows:
+        issues: list[str] = []
+        text = str(row["text"])
+        if len(text) > 700:
+            issues.append("too_verbose")
+        if _STALE_RE.search(text):
+            issues.append("stale_task_progress")
+        if _SKILL_LIKE_RE.search(text):
+            issues.append("belongs_in_skill")
+        for earlier in prior:
+            if _jaccard(text, str(earlier["text"])) >= duplicate_threshold:
+                issues.append("near_duplicate")
+                break
+        prior.append(row)
+        if issues:
+            finding = dict(row)
+            finding["issues"] = sorted(set(issues))
+            findings.append(finding)
+    return findings
+
+
+def _matches_expected(text: str, expected: Iterable[str]) -> bool:
+    lowered = text.lower()
+    return any(str(e).lower() in lowered for e in expected)
+
+
+def benchmark_memory_retrieval(cases: list[dict[str, Any]], *, k: int = 3) -> dict[str, Any]:
+    """Compute simple Precision@K and Recall@K over built-in memory entries.
+
+    Each case is ``{"query": str, "expected": [substring, ...]}``; an entry is
+    relevant if it contains one expected substring. Retrieval uses token-overlap
+    ranking, which mirrors Hermes' cheap memory-wiki behavior closely enough for
+    regression testing without embeddings or network calls.
+    """
+
+    rows = _entries()
+    k = max(1, int(k))
+    case_reports: list[dict[str, Any]] = []
+    precision_sum = 0.0
+    recall_sum = 0.0
+    for case in cases:
+        query = str(case.get("query") or "")
+        expected = [str(e) for e in case.get("expected") or []]
+        qtok = _tokens(query)
+        ranked = sorted(
+            rows,
+            key=lambda r: (len(qtok & _tokens(str(r["text"]))), _jaccard(query, str(r["text"]))),
+            reverse=True,
+        )[:k]
+
+        relevant_retrieved = [r for r in ranked if _matches_expected(str(r["text"]), expected)]
+        relevant_total = sum(1 for r in rows if _matches_expected(str(r["text"]), expected))
+        precision = len(relevant_retrieved) / k
+        recall = (len(relevant_retrieved) / relevant_total) if relevant_total else 0.0
+        precision_sum += precision
+        recall_sum += recall
+        case_reports.append(
+            {
+                "query": query,
+                "expected": expected,
+                "retrieved": ranked,
+                "precision_at_k": precision,
+                "recall_at_k": recall,
+            }
+        )
+    total = len(cases)
+    return {
+        "cases": total,
+        "k": k,
+        "precision_at_k": round(precision_sum / total, 4) if total else 0.0,
+        "recall_at_k": round(recall_sum / total, 4) if total else 0.0,
+        "case_reports": case_reports,
+    }

--- a/agent/memory_candidates.py
+++ b/agent/memory_candidates.py
@@ -1,0 +1,157 @@
+"""Governed memory candidate queue and exact memory-wiki retrieval helpers."""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+from hermes_constants import get_hermes_home
+from agent.memory_wiki import build_memory_wiki_index, select_memory_context
+
+MemoryTarget = Literal["memory", "user"]
+
+
+@dataclass(frozen=True)
+class MemoryCandidate:
+    candidate_id: str
+    target: MemoryTarget
+    content: str
+    status: str
+    path: Path
+    payload: dict[str, Any]
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _queue_dir() -> Path:
+    return get_hermes_home() / "memory-candidates"
+
+
+def _candidate_path(candidate_id: str) -> Path:
+    safe = str(candidate_id)
+    if not re.fullmatch(r"mem-\d{8}T\d{6}-\d{6}", safe):
+        raise ValueError("invalid memory candidate id")
+    return _queue_dir() / f"{safe}.json"
+
+
+def _target_file(target: str) -> Path:
+    if target == "memory":
+        return get_hermes_home() / "memories" / "MEMORY.md"
+    if target == "user":
+        return get_hermes_home() / "memories" / "USER.md"
+    raise ValueError("target must be 'memory' or 'user'")
+
+
+def _new_id() -> str:
+    return datetime.now(timezone.utc).strftime("mem-%Y%m%dT%H%M%S") + f"-{time.time_ns() % 1_000_000:06d}"
+
+
+def _write_payload(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _load_payload(candidate_id: str) -> tuple[Path, dict[str, Any]]:
+    path = _candidate_path(candidate_id)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return path, payload
+
+
+def _shape(path: Path, payload: dict[str, Any]) -> MemoryCandidate:
+    return MemoryCandidate(
+        candidate_id=str(payload["candidate_id"]),
+        target=payload["target"],
+        content=str(payload["content"]),
+        status=str(payload.get("status", "staged")),
+        path=path,
+        payload=payload,
+    )
+
+
+def stage_memory_candidate(
+    *,
+    target: MemoryTarget,
+    content: str,
+    source: dict[str, Any] | None = None,
+    rationale: str = "",
+) -> MemoryCandidate:
+    """Stage a memory write candidate without mutating active memory files."""
+    if not str(content).strip():
+        raise ValueError("content is required")
+    _target_file(target)  # validates target
+    candidate_id = _new_id()
+    path = _candidate_path(candidate_id)
+    payload = {
+        "schema_version": 1,
+        "candidate_id": candidate_id,
+        "target": target,
+        "content": str(content).strip(),
+        "status": "staged",
+        "created_at": _now_iso(),
+        "source": dict(source or {}),
+        "rationale": rationale,
+    }
+    _write_payload(path, payload)
+    return _shape(path, payload)
+
+
+def load_memory_candidate(candidate_id: str) -> MemoryCandidate:
+    path, payload = _load_payload(candidate_id)
+    return _shape(path, payload)
+
+
+def promote_memory_candidate(candidate_id: str) -> MemoryCandidate:
+    """Append a staged memory candidate to MEMORY.md or USER.md."""
+    candidate = load_memory_candidate(candidate_id)
+    if candidate.status == "promoted":
+        return candidate
+    if candidate.status != "staged":
+        raise ValueError("candidate is not staged")
+    target_path = _target_file(candidate.target)
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    existing = target_path.read_text(encoding="utf-8") if target_path.exists() else ""
+    parts = [part.strip() for part in existing.split("\n§\n") if part.strip()]
+    if candidate.content not in parts:
+        sep = "\n§\n" if existing.strip() else ""
+        target_path.write_text(existing.rstrip() + sep + candidate.content, encoding="utf-8")
+    payload = dict(candidate.payload)
+    payload["status"] = "promoted"
+    payload["promoted_at"] = _now_iso()
+    _write_payload(candidate.path, payload)
+    return _shape(candidate.path, payload)
+
+
+def reject_memory_candidate(candidate_id: str, *, reason: str = "") -> MemoryCandidate:
+    candidate = load_memory_candidate(candidate_id)
+    payload = dict(candidate.payload)
+    payload["status"] = "rejected"
+    payload["rejected_at"] = _now_iso()
+    payload["rejection_reason"] = str(reason)
+    _write_payload(candidate.path, payload)
+    return _shape(candidate.path, payload)
+
+
+def memory_wiki_find(query: str, *, max_chars: int = 4000) -> list[dict[str, Any]]:
+    """Find relevant memory-wiki entries by query."""
+    return list(select_memory_context(query, max_chars=max_chars).get("entries") or [])
+
+
+def memory_wiki_read(entry_id: str) -> dict[str, Any]:
+    """Read one exact memory-wiki entry by stable id."""
+    for entry in build_memory_wiki_index().get("entries") or []:
+        if entry.get("id") == entry_id:
+            return entry
+    raise KeyError(entry_id)
+
+
+def memory_wiki_grep(pattern: str) -> list[dict[str, Any]]:
+    """Case-insensitive regex grep across memory-wiki entries."""
+    rx = re.compile(pattern, re.IGNORECASE)
+    return [entry for entry in build_memory_wiki_index().get("entries") or [] if rx.search(str(entry.get("text") or ""))]

--- a/agent/memory_wiki.py
+++ b/agent/memory_wiki.py
@@ -1,0 +1,204 @@
+"""Local, read-only wiki-memory index over Hermes built-in memories.
+
+The module turns ``MEMORY.md`` and ``USER.md`` entries into structured,
+inspectable records. It deliberately does not summarize with an LLM, mutate
+memory files, or inject context by itself; callers can use the exported index
+for CLI/dashboard/cron surfaces and budgeted retrieval.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+ENTRY_SEPARATOR = "\n§\n"
+_INDEX_VERSION = 1
+_STOPWORDS = {
+    "about",
+    "after",
+    "again",
+    "also",
+    "and",
+    "are",
+    "because",
+    "but",
+    "for",
+    "from",
+    "has",
+    "have",
+    "into",
+    "not",
+    "only",
+    "should",
+    "that",
+    "the",
+    "their",
+    "this",
+    "use",
+    "user",
+    "uses",
+    "with",
+}
+_CATEGORY_PATTERNS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("decision", ("decision:", "decided", "choose", "chose", "use ", "switch ")),
+    ("constraint", ("constraint:", "must ", "must not", "never ", "only ", "avoid", "forbid")),
+    ("preference", ("prefer", "prefers", "likes", "wants", "expects")),
+    ("identity", ("legal name", "user name", "role:", "mission:")),
+    ("environment", ("host", "runs ", "path", "port", "repo", "project", "token", "credential")),
+    ("procedural", ("run ", "command", "workflow", "procedure", "steps", "skill")),
+)
+
+
+def _memory_dir() -> Path:
+    return get_hermes_home() / "memories"
+
+
+def _split_entries(text: str) -> list[str]:
+    return [entry.strip() for entry in text.split(ENTRY_SEPARATOR) if entry.strip()]
+
+
+def _tokenize(text: str) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for token in re.findall(r"[a-z0-9][a-z0-9_.-]{2,}", text.lower()):
+        if token in _STOPWORDS or token in seen:
+            continue
+        seen.add(token)
+        out.append(token)
+    return out
+
+
+def _classify(text: str, source: str) -> str:
+    lower = text.lower()
+    for category, needles in _CATEGORY_PATTERNS:
+        if any(needle in lower for needle in needles):
+            return category
+    if source == "user":
+        return "preference" if "prefer" in lower else "profile"
+    return "fact"
+
+
+def _stable_id(source: str, index: int, text: str) -> str:
+    digest = hashlib.sha256(f"{source}\0{index}\0{text}".encode("utf-8")).hexdigest()[:16]
+    return f"{source}:{index}:{digest}"
+
+
+def _entry_title(text: str) -> str:
+    first = text.splitlines()[0].strip().lstrip("# ").strip()
+    return (first[:96] + "…") if len(first) > 96 else first
+
+
+def _read_source(path: Path, source: str) -> list[dict[str, Any]]:
+    try:
+        raw = path.read_text(encoding="utf-8").strip()
+        timestamp = int(path.stat().st_mtime)
+    except OSError:
+        return []
+
+    entries: list[dict[str, Any]] = []
+    for idx, text in enumerate(_split_entries(raw)):
+        entries.append(
+            {
+                "id": _stable_id(source, idx, text),
+                "source": source,
+                "index": idx,
+                "category": _classify(text, source),
+                "title": _entry_title(text),
+                "text": text,
+                "keywords": _tokenize(text)[:16],
+                "timestamp": timestamp + idx,
+                "provenance": {
+                    "path": str(path),
+                    "entry_index": idx,
+                    "content_sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+                },
+            }
+        )
+    return entries
+
+
+def build_memory_wiki_index() -> dict[str, Any]:
+    """Return a structured, JSON-serializable index over built-in memory files."""
+
+    base = _memory_dir()
+    entries = _read_source(base / "MEMORY.md", "memory") + _read_source(base / "USER.md", "user")
+    sources: dict[str, int] = {}
+    categories: dict[str, int] = {}
+    for entry in entries:
+        sources[entry["source"]] = sources.get(entry["source"], 0) + 1
+        categories[entry["category"]] = categories.get(entry["category"], 0) + 1
+
+    return {
+        "version": _INDEX_VERSION,
+        "entries": entries,
+        "stats": {
+            "entries": len(entries),
+            "sources": sources,
+        },
+        "categories": categories,
+    }
+
+
+def _score_entry(query_tokens: set[str], entry: dict[str, Any]) -> int:
+    keywords = set(entry.get("keywords") or [])
+    title = str(entry.get("title") or "").lower()
+    text = str(entry.get("text") or "").lower()
+    score = 4 * len(query_tokens & keywords)
+    score += sum(2 for token in query_tokens if token in title)
+    score += sum(1 for token in query_tokens if token in text)
+    category = entry.get("category")
+    if category in {"decision", "constraint", "preference"}:
+        score += 1
+    return score
+
+
+def select_memory_context(
+    query: str,
+    *,
+    index: dict[str, Any] | None = None,
+    max_chars: int = 1200,
+) -> dict[str, Any]:
+    """Select relevant memory-wiki entries that fit within ``max_chars``.
+
+    This is retrieval-aware context assembly in miniature: relevance is scored
+    first, then entries are admitted only while the caller's character budget
+    allows. The returned string is fenced as data, not user input.
+    """
+
+    if max_chars <= 0:
+        raise ValueError("max_chars must be positive")
+    index = index or build_memory_wiki_index()
+    entries = list(index.get("entries") or [])
+    if not entries:
+        return {"entries": [], "context": "", "used_chars": 0}
+
+    query_tokens = set(_tokenize(query))
+    scored = [(_score_entry(query_tokens, entry), entry) for entry in entries]
+    scored = [(score, entry) for score, entry in scored if score > 0]
+    scored.sort(key=lambda item: (-item[0], str(item[1].get("id", ""))))
+
+    selected: list[dict[str, Any]] = []
+    chunks: list[str] = []
+    prefix = "<memory-wiki-context>\n"
+    suffix = "\n</memory-wiki-context>"
+    used = len(prefix) + len(suffix)
+    for score, entry in scored:
+        chunk = f"- [{entry['category']}/{entry['source']}] {entry['title']}: {entry['text']}"
+        cost = len(chunk) + (1 if chunks else 0)
+        if used + cost > max_chars:
+            continue
+        shaped = {k: entry[k] for k in ("id", "source", "category", "title", "provenance")}
+        shaped["score"] = score
+        selected.append(shaped)
+        chunks.append(chunk)
+        used += cost
+
+    raw_context = "\n".join(chunks)
+    if not raw_context:
+        return {"entries": [], "context": "", "used_chars": 0}
+    context = prefix + raw_context + suffix
+    return {"entries": selected, "context": context, "used_chars": len(context)}

--- a/agent/skillopt_harvest.py
+++ b/agent/skillopt_harvest.py
@@ -1,0 +1,125 @@
+"""Session trace harvesting helpers for SkillOpt."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+_EXCLUDED_SOURCES = {"cron", "subagent", "delegation"}
+_COMMAND_RE = re.compile(r"(?:^|\n)\s*((?:python3?|uv|poetry|pytest|npm|pnpm|yarn|bun|git|bash|sh)\b[^\n]*)", re.IGNORECASE)
+
+
+def harvest_skill_traces(
+    db: Any,
+    skill_name: str,
+    *,
+    limit: int = 20,
+    window: int = 4,
+    exclude_sources: set[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Return context windows anchored near mentions of a skill.
+
+    ``db`` is expected to be a ``SessionDB``-like object exposing
+    ``search_messages`` and ``get_messages_around``. The helper is deliberately
+    read-only and excludes autonomous cron/subagent scaffolding by default.
+    """
+
+    name = str(skill_name or "").strip()
+    if not name:
+        raise ValueError("skill_name is required")
+    excluded = set(exclude_sources or _EXCLUDED_SOURCES)
+    phrase = name.replace('"', ' ')
+    token = re.sub(r"[^A-Za-z0-9_.:-]+", " ", name).strip() or phrase
+    query = f'"{phrase}" OR {token} OR skill_view OR skill_manage'
+    hits = db.search_messages(
+        query,
+        role_filter=["user", "assistant", "tool"],
+        limit=limit,
+        sort="newest",
+        include_inactive=False,
+    )
+    traces: list[dict[str, Any]] = []
+    seen: set[tuple[str, int]] = set()
+    for hit in hits:
+        source = str(hit.get("source") or "")
+        if source in excluded:
+            continue
+        session_id = str(hit.get("session_id") or "")
+        msg_id_raw = hit.get("message_id", hit.get("id"))
+        try:
+            msg_id = int(msg_id_raw)
+        except (TypeError, ValueError):
+            continue
+        key = (session_id, msg_id)
+        if not session_id or key in seen:
+            continue
+        seen.add(key)
+        window_result = db.get_messages_around(session_id, msg_id, window=window)
+        messages = window_result.get("window", []) if isinstance(window_result, dict) else window_result
+        traces.append(
+            {
+                "skill_name": name,
+                "session_id": session_id,
+                "anchor_message_id": msg_id,
+                "source": source,
+                "anchor": hit,
+                "messages": messages,
+            }
+        )
+    return traces
+
+
+def _message_text(msg: dict[str, Any]) -> str:
+    content = msg.get("content")
+    if isinstance(content, str):
+        return content
+    return ""
+
+
+def _extract_commands(messages: list[dict[str, Any]]) -> list[str]:
+    commands: list[str] = []
+    seen: set[str] = set()
+    for msg in messages:
+        if str(msg.get("tool_name") or "") not in {"terminal", "process"} and msg.get("role") != "tool":
+            continue
+        for match in _COMMAND_RE.finditer(_message_text(msg)):
+            command = match.group(1).strip()
+            if command and command not in seen:
+                seen.add(command)
+                commands.append(command)
+    return commands
+
+
+def distill_trace_to_skill(trace: dict[str, Any]) -> dict[str, Any]:
+    """Distill a successful coding trajectory into a compact skill draft.
+
+    This is a deterministic CODESKILL-style first pass: extract commands and
+    coarse workflow phases. LLM rewriting can refine the staged markdown later,
+    but this function stays safe, local, and testable.
+    """
+
+    name = str(trace.get("skill_name") or "distilled-skill").strip() or "distilled-skill"
+    messages = [m for m in trace.get("messages") or [] if isinstance(m, dict)]
+    commands = _extract_commands(messages)
+    saw_patch = any(str(m.get("tool_name") or "") == "patch" or "*** Begin Patch" in _message_text(m) for m in messages)
+    saw_failure = any("fail" in _message_text(m).lower() or "error" in _message_text(m).lower() for m in messages)
+    saw_success = any("passed" in _message_text(m).lower() or "success" in _message_text(m).lower() for m in messages)
+    steps = ["Reproduce the task or failure with the narrowest command available."]
+    if saw_failure:
+        steps.append("Read the failure output and isolate the root cause before editing.")
+    if saw_patch:
+        steps.append("Apply the smallest targeted patch that addresses the root cause.")
+    if commands:
+        steps.append("Re-run the same verification command until it passes.")
+    if saw_success:
+        steps.append("Report the exact verification evidence in the final response.")
+    skill_markdown = (
+        f"---\nname: {name}\ndescription: Distilled from a successful Hermes coding trajectory.\n---\n\n"
+        f"# {name}\n\n"
+        "## Workflow\n"
+        + "\n".join(f"{idx}. {step}" for idx, step in enumerate(steps, 1))
+        + "\n\n## Commands observed\n"
+        + "\n".join(f"- `{cmd}`" for cmd in commands)
+        + "\n\n<!-- Save as SKILL.md after human/eval review. -->\n"
+    )
+    return {"name": name, "commands": commands, "steps": steps, "skill_markdown": skill_markdown}

--- a/agent/skillopt_scoring.py
+++ b/agent/skillopt_scoring.py
@@ -1,0 +1,62 @@
+"""Score adapters for SkillOpt validation gates."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+
+def _db_path() -> Path:
+    return get_hermes_home() / "verification_evidence.db"
+
+
+def score_verification_evidence(
+    *,
+    root: str | Path,
+    session_id: str | None = None,
+    min_events: int = 2,
+) -> dict[str, Any]:
+    """Return a pass-rate score from the verification evidence ledger.
+
+    ``heldout_ready`` is false until at least ``min_events`` are available. This
+    lets SkillOpt gates fail closed instead of promoting candidates from a single
+    ad-hoc success.
+    """
+
+    root_s = str(Path(root).resolve())
+    sid = str(session_id) if session_id else None
+    path = _db_path()
+    if not path.exists():
+        return {"score": 0.0, "total": 0, "passed": 0, "failed": 0, "heldout_ready": False, "events": []}
+
+    where = ["root = ?"]
+    params: list[Any] = [root_s]
+    if sid is not None:
+        where.append("session_id = ?")
+        params.append(sid)
+    sql = (
+        "SELECT id, created_at, session_id, canonical_command, kind, scope, status "
+        "FROM verification_events WHERE " + " AND ".join(where) + " ORDER BY id ASC"
+    )
+    with sqlite3.connect(path) as conn:
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = [dict(r) for r in conn.execute(sql, params).fetchall()]
+        except sqlite3.Error:
+            rows = []
+
+    total = len(rows)
+    passed = sum(1 for row in rows if row.get("status") == "passed")
+    failed = sum(1 for row in rows if row.get("status") == "failed")
+    score = (passed / total) if total else 0.0
+    return {
+        "score": score,
+        "total": total,
+        "passed": passed,
+        "failed": failed,
+        "heldout_ready": total >= max(1, int(min_events)),
+        "events": rows,
+    }

--- a/agent/skillopt_state.py
+++ b/agent/skillopt_state.py
@@ -1,0 +1,209 @@
+"""Durable staged artifacts for SkillOpt-style skill proposals.
+
+This module stores reviewable candidate skill updates under
+``$HERMES_HOME/skillopt/runs/<run_id>/``. It never mutates the live skill; adopt
+or reject decisions stay explicit and reversible in higher-level code.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import tempfile
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+SCHEMA_VERSION = 1
+_SKILL_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+
+
+@dataclass(frozen=True)
+class SkillOptProposal:
+    """Loaded or newly staged SkillOpt proposal."""
+
+    run_id: str
+    run_dir: Path
+    skill_name: str
+    current_skill_path: Path
+    current_sha256: str
+    candidate_sha256: str
+    candidate_skill: str
+    status: str
+    proposal: dict[str, Any]
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _validate_skill_name(skill_name: str) -> str:
+    value = str(skill_name or "").strip()
+    if not _SKILL_NAME_RE.fullmatch(value) or ".." in value or "/" in value or "\\" in value:
+        raise ValueError("invalid skill_name")
+    return value
+
+
+def _runs_dir() -> Path:
+    return get_hermes_home() / "skillopt" / "runs"
+
+
+def _run_id(skill_name: str) -> str:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+    return f"{skill_name}-{stamp}-{time.time_ns() % 1_000_000:06d}"
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with open(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+            f.flush()
+        Path(tmp).replace(path)
+    except Exception:
+        try:
+            Path(tmp).unlink(missing_ok=True)
+        finally:
+            raise
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    _atomic_write(path, json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n")
+
+
+def _proposal_from_payload(run_dir: Path, payload: dict[str, Any], candidate_skill: str) -> SkillOptProposal:
+    return SkillOptProposal(
+        run_id=str(payload["run_id"]),
+        run_dir=run_dir,
+        skill_name=str(payload["skill_name"]),
+        current_skill_path=Path(str(payload["current_skill_path"])),
+        current_sha256=str(payload["current_sha256"]),
+        candidate_sha256=str(payload["candidate_sha256"]),
+        candidate_skill=candidate_skill,
+        status=str(payload.get("status", "staged")),
+        proposal=payload,
+    )
+
+
+def stage_skillopt_proposal(
+    *,
+    skill_name: str,
+    current_skill_path: str | Path,
+    candidate_skill: str,
+    edits: list[dict[str, Any]] | None = None,
+    scores: dict[str, Any] | None = None,
+    source: dict[str, Any] | None = None,
+    rationale: str = "",
+    run_id: str | None = None,
+) -> SkillOptProposal:
+    """Create reviewable staged artifacts for a candidate skill update.
+
+    The live ``current_skill_path`` is read for hashing only. It is never
+    modified. The candidate document is stored as ``candidate.SKILL.md`` and the
+    proposal metadata is stored as JSON for later scoring/adopt/reject flows.
+    """
+
+    safe_name = _validate_skill_name(skill_name)
+    skill_path = Path(current_skill_path).expanduser()
+    current_skill = skill_path.read_text(encoding="utf-8")
+    candidate = str(candidate_skill)
+    rid = _validate_skill_name(run_id) if run_id else _run_id(safe_name)
+    run_dir = _runs_dir() / rid
+    run_dir.mkdir(parents=True, exist_ok=False)
+
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": rid,
+        "skill_name": safe_name,
+        "status": "staged",
+        "created_at": _now_iso(),
+        "current_skill_path": str(skill_path),
+        "current_sha256": _sha256(current_skill),
+        "candidate_sha256": _sha256(candidate),
+        "edits": list(edits or []),
+        "scores": dict(scores or {}),
+        "source": dict(source or {}),
+        "rationale": rationale,
+    }
+    _atomic_write(run_dir / "candidate.SKILL.md", candidate)
+    _write_json(run_dir / "proposal.json", payload)
+    _atomic_write(
+        run_dir / "meta.md",
+        "# SkillOpt Proposal\n\n"
+        f"- Run: `{rid}`\n"
+        f"- Skill: `{safe_name}`\n"
+        f"- Status: staged\n"
+        f"- Created: {payload['created_at']}\n\n"
+        f"## Rationale\n\n{rationale or '(none)'}\n",
+    )
+    _atomic_write(run_dir / "rejected.jsonl", "")
+    return _proposal_from_payload(run_dir, payload, candidate)
+
+
+def load_skillopt_proposal(run_dir: str | Path) -> SkillOptProposal:
+    """Load a staged proposal and fail closed if candidate content was changed."""
+
+    path = Path(run_dir)
+    payload = json.loads((path / "proposal.json").read_text(encoding="utf-8"))
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError("unsupported SkillOpt proposal schema")
+    candidate = (path / "candidate.SKILL.md").read_text(encoding="utf-8")
+    if _sha256(candidate) != payload.get("candidate_sha256"):
+        raise ValueError("candidate hash mismatch")
+    return _proposal_from_payload(path, payload, candidate)
+
+
+def append_skillopt_rejection(run_dir: str | Path, *, reason: str, reviewer: str = "") -> None:
+    """Append a rejection record and mark the proposal rejected."""
+
+    path = Path(run_dir)
+    loaded = load_skillopt_proposal(path)
+    record = {
+        "rejected_at": _now_iso(),
+        "reason": str(reason),
+        "reviewer": str(reviewer),
+    }
+    with (path / "rejected.jsonl").open("a", encoding="utf-8") as f:
+        f.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
+    payload = dict(loaded.proposal)
+    payload["status"] = "rejected"
+    payload["rejected_at"] = record["rejected_at"]
+    payload["rejection_reason"] = record["reason"]
+    _write_json(path / "proposal.json", payload)
+
+
+def mark_skillopt_adopted(run_dir: str | Path) -> None:
+    """Mark a proposal adopted after the caller has updated the live skill."""
+    path = Path(run_dir)
+    loaded = load_skillopt_proposal(path)
+    payload = dict(loaded.proposal)
+    payload["status"] = "adopted"
+    payload["adopted_at"] = _now_iso()
+    _write_json(path / "proposal.json", payload)
+
+
+def update_skillopt_evaluation(run_dir: str | Path, scores: dict[str, Any]) -> SkillOptProposal:
+    """Persist evaluation scores and gate status for a staged proposal."""
+    path = Path(run_dir)
+    loaded = load_skillopt_proposal(path)
+    payload = dict(loaded.proposal)
+    payload["scores"] = dict(scores)
+    payload["evaluated_at"] = _now_iso()
+    if not scores.get("heldout_ready"):
+        payload["status"] = "needs_evidence"
+    elif float(scores.get("score") or 0.0) <= 0.0 or int(scores.get("failed") or 0) > 0:
+        payload["status"] = "failed_evaluation"
+    else:
+        payload["status"] = "evaluated"
+    _write_json(path / "proposal.json", payload)
+    return load_skillopt_proposal(path)

--- a/agent/skillopt_text_optimizer.py
+++ b/agent/skillopt_text_optimizer.py
@@ -1,0 +1,181 @@
+"""Lightweight SkillOpt-style text update primitives for Hermes skills.
+
+This module intentionally implements only the safe, deterministic first slice of
+SkillOpt: bounded atomic edits on a single skill document plus a pure validation
+gate. It does not call models, read/write skill files, or decide what evidence
+to collect. Higher-level `/learn`, curator, cron, or future optimizers can use
+these primitives behind their own verification loop.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import isfinite
+from typing import Literal
+
+SLOW_UPDATE_START = "<!-- SLOW_UPDATE_START -->"
+SLOW_UPDATE_END = "<!-- SLOW_UPDATE_END -->"
+
+EditOp = Literal["append", "insert_after", "replace", "delete"]
+GateAction = Literal["accept_new_best", "accept", "reject"]
+
+
+@dataclass(frozen=True)
+class AtomicEdit:
+    """A bounded edit proposed for one skill document.
+
+    `append` ignores `target`. `insert_after`, `replace`, and `delete` require a
+    unique target string. This deliberately avoids regexes and shell-like patch
+    languages so model-proposed edits are easy to review and test.
+    """
+
+    op: EditOp
+    content: str = ""
+    target: str = ""
+    rationale: str = ""
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    """Pure validation-gate outcome for a candidate skill."""
+
+    action: GateAction
+    current_skill: str
+    current_score: float
+    best_skill: str
+    best_score: float
+    best_step: int
+
+
+def _word_count(text: str) -> int:
+    return len([part for part in text.split() if part])
+
+
+def _has_unterminated_slow_update(text: str) -> bool:
+    start = text.find(SLOW_UPDATE_START)
+    return start >= 0 and text.find(SLOW_UPDATE_END, start + len(SLOW_UPDATE_START)) < 0
+
+
+def _protected_ranges(text: str) -> list[range]:
+    """Return protected slow-update character ranges.
+
+    Missing end marker makes the rest of the document protected. This is
+    fail-closed: malformed skills should not receive step-level edits inside a
+    suspected slow-update block.
+    """
+
+    ranges: list[range] = []
+    start = 0
+    while True:
+        i = text.find(SLOW_UPDATE_START, start)
+        if i < 0:
+            return ranges
+        j = text.find(SLOW_UPDATE_END, i + len(SLOW_UPDATE_START))
+        if j < 0:
+            ranges.append(range(i, len(text)))
+            return ranges
+        j += len(SLOW_UPDATE_END)
+        ranges.append(range(i, j))
+        start = j
+
+
+def _overlaps_protected(text: str, start: int, end: int) -> bool:
+    if start < 0 or end < start:
+        return False
+    for r in _protected_ranges(text):
+        if start < r.stop and end > r.start:
+            return True
+    return False
+
+
+def _find_unique(text: str, target: str) -> tuple[int, int]:
+    if not target:
+        raise ValueError("target is required for this edit operation")
+    start = text.find(target)
+    if start < 0:
+        raise ValueError(f"target not found: {target!r}")
+    if text.find(target, start + len(target)) >= 0:
+        raise ValueError(f"target is not unique: {target!r}")
+    end = start + len(target)
+    if _overlaps_protected(text, start, end):
+        raise ValueError("edit would modify protected slow-update block")
+    return start, end
+
+
+def _apply_one(skill: str, edit: AtomicEdit) -> str:
+    content = edit.content.rstrip()
+    if edit.op == "append":
+        if _has_unterminated_slow_update(skill):
+            raise ValueError("unterminated slow-update block; refusing append")
+        sep = "" if skill.endswith("\n") else "\n"
+        return f"{skill}{sep}{content}\n"
+
+    start, end = _find_unique(skill, edit.target)
+    if edit.op == "delete":
+        return skill[:start] + skill[end:]
+    if edit.op == "replace":
+        return skill[:start] + content + skill[end:]
+    if edit.op == "insert_after":
+        sep = "" if skill[end:end + 1] == "\n" else "\n"
+        return skill[:end] + sep + content + "\n" + skill[end:]
+    raise ValueError(f"unknown edit op: {edit.op!r}")
+
+
+def apply_bounded_edits(
+    skill: str,
+    edits: list[AtomicEdit],
+    *,
+    edit_budget: int,
+    max_words: int = 2000,
+) -> tuple[str, int]:
+    """Apply up to `edit_budget` atomic edits and return candidate text.
+
+    The edit budget is the SkillOpt textual learning-rate analogue. All applied
+    edits are deterministic and bounded; invalid edits fail before returning a
+    partially accepted result to the caller.
+    """
+
+    if edit_budget < 0:
+        raise ValueError("edit_budget must be non-negative")
+    if max_words <= 0:
+        raise ValueError("max_words must be positive")
+
+    candidate = skill
+    applied = 0
+    for edit in edits[:edit_budget]:
+        candidate = _apply_one(candidate, edit)
+        applied += 1
+
+    words = _word_count(candidate)
+    if words > max_words:
+        raise ValueError(f"candidate skill exceeds max_words ({words} > {max_words})")
+    return candidate, applied
+
+
+def evaluate_skill_gate(
+    *,
+    candidate_skill: str,
+    candidate_score: float,
+    current_skill: str,
+    current_score: float,
+    best_skill: str,
+    best_score: float,
+    step: int,
+    best_step: int = 0,
+    epsilon: float = 0.0,
+) -> GateDecision:
+    """Accept a candidate only when it strictly improves validation score."""
+
+    cand = float(candidate_score)
+    cur = float(current_score)
+    best = float(best_score)
+    raw_epsilon = float(epsilon)
+    if not all(isfinite(value) for value in (cand, cur, best, raw_epsilon)):
+        raise ValueError("gate scores and epsilon must be finite numbers")
+    threshold = max(0.0, raw_epsilon)
+
+    if cand > cur + threshold:
+        if cand > best + threshold:
+            return GateDecision("accept_new_best", candidate_skill, cand, candidate_skill, cand, step)
+        return GateDecision("accept", candidate_skill, cand, best_skill, best, best_step)
+    return GateDecision("reject", current_skill, cur, best_skill, best, best_step)

--- a/agent/verification_gate.py
+++ b/agent/verification_gate.py
@@ -1,0 +1,72 @@
+"""Postcondition verification helpers for delegated or multi-agent work.
+
+The verifier is intentionally small and deterministic: it checks externally
+observable claims (files exist, commands passed) and returns a structured verdict
+that a parent agent can inspect before reporting success.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable
+
+
+def _resolve_required_path(raw: str, root: str | Path | None) -> tuple[Path, bool]:
+    path = Path(str(raw)).expanduser()
+    if root is None:
+        return path.resolve(), True
+    root_path = Path(root).expanduser().resolve()
+    if not path.is_absolute():
+        path = root_path / path
+    resolved = path.resolve()
+    return resolved, (resolved == root_path or root_path in resolved.parents)
+
+
+def verify_postconditions(
+    *,
+    summary: str,
+    required_paths: Iterable[str] | None = None,
+    command_results: Iterable[dict[str, Any]] | None = None,
+    root: str | Path | None = None,
+) -> dict[str, Any]:
+    """Return a fail-closed verdict for claimed task completion."""
+
+    failures: list[dict[str, Any]] = []
+    paths_verified: list[str] = []
+    commands_verified: list[dict[str, Any]] = []
+
+    for raw in required_paths or []:
+        path, in_root = _resolve_required_path(str(raw), root)
+        if not in_root:
+            failures.append({"kind": "path_outside_root", "path": str(path)})
+        elif not path.exists():
+            failures.append({"kind": "missing_path", "path": str(path)})
+        else:
+            paths_verified.append(str(path))
+
+    for result in command_results or []:
+        command = str(result.get("command") or result.get("canonical_command") or "")
+        try:
+            exit_code = int(result.get("exit_code", 1))
+        except (TypeError, ValueError):
+            exit_code = 1
+        status = "passed" if exit_code == 0 else "failed"
+        record = {
+            "command": command,
+            "exit_code": exit_code,
+            "status": status,
+            "output": str(result.get("output") or result.get("output_summary") or "")[:1000],
+        }
+        commands_verified.append(record)
+        if exit_code != 0:
+            failures.append({"kind": "command_failed", "command": command, "exit_code": exit_code})
+
+    return {
+        "passed": not failures,
+        "summary": str(summary or ""),
+        "failures": failures,
+        "evidence": {
+            "paths_verified": paths_verified,
+            "commands_verified": commands_verified,
+        },
+    }

--- a/docs/plans/2026-07-05-memory-wiki-improvements.md
+++ b/docs/plans/2026-07-05-memory-wiki-improvements.md
@@ -1,0 +1,180 @@
+# Memory Wiki Improvements Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Improve Hermes memory/wiki continuity by adding inspectable, budgeted, source-grounded wiki-memory artifacts over existing memories, sessions, skills, and future summaries.
+
+**Architecture:** Keep Hermes' built-in `MEMORY.md` / `USER.md`, `state.db` FTS5, skills, curator, and `/journey` as the source of truth. Add an incremental, local-first wiki-memory layer that exports compact JSON/Markdown indexes, supports agentic retrieval-style `find/read/grep/retrieve`, and only injects retrieved context through budgeted, fenced, provenance-aware paths.
+
+**Tech Stack:** Python stdlib first, SQLite FTS5 already in `hermes_state.py`, existing dashboard/FastAPI only for later UI, existing cron/curator for scheduling.
+
+---
+
+## Source Findings
+
+### `kiranklabs/hermes-memory-wiki`
+
+Source: https://github.com/kiranklabs/hermes-memory-wiki
+
+Useful patterns:
+- Session archive as inspectable files plus a web UI.
+- `facts.json`, `decisions.json`, `wiki-index.json` generated from Hermes `state.db`.
+- Facts are overwritten/superseded, not appended forever.
+- Decisions keep supersedence trails.
+- Cron sessions are classified separately from human work.
+- Context injection should be compact and relevance-gated.
+
+Cautions:
+- README says macOS-first launch agent setup; Yahya's host is Linux/systemd.
+- Uses Next.js frontend and LLM summaries; do not copy as core dependency.
+- Repo is small/new: 12 stars, no open issues, low evidence of robustness.
+
+### Memory OS article
+
+Source: https://www.marktechpost.com/2026/06/01/meet-memory-os-a-6-layer-open-source-memory-stack-built-on-top-of-hermes-agent/
+
+Useful patterns:
+- Layered memory: workspace files, sessions, structured facts, fabric/tool recall, vectors, LLM wiki.
+- Relevance gates before context injection.
+- Dedup per session.
+- Fallback cascade: hybrid → dense → lexical → SQLite.
+- Decay/dedup maintenance.
+
+Cautions:
+- Heavy infra: Docker, Qdrant, Redis, ARQ worker.
+- No public recall/latency/token benchmarks cited.
+- Should be optional plugin/profile feature, not Hermes core default.
+
+### Context vs Memory Engineering
+
+Source: https://machinelearningmastery.com/context-vs-memory-engineering-in-agentic-ai-systems/
+
+Useful patterns:
+- Explicit write policy: triggers, eligible data, schema, trust, provenance, conflict handling, TTL.
+- Retrieval-aware context budget: retrieval must accept a max token/char budget.
+- Placement matters: retrieved memory should be near current task, not buried in middle.
+- Maintenance: TTL, decay, dedup, stale fact pruning.
+
+Cautions:
+- Avoid unbounded automatic writes; they poison retrieval quality.
+
+### LlamaIndex Legal KB / Retrieval Harness
+
+Source: https://www.marktechpost.com/2026/07/05/llamaindex-legal-kb-agentic-retrieval-over-index-v2-with-retrieve-find-read-and-grep-tools/
+
+Useful patterns:
+- Expose knowledge base as filesystem-like agent tools: `find`, `read`, `grep`, `retrieve`.
+- Enforce order: establish inventory first, then retrieve, then confirm exact wording before citing.
+- Version files and cite exact source spans.
+
+Cautions:
+- Visual citation/bbox layer is unnecessary for Hermes memory at first.
+- Do not add LlamaCloud dependency; replicate the tool semantics locally.
+
+### DeepWiki / LangChain Wiki Memory
+
+Sources:
+- https://cognition.com/blog/deepwiki
+- https://www.langchain.com/blog/wiki-memory
+
+Useful patterns:
+- Wiki memory is precomputed synthesis over raw sources, not raw RAG chunks.
+- Files are a good substrate: inspectable, editable, versionable, agent-readable.
+- Code/wiki docs reduce repeated rediscovery for both humans and agents.
+
+Cautions:
+- Wiki memory is not all memory; keep preferences/facts/procedures distinct.
+
+---
+
+## Local Hermes Extension Points
+
+| Area | Existing files | Reuse |
+|---|---|---|
+| Built-in durable memory | `tools/memory_tool.py`, `agent/memory_manager.py` | Source of truth for profile/user facts; strict threat scanning; frozen prompt snapshot.
+| Session recall | `tools/session_search_tool.py`, `hermes_state.py` | FTS5 discovery/read/scroll; demotes cron sessions already.
+| Journey/memory graph | `agent/learning_graph.py`, `hermes_cli/journey.py` | Existing visual substrate for memories + skills.
+| Skills/procedural memory | `tools/skills_tool.py`, `tools/skill_manager_tool.py`, `tools/skill_usage.py`, `agent/curator.py` | Procedural memory and lifecycle telemetry.
+| Verification evidence | `agent/verification_evidence.py` | Provenance/evidence model for accepting learned facts or skill changes.
+| Dashboard | `hermes_cli/web_server.py` | Later Memory Wiki UI/API endpoint.
+| Cron | `cron/`, `cronjob` | Incremental indexing, backups, decay, summaries.
+
+---
+
+## Prioritized Implementation
+
+### Phase 1 — Safe local wiki-memory index
+
+**Objective:** Export existing `MEMORY.md` / `USER.md` into structured, inspectable JSON entries with source, category, stable id, keywords, timestamps, and budgeted retrieval.
+
+Files:
+- Create: `agent/memory_wiki.py`
+- Create: `tests/agent/test_memory_wiki.py`
+
+Features:
+- Parse entries split by `§` without changing memory files.
+- Stable IDs from source/index/content hash.
+- Heuristic categories: identity, preference, environment, constraint, procedural, decision, fact.
+- Keyword extraction and source provenance.
+- `select_memory_context(query, max_chars)` for retrieval-aware budgeting.
+- No LLM, no vectors, no writes to user memory.
+
+Verification:
+- `PYTHONWARNINGS=error python -m pytest tests/agent/test_memory_wiki.py -q`
+- Related: `tests/agent/test_learning_graph.py tests/tools/test_memory_tool.py`
+
+### Phase 2 — CLI export command
+
+**Objective:** Add `hermes memory wiki-index --out ~/.hermes/memory-wiki/wiki-index.json`.
+
+Files:
+- Modify: `hermes_cli/subcommands/memory.py`
+- Modify: `hermes_cli/main.py` or route through `hermes_cli/memory_setup.py` if refactoring allows.
+- Add tests under `tests/hermes_cli/`.
+
+Output:
+- JSON by default.
+- Optional Markdown page with facts/preferences/constraints/decisions.
+
+### Phase 3 — Agentic local retrieval harness
+
+**Objective:** Add local knowledge tools over generated wiki files and session summaries:
+- `wiki_find`
+- `wiki_read`
+- `wiki_grep`
+- `wiki_retrieve`
+
+Use exact source confirmation before citation. Keep disabled by default until mature.
+
+### Phase 4 — Session summaries + decisions
+
+**Objective:** Incrementally summarize sessions into `~/.hermes/memory-wiki/sessions/*.json`, `facts.json`, `decisions.json`.
+
+Rules:
+- Human sessions first; cron/subagent/tool sessions separate.
+- No auto-write into `MEMORY.md`; generate candidate facts for review.
+- Supersedence trail for decisions.
+
+### Phase 5 — Dashboard/Journey UI
+
+**Objective:** Add Memory Wiki panel to dashboard and enrich `/journey` with category counts, decision trails, and links to session provenance.
+
+### Phase 6 — Optional advanced local memory backend
+
+**Objective:** Evaluate Qdrant/BM25 hybrid retrieval as an optional plugin, not core.
+
+Acceptance criteria:
+- Benchmarked recall wins over FTS5/session_search.
+- Measured latency/token savings.
+- Docker-free fallback remains available.
+
+---
+
+## First Safe Slice Acceptance Criteria
+
+- Pure stdlib.
+- Read-only over memory files.
+- Deterministic tests.
+- No gateway restart required.
+- Does not mutate `MEMORY.md` / `USER.md` or inject into prompt.
+- Produces a reusable substrate for CLI/dashboard/cron later.

--- a/docs/plans/2026-07-05-skillopt-hermes-integration.md
+++ b/docs/plans/2026-07-05-skillopt-hermes-integration.md
@@ -1,0 +1,248 @@
+# SkillOpt-Inspired Hermes Skill Evolution Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Add a safe, Hermes-native SkillOpt-style optimization path that improves existing skills using bounded text edits, validation evidence, and staged adoption.
+
+**Architecture:** Do not vendor Microsoft SkillOpt wholesale. Reuse its validated concepts — rollout evidence, reflect, bounded edits, gate, rejected-edit buffer, slow/meta update — inside Hermes' existing skill, curator, `/learn`, verification evidence, cron, and session-search systems. Start with pure deterministic primitives and staged proposals; only later add LLM reflection/mining and cron automation.
+
+**Tech Stack:** Python stdlib, Hermes skills sidecar files, existing `skill_manage`, `skill_view`, `session_search`, `verification_evidence`, curator, cron, and tests. No new runtime dependency for the first slice.
+
+---
+
+## Research Summary
+
+Sources inspected:
+
+- Paper: arXiv `2605.23904`, **SkillOpt: Executive Strategy for Self-Evolving Agent Skills**.
+- Repo: `https://github.com/microsoft/SkillOpt`, cloned at `e4ea6a6`.
+- README states SkillOpt treats `best_skill.md` as the trainable state of a frozen agent and trains via `rollout → reflect → aggregate → select → update → gate`.
+- Repo `v0.2.0` adds **SkillOpt-Sleep**: `harvest → mine → replay → consolidate(gate) → stage → adopt`.
+
+Core concepts to port:
+
+1. **Skill document as state:** Hermes already stores procedural skills as `SKILL.md`.
+2. **Rollout evidence:** Hermes has `verification_evidence.py`, session DB, and tool outputs.
+3. **Reflect:** future LLM reviewer can propose edits from successful/failing task trajectories.
+4. **Aggregate/select:** merge duplicate edits and cap by edit budget.
+5. **Bounded update:** atomic add/delete/replace/insert operations, no whole-doc drift by default.
+6. **Validation gate:** accept only if explicit verification metric improves.
+7. **Rejected buffer:** preserve failed edits as negative feedback.
+8. **Slow/meta update:** keep optimizer-side guidance separate from deployed skill body.
+9. **Staging:** proposals must be reviewable before adoption.
+
+## Issue Scan Summary
+
+Active repo issues/PRs that matter for implementation:
+
+- `#100` / PR `#102`: semantic density / leading words. Takeaway: useful later as non-blocking ranking bonus, not as first slice.
+- `#97`: support VS Code/Visual Studio Copilot sessions. Takeaway: transcript-source adapters are important; Hermes should start with its own session DB instead.
+- PR `#99`: excludes sub-agent transcripts and agent-generated sessions from harvest. Takeaway: critical. Hermes must filter out subagent and generated prompt scaffolding when mining tasks.
+- PR `#98`, `#101`, issues `#46`, `#56`: Windows CLI plugin support. Takeaway: avoid shell/CLI plugin dependency for Hermes; use pure Python and Hermes-native data stores.
+- `#94` / PR `#96`: verifier discipline tests. Takeaway: gate tests must assert scores and gate action, not just smoke-test rejection.
+- `#90`: Qwen `enable_thinking` reproducibility. Takeaway: log target model/harness config with every optimization run.
+- `#75`: train config mismatch. Takeaway: make defaults explicit and store them in proposal metadata.
+- `#38`: slow update vs meta skill confusion. Takeaway: keep deployed skill content and optimizer-only memory visibly separate.
+- `#21`, `#10`: missing splits/artifacts. Takeaway: every Hermes run must persist train/selection/test task IDs and proposal artifacts.
+
+## Hermes Mapping
+
+| SkillOpt concept | Hermes-native home |
+|---|---|
+| `best_skill.md` | `~/.hermes/skills/<category>/<skill>/SKILL.md` |
+| rollout trajectory | session DB + `agent/verification_evidence.py` |
+| task mining | `session_search` / future `agent/skillopt_harvest.py` |
+| reflect | background subagent / auxiliary model, later |
+| bounded edits | new `agent/skillopt_text_optimizer.py` |
+| validation gate | new pure gate + evidence-backed scorer |
+| rejected buffer | sidecar under skill dir: `.skillopt/rejected.jsonl` |
+| slow update | sidecar `.skillopt/slow_update.md`, not loaded into deployed skill unless explicitly promoted |
+| meta skill | sidecar `.skillopt/meta.md`, optimizer-only |
+| staging/adopt | `.skillopt/staging/<run_id>/`, then `skill_manage patch/edit` |
+| nightly sleep | Hermes cron job + curator integration |
+
+---
+
+## Phase 1 — Pure primitives (implemented first slice)
+
+### Task 1: Add deterministic bounded-edit primitive
+
+**Objective:** Implement safe atomic operations for skill text.
+
+**Files:**
+- Create: `agent/skillopt_text_optimizer.py`
+- Test: `tests/agent/test_skillopt_text_optimizer.py`
+
+**TDD:**
+- RED: tests importing `agent.skillopt_text_optimizer` fail with `ModuleNotFoundError`.
+- GREEN: implement `AtomicEdit`, `apply_bounded_edits`, protected slow-update guard.
+
+**Verification:**
+
+```bash
+python -m pytest tests/agent/test_skillopt_text_optimizer.py -q
+```
+
+Expected: `7 passed`.
+
+### Task 2: Add pure validation gate
+
+**Objective:** Accept candidates only on strict validation improvement.
+
+**Files:**
+- Modify: `agent/skillopt_text_optimizer.py`
+- Test: `tests/agent/test_skillopt_text_optimizer.py`
+
+**Verification:** same command as Task 1.
+
+---
+
+## Phase 2 — Staged proposal artifacts
+
+### Task 3: Add sidecar schema for optimization runs
+
+**Objective:** Store proposals without mutating skills.
+
+**Files:**
+- Create: `agent/skillopt_state.py`
+- Test: `tests/agent/test_skillopt_state.py`
+
+**Schema:**
+
+```text
+<skill_dir>/.skillopt/
+  runs/<run_id>/proposal.json
+  runs/<run_id>/candidate.SKILL.md
+  rejected.jsonl
+  meta.md
+  slow_update.md
+```
+
+`proposal.json` must include:
+- skill name/path
+- target model/provider/harness
+- train task IDs
+- selection task IDs
+- baseline score
+- candidate score
+- gate action
+- edit list and rationale
+- verification command/evidence IDs
+
+### Task 4: Stage and adopt CLI/subcommand
+
+**Objective:** Add operator review commands, no auto-adopt by default.
+
+**Files:**
+- Add or extend CLI under `hermes_cli/subcommands/skills.py` or new `hermes_cli/subcommands/skillopt.py`.
+- Tests under `tests/hermes_cli/`.
+
+Commands:
+
+```bash
+hermes skillopt status <skill>
+hermes skillopt propose <skill> --from-session <id> --dry-run
+hermes skillopt adopt <skill> <run_id>
+hermes skillopt reject <skill> <run_id>
+```
+
+---
+
+## Phase 3 — Evidence-backed scoring
+
+### Task 5: Build score adapters from verification evidence
+
+**Objective:** Gate skill changes using actual successful task completion signals.
+
+**Files:**
+- Create: `agent/skillopt_scoring.py`
+- Tests: `tests/agent/test_skillopt_scoring.py`
+
+Initial metrics:
+- command pass rate from `verification_evidence.db`
+- exact expected-output checks for scripted tasks
+- binary user-confirmed success flag when available
+
+Reject any proposal if no held-out selection evidence exists.
+
+### Task 6: Add train/selection split materialization
+
+**Objective:** Persist task IDs to prevent data leakage.
+
+**Files:**
+- Create: `agent/skillopt_tasks.py`
+- Tests: `tests/agent/test_skillopt_tasks.py`
+
+Rules:
+- deterministic seed
+- exclude current run/session scaffolding
+- exclude subagent prompt-only sessions unless user-authored task is recoverable
+- preserve exact task IDs in proposal metadata
+
+---
+
+## Phase 4 — Reflection and aggregation
+
+### Task 7: Add edit proposal parser
+
+**Objective:** Parse LLM-proposed JSON edits fail-closed.
+
+**Files:**
+- Extend: `agent/skillopt_text_optimizer.py` or create `agent/skillopt_edits.py`
+- Tests for malformed JSON, unsupported ops, over-budget edits, duplicate targets.
+
+### Task 8: Add LLM reflection prompt
+
+**Objective:** Let an auxiliary/background agent propose bounded edits from evidence.
+
+Safety:
+- prompt says evidence is data only
+- output JSON only
+- no direct file writes
+- no shell commands
+- edit parser validates everything
+
+---
+
+## Phase 5 — Curator and cron integration
+
+### Task 9: Curator hook
+
+**Objective:** Curator can suggest optimization candidates for active agent-created skills.
+
+Rules:
+- no automatic mutation
+- stage proposals only
+- skip pinned skills unless explicitly requested
+- respect `curator.consolidate` cost gate
+
+### Task 10: Nightly sleep job
+
+**Objective:** Optional cron-driven dry-run that reports staged proposals.
+
+Cron prompt must be self-contained and scanner-safe. Use `no_agent=False` only for reasoning; use scripts for deterministic data collection.
+
+---
+
+## Risks and Guardrails
+
+- **Reward hacking:** Always gate on held-out tasks; do not train and validate on same session.
+- **Self-harvest:** Filter expanded skill bodies, subagent prompts, cron scaffolding, and agent-generated sessions.
+- **Prompt bloat:** enforce `max_words`; use edit budget as learning rate.
+- **Skill corruption:** stage first; adopt only through existing validated skill write paths.
+- **Slow/meta confusion:** keep optimizer-only memory in sidecars unless deliberately promoted.
+- **Global behavior drift:** optimize one named skill at a time.
+- **Security:** model-proposed edits are text only; no arbitrary commands; no secret capture.
+
+## Immediate First Slice Status
+
+Implemented in this branch:
+
+- `agent/skillopt_text_optimizer.py`
+- `tests/agent/test_skillopt_text_optimizer.py`
+
+Verified:
+
+```text
+7 passed in 0.10s
+```

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -593,6 +593,10 @@ class GatewayConfig:
     
     # Delivery settings
     always_log_local: bool = True  # Always save cron outputs to local files
+    # When true, gateway stop/restart does not send lifecycle interruption,
+    # restart-complete, or startup-online notices. Interrupt/resume bookkeeping
+    # still runs; this only mutes the user-facing lifecycle broadcasts.
+    silent_shutdown_notifications: bool = False
     # Drop outbound "silence narration" messages (e.g. *(silent)*, 🔇, a bare
     # ".") pre-send. These are model hallucinations emitted when a persona has
     # nothing actionable to say; in bot-to-bot channels they mirror back and
@@ -725,6 +729,7 @@ class GatewayConfig:
             "quick_commands": self.quick_commands,
             "sessions_dir": str(self.sessions_dir),
             "always_log_local": self.always_log_local,
+            "silent_shutdown_notifications": self.silent_shutdown_notifications,
             "filter_silence_narration": self.filter_silence_narration,
             "stt_enabled": self.stt_enabled,
             "stt_echo_transcripts": self.stt_echo_transcripts,
@@ -786,6 +791,9 @@ class GatewayConfig:
         thread_sessions_per_user = data.get("thread_sessions_per_user")
         multiplex_profiles = data.get("multiplex_profiles")
         nested_gateway = data.get("gateway") if isinstance(data.get("gateway"), dict) else {}
+        silent_shutdown_notifications = data.get("silent_shutdown_notifications")
+        if silent_shutdown_notifications is None and isinstance(nested_gateway, dict):
+            silent_shutdown_notifications = nested_gateway.get("silent_shutdown_notifications")
         if multiplex_profiles is None and isinstance(nested_gateway, dict):
             # Also honor gateway.multiplex_profiles written by
             # ``hermes config set gateway.multiplex_profiles true``.
@@ -820,6 +828,10 @@ class GatewayConfig:
             quick_commands=quick_commands,
             sessions_dir=sessions_dir,
             always_log_local=_coerce_bool(data.get("always_log_local"), True),
+            silent_shutdown_notifications=_coerce_bool(
+                silent_shutdown_notifications,
+                False,
+            ),
             filter_silence_narration=_coerce_bool(
                 data.get("filter_silence_narration"), True
             ),
@@ -963,6 +975,16 @@ def load_gateway_config() -> GatewayConfig:
 
             if "always_log_local" in yaml_cfg:
                 gw_data["always_log_local"] = yaml_cfg["always_log_local"]
+
+            gateway_section = yaml_cfg.get("gateway")
+            if isinstance(gateway_section, dict) and "silent_shutdown_notifications" in gateway_section:
+                gw_data["silent_shutdown_notifications"] = gateway_section[
+                    "silent_shutdown_notifications"
+                ]
+            if "silent_shutdown_notifications" in yaml_cfg:
+                gw_data["silent_shutdown_notifications"] = yaml_cfg[
+                    "silent_shutdown_notifications"
+                ]
 
             if "filter_silence_narration" in yaml_cfg:
                 gw_data["filter_silence_narration"] = yaml_cfg[

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -215,6 +215,28 @@ def _gateway_platform_value(platform: Any) -> str:
     return str(getattr(platform, "value", platform) or "").strip().lower()
 
 
+def _systemd_sigterm_is_planned_stop(
+    received_signal: Any, shutdown_context: Optional[Dict[str, Any]]
+) -> bool:
+    """Return True when systemd is performing a normal unit stop/restart.
+
+    ``systemctl --user stop/restart hermes-gateway`` delivers SIGTERM without
+    Hermes' planned-stop marker. Under the installed systemd service that is an
+    operator-requested lifecycle action, not a crash. Treat it as planned so
+    systemd does not record the stop phase as a failure.
+    """
+    if received_signal != signal.SIGTERM or not isinstance(shutdown_context, dict):
+        return False
+    if not shutdown_context.get("under_systemd"):
+        return False
+    parent = shutdown_context.get("parent")
+    if not isinstance(parent, dict):
+        return False
+    parent_name = str(parent.get("name") or "").strip().lower()
+    parent_cmdline = str(parent.get("cmdline") or "").strip().lower()
+    return parent_name == "systemd" or "systemd --user" in parent_cmdline
+
+
 def _non_conversational_metadata(
     metadata: Optional[Dict[str, Any]] = None,
     *,
@@ -20019,6 +20041,13 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             _shutdown_ctx = None
             logger.debug("snapshot_shutdown_context failed: %s", _e)
 
+        if (
+            not planned_takeover
+            and not planned_stop
+            and _systemd_sigterm_is_planned_stop(received_signal, _shutdown_ctx)
+        ):
+            planned_stop = True
+
         if planned_takeover:
             logger.info(
                 "Received %s as a planned --replace takeover — exiting cleanly",
@@ -20048,9 +20077,10 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         # is one line, key=value, parent_cmdline last (often long).
         if _shutdown_ctx is not None:
             try:
-                logger.warning(
-                    "Shutdown context: %s", format_context_for_log(_shutdown_ctx)
+                log_shutdown_context = (
+                    logger.info if (planned_takeover or planned_stop) else logger.warning
                 )
+                log_shutdown_context("Shutdown context: %s", format_context_for_log(_shutdown_ctx))
             except Exception as _e:
                 logger.debug("format_context_for_log failed: %s", _e)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5530,6 +5530,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         messages can be delivered. Best-effort: individual send failures are
         logged and swallowed so they never block the shutdown sequence.
         """
+        if getattr(self.config, "silent_shutdown_notifications", False):
+            logger.info(
+                "Gateway shutdown/restart notifications suppressed by "
+                "gateway.silent_shutdown_notifications=true"
+            )
+            return
+
         active = self._snapshot_running_agents()
         restart_source = self._restart_command_source if self._restart_requested else None
 
@@ -14283,6 +14290,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         notify_path = _hermes_home / ".restart_notify.json"
         if not notify_path.exists():
             return None
+        if getattr(self.config, "silent_shutdown_notifications", False):
+            logger.info(
+                "Restart notification suppressed by "
+                "gateway.silent_shutdown_notifications=true"
+            )
+            notify_path.unlink(missing_ok=True)
+            return None
 
         try:
             data = json.loads(notify_path.read_text())
@@ -14361,6 +14375,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         home channel. ``skip_targets`` lets startup avoid duplicate messages
         when a more specific restart notification is queued for the same chat.
         """
+        if getattr(self.config, "silent_shutdown_notifications", False):
+            logger.info(
+                "Home-channel startup notifications suppressed by "
+                "gateway.silent_shutdown_notifications=true"
+            )
+            return set()
+
         delivered: set[tuple[str, str, Optional[str]]] = set()
         skipped = skip_targets or set()
         message = "♻️ Gateway online — Hermes is back and ready."

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2757,6 +2757,11 @@ DEFAULT_CONFIG = {
             "idle_timeout_minutes": 5,
         },
 
+        # When true, gateway stop/restart does not send lifecycle interruption,
+        # restart-complete, or startup-online notices. Interrupt/resume bookkeeping
+        # still runs; this only mutes the user-facing lifecycle broadcasts.
+        "silent_shutdown_notifications": False,
+
         # Auto-resume restart-loop breaker (#30719, defense-3). When the
         # gateway is killed mid-turn (SIGTERM) and revived by a supervisor
         # (launchd KeepAlive / systemd Restart=), it auto-resumes the

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -304,6 +304,7 @@ from hermes_cli.subcommands.pairing import build_pairing_parser
 from hermes_cli.subcommands.plugins import build_plugins_parser
 from hermes_cli.subcommands.mcp import build_mcp_parser
 from hermes_cli.subcommands.claw import build_claw_parser
+from hermes_cli.skillopt import register_cli as register_skillopt_cli
 
 
 def _require_tty(command_name: str) -> None:
@@ -12532,6 +12533,31 @@ def cmd_memory(args):
         from hermes_cli.memory_wiki import run_memory_wiki_index
 
         return run_memory_wiki_index(args)
+    if sub == "lint":
+        import json
+        from agent.memory_benchmarker import lint_memory_entries
+
+        findings = lint_memory_entries()
+        if getattr(args, "json", False):
+            print(json.dumps(findings, ensure_ascii=False, indent=2, sort_keys=True))
+        elif not findings:
+            print("No memory lint findings.")
+        else:
+            for finding in findings:
+                print(f"- {finding['target']}[{finding['index']}]: {', '.join(finding['issues'])} — {finding['text'][:120]}")
+        return 0 if not findings else 1
+    if sub == "bench":
+        import json
+        from pathlib import Path
+        from agent.memory_benchmarker import benchmark_memory_retrieval
+
+        cases = json.loads(Path(getattr(args, "cases")).expanduser().read_text(encoding="utf-8"))
+        report = benchmark_memory_retrieval(cases, k=getattr(args, "k", 3))
+        if getattr(args, "json", False):
+            print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+        else:
+            print(f"cases={report['cases']} precision@{report['k']}={report['precision_at_k']} recall@{report['k']}={report['recall_at_k']}")
+        return 0
     if sub == "off":
         from hermes_cli.config import load_config, save_config
 
@@ -13044,6 +13070,7 @@ def main():
     # skills command  (parser built in hermes_cli/subcommands/skills.py)
     # =========================================================================
     build_skills_parser(subparsers, cmd_skills=cmd_skills)
+    register_skillopt_cli(subparsers)
 
     # =========================================================================
     # bundles command — skill bundles (alias /<name> for multiple skills)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12528,6 +12528,10 @@ def _try_termux_fast_tui_launch() -> bool:
 
 def cmd_memory(args):
     sub = getattr(args, "memory_command", None)
+    if sub == "wiki-index":
+        from hermes_cli.memory_wiki import run_memory_wiki_index
+
+        return run_memory_wiki_index(args)
     if sub == "off":
         from hermes_cli.config import load_config, save_config
 

--- a/hermes_cli/memory_wiki.py
+++ b/hermes_cli/memory_wiki.py
@@ -1,0 +1,44 @@
+"""CLI helpers for exporting local memory-wiki indexes."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def run_memory_wiki_index(args) -> int:
+    """Export or print the read-only built-in memory wiki index."""
+
+    from agent.memory_wiki import build_memory_wiki_index, select_memory_context
+    from hermes_constants import get_hermes_home
+
+    index = build_memory_wiki_index()
+    query = getattr(args, "query", None)
+    if query:
+        payload = {
+            "index_version": index["version"],
+            "selection": select_memory_context(
+                query,
+                index=index,
+                max_chars=int(getattr(args, "max_chars", 1200) or 1200),
+            ),
+        }
+    else:
+        payload = index
+
+    out = getattr(args, "out", None)
+    if out:
+        path = Path(out).expanduser()
+        if not path.is_absolute():
+            path = get_hermes_home() / "memory-wiki" / path
+        _write_json(path, payload)
+        print(f"  ✓ Wrote memory wiki index: {path}")
+    else:
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return 0

--- a/hermes_cli/skillopt.py
+++ b/hermes_cli/skillopt.py
@@ -1,0 +1,219 @@
+"""Manual SkillOpt CLI commands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+from agent.skillopt_state import (
+    append_skillopt_rejection,
+    load_skillopt_proposal,
+    mark_skillopt_adopted,
+    stage_skillopt_proposal,
+    update_skillopt_evaluation,
+)
+from tools.skill_usage import skillopt_candidate_report
+
+
+def _find_skill_path(skill_name: str) -> Path:
+    from agent.skill_utils import is_excluded_skill_path, parse_frontmatter
+
+    base = get_hermes_home() / "skills"
+    for skill_md in base.rglob("SKILL.md"):
+        if is_excluded_skill_path(skill_md):
+            continue
+        try:
+            text = skill_md.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        frontmatter, _body = parse_frontmatter(text)
+        parsed_name = frontmatter.get("name") if isinstance(frontmatter, dict) else None
+        if parsed_name == skill_name or skill_md.parent.name == skill_name:
+            return skill_md
+    raise FileNotFoundError(f"skill not found: {skill_name}")
+
+
+def _run_dir_for_id(run_id: str) -> Path:
+    from agent.skillopt_state import _validate_skill_name
+
+    try:
+        safe_id = _validate_skill_name(str(run_id))
+    except ValueError as exc:
+        raise ValueError("invalid SkillOpt run_id") from exc
+    runs_root = (get_hermes_home() / "skillopt" / "runs").resolve()
+    path = (runs_root / safe_id).resolve()
+    if path == runs_root or runs_root not in path.parents:
+        raise ValueError("invalid SkillOpt run_id")
+    if not path.exists():
+        raise FileNotFoundError(f"SkillOpt run not found: {run_id}")
+    return path
+
+
+def _ensure_skill_path_is_adoptable(path: Path) -> Path:
+    skills_root = (get_hermes_home() / "skills").resolve()
+    resolved = path.expanduser().resolve()
+    if resolved.name != "SKILL.md" or skills_root not in resolved.parents:
+        raise RuntimeError("proposal current_skill_path is outside Hermes skills directory")
+    return resolved
+
+
+def _print_json(payload: Any) -> None:
+    print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+
+
+def _cmd_status(args) -> int:
+    rows = skillopt_candidate_report(limit=getattr(args, "limit", None))
+    skill = getattr(args, "skill", None)
+    if skill:
+        rows = [r for r in rows if r.get("name") == skill]
+    if getattr(args, "json", False):
+        _print_json(rows)
+        return 0
+    if not rows:
+        print("No SkillOpt candidates found.")
+        return 0
+    print("SkillOpt candidates:")
+    for row in rows:
+        reasons = ", ".join(row.get("reasons") or [])
+        print(f"- {row['name']}: score={row['skillopt_score']} reasons={reasons}")
+    return 0
+
+
+def _cmd_distill(args) -> int:
+    from agent.skillopt_harvest import distill_trace_to_skill
+
+    trace_path = Path(getattr(args, "trace")).expanduser()
+    distilled = distill_trace_to_skill(json.loads(trace_path.read_text(encoding="utf-8")))
+    out = getattr(args, "out", None)
+    if out:
+        out_path = Path(out).expanduser()
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(distilled["skill_markdown"], encoding="utf-8")
+        print(f"Wrote distilled skill draft: {out_path}")
+    else:
+        print(distilled["skill_markdown"])
+    return 0
+
+
+def _cmd_propose(args) -> int:
+    skill_name = getattr(args, "skill")
+    skill_path = _find_skill_path(skill_name)
+    candidate_path = Path(getattr(args, "candidate")).expanduser()
+    candidate = candidate_path.read_text(encoding="utf-8")
+    staged = stage_skillopt_proposal(
+        skill_name=skill_name,
+        current_skill_path=skill_path,
+        candidate_skill=candidate,
+        source={"from_session": getattr(args, "from_session", None), "candidate_path": str(candidate_path)},
+        rationale=getattr(args, "rationale", "") or "",
+    )
+    print(f"Staged SkillOpt proposal: {staged.run_id}")
+    print(f"Run directory: {staged.run_dir}")
+    print("Live skill was not modified; run `hermes skillopt evaluate` before `adopt`.")
+    return 0
+
+
+def _cmd_reject(args) -> int:
+    run_dir = _run_dir_for_id(getattr(args, "run_id"))
+    append_skillopt_rejection(run_dir, reason=getattr(args, "reason", ""), reviewer=getattr(args, "reviewer", "cli"))
+    print(f"Rejected SkillOpt proposal: {getattr(args, 'run_id')}")
+    return 0
+
+
+def _cmd_adopt(args) -> int:
+    run_dir = _run_dir_for_id(getattr(args, "run_id"))
+    loaded = load_skillopt_proposal(run_dir)
+    if loaded.status != "evaluated":
+        raise RuntimeError("SkillOpt proposal must be evaluated successfully before adopt")
+    current_path = _ensure_skill_path_is_adoptable(loaded.current_skill_path)
+    current_text = current_path.read_text(encoding="utf-8")
+    import hashlib
+
+    current_hash = hashlib.sha256(current_text.encode("utf-8")).hexdigest()
+    if current_hash != loaded.current_sha256:
+        raise RuntimeError("live skill hash changed since proposal was staged; refusing adopt")
+    current_path.write_text(loaded.candidate_skill, encoding="utf-8")
+    mark_skillopt_adopted(run_dir)
+    print(f"Adopted SkillOpt proposal: {loaded.run_id}")
+    return 0
+
+
+def _cmd_show(args) -> int:
+    loaded = load_skillopt_proposal(_run_dir_for_id(getattr(args, "run_id")))
+    if getattr(args, "json", False):
+        _print_json(loaded.proposal)
+    else:
+        print(f"Run: {loaded.run_id}")
+        print(f"Skill: {loaded.skill_name}")
+        print(f"Status: {loaded.status}")
+        print(f"Candidate: {loaded.run_dir / 'candidate.SKILL.md'}")
+    return 0
+
+
+def _cmd_evaluate(args) -> int:
+    run_dir = _run_dir_for_id(getattr(args, "run_id"))
+    from agent.skillopt_scoring import score_verification_evidence
+
+    scores = score_verification_evidence(
+        root=getattr(args, "root"),
+        session_id=getattr(args, "session_id", None),
+        min_events=getattr(args, "min_events", 2),
+    )
+    loaded = update_skillopt_evaluation(run_dir, scores)
+    print(f"Evaluated SkillOpt proposal: {loaded.run_id}")
+    print(f"Status: {loaded.status}")
+    print(f"Score: {scores.get('score')} ({scores.get('passed')}/{scores.get('total')} passed)")
+    return 0 if loaded.status == "evaluated" else 1
+
+
+def cmd_skillopt(args) -> int:
+    command = getattr(args, "skillopt_command", None) or "status"
+    if command == "status":
+        return _cmd_status(args)
+    if command == "distill":
+        return _cmd_distill(args)
+    if command == "propose":
+        return _cmd_propose(args)
+    if command == "reject":
+        return _cmd_reject(args)
+    if command == "adopt":
+        return _cmd_adopt(args)
+    if command == "show":
+        return _cmd_show(args)
+    if command == "evaluate":
+        return _cmd_evaluate(args)
+    raise SystemExit(f"unknown skillopt command: {command}")
+
+
+def register_cli(subparsers) -> None:
+    parser = subparsers.add_parser("skillopt", help="Stage and inspect SkillOpt skill-improvement proposals")
+    sub = parser.add_subparsers(dest="skillopt_command")
+    status = sub.add_parser("status", help="List ranked SkillOpt candidate skills")
+    status.add_argument("skill", nargs="?", default=None)
+    status.add_argument("--limit", type=int, default=None)
+    status.add_argument("--json", action="store_true")
+    distilled = sub.add_parser("distill", help="Distill a JSON trace into a staged candidate skill draft")
+    distilled.add_argument("trace", help="Path to a JSON trace with skill_name and messages")
+    distilled.add_argument("--out", default=None, help="Write candidate SKILL.md to this path")
+    propose = sub.add_parser("propose", help="Stage a candidate SKILL.md without mutating the live skill")
+    propose.add_argument("skill")
+    propose.add_argument("--candidate", required=True, help="Path to candidate SKILL.md content")
+    propose.add_argument("--rationale", default="")
+    propose.add_argument("--from-session", default=None)
+    show = sub.add_parser("show", help="Show a staged proposal")
+    show.add_argument("run_id")
+    show.add_argument("--json", action="store_true")
+    reject = sub.add_parser("reject", help="Reject a staged proposal")
+    reject.add_argument("run_id")
+    reject.add_argument("--reason", default="")
+    reject.add_argument("--reviewer", default="cli")
+    adopt = sub.add_parser("adopt", help="Adopt a staged proposal if the live skill hash still matches")
+    adopt.add_argument("run_id")
+    evaluate = sub.add_parser("evaluate", help="Evaluate a staged proposal against verification evidence")
+    evaluate.add_argument("run_id")
+    evaluate.add_argument("--root", required=True, help="Workspace root whose verification evidence should be scored")
+    evaluate.add_argument("--session-id", default=None)
+    evaluate.add_argument("--min-events", type=int, default=2)
+    parser.set_defaults(func=cmd_skillopt)

--- a/hermes_cli/subcommands/memory.py
+++ b/hermes_cli/subcommands/memory.py
@@ -61,6 +61,12 @@ def build_memory_parser(subparsers, *, cmd_memory: Callable) -> None:
         help="Character budget for --query context selection (default: 1200)",
     )
     memory_sub.add_parser("off", help="Disable external provider (built-in only)")
+    lint_parser = memory_sub.add_parser("lint", help="Lint built-in memory for duplicates, stale facts, and skill-like entries")
+    lint_parser.add_argument("--json", action="store_true")
+    bench_parser = memory_sub.add_parser("bench", help="Run a tiny JSON retrieval benchmark against built-in memory")
+    bench_parser.add_argument("cases", help="Path to JSON list of {query, expected} cases")
+    bench_parser.add_argument("--k", type=_positive_int, default=3)
+    bench_parser.add_argument("--json", action="store_true")
     _reset_parser = memory_sub.add_parser(
         "reset",
         help="Erase all built-in memory (MEMORY.md and USER.md)",

--- a/hermes_cli/subcommands/memory.py
+++ b/hermes_cli/subcommands/memory.py
@@ -9,6 +9,13 @@ from __future__ import annotations
 from typing import Callable
 
 
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise ValueError("must be positive")
+    return parsed
+
+
 def build_memory_parser(subparsers, *, cmd_memory: Callable) -> None:
     """Attach the ``memory`` subcommand to ``subparsers``."""
     memory_parser = subparsers.add_parser(
@@ -33,6 +40,26 @@ def build_memory_parser(subparsers, *, cmd_memory: Callable) -> None:
         help="Provider to configure directly (e.g. honcho), skipping the picker",
     )
     memory_sub.add_parser("status", help="Show current memory provider config")
+    wiki_parser = memory_sub.add_parser(
+        "wiki-index",
+        help="Export a read-only structured index over built-in memory files",
+    )
+    wiki_parser.add_argument(
+        "--out",
+        default=None,
+        help="Write JSON to this path instead of stdout; relative paths go under ~/.hermes/memory-wiki/",
+    )
+    wiki_parser.add_argument(
+        "--query",
+        default=None,
+        help="Select relevant memory context for this query instead of dumping the full index",
+    )
+    wiki_parser.add_argument(
+        "--max-chars",
+        type=_positive_int,
+        default=1200,
+        help="Character budget for --query context selection (default: 1200)",
+    )
     memory_sub.add_parser("off", help="Disable external provider (built-in only)")
     _reset_parser = memory_sub.add_parser(
         "reset",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4162,6 +4162,62 @@ _EMPTY_MODEL_INFO: dict = {
 }
 
 
+def _provider_aware_model_capabilities(
+    *,
+    model_name: str,
+    provider: str = "",
+    base_url: str = "",
+    config_context_length: int | None = None,
+) -> dict:
+    """Return capability metadata with the enforced context window.
+
+    models.dev reports the vendor-wide model window, which can differ from the
+    route Hermes is actually using.  For example, direct OpenAI/OpenRouter may
+    advertise gpt-5.5 as 1.05M while the ChatGPT Codex OAuth route enforces
+    272K.  Dashboard/API surfaces should show the enforced value as
+    ``context_window`` and keep the raw catalog value separately.
+    """
+    caps: dict[str, Any] = {}
+    catalog_context_window = 0
+
+    try:
+        from agent.models_dev import get_model_capabilities
+
+        mc = get_model_capabilities(provider=provider, model=model_name)
+        if mc is not None:
+            catalog_context_window = int(getattr(mc, "context_window", 0) or 0)
+            caps = {
+                "supports_tools": mc.supports_tools,
+                "supports_vision": mc.supports_vision,
+                "supports_reasoning": mc.supports_reasoning,
+                "context_window": catalog_context_window,
+                "catalog_context_window": catalog_context_window,
+                "max_output_tokens": mc.max_output_tokens,
+                "model_family": mc.model_family,
+            }
+    except Exception:
+        pass
+
+    try:
+        from agent.model_metadata import get_model_context_length
+
+        resolved_context_window = get_model_context_length(
+            model=model_name,
+            base_url=base_url,
+            provider=provider,
+            config_context_length=config_context_length,
+        )
+    except Exception:
+        resolved_context_window = 0
+
+    if resolved_context_window:
+        caps["context_window"] = int(resolved_context_window)
+        if catalog_context_window and "catalog_context_window" not in caps:
+            caps["catalog_context_window"] = catalog_context_window
+
+    return caps
+
+
 @app.get("/api/model/info")
 def get_model_info(profile: Optional[str] = None):
     """Return resolved model metadata for the currently configured model.
@@ -4210,22 +4266,12 @@ def get_model_info(profile: Optional[str] = None):
         # Effective is what the agent actually uses
         effective_ctx = config_ctx_int if config_ctx_int > 0 else auto_ctx
 
-        # Try to get model capabilities from models.dev
-        caps = {}
-        try:
-            from agent.models_dev import get_model_capabilities
-            mc = get_model_capabilities(provider=provider, model=model_name)
-            if mc is not None:
-                caps = {
-                    "supports_tools": mc.supports_tools,
-                    "supports_vision": mc.supports_vision,
-                    "supports_reasoning": mc.supports_reasoning,
-                    "context_window": mc.context_window,
-                    "max_output_tokens": mc.max_output_tokens,
-                    "model_family": mc.model_family,
-                }
-        except Exception:
-            pass
+        caps = _provider_aware_model_capabilities(
+            model_name=model_name,
+            provider=provider,
+            base_url=base_url,
+            config_context_length=effective_ctx,
+        )
 
         return {
             "model": model_name,
@@ -12244,7 +12290,8 @@ async def get_models_analytics(days: int = 30, profile: Optional[str] = None):
     """Rich per-model analytics for the Models dashboard page.
 
     Returns token/cost/session breakdown per model plus capability metadata
-    from models.dev (context window, vision, tools, reasoning, etc.).
+    from models.dev, with ``context_window`` resolved through the same
+    provider-aware context resolver the agent uses.
     """
     db = _open_session_db_for_profile(profile)
     try:
@@ -12338,21 +12385,10 @@ async def get_models_analytics(days: int = 30, profile: Optional[str] = None):
         for row in rows:
             provider = row.get("billing_provider") or ""
             model_name = row["model"]
-            caps = {}
-            try:
-                from agent.models_dev import get_model_capabilities
-                mc = get_model_capabilities(provider=provider, model=model_name)
-                if mc is not None:
-                    caps = {
-                        "supports_tools": mc.supports_tools,
-                        "supports_vision": mc.supports_vision,
-                        "supports_reasoning": mc.supports_reasoning,
-                        "context_window": mc.context_window,
-                        "max_output_tokens": mc.max_output_tokens,
-                        "model_family": mc.model_family,
-                    }
-            except Exception:
-                pass
+            caps = _provider_aware_model_capabilities(
+                model_name=model_name,
+                provider=provider,
+            )
 
             models.append({
                 "model": model_name,

--- a/model_tools.py
+++ b/model_tools.py
@@ -579,8 +579,23 @@ def _resolve_active_context_length() -> int:
         model_id = (model_cfg.get("model") or model_cfg.get("default") or "").strip()
         if not model_id:
             return 0
+        provider = str(model_cfg.get("provider") or "").strip()
+        base_url = str(model_cfg.get("base_url") or "").strip()
+        context_length = model_cfg.get("context_length")
+        try:
+            config_context_length = int(context_length) if context_length is not None else None
+        except (TypeError, ValueError):
+            config_context_length = None
         from agent.model_metadata import get_model_context_length
-        return int(get_model_context_length(model_id) or 0)
+        return int(
+            get_model_context_length(
+                model_id,
+                base_url=base_url,
+                provider=provider,
+                config_context_length=config_context_length,
+                custom_providers=cfg.get("custom_providers"),
+            ) or 0
+        )
     except Exception as e:
         logger.debug("Could not resolve active context length: %s", e)
         return 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -357,6 +357,7 @@ plugins = [
 include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "cron.*", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]
 markers = [
     "integration: marks tests requiring external services (API keys, Modal, etc.)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -364,6 +364,13 @@ markers = [
 ]
 # integration tests take way too long to run in the normal CI environments
 addopts = "-m 'not integration'"
+filterwarnings = [
+    "ignore:Using `httpx` with `starlette.testclient` is deprecated.*",
+    "ignore:pkg_resources is deprecated as an API.*:UserWarning",
+    "ignore:Deprecated call to `pkg_resources\\.declare_namespace\\('lark_oapi.*:DeprecationWarning",
+    "ignore:websockets\\.InvalidStatusCode is deprecated.*:DeprecationWarning",
+    "ignore:websockets\\.legacy is deprecated.*:DeprecationWarning",
+]
 
 [tool.ty.environment]
 python-version = "3.13"

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -224,6 +224,83 @@ def test_exhausted_entry_resets_after_ttl(tmp_path, monkeypatch):
     assert entry.last_status == "ok"
 
 
+def test_429_entry_remains_unavailable_before_short_ttl(tmp_path, monkeypatch):
+    """429-exhausted credentials stay excluded during the short cooldown."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "nvidia": [
+                    {
+                        "id": "cred-1",
+                        "label": "rate-limited",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "***",
+                        "last_status": "exhausted",
+                        "last_status_at": time.time() - 30,
+                        "last_error_code": 429,
+                    },
+                    {
+                        "id": "cred-2",
+                        "label": "healthy",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "***",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("nvidia")
+    entry = pool.select()
+
+    assert entry is not None
+    assert entry.id == "cred-2"
+
+
+def test_429_entry_resets_after_short_ttl(tmp_path, monkeypatch):
+    """429-exhausted credentials recover after the local 60s cooldown."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "nvidia": [
+                    {
+                        "id": "cred-1",
+                        "label": "rate-limited",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "***",
+                        "last_status": "exhausted",
+                        "last_status_at": time.time() - 61,
+                        "last_error_code": 429,
+                    }
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("nvidia")
+    entry = pool.select()
+
+    assert entry is not None
+    assert entry.id == "cred-1"
+    assert entry.last_status == "ok"
+
+
 def test_exhausted_402_entry_resets_after_one_hour(tmp_path, monkeypatch):
     """402-exhausted credentials recover after 1 hour, not 24."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
@@ -447,7 +524,7 @@ def test_token_invalidated_marks_credential_dead(tmp_path, monkeypatch):
 def test_dead_credential_never_re_enters_rotation_after_ttl(tmp_path, monkeypatch):
     """A DEAD credential must stay excluded regardless of how much time passes.
 
-    The exhausted TTL clears entries after 5 min (401) / 1 hour (429).
+    The exhausted TTL clears entries after 5 min (401), 60s (429), or 1 hour (default).
     A DEAD credential has no recovery TTL — it stays dead until either
     (a) an explicit re-auth write-side sync rewrites the tokens, or
     (b) the manual-prune TTL elapses (covered by separate tests below).
@@ -510,8 +587,8 @@ def test_dead_credential_never_re_enters_rotation_after_ttl(tmp_path, monkeypatc
 def test_429_rate_limit_still_uses_exhausted_not_dead(tmp_path, monkeypatch):
     """429 rate limits must NOT be treated as terminal.
 
-    They should keep the existing 1-hour TTL cooldown semantics so the
-    credential re-enters rotation once the rate window resets.
+    NVIDIA NIM 429s are transient in this deployment, so credentials should
+    re-enter rotation after the locally configured short cooldown window.
     """
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(

--- a/tests/agent/test_learning_graph.py
+++ b/tests/agent/test_learning_graph.py
@@ -88,6 +88,28 @@ def test_memory_is_cards_split_on_separator(tmp_path):
     assert any(n["kind"] == "memory" for n in graph["nodes"])
 
 
+def test_memory_cards_use_memory_wiki_categories_and_provenance(tmp_path):
+    home = tmp_path / ".hermes"
+    (home / "memories").mkdir(parents=True)
+    (home / "memories" / "USER.md").write_text(
+        "User prefers concise responses\n§\nRemote host Spark runs on port 8000",
+        encoding="utf-8",
+    )
+    token = set_hermes_home_override(home)
+    try:
+        graph = learning_graph.build_learning_graph()
+    finally:
+        reset_hermes_home_override(token)
+
+    cards = {c["title"]: c for c in graph["memory"]}
+    preference = cards["User prefers concise responses"]
+    assert preference["source"] == "profile"
+    assert preference["wikiSource"] == "user"
+    assert preference["category"] == "preference"
+    assert preference["provenance"]["path"].endswith("USER.md")
+    assert preference["keywords"]
+
+
 def test_malformed_frontmatter_metadata_does_not_crash(tmp_path):
     """``parse_frontmatter``'s malformed-YAML fallback stores every value as a
     string, so ``metadata`` can be a str. The graph must tolerate that instead

--- a/tests/agent/test_loop_detector.py
+++ b/tests/agent/test_loop_detector.py
@@ -1,0 +1,40 @@
+"""Tests for repeated tool-call loop detection."""
+
+from __future__ import annotations
+
+
+def test_loop_detector_flags_repeated_identical_tool_calls():
+    from agent.loop_detector import ToolLoopDetector
+
+    detector = ToolLoopDetector(max_window=5, repeat_threshold=3)
+    assert detector.record("web_search", {"query": "self improving agents"}) is None
+    assert detector.record("web_search", {"query": "self improving agents"}) is None
+    warning = detector.record("web_search", {"query": "self improving agents"})
+
+    assert warning is not None
+    assert warning["kind"] == "repeated_tool_call"
+    assert warning["tool_name"] == "web_search"
+    assert "switch strategy" in warning["recommendation"].lower()
+
+
+def test_loop_detector_flags_similar_search_queries_after_low_information_results():
+    from agent.loop_detector import ToolLoopDetector
+
+    detector = ToolLoopDetector(max_window=6, repeat_threshold=3, similarity_threshold=0.6)
+    detector.record("web_search", {"query": "agent memory benchmark"}, result_summary="")
+    detector.record("web_search", {"query": "agent memory benchmarks"}, result_summary="no results")
+    warning = detector.record("web_search", {"query": "llm agent memory benchmark"}, result_summary="no results")
+
+    assert warning is not None
+    assert warning["kind"] == "low_information_loop"
+
+
+def test_loop_detector_does_not_flag_different_tools_or_queries():
+    from agent.loop_detector import ToolLoopDetector
+
+    detector = ToolLoopDetector(max_window=5, repeat_threshold=3)
+    detector.record("web_search", {"query": "agent memory"})
+    detector.record("web_extract", {"urls": ["https://example.com"]})
+    warning = detector.record("search_files", {"pattern": "memory"})
+
+    assert warning is None

--- a/tests/agent/test_memory_benchmarker.py
+++ b/tests/agent/test_memory_benchmarker.py
@@ -1,0 +1,88 @@
+"""Tests for memory benchmark and lint helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+def _with_home(home: Path, fn):
+    token = set_hermes_home_override(home)
+    try:
+        return fn()
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_memory_lint_flags_duplicates_stale_and_skill_like_entries(tmp_path):
+    home = tmp_path / ".hermes"
+    mem = home / "memories"
+    mem.mkdir(parents=True)
+    (mem / "MEMORY.md").write_text(
+        "Project uses pytest with xdist\n"
+        "§\n"
+        "Project uses pytest xdist\n"
+        "§\n"
+        "Submitted PR 123 yesterday\n"
+        "§\n"
+        "Run pytest -q then commit the code\n",
+        encoding="utf-8",
+    )
+
+    def run():
+        from agent.memory_benchmarker import lint_memory_entries
+
+        return lint_memory_entries()
+
+    findings = _with_home(home, run)
+    issue_sets = {f["text"]: set(f["issues"]) for f in findings}
+    assert "near_duplicate" in issue_sets["Project uses pytest xdist"]
+    assert "stale_task_progress" in issue_sets["Submitted PR 123 yesterday"]
+    assert "belongs_in_skill" in issue_sets["Run pytest -q then commit the code"]
+
+
+def test_memory_benchmark_reports_precision_and_recall_at_k(tmp_path):
+    home = tmp_path / ".hermes"
+    mem = home / "memories"
+    mem.mkdir(parents=True)
+    (mem / "USER.md").write_text(
+        "User prefers concise responses\n§\nUser works on autonomous agents",
+        encoding="utf-8",
+    )
+
+    def run():
+        from agent.memory_benchmarker import benchmark_memory_retrieval
+
+        cases = [
+            {"query": "concise responses user preference", "expected": ["concise responses"]},
+            {"query": "autonomous agents user work", "expected": ["autonomous agents"]},
+        ]
+        return benchmark_memory_retrieval(cases, k=1)
+
+    report = _with_home(home, run)
+    assert report["cases"] == 2
+    assert report["precision_at_k"] == 1.0
+    assert report["recall_at_k"] == 1.0
+
+
+def test_memory_benchmark_does_not_use_expected_substrings_for_ranking(tmp_path):
+    home = tmp_path / ".hermes"
+    mem = home / "memories"
+    mem.mkdir(parents=True)
+    (mem / "MEMORY.md").write_text(
+        "Alpha banana\n§\nExpected phrase with no query overlap",
+        encoding="utf-8",
+    )
+
+    def run():
+        from agent.memory_benchmarker import benchmark_memory_retrieval
+
+        return benchmark_memory_retrieval(
+            [{"query": "alpha", "expected": ["Expected phrase"]}],
+            k=1,
+        )
+
+    report = _with_home(home, run)
+    assert report["precision_at_k"] == 0.0
+    assert report["case_reports"][0]["retrieved"][0]["text"] == "Alpha banana"

--- a/tests/agent/test_memory_candidates.py
+++ b/tests/agent/test_memory_candidates.py
@@ -1,0 +1,95 @@
+"""Tests for governed memory candidate queue."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+def _with_home(home: Path, fn):
+    token = set_hermes_home_override(home)
+    try:
+        return fn()
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_stage_memory_candidate_does_not_mutate_memory_until_promoted(tmp_path):
+    home = tmp_path / ".hermes"
+    mem_dir = home / "memories"
+    mem_dir.mkdir(parents=True)
+    (mem_dir / "MEMORY.md").write_text("Existing fact", encoding="utf-8")
+
+    def run():
+        from agent.memory_candidates import promote_memory_candidate, stage_memory_candidate
+
+        candidate = stage_memory_candidate(
+            target="memory",
+            content="New verified fact",
+            source={"session_id": "s1"},
+            rationale="unit test",
+        )
+        before = (mem_dir / "MEMORY.md").read_text(encoding="utf-8")
+        promote_memory_candidate(candidate.candidate_id)
+        after = (mem_dir / "MEMORY.md").read_text(encoding="utf-8")
+        return candidate, before, after
+
+    candidate, before, after = _with_home(home, run)
+    assert before == "Existing fact"
+    assert candidate.status == "staged"
+    assert after == "Existing fact\n§\nNew verified fact"
+
+
+def test_memory_candidate_promotion_is_idempotent(tmp_path):
+    home = tmp_path / ".hermes"
+    mem_dir = home / "memories"
+    mem_dir.mkdir(parents=True)
+    (mem_dir / "MEMORY.md").write_text("Existing fact", encoding="utf-8")
+
+    def run():
+        from agent.memory_candidates import load_memory_candidate, promote_memory_candidate, stage_memory_candidate
+
+        candidate = stage_memory_candidate(target="memory", content="New verified fact")
+        promote_memory_candidate(candidate.candidate_id)
+        promote_memory_candidate(candidate.candidate_id)
+        return load_memory_candidate(candidate.candidate_id).status, (mem_dir / "MEMORY.md").read_text(encoding="utf-8")
+
+    assert _with_home(home, run) == ("promoted", "Existing fact\n§\nNew verified fact")
+
+
+def test_reject_memory_candidate_marks_status_and_prevents_promotion(tmp_path):
+    home = tmp_path / ".hermes"
+
+    def run():
+        from agent.memory_candidates import load_memory_candidate, promote_memory_candidate, reject_memory_candidate, stage_memory_candidate
+
+        candidate = stage_memory_candidate(target="user", content="Bad preference")
+        reject_memory_candidate(candidate.candidate_id, reason="untrusted")
+        loaded = load_memory_candidate(candidate.candidate_id)
+        try:
+            promote_memory_candidate(candidate.candidate_id)
+        except ValueError as exc:
+            promoted = str(exc)
+        else:
+            promoted = "promoted"
+        return loaded.status, promoted
+
+    assert _with_home(home, run) == ("rejected", "candidate is not staged")
+
+
+def test_memory_wiki_find_read_grep_helpers(tmp_path):
+    home = tmp_path / ".hermes"
+    mem_dir = home / "memories"
+    mem_dir.mkdir(parents=True)
+    (mem_dir / "MEMORY.md").write_text("Project uses pytest\n§\nSpark host runs local LLM", encoding="utf-8")
+
+    def run():
+        from agent.memory_candidates import memory_wiki_find, memory_wiki_grep, memory_wiki_read
+
+        found = memory_wiki_find("pytest")
+        read = memory_wiki_read(found[0]["id"])
+        grep = memory_wiki_grep("Spark")
+        return found[0]["title"], read["text"], grep[0]["title"]
+
+    assert _with_home(home, run) == ("Project uses pytest", "Project uses pytest", "Spark host runs local LLM")

--- a/tests/agent/test_memory_wiki.py
+++ b/tests/agent/test_memory_wiki.py
@@ -1,0 +1,111 @@
+"""Behavior contracts for the local memory-wiki index."""
+
+from __future__ import annotations
+
+import json
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+def _with_home(home, fn):
+    token = set_hermes_home_override(home)
+    try:
+        return fn()
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_build_memory_wiki_index_splits_and_classifies_entries(tmp_path):
+    home = tmp_path / ".hermes"
+    mem_dir = home / "memories"
+    mem_dir.mkdir(parents=True)
+    (mem_dir / "MEMORY.md").write_text(
+        "Project uses pytest with xdist\n§\nDecision: keep memory wiki stdlib-only",
+        encoding="utf-8",
+    )
+    (mem_dir / "USER.md").write_text(
+        "User prefers concise responses\n§\nConstraint: only show SF events",
+        encoding="utf-8",
+    )
+
+    def run():
+        from agent.memory_wiki import build_memory_wiki_index
+
+        return build_memory_wiki_index()
+
+    index = _with_home(home, run)
+
+    assert index["version"] == 1
+    assert index["stats"] == {"entries": 4, "sources": {"memory": 2, "user": 2}}
+    entries = index["entries"]
+    assert [entry["source"] for entry in entries] == ["memory", "memory", "user", "user"]
+    assert {entry["category"] for entry in entries} >= {"environment", "decision", "preference", "constraint"}
+    assert all(entry["id"] for entry in entries)
+    assert all(entry["keywords"] for entry in entries)
+    assert entries[0]["provenance"]["path"].endswith("MEMORY.md")
+
+
+def test_select_memory_context_is_query_relevant_and_budgeted(tmp_path):
+    home = tmp_path / ".hermes"
+    mem_dir = home / "memories"
+    mem_dir.mkdir(parents=True)
+    (mem_dir / "MEMORY.md").write_text(
+        "Cloudflare credentials live in a secured file and should stay redacted\n§\nHermes code uses pytest and ruff",
+        encoding="utf-8",
+    )
+    (mem_dir / "USER.md").write_text(
+        "User prefers beautiful UI polish",
+        encoding="utf-8",
+    )
+
+    def run():
+        from agent.memory_wiki import build_memory_wiki_index, select_memory_context
+
+        index = build_memory_wiki_index()
+        return select_memory_context("run pytest for hermes code", index=index, max_chars=160)
+
+    selected = _with_home(home, run)
+
+    assert selected["used_chars"] <= 160
+    assert selected["entries"]
+    rendered = selected["context"]
+    assert rendered.startswith("<memory-wiki-context>\n")
+    assert rendered.endswith("\n</memory-wiki-context>")
+    assert "pytest" in rendered.lower()
+    assert "Cloudflare" not in rendered
+
+
+def test_memory_wiki_index_json_round_trips(tmp_path):
+    home = tmp_path / ".hermes"
+    mem_dir = home / "memories"
+    mem_dir.mkdir(parents=True)
+    (mem_dir / "MEMORY.md").write_text("Stable fact about the environment", encoding="utf-8")
+
+    def run():
+        from agent.memory_wiki import build_memory_wiki_index
+
+        return build_memory_wiki_index()
+
+    index = _with_home(home, run)
+    decoded = json.loads(json.dumps(index))
+
+    assert decoded["entries"][0]["text"] == "Stable fact about the environment"
+    assert decoded["entries"][0]["category"] == "fact"
+
+
+def test_empty_memory_wiki_index_shape(tmp_path):
+    home = tmp_path / ".hermes"
+    (home / "memories").mkdir(parents=True)
+
+    def run():
+        from agent.memory_wiki import build_memory_wiki_index, select_memory_context
+
+        index = build_memory_wiki_index()
+        selected = select_memory_context("anything", index=index, max_chars=100)
+        return index, selected
+
+    index, selected = _with_home(home, run)
+
+    assert index["entries"] == []
+    assert index["stats"]["entries"] == 0
+    assert selected == {"entries": [], "context": "", "used_chars": 0}

--- a/tests/agent/test_skillopt_harvest.py
+++ b/tests/agent/test_skillopt_harvest.py
@@ -1,0 +1,72 @@
+"""Tests for SkillOpt trace harvesting."""
+
+from __future__ import annotations
+
+
+class FakeDB:
+    def __init__(self):
+        self.queries = []
+
+    def search_messages(self, query, role_filter=None, limit=20, sort=None, include_inactive=False):
+        self.queries.append((query, role_filter, limit, sort, include_inactive))
+        return [
+            {"session_id": "s1", "message_id": 10, "source": "discord", "content": "Loaded skill_view systematic-debugging"},
+            {"session_id": "cron1", "message_id": 20, "source": "cron", "content": "cron scaffold skill_view systematic-debugging"},
+        ]
+
+    def get_messages_around(self, session_id, message_id, window=4):
+        return {
+            "window": [
+                {"id": message_id - 1, "role": "user", "content": "fix bug"},
+                {"id": message_id, "role": "assistant", "content": "using skill"},
+                {"id": message_id + 1, "role": "tool", "tool_name": "terminal", "content": "pytest failed"},
+            ],
+            "messages_before": 1,
+            "messages_after": 1,
+        }
+
+
+def test_harvest_skill_traces_excludes_cron_and_returns_context_windows():
+    from agent.skillopt_harvest import harvest_skill_traces
+
+    db = FakeDB()
+    traces = harvest_skill_traces(db, "systematic-debugging", limit=5)
+
+    assert len(traces) == 1
+    assert traces[0]["session_id"] == "s1"
+    assert traces[0]["anchor_message_id"] == 10
+    assert traces[0]["messages"][0]["content"] == "fix bug"
+    assert db.queries[0][0] == '"systematic-debugging" OR systematic-debugging OR skill_view OR skill_manage'
+
+
+def test_harvest_skill_traces_rejects_empty_skill_name():
+    from agent.skillopt_harvest import harvest_skill_traces
+
+    try:
+        harvest_skill_traces(FakeDB(), "")
+    except ValueError as exc:
+        assert "skill_name" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+
+
+def test_distill_trace_to_skill_extracts_commands_and_generalizes_steps():
+    from agent.skillopt_harvest import distill_trace_to_skill
+
+    trace = {
+        "skill_name": "debug-python-tests",
+        "messages": [
+            {"role": "user", "content": "Fix the pytest failure"},
+            {"role": "assistant", "content": "I will reproduce it."},
+            {"role": "tool", "tool_name": "terminal", "content": "pytest tests/test_demo.py -q\nFAILED"},
+            {"role": "tool", "tool_name": "patch", "content": "*** Begin Patch\n*** Update File: demo.py"},
+            {"role": "tool", "tool_name": "terminal", "content": "pytest tests/test_demo.py -q\n1 passed"},
+        ],
+    }
+
+    distilled = distill_trace_to_skill(trace)
+
+    assert distilled["name"] == "debug-python-tests"
+    assert "pytest tests/test_demo.py -q" in distilled["commands"]
+    assert any("Reproduce" in step for step in distilled["steps"])
+    assert "SKILL.md" in distilled["skill_markdown"]

--- a/tests/agent/test_skillopt_scoring.py
+++ b/tests/agent/test_skillopt_scoring.py
@@ -1,0 +1,54 @@
+"""Tests for SkillOpt verification-evidence scoring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+def test_score_verification_evidence_computes_pass_rate_from_ledger(tmp_path):
+    home = tmp_path / ".hermes"
+    root = tmp_path / "repo"
+    root.mkdir()
+    token = set_hermes_home_override(home)
+    try:
+        from agent.verification_evidence import _connect
+        from agent.skillopt_scoring import score_verification_evidence
+
+        with _connect() as conn:
+            conn.execute(
+                "INSERT INTO verification_events(created_at, session_id, cwd, root, command, canonical_command, kind, scope, status, exit_code, output_summary) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                ("2026-01-01T00:00:00+00:00", "s1", str(root), str(root.resolve()), "pytest ok", "pytest", "test", "targeted", "passed", 0, "ok"),
+            )
+            conn.execute(
+                "INSERT INTO verification_events(created_at, session_id, cwd, root, command, canonical_command, kind, scope, status, exit_code, output_summary) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                ("2026-01-01T00:01:00+00:00", "s1", str(root), str(root.resolve()), "pytest bad", "pytest", "test", "targeted", "failed", 1, "bad"),
+            )
+            conn.commit()
+        score = score_verification_evidence(root=root, session_id="s1")
+    finally:
+        reset_hermes_home_override(token)
+
+    assert score["total"] == 2
+    assert score["passed"] == 1
+    assert score["failed"] == 1
+    assert score["score"] == 0.5
+    assert score["heldout_ready"] is True
+
+
+def test_score_verification_evidence_rejects_empty_or_too_small_sets(tmp_path):
+    home = tmp_path / ".hermes"
+    root = tmp_path / "repo"
+    root.mkdir()
+    token = set_hermes_home_override(home)
+    try:
+        from agent.skillopt_scoring import score_verification_evidence
+
+        score = score_verification_evidence(root=root, session_id="missing", min_events=1)
+    finally:
+        reset_hermes_home_override(token)
+
+    assert score["score"] == 0.0
+    assert score["total"] == 0
+    assert score["heldout_ready"] is False

--- a/tests/agent/test_skillopt_state.py
+++ b/tests/agent/test_skillopt_state.py
@@ -1,0 +1,121 @@
+"""Tests for staged SkillOpt artifact storage."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+def _with_home(home: Path, fn):
+    token = set_hermes_home_override(home)
+    try:
+        return fn()
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_stage_skillopt_proposal_writes_reviewable_artifacts_without_mutating_skill(tmp_path):
+    home = tmp_path / ".hermes"
+    skill_dir = home / "skills" / "software-development" / "demo-skill"
+    skill_dir.mkdir(parents=True)
+    skill_path = skill_dir / "SKILL.md"
+    skill_path.write_text("---\nname: demo-skill\n---\n\n# Demo\n", encoding="utf-8")
+
+    def run():
+        from agent.skillopt_state import stage_skillopt_proposal
+
+        return stage_skillopt_proposal(
+            skill_name="demo-skill",
+            current_skill_path=skill_path,
+            candidate_skill="# Demo\n\nImproved procedure.\n",
+            edits=[{"op": "append", "content": "Improved procedure."}],
+            scores={"current": 0.5, "candidate": 0.75},
+            source={"session_id": "s1", "task_id": "t1"},
+            rationale="Add missing verification step.",
+        )
+
+    proposal = _with_home(home, run)
+
+    assert skill_path.read_text(encoding="utf-8") == "---\nname: demo-skill\n---\n\n# Demo\n"
+    assert proposal.run_id.startswith("demo-skill-")
+    assert proposal.run_dir.is_dir()
+    assert (proposal.run_dir / "candidate.SKILL.md").read_text(encoding="utf-8") == "# Demo\n\nImproved procedure.\n"
+    payload = json.loads((proposal.run_dir / "proposal.json").read_text(encoding="utf-8"))
+    assert payload["schema_version"] == 1
+    assert payload["skill_name"] == "demo-skill"
+    assert payload["status"] == "staged"
+    assert payload["scores"] == {"current": 0.5, "candidate": 0.75}
+    assert payload["source"] == {"session_id": "s1", "task_id": "t1"}
+    assert payload["current_sha256"]
+    assert payload["candidate_sha256"]
+    assert "Add missing verification" in (proposal.run_dir / "meta.md").read_text(encoding="utf-8")
+
+
+def test_stage_skillopt_proposal_rejects_path_traversal_skill_names(tmp_path):
+    home = tmp_path / ".hermes"
+    skill_path = tmp_path / "SKILL.md"
+    skill_path.write_text("safe", encoding="utf-8")
+
+    def run():
+        from agent.skillopt_state import stage_skillopt_proposal
+
+        with pytest.raises(ValueError, match="invalid skill_name"):
+            stage_skillopt_proposal(
+                skill_name="../bad",
+                current_skill_path=skill_path,
+                candidate_skill="candidate",
+            )
+
+    _with_home(home, run)
+
+
+def test_load_skillopt_proposal_validates_hashes_and_detects_tampering(tmp_path):
+    home = tmp_path / ".hermes"
+    skill_path = tmp_path / "SKILL.md"
+    skill_path.write_text("current", encoding="utf-8")
+
+    def run():
+        from agent.skillopt_state import load_skillopt_proposal, stage_skillopt_proposal
+
+        staged = stage_skillopt_proposal(
+            skill_name="demo",
+            current_skill_path=skill_path,
+            candidate_skill="candidate",
+        )
+        loaded = load_skillopt_proposal(staged.run_dir)
+        assert loaded.skill_name == "demo"
+        assert loaded.candidate_skill == "candidate"
+        (staged.run_dir / "candidate.SKILL.md").write_text("tampered", encoding="utf-8")
+        with pytest.raises(ValueError, match="candidate hash mismatch"):
+            load_skillopt_proposal(staged.run_dir)
+
+    _with_home(home, run)
+
+
+def test_append_skillopt_rejection_records_jsonl(tmp_path):
+    home = tmp_path / ".hermes"
+    skill_path = tmp_path / "SKILL.md"
+    skill_path.write_text("current", encoding="utf-8")
+
+    def run():
+        from agent.skillopt_state import append_skillopt_rejection, stage_skillopt_proposal
+
+        staged = stage_skillopt_proposal(
+            skill_name="demo",
+            current_skill_path=skill_path,
+            candidate_skill="candidate",
+        )
+        append_skillopt_rejection(staged.run_dir, reason="score regressed", reviewer="unit-test")
+        lines = (staged.run_dir / "rejected.jsonl").read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["reason"] == "score regressed"
+        assert record["reviewer"] == "unit-test"
+        proposal = json.loads((staged.run_dir / "proposal.json").read_text(encoding="utf-8"))
+        assert proposal["status"] == "rejected"
+
+    _with_home(home, run)

--- a/tests/agent/test_skillopt_text_optimizer.py
+++ b/tests/agent/test_skillopt_text_optimizer.py
@@ -1,0 +1,176 @@
+"""Behavior contracts for lightweight SkillOpt-style text gates.
+
+These tests pin the safe first slice: bounded text edits on one skill document
+and a pure validation gate. They do not call an LLM or mutate real skills.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from agent.skillopt_text_optimizer import (
+    AtomicEdit,
+    GateDecision,
+    apply_bounded_edits,
+    evaluate_skill_gate,
+)
+
+
+def test_gate_accepts_strict_improvement_as_new_best():
+    decision = evaluate_skill_gate(
+        candidate_skill="new",
+        candidate_score=0.72,
+        current_skill="old",
+        current_score=0.70,
+        best_skill="old",
+        best_score=0.71,
+        step=3,
+    )
+
+    assert decision == GateDecision(
+        action="accept_new_best",
+        current_skill="new",
+        current_score=0.72,
+        best_skill="new",
+        best_score=0.72,
+        best_step=3,
+    )
+
+
+def test_gate_rejects_ties_to_prevent_unvalidated_drift():
+    decision = evaluate_skill_gate(
+        candidate_skill="changed",
+        candidate_score=0.70,
+        current_skill="stable",
+        current_score=0.70,
+        best_skill="best",
+        best_score=0.75,
+        step=4,
+    )
+
+    assert decision.action == "reject"
+    assert decision.current_skill == "stable"
+    assert decision.best_skill == "best"
+
+
+def test_gate_accept_preserves_prior_best_step_when_not_new_best():
+    decision = evaluate_skill_gate(
+        candidate_skill="better-current",
+        candidate_score=0.73,
+        current_skill="old-current",
+        current_score=0.70,
+        best_skill="historic-best",
+        best_score=0.80,
+        best_step=9,
+        step=12,
+    )
+
+    assert decision.action == "accept"
+    assert decision.current_skill == "better-current"
+    assert decision.best_skill == "historic-best"
+    assert decision.best_score == 0.80
+    assert decision.best_step == 9
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("candidate_score", math.nan),
+        ("current_score", math.inf),
+        ("best_score", -math.inf),
+        ("epsilon", math.nan),
+    ],
+)
+def test_gate_rejects_non_finite_scores(field, value):
+    kwargs = dict(
+        candidate_skill="bad",
+        candidate_score=0.3,
+        current_skill="old",
+        current_score=0.1,
+        best_skill="best",
+        best_score=0.2,
+        step=1,
+    )
+    kwargs[field] = value
+
+    with pytest.raises(ValueError, match="finite"):
+        evaluate_skill_gate(**kwargs)
+
+
+def test_apply_bounded_edits_respects_learning_rate_budget():
+    skill = "# Skill\n\nUse search.\n"
+    candidate, applied = apply_bounded_edits(
+        skill,
+        [
+            AtomicEdit(op="append", content="Always verify with tests."),
+            AtomicEdit(op="append", content="Prefer small patches."),
+        ],
+        edit_budget=1,
+    )
+
+    assert applied == 1
+    assert "Always verify with tests." in candidate
+    assert "Prefer small patches." not in candidate
+
+
+def test_apply_edits_supports_replace_insert_after_and_delete():
+    skill = "# Skill\n\nUse grep.\nRun tests.\n"
+    candidate, applied = apply_bounded_edits(
+        skill,
+        [
+            AtomicEdit(op="replace", target="Use grep.", content="Use `search_files`."),
+            AtomicEdit(op="insert_after", target="Use `search_files`.", content="Use `read_file` for exact lines."),
+            AtomicEdit(op="delete", target="Run tests."),
+        ],
+        edit_budget=3,
+    )
+
+    assert applied == 3
+    assert "Use `search_files`." in candidate
+    assert "Use `read_file` for exact lines." in candidate
+    assert "Run tests." not in candidate
+
+
+def test_apply_edits_rejects_missing_replace_target_without_partial_mutation():
+    skill = "# Skill\n\nStable text.\n"
+
+    with pytest.raises(ValueError, match="target not found"):
+        apply_bounded_edits(
+            skill,
+            [AtomicEdit(op="replace", target="Missing", content="New")],
+            edit_budget=1,
+        )
+
+
+def test_apply_edits_protects_slow_update_block_from_step_edits():
+    skill = "# Skill\n\n<!-- SLOW_UPDATE_START -->\ndo not touch\n<!-- SLOW_UPDATE_END -->\n"
+
+    with pytest.raises(ValueError, match="protected slow-update"):
+        apply_bounded_edits(
+            skill,
+            [AtomicEdit(op="replace", target="do not touch", content="changed")],
+            edit_budget=1,
+        )
+
+
+def test_apply_edits_fail_closed_on_unterminated_slow_update_append():
+    skill = "# Skill\n\n<!-- SLOW_UPDATE_START -->\nunterminated\n"
+
+    with pytest.raises(ValueError, match="unterminated slow-update"):
+        apply_bounded_edits(
+            skill,
+            [AtomicEdit(op="append", content="Should not append inside protected tail.")],
+            edit_budget=1,
+        )
+
+
+def test_apply_edits_rejects_overlarge_candidate():
+    with pytest.raises(ValueError, match="candidate skill exceeds"):
+        apply_bounded_edits(
+            "# Skill\n",
+            [AtomicEdit(op="append", content="word " * 20)],
+            edit_budget=1,
+            max_words=5,
+        )

--- a/tests/agent/test_verification_gate.py
+++ b/tests/agent/test_verification_gate.py
@@ -1,0 +1,67 @@
+"""Tests for multi-agent/post-task verification gate."""
+
+from __future__ import annotations
+
+
+def test_verification_gate_rejects_success_claim_without_required_path():
+    from agent.verification_gate import verify_postconditions
+
+    result = verify_postconditions(
+        summary="created the requested file and tests passed",
+        required_paths=["missing.py"],
+        command_results=[],
+        root=None,
+    )
+
+    assert result["passed"] is False
+    assert result["failures"][0]["kind"] == "missing_path"
+
+
+def test_verification_gate_accepts_existing_file_and_passing_command(tmp_path):
+    from agent.verification_gate import verify_postconditions
+
+    target = tmp_path / "out.py"
+    target.write_text("print('ok')\n", encoding="utf-8")
+
+    result = verify_postconditions(
+        summary="done",
+        required_paths=[str(target)],
+        command_results=[{"command": "pytest", "exit_code": 0, "output": "1 passed"}],
+        root=tmp_path,
+    )
+
+    assert result["passed"] is True
+    assert result["evidence"]["paths_verified"] == [str(target)]
+    assert result["evidence"]["commands_verified"][0]["status"] == "passed"
+
+
+def test_verification_gate_rejects_path_traversal_outside_root(tmp_path):
+    from agent.verification_gate import verify_postconditions
+
+    outside = tmp_path.parent / "outside-proof.txt"
+    outside.write_text("not in workspace", encoding="utf-8")
+
+    result = verify_postconditions(
+        summary="verified outside file",
+        required_paths=["../outside-proof.txt", str(outside)],
+        command_results=[],
+        root=tmp_path,
+    )
+
+    assert result["passed"] is False
+    assert [failure["kind"] for failure in result["failures"]] == ["path_outside_root", "path_outside_root"]
+    assert result["evidence"]["paths_verified"] == []
+
+
+def test_verification_gate_rejects_failing_command_even_with_confident_summary(tmp_path):
+    from agent.verification_gate import verify_postconditions
+
+    result = verify_postconditions(
+        summary="all tests passed successfully",
+        required_paths=[],
+        command_results=[{"command": "pytest", "exit_code": 1, "output": "failed"}],
+        root=tmp_path,
+    )
+
+    assert result["passed"] is False
+    assert result["failures"][0]["kind"] == "command_failed"

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -90,6 +90,31 @@ class TestPlatformConfigRoundtrip:
         # extra; from_dict must honor it there too (mirrors _grn fallback).
         restored = PlatformConfig.from_dict({"extra": {"typing_indicator": False}})
         assert restored.typing_indicator is False
+
+
+class TestGatewayConfigRoundtrip:
+    def test_silent_shutdown_notifications_defaults_false(self):
+        assert GatewayConfig().silent_shutdown_notifications is False
+        assert GatewayConfig.from_dict({}).silent_shutdown_notifications is False
+
+    def test_silent_shutdown_notifications_roundtrip_true(self):
+        restored = GatewayConfig.from_dict(
+            GatewayConfig(silent_shutdown_notifications=True).to_dict()
+        )
+        assert restored.silent_shutdown_notifications is True
+
+    def test_silent_shutdown_notifications_coerces_quoted_true(self):
+        restored = GatewayConfig.from_dict({"silent_shutdown_notifications": "true"})
+        assert restored.silent_shutdown_notifications is True
+
+    def test_silent_shutdown_notifications_honors_nested_gateway(self):
+        restored = GatewayConfig.from_dict(
+            {"gateway": {"silent_shutdown_notifications": True}}
+        )
+        assert restored.silent_shutdown_notifications is True
+
+
+class TestChannelOverrideRoundtrip:
     def test_channel_overrides_roundtrip(self):
         pc = PlatformConfig(
             enabled=True,
@@ -451,6 +476,22 @@ class TestLoadGatewayConfig:
 
         assert Platform.RELAY in config.platforms
         assert config.platforms[Platform.RELAY].enabled is True
+
+    def test_bridges_silent_shutdown_notifications_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n"
+            "  silent_shutdown_notifications: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.silent_shutdown_notifications is True
 
     def test_bridges_group_sessions_per_user_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -512,6 +512,26 @@ async def test_shutdown_notification_home_channel_suppressed_when_flag_disabled(
 
 
 @pytest.mark.asyncio
+async def test_shutdown_notifications_globally_suppressed_when_configured():
+    """Global shutdown silence mutes both active-session and home-channel pings."""
+    from gateway.config import HomeChannel, Platform
+
+    runner, adapter = make_restart_runner()
+    runner.config.silent_shutdown_notifications = True
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    session_key = "agent:main:telegram:dm:999"
+    runner._running_agents[session_key] = MagicMock()
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    assert adapter.sent == []
+
+
+@pytest.mark.asyncio
 async def test_shutdown_notification_uses_persisted_origin_for_colon_ids():
     """Shutdown notifications should route from persisted origin, not reparsed keys."""
     runner, adapter = make_restart_runner()

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -559,6 +559,28 @@ async def test_send_home_channel_startup_notification_skipped_when_flag_disabled
 
 
 @pytest.mark.asyncio
+async def test_send_home_channel_startup_notification_globally_suppressed(
+    tmp_path, monkeypatch
+):
+    """Global lifecycle silence mutes home-channel startup pings."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.silent_shutdown_notifications = True
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    adapter.send = AsyncMock()
+
+    delivered = await runner._send_home_channel_startup_notifications()
+
+    assert delivered == set()
+    adapter.send.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_send_home_channel_startup_notification_default_flag_true(
     tmp_path, monkeypatch
 ):
@@ -603,6 +625,30 @@ async def test_send_restart_notification_skipped_when_flag_disabled(
 
     runner, adapter = make_restart_runner()
     runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification = False
+    adapter.send = AsyncMock()
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target is None
+    adapter.send.assert_not_called()
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_globally_suppressed_cleans_marker(
+    tmp_path, monkeypatch
+):
+    """Global lifecycle silence mutes /restart completion and clears its marker."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps({
+        "platform": "telegram",
+        "chat_id": "42",
+    }))
+
+    runner, adapter = make_restart_runner()
+    runner.config.silent_shutdown_notifications = True
     adapter.send = AsyncMock()
 
     delivered_target = await runner._send_restart_notification()

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 
+from gateway import run as gateway_run
 from gateway import shutdown_forensics as sf
 
 
@@ -116,6 +117,43 @@ class TestSnapshotShutdownContext:
         )
         ctx = sf.snapshot_shutdown_context(signal.SIGTERM)
         assert "planned_stop_marker" in ctx
+
+
+# ---------------------------------------------------------------------------
+# gateway.run systemd stop classification
+# ---------------------------------------------------------------------------
+
+class TestSystemdSignalClassification:
+    def test_systemd_sigterm_is_planned_stop_by_parent_name(self):
+        ctx = {"under_systemd": True, "parent": {"name": "systemd"}}
+
+        assert (
+            gateway_run._systemd_sigterm_is_planned_stop(signal.SIGTERM, ctx) is True
+        )
+
+    def test_systemd_sigterm_is_planned_stop_by_user_cmdline(self):
+        ctx = {
+            "under_systemd": True,
+            "parent": {"cmdline": "/usr/lib/systemd/systemd --user"},
+        }
+
+        assert (
+            gateway_run._systemd_sigterm_is_planned_stop(signal.SIGTERM, ctx) is True
+        )
+
+    def test_non_systemd_sigterm_remains_unplanned(self):
+        ctx = {"under_systemd": False, "parent": {"name": "bash"}}
+
+        assert (
+            gateway_run._systemd_sigterm_is_planned_stop(signal.SIGTERM, ctx) is False
+        )
+
+    def test_systemd_non_sigterm_remains_unplanned(self):
+        ctx = {"under_systemd": True, "parent": {"name": "systemd"}}
+
+        assert (
+            gateway_run._systemd_sigterm_is_planned_stop(signal.SIGINT, ctx) is False
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_memory_wiki.py
+++ b/tests/hermes_cli/test_memory_wiki.py
@@ -1,0 +1,78 @@
+"""Tests for the `hermes memory wiki-index` CLI helper."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pytest
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+def test_memory_wiki_index_cli_writes_json(tmp_path, capsys):
+    home = tmp_path / ".hermes"
+    mem_dir = home / "memories"
+    mem_dir.mkdir(parents=True)
+    (mem_dir / "MEMORY.md").write_text("Hermes uses pytest for tests", encoding="utf-8")
+
+    token = set_hermes_home_override(home)
+    try:
+        from hermes_cli.memory_wiki import run_memory_wiki_index
+
+        out = tmp_path / "index.json"
+        rc = run_memory_wiki_index(argparse.Namespace(out=str(out), query=None, max_chars=1200))
+    finally:
+        reset_hermes_home_override(token)
+
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["stats"]["entries"] == 1
+    assert payload["entries"][0]["text"] == "Hermes uses pytest for tests"
+    assert "Wrote memory wiki index" in capsys.readouterr().out
+
+
+def test_memory_wiki_index_cli_query_prints_selection(tmp_path, capsys):
+    home = tmp_path / ".hermes"
+    mem_dir = home / "memories"
+    mem_dir.mkdir(parents=True)
+    (mem_dir / "MEMORY.md").write_text(
+        "Hermes uses pytest for tests\n§\nCloudflare uses proxied DNS records",
+        encoding="utf-8",
+    )
+
+    token = set_hermes_home_override(home)
+    try:
+        from hermes_cli.memory_wiki import run_memory_wiki_index
+
+        rc = run_memory_wiki_index(argparse.Namespace(out=None, query="pytest", max_chars=200))
+    finally:
+        reset_hermes_home_override(token)
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["selection"]["entries"]
+    context = payload["selection"]["context"]
+    assert context.startswith("<memory-wiki-context>\n")
+    assert context.endswith("\n</memory-wiki-context>")
+    assert "pytest" in context.lower()
+    assert "Cloudflare" not in context
+
+
+def test_memory_wiki_index_parser_routes_command_and_rejects_bad_budget():
+    import argparse
+
+    from hermes_cli.subcommands.memory import build_memory_parser
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    sentinel = object()
+    build_memory_parser(subparsers, cmd_memory=sentinel)
+
+    args = parser.parse_args(["memory", "wiki-index", "--query", "pytest", "--max-chars", "200"])
+    assert args.func is sentinel
+    assert args.memory_command == "wiki-index"
+    assert args.query == "pytest"
+    assert args.max_chars == 200
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["memory", "wiki-index", "--max-chars", "0"])

--- a/tests/hermes_cli/test_skillopt_cli.py
+++ b/tests/hermes_cli/test_skillopt_cli.py
@@ -1,0 +1,189 @@
+"""Tests for manual SkillOpt CLI helpers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+def _write_skill(home: Path, name: str, text: str = "# Demo\n") -> Path:
+    path = home / "skills" / name / "SKILL.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"---\nname: {name}\n---\n\n{text}", encoding="utf-8")
+    return path
+
+
+def _with_home(home: Path, fn):
+    token = set_hermes_home_override(home)
+    try:
+        return fn()
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_skillopt_status_prints_ranked_candidates(tmp_path, capsys):
+    home = tmp_path / ".hermes"
+    _write_skill(home, "demo")
+    (home / "skills" / ".usage.json").write_text(
+        '{"demo":{"created_by":"agent","use_count":3,"patch_count":1}}',
+        encoding="utf-8",
+    )
+
+    def run():
+        from hermes_cli.skillopt import cmd_skillopt
+
+        return cmd_skillopt(argparse.Namespace(skillopt_command="status", skill=None, limit=5, json=False))
+
+    assert _with_home(home, run) == 0
+    out = capsys.readouterr().out
+    assert "demo" in out
+    assert "patched-often" in out
+
+
+def test_skillopt_propose_stages_candidate_without_mutating_live_skill(tmp_path):
+    home = tmp_path / ".hermes"
+    skill_path = _write_skill(home, "demo", "# Demo\n")
+    candidate = tmp_path / "candidate.md"
+    candidate.write_text("# Better Demo\n", encoding="utf-8")
+
+    def run():
+        from hermes_cli.skillopt import cmd_skillopt
+
+        return cmd_skillopt(
+            argparse.Namespace(
+                skillopt_command="propose",
+                skill="demo",
+                candidate=str(candidate),
+                rationale="unit test",
+                from_session=None,
+            )
+        )
+
+    assert _with_home(home, run) == 0
+    assert "# Demo" in skill_path.read_text(encoding="utf-8")
+    staged = list((home / "skillopt" / "runs").glob("demo-*"))
+    assert len(staged) == 1
+    assert (staged[0] / "candidate.SKILL.md").read_text(encoding="utf-8") == "# Better Demo\n"
+
+
+def test_skillopt_reject_marks_proposal_rejected(tmp_path):
+    home = tmp_path / ".hermes"
+    skill_path = _write_skill(home, "demo")
+
+    def run():
+        from agent.skillopt_state import stage_skillopt_proposal, load_skillopt_proposal
+        from hermes_cli.skillopt import cmd_skillopt
+
+        staged = stage_skillopt_proposal(skill_name="demo", current_skill_path=skill_path, candidate_skill="# Candidate\n")
+        rc = cmd_skillopt(argparse.Namespace(skillopt_command="reject", run_id=staged.run_id, reason="no", reviewer="test"))
+        loaded = load_skillopt_proposal(staged.run_dir)
+        return rc, loaded.status
+
+    assert _with_home(home, run) == (0, "rejected")
+
+
+def test_skillopt_adopt_requires_evaluated_status_then_updates_live_skill(tmp_path):
+    home = tmp_path / ".hermes"
+    skill_path = _write_skill(home, "demo", "# Demo\n")
+
+    def run():
+        from agent.skillopt_state import load_skillopt_proposal, stage_skillopt_proposal, update_skillopt_evaluation
+        from hermes_cli.skillopt import cmd_skillopt
+
+        staged = stage_skillopt_proposal(skill_name="demo", current_skill_path=skill_path, candidate_skill="# Candidate\n")
+        update_skillopt_evaluation(staged.run_dir, {"heldout_ready": True, "score": 1.0, "passed": 2, "failed": 0, "total": 2})
+        rc = cmd_skillopt(argparse.Namespace(skillopt_command="adopt", run_id=staged.run_id))
+        loaded = load_skillopt_proposal(staged.run_dir)
+        return rc, loaded.status, skill_path.read_text(encoding="utf-8")
+
+    assert _with_home(home, run) == (0, "adopted", "# Candidate\n")
+
+
+def test_skillopt_adopt_refuses_unevaluated_proposal(tmp_path):
+    home = tmp_path / ".hermes"
+    skill_path = _write_skill(home, "demo", "# Demo\n")
+
+    def run():
+        from agent.skillopt_state import stage_skillopt_proposal
+        from hermes_cli.skillopt import cmd_skillopt
+
+        staged = stage_skillopt_proposal(skill_name="demo", current_skill_path=skill_path, candidate_skill="# Candidate\n")
+        with pytest.raises(RuntimeError, match="must be evaluated"):
+            cmd_skillopt(argparse.Namespace(skillopt_command="adopt", run_id=staged.run_id))
+        return skill_path.read_text(encoding="utf-8")
+
+    assert _with_home(home, run).endswith("# Demo\n")
+
+
+def test_skillopt_evaluate_records_scores_and_rejects_low_evidence(tmp_path):
+    home = tmp_path / ".hermes"
+    skill_path = _write_skill(home, "demo", "# Demo\n")
+
+    def run():
+        from agent.skillopt_state import load_skillopt_proposal, stage_skillopt_proposal
+        from hermes_cli.skillopt import cmd_skillopt
+
+        staged = stage_skillopt_proposal(skill_name="demo", current_skill_path=skill_path, candidate_skill="# Candidate\n")
+        rc = cmd_skillopt(
+            argparse.Namespace(
+                skillopt_command="evaluate",
+                run_id=staged.run_id,
+                root=str(tmp_path),
+                session_id="s1",
+                min_events=2,
+            )
+        )
+        loaded = load_skillopt_proposal(staged.run_dir)
+        return rc, loaded.status, loaded.proposal["scores"]
+
+    rc, status, scores = _with_home(home, run)
+    assert rc == 1
+    assert status == "needs_evidence"
+    assert scores["heldout_ready"] is False
+
+
+def test_skillopt_run_id_rejects_traversal_and_absolute_paths(tmp_path):
+    home = tmp_path / ".hermes"
+
+    def run():
+        from hermes_cli.skillopt import cmd_skillopt
+
+        with pytest.raises(ValueError, match="invalid SkillOpt run_id"):
+            cmd_skillopt(argparse.Namespace(skillopt_command="show", run_id="../evil", json=False))
+        with pytest.raises(ValueError, match="invalid SkillOpt run_id"):
+            cmd_skillopt(argparse.Namespace(skillopt_command="show", run_id=str(tmp_path / "evil"), json=False))
+
+    home.mkdir(parents=True)
+    _with_home(home, run)
+
+
+def test_skillopt_adopt_refuses_proposal_target_outside_skills_dir(tmp_path):
+    home = tmp_path / ".hermes"
+    skill_path = _write_skill(home, "demo", "# Demo\n")
+    outside = tmp_path / "outside.md"
+    outside.write_text("outside current", encoding="utf-8")
+
+    def run():
+        from agent.skillopt_state import stage_skillopt_proposal
+        from hermes_cli.skillopt import cmd_skillopt
+
+        staged = stage_skillopt_proposal(skill_name="demo", current_skill_path=skill_path, candidate_skill="# Candidate\n")
+        proposal_path = staged.run_dir / "proposal.json"
+        payload = json.loads(proposal_path.read_text(encoding="utf-8"))
+        import hashlib
+
+        payload["current_skill_path"] = str(outside)
+        payload["current_sha256"] = hashlib.sha256(outside.read_text(encoding="utf-8").encode("utf-8")).hexdigest()
+        payload["status"] = "evaluated"
+        payload["scores"] = {"heldout_ready": True, "score": 1.0, "passed": 2, "failed": 0, "total": 2}
+        proposal_path.write_text(json.dumps(payload), encoding="utf-8")
+        with pytest.raises(RuntimeError, match="outside Hermes skills directory"):
+            cmd_skillopt(argparse.Namespace(skillopt_command="adopt", run_id=staged.run_id))
+        return outside.read_text(encoding="utf-8")
+
+    assert _with_home(home, run) == "outside current"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4176,6 +4176,43 @@ class TestNewEndpoints:
         assert row["api_calls"] == 9
         assert row["avg_tokens_per_session"] == 13_550
 
+    def test_models_analytics_capabilities_use_provider_aware_context(self):
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(
+                session_id="codex-gpt55",
+                source="cli",
+                model="gpt-5.5",
+            )
+            db.update_token_counts(
+                "codex-gpt55",
+                input_tokens=1234,
+                output_tokens=56,
+                billing_provider="openai-codex",
+            )
+        finally:
+            db.close()
+
+        mock_caps = MagicMock()
+        mock_caps.supports_tools = True
+        mock_caps.supports_vision = True
+        mock_caps.supports_reasoning = True
+        mock_caps.context_window = 1_050_000
+        mock_caps.max_output_tokens = 128_000
+        mock_caps.model_family = "gpt-5"
+
+        with patch("agent.model_metadata.get_model_context_length", return_value=272_000), \
+             patch("agent.models_dev.get_model_capabilities", return_value=mock_caps):
+            resp = self.client.get("/api/analytics/models?days=7")
+
+        assert resp.status_code == 200
+        row = next(r for r in resp.json()["models"] if r["model"] == "gpt-5.5")
+        assert row["provider"] == "openai-codex"
+        assert row["capabilities"]["context_window"] == 272_000
+        assert row["capabilities"]["catalog_context_window"] == 1_050_000
+
     def test_analytics_usage_includes_skill_breakdown(self):
         from hermes_state import SessionDB
 
@@ -4602,6 +4639,33 @@ class TestModelInfoEndpoint:
         assert caps["supports_reasoning"] is True
         assert caps["max_output_tokens"] == 32000
         assert caps["model_family"] == "claude-opus"
+
+    def test_model_info_capabilities_use_provider_aware_context(self, monkeypatch):
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws, "load_config", lambda: {
+            "model": {
+                "default": "gpt-5.5",
+                "provider": "openai-codex",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+            }
+        })
+
+        mock_caps = MagicMock()
+        mock_caps.supports_tools = True
+        mock_caps.supports_vision = True
+        mock_caps.supports_reasoning = True
+        mock_caps.context_window = 1_050_000
+        mock_caps.max_output_tokens = 128_000
+        mock_caps.model_family = "gpt-5"
+
+        with patch("agent.model_metadata.get_model_context_length", return_value=272_000), \
+             patch("agent.models_dev.get_model_capabilities", return_value=mock_caps):
+            resp = self.client.get("/api/model/info")
+
+        caps = resp.json()["capabilities"]
+        assert caps["context_window"] == 272_000
+        assert caps["catalog_context_window"] == 1_050_000
 
     def test_model_info_graceful_on_metadata_error(self, monkeypatch):
         """Endpoint should return zeros on import/resolution errors, not 500."""

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -134,6 +134,36 @@ class TestRunConversationCodexPath:
         assert agent.context_compressor.last_total_tokens == 130
         assert agent.context_compressor.context_length == 200000
 
+    def test_codex_app_server_usage_does_not_override_config_context_length(self, monkeypatch):
+        def fake_run_turn(self, user_input: str, **kwargs):
+            return TurnResult(
+                final_text="done",
+                projected_messages=[{"role": "assistant", "content": "done"}],
+                turn_id="turn-config-context-1",
+                thread_id="thread-config-context-1",
+                token_usage_last={
+                    "totalTokens": 10,
+                    "inputTokens": 7,
+                    "outputTokens": 3,
+                },
+                model_context_window=1_000_000,
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession,
+            "ensure_started",
+            lambda self: "thread-config-context-1",
+        )
+        agent = _make_codex_agent()
+        agent._config_context_length = 272_000
+        agent.context_compressor.context_length = 272_000
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hello")
+
+        assert agent.context_compressor.context_length == 272_000
+
     def test_projected_messages_are_spliced(self, fake_session):
         agent = _make_codex_agent()
         with patch.object(agent, "_spawn_background_review", return_value=None):
@@ -718,4 +748,3 @@ class TestCodexToolProgressBridge:
 
         assert "on_event" in captured_init and captured_init["on_event"] is not None
         assert ("tool.started", "exec_command", "pytest") in events
-

--- a/tests/test_model_tools_context_length.py
+++ b/tests/test_model_tools_context_length.py
@@ -1,0 +1,37 @@
+"""Regression tests for model_tools active context resolution."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import model_tools
+
+
+def test_tool_search_context_gate_uses_provider_aware_model_config(monkeypatch):
+    """Tool Search must not treat Codex gpt-5.5 like direct OpenAI gpt-5.5.
+
+    The generic catalog may advertise a 1.05M window for the slug, but the
+    active ``openai-codex`` route uses the Codex OAuth cap/configured value.
+    """
+    import hermes_cli.config as cfg_mod
+
+    monkeypatch.setattr(cfg_mod, "load_config", lambda: {
+        "model": {
+            "default": "gpt-5.5",
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "context_length": 272_000,
+        },
+        "custom_providers": [{"name": "custom"}],
+    })
+
+    with patch("agent.model_metadata.get_model_context_length", return_value=272_000) as ctx:
+        assert model_tools._resolve_active_context_length() == 272_000
+
+    ctx.assert_called_once_with(
+        "gpt-5.5",
+        base_url="https://chatgpt.com/backend-api/codex",
+        provider="openai-codex",
+        config_context_length=272_000,
+        custom_providers=[{"name": "custom"}],
+    )

--- a/tests/tools/test_skill_usage_skillopt.py
+++ b/tests/tools/test_skill_usage_skillopt.py
@@ -1,0 +1,74 @@
+"""Tests for SkillOpt optimization candidate reporting."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+def _write_skill(path: Path, name: str) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "SKILL.md").write_text(f"---\nname: {name}\n---\n\n# {name}\n", encoding="utf-8")
+
+
+def _with_home(home: Path, fn):
+    token = set_hermes_home_override(home)
+    try:
+        return fn()
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_skillopt_candidate_report_ranks_active_agent_skills(tmp_path):
+    home = tmp_path / ".hermes"
+    skills = home / "skills"
+    _write_skill(skills / "alpha", "alpha")
+    _write_skill(skills / "beta", "beta")
+    _write_skill(skills / "gamma", "gamma")
+    (skills / ".usage.json").write_text(
+        json.dumps(
+            {
+                "alpha": {"created_by": "agent", "use_count": 5, "view_count": 2, "patch_count": 0},
+                "beta": {"created_by": "agent", "use_count": 1, "view_count": 0, "patch_count": 4},
+                "gamma": {"created_by": "agent", "use_count": 0, "view_count": 0, "patch_count": 0, "pinned": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def run():
+        from tools.skill_usage import skillopt_candidate_report
+
+        return skillopt_candidate_report()
+
+    rows = _with_home(home, run)
+
+    assert [row["name"] for row in rows] == ["beta", "alpha"]
+    assert rows[0]["skillopt_score"] > rows[1]["skillopt_score"]
+    assert rows[0]["reasons"] == ["patched-often", "used"]
+    assert rows[1]["reasons"] == ["used"]
+
+
+def test_skillopt_candidate_report_excludes_unpersisted_and_non_agent_skills(tmp_path):
+    home = tmp_path / ".hermes"
+    skills = home / "skills"
+    _write_skill(skills / "local", "local")
+    _write_skill(skills / "hubbed", "hubbed")
+    (skills / ".hub").mkdir(parents=True)
+    (skills / ".hub" / "lock.json").write_text(
+        json.dumps({"installed": {"hubbed": {"install_path": "hubbed"}}}),
+        encoding="utf-8",
+    )
+    (skills / ".usage.json").write_text(
+        json.dumps({"hubbed": {"use_count": 99}, "local": {"use_count": 0}}),
+        encoding="utf-8",
+    )
+
+    def run():
+        from tools.skill_usage import skillopt_candidate_report
+
+        return skillopt_candidate_report()
+
+    assert _with_home(home, run) == []

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -893,6 +893,50 @@ def agent_created_report() -> List[Dict[str, Any]]:
     return rows
 
 
+def skillopt_candidate_report(limit: Optional[int] = None) -> List[Dict[str, Any]]:
+    """Rank curator-managed skills that are worth SkillOpt review.
+
+    The report is deterministic and read-only. It deliberately excludes pinned,
+    archived, non-persisted, and zero-signal skills so automated callers can use
+    it as a safe dry-run target list before any LLM/eval-heavy optimization.
+    """
+    rows: List[Dict[str, Any]] = []
+    for row in agent_created_report():
+        if not row.get("_persisted") or row.get("pinned") or row.get("state") == STATE_ARCHIVED:
+            continue
+        use_count = int(row.get("use_count") or 0)
+        view_count = int(row.get("view_count") or 0)
+        patch_count = int(row.get("patch_count") or 0)
+        reasons: List[str] = []
+        score = 0
+        if patch_count:
+            score += patch_count * 3
+            reasons.append("patched-often")
+        if use_count:
+            score += use_count * 2
+            reasons.append("used")
+        if view_count:
+            score += view_count
+            if not reasons:
+                reasons.append("viewed")
+        if not score:
+            continue
+        candidate = {
+            "name": row["name"],
+            "skillopt_score": score,
+            "reasons": reasons,
+            "use_count": use_count,
+            "view_count": view_count,
+            "patch_count": patch_count,
+            "last_activity_at": row.get("last_activity_at"),
+            "state": row.get("state"),
+            "pinned": bool(row.get("pinned")),
+        }
+        rows.append(candidate)
+    rows.sort(key=lambda r: (-int(r["skillopt_score"]), str(r["name"])))
+    return rows[:limit] if limit is not None else rows
+
+
 def provenance(skill_name: str) -> str:
     """Classify a skill's origin: 'hub', 'bundled', or 'agent'.
 


### PR DESCRIPTION
## Summary
- add SkillOpt staged proposal artifacts, candidate scoring, verification scoring, trace harvesting/distillation, and validation-gated CLI commands
- integrate memory-wiki metadata into learning graph memory cards
- add governed memory candidate queue, memory lint/bench helpers, loop detector, and postcondition verifier

## Verification
- python -m pytest tests/agent/test_loop_detector.py tests/agent/test_memory_benchmarker.py tests/agent/test_verification_gate.py tests/agent/test_skillopt_state.py tests/tools/test_skill_usage_skillopt.py tests/agent/test_learning_graph.py tests/agent/test_skillopt_scoring.py tests/agent/test_skillopt_harvest.py tests/hermes_cli/test_skillopt_cli.py tests/agent/test_memory_candidates.py tests/agent/test_memory_wiki.py tests/hermes_cli/test_memory_wiki.py -q
- python -m ruff check edited/new files
- git diff --check
- static security scan: no findings
- independent reviewer re-review: passed