### PR TITLE
fix(auxiliary): add stream param to async_call_llm()

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6572,10 +6572,17 @@ async def async_call_llm(
     tools: list = None,
     timeout: float = None,
     extra_body: dict = None,
+    stream: bool = False,
+    stream_options: dict = None,
 ) -> Any:
     """Centralized asynchronous LLM call.
 
     Same as call_llm() but async. See call_llm() for full documentation.
+
+    When ``stream=True``, returns the raw SDK ``AsyncStream`` iterator and
+    skips all response validation, temperature/max_tokens retry, and payment
+    fallback — mirroring the sync ``call_llm()`` streaming path. The caller
+    owns chunk reassembly, stale-stream detection, and non-streaming fallback.
     """
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)
@@ -6656,6 +6663,15 @@ async def async_call_llm(
     # Convert image blocks for Anthropic-compatible endpoints (e.g. MiniMax)
     if _is_anthropic_compat_endpoint(resolved_provider, _client_base):
         kwargs["messages"] = _convert_openai_images_to_anthropic(kwargs["messages"])
+
+    # Streaming path: return the raw SDK AsyncStream iterator directly,
+    # mirroring the sync call_llm() streaming path. Skips all response
+    # validation, temperature/max_tokens retry, and payment fallback.
+    if stream:
+        kwargs["stream"] = True
+        if stream_options:
+            kwargs["stream_options"] = stream_options
+        return await client.chat.completions.create(**kwargs)
 
     try:
         # Retry ONCE on the same provider for a transient transport blip


### PR DESCRIPTION
Adds Version: ImageMagick 7.1.2-19 Q16-HDRI aarch64 23897 https://imagemagick.org
Copyright: (C) 1999 ImageMagick Studio LLC
License: https://imagemagick.org/license/
Features: Cipher DPC HDRI Modules
Delegates (built-in): bzlib freetype heic jng jpeg lcms ltdl lzma png tiff webp xml zlib zstd
Compiler: clang (21.0.0)
Usage: stream [options ...] input-image raw-image

Image Settings:
  -authenticate password
                       decipher image with this password
  -colorspace type     alternate image colorspace
  -compress type       type of pixel compression when writing the image
  -define format:option
                       define one or more image format options
  -density geometry    horizontal and vertical density of the image
  -depth value         image depth
  -extract geometry    extract area from image
  -identify            identify the format and characteristics of the image
  -interlace type      type of image interlacing scheme
  -interpolate method  pixel color interpolation method
  -limit type value    pixel cache resource limit
  -map components      one or more pixel components
  -monitor             monitor progress
  -quantize colorspace reduce colors in this colorspace
  -quiet               suppress all warning messages
  -regard-warnings     pay attention to warning messages
  -respect-parentheses settings remain in effect until parenthesis boundary
  -sampling-factor geometry
                       horizontal and vertical sampling factor
  -seed value          seed a new sequence of pseudo-random numbers
  -set attribute value set an image attribute
  -size geometry       width and height of image
  -storage-type type   pixel storage type
  -synchronize         synchronize image to storage device
  -taint               declare the image as modified
  -transparent-color color
                       transparent color
  -verbose             print detailed information about the image
  -virtual-pixel method
                       virtual pixel access method

Miscellaneous Options:
  -channel mask        set the image channel mask
  -debug events        display copious debugging information
  -help                print program options
  -list type           print a list of supported option arguments
  -log format          format of debugging information
  -version             print version information

By default, the image format of 'file' is determined by its magic
number.  To specify a particular image format, precede the filename
with an image format name and a colon (i.e. ps:image) or specify the
image type as the filename suffix (i.e. image.ps).  Specify 'file' as
'-' for standard input or output. and  parameters to ,
mirroring the synchronous  streaming path. When ,
returns the raw SDK AsyncStream iterator directly, skipping response
validation, retry, and fallback — matching the sync version's behavior.

Fixes #58876
