### PR TITLE
[codex] preserve context length on model re-pick

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1558,7 +1558,8 @@ def _apply_main_model_assignment(
     ``OPENAI_BASE_URL``) and only honors it when the configured provider matches
     and the pool entry is on the registry default, so preserving it here is what
     lets the override actually route. The hardcoded ``context_length`` override
-    is always dropped since the new model may have a different context window.
+    is dropped only on a real model/provider switch; same-model re-picks keep the
+    user's manual context-window override intact.
 
     Returns the same dict (coerced to a fresh dict if the input wasn't one) so
     callers can assign it straight back onto the model config.
@@ -1566,7 +1567,9 @@ def _apply_main_model_assignment(
     if not isinstance(model_cfg, dict):
         model_cfg = {}
     prev_provider = str(model_cfg.get("provider") or "").strip().lower()
+    prev_model = str(model_cfg.get("default") or "").strip()
     new_provider = provider.strip().lower()
+    new_model = str(model or "").strip()
     model_cfg["provider"] = provider
     model_cfg["default"] = model
     if base_url.strip():
@@ -1592,7 +1595,8 @@ def _apply_main_model_assignment(
         clear_model_endpoint_credentials(model_cfg, clear_api_mode=False)
     if new_provider != prev_provider:
         clear_model_endpoint_credentials(model_cfg, clear_api_key=False)
-    model_cfg.pop("context_length", None)
+    if new_provider != prev_provider or new_model != prev_model:
+        model_cfg.pop("context_length", None)
     return model_cfg
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1857,7 +1857,8 @@ def _apply_main_model_assignment(
     ``OPENAI_BASE_URL``) and only honors it when the configured provider matches
     and the pool entry is on the registry default, so preserving it here is what
     lets the override actually route. The hardcoded ``context_length`` override
-    is always dropped since the new model may have a different context window.
+    is dropped only on a real model/provider switch; same-model re-picks keep the
+    user's manual context-window override intact.
 
     Returns the same dict (coerced to a fresh dict if the input wasn't one) so
     callers can assign it straight back onto the model config.
@@ -1865,7 +1866,9 @@ def _apply_main_model_assignment(
     if not isinstance(model_cfg, dict):
         model_cfg = {}
     prev_provider = str(model_cfg.get("provider") or "").strip().lower()
+    prev_model = str(model_cfg.get("default") or "").strip()
     new_provider = provider.strip().lower()
+    new_model = str(model or "").strip()
     model_cfg["provider"] = provider
     model_cfg["default"] = model
     if base_url.strip():
@@ -1891,7 +1894,8 @@ def _apply_main_model_assignment(
         clear_model_endpoint_credentials(model_cfg, clear_api_mode=False)
     if new_provider != prev_provider:
         clear_model_endpoint_credentials(model_cfg, clear_api_key=False)
-    model_cfg.pop("context_length", None)
+    if new_provider != prev_provider or new_model != prev_model:
+        model_cfg.pop("context_length", None)
     return model_cfg
 
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1445,6 +1445,38 @@ class TestWebServerEndpoints:
 
 
 
+    def test_main_model_repick_preserves_context_only_for_same_assignment(self):
+        from hermes_cli.web_server import _apply_main_model_assignment
+
+        current = {
+            "provider": "custom",
+            "default": "my-local-model",
+            "base_url": "http://127.0.0.1:8000/v1",
+            "context_length": 262144,
+        }
+
+        same = _apply_main_model_assignment(
+            current.copy(),
+            "custom",
+            "my-local-model",
+            "http://127.0.0.1:8000/v1",
+        )
+        assert same["context_length"] == 262144
+
+        different_model = _apply_main_model_assignment(
+            current.copy(),
+            "custom",
+            "other-local-model",
+        )
+        assert "context_length" not in different_model
+
+        different_provider = _apply_main_model_assignment(
+            current.copy(),
+            "openrouter",
+            "my-local-model",
+        )
+        assert "context_length" not in different_provider
+
     def test_parse_model_ids_handles_openai_and_bare_shapes(self):
         """Model discovery must tolerate the common /v1/models shapes and
         never raise (so a slightly non-standard local endpoint still works)."""

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1598,6 +1598,38 @@ class TestWebServerEndpoints:
 
 
 
+    def test_main_model_repick_preserves_context_only_for_same_assignment(self):
+        from hermes_cli.web_server import _apply_main_model_assignment
+
+        current = {
+            "provider": "custom",
+            "default": "my-local-model",
+            "base_url": "http://127.0.0.1:8000/v1",
+            "context_length": 262144,
+        }
+
+        same = _apply_main_model_assignment(
+            current.copy(),
+            "custom",
+            "my-local-model",
+            "http://127.0.0.1:8000/v1",
+        )
+        assert same["context_length"] == 262144
+
+        different_model = _apply_main_model_assignment(
+            current.copy(),
+            "custom",
+            "other-local-model",
+        )
+        assert "context_length" not in different_model
+
+        different_provider = _apply_main_model_assignment(
+            current.copy(),
+            "openrouter",
+            "my-local-model",
+        )
+        assert "context_length" not in different_provider
+
     def test_parse_model_ids_handles_openai_and_bare_shapes(self):
         """Model discovery must tolerate the common /v1/models shapes and
         never raise (so a slightly non-standard local endpoint still works)."""


### PR DESCRIPTION
## Summary
- preserve model.context_length when /api/model/set re-saves the same provider/model
- continue clearing the manual context override on real provider or model switches
- update the shared assignment helper regression test to pin both cases

Fixes #59050.

## Tests
- uv run python -m pytest tests/hermes_cli/test_web_server.py -q -k "apply_main_model_assignment or model_context_length"
- uv run ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server.py
- git diff --check