### PR TITLE
fix(desktop): switching chat session triggers auto-speak of the new session's last reply

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.ts
@@ -41,18 +41,50 @@ export function useAutoSpeakReplies({
   const enabled = useStore($autoSpeakReplies)
   const latest = useRef({ conversationActive, failureLabel, markSpoken, pendingReply })
   latest.current = { conversationActive, failureLabel, markSpoken, pendingReply }
+  const prevSessionId = useRef(sessionId)
 
   useEffect(() => {
     if (!enabled) {
       return undefined
     }
 
-    // Don't read whatever reply already sits at the bottom when the toggle flips
-    // on (or a chat opens) — consume it so only later replies are spoken.
-    latest.current.markSpoken()
+    const isNewSession = prevSessionId.current !== sessionId
+    prevSessionId.current = sessionId
+
+    if (!isNewSession) {
+      // Toggle flipped on mid-conversation — consume the existing last reply
+      // immediately so only replies that arrive afterward are spoken.
+      latest.current.markSpoken()
+    }
+
+    // Skip-count strategy to handle the $messages timing gap on session switch:
+    //
+    // $messages.subscribe() fires immediately with the current value. On a session
+    // switch, the store still holds the OLD session's messages at that point, so
+    // the first tick from subscribe is stale data. The second tick is the first
+    // real $messages update — the new session's existing messages (which must be
+    // silently consumed, not spoken). Only the third tick onward (genuinely new
+    // replies) should trigger audio.
+    //
+    // For the toggle-on case (same session), skip count is 1: the initial
+    // subscribe fire with the same data that markSpoken() already consumed above.
+    let skipCount = isNewSession ? 2 : 1
 
     const speakLatest = () => {
       const { conversationActive, failureLabel, markSpoken, pendingReply } = latest.current
+
+      if (skipCount > 0) {
+        skipCount -= 1
+
+        // On the very last skip (the first real $messages update carrying the
+        // new session's existing data), consume that reply silently so it's
+        // not spoken.
+        if (skipCount === 0) {
+          markSpoken()
+        }
+
+        return
+      }
 
       if (conversationActive || $voicePlayback.get().status !== 'idle') {
         return


### PR DESCRIPTION
## Description

Fixes #59014 — when the `Read replies aloud` toggle is enabled in the desktop composer, switching to a different chat session was incorrectly auto-speaking the last assistant reply of the newly-selected session.

## Root cause

`useAutoSpeakReplies()` called `markSpoken()` at effect mount time (before subscribing to `$messages`). At that point, `$messages` still held the **old** session's messages, so `markSpoken()` consumed the old session's last reply ID. When `$messages` later updated with the **new** session's messages, the existing last reply had a different ID and was incorrectly treated as a new reply — triggering auto-speech.

## Fix

Introduced a **skip-count strategy** that accounts for the `$messages` timing gap:

| Scenario | Skip count | What happens |
|---|---|---|
| **Session switch** | 2 | Tick 1 = subscribe's initial fire (stale old data). Tick 2 = first real update (new session's existing messages — consumed silently via `markSpoken()` on the last skip). Tick 3+ = genuinely new replies spoken normally. |
| **Toggle-on** (same session) | 1 | Existing reply consumed before subscribe; skip subscribe's initial fire only. |

A `prevSessionId` ref tracks whether `sessionId` actually changed, preserving the original early-consume behavior for the toggle-on case.

## Testing

- ✅ Toggle on mid-conversation: existing reply is NOT spoken, new replies ARE spoken (unchanged behavior)
- ✅ Switch to a session with existing assistant replies: silence (no auto-speech)
- ✅ Switch to a session with no messages: silence (no auto-speech)
- ✅ New reply arrives after session switch: spoken normally
- ✅ Toggle off: no auto-speech (unchanged behavior)