### PR TITLE
Add local provider overlay

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import ipaddress
 import shutil
 import shlex
 import ssl
@@ -150,6 +151,35 @@ SERVICE_PROVIDER_NAMES: Dict[str, str] = {
 # provider as configured. This sentinel is sent only to LM Studio, never to
 # any remote service.
 LMSTUDIO_NOAUTH_PLACEHOLDER = "dummy-lm-api-key"
+LOCAL_NOAUTH_PLACEHOLDER = "no-key-required"
+
+
+def _local_base_url_allows_noauth(base_url: str) -> bool:
+    """Return True when a local provider URL is private enough for no-key mode."""
+    raw = (base_url or "").strip()
+    if not raw:
+        return False
+    candidate = raw if "://" in raw else f"//{raw}"
+    try:
+        parsed = urlparse(candidate)
+    except Exception:
+        return False
+    host = (parsed.hostname or "").lower().rstrip(".")
+    if not host:
+        return False
+    if host in {"localhost", "127.0.0.1", "::1", "0.0.0.0"}:
+        return True
+    if host.endswith(".local"):
+        return True
+    if "." not in host and ":" not in host:
+        return True
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    if addr.is_loopback or addr.is_private or addr.is_link_local:
+        return True
+    return isinstance(addr, ipaddress.IPv4Address) and addr in ipaddress.ip_network("100.64.0.0/10")
 
 
 # =============================================================================
@@ -216,6 +246,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url="http://127.0.0.1:1234/v1",
         api_key_env_vars=("LM_API_KEY",),
         base_url_env_var="LM_BASE_URL",
+    ),
+    "local": ProviderConfig(
+        id="local",
+        name="Local endpoint",
+        auth_type="api_key",
+        api_key_env_vars=("LOCAL_API_KEY",),
+        base_url_env_var="LOCAL_BASE_URL",
     ),
     "copilot": ProviderConfig(
         id="copilot",
@@ -1731,7 +1768,7 @@ def resolve_provider(
         # whose availability isn't implied by LM_API_KEY presence (it may be
         # offline, and the no-auth setup uses a placeholder value), so it
         # also requires explicit selection.
-        if pid in {"copilot", "lmstudio"}:
+        if pid in {"copilot", "lmstudio", "local"}:
             continue
         for env_var in pconfig.api_key_env_vars:
             if has_usable_secret(os.getenv(env_var, "")):
@@ -6216,13 +6253,6 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
     key_source = ""
     api_key, key_source = _resolve_api_key_provider_secret(provider_id, pconfig)
 
-    # No-auth LM Studio: substitute a placeholder so runtime / auxiliary_client
-    # see the local server as configured. doctor still reports unconfigured
-    # because get_api_key_provider_status uses the raw secret resolver.
-    if not api_key and provider_id == "lmstudio":
-        api_key = LMSTUDIO_NOAUTH_PLACEHOLDER
-        key_source = key_source or "default"
-
     env_url = ""
     if pconfig.base_url_env_var:
         env_url = os.getenv(pconfig.base_url_env_var, "").strip()
@@ -6258,6 +6288,16 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
 
     if provider_id == "lmstudio":
         base_url = _normalize_lmstudio_runtime_base_url(base_url)
+
+    # No-auth local servers: substitute a placeholder so runtime /
+    # auxiliary_client see the endpoint as configured. For the generic local
+    # provider, only do this when the resolved URL is actually local/private.
+    if not api_key and provider_id == "lmstudio":
+        api_key = LMSTUDIO_NOAUTH_PLACEHOLDER
+        key_source = key_source or "default"
+    elif not api_key and provider_id == "local" and _local_base_url_allows_noauth(base_url):
+        api_key = LOCAL_NOAUTH_PLACEHOLDER
+        key_source = key_source or "default"
 
     # Last-resort guard: an API-key provider must never hand back an empty
     # base URL (a set-but-empty COPILOT_API_BASE_URL or similar env override

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3278,6 +3278,22 @@ OPTIONAL_ENV_VARS = {
         "category": "provider",
         "advanced": True,
     },
+    "LOCAL_API_KEY": {
+        "description": "API key for a local OpenAI-compatible endpoint, when the server requires one",
+        "prompt": "Local endpoint API key",
+        "url": None,
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "LOCAL_BASE_URL": {
+        "description": "Local OpenAI-compatible endpoint base URL",
+        "prompt": "Local endpoint base URL (e.g. http://localhost:8000/v1)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
     "GLM_API_KEY": {
         "description": "Z.AI / GLM API key (also recognized as ZAI_API_KEY / Z_AI_API_KEY)",
         "prompt": "Z.AI / GLM API key",

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1630,6 +1630,29 @@ def list_authenticated_providers(
             live = [current_model]
         curated["lmstudio"] = live
 
+    if "local" not in curated and (
+        os.environ.get("LOCAL_API_KEY")
+        or os.environ.get("LOCAL_BASE_URL")
+        or current_provider.strip().lower() == "local"
+    ):
+        from hermes_cli.models import fetch_api_models
+        is_current_local = current_provider.strip().lower() == "local"
+        local_base = (
+            os.environ.get("LOCAL_BASE_URL")
+            or (current_base_url if is_current_local and current_base_url else None)
+            or ""
+        )
+        live = []
+        if local_base:
+            live = fetch_api_models(
+                os.environ.get("LOCAL_API_KEY", "") or "no-key-required",
+                local_base,
+                timeout=1.5,
+            ) or []
+        if not live and is_current_local and current_model:
+            live = [current_model]
+        curated["local"] = live
+
     # --- 1. Check Hermes-mapped providers ---
     from hermes_cli.models import _AGGREGATOR_PROVIDERS as _AGG_PROVIDERS
     from hermes_cli.providers import ALIASES as _PROVIDER_ALIAS_TABLE
@@ -1742,6 +1765,11 @@ def list_authenticated_providers(
             has_creds = _has_aws_sdk_creds_for_listing(hermes_slug)
         elif overlay.extra_env_vars:
             has_creds = any(os.environ.get(ev) for ev in overlay.extra_env_vars)
+        if not has_creds and hermes_slug == "local":
+            has_creds = bool(
+                os.environ.get("LOCAL_BASE_URL")
+                or (current_provider.strip().lower() == "local" and current_base_url)
+            )
         # Also check api_key_env_vars from PROVIDER_REGISTRY for api_key auth_type
         if not has_creds and overlay.auth_type == "api_key":
             for _key in (pid, hermes_slug):

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1033,6 +1033,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("moa",            "Mixture of Agents",        "Mixture of Agents (named presets; aggregator acts after reference models)"),
     ProviderEntry("novita",         "NovitaAI",                 "NovitaAI (Cloud: Model API, Agent Sandbox, GPU Cloud)"),
     ProviderEntry("lmstudio",       "LM Studio",                "LM Studio (Local desktop app with built-in model server)"),
+    ProviderEntry("local",          "Local endpoint",           "Local endpoint (OpenAI-compatible server via LOCAL_BASE_URL)"),
     ProviderEntry("anthropic",      "Anthropic",                "Anthropic (Claude models via API key or Claude Code)"),
     ProviderEntry("openai-codex",   "OpenAI Codex",             "OpenAI Codex (Codex CLI via ChatGPT subscription or API key)"),
     ProviderEntry("openai-api",     "OpenAI API",               "OpenAI API (api.openai.com, API key)"),
@@ -2424,6 +2425,21 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             )
             api_mode = "anthropic_messages" if _base_url_looks_like_anthropic_messages(base_url) else None
             live = fetch_api_models(api_key, base_url, api_mode=api_mode)
+            if live:
+                return live
+    if normalized == "local":
+        model_cfg = _get_model_config_dict()
+        cfg_provider = normalize_provider(str(model_cfg.get("provider", "") or ""))
+        cfg_base_url = str(model_cfg.get("base_url", "") or "").strip() if cfg_provider == "local" else ""
+        base_url = (os.getenv("LOCAL_BASE_URL", "").strip() or cfg_base_url).rstrip("/")
+        if base_url:
+            api_key = (
+                os.getenv("LOCAL_API_KEY", "").strip()
+                or str(model_cfg.get("api_key", "") or "").strip()
+                or "no-key-required"
+            )
+            api_mode = "anthropic_messages" if _base_url_looks_like_anthropic_messages(base_url) else None
+            live = fetch_api_models(api_key, base_url, timeout=1.5, api_mode=api_mode)
             if live:
                 return live
     # Bedrock uses live discovery keyed by the resolved AWS region so that

--- a/hermes_cli/provider_catalog.py
+++ b/hermes_cli/provider_catalog.py
@@ -19,8 +19,8 @@ the same universe ``hermes model`` renders (``CANONICAL_PROVIDERS``), joining:
   :class:`providers.base.ProviderProfile` when one exists, falling back to the
   ``CANONICAL_PROVIDERS`` entry's ``label`` / ``tui_desc`` and the
   ``OPTIONAL_ENV_VARS`` signup URL otherwise (many profiles leave these blank,
-  and four canonical providers have no profile at all — lmstudio, openai-api,
-  tencent-tokenhub, xai-oauth — so the fallbacks are load-bearing).
+  and some canonical providers have no profile at all — lmstudio, local,
+  openai-api, tencent-tokenhub, xai-oauth — so the fallbacks are load-bearing).
 
 Each descriptor is tagged with the ``tab`` it belongs on (``keys`` vs
 ``accounts``) based purely on how the provider authenticates.  The desktop

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -88,6 +88,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="http://127.0.0.1:1234/v1",
         base_url_env_var="LM_BASE_URL",
     ),
+    "local": HermesOverlay(
+        transport="openai_chat",
+        auth_type="api_key",
+        extra_env_vars=("LOCAL_API_KEY",),
+        base_url_env_var="LOCAL_BASE_URL",
+    ),
     "copilot-acp": HermesOverlay(
         transport="codex_responses",
         auth_type="external_process",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1462,14 +1462,20 @@ def _resolve_explicit_runtime(
         env_url = ""
         if pconfig.base_url_env_var:
             env_url = _getenv(pconfig.base_url_env_var, "").strip().rstrip("/")
+        cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+        cfg_base_url = ""
+        if cfg_provider == provider:
+            cfg_base_url = (model_cfg.get("base_url") or "").strip().rstrip("/")
 
         base_url = explicit_base_url
         if not base_url:
+            if cfg_base_url:
+                base_url = cfg_base_url
             if provider in {"kimi-coding", "kimi-coding-cn"}:
                 creds = resolve_api_key_provider_credentials(provider)
-                base_url = creds.get("base_url", "").rstrip("/")
+                base_url = base_url or creds.get("base_url", "").rstrip("/")
             else:
-                base_url = env_url or pconfig.inference_base_url
+                base_url = base_url or env_url or pconfig.inference_base_url
 
         api_key = explicit_api_key
         if not api_key:
@@ -1477,6 +1483,8 @@ def _resolve_explicit_runtime(
             api_key = creds.get("api_key", "")
             if not base_url:
                 base_url = creds.get("base_url", "").rstrip("/")
+        if provider == "local" and not api_key and auth_mod._local_base_url_allows_noauth(base_url):
+            api_key = auth_mod.LOCAL_NOAUTH_PLACEHOLDER
 
         api_mode = "chat_completions"
         if provider == "copilot":
@@ -2034,11 +2042,14 @@ def resolve_runtime_provider(
             base_url = normalize_opencode_base_url(provider, api_mode, base_url)
         if provider == "lmstudio":
             base_url = auth_mod._normalize_lmstudio_runtime_base_url(base_url)
+        api_key = creds.get("api_key", "")
+        if provider == "local" and not api_key and auth_mod._local_base_url_allows_noauth(base_url):
+            api_key = auth_mod.LOCAL_NOAUTH_PLACEHOLDER
         return {
             "provider": provider,
             "api_mode": api_mode,
             "base_url": base_url,
-            "api_key": creds.get("api_key", ""),
+            "api_key": api_key,
             "source": creds.get("source", "env"),
             "requested_provider": requested_provider,
         }

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -14,6 +14,7 @@ from hermes_cli.auth import (
     get_auth_status,
     AuthError,
     KIMI_CODE_BASE_URL,
+    LOCAL_NOAUTH_PLACEHOLDER,
     STEPFUN_STEP_PLAN_INTL_BASE_URL,
     STEPFUN_STEP_PLAN_CN_BASE_URL,
     _resolve_kimi_base_url,
@@ -65,6 +66,14 @@ class TestProviderRegistry:
         assert pconfig.api_key_env_vars == ("NVIDIA_API_KEY",)
         assert pconfig.base_url_env_var == "NVIDIA_BASE_URL"
         assert pconfig.inference_base_url == "https://integrate.api.nvidia.com/v1"
+
+    def test_local_env_vars(self):
+        pconfig = PROVIDER_REGISTRY["local"]
+        assert pconfig.name == "Local endpoint"
+        assert pconfig.auth_type == "api_key"
+        assert pconfig.api_key_env_vars == ("LOCAL_API_KEY",)
+        assert pconfig.base_url_env_var == "LOCAL_BASE_URL"
+        assert pconfig.inference_base_url == ""
 
     def test_copilot_env_vars(self):
         pconfig = PROVIDER_REGISTRY["copilot"]
@@ -137,7 +146,7 @@ class TestProviderRegistry:
 PROVIDER_ENV_VARS = (
     "OPENROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN",
     "CLAUDE_CODE_OAUTH_TOKEN",
-    "LM_API_KEY", "LM_BASE_URL",
+    "LM_API_KEY", "LM_BASE_URL", "LOCAL_API_KEY", "LOCAL_BASE_URL",
     "GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY",
     "KIMI_API_KEY", "KIMI_BASE_URL", "STEPFUN_API_KEY", "STEPFUN_BASE_URL",
     "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY",
@@ -448,6 +457,35 @@ class TestResolveApiKeyProviderCredentials:
         assert creds["provider"] == "lmstudio"
         assert creds["api_key"] == "dummy-lm-api-key"
         assert creds["base_url"] == "http://127.0.0.1:1234/v1"
+
+    def test_resolve_local_uses_token_and_base_url_from_env(self, monkeypatch):
+        monkeypatch.setenv("LOCAL_API_KEY", "local-token")
+        monkeypatch.setenv("LOCAL_BASE_URL", "http://127.0.0.1:8000/v1")
+
+        creds = resolve_api_key_provider_credentials("local")
+
+        assert creds["provider"] == "local"
+        assert creds["api_key"] == "local-token"
+        assert creds["base_url"] == "http://127.0.0.1:8000/v1"
+        assert creds["source"] == "LOCAL_API_KEY"
+
+    def test_resolve_local_private_base_url_without_key_uses_placeholder(self, monkeypatch):
+        monkeypatch.setenv("LOCAL_BASE_URL", "http://192.168.1.25:8000/v1")
+
+        creds = resolve_api_key_provider_credentials("local")
+
+        assert creds["provider"] == "local"
+        assert creds["api_key"] == LOCAL_NOAUTH_PLACEHOLDER
+        assert creds["base_url"] == "http://192.168.1.25:8000/v1"
+
+    def test_resolve_local_public_base_url_without_key_stays_unauthenticated(self, monkeypatch):
+        monkeypatch.setenv("LOCAL_BASE_URL", "https://api.example.com/v1")
+
+        creds = resolve_api_key_provider_credentials("local")
+
+        assert creds["provider"] == "local"
+        assert creds["api_key"] == ""
+        assert creds["base_url"] == "https://api.example.com/v1"
 
     def test_try_gh_cli_token_uses_homebrew_path_when_not_on_path(self, monkeypatch):
         monkeypatch.setattr("hermes_cli.copilot_auth.shutil.which", lambda command: None)

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -653,6 +653,93 @@ def test_lmstudio_picker_skips_probe_when_not_configured(monkeypatch):
     assert "base_url" not in captured
 
 
+def test_local_picker_uses_local_base_url_env_without_api_key(monkeypatch):
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.auth._load_auth_store", lambda: {})
+    monkeypatch.setattr(
+        "agent.credential_pool.load_pool",
+        lambda provider: type("Pool", (), {"has_credentials": lambda self: False})(),
+    )
+    monkeypatch.setenv("LOCAL_BASE_URL", "http://127.0.0.1:8000/v1")
+    monkeypatch.delenv("LOCAL_API_KEY", raising=False)
+
+    captured: dict = {}
+
+    def _fake_fetch(api_key=None, base_url=None, timeout=5.0, **_kwargs):
+        captured["api_key"] = api_key
+        captured["base_url"] = base_url
+        captured["timeout"] = timeout
+        return ["local-qwen"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", _fake_fetch)
+
+    providers = list_authenticated_providers(refresh=True)
+
+    local = next(p for p in providers if p["slug"] == "local")
+    assert local["models"] == ["local-qwen"]
+    assert captured["api_key"] == "no-key-required"
+    assert captured["base_url"] == "http://127.0.0.1:8000/v1"
+
+
+def test_local_picker_probes_active_config_base_url(monkeypatch):
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.auth._load_auth_store", lambda: {})
+    monkeypatch.setattr(
+        "agent.credential_pool.load_pool",
+        lambda provider: type("Pool", (), {"has_credentials": lambda self: False})(),
+    )
+    monkeypatch.delenv("LOCAL_BASE_URL", raising=False)
+    monkeypatch.delenv("LOCAL_API_KEY", raising=False)
+
+    captured: dict = {}
+
+    def _fake_fetch(api_key=None, base_url=None, timeout=5.0, **_kwargs):
+        captured["api_key"] = api_key
+        captured["base_url"] = base_url
+        return []
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", _fake_fetch)
+
+    providers = list_authenticated_providers(
+        current_provider="local",
+        current_base_url="http://192.168.1.25:8000/v1",
+        current_model="local-qwen",
+        refresh=True,
+    )
+
+    local = next(p for p in providers if p["slug"] == "local")
+    assert local["models"] == ["local-qwen"]
+    assert captured["base_url"] == "http://192.168.1.25:8000/v1"
+
+
+def test_local_picker_skips_probe_when_not_configured(monkeypatch):
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.auth._load_auth_store", lambda: {})
+    monkeypatch.setattr(
+        "agent.credential_pool.load_pool",
+        lambda provider: type("Pool", (), {"has_credentials": lambda self: False})(),
+    )
+    monkeypatch.delenv("LOCAL_BASE_URL", raising=False)
+    monkeypatch.delenv("LOCAL_API_KEY", raising=False)
+
+    captured: dict = {}
+
+    def _fake_fetch(api_key=None, base_url=None, timeout=5.0, **_kwargs):
+        captured["base_url"] = base_url
+        return []
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", _fake_fetch)
+
+    providers = list_authenticated_providers(
+        current_provider="openrouter",
+        current_base_url="https://openrouter.ai/api/v1",
+        refresh=True,
+    )
+
+    assert all(p["slug"] != "local" for p in providers)
+    assert "base_url" not in captured
+
+
 def test_custom_providers_uses_live_models_for_multi_model_endpoint(monkeypatch):
     """Custom providers with api_key + base_url should prefer live /models.
 

--- a/tests/hermes_cli/test_provider_catalog.py
+++ b/tests/hermes_cli/test_provider_catalog.py
@@ -46,12 +46,12 @@ def test_descriptor_count_matches_canonical():
 def test_profileless_providers_still_present():
     """Providers without a ProviderProfile must still resolve via fallbacks.
 
-    lmstudio / openai-api / tencent-tokenhub / xai-oauth have no profile on
+    lmstudio / local / openai-api / tencent-tokenhub / xai-oauth have no profile on
     main; they exist only as registry + canonical entries. The catalog must
     not require a profile to include a provider.
     """
     by = provider_catalog_by_slug()
-    for slug in ("lmstudio", "openai-api", "tencent-tokenhub", "xai-oauth"):
+    for slug in ("lmstudio", "local", "openai-api", "tencent-tokenhub", "xai-oauth"):
         assert slug in by, f"{slug} dropped from catalog (profile-less provider)"
         assert by[slug].label, f"{slug} has empty label despite canonical fallback"
         assert by[slug].description, f"{slug} has empty description despite fallback"
@@ -82,6 +82,14 @@ def test_copilot_surfaces_as_a_provider_with_its_own_token_var():
     assert d.api_key_env_vars[0] == "COPILOT_GITHUB_TOKEN", (
         "Copilot's primary var must be the provider-owned token, not shared GITHUB_TOKEN"
     )
+
+
+def test_local_provider_exposes_key_and_base_url_env_vars():
+    by = provider_catalog_by_slug()
+    d = by["local"]
+    assert d.tab == "keys"
+    assert d.api_key_env_vars == ("LOCAL_API_KEY",)
+    assert d.base_url_env_var == "LOCAL_BASE_URL"
 
 
 def test_bedrock_routes_to_keys():

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -473,6 +473,84 @@ def test_resolve_runtime_provider_lmstudio_normalizes_native_api_saved_base_url(
     assert resolved["base_url"] == "http://192.168.1.10:1234/v1"
 
 
+def test_resolve_runtime_provider_local_honors_saved_private_base_url_without_key(monkeypatch):
+    monkeypatch.delenv("LOCAL_API_KEY", raising=False)
+    monkeypatch.delenv("LOCAL_BASE_URL", raising=False)
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "local")
+    monkeypatch.setattr(rp, "_resolve_named_custom_runtime", lambda **k: None)
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "local",
+            "base_url": "http://192.168.1.25:8000/v1",
+            "default": "qwen/qwen3-coder-30b",
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "load_pool",
+        lambda provider: type("Pool", (), {"has_credentials": lambda self: False})(),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="local")
+
+    assert resolved["provider"] == "local"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "http://192.168.1.25:8000/v1"
+    assert resolved["api_key"] == "no-key-required"
+
+
+def test_resolve_runtime_provider_local_base_url_env_without_key(monkeypatch):
+    monkeypatch.delenv("LOCAL_API_KEY", raising=False)
+    monkeypatch.setenv("LOCAL_BASE_URL", "http://127.0.0.1:8000/v1")
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "local")
+    monkeypatch.setattr(rp, "_resolve_named_custom_runtime", lambda **k: None)
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "local", "default": "local-model"},
+    )
+    monkeypatch.setattr(
+        rp,
+        "load_pool",
+        lambda provider: type("Pool", (), {"has_credentials": lambda self: False})(),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="local")
+
+    assert resolved["provider"] == "local"
+    assert resolved["base_url"] == "http://127.0.0.1:8000/v1"
+    assert resolved["api_key"] == "no-key-required"
+
+
+def test_resolve_runtime_provider_local_public_base_url_without_key_stays_empty(monkeypatch):
+    monkeypatch.delenv("LOCAL_API_KEY", raising=False)
+    monkeypatch.delenv("LOCAL_BASE_URL", raising=False)
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "local")
+    monkeypatch.setattr(rp, "_resolve_named_custom_runtime", lambda **k: None)
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "local",
+            "base_url": "https://api.example.com/v1",
+            "default": "example-model",
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "load_pool",
+        lambda provider: type("Pool", (), {"has_credentials": lambda self: False})(),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="local")
+
+    assert resolved["provider"] == "local"
+    assert resolved["base_url"] == "https://api.example.com/v1"
+    assert resolved["api_key"] == ""
+
+
 def test_resolve_runtime_provider_openrouter_explicit(monkeypatch):
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
     monkeypatch.setattr(rp, "_get_model_config", lambda: {})


### PR DESCRIPTION
## Summary
- add `local` as a first-class OpenAI-compatible provider with `LOCAL_BASE_URL` and optional `LOCAL_API_KEY`
- allow no-key local runtime credentials only for loopback/private/link-local/Tailscale/`.local` endpoints
- surface configured local endpoints in the model picker and live-discover `/models` without changing existing `ollama`/`vllm`/`llamacpp` runtime alias behavior

Fixes #43052.
Refs #41370.

## Tests
- `uv run python -m pytest tests/hermes_cli/test_api_key_providers.py tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_provider_catalog.py tests/hermes_cli/test_provider_parity.py tests/hermes_cli/test_list_picker_providers.py -q`
- `uv run python -m pytest tests/hermes_cli/test_config.py tests/hermes_cli/test_model_provider_persistence.py tests/hermes_cli/test_provider_parity.py tests/hermes_cli/test_provider_catalog.py -q`
- `uv run ruff check hermes_cli/auth.py hermes_cli/providers.py hermes_cli/models.py hermes_cli/config.py hermes_cli/model_switch.py hermes_cli/runtime_provider.py hermes_cli/provider_catalog.py tests/hermes_cli/test_api_key_providers.py tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_provider_catalog.py`
- `git diff --check`