### PR TITLE
fix: remove stale noqa comments from root-level files (RUF100)

### DIFF
--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -16,7 +16,7 @@ Usage::
 # IMPORTANT: hermes_bootstrap must be the very first import — UTF-8 stdio
 # on Windows.  No-op on POSIX.  See hermes_bootstrap.py for full rationale.
 try:
-    import hermes_bootstrap  # noqa: F401
+    import hermes_bootstrap
 except ModuleNotFoundError:
     # Graceful fallback when hermes_bootstrap isn't registered in the venv
     # yet — happens during partial ``hermes update`` where git-reset landed
@@ -153,8 +153,8 @@ def _print_version() -> None:
 
 
 def _run_check() -> None:
-    import acp  # noqa: F401
-    from acp_adapter.server import HermesACPAgent  # noqa: F401
+    import acp
+    from acp_adapter.server import HermesACPAgent
 
     print("Hermes ACP check OK")
 

--- a/batch_runner.py
+++ b/batch_runner.py
@@ -23,7 +23,7 @@ Usage:
 # IMPORTANT: hermes_bootstrap must be the very first import — UTF-8 stdio
 # on Windows.  No-op on POSIX.  See hermes_bootstrap.py for full rationale.
 try:
-    import hermes_bootstrap  # noqa: F401
+    import hermes_bootstrap
 except ModuleNotFoundError:
     # Graceful fallback when hermes_bootstrap isn't registered in the venv
     # yet — happens during partial ``hermes update`` where git-reset landed

--- a/cli.py
+++ b/cli.py
@@ -15,7 +15,7 @@ Usage:
 # IMPORTANT: hermes_bootstrap must be the very first import — UTF-8 stdio
 # on Windows.  No-op on POSIX.  See hermes_bootstrap.py for full rationale.
 try:
-    import hermes_bootstrap  # noqa: F401
+    import hermes_bootstrap
 except ModuleNotFoundError:
     # Graceful fallback when hermes_bootstrap isn't registered in the venv
     # yet — happens during partial ``hermes update`` where git-reset landed
@@ -3081,7 +3081,7 @@ def _apply_bracketed_paste_timeout_patch() -> None:
         _vt100_mod.Vt100Parser.feed = _patched_vt100_feed
         _vt100_mod._hermes_bp_timeout_patched = True
         logger.debug("Applied Vt100Parser bracketed-paste timeout patch (#16263)")
-    except Exception as exc:  # noqa: BLE001 — defensive: never break startup
+    except Exception as exc:
         logger.debug("Bracketed-paste timeout patch skipped: %s", exc)
 
 
@@ -15956,7 +15956,7 @@ def main(
                         _build_parts = None
                         try:
                             from agent.image_routing import (
-                                build_native_content_parts as _build_parts,  # noqa: F811
+                                build_native_content_parts as _build_parts,
                             )
                             from agent.image_routing import decide_image_input_mode
                             from hermes_cli.config import load_config

--- a/cron/blueprint_catalog.py
+++ b/cron/blueprint_catalog.py
@@ -103,7 +103,7 @@ class AutomationBlueprint:
 # Curated in-repo catalog
 # ---------------------------------------------------------------------------
 
-_TIME = lambda default="08:00": BlueprintSlot(  # noqa: E731 - concise factory
+_TIME = lambda default="08:00": BlueprintSlot(
     name="time", type="time", label="What time?", default=default,
     help="24h local time, e.g. 08:00",
 )

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -62,11 +62,11 @@ from typing import Optional, Sequence
 # module (class declaration, ``isinstance`` checks, docstring) working
 # unchanged. See #44873.
 if sys.platform == "win32":
-    from concurrent_log_handler import (  # noqa: E402
+    from concurrent_log_handler import (
         ConcurrentRotatingFileHandler as RotatingFileHandler,
     )
 else:
-    from logging.handlers import RotatingFileHandler  # noqa: E402
+    from logging.handlers import RotatingFileHandler
 
 
 from hermes_constants import get_config_path, get_hermes_home

--- a/model_tools.py
+++ b/model_tools.py
@@ -1066,7 +1066,7 @@ def handle_function_call(
     # tool name, not the bridge.
     _ts_mod = None
     try:
-        from tools import tool_search as _ts_mod  # noqa: F401
+        from tools import tool_search as _ts_mod
     except Exception:
         _ts_mod = None
 

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -36,7 +36,7 @@ import logging
 import sys
 from pathlib import Path
 
-from providers.base import OMIT_TEMPERATURE, ProviderProfile  # noqa: F401
+from providers.base import OMIT_TEMPERATURE, ProviderProfile
 
 logger = logging.getLogger(__name__)
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -23,7 +23,7 @@ Usage:
 # IMPORTANT: hermes_bootstrap must be the very first import — UTF-8 stdio
 # on Windows.  No-op on POSIX.  See hermes_bootstrap.py for full rationale.
 try:
-    import hermes_bootstrap  # noqa: F401
+    import hermes_bootstrap
 except ModuleNotFoundError:
     # Graceful fallback when hermes_bootstrap isn't registered in the venv
     # yet — happens during partial ``hermes update`` where git-reset landed
@@ -109,8 +109,8 @@ def _session_source_for_agent(platform: Optional[str]) -> str:
 # siblings, or the `_ra().<X>` indirection in agent/system_prompt.py — none
 # of which ruff's in-module usage scan can see.
 from agent.process_bootstrap import (
-    OpenAI,  # noqa: F401  # re-exported for tests that mock.patch("run_agent.OpenAI")
-    _SafeWriter,  # noqa: F401  # re-exported for tests that `from run_agent import _SafeWriter`
+    OpenAI,  # re-exported for tests that mock.patch("run_agent.OpenAI")
+    _SafeWriter,  # re-exported for tests that `from run_agent import _SafeWriter`
     _get_proxy_for_base_url,
 )
 from agent.iteration_budget import IterationBudget
@@ -134,10 +134,10 @@ else:
 
 # Import our tool system
 from model_tools import (
-    get_tool_definitions,  # noqa: F401  # re-exported for tests that mock.patch("run_agent.get_tool_definitions")
+    get_tool_definitions,  # re-exported for tests that mock.patch("run_agent.get_tool_definitions")
     get_toolset_for_tool,
-    handle_function_call,  # noqa: F401  # re-exported for tests that mock.patch("run_agent.handle_function_call")
-    check_toolset_requirements,  # noqa: F401  # re-exported for tests that mock.patch("run_agent.check_toolset_requirements")
+    handle_function_call,  # re-exported for tests that mock.patch("run_agent.handle_function_call")
+    check_toolset_requirements,  # re-exported for tests that mock.patch("run_agent.check_toolset_requirements")
 )
 from tools.terminal_tool import cleanup_vm
 from tools.interrupt import set_interrupt as _set_interrupt
@@ -149,14 +149,14 @@ from agent.memory_manager import sanitize_context
 from agent.error_classifier import FailoverReason
 from agent.redact import redact_sensitive_text
 from agent.model_metadata import (
-    estimate_request_tokens_rough,  # noqa: F401  # re-exported for tests that mock.patch("run_agent.estimate_request_tokens_rough")
+    estimate_request_tokens_rough,  # re-exported for tests that mock.patch("run_agent.estimate_request_tokens_rough")
     is_local_endpoint,
 )
 from agent.usage_pricing import normalize_usage
 # Re-exported for tests that monkeypatch these symbols on run_agent.
-from agent.context_compressor import ContextCompressor  # noqa: F401
-from agent.retry_utils import jittered_backoff  # noqa: F401
-from agent.prompt_builder import (  # noqa: F401  # re-exported via _ra() / mock.patch("run_agent.<name>") / from run_agent import <name>
+from agent.context_compressor import ContextCompressor
+from agent.retry_utils import jittered_backoff
+from agent.prompt_builder import (  # re-exported via _ra() / mock.patch("run_agent.<name>") / from run_agent import <name>
     DEFAULT_AGENT_IDENTITY,
     build_skills_system_prompt,
     build_context_files_prompt,
@@ -164,8 +164,8 @@ from agent.prompt_builder import (  # noqa: F401  # re-exported via _ra() / mock
     build_nous_subscription_prompt,
     load_soul_md,
 )
-from agent.process_bootstrap import _get_proxy_from_env  # noqa: F401
-from agent.message_sanitization import (  # noqa: F401
+from agent.process_bootstrap import _get_proxy_from_env
+from agent.message_sanitization import (
     _SURROGATE_RE,
     _sanitize_surrogates,
     _sanitize_structure_surrogates,
@@ -199,16 +199,16 @@ from agent.trajectory import (
 )
 from agent.tool_dispatch_helpers import (
     _should_parallelize_tool_batch,
-    _is_destructive_command,  # noqa: F401  # re-exported for tests that access `run_agent._is_destructive_command`
-    _extract_parallel_scope_path,  # noqa: F401  # re-exported for tests that `from run_agent import _extract_parallel_scope_path`
-    _paths_overlap,  # noqa: F401  # re-exported for tests that `from run_agent import _paths_overlap`
+    _is_destructive_command,  # re-exported for tests that access `run_agent._is_destructive_command`
+    _extract_parallel_scope_path,  # re-exported for tests that `from run_agent import _extract_parallel_scope_path`
+    _paths_overlap,  # re-exported for tests that `from run_agent import _paths_overlap`
     _is_multimodal_tool_result,
     _multimodal_text_summary,
-    _append_subdir_hint_to_multimodal,  # noqa: F401  # re-exported for tests that `from run_agent import _append_subdir_hint_to_multimodal`
+    _append_subdir_hint_to_multimodal,  # re-exported for tests that `from run_agent import _append_subdir_hint_to_multimodal`
     _extract_file_mutation_targets,
     _extract_landed_file_mutation_paths,
     _extract_error_preview,
-    _trajectory_normalize_msg,  # noqa: F401  # re-exported for tests that `from run_agent import _trajectory_normalize_msg`
+    _trajectory_normalize_msg,  # re-exported for tests that `from run_agent import _trajectory_normalize_msg`
 )
 from utils import atomic_json_write, base_url_host_matches, base_url_hostname, env_float, is_truthy_value, model_forces_max_completion_tokens
 
@@ -1042,7 +1042,7 @@ class AIAgent:
 
     # Stream-diagnostic class header preserved for backward compat —
     # actual list lives in ``agent.stream_diag.STREAM_DIAG_HEADERS``.
-    from agent.stream_diag import STREAM_DIAG_HEADERS as _STREAM_DIAG_HEADERS  # noqa: E402
+    from agent.stream_diag import STREAM_DIAG_HEADERS as _STREAM_DIAG_HEADERS
 
     @staticmethod
     def _stream_diag_init() -> Dict[str, Any]:

--- a/utils.py
+++ b/utils.py
@@ -220,7 +220,7 @@ class IndentDumper(yaml.SafeDumper):
     serializers so all write paths emit byte-identical layouts (#31999).
     """
 
-    def increase_indent(self, flow=False, indentless=False):  # noqa: ARG002
+    def increase_indent(self, flow=False, indentless=False):
         return super().increase_indent(flow, False)
 
 


### PR DESCRIPTION
Auto-fixes from `ruff check --select RUF100` removing stale # noqa directives in root-level source files.

Files modified:
- acp_adapter/entry.py
- batch_runner.py
- cli.py
- cron/blueprint_catalog.py
- hermes_logging.py
- model_tools.py
- providers/__init__.py
- run_agent.py
- utils.py