### PR TITLE
fix(compression): guarantee at least one user-role message survives c…

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3015,6 +3015,25 @@ This compaction should PRIORITISE preserving all information related to the focu
         # Port of Kilo-Org/kilocode#9434.
         compressed = _strip_historical_media(compressed)
 
+        # Enforced invariant: at least one user-role message must exist in the
+        # compressed list.  After sanitization the tail can end up with zero
+        # user turns (e.g. [system, summary(assistant), tool_result, assistant])
+        # which breaks any stock chat template that expects a user turn to
+        # follow the system prompt.  Inject a minimal continuation prompt so
+        # the model always has a user-role anchor to respond to.  Fixes the
+        # "no-user-query" template crash (Qwen3.6 hard-raise, vLLM 400).
+        has_user = any(m.get("role") == "user" for m in compressed)
+        if not has_user:
+            if not self.quiet_mode:
+                logger.warning(
+                    "Compression produced zero user-role messages — injecting "
+                    "continuation prompt to preserve template compatibility",
+                )
+            compressed.append({
+                "role": "user",
+                "content": "Please continue.",
+            })
+
         new_estimate = estimate_messages_tokens_rough(compressed)
         saved_estimate = display_tokens - new_estimate
 


### PR DESCRIPTION
…ompression

After compression + sanitization the message list can end up with zero user-role messages ([system, summary(assistant), tool_result, assistant]), which breaks any stock chat template that expects a user turn — e.g. Qwen3.6's template hard-raises 'No user query found in messages', and vLLM >= 0.24 hits it at tool-parser-generation time, 400ing the request before a single token. Downstream effect: agent sessions die mid-task.

Enforce the invariant at the end of compression: if no user message survived, inject a minimal 'Please continue.' user turn. No-op when a user message exists (the common case).

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

