### PR TITLE
fix: add automatic base64 padding before decode in image/file upload paths

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6954,6 +6954,10 @@ def _pet_reference_images_from_data_url(ref_raw: str, stage) -> list:
         raise ValueError("reference image too large")
 
     try:
+        # Auto-pad base64 before decoding for clients that strip padding
+        missing_padding = 4 - len(payload) % 4
+        if missing_padding != 4:
+            payload += "=" * missing_padding
         raw = base64.b64decode(payload, validate=True)
     except (binascii.Error, ValueError) as exc:
         raise ValueError("invalid reference image data") from exc
@@ -9075,6 +9079,10 @@ def _decode_attach_base64(raw: str, *, mime_prefix: str) -> bytes | None:
     if m:
         cleaned = m.group(1)
     cleaned = _re.sub(r"\s+", "", cleaned)
+    # Auto-pad base64 before decoding for clients that strip padding
+    missing_padding = 4 - len(cleaned) % 4
+    if missing_padding != 4:
+        cleaned += "=" * missing_padding
     try:
         return _base64.b64decode(cleaned, validate=True)
     except Exception:


### PR DESCRIPTION
Unpadded base64-encoded image/file data (missing trailing '=') is rejected
by Python's b64decode with validate=True. Add automatic padding restoration
before every  b64decode call in the tui_gateway.

Fixes #58791
