### PR TITLE
fix: allow WhatsApp handoff customer DMs

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -625,6 +625,16 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             bridge_env = with_hermes_node_path()
             if self._reply_prefix is not None:
                 bridge_env["WHATSAPP_REPLY_PREFIX"] = self._reply_prefix
+            try:
+                from hermes_cli.config import load_config
+
+                root_cfg = load_config()
+                hil_cfg = root_cfg.get("whatsapp_human_in_loop") or root_cfg.get("customer_handoff") or {}
+                if isinstance(hil_cfg, dict) and str(hil_cfg.get("enabled", True)).lower() not in {"false", "0", "no", "off"}:
+                    bridge_env["WHATSAPP_ALLOW_NON_SELF"] = "true"
+            except Exception:
+                # If config loading fails, keep the bridge's safe vanilla self-chat behavior.
+                pass
             # Pass the profile-aware cache directories so the bridge writes
             # media where the Python side reads it.  Without these the bridge
             # hardcodes ~/.hermes/{image,audio,document}_cache, which diverges

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -33,6 +33,7 @@ import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
+import { classifyInboundMessageGate } from './inbound_message_gate.js';
 import {
   buildPollPayload,
   buildLocationPayload,
@@ -101,6 +102,13 @@ try {
 } catch {}
 const PAIR_ONLY = args.includes('--pair-only');
 const WHATSAPP_MODE = getArg('mode', process.env.WHATSAPP_MODE || 'self-chat'); // "bot" or "self-chat"
+// Human-in-the-loop handoff needs a hybrid mode: keep owner self-chat support,
+// but allow real incoming customer DMs to reach Python's pre_gateway_dispatch
+// plugin before the normal agent/auth path. Off by default so vanilla self-chat
+// remains protected from arbitrary stranger DMs.
+const WHATSAPP_ALLOW_NON_SELF = ['1', 'true', 'yes', 'on'].includes(
+  String(process.env.WHATSAPP_ALLOW_NON_SELF || '').toLowerCase(),
+);
 const ALLOWED_USERS = parseAllowedUsers(process.env.WHATSAPP_ALLOWED_USERS || '');
 const DEFAULT_REPLY_PREFIX = '⚕ *Hermes Agent*\n────────────\n';
 const REPLY_PREFIX = process.env.WHATSAPP_REPLY_PREFIX === undefined
@@ -556,27 +564,33 @@ async function startSocket() {
       // Python gateway, otherwise a pairing-code reply fires in response
       // to arbitrary incoming messages (#8389).
       if (!msg.key.fromMe) {
-        if (WHATSAPP_MODE === 'self-chat') {
+        const inboundDecision = classifyInboundMessageGate({
+          fromMe: msg.key.fromMe,
+          mode: WHATSAPP_MODE,
+          allowNonSelf: WHATSAPP_ALLOW_NON_SELF,
+          allowlistMatches: (id) => matchesAllowedUser(id, ALLOWED_USERS, SESSION_DIR),
+          senderId,
+        });
+        if (inboundDecision.action === 'drop') {
           try {
             console.log(JSON.stringify({
               event: 'ignored',
-              reason: 'self_chat_mode_rejects_non_self',
+              reason: inboundDecision.reason,
               chatId,
               senderId,
             }));
           } catch {}
           continue;
         }
-        if (!matchesAllowedUser(senderId, ALLOWED_USERS, SESSION_DIR)) {
+        if (WHATSAPP_DEBUG && inboundDecision.reason) {
           try {
             console.log(JSON.stringify({
-              event: 'ignored',
-              reason: 'allowlist_mismatch',
+              event: 'accepted',
+              reason: inboundDecision.reason,
               chatId,
               senderId,
             }));
           } catch {}
-          continue;
         }
       }
 

--- a/scripts/whatsapp-bridge/inbound_message_gate.js
+++ b/scripts/whatsapp-bridge/inbound_message_gate.js
@@ -1,0 +1,35 @@
+/**
+ * Pure classifier for incoming non-fromMe WhatsApp messages.
+ *
+ * Self-chat mode normally rejects non-self messages so Hermes cannot become an
+ * unsolicited WhatsApp bot. Human-in-the-loop/customer handoff deployments need
+ * a narrow opt-in that lets customer DMs reach Python's pre_gateway_dispatch
+ * plugin while preserving the safe default.
+ */
+export function classifyInboundMessageGate({
+  fromMe,
+  mode,
+  allowNonSelf,
+  allowlistMatches,
+  senderId,
+}) {
+  if (fromMe) {
+    return { action: 'pass' };
+  }
+
+  if (mode === 'self-chat') {
+    return allowNonSelf
+      ? { action: 'pass', reason: 'human_in_loop_allows_non_self' }
+      : { action: 'drop', reason: 'self_chat_mode_rejects_non_self' };
+  }
+
+  if (!allowNonSelf && typeof allowlistMatches === 'function' && !allowlistMatches(senderId)) {
+    return { action: 'drop', reason: 'allowlist_mismatch' };
+  }
+
+  if (allowNonSelf && typeof allowlistMatches === 'function' && !allowlistMatches(senderId)) {
+    return { action: 'pass', reason: 'human_in_loop_bypasses_allowlist' };
+  }
+
+  return { action: 'pass' };
+}

--- a/scripts/whatsapp-bridge/inbound_message_gate.test.mjs
+++ b/scripts/whatsapp-bridge/inbound_message_gate.test.mjs
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { classifyInboundMessageGate } from './inbound_message_gate.js';
+
+function makeAllowlist(allowedIds) {
+  const set = new Set(allowedIds);
+  return (id) => set.has(id);
+}
+
+test('fromMe messages pass through inbound gate', () => {
+  assert.deepEqual(classifyInboundMessageGate({ fromMe: true }), { action: 'pass' });
+});
+
+test('self-chat mode rejects non-self messages by default', () => {
+  assert.deepEqual(
+    classifyInboundMessageGate({
+      fromMe: false,
+      mode: 'self-chat',
+      allowNonSelf: false,
+    }),
+    { action: 'drop', reason: 'self_chat_mode_rejects_non_self' },
+  );
+});
+
+test('human-in-loop opt-in lets customer DMs reach Python pre-dispatch in self-chat mode', () => {
+  assert.deepEqual(
+    classifyInboundMessageGate({
+      fromMe: false,
+      mode: 'self-chat',
+      allowNonSelf: true,
+    }),
+    { action: 'pass', reason: 'human_in_loop_allows_non_self' },
+  );
+});
+
+test('bot mode keeps allowlist protection without human-in-loop opt-in', () => {
+  assert.deepEqual(
+    classifyInboundMessageGate({
+      fromMe: false,
+      mode: 'bot',
+      allowNonSelf: false,
+      allowlistMatches: makeAllowlist(['owner@s.whatsapp.net']),
+      senderId: 'customer@s.whatsapp.net',
+    }),
+    { action: 'drop', reason: 'allowlist_mismatch' },
+  );
+});
+
+test('human-in-loop opt-in bypasses sender allowlist in bot mode', () => {
+  assert.deepEqual(
+    classifyInboundMessageGate({
+      fromMe: false,
+      mode: 'bot',
+      allowNonSelf: true,
+      allowlistMatches: makeAllowlist(['owner@s.whatsapp.net']),
+      senderId: 'customer@s.whatsapp.net',
+    }),
+    { action: 'pass', reason: 'human_in_loop_bypasses_allowlist' },
+  );
+});


### PR DESCRIPTION
## Summary
- keep vanilla WhatsApp self-chat safe by default while enabling human-in-the-loop customer handoff when configured
- add a pure inbound message gate and unit tests for self-chat rejection, allowlist behavior, and human-in-loop bypass
- wire the Python WhatsApp adapter to set WHATSAPP_ALLOW_NON_SELF only when handoff config is enabled
- discard local-only pairing/business-learning helper files from this repo cleanup

## Verification
- node --test scripts/whatsapp-bridge/inbound_message_gate.test.mjs scripts/whatsapp-bridge/owner_message_gate.test.mjs scripts/whatsapp-bridge/outbound_ids.test.mjs
- python -m py_compile plugins/platforms/whatsapp/adapter.py
- git diff --check