### PR TITLE
fix(mattermost): accept leading-space slash commands

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -878,6 +878,8 @@ class MattermostAdapter(BasePlatformAdapter):
         # Determine message type.
         file_ids = post.get("file_ids") or []
         msg_type = MessageType.TEXT
+        if message_text[:1].isspace() and message_text.lstrip().startswith("/"):
+            message_text = message_text.lstrip()
         if message_text.startswith("/"):
             msg_type = MessageType.COMMAND
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "lohinth25@proton.me": "l0h1nth",  # PR #32210 salvage (mattermost: accept leading-space slash commands from mobile clients; #25184)
     "perkintahmaz50@gmail.com": "devatnull",  # PR #58704 salvage (whatsapp: native Baileys polls, clarify-as-poll, location pins, structured quoted replies, PTT/audio split, bridge_helpers extraction)
     "tim@iteachyouai.com": "tjp2021",  # PR #4097 salvage (copilot: per-turn x-initiator header so user prompts bill as premium requests; #3040)
     "3723267+kevinrajaram@users.noreply.github.com": "kevinrajaram",  # PR #3850 salvage (gateway: add POSIX system dirs to PATH so launchctl/systemctl resolve under UV's minimal-PATH bundled Python; #3849)

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -6,6 +6,7 @@ import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
 
 from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageType
 from gateway.run import (
     _resolve_gateway_display_bool,
     _resolve_progress_thread_id,
@@ -587,6 +588,55 @@ class TestMattermostWebSocketParsing:
         assert self.adapter.handle_message.called
         msg_event = self.adapter.handle_message.call_args[0][0]
         assert msg_event.source.chat_type == "dm"
+
+    @pytest.mark.asyncio
+    async def test_leading_space_slash_command_is_command(self):
+        """Mattermost mobile suggests leading-space slash commands."""
+        post_data = {
+            "id": "post_cmd",
+            "user_id": "user_123",
+            "channel_id": "chan_dm",
+            "message": " /new",
+        }
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": "D",
+                "sender_name": "@bob",
+            },
+        }
+
+        await self.adapter._handle_ws_event(event)
+        assert self.adapter.handle_message.called
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "/new"
+        assert msg_event.message_type is MessageType.COMMAND
+        assert msg_event.get_command() == "new"
+
+    @pytest.mark.asyncio
+    async def test_leading_space_normal_text_is_preserved(self):
+        """Only command-shaped mobile messages should be normalized."""
+        post_data = {
+            "id": "post_text",
+            "user_id": "user_123",
+            "channel_id": "chan_dm",
+            "message": " hello",
+        }
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": "D",
+                "sender_name": "@bob",
+            },
+        }
+
+        await self.adapter._handle_ws_event(event)
+        assert self.adapter.handle_message.called
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.text == " hello"
+        assert msg_event.message_type is MessageType.TEXT
 
     @pytest.mark.asyncio
     async def test_thread_id_from_root_id(self):


### PR DESCRIPTION
## Summary
Slash commands now work for Mattermost mobile users: leading-space command messages (` /new`) are normalized before command classification. Root cause: Mattermost mobile blocks sending messages that start with `/` and suggests prefixing a space, but the adapter's bare `startswith("/")` check treated `" /new"` as plain text (#25184).

Salvage of #32210 by @l0h1nth — cherry-picked onto current main with authorship preserved. Duplicate cluster: #21070 (@MinJaeLee1, same fix submitted first but against the old pre-move `gateway/platforms/mattermost.py` path) and #29842 (broader whitespace-stripping approach that alters normal-text semantics).

## Changes
- `plugins/platforms/mattermost/adapter.py`: lstrip leading whitespace only when the stripped text starts with `/`, right before command classification (+2 lines)
- `tests/gateway/test_mattermost.py`: 2 tests — leading-space command classified as COMMAND, leading-space normal text preserved verbatim
- `scripts/release.py`: AUTHOR_MAP entry for l0h1nth

## Validation
| | Before | After |
|---|---|---|
| `" /new"` (DM) | TEXT, command ignored | COMMAND, `get_command() == "new"` |
| `" hello"` (DM) | TEXT, `" hello"` | TEXT, `" hello"` (unchanged) |
| `tests/gateway/test_mattermost.py` | — | 60/60 pass |

E2E: real `MattermostAdapter._handle_ws_event()` with actual WS `posted` payloads against isolated HERMES_HOME — 5/5 cases pass including `"  /status arg"` multi-space and bare `/stop`.

Fixes #25184. Closes #32210, #21070, #29842.

## Infographic

![mattermost-leading-space-slash](https://v3b.fal.media/files/b/0aa113e8/AxLncevLrXg33IvTtv3OH_b0m2GLja.png)
