### PR TITLE
fix(docker): heal pairing-dir ownership after `docker exec` writes (#10270)

### DIFF
--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -287,6 +287,23 @@ if [ -d "$HERMES_HOME/cron" ]; then
     chown_hermes_tree "$HERMES_HOME/cron"
 fi
 
+# Always reset ownership of pairing data on every boot, same docker-exec/
+# root-write reason as profiles/ and cron/. `docker exec <container>
+# hermes pairing approve …` defaults to uid=0 and writes 0600 root-owned
+# approval files that the unprivileged hermes gateway cannot read,
+# silently leaving the approved user unauthorized (#10270). The targeted
+# data-volume chown above only runs when the top-level $HERMES_HOME is
+# mis-owned, so warm boots skip it — this block makes a container restart
+# self-heal. Tiny directory (a handful of small JSON files), so the cost
+# is negligible.
+if [ -d "$HERMES_HOME/platforms/pairing" ]; then
+    chown_hermes_tree "$HERMES_HOME/platforms/pairing"
+fi
+# Legacy location (pre-consolidated layout).
+if [ -d "$HERMES_HOME/pairing" ]; then
+    chown_hermes_tree "$HERMES_HOME/pairing"
+fi
+
 # Reset ownership of hermes-owned top-level state files on every boot.
 # The targeted data-volume chown above only covers hermes-owned
 # *subdirectories*; loose state files living directly under $HERMES_HOME

--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -228,13 +228,16 @@ class PairingStore:
                     owner_info = f"owner_uid={st.st_uid} mode={oct(st.st_mode)[-4:]}"
                 except OSError:
                     owner_info = "<stat failed>"
+                # os.geteuid doesn't exist on Windows; the Docker scenario is
+                # POSIX-only, but the gateway (and this fallback) runs anywhere.
+                euid = os.geteuid() if hasattr(os, "geteuid") else "n/a"
                 logger.warning(
                     "Pairing file %s exists but is not readable as uid=%s (%s; %s). "
                     "If you ran `docker exec <container> hermes pairing approve ...` as root, "
                     "re-run with `docker exec -u hermes <container> ...` and "
                     "chown the existing file to the hermes user, or restart the "
                     "container so the entrypoint can fix ownership.",
-                    path, os.geteuid(), owner_info, e,
+                    path, euid, owner_info, e,
                 )
                 return {}
             except (json.JSONDecodeError, OSError):

--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -20,6 +20,7 @@ Storage: ~/.hermes/pairing/
 
 import hashlib
 import json
+import logging
 import os
 import secrets
 import tempfile
@@ -34,6 +35,8 @@ from gateway.whatsapp_identity import (
 )
 from hermes_constants import get_hermes_dir
 from utils import atomic_replace
+
+logger = logging.getLogger(__name__)
 
 
 # Unambiguous alphabet -- excludes 0/O, 1/I to prevent confusion
@@ -213,6 +216,27 @@ class PairingStore:
         if path.exists():
             try:
                 return json.loads(path.read_text(encoding="utf-8"))
+            except PermissionError as e:
+                # Surface this loudly: a 0600 file owned by a different user
+                # (classic Docker symptom: `docker exec` runs as root and writes
+                # the file, then the gateway process — running as `hermes` after
+                # gosu drop — can't read it) would otherwise be swallowed by
+                # the generic OSError branch below, silently leaving the user
+                # marked unauthorized. See issue #10270.
+                try:
+                    st = path.stat()
+                    owner_info = f"owner_uid={st.st_uid} mode={oct(st.st_mode)[-4:]}"
+                except OSError:
+                    owner_info = "<stat failed>"
+                logger.warning(
+                    "Pairing file %s exists but is not readable as uid=%s (%s; %s). "
+                    "If you ran `docker exec <container> hermes pairing approve ...` as root, "
+                    "re-run with `docker exec -u hermes <container> ...` and "
+                    "chown the existing file to the hermes user, or restart the "
+                    "container so the entrypoint can fix ownership.",
+                    path, os.geteuid(), owner_info, e,
+                )
+                return {}
             except (json.JSONDecodeError, OSError):
                 return {}
         return {}

--- a/tests/gateway/test_pairing.py
+++ b/tests/gateway/test_pairing.py
@@ -4,6 +4,7 @@ import json
 import os
 import sys
 import time
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -651,3 +652,71 @@ class TestListAndClear:
             store.generate_code("discord", "user2")
             count = store.clear_pending()
         assert count == 2
+
+
+# ---------------------------------------------------------------------------
+# Unreadable approved-list file logs a warning instead of failing silently
+# (issue #10270: Docker `docker exec` writes root-owned 0600 files that the
+# post-gosu gateway can't read; the previous OSError swallow turned the bug
+# into a mystery "Unauthorized user" message)
+# ---------------------------------------------------------------------------
+
+
+class TestUnreadablePairingFile:
+    def test_permission_error_logs_warning_and_returns_empty(self, tmp_path, caplog):
+        import logging
+        import builtins
+
+        approved_path = tmp_path / "weixin-approved.json"
+        approved_path.write_text(
+            '{"o9cq80fake@im.wechat": {"user_name": "x", "approved_at": 0}}'
+        )
+
+        real_open = builtins.open
+
+        def fake_read_text(self, *a, **kw):
+            # Path.read_text uses Path.open internally; raise PermissionError
+            # to mimic a 0600 file owned by a different uid.
+            raise PermissionError(13, "Permission denied", str(self))
+
+        with patch("gateway.pairing.PAIRING_DIR", tmp_path), \
+             patch.object(Path, "read_text", fake_read_text), \
+             caplog.at_level(logging.WARNING, logger="gateway.pairing"):
+            store = PairingStore()
+            result = store._load_json(approved_path)
+
+        assert result == {}, "should fall back to empty dict, not raise"
+        assert any(
+            "not readable" in rec.getMessage() and "#10270" not in rec.getMessage()
+            or "not readable" in rec.getMessage()
+            for rec in caplog.records
+        ), f"expected a warning about unreadable pairing file, got {caplog.records!r}"
+        # And the warning should include actionable advice
+        msgs = " ".join(rec.getMessage() for rec in caplog.records)
+        assert "docker exec" in msgs
+        assert "-u hermes" in msgs
+
+    def test_is_approved_returns_false_when_file_unreadable(self, tmp_path, caplog):
+        """End-to-end: an unreadable approved.json must not crash the gateway,
+        and the affected user must stay unauthorized (the documented fallback
+        behaviour) rather than triggering a 500."""
+        import logging
+
+        approved_path = tmp_path / "weixin-approved.json"
+        approved_path.write_text(
+            '{"o9cq80fake@im.wechat": {"user_name": "x", "approved_at": 0}}'
+        )
+
+        def fake_read_text(self, *a, **kw):
+            raise PermissionError(13, "Permission denied", str(self))
+
+        with patch("gateway.pairing.PAIRING_DIR", tmp_path), \
+             patch.object(Path, "read_text", fake_read_text), \
+             caplog.at_level(logging.WARNING, logger="gateway.pairing"):
+            store = PairingStore()
+            ok = store.is_approved("weixin", "o9cq80fake@im.wechat")
+
+        assert ok is False
+        # The warning must fire — otherwise this is the silent-failure bug.
+        assert any(rec.levelno == logging.WARNING for rec in caplog.records), \
+            "PermissionError on approved.json must produce a WARNING log line"

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -306,6 +306,24 @@ hermes pairing revoke telegram 123456789
 hermes pairing clear-pending
 ```
 
+:::tip Docker users: run pairing commands as the `hermes` user
+The official Docker image runs the gateway as the unprivileged `hermes` user
+(uid 10000) via `gosu`, but `docker exec` defaults to root. Approval files
+created by root are written with mode `0600 root:root` and the gateway
+cannot read them — the approval is silently ignored ([#10270][i10270]).
+
+Always pass `-u hermes`:
+
+```bash
+docker exec -u hermes hermes-agent hermes pairing approve telegram ABC12DEF
+```
+
+If you already ran the command as root and the user is still unauthorized,
+restart the container — the entrypoint will fix ownership on the next start.
+
+[i10270]: https://github.com/NousResearch/hermes-agent/issues/10270
+:::
+
 **Storage:** Pairing data is stored in `~/.hermes/pairing/` with per-platform JSON files:
 - `{platform}-pending.json` — pending pairing requests
 - `{platform}-approved.json` — approved users


### PR DESCRIPTION
## Summary
Pairing approvals issued via `docker exec <container> hermes pairing approve …` are now honored on the official Docker image — a container restart self-heals root-owned pairing files, and an unreadable pairing file logs an actionable WARNING instead of silently marking the user unauthorized.

Root cause: `docker exec` defaults to uid 0, so the approve command writes the approval file `root:root 0600`. The stage2 hook's data-volume chown is gated on the *top-level* `$HERMES_HOME` being mis-owned, so warm boots skip it — even restarting the container didn't self-heal. `PairingStore._load_json` then swallowed the resulting `PermissionError` under a bare `except OSError`, turning the bug into a mystery "Unauthorized user" log line.

Re-salvage of #26844 onto current main: the entrypoint that PR patched (`docker/entrypoint.sh`) is now a deprecated s6 shim, so the chown lands in `docker/stage2-hook.sh` next to the existing every-boot `profiles/` and `cron/` blocks that follow the same docker-exec/root-write pattern.

Closes #10270.

## Changes
- `docker/stage2-hook.sh`: chown `platforms/pairing/` (and legacy `pairing/`) on every container start via the existing `chown_hermes_tree` helper (symlink-guarded, rootless-safe), regardless of the top-level chown gate.
- `gateway/pairing.py`: split `PermissionError` out of the `_load_json` swallow-all; log a WARNING naming the file, gateway uid, file owner/mode, and the `docker exec -u hermes` workaround. Still falls back to `{}` so the gateway stays up.
- `website/docs/user-guide/security.md`: Docker tip in the pairing-CLI section (`-u hermes` up front).
- `tests/gateway/test_pairing.py`: 2 new tests for the `PermissionError` path on `_load_json` and `is_approved` (plus the `Path` import current main's file no longer had).

## Validation
| | Before | After |
|---|---|---|
| File on disk after container restart | `root:root 600` | `hermes:hermes` (stage2 heals) |
| Gateway sees approved user after restart | 0 | 1 |
| `PermissionError` on `_load_json` | silently `{}` | WARNING + `{}` |

- Targeted tests: `tests/gateway/test_pairing.py` 45/45 pass.
- E2E: real `chmod 000` file in an isolated `HERMES_HOME` → `is_approved` returns False with one WARNING containing the `-u hermes` hint; `chmod 600` → `is_approved` returns True, zero warnings.
- `sh -n docker/stage2-hook.sh` clean.

Supersedes #26844 (stale by ~6000 commits; patched the pre-s6 entrypoint that no longer runs).

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa113ee/U8QwGBLYye4jGQor1H9RX_85fTRLCS.png)
