### PR TITLE
fix: remove stale noqa comments from hermes_cli/ files (RUF100)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -669,7 +669,7 @@ def get_container_exec_info() -> Optional[dict]:
 # =============================================================================
 
 # Re-export from hermes_constants — canonical definition lives there.
-from hermes_constants import get_hermes_home  # noqa: F811,E402
+from hermes_constants import get_hermes_home
 from utils import atomic_replace, fast_safe_load
 
 def get_config_path() -> Path:

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -21,7 +21,7 @@ from hermes_cli.colors import Colors, color
 # ``_contains_gateway_lifecycle_command`` here for back-compat: ``tools/
 # terminal_tool.py`` imports it from this module to hard-block the same
 # commands at execution time when ``_HERMES_GATEWAY=1``.
-from cron.lifecycle_guard import (  # noqa: F401  (re-exported for terminal_tool)
+from cron.lifecycle_guard import (
     contains_gateway_lifecycle_command as _contains_gateway_lifecycle_command,
 )
 

--- a/hermes_cli/dashboard_auth/prefix.py
+++ b/hermes_cli/dashboard_auth/prefix.py
@@ -161,7 +161,7 @@ def _load_dashboard_section() -> dict:
         return {}
     try:
         cfg = load_config()
-    except Exception as exc:  # noqa: BLE001 — broad catch is intentional
+    except Exception as exc:
         _log.debug(
             "dashboard-auth.prefix: load_config() raised %s; "
             "falling back to env-only configuration",

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -555,7 +555,7 @@ async def auth_logout(request: Request):
         for provider in list_providers():
             try:
                 provider.revoke_session(refresh_token=rt)
-            except Exception as e:  # noqa: BLE001 — best-effort
+            except Exception as e:
                 _log.warning(
                     "dashboard-auth: revoke on %r failed: %s",
                     provider.name, e,

--- a/hermes_cli/dashboard_auth/token_auth.py
+++ b/hermes_cli/dashboard_auth/token_auth.py
@@ -130,7 +130,7 @@ def authenticate_token(
             if unreachable is None:
                 unreachable = provider.name
             continue
-        except Exception as e:  # noqa: BLE001 — a buggy provider must not 500 the gate
+        except Exception as e:
             _log.warning(
                 "dashboard-auth: token provider %r raised during verify: %s",
                 provider.name, e,

--- a/hermes_cli/dingtalk_auth.py
+++ b/hermes_cli/dingtalk_auth.py
@@ -156,7 +156,7 @@ def wait_for_registration_success(
 def _ensure_qrcode_installed() -> bool:
     """Try to import qrcode; if missing, auto-install it via pip/uv."""
     try:
-        import qrcode  # noqa: F401
+        import qrcode
         return True
     except ImportError:
         pass
@@ -170,7 +170,7 @@ def _ensure_qrcode_installed() -> bool:
     ):
         try:
             subprocess.check_call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-            import qrcode  # noqa: F401,F811
+            import qrcode
             return True
         except (subprocess.CalledProcessError, ImportError, FileNotFoundError):
             continue

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -494,7 +494,7 @@ def managed_scope_check() -> None:
     try:
         from hermes_cli import managed_scope
         managed_dir = managed_scope.get_managed_dir()
-    except Exception:  # noqa: BLE001 — diagnostics must never crash
+    except Exception:
         return
     if managed_dir is None:
         return
@@ -1534,7 +1534,7 @@ def run_doctor(args):
                 issues,
             )
         try:
-            from daytona import Daytona  # noqa: F401 — SDK presence check
+            from daytona import Daytona
             check_ok("daytona SDK", "(installed)")
         except ImportError:
             _fail_and_issue(

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -269,7 +269,7 @@ def _apply_managed_env() -> None:
         from hermes_cli import managed_scope
 
         managed_dir = managed_scope.get_managed_dir()
-    except Exception:  # noqa: BLE001 — managed scope must never block startup
+    except Exception:
         return
     if managed_dir is None:
         return
@@ -304,7 +304,7 @@ def _apply_external_secret_sources(home_path: Path) -> None:
 
     try:
         cfg = _load_secrets_config(home_path)
-    except Exception:  # noqa: BLE001 — config errors must not block startup
+    except Exception:
         return
 
     bw_cfg = (cfg or {}).get("bitwarden") or {}
@@ -372,6 +372,6 @@ def _load_secrets_config(home_path: Path) -> dict:
     try:
         with open(config_path, "r", encoding="utf-8") as f:
             data = fast_safe_load(f) or {}
-    except Exception:  # noqa: BLE001
+    except Exception:
         return {}
     return data.get("secrets") or {}

--- a/hermes_cli/fallback_cmd.py
+++ b/hermes_cli/fallback_cmd.py
@@ -104,7 +104,7 @@ def _restore_auth_active_provider(value: Any) -> None:
 # Subcommand handlers
 # ---------------------------------------------------------------------------
 
-def cmd_fallback_list(args) -> None:  # noqa: ARG001
+def cmd_fallback_list(args) -> None:
     """Print the current fallback chain."""
     from hermes_cli.config import load_config
 
@@ -236,7 +236,7 @@ def _restore_model_cfg(model_before: Any) -> None:
     save_config(cfg)
 
 
-def cmd_fallback_remove(args) -> None:  # noqa: ARG001
+def cmd_fallback_remove(args) -> None:
     """Pick an entry from the chain and remove it."""
     from hermes_cli.config import load_config, save_config
 
@@ -276,7 +276,7 @@ def cmd_fallback_remove(args) -> None:  # noqa: ARG001
     print()
 
 
-def cmd_fallback_clear(args) -> None:  # noqa: ARG001
+def cmd_fallback_clear(args) -> None:
     """Remove all fallback entries (with confirmation)."""
     from hermes_cli.config import load_config, save_config
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7808,7 +7808,7 @@ def _default_spawn(
     # Use 'a' so a re-run on unblock appends rather than overwrites.
     log_f = open(log_path, "ab")
     try:
-        proc = subprocess.Popen(  # noqa: S603 -- argv is a fixed list built above
+        proc = subprocess.Popen(
             cmd,
             cwd=workspace if os.path.isdir(workspace) else None,
             stdin=subprocess.DEVNULL,

--- a/hermes_cli/managed_scope.py
+++ b/hermes_cli/managed_scope.py
@@ -99,7 +99,7 @@ def _cached_read(path: Path, cache: Dict[str, tuple], parse):
     try:
         with open(path, encoding="utf-8") as f:
             parsed = parse(f)
-    except Exception as exc:  # noqa: BLE001 — fail-open, but LOUD
+    except Exception as exc:
         logger.warning(
             "managed scope: failed to parse %s: %s — IGNORING this managed file. "
             "Admin policy from this file is NOT being applied. Fix and restart.",
@@ -172,7 +172,7 @@ def apply_managed_overlay(config: dict) -> dict:
             managed_expanded = dict(managed_expanded)
             managed_expanded["model"] = {"default": managed_expanded["model"]}
         return _deep_merge(config, managed_expanded)
-    except Exception:  # noqa: BLE001 — overlay must never break a caller
+    except Exception:
         logger.warning("managed scope: failed to apply config overlay", exc_info=True)
         return config
 

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -21,7 +21,7 @@ from hermes_cli.config import (
     save_config,
     get_env_value,
     save_env_value,
-    get_hermes_home,  # noqa: F401 — used by test mocks
+    get_hermes_home,
 )
 from hermes_cli.colors import Colors, color
 from hermes_constants import display_hermes_home

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -1034,7 +1034,7 @@ def _model_flow_azure_foundry(config, current_model=""):
     :func:`agent.model_metadata.get_model_context_length` chain
     (models.dev, provider metadata, hardcoded family fallbacks).
     """
-    from hermes_cli.auth import _save_model_choice, deactivate_provider  # noqa: F401
+    from hermes_cli.auth import _save_model_choice, deactivate_provider
     from hermes_cli.config import (
         get_env_value,
         save_env_value,

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1384,7 +1384,7 @@ def switch_model(
 # Process-level guard so the picker prewarm thread is spawned at most once per
 # process — mirrors run_agent's _openrouter_prewarm_done. Without a guard a
 # long-lived process (or repeated triggers) would leak one OS thread per call.
-import threading as _threading  # noqa: E402
+import threading as _threading
 
 _picker_prewarm_done = _threading.Event()
 

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -190,7 +190,7 @@ def run_oneshot(
                     toolsets=explicit_toolsets,
                     use_config_toolsets=use_config_toolsets,
                 )
-            except BaseException as exc:  # noqa: BLE001
+            except BaseException as exc:
                 # Capture anything that escapes the agent (including OSError
                 # from prompt_toolkit/Vt100 when stdout is a non-TTY pipe,
                 # KeyboardInterrupt, SystemExit, etc.) so we can surface it on

--- a/hermes_cli/pets.py
+++ b/hermes_cli/pets.py
@@ -277,7 +277,7 @@ def _cmd_doctor(args) -> int:
         _print("  → pet display is disabled. Run: hermes pets select " + active.slug)
 
     try:
-        import PIL  # noqa: F401
+        import PIL
     except ImportError:
         _print("  ✗ Pillow not importable — sprite decoding will be unavailable")
         ok = False

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -337,7 +337,7 @@ def _prompt_plugin_env_vars(manifest: dict, console) -> None:
     if not requires_env:
         return
 
-    from hermes_cli.config import get_env_value, save_env_value  # noqa: F811
+    from hermes_cli.config import get_env_value, save_env_value
     from hermes_constants import display_hermes_home
 
     # Normalise to list-of-dicts

--- a/hermes_cli/secrets_cli.py
+++ b/hermes_cli/secrets_cli.py
@@ -122,7 +122,7 @@ def cmd_setup(args: argparse.Namespace) -> int:
             binary = bw.install_bws()
         version = _bws_version(binary)
         console.print(f"  [green]✓[/green] {binary}  ({version})")
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         console.print(f"  [red]✗ Could not install bws: {exc}[/red]")
         console.print(
             "  Manual install: "
@@ -243,7 +243,7 @@ def cmd_setup(args: argparse.Namespace) -> int:
             use_cache=False,
             server_url=server_url,
         )
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         console.print(f"  [red]✗ Fetch failed: {exc}[/red]")
         return 1
 
@@ -368,7 +368,7 @@ def cmd_sync(args: argparse.Namespace) -> int:
             use_cache=False,
             server_url=server_url,
         )
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         console.print(f"[red]Fetch failed: {exc}[/red]")
         return 1
 
@@ -433,7 +433,7 @@ def cmd_install(args: argparse.Namespace) -> int:
         path = bw.install_bws(force=bool(args.force))
         console.print(f"[green]✓[/green] {path}  ({_bws_version(path)})")
         return 0
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         console.print(f"[red]Install failed: {exc}[/red]")
         return 1
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -158,13 +158,13 @@ def print_header(title: str):
     print(color(f"◆ {title}", Colors.CYAN, Colors.BOLD))
 
 
-from hermes_cli.cli_output import (  # noqa: E402
+from hermes_cli.cli_output import (
     print_error,
     print_info,
     print_success,
     print_warning,
 )
-from hermes_cli.secret_prompt import masked_secret_prompt  # noqa: E402
+from hermes_cli.secret_prompt import masked_secret_prompt
 
 
 def is_interactive_stdin() -> bool:

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -6,7 +6,7 @@ Shows the status of all Hermes Agent components.
 
 import os
 import sys
-import subprocess  # noqa: F401 — re-exported for tests that monkeypatch status.subprocess to guard against regressions
+import subprocess
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -44,7 +44,7 @@ PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 
 # ─── UI Helpers (shared with setup.py) ────────────────────────────────────────
 
-from hermes_cli.cli_output import (  # noqa: E402 — late import block
+from hermes_cli.cli_output import (
     print_error as _print_error,
     print_info as _print_info,
     print_success as _print_success,
@@ -2059,7 +2059,7 @@ def _estimate_tool_tokens() -> Dict[str, int]:
 
     try:
         # Trigger full tool discovery (imports all tool modules).
-        import model_tools  # noqa: F401
+        import model_tools
         from tools.registry import registry
     except Exception:
         logger.debug("Tool registry unavailable; skipping token estimation")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -156,7 +156,7 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
 
 def _warm_gateway_module() -> None:
     try:
-        import hermes_cli.gateway  # noqa: F401
+        import hermes_cli.gateway
     except Exception:
         pass
 
@@ -254,7 +254,7 @@ def _get_pty_active_session_files(app: "FastAPI") -> dict[str, Path]:
 app = FastAPI(title="Hermes Agent", version=__version__, lifespan=_lifespan)
 
 # Memory-provider OAuth connect routes live in the memory layer, not here.
-from hermes_cli.memory_oauth import router as _memory_oauth_router  # noqa: E402
+from hermes_cli.memory_oauth import router as _memory_oauth_router
 
 app.include_router(_memory_oauth_router)
 
@@ -2093,7 +2093,7 @@ async def fs_default_cwd():
 # these are thin, executor-offloaded wrappers (git/gh can block).
 # ---------------------------------------------------------------------------
 
-from hermes_cli import web_git as _web_git  # noqa: E402
+from hermes_cli import web_git as _web_git
 
 
 async def _git_op(fn, *args):
@@ -14976,7 +14976,7 @@ _mount_plugin_api_routes()
 # SPA catch-all so /{full_path:path} doesn't swallow them.  These are
 # always mounted — the gate middleware decides whether to enforce auth,
 # not whether the routes exist.
-from hermes_cli.dashboard_auth.routes import router as _dashboard_auth_router  # noqa: E402
+from hermes_cli.dashboard_auth.routes import router as _dashboard_auth_router
 app.include_router(_dashboard_auth_router)
 
 mount_spa(app)


### PR DESCRIPTION
Auto-fixes from `ruff check --select RUF100` removing stale # noqa directives across all `hermes_cli/` source files (22 files).