### PR TITLE
fix: remove stale noqa comments from optional-skills/ files (RUF100)

### DIFF
--- a/optional-skills/productivity/memento-flashcards/scripts/youtube_quiz.py
+++ b/optional-skills/productivity/memento-flashcards/scripts/youtube_quiz.py
@@ -27,7 +27,7 @@ def _normalize_segments(segments: list) -> str:
 
 def cmd_fetch(args: argparse.Namespace) -> None:
     try:
-        import youtube_transcript_api  # noqa: F811
+        import youtube_transcript_api
     except ImportError:
         _out({
             "ok": False,

--- a/optional-skills/research/darwinian-evolver/scripts/show_snapshot.py
+++ b/optional-skills/research/darwinian-evolver/scripts/show_snapshot.py
@@ -56,10 +56,10 @@ def main() -> int:
     # The outer pickle wraps a dict; the inner pickle contains the actual organism
     # objects, which must be importable under their original dotted path. If you
     # ran a custom driver, make sure its module is on sys.path before calling this.
-    outer = pickle.loads(args.snapshot.read_bytes())  # noqa: S301 — gated by --i-trust-this-file
+    outer = pickle.loads(args.snapshot.read_bytes())
     if not isinstance(outer, dict) or "population_snapshot" not in outer:
         sys.exit("not a darwinian-evolver snapshot (no population_snapshot key)")
-    inner = pickle.loads(outer["population_snapshot"])  # noqa: S301 — gated by --i-trust-this-file
+    inner = pickle.loads(outer["population_snapshot"])
     pairs = inner["organisms"]  # list of (Organism, EvaluationResult)
 
     print(f"# organisms: {len(pairs)}\n")

--- a/optional-skills/research/osint-investigation/scripts/_http.py
+++ b/optional-skills/research/osint-investigation/scripts/_http.py
@@ -54,7 +54,7 @@ def get(
                 # provider's actual message ("OVER_RATE_LIMIT" etc.).
                 try:
                     body = e.read(2048).decode("utf-8", errors="replace")
-                except Exception:  # noqa: BLE001
+                except Exception:
                     body = ""
                 raise RuntimeError(
                     f"HTTP 429 rate-limited by {urllib.parse.urlsplit(url).netloc}. "

--- a/optional-skills/research/osint-investigation/scripts/entity_resolution.py
+++ b/optional-skills/research/osint-investigation/scripts/entity_resolution.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 # Allow running directly or as a module.
 sys.path.insert(0, str(Path(__file__).parent))
-from _normalize import (  # noqa: E402
+from _normalize import (
     normalize_name,
     normalize_aggressive,
     token_overlap_ratio,

--- a/optional-skills/research/osint-investigation/scripts/fetch_courtlistener.py
+++ b/optional-skills/research/osint-investigation/scripts/fetch_courtlistener.py
@@ -17,7 +17,7 @@ import urllib.parse
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from _http import get_json  # noqa: E402
+from _http import get_json
 
 BASE = "https://www.courtlistener.com/api/rest/v4/search/"
 
@@ -71,7 +71,7 @@ def fetch(
     while next_url and len(rows) < limit:
         try:
             payload = get_json(next_url, headers=headers)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             print(f"CourtListener error: {e}", file=sys.stderr)
             break
         if not isinstance(payload, dict):

--- a/optional-skills/research/osint-investigation/scripts/fetch_gdelt.py
+++ b/optional-skills/research/osint-investigation/scripts/fetch_gdelt.py
@@ -17,7 +17,7 @@ import urllib.parse
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from _http import get_json  # noqa: E402
+from _http import get_json
 
 BASE = "https://api.gdeltproject.org/api/v2/doc/doc"
 
@@ -81,7 +81,7 @@ def fetch(
             print(f"GDELT error: {e}", file=sys.stderr)
             payload = {}
             break
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             print(f"GDELT error: {e}", file=sys.stderr)
             payload = {}
             break

--- a/optional-skills/research/osint-investigation/scripts/fetch_icij_offshore.py
+++ b/optional-skills/research/osint-investigation/scripts/fetch_icij_offshore.py
@@ -65,7 +65,7 @@ def _download(dest: Path, force: bool = False) -> Path:
         BULK_URL,
         headers={"User-Agent": "hermes-agent osint-investigation skill"},
     )
-    with urllib.request.urlopen(req, timeout=120) as resp:  # noqa: S310
+    with urllib.request.urlopen(req, timeout=120) as resp:
         tmp = zip_path.with_suffix(".zip.tmp")
         with open(tmp, "wb") as fh:
             while True:

--- a/optional-skills/research/osint-investigation/scripts/fetch_nyc_acris.py
+++ b/optional-skills/research/osint-investigation/scripts/fetch_nyc_acris.py
@@ -21,7 +21,7 @@ import urllib.parse
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from _http import get_json  # noqa: E402
+from _http import get_json
 
 PARTIES_URL = "https://data.cityofnewyork.us/resource/636b-3b5g.json"
 MASTER_URL = "https://data.cityofnewyork.us/resource/bnx9-e6tj.json"
@@ -115,7 +115,7 @@ def fetch(
             url = f"{MASTER_URL}?{urllib.parse.urlencode(master_params)}"
             try:
                 rows = get_json(url)
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 print(f"ACRIS master lookup failed for chunk: {e}", file=sys.stderr)
                 continue
             if isinstance(rows, list):

--- a/optional-skills/research/osint-investigation/scripts/fetch_ofac_sdn.py
+++ b/optional-skills/research/osint-investigation/scripts/fetch_ofac_sdn.py
@@ -19,7 +19,7 @@ from collections import defaultdict
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from _http import get  # noqa: E402
+from _http import get
 
 SDN_URL = "https://www.treasury.gov/ofac/downloads/sdn.csv"
 ADD_URL = "https://www.treasury.gov/ofac/downloads/add.csv"

--- a/optional-skills/research/osint-investigation/scripts/fetch_opencorporates.py
+++ b/optional-skills/research/osint-investigation/scripts/fetch_opencorporates.py
@@ -19,7 +19,7 @@ import urllib.parse
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from _http import get, get_json  # noqa: E402
+from _http import get, get_json
 
 API_URL = "https://api.opencorporates.com/v0.4/companies/search"
 HTML_URL = "https://opencorporates.com/companies"
@@ -97,7 +97,7 @@ def fetch(
         try:
             companies = _via_api(query, jurisdiction, token, limit)
             source_tag = "api"
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             print(
                 f"OpenCorporates API call failed ({e}); falling back to HTML.",
                 file=sys.stderr,

--- a/optional-skills/research/osint-investigation/scripts/fetch_sec_edgar.py
+++ b/optional-skills/research/osint-investigation/scripts/fetch_sec_edgar.py
@@ -20,7 +20,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from _http import get, get_json  # noqa: E402
+from _http import get, get_json
 
 SUBMISSIONS_URL = "https://data.sec.gov/submissions/CIK{cik}.json"
 COLUMNS = [

--- a/optional-skills/research/osint-investigation/scripts/fetch_senate_ld.py
+++ b/optional-skills/research/osint-investigation/scripts/fetch_senate_ld.py
@@ -13,7 +13,7 @@ import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from _http import get_json  # noqa: E402
+from _http import get_json
 
 ENDPOINT = "https://lda.senate.gov/api/v1/filings/"
 COLUMNS = [
@@ -57,7 +57,7 @@ def fetch(
     while page < max_pages:
         try:
             payload = get_json(url, params=params if page == 0 else None, headers=headers)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             print(f"Senate LDA error on page {page + 1}: {e}", file=sys.stderr)
             break
         if not isinstance(payload, dict):

--- a/optional-skills/research/osint-investigation/scripts/fetch_usaspending.py
+++ b/optional-skills/research/osint-investigation/scripts/fetch_usaspending.py
@@ -98,7 +98,7 @@ def fetch(
         }
         try:
             payload = _post(body)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             print(f"USAspending error on page {page}: {e}", file=sys.stderr)
             break
         results = payload.get("results", [])

--- a/optional-skills/research/osint-investigation/scripts/fetch_wayback.py
+++ b/optional-skills/research/osint-investigation/scripts/fetch_wayback.py
@@ -14,7 +14,7 @@ import urllib.parse
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from _http import get_json  # noqa: E402
+from _http import get_json
 
 BASE = "https://web.archive.org/cdx/search/cdx"
 
@@ -62,7 +62,7 @@ def fetch(
     url = f"{BASE}?{urllib.parse.urlencode(params)}"
     try:
         payload = get_json(url)
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         print(f"Wayback CDX error: {e}", file=sys.stderr)
         payload = []
 

--- a/optional-skills/security/unbroker/scripts/badbool.py
+++ b/optional-skills/security/unbroker/scripts/badbool.py
@@ -158,7 +158,7 @@ def parse(markdown: str) -> list[dict]:
 
 def fetch(url: str = DEFAULT_URL, timeout: int = 30) -> str:
     req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
-    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
         return resp.read().decode("utf-8", errors="replace")
 
 

--- a/optional-skills/security/unbroker/scripts/cdp.py
+++ b/optional-skills/security/unbroker/scripts/cdp.py
@@ -112,7 +112,7 @@ def launch_command(browser: str, port: int = DEFAULT_PORT, profile: Path | None 
 
 def _http_get(url: str, timeout: float) -> bytes:
     req = urllib.request.Request(url, headers={"User-Agent": "unbroker-cdp/1.0"})
-    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (localhost only)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
         return resp.read()
 
 

--- a/optional-skills/security/unbroker/scripts/emailer.py
+++ b/optional-skills/security/unbroker/scripts/emailer.py
@@ -244,7 +244,7 @@ def _decode_part(part) -> str:
             return ""
         charset = part.get_content_charset() or "utf-8"
         return payload.decode(charset, errors="replace")
-    except Exception:  # noqa: BLE001 - malformed MIME must not kill the poll
+    except Exception:
         return ""
 
 
@@ -310,7 +310,7 @@ def fetch_recent(env: dict | None = None, since_days: int = 3, limit: int = 30,
     finally:
         try:
             conn.logout()
-        except Exception:  # noqa: BLE001
+        except Exception:
             pass
 
 

--- a/optional-skills/security/unbroker/scripts/registry.py
+++ b/optional-skills/security/unbroker/scripts/registry.py
@@ -214,7 +214,7 @@ MIN_EXPECTED_CA = 100  # CA registry has ~500+; far fewer => wrong/empty file, w
 
 def fetch(url: str = DEFAULT_URL, timeout: int = 60) -> str:
     req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
-    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
         return resp.read().decode("utf-8", errors="replace")
 
 
@@ -224,7 +224,7 @@ def _fetch_ca_latest() -> tuple[str, list[dict]]:
     for url in ca_candidate_urls():
         try:
             recs = parse(fetch(url), jurisdiction="US-CA", has_drop=True)
-        except Exception:  # noqa: BLE001 - a missing year 404s; fall through to older years
+        except Exception:
             continue
         if recs:
             return url, recs
@@ -269,7 +269,7 @@ def refresh_all(cache_path: Path, fetched: dict[str, str] | None = None) -> dict
                 used_url, recs = _fetch_ca_latest()   # newest-year-first with fallback
             else:
                 recs = parse(fetch(src["url"]), jurisdiction=src["jurisdiction"], has_drop=src["has_drop"])
-        except Exception as exc:  # noqa: BLE001 - one source failing must not sink the rest
+        except Exception as exc:
             per_source[key] = {"jurisdiction": src["jurisdiction"], "format": "csv", "error": str(exc)}
             continue
         added = 0

--- a/optional-skills/security/unbroker/scripts/scan.py
+++ b/optional-skills/security/unbroker/scripts/scan.py
@@ -16,7 +16,7 @@ USER_AGENT = "Mozilla/5.0 (compatible; unbroker/1.0; data opt-out)"
 def fetch(url: str, timeout: int = 20) -> tuple[int, str]:
     req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
     try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (https only by convention)
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
             charset = resp.headers.get_content_charset() or "utf-8"
             return getattr(resp, "status", 200), resp.read().decode(charset, errors="replace")
     except urllib.error.HTTPError as exc:


### PR DESCRIPTION
Auto-fixes from `ruff check --select RUF100` removing stale # noqa directives across all `optional-skills/` source files (19 files).