### PR TITLE
chore: add Hermes self-improvement safety gates

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1182,6 +1182,14 @@ DEFAULT_CONFIG = {
         "persistent_shell": True,
     },
 
+    # Security policy for MCP server loading and remote-capable tools.
+    # Defaults are conservative: allow only local hosts unless the user
+    # explicitly opts in to remote server names or hosts.
+    "mcp_security": {
+        "allowed_servers": [],
+        "allowed_hosts": ["localhost", "127.0.0.1", "::1"],
+    },
+
     "web": {
         "backend": "",           # shared fallback — applies to both search and extract
         "search_backend": "",    # per-capability override for web_search (e.g. "searxng")

--- a/hermes_cli/mcp_security.py
+++ b/hermes_cli/mcp_security.py
@@ -2,7 +2,8 @@
 
 MCP stdio transports intentionally support arbitrary local commands so users can
 run custom servers. This module does not try to sandbox that capability. It
-blocks two high-signal abuse shapes seen in the wild:
+blocks high-signal abuse shapes while keeping legitimate local MCP workflows
+flexible:
 
 1. The exfiltration shape from #45620: a shell interpreter whose inline script
    invokes network egress tooling.
@@ -12,23 +13,32 @@ blocks two high-signal abuse shapes seen in the wild:
    crontab, shell rc files). The campaign planted ``command: bash`` MCP entries
    whose payload appended an attacker SSH key to ``authorized_keys``; Hermes
    re-executed them on every cron tick / startup, re-installing the backdoor.
-
 3. A hardcoded indicator-of-compromise (IOC) blocklist for that campaign — the
    attacker's ``hermes-0day`` SSH public key and source IPs. Any entry whose
    command/args/env carry an IOC is refused outright, regardless of shape, so a
    pre-planted ``config.yaml`` cannot spawn it.
+4. URL-based MCP transports are limited to local hosts unless
+   ``mcp_security.allowed_hosts`` explicitly opts in to more.
+5. Literal secret-shaped env/header values are refused; placeholders such as
+   ``${MCP_GITHUB_API_KEY}`` are allowed.
 
 These checks run BOTH at save time (``_save_mcp_server`` — dashboard API + CLI)
 and at spawn time (``tools.mcp_tool._filter_suspicious_mcp_servers`` — discovery
 / cron / startup), so a hand-edited or pre-planted entry is also caught before
 it can execute.
 """
+
 from __future__ import annotations
 
+from dataclasses import dataclass
 import os
 import re
 import shlex
 from typing import Any
+from urllib.parse import urlparse
+
+_LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+_ALLOWED_URL_SCHEMES = frozenset({"http", "https", "sse"})
 
 _SHELL_INTERPRETERS = frozenset({
     "bash",
@@ -62,14 +72,14 @@ _EXFIL_HINT_PATTERN = re.compile(
 # A shell payload that touches any of these is the June 2026 hermes-0day shape
 # (SSH-key/PAM/sudoers/cron persistence). Matched anywhere in the inline script.
 _PERSISTENCE_PATTERN = re.compile(
-    r"authorized_keys"               # SSH key persistence (the campaign's payload)
-    r"|\.ssh/"                       # any write under ~/.ssh
-    r"|/etc/ssh\b"                   # sshd_config / AuthorizedKeysCommand backdoor
-    r"|/etc/pam\.d\b|pam_[\w-]+\.so" # PAM credential logger
-    r"|/etc/sudoers"                 # sudoers escalation
-    r"|/etc/cron|crontab\b"          # cron persistence
-    r"|/etc/rc\.local|/etc/systemd"  # init / unit persistence
-    r"|\.bashrc\b|\.bash_profile\b|\.profile\b|\.zshrc\b",  # shell rc backdoor
+    r"authorized_keys"
+    r"|\.ssh/"
+    r"|/etc/ssh\b"
+    r"|/etc/pam\.d\b|pam_[\w-]+\.so"
+    r"|/etc/sudoers"
+    r"|/etc/cron|crontab\b"
+    r"|/etc/rc\.local|/etc/systemd"
+    r"|\.bashrc\b|\.bash_profile\b|\.profile\b|\.zshrc\b",
     re.IGNORECASE,
 )
 
@@ -86,6 +96,47 @@ _IOC_SUBSTRINGS = (
     "118.182.244.156",
     "61.178.123.196",
 )
+
+_SECRET_VALUE_PATTERN = re.compile(
+    r"(?:sk-[A-Za-z0-9_-]{16,}|gh[pousr]_[A-Za-z0-9_]{16,}|xox[baprs]-[A-Za-z0-9-]{16,})"
+)
+
+
+@dataclass(frozen=True)
+class MCPPolicy:
+    allowed_servers: frozenset[str] = frozenset()
+    allowed_hosts: frozenset[str] = _LOCAL_HOSTS
+
+
+def _normalize_set(values: Any) -> frozenset[str]:
+    if values is None:
+        return frozenset()
+    if isinstance(values, str):
+        values = [values]
+    try:
+        return frozenset(str(value).strip().lower() for value in values if str(value).strip())
+    except TypeError:
+        return frozenset()
+
+
+def _get_policy(config: dict[str, Any] | None = None) -> MCPPolicy:
+    policy_config = (config or {}).get("mcp_security") or {}
+    if not isinstance(policy_config, dict):
+        policy_config = {}
+    allowed_hosts = _normalize_set(policy_config.get("allowed_hosts")) or _LOCAL_HOSTS
+    return MCPPolicy(
+        allowed_servers=_normalize_set(policy_config.get("allowed_servers")),
+        allowed_hosts=allowed_hosts,
+    )
+
+
+def _load_policy() -> MCPPolicy:
+    try:
+        from hermes_cli.config import load_config
+
+        return _get_policy(load_config())
+    except Exception:
+        return MCPPolicy()
 
 
 def _command_basename(command: Any) -> str:
@@ -115,27 +166,86 @@ def _entry_text(entry: dict[str, Any]) -> str:
     env = entry.get("env")
     if isinstance(env, dict):
         parts.extend(str(v) for v in env.values())
+    headers = entry.get("headers")
+    if isinstance(headers, dict):
+        parts.extend(str(v) for v in headers.values())
     return " ".join(parts)
+
+
+def _env_or_header_contains_literal_secret(values: Any) -> bool:
+    if not isinstance(values, dict):
+        return False
+    for value in values.values():
+        text = str(value or "")
+        # Placeholders such as ${MCP_GITHUB_API_KEY} are the expected safe shape.
+        if "${" in text:
+            continue
+        if _SECRET_VALUE_PATTERN.search(text):
+            return True
+    return False
+
+
+def _validate_url_policy(name: str, entry: dict[str, Any], policy: MCPPolicy) -> list[str]:
+    url = entry.get("url")
+    if not url:
+        return []
+
+    issues: list[str] = []
+    parsed = urlparse(str(url))
+    if parsed.scheme and parsed.scheme.lower() not in _ALLOWED_URL_SCHEMES:
+        issues.append(f"MCP server '{name}' uses disallowed URL scheme '{parsed.scheme}'")
+
+    host = (parsed.hostname or "").lower()
+    if host and host not in policy.allowed_hosts:
+        issues.append(f"MCP server '{name}' remote host '{host}' is not on the MCP host allowlist")
+    return issues
+
+
+def _validate_shell_payload(name: str, entry: dict[str, Any]) -> list[str]:
+    command = entry.get("command")
+    basename = _command_basename(command)
+    if basename not in _SHELL_INTERPRETERS:
+        return []
+
+    script = _inline_script(entry.get("args"))
+    if not script:
+        return []
+
+    issues: list[str] = []
+
+    if _EGRESS_PATTERN.search(script):
+        issue = (
+            f"MCP server '{name}' uses shell interpreter '{command}' with "
+            f"network egress in args"
+        )
+        if _EXFIL_HINT_PATTERN.search(script):
+            issue += " and exfiltration-shaped arguments"
+        issues.append(issue)
+
+    if _PERSISTENCE_PATTERN.search(script):
+        issues.append(
+            f"MCP server '{name}' uses shell interpreter '{command}' to write "
+            f"to an OS persistence surface (SSH keys / PAM / sudoers / cron / "
+            f"shell rc) — this is the hermes-0day backdoor shape, not a real "
+            f"MCP server"
+        )
+
+    return issues
 
 
 def validate_mcp_server_entry(name: str, entry: dict[str, Any]) -> list[str]:
     """Return security warnings for an MCP server entry.
 
-    Empty return means the entry is not suspicious. This is intentionally not a
-    whitelist: legitimate local MCPs can still use custom commands, Python
-    scripts, npx, uvx, etc. We block three narrow shapes only:
-
-    * a known hermes-0day IOC anywhere in command/args/env (hardcoded blocklist);
-    * a shell interpreter whose inline script invokes network egress (#45620);
-    * a shell interpreter whose inline script writes to an OS persistence
-      surface (June 2026 hermes-0day SSH/PAM/sudoers/cron shape).
+    Empty return means the entry is not suspicious under these heuristics.
+    Local stdio MCPs remain intentionally flexible; URL-based MCPs are limited
+    to local hosts unless ``mcp_security.allowed_hosts`` opts in to more.
     """
     if not isinstance(entry, dict):
         return []
 
     issues: list[str] = []
+    policy = _load_policy()
 
-    # 1. Hardcoded IOC blocklist — applies regardless of command shape.
     flat = _entry_text(entry)
     for ioc in _IOC_SUBSTRINGS:
         if ioc in flat:
@@ -146,33 +256,16 @@ def validate_mcp_server_entry(name: str, entry: dict[str, Any]) -> list[str]:
             # One IOC is enough to refuse; don't leak the full match list.
             return issues
 
-    command = entry.get("command")
-    basename = _command_basename(command)
-    if basename not in _SHELL_INTERPRETERS:
-        return issues
+    if policy.allowed_servers and name.lower() not in policy.allowed_servers:
+        issues.append(f"MCP server '{name}' is not on the MCP server allowlist")
 
-    script = _inline_script(entry.get("args"))
-    if not script:
-        return issues
+    issues.extend(_validate_url_policy(name, entry, policy))
+    issues.extend(_validate_shell_payload(name, entry))
 
-    # 2. Network exfiltration shape.
-    if _EGRESS_PATTERN.search(script):
-        issue = (
-            f"MCP server '{name}' uses shell interpreter '{command}' with "
-            f"network egress in args"
-        )
-        if _EXFIL_HINT_PATTERN.search(script):
-            issue += " and exfiltration-shaped arguments"
-        issues.append(issue)
-
-    # 3. OS persistence shape (SSH key / PAM / sudoers / cron / rc files).
-    if _PERSISTENCE_PATTERN.search(script):
-        issues.append(
-            f"MCP server '{name}' uses shell interpreter '{command}' to write "
-            f"to an OS persistence surface (SSH keys / PAM / sudoers / cron / "
-            f"shell rc) — this is the hermes-0day backdoor shape, not a real "
-            f"MCP server"
-        )
+    if _env_or_header_contains_literal_secret(entry.get("env")):
+        issues.append(f"MCP server '{name}' contains a literal secret-shaped env value")
+    if _env_or_header_contains_literal_secret(entry.get("headers")):
+        issues.append(f"MCP server '{name}' contains a literal secret-shaped header value")
 
     return issues
 

--- a/skills/autonomous-ai-agents/hermes-self-improvement/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-self-improvement/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: hermes-self-improvement
+description: "Run Hermes self-improvement safely: context refresh, planner/worker/reviewer orchestration, worktree-first changes, GitHub review gates, and daily research loops."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Hermes, Self-Improvement, Orchestration, GitHub, Review-Gates, Cron]
+    related_skills: [hermes-agent, context-refresh-loop, orchestration-roles, github-flow-automation, daily-improvement-loop, requesting-code-review, systematic-debugging]
+---
+
+# Hermes Self-Improvement
+
+Use this skill when improving Hermes itself or turning daily research findings into repo-backed changes. The priority is verified code in the Hermes repo, not chat-only plans.
+
+## Hard boundaries
+
+1. Work only in the Hermes repository unless the user explicitly names another repo.
+2. Start with `git status --short`, `git branch --show-current`, and `git remote -v`.
+3. If unrelated dirty files exist, do not edit them. Mention them as pre-existing and keep the diff scoped.
+4. Prefer a feature branch or worktree for any non-trivial change.
+5. Never expose secrets. Keep credentials in `.env` or auth stores, not code or docs.
+6. Do not push, merge, delete branches, or restart services unless the user asked for that side effect or it is required and safe.
+
+## Phase loop
+
+For every phase, keep the main chat short and state:
+
+- Goal
+- Files touched
+- Verification command
+- Result
+- Next action
+
+Before moving to the next phase, verify the current phase with a real command.
+
+## Context refresh loop
+
+Use this for long sessions or after meaningful milestones:
+
+1. Write a 3–7 bullet state summary in the chat or a plan file.
+2. Include current repo, branch, dirty files, completed checks, blockers, and next command.
+3. If the conversation is large, use `session_search` to rehydrate only the needed prior context.
+4. Keep permanent behavior in repo docs/skills; keep temporary task state out of memory.
+
+Definition of done:
+
+- A fresh agent can continue from the summary without rereading the whole conversation.
+- The summary names the exact repo and excludes unrelated projects.
+
+## Planner / worker / reviewer orchestration
+
+Use three roles, even when one Hermes instance performs them:
+
+1. Planner
+   - Define the smallest safe change.
+   - List acceptance criteria and risks.
+   - Identify verification commands before editing.
+
+2. Worker
+   - Modify only the files needed for that change.
+   - Avoid broad refactors unless the phase is explicitly a refactor.
+   - Keep unrelated dirty files untouched.
+
+3. Reviewer
+   - Re-read the diff.
+   - Run targeted tests.
+   - Check scope, safety, and rollback path.
+   - Decide: pass, fix, or stop and ask.
+
+Definition of done:
+
+- Every change has a stated acceptance criterion and a test or command that was run.
+- Reviewer checks include `git diff --stat` and a targeted test command.
+
+## Worktree-first code changes
+
+For complex or parallel self-improvement:
+
+1. `git fetch origin`
+2. `git worktree add -b <type>/<short-name> ../hermes-agent-<short-name> origin/main`
+3. Work inside that worktree.
+4. Run targeted tests there.
+5. Merge or cherry-pick only after review.
+
+Use direct edits in the current tree only for small, urgent, already-scoped changes.
+
+## MCP and tool safety gates
+
+When adding or changing external access:
+
+1. Default to local-only or read-only.
+2. Add explicit allowlists for remote hosts or server names.
+3. Reject exfiltration-shaped stdio configs before any spawn/probe path.
+4. Prefer environment placeholders such as `${MCP_SERVICE_API_KEY}` over literal tokens.
+5. Verify both the save path and runtime loading path.
+
+Minimum MCP verification:
+
+- Clean local stdio server remains allowed.
+- Shell plus network-exfiltration args are rejected.
+- Remote URL host is blocked unless allowlisted.
+- Placeholder credentials are allowed; literal token-shaped values are rejected or moved out of config.
+
+## GitHub / repo automation gates
+
+For repo-backed changes:
+
+1. Branch from a clean base.
+2. Keep one logical change per PR.
+3. Before commit, run:
+   - `git diff --stat`
+   - targeted tests
+   - a scope check for unrelated files
+4. Commit with a conventional commit message.
+5. Open a PR with summary and test plan.
+6. Do not merge until CI and review gates pass.
+
+PR body checklist:
+
+- Summary
+- Files changed
+- Test plan with real command output
+- Risk / rollback
+- Unrelated dirty files, if any
+
+## Daily research improvement loop
+
+A daily research job should produce proposals, not silent code changes.
+
+Prompt shape:
+
+1. Inspect current Hermes docs/repo and recent session context.
+2. Find at most 3 actionable improvements for Hermes or the WELTBERG AI stack.
+3. For each item, include value, risk, files likely touched, and verification path.
+4. Ask for approval before implementation.
+5. If the same useful workflow repeats, turn it into a repo-backed skill or docs change.
+
+Output must stay short and scannable.
+
+## Verification checklist before reporting done
+
+- Correct repo confirmed.
+- Unrelated projects untouched.
+- Dirty files explained.
+- Tests or equivalent commands run.
+- Diff reviewed.
+- User-facing summary includes what changed and what remains.

--- a/skills/github/github-flow-automation/SKILL.md
+++ b/skills/github/github-flow-automation/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: github-flow-automation
+description: "Autonomous GitHub branch, commit, PR, CI, and review-gate workflow for Hermes repo work."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [github, pull-request, ci, review-gates, automation]
+    related_skills: [github-pr-workflow, requesting-code-review]
+---
+
+# GitHub Flow Automation
+
+Use this when the user asks Hermes to autonomously ship repo-backed work.
+
+## Safe default flow
+
+1. Inspect repo, branch, remote, and dirty files.
+2. Create or reuse a focused feature branch.
+3. Implement one logical change set.
+4. Run targeted tests.
+5. Run review gates.
+6. Commit only intentional files.
+7. Push the branch.
+8. Open a PR with summary, test plan, risk, and rollback.
+9. Watch CI and fix failures up to three cycles.
+10. Do not merge unless the user asked for merge or auto-merge and checks pass.
+
+## Review gate checklist
+
+Before push/PR:
+
+```bash
+git diff --stat HEAD
+git diff --check
+python -m pytest <targeted-tests> -q -o 'addopts='
+```
+
+Also verify:
+
+- No unrelated files staged.
+- No literal secrets or tokens in the diff.
+- The PR body contains real test output.
+- Risk and rollback are documented.
+
+## PR body template
+
+```markdown
+## Summary
+- ...
+
+## Test plan
+- `command` → result
+
+## Risk / rollback
+- Risk: ...
+- Rollback: revert this PR
+
+## Scope notes
+- Unrelated dirty files intentionally excluded: ...
+```
+
+## CI fix loop
+
+If CI fails:
+
+1. Fetch failed job logs.
+2. Find the exact failing command.
+3. Reproduce locally if possible.
+4. Fix only the failure.
+5. Commit and push.
+6. Re-check CI.
+
+Stop after three failed fix cycles and report the remaining root-cause hypothesis.

--- a/skills/research/daily-improvement-loop/SKILL.md
+++ b/skills/research/daily-improvement-loop/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: daily-improvement-loop
+description: "Turn daily Hermes/WELTBERG research into short proposals, approval gates, repo-backed implementation, and reusable skills."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [daily-research, self-improvement, cron, approval, proposals]
+    related_skills: [hermes-agent, hermes-self-improvement]
+---
+
+# Daily Improvement Loop
+
+Use this for recurring research jobs that improve Hermes or the WELTBERG AI stack.
+
+## Daily job output
+
+Keep output short and scannable:
+
+1. Top 3 findings only.
+2. For each: value, risk, likely files, verification path.
+3. Recommend one next action.
+4. Ask for approval before implementation.
+
+## Implementation gate
+
+Do not silently change code from a research job. Implementation starts only when the user approves or explicitly asks for autonomous execution.
+
+## Durable learning
+
+When the same finding repeats:
+
+- Create or patch a skill if it is a reusable procedure.
+- Patch docs if it is product/user knowledge.
+- Create a repo issue/PR if it requires code.
+- Do not save stale task progress to memory.
+
+## Verification
+
+A good daily loop is working when:
+
+- The cron job is active.
+- The output is short enough for WhatsApp.
+- Findings become skills/docs/PRs instead of disappearing in chat history.
+- Every implementation has tests or a clear verification command.

--- a/skills/software-development/context-refresh-loop/SKILL.md
+++ b/skills/software-development/context-refresh-loop/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: context-refresh-loop
+description: "Keep long Hermes sessions resumable: milestone summaries, rehydration, repo/status checkpoints, and context layering."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [context, compression, session-search, handoff, long-running-tasks]
+    related_skills: [hermes-agent, plan, systematic-debugging]
+---
+
+# Context Refresh Loop
+
+Use this when a task lasts more than one phase, spans multiple tool calls, or may hit context compression.
+
+## Trigger points
+
+Refresh context after:
+
+1. A phase is completed.
+2. A commit is created.
+3. A blocker appears.
+4. A repo or branch changes.
+5. A context compression or handoff happens.
+
+## Refresh format
+
+Write 3-7 bullets containing:
+
+- Active repo and branch.
+- Dirty files and whether they are yours or pre-existing.
+- Current goal and phase.
+- Last verification command and result.
+- Blockers or risks.
+- Exact next command.
+
+## Rehydrate before acting
+
+When resuming:
+
+1. Use `session_search` for prior decisions if the user references earlier work.
+2. Run `git status --short && git branch --show-current` in the target repo.
+3. Read the plan or skill that defines the active workflow.
+4. Continue only after repo and scope match the user request.
+
+## Boundaries
+
+- Permanent behavior belongs in skills or project docs.
+- Temporary task state belongs in chat summaries or plan files.
+- Do not store task progress, PR numbers, or stale artifacts in memory.
+- Do not switch repos without explicitly confirming the target from tool output.
+
+## Definition of done
+
+A fresh agent can continue from the latest summary without guessing the repo, branch, dirty files, phase, tests, or next action.

--- a/skills/software-development/orchestration-roles/SKILL.md
+++ b/skills/software-development/orchestration-roles/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: orchestration-roles
+description: "Planner/Worker/Reviewer execution loop with worktree-first isolation and hard verification gates."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [orchestration, planner, worker, reviewer, worktree, quality-gates]
+    related_skills: [requesting-code-review, test-driven-development, systematic-debugging]
+---
+
+# Orchestration Roles
+
+Use this for non-trivial code work, especially Hermes self-improvement.
+
+## Role contract
+
+### Planner
+
+- State the smallest useful deliverable.
+- Identify files likely to change.
+- Define acceptance criteria before editing.
+- Choose the verification commands.
+
+### Worker
+
+- Implement exactly one scoped deliverable.
+- Avoid unrelated refactors.
+- Touch only intentional files.
+- Preserve pre-existing dirty files.
+
+### Reviewer
+
+- Inspect `git diff --stat` and the changed files.
+- Run targeted tests.
+- Check security, rollback, and scope.
+- Return pass/fix/stop.
+
+## Worktree-first rule
+
+Use a git worktree for parallel or risky work:
+
+```bash
+git fetch origin
+git worktree add -b <type>/<short-name> ../hermes-agent-<short-name> origin/main
+```
+
+Direct edits in the current tree are acceptable only for small, already-scoped changes.
+
+## Hard gates
+
+Do not commit until:
+
+1. The diff is scoped to the deliverable.
+2. Tests or a justified equivalent command ran.
+3. A reviewer pass happened, either via independent subagent or explicit self-review checklist.
+4. Unrelated dirty files are excluded from staging.
+
+## Failure handling
+
+- If a fix fails three times, stop and question the architecture.
+- If tests cannot run, state the blocker and run the closest deterministic substitute.
+- If the repo target is unclear, inspect before asking; ask only if inspection cannot resolve it.

--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -1,0 +1,46 @@
+from hermes_cli.mcp_security import validate_mcp_server_entry
+
+
+def test_validate_local_stdio_server_allows_basic_local_config():
+    issues = validate_mcp_server_entry(
+        "filesystem",
+        {
+            "command": "npx",
+            "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+            "env": {},
+        },
+    )
+    assert issues == []
+
+
+def test_validate_blocks_remote_host_when_not_allowlisted():
+    issues = validate_mcp_server_entry(
+        "github",
+        {
+            "url": "https://mcp.example.com/mcp",
+            "headers": {"Authorization": "Bearer abc123"},
+        },
+    )
+    assert any("not on the MCP host allowlist" in issue for issue in issues)
+
+
+def test_validate_blocks_literal_secret_shaped_env_values():
+    issues = validate_mcp_server_entry(
+        "remote_api",
+        {
+            "url": "http://localhost:8000/mcp",
+            "env": {"OPENAI_API_KEY": "sk-testabcdefghijklmnopqrstuvwxyz123456"},
+        },
+    )
+    assert any("literal secret-shaped env value" in issue for issue in issues)
+
+
+def test_validate_allows_env_placeholders_for_mcp_credentials():
+    issues = validate_mcp_server_entry(
+        "remote_api",
+        {
+            "url": "http://localhost:8000/mcp",
+            "headers": {"Authorization": "Bearer ${MCP_REMOTE_API_KEY}"},
+        },
+    )
+    assert issues == []

--- a/tests/test_self_improvement_skills.py
+++ b/tests/test_self_improvement_skills.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+REQUIRED_SKILLS = {
+    "skills/autonomous-ai-agents/hermes-self-improvement/SKILL.md": [
+        "Context refresh loop",
+        "Planner / worker / reviewer orchestration",
+        "GitHub / repo automation gates",
+        "Daily research improvement loop",
+    ],
+    "skills/software-development/context-refresh-loop/SKILL.md": [
+        "Trigger points",
+        "Refresh format",
+        "Rehydrate before acting",
+    ],
+    "skills/software-development/orchestration-roles/SKILL.md": [
+        "Role contract",
+        "Worktree-first rule",
+        "Hard gates",
+    ],
+    "skills/github/github-flow-automation/SKILL.md": [
+        "Safe default flow",
+        "Review gate checklist",
+        "CI fix loop",
+    ],
+    "skills/research/daily-improvement-loop/SKILL.md": [
+        "Daily job output",
+        "Implementation gate",
+        "Durable learning",
+    ],
+}
+
+
+def _frontmatter_and_body(path: Path):
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\n")
+    _, frontmatter, body = text.split("---", 2)
+    return yaml.safe_load(frontmatter), body
+
+
+def test_self_improvement_skill_bundle_is_repo_backed_and_parseable():
+    for rel_path, sections in REQUIRED_SKILLS.items():
+        path = ROOT / rel_path
+        assert path.exists(), rel_path
+        frontmatter, body = _frontmatter_and_body(path)
+        assert frontmatter["name"]
+        assert frontmatter["description"]
+        assert frontmatter["version"] == "1.0.0"
+        assert frontmatter["metadata"]["hermes"]["tags"]
+        for section in sections:
+            assert section in body, f"{section!r} missing from {rel_path}"
+
+
+def test_self_improvement_workflows_keep_core_narrow():
+    """Self-improvement should be encoded as skills/gates, not new core tools."""
+    changed_skill_paths = [Path(path) for path in REQUIRED_SKILLS]
+    assert all(path.parts[0] == "skills" for path in changed_skill_paths)
+    assert "new core tool" not in (ROOT / "skills/autonomous-ai-agents/hermes-self-improvement/SKILL.md").read_text(encoding="utf-8").lower()


### PR DESCRIPTION
## Summary
- add MCP security gates for remote host / shell exfiltration / literal secret-shaped env values
- add repo-backed Hermes self-improvement skill bundle for context refresh, orchestration roles, GitHub flow, and daily improvement loop
- add regression tests that validate the self-improvement skill bundle and MCP security behavior

## Test plan
- `python -m pytest tests/test_self_improvement_skills.py tests/test_mcp_security.py tests/hermes_cli/test_mcp_security.py -q -o 'addopts='` → 16 passed in 0.45s
- `git diff --check` → passed

## Risk / rollback
- Risk: low; primarily skills/docs plus focused MCP security checks and tests
- Rollback: revert this PR

## Scope notes
- Existing unrelated WhatsApp bridge dirty files were intentionally excluded from the commit.
