### PR TITLE
fix: remove stale # noqa comments from gateway/run.py

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16,7 +16,7 @@ Usage:
 # IMPORTANT: hermes_bootstrap must be the very first import — UTF-8 stdio
 # on Windows.  No-op on POSIX.  See hermes_bootstrap.py for full rationale.
 try:
-    import hermes_bootstrap  # noqa: F401
+    import hermes_bootstrap
 except ModuleNotFoundError:
     # Graceful fallback when hermes_bootstrap isn't registered in the venv
     # yet — happens during partial ``hermes update`` where git-reset landed
@@ -968,7 +968,7 @@ _AUTO_APPEND_MEDIA_TOOL_NAMES = {
 # surface (this messaging gateway AND the TUI/WebUI gateway) shares one
 # implementation.  Re-exported under the historical private names so existing
 # call sites and tests keep working.
-from agent.replay_cleanup import (  # noqa: E402
+from agent.replay_cleanup import (
     is_interrupted_tool_result as _is_interrupted_tool_result,
     strip_interrupted_tool_tails as _strip_interrupted_tool_tails,
     strip_dangling_tool_call_tail as _strip_dangling_tool_call_tail,
@@ -1267,7 +1267,7 @@ _hermes_home = get_hermes_home()
 
 # Load environment variables from ~/.hermes/.env first.
 # User-managed env files should override stale shell exports on restart.
-from dotenv import load_dotenv  # noqa: F401  # backward-compat for tests that monkeypatch this symbol
+from dotenv import load_dotenv  # backward-compat for tests that monkeypatch this symbol
 from hermes_cli.env_loader import load_hermes_dotenv
 _env_path = _hermes_home / '.env'
 load_hermes_dotenv(hermes_home=_hermes_home, project_env=Path(__file__).resolve().parents[1] / '.env')
@@ -1732,7 +1732,7 @@ from gateway.restart import (
 
 
 from gateway.whatsapp_identity import (
-    canonical_whatsapp_identifier as _canonical_whatsapp_identifier,  # noqa: F401
+    canonical_whatsapp_identifier as _canonical_whatsapp_identifier,
     expand_whatsapp_aliases as _expand_whatsapp_auth_aliases,
     normalize_whatsapp_identifier as _normalize_whatsapp_identifier,
 )
@@ -4037,7 +4037,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             if active_count() > 0:
                 return True
-        except Exception:  # noqa: BLE001 - never let the idle check raise
+        except Exception:
             logger.debug("scale-to-zero async-delegation check failed", exc_info=True)
         try:
             from tools.process_registry import process_registry
@@ -4046,7 +4046,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return True
             if process_registry.pending_watchers:
                 return True
-        except Exception:  # noqa: BLE001 - never let the idle check raise
+        except Exception:
             logger.debug("scale-to-zero bg-work check failed", exc_info=True)
         return False
 
@@ -4060,7 +4060,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             stz = gw.get("scale_to_zero") if isinstance(gw, dict) else None
             if isinstance(stz, dict):
                 raw = stz.get("idle_timeout_minutes")
-        except Exception:  # noqa: BLE001
+        except Exception:
             raw = None
         return parse_idle_timeout_seconds(raw)
 
@@ -4083,7 +4083,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     max_restarts = rlg["max_restarts"]
                 if isinstance(rlg.get("window_seconds"), int) and rlg["window_seconds"] > 0:
                     window_seconds = rlg["window_seconds"]
-        except Exception:  # noqa: BLE001
+        except Exception:
             pass
         return max_restarts, window_seconds
 
@@ -4111,11 +4111,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if self.config
                 else []
             )
-        except Exception:  # noqa: BLE001
+        except Exception:
             platforms = []
         try:
             wake_url = relay_wake_url()
-        except Exception:  # noqa: BLE001
+        except Exception:
             wake_url = None
         return should_arm(
             enabled=scale_to_zero_enabled(),
@@ -4151,12 +4151,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if self.config
                     else []
                 )
-            except Exception:  # noqa: BLE001
+            except Exception:
                 active = []
             relay_only = messaging_is_relay_only_or_absent(active)
             try:
                 wake_url = relay_wake_url()
-            except Exception:  # noqa: BLE001
+            except Exception:
                 wake_url = None
             logger.info(
                 "scale-to-zero: NOT armed despite opt-in — "
@@ -4166,7 +4166,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 active or "none",
                 "set" if wake_url else "MISSING",
             )
-        except Exception:  # noqa: BLE001 - diagnostics must never block startup
+        except Exception:
             logger.debug("scale-to-zero: not-armed reason logging failed", exc_info=True)
 
     def _scale_to_zero_is_idle(self) -> bool:
@@ -4192,7 +4192,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if getattr(self, "_scale_to_zero_cooldown_until", 0.0) > 0:
             try:
                 self._update_runtime_status("running")
-            except Exception:  # noqa: BLE001 - status restoration is best-effort
+            except Exception:
                 logger.debug("scale-to-zero: status restore failed", exc_info=True)
             self._scale_to_zero_cooldown_until = 0.0
 
@@ -4200,7 +4200,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Return the connected RELAY adapter, if any (the one go_dormant targets)."""
         try:
             from gateway.platforms.base import Platform
-        except Exception:  # noqa: BLE001
+        except Exception:
             return None
         return self.adapters.get(Platform.RELAY)
 
@@ -4244,13 +4244,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 try:
                     self._update_runtime_status("draining")
-                except Exception:  # noqa: BLE001 - status is best-effort
+                except Exception:
                     logger.debug("scale-to-zero: status mark failed", exc_info=True)
                 try:
                     result = go_dormant()
                     if asyncio.iscoroutine(result):
                         await result
-                except Exception:  # noqa: BLE001 - dormancy is best-effort
+                except Exception:
                     logger.debug("scale-to-zero: go_dormant failed", exc_info=True)
                 # 0.F: after a wake the drained inbound updates _last_inbound_at,
                 # but give it a window so we don't immediately re-go-dormant on the
@@ -4258,7 +4258,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._scale_to_zero_cooldown_until = time.time() + max(interval, 60.0)
             except asyncio.CancelledError:
                 raise
-            except Exception:  # noqa: BLE001 - the watcher must never crash the gateway
+            except Exception:
                 logger.debug("scale-to-zero watcher iteration error", exc_info=True)
 
     def _status_action_label(self) -> str:
@@ -5035,9 +5035,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not session_key or session_store is None:
             return False
         try:
-            with session_store._lock:  # noqa: SLF001 — snapshot entry under lock
-                session_store._ensure_loaded_locked()  # noqa: SLF001
-                entry = session_store._entries.get(session_key)  # noqa: SLF001
+            with session_store._lock:
+                session_store._ensure_loaded_locked()
+                entry = session_store._entries.get(session_key)
             session_id = getattr(entry, "session_id", None) if entry is not None else None
             if not session_id:
                 return False
@@ -6376,10 +6376,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         window = _auto_continue_freshness_window()
         try:
-            with self.session_store._lock:  # noqa: SLF001 — snapshot under lock
-                self.session_store._ensure_loaded_locked()  # noqa: SLF001
+            with self.session_store._lock:
+                self.session_store._ensure_loaded_locked()
                 candidates = [
-                    entry for entry in self.session_store._entries.values()  # noqa: SLF001
+                    entry for entry in self.session_store._entries.values()
                     if entry.resume_pending
                     and not entry.suspended
                     and entry.origin is not None
@@ -6407,7 +6407,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _max_restarts, _window = self._restart_loop_guard_config()
                 if _rlg.check_and_record(_max_restarts, _window):
                     return 0
-            except Exception as exc:  # noqa: BLE001 — breaker must fail OPEN
+            except Exception as exc:
                 logger.debug("Restart-loop guard check skipped: %s", exc)
 
         now = datetime.now()
@@ -7203,7 +7203,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # not arming is normal — stay silent there). Without this, a failed
                 # arm is invisible and "why won't it suspend/wake?" needs a box-dive.
                 self._log_scale_to_zero_not_armed_reason()
-        except Exception:  # noqa: BLE001 - arming must never block startup
+        except Exception:
             logger.debug("scale-to-zero: arm check failed at startup", exc_info=True)
 
         # Start background drain-control watcher — reconciles the gateway's


### PR DESCRIPTION
## Summary

Ruff auto-fix (`RUF100`) identified and removed 26 stale `# noqa` directives from `gateway/run.py` that were suppressing lint violations no longer present in the code. No functional changes.

## Changes

- `gateway/run.py`: removed 26 `# noqa` comments (F401, E402, BLE001, SLF001)

## Verification

- `ruff check gateway/run.py`: ✅ all checks passed
- `python3 -m py_compile gateway/run.py`: ✅ compiles cleanly