### PR TITLE
fix(web): enable screen-reader mode for chat composer

### DIFF
--- a/web/src/pages/ChatPage.a11y.test.ts
+++ b/web/src/pages/ChatPage.a11y.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Regression tests for the web chat composer's accessibility fixes (#36784).
+ *
+ * These are static-source assertions rather than behavioral tests because
+ * ChatPage is a 1100+ line React component with refs, WebSocket effects,
+ * and xterm-coupled event handlers — extracting a meaningful behavioral
+ * test surface would require mocking a full module just to exercise one
+ * branch. The structural invariants below directly encode what the
+ * maintainer flagged: that there is exactly one key handler registration
+ * (because xterm silently overwrites later ones), that screen-reader mode
+ * is enabled on the terminal, and that the host element is an accessible
+ * region with a label.
+ */
+
+const CHAT_PAGE_SRC = readFileSync(
+  resolve(__dirname, "./ChatPage.tsx"),
+  "utf8",
+);
+
+// Strip block AND line comments. Line-comment stripping was added after a
+// review pass: a code comment like `// term.attachCustomKeyEventHandler(...)`
+// would otherwise inflate the "exactly one registration" count and turn a
+// helpful doc comment into a test failure. The identifiers and string
+// literals we care about (`attachCustomKeyEventHandler`, `screenReaderMode`,
+// `"Tab"`, `role`, `aria-label`) are unique enough that literal source
+// counting is reliable after stripping comments.
+function stripComments(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+
+const CHAT_PAGE_NO_COMMENTS = stripComments(CHAT_PAGE_SRC);
+
+describe("ChatPage a11y — terminal screen-reader support (#36784)", () => {
+  it("enables screenReaderMode on the xterm Terminal constructor", () => {
+    expect(CHAT_PAGE_NO_COMMENTS).toMatch(/\bscreenReaderMode\s*:\s*true\b/);
+  });
+
+  it("marks the host div as an accessible region with an aria-label", () => {
+    // Anchor on the hostRef div to make sure we are asserting against the
+    // xterm host element, not any other role="region" in the file. Use
+    // separate matchers (not a single contiguous regex) so attribute
+    // reordering by a code formatter doesn't break the test.
+    expect(CHAT_PAGE_NO_COMMENTS).toMatch(/ref=\{hostRef\}[\s\S]*?role="region"/);
+    expect(CHAT_PAGE_NO_COMMENTS).toMatch(/ref=\{hostRef\}[\s\S]*?aria-label="[^"]+"/);
+  });
+
+  it("registers exactly one attachCustomKeyEventHandler (xterm silently overwrites later registrations)", () => {
+    // xterm.js stores a single _customKeyEventHandler per Terminal and
+    // assign-overwrites on attachCustomKeyEventHandler (see
+    // node_modules/@xterm/xterm/src/browser/CoreBrowserTerminal.ts:914).
+    // A second registration would silently disable the first. Issue #36784
+    // review caught exactly this regression in the first revision of this PR.
+    const matches = CHAT_PAGE_NO_COMMENTS.match(
+      /\bterm\.attachCustomKeyEventHandler\s*\(/g,
+    );
+    expect(matches?.length ?? 0).toBe(1);
+  });
+
+  it("the single key handler routes Tab events to escape (returns false)", () => {
+    // Tab escape is the WCAG 2.1.2 No Keyboard Trap guarantee for screen-reader
+    // and keyboard users. We assert the early branch exists in the single
+    // key handler rather than invoking it — the handler closes over xterm
+    // and the navigator clipboard, which would need full module mocks.
+    expect(CHAT_PAGE_NO_COMMENTS).toMatch(/attachCustomKeyEventHandler\([\s\S]*?if\s*\(\s*ev\.key\s*===\s*"Tab"\s*\)\s*return false/);
+    // Sanity: not a keyup-only guard — Tab escape must run on keydown.
+    expect(CHAT_PAGE_NO_COMMENTS).toMatch(/if\s*\(\s*ev\.type\s*!==\s*"keydown"\s*\)\s*return true/);
+  });
+});

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -404,6 +404,11 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // Browser-embedded chat runs the TUI in inline mode. Keep transcript
       // history in xterm.js so the browser wheel can scroll it directly.
       scrollback: 5000,
+      // Enable screen-reader mode so VoiceOver / NVDA can discover the
+      // off-screen textarea xterm creates for assistive technology.
+      // Without this the chat composer is invisible to screen readers.
+      // See #36784.
+      screenReaderMode: true,
       theme: terminalTheme,
     });
     termRef.current = term;
@@ -529,6 +534,13 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     term.loadAddon(new WebLinksAddon());
 
     term.open(host);
+
+    // Let Tab / Shift-Tab escape the terminal so screen-reader and keyboard
+    // users can navigate to other page controls (WCAG 2.1.2 No Keyboard Trap).
+    term.attachCustomKeyEventHandler((event) => {
+      if (event.key === "Tab") return false;
+      return true;
+    });
 
     // WebGL draws from a texture atlas sized with device pixels. On phones and
     // in DevTools device mode that often produces *visually* much larger cells
@@ -1035,6 +1047,8 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         >
           <div
             ref={hostRef}
+            role="region"
+            aria-label="Chat terminal"
             className="hermes-chat-xterm-host min-h-0 min-w-0 flex-1"
           />
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -464,6 +464,15 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     term.attachCustomKeyEventHandler((ev) => {
       if (ev.type !== "keydown") return true;
 
+      // Let Tab / Shift-Tab escape the terminal so screen-reader and keyboard
+      // users can navigate to other page controls (WCAG 2.1.2 No Keyboard Trap).
+      // Folding into the existing handler — xterm stores one handler per
+      // terminal (lib/xterm.js CoreBrowserTerminal.attachCustomKeyEventHandler
+      // assigns directly to `_customKeyEventHandler`), so registering Tab
+      // escape separately would silently overwrite the clipboard handler and
+      // Tab would never escape. See #36784.
+      if (ev.key === "Tab") return false;
+
       // Copy: Cmd+C on macOS, Ctrl+Shift+C on other platforms. Bare Ctrl+C
       // is reserved for SIGINT to the TUI child — matches xterm / gnome-terminal /
       // konsole / Windows Terminal. Ctrl+Shift+C only copies if a selection exists;
@@ -534,13 +543,6 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     term.loadAddon(new WebLinksAddon());
 
     term.open(host);
-
-    // Let Tab / Shift-Tab escape the terminal so screen-reader and keyboard
-    // users can navigate to other page controls (WCAG 2.1.2 No Keyboard Trap).
-    term.attachCustomKeyEventHandler((event) => {
-      if (event.key === "Tab") return false;
-      return true;
-    });
 
     // WebGL draws from a texture atlas sized with device pixels. On phones and
     // in DevTools device mode that often produces *visually* much larger cells


### PR DESCRIPTION
## Summary

The web UI chat composer uses xterm.js, which renders to a canvas — invisible to VoiceOver/NVDA. This PR makes the composer discoverable by screen readers.

## Changes

1. **`screenReaderMode: true`** on the xterm Terminal constructor — creates the offscreen textarea that screen readers need to interact with the input
2. **Tab escape handler** via `attachCustomKeyEventHandler` — prevents keyboard traps so screen-reader and keyboard users can navigate to other page controls (WCAG 2.1.2)
3. **`role="region"` + `aria-label`** on the xterm host div — labeled landmark for the chat area

## Context

- PR #49413 adds `screenReaderMode` to the **desktop app's** terminal panel but does not touch the web UI
- The desktop app's composer (React contenteditable) already has `role="textbox"` + `aria-label="Message"` — that's a different component
- Fixes #36784
