### PR TITLE
fix: remove stale noqa comments from skills/ files (RUF100)

### DIFF
--- a/skills/creative/comfyui/scripts/auto_fix_deps.py
+++ b/skills/creative/comfyui/scripts/auto_fix_deps.py
@@ -31,11 +31,11 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _common import (  # noqa: E402
+from _common import (
     DEFAULT_LOCAL_HOST, ENV_API_KEY, emit_json, log, resolve_api_key,
 )
-from check_deps import check_deps  # noqa: E402
-from _common import unwrap_workflow  # noqa: E402
+from check_deps import check_deps
+from _common import unwrap_workflow
 
 
 def comfy_cli_available() -> str | None:

--- a/skills/creative/comfyui/scripts/check_deps.py
+++ b/skills/creative/comfyui/scripts/check_deps.py
@@ -30,7 +30,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _common import (  # noqa: E402
+from _common import (
     DEFAULT_LOCAL_HOST, ENV_API_KEY,
     emit_json, folder_aliases_for, http_get, is_cloud_host,
     iter_embedding_refs, iter_model_deps, iter_nodes, parse_model_list,

--- a/skills/creative/comfyui/scripts/extract_schema.py
+++ b/skills/creative/comfyui/scripts/extract_schema.py
@@ -31,7 +31,7 @@ from pathlib import Path
 from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _common import (  # noqa: E402
+from _common import (
     OUTPUT_NODES, PARAM_PATTERNS, PROMPT_FIELDS,
     is_link, iter_embedding_refs, iter_model_deps, iter_nodes, unwrap_workflow,
 )

--- a/skills/creative/comfyui/scripts/fetch_logs.py
+++ b/skills/creative/comfyui/scripts/fetch_logs.py
@@ -19,7 +19,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _common import (  # noqa: E402
+from _common import (
     DEFAULT_LOCAL_HOST, ENV_API_KEY, emit_json, http_get, is_cloud_host,
     resolve_api_key, resolve_url,
 )

--- a/skills/creative/comfyui/scripts/health_check.py
+++ b/skills/creative/comfyui/scripts/health_check.py
@@ -25,7 +25,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _common import (  # noqa: E402
+from _common import (
     DEFAULT_LOCAL_HOST, ENV_API_KEY, emit_json, http_get, parse_model_list,
     resolve_api_key, resolve_url, unwrap_workflow,
 )

--- a/skills/creative/comfyui/scripts/run_batch.py
+++ b/skills/creative/comfyui/scripts/run_batch.py
@@ -33,14 +33,14 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _common import (  # noqa: E402
+from _common import (
     DEFAULT_LOCAL_HOST, ENV_API_KEY, coerce_seed, emit_json, log,
     looks_like_video_workflow, resolve_api_key, unwrap_workflow,
 )
-from run_workflow import (  # noqa: E402
+from run_workflow import (
     ComfyRunner, download_outputs, inject_params,
 )
-from extract_schema import extract_schema  # noqa: E402
+from extract_schema import extract_schema
 
 
 def expand_sweep(sweep: dict, base_args: dict, count: int, randomize_seed: bool) -> list[dict]:

--- a/skills/creative/comfyui/scripts/run_workflow.py
+++ b/skills/creative/comfyui/scripts/run_workflow.py
@@ -59,7 +59,7 @@ from urllib.parse import urlencode, urlparse
 
 # Local import — _common.py sits next to this script.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _common import (  # noqa: E402
+from _common import (
     DEFAULT_LOCAL_HOST, ENV_API_KEY,
     coerce_seed, emit_json, http_get, http_post, http_request,
     is_cloud_host, is_link, log, looks_like_video_workflow,

--- a/skills/creative/comfyui/scripts/ws_monitor.py
+++ b/skills/creative/comfyui/scripts/ws_monitor.py
@@ -35,7 +35,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _common import (  # noqa: E402
+from _common import (
     DEFAULT_LOCAL_HOST, ENV_API_KEY, log, new_client_id, resolve_api_key, is_cloud_host,
 )
 

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -96,8 +96,8 @@ def _format_missing_scopes(missing_scopes: list[str]) -> str:
 def install_deps():
     """Install Google API packages if missing. Returns True on success."""
     try:
-        import googleapiclient  # noqa: F401
-        import google_auth_oauthlib  # noqa: F401
+        import googleapiclient
+        import google_auth_oauthlib
         print("Dependencies already installed.")
         return True
     except ImportError:
@@ -149,8 +149,8 @@ def install_deps():
 def _ensure_deps():
     """Check deps are available, install if not, exit on failure."""
     try:
-        import googleapiclient  # noqa: F401
-        import google_auth_oauthlib  # noqa: F401
+        import googleapiclient
+        import google_auth_oauthlib
     except ImportError:
         if not install_deps():
             sys.exit(1)


### PR DESCRIPTION
Auto-fixes from `ruff check --select RUF100` removing stale # noqa directives across all `skills/` source files (9 files).