### PR TITLE
feat(gateway): make Telegram clarify durable

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4874,6 +4874,30 @@ def run_conversation(
 
                 agent._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
 
+                try:
+                    from gateway.extensions.deferred_clarify import (
+                        find_deferred_clarify_interaction_id,
+                    )
+                    _tool_call_ids = {
+                        getattr(tc, "id", None)
+                        for tc in assistant_message.tool_calls
+                        if getattr(tc, "id", None)
+                    }
+                    _deferred_clarify_id = find_deferred_clarify_interaction_id(
+                        messages,
+                        _tool_call_ids,
+                    )
+                    if _deferred_clarify_id:
+                        final_response = "NO_REPLY"
+                        _turn_exit_reason = f"deferred_clarify({_deferred_clarify_id})"
+                        try:
+                            agent._deferred_clarify_interaction_id = _deferred_clarify_id
+                        except Exception:
+                            pass
+                        break
+                except Exception:
+                    logger.debug("deferred clarify marker detection failed", exc_info=True)
+
                 if agent._tool_guardrail_halt_decision is not None:
                     decision = agent._tool_guardrail_halt_decision
                     _turn_exit_reason = "guardrail_halt"

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -6774,6 +6774,30 @@ def run_conversation(
                     failed = True
                     break
 
+                try:
+                    from gateway.extensions.deferred_clarify import (
+                        find_deferred_clarify_interaction_id,
+                    )
+                    _tool_call_ids = {
+                        getattr(tc, "id", None)
+                        for tc in assistant_message.tool_calls
+                        if getattr(tc, "id", None)
+                    }
+                    _deferred_clarify_id = find_deferred_clarify_interaction_id(
+                        messages,
+                        _tool_call_ids,
+                    )
+                    if _deferred_clarify_id:
+                        final_response = "NO_REPLY"
+                        _turn_exit_reason = f"deferred_clarify({_deferred_clarify_id})"
+                        try:
+                            agent._deferred_clarify_interaction_id = _deferred_clarify_id
+                        except Exception:
+                            pass
+                        break
+                except Exception:
+                    logger.debug("deferred clarify marker detection failed", exc_info=True)
+
                 if agent._tool_guardrail_halt_decision is not None:
                     decision = agent._tool_guardrail_halt_decision
                     _turn_exit_reason = "guardrail_halt"

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -465,6 +465,9 @@ def finalize_turn(
         ).get("service_tier"),
         "session_id": agent.session_id,
     }
+    _deferred_clarify_interaction_id = getattr(agent, "_deferred_clarify_interaction_id", None)
+    if _deferred_clarify_interaction_id:
+        result["deferred_clarify_interaction_id"] = _deferred_clarify_interaction_id
     if agent._tool_guardrail_halt_decision is not None:
         result["guardrail"] = agent._tool_guardrail_halt_decision.to_metadata()
     # Surface any post-loop cleanup failures so the caller can distinguish a

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -688,6 +688,9 @@ def finalize_turn(
         ).get("service_tier"),
         "session_id": agent.session_id,
     }
+    _deferred_clarify_interaction_id = getattr(agent, "_deferred_clarify_interaction_id", None)
+    if _deferred_clarify_interaction_id:
+        result["deferred_clarify_interaction_id"] = _deferred_clarify_interaction_id
     if agent._tool_guardrail_halt_decision is not None:
         result["guardrail"] = agent._tool_guardrail_halt_decision.to_metadata()
     # Persistence failures already set failed=True + an explanation in

--- a/gateway/extensions/deferred_clarify.py
+++ b/gateway/extensions/deferred_clarify.py
@@ -1,0 +1,105 @@
+"""Helpers for durable deferred gateway clarify turns."""
+
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+DEFERRED_CLARIFY_KIND = "hermes.deferred_clarify.v1"
+
+
+def make_deferred_marker(interaction_id: str) -> str:
+    """Return a provider-valid tool result that asks the loop to suspend."""
+    return json.dumps(
+        {
+            "status": "deferred",
+            "kind": DEFERRED_CLARIFY_KIND,
+            "interaction_id": str(interaction_id),
+            "message": "Clarify prompt sent to user; current turn is suspended.",
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
+def parse_deferred_marker(content: object) -> Optional[str]:
+    """Extract a deferred clarify interaction id from a tool result string."""
+    if not isinstance(content, str):
+        return None
+    try:
+        payload = json.loads(content)
+    except Exception:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("status") != "deferred" or payload.get("kind") != DEFERRED_CLARIFY_KIND:
+        return None
+    interaction_id = payload.get("interaction_id")
+    if not isinstance(interaction_id, str) or not interaction_id:
+        return None
+    return interaction_id
+
+
+def is_deferred_clarify_result(content: object) -> bool:
+    return parse_deferred_marker(content) is not None
+
+
+def find_deferred_clarify_interaction_id(
+    messages: list[dict],
+    tool_call_ids: set[str],
+) -> Optional[str]:
+    """Find a deferred marker in the real ``clarify_tool`` result envelope.
+
+    ``clarify_tool`` wraps the callback value under ``user_response``.  Keep
+    detection constrained to tool rows produced by the current assistant turn
+    and explicitly named ``clarify`` so arbitrary tool output cannot suspend
+    the conversation loop by mimicking the marker.
+    """
+    for message in reversed(messages):
+        if not isinstance(message, dict):
+            continue
+        if message.get("role") == "assistant":
+            break
+        if message.get("role") != "tool":
+            continue
+        if message.get("tool_call_id") not in tool_call_ids:
+            continue
+        if (message.get("name") or message.get("tool_name")) != "clarify":
+            continue
+        content = message.get("content")
+        if not isinstance(content, str):
+            continue
+        try:
+            envelope = json.loads(content)
+        except Exception:
+            continue
+        if not isinstance(envelope, dict):
+            continue
+        user_response = envelope.get("user_response")
+        interaction_id = parse_deferred_marker(user_response)
+        if interaction_id:
+            return interaction_id
+    return None
+
+
+def build_recovery_prompt(*, question: str, answer: str) -> str:
+    """Build the synthetic user turn that resumes a deferred clarify."""
+    return (
+        "The user answered a clarify prompt from the previous Hermes turn.\n\n"
+        "Previous question:\n"
+        f"{question}\n\n"
+        "User answer:\n"
+        f"{answer}\n\n"
+        "Continue the previous task using this answer. Do not ask the same "
+        "clarification again unless the answer is still ambiguous."
+    )
+
+
+__all__ = [
+    "DEFERRED_CLARIFY_KIND",
+    "make_deferred_marker",
+    "parse_deferred_marker",
+    "is_deferred_clarify_result",
+    "find_deferred_clarify_interaction_id",
+    "build_recovery_prompt",
+]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7700,7 +7700,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # ends the prior session in SQLite and reopens the CLI session under
         # the new key. The CLI's transcript becomes the active one for the
         # gateway from this moment on.
-        switched = await self.async_session_store.switch_session(session_key, cli_session_id)
+        await self._cancel_deferred_clarify_session(session_key, reason="session_handoff")
+        switched = await self.async_session_store.switch_session(
+            session_key,
+            cli_session_id,
+        )
         if switched is None:
             raise RuntimeError(
                 f"could not switch session key {session_key} → {cli_session_id}"
@@ -8249,6 +8253,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             self._running = False
             self._draining = True
+            await self._cancel_all_deferred_clarify(
+                reason=("gateway_restart" if self._restart_requested else "gateway_shutdown")
+            )
 
             # Notify all chats with active agents BEFORE draining.
             # Adapters are still connected here, so messages can be sent.
@@ -8422,6 +8429,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.info(
                 "Shutdown phase: all adapters disconnected at +%.2fs",
                 _phase_elapsed(),
+            )
+            # A turn already draining when shutdown began may create a deferred
+            # prompt after the initial cancellation pass.  Once agents are
+            # finalized and adapters are disconnected, sweep again so no button
+            # from that race can resume work after the session boundary.
+            await self._cancel_all_deferred_clarify(
+                reason=(
+                    "gateway_restart_final"
+                    if self._restart_requested
+                    else "gateway_shutdown_final"
+                )
             )
 
             for _task in list(self._background_tasks):
@@ -10562,6 +10580,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _safe_user_name = neutralize_untrusted_inline_text(source.user_name)
             message_text = f"[{_safe_user_name}] {message_text}"
 
+        # Durable deferred clarify text answers must be consumed before the
+        # normal message reaches the agent; otherwise an open-ended answer (or
+        # an "Other" response) becomes an unrelated user turn after restart.
+        if message_text and not str(message_text).lstrip().startswith("/"):
+            try:
+                from gateway.extensions.deferred_clarify import build_recovery_prompt
+                from tools.clarify_interaction import resolve_text_for_session
+
+                _resolved_clarify = resolve_text_for_session(
+                    session_key,
+                    str(message_text),
+                    user_id=str(source.user_id) if source.user_id is not None else None,
+                    chat_id=str(source.chat_id) if source.chat_id is not None else None,
+                    thread_id=str(source.thread_id) if source.thread_id is not None else None,
+                )
+                if _resolved_clarify is not None:
+                    message_text = build_recovery_prompt(
+                        question=_resolved_clarify.question,
+                        answer=_resolved_clarify.answer or str(message_text),
+                    )
+                    try:
+                        event.metadata["deferred_clarify_interaction_id"] = _resolved_clarify.interaction_id
+                    except Exception:
+                        pass
+            except Exception:
+                logger.debug("deferred clarify text intercept failed", exc_info=True)
+
         # Prepend channel context from history backfill (if any).  This
         # happens after sender-prefix so the prefix only applies to the
         # trigger message, not the backfill block.
@@ -11055,7 +11100,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # lane session is ended cleanly. Mutating session_entry in
                     # place here created a split-brain state where the JSON
                     # index pointed at one id but code downstream used another.
-                    switched = await self.async_session_store.switch_session(session_key, bound_session_id)
+                    await self._cancel_deferred_clarify_session(
+                        session_key,
+                        reason="telegram_topic_session_switch",
+                    )
+                    switched = await self.async_session_store.switch_session(
+                        session_key,
+                        bound_session_id,
+                    )
                     if switched is not None:
                         session_entry = switched
                 # If the stored binding pointed at a parent, rewrite it to the
@@ -11082,6 +11134,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # session-scoped transient state so the fresh session does not
             # inherit the previous conversation's model/reasoning overrides
             # or a queued "/model switched" note.
+            await self._cancel_deferred_clarify_session(
+                session_key,
+                reason="automatic_session_reset",
+            )
             self._session_model_overrides.pop(session_key, None)
             self._set_session_reasoning_override(session_key, None)
             if hasattr(self, "_pending_model_notes"):
@@ -12146,6 +12202,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.info(
                     "Auto-resetting session %s after compression exhaustion.",
                     session_entry.session_id,
+                )
+                await self._cancel_deferred_clarify_session(
+                    session_key,
+                    reason="compression_exhausted_reset",
                 )
                 new_entry = await self.async_session_store.reset_session(session_key)
                 self._evict_cached_agent(session_key)
@@ -16475,6 +16535,61 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             pass
 
+    async def _cancel_deferred_clarify_session(
+        self,
+        session_key: str,
+        *,
+        reason: str,
+    ) -> int:
+        """Best-effort cancellation for durable prompts at session boundaries."""
+        if not session_key:
+            return 0
+        try:
+            from tools.clarify_interaction import cancel_session
+
+            cancelled = await asyncio.to_thread(
+                cancel_session,
+                session_key,
+                reason=reason,
+            )
+            if cancelled:
+                logger.info(
+                    "Cancelled %d deferred clarify interaction(s) for %s (%s)",
+                    cancelled,
+                    session_key,
+                    reason,
+                )
+            return cancelled
+        except Exception as exc:
+            logger.warning(
+                "Failed to cancel deferred clarify interactions for %s (%s): %s",
+                session_key,
+                reason,
+                exc,
+            )
+            return 0
+
+    async def _cancel_all_deferred_clarify(self, *, reason: str) -> int:
+        """Best-effort cancellation for profile-wide gateway shutdown."""
+        try:
+            from tools.clarify_interaction import cancel_all
+
+            cancelled = await asyncio.to_thread(cancel_all, reason=reason)
+            if cancelled:
+                logger.info(
+                    "Cancelled %d deferred clarify interaction(s) (%s)",
+                    cancelled,
+                    reason,
+                )
+            return cancelled
+        except Exception as exc:
+            logger.warning(
+                "Failed to cancel deferred clarify interactions (%s): %s",
+                reason,
+                exc,
+            )
+            return 0
+
     async def _interrupt_and_clear_session(
         self,
         session_key: str,
@@ -16487,6 +16602,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Interrupt the current run and clear queued session state consistently."""
         if not session_key:
             return
+        await self._cancel_deferred_clarify_session(
+            session_key,
+            reason=invalidation_reason,
+        )
         running_agent = self._running_agents.get(session_key)
         if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
             running_agent.interrupt(interrupt_reason)
@@ -18982,12 +19101,87 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if not _status_adapter:
                     return ""
 
+                choice_list = list(choices) if choices else None
+                use_deferred = source.platform == Platform.TELEGRAM
+
+                # Telegram gateway clarify is durable/deferred: store the
+                # prompt, send buttons/text, return a provider-valid tool
+                # result marker, and let the current turn end cleanly. The
+                # callback/text answer starts a new recovery turn later.
+                if use_deferred:
+                    try:
+                        from gateway.extensions.deferred_clarify import make_deferred_marker
+                        from tools.clarify_interaction import (
+                            cancel_interaction as _cancel_deferred_interaction,
+                            create_clarify_interaction,
+                            set_prompt_message_id,
+                        )
+
+                        ttl = float(
+                            user_config.get("gateway", {}).get(
+                                "clarify_interaction_ttl",
+                                user_config.get("agent", {}).get("clarify_interaction_ttl", 24 * 60 * 60),
+                            )
+                        )
+                        metadata = dict(_status_thread_metadata or {})
+                        metadata["durable_clarify"] = True
+                        metadata["reply_to_message_id"] = event_message_id
+                        interaction = create_clarify_interaction(
+                            session_id=session_entry.session_id,
+                            session_key=session_key or "",
+                            platform=source.platform.value if source.platform else "telegram",
+                            question=question,
+                            choices=choice_list,
+                            chat_id=str(source.chat_id or _status_chat_id or ""),
+                            thread_id=str(source.thread_id) if source.thread_id is not None else None,
+                            user_id=str(source.user_id) if source.user_id is not None else None,
+                            metadata={"chat_type": source.chat_type or ""},
+                            ttl_seconds=ttl,
+                        )
+
+                        try:
+                            _status_adapter.pause_typing_for_chat(_status_chat_id)
+                        except Exception:
+                            pass
+
+                        fut = safe_schedule_threadsafe(
+                            _status_adapter.send_clarify(
+                                chat_id=_status_chat_id,
+                                question=question,
+                                choices=choice_list,
+                                clarify_id=interaction.interaction_id,
+                                session_key=session_key or "",
+                                metadata=metadata,
+                            ),
+                            _loop_for_step,
+                            logger=logger,
+                            log_message="Deferred clarify send failed to schedule",
+                        )
+                        send_ok = False
+                        result = None
+                        if fut is not None:
+                            try:
+                                result = fut.result(timeout=15)
+                                send_ok = bool(getattr(result, "success", False))
+                            except Exception as exc:
+                                logger.warning("Deferred clarify send failed: %s", exc)
+                        if not send_ok:
+                            _cancel_deferred_interaction(interaction.interaction_id, reason="send_failed")
+                            return "[clarify prompt could not be delivered]"
+                        set_prompt_message_id(
+                            interaction.interaction_id,
+                            str(getattr(result, "message_id", "") or "") or None,
+                        )
+                        return make_deferred_marker(interaction.interaction_id)
+                    except Exception as exc:
+                        logger.warning("Deferred clarify setup failed; falling back to blocking clarify: %s", exc)
+
                 clarify_id = _uuid.uuid4().hex[:10]
                 _clarify_mod.register(
                     clarify_id=clarify_id,
                     session_key=session_key or "",
                     question=question,
-                    choices=list(choices) if choices else None,
+                    choices=choice_list,
                 )
 
                 # Pause typing — like approval, we don't want a "thinking..."
@@ -19004,7 +19198,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _status_adapter.send_clarify(
                         chat_id=_status_chat_id,
                         question=question,
-                        choices=list(choices) if choices else None,
+                        choices=choice_list,
                         clarify_id=clarify_id,
                         session_key=session_key or "",
                         metadata=_status_thread_metadata,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12294,7 +12294,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # ends the prior session in SQLite and reopens the CLI session under
         # the new key. The CLI's transcript becomes the active one for the
         # gateway from this moment on.
-        switched = await self.async_session_store.switch_session(session_key, cli_session_id)
+        await self._cancel_deferred_clarify_session(session_key, reason="session_handoff")
+        switched = await self.async_session_store.switch_session(
+            session_key,
+            cli_session_id,
+        )
         if switched is None:
             raise RuntimeError(
                 f"could not switch session key {session_key} → {cli_session_id}"
@@ -13248,6 +13252,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             self._running = False
             self._draining = True
+            await self._cancel_all_deferred_clarify(
+                reason=("gateway_restart" if self._restart_requested else "gateway_shutdown")
+            )
 
             stop_watchdog = getattr(self, "_stop_systemd_watchdog", None)
             if callable(stop_watchdog):
@@ -13454,6 +13461,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.info(
                 "Shutdown phase: all adapters disconnected at +%.2fs",
                 _phase_elapsed(),
+            )
+            # A turn already draining when shutdown began may create a deferred
+            # prompt after the initial cancellation pass.  Once agents are
+            # finalized and adapters are disconnected, sweep again so no button
+            # from that race can resume work after the session boundary.
+            await self._cancel_all_deferred_clarify(
+                reason=(
+                    "gateway_restart_final"
+                    if self._restart_requested
+                    else "gateway_shutdown_final"
+                )
             )
 
             for _task in list(self._background_tasks):
@@ -16522,6 +16540,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
             message_text = f"[{_safe_user_name}] {message_text}"
 
+        # Durable deferred clarify text answers must be consumed before the
+        # normal message reaches the agent; otherwise an open-ended answer (or
+        # an "Other" response) becomes an unrelated user turn after restart.
+        if message_text and not str(message_text).lstrip().startswith("/"):
+            try:
+                from gateway.extensions.deferred_clarify import build_recovery_prompt
+                from tools.clarify_interaction import resolve_text_for_session
+
+                _resolved_clarify = resolve_text_for_session(
+                    session_key,
+                    str(message_text),
+                    user_id=str(source.user_id) if source.user_id is not None else None,
+                    chat_id=str(source.chat_id) if source.chat_id is not None else None,
+                    thread_id=str(source.thread_id) if source.thread_id is not None else None,
+                )
+                if _resolved_clarify is not None:
+                    message_text = build_recovery_prompt(
+                        question=_resolved_clarify.question,
+                        answer=_resolved_clarify.answer or str(message_text),
+                    )
+                    try:
+                        event.metadata["deferred_clarify_interaction_id"] = _resolved_clarify.interaction_id
+                    except Exception:
+                        pass
+            except Exception:
+                logger.debug("deferred clarify text intercept failed", exc_info=True)
+
         # Prepend channel context from history backfill (if any).  This
         # happens after sender-prefix so the prefix only applies to the
         # trigger message, not the backfill block.
@@ -17104,7 +17149,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # lane session is ended cleanly. Mutating session_entry in
                     # place here created a split-brain state where the JSON
                     # index pointed at one id but code downstream used another.
-                    switched = await self.async_session_store.switch_session(session_key, bound_session_id)
+                    await self._cancel_deferred_clarify_session(
+                        session_key,
+                        reason="telegram_topic_session_switch",
+                    )
+                    switched = await self.async_session_store.switch_session(
+                        session_key,
+                        bound_session_id,
+                    )
                     if switched is not None:
                         session_entry = switched
                 # If the stored binding pointed at a parent, rewrite it to the
@@ -17133,6 +17185,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # model/reasoning overrides, a queued "/model switched" note, or
             # a stale resolved-model cache (#48031, #58403). See
             # _CONVERSATION_SCOPED_STATE.
+            await self._cancel_deferred_clarify_session(
+                session_key,
+                reason="automatic_session_reset",
+            )
             self._clear_conversation_scope(session_key, reason="auto_reset")
             # Evict the cached agent so the fresh session does not inherit the
             # previous conversation's context_compressor._previous_summary —
@@ -18677,6 +18733,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.info(
                     "Auto-resetting session %s after compression exhaustion.",
                     session_entry.session_id,
+                )
+                await self._cancel_deferred_clarify_session(
+                    session_key,
+                    reason="compression_exhausted_reset",
                 )
                 new_entry = await self.async_session_store.reset_session(session_key)
                 self._evict_cached_agent(session_key)
@@ -23994,6 +24054,61 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             pass
 
+    async def _cancel_deferred_clarify_session(
+        self,
+        session_key: str,
+        *,
+        reason: str,
+    ) -> int:
+        """Best-effort cancellation for durable prompts at session boundaries."""
+        if not session_key:
+            return 0
+        try:
+            from tools.clarify_interaction import cancel_session
+
+            cancelled = await asyncio.to_thread(
+                cancel_session,
+                session_key,
+                reason=reason,
+            )
+            if cancelled:
+                logger.info(
+                    "Cancelled %d deferred clarify interaction(s) for %s (%s)",
+                    cancelled,
+                    session_key,
+                    reason,
+                )
+            return cancelled
+        except Exception as exc:
+            logger.warning(
+                "Failed to cancel deferred clarify interactions for %s (%s): %s",
+                session_key,
+                reason,
+                exc,
+            )
+            return 0
+
+    async def _cancel_all_deferred_clarify(self, *, reason: str) -> int:
+        """Best-effort cancellation for profile-wide gateway shutdown."""
+        try:
+            from tools.clarify_interaction import cancel_all
+
+            cancelled = await asyncio.to_thread(cancel_all, reason=reason)
+            if cancelled:
+                logger.info(
+                    "Cancelled %d deferred clarify interaction(s) (%s)",
+                    cancelled,
+                    reason,
+                )
+            return cancelled
+        except Exception as exc:
+            logger.warning(
+                "Failed to cancel deferred clarify interactions (%s): %s",
+                reason,
+                exc,
+            )
+            return 0
+
     async def _interrupt_and_clear_session(
         self,
         session_key: str,
@@ -24006,6 +24121,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Interrupt the current run and clear queued session state consistently."""
         if not session_key:
             return
+        await self._cancel_deferred_clarify_session(
+            session_key,
+            reason=invalidation_reason,
+        )
         _iac_state = self._peek_session_state(session_key)
         running_agent = _iac_state.turn.agent if _iac_state else None
         _process_task_id = ""

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -201,6 +201,7 @@ class GatewaySlashCommandsMixin:
             pass
 
         # Reset the session
+        await self._cancel_deferred_clarify_session(session_key, reason="session_reset")
         new_entry = await self.async_session_store.reset_session(session_key)
 
         # Clear any session-scoped model/reasoning overrides so the next agent
@@ -3674,6 +3675,7 @@ class GatewaySlashCommandsMixin:
         self._release_running_agent_state(session_key)
 
         # Switch the session entry to point at the old session
+        await self._cancel_deferred_clarify_session(session_key, reason="session_resume")
         new_entry = await self.async_session_store.switch_session(session_key, target_id)
         if not new_entry:
             return t("gateway.resume.switch_failed")
@@ -3879,7 +3881,11 @@ class GatewaySlashCommandsMixin:
             pass
 
         # Switch the session store entry to the new session
-        new_entry = await self.async_session_store.switch_session(session_key, new_session_id)
+        await self._cancel_deferred_clarify_session(session_key, reason="session_branch")
+        new_entry = await self.async_session_store.switch_session(
+            session_key,
+            new_session_id,
+        )
         if not new_entry:
             return t("gateway.branch.switch_failed")
         self._clear_session_boundary_security_state(session_key)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -214,6 +214,7 @@ class GatewaySlashCommandsMixin:
             pass
 
         # Reset the session
+        await self._cancel_deferred_clarify_session(session_key, reason="session_reset")
         new_entry = await self.async_session_store.reset_session(session_key)
 
         # (Conversation-scoped overrides + security state were already
@@ -4625,6 +4626,7 @@ class GatewaySlashCommandsMixin:
         self._release_running_agent_state(session_key)
 
         # Switch the session entry to point at the old session
+        await self._cancel_deferred_clarify_session(session_key, reason="session_resume")
         new_entry = await self.async_session_store.switch_session(session_key, target_id)
         if not new_entry:
             return t("gateway.resume.switch_failed")
@@ -4873,7 +4875,11 @@ class GatewaySlashCommandsMixin:
             pass
 
         # Switch the session store entry to the new session
-        new_entry = await self.async_session_store.switch_session(session_key, new_session_id)
+        await self._cancel_deferred_clarify_session(session_key, reason="session_branch")
+        new_entry = await self.async_session_store.switch_session(
+            session_key,
+            new_session_id,
+        )
         if not new_entry:
             return t("gateway.branch.switch_failed")
         self._clear_session_boundary_security_state(session_key)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5035,6 +5035,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 **self._link_preview_kwargs(),
             }
 
+            durable_clarify = bool(metadata and metadata.get("durable_clarify"))
+            callback_prefix = "cld" if durable_clarify else "cl"
             if choices:
                 # Telegram caps callback_data at 64 bytes; keep "cl:<id>:<idx>"
                 # short.
@@ -5043,13 +5045,13 @@ class TelegramAdapter(BasePlatformAdapter):
                     rows.append([
                         InlineKeyboardButton(
                             str(idx + 1),
-                            callback_data=f"cl:{clarify_id}:{idx}",
+                            callback_data=f"{callback_prefix}:{clarify_id}:{idx}",
                         )
                     ])
                 rows.append([
                     InlineKeyboardButton(
                         "✏️ Other (type answer)",
-                        callback_data=f"cl:{clarify_id}:other",
+                        callback_data=f"{callback_prefix}:{clarify_id}:other",
                     )
                 ])
                 kwargs["reply_markup"] = InlineKeyboardMarkup(rows)
@@ -5066,7 +5068,8 @@ class TelegramAdapter(BasePlatformAdapter):
             )
 
             msg = await self._send_message_with_thread_fallback(**kwargs)
-            self._clarify_state[clarify_id] = session_key
+            if not durable_clarify:
+                self._clarify_state[clarify_id] = session_key
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
             logger.warning("[%s] send_clarify failed: %s", self.name, e)
@@ -5822,6 +5825,122 @@ class TelegramAdapter(BasePlatformAdapter):
                         await self._send_message_with_thread_fallback(**send_kwargs)
                 except Exception as exc:
                     logger.error("[%s] slash-confirm callback failed: %s", self.name, exc, exc_info=True)
+            return
+
+        # --- Durable deferred clarify callbacks (cld:interaction_id:idx | cld:interaction_id:other) ---
+        if data.startswith("cld:"):
+            parts = data.split(":", 2)
+            if len(parts) == 3:
+                interaction_id = parts[1]
+                choice_token = parts[2]
+                caller_id = str(getattr(query.from_user, "id", ""))
+                if not self._is_callback_user_authorized(
+                    caller_id,
+                    chat_id=query_chat_id,
+                    chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                    thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                    user_name=query_user_name,
+                ):
+                    await query.answer(text="⛔ You are not authorized to answer this prompt.")
+                    return
+
+                user_display = getattr(query.from_user, "first_name", "User")
+                chat_id_s = str(query_chat_id) if query_chat_id is not None else None
+                thread_id_s = str(query_thread_id) if query_thread_id is not None else None
+
+                if choice_token == "other":
+                    try:
+                        from tools.clarify_interaction import mark_awaiting_text
+                        marked = mark_awaiting_text(
+                            interaction_id,
+                            user_id=caller_id,
+                            chat_id=chat_id_s,
+                            thread_id=thread_id_s,
+                        )
+                    except Exception as exc:
+                        logger.warning("[%s] durable mark_awaiting_text failed: %s", self.name, exc)
+                        marked = None
+                    if not marked or not marked.ok:
+                        await self._notify_clarify_expired(query, user_display)
+                        return
+                    await query.answer(text="✏️ Type your answer in the chat.")
+                    try:
+                        await query.edit_message_text(
+                            text=f"{query.message.text or ''}\n\n<i>Awaiting typed response from {_html.escape(user_display)}…</i>",
+                            parse_mode=ParseMode.HTML,
+                            reply_markup=None,
+                        )
+                    except Exception:
+                        pass
+                    return
+
+                try:
+                    idx = int(choice_token)
+                except (ValueError, TypeError):
+                    await query.answer(text="Invalid choice.")
+                    return
+
+                try:
+                    from gateway.extensions.deferred_clarify import build_recovery_prompt
+                    from gateway.session import SessionSource
+                    from tools.clarify_interaction import resolve_choice
+
+                    resolved = resolve_choice(
+                        interaction_id,
+                        idx,
+                        user_id=caller_id,
+                        chat_id=chat_id_s,
+                        thread_id=thread_id_s,
+                    )
+                except Exception as exc:
+                    logger.error("[%s] durable resolve_choice failed: %s", self.name, exc, exc_info=True)
+                    resolved = None
+
+                if not resolved or not resolved.ok or not resolved.interaction:
+                    await self._notify_clarify_expired(query, user_display)
+                    return
+
+                resolved_text = resolved.answer or ""
+                await query.answer(text=f"✓ {resolved_text[:60]}")
+                try:
+                    await query.edit_message_text(
+                        text=f"{query.message.text or ''}\n\n<b>{_html.escape(user_display)}:</b> {_html.escape(resolved_text)}",
+                        parse_mode=ParseMode.HTML,
+                        reply_markup=None,
+                    )
+                except Exception:
+                    pass
+
+                if self._message_handler:
+                    chat_type = str(query_chat_type or "dm").lower()
+                    if chat_type == "private":
+                        chat_type = "dm"
+                    elif chat_type == "supergroup":
+                        chat_type = "forum" if thread_id_s else "group"
+                    source = SessionSource(
+                        platform=Platform.TELEGRAM,
+                        chat_id=str(query_chat_id or ""),
+                        chat_type=chat_type,
+                        user_id=caller_id,
+                        user_name=query_user_name,
+                        thread_id=thread_id_s,
+                    )
+                    event = MessageEvent(
+                        text=build_recovery_prompt(
+                            question=resolved.interaction.question,
+                            answer=resolved_text,
+                        ),
+                        message_type=MessageType.TEXT,
+                        source=source,
+                        raw_message=query,
+                        message_id=str(getattr(query.message, "message_id", "") or ""),
+                        internal=True,
+                        metadata={"deferred_clarify_interaction_id": interaction_id},
+                    )
+                    response = await self._message_handler(event)
+                    if response:
+                        metadata = {"thread_id": thread_id_s} if thread_id_s else None
+                        await self.send(str(query_chat_id), response, metadata=metadata)
             return
 
         # --- Clarify callbacks (cl:clarify_id:idx | cl:clarify_id:other) ---

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5718,6 +5718,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 **self._link_preview_kwargs(),
             }
 
+            durable_clarify = bool(metadata and metadata.get("durable_clarify"))
+            callback_prefix = "cld" if durable_clarify else "cl"
             if choices:
                 # Telegram caps callback_data at 64 bytes; keep "cl:<id>:<idx>"
                 # short.
@@ -5726,13 +5728,13 @@ class TelegramAdapter(BasePlatformAdapter):
                     rows.append([
                         InlineKeyboardButton(
                             str(idx + 1),
-                            callback_data=f"cl:{clarify_id}:{idx}",
+                            callback_data=f"{callback_prefix}:{clarify_id}:{idx}",
                         )
                     ])
                 rows.append([
                     InlineKeyboardButton(
                         "✏️ Other (type answer)",
-                        callback_data=f"cl:{clarify_id}:other",
+                        callback_data=f"{callback_prefix}:{clarify_id}:other",
                     )
                 ])
                 kwargs["reply_markup"] = InlineKeyboardMarkup(rows)
@@ -5749,7 +5751,8 @@ class TelegramAdapter(BasePlatformAdapter):
             )
 
             msg = await self._send_message_with_thread_fallback(**kwargs)
-            self._clarify_state[clarify_id] = session_key
+            if not durable_clarify:
+                self._clarify_state[clarify_id] = session_key
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
             logger.warning("[%s] send_clarify failed: %s", self.name, _redact_telegram_error_text(e))
@@ -6641,6 +6644,122 @@ class TelegramAdapter(BasePlatformAdapter):
                         await self._send_message_with_thread_fallback(**send_kwargs)
                 except Exception as exc:
                     logger.error("[%s] slash-confirm callback failed: %s", self.name, exc, exc_info=True)
+            return
+
+        # --- Durable deferred clarify callbacks (cld:interaction_id:idx | cld:interaction_id:other) ---
+        if data.startswith("cld:"):
+            parts = data.split(":", 2)
+            if len(parts) == 3:
+                interaction_id = parts[1]
+                choice_token = parts[2]
+                caller_id = str(getattr(query.from_user, "id", ""))
+                if not self._is_callback_user_authorized(
+                    caller_id,
+                    chat_id=query_chat_id,
+                    chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                    thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                    user_name=query_user_name,
+                ):
+                    await query.answer(text="⛔ You are not authorized to answer this prompt.")
+                    return
+
+                user_display = getattr(query.from_user, "first_name", "User")
+                chat_id_s = str(query_chat_id) if query_chat_id is not None else None
+                thread_id_s = str(query_thread_id) if query_thread_id is not None else None
+
+                if choice_token == "other":
+                    try:
+                        from tools.clarify_interaction import mark_awaiting_text
+                        marked = mark_awaiting_text(
+                            interaction_id,
+                            user_id=caller_id,
+                            chat_id=chat_id_s,
+                            thread_id=thread_id_s,
+                        )
+                    except Exception as exc:
+                        logger.warning("[%s] durable mark_awaiting_text failed: %s", self.name, exc)
+                        marked = None
+                    if not marked or not marked.ok:
+                        await self._notify_clarify_expired(query, user_display)
+                        return
+                    await query.answer(text="✏️ Type your answer in the chat.")
+                    try:
+                        await query.edit_message_text(
+                            text=f"{query.message.text or ''}\n\n<i>Awaiting typed response from {_html.escape(user_display)}…</i>",
+                            parse_mode=ParseMode.HTML,
+                            reply_markup=None,
+                        )
+                    except Exception:
+                        pass
+                    return
+
+                try:
+                    idx = int(choice_token)
+                except (ValueError, TypeError):
+                    await query.answer(text="Invalid choice.")
+                    return
+
+                try:
+                    from gateway.extensions.deferred_clarify import build_recovery_prompt
+                    from gateway.session import SessionSource
+                    from tools.clarify_interaction import resolve_choice
+
+                    resolved = resolve_choice(
+                        interaction_id,
+                        idx,
+                        user_id=caller_id,
+                        chat_id=chat_id_s,
+                        thread_id=thread_id_s,
+                    )
+                except Exception as exc:
+                    logger.error("[%s] durable resolve_choice failed: %s", self.name, exc, exc_info=True)
+                    resolved = None
+
+                if not resolved or not resolved.ok or not resolved.interaction:
+                    await self._notify_clarify_expired(query, user_display)
+                    return
+
+                resolved_text = resolved.answer or ""
+                await query.answer(text=f"✓ {resolved_text[:60]}")
+                try:
+                    await query.edit_message_text(
+                        text=f"{query.message.text or ''}\n\n<b>{_html.escape(user_display)}:</b> {_html.escape(resolved_text)}",
+                        parse_mode=ParseMode.HTML,
+                        reply_markup=None,
+                    )
+                except Exception:
+                    pass
+
+                if self._message_handler:
+                    chat_type = str(query_chat_type or "dm").lower()
+                    if chat_type == "private":
+                        chat_type = "dm"
+                    elif chat_type == "supergroup":
+                        chat_type = "forum" if thread_id_s else "group"
+                    source = SessionSource(
+                        platform=Platform.TELEGRAM,
+                        chat_id=str(query_chat_id or ""),
+                        chat_type=chat_type,
+                        user_id=caller_id,
+                        user_name=query_user_name,
+                        thread_id=thread_id_s,
+                    )
+                    event = MessageEvent(
+                        text=build_recovery_prompt(
+                            question=resolved.interaction.question,
+                            answer=resolved_text,
+                        ),
+                        message_type=MessageType.TEXT,
+                        source=source,
+                        raw_message=query,
+                        message_id=str(getattr(query.message, "message_id", "") or ""),
+                        internal=True,
+                        metadata={"deferred_clarify_interaction_id": interaction_id},
+                    )
+                    response = await self._message_handler(event)
+                    if response:
+                        metadata = {"thread_id": thread_id_s} if thread_id_s else None
+                        await self.send(str(query_chat_id), response, metadata=metadata)
             return
 
         # --- Clarify callbacks (cl:clarify_id:idx | cl:clarify_id:other) ---

--- a/tests/gateway/test_deferred_clarify.py
+++ b/tests/gateway/test_deferred_clarify.py
@@ -1,0 +1,108 @@
+import json
+
+
+def test_deferred_marker_round_trips_as_provider_valid_tool_result():
+    from gateway.extensions.deferred_clarify import (
+        DEFERRED_CLARIFY_KIND,
+        is_deferred_clarify_result,
+        make_deferred_marker,
+        parse_deferred_marker,
+    )
+
+    marker = make_deferred_marker("cld_123")
+    payload = json.loads(marker)
+
+    assert payload["status"] == "deferred"
+    assert payload["kind"] == DEFERRED_CLARIFY_KIND
+    assert payload["interaction_id"] == "cld_123"
+    assert is_deferred_clarify_result(marker) is True
+    assert parse_deferred_marker(marker) == "cld_123"
+
+
+def test_recovery_prompt_includes_question_answer_and_instruction():
+    from gateway.extensions.deferred_clarify import build_recovery_prompt
+
+    prompt = build_recovery_prompt(
+        question="Deploy where?",
+        answer="staging",
+    )
+
+    assert "previous Hermes turn" in prompt
+    assert "Deploy where?" in prompt
+    assert "staging" in prompt
+    assert "Do not ask the same clarification again" in prompt
+
+
+def test_marker_parser_ignores_malformed_or_other_tool_results():
+    from gateway.extensions.deferred_clarify import (
+        is_deferred_clarify_result,
+        parse_deferred_marker,
+    )
+
+    assert parse_deferred_marker("not json") is None
+    assert parse_deferred_marker('{"status":"ok"}') is None
+    assert is_deferred_clarify_result('{"status":"ok"}') is False
+
+
+def test_finds_marker_inside_actual_clarify_tool_result_envelope():
+    from agent.tool_dispatch_helpers import make_tool_result_message
+    from gateway.extensions.deferred_clarify import (
+        find_deferred_clarify_interaction_id,
+        make_deferred_marker,
+    )
+    from tools.clarify_tool import clarify_tool
+
+    tool_result = clarify_tool(
+        question="Deploy where?",
+        choices=["staging", "production"],
+        callback=lambda _question, _choices: make_deferred_marker("cld_executor_123"),
+    )
+    messages = [make_tool_result_message("clarify", tool_result, "call_clarify")]
+
+    assert (
+        find_deferred_clarify_interaction_id(messages, {"call_clarify"})
+        == "cld_executor_123"
+    )
+
+
+def test_deferred_detection_is_constrained_to_clarify_tool_envelope():
+    from gateway.extensions.deferred_clarify import (
+        find_deferred_clarify_interaction_id,
+        make_deferred_marker,
+    )
+    from tools.clarify_tool import clarify_tool
+
+    marker = make_deferred_marker("cld_other_tool")
+    clarify_envelope = clarify_tool(
+        question="Deploy where?",
+        callback=lambda _question, _choices: marker,
+    )
+
+    assert (
+        find_deferred_clarify_interaction_id(
+            [
+                {
+                    "role": "tool",
+                    "name": "terminal",
+                    "tool_call_id": "call_1",
+                    "content": clarify_envelope,
+                }
+            ],
+            {"call_1"},
+        )
+        is None
+    )
+    assert (
+        find_deferred_clarify_interaction_id(
+            [
+                {
+                    "role": "tool",
+                    "name": "clarify",
+                    "tool_call_id": "call_1",
+                    "content": marker,
+                }
+            ],
+            {"call_1"},
+        )
+        is None
+    )

--- a/tests/gateway/test_deferred_clarify_boundaries.py
+++ b/tests/gateway/test_deferred_clarify_boundaries.py
@@ -1,0 +1,96 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gateway.session import build_session_key
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from tests.gateway.restart_test_helpers import make_restart_runner, make_restart_source
+from tests.gateway.test_35994_reset_button_deadlock import (
+    _make_event as make_reset_event,
+    _make_runner_with_cached_agent,
+)
+
+
+def _pending_interaction(session_key: str):
+    from tools.clarify_interaction import create_clarify_interaction
+
+    return create_clarify_interaction(
+        session_key=session_key,
+        platform="telegram",
+        question="Deploy where?",
+        choices=["staging", "production"],
+        chat_id="c1",
+        user_id="u1",
+        ttl_seconds=3600,
+    )
+
+
+def _status(interaction_id: str) -> str:
+    from tools.clarify_interaction import get_interaction
+
+    interaction = get_interaction(interaction_id)
+    assert interaction is not None
+    return interaction.status
+
+
+@pytest.mark.asyncio
+async def test_new_session_cancels_pending_durable_clarify(tmp_path):
+    token = set_hermes_home_override(tmp_path)
+    try:
+        runner = _make_runner_with_cached_agent(lambda: None)
+        session_key = next(iter(runner.session_store._entries))
+        interaction = _pending_interaction(session_key)
+
+        await runner._handle_reset_command(make_reset_event("/new"))
+
+        assert _status(interaction.interaction_id) == "cancelled"
+    finally:
+        reset_hermes_home_override(token)
+
+
+@pytest.mark.asyncio
+async def test_interrupt_cancels_pending_durable_clarify(tmp_path):
+    token = set_hermes_home_override(tmp_path)
+    try:
+        runner, _adapter = make_restart_runner()
+        source = make_restart_source()
+        session_key = build_session_key(source)
+        interaction = _pending_interaction(session_key)
+
+        await runner._interrupt_and_clear_session(
+            session_key,
+            source,
+            interrupt_reason="test interrupt",
+            invalidation_reason="test_interrupt",
+        )
+
+        assert _status(interaction.interaction_id) == "cancelled"
+    finally:
+        reset_hermes_home_override(token)
+
+
+@pytest.mark.asyncio
+async def test_gateway_shutdown_cancels_all_pending_durable_clarify(tmp_path):
+    token = set_hermes_home_override(tmp_path)
+    try:
+        runner, adapter = make_restart_runner()
+        adapter.disconnect = AsyncMock()
+        interaction = _pending_interaction("session-not-currently-running")
+        late_interaction = None
+
+        async def create_prompt_during_shutdown(_active_agents):
+            nonlocal late_interaction
+            late_interaction = _pending_interaction("session-created-during-drain")
+
+        runner._finalize_shutdown_agents = create_prompt_during_shutdown
+
+        with patch("gateway.status.remove_pid_file"), patch(
+            "gateway.status.write_runtime_status"
+        ):
+            await runner.stop()
+
+        assert _status(interaction.interaction_id) == "cancelled"
+        assert late_interaction is not None
+        assert _status(late_interaction.interaction_id) == "cancelled"
+    finally:
+        reset_hermes_home_override(token)

--- a/tests/gateway/test_telegram_deferred_clarify.py
+++ b/tests/gateway/test_telegram_deferred_clarify.py
@@ -1,0 +1,319 @@
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+from tests.gateway.test_telegram_clarify_buttons import _ensure_telegram_mock
+
+_ensure_telegram_mock()
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+def _make_adapter(extra=None):
+    config = PlatformConfig(enabled=True, token="test-token", extra=extra or {})
+    adapter = TelegramAdapter(config)
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    return adapter
+
+
+def _make_runner():
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+    )
+    runner.adapters = {}
+    runner._model = "openai/gpt-4.1-mini"
+    runner._base_url = None
+    return runner
+
+
+def _make_callback_query(data, *, chat_id=12345, user_id="777", thread_id=None):
+    query = AsyncMock()
+    query.data = data
+    query.message = MagicMock()
+    query.message.chat_id = chat_id
+    query.message.chat = MagicMock()
+    query.message.chat.type = "private"
+    query.message.text = "Deploy where?"
+    query.message.message_id = 321
+    query.message.message_thread_id = thread_id
+    query.from_user = MagicMock()
+    query.from_user.id = user_id
+    query.from_user.first_name = "Tester"
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+
+    update = MagicMock()
+    update.callback_query = query
+    return update, query
+
+
+@pytest.mark.asyncio
+async def test_durable_send_clarify_uses_durable_prefix_without_in_memory_state():
+    adapter = _make_adapter()
+    mock_msg = MagicMock()
+    mock_msg.message_id = 200
+    adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+    result = await adapter.send_clarify(
+        chat_id="12345",
+        question="Which option?",
+        choices=["alpha", "beta"],
+        clarify_id="cld_test",
+        session_key="session-key",
+        metadata={"durable_clarify": True},
+    )
+
+    assert result.success is True
+    assert "cld_test" not in adapter._clarify_state
+    kwargs = adapter._bot.send_message.call_args[1]
+    assert kwargs["reply_markup"] is not None
+
+
+@pytest.mark.asyncio
+async def test_durable_callback_resolves_choice_and_dispatches_recovery_turn(tmp_path):
+    token = set_hermes_home_override(tmp_path)
+    try:
+        from tools.clarify_interaction import create_clarify_interaction, get_interaction
+
+        adapter = _make_adapter()
+        adapter._message_handler = AsyncMock(return_value="continued")
+        adapter.send = AsyncMock()
+
+        interaction = create_clarify_interaction(
+            session_key="telegram:12345:777",
+            platform="telegram",
+            question="Deploy where?",
+            choices=["staging", "production"],
+            chat_id="12345",
+            user_id="777",
+            ttl_seconds=3600,
+        )
+
+        update, query = _make_callback_query(f"cld:{interaction.interaction_id}:1")
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            await adapter._handle_callback_query(update, MagicMock())
+
+        loaded = get_interaction(interaction.interaction_id)
+        assert loaded.status == "resolved"
+        assert loaded.answer == "production"
+        adapter._message_handler.assert_awaited_once()
+        dispatched_event = adapter._message_handler.call_args.args[0]
+        assert "Deploy where?" in dispatched_event.text
+        assert "production" in dispatched_event.text
+        adapter.send.assert_awaited_once()
+    finally:
+        reset_hermes_home_override(token)
+
+
+@pytest.mark.asyncio
+async def test_durable_other_marks_awaiting_text_without_dispatching_turn(tmp_path):
+    token = set_hermes_home_override(tmp_path)
+    try:
+        from tools.clarify_interaction import create_clarify_interaction, get_interaction
+
+        adapter = _make_adapter()
+        adapter._message_handler = AsyncMock(return_value="should not run yet")
+        adapter.send = AsyncMock()
+
+        interaction = create_clarify_interaction(
+            session_key="telegram:12345:777",
+            platform="telegram",
+            question="Deploy where?",
+            choices=["staging", "production"],
+            chat_id="12345",
+            user_id="777",
+            ttl_seconds=3600,
+        )
+
+        update, query = _make_callback_query(f"cld:{interaction.interaction_id}:other")
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            await adapter._handle_callback_query(update, MagicMock())
+
+        loaded = get_interaction(interaction.interaction_id)
+        assert loaded.status == "awaiting_text"
+        assert loaded.answer is None
+        adapter._message_handler.assert_not_awaited()
+        adapter.send.assert_not_awaited()
+        query.edit_message_text.assert_awaited_once()
+    finally:
+        reset_hermes_home_override(token)
+
+
+@pytest.mark.asyncio
+async def test_durable_callback_rejects_wrong_user_without_dispatching_turn(tmp_path):
+    token = set_hermes_home_override(tmp_path)
+    try:
+        from tools.clarify_interaction import create_clarify_interaction, get_interaction
+
+        adapter = _make_adapter()
+        adapter._message_handler = AsyncMock(return_value="should not run")
+        adapter.send = AsyncMock()
+
+        interaction = create_clarify_interaction(
+            session_key="telegram:12345:777",
+            platform="telegram",
+            question="Deploy where?",
+            choices=["staging", "production"],
+            chat_id="12345",
+            user_id="777",
+            ttl_seconds=3600,
+        )
+
+        update, _query = _make_callback_query(
+            f"cld:{interaction.interaction_id}:1",
+            user_id="intruder",
+        )
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            await adapter._handle_callback_query(update, MagicMock())
+
+        loaded = get_interaction(interaction.interaction_id)
+        assert loaded.status == "pending"
+        assert loaded.answer is None
+        adapter._message_handler.assert_not_awaited()
+        adapter.send.assert_not_awaited()
+    finally:
+        reset_hermes_home_override(token)
+
+
+@pytest.mark.asyncio
+async def test_durable_duplicate_callback_dispatches_recovery_turn_only_once(tmp_path):
+    token = set_hermes_home_override(tmp_path)
+    try:
+        from tools.clarify_interaction import create_clarify_interaction, get_interaction
+
+        adapter = _make_adapter()
+        adapter._message_handler = AsyncMock(return_value="continued")
+        adapter.send = AsyncMock()
+
+        interaction = create_clarify_interaction(
+            session_key="telegram:12345:777",
+            platform="telegram",
+            question="Deploy where?",
+            choices=["staging", "production"],
+            chat_id="12345",
+            user_id="777",
+            ttl_seconds=3600,
+        )
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            first_update, _first_query = _make_callback_query(f"cld:{interaction.interaction_id}:1")
+            await adapter._handle_callback_query(first_update, MagicMock())
+            second_update, _second_query = _make_callback_query(f"cld:{interaction.interaction_id}:0")
+            await adapter._handle_callback_query(second_update, MagicMock())
+
+        loaded = get_interaction(interaction.interaction_id)
+        assert loaded.status == "resolved"
+        assert loaded.answer == "production"
+        adapter._message_handler.assert_awaited_once()
+        adapter.send.assert_awaited_once()
+    finally:
+        reset_hermes_home_override(token)
+
+@pytest.mark.asyncio
+async def test_text_intercept_resolves_awaiting_durable_answer_in_same_session(tmp_path):
+    token = set_hermes_home_override(tmp_path)
+    try:
+        from tools.clarify_interaction import (
+            create_clarify_interaction,
+            get_interaction,
+            mark_awaiting_text,
+        )
+
+        runner = _make_runner()
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="dm",
+            user_id="777",
+        )
+        event = MessageEvent(text="custom production", message_type=MessageType.TEXT, source=source)
+        event.metadata = {}
+        session_key = "telegram:12345:777"
+        interaction = create_clarify_interaction(
+            session_key=session_key,
+            platform="telegram",
+            question="Deploy where?",
+            choices=["staging", "production"],
+            chat_id="12345",
+            user_id="777",
+            ttl_seconds=3600,
+        )
+        assert mark_awaiting_text(interaction.interaction_id, user_id="777", chat_id="12345").ok
+
+        prepared = await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+            session_key=session_key,
+        )
+
+        loaded = get_interaction(interaction.interaction_id)
+        assert loaded.status == "resolved"
+        assert loaded.answer == "custom production"
+        assert event.metadata["deferred_clarify_interaction_id"] == interaction.interaction_id
+        assert "Deploy where?" in prepared
+        assert "custom production" in prepared
+    finally:
+        reset_hermes_home_override(token)
+
+
+@pytest.mark.asyncio
+async def test_text_intercept_ignores_slash_commands_for_awaiting_durable_answer(tmp_path):
+    token = set_hermes_home_override(tmp_path)
+    try:
+        from tools.clarify_interaction import (
+            create_clarify_interaction,
+            get_interaction,
+            mark_awaiting_text,
+        )
+
+        runner = _make_runner()
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="dm",
+            user_id="777",
+        )
+        event = MessageEvent(text="/help", message_type=MessageType.TEXT, source=source)
+        event.metadata = {}
+        session_key = "telegram:12345:777"
+        interaction = create_clarify_interaction(
+            session_key=session_key,
+            platform="telegram",
+            question="Deploy where?",
+            choices=["staging", "production"],
+            chat_id="12345",
+            user_id="777",
+            ttl_seconds=3600,
+        )
+        assert mark_awaiting_text(interaction.interaction_id, user_id="777", chat_id="12345").ok
+
+        prepared = await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+            session_key=session_key,
+        )
+
+        loaded = get_interaction(interaction.interaction_id)
+        assert prepared == "/help"
+        assert loaded.status == "awaiting_text"
+        assert "deferred_clarify_interaction_id" not in event.metadata
+    finally:
+        reset_hermes_home_override(token)

--- a/tests/tools/test_clarify_interaction.py
+++ b/tests/tools/test_clarify_interaction.py
@@ -1,0 +1,204 @@
+import time
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+def _use_home(tmp_path):
+    token = set_hermes_home_override(tmp_path)
+    return token
+
+
+def test_create_and_resolve_choice_round_trips_from_sqlite(tmp_path):
+    token = _use_home(tmp_path)
+    try:
+        from tools.clarify_interaction import (
+            create_clarify_interaction,
+            get_interaction,
+            resolve_choice,
+        )
+
+        created = create_clarify_interaction(
+            session_key="telegram:chat:thread:user",
+            platform="telegram",
+            question="Deploy where?",
+            choices=["staging", "production"],
+            chat_id="123",
+            thread_id="456",
+            user_id="789",
+            ttl_seconds=3600,
+        )
+
+        loaded = get_interaction(created.interaction_id)
+        assert loaded is not None
+        assert loaded.status == "pending"
+        assert loaded.question == "Deploy where?"
+        assert loaded.choices == ["staging", "production"]
+
+        resolved = resolve_choice(
+            created.interaction_id,
+            1,
+            user_id="789",
+            chat_id="123",
+            thread_id="456",
+        )
+        assert resolved.ok is True
+        assert resolved.status == "resolved"
+        assert resolved.answer == "production"
+
+        loaded_again = get_interaction(created.interaction_id)
+        assert loaded_again is not None
+        assert loaded_again.status == "resolved"
+        assert loaded_again.answer == "production"
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_resolve_choice_is_idempotent_and_authorized(tmp_path):
+    token = _use_home(tmp_path)
+    try:
+        from tools.clarify_interaction import create_clarify_interaction, resolve_choice
+
+        created = create_clarify_interaction(
+            session_key="s1",
+            platform="telegram",
+            question="Pick?",
+            choices=["a", "b"],
+            chat_id="chat",
+            thread_id="topic",
+            user_id="owner",
+            ttl_seconds=3600,
+        )
+
+        wrong_user = resolve_choice(
+            created.interaction_id,
+            0,
+            user_id="intruder",
+            chat_id="chat",
+            thread_id="topic",
+        )
+        assert wrong_user.ok is False
+        assert wrong_user.status == "unauthorized"
+
+        first = resolve_choice(
+            created.interaction_id,
+            0,
+            user_id="owner",
+            chat_id="chat",
+            thread_id="topic",
+        )
+        second = resolve_choice(
+            created.interaction_id,
+            1,
+            user_id="owner",
+            chat_id="chat",
+            thread_id="topic",
+        )
+
+        assert first.ok is True
+        assert first.answer == "a"
+        assert second.ok is False
+        assert second.status == "already_resolved"
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_awaiting_text_resolves_oldest_matching_session(tmp_path):
+    token = _use_home(tmp_path)
+    try:
+        from tools.clarify_interaction import (
+            create_clarify_interaction,
+            get_interaction,
+            mark_awaiting_text,
+            resolve_text_for_session,
+        )
+
+        first = create_clarify_interaction(
+            session_key="s1",
+            platform="telegram",
+            question="Explain?",
+            choices=["short"],
+            chat_id="chat",
+            thread_id="topic",
+            user_id="owner",
+            ttl_seconds=3600,
+        )
+        second = create_clarify_interaction(
+            session_key="s1",
+            platform="telegram",
+            question="Later?",
+            choices=None,
+            chat_id="chat",
+            thread_id="topic",
+            user_id="owner",
+            ttl_seconds=3600,
+        )
+        assert mark_awaiting_text(first.interaction_id, user_id="owner", chat_id="chat", thread_id="topic").ok
+
+        resolved = resolve_text_for_session(
+            "s1",
+            "custom answer",
+            user_id="owner",
+            chat_id="chat",
+            thread_id="topic",
+        )
+
+        assert resolved is not None
+        assert resolved.interaction_id == first.interaction_id
+        assert resolved.answer == "custom answer"
+        assert get_interaction(first.interaction_id).status == "resolved"
+        assert get_interaction(second.interaction_id).status == "pending"
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_cancel_interaction_only_cancels_one_row(tmp_path):
+    token = _use_home(tmp_path)
+    try:
+        from tools.clarify_interaction import (
+            cancel_interaction,
+            create_clarify_interaction,
+            get_interaction,
+        )
+
+        first = create_clarify_interaction(
+            session_key="s1",
+            platform="telegram",
+            question="First?",
+            choices=["a"],
+            ttl_seconds=3600,
+        )
+        second = create_clarify_interaction(
+            session_key="s1",
+            platform="telegram",
+            question="Second?",
+            choices=["b"],
+            ttl_seconds=3600,
+        )
+
+        assert cancel_interaction(first.interaction_id) is True
+        assert get_interaction(first.interaction_id).status == "cancelled"
+        assert get_interaction(second.interaction_id).status == "pending"
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_expired_interaction_cannot_resolve(tmp_path):
+    token = _use_home(tmp_path)
+    try:
+        from tools.clarify_interaction import create_clarify_interaction, resolve_choice
+
+        created = create_clarify_interaction(
+            session_key="s1",
+            platform="telegram",
+            question="Pick?",
+            choices=["a"],
+            user_id="owner",
+            ttl_seconds=-1,
+            now=time.time() - 10,
+        )
+
+        result = resolve_choice(created.interaction_id, 0, user_id="owner")
+        assert result.ok is False
+        assert result.status == "expired"
+    finally:
+        reset_hermes_home_override(token)

--- a/tools/clarify_interaction.py
+++ b/tools/clarify_interaction.py
@@ -1,0 +1,409 @@
+"""Durable gateway clarify interaction storage.
+
+This module stores pending gateway clarify prompts in profile-local SQLite so
+Telegram button/text answers can be resolved after a gateway restart. It is
+intentionally dependency-free and stores only the routing/question/answer data
+needed to resume the user turn.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+from hermes_constants import get_hermes_home
+
+_DB_FILENAME = "gateway_interactions.db"
+_KIND_CLARIFY = "clarify"
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS gateway_interactions (
+  interaction_id TEXT PRIMARY KEY,
+  kind TEXT NOT NULL,
+  status TEXT NOT NULL,
+  session_id TEXT,
+  session_key TEXT NOT NULL,
+  platform TEXT NOT NULL,
+  chat_id TEXT,
+  thread_id TEXT,
+  user_id TEXT,
+  message_id TEXT,
+  question TEXT NOT NULL,
+  choices_json TEXT,
+  answer TEXT,
+  created_at REAL NOT NULL,
+  expires_at REAL NOT NULL,
+  resolved_at REAL,
+  updated_at REAL NOT NULL,
+  metadata_json TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_gateway_interactions_session
+ON gateway_interactions(session_key, status, created_at);
+CREATE INDEX IF NOT EXISTS idx_gateway_interactions_expiry
+ON gateway_interactions(status, expires_at);
+"""
+
+
+@dataclass(frozen=True)
+class ClarifyInteraction:
+    interaction_id: str
+    kind: str
+    status: str
+    session_key: str
+    platform: str
+    question: str
+    choices: Optional[list[str]] = None
+    answer: Optional[str] = None
+    session_id: Optional[str] = None
+    chat_id: Optional[str] = None
+    thread_id: Optional[str] = None
+    user_id: Optional[str] = None
+    message_id: Optional[str] = None
+    created_at: float = 0.0
+    expires_at: float = 0.0
+    resolved_at: Optional[float] = None
+    updated_at: float = 0.0
+    metadata: Optional[dict[str, Any]] = None
+
+
+@dataclass(frozen=True)
+class ResolveResult:
+    ok: bool
+    status: str
+    interaction_id: Optional[str] = None
+    answer: Optional[str] = None
+    interaction: Optional[ClarifyInteraction] = None
+
+
+def _db_path() -> Path:
+    home = get_hermes_home()
+    home.mkdir(parents=True, exist_ok=True)
+    return home / _DB_FILENAME
+
+
+def _connect() -> sqlite3.Connection:
+    conn = sqlite3.connect(_db_path(), timeout=30.0)
+    conn.row_factory = sqlite3.Row
+    conn.executescript(_SCHEMA)
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+    except sqlite3.DatabaseError:
+        pass
+    return conn
+
+
+def _json_dumps(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+
+
+def _json_loads(value: Optional[str], default: Any) -> Any:
+    if not value:
+        return default
+    try:
+        return json.loads(value)
+    except Exception:
+        return default
+
+
+def _row_to_interaction(row: sqlite3.Row | None) -> Optional[ClarifyInteraction]:
+    if row is None:
+        return None
+    choices = _json_loads(row["choices_json"], None)
+    if choices is not None:
+        choices = [str(c) for c in choices]
+    metadata = _json_loads(row["metadata_json"], None)
+    return ClarifyInteraction(
+        interaction_id=str(row["interaction_id"]),
+        kind=str(row["kind"]),
+        status=str(row["status"]),
+        session_id=row["session_id"],
+        session_key=str(row["session_key"]),
+        platform=str(row["platform"]),
+        chat_id=row["chat_id"],
+        thread_id=row["thread_id"],
+        user_id=row["user_id"],
+        message_id=row["message_id"],
+        question=str(row["question"]),
+        choices=choices,
+        answer=row["answer"],
+        created_at=float(row["created_at"]),
+        expires_at=float(row["expires_at"]),
+        resolved_at=row["resolved_at"],
+        updated_at=float(row["updated_at"]),
+        metadata=metadata,
+    )
+
+
+def _same(expected: Optional[str], actual: Optional[str]) -> bool:
+    return expected in (None, "") or str(expected) == str(actual or "")
+
+
+def _authorized(interaction: ClarifyInteraction, *, user_id: Optional[str] = None,
+                chat_id: Optional[str] = None, thread_id: Optional[str] = None) -> bool:
+    return (
+        _same(interaction.user_id, user_id)
+        and _same(interaction.chat_id, chat_id)
+        and _same(interaction.thread_id, thread_id)
+    )
+
+
+def create_clarify_interaction(
+    *,
+    session_key: str,
+    platform: str,
+    question: str,
+    choices: Optional[Iterable[Any]] = None,
+    session_id: Optional[str] = None,
+    chat_id: Optional[str] = None,
+    thread_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+    message_id: Optional[str] = None,
+    metadata: Optional[dict[str, Any]] = None,
+    ttl_seconds: float = 24 * 60 * 60,
+    now: Optional[float] = None,
+    interaction_id: Optional[str] = None,
+) -> ClarifyInteraction:
+    now_f = float(time.time() if now is None else now)
+    iid = interaction_id or f"cld_{uuid.uuid4().hex[:24]}"
+    normalized_choices = [str(c) for c in choices] if choices else None
+    expires_at = now_f + float(ttl_seconds)
+    status = "pending"
+    with _connect() as conn:
+        conn.execute(
+            """
+            INSERT INTO gateway_interactions (
+              interaction_id, kind, status, session_id, session_key, platform,
+              chat_id, thread_id, user_id, message_id, question, choices_json,
+              answer, created_at, expires_at, resolved_at, updated_at, metadata_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, NULL, ?, ?)
+            """,
+            (
+                iid, _KIND_CLARIFY, status, session_id, session_key, platform,
+                chat_id, thread_id, user_id, message_id, question,
+                _json_dumps(normalized_choices), now_f, expires_at, now_f,
+                _json_dumps(metadata),
+            ),
+        )
+    loaded = get_interaction(iid)
+    assert loaded is not None
+    return loaded
+
+
+def get_interaction(interaction_id: str) -> Optional[ClarifyInteraction]:
+    with _connect() as conn:
+        row = conn.execute(
+            "SELECT * FROM gateway_interactions WHERE interaction_id = ?",
+            (interaction_id,),
+        ).fetchone()
+    return _row_to_interaction(row)
+
+
+def set_prompt_message_id(interaction_id: str, message_id: Optional[str]) -> bool:
+    with _connect() as conn:
+        cur = conn.execute(
+            "UPDATE gateway_interactions SET message_id = ?, updated_at = ? WHERE interaction_id = ?",
+            (message_id, time.time(), interaction_id),
+        )
+        return cur.rowcount > 0
+
+
+def _expire_if_needed(conn: sqlite3.Connection, interaction: ClarifyInteraction, now_f: float) -> Optional[ResolveResult]:
+    if interaction.expires_at <= now_f and interaction.status in {"pending", "awaiting_text"}:
+        conn.execute(
+            "UPDATE gateway_interactions SET status = 'expired', updated_at = ? WHERE interaction_id = ?",
+            (now_f, interaction.interaction_id),
+        )
+        return ResolveResult(False, "expired", interaction.interaction_id, interaction=interaction)
+    return None
+
+
+def mark_awaiting_text(
+    interaction_id: str,
+    *,
+    user_id: Optional[str] = None,
+    chat_id: Optional[str] = None,
+    thread_id: Optional[str] = None,
+    now: Optional[float] = None,
+) -> ResolveResult:
+    now_f = float(time.time() if now is None else now)
+    with _connect() as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        row = conn.execute("SELECT * FROM gateway_interactions WHERE interaction_id = ?", (interaction_id,)).fetchone()
+        interaction = _row_to_interaction(row)
+        if interaction is None:
+            return ResolveResult(False, "missing", interaction_id)
+        expired = _expire_if_needed(conn, interaction, now_f)
+        if expired:
+            return expired
+        if interaction.status == "resolved":
+            return ResolveResult(False, "already_resolved", interaction_id, interaction=interaction)
+        if interaction.status not in {"pending", "awaiting_text"}:
+            return ResolveResult(False, interaction.status, interaction_id, interaction=interaction)
+        if not _authorized(interaction, user_id=user_id, chat_id=chat_id, thread_id=thread_id):
+            return ResolveResult(False, "unauthorized", interaction_id, interaction=interaction)
+        conn.execute(
+            "UPDATE gateway_interactions SET status = 'awaiting_text', updated_at = ? WHERE interaction_id = ?",
+            (now_f, interaction_id),
+        )
+        updated_row = conn.execute(
+            "SELECT * FROM gateway_interactions WHERE interaction_id = ?",
+            (interaction_id,),
+        ).fetchone()
+        updated = _row_to_interaction(updated_row)
+        return ResolveResult(True, "awaiting_text", interaction_id, interaction=updated)
+
+
+def resolve_choice(
+    interaction_id: str,
+    choice_index: int,
+    *,
+    user_id: Optional[str] = None,
+    chat_id: Optional[str] = None,
+    thread_id: Optional[str] = None,
+    now: Optional[float] = None,
+) -> ResolveResult:
+    now_f = float(time.time() if now is None else now)
+    with _connect() as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        row = conn.execute("SELECT * FROM gateway_interactions WHERE interaction_id = ?", (interaction_id,)).fetchone()
+        interaction = _row_to_interaction(row)
+        if interaction is None:
+            return ResolveResult(False, "missing", interaction_id)
+        expired = _expire_if_needed(conn, interaction, now_f)
+        if expired:
+            return expired
+        if interaction.status == "resolved":
+            return ResolveResult(False, "already_resolved", interaction_id, interaction=interaction)
+        if interaction.status not in {"pending", "awaiting_text"}:
+            return ResolveResult(False, interaction.status, interaction_id, interaction=interaction)
+        if not _authorized(interaction, user_id=user_id, chat_id=chat_id, thread_id=thread_id):
+            return ResolveResult(False, "unauthorized", interaction_id, interaction=interaction)
+        choices = interaction.choices or []
+        if choice_index < 0 or choice_index >= len(choices):
+            return ResolveResult(False, "invalid_choice", interaction_id, interaction=interaction)
+        answer = choices[choice_index]
+        cur = conn.execute(
+            """
+            UPDATE gateway_interactions
+            SET status = 'resolved', answer = ?, resolved_at = ?, updated_at = ?
+            WHERE interaction_id = ? AND status IN ('pending', 'awaiting_text') AND expires_at > ?
+            """,
+            (answer, now_f, now_f, interaction_id, now_f),
+        )
+        if cur.rowcount != 1:
+            return ResolveResult(False, "already_resolved", interaction_id, interaction=interaction)
+        updated_row = conn.execute("SELECT * FROM gateway_interactions WHERE interaction_id = ?", (interaction_id,)).fetchone()
+        updated = _row_to_interaction(updated_row)
+        return ResolveResult(True, "resolved", interaction_id, answer=answer, interaction=updated)
+
+
+def resolve_text_for_session(
+    session_key: str,
+    text: str,
+    *,
+    user_id: Optional[str] = None,
+    chat_id: Optional[str] = None,
+    thread_id: Optional[str] = None,
+    now: Optional[float] = None,
+) -> Optional[ClarifyInteraction]:
+    now_f = float(time.time() if now is None else now)
+    with _connect() as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        rows = conn.execute(
+            """
+            SELECT * FROM gateway_interactions
+            WHERE session_key = ? AND kind = ? AND status IN ('awaiting_text', 'pending')
+            ORDER BY CASE status WHEN 'awaiting_text' THEN 0 ELSE 1 END, created_at ASC
+            """,
+            (session_key, _KIND_CLARIFY),
+        ).fetchall()
+        for row in rows:
+            interaction = _row_to_interaction(row)
+            if interaction is None:
+                continue
+            expired = _expire_if_needed(conn, interaction, now_f)
+            if expired:
+                continue
+            if not _authorized(interaction, user_id=user_id, chat_id=chat_id, thread_id=thread_id):
+                continue
+            cur = conn.execute(
+                """
+                UPDATE gateway_interactions
+                SET status = 'resolved', answer = ?, resolved_at = ?, updated_at = ?
+                WHERE interaction_id = ? AND status IN ('pending', 'awaiting_text') AND expires_at > ?
+                """,
+                (text, now_f, now_f, interaction.interaction_id, now_f),
+            )
+            if cur.rowcount == 1:
+                updated_row = conn.execute(
+                    "SELECT * FROM gateway_interactions WHERE interaction_id = ?",
+                    (interaction.interaction_id,),
+                ).fetchone()
+                return _row_to_interaction(updated_row)
+    return None
+
+
+def expire_old(now: Optional[float] = None) -> int:
+    now_f = float(time.time() if now is None else now)
+    with _connect() as conn:
+        cur = conn.execute(
+            "UPDATE gateway_interactions SET status = 'expired', updated_at = ? WHERE status IN ('pending', 'awaiting_text') AND expires_at <= ?",
+            (now_f, now_f),
+        )
+        return int(cur.rowcount or 0)
+
+
+def cancel_interaction(interaction_id: str, *, reason: str = "cancelled", now: Optional[float] = None) -> bool:
+    del reason  # reserved for metadata in a future migration
+    now_f = float(time.time() if now is None else now)
+    with _connect() as conn:
+        cur = conn.execute(
+            "UPDATE gateway_interactions SET status = 'cancelled', updated_at = ? WHERE interaction_id = ? AND status IN ('pending', 'awaiting_text')",
+            (now_f, interaction_id),
+        )
+        return bool(cur.rowcount == 1)
+
+
+def cancel_session(session_key: str, *, reason: str = "cancelled", now: Optional[float] = None) -> int:
+    del reason  # reserved for metadata in a future migration
+    now_f = float(time.time() if now is None else now)
+    with _connect() as conn:
+        cur = conn.execute(
+            "UPDATE gateway_interactions SET status = 'cancelled', updated_at = ? WHERE session_key = ? AND status IN ('pending', 'awaiting_text')",
+            (now_f, session_key),
+        )
+        return int(cur.rowcount or 0)
+
+
+def cancel_all(*, reason: str = "cancelled", now: Optional[float] = None) -> int:
+    """Cancel every active durable interaction in the current profile."""
+    del reason  # reserved for metadata in a future migration
+    now_f = float(time.time() if now is None else now)
+    with _connect() as conn:
+        cur = conn.execute(
+            "UPDATE gateway_interactions SET status = 'cancelled', updated_at = ? WHERE status IN ('pending', 'awaiting_text')",
+            (now_f,),
+        )
+        return int(cur.rowcount or 0)
+
+
+__all__ = [
+    "ClarifyInteraction",
+    "ResolveResult",
+    "create_clarify_interaction",
+    "get_interaction",
+    "set_prompt_message_id",
+    "mark_awaiting_text",
+    "resolve_choice",
+    "resolve_text_for_session",
+    "expire_old",
+    "cancel_interaction",
+    "cancel_session",
+    "cancel_all",
+]


### PR DESCRIPTION
## Summary

Implements durable deferred Telegram clarify interactions.

- stores gateway clarify prompts as profile-local SQLite interaction rows under `$HERMES_HOME`
- returns a provider-valid deferred tool result marker instead of pinning the worker on Telegram
- resolves Telegram button and typed answers through the durable interaction id after restart
- starts a normal recovery turn with the original question and answer
- keeps the legacy blocking clarify path intact as fallback for non-deferred platforms

Fixes #44845.

This builds on the lessons from #33850, but unlike that restart-ack approach this resolves the durable decision and resumes the task through a new gateway turn.

## Privacy / storage

- storage is local to the active Hermes profile (`$HERMES_HOME/gateway_interactions.db`)
- no external service or cloud storage is introduced
- rows store only interaction routing metadata, question, choices, answer, status, and timestamps
- pending rows support TTL expiry and session cancellation
- callback resolution is scoped by user/chat/thread ids and is idempotent

## Implementation notes

- Adds `tools/clarify_interaction.py` for SQLite-backed interaction lifecycle.
- Adds `gateway/extensions/deferred_clarify.py` for marker parsing and recovery prompt construction.
- Telegram durable prompts use a separate `cld:<interaction_id>:...` callback prefix, leaving existing `cl:` in-memory clarify behavior untouched.
- The conversation loop detects deferred clarify tool results and exits the current turn with `NO_REPLY`, avoiding another LLM call in the same turn.

## Test plan

- [x] `python -m py_compile tools/clarify_interaction.py gateway/extensions/deferred_clarify.py agent/conversation_loop.py agent/turn_finalizer.py gateway/run.py plugins/platforms/telegram/adapter.py`
- [x] `python -m pytest tests/tools/test_clarify_interaction.py tests/gateway/test_deferred_clarify.py tests/tools/test_clarify_gateway.py tests/gateway/test_telegram_clarify_buttons.py tests/gateway/test_telegram_deferred_clarify.py tests/gateway/test_approve_deny_commands.py tests/gateway/test_telegram_text_batching.py tests/gateway/test_update_streaming.py tests/gateway/test_gateway_shutdown.py -q`

Result: `125 passed`.
