### PR TITLE
simplicio/fix 58672 snapshot keep

### DIFF
--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -875,6 +875,8 @@ export interface MoaConfigResponse {
   max_tokens: number
   reference_models: MoaModelSlot[]
   reference_temperature: number
+  save_traces: boolean
+  trace_dir: string
 }
 
 export interface ModelAssignmentRequest {

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9707,7 +9707,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         try:
             from hermes_cli.backup import create_quick_snapshot
 
-            pre_update_snapshot_id = create_quick_snapshot(label="pre-update", keep=1)
+            pre_update_snapshot_id = create_quick_snapshot(label="pre-update", keep=3)
             if pre_update_snapshot_id:
                 print(f"  ✓ Pre-update snapshot: {pre_update_snapshot_id}")
         except Exception as exc:

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -193,6 +193,9 @@ def normalize_moa_config(raw: Any) -> dict[str, Any]:
         "reference_max_tokens": active.get("reference_max_tokens"),
         "fanout": active.get("fanout", "per_iteration"),
         "enabled": active["enabled"],
+        # Top-level MoA config fields (not per-preset).
+        "save_traces": bool(raw.get("save_traces", False)),
+        "trace_dir": str(raw.get("trace_dir", "")),
     }
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -972,6 +972,8 @@ class MoaConfigPayload(BaseModel):
     aggregator_temperature: Optional[float] = None
     max_tokens: int = 4096
     enabled: bool = True
+    save_traces: bool = False
+    trace_dir: str = ""
     profile: Optional[str] = None
 
 
@@ -4464,6 +4466,8 @@ def set_moa_models(body: MoaConfigPayload, profile: Optional[str] = None):
                 raw = {
                     "default_preset": body.default_preset,
                     "active_preset": body.active_preset,
+                    "save_traces": body.save_traces,
+                    "trace_dir": body.trace_dir,
                     "presets": {
                         name: {
                             "reference_models": [slot.dict() for slot in preset.reference_models],
@@ -4484,6 +4488,8 @@ def set_moa_models(body: MoaConfigPayload, profile: Optional[str] = None):
                     "aggregator_temperature": body.aggregator_temperature,
                     "max_tokens": body.max_tokens,
                     "enabled": body.enabled,
+                    "save_traces": body.save_traces,
+                    "trace_dir": body.trace_dir,
                 }
             normalized = normalize_moa_config(raw)
             cfg["moa"] = normalized

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -392,3 +392,8 @@ select = ["PLW1514"]
 "skills/**" = ["PLW1514"]
 "optional-skills/**" = ["PLW1514"]
 "plugins/**" = ["PLW1514"]
+
+[dependency-groups]
+dev = [
+    "pytest-asyncio>=1.3.0",
+]

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1671,7 +1671,8 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         return _transcribe_local_command(file_path, model_name)
 
     if provider == "groq":
-        model_name = model or DEFAULT_GROQ_STT_MODEL
+        groq_cfg = stt_config.get("groq", {})
+        model_name = model or groq_cfg.get("model", DEFAULT_GROQ_STT_MODEL)
         return _transcribe_groq(file_path, model_name)
 
     if provider == "openai":

--- a/uv.lock
+++ b/uv.lock
@@ -1730,6 +1730,11 @@ youtube = [
     { name = "youtube-transcript-api" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest-asyncio" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "agent-client-protocol", marker = "extra == 'acp'", specifier = "==0.9.0" },
@@ -1854,6 +1859,9 @@ requires-dist = [
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
 provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "pty", "honcho", "supermemory", "mem0", "vision", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest-asyncio", specifier = ">=1.3.0" }]
 
 [[package]]
 name = "hf-xet"


### PR DESCRIPTION
- **fix: Groq STT now reads model from config.yaml instead of hardcoding**
- **fix(update): change pre-update snapshot keep=1 to keep=3 to avoid silently pruning all other snapshots**
- **fix: preserve save_traces and trace_dir fields in MOA settings save path**
