### PR TITLE
fix: remove stale noqa comments from scripts/ files (RUF100)

### DIFF
--- a/scripts/build_model_catalog.py
+++ b/scripts/build_model_catalog.py
@@ -33,7 +33,7 @@ sys.path.insert(0, REPO_ROOT)
 # Ensure HERMES_HOME is set for imports that touch it at module level.
 os.environ.setdefault("HERMES_HOME", os.path.join(os.path.expanduser("~"), ".hermes"))
 
-from hermes_cli.models import OPENROUTER_MODELS, _PROVIDER_MODELS  # noqa: E402
+from hermes_cli.models import OPENROUTER_MODELS, _PROVIDER_MODELS
 
 OUTPUT_PATH = os.path.join(REPO_ROOT, "website", "static", "api", "model-catalog.json")
 CATALOG_VERSION = 1

--- a/scripts/contributor_audit.py
+++ b/scripts/contributor_audit.py
@@ -29,7 +29,7 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR))
 
-from release import resolve_author  # noqa: E402
+from release import resolve_author
 
 REPO_ROOT = SCRIPT_DIR.parent
 

--- a/scripts/keystroke_diagnostic.py
+++ b/scripts/keystroke_diagnostic.py
@@ -60,7 +60,7 @@ def main() -> None:
     kb = KeyBindings()
 
     @kb.add("<any>")
-    def _on_any(event):  # noqa: ANN001 — prompt_toolkit event type
+    def _on_any(event):
         parts = []
         for kp in event.key_sequence:
             parts.append(f"key={kp.key!r} data={kp.data!r}")
@@ -69,7 +69,7 @@ def main() -> None:
 
     @kb.add("c-q")
     @kb.add("c-c")
-    def _quit(event):  # noqa: ANN001
+    def _quit(event):
         event.app.exit()
 
     control = FormattedTextControl(text=_render_text)

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -761,7 +761,7 @@ def main() -> int:
 
         if args.include_integration:
             # Caller takes responsibility — typically used via explicit -k filter.
-            global _SKIP_PARTS  # noqa: PLW0603 — config knob
+            global _SKIP_PARTS
             _SKIP_PARTS = set()
 
         files = _discover_files(roots)
@@ -834,7 +834,7 @@ def main() -> int:
         n_tests = test_counts.get(file, 0)
         try:
             fpath, rc, output, summary, subproc_wall = fut.result()
-        except Exception as exc:  # noqa: BLE001 — must always advance counter
+        except Exception as exc:
             with lock:
                 files_done += 1
                 tests_done += n_tests


### PR DESCRIPTION
Auto-fixes from `ruff check --select RUF100` removing stale # noqa directives across all `scripts/` source files (4 files).