### PR TITLE
fix: remove stale noqa comments from agent/ files (RUF100)

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -5,4 +5,4 @@ that were previously embedded in the 3,600-line run_agent.py. Extracting
 them makes run_agent.py focused on the AIAgent orchestrator class.
 """
 
-from . import jiter_preload as _jiter_preload  # noqa: F401
+from . import jiter_preload as _jiter_preload

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -682,7 +682,7 @@ def init_agent(
                 try:
                     from hermes_cli.auth import build_minimax_oauth_token_provider
                     effective_key = build_minimax_oauth_token_provider()
-                except Exception as _mm_exc:  # noqa: BLE001 — never block startup on this
+                except Exception as _mm_exc:
                     import logging as _logging
                     _logging.getLogger(__name__).warning(
                         "MiniMax OAuth: failed to install per-request token provider "

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1820,7 +1820,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             try:
                 from agent.credential_pool import load_pool
                 agent._credential_pool = load_pool(new_provider)
-            except Exception as _pool_exc:  # noqa: BLE001
+            except Exception as _pool_exc:
                 logger.warning(
                     "switch_model: credential pool reload failed for %s (%s); "
                     "continuing without pool rotation this turn",
@@ -1866,7 +1866,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
                 try:
                     from hermes_cli.auth import build_minimax_oauth_token_provider
                     effective_key = build_minimax_oauth_token_provider()
-                except Exception as _mm_exc:  # noqa: BLE001
+                except Exception as _mm_exc:
                     import logging as _logging
                     _logging.getLogger(__name__).warning(
                         "MiniMax OAuth: failed to install per-request token provider "
@@ -1929,7 +1929,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
                 continue
             try:
                 setattr(agent, _name, _value)
-            except Exception:  # noqa: BLE001
+            except Exception:
                 pass
         raise
 

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1443,7 +1443,7 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
     try:
         from hermes_cli.auth import _can_open_graphical_browser as _can_open_gui
     except Exception:
-        _can_open_gui = lambda: True  # noqa: E731 — degrade to prior behavior
+        _can_open_gui = lambda: True
 
     if _can_open_gui():
         try:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -46,7 +46,7 @@ import logging
 import os
 import threading
 import time
-from pathlib import Path  # noqa: F401 — used by test mocks
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 from urllib.parse import urlparse, parse_qs, urlunparse
@@ -65,7 +65,7 @@ from urllib.parse import urlparse, parse_qs, urlunparse
 #       (which is harmless — annotations aren't type-checked at runtime).
 # See tests/agent/test_auxiliary_client.py for patch patterns this supports.
 if TYPE_CHECKING:
-    from openai import OpenAI  # noqa: F401 — type hints only
+    from openai import OpenAI
 
 _OPENAI_CLS_CACHE: Optional[type] = None
 

--- a/agent/azure_identity_adapter.py
+++ b/agent/azure_identity_adapter.py
@@ -63,7 +63,7 @@ def has_azure_identity_installed() -> bool:
     Cheap check — does not walk the credential chain.
     """
     try:
-        import azure.identity  # noqa: F401
+        import azure.identity
         return True
     except Exception:
         return False

--- a/agent/browser_registry.py
+++ b/agent/browser_registry.py
@@ -150,7 +150,7 @@ def _resolve(configured: Optional[str]) -> Optional[BrowserProvider]:
         """Wrap ``is_available()`` so a buggy provider doesn't kill resolution."""
         try:
             return bool(p.is_available())
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             logger.warning(
                 "Browser provider %s.is_available() raised %s — treating as unavailable",
                 p.name, exc, exc_info=True,

--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -528,7 +528,7 @@ def _restore_cron_skill_links(snapshot_dir: Path) -> Dict[str, Any]:
 
             if changed:
                 save_jobs(live_jobs)
-    except Exception as e:  # noqa: BLE001 — rollback must not die mid-restore
+    except Exception as e:
         logger.debug("Cron skill-link restore failed: %s", e, exc_info=True)
         report["error"] = f"restore failed mid-flight: {e}"
 

--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -322,7 +322,7 @@ def raise_if_read_blocked(path: str) -> None:
     """
     try:
         blocked = get_read_block_error(path)
-    except Exception:  # noqa: BLE001 - guard must never break local-file loading
+    except Exception:
         return
     if blocked:
         raise ValueError(blocked)

--- a/agent/image_gen_registry.py
+++ b/agent/image_gen_registry.py
@@ -109,7 +109,7 @@ def get_active_provider() -> Optional[ImageGenProvider]:
         """Wrap ``is_available()`` so a buggy provider doesn't kill resolution."""
         try:
             return bool(p.is_available())
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             logger.debug("image_gen provider %s.is_available() raised %s", p.name, exc)
             return False
 

--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -562,7 +562,7 @@ def _transcode_to_png(raw: bytes) -> Optional[bytes]:
     except Exception:
         pass
     try:
-        import pillow_avif  # type: ignore  # noqa: F401  -- registers AVIF on import
+        import pillow_avif  # type: ignore
     except Exception:
         pass
     try:

--- a/agent/jiter_preload.py
+++ b/agent/jiter_preload.py
@@ -26,7 +26,7 @@ def preload_jiter_native_extension() -> bool:
 
     try:
         importlib.import_module("jiter.jiter")
-        from jiter import from_json as _from_json  # noqa: F401
+        from jiter import from_json as _from_json
     except Exception as exc:
         _JITER_PRELOAD_ERROR = exc
         return False

--- a/agent/lsp/__init__.py
+++ b/agent/lsp/__init__.py
@@ -89,7 +89,7 @@ def shutdown_service() -> None:
     if svc is not None:
         try:
             svc.shutdown()
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.debug("LSP shutdown error: %s", e)
 
 
@@ -99,7 +99,7 @@ def _atexit_shutdown() -> None:
     a noisy shutdown line on top of that is just clutter."""
     try:
         shutdown_service()
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.debug("atexit LSP shutdown failed: %s", e)
 
 

--- a/agent/pet/generate/imagegen.py
+++ b/agent/pet/generate/imagegen.py
@@ -66,7 +66,7 @@ def _discover() -> None:
         from hermes_cli.plugins import _ensure_plugins_discovered
 
         _ensure_plugins_discovered()
-    except Exception as exc:  # noqa: BLE001 - discovery is best-effort
+    except Exception as exc:
         logger.debug("image-gen plugin discovery failed: %s", exc)
 
 
@@ -101,7 +101,7 @@ def resolve_provider(*, require_references: bool = True, prefer: str | None = No
     active = None
     try:
         active = get_active_provider()
-    except Exception:  # noqa: BLE001
+    except Exception:
         active = None
     if active is not None:
         name = getattr(active, "name", "")
@@ -218,7 +218,7 @@ def generate(
             kwargs["reference_image_urls"] = refs
         try:
             result = sprite.provider.generate(prompt, **kwargs)
-        except Exception as exc:  # noqa: BLE001 - normalize provider crashes
+        except Exception as exc:
             logger.debug("provider.generate crashed: %s", exc)
             return None, str(exc)
         if not isinstance(result, dict) or not result.get("success"):
@@ -228,7 +228,7 @@ def generate(
             return None, "provider returned no image"
         try:
             return _save_local(str(image_ref), prefix=prefix), ""
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             return None, f"could not save generated image: {exc}"
 
     out: list[Path] = []

--- a/agent/pet/generate/orchestrate.py
+++ b/agent/pet/generate/orchestrate.py
@@ -74,7 +74,7 @@ def _harden_transparency(path: Path) -> Path:
         out = path.with_suffix(".png")
         keyed.save(out, format="PNG")
         return out
-    except Exception as exc:  # noqa: BLE001 - cosmetic; fall back to the raw image
+    except Exception as exc:
         logger.debug("base draft transparency hardening failed for %s: %s", path, exc)
         return path
 
@@ -120,7 +120,7 @@ def generate_base_drafts(
         prompt = prompts.build_base_prompt(concept, style=style, variation=variation)
         try:
             out = imagegen.generate(prompt, n=1, reference_images=refs, provider=sprite, prefix="pet_base")
-        except Exception as exc:  # noqa: BLE001 - tolerate a single failed draft
+        except Exception as exc:
             logger.warning("pet generate: draft %d failed after %.1fs: %s", index, time.monotonic() - t0, exc)
             return index, None, str(exc)
         if not out:
@@ -152,7 +152,7 @@ def generate_base_drafts(
             if on_draft is not None:
                 try:
                     on_draft(index, path)
-                except Exception as exc:  # noqa: BLE001 - progress is best-effort
+                except Exception as exc:
                     logger.debug("on_draft callback failed: %s", exc)
 
     drafts = [results[i] for i in sorted(results)]
@@ -268,7 +268,7 @@ def hatch_pet(
                     slug, state, time.monotonic() - t0, attempt + 1,
                 )
                 return state, frames
-            except Exception as exc:  # noqa: BLE001 - retried; one bad row is tolerated
+            except Exception as exc:
                 last_exc = exc
                 logger.warning(
                     "pet hatch %r: row %r attempt %d/%d failed: %s",

--- a/agent/pet/manifest.py
+++ b/agent/pet/manifest.py
@@ -74,7 +74,7 @@ def prefetch(*, timeout: float = _DEFAULT_TIMEOUT) -> None:
         global _prefetching
         try:
             fetch_manifest(timeout=timeout)
-        except Exception as exc:  # noqa: BLE001 - best-effort warm
+        except Exception as exc:
             logger.debug("petdex manifest prefetch failed: %s", exc)
         finally:
             _prefetching = False
@@ -137,7 +137,7 @@ def fetch_manifest(*, timeout: float = _DEFAULT_TIMEOUT, force: bool = False) ->
         )
         resp.raise_for_status()
         payload = resp.json()
-    except Exception as exc:  # noqa: BLE001 - normalize to one error type
+    except Exception as exc:
         raise ManifestError(f"could not fetch petdex manifest: {exc}") from exc
 
     pets = payload.get("pets") if isinstance(payload, dict) else None

--- a/agent/pet/render.py
+++ b/agent/pet/render.py
@@ -171,7 +171,7 @@ def _raw_frames(
                 break  # trailing transparent padding — real frames end here
             frames.append(frame)
         return tuple(frames)
-    except Exception as exc:  # noqa: BLE001 - cosmetic feature, never fatal
+    except Exception as exc:
         logger.debug("pet frame decode failed (%s, %s): %s", sheet_path, state_value, exc)
         return ()
 
@@ -236,7 +236,7 @@ def _union_alpha_bbox(frames) -> tuple[int, int, int, int] | None:
     for frame in frames:
         try:
             bbox = frame.getchannel("A").getbbox()
-        except Exception:  # noqa: BLE001 - cosmetic; fail open
+        except Exception:
             bbox = None
         if not bbox:
             continue
@@ -659,7 +659,7 @@ class PetRenderer:
             if self.mode == "sixel":
                 return _encode_sixel(frame)
             return _encode_unicode(frame, target_cols=self.unicode_cols)
-        except Exception as exc:  # noqa: BLE001 - degrade silently
+        except Exception as exc:
             logger.debug("pet frame encode failed (mode=%s): %s", self.mode, exc)
             return ""
 

--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -234,7 +234,7 @@ def find_bws(*, install_if_missing: bool = False) -> Optional[Path]:
     if install_if_missing:
         try:
             return install_bws()
-        except Exception as exc:  # noqa: BLE001 — never block startup
+        except Exception as exc:
             logger.warning("bws auto-install failed: %s", exc)
             return None
     return None
@@ -351,7 +351,7 @@ def install_bws(*, force: bool = False) -> Path:
 def _http_download(url: str, dest: Path) -> None:
     req = urllib.request.Request(url, headers={"User-Agent": "hermes-agent"})
     try:
-        with urllib.request.urlopen(req, timeout=_BWS_DOWNLOAD_TIMEOUT) as resp:  # noqa: S310
+        with urllib.request.urlopen(req, timeout=_BWS_DOWNLOAD_TIMEOUT) as resp:
             with open(dest, "wb") as f:
                 shutil.copyfileobj(resp, f)
     except urllib.error.URLError as exc:
@@ -520,7 +520,7 @@ def _run_bws_list(
         env["BWS_SERVER_URL"] = server_url
 
     try:
-        proc = subprocess.run(  # noqa: S603 — bws path is trusted
+        proc = subprocess.run(
             cmd,
             env=env,
             capture_output=True,

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -246,6 +246,6 @@ class AnthropicTransport(ProviderTransport):
 
 
 # Auto-register on import
-from agent.transports import register_transport  # noqa: E402
+from agent.transports import register_transport
 
 register_transport("anthropic_messages", AnthropicTransport)

--- a/agent/transports/bedrock.py
+++ b/agent/transports/bedrock.py
@@ -149,6 +149,6 @@ class BedrockTransport(ProviderTransport):
 
 
 # Auto-register on import
-from agent.transports import register_transport  # noqa: E402
+from agent.transports import register_transport
 
 register_transport("bedrock_converse", BedrockTransport)

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -739,6 +739,6 @@ class ChatCompletionsTransport(ProviderTransport):
 
 
 # Auto-register on import
-from agent.transports import register_transport  # noqa: E402
+from agent.transports import register_transport
 
 register_transport("chat_completions", ChatCompletionsTransport)

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -464,6 +464,6 @@ class ResponsesApiTransport(ProviderTransport):
 
 
 # Auto-register on import
-from agent.transports import register_transport  # noqa: E402
+from agent.transports import register_transport
 
 register_transport("codex_responses", ResponsesApiTransport)

--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -174,7 +174,7 @@ def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearc
         """Wrap ``is_available()`` so a buggy provider doesn't kill resolution."""
         try:
             return bool(p.is_available())
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             logger.debug("provider %s.is_available() raised %s", p.name, exc)
             return False
 


### PR DESCRIPTION
Auto-fixes from `ruff check --select RUF100` removing stale # noqa directives across all `agent/` source files (23 files).