### PR TITLE
fix: remove stale # noqa: BLE001 comments from tui_gateway/server.py

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6272,7 +6272,7 @@ def _pet_frame_counts(spritesheet) -> dict:
         from agent.pet import render
 
         return render.state_frame_counts(str(spritesheet))
-    except Exception:  # noqa: BLE001 - cosmetic, never break the surface
+    except Exception:
         return {}
 
 
@@ -6285,7 +6285,7 @@ def _pet_sheet_revision(spritesheet) -> str:
     try:
         stat = spritesheet.stat()
         return f"{stat.st_mtime_ns}:{stat.st_size}"
-    except Exception:  # noqa: BLE001 - cosmetic, never break the surface
+    except Exception:
         return "0:0"
 
 
@@ -6293,7 +6293,7 @@ def _pet_payload_cache_key(pet, *, scale: float) -> tuple | None:
     """Cache key for the expensive sprite payload build."""
     try:
         stat = pet.spritesheet.stat()
-    except Exception:  # noqa: BLE001
+    except Exception:
         return None
     return (
         str(pet.spritesheet),
@@ -6341,7 +6341,7 @@ def _pet_row_frame_counts(spritesheet) -> dict:
                 count += 1
             out[name] = count
         return out
-    except Exception:  # noqa: BLE001 - cosmetic, never break the surface
+    except Exception:
         return {}
 
 
@@ -6356,7 +6356,7 @@ def _pet_config_scale() -> float:
         display = cfg.get("display", {}) if isinstance(cfg.get("display"), dict) else {}
         pet_cfg = display.get("pet", {}) if isinstance(display.get("pet"), dict) else {}
         return float(pet_cfg.get("scale", constants.DEFAULT_SCALE) or constants.DEFAULT_SCALE)
-    except Exception:  # noqa: BLE001
+    except Exception:
         return constants.DEFAULT_SCALE
 
 
@@ -6438,7 +6438,7 @@ def _pet_state_rows(spritesheet) -> list[str]:
         with Image.open(spritesheet) as image:
             row_count = max(1, image.height // constants.FRAME_H)
         return list(constants.state_rows_for_grid(row_count))
-    except Exception:  # noqa: BLE001 - cosmetic, never break the surface
+    except Exception:
         from agent.pet import constants
 
         return list(constants.STATE_ROWS)
@@ -6465,7 +6465,7 @@ def _(rid, params: dict) -> dict:
             return _ok(rid, {"enabled": False})
 
         return _ok(rid, {"enabled": True, **_pet_sprite_payload(pet, scale=scale)})
-    except Exception as exc:  # noqa: BLE001 - cosmetic, never break the surface
+    except Exception as exc:
         logger.debug("pet.info failed: %s", exc)
         return _ok(rid, {"enabled": False})
 
@@ -6488,7 +6488,7 @@ def _(rid, params: dict) -> dict:
                 "spritesheetRevision": _pet_sheet_revision(pet.spritesheet),
             },
         )
-    except Exception as exc:  # noqa: BLE001 - cosmetic, never break the surface
+    except Exception as exc:
         logger.debug("pet.info.meta failed: %s", exc)
         return _ok(rid, {"enabled": False})
 
@@ -6593,7 +6593,7 @@ def _(rid, params: dict) -> dict:
                 "scale": scale,
             },
         )
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         logger.debug("pet.cells failed: %s", exc)
         return _ok(rid, {"enabled": False})
 
@@ -6652,7 +6652,7 @@ def _(rid, params: dict) -> dict:
                         "generated": entry.slug in installed and installed[entry.slug].generated,
                     }
                 )
-        except Exception as exc:  # noqa: BLE001 - offline: fall back to installed
+        except Exception as exc:
             logger.debug("pet.gallery manifest fetch failed: %s", exc)
 
         # Always include locally-installed pets even if the gallery is unreachable.
@@ -6676,7 +6676,7 @@ def _(rid, params: dict) -> dict:
                 "pets": gallery,
             },
         )
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         logger.debug("pet.gallery failed: %s", exc)
         return _ok(rid, {"enabled": False, "active": "", "pets": []})
 
@@ -6703,7 +6703,7 @@ def _(rid, params: dict) -> dict:
             return _err(rid, 5031, f"could not adopt '{slug}': {exc}")
         _set_active(slug)
         return _ok(rid, {"ok": True, "slug": slug, "displayName": pet.display_name})
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         logger.debug("pet.select failed: %s", exc)
         return _err(rid, 5031, f"pet.select failed: {exc}")
 
@@ -6729,11 +6729,11 @@ def _(rid, params: dict) -> dict:
         # If that was the active pet, stop surfaces pointing at a deleted sprite.
         try:
             _clear_active_if(slug)
-        except Exception as exc:  # noqa: BLE001 - removal already succeeded
+        except Exception as exc:
             logger.debug("pet.remove config update failed: %s", exc)
 
         return _ok(rid, {"ok": removed, "slug": slug})
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         logger.debug("pet.remove failed: %s", exc)
         return _err(rid, 5031, f"pet.remove failed: {exc}")
 
@@ -6760,7 +6760,7 @@ def _(rid, params: dict) -> dict:
             rid,
             {"ok": True, "filename": filename, "zipBase64": base64.standard_b64encode(data).decode("ascii")},
         )
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         logger.debug("pet.export failed: %s", exc)
         return _err(rid, 5031, f"pet.export failed: {exc}")
 
@@ -6794,11 +6794,11 @@ def _(rid, params: dict) -> dict:
                 from hermes_cli.pets import _rename_active_if
 
                 _rename_active_if(slug, new_slug)
-            except Exception as exc:  # noqa: BLE001 - rename already succeeded
+            except Exception as exc:
                 logger.debug("pet.rename config update failed: %s", exc)
 
         return _ok(rid, {"ok": True, "slug": new_slug, "displayName": name})
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         logger.debug("pet.rename failed: %s", exc)
         return _err(rid, 5031, f"pet.rename failed: {exc}")
 
@@ -6833,7 +6833,7 @@ def _(rid, params: dict) -> dict:
                 "dataUri": "data:image/png;base64," + base64.standard_b64encode(data).decode("ascii"),
             },
         )
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         logger.debug("pet.thumb failed: %s", exc)
         return _ok(rid, {"ok": False, "slug": slug})
 
@@ -6847,7 +6847,7 @@ def _(rid, params: dict) -> dict:
 
         _set_enabled(False)
         return _ok(rid, {"ok": True})
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         logger.debug("pet.disable failed: %s", exc)
         return _err(rid, 5031, f"pet.disable failed: {exc}")
 
@@ -6868,7 +6868,7 @@ def _(rid, params: dict) -> dict:
         if err:
             return _err(rid, 4004, err)
         return _ok(rid, {"ok": True, "scale": scale})
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         logger.debug("pet.scale failed: %s", exc)
         return _err(rid, 5031, f"pet.scale failed: {exc}")
 
@@ -6892,7 +6892,7 @@ def _pet_gen_sweep(root, *, max_age_s: float = 3600.0) -> None:
         for child in root.iterdir():
             if child.is_dir() and now - child.stat().st_mtime > max_age_s:
                 shutil.rmtree(child, ignore_errors=True)
-    except Exception as exc:  # noqa: BLE001 - cleanup is best-effort
+    except Exception as exc:
         logger.debug("pet-gen sweep failed: %s", exc)
 
 
@@ -7023,11 +7023,11 @@ def _(rid, params: dict) -> dict:
             available = False
         try:
             providers = list_sprite_providers()
-        except Exception as exc:  # noqa: BLE001 - picker is best-effort
+        except Exception as exc:
             logger.debug("pet provider list failed: %s", exc)
             providers = []
         return _ok(rid, {"available": available, "providers": providers})
-    except Exception as exc:  # noqa: BLE001 - never break the surface
+    except Exception as exc:
         logger.debug("pet.generate.status failed: %s", exc)
         return _ok(rid, {"available": False, "providers": []})
 
@@ -7095,7 +7095,7 @@ def _(rid, params: dict) -> dict:
         # fired before the first draft lands can still target this run.
         try:
             _emit("pet.generate.progress", "", {"token": token, "count": count})
-        except Exception as exc:  # noqa: BLE001 - streaming is best-effort
+        except Exception as exc:
             logger.debug("pet.generate init emit failed: %s", exc)
 
         def _on_draft(index: int, src) -> None:
@@ -7103,7 +7103,7 @@ def _(rid, params: dict) -> dict:
             try:
                 shutil.copyfile(src, dest)
                 data_uri = _pet_png_data_uri(dest)
-            except Exception as exc:  # noqa: BLE001 - skip a bad draft, keep the rest
+            except Exception as exc:
                 logger.debug("pet.generate draft %d failed: %s", index, exc)
                 return
             out.append({"index": index, "dataUri": data_uri})
@@ -7115,7 +7115,7 @@ def _(rid, params: dict) -> dict:
                     "",
                     {"token": token, "index": index, "dataUri": data_uri, "count": count},
                 )
-            except Exception as exc:  # noqa: BLE001
+            except Exception as exc:
                 logger.debug("pet.generate progress emit failed: %s", exc)
 
         try:
@@ -7140,7 +7140,7 @@ def _(rid, params: dict) -> dict:
             return _err(rid, 5031, "generation produced no usable drafts")
         out.sort(key=lambda d: d["index"])
         return _ok(rid, {"ok": True, "token": token, "drafts": out})
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         logger.debug("pet.generate failed: %s", exc)
         return _err(rid, 5031, f"pet.generate failed: {exc}")
 
@@ -7207,7 +7207,7 @@ def _(rid, params: dict) -> dict:
                 payload = {"event": "row", "state": state, "done": done, "total": total}
             try:
                 _emit("pet.hatch.progress", "", payload)
-            except Exception as exc:  # noqa: BLE001
+            except Exception as exc:
                 logger.debug("pet.hatch progress emit failed: %s", exc)
 
         try:
@@ -7239,7 +7239,7 @@ def _(rid, params: dict) -> dict:
                 "pet": payload,
             },
         )
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         logger.debug("pet.hatch failed: %s", exc)
         return _err(rid, 5031, f"pet.hatch failed: {exc}")
 
@@ -13585,7 +13585,7 @@ def _(rid, params: dict) -> dict:
 
         payload = build_learning_graph()
         return _ok(rid, render_frames(payload, cols=max(20, cols), rows=max(10, rows), frames=frames))
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         return _err(rid, 5000, f"learning.frames failed: {exc}")
 
 
@@ -13596,7 +13596,7 @@ def _(rid, params: dict) -> dict:
         from agent.learning_mutations import node_detail
 
         return _ok(rid, node_detail(str(params.get("id", ""))))
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         return _err(rid, 5000, f"learning.detail failed: {exc}")
 
 
@@ -13607,7 +13607,7 @@ def _(rid, params: dict) -> dict:
         from agent.learning_mutations import delete_node
 
         return _ok(rid, delete_node(str(params.get("id", ""))))
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         return _err(rid, 5000, f"learning.delete failed: {exc}")
 
 
@@ -13618,7 +13618,7 @@ def _(rid, params: dict) -> dict:
         from agent.learning_mutations import edit_node
 
         return _ok(rid, edit_node(str(params.get("id", "")), str(params.get("content", ""))))
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         return _err(rid, 5000, f"learning.edit failed: {exc}")
 
 


### PR DESCRIPTION
Removes 33 stale `# noqa: BLE001` comments from `tui_gateway/server.py`.

The project's ruff config (`pyproject.toml`) only selects `PLW1514` — BLE001 is not among the checked rules. All 33 noqas were suppressing a rule that was never evaluated, making them entirely stale.

```
ruff check tui_gateway/server.py  # All checks passed!
```