### PR TITLE
[codex] fix LM Studio context metadata fallback

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1149,6 +1149,81 @@ def _add_model_aliases(cache: Dict[str, Dict[str, Any]], model_id: str, entry: D
         cache.setdefault(bare_model, entry)
 
 
+def _lmstudio_native_context_length(model_payload: Dict[str, Any]) -> Optional[int]:
+    """Return the best context length from an LM Studio native model record.
+
+    Loaded instance context is the actual runtime allocation. When a model is
+    not loaded, LM Studio still exposes ``max_context_length`` as the training
+    max; use that as the best available fallback.
+    """
+    for inst in model_payload.get("loaded_instances", []) or []:
+        if not isinstance(inst, dict):
+            continue
+        cfg = inst.get("config", {})
+        ctx = cfg.get("context_length") if isinstance(cfg, dict) else None
+        coerced = _coerce_reasonable_int(ctx)
+        if coerced is not None:
+            return coerced
+
+    for key in ("max_context_length", "context_length"):
+        coerced = _coerce_reasonable_int(model_payload.get(key))
+        if coerced is not None:
+            return coerced
+
+    return None
+
+
+def _lmstudio_native_metadata_cache(payload: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    cache: Dict[str, Dict[str, Any]] = {}
+    for model in payload.get("models", []):
+        if not isinstance(model, dict):
+            continue
+        model_id = model.get("key") or model.get("id")
+        if not model_id:
+            continue
+        entry: Dict[str, Any] = {"name": model.get("name", model_id)}
+
+        context_length = _lmstudio_native_context_length(model)
+        if context_length is not None:
+            entry["context_length"] = context_length
+
+        max_completion_tokens = _extract_max_completion_tokens(model)
+        if max_completion_tokens is not None:
+            entry["max_completion_tokens"] = max_completion_tokens
+
+        pricing = _extract_pricing(model)
+        if pricing:
+            entry["pricing"] = pricing
+
+        _add_model_aliases(cache, model_id, entry)
+        alt_id = model.get("id")
+        if isinstance(alt_id, str) and alt_id and alt_id != model_id:
+            _add_model_aliases(cache, alt_id, entry)
+    return cache
+
+
+def _fetch_lmstudio_native_metadata(
+    base_url: str,
+    headers: Dict[str, str],
+    *,
+    timeout: Any = (5, 10),
+) -> Dict[str, Dict[str, Any]]:
+    server_url = _lmstudio_server_root(base_url)
+    response = requests.get(
+        server_url.rstrip("/") + "/api/v1/models",
+        headers=headers,
+        timeout=timeout,
+        verify=_resolve_requests_verify(),
+    )
+    response.raise_for_status()
+    payload = response.json()
+    return _lmstudio_native_metadata_cache(payload)
+
+
+def _metadata_has_context_length(cache: Dict[str, Dict[str, Any]]) -> bool:
+    return any(isinstance(entry.get("context_length"), int) for entry in cache.values())
+
+
 def fetch_model_metadata(force_refresh: bool = False) -> Dict[str, Dict[str, Any]]:
     """Fetch model metadata from OpenRouter (cached for 1 hour)."""
     global _model_metadata_cache, _model_metadata_cache_time
@@ -1251,49 +1326,7 @@ def fetch_endpoint_model_metadata(
     if is_local_endpoint(normalized):
         try:
             if detect_local_server_type(normalized, api_key=api_key) == "lm-studio":
-                server_url = _lmstudio_server_root(normalized)
-                response = requests.get(
-                    server_url.rstrip("/") + "/api/v1/models",
-                    headers=headers,
-                    timeout=(5, 10),
-                    verify=_resolve_requests_verify(),
-                )
-                response.raise_for_status()
-                payload = response.json()
-                cache: Dict[str, Dict[str, Any]] = {}
-                for model in payload.get("models", []):
-                    if not isinstance(model, dict):
-                        continue
-                    model_id = model.get("key") or model.get("id")
-                    if not model_id:
-                        continue
-                    entry: Dict[str, Any] = {"name": model.get("name", model_id)}
-
-                    context_length = None
-                    for inst in model.get("loaded_instances", []) or []:
-                        if not isinstance(inst, dict):
-                            continue
-                        cfg = inst.get("config", {})
-                        ctx = cfg.get("context_length") if isinstance(cfg, dict) else None
-                        if isinstance(ctx, int) and ctx > 0:
-                            context_length = ctx
-                            break
-                    if context_length is not None:
-                        entry["context_length"] = context_length
-
-                    max_completion_tokens = _extract_max_completion_tokens(model)
-                    if max_completion_tokens is not None:
-                        entry["max_completion_tokens"] = max_completion_tokens
-
-                    pricing = _extract_pricing(model)
-                    if pricing:
-                        entry["pricing"] = pricing
-
-                    _add_model_aliases(cache, model_id, entry)
-                    alt_id = model.get("id")
-                    if isinstance(alt_id, str) and alt_id and alt_id != model_id:
-                        _add_model_aliases(cache, alt_id, entry)
-
+                cache = _fetch_lmstudio_native_metadata(normalized, headers)
                 _endpoint_model_metadata_cache[normalized] = cache
                 _endpoint_model_metadata_cache_time[normalized] = time.time()
                 return cache
@@ -1349,6 +1382,23 @@ def fetch_endpoint_model_metadata(
                 if pricing:
                     entry["pricing"] = pricing
                 _add_model_aliases(cache, model_id, entry)
+
+            is_lmstudio = any(
+                str(model.get("owned_by", "")).lower() in {"lmstudio", "lm-studio"}
+                for model in payload.get("data", [])
+                if isinstance(model, dict)
+            )
+            if is_lmstudio and cache and not _metadata_has_context_length(cache):
+                try:
+                    lmstudio_cache = _fetch_lmstudio_native_metadata(
+                        normalized,
+                        headers,
+                        timeout=3,
+                    )
+                    if lmstudio_cache:
+                        cache = lmstudio_cache
+                except Exception as exc:
+                    last_error = exc
 
             # If this is a llama.cpp server, query /props for actual allocated context
             is_llamacpp = any(
@@ -2117,12 +2167,9 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
                     data = resp.json()
                     for m in data.get("models", []):
                         if _model_id_matches(m.get("key", ""), model) or _model_id_matches(m.get("id", ""), model):
-                            # Prefer loaded instance context (actual runtime value)
-                            for inst in m.get("loaded_instances", []):
-                                cfg = inst.get("config", {})
-                                ctx = cfg.get("context_length")
-                                if ctx and isinstance(ctx, (int, float)):
-                                    return int(ctx)
+                            ctx = _lmstudio_native_context_length(m)
+                            if ctx is not None:
+                                return ctx
                             break
 
             # LM Studio / vLLM / llama.cpp: try /v1/models/{model}

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1267,6 +1267,81 @@ def _add_model_aliases(cache: Dict[str, Dict[str, Any]], model_id: str, entry: D
         cache.setdefault(bare_model, entry)
 
 
+def _lmstudio_native_context_length(model_payload: Dict[str, Any]) -> Optional[int]:
+    """Return the best context length from an LM Studio native model record.
+
+    Loaded instance context is the actual runtime allocation. When a model is
+    not loaded, LM Studio still exposes ``max_context_length`` as the training
+    max; use that as the best available fallback.
+    """
+    for inst in model_payload.get("loaded_instances", []) or []:
+        if not isinstance(inst, dict):
+            continue
+        cfg = inst.get("config", {})
+        ctx = cfg.get("context_length") if isinstance(cfg, dict) else None
+        coerced = _coerce_reasonable_int(ctx)
+        if coerced is not None:
+            return coerced
+
+    for key in ("max_context_length", "context_length"):
+        coerced = _coerce_reasonable_int(model_payload.get(key))
+        if coerced is not None:
+            return coerced
+
+    return None
+
+
+def _lmstudio_native_metadata_cache(payload: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    cache: Dict[str, Dict[str, Any]] = {}
+    for model in payload.get("models", []):
+        if not isinstance(model, dict):
+            continue
+        model_id = model.get("key") or model.get("id")
+        if not model_id:
+            continue
+        entry: Dict[str, Any] = {"name": model.get("name", model_id)}
+
+        context_length = _lmstudio_native_context_length(model)
+        if context_length is not None:
+            entry["context_length"] = context_length
+
+        max_completion_tokens = _extract_max_completion_tokens(model)
+        if max_completion_tokens is not None:
+            entry["max_completion_tokens"] = max_completion_tokens
+
+        pricing = _extract_pricing(model)
+        if pricing:
+            entry["pricing"] = pricing
+
+        _add_model_aliases(cache, model_id, entry)
+        alt_id = model.get("id")
+        if isinstance(alt_id, str) and alt_id and alt_id != model_id:
+            _add_model_aliases(cache, alt_id, entry)
+    return cache
+
+
+def _fetch_lmstudio_native_metadata(
+    base_url: str,
+    headers: Dict[str, str],
+    *,
+    timeout: Any = (5, 10),
+) -> Dict[str, Dict[str, Any]]:
+    server_url = _lmstudio_server_root(base_url)
+    response = requests.get(
+        server_url.rstrip("/") + "/api/v1/models",
+        headers=headers,
+        timeout=timeout,
+        verify=_resolve_requests_verify(base_url),
+    )
+    response.raise_for_status()
+    payload = response.json()
+    return _lmstudio_native_metadata_cache(payload)
+
+
+def _metadata_has_context_length(cache: Dict[str, Dict[str, Any]]) -> bool:
+    return any(isinstance(entry.get("context_length"), int) for entry in cache.values())
+
+
 def fetch_model_metadata(force_refresh: bool = False) -> Dict[str, Dict[str, Any]]:
     """Fetch model metadata from OpenRouter (cached for 1 hour)."""
     global _model_metadata_cache, _model_metadata_cache_time
@@ -1369,49 +1444,7 @@ def fetch_endpoint_model_metadata(
     if is_local_endpoint(normalized):
         try:
             if detect_local_server_type(normalized, api_key=api_key) == "lm-studio":
-                server_url = _lmstudio_server_root(normalized)
-                response = requests.get(
-                    server_url.rstrip("/") + "/api/v1/models",
-                    headers=headers,
-                    timeout=(5, 10),
-                    verify=_resolve_requests_verify(normalized),
-                )
-                response.raise_for_status()
-                payload = response.json()
-                cache: Dict[str, Dict[str, Any]] = {}
-                for model in payload.get("models", []):
-                    if not isinstance(model, dict):
-                        continue
-                    model_id = model.get("key") or model.get("id")
-                    if not model_id:
-                        continue
-                    entry: Dict[str, Any] = {"name": model.get("name", model_id)}
-
-                    context_length = None
-                    for inst in model.get("loaded_instances", []) or []:
-                        if not isinstance(inst, dict):
-                            continue
-                        cfg = inst.get("config", {})
-                        ctx = cfg.get("context_length") if isinstance(cfg, dict) else None
-                        if isinstance(ctx, int) and ctx > 0:
-                            context_length = ctx
-                            break
-                    if context_length is not None:
-                        entry["context_length"] = context_length
-
-                    max_completion_tokens = _extract_max_completion_tokens(model)
-                    if max_completion_tokens is not None:
-                        entry["max_completion_tokens"] = max_completion_tokens
-
-                    pricing = _extract_pricing(model)
-                    if pricing:
-                        entry["pricing"] = pricing
-
-                    _add_model_aliases(cache, model_id, entry)
-                    alt_id = model.get("id")
-                    if isinstance(alt_id, str) and alt_id and alt_id != model_id:
-                        _add_model_aliases(cache, alt_id, entry)
-
+                cache = _fetch_lmstudio_native_metadata(normalized, headers)
                 _endpoint_model_metadata_cache[normalized] = cache
                 _endpoint_model_metadata_cache_time[normalized] = time.time()
                 return cache
@@ -1467,6 +1500,23 @@ def fetch_endpoint_model_metadata(
                 if pricing:
                     entry["pricing"] = pricing
                 _add_model_aliases(cache, model_id, entry)
+
+            is_lmstudio = any(
+                str(model.get("owned_by", "")).lower() in {"lmstudio", "lm-studio"}
+                for model in payload.get("data", [])
+                if isinstance(model, dict)
+            )
+            if is_lmstudio and cache and not _metadata_has_context_length(cache):
+                try:
+                    lmstudio_cache = _fetch_lmstudio_native_metadata(
+                        normalized,
+                        headers,
+                        timeout=3,
+                    )
+                    if lmstudio_cache:
+                        cache = lmstudio_cache
+                except Exception as exc:
+                    last_error = exc
 
             # If this is a llama.cpp server, query /props for actual allocated context
             is_llamacpp = any(
@@ -2346,12 +2396,9 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
                     data = resp.json()
                     for m in data.get("models", []):
                         if _model_id_matches(m.get("key", ""), model) or _model_id_matches(m.get("id", ""), model):
-                            # Prefer loaded instance context (actual runtime value)
-                            for inst in m.get("loaded_instances", []):
-                                cfg = inst.get("config", {})
-                                ctx = cfg.get("context_length")
-                                if ctx and isinstance(ctx, (int, float)):
-                                    return int(ctx)
+                            ctx = _lmstudio_native_context_length(m)
+                            if ctx is not None:
+                                return ctx
                             break
 
             # LM Studio / vLLM / llama.cpp / Anthropic-compat proxies:

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -539,6 +539,34 @@ class TestQueryLocalContextLengthLmStudio:
 
 
 
+    def test_lmstudio_unloaded_model_uses_max_context_length(self):
+        """Falls back to max_context_length when the matching model is not loaded."""
+        from agent.model_metadata import _query_local_context_length
+
+        native_resp = self._make_resp(200, {
+            "models": [
+                {
+                    "key": "nvidia/nvidia-nemotron-super-49b-v1",
+                    "id": "nvidia/nvidia-nemotron-super-49b-v1",
+                    "max_context_length": 1_048_576,
+                    "loaded_instances": [],
+                },
+            ]
+        })
+        client_mock = self._make_client(
+            native_resp,
+            self._make_resp(404, {}),
+            self._make_resp(404, {}),
+        )
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value="lm-studio"), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length(
+                "nvidia-nemotron-super-49b-v1", "http://192.168.1.22:1234/v1"
+            )
+
+        assert result == 1_048_576
+
     def test_lmstudio_native_api_base_url_is_not_doubled(self):
         from agent.model_metadata import _query_local_context_length
 
@@ -716,6 +744,92 @@ class TestFetchEndpointModelMetadataLmStudio:
 
         assert mock_get.call_args[0][0] == "http://localhost:1234/api/v1/models"
         assert result["publisher/model-a"]["context_length"] == 65536
+
+    def test_unloaded_model_uses_max_context_length(self):
+        from agent.model_metadata import fetch_endpoint_model_metadata
+
+        native_resp = self._make_resp(
+            {
+                "models": [
+                    {
+                        "key": "publisher/model-a",
+                        "id": "publisher/model-a",
+                        "max_context_length": 1_048_576,
+                        "loaded_instances": [],
+                    }
+                ]
+            }
+        )
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value="lm-studio"), \
+             patch("agent.model_metadata.requests.get", return_value=native_resp):
+            result = fetch_endpoint_model_metadata(
+                "http://localhost:1234/v1",
+                force_refresh=True,
+            )
+
+        assert result["publisher/model-a"]["context_length"] == 1_048_576
+
+    def test_remote_lmstudio_falls_back_to_native_context_metadata(self):
+        from agent.model_metadata import fetch_endpoint_model_metadata
+
+        openai_resp = self._make_resp(
+            {
+                "data": [
+                    {
+                        "id": "publisher/model-a",
+                        "object": "model",
+                        "owned_by": "lmstudio",
+                    }
+                ]
+            }
+        )
+        native_resp = self._make_resp(
+            {
+                "models": [
+                    {
+                        "key": "publisher/model-a",
+                        "id": "publisher/model-a",
+                        "max_context_length": 100_000,
+                        "loaded_instances": [],
+                    }
+                ]
+            }
+        )
+
+        with patch("agent.model_metadata.requests.get", side_effect=[openai_resp, native_resp]) as mock_get:
+            result = fetch_endpoint_model_metadata(
+                "https://lmstudio.example.com/v1",
+                force_refresh=True,
+            )
+
+        assert mock_get.call_args_list[0].args[0] == "https://lmstudio.example.com/v1/models"
+        assert mock_get.call_args_list[1].args[0] == "https://lmstudio.example.com/api/v1/models"
+        assert result["publisher/model-a"]["context_length"] == 100_000
+
+    def test_remote_non_lmstudio_does_not_probe_native_api(self):
+        from agent.model_metadata import fetch_endpoint_model_metadata
+
+        openai_resp = self._make_resp(
+            {
+                "data": [
+                    {
+                        "id": "publisher/model-a",
+                        "object": "model",
+                        "owned_by": "vllm",
+                    }
+                ]
+            }
+        )
+
+        with patch("agent.model_metadata.requests.get", return_value=openai_resp) as mock_get:
+            result = fetch_endpoint_model_metadata(
+                "https://vllm.example.com/v1",
+                force_refresh=True,
+            )
+
+        assert mock_get.call_count == 1
+        assert result["publisher/model-a"] == {"name": "publisher/model-a"}
 
 
 class TestQueryLocalContextLengthNetworkError:

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -331,6 +331,34 @@ class TestQueryLocalContextLengthLmStudio:
 
 
 
+    def test_lmstudio_unloaded_model_uses_max_context_length(self):
+        """Falls back to max_context_length when the matching model is not loaded."""
+        from agent.model_metadata import _query_local_context_length
+
+        native_resp = self._make_resp(200, {
+            "models": [
+                {
+                    "key": "nvidia/nvidia-nemotron-super-49b-v1",
+                    "id": "nvidia/nvidia-nemotron-super-49b-v1",
+                    "max_context_length": 1_048_576,
+                    "loaded_instances": [],
+                },
+            ]
+        })
+        client_mock = self._make_client(
+            native_resp,
+            self._make_resp(404, {}),
+            self._make_resp(404, {}),
+        )
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value="lm-studio"), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length(
+                "nvidia-nemotron-super-49b-v1", "http://192.168.1.22:1234/v1"
+            )
+
+        assert result == 1_048_576
+
     def test_lmstudio_native_api_base_url_is_not_doubled(self):
         from agent.model_metadata import _query_local_context_length
 
@@ -508,6 +536,92 @@ class TestFetchEndpointModelMetadataLmStudio:
 
         assert mock_get.call_args[0][0] == "http://localhost:1234/api/v1/models"
         assert result["publisher/model-a"]["context_length"] == 65536
+
+    def test_unloaded_model_uses_max_context_length(self):
+        from agent.model_metadata import fetch_endpoint_model_metadata
+
+        native_resp = self._make_resp(
+            {
+                "models": [
+                    {
+                        "key": "publisher/model-a",
+                        "id": "publisher/model-a",
+                        "max_context_length": 1_048_576,
+                        "loaded_instances": [],
+                    }
+                ]
+            }
+        )
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value="lm-studio"), \
+             patch("agent.model_metadata.requests.get", return_value=native_resp):
+            result = fetch_endpoint_model_metadata(
+                "http://localhost:1234/v1",
+                force_refresh=True,
+            )
+
+        assert result["publisher/model-a"]["context_length"] == 1_048_576
+
+    def test_remote_lmstudio_falls_back_to_native_context_metadata(self):
+        from agent.model_metadata import fetch_endpoint_model_metadata
+
+        openai_resp = self._make_resp(
+            {
+                "data": [
+                    {
+                        "id": "publisher/model-a",
+                        "object": "model",
+                        "owned_by": "lmstudio",
+                    }
+                ]
+            }
+        )
+        native_resp = self._make_resp(
+            {
+                "models": [
+                    {
+                        "key": "publisher/model-a",
+                        "id": "publisher/model-a",
+                        "max_context_length": 100_000,
+                        "loaded_instances": [],
+                    }
+                ]
+            }
+        )
+
+        with patch("agent.model_metadata.requests.get", side_effect=[openai_resp, native_resp]) as mock_get:
+            result = fetch_endpoint_model_metadata(
+                "https://lmstudio.example.com/v1",
+                force_refresh=True,
+            )
+
+        assert mock_get.call_args_list[0].args[0] == "https://lmstudio.example.com/v1/models"
+        assert mock_get.call_args_list[1].args[0] == "https://lmstudio.example.com/api/v1/models"
+        assert result["publisher/model-a"]["context_length"] == 100_000
+
+    def test_remote_non_lmstudio_does_not_probe_native_api(self):
+        from agent.model_metadata import fetch_endpoint_model_metadata
+
+        openai_resp = self._make_resp(
+            {
+                "data": [
+                    {
+                        "id": "publisher/model-a",
+                        "object": "model",
+                        "owned_by": "vllm",
+                    }
+                ]
+            }
+        )
+
+        with patch("agent.model_metadata.requests.get", return_value=openai_resp) as mock_get:
+            result = fetch_endpoint_model_metadata(
+                "https://vllm.example.com/v1",
+                force_refresh=True,
+            )
+
+        assert mock_get.call_count == 1
+        assert result["publisher/model-a"] == {"name": "publisher/model-a"}
 
 
 class TestQueryLocalContextLengthNetworkError:


### PR DESCRIPTION
## Summary
- prefer LM Studio loaded instance `context_length` but fall back to native `max_context_length` when the model is not loaded
- reuse the native LM Studio parser for endpoint metadata and direct local context probes
- fall back from bare OpenAI-compatible `/models` metadata to LM Studio native `/api/v1/models` when remote LM Studio listings omit context length

Fixes #47678.
Fixes #47200.

## Validation
- `uv run python -m pytest tests/agent/test_model_metadata.py tests/agent/test_model_metadata_local_ctx.py -q`
- `uv run ruff check agent/model_metadata.py tests/agent/test_model_metadata_local_ctx.py`