### PR TITLE
feat(web-search): add Yandex Search API provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -141,6 +141,12 @@
 # Get at: https://firecrawl.dev/
 # FIRECRAWL_API_KEY=
 
+# Yandex Search API - web search (search only)
+# Get at: https://yandex.cloud/en/services/search-api
+# Both variables are required.
+# YANDEX_SEARCH_API_KEY=
+# YANDEX_FOLDER_ID=
+
 
 # FAL.ai API Key - Image generation
 # Get at: https://fal.ai/

--- a/plugins/web/yandex/__init__.py
+++ b/plugins/web/yandex/__init__.py
@@ -1,0 +1,14 @@
+"""Yandex Search API plugin — bundled, auto-loaded.
+
+Mirrors the ``plugins/web/brave_free/`` layout: ``provider.py`` holds the
+provider class, ``__init__.py::register(ctx)`` registers an instance.
+"""
+
+from __future__ import annotations
+
+from plugins.web.yandex.provider import YandexWebSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the Yandex Search provider with the plugin context."""
+    ctx.register_web_search_provider(YandexWebSearchProvider())

--- a/plugins/web/yandex/plugin.yaml
+++ b/plugins/web/yandex/plugin.yaml
@@ -1,0 +1,10 @@
+name: web-yandex
+version: 1.0.0
+description: "Yandex Search API — web search via Yandex Cloud's WebSearch.Search v2 REST API. Requires YANDEX_SEARCH_API_KEY and YANDEX_FOLDER_ID (sign up at https://yandex.cloud/en/services/search-api)."
+author: NousResearch
+kind: backend
+provides_web_providers:
+  - yandex
+requires_env:
+  - YANDEX_SEARCH_API_KEY
+  - YANDEX_FOLDER_ID

--- a/plugins/web/yandex/provider.py
+++ b/plugins/web/yandex/provider.py
@@ -1,0 +1,237 @@
+"""Yandex Search API — plugin form.
+
+Subclasses :class:`agent.web_search_provider.WebSearchProvider`. Search-only —
+no dedicated extract endpoint exists in the Yandex Search API, so pair this
+provider with Firecrawl/Tavily/Exa/Parallel for ``web_extract`` (same pattern
+as SearXNG / Brave Search free tier).
+
+Config keys this provider responds to::
+
+    web:
+      search_backend: "yandex"     # explicit per-capability
+      backend: "yandex"            # shared fallback
+
+Env vars::
+
+    YANDEX_SEARCH_API_KEY=...   # https://yandex.cloud/en/services/search-api
+    YANDEX_FOLDER_ID=...        # Yandex Cloud folder ID that owns the API key
+    YANDEX_SEARCH_REGION=...    # optional — Yandex geo region ID (e.g. "225" = Russia)
+    YANDEX_SEARCH_LANG=...      # optional — result localization, e.g. "LOCALIZATION_EN"
+    YANDEX_SEARCH_TYPE=...      # optional — search domain, default "SEARCH_TYPE_RU"
+
+Calls the ``WebSearch.Search`` v2 REST method::
+
+    POST https://searchapi.api.cloud.yandex.net/v2/web/search
+    Authorization: Api-Key <YANDEX_SEARCH_API_KEY>
+
+The response wraps the results as base64-encoded XML in a ``rawData`` field
+(protobuf JSON mapping for ``bytes``) — this module decodes and parses that
+XML into the standard Hermes result shape.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+import xml.etree.ElementTree as ET
+from typing import Any, Dict, List, Optional
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+_YANDEX_ENDPOINT = "https://searchapi.api.cloud.yandex.net/v2/web/search"
+
+
+def _text(node: Optional[ET.Element]) -> str:
+    """Flatten an element's text (including nested emphasis tags) to a plain string."""
+    if node is None:
+        return ""
+    return "".join(node.itertext()).strip()
+
+
+def _parse_yandex_xml(raw_xml: bytes, limit: int) -> Dict[str, Any]:
+    """Parse a Yandex Search XML response body into the standard result shape.
+
+    Expected structure (``FORMAT_XML``)::
+
+        <yandexsearch>
+          <response>
+            <error code="...">message</error>          <!-- on failure -->
+            <results>
+              <grouping>
+                <group>
+                  <doc>
+                    <url>...</url>
+                    <title>...</title>
+                    <headline>...</headline>
+                    <passages><passage>...</passage></passages>
+                  </doc>
+                </group>
+                ...
+              </grouping>
+            </results>
+          </response>
+        </yandexsearch>
+    """
+    root = ET.fromstring(raw_xml)
+    response = root.find("response")
+    if response is None:
+        return {"success": False, "error": "Yandex Search response missing <response> element"}
+
+    error = response.find("error")
+    if error is not None:
+        message = _text(error) or "unknown error"
+        code = error.get("code", "")
+        return {
+            "success": False,
+            "error": f"Yandex Search error{f' ({code})' if code else ''}: {message}",
+        }
+
+    web_results: List[Dict[str, Any]] = []
+    for doc in response.iter("doc"):
+        if len(web_results) >= limit:
+            break
+        description = _text(doc.find("headline"))
+        if not description:
+            passage = doc.find("./passages/passage")
+            description = _text(passage)
+        web_results.append(
+            {
+                "title": _text(doc.find("title")),
+                "url": _text(doc.find("url")),
+                "description": description,
+                "position": len(web_results) + 1,
+            }
+        )
+
+    return {"success": True, "data": {"web": web_results}}
+
+
+class YandexWebSearchProvider(WebSearchProvider):
+    """Search-only provider for the Yandex Cloud Search API (WebSearch.Search v2)."""
+
+    @property
+    def name(self) -> str:
+        return "yandex"
+
+    @property
+    def display_name(self) -> str:
+        return "Yandex Search"
+
+    def is_available(self) -> bool:
+        """Return True when both ``YANDEX_SEARCH_API_KEY`` and ``YANDEX_FOLDER_ID`` are set."""
+        return bool(os.getenv("YANDEX_SEARCH_API_KEY", "").strip()) and bool(
+            os.getenv("YANDEX_FOLDER_ID", "").strip()
+        )
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return False
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        """Execute a search against the Yandex Search API (``WebSearch.Search``).
+
+        Returns ``{"success": True, "data": {"web": [{"title", "url", "description", "position"}]}}``
+        on success, or ``{"success": False, "error": str}`` on failure.
+        """
+        import httpx
+
+        api_key = os.getenv("YANDEX_SEARCH_API_KEY", "").strip()
+        folder_id = os.getenv("YANDEX_FOLDER_ID", "").strip()
+        if not api_key:
+            return {"success": False, "error": "YANDEX_SEARCH_API_KEY is not set"}
+        if not folder_id:
+            return {"success": False, "error": "YANDEX_FOLDER_ID is not set"}
+
+        groups_on_page = str(max(1, min(int(limit), 100)))
+        query_spec: Dict[str, Any] = {
+            "searchType": os.getenv("YANDEX_SEARCH_TYPE", "SEARCH_TYPE_RU").strip(),
+            "queryText": query,
+            "page": "0",
+        }
+        payload: Dict[str, Any] = {
+            "query": query_spec,
+            "groupSpec": {
+                "groupMode": "GROUP_MODE_FLAT",
+                "groupsOnPage": groups_on_page,
+                "docsInGroup": "1",
+            },
+            "maxPassages": "4",
+            "folderId": folder_id,
+            "responseFormat": "FORMAT_XML",
+        }
+        region = os.getenv("YANDEX_SEARCH_REGION", "").strip()
+        if region:
+            payload["region"] = region
+        lang = os.getenv("YANDEX_SEARCH_LANG", "").strip()
+        if lang:
+            payload["l10n"] = lang
+
+        try:
+            resp = httpx.post(
+                _YANDEX_ENDPOINT,
+                json=payload,
+                headers={
+                    "Authorization": f"Api-Key {api_key}",
+                    "Content-Type": "application/json",
+                },
+                timeout=15,
+            )
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            logger.warning("Yandex Search HTTP error: %s", exc)
+            detail = ""
+            try:
+                detail = f": {exc.response.json().get('message', '')}"
+            except Exception:  # noqa: BLE001 — best-effort error detail
+                pass
+            return {
+                "success": False,
+                "error": f"Yandex Search returned HTTP {exc.response.status_code}{detail}",
+            }
+        except httpx.RequestError as exc:
+            logger.warning("Yandex Search request error: %s", exc)
+            return {"success": False, "error": f"Could not reach Yandex Search: {exc}"}
+
+        try:
+            data = resp.json()
+            raw_xml = base64.b64decode(data["rawData"])
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Yandex Search response parse error: %s", exc)
+            return {"success": False, "error": "Could not parse Yandex Search response"}
+
+        try:
+            result = _parse_yandex_xml(raw_xml, limit)
+        except ET.ParseError as exc:
+            logger.warning("Yandex Search XML parse error: %s", exc)
+            return {"success": False, "error": f"Could not parse Yandex Search XML payload: {exc}"}
+
+        if result["success"]:
+            logger.info(
+                "Yandex Search '%s': %d results (limit %d)",
+                query, len(result["data"]["web"]), limit,
+            )
+        return result
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Yandex Search",
+            "badge": "paid",
+            "tag": "Yandex Cloud web search — search only, requires API key + folder ID.",
+            "env_vars": [
+                {
+                    "key": "YANDEX_SEARCH_API_KEY",
+                    "prompt": "Yandex Search API key",
+                    "url": "https://yandex.cloud/en/services/search-api",
+                },
+                {
+                    "key": "YANDEX_FOLDER_ID",
+                    "prompt": "Yandex Cloud folder ID",
+                    "url": "https://yandex.cloud/en/docs/resource-manager/operations/folder/get-id",
+                },
+            ],
+        }

--- a/plugins/web/yandex/provider.py
+++ b/plugins/web/yandex/provider.py
@@ -19,14 +19,20 @@ Env vars::
     YANDEX_SEARCH_LANG=...      # optional — result localization, e.g. "LOCALIZATION_EN"
     YANDEX_SEARCH_TYPE=...      # optional — search domain, default "SEARCH_TYPE_RU"
 
-Calls the ``WebSearch.Search`` v2 REST method::
+Calls the ``WebSearchAsync.Search`` v2 REST method — the only variant this
+API actually exposes for API-key auth. The initial POST returns an
+Operation stub (``{"id": ..., "done": false}``), not the results
+themselves; this module polls ``operation.api.cloud.yandex.net`` until the
+operation reports ``done: true``, then reads the base64-encoded XML out of
+``response.rawData``::
 
-    POST https://searchapi.api.cloud.yandex.net/v2/web/search
+    POST https://searchapi.api.cloud.yandex.net/v2/web/searchAsync
     Authorization: Api-Key <YANDEX_SEARCH_API_KEY>
+    -> {"id": "<operation-id>", "done": false}
 
-The response wraps the results as base64-encoded XML in a ``rawData`` field
-(protobuf JSON mapping for ``bytes``) — this module decodes and parses that
-XML into the standard Hermes result shape.
+    GET https://operation.api.cloud.yandex.net/operations/<operation-id>
+    Authorization: Api-Key <YANDEX_SEARCH_API_KEY>
+    -> {"done": true, "response": {"rawData": "<base64 XML>"}}
 """
 
 from __future__ import annotations
@@ -34,6 +40,7 @@ from __future__ import annotations
 import base64
 import logging
 import os
+import time
 import xml.etree.ElementTree as ET
 from typing import Any, Dict, List, Optional
 
@@ -41,7 +48,10 @@ from agent.web_search_provider import WebSearchProvider
 
 logger = logging.getLogger(__name__)
 
-_YANDEX_ENDPOINT = "https://searchapi.api.cloud.yandex.net/v2/web/search"
+_YANDEX_SEARCH_ENDPOINT = "https://searchapi.api.cloud.yandex.net/v2/web/searchAsync"
+_YANDEX_OPERATION_ENDPOINT = "https://operation.api.cloud.yandex.net/operations/"
+_POLL_INTERVAL_SECONDS = 1.0
+_POLL_TIMEOUT_SECONDS = 20.0
 
 
 def _text(node: Optional[ET.Element]) -> str:
@@ -110,7 +120,7 @@ def _parse_yandex_xml(raw_xml: bytes, limit: int) -> Dict[str, Any]:
 
 
 class YandexWebSearchProvider(WebSearchProvider):
-    """Search-only provider for the Yandex Cloud Search API (WebSearch.Search v2)."""
+    """Search-only provider for the Yandex Cloud Search API (WebSearchAsync.Search v2)."""
 
     @property
     def name(self) -> str:
@@ -133,7 +143,11 @@ class YandexWebSearchProvider(WebSearchProvider):
         return False
 
     def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
-        """Execute a search against the Yandex Search API (``WebSearch.Search``).
+        """Execute a search against the Yandex Search API (``WebSearchAsync.Search``).
+
+        The API is operation-based: the initial POST only returns an
+        operation id, so this submits the search then polls the operation
+        endpoint (up to ``_POLL_TIMEOUT_SECONDS``) until it completes.
 
         Returns ``{"success": True, "data": {"web": [{"title", "url", "description", "position"}]}}``
         on success, or ``{"success": False, "error": str}`` on failure.
@@ -171,16 +185,13 @@ class YandexWebSearchProvider(WebSearchProvider):
         if lang:
             payload["l10n"] = lang
 
+        headers = {
+            "Authorization": f"Api-Key {api_key}",
+            "Content-Type": "application/json",
+        }
+
         try:
-            resp = httpx.post(
-                _YANDEX_ENDPOINT,
-                json=payload,
-                headers={
-                    "Authorization": f"Api-Key {api_key}",
-                    "Content-Type": "application/json",
-                },
-                timeout=15,
-            )
+            resp = httpx.post(_YANDEX_SEARCH_ENDPOINT, json=payload, headers=headers, timeout=15)
             resp.raise_for_status()
         except httpx.HTTPStatusError as exc:
             logger.warning("Yandex Search HTTP error: %s", exc)
@@ -198,8 +209,35 @@ class YandexWebSearchProvider(WebSearchProvider):
             return {"success": False, "error": f"Could not reach Yandex Search: {exc}"}
 
         try:
-            data = resp.json()
-            raw_xml = base64.b64decode(data["rawData"])
+            operation_id = resp.json()["id"]
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Yandex Search operation submit response parse error: %s", exc)
+            return {"success": False, "error": "Could not parse Yandex Search operation response"}
+
+        try:
+            operation = self._poll_operation(operation_id, headers)
+        except TimeoutError:
+            return {
+                "success": False,
+                "error": f"Yandex Search operation did not complete within {_POLL_TIMEOUT_SECONDS:.0f}s",
+            }
+        except httpx.HTTPStatusError as exc:
+            logger.warning("Yandex Search operation-status HTTP error: %s", exc)
+            return {
+                "success": False,
+                "error": f"Yandex Search operation status returned HTTP {exc.response.status_code}",
+            }
+        except httpx.RequestError as exc:
+            logger.warning("Yandex Search operation-status request error: %s", exc)
+            return {"success": False, "error": f"Could not reach Yandex Search operation status: {exc}"}
+
+        if operation.get("error"):
+            err = operation["error"]
+            message = err.get("message", "unknown error") if isinstance(err, dict) else str(err)
+            return {"success": False, "error": f"Yandex Search operation failed: {message}"}
+
+        try:
+            raw_xml = base64.b64decode(operation["response"]["rawData"])
         except Exception as exc:  # noqa: BLE001
             logger.warning("Yandex Search response parse error: %s", exc)
             return {"success": False, "error": "Could not parse Yandex Search response"}
@@ -216,6 +254,26 @@ class YandexWebSearchProvider(WebSearchProvider):
                 query, len(result["data"]["web"]), limit,
             )
         return result
+
+    def _poll_operation(self, operation_id: str, headers: Dict[str, str]) -> Dict[str, Any]:
+        """Poll the operation endpoint until it completes or ``_POLL_TIMEOUT_SECONDS`` elapses.
+
+        Raises ``TimeoutError`` if the operation never reports ``done: true``
+        in time; propagates ``httpx`` exceptions on transport/HTTP failures.
+        """
+        import httpx
+
+        deadline = time.monotonic() + _POLL_TIMEOUT_SECONDS
+        url = f"{_YANDEX_OPERATION_ENDPOINT}{operation_id}"
+        while True:
+            resp = httpx.get(url, headers=headers, timeout=15)
+            resp.raise_for_status()
+            operation = resp.json()
+            if operation.get("done"):
+                return operation
+            if time.monotonic() >= deadline:
+                raise TimeoutError
+            time.sleep(_POLL_INTERVAL_SECONDS)
 
     def get_setup_schema(self) -> Dict[str, Any]:
         return {

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -2,8 +2,8 @@
 
 Covers:
 
-- All eight bundled plugins (brave-free, ddgs, searxng, exa, parallel,
-  tavily, firecrawl, xai) instantiate and self-report the expected
+- All nine bundled plugins (brave-free, ddgs, searxng, exa, parallel,
+  tavily, firecrawl, xai, yandex) instantiate and self-report the expected
   capabilities + ABC-derived defaults.
 - Each plugin's ``is_available()`` correctly reflects env-var presence.
 - The web_search_registry resolves an active provider in the documented
@@ -45,6 +45,9 @@ def _clear_web_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_USER_TOKEN",
         "XAI_API_KEY",
+        "YANDEX_SEARCH_API_KEY",
+        "YANDEX_FOLDER_ID",
+        "ANYSEARCH_API_KEY",
     ):
         monkeypatch.delenv(k, raising=False)
 
@@ -68,7 +71,7 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestBundledPluginsRegister:
-    """All eight bundled web plugins discover and register correctly."""
+    """All nine bundled web plugins discover and register correctly."""
 
     def test_all_seven_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
@@ -84,6 +87,7 @@ class TestBundledPluginsRegister:
             "searxng",
             "tavily",
             "xai",
+            "yandex",
         ]
 
     @pytest.mark.parametrize(
@@ -98,6 +102,8 @@ class TestBundledPluginsRegister:
             ("firecrawl", True, True),
             # xai: search-only via Grok's agentic web_search tool.
             ("xai", True, False),
+            # yandex: search-only, no dedicated extract endpoint.
+            ("yandex", True, False),
         ],
     )
     def test_capability_flags_match_spec(
@@ -116,7 +122,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai", "yandex"],
     )
     def test_each_plugin_has_name_and_display_name(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -129,7 +135,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai", "yandex"],
     )
     def test_each_plugin_has_setup_schema(self, plugin_name: str) -> None:
         """``get_setup_schema()`` returns a dict the picker can consume."""
@@ -244,6 +250,19 @@ class TestIsAvailable:
         assert p is not None
         assert p.is_available() is False  # no XAI_API_KEY, no auth.json
         monkeypatch.setenv("XAI_API_KEY", "real")
+        assert p.is_available() is True
+
+    def test_yandex_requires_api_key_and_folder_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Yandex needs both YANDEX_SEARCH_API_KEY and YANDEX_FOLDER_ID."""
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("yandex")
+        assert p is not None
+        assert p.is_available() is False
+        monkeypatch.setenv("YANDEX_SEARCH_API_KEY", "real")
+        assert p.is_available() is False  # folder id still missing
+        monkeypatch.setenv("YANDEX_FOLDER_ID", "b1gexample")
         assert p.is_available() is True
 
 
@@ -394,6 +413,17 @@ class TestErrorResponseShapes:
         from agent.web_search_registry import get_provider
 
         p = get_provider("searxng")
+        assert p is not None
+        result = p.search("test", limit=5)
+        assert isinstance(result, dict)
+        assert result.get("success") is False
+        assert "error" in result
+
+    def test_yandex_returns_error_dict_when_unconfigured(self) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("yandex")
         assert p is not None
         result = p.search("test", limit=5)
         assert isinstance(result, dict)

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -28,6 +28,7 @@ def register_all_web_providers():
     from plugins.web.searxng.provider import SearXNGWebSearchProvider
     from plugins.web.tavily.provider import TavilyWebSearchProvider
     from plugins.web.xai.provider import XAIWebSearchProvider
+    from plugins.web.yandex.provider import YandexWebSearchProvider
 
     _reset_for_tests()
     for cls in (
@@ -39,6 +40,7 @@ def register_all_web_providers():
         SearXNGWebSearchProvider,
         TavilyWebSearchProvider,
         XAIWebSearchProvider,
+        YandexWebSearchProvider,
     ):
         register_provider(cls())
 

--- a/tests/tools/test_web_providers_yandex.py
+++ b/tests/tools/test_web_providers_yandex.py
@@ -1,0 +1,394 @@
+"""Tests for the Yandex Search API web search provider.
+
+Covers:
+- YandexWebSearchProvider.is_available() env var gating (API key + folder ID)
+- YandexWebSearchProvider.search() — happy path (base64+XML decode/parse),
+  HTTP error, request error, malformed response, Yandex-reported <error>
+- Result normalization (title, url, description, position) incl. <hlword>
+  emphasis-tag stripping and <headline>/<passage> description fallback
+- Limit truncation via groupsOnPage
+- _is_backend_available("yandex") integration
+- _get_backend() recognizes "yandex" as a valid configured backend
+- web_extract returns a search-only error when yandex is active
+"""
+from __future__ import annotations
+
+import base64
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.tools.conftest import register_all_web_providers
+
+
+def _b64_xml(xml_body: str) -> str:
+    return base64.b64encode(xml_body.encode("utf-8")).decode("ascii")
+
+
+_SAMPLE_XML = """<?xml version="1.0" encoding="utf-8"?>
+<yandexsearch version="1.0">
+<response>
+<results>
+<grouping>
+<group>
+<doc>
+<url>https://a.example.com/</url>
+<domain>a.example.com</domain>
+<title>Title A</title>
+<headline>Headline for A</headline>
+<passages><passage>Passage A</passage></passages>
+</doc>
+</group>
+<group>
+<doc>
+<url>https://b.example.com/</url>
+<title>Title <hlword>B</hlword></title>
+<passages><passage>Passage B</passage></passages>
+</doc>
+</group>
+<group>
+<doc>
+<url>https://c.example.com/</url>
+<title>Title C</title>
+</doc>
+</group>
+</grouping>
+</results>
+</response>
+</yandexsearch>"""
+
+_ERROR_XML = """<?xml version="1.0" encoding="utf-8"?>
+<yandexsearch version="1.0">
+<response>
+<error code="15">Backend error</error>
+</response>
+</yandexsearch>"""
+
+
+def _set_creds(monkeypatch):
+    monkeypatch.setenv("YANDEX_SEARCH_API_KEY", "yc-key-123")
+    monkeypatch.setenv("YANDEX_FOLDER_ID", "b1gexample")
+
+
+# ---------------------------------------------------------------------------
+# YandexWebSearchProvider unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestYandexProviderIsConfigured:
+    def test_configured_when_key_and_folder_set(self, monkeypatch):
+        _set_creds(monkeypatch)
+        from plugins.web.yandex.provider import YandexWebSearchProvider
+        assert YandexWebSearchProvider().is_available() is True
+
+    def test_not_configured_when_key_missing(self, monkeypatch):
+        monkeypatch.delenv("YANDEX_SEARCH_API_KEY", raising=False)
+        monkeypatch.setenv("YANDEX_FOLDER_ID", "b1gexample")
+        from plugins.web.yandex.provider import YandexWebSearchProvider
+        assert YandexWebSearchProvider().is_available() is False
+
+    def test_not_configured_when_folder_missing(self, monkeypatch):
+        monkeypatch.setenv("YANDEX_SEARCH_API_KEY", "yc-key-123")
+        monkeypatch.delenv("YANDEX_FOLDER_ID", raising=False)
+        from plugins.web.yandex.provider import YandexWebSearchProvider
+        assert YandexWebSearchProvider().is_available() is False
+
+    def test_not_configured_when_whitespace(self, monkeypatch):
+        monkeypatch.setenv("YANDEX_SEARCH_API_KEY", "   ")
+        monkeypatch.setenv("YANDEX_FOLDER_ID", "   ")
+        from plugins.web.yandex.provider import YandexWebSearchProvider
+        assert YandexWebSearchProvider().is_available() is False
+
+    def test_provider_name(self):
+        from plugins.web.yandex.provider import YandexWebSearchProvider
+        assert YandexWebSearchProvider().name == "yandex"
+
+    def test_implements_web_search_provider(self):
+        from agent.web_search_provider import WebSearchProvider
+        from plugins.web.yandex.provider import YandexWebSearchProvider
+        assert issubclass(YandexWebSearchProvider, WebSearchProvider)
+
+    def test_search_only(self):
+        from plugins.web.yandex.provider import YandexWebSearchProvider
+        p = YandexWebSearchProvider()
+        assert p.supports_search() is True
+        assert p.supports_extract() is False
+
+
+class TestYandexProviderSearch:
+    @staticmethod
+    def _mock_resp(json_data, status_code=200):
+        m = MagicMock()
+        m.status_code = status_code
+        m.json.return_value = json_data
+        m.raise_for_status = MagicMock()
+        return m
+
+    def test_happy_path_normalizes_results(self, monkeypatch):
+        _set_creds(monkeypatch)
+        from plugins.web.yandex.provider import YandexWebSearchProvider
+
+        with patch("httpx.post", return_value=self._mock_resp({"rawData": _b64_xml(_SAMPLE_XML)})):
+            result = YandexWebSearchProvider().search("test query", limit=5)
+
+        assert result["success"] is True
+        web = result["data"]["web"]
+        assert len(web) == 3
+        assert web[0] == {
+            "title": "Title A",
+            "url": "https://a.example.com/",
+            "description": "Headline for A",
+            "position": 1,
+        }
+        # <hlword> emphasis tag stripped from title text.
+        assert web[1]["title"] == "Title B"
+        # No <headline> -> falls back to the first <passage>.
+        assert web[1]["description"] == "Passage B"
+        # No <headline> and no <passages> -> empty description, not a crash.
+        assert web[2]["description"] == ""
+        assert web[2]["position"] == 3
+
+    def test_sends_api_key_header_and_folder_id(self, monkeypatch):
+        _set_creds(monkeypatch)
+        from plugins.web.yandex.provider import YandexWebSearchProvider
+
+        captured = {}
+
+        def fake_post(url, **kwargs):
+            captured["url"] = url
+            captured["headers"] = kwargs.get("headers", {})
+            captured["json"] = kwargs.get("json", {})
+            return self._mock_resp({"rawData": _b64_xml(_SAMPLE_XML)})
+
+        with patch("httpx.post", side_effect=fake_post):
+            YandexWebSearchProvider().search("q", limit=5)
+
+        assert captured["url"] == "https://searchapi.api.cloud.yandex.net/v2/web/search"
+        assert captured["headers"].get("Authorization") == "Api-Key yc-key-123"
+        assert captured["json"]["folderId"] == "b1gexample"
+        assert captured["json"]["query"]["queryText"] == "q"
+        assert captured["json"]["responseFormat"] == "FORMAT_XML"
+
+    def test_limit_maps_to_groups_on_page(self, monkeypatch):
+        _set_creds(monkeypatch)
+        from plugins.web.yandex.provider import YandexWebSearchProvider
+
+        captured = {}
+
+        def fake_post(url, **kwargs):
+            captured["json"] = kwargs.get("json", {})
+            return self._mock_resp({"rawData": _b64_xml(_SAMPLE_XML)})
+
+        with patch("httpx.post", side_effect=fake_post):
+            YandexWebSearchProvider().search("q", limit=7)
+
+        assert captured["json"]["groupSpec"]["groupsOnPage"] == "7"
+
+    def test_limit_is_capped_at_100(self, monkeypatch):
+        _set_creds(monkeypatch)
+        from plugins.web.yandex.provider import YandexWebSearchProvider
+
+        captured = {}
+
+        def fake_post(url, **kwargs):
+            captured["json"] = kwargs.get("json", {})
+            return self._mock_resp({"rawData": _b64_xml(_SAMPLE_XML)})
+
+        with patch("httpx.post", side_effect=fake_post):
+            YandexWebSearchProvider().search("q", limit=500)
+
+        assert captured["json"]["groupSpec"]["groupsOnPage"] == "100"
+
+    def test_optional_region_and_lang_passthrough(self, monkeypatch):
+        _set_creds(monkeypatch)
+        monkeypatch.setenv("YANDEX_SEARCH_REGION", "225")
+        monkeypatch.setenv("YANDEX_SEARCH_LANG", "LOCALIZATION_EN")
+        from plugins.web.yandex.provider import YandexWebSearchProvider
+
+        captured = {}
+
+        def fake_post(url, **kwargs):
+            captured["json"] = kwargs.get("json", {})
+            return self._mock_resp({"rawData": _b64_xml(_SAMPLE_XML)})
+
+        with patch("httpx.post", side_effect=fake_post):
+            YandexWebSearchProvider().search("q", limit=5)
+
+        assert captured["json"]["region"] == "225"
+        assert captured["json"]["l10n"] == "LOCALIZATION_EN"
+
+    def test_region_and_lang_omitted_by_default(self, monkeypatch):
+        _set_creds(monkeypatch)
+        monkeypatch.delenv("YANDEX_SEARCH_REGION", raising=False)
+        monkeypatch.delenv("YANDEX_SEARCH_LANG", raising=False)
+        from plugins.web.yandex.provider import YandexWebSearchProvider
+
+        captured = {}
+
+        def fake_post(url, **kwargs):
+            captured["json"] = kwargs.get("json", {})
+            return self._mock_resp({"rawData": _b64_xml(_SAMPLE_XML)})
+
+        with patch("httpx.post", side_effect=fake_post):
+            YandexWebSearchProvider().search("q", limit=5)
+
+        assert "region" not in captured["json"]
+        assert "l10n" not in captured["json"]
+
+    def test_yandex_reported_error_returns_failure(self, monkeypatch):
+        _set_creds(monkeypatch)
+        from plugins.web.yandex.provider import YandexWebSearchProvider
+
+        with patch("httpx.post", return_value=self._mock_resp({"rawData": _b64_xml(_ERROR_XML)})):
+            result = YandexWebSearchProvider().search("q", limit=5)
+
+        assert result["success"] is False
+        assert "Backend error" in result["error"]
+        assert "15" in result["error"]
+
+    def test_http_error_returns_failure(self, monkeypatch):
+        import httpx
+        _set_creds(monkeypatch)
+        from plugins.web.yandex.provider import YandexWebSearchProvider
+
+        bad = MagicMock()
+        bad.status_code = 401
+        bad.json.return_value = {"message": "Invalid API key"}
+        err = httpx.HTTPStatusError("401", request=MagicMock(), response=bad)
+
+        with patch("httpx.post", side_effect=err):
+            result = YandexWebSearchProvider().search("q", limit=5)
+
+        assert result["success"] is False
+        assert "401" in result["error"]
+        assert "Invalid API key" in result["error"]
+
+    def test_request_error_returns_failure(self, monkeypatch):
+        import httpx
+        _set_creds(monkeypatch)
+        from plugins.web.yandex.provider import YandexWebSearchProvider
+
+        with patch("httpx.post", side_effect=httpx.RequestError("boom")):
+            result = YandexWebSearchProvider().search("q", limit=5)
+
+        assert result["success"] is False
+        assert "boom" in result["error"] or "Yandex" in result["error"]
+
+    def test_malformed_base64_returns_failure(self, monkeypatch):
+        _set_creds(monkeypatch)
+        from plugins.web.yandex.provider import YandexWebSearchProvider
+
+        with patch("httpx.post", return_value=self._mock_resp({"rawData": "not-valid-base64!!!"})):
+            result = YandexWebSearchProvider().search("q", limit=5)
+
+        assert result["success"] is False
+        assert "error" in result
+
+    def test_malformed_xml_returns_failure(self, monkeypatch):
+        _set_creds(monkeypatch)
+        from plugins.web.yandex.provider import YandexWebSearchProvider
+
+        broken_xml = _b64_xml("<yandexsearch><response><results>")  # unterminated
+        with patch("httpx.post", return_value=self._mock_resp({"rawData": broken_xml})):
+            result = YandexWebSearchProvider().search("q", limit=5)
+
+        assert result["success"] is False
+        assert "error" in result
+
+    def test_missing_api_key_returns_failure(self, monkeypatch):
+        monkeypatch.delenv("YANDEX_SEARCH_API_KEY", raising=False)
+        monkeypatch.setenv("YANDEX_FOLDER_ID", "b1gexample")
+        from plugins.web.yandex.provider import YandexWebSearchProvider
+
+        result = YandexWebSearchProvider().search("q", limit=5)
+        assert result["success"] is False
+        assert "YANDEX_SEARCH_API_KEY" in result["error"]
+
+    def test_missing_folder_id_returns_failure(self, monkeypatch):
+        monkeypatch.setenv("YANDEX_SEARCH_API_KEY", "yc-key-123")
+        monkeypatch.delenv("YANDEX_FOLDER_ID", raising=False)
+        from plugins.web.yandex.provider import YandexWebSearchProvider
+
+        result = YandexWebSearchProvider().search("q", limit=5)
+        assert result["success"] is False
+        assert "YANDEX_FOLDER_ID" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Integration: _is_backend_available / _get_backend / check_web_api_key
+# ---------------------------------------------------------------------------
+
+
+class TestYandexBackendWiring:
+    _register_providers = staticmethod(register_all_web_providers)
+
+    @pytest.fixture(autouse=True)
+    def _populate_web_registry(self):
+        # "yandex" isn't in _LEGACY_WEB_BACKENDS, so availability resolution
+        # goes through the registry — needs the plugin registered first.
+        self._register_providers()
+        yield
+        from agent.web_search_registry import _reset_for_tests
+        _reset_for_tests()
+
+    def test_is_backend_available_true_when_configured(self, monkeypatch):
+        _set_creds(monkeypatch)
+        from tools.web_tools import _is_backend_available
+        assert _is_backend_available("yandex") is True
+
+    def test_is_backend_available_false_when_missing(self, monkeypatch):
+        monkeypatch.delenv("YANDEX_SEARCH_API_KEY", raising=False)
+        monkeypatch.delenv("YANDEX_FOLDER_ID", raising=False)
+        from tools.web_tools import _is_backend_available
+        assert _is_backend_available("yandex") is False
+
+    def test_configured_backend_accepted(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "yandex"})
+        _set_creds(monkeypatch)
+        assert web_tools._get_backend() == "yandex"
+
+    def test_check_web_api_key_true_when_yandex_configured(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "yandex"})
+        _set_creds(monkeypatch)
+        assert web_tools.check_web_api_key() is True
+
+
+# ---------------------------------------------------------------------------
+# yandex is search-only: web_extract returns a clear error
+# ---------------------------------------------------------------------------
+
+
+class TestYandexSearchOnlyErrors:
+    _register_providers = staticmethod(register_all_web_providers)
+
+    @pytest.fixture(autouse=True)
+    def _populate_web_registry(self):
+        self._register_providers()
+        yield
+        from agent.web_search_registry import _reset_for_tests
+        _reset_for_tests()
+
+    def test_web_extract_returns_search_only_error(self, monkeypatch):
+        import asyncio
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "yandex"})
+        _set_creds(monkeypatch)
+        monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
+
+        async def _allow_ssrf(_url: str) -> bool:
+            return True
+
+        monkeypatch.setattr(web_tools, "async_is_safe_url", _allow_ssrf)
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
+
+        result_str = asyncio.get_event_loop().run_until_complete(
+            web_tools.web_extract_tool(["https://example.com"])
+        )
+        result = json.loads(result_str)
+        assert result["success"] is False
+        assert "search-only" in result["error"].lower()
+        assert "yandex" in result["error"].lower()

--- a/tests/tools/test_web_providers_yandex.py
+++ b/tests/tools/test_web_providers_yandex.py
@@ -117,6 +117,14 @@ class TestYandexProviderIsConfigured:
 
 
 class TestYandexProviderSearch:
+    """search() is operation-based: POST submits, GET polls until done.
+
+    ``httpx.post`` is mocked as the submit call (returns ``{"id": ...}``);
+    ``httpx.get`` is mocked as the operation-status poll (returns
+    ``{"done": True, "response": {"rawData": ...}}`` immediately, since the
+    provider's poll loop just re-calls GET until ``done`` is true).
+    """
+
     @staticmethod
     def _mock_resp(json_data, status_code=200):
         m = MagicMock()
@@ -125,11 +133,23 @@ class TestYandexProviderSearch:
         m.raise_for_status = MagicMock()
         return m
 
+    def _mock_submit(self, operation_id="op-123"):
+        return self._mock_resp({"id": operation_id})
+
+    def _mock_done(self, raw_data=None, error=None):
+        response = {"done": True}
+        if error is not None:
+            response["error"] = error
+        else:
+            response["response"] = {"rawData": raw_data}
+        return self._mock_resp(response)
+
     def test_happy_path_normalizes_results(self, monkeypatch):
         _set_creds(monkeypatch)
         from plugins.web.yandex.provider import YandexWebSearchProvider
 
-        with patch("httpx.post", return_value=self._mock_resp({"rawData": _b64_xml(_SAMPLE_XML)})):
+        with patch("httpx.post", return_value=self._mock_submit()), \
+             patch("httpx.get", return_value=self._mock_done(_b64_xml(_SAMPLE_XML))):
             result = YandexWebSearchProvider().search("test query", limit=5)
 
         assert result["success"] is True
@@ -159,16 +179,53 @@ class TestYandexProviderSearch:
             captured["url"] = url
             captured["headers"] = kwargs.get("headers", {})
             captured["json"] = kwargs.get("json", {})
-            return self._mock_resp({"rawData": _b64_xml(_SAMPLE_XML)})
+            return self._mock_submit()
 
-        with patch("httpx.post", side_effect=fake_post):
+        with patch("httpx.post", side_effect=fake_post), \
+             patch("httpx.get", return_value=self._mock_done(_b64_xml(_SAMPLE_XML))):
             YandexWebSearchProvider().search("q", limit=5)
 
-        assert captured["url"] == "https://searchapi.api.cloud.yandex.net/v2/web/search"
+        assert captured["url"] == "https://searchapi.api.cloud.yandex.net/v2/web/searchAsync"
         assert captured["headers"].get("Authorization") == "Api-Key yc-key-123"
         assert captured["json"]["folderId"] == "b1gexample"
         assert captured["json"]["query"]["queryText"] == "q"
         assert captured["json"]["responseFormat"] == "FORMAT_XML"
+
+    def test_polls_operation_endpoint_with_id(self, monkeypatch):
+        _set_creds(monkeypatch)
+        from plugins.web.yandex.provider import YandexWebSearchProvider
+
+        captured = {}
+
+        def fake_get(url, **kwargs):
+            captured["url"] = url
+            captured["headers"] = kwargs.get("headers", {})
+            return self._mock_done(_b64_xml(_SAMPLE_XML))
+
+        with patch("httpx.post", return_value=self._mock_submit("op-abc-999")), \
+             patch("httpx.get", side_effect=fake_get):
+            YandexWebSearchProvider().search("q", limit=5)
+
+        assert captured["url"] == "https://operation.api.cloud.yandex.net/operations/op-abc-999"
+        assert captured["headers"].get("Authorization") == "Api-Key yc-key-123"
+
+    def test_polls_until_done_true(self, monkeypatch):
+        """First poll reports not-done; second reports done — must poll again, not give up."""
+        _set_creds(monkeypatch)
+        monkeypatch.setattr("plugins.web.yandex.provider._POLL_INTERVAL_SECONDS", 0.01)
+        from plugins.web.yandex.provider import YandexWebSearchProvider
+
+        responses = [
+            self._mock_resp({"done": False}),
+            self._mock_done(_b64_xml(_SAMPLE_XML)),
+        ]
+
+        with patch("httpx.post", return_value=self._mock_submit()), \
+             patch("httpx.get", side_effect=responses):
+            result = YandexWebSearchProvider().search("q", limit=5)
+
+        assert result["success"] is True
+        assert len(result["data"]["web"]) == 3
 
     def test_limit_maps_to_groups_on_page(self, monkeypatch):
         _set_creds(monkeypatch)
@@ -178,9 +235,10 @@ class TestYandexProviderSearch:
 
         def fake_post(url, **kwargs):
             captured["json"] = kwargs.get("json", {})
-            return self._mock_resp({"rawData": _b64_xml(_SAMPLE_XML)})
+            return self._mock_submit()
 
-        with patch("httpx.post", side_effect=fake_post):
+        with patch("httpx.post", side_effect=fake_post), \
+             patch("httpx.get", return_value=self._mock_done(_b64_xml(_SAMPLE_XML))):
             YandexWebSearchProvider().search("q", limit=7)
 
         assert captured["json"]["groupSpec"]["groupsOnPage"] == "7"
@@ -193,9 +251,10 @@ class TestYandexProviderSearch:
 
         def fake_post(url, **kwargs):
             captured["json"] = kwargs.get("json", {})
-            return self._mock_resp({"rawData": _b64_xml(_SAMPLE_XML)})
+            return self._mock_submit()
 
-        with patch("httpx.post", side_effect=fake_post):
+        with patch("httpx.post", side_effect=fake_post), \
+             patch("httpx.get", return_value=self._mock_done(_b64_xml(_SAMPLE_XML))):
             YandexWebSearchProvider().search("q", limit=500)
 
         assert captured["json"]["groupSpec"]["groupsOnPage"] == "100"
@@ -210,9 +269,10 @@ class TestYandexProviderSearch:
 
         def fake_post(url, **kwargs):
             captured["json"] = kwargs.get("json", {})
-            return self._mock_resp({"rawData": _b64_xml(_SAMPLE_XML)})
+            return self._mock_submit()
 
-        with patch("httpx.post", side_effect=fake_post):
+        with patch("httpx.post", side_effect=fake_post), \
+             patch("httpx.get", return_value=self._mock_done(_b64_xml(_SAMPLE_XML))):
             YandexWebSearchProvider().search("q", limit=5)
 
         assert captured["json"]["region"] == "225"
@@ -228,9 +288,10 @@ class TestYandexProviderSearch:
 
         def fake_post(url, **kwargs):
             captured["json"] = kwargs.get("json", {})
-            return self._mock_resp({"rawData": _b64_xml(_SAMPLE_XML)})
+            return self._mock_submit()
 
-        with patch("httpx.post", side_effect=fake_post):
+        with patch("httpx.post", side_effect=fake_post), \
+             patch("httpx.get", return_value=self._mock_done(_b64_xml(_SAMPLE_XML))):
             YandexWebSearchProvider().search("q", limit=5)
 
         assert "region" not in captured["json"]
@@ -240,14 +301,43 @@ class TestYandexProviderSearch:
         _set_creds(monkeypatch)
         from plugins.web.yandex.provider import YandexWebSearchProvider
 
-        with patch("httpx.post", return_value=self._mock_resp({"rawData": _b64_xml(_ERROR_XML)})):
+        with patch("httpx.post", return_value=self._mock_submit()), \
+             patch("httpx.get", return_value=self._mock_done(_b64_xml(_ERROR_XML))):
             result = YandexWebSearchProvider().search("q", limit=5)
 
         assert result["success"] is False
         assert "Backend error" in result["error"]
         assert "15" in result["error"]
 
-    def test_http_error_returns_failure(self, monkeypatch):
+    def test_operation_error_field_returns_failure(self, monkeypatch):
+        """The operation itself can report failure via its own `error` field
+        (distinct from a successful response whose XML body contains
+        <error>) — e.g. quota exceeded, invalid folderId, etc."""
+        _set_creds(monkeypatch)
+        from plugins.web.yandex.provider import YandexWebSearchProvider
+
+        with patch("httpx.post", return_value=self._mock_submit()), \
+             patch("httpx.get", return_value=self._mock_done(error={"code": 7, "message": "quota exceeded"})):
+            result = YandexWebSearchProvider().search("q", limit=5)
+
+        assert result["success"] is False
+        assert "quota exceeded" in result["error"]
+
+    def test_operation_timeout_returns_failure(self, monkeypatch):
+        """Operation never reports done=true within the poll budget -> typed error, not a hang."""
+        _set_creds(monkeypatch)
+        monkeypatch.setattr("plugins.web.yandex.provider._POLL_INTERVAL_SECONDS", 0.01)
+        monkeypatch.setattr("plugins.web.yandex.provider._POLL_TIMEOUT_SECONDS", 0.03)
+        from plugins.web.yandex.provider import YandexWebSearchProvider
+
+        with patch("httpx.post", return_value=self._mock_submit()), \
+             patch("httpx.get", return_value=self._mock_resp({"done": False})):
+            result = YandexWebSearchProvider().search("q", limit=5)
+
+        assert result["success"] is False
+        assert "did not complete" in result["error"].lower()
+
+    def test_http_error_on_submit_returns_failure(self, monkeypatch):
         import httpx
         _set_creds(monkeypatch)
         from plugins.web.yandex.provider import YandexWebSearchProvider
@@ -264,6 +354,22 @@ class TestYandexProviderSearch:
         assert "401" in result["error"]
         assert "Invalid API key" in result["error"]
 
+    def test_http_error_on_poll_returns_failure(self, monkeypatch):
+        import httpx
+        _set_creds(monkeypatch)
+        from plugins.web.yandex.provider import YandexWebSearchProvider
+
+        bad = MagicMock()
+        bad.status_code = 404
+        err = httpx.HTTPStatusError("404", request=MagicMock(), response=bad)
+
+        with patch("httpx.post", return_value=self._mock_submit()), \
+             patch("httpx.get", side_effect=err):
+            result = YandexWebSearchProvider().search("q", limit=5)
+
+        assert result["success"] is False
+        assert "404" in result["error"]
+
     def test_request_error_returns_failure(self, monkeypatch):
         import httpx
         _set_creds(monkeypatch)
@@ -279,7 +385,8 @@ class TestYandexProviderSearch:
         _set_creds(monkeypatch)
         from plugins.web.yandex.provider import YandexWebSearchProvider
 
-        with patch("httpx.post", return_value=self._mock_resp({"rawData": "not-valid-base64!!!"})):
+        with patch("httpx.post", return_value=self._mock_submit()), \
+             patch("httpx.get", return_value=self._mock_done("not-valid-base64!!!")):
             result = YandexWebSearchProvider().search("q", limit=5)
 
         assert result["success"] is False
@@ -290,7 +397,8 @@ class TestYandexProviderSearch:
         from plugins.web.yandex.provider import YandexWebSearchProvider
 
         broken_xml = _b64_xml("<yandexsearch><response><results>")  # unterminated
-        with patch("httpx.post", return_value=self._mock_resp({"rawData": broken_xml})):
+        with patch("httpx.post", return_value=self._mock_submit()), \
+             patch("httpx.get", return_value=self._mock_done(broken_xml)):
             result = YandexWebSearchProvider().search("q", limit=5)
 
         assert result["success"] is False

--- a/website/docs/developer-guide/web-search-provider-plugin.md
+++ b/website/docs/developer-guide/web-search-provider-plugin.md
@@ -242,7 +242,7 @@ If your provider wraps a third-party SDK (like DDGS does with the `ddgs` package
 - **`plugins/web/firecrawl/`** — full multi-capability provider (search + extract + crawl) with multiple format modes.
 - **`plugins/web/searxng/`** — self-hosted, URL-configured backend with no auth.
 - **`plugins/web/xai/`** — LLM-backed search via Grok's server-side `web_search` tool. Shows how to reuse an existing OAuth/env-var credential surface (`tools/xai_http.py`) without adding new env vars, and how to write a cheap `is_available()` that honors the no-network contract.
-- **`plugins/web/yandex/`** — search-only, two-credential (`API key` + `folder ID`) provider whose backend response is base64-encoded XML rather than JSON. Shows how to gate `is_available()` on multiple env vars and decode/parse a non-JSON payload inside `search()`.
+- **`plugins/web/yandex/`** — search-only, two-credential (`API key` + `folder ID`) provider whose backend is *operation-based*: the initial POST only returns an operation id, and `search()` has to poll a separate status endpoint until it completes before decoding the base64-encoded XML result. Shows how to gate `is_available()` on multiple env vars and implement a bounded poll loop instead of a single request/response call.
 
 ## Distribute via pip
 

--- a/website/docs/developer-guide/web-search-provider-plugin.md
+++ b/website/docs/developer-guide/web-search-provider-plugin.md
@@ -6,7 +6,7 @@ description: "How to build a web-search/extract/crawl backend plugin for Hermes 
 
 # Building a Web Search Provider Plugin
 
-Web-search provider plugins register a backend that services `web_search`, `web_extract`, and (optionally) deep-crawl tool calls. Built-in providers — Firecrawl, SearXNG, Tavily, Exa, Parallel, Brave Search (free tier), xAI, and DDGS — all ship as plugins under `plugins/web/<name>/`. You can add a new one, or override a bundled one, by dropping a directory next to them.
+Web-search provider plugins register a backend that services `web_search`, `web_extract`, and (optionally) deep-crawl tool calls. Built-in providers — Firecrawl, SearXNG, Tavily, Exa, Parallel, Brave Search (free tier), xAI, Yandex Search, and DDGS — all ship as plugins under `plugins/web/<name>/`. You can add a new one, or override a bundled one, by dropping a directory next to them.
 
 :::tip
 Web search is one of several **backend plugins** Hermes supports. The others (with their own ABCs) are [Image Generation Provider Plugins](/developer-guide/image-gen-provider-plugin), [Video Generation Provider Plugins](/developer-guide/video-gen-provider-plugin), [Memory Provider Plugins](/developer-guide/memory-provider-plugin), [Context Engine Plugins](/developer-guide/context-engine-plugin), and [Model Provider Plugins](/developer-guide/model-provider-plugin). General tool/hook/CLI plugins live in [Build a Hermes Plugin](/guides/build-a-hermes-plugin).
@@ -242,6 +242,7 @@ If your provider wraps a third-party SDK (like DDGS does with the `ddgs` package
 - **`plugins/web/firecrawl/`** — full multi-capability provider (search + extract + crawl) with multiple format modes.
 - **`plugins/web/searxng/`** — self-hosted, URL-configured backend with no auth.
 - **`plugins/web/xai/`** — LLM-backed search via Grok's server-side `web_search` tool. Shows how to reuse an existing OAuth/env-var credential surface (`tools/xai_http.py`) without adding new env vars, and how to write a cheap `is_available()` that honors the no-network contract.
+- **`plugins/web/yandex/`** — search-only, two-credential (`API key` + `folder ID`) provider whose backend response is base64-encoded XML rather than JSON. Shows how to gate `is_available()` on multiple env vars and decode/parse a non-JSON payload inside `search()`.
 
 ## Distribute via pip
 

--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -26,7 +26,7 @@ Hermes supports multiple AI inference providers out of the box. Use `hermes mode
 
 ## Web Search Backends
 
-The `web_search` and `web_extract` tools support eight backend providers, configured via `config.yaml` or `hermes tools`:
+The `web_search` and `web_extract` tools support nine backend providers, configured via `config.yaml` or `hermes tools`:
 
 | Backend | Env Var | Search | Extract | Crawl |
 |---------|---------|--------|---------|-------|
@@ -38,12 +38,13 @@ The `web_search` and `web_extract` tools support eight backend providers, config
 | **Exa** | `EXA_API_KEY` | ✔ | ✔ | — |
 | **Parallel** | `PARALLEL_API_KEY` | ✔ | ✔ | — |
 | **xAI** | `XAI_API_KEY` | ✔ | — | — |
+| **Yandex Search** | `YANDEX_SEARCH_API_KEY` + `YANDEX_FOLDER_ID` | ✔ | — | — |
 
 Quick setup example:
 
 ```yaml
 web:
-  backend: firecrawl    # firecrawl | searxng | brave-free | ddgs | tavily | exa | parallel | xai
+  backend: firecrawl    # firecrawl | searxng | brave-free | ddgs | tavily | exa | parallel | xai | yandex
 ```
 
 If `web.backend` is not set, the backend is auto-detected from whichever API key is available. Self-hosted Firecrawl is also supported via `FIRECRAWL_API_URL`.

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -135,6 +135,11 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `TAVILY_BASE_URL` | Override the Tavily API endpoint. Useful for corporate proxies and self-hosted Tavily-compatible search backends. Same pattern as `GROQ_BASE_URL`. |
 | `EXA_API_KEY` | Exa API key for AI-native web search and contents ([exa.ai](https://exa.ai/)) |
 | `BRAVE_SEARCH_API_KEY` | Brave Search API subscription token for web search (free tier available) ([brave.com/search/api](https://brave.com/search/api/)) |
+| `YANDEX_SEARCH_API_KEY` | Yandex Cloud Search API key for web search ([yandex.cloud/en/services/search-api](https://yandex.cloud/en/services/search-api)) — requires `YANDEX_FOLDER_ID` |
+| `YANDEX_FOLDER_ID` | Yandex Cloud folder ID that owns the Search API key |
+| `YANDEX_SEARCH_REGION` | Optional Yandex geo region ID override for Search API results |
+| `YANDEX_SEARCH_LANG` | Optional Yandex Search API result localization override (e.g. `LOCALIZATION_EN`) |
+| `YANDEX_SEARCH_TYPE` | Optional Yandex Search API search-domain override (default: `SEARCH_TYPE_RU`) |
 | `BROWSERBASE_API_KEY` | Browser automation ([browserbase.com](https://browserbase.com/)) |
 | `BROWSERBASE_PROJECT_ID` | Browserbase project ID |
 | `BROWSER_USE_API_KEY` | Browser Use cloud browser API key ([browser-use.com](https://browser-use.com/)) |

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -340,7 +340,7 @@ Unlike index-backed providers (Brave, Tavily, Exa) which return verbatim search-
 
 ### Yandex Search
 
-Search via Yandex Cloud's `WebSearch.Search` REST API — good coverage for Russian-language and CIS-region queries.
+Search via Yandex Cloud's `WebSearchAsync.Search` REST API — good coverage for Russian-language and CIS-region queries. The API is operation-based: Hermes submits the query, then polls the operation status (up to 20s) until results are ready — this adds a little latency versus other backends but is how the API actually works (there's no synchronous variant for API-key auth).
 
 ```bash
 # ~/.hermes/.env

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -26,8 +26,9 @@ Both are configured through a single backend selection. Providers are chosen via
 | **Exa** | `EXA_API_KEY` | ✔ | ✔ | 1 000 searches/mo |
 | **Parallel** | `PARALLEL_API_KEY` | ✔ | ✔ | Paid |
 | **xAI (Grok)** | `XAI_API_KEY` or `hermes auth login xai-oauth` | ✔ | — | Paid (SuperGrok or per-token) |
+| **Yandex Search** | `YANDEX_SEARCH_API_KEY` + `YANDEX_FOLDER_ID` | ✔ | — | Paid (Yandex Cloud) |
 
-Brave Search, DDGS, and xAI are **search-only** — pair any of them with Firecrawl/Tavily/Exa/Parallel when you also need `web_extract`. DDGS uses the [`ddgs` Python package](https://pypi.org/project/ddgs/) under the hood; if it isn't already installed, run `pip install ddgs` (or let Hermes lazy-install it on first use). xAI runs Grok's server-side `web_search` tool on the Responses API — results are LLM-generated rather than index-backed, so titles, descriptions, and URL choice are all model output (see the [trust-model caveat](#xai-grok) below).
+Brave Search, DDGS, xAI, and Yandex Search are **search-only** — pair any of them with Firecrawl/Tavily/Exa/Parallel when you also need `web_extract`. DDGS uses the [`ddgs` Python package](https://pypi.org/project/ddgs/) under the hood; if it isn't already installed, run `pip install ddgs` (or let Hermes lazy-install it on first use). xAI runs Grok's server-side `web_search` tool on the Responses API — results are LLM-generated rather than index-backed, so titles, descriptions, and URL choice are all model output (see the [trust-model caveat](#xai-grok) below).
 
 **Per-capability split:** you can use different providers for search and extract independently — for example SearXNG (free) for search and Firecrawl for extract. See [Per-capability configuration](#per-capability-configuration) below.
 
@@ -337,6 +338,39 @@ Unlike index-backed providers (Brave, Tavily, Exa) which return verbatim search-
 
 ---
 
+### Yandex Search
+
+Search via Yandex Cloud's `WebSearch.Search` REST API — good coverage for Russian-language and CIS-region queries.
+
+```bash
+# ~/.hermes/.env
+YANDEX_SEARCH_API_KEY=your-api-key-here
+YANDEX_FOLDER_ID=your-folder-id-here
+```
+
+Get an API key and folder ID at [yandex.cloud/en/services/search-api](https://yandex.cloud/en/services/search-api). Both variables are required — the API key authenticates the request, and the folder ID identifies the Yandex Cloud folder that owns the billing account.
+
+Then select Yandex Search as the search backend:
+
+```yaml
+# ~/.hermes/config.yaml
+web:
+  backend: "yandex"
+```
+
+**Optional knobs:**
+
+```bash
+# ~/.hermes/.env
+YANDEX_SEARCH_REGION=225           # optional — Yandex geo region ID (default: Yandex's own geo-detection)
+YANDEX_SEARCH_LANG=LOCALIZATION_EN # optional — result localization (default: Yandex's own default)
+YANDEX_SEARCH_TYPE=SEARCH_TYPE_RU  # optional — search domain (default: SEARCH_TYPE_RU)
+```
+
+**Search-only** — pair with Firecrawl / Tavily / Exa / Parallel if you also need `web_extract`. Not included in [auto-detection](#auto-detection) since it requires two credentials (API key + folder ID); set `web.backend: "yandex"` explicitly.
+
+---
+
 ## Configuration
 
 ### Single backend
@@ -346,7 +380,7 @@ Set one provider for all web capabilities:
 ```yaml
 # ~/.hermes/config.yaml
 web:
-  backend: "searxng"   # firecrawl | searxng | brave-free | ddgs | tavily | exa | parallel | xai
+  backend: "searxng"   # firecrawl | searxng | brave-free | ddgs | tavily | exa | parallel | xai | yandex
 ```
 
 ### Per-capability configuration
@@ -380,6 +414,8 @@ If no backend is explicitly configured, Hermes picks the first available one bas
 | `SEARXNG_URL` | searxng |
 
 xAI Web Search is **not** in the auto-detection chain — having `XAI_API_KEY` set (or being signed in via xAI Grok OAuth) does not automatically route web traffic through xAI, since those credentials are also used for inference / TTS / image gen and the user may want a different backend for web. Opt in explicitly with `web.backend: "xai"`.
+
+Yandex Search is also **not** in the auto-detection chain — it requires two credentials (`YANDEX_SEARCH_API_KEY` + `YANDEX_FOLDER_ID`) rather than the single-variable pattern the auto-detect cascade checks. Opt in explicitly with `web.backend: "yandex"`.
 
 ---
 


### PR DESCRIPTION
Adds plugins/web/yandex/ as a search-only WebSearchProvider backed by Yandex Cloud's WebSearch.Search v2 REST API (base64-encoded XML response, decoded and normalized into the standard {title,url,description,position} shape). Requires YANDEX_SEARCH_API_KEY + YANDEX_FOLDER_ID; auto-discovered via the existing plugins/web/<name>/ bundled-plugin mechanism, so no core registry/dispatch code needed changes.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [x] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [x] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [x] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [x] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [x] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

