### PR TITLE
fix(doctor): add 'moa' to recognised provider list

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -749,7 +749,7 @@ def run_doctor(args):
                     PROVIDER_REGISTRY,
                     resolve_provider as _resolve_auth_provider,
                 )
-                known_providers = set(PROVIDER_REGISTRY.keys()) | {"openrouter", "custom", "auto"}
+                known_providers = set(PROVIDER_REGISTRY.keys()) | {"openrouter", "moa", "custom", "auto"}
             except Exception:
                 _resolve_auth_provider = None
                 pass


### PR DESCRIPTION
hermes doctor was reporting model.provider 'moa' as unrecognised because
the known_providers set only included PROVIDER_REGISTRY keys plus
openrouter, custom, and auto. MoA (Mixture of Agents) is a legitimate
internal provider defined as a HermesOverlay, not a ProviderConfig, so
it was missing from the set.

Closes #58759.
