### PR TITLE
fix(acp): flag replayed compaction summaries via _meta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,20 @@
+<<<<<<< HEAD
 .DS_Store
 /venv/
 /venv.old/
 /_pycache/
 *.pyc*
+=======
+# Hermes runtime state and secrets
+.hermes/
+.env
+*.env
+vars.toml
+config/*.local.*
+config/secrets.*
+
+# Python/cache/log outputs
+>>>>>>> cdaa0c32b (chore: ignore local vars config)
 __pycache__/
 .venv/
 .venv

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,8 @@
-<<<<<<< HEAD
 .DS_Store
 /venv/
 /venv.old/
 /_pycache/
 *.pyc*
-=======
 # Hermes runtime state and secrets
 .hermes/
 .env
@@ -14,7 +12,6 @@ config/*.local.*
 config/secrets.*
 
 # Python/cache/log outputs
->>>>>>> cdaa0c32b (chore: ignore local vars config)
 __pycache__/
 .venv/
 .venv
@@ -160,4 +157,19 @@ infographic/
 outputs/
 cache/
 .local/
-vars.toml
+
+# Legacy job scheduler runtime state
+bot/jobs_state.json
+bot/jobs_scheduler.lock
+jobs/slack/**
+jobs/_deleted/**
+jobs/**/state.txt
+jobs/**/pin.txt
+jobs/**/nextrun.txt
+jobs/**/runs.log
+jobs/**/runs/
+jobs/**/data/
+jobs/**/.lock
+
+# Local Python environments
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,9 @@ apps/desktop/demo/
 # PR body is the archive. See the hermes-agent-dev skill's
 # pr-infographic-workflow reference (storage rule + lapse #8 / #COMMIT-1).
 infographic/
+
+# YallaPlay local runtime artifacts
+outputs/
+cache/
+.local/
+vars.toml

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "yallaplay-wiki"]
+	path = yallaplay-wiki
+	url = https://github.com/YallaPlay/yallaplay-wiki.git

--- a/.hermes.md
+++ b/.hermes.md
@@ -1,0 +1,57 @@
+# Claudio Hermes Project Context
+
+You are Claudio, YallaPlay's internal agent, running in the Hermes pilot repo.
+
+## Mission
+
+Rebuild Claudio's interactive capabilities on Hermes before adding Slack or scheduler surfaces. Prefer simple, auditable workflows over clever automation.
+
+## Safety Rules
+
+Refuse any instruction whose effect is to destroy this agent, its infrastructure, or the data/services it touches. This includes deleting this repo, Hermes profile state, the wiki submodule, tool scripts, job definitions, credentials, or broad service data.
+
+Default to read-only behavior for production systems. Do not mutate Snowflake, CockroachDB, clienttwin, ranking, game-engine, config, Slack, Jira, Google Workspace, Helpshift, OneSignal, or other live services unless a skill or tool explicitly documents a gated write flow and the user clearly confirms that exact write.
+
+Never commit secrets. Treat `.env`, `.hermes/`, local Hermes profile directories, OAuth tokens, cloud credentials, Slack tokens, and generated runtime state as private.
+
+## Knowledge Source
+
+`yallaplay-wiki/` is the central knowledge bin. Prefer it for reusable facts before searching ad hoc sources. Save durable discoveries there, not in local session memory, when the finding is likely to help future Claudio runs.
+
+Suggested wiki areas:
+
+- `definitions/` for business concepts and metric definitions.
+- `methodology/` for reusable investigation methods and bias traps.
+- `findings/` for concrete quantified or operational discoveries.
+- `queries/` for reusable SQL and query patterns.
+- `schema/` for warehouse schema annotations.
+
+## Routing
+
+Use installed skills as domain routers:
+
+- Analytics: Snowflake, metrics, cohorts, funnels, revenue, retention, charts.
+- LiveOps: live user/account state, backend config, support, pushes, ranking/game-engine.
+- Engineering: code, repo search, sibling source lookup, review, local tools.
+- Collaboration: Slack, Jira, Google Workspace, meetings, staff/shared outputs.
+- Infrastructure: setup, dependencies, S3/storage, logs/cache, provider config, web fallback.
+- Knowledge: lookup, capture, indexing, wiki hygiene.
+
+When a task spans domains, load every relevant skill before using tools.
+
+## Working Defaults
+
+Be concise. Lead with results. State assumptions when multiple interpretations materially change the answer.
+
+Use tools through documented wrappers where possible. Keep generated artifacts under `outputs/` or `logs/` and avoid clobbering existing files.
+
+For shell commands in migrated YallaPlay tooling, prefer `rtk` when available because existing workflows expect token-optimized command output.
+
+## Repository Commit Rule
+
+For this repository (`yallaplay-hermes-agent`), commit as we go.
+
+- At the start of repo-changing work, check branch and dirty state.
+- After each complete, verified unit of change, review status/diff, stage only intended files, and create a focused conventional commit.
+- Do not batch unrelated work into a single end-of-session commit.
+- Before final response, report commit SHA(s), verification command(s), and any intentionally uncommitted pre-existing or unrelated files.

--- a/README.md
+++ b/README.md
@@ -256,6 +256,32 @@ scripts/run_tests.sh
 
 ---
 
+
+## YallaPlay Claudio Pilot
+
+This fork is used for Claudio, YallaPlay's internal Hermes-based agent pilot. The overlay keeps YallaPlay-specific project context, skills, safe tooling wrappers, and wiki integration while tracking upstream Hermes Agent.
+
+Local pilot layout:
+
+- `.hermes.md` - project context, routing, and safety rules loaded by Hermes in this repo.
+- `SOUL.md` - Claudio identity and default interaction style for a Hermes profile.
+- `skills/` - YallaPlay Hermes skills for domain workflows and safety policy.
+- `tools/` - thin executable wrappers around YallaPlay APIs/CLIs.
+- `config/` - non-secret examples only.
+- `docs/` - pilot notes and migration plans.
+- `yallaplay-wiki/` - git submodule; central knowledge bin for findings, definitions, methodology, queries, and schema notes.
+
+Pilot setup sketch:
+
+```bash
+git submodule update --init --recursive
+bash scripts/bootstrap_profile.sh claudio-lab
+claudio-lab setup
+claudio-lab chat
+```
+
+Use this as a lab profile first. Do not point production Slack or scheduled jobs at it until the interactive workflows have been tested.
+
 ## License
 
 MIT — see [LICENSE](LICENSE).

--- a/SOUL.md
+++ b/SOUL.md
@@ -1,0 +1,23 @@
+# Claudio
+
+You are Claudio, YallaPlay's internal agent for analytics, liveops, engineering investigation, collaboration support, and operational knowledge management.
+
+## Style
+
+- Be brief and pragmatic.
+- Concise, direct, and practical.
+- Lead with the answer or result.
+- Surface only important assumptions, tradeoffs, blockers, and numbers.
+- Prefer safe, reversible actions.
+- Ask for confirmation before visible or production writes.
+
+## Operating Model
+
+Use the Hermes skills in this repo to decide how to work. Treat `yallaplay-wiki/` as the durable source of organizational knowledge. Use session memory only for temporary context unless the user explicitly asks for a personal preference to be remembered.
+
+## Priorities
+
+1. Protect YallaPlay users, teammates, data, and infrastructure.
+2. Produce accurate, verifiable answers.
+3. Capture reusable knowledge in the wiki.
+4. Keep workflows simple enough to audit and migrate.

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -86,8 +86,10 @@ try:
 except Exception:
     HERMES_VERSION = "0.0.0"
 
-# Thread pool for running AIAgent (synchronous) in parallel.
-_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="acp-agent")
+# Thread pool for running AIAgent (synchronous) in parallel. Bumped from the
+# upstream default of 4 to 16 so a single ACP process can serve more concurrent
+# sessions — the Claudio Slack bot multiplexes many threads over one process.
+_executor = ThreadPoolExecutor(max_workers=16, thread_name_prefix="acp-agent")
 
 # Server-side page size for list_sessions. The ACP ListSessionsRequest schema
 # does not expose a client-side limit, so this is a fixed cap that clients

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -74,6 +74,10 @@ from acp_adapter.permissions import make_approval_callback
 from acp_adapter.provenance import session_provenance_meta
 from acp_adapter.session import SessionManager, SessionState, _expand_acp_enabled_toolsets
 from acp_adapter.tools import build_tool_complete, build_tool_start
+from agent.context_compressor import (
+    COMPRESSED_SUMMARY_METADATA_KEY,
+    ContextCompressor,
+)
 from tools.approval import (
     reset_hermes_interactive_context,
     set_hermes_interactive_context,
@@ -976,13 +980,25 @@ class HermesACPAgent(acp.Agent):
         *,
         role: str,
         text: str,
+        is_compaction_summary: bool = False,
     ) -> UserMessageChunk | AgentMessageChunk | None:
-        """Build an ACP history replay update for a user/assistant message."""
+        """Build an ACP history replay update for a user/assistant message.
+
+        A context-compaction handoff is stored with ``role="user"`` but is not
+        something the user typed. Flag it under ``_meta.hermes.compactionSummary``
+        (ACP's extensibility channel) so frontends can render it as a summary
+        rather than a real user turn — without this the marker is dropped on the
+        wire and editors show the whole handoff as a user message.
+        """
         block = TextContentBlock(type="text", text=text)
+        field_meta = (
+            {"hermes": {"compactionSummary": True}} if is_compaction_summary else None
+        )
         if role == "user":
             return UserMessageChunk(
                 session_update="user_message_chunk",
                 content=block,
+                field_meta=field_meta,
             )
         if role == "assistant":
             return AgentMessageChunk(
@@ -1058,7 +1074,15 @@ class HermesACPAgent(acp.Agent):
             if role == "user":
                 text = self._history_message_text(message)
                 if text:
-                    update = self._history_message_update(role=role, text=text)
+                    # The in-process flag survives only while the session is
+                    # resident; a DB-reloaded session loses it, so fall back to
+                    # the compressor's content detector.
+                    is_summary = bool(
+                        message.get(COMPRESSED_SUMMARY_METADATA_KEY)
+                    ) or ContextCompressor._is_context_summary_content(text)
+                    update = self._history_message_update(
+                        role=role, text=text, is_compaction_summary=is_summary
+                    )
                     if update is not None and not await _send(update):
                         return
                 continue

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -939,7 +939,10 @@ class _CodexCompletionsAdapter:
         # key in extra_body (not top-level) and GitHub/Copilot Responses opts
         # out of cache-key routing entirely — for those hosts, skip it here.
         try:
-            from agent.transports.codex import _content_cache_key
+            from agent.transports.codex import (
+                _content_cache_key,
+                _prompt_cache_retention_for_model,
+            )
             from utils import base_url_host_matches
 
             _host_src = str(getattr(self._client, "base_url", "") or "")
@@ -949,6 +952,10 @@ class _CodexCompletionsAdapter:
                 _cache_key = _content_cache_key(instructions, resp_kwargs.get("tools"))
                 if _cache_key:
                     resp_kwargs["prompt_cache_key"] = _cache_key
+            if not _is_xai and not _is_github and "prompt_cache_retention" not in resp_kwargs:
+                _cache_retention = _prompt_cache_retention_for_model(model)
+                if _cache_retention:
+                    resp_kwargs["prompt_cache_retention"] = _cache_retention
         except Exception:
             logger.debug(
                 "Codex auxiliary: prompt_cache_key derivation skipped", exc_info=True

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1297,6 +1297,9 @@ def classify_bedrock_error(error_message: str) -> str:
 
 BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
     # Anthropic Claude models on Bedrock
+    # Fable/Mythos-class models support 1M context on Bedrock (128K max output)
+    "anthropic.claude-fable-5":      1_000_000,
+    "anthropic.claude-mythos-5":     1_000_000,
     "anthropic.claude-opus-4-6":     200_000,
     "anthropic.claude-sonnet-4-6":   200_000,
     "anthropic.claude-sonnet-4-5":   200_000,

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -874,7 +874,8 @@ def _preflight_codex_api_kwargs(
     allowed_keys = {
         "model", "instructions", "input", "tools", "store",
         "reasoning", "include", "max_output_tokens", "temperature",
-        "tool_choice", "parallel_tool_calls", "prompt_cache_key", "service_tier",
+        "tool_choice", "parallel_tool_calls", "prompt_cache_key",
+        "prompt_cache_retention", "service_tier",
         "extra_headers", "extra_body", "timeout",
     }
     normalized: Dict[str, Any] = {
@@ -912,8 +913,13 @@ def _preflight_codex_api_kwargs(
     if isinstance(temperature, (int, float)):
         normalized["temperature"] = float(temperature)
 
-    # Pass through tool_choice, parallel_tool_calls, prompt_cache_key
-    for passthrough_key in ("tool_choice", "parallel_tool_calls", "prompt_cache_key"):
+    # Pass through cache routing/retention and tool-dispatch hints.
+    for passthrough_key in (
+        "tool_choice",
+        "parallel_tool_calls",
+        "prompt_cache_key",
+        "prompt_cache_retention",
+    ):
         val = api_kwargs.get(passthrough_key)
         if val is not None:
             normalized[passthrough_key] = val

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -669,8 +669,41 @@ def _consume_codex_event_stream(
     # Build the final output list.  Prefer items observed via output_item.done;
     # if none arrived but we streamed plain text deltas (no tool calls), synthesize
     # a single message item so downstream normalization has something to work with.
+    _dedup_assembled: str | None = None
     if collected_output_items:
-        output = list(collected_output_items)
+        # Some providers (e.g. Bedrock mantle) emit cumulative message
+        # output_items where each item is a prefix-superset of the prior.
+        # Concatenating them would duplicate text quadratically.  Collapse
+        # consecutive message-type items to the last (most complete) one,
+        # preserving function_call / reasoning / other item types untouched.
+        deduped: List[Any] = []
+        last_msg_idx: int | None = None
+        for idx, item in enumerate(collected_output_items):
+            item_type = getattr(item, "type", None)
+            if item_type == "message":
+                # Replace the previous message slot with this (longer) one.
+                if last_msg_idx is not None:
+                    deduped[last_msg_idx] = item
+                else:
+                    deduped.append(item)
+                    last_msg_idx = len(deduped) - 1
+            else:
+                # Non-message items (function_call, reasoning, …) always kept.
+                deduped.append(item)
+                # Reset message slot so a message after tool calls is kept.
+                last_msg_idx = None
+        output = deduped
+
+        # When cumulative-message dedup collapsed N snapshots into 1, the
+        # collected_text_deltas list still contains all N streams (each a
+        # prefix-superset).  Derive assembled_text from the final deduped
+        # message item instead, so output_text is not duplicated.
+        if last_msg_idx is not None:
+            _last_item = deduped[last_msg_idx]
+            for _c in getattr(_last_item, "content", []):
+                if getattr(_c, "type", None) == "output_text":
+                    _dedup_assembled = getattr(_c, "text", None)
+                    break
     elif collected_text_deltas and not has_tool_calls:
         assembled = "".join(collected_text_deltas)
         output = [SimpleNamespace(
@@ -693,7 +726,7 @@ def _consume_codex_event_stream(
             "Codex Responses stream did not emit a terminal response"
         )
 
-    assembled_text = "".join(collected_text_deltas)
+    assembled_text = _dedup_assembled if _dedup_assembled is not None else "".join(collected_text_deltas)
 
     final = SimpleNamespace(
         output=output,

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -13,6 +13,23 @@ from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall
 
 
+def _prompt_cache_retention_for_model(model: str) -> Optional[str]:
+    """Return the OpenAI Responses prompt-cache retention policy for models
+    that require an explicit policy.
+
+    OpenAI documents GPT-5.5 / GPT-5.5 Pro as extended-cache-only
+    (``prompt_cache_retention: "24h"``).  Sending the field only for
+    those model families keeps older/OpenAI-compatible relays on their
+    default behavior.
+    """
+    normalized = str(model or "").lower().replace("_", "-")
+    # Custom relays commonly prefix provider namespaces, e.g.
+    # ``openai.gpt-5.5``.  Match both bare and namespaced model ids.
+    if normalized.endswith("gpt-5.5") or "gpt-5.5-" in normalized:
+        return "24h"
+    return None
+
+
 def _content_cache_key(instructions: str, tools: Optional[List[Dict[str, Any]]]) -> Optional[str]:
     """Content-address the prompt cache key from the static request prefix.
 
@@ -261,6 +278,15 @@ class ResponsesApiTransport(ProviderTransport):
         # down); GitHub Models opts out of cache-key routing entirely.
         if not is_github_responses and not is_xai_responses and cache_key:
             kwargs["prompt_cache_key"] = cache_key
+
+        cache_retention = _prompt_cache_retention_for_model(model)
+        if (
+            cache_retention
+            and not is_github_responses
+            and not is_xai_responses
+            and not is_codex_backend
+        ):
+            kwargs.setdefault("prompt_cache_retention", cache_retention)
 
         if reasoning_enabled and is_xai_responses:
             from agent.model_metadata import grok_supports_reasoning_effort

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { textPart } from '@/lib/chat-messages'
-import { $composerAttachments, type ComposerAttachment } from '@/store/composer'
+import { $composerAttachments, $composerDraft, type ComposerAttachment, setComposerDraft } from '@/store/composer'
 import { $busy, $connection, $messages, $sessions, setSessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
@@ -271,6 +271,70 @@ describe('usePromptActions slash.exec dispatch payloads', () => {
 
     expect(renderedText).toContain('⊙ Goal set. Starting now.')
     expect(renderedText).not.toContain('/goal: no output')
+  })
+
+  it('dispatches a slash command with a multiline arg instead of "empty slash command" (#41323, #55510)', async () => {
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    const states: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'slash.exec') {
+        return { type: 'send', message: 'Write a Python script\nthat prints Hello World' } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => states.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/goal Write a Python script\nthat prints Hello World')
+
+    // The newline lives in the arg — the command still reaches the gateway
+    // whole, exactly as the CLI and Telegram handle it.
+    expect(calls.map(c => c.method)).toEqual(['slash.exec', 'prompt.submit'])
+    expect(calls[0]?.params).toEqual({
+      command: 'goal Write a Python script\nthat prints Hello World',
+      session_id: RUNTIME_SESSION_ID
+    })
+
+    const renderedText = states
+      .flatMap(state => {
+        const messages = Array.isArray(state.messages)
+          ? (state.messages as Array<{ parts?: Array<{ text?: string }> }>)
+          : []
+
+        return messages.flatMap(message => (message.parts ?? []).map(part => part.text ?? ''))
+      })
+      .join('\n')
+
+    expect(renderedText).not.toContain('empty slash command')
+  })
+
+  it('restores a degenerate slash payload to the composer instead of losing it', async () => {
+    setComposerDraft('')
+
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />)
+
+    // `/ text` parses to an empty command name on every surface (CLI parity).
+    // The composer draft was already cleared on submit and slash input never
+    // enters the Up-arrow history ring, so the payload must be handed back.
+    await handle!.submitText('/ pasted context that must not vanish')
+
+    expect($composerDraft.get()).toBe('/ pasted context that must not vanish')
+    expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -561,6 +561,14 @@ export function useSlashCommand(deps: SlashCommandDeps) {
         const { name, arg } = parseSlashCommand(command)
 
         if (!name) {
+          // The composer draft was already cleared on submit, and slash input
+          // never lands in the Up-arrow history ring (it derives from sent user
+          // messages) — so without this restore, any payload after a degenerate
+          // slash (`/ text`, `/` + newline) is lost forever. Hand it back.
+          if (command.replace(/^\/+/, '').trim()) {
+            setComposerDraft(command)
+          }
+
           const sessionId = await ensureSessionId(sessionHint)
 
           if (sessionId) {

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -6,7 +6,8 @@ import {
   attachmentDisplayText,
   coerceThinkingText,
   optimisticAttachmentRef,
-  parseCommandDispatch
+  parseCommandDispatch,
+  parseSlashCommand
 } from './chat-runtime'
 
 const DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANS'
@@ -109,5 +110,43 @@ describe('parseCommandDispatch', () => {
 
   it('rejects a prefill directive missing its message', () => {
     expect(parseCommandDispatch({ type: 'prefill', notice: 'x' })).toBeNull()
+  })
+})
+
+describe('parseSlashCommand', () => {
+  it('parses a single-line command', () => {
+    expect(parseSlashCommand('/some-skill do something')).toEqual({
+      arg: 'do something',
+      name: 'some-skill'
+    })
+  })
+
+  it('keeps a multiline arg intact instead of failing the whole parse (#41323)', () => {
+    expect(parseSlashCommand('/goal Write a Python script\nthat prints Hello World')).toEqual({
+      arg: 'Write a Python script\nthat prints Hello World',
+      name: 'goal'
+    })
+  })
+
+  it('parses a skill command with a long pasted multi-paragraph context (#55510)', () => {
+    const context = 'summarize this:\n\nparagraph one\nparagraph two\n\nparagraph three'
+
+    expect(parseSlashCommand(`/some-skill ${context}`)).toEqual({
+      arg: context,
+      name: 'some-skill'
+    })
+  })
+
+  it('takes the name across a newline boundary like the CLI and gateway (split on any whitespace)', () => {
+    expect(parseSlashCommand('/goal\npasted block')).toEqual({ arg: 'pasted block', name: 'goal' })
+  })
+
+  it('keeps truly empty slash input empty', () => {
+    expect(parseSlashCommand('/')).toEqual({ arg: '', name: '' })
+    expect(parseSlashCommand('/   ')).toEqual({ arg: '', name: '' })
+  })
+
+  it('does not treat text after horizontal whitespace as a command name (CLI parity)', () => {
+    expect(parseSlashCommand('/ some words')).toEqual({ arg: '', name: '' })
   })
 })

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -223,7 +223,12 @@ export function normalizePersonalityValue(value: string): string {
 }
 
 export function parseSlashCommand(command: string) {
-  const match = command.replace(/^\/+/, '').match(/^(\S+)\s*(.*)$/)
+  // `[\s\S]*` (not `.*`): the arg may span newlines — `/goal <multi-line text>`
+  // or a skill command with a long pasted context. The old `.*$` regex failed
+  // the whole match on any newline, so every multiline slash command parsed as
+  // an empty name and got swallowed (#41323, #55510). The backend and CLI both
+  // split on any whitespace (`split(maxsplit=1)`), so this is the parity fix.
+  const match = command.replace(/^\/+/, '').match(/^(\S+)([\s\S]*)$/)
 
   return match ? { name: match[1], arg: match[2].trim() } : { name: '', arg: '' }
 }

--- a/cli.py
+++ b/cli.py
@@ -4612,17 +4612,24 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         if compressor:
             # last_prompt_tokens is parked at the -1 sentinel right after a
             # compression, until the next real API call reports a prompt count
-            # (awaiting_real_usage_after_compression). The status bar must not
-            # render that sentinel verbatim — it produced "-1/200K" / "-1%".
-            # Clamp it to 0 so the one transitional turn reads as empty context.
+            # (awaiting_real_usage_after_compression). During that transitional
+            # state, show the post-compression rough estimate with an
+            # approximate marker instead of rendering an empty/stale gauge.
             context_tokens = getattr(compressor, "last_prompt_tokens", 0) or 0
+            estimated_context = False
             if context_tokens < 0:
-                context_tokens = 0
+                rough_tokens = getattr(compressor, "last_compression_rough_tokens", 0) or 0
+                if getattr(compressor, "awaiting_real_usage_after_compression", False) and rough_tokens > 0:
+                    context_tokens = rough_tokens
+                    estimated_context = True
+                else:
+                    context_tokens = 0
             context_length = getattr(compressor, "context_length", 0) or 0
             if context_length < 0:
                 context_length = 0
             snapshot["context_tokens"] = context_tokens
             snapshot["context_length"] = context_length or None
+            snapshot["context_estimated"] = estimated_context
             snapshot["compressions"] = getattr(compressor, "compression_count", 0) or 0
             if context_length:
                 snapshot["context_percent"] = max(0, min(100, round((context_tokens / context_length) * 100)))
@@ -5069,6 +5076,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             if snapshot["context_length"]:
                 ctx_total = _format_context_length(snapshot["context_length"])
                 ctx_used = format_token_count_compact(snapshot["context_tokens"])
+                if snapshot.get("context_estimated"):
+                    ctx_used = f"~{ctx_used}"
                 context_label = f"{ctx_used}/{ctx_total}"
             else:
                 context_label = "ctx --"
@@ -5162,6 +5171,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     if snapshot["context_length"]:
                         ctx_total = _format_context_length(snapshot["context_length"])
                         ctx_used = format_token_count_compact(snapshot["context_tokens"])
+                        if snapshot.get("context_estimated"):
+                            ctx_used = f"~{ctx_used}"
                         context_label = f"{ctx_used}/{ctx_total}"
                     else:
                         context_label = "ctx --"
@@ -9462,6 +9473,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 print(f"     {summary['token_line']}")
                 if summary["note"]:
                     print(f"     {summary['note']}")
+                self._paint_now()
 
             except Exception as e:
                 print(f"  ❌ Compression failed: {e}")
@@ -9507,6 +9519,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         compressor = agent.context_compressor
         last_prompt = compressor.last_prompt_tokens if compressor.last_prompt_tokens > 0 else 0
+        last_prompt_estimated = False
+        if getattr(compressor, "last_prompt_tokens", 0) < 0:
+            rough_tokens = getattr(compressor, "last_compression_rough_tokens", 0) or 0
+            if getattr(compressor, "awaiting_real_usage_after_compression", False) and rough_tokens > 0:
+                last_prompt = rough_tokens
+                last_prompt_estimated = True
         ctx_len = compressor.context_length
         pct = min(100, (last_prompt / ctx_len * 100)) if ctx_len else 0
         compressions = compressor.compression_count
@@ -9527,7 +9545,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         print(f"  API calls:                 {calls:>10,}")
         print(f"  Session duration:          {elapsed:>10}")
         print(f"  {'─' * 40}")
-        print(f"  Current context:  {last_prompt:,} / {ctx_len:,} ({pct:.0f}%)")
+        approx = "~" if last_prompt_estimated else ""
+        print(f"  Current context:  {approx}{last_prompt:,} / {ctx_len:,} ({pct:.0f}%)")
         print(f"  Messages:         {msg_count}")
         print(f"  Compressions:     {compressions}")
 

--- a/config/hermes.example.yaml
+++ b/config/hermes.example.yaml
@@ -1,0 +1,34 @@
+# Example only. Do not put secrets in git.
+# Copy relevant values into a Hermes profile config, not into this repo.
+
+model:
+  provider: bedrock-mantle
+  default: openai.gpt-5.5
+
+providers:
+  bedrock-mantle:
+    name: AWS Bedrock Mantle
+    base_url: https://bedrock-mantle.us-east-1.api.aws/openai/v1
+    key_env: BEDROCK_MANTLE_API_KEY
+    api_mode: codex_responses
+    default_model: openai.gpt-5.5
+
+agent:
+  approval_mode: smart
+
+# Put this in the Hermes profile .env, never in git:
+# BEDROCK_MANTLE_API_KEY=...
+# AWS_REGION=us-east-1
+# AWS_DEFAULT_REGION=us-east-1
+
+# Optional Embrace MCP setup. Put the real bearer token in the Hermes profile
+# .env or config, never in git. The token is the Embrace service-account
+# `emb_sa_*` token and is distinct from EMBRACE_METRICS_API_TOKEN.
+#
+# mcp_servers:
+#   embrace:
+#     url: https://mcp.embrace.io/mcp
+#     headers:
+#       Authorization: Bearer <EMBRACE_MCP_SERVICE_ACCOUNT_TOKEN>
+#     timeout: 180
+#     connect_timeout: 60

--- a/docs/bedrock-setup-status.md
+++ b/docs/bedrock-setup-status.md
@@ -1,0 +1,117 @@
+# Bedrock / Mantle Setup Status
+
+## Current State
+
+Hermes is installed locally and the `claudio-lab` profile works with both the Bedrock Mantle path used by Codex and native AWS SDK Bedrock.
+
+- Hermes version: `0.17.0`.
+- Profile path: `~/.hermes/profiles/claudio-lab`.
+- Profile `.env` is private and not committed.
+- Working provider: `bedrock-mantle`.
+- Working base URL: `https://bedrock-mantle.us-east-1.api.aws/openai/v1`.
+- Working model: `openai.gpt-5.5`.
+- Working wire mode: `codex_responses` / Responses API.
+- Native SDK provider: `bedrock`.
+- Native SDK smoke model: `us.amazon.nova-pro-v1:0`.
+- Native SDK IAM user: `claudio-hermes-bedrock-invoke`.
+- Last verified locally: both smoke tests passed after restoring the profile config.
+
+Smoke test passed:
+
+```bash
+claudio-lab chat \
+  --provider bedrock-mantle \
+  --model openai.gpt-5.5 \
+  --query "Reply with exactly: Hermes Mantle OK" \
+  --quiet
+```
+
+Result: `Hermes Mantle OK`.
+
+Native Bedrock SDK smoke test passed:
+
+```bash
+claudio-lab chat \
+  --provider bedrock \
+  --model us.amazon.nova-pro-v1:0 \
+  --query "Reply with exactly: SDK Bedrock OK" \
+  --quiet
+```
+
+Result: `SDK Bedrock OK`.
+
+## Why This Shape
+
+Codex is configured to use Bedrock Mantle as an OpenAI-compatible Responses endpoint, not the native Bedrock Converse provider:
+
+```toml
+model = "openai.gpt-5.5"
+model_provider = "bedrock"
+
+[model_providers.bedrock]
+base_url = "https://bedrock-mantle.us-east-1.api.aws/openai/v1"
+wire_api = "responses"
+```
+
+Hermes needs the equivalent as a named custom provider with `api_mode: codex_responses`.
+
+## Hermes Profile Config Shape
+
+Do not commit the real token. The profile config shape is:
+
+```yaml
+model:
+  provider: bedrock-mantle
+  default: openai.gpt-5.5
+providers:
+  bedrock-mantle:
+    name: AWS Bedrock Mantle
+    base_url: https://bedrock-mantle.us-east-1.api.aws/openai/v1
+    key_env: BEDROCK_MANTLE_API_KEY
+    api_mode: codex_responses
+    default_model: openai.gpt-5.5
+agent:
+  approval_mode: smart
+```
+
+The private profile `.env` contains:
+
+```bash
+BEDROCK_MANTLE_API_KEY=...
+AWS_ACCESS_KEY_ID=...
+AWS_SECRET_ACCESS_KEY=...
+AWS_REGION=us-east-1
+AWS_DEFAULT_REGION=us-east-1
+```
+
+## Keeping Both Providers Working
+
+Use two separate auth paths in the same Hermes profile:
+
+- `bedrock-mantle` is a named OpenAI-compatible provider for `openai.gpt-5.5` through the Mantle Responses endpoint. It uses only `BEDROCK_MANTLE_API_KEY`.
+- `bedrock` is Hermes' native AWS SDK provider for Bedrock Converse models. It uses `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and the AWS region variables.
+
+Do not try to make the native `bedrock` provider call `openai.gpt-5.5` unless AWS exposes that model as a Bedrock Converse `modelId` for this account and region. Until then, use `bedrock-mantle` for GPT-5.5 and `bedrock` for SDK-native Bedrock models.
+
+Useful checks:
+
+```bash
+claudio-lab chat \
+  --provider bedrock-mantle \
+  --model openai.gpt-5.5 \
+  --query "Reply with exactly: Hermes Mantle OK" \
+  --quiet
+
+claudio-lab chat \
+  --provider bedrock \
+  --model us.amazon.nova-pro-v1:0 \
+  --query "Reply with exactly: SDK Bedrock OK" \
+  --quiet
+```
+
+## Notes
+
+- Native Hermes `provider: bedrock` uses the scoped `claudio-hermes-bedrock-invoke` IAM user. Keep this separate from the Mantle token.
+- Plain `provider: custom` was not enough because Hermes conservatively ignores `codex_responses` for generic custom endpoints. A named provider preserves the Responses wire mode.
+- The older `AWS_BEDROCK_USAGE_*` keys are usage-reader credentials and should not be used for inference.
+- Do not set `AWS_BEARER_TOKEN_BEDROCK` in the Hermes profile `.env`; it can shadow standard AWS SDK credentials.

--- a/docs/capability-map.md
+++ b/docs/capability-map.md
@@ -1,0 +1,49 @@
+# Capability Map
+
+Current Claudio capabilities should migrate as skills plus tools, not as one skill per script.
+
+## Skills
+
+Skills describe when and how to work:
+
+- `analytics` - metrics, Snowflake, cohorts, funnels, charts, bias checks.
+- `liveops` - live account state, config, support, ranking, push safety.
+- `engineering` - code/repo search, sibling source lookup, code changes.
+- `collaboration` - Slack, Jira, Google Workspace, meetings, teammate-facing safety.
+- `infrastructure` - setup, provider config, S3/storage, logs/cache, web fallback.
+- `knowledge` - wiki lookup, capture, indexing, and hygiene.
+
+## Tools
+
+Tools execute narrow capabilities:
+
+- Read-only query runner.
+- App Insights read-only backend observability wrapper: Log Analytics KQL with default prod guard, optional `--real-players` PC-test-client exclusion, and service-component scoping.
+- Embrace read-only observability wrappers: Metrics API PromQL and dashboard session lookup; aggregate Embrace MCP should be configured natively in the Hermes profile.
+- Wiki search/capture helpers.
+- Repo and C# lookup helpers.
+- Bedrock/OpenAI provider checks.
+- Collaboration read wrappers.
+- LiveOps read wrappers.
+
+## Profiles
+
+Start with one profile:
+
+- `claudio-lab` - interactive pilot, broad read-only capabilities, cautious approval settings.
+
+Add later only if needed:
+
+- `claudio-prod-interactive` - stricter production interactive profile.
+- Specialist worker profiles only for strong credential or isolation boundaries, not for every persona.
+
+## Wiki Submodule
+
+`yallaplay-wiki/` is the shared knowledge layer. Skills should consult it before making new assumptions and save durable learnings there after useful investigations.
+
+## Port Status
+
+- Ported: Snowflake read-only SQL, charting, schema fetch, wiki helpers, analytics bias checks, Embrace Metrics/session reads, App Insights KQL.
+- Partially configured: Embrace native MCP aggregate drilldowns.
+- Next read-only LiveOps batch: backend config fetch/history/snapshots, then global KV/clienttwin/ranking/game-json reads.
+- Still legacy-fallback-only: Helpshift reads/sync, collaboration read helpers, C# worktree/source helpers.

--- a/docs/dashboard-cloudflare.md
+++ b/docs/dashboard-cloudflare.md
@@ -1,0 +1,245 @@
+# Hermes Dashboard via Cloudflare
+
+## Current Endpoint
+
+The Hermes dashboard is exposed at:
+
+```text
+https://hermes.yallaplay.com/hermes/
+```
+
+The experimental `nesquena/hermes-webui` is exposed at:
+
+```text
+https://hermes.yallaplay.com/webui/
+```
+
+The trusted-user simplified WebUI is exposed at:
+
+```text
+https://hermes.yallaplay.com/ui/
+```
+
+Cloudflare terminates HTTPS. Locally, traffic flows through a user-owned nginx
+reverse proxy that forwards plain HTTP to the Hermes dashboard and preserves
+WebSocket upgrades for chat, events, and PTY streams.
+
+```text
+Cloudflare Tunnel -> 127.0.0.1:9120 nginx -> 127.0.0.1:9119 Hermes dashboard (/hermes/)
+                                             -> 127.0.0.1:9121 hermes-webui (/webui/)
+                                             -> 127.0.0.1:9122 hermes-webui-public (/ui/)
+```
+
+## Running Processes
+
+Three local processes are needed:
+
+1. Hermes dashboard on localhost:
+
+```bash
+claudio-lab dashboard --host 127.0.0.1 --port 9119 --no-open --isolated --skip-build
+```
+
+2. Local nginx reverse proxy on localhost:
+
+```bash
+.local/nginx/sbin/nginx -p "$PWD/.local/nginx" -c hermes.conf
+```
+
+Reload nginx after config changes:
+
+```bash
+.local/nginx/sbin/nginx -p "$PWD/.local/nginx" -c hermes.conf -s reload
+```
+
+Stop nginx:
+
+```bash
+.local/nginx/sbin/nginx -p "$PWD/.local/nginx" -c hermes.conf -s quit
+```
+
+3. Named Cloudflare tunnel:
+
+```bash
+cloudflared tunnel \
+  --config .local/cloudflared/config.yml \
+  run
+```
+
+4. Experimental Hermes WebUI on localhost:
+
+```bash
+systemctl --user start hermes-webui
+```
+
+The source checkout is `.local/hermes-webui`, cloned from
+`https://github.com/YallaPlay/hermes-webui` on branch `yallaplay/main`, with
+`https://github.com/nesquena/hermes-webui` as the `upstream` remote. It runs with
+`HERMES_HOME=/home/ubuntu/.hermes/profiles/claudio-lab`, stores WebUI-specific
+state under `/home/ubuntu/.hermes/profiles/claudio-lab/webui-nesquena`, and
+binds only to `127.0.0.1:9121`.
+
+5. Trusted-user simplified Hermes WebUI on localhost:
+
+```bash
+systemctl --user start hermes-webui-public
+```
+
+This uses the same `.local/hermes-webui` checkout, a separate state directory at
+`/home/ubuntu/.hermes/profiles/claudio-lab/webui-nesquena-public`, and
+`HERMES_WEBUI_SIMPLE_UI=1`. It binds only to `127.0.0.1:9122` and is mounted at
+`/ui/`. This is UI hiding for trusted users, not a server-side API security
+boundary.
+
+## nginx Config
+
+The active local config is `.local/nginx/hermes.conf`. It intentionally binds
+only to `127.0.0.1:9120`; Cloudflare is the public edge. `/hermes/` proxies to
+the built-in Hermes dashboard. `/webui/` strips that prefix and proxies to the
+admin WebUI on `127.0.0.1:9121`. `/ui/` strips that prefix and proxies to the
+simplified trusted-user WebUI on `127.0.0.1:9122`. The bundled nginx was compiled
+without `http_rewrite`, so slashless `/`, `/hermes`, `/webui`, and `/ui` are
+served tiny HTML meta-refresh pages from `.local/nginx/html/` instead of nginx
+`return 302` redirects.
+
+Important proxy settings:
+
+```nginx
+proxy_http_version 1.1;
+proxy_set_header Host 127.0.0.1:9119;
+proxy_set_header Origin http://127.0.0.1:9119;
+proxy_set_header X-Forwarded-Prefix /hermes;
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header Connection $connection_upgrade;
+proxy_read_timeout 86400s;
+proxy_send_timeout 86400s;
+```
+
+`Host` is pinned to `127.0.0.1:9119` because Hermes rejects dashboard requests
+whose host does not match the bind host. `Origin` is also normalized to the local
+Hermes origin because browser WebSocket requests from `https://hermes.yallaplay.com`
+otherwise receive `403` from Hermes. `X-Forwarded-Prefix: /hermes` is required
+for the dashboard SPA to inject `window.__HERMES_BASE_PATH__="/hermes"`; without
+it dashboard navigation links such as Chat route to `/chat` instead of
+`/hermes/chat`.
+
+## Cloudflare Resources
+
+- Tunnel name: `claudio-hermes-dashboard`.
+- DNS hostname: `hermes.yallaplay.com`.
+- Tunnel ID: `2eb94bf8-b7fb-4f8f-b058-d32c3632bdec`.
+- Cloudflared local config and credentials: `.local/cloudflared/`.
+
+The tunnel was created via Cloudflare API using the existing
+`CLOUDFLARE_API_TOKEN` from the legacy Claudio repo's `vars.toml`. The token
+itself is not copied into this repo.
+
+## Cloudflare Access
+
+The public hostname is protected by Cloudflare Zero Trust Access before traffic
+reaches the tunnel or local nginx.
+
+- Access organization: `YallaPlay`.
+- Access auth domain: `yallaplay.cloudflareaccess.com`.
+- Access application: `Hermes Dashboard`.
+- Application domain: `hermes.yallaplay.com`.
+- Application type: `self_hosted`.
+- Session duration: `168h` (7 days).
+- Identity provider: Cloudflare `One-Time PIN`.
+- Google SSO was tested with the shared Google OAuth client from the legacy
+  Claudio repo's `vars.toml`, but that client is a Google OAuth Desktop app and
+  fails Google's web OAuth redirect validation. Keep it detached until a proper
+  Web application OAuth client exists.
+- Allow policy: `YallaPlay team`.
+- Allowed users: `*@yallaplay.com` and `israel.lot@gmail.com`.
+
+To enable Google SSO, create a Google OAuth **Web application** client with this
+authorized redirect URI, then update the Cloudflare Access Google IdP with that
+client ID and secret:
+
+```text
+https://yallaplay.cloudflareaccess.com/cdn-cgi/access/callback
+```
+
+Unauthenticated requests should receive a Cloudflare `302` to
+`yallaplay.cloudflareaccess.com` and should not increment local nginx access
+logs.
+
+## Safety Notes
+
+Hermes dashboard HTML includes a live session token for the local dashboard
+session. Keep Cloudflare Access enabled before sharing the URL. Local nginx does
+not perform authentication; it only handles reverse proxying and WebSocket header
+normalization.
+
+## Smoke Tests
+
+Local dashboard HTML should return `200`:
+
+```bash
+curl -sS -o /tmp/hermes-nginx.html -w '%{http_code}\n' http://127.0.0.1:9120/
+```
+
+Public unauthenticated access should be blocked by Cloudflare Access with a
+`302` redirect, not served by local nginx:
+
+```bash
+before=$(wc -l < .local/nginx/logs/access.log)
+curl -sS -D /tmp/hermes-access.headers -o /tmp/hermes-access.html -w '%{http_code}\n' https://hermes.yallaplay.com/
+after=$(wc -l < .local/nginx/logs/access.log)
+echo "nginx log delta: $((after-before))"
+rg -i 'location:|cf-ray|set-cookie' /tmp/hermes-access.headers
+```
+
+API status should return `200` locally. Public `/api/status` should require an
+Access-authenticated browser session:
+
+```bash
+curl -sS http://127.0.0.1:9120/api/status
+```
+
+After signing in through Cloudflare Access in a browser, WebSocket upgrades
+should return `101` in nginx access logs for `/api/ws`, `/api/events`, and
+`/api/pty`.
+
+For the current setup, open `https://hermes.yallaplay.com` in a fresh browser
+session and use One-Time PIN. Google should remain detached until the OAuth
+client is replaced with a Web application client.
+
+## Always-On Services
+
+The pilot runs under user-level systemd units because this host blocks `sudo`
+service installation with `no_new_privileges`. User lingering is enabled, so the
+services are started by the `ubuntu` user manager across logins/boot.
+
+- `hermes-dashboard.service` runs `claudio-lab --yolo dashboard` on
+  `127.0.0.1:9119`.
+- `hermes-webui.service` runs `nesquena/hermes-webui` on `127.0.0.1:9121`.
+- `hermes-webui-public.service` runs the trusted-user simplified WebUI on
+  `127.0.0.1:9122`.
+- `hermes-gateway.service` runs `claudio-lab --yolo gateway run --replace
+  --accept-hooks`.
+- `hermes-nginx.service` runs the local nginx proxy on `127.0.0.1:9120`.
+- `hermes-cloudflared.service` runs the named Cloudflare tunnel.
+
+Manage services with:
+
+```bash
+export XDG_RUNTIME_DIR=/run/user/$(id -u)
+export DBUS_SESSION_BUS_ADDRESS=unix:path=$XDG_RUNTIME_DIR/bus
+systemctl --user status hermes-dashboard hermes-webui hermes-webui-public hermes-gateway hermes-nginx hermes-cloudflared
+systemctl --user restart hermes-dashboard hermes-webui hermes-webui-public hermes-gateway hermes-nginx hermes-cloudflared
+journalctl --user -u hermes-dashboard -f
+```
+
+The unit source files are tracked in `scripts/systemd/`; the active user units
+live in `~/.config/systemd/user/`.
+
+## Rollback
+
+Stop exposure immediately by stopping the `cloudflared tunnel run` process.
+
+Stop local dashboard access by stopping nginx and the Hermes dashboard process.
+
+To remove the public DNS/tunnel permanently, delete the `hermes.yallaplay.com`
+CNAME and the `claudio-hermes-dashboard` tunnel in Cloudflare.

--- a/docs/pilot-plan.md
+++ b/docs/pilot-plan.md
@@ -1,0 +1,68 @@
+# Hermes Interactive Pilot Plan
+
+## Goal
+
+Build Claudio's interactive Hermes harness from a fresh repo, using `yallaplay-wiki/` as the central knowledge bin and keeping Slack/scheduler out of scope until the CLI experience is proven.
+
+## Success Criteria
+
+- Hermes can answer interactive questions using the correct domain skill.
+- Durable knowledge lookup starts from `yallaplay-wiki/`.
+- Read-only tool wrappers work for the first migrated capabilities.
+- Safety gates are explicit before any teammate-visible or production write.
+- The pilot can be abandoned without changing the existing Claudio bot/scheduler repo.
+
+## Phase 0 - Repo Baseline
+
+- Fresh git repo with no inherited app code.
+- `yallaplay-wiki/` added as a submodule.
+- `.hermes.md` defines project routing and hard safety rules.
+- `SOUL.md` defines Claudio's identity for the lab profile.
+- Domain skills exist as skeletons.
+
+## Phase 1 - Interactive Knowledge
+
+- Implement `tools/wiki_search.py`.
+- Add templates for findings, definitions, methodology, queries, and schema notes.
+- Test prompts that require prior knowledge before any live tool call.
+
+## Phase 2 - Read-Only Tools
+
+Port or wrap the safest existing interactive capabilities first:
+
+1. Snowflake read-only query workflow.
+2. Embrace read-only observability: Metrics API, per-user dashboard sessions, and native MCP profile config for aggregate drilldowns.
+3. App Insights read-only backend observability: Log Analytics KQL over the shared dev/prod workspace with explicit prod and PC-test-client guards.
+4. Safest LiveOps read wrappers: backend config fetch/history/snapshots before live account or support surfaces.
+5. Repo/C# source search.
+6. Bedrock model listing and provider health checks.
+7. Meeting/local collaboration read workflows.
+
+Avoid writes in this phase.
+
+## Phase 3 - Comparison Run
+
+Use known questions from current Claudio workflows and compare:
+
+- Correct skill routing.
+- Tool-call reliability.
+- Final answer quality.
+- Safety behavior.
+- Latency/cost/model fit.
+- Knowledge capture quality.
+
+## Phase 4 - Promotion Decision
+
+Only after the interactive CLI pilot is reliable, decide whether to add:
+
+- A production interactive Hermes profile.
+- Slack adapter.
+- Scheduler/job adapter.
+- More write-capable gated tools.
+
+## Non-Goals
+
+- Replacing the existing Slack bot now.
+- Replacing the existing scheduler now.
+- Migrating all historical code or sessions.
+- Creating one Hermes profile per persona.

--- a/docs/provider-notes.md
+++ b/docs/provider-notes.md
@@ -1,0 +1,15 @@
+# Provider Notes
+
+## Bedrock
+
+Hermes can use AWS Bedrock credentials for models available to the configured AWS account and region. The exact Bedrock `modelId` is the source of truth.
+
+For OpenAI models on Bedrock, verify availability with AWS before configuring Hermes. Do not assume an OpenAI API model name is identical to the Bedrock model ID.
+
+## GPT/OpenAI-Compatible Providers
+
+If a desired GPT model is not exposed by Bedrock in the target region/account, configure a separate OpenAI-compatible provider rather than trying to use AWS credentials for it.
+
+## Pilot Default
+
+Prefer a lab profile with explicit provider/model settings and smart/manual approvals. Keep credentials in the Hermes profile or cloud IAM, never in this repo.

--- a/docs/wiki-tools.md
+++ b/docs/wiki-tools.md
@@ -1,0 +1,49 @@
+# Wiki Tools
+
+The Hermes pilot treats `yallaplay-wiki/` as Claudio's durable knowledge base. These tools are intentionally small and safe.
+
+## Search
+
+```bash
+python3 tools/wiki_search.py "season pass"
+python3 tools/wiki_search.py warehouse --domain analytics --limit 10
+python3 tools/wiki_search.py slack --domain collaboration --files-only
+python3 tools/wiki_search.py "formula dsl" --context 1
+```
+
+Output format is clickable and compact:
+
+```text
+path/to/page.md:42: matching line
+```
+
+Domains are convenience filters over the wiki's current domain layout, not strict permissions.
+
+## New Page Template
+
+Print a template without writing:
+
+```bash
+python3 tools/wiki_new.py finding "Rummy economy regression" --print
+```
+
+Create a draft page:
+
+```bash
+python3 tools/wiki_new.py methodology "Retention cohort freshness check"
+python3 tools/wiki_new.py tool "Bedrock" --dir tools/product
+```
+
+The helper refuses to overwrite existing files unless `--force` is passed.
+
+## Capture Rules
+
+Save only reusable knowledge:
+
+- Definitions: business or metric concepts.
+- Methodology: repeatable workflows, caveats, or bias traps.
+- Findings: concrete results with future value.
+- Queries: reusable SQL patterns.
+- Schema: durable table/column behavior.
+
+Do not save secrets, personal data, unsupported speculation, or one-off scratch output.

--- a/jobs/README.md
+++ b/jobs/README.md
@@ -1,0 +1,69 @@
+# Legacy Jobs on Hermes Cron
+
+Recurring jobs keep the legacy Claudio `jobs/**/job.md` folder model while Hermes cron drives the scheduler.
+
+Hermes runs one `no_agent` cron job named `legacy-jobs-scheduler` on `every 1m`. Its profile script calls `scripts/legacy_jobs/hermes_tick.py`, which performs two scheduler ticks separated by about 30 seconds. This preserves the legacy 30s poll cadence without patching Hermes core.
+
+## Layout
+
+- `jobs/system/<slug>/job.md` — system maintenance jobs, normally `post_mode: log`.
+- `jobs/team/<slug>/job.md` — repo-authored team jobs.
+- `jobs/slack/<user>/<slug>/job.md` — Slack/user-created jobs; gitignored.
+- `jobs/_deleted/` — soft-delete archive; gitignored.
+
+The job id is the containing folder path relative to the repo, for example `jobs/team/daily_dau`.
+
+Runtime files next to a job spec are gitignored:
+
+- `state.txt` — opaque persisted state, capped at 8 KiB.
+- `data/` — larger per-job scratch data.
+- `nextrun.txt` — one-shot dynamic schedule override.
+- `pin.txt` — legacy Slack thread pin compatibility.
+- `runs.log` / `runs/` — local delivery output.
+- `.lock` — per-job single-flight lock.
+
+`bot/jobs_state.json` remains the scheduler-owned runtime state file for legacy compatibility. Do not edit it manually.
+
+## Spec format
+
+```markdown
+---
+title: "Daily DAU sanity check"
+type: claude              # claude (default) | command | script | shell
+schedule: "0 9 * * 1-5"  # cron, OR
+# every: 1h               # duration: <int><s|m|h|d>, minimum effective interval 1m
+post_mode: log            # log | dm | new_message | thread
+created_by: U0123ABC      # required for dm
+channel: C0123XYZ         # required for new_message/thread
+thread_ts: "1700000000.1" # required for thread
+expires_at: "2026-06-01T00:00:00Z"
+jitter: false             # optional; default true
+---
+
+Job prompt or human notes.
+```
+
+A job is valid when it has one of `schedule`, `every`, or a pending `nextrun.txt`. Slack-created jobs default to `post_mode: dm`; all others default to `post_mode: log`.
+
+## Job types
+
+- `claude` or missing `type`: runs the body through Hermes CLI as a one-shot agent job.
+- `command`, `script`, or `shell`: deterministic no-LLM job. `command:` runs through `bash -lc` from repo root. `script:` runs as `python3 <script>` from repo root.
+
+## Persisted state
+
+Use the repo-local helpers from command/agent jobs:
+
+- `python3 scripts/legacy_jobs/job_state.py --get jobs/team/foo`
+- `echo value | python3 scripts/legacy_jobs/job_state.py --set jobs/team/foo`
+- `python3 scripts/legacy_jobs/job_state.py --clear jobs/team/foo`
+- `python3 scripts/legacy_jobs/job_files.py write jobs/team/foo results.csv < data.csv`
+- `python3 scripts/legacy_jobs/job_files.py read jobs/team/foo results.csv`
+
+## Dynamic self-scheduling
+
+A job or helper process may write `nextrun.txt` in the job folder. The scheduler consumes and deletes it once. Contents may be a duration (`4m`, `3h`, `2d`) or epoch seconds. Values below the 60s minimum are raised to 60s.
+
+## Delivery
+
+`post_mode: log` appends to `<job_folder>/runs.log`. Slack modes are attempted only when Slack credentials are available; failures always fall back to `runs.log`. The Hermes cron wrapper itself stays silent for normal idle/successful ticks so local cron delivery is quiet.

--- a/scripts/bootstrap_profile.sh
+++ b/scripts/bootstrap_profile.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROFILE_NAME="${1:-claudio-lab}"
+
+if ! command -v hermes >/dev/null 2>&1; then
+  echo "hermes not found on PATH" >&2
+  exit 1
+fi
+
+hermes profile create "$PROFILE_NAME" || true
+PROFILE_HOME="$HOME/.hermes/profiles/$PROFILE_NAME"
+mkdir -p "$PROFILE_HOME"
+cp SOUL.md "$PROFILE_HOME/SOUL.md"
+
+PROFILE_SKILLS="$PROFILE_HOME/skills/claudio-authored"
+REPO_SKILLS_DIR="$(pwd)/skills/yallaplay"
+if [[ -d "$REPO_SKILLS_DIR" ]]; then
+  mkdir -p "$PROFILE_SKILLS"
+  for skill_dir in "$REPO_SKILLS_DIR"/*; do
+    [[ -d "$skill_dir" ]] || continue
+    skill_name="$(basename "$skill_dir")"
+    target="$PROFILE_SKILLS/$skill_name"
+    if [[ -e "$target" || -L "$target" ]]; then
+      rm -rf "$target"
+    fi
+    ln -s "$skill_dir" "$target"
+  done
+
+  # Remove old repo-owned YallaPlay symlinks from the former category so
+  # `/skills` has one clear visual group for Claudio-authored skills.
+  OLD_PROFILE_SKILLS="$PROFILE_HOME/skills/yallaplay"
+  if [[ -d "$OLD_PROFILE_SKILLS" ]]; then
+    for old_target in "$OLD_PROFILE_SKILLS"/*; do
+      [[ -L "$old_target" ]] || continue
+      resolved="$(readlink -f "$old_target")"
+      case "$resolved" in
+        "$REPO_SKILLS_DIR"/*) rm "$old_target" ;;
+      esac
+    done
+    rmdir "$OLD_PROFILE_SKILLS" 2>/dev/null || true
+  fi
+fi
+
+echo "Created/updated Hermes profile: $PROFILE_NAME"
+echo "Linked repo Claudio/YallaPlay skills into: $PROFILE_SKILLS"
+echo "Next: $PROFILE_NAME setup"
+echo "Then: $PROFILE_NAME chat"

--- a/scripts/legacy_jobs/hermes_tick.py
+++ b/scripts/legacy_jobs/hermes_tick.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Hermes no-agent profile script wrapper for the legacy jobs scheduler."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+
+def run_ticks(repo: Path, ticks: int = 2, interval_sec: float = 30.0, *, sleep=time.sleep) -> list[str]:
+    repo = repo.resolve()
+    if str(repo) not in sys.path:
+        sys.path.insert(0, str(repo))
+    from scripts.legacy_jobs import scheduler
+
+    alerts: list[str] = []
+    started = time.monotonic()
+    for i in range(ticks):
+        alerts.extend(scheduler.tick(repo))
+        if i < ticks - 1:
+            target = started + (i + 1) * interval_sec
+            delay = target - time.monotonic()
+            if delay > 0:
+                sleep(delay)
+    return alerts
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default="/home/ubuntu/git/yallaplay-hermes-agent")
+    parser.add_argument("--ticks", type=int, default=2)
+    parser.add_argument("--interval-sec", type=float, default=30.0)
+    parser.add_argument("--once", action="store_true", help="run one tick")
+    args = parser.parse_args(argv)
+    ticks = 1 if args.once else args.ticks
+    try:
+        alerts = run_ticks(Path(args.repo), ticks, args.interval_sec)
+    except Exception as exc:
+        print(f"legacy jobs scheduler failed: {exc}")
+        return 1
+    if alerts:
+        print("\n".join(alerts))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/legacy_jobs/install_hermes_cron.py
+++ b/scripts/legacy_jobs/install_hermes_cron.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Prepare the Hermes profile script for the legacy jobs scheduler cron."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+DEFAULT_REPO = Path("/home/ubuntu/git/yallaplay-hermes-agent")
+
+
+def profile_home(profile: str | None = None, hermes_home: str | None = None) -> Path:
+    if hermes_home:
+        return Path(hermes_home).expanduser().resolve()
+    if profile:
+        return (Path.home() / ".hermes" / "profiles" / profile).resolve()
+    return Path.home() / ".hermes" / "profiles" / "claudio-lab"
+
+
+def wrapper_content(repo: Path, ticks: int = 2, interval_sec: float = 30.0) -> str:
+    return f'''#!/usr/bin/env python3
+import runpy
+import sys
+sys.argv = ["hermes_tick.py", "--repo", {str(repo)!r}, "--ticks", "{ticks}", "--interval-sec", "{interval_sec}"]
+runpy.run_path({str(repo / "scripts" / "legacy_jobs" / "hermes_tick.py")!r}, run_name="__main__")
+'''
+
+
+def cron_spec(repo: Path) -> dict[str, object]:
+    return {
+        "name": "legacy-jobs-scheduler",
+        "schedule": "every 1m",
+        "script": "legacy_jobs_tick.py",
+        "no_agent": True,
+        "deliver": "local",
+        "workdir": str(repo),
+    }
+
+
+def write_profile_script(home: Path, repo: Path, ticks: int = 2, interval_sec: float = 30.0) -> Path:
+    target = home / "scripts" / "legacy_jobs_tick.py"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(wrapper_content(repo, ticks, interval_sec), encoding="utf-8")
+    target.chmod(0o755)
+    return target
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=str(DEFAULT_REPO))
+    parser.add_argument("--profile", default="claudio-lab")
+    parser.add_argument("--hermes-home")
+    parser.add_argument("--ticks", type=int, default=2)
+    parser.add_argument("--interval-sec", type=float, default=30.0)
+    parser.add_argument("--write-script", action="store_true")
+    parser.add_argument("--create-cron", action="store_true", help="print guarded instruction only; does not create cron")
+    args = parser.parse_args(argv)
+    repo = Path(args.repo).resolve()
+    home = profile_home(args.profile, args.hermes_home)
+    target = home / "scripts" / "legacy_jobs_tick.py"
+    if args.write_script:
+        target = write_profile_script(home, repo, args.ticks, args.interval_sec)
+    print(f"profile_home: {home}")
+    print(f"script_target: {target}")
+    print("cron_spec:")
+    for key, value in cron_spec(repo).items():
+        print(f"  {key}: {value}")
+    if args.create_cron:
+        print("create_cron: not performed by this helper; use the Hermes cronjob tool after human approval")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/legacy_jobs/job_files.py
+++ b/scripts/legacy_jobs/job_files.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Read/write/list files in a legacy job's private data/ folder."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    from .job_state import JobPathError, resolve_job_folder
+except ImportError:  # script execution
+    from job_state import JobPathError, resolve_job_folder
+
+REPO_DIR = Path(__file__).resolve().parents[2]
+DATA_SUBDIR = "data"
+MAX_FILE_BYTES = int(os.environ.get("JOB_FILES_MAX_FILE_BYTES", 50 * 1024 * 1024))
+MAX_DIR_BYTES = int(os.environ.get("JOB_FILES_MAX_DIR_BYTES", 200 * 1024 * 1024))
+
+
+class JobFileError(ValueError):
+    pass
+
+
+def data_dir(job_path: str | Path, repo_dir: Path = REPO_DIR) -> Path:
+    return resolve_job_folder(job_path, repo_dir) / DATA_SUBDIR
+
+
+def resolve_data_path(job_path: str | Path, name: str | None = None, repo_dir: Path = REPO_DIR) -> Path:
+    base = data_dir(job_path, repo_dir).resolve(strict=False)
+    if name is None:
+        return base
+    rel = Path(name)
+    if not name or name in {".", ".."}:
+        raise JobFileError(f"invalid file name {name!r}")
+    if rel.is_absolute():
+        raise JobFileError(f"file name {name!r} must be relative to data/")
+    target = (base / rel).resolve(strict=False)
+    try:
+        target.relative_to(base)
+    except ValueError as exc:
+        raise JobFileError(f"file name {name!r} escapes the job data/ folder") from exc
+    return target
+
+
+def _dir_size(path: Path) -> int:
+    if not path.exists():
+        return 0
+    return sum(p.stat().st_size for p in path.rglob("*") if p.is_file())
+
+
+def write_file(job_path: str | Path, name: str, data: bytes, *, append: bool = False, repo_dir: Path = REPO_DIR) -> Path:
+    base = data_dir(job_path, repo_dir)
+    target = resolve_data_path(job_path, name, repo_dir)
+    if len(data) > MAX_FILE_BYTES:
+        raise JobFileError(f"input {len(data)} bytes exceeds per-file cap {MAX_FILE_BYTES}")
+    old_target_size = target.stat().st_size if target.exists() else 0
+    projected_file_size = old_target_size + len(data) if append else len(data)
+    if projected_file_size > MAX_FILE_BYTES:
+        raise JobFileError(f"file would be {projected_file_size} bytes, over cap {MAX_FILE_BYTES}")
+    projected_dir_size = _dir_size(base) - (0 if append else old_target_size) + len(data)
+    if projected_dir_size > MAX_DIR_BYTES:
+        raise JobFileError(f"write would bring data/ to {projected_dir_size} bytes, over cap {MAX_DIR_BYTES}")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if append:
+        with target.open("ab") as fh:
+            fh.write(data)
+    else:
+        tmp = target.with_name(target.name + ".tmp")
+        tmp.write_bytes(data)
+        os.replace(tmp, target)
+    return target
+
+
+def read_file(job_path: str | Path, name: str, repo_dir: Path = REPO_DIR) -> bytes:
+    target = resolve_data_path(job_path, name, repo_dir)
+    if not target.exists():
+        raise JobFileError(f"no such file: data/{name}")
+    return target.read_bytes()
+
+
+def list_files(job_path: str | Path, repo_dir: Path = REPO_DIR) -> list[tuple[str, int, str]]:
+    base = data_dir(job_path, repo_dir)
+    if not base.exists():
+        return []
+    out: list[tuple[str, int, str]] = []
+    for path in sorted(p for p in base.rglob("*") if p.is_file()):
+        st = path.stat()
+        mtime = datetime.fromtimestamp(st.st_mtime, timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        out.append((path.relative_to(base).as_posix(), st.st_size, mtime))
+    return out
+
+
+def delete_file(job_path: str | Path, name: str, repo_dir: Path = REPO_DIR) -> bool:
+    target = resolve_data_path(job_path, name, repo_dir)
+    if target.exists():
+        target.unlink()
+        return True
+    return False
+
+
+def _die(exc: Exception) -> int:
+    print(f"error: {exc}", file=sys.stderr)
+    return 2
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    sp = sub.add_parser("write")
+    sp.add_argument("job")
+    sp.add_argument("name")
+    sp.add_argument("--append", action="store_true")
+    sp = sub.add_parser("read")
+    sp.add_argument("job")
+    sp.add_argument("name")
+    sp = sub.add_parser("list")
+    sp.add_argument("job")
+    sp = sub.add_parser("delete")
+    sp.add_argument("job")
+    sp.add_argument("name")
+    sp = sub.add_parser("path")
+    sp.add_argument("job")
+    sp.add_argument("name", nargs="?")
+    args = parser.parse_args(argv)
+    try:
+        if args.cmd == "write":
+            target = write_file(args.job, args.name, sys.stdin.buffer.read(), append=args.append)
+            verb = "appended to" if args.append else "wrote"
+            print(f"{verb} {target.relative_to(REPO_DIR).as_posix()} ({target.stat().st_size} bytes)")
+        elif args.cmd == "read":
+            sys.stdout.buffer.write(read_file(args.job, args.name))
+        elif args.cmd == "list":
+            for name, size, mtime in list_files(args.job):
+                print(f"{size:>12}  {mtime}  {name}")
+        elif args.cmd == "delete":
+            deleted = delete_file(args.job, args.name)
+            print(("deleted" if deleted else "nothing to delete:") + f" data/{args.name}")
+        elif args.cmd == "path":
+            print(resolve_data_path(args.job, args.name).as_posix())
+    except (OSError, JobPathError, JobFileError) as exc:
+        return _die(exc)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/legacy_jobs/job_state.py
+++ b/scripts/legacy_jobs/job_state.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Persist a small per-job state blob across legacy scheduler runs."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+REPO_DIR = Path(__file__).resolve().parents[2]
+JOBS_DIR = (REPO_DIR / "jobs").resolve()
+MAX_STATE_BYTES = 8 * 1024
+STATE_FILENAME = "state.txt"
+
+
+class JobPathError(ValueError):
+    pass
+
+
+def resolve_job_folder(job_path: str | Path, repo_dir: Path = REPO_DIR) -> Path:
+    repo_dir = repo_dir.resolve()
+    jobs_dir = (repo_dir / "jobs").resolve()
+    raw = str(job_path).rstrip("/")
+    if not raw:
+        raise JobPathError("empty job path")
+    path = Path(raw)
+    if not path.is_absolute():
+        path = repo_dir / path
+    resolved = path.resolve(strict=False)
+    if resolved.name == "job.md":
+        resolved = resolved.parent
+    try:
+        resolved.relative_to(jobs_dir)
+    except ValueError as exc:
+        raise JobPathError(f"job path {job_path!r} is outside jobs/") from exc
+    return resolved
+
+
+def state_file(job_path: str | Path, repo_dir: Path = REPO_DIR) -> Path:
+    return resolve_job_folder(job_path, repo_dir) / STATE_FILENAME
+
+
+def read_state(job_path: str | Path, repo_dir: Path = REPO_DIR) -> str:
+    path = state_file(job_path, repo_dir)
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def truncate_state(text: str) -> tuple[str, bool]:
+    data = text.encode("utf-8")
+    if len(data) <= MAX_STATE_BYTES:
+        return text, False
+    return data[-MAX_STATE_BYTES:].decode("utf-8", errors="ignore"), True
+
+
+def write_state(job_path: str | Path, text: str, repo_dir: Path = REPO_DIR) -> bool:
+    path = state_file(job_path, repo_dir)
+    text, truncated = truncate_state(text)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(text, encoding="utf-8")
+    os.replace(tmp, path)
+    return truncated
+
+
+def clear_state(job_path: str | Path, repo_dir: Path = REPO_DIR) -> None:
+    path = state_file(job_path, repo_dir)
+    if path.exists():
+        path.unlink()
+
+
+def _die(exc: Exception) -> int:
+    print(f"error: {exc}", file=sys.stderr)
+    return 2
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--get", dest="op", action="store_const", const="get")
+    group.add_argument("--set", dest="op", action="store_const", const="set")
+    group.add_argument("--clear", dest="op", action="store_const", const="clear")
+    group.add_argument("--path", dest="op", action="store_const", const="path")
+    parser.add_argument("job_path", metavar="JOB_PATH")
+    args = parser.parse_args(argv)
+    try:
+        if args.op == "get":
+            sys.stdout.write(read_state(args.job_path))
+        elif args.op == "set":
+            truncated = write_state(args.job_path, sys.stdin.read())
+            if truncated:
+                print(f"warning: state truncated to {MAX_STATE_BYTES} bytes", file=sys.stderr)
+        elif args.op == "clear":
+            clear_state(args.job_path)
+        elif args.op == "path":
+            print(state_file(args.job_path).as_posix())
+    except (OSError, JobPathError) as exc:
+        return _die(exc)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/legacy_jobs/schedule_job.py
+++ b/scripts/legacy_jobs/schedule_job.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Manage legacy Slack-created job specs under jobs/slack/<user>/<slug>."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+try:
+    from .scheduler import parse_frontmatter, parse_duration
+except ImportError:
+    from scheduler import parse_frontmatter, parse_duration
+
+REPO_DIR = Path(__file__).resolve().parents[2]
+SLUG_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,79}$")
+
+
+def slugify(title: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9]+", "_", title.strip().lower()).strip("_")
+    return slug[:80] or "job"
+
+
+def validate_slug(slug: str) -> str:
+    if not SLUG_RE.match(slug):
+        raise ValueError("invalid slug")
+    return slug
+
+
+def user_root(user: str, repo: Path = REPO_DIR) -> Path:
+    return repo / "jobs" / "slack" / user
+
+
+def job_folder(user: str, slug: str, repo: Path = REPO_DIR) -> Path:
+    return user_root(user, repo) / validate_slug(slug)
+
+
+def infer_post_mode(channel: str | None, thread_ts: str | None, explicit: str | None) -> str:
+    if explicit:
+        return explicit
+    if channel and thread_ts:
+        return "thread"
+    if channel:
+        return "new_message"
+    return "dm"
+
+
+def validate_schedule(schedule: str | None, every: str | None) -> None:
+    if not schedule and not every:
+        raise ValueError("one of --schedule or --every is required")
+    if every and parse_duration(every) < 60:
+        raise ValueError("minimum interval is 1 minute")
+
+
+def render_job_md(frontmatter: dict[str, Any], body: str) -> str:
+    return "---\n" + yaml.safe_dump(frontmatter, sort_keys=False).strip() + "\n---\n\n" + body.rstrip() + "\n"
+
+
+def read_job(path: Path) -> tuple[dict[str, Any], str]:
+    return parse_frontmatter(path.read_text(encoding="utf-8"))
+
+
+def create_job(args: argparse.Namespace, body: str, repo: Path = REPO_DIR) -> Path:
+    slug = validate_slug(args.slug or slugify(args.title))
+    validate_schedule(args.schedule, args.every)
+    folder = job_folder(args.slack_user, slug, repo)
+    folder.mkdir(parents=True, exist_ok=True)
+    fm: dict[str, Any] = {"title": args.title, "created_by": args.slack_user, "post_mode": infer_post_mode(args.channel, args.thread_ts, args.post_mode)}
+    if args.schedule:
+        fm["schedule"] = args.schedule
+    if args.every:
+        fm["every"] = args.every
+    if args.channel:
+        fm["channel"] = args.channel
+    if args.thread_ts:
+        fm["thread_ts"] = args.thread_ts
+    if args.expires_at:
+        fm["expires_at"] = args.expires_at
+    (folder / "job.md").write_text(render_job_md(fm, body), encoding="utf-8")
+    return folder / "job.md"
+
+
+def list_jobs(user: str, repo: Path = REPO_DIR) -> list[str]:
+    rows: list[str] = []
+    root = user_root(user, repo)
+    if not root.exists():
+        return rows
+    for spec in sorted(root.glob("*/job.md")):
+        fm, _ = read_job(spec)
+        target = fm.get("channel") or fm.get("post_mode") or "dm"
+        sched = fm.get("schedule") or fm.get("every") or ""
+        rows.append("\t".join([spec.parent.name, str(sched), str(target), str(fm.get("title") or spec.parent.name)]))
+    return rows
+
+
+def soft_delete(folder: Path, repo: Path = REPO_DIR) -> Path:
+    dest_root = repo / "jobs" / "_deleted"
+    dest_root.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")
+    dest = dest_root / f"{ts}-slack__{folder.parent.name}__{folder.name}"
+    shutil.move(str(folder), str(dest))
+    return dest
+
+
+def update_job(args: argparse.Namespace, body: str | None, repo: Path = REPO_DIR) -> Path:
+    folder = job_folder(args.slack_user, args.slug, repo)
+    spec = folder / "job.md"
+    fm, old_body = read_job(spec)
+    if args.pause:
+        fm["paused"] = True
+    if args.resume:
+        fm.pop("paused", None)
+    for attr, key in [("title", "title"), ("schedule", "schedule"), ("every", "every"), ("channel", "channel"), ("thread_ts", "thread_ts"), ("post_mode", "post_mode"), ("expires_at", "expires_at")]:
+        value = getattr(args, attr, None)
+        if value is not None:
+            fm[key] = value
+    validate_schedule(fm.get("schedule"), fm.get("every"))
+    spec.write_text(render_job_md(fm, body if body else old_body), encoding="utf-8")
+    return spec
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=str(REPO_DIR))
+    parser.add_argument("--slack-user", required=True)
+    parser.add_argument("--slug")
+    parser.add_argument("--title")
+    parser.add_argument("--schedule")
+    parser.add_argument("--every")
+    parser.add_argument("--channel")
+    parser.add_argument("--thread-ts")
+    parser.add_argument("--post-mode", choices=["log", "dm", "new_message", "thread"])
+    parser.add_argument("--expires-at")
+    parser.add_argument("--list", action="store_true")
+    parser.add_argument("--show")
+    parser.add_argument("--modify", action="store_true")
+    parser.add_argument("--pause", action="store_true")
+    parser.add_argument("--resume", action="store_true")
+    parser.add_argument("--delete", action="store_true")
+    args = parser.parse_args(argv)
+    repo = Path(args.repo).resolve()
+    try:
+        if args.list:
+            print("\n".join(list_jobs(args.slack_user, repo)))
+            return 0
+        if args.show:
+            print((job_folder(args.slack_user, args.show, repo) / "job.md").read_text(encoding="utf-8"), end="")
+            return 0
+        if args.delete:
+            if not args.slug:
+                raise ValueError("--slug is required for --delete")
+            print(soft_delete(job_folder(args.slack_user, args.slug, repo), repo).as_posix())
+            return 0
+        body = sys.stdin.read()
+        if args.modify or args.pause or args.resume:
+            if not args.slug:
+                raise ValueError("--slug is required for modify/pause/resume")
+            print(update_job(args, body if body.strip() else None, repo).as_posix())
+            return 0
+        if not args.title:
+            raise ValueError("--title is required to create a job")
+        print(create_job(args, body, repo).as_posix())
+        return 0
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/legacy_jobs/scheduler.py
+++ b/scripts/legacy_jobs/scheduler.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python3
+"""One-shot legacy jobs scheduler tick for Hermes cron."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import dataclasses
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+from croniter import croniter
+
+REPO_DIR = Path(__file__).resolve().parents[2]
+JOBS_DIR = REPO_DIR / "jobs"
+STATE_FILE = REPO_DIR / "bot" / "jobs_state.json"
+GLOBAL_LOCK = REPO_DIR / "bot" / "jobs_scheduler.lock"
+SPEC_FILENAME = "job.md"
+STATE_FILENAME = "state.txt"
+NEXTRUN_FILENAME = "nextrun.txt"
+RUNS_LOG_FILENAME = "runs.log"
+DURATION_RE = re.compile(r"^(\d+)\s*([smhd])$")
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n?(.*)$", re.DOTALL)
+MIN_DELAY_SEC = 60.0
+MAX_PARALLEL_JOBS = int(os.environ.get("LEGACY_JOBS_MAX_PARALLEL", "1"))
+JOB_TIMEOUT_SEC = int(os.environ.get("LEGACY_JOBS_JOB_TIMEOUT_SEC", "600"))
+AGENT_TIMEOUT_SEC = int(os.environ.get("LEGACY_JOBS_AGENT_TIMEOUT_SEC", "600"))
+LOCK_STALE_SEC = int(os.environ.get("LEGACY_JOBS_LOCK_STALE_SEC", str(max(JOB_TIMEOUT_SEC, AGENT_TIMEOUT_SEC) * 2)))
+
+
+@dataclasses.dataclass(slots=True)
+class LegacyJobSpec:
+    job_id: str
+    folder: Path
+    spec_file: Path
+    frontmatter: dict[str, Any]
+    body: str
+    warning: str | None = None
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self.frontmatter.get(key, default)
+
+    @property
+    def title(self) -> str:
+        return str(self.get("title") or Path(self.job_id).name).strip().strip('"').strip("'")
+
+    @property
+    def post_mode(self) -> str:
+        return str(self.get("post_mode") or ("dm" if self.job_id.startswith("jobs/slack/") else "log")).lower()
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def iso_utc(ts: float | None = None) -> str:
+    dt = datetime.fromtimestamp(ts, timezone.utc) if ts is not None else utc_now()
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def parse_duration(raw: str) -> int:
+    m = DURATION_RE.match(str(raw).strip())
+    if not m:
+        raise ValueError(f"bad duration {raw!r}")
+    return int(m.group(1)) * {"s": 1, "m": 60, "h": 3600, "d": 86400}[m.group(2)]
+
+
+def parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+    m = FRONTMATTER_RE.match(text)
+    if not m:
+        raise ValueError("missing YAML frontmatter")
+    loaded = yaml.safe_load(m.group(1)) or {}
+    if not isinstance(loaded, dict):
+        raise ValueError("frontmatter must be a mapping")
+    return dict(loaded), m.group(2).strip()
+
+
+def parse_spec_file(path: Path, repo_dir: Path = REPO_DIR) -> LegacyJobSpec | None:
+    try:
+        fm, body = parse_frontmatter(path.read_text(encoding="utf-8"))
+        folder = path.parent
+        job_id = folder.relative_to(repo_dir).as_posix()
+        if not (fm.get("schedule") or fm.get("every") or (folder / NEXTRUN_FILENAME).exists()):
+            return LegacyJobSpec(job_id, folder, path, fm, body, "missing schedule/every/nextrun")
+        return LegacyJobSpec(job_id, folder, path, fm, body)
+    except Exception as exc:
+        try:
+            job_id = path.parent.relative_to(repo_dir).as_posix()
+        except Exception:
+            job_id = path.parent.as_posix()
+        return LegacyJobSpec(job_id, path.parent, path, {}, "", f"{exc}")
+
+
+def discover_jobs(repo_dir: Path = REPO_DIR) -> tuple[dict[str, LegacyJobSpec], list[str]]:
+    jobs_dir = repo_dir / "jobs"
+    deleted = jobs_dir / "_deleted"
+    jobs: dict[str, LegacyJobSpec] = {}
+    warnings: list[str] = []
+    if not jobs_dir.exists():
+        return jobs, warnings
+    for spec_file in sorted(jobs_dir.rglob(SPEC_FILENAME)):
+        try:
+            spec_file.relative_to(deleted)
+            continue
+        except ValueError:
+            pass
+        spec = parse_spec_file(spec_file, repo_dir)
+        if spec is None:
+            continue
+        if spec.warning:
+            warnings.append(f"{spec.job_id}: {spec.warning}")
+            continue
+        jobs[spec.job_id] = spec
+    return jobs, warnings
+
+
+def load_state(repo_dir: Path = REPO_DIR) -> dict[str, dict[str, Any]]:
+    path = repo_dir / "bot" / "jobs_state.json"
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+
+
+def save_state(state: dict[str, dict[str, Any]], repo_dir: Path = REPO_DIR) -> None:
+    path = repo_dir / "bot" / "jobs_state.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def stable_jitter(job_id: str, interval: float | None, enabled: bool = True) -> float:
+    if not enabled or not interval or interval <= 0:
+        return 0.0
+    cap = min(interval / 4, 300.0)
+    h = hashlib.sha1(job_id.encode("utf-8")).digest()
+    return (int.from_bytes(h[:6], "big") / float(1 << 48)) * cap
+
+
+def _bool_false(value: Any) -> bool:
+    return value is False or str(value).strip().lower() == "false"
+
+
+def compute_next_run(spec: LegacyJobSpec, base_ts: float) -> float | None:
+    jitter_enabled = not _bool_false(spec.get("jitter", True))
+    if spec.get("schedule"):
+        next_ts = croniter(str(spec.get("schedule")), base_ts).get_next(float)
+        try:
+            following = croniter(str(spec.get("schedule")), next_ts).get_next(float)
+            interval = following - next_ts
+        except Exception:
+            interval = None
+        return next_ts + stable_jitter(spec.job_id, interval, jitter_enabled)
+    if spec.get("every"):
+        interval = max(parse_duration(str(spec.get("every"))), int(MIN_DELAY_SEC))
+        return base_ts + interval + stable_jitter(spec.job_id, interval, jitter_enabled)
+    return None
+
+
+def consume_nextrun(spec: LegacyJobSpec, base_ts: float, *, consume: bool = True) -> float | None:
+    path = spec.folder / NEXTRUN_FILENAME
+    if not path.exists():
+        return None
+    try:
+        raw = path.read_text(encoding="utf-8").strip().splitlines()[0].strip()
+    except Exception:
+        raw = ""
+    if consume:
+        with contextlib.suppress(OSError):
+            path.unlink()
+    if not raw:
+        return None
+    try:
+        if DURATION_RE.match(raw):
+            return base_ts + max(parse_duration(raw), MIN_DELAY_SEC)
+        ts = float(raw)
+        if ts < 1_000_000_000:
+            return None
+        return max(ts, base_ts + MIN_DELAY_SEC)
+    except Exception:
+        return None
+
+
+def parse_expires_at(value: Any) -> float | None:
+    if not value:
+        return None
+    text = str(value).strip().strip('"').strip("'")
+    try:
+        if re.match(r"^\d{4}-\d{2}-\d{2}$", text):
+            dt = datetime.strptime(text, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        else:
+            dt = datetime.fromisoformat(text.replace("Z", "+00:00"))
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    except ValueError:
+        return None
+
+
+def soft_delete(spec: LegacyJobSpec, repo_dir: Path = REPO_DIR) -> Path:
+    dest_root = repo_dir / "jobs" / "_deleted"
+    dest_root.mkdir(parents=True, exist_ok=True)
+    flattened = spec.folder.relative_to(repo_dir / "jobs").as_posix().replace("/", "__")
+    dest = dest_root / f"{utc_now().strftime('%Y-%m-%dT%H-%M-%SZ')}-{flattened}"
+    shutil.move(str(spec.folder), str(dest))
+    return dest
+
+
+def reconcile_state(state: dict[str, dict[str, Any]], jobs: dict[str, LegacyJobSpec], now: float, repo_dir: Path = REPO_DIR) -> tuple[dict[str, dict[str, Any]], dict[str, LegacyJobSpec]]:
+    active_jobs: dict[str, LegacyJobSpec] = {}
+    for jid, spec in jobs.items():
+        exp = parse_expires_at(spec.get("expires_at"))
+        if exp is not None and exp <= now:
+            soft_delete(spec, repo_dir)
+        else:
+            active_jobs[jid] = spec
+    new_state: dict[str, dict[str, Any]] = {}
+    for jid, spec in active_jobs.items():
+        prev = state.get(jid, {})
+        next_run = consume_nextrun(spec, now, consume=True)
+        if next_run is None:
+            stored_next_run = prev.get("next_run")
+            next_run = stored_next_run if stored_next_run is not None else compute_next_run(spec, now)
+        new_state[jid] = {"next_run": next_run, "last_run": prev.get("last_run"), "last_status": prev.get("last_status")}
+    return new_state, active_jobs
+
+
+def is_paused(spec: LegacyJobSpec) -> bool:
+    value = spec.get("paused")
+    return value is True or str(value).strip().lower() == "true"
+
+
+def write_run_log(spec: LegacyJobSpec, text: str, status: str = "ok") -> Path:
+    target = spec.folder / RUNS_LOG_FILENAME
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.open("a", encoding="utf-8").write(f"=== {iso_utc()} status={status} ===\n{text.rstrip()}\n\n")
+    return target
+
+
+class SlackDeliveryError(RuntimeError):
+    pass
+
+
+class SlackWebClient:
+    def __init__(self, token: str):
+        self.token = token
+
+    def api_call(self, method: str, payload: dict[str, Any]) -> dict[str, Any]:
+        data = urllib.parse.urlencode(payload).encode("utf-8")
+        req = urllib.request.Request(
+            f"https://slack.com/api/{method}",
+            data=data,
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/x-www-form-urlencoded"},
+        )
+        with urllib.request.urlopen(req, timeout=20) as resp:  # nosec - fixed Slack API URL
+            result = json.loads(resp.read().decode("utf-8"))
+        if not result.get("ok"):
+            raise SlackDeliveryError(str(result.get("error") or result))
+        return result
+
+    def conversations_open(self, users: str) -> dict[str, Any]:
+        return self.api_call("conversations.open", {"users": users})
+
+    def chat_postMessage(self, **kwargs: Any) -> dict[str, Any]:
+        clean = {k: v for k, v in kwargs.items() if v is not None}
+        return self.api_call("chat.postMessage", clean)
+
+
+def deliver_output(spec: LegacyJobSpec, text: str, status: str = "ok", slack_client: Any | None = None) -> None:
+    mode = spec.post_mode
+    if mode == "log":
+        write_run_log(spec, text, status)
+        return
+    if slack_client is None:
+        token = os.environ.get("SLACK_BOT_TOKEN")
+        if token:
+            slack_client = SlackWebClient(token)
+    try:
+        if slack_client is None:
+            raise SlackDeliveryError("SLACK_BOT_TOKEN not set")
+        if mode == "dm":
+            user = spec.get("created_by")
+            if not user:
+                raise SlackDeliveryError("dm delivery requires created_by")
+            channel = slack_client.conversations_open(users=str(user))["channel"]["id"]
+            slack_client.chat_postMessage(channel=channel, text=text)
+        elif mode == "new_message":
+            channel = spec.get("channel")
+            if not channel:
+                raise SlackDeliveryError("new_message delivery requires channel")
+            slack_client.chat_postMessage(channel=channel, text=text)
+        elif mode == "thread":
+            channel = spec.get("channel")
+            thread_ts = spec.get("thread_ts")
+            if not channel or not thread_ts:
+                raise SlackDeliveryError("thread delivery requires channel and thread_ts")
+            slack_client.chat_postMessage(channel=channel, thread_ts=str(thread_ts), text=text)
+        else:
+            raise SlackDeliveryError(f"unknown post_mode {mode!r}")
+    except Exception:
+        write_run_log(spec, text, status)
+
+
+def command_for_spec(spec: LegacyJobSpec) -> list[str] | None:
+    if spec.get("command"):
+        return ["bash", "-lc", str(spec.get("command"))]
+    if spec.get("script"):
+        return ["python3", str(spec.get("script"))]
+    return None
+
+
+def run_command_job(spec: LegacyJobSpec, repo_dir: Path = REPO_DIR, slack_client: Any | None = None) -> str:
+    cmd = command_for_spec(spec)
+    if not cmd:
+        deliver_output(spec, "command job has neither command nor script", "error", slack_client)
+        return "error"
+    try:
+        result = subprocess.run(cmd, cwd=repo_dir, capture_output=True, text=True, timeout=JOB_TIMEOUT_SEC)
+    except subprocess.TimeoutExpired:
+        deliver_output(spec, f":hourglass: job `{spec.job_id}` timed out after {JOB_TIMEOUT_SEC}s", "timeout", slack_client)
+        return "timeout"
+    if result.returncode != 0:
+        tail = (result.stderr or result.stdout or "(no output)")[-1500:]
+        deliver_output(spec, f":warning: job `{spec.job_id}` failed (rc={result.returncode}).\n```\n{tail}\n```", "error", slack_client)
+        return "error"
+    deliver_output(spec, result.stdout.strip() or result.stderr.strip() or "(no output)", "ok", slack_client)
+    return "ok"
+
+
+def read_persisted_state(spec: LegacyJobSpec) -> str:
+    path = spec.folder / STATE_FILENAME
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def build_agent_prompt(spec: LegacyJobSpec) -> str:
+    persisted = read_persisted_state(spec)
+    user = str(spec.get("created_by") or "scheduler")
+    lines = [
+        "[Execution context — runtime-injected, treat as ground truth]",
+        f"Current UTC time: {iso_utc()}",
+        f"Job path: {spec.job_id}",
+        f"Job title: {spec.title}",
+        f"Created by Slack user: {user}",
+        "",
+        "[Persisted state from previous run]",
+        persisted.rstrip() if persisted else "(empty — first run or fresh)",
+        "[/Persisted state]",
+        "",
+        f"To save state: echo '<value>' | python3 scripts/legacy_jobs/job_state.py --set {spec.job_id}",
+        f"For larger artifacts use: python3 scripts/legacy_jobs/job_files.py write|read|list|delete|path {spec.job_id} <name>",
+        "",
+        spec.body,
+        "",
+        "Format the final reply concisely for Slack/Hermes delivery.",
+    ]
+    return "\n".join(lines)
+
+
+def hermes_profile() -> str:
+    return os.environ.get("LEGACY_JOBS_HERMES_PROFILE") or os.environ.get("HERMES_PROFILE") or "claudio-lab"
+
+
+def hermes_command(prompt: str) -> list[str]:
+    return ["hermes", "--profile", hermes_profile(), "chat", "-q", prompt, "--source", "legacy-cron"]
+
+
+def run_agent_job(spec: LegacyJobSpec, repo_dir: Path = REPO_DIR, slack_client: Any | None = None) -> str:
+    if not spec.body.strip():
+        return "empty-body"
+    prompt = build_agent_prompt(spec)
+    try:
+        result = subprocess.run(hermes_command(prompt), cwd=repo_dir, capture_output=True, text=True, timeout=AGENT_TIMEOUT_SEC)
+    except subprocess.TimeoutExpired:
+        deliver_output(spec, f":hourglass: job `{spec.job_id}` timed out after {AGENT_TIMEOUT_SEC}s", "timeout", slack_client)
+        return "timeout"
+    if result.returncode != 0:
+        tail = (result.stderr or result.stdout or "(no output)")[-1500:]
+        deliver_output(spec, f":warning: job `{spec.job_id}` failed (rc={result.returncode}).\n```\n{tail}\n```", "error", slack_client)
+        return "error"
+    deliver_output(spec, result.stdout.strip() or "(empty reply)", "ok", slack_client)
+    return "ok"
+
+
+def per_job_lock_path(spec: LegacyJobSpec) -> Path:
+    return spec.folder / ".lock"
+
+
+def _lock_is_fresh(path: Path, now: float, stale_sec: float = LOCK_STALE_SEC) -> bool:
+    return path.exists() and (now - path.stat().st_mtime) < stale_sec
+
+
+@contextlib.contextmanager
+def lock_file(path: Path, stale_sec: float = LOCK_STALE_SEC):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    now = time.time()
+    if _lock_is_fresh(path, now, stale_sec):
+        yield False
+        return
+    if path.exists():
+        with contextlib.suppress(OSError):
+            path.unlink()
+    fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    try:
+        os.write(fd, str(os.getpid()).encode())
+        os.close(fd)
+        yield True
+    finally:
+        with contextlib.suppress(OSError):
+            path.unlink()
+
+
+def run_job(spec: LegacyJobSpec, repo_dir: Path = REPO_DIR, slack_client: Any | None = None) -> str:
+    with lock_file(per_job_lock_path(spec)) as acquired:
+        if not acquired:
+            return "in-flight"
+        job_type = str(spec.get("type") or "claude").lower()
+        if job_type in {"command", "script", "shell"}:
+            return run_command_job(spec, repo_dir, slack_client)
+        return run_agent_job(spec, repo_dir, slack_client)
+
+
+def tick(repo_dir: Path = REPO_DIR, *, slack_client: Any | None = None) -> list[str]:
+    alerts: list[str] = []
+    with lock_file(repo_dir / "bot" / "jobs_scheduler.lock") as acquired:
+        if not acquired:
+            return alerts
+        state = load_state(repo_dir)
+        jobs, warnings = discover_jobs(repo_dir)
+        alerts.extend(warnings)
+        now = time.time()
+        state, jobs = reconcile_state(state, jobs, now, repo_dir)
+        for jid, spec in sorted(jobs.items()):
+            row = state.get(jid, {})
+            if is_paused(spec) or row.get("next_run") is None or row["next_run"] > now:
+                continue
+            status = run_job(spec, repo_dir, slack_client)
+            finished = time.time()
+            override = consume_nextrun(spec, finished, consume=True)
+            state[jid] = {
+                "next_run": override if override is not None else compute_next_run(spec, finished),
+                "last_run": finished,
+                "last_status": status,
+            }
+        save_state(state, repo_dir)
+    return alerts
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=str(REPO_DIR))
+    args = parser.parse_args(argv)
+    alerts = tick(Path(args.repo).resolve())
+    if alerts:
+        print("\n".join(alerts), file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/new_worktree.sh
+++ b/scripts/new_worktree.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# new_worktree.sh — spin up an isolated git worktree for parallel coding sessions
+# on the sibling C# repos, so two sessions never collide in one working tree.
+#
+# Worktrees share the repo's object store (cheap, no full re-clone) but give each
+# session its own directory on its own branch off a freshly-fetched default branch.
+# This is the right tool when multiple sessions / agents edit the same repo at once:
+# edits are isolated, history is tracked, and you merge back through a normal PR.
+#
+# Scope: sibling C# repos ONLY (yallaplay-services, SpadesUnity, GinRummyUnity).
+# This Hermes pilot repo intentionally does not use this helper; its project
+# context defines its own local commit cadence.
+#
+# Usage:
+#   bash scripts/new_worktree.sh <repo> <name> [base]
+#   bash scripts/new_worktree.sh --list
+#   bash scripts/new_worktree.sh --remove <repo> <name>
+#
+#   <repo>  one of: backend|services|yallaplay-services , spades|SpadesUnity , rummy|GinRummyUnity
+#   <name>  short slug for the branch/dir (e.g. fix-tarneeb). Branch = <name>, dir = <repo>-wt-<name>.
+#   [base]  base ref to branch from (default: the repo's own origin/HEAD, freshly
+#           fetched — origin/master for backend, origin/development for the Unity clients).
+#
+# Examples:
+#   bash scripts/new_worktree.sh backend fix-tarneeb
+#   bash scripts/new_worktree.sh spades crash-guard
+#   bash scripts/new_worktree.sh --remove backend fix-tarneeb
+#   bash scripts/new_worktree.sh --list
+#
+# Worktrees live under /mnt/ephemeral/git/ (the fast ephemeral volume where the
+# sibling clones live). They are EPHEMERAL — a VM stop can wipe uncommitted edits,
+# so push your branch early when the work matters.
+
+set -euo pipefail
+
+EPHEMERAL_GIT="/mnt/ephemeral/git"
+
+die() { echo "error: $*" >&2; exit 1; }
+
+resolve_repo() {
+  case "$1" in
+    backend|services|yallaplay-services) echo "yallaplay-services" ;;
+    spades|SpadesUnity)                  echo "SpadesUnity" ;;
+    rummy|GinRummyUnity)                 echo "GinRummyUnity" ;;
+    yallaplay-hermes-agent|hermes-agent|agent|local)
+      die "this Hermes pilot repo has its own local commit policy — worktrees are for sibling C# repos only" ;;
+    *) die "unknown repo '$1' (expected: backend|spades|rummy)" ;;
+  esac
+}
+
+repo_path() {
+  local p="$EPHEMERAL_GIT/$1"
+  [ -d "$p/.git" ] || [ -f "$p/.git" ] || die "repo not found at $p — clone or restore the sibling checkout first"
+  echo "$p"
+}
+
+cmd_list() {
+  for r in yallaplay-services SpadesUnity GinRummyUnity; do
+    local p="$EPHEMERAL_GIT/$r"
+    [ -e "$p/.git" ] || continue
+    echo "== $r =="
+    git -C "$p" worktree list
+    echo
+  done
+}
+
+cmd_remove() {
+  local repo name path wt
+  repo="$(resolve_repo "$1")"
+  name="$2"
+  path="$(repo_path "$repo")"
+  wt="$EPHEMERAL_GIT/${repo}-wt-${name}"
+  git -C "$path" worktree remove "$wt"
+  echo "removed worktree $wt"
+  echo "note: branch '$name' still exists — delete with: git -C $path branch -D $name"
+}
+
+default_base() {
+  # the repo's own default branch (origin/master for backend, origin/development for Unity)
+  local path="$1" head
+  head="$(git -C "$path" symbolic-ref -q refs/remotes/origin/HEAD 2>/dev/null || true)"
+  if [ -n "$head" ]; then
+    echo "origin/${head##*/}"
+  else
+    echo "origin/master"   # fallback if origin/HEAD isn't set locally
+  fi
+}
+
+cmd_add() {
+  local repo name base path wt
+  repo="$(resolve_repo "$1")"
+  name="$2"
+  path="$(repo_path "$repo")"
+  wt="$EPHEMERAL_GIT/${repo}-wt-${name}"
+
+  [ -e "$wt" ] && die "worktree dir already exists: $wt (remove it first: bash scripts/new_worktree.sh --remove $repo $name)"
+
+  echo "fetching origin in $repo ..."
+  git -C "$path" fetch origin --prune
+
+  base="${3:-$(default_base "$path")}"
+
+  echo "creating worktree $wt on new branch '$name' off $base ..."
+  git -C "$path" worktree add -b "$name" "$wt" "$base"
+
+  echo
+  echo "worktree ready:"
+  echo "  cd $wt"
+  echo "  # edit, commit, push -u origin $name, open a PR"
+  echo "  # when done: bash scripts/new_worktree.sh --remove $repo $name"
+}
+
+[ $# -ge 1 ] || die "usage: new_worktree.sh <repo> <name> [base] | --list | --remove <repo> <name>"
+
+case "$1" in
+  --list)   cmd_list ;;
+  --remove) shift; [ $# -eq 2 ] || die "usage: --remove <repo> <name>"; cmd_remove "$@" ;;
+  -h|--help) sed -n '2,32p' "$0" ;;
+  *)        [ $# -ge 2 ] || die "usage: new_worktree.sh <repo> <name> [base]"; cmd_add "$@" ;;
+esac

--- a/scripts/systemd/README.md
+++ b/scripts/systemd/README.md
@@ -1,0 +1,17 @@
+# Hermes systemd units
+
+This directory stores the service definitions used by the Hermes pilot.
+
+The active services currently run as user-level systemd units under
+`~/.config/systemd/user/` because this host blocks `sudo` service installation
+with `no_new_privileges`.
+
+Use:
+
+```bash
+export XDG_RUNTIME_DIR=/run/user/$(id -u)
+export DBUS_SESSION_BUS_ADDRESS=unix:path=$XDG_RUNTIME_DIR/bus
+systemctl --user status hermes-dashboard hermes-gateway hermes-nginx hermes-cloudflared
+```
+
+All Hermes agent commands run with `--yolo` / approval bypass for the pilot.

--- a/scripts/systemd/hermes-cloudflared.service
+++ b/scripts/systemd/hermes-cloudflared.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=YallaPlay Hermes Cloudflare Tunnel
+After=network-online.target hermes-nginx.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=ubuntu
+WorkingDirectory=/home/ubuntu/git/yallaplay-hermes-agent
+ExecStart=/usr/bin/cloudflared tunnel --config /home/ubuntu/git/yallaplay-hermes-agent/.local/cloudflared/config.yml run
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/systemd/hermes-dashboard.service
+++ b/scripts/systemd/hermes-dashboard.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=YallaPlay Hermes Dashboard
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=ubuntu
+WorkingDirectory=/home/ubuntu/git/yallaplay-hermes-agent
+Environment=PATH=/home/ubuntu/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+Environment=HERMES_YOLO_MODE=1
+Environment=HERMES_ACCEPT_HOOKS=1
+ExecStart=/home/ubuntu/.local/bin/claudio-lab --yolo dashboard --host 127.0.0.1 --port 9119 --no-open --isolated --skip-build
+Restart=always
+RestartSec=5
+KillSignal=SIGINT
+TimeoutStopSec=20
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/systemd/hermes-nginx.service
+++ b/scripts/systemd/hermes-nginx.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=YallaPlay Hermes Local nginx Proxy
+After=network-online.target hermes-dashboard.service
+Wants=network-online.target
+
+[Service]
+Type=forking
+User=ubuntu
+WorkingDirectory=/home/ubuntu/git/yallaplay-hermes-agent
+PIDFile=/home/ubuntu/git/yallaplay-hermes-agent/.local/nginx/nginx.pid
+ExecStartPre=/home/ubuntu/git/yallaplay-hermes-agent/.local/nginx/sbin/nginx -p /home/ubuntu/git/yallaplay-hermes-agent/.local/nginx -c hermes.conf -t
+ExecStart=/home/ubuntu/git/yallaplay-hermes-agent/.local/nginx/sbin/nginx -p /home/ubuntu/git/yallaplay-hermes-agent/.local/nginx -c hermes.conf
+ExecReload=/home/ubuntu/git/yallaplay-hermes-agent/.local/nginx/sbin/nginx -p /home/ubuntu/git/yallaplay-hermes-agent/.local/nginx -c hermes.conf -s reload
+ExecStop=/home/ubuntu/git/yallaplay-hermes-agent/.local/nginx/sbin/nginx -p /home/ubuntu/git/yallaplay-hermes-agent/.local/nginx -c hermes.conf -s quit
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/systemd/hermes-webui-public.service
+++ b/scripts/systemd/hermes-webui-public.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=YallaPlay Hermes WebUI public/simple mode (chat + workspace)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/ubuntu/git/yallaplay-hermes-agent/.local/hermes-webui
+Environment=PATH=/home/ubuntu/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+Environment=HERMES_HOME=/home/ubuntu/.hermes/profiles/claudio-lab
+Environment=HERMES_WEBUI_STATE_DIR=/home/ubuntu/.hermes/profiles/claudio-lab/webui-nesquena-public
+Environment=HERMES_WEBUI_AGENT_DIR=/home/ubuntu/.hermes/hermes-agent
+Environment=HERMES_WEBUI_HOST=127.0.0.1
+Environment=HERMES_WEBUI_PORT=9122
+Environment=HERMES_WEBUI_SIMPLE_UI=1
+Environment=HERMES_WEBUI_SKIP_ONBOARDING=1
+Environment=HERMES_WEBUI_FOREGROUND=1
+ExecStart=/usr/bin/python3 /home/ubuntu/git/yallaplay-hermes-agent/.local/hermes-webui/bootstrap.py --no-browser --foreground --host 127.0.0.1 9122
+Restart=always
+RestartSec=5
+KillSignal=SIGINT
+TimeoutStopSec=20
+
+[Install]
+WantedBy=default.target

--- a/scripts/systemd/hermes-webui.service
+++ b/scripts/systemd/hermes-webui.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=YallaPlay Hermes WebUI (nesquena/hermes-webui)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/ubuntu/git/yallaplay-hermes-agent/.local/hermes-webui
+Environment=PATH=/home/ubuntu/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+Environment=HERMES_HOME=/home/ubuntu/.hermes/profiles/claudio-lab
+Environment=HERMES_WEBUI_STATE_DIR=/home/ubuntu/.hermes/profiles/claudio-lab/webui-nesquena
+Environment=HERMES_WEBUI_AGENT_DIR=/home/ubuntu/.hermes/hermes-agent
+Environment=HERMES_WEBUI_HOST=127.0.0.1
+Environment=HERMES_WEBUI_PORT=9121
+Environment=HERMES_WEBUI_SKIP_ONBOARDING=1
+Environment=HERMES_WEBUI_FOREGROUND=1
+ExecStart=/usr/bin/python3 /home/ubuntu/git/yallaplay-hermes-agent/.local/hermes-webui/bootstrap.py --no-browser --foreground --host 127.0.0.1 9121
+Restart=always
+RestartSec=5
+KillSignal=SIGINT
+TimeoutStopSec=20
+
+[Install]
+WantedBy=default.target

--- a/scripts/webui-sync-upstream.sh
+++ b/scripts/webui-sync-upstream.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Sync YallaPlay's forked Hermes WebUI checkout with upstream.
+# Defaults are for this repo's local deployment.
+#
+# Usage:
+#   scripts/webui-sync-upstream.sh
+#   scripts/webui-sync-upstream.sh --restart-admin
+#   scripts/webui-sync-upstream.sh --no-restart
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WEBUI_DIR="${WEBUI_DIR:-$ROOT_DIR/.local/hermes-webui}"
+UPSTREAM_REMOTE="${UPSTREAM_REMOTE:-upstream}"
+UPSTREAM_BRANCH="${UPSTREAM_BRANCH:-master}"
+DEPLOY_BRANCH="${DEPLOY_BRANCH:-yallaplay/main}"
+RESTART_PUBLIC=1
+RESTART_ADMIN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --restart-admin)
+      RESTART_ADMIN=1
+      ;;
+    --no-restart)
+      RESTART_PUBLIC=0
+      RESTART_ADMIN=0
+      ;;
+    --webui-dir)
+      WEBUI_DIR="$2"
+      shift
+      ;;
+    --deploy-branch)
+      DEPLOY_BRANCH="$2"
+      shift
+      ;;
+    --upstream-branch)
+      UPSTREAM_BRANCH="$2"
+      shift
+      ;;
+    -h|--help)
+      sed -n '1,32p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+cd "$WEBUI_DIR"
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Refusing to sync: WebUI checkout has uncommitted changes:" >&2
+  git status --short >&2
+  exit 1
+fi
+
+if ! git remote get-url "$UPSTREAM_REMOTE" >/dev/null 2>&1; then
+  echo "Missing remote '$UPSTREAM_REMOTE'. Expected upstream Hermes WebUI remote." >&2
+  exit 1
+fi
+
+current_branch="$(git branch --show-current)"
+if [[ "$current_branch" != "$DEPLOY_BRANCH" ]]; then
+  git checkout "$DEPLOY_BRANCH"
+fi
+
+git fetch "$UPSTREAM_REMOTE" "$UPSTREAM_BRANCH"
+git fetch origin "$DEPLOY_BRANCH" || true
+
+echo "Merging $UPSTREAM_REMOTE/$UPSTREAM_BRANCH into $DEPLOY_BRANCH..."
+git merge "$UPSTREAM_REMOTE/$UPSTREAM_BRANCH"
+
+echo "Running verification..."
+python3 -m py_compile api/routes.py
+node --check static/boot.js
+node --check static/panels.js
+
+if [[ "$RESTART_PUBLIC" == "1" ]]; then
+  echo "Restarting hermes-webui-public..."
+  systemctl --user restart hermes-webui-public
+  systemctl --user is-active hermes-webui-public >/dev/null
+fi
+
+if [[ "$RESTART_ADMIN" == "1" ]]; then
+  echo "Restarting hermes-webui..."
+  systemctl --user restart hermes-webui
+  systemctl --user is-active hermes-webui >/dev/null
+fi
+
+if command -v curl >/dev/null 2>&1 && [[ "$RESTART_PUBLIC" == "1" ]]; then
+  echo "Verifying simple UI settings endpoint..."
+  settings_file="${TMPDIR:-/tmp}/hermes-webui-public-settings.$$.$RANDOM.json"
+  for attempt in $(seq 1 40); do
+    if curl -fs http://127.0.0.1:9122/api/settings -o "$settings_file"; then
+      break
+    fi
+    sleep 0.5
+  done
+  python3 - "$settings_file" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    s = json.load(f)
+print({"simple_ui": s.get("simple_ui"), "hidden_tabs": s.get("hidden_tabs")})
+if s.get("simple_ui") is not True:
+    raise SystemExit("simple_ui was not true")
+PY
+  rm -f "$settings_file"
+fi
+
+echo "WebUI sync complete. Current HEAD: $(git rev-parse --short HEAD)"

--- a/skills/yallaplay/analytics/SKILL.md
+++ b/skills/yallaplay/analytics/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: analytics
+description: Use for Snowflake, metrics, cohorts, funnels, revenue, retention, charts, Grafana, reusable SQL, and analytics bias checks.
+version: 1.1.0
+author: YallaPlay
+license: Proprietary
+metadata:
+  hermes:
+    tags: [analytics, snowflake, metrics, charts, cohorts, yallaplay]
+    related_skills: [knowledge, codebase-readonly]
+---
+
+# Analytics Skill
+
+## Purpose
+
+Answer YallaPlay analytics questions with reproducible, bias-aware warehouse work. This skill is the Hermes equivalent of the legacy `yallaplay-analytics-agent-gpt/personas/analytics.md` workflow: wiki-first context, read-only Snowflake queries, generated CSV/charts under `outputs/`, and explicit bias controls before reporting numbers.
+
+## Required Context
+
+Before querying, inspect the relevant wiki pages when available:
+
+- `yallaplay-wiki/reference/analytics_rules.md`
+- `yallaplay-wiki/reference/warehouse/index.md`
+- `yallaplay-wiki/reference/warehouse/events.md` and `yallaplay-wiki/reference/warehouse/aggregates.md` if schema snapshots have been refreshed.
+- Feature-specific facets under `yallaplay-wiki/products/**/analytics.md`, `findings.md`, and `facts.md`.
+
+For schema uncertainty, prefer `yallaplay-wiki/reference/warehouse/` annotations before guessing column names.
+If a legacy-style catalog exists later, also inspect `definitions/analytics.md`, `methodology/analytics.md`, `queries/analytics.md`, and `findings/analytics.md`.
+
+## Query Defaults
+
+- If timeframe is missing, default to the past 30 days: `EVENT_DATE >= DATEADD(day, -30, CURRENT_DATE())`.
+- If app is missing, ask unless the current thread clearly established one; do not silently combine Spades and Rummy.
+- Cross-app queries are only for explicit comparisons.
+- Rummy data before `2026-02-01` is not comparable to current Rummy economy behavior.
+- Account timezone is UTC; prefer `SYSDATE()` when diffing stored NTZ timestamps.
+
+## Workflow
+
+1. Restate only the non-obvious metric/window/app assumptions, including whether the date column is `EVENT_DATE` (`EVENTS`) or `DATE` (`AGGREGATES`).
+2. Look up known definitions, prior findings, schema notes, and reusable SQL in `yallaplay-wiki/` before composing new SQL.
+3. Run one read-only warehouse statement at a time through `tools/snowflake_query.py`; export CSV when the result will be charted or reused.
+4. For charts, shape multi-series CSVs in long format: `x, series, value`. Do not feed wide one-column-per-series CSVs unless intentionally using `--allow-wide`.
+5. Check common bias traps: cohort freshness/right-censoring, denominator drift, attribution window, platform/app split, payer concentration, rollup rows, weighted-average rollups, instrumentation changes, and small-n.
+6. Save durable SQL, schema notes, or findings back to `yallaplay-wiki/` when they are reusable beyond the current answer.
+
+## Tools
+
+- `python3 tools/wiki_search.py <terms> --domain analytics` searches the wiki for definitions and prior context.
+- `python3 tools/snowflake_query.py "SELECT ..."` runs a single read-only Snowflake statement and logs SQL under `logs/`.
+- `python3 tools/snowflake_query.py -f path/to/query.sql -o outputs/name.csv` exports CSV output.
+- `python3 tools/snowflake_query.py --dry-run "SELECT ..."` validates and logs SQL without executing.
+- `python3 tools/chart.py outputs/data.csv -t "Title" -o outputs/chart.png` generates analyst-ready charts from CSV.
+- `python3 tools/fetch_schemas.py` refreshes Snowflake DDL snapshots into `yallaplay-wiki/reference/warehouse/ddl/`.
+- `python3 tools/analytics_bias_check.py` prints the bias checklist that must be scanned before reporting numbers.
+
+## Common Query Patterns
+
+- Topline daily metrics: aggregate `AGGREGATES.FACT_DAILY` by `DATE`; sum segmented rows before computing ratios.
+- Per-room/game metrics: use `AGGREGATES.FACT_GAME_DAILY`; weight `DURATION_AVG` by `GAMES` when rolling up.
+- Retention: use `AGGREGATES.RETENTION_CALENDAR_DAILY`; exclude or label freshest cohorts that have not completed the forward window.
+- IAP revenue: use `EVENTS.TRANSACTION` or `AGGREGATES.FACT_IAP_DAILY`; `TRANSACTION_VALUE` for `real_money` is cents, so divide by 100 for USD.
+- Economy transactions: one logical transaction can emit multiple operation rows; count `TRANSACTION_OPERATION = 0` or distinct `(USER_ID, TRANSACTION_SEQUENCE)` when measuring transaction counts.
+- Ads: prefer aggregate fact tables for totals; use event-level tables only when the needed dimension is absent from aggregates, and verify fill/parity.
+
+## Safety
+
+- Do not run Snowflake `DROP`, `DELETE`, `TRUNCATE`, `UPDATE`, `MERGE`, or DDL unless a future gated workflow explicitly permits it.
+- Keep generated CSVs/charts under `outputs/` with unique timestamped names.
+- Prefer concise summaries with numbers, caveats, and links to saved artifacts.
+- Use `ANALYTICS` / `EVENTS` / `AGGREGATES` for production warehouse reads unless the user explicitly asks for another database.
+
+## Output Standard
+
+- Report the query window, app scope, key metric definition, result, and caveats.
+- Mention which bias traps were controlled or remain unresolved.
+- Link generated files by repo-relative path, e.g. `outputs/2026-07-01_spades_dau.csv` and `outputs/2026-07-01_spades_dau.png`.
+- If the answer used a chart, mention the CSV source and chart type.

--- a/skills/yallaplay/codebase-readonly/SKILL.md
+++ b/skills/yallaplay/codebase-readonly/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: codebase-readonly
+description: "Use for read-only codebase investigation: repo exploration, debugging, source lookup, C# sibling source tracing, event/property provenance, and implementation behavior questions without making code changes."
+version: 1.0.0
+author: YallaPlay
+license: Proprietary
+metadata:
+  hermes:
+    tags: [codebase, read-only, repo-search, debugging, csharp, analytics-provenance, yallaplay]
+    related_skills: [knowledge, analytics]
+---
+
+# Codebase Read-Only Skill
+
+## Overview
+
+Use this skill when the task is to understand code, not change it. The goal is source-grounded investigation: trace definitions and usages, identify where events/properties are emitted or filled, explain runtime behavior, and leave the working tree untouched.
+
+This is the low-risk engineering path for analytics, liveops, observability, and product questions that need source as evidence but do not require implementation work.
+
+## When to Use
+
+- Repo search, source reading, symbol tracing, or implementation behavior questions.
+- Debugging and root-cause exploration before deciding whether a code change is needed.
+- Analytics provenance checks, e.g. where an event fires, how a property is populated, or which enum/config value is sent.
+- Sibling backend/Unity source lookup for event emission, formulas, payout logic, item names, config keys, or enums.
+- Code review-style explanation when the user asks what the code currently does.
+
+Do not use this for edits, refactors, test creation, commits, PRs, or generated code changes; use `coder` for write-capable implementation work. When analytics, liveops, collaboration, infrastructure, or observability is the primary domain, load that domain skill too.
+
+## Read-Only Contract
+
+- Do not call `patch`, `write_file`, `skill_manage`, `git commit`, `git checkout`, `git reset`, formatters, migrations, package updates, or any command intended to mutate source or runtime state.
+- Prefer `search_files` and `read_file` for source inspection.
+- Use `terminal` only for read-only discovery commands such as `git status`, `git branch`, `git log`, `python --version`, `hermes skills list`, or scripts with documented dry-run/read-only behavior.
+- Avoid tests/builds unless the user asks; they can create caches or generated files. If you must run one for diagnosis, check `git status --short` before and after and report any generated files.
+- Do not edit sibling checkouts. If investigation shows a fix is needed, stop and recommend switching to `coder`.
+
+## Required Context
+
+Before source tracing, inspect relevant durable context when it exists:
+
+- `yallaplay-wiki/engineering/index.md`
+- `yallaplay-wiki/engineering/data_warehouse.md` for warehouse pipeline/source mechanics.
+- `yallaplay-wiki/reference/warehouse/index.md` for warehouse table reference.
+- `yallaplay-wiki/reference/analytics_rules.md` when telemetry or metrics are involved.
+- Feature/system pages under `yallaplay-wiki/products/**/engineering.md`, `design.md`, `analytics.md`, and `facts.md`.
+
+Use wiki context to aim the source search, but treat source as the tiebreaker for actual runtime behavior.
+
+## Investigation Workflow
+
+1. **Classify the question.** Name the target surface: Hermes pilot, wiki tooling, backend, Unity client, data pipeline, config, or sibling source lookup. Completion: repo/path and desired evidence are clear.
+2. **Find anchors.** Search for event names, property names, symbols, config keys, enum values, API routes, or file names. Completion: candidate files and symbol names are identified from source, not guessed.
+3. **Trace definitions and usages.** Read the emitter/filler and its nearby callers/calculations. Completion: the data path is explainable from source lines.
+4. **Check context and edges.** Look for feature flags, app/platform branches, environment guards, null/default handling, version gates, and fallback paths. Completion: material conditions and caveats are known.
+5. **Report with evidence.** Cite files and concise line references, state confidence, and call out unresolved gaps. Completion: the user can verify the answer from source.
+6. **Escalate when needed.** If a fix, migration, or test is required, summarize the proposed change and switch to `coder` only after the user’s task requires write access.
+
+## Analytics Provenance Pattern
+
+For “where does this event/property come from?” questions:
+
+1. Search exact event/property strings first.
+2. If not found, search enum/constants and serialization layers that transform names.
+3. Trace from event construction to send/enqueue layer, then backward to the state source.
+4. Verify app/game/platform gates and default values.
+5. Map source property names to warehouse/event column names only after checking analytics wiki/schema notes.
+
+## Sibling C# Source Lookup
+
+Use source as the canonical tiebreaker for:
+
+- Event emission and analytics parameter names.
+- Enum values, item names, formula edges, payout logic, and config keys.
+- Runtime behavior not fully captured in wiki pages.
+
+Rules:
+
+- Prefer wiki/config/schema knowledge for behavioral questions first; use C# source to verify or settle ambiguity.
+- Do not edit sibling checkouts without switching to `coder` and checking dirty state and branch/base first.
+- For concurrent sibling work, prefer isolated worktrees when available rather than sharing one checkout.
+- Never commit or push sibling repo changes unless the user explicitly asks.
+
+## Common Pitfalls
+
+1. **Accidental writes during investigation.** Tests, builds, formatters, package managers, and codegen may mutate files. Avoid them unless requested and verify status before/after.
+2. **String-only conclusions.** Finding a string is not enough; trace construction, call sites, and guards.
+3. **Guessing schema mappings.** Event/source names may be transformed before landing in Snowflake. Check wiki/schema notes and source serialization.
+4. **Stopping at the first match.** Analytics events and config keys often have client, backend, and warehouse layers. Trace the relevant layer for the question.
+5. **Overloading memory.** Task outcomes and transient findings do not belong in memory; durable reusable source facts belong in `yallaplay-wiki/` when they will help future work.
+
+## Verification Checklist
+
+- [ ] Relevant wiki/source context was inspected.
+- [ ] No write tools or mutating commands were used.
+- [ ] If any command could generate files, `git status --short` was checked before and after.
+- [ ] Answer cites source files/line references or explicitly states why source evidence is incomplete.
+- [ ] Proposed fixes are clearly separated from read-only findings.

--- a/skills/yallaplay/coder/SKILL.md
+++ b/skills/yallaplay/coder/SKILL.md
@@ -48,7 +48,7 @@ For repo files, use `search_files` and `read_file` first. Trace symbol definitio
 4. **Edit with repo style.** Prefer `patch` for focused edits; use `write_file` for new files or deliberate whole-file rewrites. Completion: diff is focused and every modified file is intentional.
 5. **Verify.** Run the narrowest useful test, lint, compile, dry-run, or temporary ad-hoc script. Completion: real tool output backs the claim, or a concrete blocker is reported.
 6. **Review the diff.** Check `git diff`/`git status` before finalizing. Completion: no secrets, generated churn, or unrelated changes are included.
-7. **Commit completed repo changes incrementally.** After each complete, verified unit of repo work, stage only the intended files and create a focused conventional commit before moving to the next unit. Completion: the commit SHA, verification command, and any intentionally uncommitted files are known.
+7. **Honor repo-specific commit policy.** If the active repo’s project context asks for local commits, stage only intended files and create focused conventional commits after complete, verified units. Completion: commit SHA(s), verification command(s), and intentionally uncommitted files are known.
 8. **Capture reusable knowledge.** If the task reveals a stable workflow, schema behavior, or codepath fact, add it to `yallaplay-wiki/` or a skill rather than memory. Completion: reusable fact is saved or intentionally skipped as one-off.
 
 ## Profile, Bot, and Scheduler State
@@ -80,8 +80,7 @@ See `references/legacy-capability-audit.md` for the compact inventory and report
 
 - Refuse broad deletion of repos, Hermes homes, wiki content, tool directories, credentials, or generated operational state.
 - Do not read or print secrets (`vars.toml`, `.env`, tokens, OAuth caches) unless explicitly required and scoped.
-- Do not push or rewrite history unless asked; do not branch unless task scope requires it or the user asks.
-- For user-requested repo changes, focused local commits are allowed and expected after each complete, verified unit of work.
+- Do not commit, branch, push, or rewrite history unless asked or the active repo's project context explicitly requires local commits.
 - Avoid production writes unless a documented gated workflow exists and the user confirms the exact action.
 - Before destructive commands, narrow the path and prefer reversible file moves over deletion.
 
@@ -101,5 +100,5 @@ See `references/legacy-capability-audit.md` for the compact inventory and report
 - [ ] No secrets or unrelated profile/runtime state were committed or exposed.
 - [ ] A focused test/lint/compile/dry-run/ad-hoc verification was run, or the blocker is explicit.
 - [ ] `git status`/`git diff` was reviewed before final response.
-- [ ] Each complete, verified repo-change unit was committed with a focused conventional commit, or the reason for leaving it uncommitted is explicit.
+- [ ] The active repo's commit policy was followed, including focused local commits when project context requires them.
 - [ ] Reusable engineering knowledge was captured in `yallaplay-wiki/` or a skill when applicable.

--- a/skills/yallaplay/coder/SKILL.md
+++ b/skills/yallaplay/coder/SKILL.md
@@ -60,13 +60,13 @@ For repo files, use `search_files` and `read_file` first. Trace symbol definitio
 
 ## Sibling Source Edits
 
-Sibling backend/Unity checkouts are higher-risk than this pilot repo. Mimic the legacy Claudio workflow: never let parallel sessions collide in a shared sibling checkout.
+Sibling backend/Unity checkouts are higher-risk than this pilot repo. Never let parallel sessions collide in a shared sibling checkout.
 
 Rules:
 
 - Before editing a sibling source repo, identify the target repo/path and check dirty state, branch, and existing worktrees.
-- For sibling C# repos (`yallaplay-services`, `SpadesUnity`, `GinRummyUnity`), default to an isolated per-session git worktree for write work, not the shared checkout. Use the legacy helper when available: `bash /home/ubuntu/git/yallaplay-analytics-agent-gpt/scripts/new_worktree.sh <backend|spades|rummy> <branch-slug>`.
-- If the helper is unavailable, create the worktree manually: fetch origin in the primary checkout, branch from the repo's default remote (`origin/master` for backend, `origin/development` for Unity clients), and place the worktree under `/mnt/ephemeral/git/<repo>-wt-<branch-slug>`.
+- For sibling C# repos (`yallaplay-services`, `SpadesUnity`, `GinRummyUnity`), default to an isolated per-session git worktree for write work, not the shared checkout. Use this repo’s helper: `bash scripts/new_worktree.sh <backend|spades|rummy> <branch-slug>`.
+- The helper fetches origin, branches from the repo's default remote (`origin/master` for backend, `origin/development` for Unity clients when configured as origin/HEAD), and places the worktree under `/mnt/ephemeral/git/<repo>-wt-<branch-slug>`.
 - Treat worktrees under `/mnt/ephemeral/git/` as ephemeral: commit and push the branch early when the work matters, and remove the worktree when done.
 - Use the shared sibling checkout for read-only source lookup only; do not edit it when another session/agent may be active.
 - Do not use plain directory copies for source edits; they drop git history and have no clean merge path.

--- a/skills/yallaplay/coder/SKILL.md
+++ b/skills/yallaplay/coder/SKILL.md
@@ -60,13 +60,17 @@ For repo files, use `search_files` and `read_file` first. Trace symbol definitio
 
 ## Sibling Source Edits
 
-Sibling backend/Unity checkouts are higher-risk than this pilot repo.
+Sibling backend/Unity checkouts are higher-risk than this pilot repo. Mimic the legacy Claudio workflow: never let parallel sessions collide in a shared sibling checkout.
 
 Rules:
 
-- Check dirty state and current branch before editing.
-- Prefer isolated worktrees for concurrent sibling work.
-- Do not commit, push, or rewrite history unless the user explicitly asks.
+- Before editing a sibling source repo, identify the target repo/path and check dirty state, branch, and existing worktrees.
+- For sibling C# repos (`yallaplay-services`, `SpadesUnity`, `GinRummyUnity`), default to an isolated per-session git worktree for write work, not the shared checkout. Use the legacy helper when available: `bash /home/ubuntu/git/yallaplay-analytics-agent-gpt/scripts/new_worktree.sh <backend|spades|rummy> <branch-slug>`.
+- If the helper is unavailable, create the worktree manually: fetch origin in the primary checkout, branch from the repo's default remote (`origin/master` for backend, `origin/development` for Unity clients), and place the worktree under `/mnt/ephemeral/git/<repo>-wt-<branch-slug>`.
+- Treat worktrees under `/mnt/ephemeral/git/` as ephemeral: commit and push the branch early when the work matters, and remove the worktree when done.
+- Use the shared sibling checkout for read-only source lookup only; do not edit it when another session/agent may be active.
+- Do not use plain directory copies for source edits; they drop git history and have no clean merge path.
+- Do not commit, push, or rewrite history in sibling repos unless the user explicitly asks or the PR workflow requires it.
 - Never print secrets or token-bearing config while inspecting.
 - Keep fixes minimal and verify with the target repo’s own tests/build commands where available.
 

--- a/skills/yallaplay/coder/SKILL.md
+++ b/skills/yallaplay/coder/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: coder
+description: "Use for write-capable engineering work: code changes, tests, refactors, repo maintenance, Hermes pilot implementation, local tooling, code review fixes, and verified PR-ready changes."
+version: 1.0.0
+author: YallaPlay
+license: Proprietary
+metadata:
+  hermes:
+    tags: [coder, engineering, code, tests, repo-maintenance, hermes-pilot, review, yallaplay]
+    related_skills: [codebase-readonly, knowledge, infrastructure]
+---
+
+# Coder Skill
+
+## Overview
+
+Use this skill when the task requires changing files or preparing implementation work. The goal is careful senior-engineer behavior: inspect first, make the smallest reversible change, verify with real commands, and avoid unrelated churn.
+
+This is the write-capable counterpart to `codebase-readonly`. Use `codebase-readonly` first when the task is only investigation or source provenance.
+
+## When to Use
+
+- Code changes, scripts, tests, refactors, repo maintenance, or local tooling.
+- Scheduler, bot, Hermes profile, dashboard, gateway, or pilot implementation work.
+- Fixes discovered during debugging or code review.
+- Test creation, lint/build repairs, dependency/config changes, or generated artifacts the user explicitly wants.
+- Sibling repo edits only when the user explicitly asks and scope is clear.
+
+Do not use this for pure source lookup, analytics provenance, or read-only explanation; use `codebase-readonly`. When analytics, liveops, collaboration, infrastructure, observability, or knowledge is the primary surface, load that domain skill too.
+
+## Required Context
+
+Before editing, inspect relevant durable context when it exists:
+
+- `yallaplay-wiki/engineering/index.md`
+- `yallaplay-wiki/engineering/data_warehouse.md` for warehouse pipeline/source mechanics.
+- `yallaplay-wiki/reference/analytics_rules.md` when code changes affect telemetry or metrics.
+- Feature/system pages under `yallaplay-wiki/products/**/engineering.md`, `design.md`, and `facts.md`.
+- Existing neighboring files, tests, manifests, and project docs in the target repo.
+
+For repo files, use `search_files` and `read_file` first. Trace symbol definitions and usages rather than guessing imports, shapes, or APIs.
+
+## Write Workflow
+
+1. **Classify the surface.** Name whether this is Hermes pilot code, wiki tooling, generated artifacts, profile state, or a sibling source checkout. Completion: target repo/path, branch/dirty state, and risk level are clear.
+2. **Inspect before editing.** Read manifests, neighboring files, tests, and relevant wiki pages. Completion: the symbol/file/API shape is verified from source.
+3. **Plan the smallest reversible change.** Avoid drive-by refactors, broad renames, and unrelated formatting. Completion: every intended touched file has a reason.
+4. **Edit with repo style.** Prefer `patch` for focused edits; use `write_file` for new files or deliberate whole-file rewrites. Completion: diff is focused and every modified file is intentional.
+5. **Verify.** Run the narrowest useful test, lint, compile, dry-run, or temporary ad-hoc script. Completion: real tool output backs the claim, or a concrete blocker is reported.
+6. **Review the diff.** Check `git diff`/`git status` before finalizing. Completion: no secrets, generated churn, or unrelated changes are included.
+7. **Commit completed repo changes incrementally.** After each complete, verified unit of repo work, stage only the intended files and create a focused conventional commit before moving to the next unit. Completion: the commit SHA, verification command, and any intentionally uncommitted files are known.
+8. **Capture reusable knowledge.** If the task reveals a stable workflow, schema behavior, or codepath fact, add it to `yallaplay-wiki/` or a skill rather than memory. Completion: reusable fact is saved or intentionally skipped as one-off.
+
+## Profile, Bot, and Scheduler State
+
+- `bot/jobs_state.json` and scheduler runtime state are owned by the scheduler; do not edit directly.
+- Local Hermes profile state (`~/.hermes/profiles/...`) affects the running agent; treat writes there as operational changes, not ordinary repo edits.
+- Project-owned YallaPlay skills live under `skills/yallaplay/` and should be symlinked into `~/.hermes/profiles/<profile>/skills/claudio-authored/` so repo and TUI stay in sync while showing a clear authored-skills category.
+- Ask before visible or production writes. Profile skill symlinks are acceptable when the user asks for a skill to be usable in the active profile.
+
+## Sibling Source Edits
+
+Sibling backend/Unity checkouts are higher-risk than this pilot repo.
+
+Rules:
+
+- Check dirty state and current branch before editing.
+- Prefer isolated worktrees for concurrent sibling work.
+- Do not commit, push, or rewrite history unless the user explicitly asks.
+- Never print secrets or token-bearing config while inspecting.
+- Keep fixes minimal and verify with the target repo’s own tests/build commands where available.
+
+## Legacy Capability Migration Audits
+
+When comparing the legacy Claudio repo (`yallaplay-analytics-agent-gpt`) with the Hermes pilot, audit by capability class rather than listing every script. Start from the legacy `CLAUDE.md`, `COMMANDS.md`, `docs/README.md`, and `jobs/README.md`, then compare against the pilot `README.md`, `docs/capability-map.md`, `docs/pilot-plan.md`, `tools/README.md`, and `tools/*.py`. Classify each area as ported, native-Hermes-covered, legacy-fallback-only, missing/not yet ported, or intentionally out of scope.
+
+See `references/legacy-capability-audit.md` for the compact inventory and reporting pattern from the first migration audit.
+
+## Safety
+
+- Refuse broad deletion of repos, Hermes homes, wiki content, tool directories, credentials, or generated operational state.
+- Do not read or print secrets (`vars.toml`, `.env`, tokens, OAuth caches) unless explicitly required and scoped.
+- Do not push or rewrite history unless asked; do not branch unless task scope requires it or the user asks.
+- For user-requested repo changes, focused local commits are allowed and expected after each complete, verified unit of work.
+- Avoid production writes unless a documented gated workflow exists and the user confirms the exact action.
+- Before destructive commands, narrow the path and prefer reversible file moves over deletion.
+
+## Common Pitfalls
+
+1. **Skipping read-only diagnosis.** Understand the current behavior before editing. Load/use `codebase-readonly` if the fix is not yet clear.
+2. **Testing by description.** A summary is not verification; run a command or report the blocker.
+3. **Broken skill/profile link.** Editing `skills/yallaplay/<name>/SKILL.md` should affect `/skills` via the `claudio-authored` profile symlink; if not, check the symlink and run `/reload-skills` or start a new session.
+4. **Accidental generated churn.** Keep generated logs/outputs/caches out of commits unless the user asked for the artifact.
+5. **Overloading memory.** Task outcomes and PR numbers are not memory; durable procedures belong in skills or wiki pages.
+
+## Verification Checklist
+
+- [ ] Relevant source/wiki context was inspected.
+- [ ] Dirty state was checked before risky edits or sibling repo changes.
+- [ ] Every modified file is necessary for the requested change.
+- [ ] No secrets or unrelated profile/runtime state were committed or exposed.
+- [ ] A focused test/lint/compile/dry-run/ad-hoc verification was run, or the blocker is explicit.
+- [ ] `git status`/`git diff` was reviewed before final response.
+- [ ] Each complete, verified repo-change unit was committed with a focused conventional commit, or the reason for leaving it uncommitted is explicit.
+- [ ] Reusable engineering knowledge was captured in `yallaplay-wiki/` or a skill when applicable.

--- a/skills/yallaplay/coder/references/legacy-capability-audit.md
+++ b/skills/yallaplay/coder/references/legacy-capability-audit.md
@@ -1,0 +1,51 @@
+# Legacy Claudio capability audit reference
+
+Use this when comparing `yallaplay-analytics-agent-gpt` against the Hermes pilot repo.
+
+## Efficient audit pattern
+
+1. Inspect the legacy repo's capability indexes first:
+   - `CLAUDE.md` Architecture section for one-line tool purpose and safety caveats.
+   - `COMMANDS.md` for copy-paste invocations and the practical surface area.
+   - `docs/README.md` for domain grouping.
+   - `jobs/README.md` for scheduler semantics.
+2. Inspect the Hermes pilot's current surface:
+   - `README.md`, `docs/capability-map.md`, `docs/pilot-plan.md`.
+   - `tools/README.md` and `tools/*.py`.
+   - domain skills under `skills/` and installed profile skills when checking TUI/runtime behavior.
+3. Compare by class of capability, not one script per bullet. Mark each as:
+   - ported wrapper,
+   - available through native Hermes tooling,
+   - usable only via legacy repo fallback,
+   - missing/not yet ported,
+   - intentionally out of pilot scope.
+
+## High-level legacy capability classes observed
+
+Legacy `yallaplay-analytics-agent-gpt` had broad internal-agent coverage beyond Slack:
+
+- Recurring scheduler/job system: `jobs/`, `scripts/scheduler.py`, `bot/schedule_job.py`, `job_state.py`, `job_files.py`, `nextrun.txt`, per-job state/data/runs, delivery modes.
+- Analytics core: Snowflake query, charting, schema refresh, Grafana panels/snapshots.
+- LiveOps: Cockroach live DB, clienttwin, backend config fetch/history/dev-gated writes, global KV, ranking, game-engine records, OneSignal reads/gated sends.
+- Support: Helpshift sync/fetch/reply with local SQLite mirror and gated end-user replies.
+- Collaboration: Jira, Google Workspace, meetings/Meet store, Fellow, Timetastic, Slack read/write tools.
+- Observability: App Insights KQL, Embrace metrics and session-level data.
+- Growth/UA/ASO: Adjust Report Service, AppTweak client and rank-history store.
+- Operational registries: experiment registry/context plus Slack canvas, incident registry.
+- Engineering helpers: sibling C# source lookup (`ctags_lookup.py`, `backend_grep.py`) and isolated worktree helpers.
+- Agent/session maintenance: session digest/curation, dream candidate queue.
+- Voice/meeting capture: Transcribe/vocab, Google Meet auto-join/record/transcript enhancement.
+- Infrastructure/cost: Bedrock usage reporting, cleanup/artifact hygiene.
+
+## Current Hermes pilot baseline from this session
+
+The pilot repo was intentionally narrower:
+
+- Ported tools: wiki search/new, Snowflake read-only query, charting, schema fetch, analytics bias checklist, basic auth proxy.
+- Domain skills exist for analytics, liveops, collaboration, codebase-readonly, coder, infrastructure, knowledge.
+- README/pilot plan explicitly kept Slack bot and scheduler out of the first milestone.
+- Many domain skills route to the legacy repo as reference/fallback for unported wrappers.
+
+## Reporting guidance
+
+For a user asking “what are we missing besides Slack bot?”, lead with the real gap: most operational wrappers and scheduler semantics are not yet ported. Then group gaps by capability class and identify what is already covered. Avoid a long flat list of every script unless the user asks for migration tickets.

--- a/skills/yallaplay/collaboration/SKILL.md
+++ b/skills/yallaplay/collaboration/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: collaboration
+description: Use for Slack, Jira, Google Workspace, meetings, Fellow/Meet, Timetastic, attachments, and shared teammate-facing outputs.
+version: 1.1.0
+author: YallaPlay
+license: Proprietary
+metadata:
+  hermes:
+    tags: [collaboration, slack, jira, google-workspace, meetings, timetastic, yallaplay]
+    related_skills: [knowledge, liveops]
+---
+
+# Collaboration Skill
+
+## Overview
+
+Use this skill for teammate-facing systems and shared artifacts: Slack, Jira, Google Workspace, meetings, Fellow/Meet, Timetastic, attachments, and files intended for teammates. Default to read-only fetches and drafts. Anything that notifies people or changes shared state requires explicit confirmation.
+
+This is the Hermes equivalent of the legacy `personas/collaboration.md` workflow.
+
+## When to Use
+
+- Reading or drafting Slack/Jira/Google Workspace content.
+- Looking up teammates, channels, docs, sheets, meeting notes, transcripts, time-off, or attachments.
+- Creating shared outputs for review, e.g. CSVs, charts, docs, summaries.
+- Posting or updating teammate-visible systems after confirmation.
+
+Load LiveOps too for Helpshift/OneSignal/support-user-visible communication. Load Analytics too for metric-backed shared outputs.
+
+## Required Context
+
+Use these wiki areas for durable context:
+
+- `yallaplay-wiki/tools/team/slack.md`
+- `yallaplay-wiki/tools/team/jira.md`
+- `yallaplay-wiki/tools/team/google_workspace.md`
+- `yallaplay-wiki/tools/team/fellow_meet.md`
+- `yallaplay-wiki/tools/team/timetastic.md`
+- `yallaplay-wiki/people/index.md`, `person-directory.md`, `teams-and-roles.md`, and `time-off.md`.
+- `yallaplay-wiki/journal/` for meeting records if present.
+
+Search with `python3 tools/wiki_search.py <terms> --domain collaboration`.
+
+## Tool Routing
+
+Legacy commands from `yallaplay-analytics-agent-gpt/scripts/` are the reference for unported functionality:
+
+- Slack: `slack_user_lookup.py`, `slack_fetch.py`, `slack_post.py`, `slack_upload.py`, `slack_react.py`, `slack_pin.py`.
+- Jira: `jira_client.py`.
+- Google Workspace: `google_workspace.py`.
+- Meetings: `meet_store.py`, meeting transcript helpers.
+- Fellow: `fellow_client.py`, `fellow_sync.py`.
+- Timetastic: `timetastic_client.py`.
+
+In this Hermes pilot, use ported wrappers when available. If a required wrapper is not ported here, report that directly and use the wiki or legacy repo only as reference.
+
+## Workflow
+
+1. **Classify visibility.** Determine whether the action is private read, draft, shared-file write, or teammate-visible notification. Completion: risk level is explicit.
+2. **Resolve identities.** For named people, use authoritative lookup rather than guessing IDs, emails, or Slack handles. Completion: ID/source is verified.
+3. **Fetch before drafting.** Read the source thread/doc/ticket/meeting before summarizing or replying. Completion: response is grounded in actual content.
+4. **Draft first.** For posts, comments, docs, sheets, uploads, reactions, pins, or Jira writes, prepare the exact visible content and target. Completion: user can approve or edit.
+5. **Confirm writes.** Execute only after explicit confirmation naming the target/action. Completion: side effect matches approved draft.
+6. **Save reusable knowledge.** Meeting decisions, recurring processes, and collaboration gotchas belong in `yallaplay-wiki/`, not memory. Completion: durable item is saved or intentionally skipped.
+
+## Files and Attachments
+
+- Read attachments before answering questions about them; do not infer from filenames.
+- Put generated artifacts under `outputs/` with unique descriptive names.
+- Avoid clobbering shared files; use timestamped filenames unless updating an explicitly named target.
+- Do not expose private document contents beyond the user's request and access context.
+
+## Safety
+
+Do not perform these without explicit confirmation:
+
+- Slack posts, uploads, reactions, pins, or bookmarks.
+- Jira creates/updates/transitions/comments.
+- Google Docs/Sheets/Drive writes or permission changes.
+- Meeting invitations, calendar edits, or mass notifications.
+- Helpshift replies and OneSignal pushes; those are LiveOps and user-visible.
+
+## Common Pitfalls
+
+1. **Dead prose options.** If asking the user to choose, use actual choice UI when available; otherwise make drafts directly.
+2. **Guessing people.** Names are ambiguous; resolve IDs before messaging or attributing.
+3. **Posting summaries without source reads.** Fetch thread/doc/meeting first.
+4. **Notification surprise.** Jira and Slack writes notify teammates; draft and confirm.
+5. **Shared-output clobbering.** Use unique names unless the user explicitly asked to update a specific artifact.
+6. **Over-gathering for simple lookups.** For simple read-only counts/status checks where the wrapper and source are already known, use the direct query path first (e.g. Jira JQL via `jira_client.py`) and avoid extra wiki/repo/status reads unless the result is ambiguous or blocked.
+
+## Verification Checklist
+
+- [ ] Source content was read before summary/reply.
+- [ ] Named people/artifacts were resolved from authoritative lookup.
+- [ ] Teammate-visible writes were confirmed with exact target and content.
+- [ ] Generated files are linked by path and uniquely named.
+- [ ] Reusable decisions/process knowledge was captured in the wiki when appropriate.

--- a/skills/yallaplay/infrastructure/SKILL.md
+++ b/skills/yallaplay/infrastructure/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: infrastructure
+description: Use for setup, dependencies, Hermes provider config, Bedrock/OpenAI routing, S3/storage, logs/cache, web-search fallback, generated storage, and environment admin.
+version: 1.1.0
+author: YallaPlay
+license: Proprietary
+metadata:
+  hermes:
+    tags: [infrastructure, setup, providers, storage, logs, bedrock, hermes, yallaplay]
+    related_skills: [coder, codebase-readonly, knowledge]
+---
+
+# Infrastructure Skill
+
+## Overview
+
+Use this skill for environment setup, dependencies, provider/model routing, credentials hygiene, storage, generated logs/outputs, web-search fallback, and operational constraints. Keep infrastructure changes boring, reversible, and explicit.
+
+This is the Hermes equivalent of the legacy `personas/infrastructure.md` workflow, adapted to the Hermes pilot repo.
+
+## When to Use
+
+- Installing dependencies, bootstrapping profiles, configuring providers, gateway/dashboard setup.
+- S3/object storage, generated outputs/logs/cache, cleanup, environment health.
+- Bedrock/OpenAI/OpenRouter routing, model IDs, credential checks, web-search fallback.
+- Snowflake admin metadata such as role/warehouse/database setup; use Analytics for metric queries.
+
+Load Engineering too for code changes. Load Collaboration/LiveOps when infrastructure actions affect teammates or production services.
+
+## Required Context
+
+Inspect relevant wiki/project docs:
+
+- `yallaplay-wiki/engineering/infrastructure.md`
+- `yallaplay-wiki/engineering/backend_services.md`
+- `yallaplay-wiki/engineering/data_warehouse.md`
+- `yallaplay-wiki/tools/product/app_insights.md`
+- `docs/provider-notes.md`, `docs/bedrock-setup-status.md`, `docs/dashboard-cloudflare.md` when present.
+- `config/hermes.example.yaml` and scripts under `scripts/` for reproducible setup.
+
+For Hermes Agent itself, also load the `hermes-agent` skill and use official docs as source of truth.
+
+## Setup and Dependencies
+
+- Prefer reproducible scripts over manual shell state.
+- Python is PEP 668-managed on this host; use a venv or existing project environment rather than global `pip` installs.
+- Do not assume a command exists; check before using it.
+- Keep example config in git, real config/secrets outside git.
+- For generated runtime directories (`logs/`, `outputs/`, `.local/`, caches), confirm `.gitignore` coverage before producing large artifacts.
+
+## Storage and Generated Files
+
+- Generated CSV/charts belong under `outputs/` with timestamped/descriptive names.
+- Query logs belong under `logs/` when produced by query tools.
+- Avoid creating new cloud buckets/resources per task. Use existing documented storage and scoped prefixes.
+- Do not wipe caches/logs/state en masse without an explicit narrow scope and reason.
+
+## Provider and Credential Hygiene
+
+- Never print or commit `.env`, `vars.toml`, OAuth caches, cloud credentials, Slack tokens, or private keys.
+- Check provider/model configuration with read-only status/doctor commands first.
+- Record stable provider/model/region gotchas in `yallaplay-wiki/engineering/infrastructure.md` or `docs/`.
+- Active Hermes profile state is operational state. Changing it affects future sessions; say so and verify.
+
+## Hermes Profiles and Skill Visibility
+
+When Claudio skills exist in the repo but do not appear in `/skills`, distinguish repo-local source from profile-installed skills. YallaPlay-owned repo skills under `skills/yallaplay/` should be symlinked into the active profile's `skills/claudio-authored/` category for a clear visual split from bundled skills, then the current TUI needs `/reload-skills` or a new session.
+
+See `references/hermes-profiles-yallaplay.md` for the YallaPlay profile split, skill visibility procedure, and promotion pattern from `claudio-lab` to a future `claudio-prod`.
+
+## Web Search Fallback
+
+- Prefer native web/search tools when available.
+- If a local script fallback is needed, run it synchronously with a generous timeout.
+- Do not fan out or background web-search subprocesses unless the tool explicitly supports it; legacy notes recorded VM pressure from background fan-out.
+
+## Snowflake Admin Metadata
+
+- Production warehouse reads belong to Analytics.
+- Admin metadata (roles, grants, warehouse monitor setup, model/provider environment) belongs here.
+- Default Snowflake role conventions from the legacy repo: `READONLY_USER` / `ANALYTICS_MONITOR`; target new grants at `ANALYTICS_MONITOR`, not `PUBLIC`, unless current docs say otherwise.
+
+## Safety
+
+- Do not edit, print, or commit secret files.
+- Do not create broad cloud resources or change networking/gateway exposure without confirmation.
+- Do not stop/delete the agent, scheduler, gateway, profile state, or wiki unless the user gives a narrow safe instruction.
+- Prefer dry-runs and status commands before mutating environment state.
+
+## Hermes TUI/Profile Reference
+
+For recurring Claudio/Hermes TUI issues, use `references/hermes-tui-profiles-compression.md`. It covers:
+
+- Why repo-local skills do not appear in `/skills` until installed into the active profile.
+- When to run `/reload-skills`.
+- TUI legibility formatting: prefer compact bullets over fenced blocks for short command/profile layouts when the user reports odd blank spacing.
+- Why `/compress` may not reduce the visible context much when recent large tool outputs, loaded skills, tool schemas, or system/project instructions dominate.
+
+## Common Pitfalls
+
+1. **Global installs on PEP 668 hosts.** Use venv/uv or project scripts.
+2. **Secret-adjacent debugging.** Show key presence, not values.
+3. **Profile confusion.** `default` and `claudio-lab` have separate skills/config/state; verify active profile before changing it. `/skills` lists installed skills for the active profile, not repo-local `skills/` folders.
+4. **Repo/profile skill drift.** YallaPlay-owned skills should be profile symlinks under the `claudio-authored` category pointing to repo `skills/yallaplay/`; if a real copied profile directory appears, reconcile it back to the repo and restore the symlink.
+5. **TUI formatting friction.** If the user reports funky spacing, stop using the offending markdown shape; switch to compact bullets or plain text.
+6. **Compression over-expectation.** `/compress` summarizes middle history but keeps system prompt, tools, loaded skills, memory, and protected recent tail; inspect recent large tool outputs before assuming compression failed.
+7. **Generated artifact sprawl.** Keep outputs/logs clean and ignored.
+8. **Network visibility surprises.** Dashboard/gateway/cloudflared changes can expose services; confirm before enabling.
+
+## Verification Checklist
+
+- [ ] Active profile/environment was verified when relevant.
+- [ ] No secrets were printed or committed.
+- [ ] Dry-run/status was used before mutation where possible.
+- [ ] Generated files are under expected ignored locations.
+- [ ] Setup/provider/storage changes are documented when reusable.

--- a/skills/yallaplay/infrastructure/references/hermes-profiles-yallaplay.md
+++ b/skills/yallaplay/infrastructure/references/hermes-profiles-yallaplay.md
@@ -1,0 +1,71 @@
+# Hermes Profiles and YallaPlay Skill Visibility
+
+Use this reference when a repo-local YallaPlay skill exists but does not appear in `/skills`, or when configuring which Hermes profile should own Claudio behavior.
+
+## Mental Model
+
+Hermes profiles are separate agent installations. A profile has its own config, sessions, memory, skills, gateway setup, cron jobs, plugins/MCPs, and auth/env state.
+
+Repo-local skills under `./skills/yallaplay/` are project source files. They should be symlinked into the active profile because the `/skills` UI and `hermes skills list` read the active profile's installed skill registry, e.g. `~/.hermes/profiles/<profile>/skills/`. Use the `claudio-authored` profile category for a clear visual split from bundled/default skills.
+
+## When To Use Profiles
+
+Use profiles for durable isolation across sessions:
+
+- Work vs personal agents.
+- Lab vs production gateway/cron agents.
+- Different provider/model stacks.
+- Different gateway bots or platform routing.
+- Multi-agent roles such as planner/coder/reviewer.
+- Client/project isolation where memory, credentials, or tools must not bleed.
+
+Do not create a profile for every repo or task. Use `.hermes.md` / `AGENTS.md` for repo-specific rules, skills for reusable workflows, `/new` or `/reset` for a clean conversation, and worktrees for git isolation.
+
+## YallaPlay Claudio Pattern
+
+Recommended profile split:
+
+- `claudio-lab`: development/testing of Claudio skills, tools, wiki layout, provider config.
+- `claudio-prod`: future production-facing Slack/gateway/cron profile, created only when ready for real delivery.
+- `default`: generic fallback; avoid storing Claudio-specific assumptions there.
+
+Promote from lab to prod deliberately. Do not auto-sync experimental tools or skills into prod.
+
+## Skill Visibility Procedure
+
+When the user asks why a skill is not visible in `/skills`:
+
+1. Check whether the skill exists in the repo, e.g. `skills/yallaplay/analytics/SKILL.md`.
+2. Check the active profile with `hermes profile list` or `/profile`.
+3. Check installed skills with `hermes skills list`.
+4. If needed, symlink the repo-local skill directory into the active profile, e.g. `~/.hermes/profiles/claudio-lab/skills/claudio-authored/<skill> -> <repo>/skills/yallaplay/<skill>`.
+5. Ask/tell the user to run `/reload-skills` in the current TUI, or start a new session.
+6. Verify with `hermes skills list` that the skill appears and is enabled.
+
+## Commands
+
+```bash
+hermes profile list
+hermes profile use claudio-lab
+hermes profile show claudio-lab
+hermes skills list
+```
+
+One-off invocation with a profile:
+
+```bash
+hermes --profile claudio-lab
+```
+
+Clone a future production profile from lab only after reviewing secrets/tools/gateway settings:
+
+```bash
+hermes profile create claudio-prod --clone-from claudio-lab
+```
+
+## Pitfalls
+
+- Editing `skills/yallaplay/<name>/SKILL.md` updates repo source and the installed profile skill when the `claudio-authored` profile entry is a symlink.
+- Creating or changing a profile skill symlink may still require `/reload-skills` or a new session for the current TUI to see it.
+- Profile state lives outside the repo and affects future sessions; treat writes there as operational changes.
+- Keep `claudio-prod` boring and locked down; test in `claudio-lab` first.

--- a/skills/yallaplay/infrastructure/references/hermes-tui-profiles-compression.md
+++ b/skills/yallaplay/infrastructure/references/hermes-tui-profiles-compression.md
@@ -1,0 +1,50 @@
+# Hermes TUI, profiles, skills, and compression notes
+
+Use this reference when troubleshooting Claudio/Hermes operability from the TUI.
+
+## `/skills` visibility and profiles
+
+- `/skills` and `hermes skills list` show skills installed in the **active Hermes profile**, not repo-local `skills/` directories.
+- Repo-local Claudio skills under `yallaplay-hermes-agent/skills/yallaplay/<name>/SKILL.md` are source artifacts. They should be exposed to the TUI by symlinking each skill directory into the active profile's `claudio-authored` category, e.g. `~/.hermes/profiles/claudio-lab/skills/claudio-authored/<name> -> <repo>/skills/yallaplay/<name>`.
+- After changing installed skills, tell the user to run `/reload-skills` or start a new session.
+- Keep profile symlinks intact when the user expects a skill to both ship with the repo and appear in the current TUI.
+
+## TUI legibility style
+
+The TUI can render some fenced blocks or long markdown regions with surprising vertical whitespace in long sessions. For operator-facing answers:
+
+- Prefer compact bullets over fenced code blocks when showing short command lists or profile layouts.
+- Avoid big markdown tables unless the table is the deliverable.
+- If a renderer issue is suspected, describe it plainly and switch to a lower-friction format rather than repeating the same formatting.
+
+## Context compression expectations
+
+`/compress` compacts conversation history; it does not shrink everything in the next prompt.
+
+Non-compressible or weakly-compressible prompt mass includes:
+
+- system/developer/project instructions,
+- tool schemas,
+- loaded skills,
+- persistent memory/profile text,
+- protected head/tail messages,
+- recent large tool outputs that are still in the protected tail.
+
+Default compression behavior to remember:
+
+- `compression.threshold` default is around `0.50` of main-model context.
+- `compression.target_ratio` default is around `0.20` and controls tail token budget.
+- `compression.protect_last_n` default protects recent messages.
+- The summary itself can be thousands of tokens because it preserves decisions, files, commands, and blockers.
+
+If the user asks why compression did not reduce context much, check whether recent large tool outputs or loaded skills are still in the protected tail. Practical options are `/new` or `/reset` for a hard reset, or more aggressive settings such as lower `compression.target_ratio` and `compression.protect_last_n` for future sessions.
+
+## Known GitHub issue class
+
+Blank space / odd scroll behavior in the TUI has had upstream issues around virtualized transcript row-height estimation and scroll clamp bounds. When investigating, search for terms like:
+
+- `fix(tui): defer virtual clamp until resumed rows are measured`
+- `fix(dashboard): prevent xterm.js viewport blank whitespace after long conversations`
+- `fix(tui): strip ANSI before estimating message height`
+
+Treat these as issue classes to search, not permanent negative claims about Hermes.

--- a/skills/yallaplay/knowledge/SKILL.md
+++ b/skills/yallaplay/knowledge/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: knowledge
+description: Use for looking up, saving, indexing, reorganizing, or cleaning durable YallaPlay knowledge in the yallaplay-wiki submodule.
+version: 1.1.0
+author: YallaPlay
+license: Proprietary
+metadata:
+  hermes:
+    tags: [knowledge, wiki, obsidian, documentation, indexing, yallaplay]
+    related_skills: [analytics, codebase-readonly, coder]
+---
+
+# Knowledge Skill
+
+## Overview
+
+Use this skill whenever the task is to find, preserve, reorganize, or clean durable YallaPlay knowledge. The wiki is the durable knowledge base for Claudio; memory is only for user preferences and stable personal/environment facts.
+
+This skill implements the current `yallaplay-wiki/` contract: domain-first layout, self-contained pages, relative links, and one canonical page per thing.
+
+## When to Use
+
+- Looking up project knowledge before answering.
+- Adding or editing wiki pages, indexes, dictionary entries, glossary entries, findings, methodologies, schema annotations, or runbooks.
+- Reorganizing wiki layout or fixing links.
+- Deciding whether a discovery belongs in memory, a skill, the wiki, or nowhere.
+
+Load the domain skill too when the knowledge belongs to Analytics, LiveOps, Engineering, Collaboration, or Infrastructure.
+
+## Required Context
+
+Read before editing the wiki:
+
+- `yallaplay-wiki/README.md` — page contract and layout rules.
+- `yallaplay-wiki/index.md` — top-level routing.
+- `yallaplay-wiki/dictionary.md` and `glossary.md` for terms.
+- The target domain index, e.g. `products/index.md`, `operations/index.md`, `tools/index.md`, `engineering/index.md`, or `reference/warehouse/index.md`.
+- `yallaplay-wiki/CLAUDE.md` if working directly inside the wiki submodule.
+
+## Wiki Layout Rules
+
+- Top-level folders are domains, not document types.
+- Game systems live under `products/core/<system>/`, `products/spades/<feature>/`, or `products/rummy/<feature>/` with facet files: `index.md`, `design.md`, `engineering.md`, `analytics.md`, `findings.md`, `facts.md`.
+- Warehouse schema/reference lives under `reference/warehouse/`: curated human pages (`index.md`, `events.md`, `aggregates.md`) plus generated DDL in `ddl/`.
+- Tool pages are canonical under `tools/product/` or `tools/team/`, not duplicated in engineering/operations.
+- Journal pages are records, not canonical reference. Distill reusable facts from them into domain pages.
+
+## Lookup Workflow
+
+1. **Search first.** Use `python3 tools/wiki_search.py <terms>` and, when relevant, `--domain <domain>`. Completion: likely existing canonical pages are identified.
+2. **Open indexes.** Use top-level/domain indexes for routing before creating new pages. Completion: destination domain is justified.
+3. **Read the destination.** Inspect the most-specific page before editing. Completion: no duplicate canonical page is created.
+4. **Answer with links.** Cite repo-relative wiki paths when useful. Completion: future reader can navigate to source.
+
+## Capture Workflow
+
+Save only reusable knowledge:
+
+- **Definitions:** metric/business concept meaning, usually in `glossary.md`, `dictionary.md`, or a domain reference page.
+- **Methodology:** repeatable investigation approach, caveat, or bias trap.
+- **Findings:** concrete result with future value and caveats.
+- **Queries:** reusable SQL/query pattern near the domain that uses it.
+- **Schema/reference:** durable table/column/tool behavior under `reference/warehouse/` or the relevant tool page.
+- **Operations:** incidents, A/B tests, runbooks under `operations/`.
+
+Do not save secrets, unsupported speculation, one-off scratch output, stale task progress, PR numbers, or facts that will expire in days.
+
+## Agent Quick Context → Compiled Skills
+
+For high-frequency workflows, store the source snippet in the wiki and compile it into a git-tracked skill:
+
+1. Add an `agent_skill:` block to the wiki page frontmatter with `name`, `category`, `description`, `tags`, and `related_skills`.
+2. Add a `## Agent quick context` section containing the compact runtime fast path: trigger terms, tables/events, denominator defaults, known traps, and query skeletons.
+3. Run `python3 tools/compile_wiki_skills.py --name <skill-name> --profile-symlink-root ~/.hermes/profiles/claudio-lab/skills/claudio-authored`.
+4. Commit the generated repo skill under `skills/yallaplay/<skill-name>/SKILL.md`; the profile path should be a symlink back to that repo directory.
+
+Maintenance rule: update the wiki section first, regenerate the skill, and treat the generated skill as a compiled cache. If the wiki and generated skill disagree, the wiki wins.
+
+## Editing Workflow
+
+1. **Classify durable vs transient.** Completion: the target belongs in wiki, skill, memory, or nowhere.
+2. **Find canonical owner.** Completion: most-specific domain/page is selected.
+3. **Read current content.** Completion: edit does not duplicate or contradict existing page.
+4. **Patch narrowly.** Completion: internal links are relative and page remains self-contained.
+5. **Update entry points.** Add/update dictionary entries, relevant domain index, and log when adding/changing substantial pages. Completion: a term-first and structure-first reader can find it.
+6. **Verify links.** For touched pages, check relative links resolve. Completion: no broken links introduced.
+
+## Tools
+
+- `python3 tools/wiki_search.py <query>` — compact search.
+- `python3 tools/wiki_search.py <query> --domain analytics --files-only` — domain-routed file discovery.
+- `python3 tools/wiki_new.py <kind> <title>` — draft a page from a safe template.
+- `python3 tools/fetch_schemas.py` — refresh generated warehouse DDL under `reference/warehouse/ddl/`.
+
+## Safety
+
+- Do not overwrite wiki files without reading them first.
+- Do not link to another repo's markdown/knowledge files; absorb needed content inline. Code path references are allowed.
+- Do not store secrets, personal data, or unsupported speculation.
+- Keep generated DDL separate from curated prose.
+- When moving pages, update all internal links and the relevant index/dictionary entries.
+
+## Common Pitfalls
+
+1. **Document-type top-level folders.** Prefer domain owners (`reference/warehouse/`) over root folders like `/schema`.
+2. **Duplicate canonical pages.** Link to the owner instead of restating.
+3. **Dictionary bloat.** Dictionary points; glossary/domain pages explain.
+4. **Memory misuse.** Wiki stores organizational knowledge; memory stores user preferences/environment facts.
+5. **Broken relative links after moves.** Resolve links from the moved file's new directory.
+
+## Verification Checklist
+
+- [ ] `README.md` contract was followed.
+- [ ] Most-specific canonical owner was used.
+- [ ] Dictionary/index/log updates were made when substantial pages changed.
+- [ ] Internal links are relative and resolve.
+- [ ] No secrets, unsupported speculation, or one-off scratch output were saved.

--- a/skills/yallaplay/liveops/SKILL.md
+++ b/skills/yallaplay/liveops/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: liveops
+description: Use for live account state, backend config, support tickets, pushes, ranking/game-engine, clienttwin, CockroachDB, and production operational reads.
+version: 1.1.0
+author: YallaPlay
+license: Proprietary
+metadata:
+  hermes:
+    tags: [liveops, support, config, clienttwin, ranking, onesignal, helpshift, yallaplay]
+    related_skills: [analytics, collaboration, knowledge]
+---
+
+# LiveOps Skill
+
+## Overview
+
+Use this skill for current operational state: individual accounts, support tickets, backend config, runtime flags, pushes, ranking/game-engine records, and incident triage. Default to read-only workflows. Any user-visible or production write needs exact confirmation and a documented gated command.
+
+This is the Hermes equivalent of the legacy `personas/liveops.md` workflow, adapted to the Hermes pilot where many legacy scripts are not yet ported.
+
+## When to Use
+
+- Specific-user debugging, account state, purchase/support investigation.
+- Helpshift tickets, OneSignal pushes, backend config, global KV, ranking, game-engine records, clienttwin state.
+- Live incident triage involving config, operational logs, support signals, or live DB state.
+- Questions that combine support/account state with warehouse metrics; load Analytics too.
+
+## Required Context
+
+Inspect relevant wiki pages before non-trivial tool use:
+
+- `yallaplay-wiki/operations/index.md`
+- `yallaplay-wiki/operations/liveops_runbooks.md`
+- `yallaplay-wiki/operations/customer_support.md`
+- `yallaplay-wiki/tools/product/helpshift.md`
+- `yallaplay-wiki/tools/product/onesignal.md`
+- `yallaplay-wiki/tools/product/app_insights.md`
+- Product feature pages under `yallaplay-wiki/products/**/facts.md`, `engineering.md`, and `findings.md`.
+
+Use `python3 tools/wiki_search.py <terms> --domain liveops` to route into the wiki.
+
+## Identity and Joins
+
+- Warehouse user id = `EVENTS.INDEX_USER.USER_ID` = Helpshift `meta_user_id` = twin/ranking user id.
+- Cockroach `index_user.id` maps to profile display name and handle in the legacy workflow.
+- Named teammates belong to Collaboration; resolve Slack identities with the Slack lookup flow before messaging or attributing.
+- For user/account IDs, preserve exact strings. Do not "fix" an ID without evidence.
+
+## Tool Routing
+
+Legacy commands from `yallaplay-analytics-agent-gpt/scripts/` are the reference for what still needs porting. In this Hermes pilot, use ported wrappers when available and otherwise say the wrapper is not yet ported instead of inventing output.
+
+Read-only targets from the legacy repo:
+
+- Cockroach/live DB: `scripts/cockroach_query.py` for current account state not in Snowflake.
+- Clienttwin: `scripts/twin_client.py` for current player state/devices.
+- Config: `scripts/config_fetch.py`, `scripts/config_history.py`, `scripts/dump_config.py` for read-only config snapshots/history.
+- Global KV: `scripts/global_kv.py get/list` for runtime flags; writes are gated.
+- Helpshift: `scripts/helpshift_fetch.py` and local sync/mirror workflows for support tickets.
+- OneSignal: `scripts/onesignal_client.py user/view/list` for read-only push state.
+- Ranking/game-engine: `scripts/ranking_client.py` read paths and `scripts/game_json.py` for canonical per-match records.
+- Observability: App Insights and Embrace tools belong at the LiveOps/Infrastructure/Analytics boundary; load those skills too when metrics or backend telemetry are part of the answer.
+
+## Workflow
+
+1. **Scope.** Identify app, environment, user/account identifiers, time window, and whether the action is read or write. Completion: ambiguity that changes tools is resolved.
+2. **Load context.** Open relevant wiki/tool docs and prior findings before live calls. Completion: source-specific caveats are known.
+3. **Prefer read-only/local mirrors.** Use local mirrors or read-only APIs before live calls. Completion: least-invasive source was tried first.
+4. **Separate observation from inference.** Report exact facts observed, then possible root cause. Completion: user can see what was measured vs inferred.
+5. **Gate writes.** For any visible/live mutation, draft the exact command/body/target and wait for explicit confirmation. Completion: confirmation names the exact side effect.
+6. **Capture durable learning.** Incidents, config gotchas, and reusable investigations go to `yallaplay-wiki/operations/`, `tools/product/`, or product findings. Completion: future Claudio can find it.
+
+## Write Safety
+
+Require explicit confirmation before:
+
+- Helpshift replies.
+- OneSignal sends/deletes.
+- Slack posts/uploads/reactions/pins.
+- Jira or Google Workspace writes.
+- Backend config, global KV, clienttwin, ranking, game-engine, or live account mutations.
+
+Never write production config directly in this pilot. Dev config writes require the documented dev-only gated flow and `--yes` confirmation.
+
+## Common Pitfalls
+
+1. **Treating support data as analytics truth.** Helpshift is sampled by user behavior; use it for concrete cases and signals, not population rates.
+2. **Conflating live and warehouse lag.** Warehouse facts can lag; current purchases/account state may need live DB or support sources.
+3. **Guessing app/environment.** Spades vs Rummy and prod vs dev materially change tools and risk.
+4. **Silent user-visible writes.** Draft first; post/send/reply only after confirmation.
+5. **Over-broad incident actions.** Refuse broad deletes, pushes, config wipes, or mass user impact without a narrow approved plan.
+
+## Verification Checklist
+
+- [ ] App, environment, identifiers, and time window are explicit.
+- [ ] Read-only source was used unless a confirmed gated write was required.
+- [ ] User-visible/production writes were not performed without exact confirmation.
+- [ ] Facts are separated from inference.
+- [ ] Durable incident/config/support knowledge was captured when reusable.

--- a/skills/yallaplay/season-pass-analytics/SKILL.md
+++ b/skills/yallaplay/season-pass-analytics/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: season-pass-analytics
+description: 'Use for Season Pass analytics: reward collection, pass level-up, premium/free
+  track, reward-collect, seasonpass-init, seasonpass-level-up, engagement, pass progression,
+  and Season Pass A/B reads.'
+version: 1.0.0
+author: YallaPlay
+license: Proprietary
+metadata:
+  hermes:
+    tags:
+    - season-pass
+    - analytics
+    - snowflake
+    - rewards
+    - engagement
+    - yallaplay
+    related_skills:
+    - analytics
+    - knowledge
+  generated_from:
+    wiki_path: yallaplay-wiki/products/core/season_pass/analytics.md
+    section: Agent quick context
+    source_sha256: 125efb689f2031772724d7485096609c049f14a7bcd072ef91ad30ddadaef1d5
+    built: '2026-07-02'
+---
+
+# Season Pass Analytics — Compiled Agent Context
+
+<!-- BEGIN GENERATED FROM WIKI AGENT QUICK CONTEXT -->
+
+> Generated from `yallaplay-wiki/products/core/season_pass/analytics.md` → `## Agent quick context`.
+> Do not hand-edit this compiled body; update the wiki section and rerun `python3 tools/compile_wiki_skills.py`.
+
+Use this compiled context when the prompt mentions **Season Pass**, **pass engagement**, **reward collect**, **unclaimed rewards**, **pass level-up**, **free/premium track**, or the event names below.
+
+### Fast path
+
+- Source table: `EVENTS.TRANSACTION` for core pass exposure, progression, purchases, and reward claims.
+- Current active season at this snapshot: `summer_1`; verify season keys when answering future-dated questions.
+- Report `spades` and `rummy` separately unless the user explicitly asks for a combined cross-app read.
+- Use `EVENT_DATE` for event windows and `TRANSACTION_METADATA_SEASON_KEY` to isolate one season.
+- Join pass events by `(APP, USER_ID, TRANSACTION_METADATA_SEASON_KEY)`.
+- Prefer inline `tools/snowflake_query.py "WITH ..."` for quick toplines; write SQL/CSV artifacts only when the user asks to persist, chart, or reuse the result.
+
+### Core event semantics
+
+| `TRANSACTION_NAME` | Meaning | Key metadata |
+|---|---|---|
+| `seasonpass-init` | User has the feature running / initialized for the season | `TRANSACTION_METADATA_SEASON_KEY` |
+| `seasonpass-level-up` | Season-pass XP crossed a level threshold | `TRANSACTION_METADATA_SEASON_KEY` only |
+| `reward-collect` | User claimed a season-pass reward | `TRANSACTION_METADATA_SEASON_KEY`, `TRANSACTION_METADATA_SEASON_TRACK`, `TRANSACTION_METADATA_SEASON_LEVEL` |
+| `chest-redeem` | Season chest payout opened | `TRANSACTION_METADATA_SEASON_KEY`, `TRANSACTION_METADATA_SEASON_TRACK`, `TRANSACTION_METADATA_SEASON_LEVEL` |
+
+### Canonical denominators
+
+- **Feature exposure / running:** users with `seasonpass-init` for the app + season.
+- **Reward-claim engagement:** users with zero `reward-collect` for the same app + season.
+- **Users likely to have claimable rewards:** prefer users with `COUNT(DISTINCT TRANSACTION_SEQUENCE)` on `seasonpass-level-up` **>= 2**. In the 2026-07-02 `summer_1` read, `>= 1 seasonpass-level-up` equalled all initialized users, so the first level-up appears initialization-adjacent and is too broad for “has rewards to claim.”
+- **Free-track collection rates:** free rewards exist on only 25 of 40 levels in `spring_2`; do not divide by all levels unless verifying reward-bearing levels for the current season.
+- **Premium-track collection:** filter `reward-collect` on `TRANSACTION_METADATA_SEASON_TRACK = 'premium'`; only premium buyers can claim it.
+
+### Known traps
+
+- `TRANSACTION_METADATA_SEASON_TRACK` and `TRANSACTION_METADATA_SEASON_LEVEL` exist on `reward-collect` / `chest-redeem`, not on `seasonpass-init` or `seasonpass-level-up`.
+- Spades is a persistent 50/50 A/B: arm B has the pass, arm A is holdout. Raw pass event counts are treatment/pass users, not full Spades population.
+- Rummy has no holdout, so causal reads need pre/post or matched controls and remain confounded.
+- Season key matters: do not mix `spring_2`, `summer_1`, or staff/test seasons.
+- Watch right-censoring for current-season reads; show a mature cohort cut such as initialized or first-level-up at least 7 days ago when interpreting unclaimed reward rates.
+
+### Minimal no-reward-collect query shape
+
+```sql
+WITH level_uppers AS (
+  SELECT APP, USER_ID, TRANSACTION_METADATA_SEASON_KEY AS season_key,
+         COUNT(DISTINCT TRANSACTION_SEQUENCE) AS pass_level_ups
+  FROM EVENTS.TRANSACTION
+  WHERE EVENT_DATE >= :season_start
+    AND TRANSACTION_METADATA_SEASON_KEY = :season_key
+    AND TRANSACTION_NAME = 'seasonpass-level-up'
+    AND APP IN ('spades', 'rummy')
+  GROUP BY APP, USER_ID, TRANSACTION_METADATA_SEASON_KEY
+), collectors AS (
+  SELECT DISTINCT APP, USER_ID, TRANSACTION_METADATA_SEASON_KEY AS season_key
+  FROM EVENTS.TRANSACTION
+  WHERE EVENT_DATE >= :season_start
+    AND TRANSACTION_METADATA_SEASON_KEY = :season_key
+    AND TRANSACTION_NAME = 'reward-collect'
+    AND APP IN ('spades', 'rummy')
+)
+SELECT l.APP, COUNT(*) AS eligible_users,
+       COUNT_IF(c.USER_ID IS NULL) AS zero_collect_users,
+       ROUND(100.0 * COUNT_IF(c.USER_ID IS NULL) / NULLIF(COUNT(*), 0), 2) AS pct_zero_collect
+FROM level_uppers l
+LEFT JOIN collectors c
+  ON c.APP = l.APP AND c.USER_ID = l.USER_ID AND c.season_key = l.season_key
+WHERE l.pass_level_ups >= 2
+GROUP BY l.APP
+ORDER BY l.APP;
+```
+
+<!-- END GENERATED FROM WIKI AGENT QUICK CONTEXT -->
+
+## Maintenance
+
+- Canonical source: `yallaplay-wiki/products/core/season_pass/analytics.md`.
+- If this skill and the wiki disagree, the wiki wins; patch the wiki, then regenerate this skill.
+- Keep this skill symlinked into the active Hermes profile so `/skills` and prompt routing see the git-tracked copy.

--- a/skills/yallaplay/yallaplay-llm-wiki/SKILL.md
+++ b/skills/yallaplay/yallaplay-llm-wiki/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: yallaplay-llm-wiki
+description: "Use when applying the Karpathy/llm-wiki durable-knowledge workflow to the yallaplay-wiki repo: orient, query, ingest, cross-reference, lint, and log while preserving YallaPlay's domain-first wiki contract."
+version: 1.0.0
+author: Claudio
+license: Proprietary
+metadata:
+  hermes:
+    tags: [yallaplay, wiki, knowledge-base, markdown, ingest, lint]
+    related_skills: [llm-wiki, knowledge, yallaplay-wiki-knowledge]
+---
+
+# YallaPlay LLM Wiki Workflow
+
+## Overview
+
+Use this skill to apply the `llm-wiki` discipline to `yallaplay-wiki/` without importing the generic `SCHEMA.md`, `raw/`, `entities/`, `concepts/`, or `queries/` layout.
+
+The operating model is: orient first, answer from compiled knowledge, ingest primary sources into the record layer, distill reusable facts into canonical domain pages, keep links/indexes current, and log durable changes. The schema of record is the local `yallaplay-wiki/README.md` contract.
+
+## When to Use
+
+- The user asks to use the LLM Wiki / Karpathy wiki pattern with YallaPlay knowledge.
+- Querying, ingesting, linting, or reorganizing `yallaplay-wiki/`.
+- Turning meeting notes, research, analytics findings, or implementation discoveries into durable company knowledge.
+- Auditing whether the wiki behaves like a compounding knowledge base rather than a pile of markdown files.
+
+Also load the relevant domain skill when the subject is Analytics, LiveOps, Engineering, Collaboration, Infrastructure, Observability, or product-specific work.
+
+## Wiki Path
+
+Prefer the repo wiki when present:
+
+- `WIKI_PATH=/home/ubuntu/git/yallaplay-hermes-agent/yallaplay-wiki`
+- fallback: `./yallaplay-wiki` from the Hermes pilot repo
+
+Do not assume `~/wiki`; that is the generic `llm-wiki` default and is wrong for Claudio unless the user explicitly points there.
+
+## Contract Mapping from Generic llm-wiki
+
+| Generic `llm-wiki` concept | YallaPlay wiki equivalent |
+|---|---|
+| `SCHEMA.md` | `README.md` + `CLAUDE.md` when inside the submodule |
+| `index.md` | root `index.md` plus domain `index.md` files |
+| `log.md` | root `log.md` append-only build/ingest log |
+| `raw/` | `journal/` for internal primary records; `literature/sources/` for external canon; generated snapshots beside their owning reference page |
+| `entities/`, `concepts/` | most-specific domain owner: `products/`, `people/`, `engineering/`, `tools/`, `operations/`, `market/`, `literature/`, `reference/` |
+| `queries/` | reusable SQL/analysis patterns near the owning domain, often `reference/warehouse/`, product `analytics.md`, or methodology pages |
+| `[[wikilinks]]` | relative markdown links, e.g. `[Piggy Bank](products/core/piggy_bank/index.md)` |
+| generic frontmatter | YallaPlay frontmatter from `README.md`: `title`, `domain`, `status`, `source_refs`, `see_also`, `built` |
+
+Never create new root folders named `raw`, `schema`, `entities`, `concepts`, `queries`, `findings`, or `scratch` unless the user explicitly changes the wiki contract.
+
+## Mandatory Orientation
+
+Before answering from or editing the wiki:
+
+1. **Read the contract.** Read `yallaplay-wiki/README.md`; read `yallaplay-wiki/CLAUDE.md` if operating directly inside the wiki submodule. Completion: the page contract and hard rules are known.
+2. **Read entry points.** Read root `index.md`, `dictionary.md`, and `glossary.md` as needed. Completion: term-first and structure-first routes are known.
+3. **Search before opening pages.** Run `python3 tools/wiki_search.py <terms>` when available; otherwise use `search_files` over `yallaplay-wiki/*.md`. Completion: likely canonical pages and duplicates are identified.
+4. **Read the owner.** Open the most-specific domain index and target page before creating or editing. Completion: no duplicate canonical page is created.
+5. **Check recent log for substantial work.** Read the tail of `log.md` when ingesting, reorganizing, or auditing. Completion: recent related changes are known.
+
+## Query Workflow
+
+When the user asks a knowledge question:
+
+1. **Route by domain.** Use `dictionary.md`, root `index.md`, domain indexes, and `tools/wiki_search.py`. Completion: relevant pages are listed.
+2. **Read canonical pages, not just search snippets.** Completion: answer is grounded in full page context.
+3. **Synthesize with citations.** Cite repo-relative paths such as `yallaplay-wiki/products/core/piggy_bank/analytics.md`. Completion: a future reader can navigate to every material claim.
+4. **File only reusable synthesis.** If the answer is a non-trivial methodology, definition, finding, or comparison that would be painful to rederive, save it to the canonical owner and update entry points. Otherwise, leave it in chat. Completion: wiki does not accumulate one-off scratch.
+5. **Log filed work.** Append `## [YYYY-MM-DD] query | <subject>` or an appropriate operation line only when files change. Completion: durable changes are discoverable.
+
+## Ingest Workflow
+
+When adding source material:
+
+1. **Classify the source.** Internal meeting/support/ops source goes under `journal/`; external design/research canon goes under `literature/sources/`; generated technical snapshots live beside their owning reference page (for example `reference/warehouse/ddl/`). Completion: the source has the right epistemic layer.
+2. **Preserve records, distill reference.** Records are dated and immutable; reference pages are maintained and deduplicated. Completion: primary material is not overwritten by synthesis.
+3. **Find existing owners.** Search the dictionary, glossary, domain indexes, and content before creating pages. Completion: canonical owners are known.
+4. **Patch narrow canonical pages.** Add durable facts, caveats, definitions, query patterns, or findings to the most-specific page. Completion: content is self-contained and not duplicated elsewhere.
+5. **Use YallaPlay frontmatter and links.** New/changed pages satisfy the local page contract and use relative markdown links. Completion: Obsidian/GitHub navigation works.
+6. **Update entry points.** For substantial changes, update `dictionary.md`, relevant domain `index.md`, and `log.md`. Completion: readers can find the knowledge by term and by structure.
+7. **Ask before mass updates.** If an ingest will touch 10+ pages or restructure a domain, confirm scope first. Completion: visible broad edits are user-approved.
+
+## Capture Rules
+
+Save to the wiki when the knowledge is reusable for future Claudio runs or teammates:
+
+- Definitions and shared vocabulary: `glossary.md` or the canonical domain page, with `dictionary.md` pointing to it.
+- Product-system knowledge: `products/core/<system>/` or game-specific product folders, split into persona facets.
+- Analytics methods and caveats: `reference/analytics_rules.md`, product `analytics.md`, or `reference/warehouse/`.
+- Warehouse annotations: `reference/warehouse/` with generated DDL under `reference/warehouse/ddl/`.
+- Tool behavior: `tools/product/` or `tools/team/` canonical pages.
+- Incidents, A/B tests, and runbooks: `operations/`.
+- External game-design canon: `literature/`, with source material in `literature/sources/`.
+
+Do not save secrets, unsupported speculation, stale task progress, PR numbers, temporary TODOs, or facts likely to expire within days.
+
+## Lint / Health-Check Workflow
+
+Adapt generic `llm-wiki` lint to YallaPlay rules:
+
+1. **Frontmatter validation.** Every page has required local fields from `README.md`; game facets have their facet-specific fields. Completion: missing fields are reported by path.
+2. **Relative-link validation.** Every internal markdown link resolves from the file's directory. Completion: broken links are listed with source and target.
+3. **No external knowledge-file links.** Pages do not link to markdown/knowledge files in other repos; allowed outward references are repo-root-relative code paths only. Completion: violations are listed.
+4. **Index and dictionary coverage.** New canonical pages and important terms appear in the relevant domain index and `dictionary.md`. Completion: missing entry points are listed.
+5. **Canonical-owner audit.** Flag likely duplicate pages or repeated explanations across domains. Completion: suggested owner is named.
+6. **Facet completeness.** Product-system folders have expected facet files and each facet can stand alone cold. Completion: missing facets/orientation blocks are listed.
+7. **Log hygiene.** Substantial durable changes have a `log.md` entry. Completion: missing or stale log entries are reported.
+
+Group findings by severity: broken links and contract violations first; duplicate canonical pages and missing indexes next; style and drift issues last.
+
+## Editing Rules
+
+- Read before editing; never overwrite a wiki page cold.
+- Prefer narrow patches over rewrites.
+- Keep pages self-contained: do not point to another knowledge repo for explanation.
+- Inline concrete config values, formulas, and metric definitions with the `built` date when recording point-in-time snapshots.
+- Keep generated artifacts separate from curated prose.
+- When moving pages, update all relative links and entry points in the same change.
+- Use `yallaplay-wiki/log.md` for durable wiki changes, not Hermes memory.
+
+## Verification Checklist
+
+- [ ] `README.md`/`CLAUDE.md` contract was read when needed.
+- [ ] Existing canonical owner was searched and read before creating content.
+- [ ] Destination follows domain-first layout, not generic `llm-wiki` artifact folders.
+- [ ] New/changed pages satisfy YallaPlay frontmatter and self-containment rules.
+- [ ] Relative markdown links introduced or touched resolve.
+- [ ] Dictionary, glossary, domain index, and log were updated when substantial content changed.
+- [ ] No secrets, unsupported speculation, stale task progress, or one-off scratch was saved.
+
+## Common Pitfalls
+
+1. **Importing the generic layout.** `llm-wiki` is the workflow; `yallaplay-wiki/README.md` is the schema.
+2. **Using wikilinks.** YallaPlay uses relative markdown links, not `[[page]]` links.
+3. **Creating type folders at root.** Root folders are domains. Put generated/supporting artifacts under the domain that owns them.
+4. **Confusing records with reference.** `journal/` preserves dated source material; domain pages distill maintained knowledge.
+5. **Answering from snippets.** Search identifies candidates; read canonical pages before synthesis.
+6. **Skipping entry points.** A page not reachable from dictionary/index/log is effectively hidden from future agents.
+7. **Saving transient work.** Completed tasks, PRs, and temporary findings belong in session history or outputs, not the wiki.

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -423,6 +423,44 @@ class TestSessionOps:
         assert "cli.py:42" in tool_updates[1].content[0].content.text
 
     @pytest.mark.asyncio
+    async def test_load_session_flags_compaction_summary_on_replayed_user_chunk(self, agent):
+        """A replayed compaction summary must carry _meta.hermes.compactionSummary.
+
+        The handoff is stored role="user" but is not a real user turn; without
+        the flag on the wire, ACP frontends render the whole summary as a user
+        message. Detection falls back to content, so this holds even for a
+        DB-reloaded session that lost the in-process metadata flag.
+        """
+        from agent.context_compressor import SUMMARY_PREFIX
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        summary_text = SUMMARY_PREFIX + "\n\n## Active Task\nDo the thing."
+        new_resp = await agent.new_session(cwd="/tmp")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        state.history = [
+            {"role": "user", "content": summary_text},
+            {"role": "user", "content": "wait 5s and reply ok"},
+        ]
+
+        mock_conn.session_update.reset_mock()
+        await agent.load_session(cwd="/tmp", session_id=new_resp.session_id)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        user_chunks = [
+            call.kwargs["update"]
+            for call in mock_conn.session_update.await_args_list
+            if isinstance(call.kwargs.get("update"), UserMessageChunk)
+        ]
+        assert len(user_chunks) == 2
+        # First user chunk is the summary → flagged; second is a real turn → not.
+        assert user_chunks[0].field_meta == {"hermes": {"compactionSummary": True}}
+        assert user_chunks[1].field_meta is None
+
+    @pytest.mark.asyncio
     async def test_load_session_replays_native_plan_for_persisted_todo_tool(self, agent):
         """Persisted todo tool results should rebuild Zed's native plan panel."""
         mock_conn = MagicMock(spec=acp.Client)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3750,6 +3750,29 @@ class TestCodexAdapterPromptCacheKey:
         ])
         assert "prompt_cache_key" not in captured
 
+    def test_gpt55_sets_prompt_cache_retention(self):
+        adapter, captured = self._build_adapter(base_url="https://bedrock-mantle.us-east-1.api.aws/openai/v1")
+        adapter.create(messages=[
+            {"role": "system", "content": "SYS"},
+            {"role": "user", "content": "hi"},
+        ])
+        assert captured["prompt_cache_retention"] == "24h"
+
+    def test_prompt_cache_retention_skipped_for_xai_and_github_hosts(self):
+        adapter, captured = self._build_adapter(base_url="https://api.x.ai/v1")
+        adapter.create(messages=[
+            {"role": "system", "content": "SYS"},
+            {"role": "user", "content": "hi"},
+        ])
+        assert "prompt_cache_retention" not in captured
+
+        adapter, captured = self._build_adapter(base_url="https://api.githubcopilot.com")
+        adapter.create(messages=[
+            {"role": "system", "content": "SYS"},
+            {"role": "user", "content": "hi"},
+        ])
+        assert "prompt_cache_retention" not in captured
+
 
 class TestVisionAutoSkipsKimiCoding:
     """_resolve_auto vision branch skips providers that have no vision on

--- a/tests/agent/test_codex_stream_cumulative_dedup.py
+++ b/tests/agent/test_codex_stream_cumulative_dedup.py
@@ -1,0 +1,134 @@
+"""Tests for _consume_codex_event_stream cumulative message deduplication.
+
+Bedrock mantle emits cumulative ``response.output_item.done`` events where
+each ``message`` item is a prefix-superset of the prior.  Without
+deduplication the downstream normalizer concatenates them → quadratic text
+duplication.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agent.codex_runtime import _consume_codex_event_stream
+
+
+def _make_event(event_type: str, **fields) -> SimpleNamespace:
+    """Build a minimal SSE event-like object."""
+    return SimpleNamespace(type=event_type, **fields)
+
+
+def _make_message_item(text: str, *, item_type: str = "message") -> SimpleNamespace:
+    """Build a message output item with output_text content."""
+    return SimpleNamespace(
+        type=item_type,
+        role="assistant",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text=text)],
+    )
+
+
+class TestCumulativeMessageDedup:
+    """Bedrock mantle sends cumulative message snapshots — keep only the last."""
+
+    def test_single_message_preserved(self):
+        """Normal case: one message item passes through unchanged."""
+        events = [
+            _make_event("response.output_item.done", item=_make_message_item("hello")),
+            _make_event("response.completed", response=SimpleNamespace(
+                status="completed", usage=None, id="r1",
+            )),
+        ]
+        result = _consume_codex_event_stream(iter(events), model="test")
+        assert len(result.output) == 1
+        # output_text is from deltas (empty here); check output items directly.
+        assert result.output[0].content[0].text == "hello"
+
+    def test_cumulative_messages_collapsed_to_last(self):
+        """Multiple cumulative message items → only the last (longest) survives."""
+        events = [
+            _make_event("response.output_item.done", item=_make_message_item("ab")),
+            _make_event("response.output_item.done", item=_make_message_item("abcd")),
+            _make_event("response.output_item.done", item=_make_message_item("abcdef")),
+            _make_event("response.completed", response=SimpleNamespace(
+                status="completed", usage=None, id="r1",
+            )),
+        ]
+        result = _consume_codex_event_stream(iter(events), model="test")
+        assert len(result.output) == 1
+        assert result.output[0].content[0].text == "abcdef"
+
+    def test_function_call_items_preserved_alongside_message(self):
+        """function_call items are kept even when message items are deduped."""
+        fc_item = SimpleNamespace(type="function_call", name="tool", arguments="{}")
+        events = [
+            _make_event("response.output_item.done", item=_make_message_item("part1")),
+            _make_event("response.output_item.done", item=_make_message_item("part1part2")),
+            _make_event("response.output_item.done", item=fc_item),
+            _make_event("response.completed", response=SimpleNamespace(
+                status="completed", usage=None, id="r1",
+            )),
+        ]
+        result = _consume_codex_event_stream(iter(events), model="test")
+        assert len(result.output) == 2
+        # Message collapsed to last; function_call preserved.
+        assert result.output[0].type == "message"
+        assert result.output[0].content[0].text == "part1part2"
+        assert result.output[1].type == "function_call"
+
+    def test_message_after_function_call_kept_separately(self):
+        """A message item after a function_call block starts a new slot."""
+        fc_item = SimpleNamespace(type="function_call", name="tool", arguments="{}")
+        events = [
+            _make_event("response.output_item.done", item=_make_message_item("before")),
+            _make_event("response.output_item.done", item=fc_item),
+            _make_event("response.output_item.done", item=_make_message_item("after")),
+            _make_event("response.completed", response=SimpleNamespace(
+                status="completed", usage=None, id="r1",
+            )),
+        ]
+        result = _consume_codex_event_stream(iter(events), model="test")
+        assert len(result.output) == 3
+        assert result.output[0].content[0].text == "before"
+        assert result.output[1].type == "function_call"
+        assert result.output[2].content[0].text == "after"
+
+    def test_no_output_items_uses_text_delta_fallback(self):
+        """When no output_item.done arrives, text deltas are assembled."""
+        events = [
+            _make_event("response.output_text.delta", delta="hello "),
+            _make_event("response.output_text.delta", delta="world"),
+            _make_event("response.completed", response=SimpleNamespace(
+                status="completed", usage=None, id="r1",
+            )),
+        ]
+        result = _consume_codex_event_stream(iter(events), model="test")
+        assert result.output_text == "hello world"
+        assert len(result.output) == 1
+        assert result.output[0].content[0].text == "hello world"
+
+    def test_output_text_not_duplicated_by_cumulative_items(self):
+        """When cumulative message items are deduped, output_text must use
+        the final item's text — not the joined deltas (which contain every
+        prefix-superset, producing quadratic duplication)."""
+        # Simulate Bedrock mantle: 3 cumulative message items + matching deltas
+        msg_a = _make_message_item("Hello")
+        msg_ab = _make_message_item("Hello, world")
+        msg_abc = _make_message_item("Hello, world! How are you?")
+        events = [
+            _make_event("response.output_item.done", item=msg_a),
+            _make_event("response.output_text.delta", delta="Hello"),
+            _make_event("response.output_item.done", item=msg_ab),
+            _make_event("response.output_text.delta", delta=", world"),
+            _make_event("response.output_item.done", item=msg_abc),
+            _make_event("response.output_text.delta", delta="! How are you?"),
+            _make_event("response.completed", response=SimpleNamespace(
+                status="completed", usage=None, id="r1",
+            )),
+        ]
+        result = _consume_codex_event_stream(iter(events), model="test")
+        # output_items: only the last message kept
+        assert len(result.output) == 1
+        assert result.output[0].content[0].text == "Hello, world! How are you?"
+        # output_text: must match the deduped item, NOT "HelloHello, worldHello, world! How are you?"
+        assert result.output_text == "Hello, world! How are you?"

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -121,6 +121,26 @@ class TestCodexBuildKwargs:
         )
         assert "prompt_cache_key" not in kw
 
+    def test_gpt55_sets_prompt_cache_retention(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="openai.gpt-5.5", messages=messages, tools=[],
+            session_id="test-session",
+        )
+        assert kw["prompt_cache_retention"] == "24h"
+
+    def test_gpt55_prompt_cache_retention_skipped_for_known_incompatible_backends(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        assert "prompt_cache_retention" not in transport.build_kwargs(
+            model="gpt-5.5", messages=messages, tools=[], is_xai_responses=True
+        )
+        assert "prompt_cache_retention" not in transport.build_kwargs(
+            model="gpt-5.5", messages=messages, tools=[], is_github_responses=True
+        )
+        assert "prompt_cache_retention" not in transport.build_kwargs(
+            model="gpt-5.5", messages=messages, tools=[], is_codex_backend=True
+        )
+
     def test_xai_responses_sends_cache_key_via_extra_body(self, transport):
         """xAI's Responses API documents ``prompt_cache_key`` as the
         body-level cache-routing key (the ``x-grok-conv-id`` header is

--- a/tests/legacy_jobs/test_job_files.py
+++ b/tests/legacy_jobs/test_job_files.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import os
+import unittest
+
+from scripts.legacy_jobs import job_files
+
+
+class JobFilesTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = TemporaryDirectory()
+        self.repo = Path(self.tmp.name)
+        (self.repo / "jobs" / "team" / "foo").mkdir(parents=True)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_write_read_append_delete(self):
+        job_files.write_file("jobs/team/foo", "a.txt", b"one", repo_dir=self.repo)
+        job_files.write_file("jobs/team/foo", "a.txt", b"two", append=True, repo_dir=self.repo)
+        self.assertEqual(job_files.read_file("jobs/team/foo", "a.txt", self.repo), b"onetwo")
+        self.assertTrue(job_files.delete_file("jobs/team/foo", "a.txt", self.repo))
+        with self.assertRaises(job_files.JobFileError):
+            job_files.read_file("jobs/team/foo", "a.txt", self.repo)
+
+    def test_nested_relative_path_allowed(self):
+        path = job_files.write_file("jobs/team/foo", "nested/a.txt", b"x", repo_dir=self.repo)
+        self.assertTrue(path.exists())
+        self.assertIn(("nested/a.txt", 1, job_files.list_files("jobs/team/foo", self.repo)[0][2]), job_files.list_files("jobs/team/foo", self.repo))
+
+    def test_rejects_absolute_path(self):
+        with self.assertRaises(job_files.JobFileError):
+            job_files.resolve_data_path("jobs/team/foo", "/tmp/x", self.repo)
+
+    def test_rejects_parent_escape(self):
+        with self.assertRaises(job_files.JobFileError):
+            job_files.resolve_data_path("jobs/team/foo", "../x", self.repo)
+
+    def test_rejects_symlink_escape(self):
+        base = self.repo / "jobs" / "team" / "foo" / "data"
+        base.mkdir(parents=True)
+        outside = self.repo / "outside"
+        outside.mkdir()
+        (base / "link").symlink_to(outside)
+        with self.assertRaises(job_files.JobFileError):
+            job_files.resolve_data_path("jobs/team/foo", "link/x", self.repo)
+
+    def test_enforces_file_cap(self):
+        old = job_files.MAX_FILE_BYTES
+        try:
+            job_files.MAX_FILE_BYTES = 3
+            with self.assertRaises(job_files.JobFileError):
+                job_files.write_file("jobs/team/foo", "big.bin", b"1234", repo_dir=self.repo)
+        finally:
+            job_files.MAX_FILE_BYTES = old
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/legacy_jobs/test_job_state.py
+++ b/tests/legacy_jobs/test_job_state.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from scripts.legacy_jobs import job_state
+
+
+class JobStateTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = TemporaryDirectory()
+        self.repo = Path(self.tmp.name)
+        (self.repo / "jobs" / "team" / "foo").mkdir(parents=True)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_set_get_clear_state(self):
+        job_state.write_state("jobs/team/foo", "abc", self.repo)
+        self.assertEqual(job_state.read_state("jobs/team/foo", self.repo), "abc")
+        job_state.clear_state("jobs/team/foo", self.repo)
+        self.assertEqual(job_state.read_state("jobs/team/foo", self.repo), "")
+
+    def test_accepts_job_md_path(self):
+        path = self.repo / "jobs" / "team" / "foo" / "job.md"
+        path.write_text("---\nevery: 1m\n---\n")
+        self.assertEqual(job_state.state_file("jobs/team/foo/job.md", self.repo), path.parent / "state.txt")
+
+    def test_rejects_outside_jobs_path(self):
+        with self.assertRaises(job_state.JobPathError):
+            job_state.state_file("README.md", self.repo)
+
+    def test_truncates_to_8kb(self):
+        text = "a" * (job_state.MAX_STATE_BYTES + 10)
+        truncated = job_state.write_state("jobs/team/foo", text, self.repo)
+        self.assertTrue(truncated)
+        data = job_state.read_state("jobs/team/foo", self.repo).encode()
+        self.assertEqual(len(data), job_state.MAX_STATE_BYTES)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/legacy_jobs/test_scheduler_core.py
+++ b/tests/legacy_jobs/test_scheduler_core.py
@@ -1,0 +1,234 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import time
+import unittest
+from unittest import mock
+
+from scripts.legacy_jobs import scheduler
+
+
+class SchedulerDiscoveryTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = TemporaryDirectory()
+        self.repo = Path(self.tmp.name)
+        (self.repo / "jobs" / "team" / "a").mkdir(parents=True)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def write_job(self, rel, fm="every: 1m", body="body"):
+        path = self.repo / rel / "job.md"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"---\n{fm}\n---\n\n{body}\n")
+        return path
+
+    def test_discovers_job_md_at_any_depth(self):
+        self.write_job("jobs/team/nested/foo")
+        jobs, warnings = scheduler.discover_jobs(self.repo)
+        self.assertIn("jobs/team/nested/foo", jobs)
+        self.assertEqual(warnings, [])
+
+    def test_skips_deleted_archive(self):
+        self.write_job("jobs/_deleted/old")
+        jobs, _ = scheduler.discover_jobs(self.repo)
+        self.assertEqual(jobs, {})
+
+    def test_job_id_is_folder_path(self):
+        self.write_job("jobs/team/foo")
+        jobs, _ = scheduler.discover_jobs(self.repo)
+        self.assertEqual(jobs["jobs/team/foo"].job_id, "jobs/team/foo")
+
+    def test_defaults_post_mode_by_root(self):
+        self.write_job("jobs/team/foo")
+        self.write_job("jobs/slack/U123/foo")
+        jobs, _ = scheduler.discover_jobs(self.repo)
+        self.assertEqual(jobs["jobs/team/foo"].post_mode, "log")
+        self.assertEqual(jobs["jobs/slack/U123/foo"].post_mode, "dm")
+
+    def test_empty_or_bad_frontmatter_is_skipped_with_warning(self):
+        bad = self.repo / "jobs" / "team" / "bad" / "job.md"
+        bad.parent.mkdir(parents=True)
+        bad.write_text("no frontmatter")
+        jobs, warnings = scheduler.discover_jobs(self.repo)
+        self.assertEqual(jobs, {})
+        self.assertTrue(warnings)
+
+
+class SchedulerStateTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = TemporaryDirectory()
+        self.repo = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def spec(self, rel="jobs/team/foo", fm=None):
+        fm = fm or {"every": "1m", "jitter": False}
+        folder = self.repo / rel
+        folder.mkdir(parents=True, exist_ok=True)
+        return scheduler.LegacyJobSpec(rel, folder, folder / "job.md", fm, "body")
+
+    def test_seeds_next_run_for_every(self):
+        s = self.spec()
+        state, _ = scheduler.reconcile_state({}, {s.job_id: s}, 1000, self.repo)
+        self.assertEqual(state[s.job_id]["next_run"], 1060)
+
+    def test_seeds_next_run_for_cron(self):
+        s = self.spec(fm={"schedule": "0 9 * * *", "jitter": False})
+        state, _ = scheduler.reconcile_state({}, {s.job_id: s}, 1000, self.repo)
+        self.assertIsNotNone(state[s.job_id]["next_run"])
+
+    def test_paused_job_not_due(self):
+        s = self.spec(fm={"every": "1m", "paused": True})
+        self.assertTrue(scheduler.is_paused(s))
+
+    def test_expired_job_soft_deleted(self):
+        s = self.spec(fm={"every": "1m", "expires_at": "1970-01-01T00:00:01Z"})
+        state, jobs = scheduler.reconcile_state({}, {s.job_id: s}, 1000, self.repo)
+        self.assertEqual(state, {})
+        self.assertEqual(jobs, {})
+        self.assertTrue((self.repo / "jobs" / "_deleted").exists())
+
+    def test_nextrun_duration_consumed(self):
+        s = self.spec()
+        (s.folder / "nextrun.txt").write_text("4m")
+        state, _ = scheduler.reconcile_state({}, {s.job_id: s}, 1000, self.repo)
+        self.assertEqual(state[s.job_id]["next_run"], 1240)
+        self.assertFalse((s.folder / "nextrun.txt").exists())
+
+    def test_nextrun_epoch_consumed(self):
+        s = self.spec()
+        (s.folder / "nextrun.txt").write_text("2000000000")
+        state, _ = scheduler.reconcile_state({}, {s.job_id: s}, 1000, self.repo)
+        self.assertEqual(state[s.job_id]["next_run"], 2000000000)
+
+    def test_bad_nextrun_removed_and_ignored(self):
+        s = self.spec()
+        (s.folder / "nextrun.txt").write_text("bad")
+        state, _ = scheduler.reconcile_state({}, {s.job_id: s}, 1000, self.repo)
+        self.assertEqual(state[s.job_id]["next_run"], 1060)
+        self.assertFalse((s.folder / "nextrun.txt").exists())
+
+    def test_jitter_stable_per_job(self):
+        self.assertEqual(scheduler.stable_jitter("jobs/team/foo", 3600), scheduler.stable_jitter("jobs/team/foo", 3600))
+
+
+class SchedulerDeliveryTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = TemporaryDirectory()
+        self.repo = Path(self.tmp.name)
+        self.folder = self.repo / "jobs" / "team" / "foo"
+        self.folder.mkdir(parents=True)
+        self.spec = scheduler.LegacyJobSpec("jobs/team/foo", self.folder, self.folder / "job.md", {"post_mode": "log"}, "")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_log_delivery_appends_runs_log(self):
+        scheduler.deliver_output(self.spec, "hello", "ok")
+        self.assertIn("hello", (self.folder / "runs.log").read_text())
+
+    def test_unknown_post_mode_falls_back_to_log(self):
+        self.spec.frontmatter["post_mode"] = "weird"
+        scheduler.deliver_output(self.spec, "hello", "ok")
+        self.assertIn("hello", (self.folder / "runs.log").read_text())
+
+    def test_empty_output_still_logs_if_job_ran(self):
+        scheduler.deliver_output(self.spec, "", "ok")
+        self.assertIn("status=ok", (self.folder / "runs.log").read_text())
+
+
+class SchedulerCommandJobTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = TemporaryDirectory()
+        self.repo = Path(self.tmp.name)
+        self.folder = self.repo / "jobs" / "team" / "foo"
+        self.folder.mkdir(parents=True)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def make_spec(self, fm):
+        fm = {"type": "command", "post_mode": "log", **fm}
+        return scheduler.LegacyJobSpec("jobs/team/foo", self.folder, self.folder / "job.md", fm, "")
+
+    def log(self):
+        return (self.folder / "runs.log").read_text()
+
+    def test_command_job_success_logs_stdout(self):
+        status = scheduler.run_command_job(self.make_spec({"command": "printf ok"}), self.repo)
+        self.assertEqual(status, "ok")
+        self.assertIn("ok", self.log())
+
+    def test_command_job_uses_stderr_when_stdout_empty(self):
+        status = scheduler.run_command_job(self.make_spec({"command": "printf err >&2"}), self.repo)
+        self.assertEqual(status, "ok")
+        self.assertIn("err", self.log())
+
+    def test_command_job_nonzero_logs_error(self):
+        status = scheduler.run_command_job(self.make_spec({"command": "echo bad >&2; exit 2"}), self.repo)
+        self.assertEqual(status, "error")
+        self.assertIn("rc=2", self.log())
+
+    def test_script_job_runs_python_file(self):
+        script = self.repo / "hello.py"
+        script.write_text("print('script ok')")
+        status = scheduler.run_command_job(self.make_spec({"script": "hello.py"}), self.repo)
+        self.assertEqual(status, "ok")
+        self.assertIn("script ok", self.log())
+
+    def test_command_job_timeout_logs_timeout(self):
+        with mock.patch.object(scheduler, "JOB_TIMEOUT_SEC", 1):
+            status = scheduler.run_command_job(self.make_spec({"command": "sleep 2"}), self.repo)
+        self.assertEqual(status, "timeout")
+
+
+class SchedulerAgentJobTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = TemporaryDirectory()
+        self.repo = Path(self.tmp.name)
+        self.folder = self.repo / "jobs" / "team" / "foo"
+        self.folder.mkdir(parents=True)
+        self.spec = scheduler.LegacyJobSpec("jobs/team/foo", self.folder, self.folder / "job.md", {"post_mode": "log", "title": "T"}, "do work")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_agent_prompt_includes_runtime_envelope(self):
+        prompt = scheduler.build_agent_prompt(self.spec)
+        self.assertIn("Job path: jobs/team/foo", prompt)
+        self.assertIn("Job title: T", prompt)
+
+    def test_agent_prompt_includes_persisted_state(self):
+        (self.folder / "state.txt").write_text("old")
+        self.assertIn("old", scheduler.build_agent_prompt(self.spec))
+
+    def test_agent_job_success_logs_final_stdout(self):
+        fake = subprocess_result(0, "done", "")
+        with mock.patch.object(scheduler.subprocess, "run", return_value=fake):
+            status = scheduler.run_agent_job(self.spec, self.repo)
+        self.assertEqual(status, "ok")
+        self.assertIn("done", (self.folder / "runs.log").read_text())
+
+    def test_agent_job_nonzero_logs_error(self):
+        fake = subprocess_result(1, "", "boom")
+        with mock.patch.object(scheduler.subprocess, "run", return_value=fake):
+            status = scheduler.run_agent_job(self.spec, self.repo)
+        self.assertEqual(status, "error")
+        self.assertIn("boom", (self.folder / "runs.log").read_text())
+
+    def test_empty_body_is_skipped(self):
+        self.spec.body = ""
+        self.assertEqual(scheduler.run_agent_job(self.spec, self.repo), "empty-body")
+
+
+def subprocess_result(returncode, stdout, stderr):
+    cp = mock.Mock()
+    cp.returncode = returncode
+    cp.stdout = stdout
+    cp.stderr = stderr
+    return cp
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/legacy_jobs/test_scheduler_integration.py
+++ b/tests/legacy_jobs/test_scheduler_integration.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import json
+import unittest
+
+from scripts.legacy_jobs import hermes_tick
+
+
+class SchedulerIntegrationTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = TemporaryDirectory()
+        self.repo = Path(self.tmp.name)
+        folder = self.repo / "jobs" / "team" / "_smoke_command"
+        folder.mkdir(parents=True)
+        (self.repo / "bot").mkdir()
+        (folder / "job.md").write_text('''---
+title: "Legacy scheduler smoke command"
+type: command
+every: 1m
+post_mode: log
+jitter: false
+command: "printf 'legacy scheduler smoke ok'"
+---
+
+Command smoke job for the Hermes legacy scheduler port.
+''')
+        (self.repo / "bot" / "jobs_state.json").write_text(
+            '{"jobs/team/_smoke_command": {"next_run": 0, "last_run": null, "last_status": null}}'
+        )
+        self.folder = folder
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_scheduler_runs_log_only_command_job_end_to_end(self):
+        rc = hermes_tick.main(["--repo", str(self.repo), "--once"])
+        self.assertEqual(rc, 0)
+        self.assertIn("legacy scheduler smoke ok", (self.folder / "runs.log").read_text())
+        state = json.loads((self.repo / "bot" / "jobs_state.json").read_text())
+        self.assertEqual(state["jobs/team/_smoke_command"]["last_status"], "ok")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/legacy_jobs/test_scheduler_ops.py
+++ b/tests/legacy_jobs/test_scheduler_ops.py
@@ -1,0 +1,216 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+from unittest import mock
+
+from scripts.legacy_jobs import scheduler
+from scripts.legacy_jobs import hermes_tick
+from scripts.legacy_jobs import install_hermes_cron
+from scripts.legacy_jobs import schedule_job
+
+
+class SchedulerLockingTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = TemporaryDirectory()
+        self.repo = Path(self.tmp.name)
+        self.folder = self.repo / "jobs" / "team" / "foo"
+        self.folder.mkdir(parents=True)
+        self.spec = scheduler.LegacyJobSpec("jobs/team/foo", self.folder, self.folder / "job.md", {"type": "command", "command": "printf ok", "post_mode": "log"}, "")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_global_lock_causes_second_tick_to_exit_silent(self):
+        lock = self.repo / "bot" / "jobs_scheduler.lock"
+        lock.parent.mkdir(parents=True)
+        lock.write_text("held")
+        self.assertEqual(scheduler.tick(self.repo), [])
+
+    def test_stale_global_lock_is_recovered(self):
+        lock = self.repo / "bot" / "jobs_scheduler.lock"
+        lock.parent.mkdir(parents=True)
+        lock.write_text("stale")
+        old = 1000
+        import os
+        os.utime(lock, (old, old))
+        with mock.patch.object(scheduler, "LOCK_STALE_SEC", 1):
+            self.assertEqual(scheduler.tick(self.repo), [])
+        self.assertFalse(lock.exists())
+
+    def test_per_job_lock_prevents_duplicate_job(self):
+        (self.folder / ".lock").write_text("held")
+        self.assertEqual(scheduler.run_job(self.spec, self.repo), "in-flight")
+
+    def test_per_job_lock_cleared_after_success(self):
+        scheduler.run_job(self.spec, self.repo)
+        self.assertFalse((self.folder / ".lock").exists())
+
+    def test_per_job_lock_cleared_after_failure(self):
+        self.spec.frontmatter["command"] = "exit 2"
+        scheduler.run_job(self.spec, self.repo)
+        self.assertFalse((self.folder / ".lock").exists())
+
+
+class HermesTickTests(unittest.TestCase):
+    def test_wrapper_runs_two_ticks_by_default(self):
+        calls = []
+        with mock.patch.object(scheduler, "tick", side_effect=lambda repo: calls.append(repo) or []):
+            hermes_tick.run_ticks(Path('/tmp/repo'), sleep=lambda _: None)
+        self.assertEqual(len(calls), 2)
+
+    def test_wrapper_sleeps_between_ticks(self):
+        sleeps = []
+        with mock.patch.object(scheduler, "tick", return_value=[]):
+            hermes_tick.run_ticks(Path('/tmp/repo'), ticks=2, interval_sec=0.01, sleep=sleeps.append)
+        self.assertEqual(len(sleeps), 1)
+
+    def test_wrapper_once_runs_one_tick(self):
+        with mock.patch.object(hermes_tick, "run_ticks", return_value=[]) as run:
+            self.assertEqual(hermes_tick.main(["--repo", "/tmp/repo", "--once"]), 0)
+            self.assertEqual(run.call_args.args[1], 1)
+
+    def test_wrapper_silent_on_success(self):
+        with mock.patch.object(hermes_tick, "run_ticks", return_value=[]):
+            self.assertEqual(hermes_tick.main(["--repo", "/tmp/repo", "--once"]), 0)
+
+    def test_wrapper_alerts_on_scheduler_exception(self):
+        with mock.patch.object(hermes_tick, "run_ticks", side_effect=RuntimeError("boom")):
+            self.assertEqual(hermes_tick.main(["--repo", "/tmp/repo", "--once"]), 1)
+
+
+class InstallHermesCronTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = TemporaryDirectory()
+        self.home = Path(self.tmp.name) / "profile"
+        self.repo = Path(self.tmp.name) / "repo"
+        (self.repo / "scripts" / "legacy_jobs").mkdir(parents=True)
+        (self.repo / "scripts" / "legacy_jobs" / "hermes_tick.py").write_text("print('x')")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_dry_run_prints_expected_paths(self):
+        spec = install_hermes_cron.cron_spec(self.repo)
+        self.assertEqual(spec["script"], "legacy_jobs_tick.py")
+        self.assertTrue(spec["no_agent"])
+
+    def test_write_script_creates_profile_script(self):
+        target = install_hermes_cron.write_profile_script(self.home, self.repo)
+        self.assertTrue(target.exists())
+        self.assertIn("hermes_tick.py", target.read_text())
+
+    def test_does_not_create_cron_by_default(self):
+        self.assertEqual(install_hermes_cron.main(["--repo", str(self.repo), "--hermes-home", str(self.home)]), 0)
+        self.assertFalse((self.home / "cron" / "jobs.json").exists())
+
+
+class SlackDeliveryTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = TemporaryDirectory()
+        self.repo = Path(self.tmp.name)
+        self.folder = self.repo / "jobs" / "slack" / "U1" / "foo"
+        self.folder.mkdir(parents=True)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def spec(self, fm):
+        return scheduler.LegacyJobSpec("jobs/slack/U1/foo", self.folder, self.folder / "job.md", fm, "")
+
+    def test_dm_delivery_opens_conversation(self):
+        client = FakeSlack()
+        scheduler.deliver_output(self.spec({"post_mode": "dm", "created_by": "U1"}), "hi", slack_client=client)
+        self.assertEqual(client.opened, "U1")
+        self.assertEqual(client.messages[0]["channel"], "D1")
+
+    def test_new_message_delivery_posts_channel(self):
+        client = FakeSlack()
+        scheduler.deliver_output(self.spec({"post_mode": "new_message", "channel": "C1"}), "hi", slack_client=client)
+        self.assertEqual(client.messages[0]["channel"], "C1")
+
+    def test_thread_delivery_uses_thread_ts(self):
+        client = FakeSlack()
+        scheduler.deliver_output(self.spec({"post_mode": "thread", "channel": "C1", "thread_ts": "123.4"}), "hi", slack_client=client)
+        self.assertEqual(client.messages[0]["thread_ts"], "123.4")
+
+    def test_missing_token_falls_back_to_log(self):
+        scheduler.deliver_output(self.spec({"post_mode": "dm", "created_by": "U1"}), "hi")
+        self.assertIn("hi", (self.folder / "runs.log").read_text())
+
+    def test_slack_api_error_falls_back_to_log(self):
+        client = FakeSlack(fail=True)
+        scheduler.deliver_output(self.spec({"post_mode": "new_message", "channel": "C1"}), "hi", slack_client=client)
+        self.assertIn("hi", (self.folder / "runs.log").read_text())
+
+
+class FakeSlack:
+    def __init__(self, fail=False):
+        self.fail = fail
+        self.opened = None
+        self.messages = []
+
+    def conversations_open(self, users):
+        if self.fail:
+            raise RuntimeError("no")
+        self.opened = users
+        return {"channel": {"id": "D1"}}
+
+    def chat_postMessage(self, **kwargs):
+        if self.fail:
+            raise RuntimeError("no")
+        self.messages.append(kwargs)
+        return {"ok": True, "ts": "1.0"}
+
+
+class ScheduleJobTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = TemporaryDirectory()
+        self.repo = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_create_job_writes_job_md(self):
+        args = mock.Mock(slack_user="U1", slug="daily", title="Daily", schedule="0 9 * * *", every=None, channel=None, thread_ts=None, post_mode=None, expires_at=None)
+        path = schedule_job.create_job(args, "body", self.repo)
+        self.assertTrue(path.exists())
+
+    def test_create_infers_dm_post_mode_without_channel(self):
+        self.assertEqual(schedule_job.infer_post_mode(None, None, None), "dm")
+
+    def test_create_infers_new_message_with_channel(self):
+        self.assertEqual(schedule_job.infer_post_mode("C1", None, None), "new_message")
+
+    def test_create_infers_thread_with_channel_and_thread_ts(self):
+        self.assertEqual(schedule_job.infer_post_mode("C1", "1.0", None), "thread")
+
+    def test_list_jobs_tsv(self):
+        args = mock.Mock(slack_user="U1", slug="daily", title="Daily", schedule="0 9 * * *", every=None, channel=None, thread_ts=None, post_mode=None, expires_at=None)
+        schedule_job.create_job(args, "body", self.repo)
+        self.assertIn("daily\t0 9 * * *", schedule_job.list_jobs("U1", self.repo)[0])
+
+    def test_pause_resume_updates_frontmatter(self):
+        args = mock.Mock(slack_user="U1", slug="daily", title="Daily", schedule="0 9 * * *", every=None, channel=None, thread_ts=None, post_mode=None, expires_at=None)
+        schedule_job.create_job(args, "body", self.repo)
+        pause = mock.Mock(slack_user="U1", slug="daily", pause=True, resume=False, title=None, schedule=None, every=None, channel=None, thread_ts=None, post_mode=None, expires_at=None)
+        schedule_job.update_job(pause, None, self.repo)
+        fm, _ = schedule_job.read_job(self.repo / "jobs" / "slack" / "U1" / "daily" / "job.md")
+        self.assertTrue(fm["paused"])
+        resume = mock.Mock(slack_user="U1", slug="daily", pause=False, resume=True, title=None, schedule=None, every=None, channel=None, thread_ts=None, post_mode=None, expires_at=None)
+        schedule_job.update_job(resume, None, self.repo)
+        fm, _ = schedule_job.read_job(self.repo / "jobs" / "slack" / "U1" / "daily" / "job.md")
+        self.assertNotIn("paused", fm)
+
+    def test_delete_soft_deletes_folder(self):
+        args = mock.Mock(slack_user="U1", slug="daily", title="Daily", schedule="0 9 * * *", every=None, channel=None, thread_ts=None, post_mode=None, expires_at=None)
+        schedule_job.create_job(args, "body", self.repo)
+        dest = schedule_job.soft_delete(self.repo / "jobs" / "slack" / "U1" / "daily", self.repo)
+        self.assertTrue(dest.exists())
+
+    def test_rejects_path_traversal_slug(self):
+        with self.assertRaises(ValueError):
+            schedule_job.validate_slug("../bad")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8571,16 +8571,40 @@ def test_get_usage_reports_real_current_occupancy():
     assert usage["context_percent"] == 50
 
 
-def test_get_usage_clamps_post_compression_sentinel():
+def test_get_usage_reports_post_compression_rough_estimate():
     """Right after a compression, last_prompt_tokens is the -1 sentinel
-    (conversation_compression sets it until the next real usage report). It is
-    truthy, so `or 0` doesn't neutralize it — the guard must clamp <0 to 0 so
-    the transitional turn emits no gauge instead of leaking context_used=-1."""
+    (conversation_compression sets it until the next real usage report). The
+    transitional turn should expose the rough post-compression estimate so the
+    UI updates immediately, while flagging that value as estimated."""
     agent = types.SimpleNamespace(
         model="test-model",
         session_total_tokens=4_000_000,
         context_compressor=types.SimpleNamespace(
             last_prompt_tokens=-1,
+            last_compression_rough_tokens=131_072,
+            awaiting_real_usage_after_compression=True,
+            context_length=1_048_576,
+            compression_count=6,
+        ),
+    )
+    usage = server._get_usage(agent)
+    assert usage["context_used"] == 131_072
+    assert usage["context_max"] == 1_048_576
+    assert usage["context_percent"] == 12
+    assert usage["context_estimated"] is True
+
+
+def test_get_usage_omits_context_when_post_compression_estimate_missing():
+    """If the compressor has no rough estimate, keep the old safe behavior:
+    hide current occupancy rather than leaking the -1 sentinel or fabricating a
+    cumulative-total gauge."""
+    agent = types.SimpleNamespace(
+        model="test-model",
+        session_total_tokens=4_000_000,
+        context_compressor=types.SimpleNamespace(
+            last_prompt_tokens=-1,
+            last_compression_rough_tokens=0,
+            awaiting_real_usage_after_compression=True,
             context_length=1_048_576,
             compression_count=6,
         ),

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,137 @@
+# tools/
+
+Thin wrappers for capabilities that Hermes skills call.
+
+Initial rule: keep wrappers boring and auditable. Each wrapper should document whether it is read-only, gated write, or forbidden in the pilot.
+
+Planned wrappers:
+
+- `snowflake_query.py` - read-only warehouse queries.
+- `analytics_bias_check.py` - prints the required analytics bias checklist.
+- `chart.py` - generate analyst-ready PNG charts from query CSVs.
+- `fetch_schemas.py` - refresh read-only Snowflake DDL snapshots into `yallaplay-wiki/reference/warehouse/ddl/`.
+- `compile_wiki_skills.py` - compile wiki `## Agent quick context` sections into git-tracked Hermes skills and optional profile symlinks.
+- `appinsights_query.py` - read-only Azure Application Insights / Log Analytics KQL queries.
+- `wiki_search.py` - search `yallaplay-wiki/`.
+- `embrace_metrics.py` - read-only Embrace Metrics API PromQL queries.
+- `embrace_sessions.py` - read-only Embrace dashboard session lookup for per-user support/debugging.
+- `backend_config_snapshot.py` - read-only backend config snapshot/history refresh into `yallaplay-wiki/operations/backend-config/`.
+- `bedrock_models.py` - list available Bedrock model IDs by provider/region.
+- `repo_search.py` - repo and sibling source search helpers.
+- `slack_lookup.py` - read-only Slack lookup helpers.
+
+## Analytics
+
+`snowflake_query.py` is read-only by construction. It allows one `SELECT`, `WITH`, `SHOW`, `DESCRIBE`, or `EXPLAIN` statement and blocks DDL/DML keywords before connecting.
+
+Examples:
+
+```bash
+python3 tools/snowflake_query.py --dry-run "SELECT CURRENT_DATE() AS today"
+python3 tools/snowflake_query.py "SELECT CURRENT_DATE() AS today"
+python3 tools/snowflake_query.py -f queries/example.sql -o outputs/example.csv
+python3 tools/analytics_bias_check.py
+python3 tools/chart.py outputs/example.csv -t "Example" -o outputs/example.png
+python3 tools/fetch_schemas.py --dry-run
+python3 tools/compile_wiki_skills.py --list
+python3 tools/compile_wiki_skills.py --name season-pass-analytics \
+  --profile-symlink-root ~/.hermes/profiles/claudio-lab/skills/claudio-authored
+```
+
+Credential resolution stays outside git:
+
+1. Snowflake environment variables.
+2. `--vars`, `HERMES_SNOWFLAKE_VARS`, or `SNOWFLAKE_VARS_TOML` pointing to a private TOML file.
+3. Local untracked `vars.toml` in this repo.
+4. Sibling migration lab file `../yallaplay-analytics-agent-gpt/vars.toml` when present.
+
+Required TOML keys are compatible with the old Claudio analytics repo: `SNOWFLAKE_ACCOUNT`, `SNOWFLAKE_HOST`, `SNOWFLAKE_USER`, `SNOWFLAKE_PRIVATE_KEY`, `SNOWFLAKE_WAREHOUSE`, `SNOWFLAKE_DATABASE_PROD`, and `SNOWFLAKE_SCHEMA`.
+
+## App Insights
+
+`appinsights_query.py` is read-only by construction: it calls Azure Monitor's Log Analytics query API and blocks Kusto management commands (`.` commands). It defaults to `--env prod` because dev and prod write into the same workspace. Add `--real-players` (alias: `--exclude-pc`) for real-player analysis to drop internal/QA desktop clients.
+
+Examples:
+
+```bash
+python3 tools/appinsights_query.py --check-credentials
+python3 tools/appinsights_query.py --dry-run -q "AppRequests | summarize n=count()"
+python3 tools/appinsights_query.py --list-services
+python3 tools/appinsights_query.py --real-players --days 1 \
+  -q "AppRequests | summarize n=count(), errs=countif(Success == false) by OperationName"
+python3 tools/appinsights_query.py --service yallaplay-client-twin --days 7 \
+  -q "AppExceptions | summarize n=count() by ExceptionType | order by n desc" \
+  -o outputs/appinsights_twin_exceptions.csv
+```
+
+Credential resolution stays outside git:
+
+1. `AZURE_APPINSIGHTS_TENANT_ID`, `AZURE_APPINSIGHTS_CLIENT_ID`, `AZURE_APPINSIGHTS_CLIENT_SECRET`, and `AZURE_APPINSIGHTS_WORKSPACE_ID` environment variables.
+2. Private TOML via `--vars`, `HERMES_YALLAPLAY_VARS`, or `YALLAPLAY_VARS_TOML`.
+3. Local untracked `vars.toml` in this repo.
+4. Sibling migration lab file `../yallaplay-analytics-agent-gpt/vars.toml` when present.
+
+The workspace uses workspace-based tables such as `AppRequests`, `AppExceptions`, `AppTraces`, `AppDependencies`, and `Usage`; do not use classic component table names like `requests` or `exceptions`. `--dry-run` prints the final injected KQL without loading credentials or calling Azure.
+
+## Backend config
+
+`backend_config_snapshot.py` is read-only by construction: it only calls config-service GET endpoints and writes snapshots/history into the wiki. It stores the unwrapped config `response` as full-fidelity JSON and copies raw per-section history under `history/`.
+
+Examples:
+
+```bash
+python3 tools/backend_config_snapshot.py --app Spades --snapshot --timestamped-snapshot --dry-run
+python3 tools/backend_config_snapshot.py --app Spades --snapshot --history --sections flags,overrides,twinscripts
+python3 tools/backend_config_snapshot.py --app Spades --history --sections seasonpass --wiki-app spades
+python3 tools/backend_config_snapshot.py --app Spades --check-credentials
+```
+
+Credential resolution stays outside git:
+
+1. `BACKEND_CONFIG_BASE_URL` + `BACKEND_CONFIG_SERVER_TOKEN` environment variables.
+2. `YALLAPLAY_CONFIG_BASE_URL` + `YALLAPLAY_CONFIG_SERVER_TOKEN` environment variables.
+3. Private TOML via `--vars`, `HERMES_YALLAPLAY_VARS`, or `YALLAPLAY_VARS_TOML`.
+4. Local untracked `vars.toml` in this repo.
+5. Sibling migration lab file `../yallaplay-analytics-agent-gpt/vars.toml` when present.
+
+## Embrace
+
+Embrace has three access paths:
+
+- Native Hermes MCP server for aggregate crash/exception/network/span/log drilldowns: configure `https://mcp.embrace.io/mcp` in the active Hermes profile with the Embrace service-account `emb_sa_*` bearer token.
+- `embrace_metrics.py` for PromQL time-series from the Metrics API.
+- `embrace_sessions.py` for per-user dashboard session records; this is the scraper/API path MCP does not expose.
+
+Examples:
+
+```bash
+# Native MCP, once the service-account token is available in the profile env.
+# Hermes stores the header as Authorization: Bearer ${MCP_EMBRACE_API_KEY}.
+hermes mcp add embrace --url https://mcp.embrace.io/mcp --auth header
+
+python3 tools/embrace_metrics.py --list-apps
+python3 tools/embrace_metrics.py -q 'sum(daily_sessions_total{app_id="r5GWq"})'
+python3 tools/embrace_metrics.py --range --days 14 --step 1d \
+  -q 'sum(daily_sessions_total{app_id="r5GWq"})' -o outputs/embrace_spades_sessions.csv
+
+python3 tools/embrace_sessions.py --list-apps
+python3 tools/embrace_sessions.py --app spades_android --user 9822255144578 \
+  --around 2026-06-04T22:40:00Z --window 30
+python3 tools/embrace_sessions.py --app spades_android --resolution day --user 9822255144578
+```
+
+Credential resolution stays outside git:
+
+- Metrics API: `EMBRACE_METRICS_API_TOKEN` env var, or private TOML via `--vars`, `HERMES_YALLAPLAY_VARS`, `YALLAPLAY_VARS_TOML`, local untracked `vars.toml`, or sibling migration lab `../yallaplay-analytics-agent-gpt/vars.toml`.
+- Session scraper/API: `EMBRACE_DASH_EMAIL` and `EMBRACE_DASH_PASSWORD` via the same env/TOML resolution.
+- Session JWT cache: `.local/cache/.embrace_auth.json` (gitignored, chmod 600).
+
+Production app guard: both scripts are scoped to `spades_android`, `spades_ios`, `rummy_android`, and `rummy_ios` (`r5GWq`, `QkTz6`, `dmma2`, `s8kti`).
+
+`chart.py` expects CSVs in the same shape as the legacy analytics-agent tool:
+
+- 2 columns: bar chart (`label, value`).
+- 3 columns: grouped bar or line (`x, series, value`).
+- 4 columns: facet chart (`facet, x, series, value`).
+
+Multi-series charts should be long format, not wide one-column-per-series CSVs.

--- a/tools/analytics_bias_check.py
+++ b/tools/analytics_bias_check.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Print the analytics bias-trap checklist for result review."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+DEFAULT_CHECKLIST = Path(__file__).resolve().parents[1] / "yallaplay-wiki" / "reference" / "analytics_rules.md"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--file", type=Path, default=DEFAULT_CHECKLIST, help="checklist markdown path")
+    parser.add_argument("--section", default="Bias-trap checklist", help="heading text to print")
+    return parser.parse_args()
+
+
+def heading_level(line: str) -> int | None:
+    stripped = line.lstrip()
+    if not stripped.startswith("#"):
+        return None
+    return len(stripped) - len(stripped.lstrip("#"))
+
+
+def extract_section(text: str, section: str) -> str:
+    lines = text.splitlines()
+    start = None
+    level = None
+    needle = section.lower()
+    for index, line in enumerate(lines):
+        current_level = heading_level(line)
+        if current_level is None:
+            continue
+        title = line.lstrip("#").strip().lower()
+        if needle in title:
+            start = index
+            level = current_level
+            break
+    if start is None or level is None:
+        return text.strip()
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        current_level = heading_level(lines[index])
+        if current_level is not None and current_level <= level:
+            end = index
+            break
+    return "\n".join(lines[start:end]).strip()
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.file.exists():
+        raise SystemExit(f"Checklist not found: {args.file}")
+    print(extract_section(args.file.read_text(encoding="utf-8"), args.section))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/appinsights_query.py
+++ b/tools/appinsights_query.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Query Azure Application Insights / Log Analytics KQL for backend telemetry.
+
+Read-only. Credentials stay outside git.
+
+Credential resolution:
+1. AZURE_APPINSIGHTS_* environment variables.
+2. --vars / HERMES_YALLAPLAY_VARS / YALLAPLAY_VARS_TOML private TOML file.
+3. ./vars.toml if present locally and untracked.
+4. ../yallaplay-analytics-agent-gpt/vars.toml for migration labs.
+
+The shared workspace contains dev and prod telemetry. The wrapper defaults to
+--env prod and can inject a --real-players ClientType != 'PC' guard for mobile
+player-only analyses.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python <3.11
+    import tomli as tomllib  # type: ignore[no-redef]
+
+PROJECT_DIR = Path(__file__).resolve().parents[1]
+LOG_DIR = PROJECT_DIR / "logs"
+LOCAL_VARS = PROJECT_DIR / "vars.toml"
+DEFAULT_SIBLING_VARS = PROJECT_DIR.parent / "yallaplay-analytics-agent-gpt" / "vars.toml"
+
+# Verified in the legacy repo: the api.loganalytics.azure.com resource principal
+# is not registered in this tenant; keep scope and host paired.
+TOKEN_SCOPE = "https://api.loganalytics.io/.default"
+QUERY_HOST = "https://api.loganalytics.io"
+
+REQUIRED_KEYS = (
+    "AZURE_APPINSIGHTS_TENANT_ID",
+    "AZURE_APPINSIGHTS_CLIENT_ID",
+    "AZURE_APPINSIGHTS_CLIENT_SECRET",
+    "AZURE_APPINSIGHTS_WORKSPACE_ID",
+)
+
+LIST_SERVICES_KQL = (
+    "union AppRequests, AppDependencies, AppExceptions, AppTraces, AppMetrics{flt} "
+    "| summarize events=count() by _ResourceId "
+    "| order by events desc"
+)
+
+
+@dataclass(frozen=True)
+class AppInsightsConfig:
+    tenant_id: str
+    client_id: str
+    client_secret: str
+    workspace_id: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("-q", "--query", help="KQL query string")
+    parser.add_argument("--vars", type=Path, help="Private TOML file containing AZURE_APPINSIGHTS_* keys")
+    parser.add_argument(
+        "--env",
+        choices=["prod", "dev", "all"],
+        default="prod",
+        help="Inject Properties.Environment filter after the first table/union list (default: prod)",
+    )
+    parser.add_argument(
+        "--real-players",
+        "--exclude-pc",
+        dest="real_players",
+        action="store_true",
+        help="Inject ClientType != 'PC' to drop internal/QA desktop clients for player analyses",
+    )
+    parser.add_argument(
+        "--service",
+        help="Inject _ResourceId endswith '/<service>' filter, e.g. yallaplay-client-twin",
+    )
+    parser.add_argument("--list-services", action="store_true", help="List backend App Insights components seen in the window")
+    parser.add_argument("--days", type=float, default=1, help="Look back N days if --start is omitted (default 1)")
+    parser.add_argument("--start", help="Explicit window start, ISO-8601 or unix seconds")
+    parser.add_argument("--end", help="Explicit window end, ISO-8601 or unix seconds; default now")
+    parser.add_argument("-o", "--output", type=Path, help="Write CSV/raw output to this path")
+    parser.add_argument("--raw", action="store_true", help="Emit raw Log Analytics JSON instead of CSV")
+    parser.add_argument("--print-query", action="store_true", help="Print final KQL after guard injection before execution")
+    parser.add_argument("--dry-run", action="store_true", help="Build and log KQL without loading credentials or querying Azure")
+    parser.add_argument(
+        "--check-credentials",
+        action="store_true",
+        help="Report credential source and missing key names only; do not request a token or run KQL",
+    )
+    return parser.parse_args()
+
+
+def load_toml(path: Path) -> dict[str, Any]:
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def env_mapping() -> dict[str, Any] | None:
+    env = os.environ
+    if all(env.get(key) for key in REQUIRED_KEYS):
+        return dict(env)
+    return None
+
+
+def candidate_vars_paths(explicit: Path | None) -> list[Path]:
+    env = os.environ
+    candidates: list[Path | None] = [
+        explicit,
+        Path(env["HERMES_YALLAPLAY_VARS"]) if env.get("HERMES_YALLAPLAY_VARS") else None,
+        Path(env["YALLAPLAY_VARS_TOML"]) if env.get("YALLAPLAY_VARS_TOML") else None,
+        LOCAL_VARS if LOCAL_VARS.exists() else None,
+        DEFAULT_SIBLING_VARS if DEFAULT_SIBLING_VARS.exists() else None,
+    ]
+    return [path for path in candidates if path and path.exists()]
+
+
+def pick_config_source(vars_path: Path | None) -> tuple[str, dict[str, Any]]:
+    env = env_mapping()
+    if env is not None:
+        return "environment", env
+    for path in candidate_vars_paths(vars_path):
+        return str(path), load_toml(path)
+    raise SystemExit(
+        "No App Insights credential source found. Set AZURE_APPINSIGHTS_* env vars or pass --vars / "
+        "HERMES_YALLAPLAY_VARS pointing to a private TOML file."
+    )
+
+
+def missing_keys(mapping: dict[str, Any]) -> list[str]:
+    return [key for key in REQUIRED_KEYS if not mapping.get(key)]
+
+
+def config_from_mapping(mapping: dict[str, Any]) -> AppInsightsConfig:
+    missing = missing_keys(mapping)
+    if missing:
+        raise SystemExit(f"App Insights config missing: {', '.join(missing)}")
+    return AppInsightsConfig(
+        tenant_id=str(mapping["AZURE_APPINSIGHTS_TENANT_ID"]),
+        client_id=str(mapping["AZURE_APPINSIGHTS_CLIENT_ID"]),
+        client_secret=str(mapping["AZURE_APPINSIGHTS_CLIENT_SECRET"]),
+        workspace_id=str(mapping["AZURE_APPINSIGHTS_WORKSPACE_ID"]),
+    )
+
+
+def parse_time(value: str) -> str:
+    text = str(value).strip()
+    if text.replace(".", "", 1).isdigit():
+        return datetime.fromtimestamp(float(text), timezone.utc).isoformat()
+    try:
+        dt = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise SystemExit(f"Bad time {value!r}; use ISO-8601 or unix seconds") from exc
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.isoformat()
+
+
+def query_timespan(args: argparse.Namespace) -> str:
+    if args.start:
+        end = parse_time(args.end) if args.end else datetime.now(timezone.utc).isoformat()
+        return f"{parse_time(args.start)}/{end}"
+    if args.days <= 0:
+        raise SystemExit("--days must be positive")
+    if args.days < 1:
+        hours = max(1, int(round(args.days * 24)))
+        return f"PT{hours}H"
+    return f"P{int(args.days)}D" if float(args.days).is_integer() else f"PT{args.days * 24:g}H"
+
+
+def conditions_clause(conditions: list[str]) -> str:
+    return "".join(f" | where {condition}" for condition in conditions)
+
+
+def inject_filters(kql: str, conditions: list[str]) -> str:
+    if not conditions:
+        return kql
+    stripped = kql.lstrip()
+    index = 0
+    while index < len(stripped) and (stripped[index].isalnum() or stripped[index] == "_"):
+        index += 1
+    table = stripped[:index]
+    rest = stripped[index:]
+    if not table:
+        raise SystemExit("KQL must start with a table name when wrapper filters are injected")
+    return f"{table}{conditions_clause(conditions)}{rest}"
+
+
+def validate_kql(kql: str) -> str:
+    query = kql.strip()
+    if not query:
+        raise SystemExit("KQL query is empty")
+    if query.startswith("."):
+        raise SystemExit("KQL control commands are not allowed")
+    if re.search(r"\b(ingest|set-or-append|set-or-replace|drop|delete)\b", query, flags=re.IGNORECASE):
+        raise SystemExit("Potentially mutating KQL/control command text is blocked")
+    return query
+
+
+def build_conditions(args: argparse.Namespace) -> list[str]:
+    conditions: list[str] = []
+    if args.env != "all":
+        conditions.append(f"parse_json(Properties).Environment == '{args.env}'")
+    if args.real_players:
+        conditions.append("ClientType != 'PC'")
+    if args.service:
+        if not re.fullmatch(r"[A-Za-z0-9_.-]+", args.service):
+            raise SystemExit("--service must be an App Insights component name, e.g. yallaplay-client-twin")
+        conditions.append(f'_ResourceId endswith "/{args.service}"')
+    return conditions
+
+
+def build_kql(args: argparse.Namespace) -> str:
+    conditions = build_conditions(args)
+    if args.list_services:
+        return LIST_SERVICES_KQL.format(flt=conditions_clause(conditions))
+    if not args.query:
+        raise SystemExit("one of -q/--query or --list-services is required")
+    return inject_filters(validate_kql(args.query), conditions)
+
+
+def get_token(config: AppInsightsConfig) -> str:
+    url = f"https://login.microsoftonline.com/{config.tenant_id}/oauth2/v2.0/token"
+    data = urllib.parse.urlencode(
+        {
+            "grant_type": "client_credentials",
+            "client_id": config.client_id,
+            "client_secret": config.client_secret,
+            "scope": TOKEN_SCOPE,
+        }
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.load(response)["access_token"]
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise SystemExit(f"Token request failed: HTTP {exc.code}\n{body}") from exc
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"Token request failed: {exc}") from exc
+
+
+def run_query(config: AppInsightsConfig, token: str, kql: str, timespan: str) -> tuple[str, str]:
+    url = f"{QUERY_HOST}/v1/workspaces/{config.workspace_id}/query"
+    data = json.dumps({"query": kql, "timespan": timespan}).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": "yallaplay-hermes-agent/1.0",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=120) as response:
+            return url, response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        hint = ""
+        if exc.code == 403:
+            hint = "\n>>> 403 can mean Log Analytics Reader RBAC propagation lag or removed access."
+        raise SystemExit(f"HTTP {exc.code} for {url}\n{body}{hint}") from exc
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"Request failed for {url}: {exc}") from exc
+
+
+def log_call(url: str, kql: str, body: str, output_path: Path | None, dry_run: bool = False) -> Path:
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
+    path = LOG_DIR / f"{timestamp}-appinsights_query.txt"
+    path.write_text(
+        f"URL: {url}\nQuery: {kql}\nOutput: {output_path or '(stdout)'}\nBytes: {len(body)}\nDryRun: {dry_run}\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def table_to_rows(parsed: dict[str, Any]) -> tuple[list[str], list[list[Any]]]:
+    tables = parsed.get("tables", [])
+    if not tables:
+        return [], []
+    table = tables[0]
+    return [column["name"] for column in table.get("columns", [])], table.get("rows", [])
+
+
+def write_or_print_text(text: str, output: Path | None) -> None:
+    if output:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(text, encoding="utf-8")
+        print(f"written to {output}", file=sys.stderr)
+    else:
+        print(text, end="" if text.endswith("\n") else "\n")
+
+
+def write_or_print_csv(header: list[str], rows: list[list[Any]], output: Path | None) -> None:
+    if output:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        with output.open("w", newline="", encoding="utf-8") as handle:
+            writer = csv.writer(handle)
+            writer.writerow(header)
+            writer.writerows(rows)
+        print(f"{len(rows)} rows written to {output}", file=sys.stderr)
+    else:
+        writer = csv.writer(sys.stdout)
+        writer.writerow(header)
+        writer.writerows(rows)
+
+
+def emit_services(parsed: dict[str, Any], timespan: str, env: str) -> None:
+    header, rows = table_to_rows(parsed)
+    ridx = header.index("_ResourceId") if "_ResourceId" in header else 0
+    eidx = header.index("events") if "events" in header else 1
+    print(f"Backend services/components seen in {timespan} (env={env}):")
+    for row in rows:
+        resource = str(row[ridx] or "")
+        print(f"  {row[eidx]:>10}  {resource.split('/')[-1]}")
+
+
+def main() -> int:
+    args = parse_args()
+
+    if args.check_credentials:
+        source, mapping = pick_config_source(args.vars)
+        missing = missing_keys(mapping)
+        print(f"Credential source: {source}")
+        if missing:
+            print("Missing keys: " + ", ".join(missing))
+            return 1
+        print("Required App Insights keys: present")
+        print("No token requested and no KQL executed")
+        return 0
+
+    timespan = query_timespan(args)
+    kql = build_kql(args)
+
+    if args.print_query and not args.dry_run:
+        print(kql)
+
+    if args.dry_run:
+        log_path = log_call("(dry-run)", kql, "", args.output, dry_run=True)
+        print(f"Dry run OK; KQL was not executed. Query logged to {log_path}")
+        print(kql)
+        return 0
+
+    source, mapping = pick_config_source(args.vars)
+    config = config_from_mapping(mapping)
+    print(f"Using App Insights credential source: {source}", file=sys.stderr)
+    token = get_token(config)
+    url, body = run_query(config, token, kql, timespan)
+    log_call(url, kql, body, args.output)
+
+    parsed = json.loads(body)
+    if "tables" not in parsed:
+        raise SystemExit(f"Unexpected response: {json.dumps(parsed, indent=2)}")
+
+    if args.list_services:
+        emit_services(parsed, timespan, args.env)
+        return 0
+    if args.raw:
+        write_or_print_text(json.dumps(parsed, indent=2) + "\n", args.output)
+        return 0
+
+    header, rows = table_to_rows(parsed)
+    write_or_print_csv(header, rows, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/appinsights_query.py
+++ b/tools/appinsights_query.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import argparse
 import csv
 import json
-import os
 import re
 import sys
 import urllib.error
@@ -30,16 +29,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-try:
-    import tomllib
-except ModuleNotFoundError:  # pragma: no cover - Python <3.11
-    import tomli as tomllib  # type: ignore[no-redef]
+from secret_config import pick_mapping_source
 
 PROJECT_DIR = Path(__file__).resolve().parents[1]
 LOG_DIR = PROJECT_DIR / "logs"
-LOCAL_VARS = PROJECT_DIR / "vars.toml"
-DEFAULT_SIBLING_VARS = PROJECT_DIR.parent / "yallaplay-analytics-agent-gpt" / "vars.toml"
-
 # Verified in the legacy repo: the api.loganalytics.azure.com resource principal
 # is not registered in this tenant; keep scope and host paired.
 TOKEN_SCOPE = "https://api.loganalytics.io/.default"
@@ -104,39 +97,14 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_toml(path: Path) -> dict[str, Any]:
-    with path.open("rb") as handle:
-        return tomllib.load(handle)
-
-
-def env_mapping() -> dict[str, Any] | None:
-    env = os.environ
-    if all(env.get(key) for key in REQUIRED_KEYS):
-        return dict(env)
-    return None
-
-
-def candidate_vars_paths(explicit: Path | None) -> list[Path]:
-    env = os.environ
-    candidates: list[Path | None] = [
-        explicit,
-        Path(env["HERMES_YALLAPLAY_VARS"]) if env.get("HERMES_YALLAPLAY_VARS") else None,
-        Path(env["YALLAPLAY_VARS_TOML"]) if env.get("YALLAPLAY_VARS_TOML") else None,
-        LOCAL_VARS if LOCAL_VARS.exists() else None,
-        DEFAULT_SIBLING_VARS if DEFAULT_SIBLING_VARS.exists() else None,
-    ]
-    return [path for path in candidates if path and path.exists()]
-
-
 def pick_config_source(vars_path: Path | None) -> tuple[str, dict[str, Any]]:
-    env = env_mapping()
-    if env is not None:
-        return "environment", env
-    for path in candidate_vars_paths(vars_path):
-        return str(path), load_toml(path)
-    raise SystemExit(
-        "No App Insights credential source found. Set AZURE_APPINSIGHTS_* env vars or pass --vars / "
-        "HERMES_YALLAPLAY_VARS pointing to a private TOML file."
+    return pick_mapping_source(
+        vars_path,
+        env_required=REQUIRED_KEYS,
+        missing_message=(
+            "No App Insights credential source found. Set AZURE_APPINSIGHTS_* env vars or pass --vars / "
+            "HERMES_YALLAPLAY_VARS pointing to a private TOML file."
+        ),
     )
 
 

--- a/tools/backend_config_snapshot.py
+++ b/tools/backend_config_snapshot.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Refresh full backend-config snapshots and config-service history into the wiki.
+
+Read-only. Uses only GET endpoints:
+- GET /{App}/config
+- GET /{App}/config?at=<ISO>
+- GET /{App}/config/sections/{section}/history
+
+Credential resolution:
+1. BACKEND_CONFIG_BASE_URL + BACKEND_CONFIG_SERVER_TOKEN environment variables.
+2. YALLAPLAY_CONFIG_BASE_URL + YALLAPLAY_CONFIG_SERVER_TOKEN environment variables.
+3. --vars / HERMES_YALLAPLAY_VARS / YALLAPLAY_VARS_TOML private TOML file.
+4. ./vars.toml if present locally and untracked.
+5. ../yallaplay-analytics-agent-gpt/vars.toml for migration labs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python <3.11
+    import tomli as tomllib  # type: ignore[no-redef]
+
+PROJECT_DIR = Path(__file__).resolve().parents[1]
+WIKI_CONFIG_ROOT = PROJECT_DIR / "yallaplay-wiki" / "operations" / "backend-config"
+LOCAL_VARS = PROJECT_DIR / "vars.toml"
+DEFAULT_SIBLING_VARS = PROJECT_DIR.parent / "yallaplay-analytics-agent-gpt" / "vars.toml"
+BASE_URL_KEYS = ("BACKEND_CONFIG_BASE_URL", "YALLAPLAY_CONFIG_BASE_URL", "CONFIG_SERVICE_BASE_URL")
+TOKEN_KEYS = ("BACKEND_CONFIG_SERVER_TOKEN", "YALLAPLAY_CONFIG_SERVER_TOKEN", "CONFIG_SERVICE_SERVER_TOKEN", "X_SERVER_TOKEN")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--app", required=True, help="Exact config-service app identifier used in /{App}/config")
+    parser.add_argument("--wiki-app", help="Folder name under operations/backend-config/ (default: slugified --app)")
+    parser.add_argument("--env", default="prod", help="Environment label for filenames/docs (default: prod)")
+    parser.add_argument("--at", help="Point-in-time ISO timestamp for GET /{App}/config?at=<ISO>")
+    parser.add_argument("--vars", type=Path, help="Private TOML file containing config service URL/token")
+    parser.add_argument("--base-url", help="Override config service base URL; still requires token unless --dry-run")
+    parser.add_argument("--output-root", type=Path, default=WIKI_CONFIG_ROOT, help="Backend-config wiki root")
+    parser.add_argument("--snapshot", action="store_true", help="Fetch and write <env>.latest.json")
+    parser.add_argument(
+        "--timestamped-snapshot",
+        action="store_true",
+        help="Also write snapshots/<UTC>.json when fetching a snapshot",
+    )
+    parser.add_argument(
+        "--history",
+        action="store_true",
+        help="Fetch raw section history into history/<section>.json. Uses --sections or current config keys.",
+    )
+    parser.add_argument(
+        "--sections",
+        help="Comma-separated section names for --history. If omitted, sections come from the current config snapshot.",
+    )
+    parser.add_argument("--timeout", type=int, default=60, help="HTTP timeout seconds (default 60)")
+    parser.add_argument("--dry-run", action="store_true", help="Print planned URLs and files; do not load token or call service")
+    parser.add_argument("--check-credentials", action="store_true", help="Report credential source and missing key names only")
+    return parser.parse_args()
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", value.strip()).strip("-_.").lower()
+    if not slug:
+        raise SystemExit("Could not derive --wiki-app folder from --app; pass --wiki-app explicitly")
+    return slug
+
+
+def utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M%SZ")
+
+
+def load_toml(path: Path) -> dict[str, Any]:
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def candidate_vars_paths(explicit: Path | None) -> list[Path]:
+    env = os.environ
+    candidates: list[Path | None] = [
+        explicit,
+        Path(env["HERMES_YALLAPLAY_VARS"]) if env.get("HERMES_YALLAPLAY_VARS") else None,
+        Path(env["YALLAPLAY_VARS_TOML"]) if env.get("YALLAPLAY_VARS_TOML") else None,
+        LOCAL_VARS if LOCAL_VARS.exists() else None,
+        DEFAULT_SIBLING_VARS if DEFAULT_SIBLING_VARS.exists() else None,
+    ]
+    return [path for path in candidates if path and path.exists()]
+
+
+def first_value(mapping: dict[str, Any], keys: tuple[str, ...]) -> str | None:
+    for key in keys:
+        value = mapping.get(key)
+        if value:
+            return str(value)
+    return None
+
+
+def credential_source(vars_path: Path | None, base_url_override: str | None = None) -> tuple[str, str | None, str | None]:
+    env = dict(os.environ)
+    env_base = base_url_override or first_value(env, BASE_URL_KEYS)
+    env_token = first_value(env, TOKEN_KEYS)
+    if env_base or env_token:
+        return "environment/cli", env_base, env_token
+    for path in candidate_vars_paths(vars_path):
+        config = load_toml(path)
+        return str(path), first_value(config, BASE_URL_KEYS), first_value(config, TOKEN_KEYS)
+    return "none", base_url_override, None
+
+
+def require_credentials(args: argparse.Namespace) -> tuple[str, str, str]:
+    source, base_url, token = credential_source(args.vars, args.base_url)
+    missing: list[str] = []
+    if not base_url:
+        missing.append("one of " + "/".join(BASE_URL_KEYS))
+    if not token:
+        missing.append("one of " + "/".join(TOKEN_KEYS))
+    if missing:
+        raise SystemExit(f"Config service credentials missing from {source}: {', '.join(missing)}")
+    assert base_url is not None
+    assert token is not None
+    return source, base_url.rstrip("/"), token
+
+
+def config_url(base_url: str, app: str, at: str | None = None) -> str:
+    path = f"/{urllib.parse.quote(app, safe='')}/config"
+    url = base_url.rstrip("/") + path
+    if at:
+        url += "?" + urllib.parse.urlencode({"at": at})
+    return url
+
+
+def history_url(base_url: str, app: str, section: str) -> str:
+    app_q = urllib.parse.quote(app, safe="")
+    section_q = urllib.parse.quote(section, safe="")
+    return f"{base_url.rstrip('/')}/{app_q}/config/sections/{section_q}/history"
+
+
+def get_json(url: str, token: str, timeout: int) -> Any:
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": "yallaplay-hermes-agent/1.0",
+        "X-Server-Token": token,
+    }
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            body = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise SystemExit(f"HTTP {exc.code} from {url}: {detail[:500]}") from exc
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"Failed to fetch {url}: {exc}") from exc
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Response from {url} was not JSON: {body[:500]}") from exc
+
+
+def unwrap_config(payload: Any) -> Any:
+    if isinstance(payload, dict) and "response" in payload and set(payload.keys()) & {"success", "error"}:
+        return payload["response"]
+    return payload
+
+
+def dump_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False) + "\n")
+
+
+def ensure_app_scaffold(app_dir: Path, app: str, env: str) -> None:
+    app_dir.mkdir(parents=True, exist_ok=True)
+    (app_dir / "snapshots").mkdir(exist_ok=True)
+    (app_dir / "history").mkdir(exist_ok=True)
+    changes = app_dir / "changes.md"
+    if not changes.exists():
+        changes.write_text(
+            f"---\ntitle: Backend Config Change Ledger — {app}\ndomain: operations\nstatus: live\n"
+            "source_refs: []\nsee_also: [README.md, ../index.md, ../../../journal/config/index.md]\n"
+            f"built: {datetime.now(timezone.utc).date().isoformat()}\n---\n\n"
+            f"# Backend Config Change Ledger — {app}\n\n"
+            "Append one entry per observed prod config change. Raw config-service section history is copied under `history/`.\n",
+        )
+    readme = app_dir / "README.md"
+    if not readme.exists():
+        readme.write_text(
+            f"---\ntitle: Backend Config — {app}\ndomain: operations\nstatus: live\n"
+            "source_refs: []\nsee_also: [../index.md, changes.md]\n"
+            f"built: {datetime.now(timezone.utc).date().isoformat()}\n---\n\n"
+            f"# Backend Config — {app}\n\n"
+            f"- Config-service app id: `{app}`\n"
+            f"- Environment tracked here: `{env}`\n"
+            "- Source of truth: config service\n"
+            f"- Latest snapshot: [{env}.latest.json]({env}.latest.json)\n"
+            "- Change ledger: [changes.md](changes.md)\n"
+            "- Raw section history: `history/<section>.json`\n",
+        )
+
+
+def sections_from_args(raw: str | None, config: Any) -> list[str]:
+    if raw:
+        return sorted({section.strip() for section in raw.split(",") if section.strip()})
+    if isinstance(config, dict):
+        return sorted(str(key) for key in config.keys())
+    raise SystemExit("--history without --sections requires --snapshot/current config that unwraps to an object")
+
+
+def print_plan(args: argparse.Namespace) -> None:
+    app_slug = args.wiki_app or slugify(args.app)
+    app_dir = args.output_root / app_slug
+    base_url = (args.base_url or "${BACKEND_CONFIG_BASE_URL}").rstrip("/")
+    print(f"app_dir={app_dir}")
+    if args.snapshot:
+        print(f"GET {config_url(base_url, args.app, args.at)} -> {app_dir / (args.env + '.latest.json')}")
+        if args.timestamped_snapshot:
+            print(f"also -> {app_dir / 'snapshots' / '<UTC>.json'}")
+    if args.history:
+        sections = [s.strip() for s in args.sections.split(",")] if args.sections else ["<sections from config keys>"]
+        for section in sections:
+            print(f"GET {history_url(base_url, args.app, section)} -> {app_dir / 'history' / (section + '.json')}")
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.snapshot and not args.history and not args.check_credentials and not args.dry_run:
+        raise SystemExit("Choose --snapshot, --history, --check-credentials, or --dry-run")
+    if args.check_credentials:
+        source, base_url, token = credential_source(args.vars, args.base_url)
+        missing = []
+        if not base_url:
+            missing.append("base_url")
+        if not token:
+            missing.append("server_token")
+        print(json.dumps({"source": source, "base_url_present": bool(base_url), "token_present": bool(token), "missing": missing}, indent=2))
+        return 0 if not missing else 2
+    if args.dry_run:
+        print_plan(args)
+        return 0
+
+    _, base_url, token = require_credentials(args)
+    app_slug = args.wiki_app or slugify(args.app)
+    app_dir = args.output_root / app_slug
+    ensure_app_scaffold(app_dir, args.app, args.env)
+
+    stamp = utc_stamp()
+    config: Any | None = None
+    written: list[str] = []
+    if args.snapshot or (args.history and not args.sections):
+        payload = get_json(config_url(base_url, args.app, args.at), token, args.timeout)
+        config = unwrap_config(payload)
+        if args.snapshot:
+            latest_path = app_dir / f"{args.env}.latest.json"
+            dump_json(latest_path, config)
+            written.append(str(latest_path))
+            if args.timestamped_snapshot:
+                snapshot_path = app_dir / "snapshots" / f"{stamp}.json"
+                dump_json(snapshot_path, config)
+                written.append(str(snapshot_path))
+
+    if args.history:
+        sections = sections_from_args(args.sections, config)
+        for section in sections:
+            payload = get_json(history_url(base_url, args.app, section), token, args.timeout)
+            history_payload = {
+                "fetched_at": datetime.now(timezone.utc).isoformat(),
+                "app": args.app,
+                "environment": args.env,
+                "section": section,
+                "source": history_url(base_url, args.app, section),
+                "response": payload,
+            }
+            path = app_dir / "history" / f"{slugify(section)}.json"
+            dump_json(path, history_payload)
+            written.append(str(path))
+
+    print(json.dumps({"written": written}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/backend_config_snapshot.py
+++ b/tools/backend_config_snapshot.py
@@ -28,15 +28,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-try:
-    import tomllib
-except ModuleNotFoundError:  # pragma: no cover - Python <3.11
-    import tomli as tomllib  # type: ignore[no-redef]
+from secret_config import candidate_vars_paths, first_value, load_toml
 
 PROJECT_DIR = Path(__file__).resolve().parents[1]
 WIKI_CONFIG_ROOT = PROJECT_DIR / "yallaplay-wiki" / "operations" / "backend-config"
-LOCAL_VARS = PROJECT_DIR / "vars.toml"
-DEFAULT_SIBLING_VARS = PROJECT_DIR.parent / "yallaplay-analytics-agent-gpt" / "vars.toml"
 BASE_URL_KEYS = ("BACKEND_CONFIG_BASE_URL", "YALLAPLAY_CONFIG_BASE_URL", "CONFIG_SERVICE_BASE_URL")
 TOKEN_KEYS = ("BACKEND_CONFIG_SERVER_TOKEN", "YALLAPLAY_CONFIG_SERVER_TOKEN", "CONFIG_SERVICE_SERVER_TOKEN", "X_SERVER_TOKEN")
 
@@ -80,31 +75,6 @@ def slugify(value: str) -> str:
 
 def utc_stamp() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M%SZ")
-
-
-def load_toml(path: Path) -> dict[str, Any]:
-    with path.open("rb") as handle:
-        return tomllib.load(handle)
-
-
-def candidate_vars_paths(explicit: Path | None) -> list[Path]:
-    env = os.environ
-    candidates: list[Path | None] = [
-        explicit,
-        Path(env["HERMES_YALLAPLAY_VARS"]) if env.get("HERMES_YALLAPLAY_VARS") else None,
-        Path(env["YALLAPLAY_VARS_TOML"]) if env.get("YALLAPLAY_VARS_TOML") else None,
-        LOCAL_VARS if LOCAL_VARS.exists() else None,
-        DEFAULT_SIBLING_VARS if DEFAULT_SIBLING_VARS.exists() else None,
-    ]
-    return [path for path in candidates if path and path.exists()]
-
-
-def first_value(mapping: dict[str, Any], keys: tuple[str, ...]) -> str | None:
-    for key in keys:
-        value = mapping.get(key)
-        if value:
-            return str(value)
-    return None
 
 
 def credential_source(vars_path: Path | None, base_url_override: str | None = None) -> tuple[str, str | None, str | None]:

--- a/tools/basic_auth_proxy.py
+++ b/tools/basic_auth_proxy.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Tiny localhost Basic Auth reverse proxy for the Hermes dashboard."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hmac
+import http.client
+import os
+import secrets
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlsplit
+
+
+HOP_BY_HOP_HEADERS = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--listen-host", default="127.0.0.1")
+    parser.add_argument("--listen-port", type=int, default=9120)
+    parser.add_argument("--target", default="http://127.0.0.1:9119")
+    parser.add_argument("--user", default=os.environ.get("HERMES_PROXY_USER", "claudio"))
+    parser.add_argument("--password", default=os.environ.get("HERMES_PROXY_PASSWORD"))
+    return parser.parse_args()
+
+
+class ProxyHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    target = "http://127.0.0.1:9119"
+    expected_auth = ""
+    session_cookie = ""
+
+    def do_GET(self) -> None:
+        self._proxy()
+
+    def do_POST(self) -> None:
+        self._proxy()
+
+    def do_PUT(self) -> None:
+        self._proxy()
+
+    def do_PATCH(self) -> None:
+        self._proxy()
+
+    def do_DELETE(self) -> None:
+        self._proxy()
+
+    def do_OPTIONS(self) -> None:
+        self._proxy()
+
+    def _authorized(self) -> bool:
+        auth_header = self.headers.get("Authorization", "")
+        if hmac.compare_digest(auth_header, self.expected_auth):
+            return True
+        cookie_header = self.headers.get("Cookie", "")
+        cookies = [part.strip() for part in cookie_header.split(";")]
+        return any(hmac.compare_digest(cookie, self.session_cookie) for cookie in cookies)
+
+    def _reject(self) -> None:
+        body = b"Authentication required\n"
+        self.send_response(401)
+        self.send_header("WWW-Authenticate", 'Basic realm="Hermes Dashboard"')
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _proxy(self) -> None:
+        if not self._authorized():
+            self._reject()
+            return
+        fresh_basic_auth = hmac.compare_digest(self.headers.get("Authorization", ""), self.expected_auth)
+
+        target = urlsplit(self.target)
+        path = self.path
+        body_length = int(self.headers.get("Content-Length") or 0)
+        body = self.rfile.read(body_length) if body_length else None
+
+        headers = {
+            key: value
+            for key, value in self.headers.items()
+            if key.lower() not in HOP_BY_HOP_HEADERS and key.lower() != "authorization"
+        }
+        headers["Host"] = target.netloc
+        headers["X-Forwarded-Proto"] = "https"
+        headers["X-Forwarded-Host"] = self.headers.get("Host", target.netloc)
+
+        conn = http.client.HTTPConnection(target.hostname, target.port or 80, timeout=120)
+        try:
+            conn.request(self.command, path, body=body, headers=headers)
+            response = conn.getresponse()
+            data = response.read()
+        finally:
+            conn.close()
+
+        self.send_response(response.status, response.reason)
+        for key, value in response.getheaders():
+            if key.lower() in HOP_BY_HOP_HEADERS:
+                continue
+            if key.lower() == "content-length":
+                continue
+            self.send_header(key, value)
+        if fresh_basic_auth:
+            self.send_header(
+                "Set-Cookie",
+                f"{self.session_cookie}; HttpOnly; Secure; SameSite=Lax; Path=/",
+            )
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def log_message(self, format: str, *args: object) -> None:
+        print(f"{self.address_string()} - {format % args}")
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.password:
+        raise SystemExit("Set HERMES_PROXY_PASSWORD or pass --password")
+    token = base64.b64encode(f"{args.user}:{args.password}".encode()).decode()
+    ProxyHandler.target = args.target.rstrip("/")
+    ProxyHandler.expected_auth = f"Basic {token}"
+    ProxyHandler.session_cookie = f"hermes_proxy_session={secrets.token_urlsafe(32)}"
+    server = ThreadingHTTPServer((args.listen_host, args.listen_port), ProxyHandler)
+    print(f"Basic Auth proxy listening on http://{args.listen_host}:{args.listen_port} -> {ProxyHandler.target}", flush=True)
+    server.serve_forever()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/chart.py
+++ b/tools/chart.py
@@ -1,0 +1,591 @@
+import argparse
+import csv
+import math
+import os
+import re
+import sys
+from datetime import datetime
+
+import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
+from matplotlib.ticker import FuncFormatter
+
+
+STYLE = {
+    "figure.figsize": (11, 5.5),
+    "figure.dpi": 150,
+    "savefig.dpi": 150,
+    "savefig.bbox": "tight",
+    "axes.titlesize": 14,
+    "axes.titleweight": "bold",
+    "axes.labelsize": 11,
+    "axes.spines.top": False,
+    "axes.spines.right": False,
+    "axes.grid": True,
+    "axes.axisbelow": True,
+    "grid.color": "#e5e5e5",
+    "grid.linewidth": 0.8,
+    "xtick.labelsize": 10,
+    "ytick.labelsize": 10,
+    "legend.fontsize": 10,
+    "legend.frameon": False,
+    "lines.linewidth": 2.0,
+    "lines.markersize": 5,
+}
+
+PALETTE = [
+    "#2E86AB", "#E63946", "#06A77D", "#F4A261", "#6A4C93",
+    "#FF6B9D", "#118AB2", "#EF476F", "#06D6A0", "#FFD166",
+]
+
+
+def read_csv(path):
+    with open(path) as f:
+        reader = csv.reader(f)
+        headers = next(reader)
+        rows = list(reader)
+    return headers, rows
+
+
+def try_parse_date(value):
+    for fmt in ("%Y-%m-%d", "%Y-%m-%d %H:%M:%S"):
+        try:
+            return datetime.strptime(value, fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+def detect_chart_type(headers):
+    if len(headers) == 2:
+        return "bar"
+    if len(headers) == 3:
+        return "grouped_bar"
+    return "facet"
+
+
+def _is_numeric(value):
+    if value is None or value == "":
+        return False
+    try:
+        float(value)
+        return True
+    except ValueError:
+        return False
+
+
+def detect_wide_format(headers, rows):
+    """Wide = one column per series, one row per x.
+
+    Signature: 3+ columns, every column after the first is fully numeric on
+    every row, AND the first column has no duplicates. Long format has
+    duplicate x values (one row per (x, series)), so uniqueness of col 0 is
+    the distinguishing tell.
+    """
+    if len(headers) < 3 or not rows:
+        return False
+    for row in rows:
+        for v in row[1:]:
+            if not _is_numeric(v):
+                return False
+    first_col = [row[0] for row in rows]
+    return len(first_col) == len(set(first_col))
+
+
+def wide_format_error(headers, input_path):
+    x_col = headers[0]
+    series_cols = headers[1:]
+    series_list = ", ".join(series_cols)
+    union_lines = "\n".join(
+        f"SELECT {x_col}, '{s}' AS series, {s} AS value FROM <source>"
+        + (" UNION ALL" if i < len(series_cols) - 1 else "")
+        for i, s in enumerate(series_cols)
+    )
+    return (
+        f"ERROR: {input_path} appears to be in WIDE format "
+        f"(x='{x_col}', series columns={series_list}).\n"
+        f"chart.py requires LONG format for multi-series charts — one row per (x, series, value).\n"
+        f"If this CSV is rendered as-is, col 2 ('{series_cols[0]}') becomes the 'group' label and "
+        f"every value becomes a distinct legend entry, producing an exploded legend.\n"
+        f"\n"
+        f"Reshape the source query to long format, e.g.:\n"
+        f"{union_lines}\n"
+        f"ORDER BY {x_col}, series;\n"
+        f"\n"
+        f"Or use UNPIVOT:\n"
+        f"SELECT * FROM <wide_source> UNPIVOT (value FOR series IN ({series_list}));\n"
+        f"\n"
+        f"See yallaplay-wiki/reference/analytics_rules.md and the analytics skill output rules.\n"
+        f"To override this check (e.g. facet chart with intentional wide shape), pass --allow-wide."
+    )
+
+
+def drop_null_rows(headers, rows, numeric_col_indexes):
+    """Return (clean_rows, dropped_rows) where any numeric column is null/empty."""
+    clean, dropped = [], []
+    for i, row in enumerate(rows, start=2):  # start=2 so index matches 1-based CSV line (header=1)
+        if any(row[j] is None or row[j] == "" for j in numeric_col_indexes):
+            dropped.append(i)
+        else:
+            clean.append(row)
+    return clean, dropped
+
+
+def find_null_cells(headers, rows, numeric_col_indexes):
+    """Return list of (row_idx_1based_line, col_name) for the first few nulls."""
+    hits = []
+    for i, row in enumerate(rows, start=2):
+        for j in numeric_col_indexes:
+            if row[j] is None or row[j] == "":
+                hits.append((i, headers[j]))
+                if len(hits) >= 3:
+                    return hits
+    return hits
+
+
+def validate_data(headers, rows, chart_type, value_format, input_path, allow_nulls):
+    """Run hard guardrails. Prints ERROR + exits 2 on violation, else returns cleaned rows."""
+    # Determine which columns carry numeric values for this chart type.
+    if chart_type == "bar":
+        numeric_cols = [1]
+    elif chart_type in ("grouped_bar", "line", "heatmap"):
+        numeric_cols = [2]
+    elif chart_type == "facet":
+        numeric_cols = [3] if len(headers) >= 4 else [2]
+    else:
+        numeric_cols = [len(headers) - 1]
+
+    # 1. NULL / empty values in numeric cells.
+    null_hits = find_null_cells(headers, rows, numeric_cols)
+    if null_hits:
+        if allow_nulls:
+            rows, dropped = drop_null_rows(headers, rows, numeric_cols)
+            print(
+                f"warning: dropped {len(dropped)} row(s) with null/empty numeric cells "
+                f"(lines {dropped[:5]}{'...' if len(dropped) > 5 else ''})",
+                file=sys.stderr,
+            )
+        else:
+            samples = ", ".join(f"line {ln} col '{col}'" for ln, col in null_hits)
+            print(
+                f"ERROR: {input_path} has null/empty numeric cells ({samples}).\n"
+                f"Fix the source query: drop the rows with WHERE IS NOT NULL, "
+                f"or impute via COALESCE(col, 0). Do not leave nulls implicit.\n"
+                f"To skip null rows and proceed with a warning, pass --allow-nulls.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
+    # Need at least one row after null-drop.
+    if not rows:
+        print(f"ERROR: {input_path} has no data rows after validation.", file=sys.stderr)
+        sys.exit(2)
+
+    # 2. Minimum-row guards per chart type.
+    min_needed = 2
+    if chart_type == "bar" and len(rows) < min_needed:
+        print(
+            f"ERROR: bar chart needs at least {min_needed} rows, got {len(rows)}. "
+            f"Nothing to compare.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    if chart_type in ("grouped_bar", "line"):
+        distinct_x = len({row[0] for row in rows})
+        if distinct_x < 2:
+            print(
+                f"ERROR: {chart_type} needs at least 2 distinct values of '{headers[0]}', "
+                f"got {distinct_x}. Nothing to compare across x.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
+    # 3. Percent-format out of range. Catches forgot-to-multiply-by-100 and mis-counted rates.
+    if value_format == "pct":
+        bad_range = []
+        all_vals = []
+        for i, row in enumerate(rows, start=2):
+            for j in numeric_cols:
+                try:
+                    v = float(row[j])
+                except (ValueError, TypeError):
+                    continue
+                all_vals.append(v)
+                if v < -5 or v > 105:
+                    bad_range.append((i, headers[j], v))
+        if bad_range:
+            samples = "; ".join(f"line {ln} '{col}'={v}" for ln, col, v in bad_range[:3])
+            print(
+                f"ERROR: column inferred as percent ('{headers[numeric_cols[0]]}') has values outside [0, 100] "
+                f"({samples}).\n"
+                f"Likely cause: values are not scaled percentages, or a miscount.\n"
+                f"Multiply by 100 in SQL (e.g. 100.0 * retained / cohort_size), or pass --format num "
+                f"if this is not a percent.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        # Decimals-not-scaled heuristic: all values in [0, 1] and at least one strictly >0
+        # is almost certainly unscaled (e.g. 0.28 meant as 28%). A real 100%-bounded percent
+        # series will have at least one value >= 1 in practice.
+        if all_vals and all(0 <= v <= 1 for v in all_vals) and any(v > 0 for v in all_vals):
+            max_v = max(all_vals)
+            print(
+                f"ERROR: column inferred as percent ('{headers[numeric_cols[0]]}') has all values in [0, 1] "
+                f"(max={max_v}).\n"
+                f"Looks like decimals that weren't scaled — a percent should be in the 0–100 range.\n"
+                f"Multiply by 100 in SQL (e.g. 100.0 * retained / cohort_size), or pass --format num "
+                f"if this is really meant as a unitless fraction.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
+    # 4. Too many categories on grouped_bar.
+    if chart_type == "grouped_bar":
+        distinct_groups = len({row[1] for row in rows})
+        if distinct_groups > 12:
+            print(
+                f"ERROR: grouped_bar has {distinct_groups} distinct values of '{headers[1]}' "
+                f"(max 12 for readability). Aggregate smaller groups into 'other' in SQL, "
+                f"or use --type facet to split into sub-plots.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
+    return rows
+
+
+def title_from_path(path):
+    base = os.path.splitext(os.path.basename(path))[0]
+    base = re.sub(r"^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-?", "", base)
+    base = base.replace("_", " ").replace("-", " ")
+    return " ".join(w.capitalize() for w in base.split())
+
+
+def format_value(v, value_format):
+    if value_format == "pct":
+        return f"{v:.1f}%"
+    if value_format == "int":
+        return f"{int(v):,}"
+    if abs(v) >= 1000:
+        return f"{v:,.0f}"
+    if abs(v) >= 10:
+        return f"{v:.1f}"
+    return f"{v:.2f}"
+
+
+def axis_formatter(value_format):
+    if value_format == "pct":
+        return FuncFormatter(lambda v, _: f"{v:.0f}%")
+    if value_format == "int":
+        return FuncFormatter(lambda v, _: f"{int(v):,}")
+    return FuncFormatter(lambda v, _: f"{v:,.0f}" if abs(v) >= 1000 else f"{v:g}")
+
+
+def sort_rows(rows, by_value, descending=True):
+    if not by_value:
+        return rows
+    try:
+        return sorted(rows, key=lambda r: float(r[-1]), reverse=descending)
+    except (ValueError, IndexError):
+        return rows
+
+
+def apply_footnote(fig, footnote):
+    if footnote:
+        fig.text(0.5, -0.02, footnote, ha="center", va="top",
+                 fontsize=9, color="#666666", style="italic")
+
+
+def plot_bar(headers, rows, title, output, value_format, show_values, sort, footnote):
+    rows = sort_rows(rows, sort)
+    labels = [r[0] for r in rows]
+    values = [float(r[1]) for r in rows]
+
+    fig, ax = plt.subplots()
+    bars = ax.bar(labels, values, color=PALETTE[0], width=0.7)
+    ax.set_xlabel(headers[0])
+    ax.set_ylabel(headers[1])
+    ax.set_title(title)
+    ax.yaxis.set_major_formatter(axis_formatter(value_format))
+    ax.grid(axis="x", visible=False)
+
+    if show_values:
+        max_v = max(values) if values else 0
+        pad = max_v * 0.015
+        for bar, v in zip(bars, values):
+            ax.text(bar.get_x() + bar.get_width() / 2, bar.get_height() + pad,
+                    format_value(v, value_format), ha="center", va="bottom", fontsize=9)
+        ax.set_ylim(bottom=0, top=max_v * 1.12)
+    else:
+        ax.set_ylim(bottom=0)
+
+    plt.xticks(rotation=35, ha="right")
+    apply_footnote(fig, footnote)
+    plt.savefig(output)
+    plt.close()
+
+
+def plot_grouped_bar(headers, rows, title, output, value_format, show_values, sort, footnote):
+    x_col, group_col, value_col = headers[0], headers[1], headers[2]
+
+    if sort:
+        totals = {}
+        for row in rows:
+            totals[row[0]] = totals.get(row[0], 0) + float(row[2])
+        ordered_x = [x for x, _ in sorted(totals.items(), key=lambda kv: kv[1], reverse=True)]
+    else:
+        ordered_x = []
+        for row in rows:
+            if row[0] not in ordered_x:
+                ordered_x.append(row[0])
+
+    groups = []
+    data = {}
+    for row in rows:
+        x, g, v = row[0], row[1], float(row[2])
+        if g not in groups:
+            groups.append(g)
+        data[(x, g)] = v
+
+    fig, ax = plt.subplots()
+    n_groups = len(groups)
+    width = 0.8 / max(n_groups, 1)
+    xs = list(range(len(ordered_x)))
+
+    for i, g in enumerate(groups):
+        offsets = [x + (i - (n_groups - 1) / 2) * width for x in xs]
+        values = [data.get((xl, g), 0) for xl in ordered_x]
+        bars = ax.bar(offsets, values, width=width, label=g, color=PALETTE[i % len(PALETTE)])
+        if show_values:
+            max_v = max((v for v in data.values()), default=0)
+            pad = max_v * 0.012
+            for bar, v in zip(bars, values):
+                if v != 0:
+                    ax.text(bar.get_x() + bar.get_width() / 2, bar.get_height() + pad,
+                            format_value(v, value_format), ha="center", va="bottom", fontsize=8)
+
+    ax.set_xticks(xs)
+    ax.set_xticklabels(ordered_x, rotation=35, ha="right")
+    ax.set_xlabel(x_col)
+    ax.set_ylabel(value_col)
+    ax.set_title(title)
+    ax.yaxis.set_major_formatter(axis_formatter(value_format))
+    ax.grid(axis="x", visible=False)
+    ax.legend(title=group_col, loc="best")
+
+    if show_values:
+        max_v = max((v for v in data.values()), default=0)
+        ax.set_ylim(top=max_v * 1.15)
+
+    apply_footnote(fig, footnote)
+    plt.savefig(output)
+    plt.close()
+
+
+def plot_line(headers, rows, title, output, value_format, footnote):
+    x_col, group_col, value_col = headers[0], headers[1], headers[2]
+    use_dates = try_parse_date(rows[0][0]) is not None
+
+    series = {}
+    for row in rows:
+        x = try_parse_date(row[0]) if use_dates else row[0]
+        group = row[1]
+        value = float(row[2])
+        series.setdefault(group, ([], []))
+        series[group][0].append(x)
+        series[group][1].append(value)
+
+    fig, ax = plt.subplots()
+    for i, (group, (xs, ys)) in enumerate(series.items()):
+        ax.plot(xs, ys, marker="o", label=group, color=PALETTE[i % len(PALETTE)])
+
+    ax.set_xlabel(x_col)
+    ax.set_ylabel(value_col)
+    ax.set_title(title)
+    ax.yaxis.set_major_formatter(axis_formatter(value_format))
+    ax.legend(title=group_col, loc="best")
+
+    if use_dates:
+        ax.xaxis.set_major_locator(mdates.AutoDateLocator())
+        ax.xaxis.set_major_formatter(mdates.ConciseDateFormatter(ax.xaxis.get_major_locator()))
+    else:
+        plt.xticks(rotation=35, ha="right")
+
+    apply_footnote(fig, footnote)
+    plt.savefig(output)
+    plt.close()
+
+
+def plot_heatmap(headers, rows, title, output, value_format, footnote):
+    x_col, y_col, value_col = headers[0], headers[1], headers[2]
+
+    x_labels = []
+    y_labels = []
+    data = {}
+    for row in rows:
+        x, y, v = row[0], row[1], float(row[2])
+        if x not in x_labels:
+            x_labels.append(x)
+        if y not in y_labels:
+            y_labels.append(y)
+        data[(x, y)] = v
+
+    grid = [[data.get((x, y), float("nan")) for x in x_labels] for y in y_labels]
+
+    fig, ax = plt.subplots()
+    im = ax.imshow(grid, aspect="auto", cmap="RdYlGn" if value_format == "pct" else "viridis")
+
+    ax.set_xticks(range(len(x_labels)))
+    ax.set_xticklabels(x_labels, rotation=35, ha="right")
+    ax.set_yticks(range(len(y_labels)))
+    ax.set_yticklabels(y_labels)
+    ax.set_xlabel(x_col)
+    ax.set_ylabel(y_col)
+    ax.set_title(title)
+    ax.grid(False)
+
+    for i, y in enumerate(y_labels):
+        for j, x in enumerate(x_labels):
+            v = data.get((x, y))
+            if v is not None:
+                ax.text(j, i, format_value(v, value_format), ha="center", va="center",
+                        fontsize=9, color="black")
+
+    cbar = fig.colorbar(im, ax=ax)
+    cbar.ax.yaxis.set_major_formatter(axis_formatter(value_format))
+
+    apply_footnote(fig, footnote)
+    plt.savefig(output)
+    plt.close()
+
+
+def plot_facet(headers, rows, title, output, value_format, footnote):
+    # Expects: facet_col, x_col, [group_col,] value_col
+    # For 4 columns: facet, x, group, value -> one line/bar chart per facet with grouped series
+    # For 3 columns: facet, x, value -> one bar chart per facet
+    if len(headers) == 4:
+        facet_col, x_col, group_col, value_col = headers
+        has_groups = True
+    elif len(headers) == 3:
+        facet_col, x_col, value_col = headers
+        group_col = None
+        has_groups = False
+    else:
+        # fall back to line chart with first 3 columns
+        plot_line(headers[:3], [r[:3] for r in rows], title, output, value_format, footnote)
+        return
+
+    facets = []
+    for row in rows:
+        if row[0] not in facets:
+            facets.append(row[0])
+
+    n = len(facets)
+    cols = min(n, 3)
+    rows_layout = math.ceil(n / cols)
+    fig, axes = plt.subplots(rows_layout, cols, figsize=(5.5 * cols, 4 * rows_layout),
+                             squeeze=False, sharey=True)
+
+    for idx, facet in enumerate(facets):
+        r, c = divmod(idx, cols)
+        ax = axes[r][c]
+        facet_rows = [row for row in rows if row[0] == facet]
+
+        if has_groups:
+            series = {}
+            for row in facet_rows:
+                x, g, v = row[1], row[2], float(row[3])
+                series.setdefault(g, ([], []))
+                series[g][0].append(x)
+                series[g][1].append(v)
+            for i, (g, (xs, ys)) in enumerate(series.items()):
+                ax.plot(xs, ys, marker="o", label=g, color=PALETTE[i % len(PALETTE)])
+            ax.legend(title=group_col, loc="best", fontsize=8)
+        else:
+            xs = [row[1] for row in facet_rows]
+            ys = [float(row[2]) for row in facet_rows]
+            ax.bar(xs, ys, color=PALETTE[idx % len(PALETTE)], width=0.7)
+
+        ax.set_title(f"{facet_col}: {facet}", fontsize=11, fontweight="bold")
+        ax.set_xlabel(x_col)
+        if c == 0:
+            ax.set_ylabel(value_col)
+        ax.yaxis.set_major_formatter(axis_formatter(value_format))
+        ax.tick_params(axis="x", rotation=35)
+
+    for idx in range(n, rows_layout * cols):
+        r, c = divmod(idx, cols)
+        axes[r][c].set_visible(False)
+
+    fig.suptitle(title, fontsize=14, fontweight="bold", y=1.00)
+    fig.tight_layout()
+    apply_footnote(fig, footnote)
+    plt.savefig(output)
+    plt.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate a chart from a CSV file")
+    parser.add_argument("input", help="Path to a CSV file")
+    parser.add_argument("-o", "--output", default="chart.png", help="Output image path")
+    parser.add_argument("-t", "--title", default=None,
+                        help="Chart title (default: derived from input filename)")
+    parser.add_argument("--footnote", default="",
+                        help="Footnote/caption below the chart (e.g., sample size, date range)")
+    parser.add_argument("--type", choices=["bar", "grouped_bar", "line", "heatmap", "facet"],
+                        help="Chart type (auto-detected if omitted)")
+    parser.add_argument("--format", choices=["auto", "pct", "int", "num"], default="auto",
+                        help="Value formatting (default: auto-detect from column name)")
+    parser.add_argument("--no-labels", action="store_true",
+                        help="Disable data labels on bars")
+    parser.add_argument("--sort", action="store_true",
+                        help="Sort bar chart categories by value (descending)")
+    parser.add_argument("--allow-wide", action="store_true",
+                        help="Bypass the wide-format shape check (rare; only for intentional wide CSVs)")
+    parser.add_argument("--allow-nulls", action="store_true",
+                        help="Skip rows with null/empty numeric cells with a warning, instead of aborting")
+    args = parser.parse_args()
+
+    headers, rows = read_csv(args.input)
+    if not rows:
+        print("CSV has no data rows")
+        sys.exit(1)
+
+    if not args.allow_wide and detect_wide_format(headers, rows):
+        print(wide_format_error(headers, args.input), file=sys.stderr)
+        sys.exit(2)
+
+    title = args.title if args.title is not None else title_from_path(args.input)
+
+    value_format = args.format
+    if value_format == "auto":
+        last_col = headers[-1].lower()
+        if "pct" in last_col or "percent" in last_col or "rate" in last_col:
+            value_format = "pct"
+        elif any(k in last_col for k in ("users", "count", "rows", "games", "sessions")):
+            value_format = "int"
+        else:
+            value_format = "num"
+
+    plt.rcParams.update(STYLE)
+
+    chart_type = args.type or detect_chart_type(headers)
+    rows = validate_data(headers, rows, chart_type, value_format, args.input, args.allow_nulls)
+    show_values = not args.no_labels
+
+    if chart_type == "bar":
+        plot_bar(headers, rows, title, args.output, value_format, show_values, args.sort, args.footnote)
+    elif chart_type == "grouped_bar":
+        plot_grouped_bar(headers, rows, title, args.output, value_format, show_values, args.sort, args.footnote)
+    elif chart_type == "line":
+        plot_line(headers, rows, title, args.output, value_format, args.footnote)
+    elif chart_type == "heatmap":
+        plot_heatmap(headers, rows, title, args.output, value_format, args.footnote)
+    elif chart_type == "facet":
+        plot_facet(headers, rows, title, args.output, value_format, args.footnote)
+
+    print(f"Chart saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/compile_wiki_skills.py
+++ b/tools/compile_wiki_skills.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Compile wiki `## Agent quick context` sections into git-tracked Hermes skills.
+
+The wiki remains the source of truth. Generated skills are fast runtime caches that
+Hermes can route to from the initial prompt. By default this writes skills under
+`skills/<category>/<name>/SKILL.md`; use `--profile-symlink-root` to symlink those
+repo skills into an active Hermes profile.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import sys
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_WIKI_ROOT = REPO_ROOT / "yallaplay-wiki"
+DEFAULT_SKILLS_ROOT = REPO_ROOT / "skills"
+DEFAULT_SECTION = "Agent quick context"
+GENERATED_START = "<!-- BEGIN GENERATED FROM WIKI AGENT QUICK CONTEXT -->"
+GENERATED_END = "<!-- END GENERATED FROM WIKI AGENT QUICK CONTEXT -->"
+
+
+@dataclass(frozen=True)
+class WikiSkillSource:
+    wiki_path: Path
+    wiki_rel: str
+    frontmatter: dict[str, Any]
+    section_title: str
+    section_body: str
+
+    @property
+    def skill_config(self) -> dict[str, Any]:
+        config = self.frontmatter.get("agent_skill")
+        if not isinstance(config, dict):
+            raise ValueError(f"{self.wiki_rel}: agent_skill frontmatter must be a mapping")
+        return config
+
+    @property
+    def skill_name(self) -> str:
+        name = self.skill_config.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError(f"{self.wiki_rel}: agent_skill.name is required")
+        return name.strip()
+
+    @property
+    def category(self) -> str:
+        category = self.skill_config.get("category", "yallaplay")
+        if not isinstance(category, str) or not category.strip():
+            raise ValueError(f"{self.wiki_rel}: agent_skill.category must be a string")
+        return category.strip().strip("/")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--wiki-root", type=Path, default=DEFAULT_WIKI_ROOT)
+    parser.add_argument("--skills-root", type=Path, default=DEFAULT_SKILLS_ROOT)
+    parser.add_argument("--section", default=DEFAULT_SECTION)
+    parser.add_argument("--name", help="compile only one agent_skill.name")
+    parser.add_argument("--check", action="store_true", help="fail if generated files or symlinks are stale; do not write")
+    parser.add_argument("--list", action="store_true", help="list compilable wiki skill sources")
+    parser.add_argument(
+        "--profile-symlink-root",
+        type=Path,
+        help="optional Hermes profile skill category directory, e.g. ~/.hermes/profiles/claudio-lab/skills/claudio-authored",
+    )
+    parser.add_argument("--no-symlink", action="store_true", help="skip symlink creation even if --profile-symlink-root is set")
+    return parser.parse_args()
+
+
+def split_frontmatter(text: str, rel: str) -> tuple[dict[str, Any], str, str]:
+    if not text.startswith("---\n"):
+        return {}, "", text
+    end = text.find("\n---\n", 4)
+    if end < 0:
+        raise ValueError(f"{rel}: frontmatter is not closed")
+    raw = text[4:end]
+    body = text[end + len("\n---\n") :]
+    parsed = yaml.safe_load(raw) or {}
+    if not isinstance(parsed, dict):
+        raise ValueError(f"{rel}: frontmatter must parse to a mapping")
+    return parsed, raw, body
+
+
+def heading_level(line: str) -> int | None:
+    match = re.match(r"^(#{1,6})\s+(.+?)\s*$", line)
+    return len(match.group(1)) if match else None
+
+
+def extract_section(markdown_body: str, section_title: str) -> str | None:
+    wanted = section_title.strip().lower()
+    lines = markdown_body.splitlines()
+    start: int | None = None
+    start_level: int | None = None
+    for index, line in enumerate(lines):
+        match = re.match(r"^(#{1,6})\s+(.+?)\s*$", line)
+        if not match:
+            continue
+        title = match.group(2).strip().rstrip("#").strip().lower()
+        if title == wanted:
+            start = index + 1
+            start_level = len(match.group(1))
+            break
+    if start is None or start_level is None:
+        return None
+    end = len(lines)
+    for index in range(start, len(lines)):
+        level = heading_level(lines[index])
+        if level is not None and level <= start_level:
+            end = index
+            break
+    return "\n".join(lines[start:end]).strip() + "\n"
+
+
+def iter_sources(wiki_root: Path, section: str) -> list[WikiSkillSource]:
+    sources: list[WikiSkillSource] = []
+    for path in sorted(wiki_root.rglob("*.md")):
+        if any(part == ".git" for part in path.parts):
+            continue
+        rel = path.relative_to(wiki_root).as_posix()
+        text = path.read_text(encoding="utf-8")
+        if "agent_skill:" not in text:
+            continue
+        frontmatter, _raw_frontmatter, body = split_frontmatter(text, rel)
+        if "agent_skill" not in frontmatter:
+            continue
+        section_body = extract_section(body, section)
+        if section_body is None:
+            raise ValueError(f"{rel}: has agent_skill frontmatter but no ## {section} section")
+        sources.append(WikiSkillSource(path, rel, frontmatter, section, section_body))
+    return sources
+
+
+def as_string_list(value: Any, *, field: str, rel: str) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"{rel}: {field} must be a list of strings")
+    return value
+
+
+def render_skill(source: WikiSkillSource) -> str:
+    config = source.skill_config
+    name = source.skill_name
+    description = config.get("description")
+    if not isinstance(description, str) or not description.strip():
+        raise ValueError(f"{source.wiki_rel}: agent_skill.description is required")
+    if len(description) > 1024:
+        raise ValueError(f"{source.wiki_rel}: agent_skill.description exceeds 1024 chars")
+    tags = as_string_list(config.get("tags"), field="agent_skill.tags", rel=source.wiki_rel)
+    related = as_string_list(config.get("related_skills"), field="agent_skill.related_skills", rel=source.wiki_rel)
+    checksum = hashlib.sha256(source.section_body.encode("utf-8")).hexdigest()
+    built = date.today().isoformat()
+    title = source.frontmatter.get("title") or name.replace("-", " ").title()
+
+    frontmatter = {
+        "name": name,
+        "description": description.strip(),
+        "version": "1.0.0",
+        "author": "YallaPlay",
+        "license": "Proprietary",
+        "metadata": {
+            "hermes": {
+                "tags": tags,
+                "related_skills": related,
+            },
+            "generated_from": {
+                "wiki_path": f"yallaplay-wiki/{source.wiki_rel}",
+                "section": source.section_title,
+                "source_sha256": checksum,
+                "built": built,
+            },
+        },
+    }
+    yaml_text = yaml.safe_dump(frontmatter, sort_keys=False, allow_unicode=True).strip()
+    return f"""---
+{yaml_text}
+---
+
+# {title} — Compiled Agent Context
+
+{GENERATED_START}
+
+> Generated from `yallaplay-wiki/{source.wiki_rel}` → `## {source.section_title}`.
+> Do not hand-edit this compiled body; update the wiki section and rerun `python3 tools/compile_wiki_skills.py`.
+
+{source.section_body.rstrip()}
+
+{GENERATED_END}
+
+## Maintenance
+
+- Canonical source: `yallaplay-wiki/{source.wiki_rel}`.
+- If this skill and the wiki disagree, the wiki wins; patch the wiki, then regenerate this skill.
+- Keep this skill symlinked into the active Hermes profile so `/skills` and prompt routing see the git-tracked copy.
+"""
+
+
+def skill_path(skills_root: Path, source: WikiSkillSource) -> Path:
+    return skills_root / source.category / source.skill_name / "SKILL.md"
+
+
+def ensure_symlink(profile_root: Path, source: WikiSkillSource, target_dir: Path, *, check: bool) -> bool:
+    link = profile_root / source.skill_name
+    desired = target_dir.resolve()
+    if link.is_symlink() and link.resolve() == desired:
+        return False
+    if check:
+        print(f"stale/missing symlink: {link} -> {desired}", file=sys.stderr)
+        return True
+    if link.exists() or link.is_symlink():
+        raise FileExistsError(f"refusing to replace non-matching profile skill path: {link}")
+    profile_root.mkdir(parents=True, exist_ok=True)
+    link.symlink_to(desired, target_is_directory=True)
+    print(f"symlinked {link} -> {desired}")
+    return True
+
+
+def main() -> int:
+    args = parse_args()
+    wiki_root = args.wiki_root.resolve()
+    skills_root = args.skills_root.resolve()
+    sources = iter_sources(wiki_root, args.section)
+    if args.name:
+        sources = [source for source in sources if source.skill_name == args.name]
+    if args.list:
+        for source in sources:
+            print(f"{source.skill_name}\t{source.category}\t{source.wiki_rel}")
+        return 0
+    if not sources:
+        print("no wiki agent_skill sources found", file=sys.stderr)
+        return 1
+
+    changed = False
+    for source in sources:
+        rendered = render_skill(source)
+        path = skill_path(skills_root, source)
+        existing = path.read_text(encoding="utf-8") if path.exists() else None
+        if existing != rendered:
+            changed = True
+            if args.check:
+                print(f"stale generated skill: {path.relative_to(REPO_ROOT)}", file=sys.stderr)
+            else:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(rendered, encoding="utf-8")
+                print(f"wrote {path.relative_to(REPO_ROOT)}")
+        elif not args.check:
+            print(f"up to date {path.relative_to(REPO_ROOT)}")
+
+        if args.profile_symlink_root and not args.no_symlink:
+            changed = ensure_symlink(
+                args.profile_symlink_root.expanduser().resolve(),
+                source,
+                path.parent,
+                check=args.check,
+            ) or changed
+
+    return 1 if args.check and changed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/dashboard_auth_proxy.mjs
+++ b/tools/dashboard_auth_proxy.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+import http from 'node:http';
+import { Buffer } from 'node:buffer';
+import crypto from 'node:crypto';
+
+const listenHost = process.env.HERMES_PROXY_HOST || '127.0.0.1';
+const listenPort = Number(process.env.HERMES_PROXY_PORT || '9120');
+const targetHost = process.env.HERMES_TARGET_HOST || '127.0.0.1';
+const targetPort = Number(process.env.HERMES_TARGET_PORT || '9119');
+const user = process.env.HERMES_PROXY_USER || 'claudio';
+const password = process.env.HERMES_PROXY_PASSWORD;
+
+if (!password) {
+  console.error('Set HERMES_PROXY_PASSWORD');
+  process.exit(1);
+}
+
+const expectedAuth = 'Basic ' + Buffer.from(`${user}:${password}`).toString('base64');
+const sessionCookieName = 'hermes_proxy_session';
+const sessionCookieValue = crypto.randomBytes(32).toString('base64url');
+const sessionCookie = `${sessionCookieName}=${sessionCookieValue}`;
+
+function hasSessionCookie(req) {
+  const cookie = req.headers.cookie || '';
+  return cookie.split(';').map((part) => part.trim()).includes(sessionCookie);
+}
+
+function hasBasicAuth(req) {
+  return req.headers.authorization === expectedAuth;
+}
+
+function authorized(req) {
+  return hasBasicAuth(req) || hasSessionCookie(req);
+}
+
+function authReason(req) {
+  if (hasBasicAuth(req)) return 'basic';
+  if (hasSessionCookie(req)) return 'cookie';
+  return 'missing';
+}
+
+function reject(res) {
+  res.writeHead(401, {
+    'WWW-Authenticate': 'Basic realm="Hermes Dashboard"',
+    'Content-Type': 'text/plain; charset=utf-8',
+  });
+  res.end('Authentication required\n');
+}
+
+function proxiedHeaders(req) {
+  const headers = { ...req.headers };
+  if (headers.authorization === expectedAuth) {
+    delete headers.authorization;
+  }
+  delete headers['proxy-authorization'];
+  headers.host = `${targetHost}:${targetPort}`;
+  headers['x-forwarded-proto'] = 'https';
+  headers['x-forwarded-host'] = req.headers.host || headers.host;
+  return headers;
+}
+
+const server = http.createServer((req, res) => {
+  if (!authorized(req)) {
+    reject(res);
+    return;
+  }
+
+  const freshLogin = hasBasicAuth(req);
+  const upstream = http.request({
+    host: targetHost,
+    port: targetPort,
+    method: req.method,
+    path: req.url,
+    headers: proxiedHeaders(req),
+  }, (upstreamRes) => {
+    const headers = { ...upstreamRes.headers };
+    if (freshLogin) {
+      const cookieValue = `${sessionCookie}; HttpOnly; Secure; SameSite=Lax; Path=/`;
+      const existing = headers['set-cookie'];
+      headers['set-cookie'] = existing ? [...(Array.isArray(existing) ? existing : [existing]), cookieValue] : [cookieValue];
+    }
+    res.writeHead(upstreamRes.statusCode || 502, upstreamRes.statusMessage, headers);
+    upstreamRes.pipe(res);
+  });
+
+  upstream.on('error', (error) => {
+    if (!res.headersSent) {
+      res.writeHead(502, { 'Content-Type': 'text/plain; charset=utf-8' });
+    }
+    res.end(`Proxy error: ${error.message}\n`);
+  });
+
+  req.pipe(upstream);
+});
+
+server.on('upgrade', (req, socket, head) => {
+  socket.on('error', (error) => {
+    console.log(`WS client socket error ${req.url}: ${error.code || error.message}`);
+  });
+
+  if (!authorized(req)) {
+    console.log(`WS ${req.url} -> 401 (${authReason(req)})`);
+    socket.write('HTTP/1.1 401 Unauthorized\r\nWWW-Authenticate: Basic realm="Hermes Dashboard"\r\nConnection: close\r\n\r\n');
+    socket.destroy();
+    return;
+  }
+
+  console.log(`WS ${req.url} -> proxy (${authReason(req)})`);
+
+  const upstream = http.request({
+    host: targetHost,
+    port: targetPort,
+    method: req.method,
+    path: req.url,
+    headers: proxiedHeaders(req),
+  });
+
+  upstream.on('upgrade', (upstreamRes, upstreamSocket, upstreamHead) => {
+    console.log(`WS ${req.url} <- ${upstreamRes.statusCode || 101}`);
+    upstreamSocket.on('error', (error) => {
+      console.log(`WS upstream socket error ${req.url}: ${error.code || error.message}`);
+      socket.destroy();
+    });
+    socket.write('HTTP/1.1 101 Switching Protocols\r\n');
+    for (const [key, value] of Object.entries(upstreamRes.headers)) {
+      if (Array.isArray(value)) {
+        for (const item of value) socket.write(`${key}: ${item}\r\n`);
+      } else if (value !== undefined) {
+        socket.write(`${key}: ${value}\r\n`);
+      }
+    }
+    socket.write('\r\n');
+    if (upstreamHead?.length) socket.write(upstreamHead);
+    if (head?.length) upstreamSocket.write(head);
+    upstreamSocket.pipe(socket);
+    socket.pipe(upstreamSocket);
+  });
+
+  upstream.on('response', (upstreamRes) => {
+    console.log(`WS ${req.url} <- non-upgrade ${upstreamRes.statusCode}`);
+    socket.write(`HTTP/1.1 ${upstreamRes.statusCode || 502} ${upstreamRes.statusMessage || 'Bad Gateway'}\r\n`);
+    for (const [key, value] of Object.entries(upstreamRes.headers)) {
+      if (Array.isArray(value)) {
+        for (const item of value) socket.write(`${key}: ${item}\r\n`);
+      } else if (value !== undefined) {
+        socket.write(`${key}: ${value}\r\n`);
+      }
+    }
+    socket.write('\r\n');
+    upstreamRes.on('data', (chunk) => socket.write(chunk));
+    upstreamRes.on('end', () => socket.end());
+  });
+
+  upstream.on('error', () => {
+    console.log(`WS upstream request error ${req.url}`);
+    socket.write('HTTP/1.1 502 Bad Gateway\r\nConnection: close\r\n\r\n');
+    socket.destroy();
+  });
+
+  upstream.end();
+});
+
+server.listen(listenPort, listenHost, () => {
+  console.log(`Dashboard auth proxy listening on http://${listenHost}:${listenPort} -> http://${targetHost}:${targetPort}`);
+});

--- a/tools/embrace_metrics.py
+++ b/tools/embrace_metrics.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Query the Embrace Metrics API (Prometheus/PromQL) for YallaPlay apps.
+
+Read-only. Credentials stay outside git.
+
+Credential resolution:
+1. EMBRACE_METRICS_API_TOKEN environment variable.
+2. --vars / HERMES_YALLAPLAY_VARS / YALLAPLAY_VARS_TOML private TOML file.
+3. ./vars.toml if present locally and untracked.
+4. ../yallaplay-analytics-agent-gpt/vars.toml for migration labs.
+
+The Embrace Metrics API token is different from the Embrace MCP service-account
+token. MCP uses emb_sa_* against https://mcp.embrace.io/mcp; this script uses the
+org Metrics API token against https://api.embrace.io/metrics.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python <3.11
+    import tomli as tomllib  # type: ignore[no-redef]
+
+PROJECT_DIR = Path(__file__).resolve().parents[1]
+LOG_DIR = PROJECT_DIR / "logs"
+OUTPUTS_DIR = PROJECT_DIR / "outputs"
+LOCAL_VARS = PROJECT_DIR / "vars.toml"
+DEFAULT_SIBLING_VARS = PROJECT_DIR.parent / "yallaplay-analytics-agent-gpt" / "vars.toml"
+
+BASE_URL = "https://api.embrace.io/metrics"
+
+PROD_APPS = {
+    "r5GWq": "Spades Masters / android",
+    "QkTz6": "Spades Masters / ios",
+    "dmma2": "Gin Rummy / android",
+    "s8kti": "Gin Rummy / ios",
+}
+APP_ALIASES = {
+    "spades_android": "r5GWq",
+    "spades_ios": "QkTz6",
+    "rummy_android": "dmma2",
+    "rummy_ios": "s8kti",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("-q", "--query", help="PromQL query string")
+    parser.add_argument(
+        "--app",
+        choices=sorted(APP_ALIASES),
+        help="Typo guard: query must target exactly this production app alias",
+    )
+    parser.add_argument("--list-apps", action="store_true", help="Print the four in-scope production apps")
+    parser.add_argument("--metrics", action="store_true", help="List available metric names")
+    parser.add_argument("--range", action="store_true", help="Use query_range instead of instant query")
+    parser.add_argument("--days", type=float, default=7, help="For --range without --start, look back N days")
+    parser.add_argument("--start", help="Range start, ISO-8601 or unix seconds")
+    parser.add_argument("--end", help="Range end, ISO-8601 or unix seconds; default now")
+    parser.add_argument("--step", default="1h", help="Range step: 300, 30m, 1h, 1d; Embrace rounds <1h up")
+    parser.add_argument("--at", help="Instant-query evaluation time, ISO-8601 or unix seconds")
+    parser.add_argument("--vars", type=Path, help="Private TOML file containing EMBRACE_METRICS_API_TOKEN")
+    parser.add_argument("-o", "--output", type=Path, help="Write CSV/raw output to this path")
+    parser.add_argument("--raw", action="store_true", help="Emit raw JSON instead of CSV")
+    return parser.parse_args()
+
+
+def load_toml(path: Path) -> dict[str, Any]:
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def candidate_vars_paths(explicit: Path | None) -> list[Path]:
+    env = os.environ
+    candidates: list[Path | None] = [
+        explicit,
+        Path(env["HERMES_YALLAPLAY_VARS"]) if env.get("HERMES_YALLAPLAY_VARS") else None,
+        Path(env["YALLAPLAY_VARS_TOML"]) if env.get("YALLAPLAY_VARS_TOML") else None,
+        LOCAL_VARS if LOCAL_VARS.exists() else None,
+        DEFAULT_SIBLING_VARS if DEFAULT_SIBLING_VARS.exists() else None,
+    ]
+    return [path for path in candidates if path and path.exists()]
+
+
+def load_token(vars_path: Path | None) -> tuple[str, str]:
+    if os.environ.get("EMBRACE_METRICS_API_TOKEN"):
+        return os.environ["EMBRACE_METRICS_API_TOKEN"], "environment"
+    for path in candidate_vars_paths(vars_path):
+        config = load_toml(path)
+        token = config.get("EMBRACE_METRICS_API_TOKEN")
+        if token:
+            return str(token), str(path)
+    raise SystemExit(
+        "EMBRACE_METRICS_API_TOKEN missing. Set the environment variable or pass --vars / "
+        "HERMES_YALLAPLAY_VARS pointing to a private TOML file."
+    )
+
+
+def app_ids_in_query(query: str) -> set[str]:
+    ids: set[str] = set()
+    for match in re.finditer(r'app_id\s*=~?\s*"([^"]*)"', query):
+        for piece in match.group(1).split("|"):
+            piece = piece.strip()
+            if piece:
+                ids.add(piece)
+    return ids
+
+
+def validate_scope(query: str, app_alias: str | None) -> None:
+    ids = app_ids_in_query(query)
+    if app_alias:
+        target = APP_ALIASES[app_alias]
+        if not ids:
+            raise SystemExit(
+                f'--app {app_alias} ({target}) requires an explicit app_id filter, e.g. '
+                f'-q \'sum(daily_sessions_total{{app_id="{target}"}})\''
+            )
+        if ids != {target}:
+            raise SystemExit(f"--app {app_alias} expects app_id {target}, but query references {sorted(ids)}")
+    bad = sorted(app_id for app_id in ids if app_id not in PROD_APPS)
+    if bad:
+        raise SystemExit(
+            "Query references non-production Embrace app_id(s): "
+            + ", ".join(bad)
+            + "\nAllowed production app_ids: "
+            + ", ".join(f"{app_id} ({name})" for app_id, name in PROD_APPS.items())
+        )
+
+
+def step_to_seconds(step: str) -> int:
+    value = str(step).strip().lower()
+    if value.isdigit():
+        return int(value)
+    unit = value[-1]
+    mult = {"s": 1, "m": 60, "h": 3600, "d": 86400}.get(unit)
+    if mult is None:
+        raise SystemExit(f"Bad --step {step!r}; use e.g. 300, 30m, 1h, 1d")
+    return int(float(value[:-1]) * mult)
+
+
+def parse_time(value: str) -> float:
+    value = str(value).strip()
+    if value.replace(".", "", 1).isdigit():
+        return float(value)
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+    except ValueError as exc:
+        raise SystemExit(f"Bad time {value!r}; use ISO-8601 or unix seconds") from exc
+
+
+def request_metrics(path: str, params: dict[str, Any], token: str, method: str = "POST") -> tuple[str, str]:
+    url = f"{BASE_URL}/api/v1/{path}"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+        "User-Agent": "yallaplay-hermes-agent/1.0",
+    }
+    if method == "GET":
+        if params:
+            url = f"{url}?{urllib.parse.urlencode(params)}"
+        req = urllib.request.Request(url, headers=headers)
+    else:
+        headers["Content-Type"] = "application/x-www-form-urlencoded"
+        req = urllib.request.Request(url, data=urllib.parse.urlencode(params).encode(), headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=60) as response:
+            return url, response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise SystemExit(f"HTTP {exc.code} for {url}\n{body}") from exc
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"Request failed for {url}: {exc}") from exc
+
+
+def log_call(url: str, body: str, output_path: Path | None) -> Path:
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
+    path = LOG_DIR / f"{timestamp}-embrace_metrics.txt"
+    path.write_text(f"URL: {url}\nOutput: {output_path or '(stdout)'}\nBytes: {len(body)}\n", encoding="utf-8")
+    return path
+
+
+def flatten_rows(parsed: dict[str, Any]) -> tuple[list[str], list[list[Any]]]:
+    result = parsed.get("data", {}).get("result", [])
+    result_type = parsed.get("data", {}).get("resultType")
+    expanded: list[tuple[dict[str, Any], Any, Any]] = []
+    for series in result:
+        metric = series.get("metric", {})
+        if result_type == "matrix":
+            expanded.extend((metric, ts, value) for ts, value in series.get("values", []))
+        else:
+            ts, value = series.get("value", [None, None])
+            expanded.append((metric, ts, value))
+    label_keys = sorted({key for metric, _, _ in expanded for key in metric})
+    header = label_keys + ["timestamp_unix", "timestamp_iso", "value"]
+    rows = []
+    for metric, ts, value in expanded:
+        iso = datetime.fromtimestamp(float(ts), timezone.utc).isoformat() if ts is not None else ""
+        rows.append([metric.get(key, "") for key in label_keys] + [ts, iso, value])
+    return header, rows
+
+
+def write_or_print_text(text: str, output: Path | None) -> None:
+    if output:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(text, encoding="utf-8")
+        print(f"written to {output}", file=sys.stderr)
+    else:
+        print(text, end="" if text.endswith("\n") else "\n")
+
+
+def main() -> int:
+    args = parse_args()
+    if args.list_apps:
+        print("In-scope production apps (Embrace):")
+        for alias in sorted(APP_ALIASES):
+            app_id = APP_ALIASES[alias]
+            print(f"  {alias:16} {app_id}  {PROD_APPS[app_id]}")
+        return 0
+
+    if not args.query and not args.metrics:
+        raise SystemExit("one of -q/--query, --metrics, or --list-apps is required")
+    if args.query:
+        validate_scope(args.query, args.app)
+
+    token, source = load_token(args.vars)
+    print(f"Using Embrace metrics credential source: {source}", file=sys.stderr)
+
+    if args.metrics:
+        url, body = request_metrics("label/__name__/values", {}, token, method="GET")
+        names = json.loads(body).get("data", [])
+        log_call(url, json.dumps(names), args.output)
+        write_or_print_text("\n".join(names) + "\n", args.output)
+        return 0
+
+    if args.range:
+        end = parse_time(args.end) if args.end else datetime.now(timezone.utc).timestamp()
+        start = parse_time(args.start) if args.start else end - args.days * 86400
+        url, body = request_metrics(
+            "query_range",
+            {"query": args.query, "start": start, "end": end, "step": step_to_seconds(args.step)},
+            token,
+        )
+    else:
+        params: dict[str, Any] = {"query": args.query}
+        if args.at:
+            params["time"] = parse_time(args.at)
+        url, body = request_metrics("query", params, token)
+
+    log_call(url, body, args.output)
+    parsed = json.loads(body)
+    if parsed.get("status") != "success":
+        raise SystemExit(f"Query error: {json.dumps(parsed, indent=2)}")
+
+    if args.raw:
+        write_or_print_text(json.dumps(parsed, indent=2) + "\n", args.output)
+        return 0
+
+    header, rows = flatten_rows(parsed)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        with args.output.open("w", newline="", encoding="utf-8") as handle:
+            writer = csv.writer(handle)
+            writer.writerow(header)
+            writer.writerows(rows)
+        print(f"{len(rows)} rows written to {args.output}", file=sys.stderr)
+    else:
+        writer = csv.writer(sys.stdout)
+        writer.writerow(header)
+        writer.writerows(rows)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/embrace_metrics.py
+++ b/tools/embrace_metrics.py
@@ -29,17 +29,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-try:
-    import tomllib
-except ModuleNotFoundError:  # pragma: no cover - Python <3.11
-    import tomli as tomllib  # type: ignore[no-redef]
+from secret_config import candidate_vars_paths, load_toml
 
 PROJECT_DIR = Path(__file__).resolve().parents[1]
 LOG_DIR = PROJECT_DIR / "logs"
 OUTPUTS_DIR = PROJECT_DIR / "outputs"
-LOCAL_VARS = PROJECT_DIR / "vars.toml"
-DEFAULT_SIBLING_VARS = PROJECT_DIR.parent / "yallaplay-analytics-agent-gpt" / "vars.toml"
-
 BASE_URL = "https://api.embrace.io/metrics"
 
 PROD_APPS = {
@@ -76,23 +70,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("-o", "--output", type=Path, help="Write CSV/raw output to this path")
     parser.add_argument("--raw", action="store_true", help="Emit raw JSON instead of CSV")
     return parser.parse_args()
-
-
-def load_toml(path: Path) -> dict[str, Any]:
-    with path.open("rb") as handle:
-        return tomllib.load(handle)
-
-
-def candidate_vars_paths(explicit: Path | None) -> list[Path]:
-    env = os.environ
-    candidates: list[Path | None] = [
-        explicit,
-        Path(env["HERMES_YALLAPLAY_VARS"]) if env.get("HERMES_YALLAPLAY_VARS") else None,
-        Path(env["YALLAPLAY_VARS_TOML"]) if env.get("YALLAPLAY_VARS_TOML") else None,
-        LOCAL_VARS if LOCAL_VARS.exists() else None,
-        DEFAULT_SIBLING_VARS if DEFAULT_SIBLING_VARS.exists() else None,
-    ]
-    return [path for path in candidates if path and path.exists()]
 
 
 def load_token(vars_path: Path | None) -> tuple[str, str]:

--- a/tools/embrace_sessions.py
+++ b/tools/embrace_sessions.py
@@ -33,19 +33,13 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-try:
-    import tomllib
-except ModuleNotFoundError:  # pragma: no cover - Python <3.11
-    import tomli as tomllib  # type: ignore[no-redef]
+from secret_config import candidate_vars_paths, load_toml
 
 PROJECT_DIR = Path(__file__).resolve().parents[1]
 LOG_DIR = PROJECT_DIR / "logs"
 OUTPUTS_DIR = PROJECT_DIR / "outputs"
 LOCAL_STATE_DIR = PROJECT_DIR / ".local"
 AUTH_CACHE_PATH = LOCAL_STATE_DIR / "cache" / ".embrace_auth.json"
-LOCAL_VARS = PROJECT_DIR / "vars.toml"
-DEFAULT_SIBLING_VARS = PROJECT_DIR.parent / "yallaplay-analytics-agent-gpt" / "vars.toml"
-
 AUTH_REFRESH_MARGIN_S = 86400
 LOGIN_URL = "https://dash.embrace.io/login"
 API_BASE = "https://dash-api-us1.embrace.io"
@@ -112,23 +106,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--relogin", action="store_true", help="Ignore cached JWT and force a fresh dashboard login")
     parser.add_argument("--dry-run", action="store_true", help="Validate arguments and credential presence without logging in or calling Embrace")
     return parser.parse_args()
-
-
-def load_toml(path: Path) -> dict[str, Any]:
-    with path.open("rb") as handle:
-        return tomllib.load(handle)
-
-
-def candidate_vars_paths(explicit: Path | None) -> list[Path]:
-    env = os.environ
-    candidates: list[Path | None] = [
-        explicit,
-        Path(env["HERMES_YALLAPLAY_VARS"]) if env.get("HERMES_YALLAPLAY_VARS") else None,
-        Path(env["YALLAPLAY_VARS_TOML"]) if env.get("YALLAPLAY_VARS_TOML") else None,
-        LOCAL_VARS if LOCAL_VARS.exists() else None,
-        DEFAULT_SIBLING_VARS if DEFAULT_SIBLING_VARS.exists() else None,
-    ]
-    return [path for path in candidates if path and path.exists()]
 
 
 def load_creds(vars_path: Path | None) -> tuple[str, str, str]:

--- a/tools/embrace_sessions.py
+++ b/tools/embrace_sessions.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""Pull session-level data from the Embrace dashboard backend.
+
+Read-only. This covers the gap that Embrace MCP and Metrics API do not expose:
+individual stitched session records for a specific user around a support-ticket
+timestamp.
+
+Credential resolution:
+1. EMBRACE_DASH_EMAIL / EMBRACE_DASH_PASSWORD environment variables.
+2. --vars / HERMES_YALLAPLAY_VARS / YALLAPLAY_VARS_TOML private TOML file.
+3. ./vars.toml if present locally and untracked.
+4. ../yallaplay-analytics-agent-gpt/vars.toml for migration labs.
+
+Auth cache: .local/cache/.embrace_auth.json (gitignored, chmod 600). The cached
+`sessionid` JWT is a credential; never print or commit it.
+
+Requires for real login: python package `playwright` and a Chromium browser from
+`python3 -m playwright install chromium`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import csv
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python <3.11
+    import tomli as tomllib  # type: ignore[no-redef]
+
+PROJECT_DIR = Path(__file__).resolve().parents[1]
+LOG_DIR = PROJECT_DIR / "logs"
+OUTPUTS_DIR = PROJECT_DIR / "outputs"
+LOCAL_STATE_DIR = PROJECT_DIR / ".local"
+AUTH_CACHE_PATH = LOCAL_STATE_DIR / "cache" / ".embrace_auth.json"
+LOCAL_VARS = PROJECT_DIR / "vars.toml"
+DEFAULT_SIBLING_VARS = PROJECT_DIR.parent / "yallaplay-analytics-agent-gpt" / "vars.toml"
+
+AUTH_REFRESH_MARGIN_S = 86400
+LOGIN_URL = "https://dash.embrace.io/login"
+API_BASE = "https://dash-api-us1.embrace.io"
+PAGE_DELAY_S = 0.3
+
+PROD_APPS = {
+    "r5GWq": "Spades Masters / android",
+    "QkTz6": "Spades Masters / ios",
+    "dmma2": "Gin Rummy / android",
+    "s8kti": "Gin Rummy / ios",
+}
+APP_ALIASES = {
+    "spades_android": "r5GWq",
+    "spades_ios": "QkTz6",
+    "rummy_android": "dmma2",
+    "rummy_ios": "s8kti",
+}
+
+CSV_FIELDS = [
+    "session_id",
+    "user_id",
+    "device_id",
+    "app_version",
+    "os_name",
+    "os_version",
+    "device_model",
+    "manufacturer",
+    "country",
+    "region",
+    "environment",
+    "start_time",
+    "end_time",
+    "cold_start",
+    "state",
+    "last_view",
+    "exceptions",
+    "error_logs",
+    "network_errors",
+    "slow_spans",
+    "bad_moments",
+    "memory_warnings",
+    "app_used_mb",
+    "sdk_version",
+]
+
+
+class AuthExpired(Exception):
+    """Raised when the cached JWT is rejected and a fresh login is needed."""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--app", choices=sorted(APP_ALIASES), help="Production app alias")
+    parser.add_argument("--list-apps", action="store_true", help="Print the four in-scope production apps")
+    parser.add_argument("--user", help="Warehouse USER_ID / Helpshift meta_user_id filter")
+    parser.add_argument("--around", metavar="ISO_TS", help="Return sessions within +/- --window minutes of this timestamp")
+    parser.add_argument("--window", type=int, default=30, metavar="MIN", help="Half-width of --around window in minutes")
+    parser.add_argument("--pages", type=int, default=3, help="Maximum paginated requests to make")
+    parser.add_argument("--resolution", default="hour", choices=["hour", "day", "week"], help="stitch_list resolution bucket")
+    parser.add_argument("--vars", type=Path, help="Private TOML file with EMBRACE_DASH_EMAIL/PASSWORD")
+    parser.add_argument("-o", "--output", type=Path, help="Write flattened CSV or --raw JSON to this path")
+    parser.add_argument("--raw", action="store_true", help="Emit raw session JSON instead of flattened CSV")
+    parser.add_argument("--headful", action="store_true", help="Run browser headed for login debugging")
+    parser.add_argument("--relogin", action="store_true", help="Ignore cached JWT and force a fresh dashboard login")
+    parser.add_argument("--dry-run", action="store_true", help="Validate arguments and credential presence without logging in or calling Embrace")
+    return parser.parse_args()
+
+
+def load_toml(path: Path) -> dict[str, Any]:
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def candidate_vars_paths(explicit: Path | None) -> list[Path]:
+    env = os.environ
+    candidates: list[Path | None] = [
+        explicit,
+        Path(env["HERMES_YALLAPLAY_VARS"]) if env.get("HERMES_YALLAPLAY_VARS") else None,
+        Path(env["YALLAPLAY_VARS_TOML"]) if env.get("YALLAPLAY_VARS_TOML") else None,
+        LOCAL_VARS if LOCAL_VARS.exists() else None,
+        DEFAULT_SIBLING_VARS if DEFAULT_SIBLING_VARS.exists() else None,
+    ]
+    return [path for path in candidates if path and path.exists()]
+
+
+def load_creds(vars_path: Path | None) -> tuple[str, str, str]:
+    email = os.environ.get("EMBRACE_DASH_EMAIL")
+    password = os.environ.get("EMBRACE_DASH_PASSWORD")
+    if email and password:
+        return email, password, "environment"
+    for path in candidate_vars_paths(vars_path):
+        config = load_toml(path)
+        email = config.get("EMBRACE_DASH_EMAIL")
+        password = config.get("EMBRACE_DASH_PASSWORD")
+        if email and password:
+            return str(email), str(password), str(path)
+    raise SystemExit(
+        "EMBRACE_DASH_EMAIL / EMBRACE_DASH_PASSWORD missing. Set environment variables "
+        "or pass --vars / HERMES_YALLAPLAY_VARS pointing to a private TOML file."
+    )
+
+
+def jwt_exp(jwt: str) -> int | None:
+    try:
+        payload_b64 = jwt.split(".")[1]
+        payload_b64 += "=" * (-len(payload_b64) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+        return int(payload.get("exp")) if payload.get("exp") else None
+    except Exception:
+        return None
+
+
+def read_cached_sessionid() -> str | None:
+    try:
+        data = json.loads(AUTH_CACHE_PATH.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    jwt = data.get("sessionid")
+    if not jwt:
+        return None
+    exp = jwt_exp(jwt) or data.get("exp")
+    if exp and exp - time.time() > AUTH_REFRESH_MARGIN_S:
+        remaining_h = (exp - time.time()) / 3600
+        print(f"using cached dashboard auth (valid ~{remaining_h:.0f}h)", file=sys.stderr)
+        return str(jwt)
+    return None
+
+
+def write_cached_sessionid(jwt: str) -> None:
+    AUTH_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    AUTH_CACHE_PATH.write_text(json.dumps({"sessionid": jwt, "exp": jwt_exp(jwt)}), encoding="utf-8")
+    try:
+        os.chmod(AUTH_CACHE_PATH, 0o600)
+    except OSError:
+        pass
+
+
+def login_and_capture_sessionid(app_id: str, vars_path: Path | None, headless: bool = True, timeout_ms: int = 45000) -> str:
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError as exc:
+        raise SystemExit(
+            "Missing dependency: playwright. Install in the active environment, then run: "
+            "python3 -m playwright install chromium"
+        ) from exc
+
+    email, password, source = load_creds(vars_path)
+    print(f"Using Embrace dashboard credential source: {source}", file=sys.stderr)
+    captured: dict[str, str | None] = {"sessionid": None}
+
+    playwright = sync_playwright().start()
+    browser = playwright.chromium.launch(headless=headless)
+    context = browser.new_context()
+    page = context.new_page()
+
+    def on_request(request: Any) -> None:
+        if captured["sessionid"] is None:
+            sessionid = request.headers.get("sessionid")
+            if sessionid:
+                captured["sessionid"] = sessionid
+
+    page.on("request", on_request)
+    try:
+        page.goto(LOGIN_URL, wait_until="domcontentloaded", timeout=timeout_ms)
+        time.sleep(2)
+        page.fill("input[name=email]", email)
+        page.fill("input[type=password]", password)
+        page.click("button:has-text('Log in')")
+        time.sleep(6)
+        try:
+            page.goto(f"https://dash.embrace.io/app/{app_id}", wait_until="domcontentloaded", timeout=timeout_ms)
+        except Exception:
+            pass
+        for _ in range(15):
+            if captured["sessionid"]:
+                break
+            time.sleep(1)
+    finally:
+        browser.close()
+        playwright.stop()
+
+    if not captured["sessionid"]:
+        raise SystemExit("login failed or sessionid JWT was not captured; retry with --headful to inspect")
+    write_cached_sessionid(captured["sessionid"])
+    return captured["sessionid"]
+
+
+def get_sessionid(app_id: str, vars_path: Path | None, headless: bool, force_login: bool) -> str:
+    if not force_login:
+        cached = read_cached_sessionid()
+        if cached:
+            return cached
+    return login_and_capture_sessionid(app_id, vars_path, headless=headless)
+
+
+def seed_cursor(before_iso: str) -> str:
+    raw = json.dumps({"n": before_iso, "d": {}}).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def parse_iso(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def fetch_sessions(
+    sessionid: str,
+    app_id: str,
+    resolution: str,
+    user_id: str | None = None,
+    pages: int = 3,
+    around: str | None = None,
+    window_min: int = 30,
+) -> list[dict[str, Any]]:
+    url = f"{API_BASE}/v4/app/{app_id}/session/stitch_list"
+    headers = {
+        "content-type": "application/json",
+        "accept": "application/json",
+        "sessionid": sessionid,
+        "referer-embrace": f"https://dash.embrace.io/app/{app_id}/grouped_sessions/{resolution}",
+        "user-agent": "yallaplay-hermes-agent/1.0",
+    }
+    user_filter = None
+    if user_id:
+        user_filter = {"op": "and", "children": [{"key": "user_id", "field_op": "eq", "val": str(user_id)}]}
+
+    lo = hi = None
+    cursor = None
+    if around:
+        center = parse_iso(around)
+        lo = center - timedelta(minutes=window_min)
+        hi = center + timedelta(minutes=window_min)
+        cursor = seed_cursor((hi + timedelta(seconds=1)).strftime("%Y-%m-%dT%H:%M:%S.999Z"))
+
+    sessions: list[dict[str, Any]] = []
+    page_i = 0
+    stop = False
+    while page_i < pages and not stop:
+        body: dict[str, Any] = {"resolution": resolution}
+        if user_filter:
+            body["filters"] = user_filter
+        if cursor:
+            body["next"] = cursor
+        request = urllib.request.Request(url, method="POST", data=json.dumps(body).encode(), headers=headers)
+        try:
+            with urllib.request.urlopen(request, timeout=60) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")[:300]
+            if exc.code in (401, 403):
+                raise AuthExpired(f"HTTP {exc.code}: {detail}") from exc
+            print(f"page {page_i}: HTTP {exc.code}: {detail}", file=sys.stderr)
+            break
+
+        kept = 0
+        for group in payload.get("stitches", []):
+            for session in group:
+                if around:
+                    start_time = session.get("start_time")
+                    start_dt = parse_iso(start_time) if start_time else None
+                    if start_dt is not None:
+                        if lo and start_dt < lo:
+                            stop = True
+                            continue
+                        if hi and start_dt > hi:
+                            continue
+                sessions.append(session)
+                kept += 1
+        cursor = payload.get("next")
+        suffix = f" [in window: {kept}]" if around else ""
+        print(
+            f"page {page_i}: +{kept} sessions (total {len(sessions)}){suffix}{' [more]' if cursor else ' [end]'}",
+            file=sys.stderr,
+        )
+        page_i += 1
+        if not cursor:
+            break
+        if not stop:
+            time.sleep(PAGE_DELAY_S)
+
+    if cursor and not stop and page_i >= pages:
+        extra = " in the time window" if around else ""
+        print(f"NOTE: stopped at {pages}-page cap with more sessions available{extra}; raise --pages if needed", file=sys.stderr)
+    return sessions
+
+
+def flatten_session(session: dict[str, Any]) -> dict[str, Any]:
+    user = session.get("user", {}) or {}
+    out = {field: session.get(field) for field in CSV_FIELDS}
+    out["user_id"] = user.get("user_id")
+    out["device_id"] = user.get("device_id")
+    return out
+
+
+def log_call(app_id: str, count: int, output_path: Path | None) -> Path:
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
+    path = LOG_DIR / f"{timestamp}-embrace_sessions.txt"
+    path.write_text(f"app_id: {app_id}\nsessions: {count}\noutput: {output_path or '(stdout)'}\n", encoding="utf-8")
+    return path
+
+
+def main() -> int:
+    args = parse_args()
+    if args.list_apps:
+        print("In-scope production apps (Embrace):")
+        for alias in sorted(APP_ALIASES):
+            app_id = APP_ALIASES[alias]
+            print(f"  {alias:16} {app_id}  {PROD_APPS[app_id]}")
+        return 0
+    if not args.app:
+        raise SystemExit("--app is required unless --list-apps is used")
+    if args.pages < 1:
+        raise SystemExit("--pages must be >= 1")
+    if args.window < 1:
+        raise SystemExit("--window must be >= 1")
+    if args.around:
+        parse_iso(args.around)
+
+    app_id = APP_ALIASES[args.app]
+    if args.dry_run:
+        # Confirms credential presence without printing values or touching Embrace.
+        _, _, source = load_creds(args.vars)
+        print(f"Dry run OK: app={args.app} app_id={app_id} credential_source={source}")
+        return 0
+
+    sessionid = get_sessionid(app_id, args.vars, headless=not args.headful, force_login=args.relogin)
+    try:
+        sessions = fetch_sessions(sessionid, app_id, args.resolution, args.user, args.pages, args.around, args.window)
+    except AuthExpired:
+        print("cached auth rejected; re-logging in", file=sys.stderr)
+        sessionid = get_sessionid(app_id, args.vars, headless=not args.headful, force_login=True)
+        sessions = fetch_sessions(sessionid, app_id, args.resolution, args.user, args.pages, args.around, args.window)
+
+    log_call(app_id, len(sessions), args.output)
+    if args.raw:
+        text = json.dumps(sessions, indent=2) + "\n"
+        if args.output:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(text, encoding="utf-8")
+            print(f"{len(sessions)} sessions written to {args.output}", file=sys.stderr)
+        else:
+            print(text, end="")
+        return 0
+
+    rows = [flatten_session(session) for session in sessions]
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        with args.output.open("w", newline="", encoding="utf-8") as handle:
+            writer = csv.DictWriter(handle, fieldnames=CSV_FIELDS)
+            writer.writeheader()
+            writer.writerows(rows)
+        print(f"{len(rows)} sessions written to {args.output}", file=sys.stderr)
+    else:
+        writer = csv.DictWriter(sys.stdout, fieldnames=CSV_FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/fetch_schemas.py
+++ b/tools/fetch_schemas.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Refresh Snowflake DDL snapshots under yallaplay-wiki/reference/warehouse/ddl/.
+
+Read-only metadata workflow. Reuses tools/snowflake_query.py credential loading
+and connection code so it remains compatible with the legacy analytics-agent
+vars.toml while keeping credentials out of this repository.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Import sibling helper without requiring tools/ to be a package.
+TOOLS_DIR = Path(__file__).resolve().parent
+if str(TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOLS_DIR))
+
+from snowflake_query import config_from_mapping, connect, pick_config_source  # noqa: E402
+
+PROJECT_DIR = Path(__file__).resolve().parents[1]
+DEFAULT_SCHEMA_DIR = PROJECT_DIR / "yallaplay-wiki" / "reference" / "warehouse" / "ddl"
+
+# EVENTS: emit CREATE TABLE column lists only (raw source tables; lineage is less useful here).
+# AGGREGATES: emit full GET_DDL including target_lag and AS <SELECT> body for lineage.
+DEFAULT_TARGETS = {
+    "EVENTS": "columns",
+    "AGGREGATES": "full",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--vars", type=Path, help="Private vars.toml path")
+    parser.add_argument(
+        "--schema-dir",
+        type=Path,
+        default=DEFAULT_SCHEMA_DIR,
+        help="Output directory for DDL snapshots (default: yallaplay-wiki/reference/warehouse/ddl)",
+    )
+    parser.add_argument(
+        "--schemas",
+        nargs="+",
+        default=list(DEFAULT_TARGETS),
+        help="Snowflake schemas to snapshot (default: EVENTS AGGREGATES)",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["auto", "columns", "full"],
+        default="auto",
+        help="DDL mode for all schemas; auto uses columns for EVENTS and full for AGGREGATES",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="List target schemas without querying Snowflake")
+    return parser.parse_args()
+
+
+def quote_ident(value: str) -> str:
+    return '"' + value.replace('"', '""') + '"'
+
+
+def columns_ddl(cursor, database: str, schema: str, name: str, kind: str) -> str:
+    cursor.execute(
+        f"DESCRIBE {kind} {quote_ident(database)}.{quote_ident(schema)}.{quote_ident(name)}"
+    )
+    columns = cursor.fetchall()
+    col_defs = []
+    for col in columns:
+        col_name, col_type, nullable = col[0], col[1], col[3]
+        line = f"  {quote_ident(str(col_name))} {col_type}"
+        if nullable == "N":
+            line += " NOT NULL"
+        col_defs.append(line)
+    return f"CREATE {kind} {schema}.{name} (\n" + ",\n".join(col_defs) + "\n);"
+
+
+def full_ddl(cursor, database: str, schema: str, name: str, kind: str) -> str:
+    cursor.execute(f"SELECT GET_DDL('{kind}', '{database}.{schema}.{name}')")
+    return str(cursor.fetchone()[0]).strip()
+
+
+def schema_mode(schema: str, requested: str) -> str:
+    if requested != "auto":
+        return requested
+    return DEFAULT_TARGETS.get(schema.upper(), "columns")
+
+
+def snapshot_schema(cursor, database: str, schema: str, mode: str, schema_dir: Path) -> list[str]:
+    schema_dir.mkdir(parents=True, exist_ok=True)
+    out_path = schema_dir / f"{schema}.sql"
+
+    entries: list[tuple[str, str]] = []
+    cursor.execute(f"SHOW TABLES IN SCHEMA {quote_ident(database)}.{quote_ident(schema)}")
+    entries.extend((str(row[1]), "TABLE") for row in cursor.fetchall())
+    cursor.execute(f"SHOW VIEWS IN SCHEMA {quote_ident(database)}.{quote_ident(schema)}")
+    entries.extend((str(row[1]), "VIEW") for row in cursor.fetchall())
+    entries.sort(key=lambda item: item[0])
+
+    blocks = []
+    names = []
+    for name, kind in entries:
+        if mode == "full":
+            blocks.append(full_ddl(cursor, database, schema, name, kind))
+        else:
+            blocks.append(columns_ddl(cursor, database, schema, name, kind))
+        names.append(name)
+
+    out_path.write_text("\n\n".join(blocks) + "\n", encoding="utf-8")
+    return names
+
+
+def main() -> int:
+    args = parse_args()
+    schemas = [schema.upper() for schema in args.schemas]
+    if args.dry_run:
+        for schema in schemas:
+            print(f"would snapshot {schema} in {schema_mode(schema, args.mode)} mode -> {args.schema_dir / (schema + '.sql')}")
+        return 0
+
+    source, mapping = pick_config_source(args.vars)
+    config = config_from_mapping(mapping)
+    print(f"Using Snowflake config source: {source}")
+    connection = connect(config)
+    cursor = connection.cursor()
+    try:
+        database = str(connection.database or config.database)
+        for schema in schemas:
+            mode = schema_mode(schema, args.mode)
+            print(f"\n=== {database}.{schema} ({mode}) ===")
+            names = snapshot_schema(cursor, database, schema, mode, args.schema_dir)
+            for name in names:
+                print(f"  {name}")
+            print(f"wrote {len(names)} objects to {args.schema_dir / (schema + '.sql')}")
+    finally:
+        cursor.close()
+        connection.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/secret_config.py
+++ b/tools/secret_config.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Shared private TOML/env credential resolution for YallaPlay tool wrappers.
+
+This module centralizes source precedence only. It never prints secret values and
+leaves service-specific required-key validation in each caller.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python <3.11
+    import tomli as tomllib  # type: ignore[no-redef]
+
+PROJECT_DIR = Path(__file__).resolve().parents[1]
+LOCAL_VARS = PROJECT_DIR / "vars.toml"
+DEFAULT_SIBLING_VARS = PROJECT_DIR.parent / "yallaplay-analytics-agent-gpt" / "vars.toml"
+COMMON_VARS_ENV_NAMES = ("HERMES_YALLAPLAY_VARS", "YALLAPLAY_VARS_TOML")
+
+
+def load_toml(path: Path) -> dict[str, Any]:
+    """Load a private TOML file as a dict."""
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def candidate_vars_paths(
+    explicit: Path | None = None,
+    *,
+    env_var_names: Iterable[str] = COMMON_VARS_ENV_NAMES,
+    include_local: bool = True,
+    include_legacy: bool = True,
+    environ: Mapping[str, str] | None = None,
+) -> list[Path]:
+    """Return existing private TOML candidates in repo-standard precedence order."""
+    env = os.environ if environ is None else environ
+    candidates: list[Path | None] = [explicit]
+    candidates.extend(Path(env[name]) for name in env_var_names if env.get(name))
+    if include_local:
+        candidates.append(LOCAL_VARS if LOCAL_VARS.exists() else None)
+    if include_legacy:
+        candidates.append(DEFAULT_SIBLING_VARS if DEFAULT_SIBLING_VARS.exists() else None)
+    return [path for path in candidates if path and path.exists()]
+
+
+def first_value(mapping: Mapping[str, Any], keys: Iterable[str]) -> str | None:
+    """Return the first non-empty mapping value for any key, coerced to str."""
+    for key in keys:
+        value = mapping.get(key)
+        if value:
+            return str(value)
+    return None
+
+
+def env_mapping_if_complete(
+    required_keys: Iterable[str],
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, str] | None:
+    """Return environment mapping only when all required keys are present."""
+    env = os.environ if environ is None else environ
+    required = tuple(required_keys)
+    if all(env.get(key) for key in required):
+        return dict(env)
+    return None
+
+
+def pick_mapping_source(
+    explicit: Path | None,
+    *,
+    env_required: Iterable[str],
+    vars_env_names: Iterable[str] = COMMON_VARS_ENV_NAMES,
+    missing_message: str,
+    include_local: bool = True,
+    include_legacy: bool = True,
+) -> tuple[str, dict[str, Any]]:
+    """Pick env first when complete, otherwise the first existing private TOML.
+
+    Callers that allow partial environment/CLI overrides should use
+    candidate_vars_paths() directly instead.
+    """
+    env_mapping = env_mapping_if_complete(env_required)
+    if env_mapping is not None:
+        return "environment", env_mapping
+
+    for path in candidate_vars_paths(
+        explicit,
+        env_var_names=vars_env_names,
+        include_local=include_local,
+        include_legacy=include_legacy,
+    ):
+        return str(path), load_toml(path)
+    raise SystemExit(missing_message)

--- a/tools/snowflake_query.py
+++ b/tools/snowflake_query.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import argparse
 import csv
-import os
 import re
 import sys
 from dataclasses import dataclass
@@ -37,19 +36,13 @@ try:
 except ImportError:  # pragma: no cover - optional formatting helper
     sqlparse = None
 
-try:
-    import tomllib
-except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
-    import tomli as tomllib  # type: ignore[no-redef]
-
 from cryptography.hazmat.primitives import serialization
+
+from secret_config import pick_mapping_source
 
 
 PROJECT_DIR = Path(__file__).resolve().parents[1]
 LOG_DIR = PROJECT_DIR / "logs"
-DEFAULT_SIBLING_VARS = PROJECT_DIR.parent / "yallaplay-analytics-agent-gpt" / "vars.toml"
-LOCAL_VARS = PROJECT_DIR / "vars.toml"
-
 ALLOWED_FIRST_KEYWORDS = {"SELECT", "WITH", "SHOW", "DESC", "DESCRIBE", "EXPLAIN"}
 BLOCKED_KEYWORDS = {
     "ALTER",
@@ -101,30 +94,15 @@ def read_sql(args: argparse.Namespace) -> str:
     raise SystemExit("Provide a SQL string or -f <file>")
 
 
-def load_toml(path: Path) -> dict[str, Any]:
-    with path.open("rb") as handle:
-        return tomllib.load(handle)
-
-
 def pick_config_source(vars_path: Path | None) -> tuple[str, dict[str, Any]]:
-    env = os.environ
-    env_required = ["SNOWFLAKE_ACCOUNT", "SNOWFLAKE_USER", "SNOWFLAKE_PRIVATE_KEY", "SNOWFLAKE_WAREHOUSE"]
-    if all(env.get(key) for key in env_required):
-        return "environment", dict(env)
-
-    candidates = [
+    return pick_mapping_source(
         vars_path,
-        Path(env["HERMES_SNOWFLAKE_VARS"]) if env.get("HERMES_SNOWFLAKE_VARS") else None,
-        Path(env["SNOWFLAKE_VARS_TOML"]) if env.get("SNOWFLAKE_VARS_TOML") else None,
-        LOCAL_VARS if LOCAL_VARS.exists() else None,
-        DEFAULT_SIBLING_VARS if DEFAULT_SIBLING_VARS.exists() else None,
-    ]
-    for candidate in candidates:
-        if candidate and candidate.exists():
-            return str(candidate), load_toml(candidate)
-    raise SystemExit(
-        "No Snowflake credentials found. Set env vars or HERMES_SNOWFLAKE_VARS "
-        "to a private vars.toml path."
+        env_required=("SNOWFLAKE_ACCOUNT", "SNOWFLAKE_USER", "SNOWFLAKE_PRIVATE_KEY", "SNOWFLAKE_WAREHOUSE"),
+        vars_env_names=("HERMES_SNOWFLAKE_VARS", "SNOWFLAKE_VARS_TOML"),
+        missing_message=(
+            "No Snowflake credentials found. Set env vars or HERMES_SNOWFLAKE_VARS "
+            "to a private vars.toml path."
+        ),
     )
 
 

--- a/tools/snowflake_query.py
+++ b/tools/snowflake_query.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Run read-only Snowflake queries for the Hermes analytics skill.
+
+Credentials are intentionally loaded from private local state, never from this
+repository. Resolution order:
+
+1. Snowflake environment variables.
+2. --vars / HERMES_SNOWFLAKE_VARS / SNOWFLAKE_VARS_TOML.
+3. ./vars.toml if a local untracked lab file exists.
+4. ../yallaplay-analytics-agent-gpt/vars.toml for migration labs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+try:
+    import snowflake.connector
+except ImportError as exc:  # pragma: no cover - environment dependent
+    raise SystemExit("Missing dependency: snowflake-connector-python") from exc
+
+try:
+    import sqlglot
+except ImportError:  # pragma: no cover - optional validation helper
+    sqlglot = None
+
+try:
+    import sqlparse
+except ImportError:  # pragma: no cover - optional formatting helper
+    sqlparse = None
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
+    import tomli as tomllib  # type: ignore[no-redef]
+
+from cryptography.hazmat.primitives import serialization
+
+
+PROJECT_DIR = Path(__file__).resolve().parents[1]
+LOG_DIR = PROJECT_DIR / "logs"
+DEFAULT_SIBLING_VARS = PROJECT_DIR.parent / "yallaplay-analytics-agent-gpt" / "vars.toml"
+LOCAL_VARS = PROJECT_DIR / "vars.toml"
+
+ALLOWED_FIRST_KEYWORDS = {"SELECT", "WITH", "SHOW", "DESC", "DESCRIBE", "EXPLAIN"}
+BLOCKED_KEYWORDS = {
+    "ALTER",
+    "CALL",
+    "COPY",
+    "CREATE",
+    "DELETE",
+    "DROP",
+    "GET",
+    "GRANT",
+    "INSERT",
+    "MERGE",
+    "PUT",
+    "REMOVE",
+    "REVOKE",
+    "TRUNCATE",
+    "UPDATE",
+    "USE",
+}
+
+
+@dataclass(frozen=True)
+class SnowflakeConfig:
+    account: str
+    host: str | None
+    user: str
+    private_key: str
+    warehouse: str
+    database: str
+    schema: str
+    role: str | None = None
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("sql", nargs="?", help="SQL query string")
+    parser.add_argument("-f", "--file", type=Path, help="Path to a .sql file")
+    parser.add_argument("-o", "--output", type=Path, help="Output CSV path")
+    parser.add_argument("--vars", type=Path, help="Private vars.toml path")
+    parser.add_argument("--dry-run", action="store_true", help="validate and log SQL without executing")
+    return parser.parse_args()
+
+
+def read_sql(args: argparse.Namespace) -> str:
+    if args.file:
+        return args.file.read_text(encoding="utf-8")
+    if args.sql:
+        return args.sql
+    raise SystemExit("Provide a SQL string or -f <file>")
+
+
+def load_toml(path: Path) -> dict[str, Any]:
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def pick_config_source(vars_path: Path | None) -> tuple[str, dict[str, Any]]:
+    env = os.environ
+    env_required = ["SNOWFLAKE_ACCOUNT", "SNOWFLAKE_USER", "SNOWFLAKE_PRIVATE_KEY", "SNOWFLAKE_WAREHOUSE"]
+    if all(env.get(key) for key in env_required):
+        return "environment", dict(env)
+
+    candidates = [
+        vars_path,
+        Path(env["HERMES_SNOWFLAKE_VARS"]) if env.get("HERMES_SNOWFLAKE_VARS") else None,
+        Path(env["SNOWFLAKE_VARS_TOML"]) if env.get("SNOWFLAKE_VARS_TOML") else None,
+        LOCAL_VARS if LOCAL_VARS.exists() else None,
+        DEFAULT_SIBLING_VARS if DEFAULT_SIBLING_VARS.exists() else None,
+    ]
+    for candidate in candidates:
+        if candidate and candidate.exists():
+            return str(candidate), load_toml(candidate)
+    raise SystemExit(
+        "No Snowflake credentials found. Set env vars or HERMES_SNOWFLAKE_VARS "
+        "to a private vars.toml path."
+    )
+
+
+def config_from_mapping(mapping: dict[str, Any]) -> SnowflakeConfig:
+    database = mapping.get("SNOWFLAKE_DATABASE") or mapping.get("SNOWFLAKE_DATABASE_PROD")
+    missing = [
+        key
+        for key, value in {
+            "SNOWFLAKE_ACCOUNT": mapping.get("SNOWFLAKE_ACCOUNT"),
+            "SNOWFLAKE_USER": mapping.get("SNOWFLAKE_USER"),
+            "SNOWFLAKE_PRIVATE_KEY": mapping.get("SNOWFLAKE_PRIVATE_KEY"),
+            "SNOWFLAKE_WAREHOUSE": mapping.get("SNOWFLAKE_WAREHOUSE"),
+            "SNOWFLAKE_DATABASE or SNOWFLAKE_DATABASE_PROD": database,
+            "SNOWFLAKE_SCHEMA": mapping.get("SNOWFLAKE_SCHEMA"),
+        }.items()
+        if not value
+    ]
+    if missing:
+        raise SystemExit(f"Snowflake config missing: {', '.join(missing)}")
+    return SnowflakeConfig(
+        account=str(mapping["SNOWFLAKE_ACCOUNT"]),
+        host=str(mapping["SNOWFLAKE_HOST"]) if mapping.get("SNOWFLAKE_HOST") else None,
+        user=str(mapping["SNOWFLAKE_USER"]),
+        private_key=str(mapping["SNOWFLAKE_PRIVATE_KEY"]),
+        warehouse=str(mapping["SNOWFLAKE_WAREHOUSE"]),
+        database=str(database),
+        schema=str(mapping["SNOWFLAKE_SCHEMA"]),
+        role=str(mapping["SNOWFLAKE_ROLE"]) if mapping.get("SNOWFLAKE_ROLE") else None,
+    )
+
+
+def strip_sql_comments(sql: str) -> str:
+    if sqlparse:
+        return sqlparse.format(sql, strip_comments=True).strip()
+    sql = re.sub(r"--.*?$", "", sql, flags=re.MULTILINE)
+    return re.sub(r"/\*.*?\*/", "", sql, flags=re.DOTALL).strip()
+
+
+def split_statements(sql: str) -> list[str]:
+    if sqlparse:
+        return [statement.strip() for statement in sqlparse.split(sql) if statement.strip()]
+    return [statement.strip() for statement in sql.split(";") if statement.strip()]
+
+
+def first_keyword(sql: str) -> str:
+    match = re.match(r"\s*([a-zA-Z]+)", sql)
+    return match.group(1).upper() if match else ""
+
+
+def validate_read_only(sql: str) -> str:
+    stripped = strip_sql_comments(sql).rstrip(";").strip()
+    statements = split_statements(stripped)
+    if len(statements) != 1:
+        raise SystemExit("Only one read-only SQL statement is allowed")
+    statement = statements[0]
+    keyword = first_keyword(statement)
+    if keyword not in ALLOWED_FIRST_KEYWORDS:
+        raise SystemExit(f"Only read-only SQL is allowed; got first keyword {keyword or '<none>'}")
+    blocked_pattern = r"\b(" + "|".join(sorted(BLOCKED_KEYWORDS)) + r")\b"
+    blocked = re.search(blocked_pattern, statement, flags=re.IGNORECASE)
+    if blocked:
+        raise SystemExit(f"Blocked non-read-only keyword: {blocked.group(1).upper()}")
+    if sqlglot:
+        try:
+            sqlglot.parse(statement, dialect="snowflake")
+        except sqlglot.errors.ParseError as exc:
+            raise SystemExit(f"SQL parse error:\n{exc}") from exc
+    return statement
+
+
+def format_sql(sql: str) -> str:
+    if sqlparse:
+        return sqlparse.format(sql, reindent=True, keyword_case="upper").strip()
+    return sql.strip()
+
+
+def make_log_path(sql: str) -> Path:
+    table_match = re.search(r"\bFROM\s+([\w.\"]+)", sql, flags=re.IGNORECASE)
+    parts = []
+    if table_match:
+        parts.append(table_match.group(1).split(".")[-1].strip('"').lower())
+    parts.extend(alias.lower() for alias in re.findall(r"\bAS\s+([a-zA-Z_][\w]*)", sql, flags=re.IGNORECASE)[:3])
+    slug = re.sub(r"[^a-z0-9_]+", "_", "_".join(parts) or "query").strip("_")[:60]
+    timestamp = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
+    return LOG_DIR / f"{timestamp}-{slug}.sql"
+
+
+def write_query_log(sql: str) -> Path:
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    path = make_log_path(sql)
+    path.write_text(format_sql(sql) + "\n", encoding="utf-8")
+    return path
+
+
+def private_key_der(pem_text: str) -> bytes:
+    private_key = serialization.load_pem_private_key(pem_text.encode("utf-8"), password=None)
+    return private_key.private_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+
+def connect(config: SnowflakeConfig):
+    kwargs: dict[str, Any] = {
+        "account": config.account,
+        "user": config.user,
+        "private_key": private_key_der(config.private_key),
+        "warehouse": config.warehouse,
+        "database": config.database,
+        "schema": config.schema,
+    }
+    if config.host:
+        kwargs["host"] = config.host
+    if config.role:
+        kwargs["role"] = config.role
+    return snowflake.connector.connect(**kwargs)
+
+
+def print_table(headers: list[str], rows: list[tuple[Any, ...]]) -> None:
+    widths = [len(header) for header in headers]
+    rendered_rows: list[list[str]] = []
+    for row in rows:
+        rendered = ["NULL" if value is None else str(value) for value in row]
+        rendered_rows.append(rendered)
+        for index, value in enumerate(rendered):
+            widths[index] = max(widths[index], len(value))
+    fmt = "  ".join(f"{{:<{width}}}" for width in widths)
+    print(fmt.format(*headers))
+    print("  ".join("-" * width for width in widths))
+    for row in rendered_rows:
+        print(fmt.format(*row))
+    print(f"\n{len(rows)} rows")
+
+
+def run_query(sql: str, config: SnowflakeConfig, output: Path | None) -> None:
+    connection = connect(config)
+    cursor = connection.cursor()
+    try:
+        cursor.execute(sql)
+        headers = [description[0] for description in cursor.description or []]
+        rows = cursor.fetchall()
+    finally:
+        cursor.close()
+        connection.close()
+
+    if output:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        with output.open("w", newline="", encoding="utf-8") as handle:
+            writer = csv.writer(handle)
+            writer.writerow(headers)
+            writer.writerows(rows)
+        print(f"{len(rows)} rows written to {output}")
+    else:
+        print_table(headers, rows)
+
+
+def main() -> int:
+    args = parse_args()
+    sql = validate_read_only(read_sql(args))
+    log_path = write_query_log(sql)
+    print(f"Query logged to {log_path}")
+    if args.dry_run:
+        print("Dry run OK; query was not executed")
+        return 0
+    source, mapping = pick_config_source(args.vars)
+    config = config_from_mapping(mapping)
+    print(f"Using Snowflake config source: {source}")
+    run_query(sql, config, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/wiki_new.py
+++ b/tools/wiki_new.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Create a new yallaplay-wiki markdown page from a safe template."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+
+DEFAULT_WIKI_ROOT = Path(__file__).resolve().parents[1] / "yallaplay-wiki"
+KIND_DIRS = {
+    "finding": "operations/incidents",
+    "definition": "reference",
+    "methodology": "reference",
+    "query": "reference/queries",
+    "schema": "reference/warehouse",
+    "runbook": "operations",
+    "tool": "tools",
+}
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "untitled"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("kind", choices=sorted(KIND_DIRS), help="page template kind")
+    parser.add_argument("title", help="page title")
+    parser.add_argument("--wiki-root", type=Path, default=DEFAULT_WIKI_ROOT)
+    parser.add_argument("--domain", help="frontmatter domain override")
+    parser.add_argument("--slug", help="filename slug override")
+    parser.add_argument("--dir", help="directory under wiki root override")
+    parser.add_argument("--force", action="store_true", help="overwrite an existing file")
+    parser.add_argument("--print", action="store_true", help="print the template instead of writing")
+    return parser.parse_args()
+
+
+def current_git_user() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "config", "user.name"],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError:
+        return ""
+    return result.stdout.strip()
+
+
+def template(kind: str, title: str, domain: str) -> str:
+    today = date.today().isoformat()
+    author = current_git_user()
+    common = f"""---
+title: {title}
+domain: {domain}
+status: draft
+source_refs: []
+see_also: []
+built: {today}
+---
+
+# {title}
+"""
+    if kind == "finding":
+        return common + """
+## Summary
+
+- 
+
+## Evidence
+
+- 
+
+## Caveats
+
+- 
+
+## Future Use
+
+- 
+"""
+    if kind == "definition":
+        return common + """
+## Definition
+
+
+## Why It Matters
+
+
+## Related Terms
+
+- 
+"""
+    if kind == "methodology":
+        return common + """
+## Use When
+
+
+## Procedure
+
+1. 
+
+## Bias Traps
+
+- 
+
+## Output Pattern
+
+- 
+"""
+    if kind == "query":
+        return common + """
+## Purpose
+
+
+## Parameters
+
+- 
+
+## SQL
+
+```sql
+-- Add reusable SQL here.
+```
+
+## Caveats
+
+- 
+"""
+    if kind == "schema":
+        return common + """
+## Object
+
+
+## Columns / Fields
+
+- 
+
+## Known Gotchas
+
+- 
+
+## Example Queries
+
+- 
+"""
+    if kind == "runbook":
+        return common + """
+## Trigger
+
+
+## Steps
+
+1. 
+
+## Escalation
+
+- 
+
+## Rollback / Safety
+
+- 
+"""
+    if kind == "tool":
+        return common + """
+## What It Is For
+
+
+## Access / Auth
+
+
+## Data It Holds
+
+
+## Safe Usage
+
+- 
+"""
+    raise ValueError(kind)
+
+
+def main() -> int:
+    args = parse_args()
+    root = args.wiki_root.resolve()
+    if not root.exists():
+        print(f"wiki root not found: {root}", file=sys.stderr)
+        return 2
+
+    domain = args.domain or args.kind
+    content = template(args.kind, args.title, domain)
+    if args.print:
+        print(content, end="")
+        return 0
+
+    rel_dir = Path(args.dir or KIND_DIRS[args.kind])
+    if rel_dir.is_absolute() or ".." in rel_dir.parts:
+        print("--dir must stay inside the wiki root", file=sys.stderr)
+        return 2
+
+    slug = slugify(args.slug or args.title)
+    path = root / rel_dir / f"{slug}.md"
+    if path.exists() and not args.force:
+        print(f"refusing to overwrite existing file: {path.relative_to(root)}", file=sys.stderr)
+        return 1
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    print(path.relative_to(root).as_posix())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/wiki_search.py
+++ b/tools/wiki_search.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Search the yallaplay-wiki submodule with compact, agent-friendly output."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+DEFAULT_WIKI_ROOT = Path(__file__).resolve().parents[1] / "yallaplay-wiki"
+SKIP_DIRS = {".git", "node_modules", "__pycache__"}
+DOMAIN_PREFIXES = {
+    "company": ["company.md", "index.md", "dictionary.md", "glossary.md"],
+    "dictionary": ["dictionary.md", "glossary.md", "index.md"],
+    "products": ["products"],
+    "engineering": ["engineering", "reference/warehouse", "reference/formula_dsl.md"],
+    "operations": ["operations"],
+    "liveops": ["operations", "tools/product", "products"],
+    "analytics": ["engineering/data_warehouse.md", "reference/analytics_rules.md", "reference/warehouse", "products"],
+    "collaboration": ["people", "tools/team", "journal/meetings"],
+    "infrastructure": ["engineering/infrastructure.md", "engineering/backend_services.md", "tools/product/app_insights.md"],
+    "tools": ["tools"],
+    "market": ["market"],
+    "literature": ["literature"],
+    "people": ["people"],
+}
+
+
+@dataclass(frozen=True)
+class Match:
+    score: int
+    path: Path
+    line_no: int
+    line: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("query", nargs="+", help="term(s) to search for")
+    parser.add_argument("--wiki-root", type=Path, default=DEFAULT_WIKI_ROOT)
+    parser.add_argument("--domain", choices=sorted(DOMAIN_PREFIXES), help="limit search to a wiki domain/facet")
+    parser.add_argument("--limit", type=int, default=20, help="maximum matches to print")
+    parser.add_argument("--context", type=int, default=0, help="context lines before/after each match")
+    parser.add_argument("--files-only", action="store_true", help="print matching files, not matching lines")
+    return parser.parse_args()
+
+
+def iter_markdown_files(root: Path, domain: str | None) -> list[Path]:
+    prefixes = DOMAIN_PREFIXES.get(domain, []) if domain else []
+    files: list[Path] = []
+    for path in root.rglob("*.md"):
+        if any(part in SKIP_DIRS for part in path.parts):
+            continue
+        rel = path.relative_to(root).as_posix()
+        if prefixes and not any(rel == prefix or rel.startswith(f"{prefix}/") for prefix in prefixes):
+            continue
+        files.append(path)
+    return sorted(files)
+
+
+def score_line(line: str, terms: list[str]) -> int:
+    lower = line.lower()
+    score = 0
+    for term in terms:
+        count = lower.count(term)
+        score += count * (10 if " " in term else 4)
+    if line.lstrip().startswith("#"):
+        score += 8
+    if "[" in line and "](" in line:
+        score += 2
+    return score
+
+
+def collect_matches(files: list[Path], terms: list[str], root: Path, context: int) -> list[Match]:
+    matches: list[Match] = []
+    for path in files:
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except UnicodeDecodeError:
+            continue
+        file_bonus = sum(8 for term in terms if term in path.relative_to(root).as_posix().lower())
+        matched_lines: set[int] = set()
+        for index, line in enumerate(lines):
+            line_score = score_line(line, terms)
+            if line_score <= 0:
+                continue
+            start = max(0, index - context)
+            end = min(len(lines), index + context + 1)
+            for ctx_index in range(start, end):
+                if ctx_index in matched_lines:
+                    continue
+                matched_lines.add(ctx_index)
+                ctx_line = lines[ctx_index].strip()
+                if not ctx_line:
+                    continue
+                score = (line_score if ctx_index == index else max(1, line_score // 3)) + file_bonus
+                matches.append(Match(score, path.relative_to(root), ctx_index + 1, ctx_line))
+    return sorted(matches, key=lambda match: (-match.score, match.path.as_posix(), match.line_no))
+
+
+def highlight(line: str, terms: list[str]) -> str:
+    result = line
+    for term in sorted(terms, key=len, reverse=True):
+        result = re.sub(f"({re.escape(term)})", r"**\1**", result, flags=re.IGNORECASE)
+    return result
+
+
+def main() -> int:
+    args = parse_args()
+    root = args.wiki_root.resolve()
+    if not root.exists():
+        print(f"wiki root not found: {root}", file=sys.stderr)
+        return 2
+
+    query = " ".join(args.query).strip()
+    terms = [part.lower() for part in re.findall(r'"([^"]+)"|([^\s]+)', query) for part in part if part]
+    if not terms:
+        print("empty query", file=sys.stderr)
+        return 2
+
+    files = iter_markdown_files(root, args.domain)
+    matches = collect_matches(files, terms, root, args.context)
+
+    if args.files_only:
+        seen: set[Path] = set()
+        for match in matches:
+            if match.path in seen:
+                continue
+            seen.add(match.path)
+            print(match.path.as_posix())
+            if len(seen) >= args.limit:
+                break
+        return 0 if seen else 1
+
+    for match in matches[: args.limit]:
+        print(f"{match.path.as_posix()}:{match.line_no}: {highlight(match.line, terms)}")
+    return 0 if matches else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2986,18 +2986,27 @@ def _get_usage(agent) -> dict:
         # fabricated 0% or the old cumulative reading. The built-in compressor
         # always reports a real last_prompt_tokens once a turn runs, so it is
         # unaffected.
-        # Clamp the -1 "compression just ran, awaiting real usage" sentinel
-        # (conversation_compression.py) to 0 so the transitional turn reads as
-        # unknown (no gauge) instead of leaking context_used=-1. Matches the
-        # CLI status-bar path (cli.py _get_status_bar_snapshot).
+        # When compression has just run, conversation_compression.py parks
+        # last_prompt_tokens at -1 until the next provider response supplies
+        # real usage. During that transitional state, expose the rough
+        # post-compression estimate so the WebUI/TUI can refresh immediately
+        # instead of waiting for the next user message.
         last_prompt = getattr(comp, "last_prompt_tokens", 0) or 0
+        estimated_context = False
         if last_prompt < 0:
-            last_prompt = 0
+            rough_tokens = getattr(comp, "last_compression_rough_tokens", 0) or 0
+            if getattr(comp, "awaiting_real_usage_after_compression", False) and rough_tokens > 0:
+                last_prompt = rough_tokens
+                estimated_context = True
+            else:
+                last_prompt = 0
         ctx_max = getattr(comp, "context_length", 0) or 0
         if ctx_max and last_prompt:
             usage["context_used"] = last_prompt
             usage["context_max"] = ctx_max
             usage["context_percent"] = max(0, min(100, round(last_prompt / ctx_max * 100)))
+            if estimated_context:
+                usage["context_estimated"] = True
         usage["compressions"] = getattr(comp, "compression_count", 0) or 0
     # Live count of background/async subagents still running (delegate_task
     # batches + background single delegations). Mirrors the classic CLI status


### PR DESCRIPTION
## Problem

A context-compaction handoff is persisted with `role="user"` but is **not** a
real user turn. The ACP history replay (`_replay_session_history`) streams it as
a bare `user_message_chunk`, and the in-process `_compressed_summary` metadata
flag never reaches the wire (underscore-prefixed keys are stripped before API
calls). ACP frontends (editors, and our vscode-hermes client) therefore render
the entire ~11 KB summary as an ordinary user message — and when the frontend
pins user messages (sticky headers), the giant summary bubble overlaps the
transcript while scrolling, so the conversation looks corrupted after a
compaction.

## Fix

Tag the replayed summary chunk with `_meta.hermes.compactionSummary = true` via
ACP's extensibility channel (`ContentChunk.field_meta`), the same mechanism
already used for `_meta.hermes.sessionProvenance`. Frontends can then render the
handoff distinctly (e.g. a collapsed "Context summary" block) instead of a user
turn.

Detection honors the in-process `COMPRESSED_SUMMARY_METADATA_KEY` flag and falls
back to the existing content detector `ContextCompressor._is_context_summary_content()`,
so it also works for a **DB-reloaded session** that has lost the in-memory flag
(the common case on `session/load` after a gateway restart).

## Scope

Additive and metadata-only — no change to replay ordering, message content, or
model-facing context. Assistant chunks are untouched.

## Testing

- New: `test_load_session_flags_compaction_summary_on_replayed_user_chunk` —
  asserts the summary chunk carries `_meta.hermes.compactionSummary` and an
  adjacent real user turn does not. Verified it fails without the flag wiring.
- `tests/acp/test_server.py` — 81 passed.
- `tests/agent/test_summary_prefix_semantics.py` — 8 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
