### PR TITLE
fix(acp): preserve explicit model providers

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -649,10 +649,44 @@ class HermesACPAgent(acp.Agent):
         new_model = raw_model.strip()
 
         try:
-            from hermes_cli.models import detect_provider_for_model, parse_model_input
+            from hermes_cli.models import (
+                _KNOWN_PROVIDER_NAMES,
+                detect_provider_for_model,
+                normalize_provider,
+                parse_model_input,
+            )
 
-            target_provider, new_model = parse_model_input(new_model, current_provider)
-            if target_provider == current_provider:
+            stripped_model = new_model.strip()
+            explicit_provider = False
+
+            colon = stripped_model.find(":")
+            if colon > 0:
+                provider_part = stripped_model[:colon].strip().lower()
+                model_part = stripped_model[colon + 1 :].strip()
+                explicit_provider = bool(
+                    provider_part and model_part and provider_part in _KNOWN_PROVIDER_NAMES
+                )
+
+            slash_handled = False
+            slash = stripped_model.find("/")
+            if not explicit_provider and slash > 0:
+                provider_part = stripped_model[:slash].strip().lower()
+                model_part = stripped_model[slash + 1 :].strip()
+                if (
+                    provider_part
+                    and model_part
+                    and provider_part in _KNOWN_PROVIDER_NAMES
+                    and normalize_provider(provider_part) == normalize_provider(current_provider)
+                ):
+                    target_provider = normalize_provider(provider_part)
+                    new_model = model_part
+                    explicit_provider = True
+                    slash_handled = True
+
+            if not slash_handled:
+                target_provider, new_model = parse_model_input(new_model, current_provider)
+
+            if not explicit_provider and target_provider == current_provider:
                 detected = detect_provider_for_model(new_model, current_provider)
                 if detected:
                     target_provider, new_model = detected

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -67,6 +67,43 @@ def make_agent_and_state():
     return acp_agent, state, fake, conn
 
 
+def test_acp_model_selection_preserves_explicit_provider(monkeypatch):
+    """ACP provider-qualified model IDs must not be re-detected as OpenRouter."""
+    from hermes_cli import models
+
+    detect_calls = []
+
+    def fake_detect_provider_for_model(model_name, current_provider):
+        detect_calls.append((model_name, current_provider))
+        return "openrouter", f"anthropic/{model_name}"
+
+    monkeypatch.setattr(models, "detect_provider_for_model", fake_detect_provider_for_model)
+
+    assert HermesACPAgent._resolve_model_selection(
+        "anthropic:claude-sonnet-5",
+        "anthropic",
+    ) == ("anthropic", "claude-sonnet-5")
+    assert detect_calls == []
+
+    assert HermesACPAgent._resolve_model_selection(
+        "anthropic:claude-sonnet-5",
+        "openrouter",
+    ) == ("anthropic", "claude-sonnet-5")
+    assert detect_calls == []
+
+    assert HermesACPAgent._resolve_model_selection(
+        "anthropic/claude-sonnet-5",
+        "anthropic",
+    ) == ("anthropic", "claude-sonnet-5")
+    assert detect_calls == []
+
+    assert HermesACPAgent._resolve_model_selection(
+        "claude-sonnet-5",
+        "anthropic",
+    ) == ("openrouter", "anthropic/claude-sonnet-5")
+    assert detect_calls == [("claude-sonnet-5", "anthropic")]
+
+
 def test_acp_real_agent_gets_session_db_for_recall(monkeypatch):
     """ACP sessions persist to SessionDB; recall must receive the same DB handle."""
     captured = {}


### PR DESCRIPTION
## Summary
- Preserve explicit ACP `provider:model` selections instead of running provider auto-detection over them.
- Refs #59089.

## Why
- `session/set_model` could parse `anthropic:claude-sonnet-5` correctly, then immediately re-run `detect_provider_for_model` because the parsed provider matched the current provider.
- For new Anthropic model IDs that OpenRouter also indexes, that fallback can silently rewrite the provider to `openrouter` and fail sessions without OpenRouter credentials.

## Changes
- `acp_adapter/server.py`: track provider-qualified ACP model inputs and skip provider auto-detection for explicit provider selections; also normalize current-provider slash form like `anthropic/claude-sonnet-5` for ACP callers.
- `tests/acp_adapter/test_acp_commands.py`: cover explicit colon and current-provider slash selections, plus the unchanged bare-model auto-detection path.

## Validation
- `python -m pytest tests/acp_adapter/test_acp_commands.py -q -o 'addopts='` (7 passed)
- `python -m py_compile acp_adapter/server.py`
- `git diff --check`

## Scope
- In scope: ACP `session/set_model` provider resolution for explicit provider-qualified model inputs.
- Out of scope: broader `/model` slash-command/provider auto-detection behavior tracked by related issues.
