### PR TITLE
fix(telegram): fall back to reachable IP when proxy can't reach primary anycast IP

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3049,12 +3049,31 @@ class TelegramAdapter(BasePlatformAdapter):
 
             proxy_targets = ["api.telegram.org", *fallback_ips]
             proxy_url = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=proxy_targets)
-            if fallback_ips and not proxy_url and not disable_fallback:
-                logger.info(
-                    "[%s] Telegram fallback IPs active: %s",
-                    self.name,
-                    ", ".join(fallback_ips),
-                )
+            if fallback_ips and not disable_fallback:
+                # The fallback-IP transport pins the TCP connection to a
+                # known-reachable Telegram IP while preserving the
+                # api.telegram.org SNI/Host. It also threads TELEGRAM_PROXY
+                # through internally, so this single branch handles three
+                # cases: fallback-only, proxy-only-with-pinned-IPs, and
+                # proxy+fallback together. Combining a proxy with pinned IPs is
+                # required when the proxy's upstream egress can only reach a
+                # subset of the api.telegram.org anycast block (e.g. a
+                # DPI-bypass router): plain httpx DNS through the proxy would
+                # pick an unreachable IP, but the transport falls through to
+                # the reachable one.
+                if proxy_url:
+                    logger.info(
+                        "[%s] Telegram fallback IPs active via proxy %s: %s",
+                        self.name,
+                        proxy_url,
+                        ", ".join(fallback_ips),
+                    )
+                else:
+                    logger.info(
+                        "[%s] Telegram fallback IPs active: %s",
+                        self.name,
+                        ", ".join(fallback_ips),
+                    )
                 # Keep request/update pools separate to reduce contention during
                 # polling reconnect + bot API bootstrap/delete_webhook calls.
                 # httpx ignores the client-level `limits` kwarg when a custom

--- a/plugins/platforms/telegram/telegram_network.py
+++ b/plugins/platforms/telegram/telegram_network.py
@@ -256,4 +256,13 @@ def _rewrite_request_for_ip(request: httpx.Request, ip: str) -> httpx.Request:
 
 
 def _is_retryable_connect_error(exc: Exception) -> bool:
-    return isinstance(exc, (httpx.ConnectTimeout, httpx.ConnectError))
+    # httpx.ProxyError is NOT a subclass of ConnectError. When TELEGRAM_PROXY
+    # points at a proxy that can reach some Telegram IPs but not the one the
+    # primary DNS path resolved to (e.g. a DPI-bypass router whose upstream
+    # egress only routes a subset of the api.telegram.org anycast block), the
+    # primary attempt raises ProxyError "Host unreachable". Treat that as
+    # retryable so the transport falls through to the reachable fallback IPs
+    # instead of failing the whole request.
+    return isinstance(
+        exc, (httpx.ConnectTimeout, httpx.ConnectError, httpx.ProxyError)
+    )


### PR DESCRIPTION
## Summary

`TELEGRAM_PROXY` and the fallback-IP transport were mutually exclusive, so a proxy whose upstream egress can only reach **part** of the `api.telegram.org` anycast block (e.g. a DPI-bypass router) could not connect at all — even when a reachable Telegram IP existed.

Two root causes:

1. **`_is_retryable_connect_error()` excluded `httpx.ProxyError`.** `httpx.ProxyError` is **not** a subclass of `httpx.ConnectError`, so when the primary DNS path resolved to an IP the proxy couldn't reach, the resulting `ProxyError: Host unreachable` was treated as fatal and the transport never fell through to the fallback IPs.

2. **The adapter engaged `TelegramFallbackTransport` only when no proxy was set** (`if fallback_ips and not proxy_url`). With a proxy configured, plain httpx DNS picked an unreachable IP and there was no IP-pinning fallback.

## Fix

- Treat `httpx.ProxyError` as retryable so the transport falls through to the configured/discovered fallback IPs.
- Engage `TelegramFallbackTransport` whenever fallback IPs are present (it already threads `TELEGRAM_PROXY` through internally), so **proxy + pinned IPs work together**. The log line now distinguishes the proxied path.

Net diff: `+35 / -7` across two files, no behavior change for the default (no-proxy, no-fallback) path.

## Repro

With `TELEGRAM_PROXY=socks5://<proxy>` where the proxy's egress reaches only a subset of Telegram's anycast IPs, the gateway logged repeated `Proxy Server could not connect: Host unreachable.` and never connected. After this change it falls through to the reachable IP and polling succeeds.

## Test Plan

Ran the relevant Telegram suites locally — **104 passed**:

- `tests/gateway/test_telegram_network.py`
- `tests/gateway/test_telegram_network_reconnect.py`
- `tests/gateway/test_telegram_send_path_health.py`
- `tests/gateway/test_telegram_conflict.py`
- `tests/gateway/test_telegram_init_deadline.py`
- `tests/gateway/test_telegram_closewait_limits_31599.py`
- `tests/gateway/test_telegram_send_draft_format.py`

No new env vars, no config surface, no core-tool changes — a self-contained bug fix in the Telegram adapter's connection path.
