### PR TITLE
fix: remove stale noqa comments from gateway/ files (RUF100)

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -171,7 +171,7 @@ def _build_discord(adapter) -> List[Dict[str, str]]:
         return channels
 
     try:
-        import discord as _discord  # noqa: F401 — SDK presence check
+        import discord as _discord
     except ImportError:
         return channels
 

--- a/gateway/platforms/__init__.py
+++ b/gateway/platforms/__init__.py
@@ -33,10 +33,10 @@ __all__ = [
 
 def __getattr__(name):
     if name == "QQAdapter":
-        from .qqbot import QQAdapter  # noqa: F401
+        from .qqbot import QQAdapter
         return QQAdapter
     if name == "YuanbaoAdapter":
-        from .yuanbao import YuanbaoAdapter  # noqa: F401
+        from .yuanbao import YuanbaoAdapter
         return YuanbaoAdapter
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3017,7 +3017,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     final_response_text = agent_final
                 if isinstance(result, dict) and result.get("error") and not final_response_text:
                     agent_error = _redact_api_error_text(result["error"])
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 logger.error("Error running agent for streaming responses: %s", e, exc_info=True)
                 agent_error = _redact_api_error_text(e)
 

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -86,8 +86,8 @@ def _redact(text: str) -> str:
 
 def check_bluebubbles_requirements() -> bool:
     try:
-        import aiohttp  # noqa: F401
-        import httpx  # noqa: F401
+        import aiohttp
+        import httpx
     except ImportError:
         return False
     return True

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -610,7 +610,7 @@ def _assert_weixin_cdn_url(url: str) -> None:
         parsed = urlparse(url)
         scheme = parsed.scheme.lower()
         host = parsed.hostname or ""
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         raise ValueError(f"Unparseable media URL: {url!r}") from exc
 
     if scheme not in {"http", "https"}:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -86,12 +86,12 @@ def _hash_chat_id(value: str) -> str:
 from .config import (
     Platform,
     GatewayConfig,
-    SessionResetPolicy,  # noqa: F401 — re-exported via gateway/__init__.py
+    SessionResetPolicy,
     HomeChannel,
 )
 from .whatsapp_identity import (
     canonical_whatsapp_identifier,
-    normalize_whatsapp_identifier,  # noqa: F401 - re-exported for gateway.session callers
+    normalize_whatsapp_identifier,
 )
 from utils import atomic_replace
 

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -188,7 +188,7 @@ def snapshot_shutdown_context(received_signal: Any = None) -> Dict[str, Any]:
                     ctx["planned_stop_marker"] = raw[:300]
                 except OSError:
                     pass
-    except Exception:  # noqa: BLE001 — never raise from a signal handler
+    except Exception:
         pass
 
     return ctx


### PR DESCRIPTION
Auto-fixes from `ruff check --select RUF100` removing stale # noqa directives across all `gateway/` source files (7 files).