### PR TITLE
fix: remove stale noqa comments from tools/ files (RUF100)

### DIFF
--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -205,7 +205,7 @@ def dispatch_async_delegation(
         try:
             result = runner() or {}
             status = result.get("status") or "completed"
-        except Exception as exc:  # noqa: BLE001 — must never crash the worker
+        except Exception as exc:
             logger.exception("Async delegation %s crashed", delegation_id)
             result = {
                 "status": "error",
@@ -394,7 +394,7 @@ def dispatch_async_delegation_batch(
                 status = "error"
             else:
                 status = "completed"
-        except Exception as exc:  # noqa: BLE001 — must never crash the worker
+        except Exception as exc:
             logger.exception("Async delegation batch %s crashed", delegation_id)
             combined = {
                 "results": [],

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -173,7 +173,7 @@ def _browser_cdp_private_guard(
             blocked_url = bt._current_page_private_url(task_id)  # type: ignore[attr-defined]
             if blocked_url:
                 return _private_page_guard_error(blocked_url, method)
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         # Match the existing browser guards' posture: guard probes are
         # best-effort and should not break local/custom CDP workflows.
         logger.debug("browser_cdp: private-page guard probe failed: %s", exc)

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -613,7 +613,7 @@ class CDPSupervisor:
         try:
             asyncio.set_event_loop(loop)
             loop.run_until_complete(self._run())
-        except BaseException as e:  # noqa: BLE001 — propagate via _start_error
+        except BaseException as e:
             if not self._ready_event.is_set():
                 self._start_error = e
                 self._ready_event.set()

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -162,7 +162,7 @@ def _scrub_child_env(source_env, is_passthrough=None, is_windows=None):
         try:
             from tools.env_passthrough import is_env_passthrough as _ep
         except Exception:
-            _ep = lambda _: False  # noqa: E731
+            _ep = lambda _: False
         is_passthrough = _ep
     if is_windows is None:
         is_windows = _IS_WINDOWS

--- a/tools/computer_use/__init__.py
+++ b/tools/computer_use/__init__.py
@@ -35,7 +35,7 @@ agent/prompt_builder.py for the salvaged hunks from PR #4562.
 from __future__ import annotations
 
 # Re-export the public surface so `from tools.computer_use import ...` works.
-from tools.computer_use.tool import (  # noqa: F401
+from tools.computer_use.tool import (
     handle_computer_use,
     set_approval_callback,
     check_computer_use_requirements,

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -348,7 +348,7 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     try:
         from tools.env_passthrough import is_env_passthrough as _is_passthrough
     except Exception:
-        _is_passthrough = lambda _: False  # noqa: E731
+        _is_passthrough = lambda _: False
 
     sanitized: dict[str, str] = {}
 
@@ -796,7 +796,7 @@ def _make_run_env(env: dict) -> dict:
     try:
         from tools.env_passthrough import is_env_passthrough as _is_passthrough
     except Exception:
-        _is_passthrough = lambda _: False  # noqa: E731
+        _is_passthrough = lambda _: False
 
     merged = dict(os.environ | env)
     run_env = {}

--- a/tools/fal_common.py
+++ b/tools/fal_common.py
@@ -46,7 +46,7 @@ def import_fal_client() -> Any:
         _lazy_ensure("image.fal", prompt=False)
     except ImportError:
         pass
-    except Exception as exc:  # noqa: BLE001 — lazy_deps surfaces install hints
+    except Exception as exc:
         raise ImportError(str(exc))
     import fal_client  # type: ignore  # noqa: WPS433 — intentionally lazy
     return fal_client

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -126,7 +126,7 @@ async def resolve_image_source(src: str, ctx: ResolveContext) -> ResolvedImage:
         # a real block always propagates.
         try:
             from agent.file_safety import raise_if_read_blocked
-        except Exception:  # noqa: BLE001 — guard unavailable: proceed
+        except Exception:
             raise_if_read_blocked = None
         if raise_if_read_blocked is not None:
             try:
@@ -240,7 +240,7 @@ def _permitted_host_read_target(p: Path, ctx: ResolveContext) -> Optional[Path]:
     if _is_local_terminal_backend():
         try:
             return p.resolve()
-        except Exception:  # noqa: BLE001 — unresolved path: let is_file() fail downstream
+        except Exception:
             return p
 
     from tools.credential_files import from_agent_visible_cache_path
@@ -248,7 +248,7 @@ def _permitted_host_read_target(p: Path, ctx: ResolveContext) -> Optional[Path]:
     host_candidate = Path(from_agent_visible_cache_path(str(p)))
     try:
         real = host_candidate.resolve()
-    except Exception:  # noqa: BLE001 — cannot resolve -> not a safe host read
+    except Exception:
         return None
     for root in _media_cache_roots():
         try:

--- a/tools/interrupt.py
+++ b/tools/interrupt.py
@@ -84,7 +84,7 @@ class _ThreadAwareEventProxy:
     def is_set(self) -> bool:
         return is_interrupted()
 
-    def set(self) -> None:  # noqa: A003
+    def set(self) -> None:
         set_interrupt(True)
 
     def clear(self) -> None:

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -505,7 +505,7 @@ def _make_callback_handler() -> tuple[type, dict]:
     result: dict[str, Any] = {"auth_code": None, "state": None, "error": None}
 
     class _Handler(BaseHTTPRequestHandler):
-        def do_GET(self) -> None:  # noqa: N802
+        def do_GET(self) -> None:
             params = parse_qs(urlparse(self.path).query)
             code = params.get("code", [None])[0]
             state = params.get("state", [None])[0]

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -603,7 +603,7 @@ class MCPOAuthManager:
                 # on its next auth flow. `_initialized` is private API but
                 # stable across the MCP SDK versions we pin (>=1.26.0).
                 if hasattr(entry.provider, "_initialized"):
-                    entry.provider._initialized = False  # noqa: SLF001
+                    entry.provider._initialized = False
                 logger.info(
                     "MCP OAuth '%s': tokens file changed (mtime %d -> %d), "
                     "forcing reload",

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -811,7 +811,7 @@ def _check_structure(skill_dir: Path, ignore=None) -> List[Finding]:
             or any structural finding.
     """
     if ignore is None:
-        ignore = lambda _rel: False  # noqa: E731
+        ignore = lambda _rel: False
 
     findings = []
     file_count = 0

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -55,7 +55,7 @@ logger = logging.getLogger(__name__)
 # The terminal tool polls this during command execution so it can kill
 # long-running subprocesses immediately instead of blocking until timeout.
 # ---------------------------------------------------------------------------
-from tools.interrupt import is_interrupted, _interrupt_event  # noqa: F401 — re-exported
+from tools.interrupt import is_interrupted, _interrupt_event
 # display_hermes_home imported lazily at call site (stale-module safety during hermes update)
 
 
@@ -2857,7 +2857,7 @@ def check_terminal_requirements() -> bool:
             return True
 
         elif env_type == "daytona":
-            from daytona import Daytona  # noqa: F401 — SDK presence check
+            from daytona import Daytona
             return os.getenv("DAYTONA_API_KEY") is not None
 
         else:

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -941,7 +941,7 @@ def _dispatch_to_plugin_provider(
             # recovery pattern.
             _ensure_plugins_discovered(force=True)
             plugin_provider = get_provider(key)
-    except Exception as exc:  # noqa: BLE001 — discovery failure is non-fatal
+    except Exception as exc:
         logger.debug("STT plugin dispatch skipped (discovery failed): %s", exc)
         return None
     if plugin_provider is None:
@@ -960,7 +960,7 @@ def _dispatch_to_plugin_provider(
     # anyway so a buggy plugin can't break dispatch for everyone.
     try:
         available = plugin_provider.is_available()
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         logger.warning(
             "STT plugin provider '%s' is_available() raised: %s — "
             "treating as unavailable", key, exc, exc_info=True,
@@ -988,7 +988,7 @@ def _dispatch_to_plugin_provider(
             model=model,
             language=language,
         )
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         logger.warning(
             "STT plugin provider '%s' raised: %s", key, exc, exc_info=True,
         )

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -524,7 +524,7 @@ def _dispatch_to_plugin_provider(
             # recovery pattern.
             _ensure_plugins_discovered(force=True)
             plugin_provider = get_provider(key)
-    except Exception as exc:  # noqa: BLE001 — discovery failure is non-fatal
+    except Exception as exc:
         logger.debug("tts plugin dispatch skipped (discovery failed): %s", exc)
         return None
     if plugin_provider is None:
@@ -579,7 +579,7 @@ def _plugin_provider_is_voice_compatible(provider: str) -> bool:
         if plugin_provider is None:
             return False
         return bool(plugin_provider.voice_compatible)
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         logger.debug(
             "tts plugin voice_compatible check failed for '%s': %s", key, exc,
         )

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -106,7 +106,7 @@ _VISION_MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024
 # through model_tools._run_async on a PER-THREAD event loop, so an asyncio
 # executor/semaphore bound to one loop cannot coordinate across them. A
 # ThreadPoolExecutor is loop- and thread-agnostic.
-import threading  # noqa: F401  (kept for downstream importers / patch targets)
+import threading
 
 
 def _detect_host_cpus() -> int:

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -535,7 +535,7 @@ class AudioRecorder:
 
         sd, np = _import_audio()
 
-        def _callback(indata, frames, time_info, status):  # noqa: ARG001
+        def _callback(indata, frames, time_info, status):
             if status:
                 logger.debug("sounddevice status: %s", status)
             # When not recording the stream is idle — discard audio.

--- a/tools/yuanbao_tools.py
+++ b/tools/yuanbao_tools.py
@@ -414,7 +414,7 @@ async def send_dm(
 # Registry registration
 # ---------------------------------------------------------------------------
 
-from tools.registry import registry, tool_result  # noqa: E402
+from tools.registry import registry, tool_result
 
 
 def _check_yuanbao():


### PR DESCRIPTION
Auto-fixes from `ruff check --select RUF100` removing stale # noqa directives across all `tools/` source files (18 files).