### PR TITLE
fix(qqbot): add return_exceptions to asyncio.gather in chunked upload

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3471,18 +3471,17 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
 
         return sum(_results)
     finally:
-        if lock_fd is not None and not lock_fd.closed:
-            if fcntl:
-                try:
-                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
-                except (OSError, IOError):
-                    pass
-            elif msvcrt:
-                try:
-                    msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
-                except (OSError, IOError):
-                    pass
-            lock_fd.close()
+        if fcntl:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            except (OSError, IOError):
+                pass
+        elif msvcrt:
+            try:
+                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
+            except (OSError, IOError):
+                pass
+        lock_fd.close()
 
 
 if __name__ == "__main__":

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3471,17 +3471,18 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
 
         return sum(_results)
     finally:
-        if fcntl:
-            try:
-                fcntl.flock(lock_fd, fcntl.LOCK_UN)
-            except (OSError, IOError):
-                pass
-        elif msvcrt:
-            try:
-                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
-            except (OSError, IOError):
-                pass
-        lock_fd.close()
+        if lock_fd is not None and not lock_fd.closed:
+            if fcntl:
+                try:
+                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                except (OSError, IOError):
+                    pass
+            elif msvcrt:
+                try:
+                    msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
+                except (OSError, IOError):
+                    pass
+            lock_fd.close()
 
 
 if __name__ == "__main__":

--- a/gateway/platforms/qqbot/chunked_upload.py
+++ b/gateway/platforms/qqbot/chunked_upload.py
@@ -599,4 +599,9 @@ async def _run_with_concurrency(
         async with sem:
             await thunk()
 
-    await asyncio.gather(*(_wrap(t) for t in tasks))
+    results = await asyncio.gather(
+        *(_wrap(t) for t in tasks), return_exceptions=True,
+    )
+    for r in results:
+        if isinstance(r, Exception):
+            raise r


### PR DESCRIPTION
## Summary

Add  to  in the QQBot chunked upload helper.

## Problem

 in  called  without . If any single chunk upload task raised an exception (e.g. network timeout, API error), the entire gather would fail immediately, leaving in-flight chunk uploads orphaned.

## Fix

Add  and re-raise the first exception after all tasks complete. This ensures every task finishes (or is cancelled cleanly) before the caller sees the error, avoiding orphaned partial uploads.

## Testing
- Syntax check passed (py_compile)
- Behavior verified