### PR TITLE
fix: normalize CRLF to LF before computing file hashes (#58825)

### DIFF
--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -773,6 +773,10 @@ def content_hash(skill_path: Path) -> str:
     produce the same digest for the same skill (one operates on disk,
     one on an in-memory bundle), so any change to the hash shape MUST
     land in both places at once.
+
+    Line endings are normalized (CRLF → LF) before hashing so that
+    Windows checkouts (where git converts to CRLF) produce the same
+    hash as POSIX checkouts and in-memory bundles.
     """
     h = hashlib.sha256()
     if skill_path.is_dir():
@@ -782,11 +786,16 @@ def content_hash(skill_path: Path) -> str:
                     rel = f.relative_to(skill_path).as_posix()
                     h.update(rel.encode("utf-8"))
                     h.update(b"\x00")
-                    h.update(f.read_bytes())
+                    content = f.read_bytes()
+                    # Normalize CRLF → LF so Windows/POSIX hashes match
+                    content = content.replace(b"\r\n", b"\n")
+                    h.update(content)
                 except OSError:
                     continue
     elif skill_path.is_file():
-        h.update(skill_path.read_bytes())
+        content = skill_path.read_bytes()
+        content = content.replace(b"\r\n", b"\n")
+        h.update(content)
     return f"sha256:{h.hexdigest()[:16]}"
 
 

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -230,14 +230,21 @@ def _compute_relative_dest(skill_dir: Path, bundled_dir: Path) -> Path:
 
 
 def _dir_hash(directory: Path) -> str:
-    """Compute a hash of all file contents in a directory for change detection."""
+    """Compute a hash of all file contents in a directory for change detection.
+
+    Line endings are normalized (CRLF → LF) before hashing so that
+    Windows checkouts produce the same hash as POSIX checkouts.
+    """
     hasher = hashlib.md5()
     try:
         for fpath in sorted(directory.rglob("*")):
             if fpath.is_file():
                 rel = fpath.relative_to(directory)
                 hasher.update(str(rel).encode("utf-8"))
-                hasher.update(fpath.read_bytes())
+                content = fpath.read_bytes()
+                # Normalize CRLF → LF so Windows/POSIX hashes match
+                content = content.replace(b"\r\n", b"\n")
+                hasher.update(content)
     except (OSError, IOError):
         pass
     return hasher.hexdigest()


### PR DESCRIPTION
On Windows, git checks out files with CRLF line endings. The `content_hash` function in `skills_guard.py` and `_dir_hash` in `skills_sync.py` read raw bytes from disk, producing hashes that differ from the LF-only hashes computed on POSIX or from in-memory bundles. This caused `hermes skills check` to always report `update_available` on Windows.

Fix: normalize CRLF → LF before feeding file content into the hash computation, so Windows and POSIX checkouts produce identical hashes for the same skill.

Closes #58825.