### PR TITLE
fix(settings): clear model selection when switching providers

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -600,7 +600,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
       <section>
         <p className="mb-3 text-xs text-muted-foreground">{m.appliesDesc}</p>
         <div className="flex flex-wrap items-center gap-2">
-          <Select onValueChange={setSelectedProvider} value={selectedProvider}>
+          <Select onValueChange={value => { setSelectedProvider(value); setSelectedModel('') }} value={selectedProvider}>
             <SelectTrigger className={cn('min-w-40', CONTROL_TEXT)}>
               <SelectValue placeholder={m.provider} />
             </SelectTrigger>


### PR DESCRIPTION
When switching to a different provider in Settings -> Model, the model
dropdown retained the previously selected model. The  helper
prepended the stale model value to the new provider's (possibly empty)
model list, making it appear as if models from the old provider were still
available.

Both the auxiliary draft editor and MoA slot selector already clear the
model on provider change — this fix applies the same pattern to the main
provider selector.

Fixes #59063
