### PR TITLE
fix(setup+toolsets): blank slate no longer strips its own core tools via the coding posture bundle

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -3054,6 +3054,12 @@ def _blank_slate_minimal_toolsets(config: dict):
                 continue  # platform composites — not user-facing toolsets
             if isinstance(tdef, dict) and tdef.get("includes"):
                 continue  # composite groupings, not leaf toolsets
+            if isinstance(tdef, dict) and tdef.get("posture"):
+                continue  # posture toolsets (e.g. coding) are session-level
+                # selections made by agent/coding_context.py — not permanent
+                # user-facing disables. Adding them here causes model_tools
+                # to subtract their tools (terminal, read_file, …) from the
+                # minimal Blank Slate surface (#57315).
             all_keys.add(k)
 
         disabled = sorted(all_keys - keep)

--- a/model_tools.py
+++ b/model_tools.py
@@ -399,16 +399,19 @@ def _compute_tool_definitions(
     if disabled_toolsets:
         for toolset_name in disabled_toolsets:
             if validate_toolset(toolset_name):
-                if toolset_name.startswith("hermes-"):
-                    # Platform bundles (hermes-*) include _HERMES_CORE_TOOLS, so
-                    # subtracting the whole bundle would strip core tools shared
-                    # by other enabled toolsets and empty the tool list (#33924).
-                    # Subtract only the bundle's non-core delta; keep core.
-                    from toolsets import bundle_non_core_tools
+                from toolsets import bundle_non_core_tools, get_toolset
+                if toolset_name.startswith("hermes-") or (get_toolset(toolset_name) or {}).get("posture"):
+                    # Platform bundles (hermes-*) include _HERMES_CORE_TOOLS, and
+                    # posture toolsets (`posture: True`, e.g. `coding`) re-list
+                    # those same core tools without owning them, so subtracting
+                    # the whole toolset would strip core tools shared by other
+                    # enabled toolsets and empty the tool list (#33924, #57315).
+                    # Subtract only the non-core delta; keep core.
                     to_remove = bundle_non_core_tools(toolset_name)
                     tools_to_include.difference_update(to_remove)
                     resolved = sorted(to_remove)
-                    if not quiet_mode and toolset_name not in _WARNED_DISABLED_BUNDLES:
+                    if (not quiet_mode and toolset_name.startswith("hermes-")
+                            and toolset_name not in _WARNED_DISABLED_BUNDLES):
                         _WARNED_DISABLED_BUNDLES.add(toolset_name)
                         logger.info(
                             "agent.disabled_toolsets contains platform-bundle "

--- a/tests/hermes_cli/test_setup_blank_slate.py
+++ b/tests/hermes_cli/test_setup_blank_slate.py
@@ -45,6 +45,25 @@ class TestBlankSlateMinimalToolsets:
         disabled = set(cfg["agent"]["disabled_toolsets"])
         assert "coding" not in disabled
 
+    def test_no_disabled_bundle_overlaps_kept_tools(self):
+        """Invariant: ``disabled_toolsets`` is applied at *tool* granularity and
+        a single tool can belong to several toolsets, so no disabled entry may
+        share a tool with a kept toolset — it would silently strip that tool
+        from the blank-slate agent (#57315, #58281).
+        """
+        from toolsets import resolve_toolset
+        cfg = {}
+        _blank_slate_minimal_toolsets(cfg)
+        kept_tools = set()
+        for ts in cfg["platform_toolsets"]["cli"]:
+            kept_tools.update(resolve_toolset(ts))
+        for ts in cfg["agent"]["disabled_toolsets"]:
+            overlap = set(resolve_toolset(ts)) & kept_tools
+            assert not overlap, (
+                f"disabled toolset '{ts}' overlaps kept tools {sorted(overlap)}; "
+                "it would silently strip them from the blank-slate agent"
+            )
+
     def test_resolver_yields_exactly_file_and_terminal(self):
         from hermes_cli.tools_config import _get_platform_tools
         cfg = {}

--- a/tests/hermes_cli/test_setup_blank_slate.py
+++ b/tests/hermes_cli/test_setup_blank_slate.py
@@ -34,6 +34,17 @@ class TestBlankSlateMinimalToolsets:
         # The recovered non-configurable toolset that used to leak is suppressed.
         assert "kanban" in disabled
 
+    def test_disabled_toolsets_excludes_posture_toolsets(self):
+        """Posture toolsets (e.g. coding) are session-level selections made by
+        agent/coding_context.py — not permanent user-facing disables.  Including
+        them in disabled_toolsets causes model_tools to subtract their tools
+        (terminal, read_file, …) from the minimal Blank Slate surface (#57315).
+        """
+        cfg = {}
+        _blank_slate_minimal_toolsets(cfg)
+        disabled = set(cfg["agent"]["disabled_toolsets"])
+        assert "coding" not in disabled
+
     def test_resolver_yields_exactly_file_and_terminal(self):
         from hermes_cli.tools_config import _get_platform_tools
         cfg = {}
@@ -52,6 +63,30 @@ class TestBlankSlateMinimalToolsets:
         enabled = sorted(_get_platform_tools(cfg, "cli"))
         defs = model_tools.get_tool_definitions(
             enabled_toolsets=enabled, disabled_toolsets=None, quiet_mode=True
+        )
+        names = sorted(
+            {(d.get("function") or {}).get("name") or d.get("name") for d in defs}
+        )
+        assert names == ["patch", "process", "read_file", "search_files",
+                         "terminal", "write_file"]
+
+    def test_tool_schema_survives_disabled_toolsets_from_config(self):
+        """Regression: disabled_toolsets must not erase the minimal Blank Slate
+        surface when passed to model_tools.  Before the fix, posture toolsets
+        like ``coding`` in disabled_toolsets caused model_tools to subtract
+        terminal, read_file, write_file, etc. (#57315).
+        """
+        import model_tools
+        from hermes_cli.tools_config import _get_platform_tools
+        cfg = {}
+        _blank_slate_minimal_toolsets(cfg)
+        _blank_slate_minimize_config(cfg)
+        enabled = sorted(_get_platform_tools(cfg, "cli"))
+        disabled = cfg.get("agent", {}).get("disabled_toolsets") or []
+        defs = model_tools.get_tool_definitions(
+            enabled_toolsets=enabled,
+            disabled_toolsets=disabled,
+            quiet_mode=True,
         )
         names = sorted(
             {(d.get("function") or {}).get("name") or d.get("name") for d in defs}

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -536,3 +536,54 @@ class TestDisabledToolsetsPlatformBundle:
         from toolsets import bundle_non_core_tools
         # A non-existent bundle resolves to an empty set (no tools), not a crash.
         assert bundle_non_core_tools("hermes-does-not-exist") == set()
+
+
+class TestDisabledToolsetsPostureToolset:
+    """Regression test for #57315: disabling a posture toolset (`coding`,
+    posture: True) must preserve the shared core tools it re-lists but does
+    not own -- same non-core-delta subtraction as hermes-* bundles (#33924) --
+    while atomic toolsets stay fully removable."""
+
+    def test_disabling_coding_preserves_core_but_atomic_disables_still_remove(self):
+        from model_tools import get_tool_definitions
+
+        # web_search is check_fn-gated (needs an API key); probe only the core
+        # tools actually present in baseline so gating cannot mask the fix.
+        core_probe = {"terminal", "read_file", "write_file", "web_search", "execute_code"}
+
+        baseline = {
+            t["function"]["name"]
+            for t in get_tool_definitions(quiet_mode=True)
+        }
+        present_core = core_probe & baseline
+        # Sanity: at least some probed core tools are available in this env.
+        assert present_core, "no probed core tools present in baseline"
+
+        no_coding = {
+            t["function"]["name"]
+            for t in get_tool_definitions(
+                disabled_toolsets=["coding"], quiet_mode=True
+            )
+        }
+        # Previously the full resolve_toolset("coding") subtraction stripped
+        # these shared core tools, collapsing the schema to a handful (#57315).
+        assert present_core <= no_coding, (
+            f"Core tools stripped by disabling 'coding': {present_core - no_coding}"
+        )
+
+        # Atomic (non-posture) toolsets must still be fully removable.
+        no_terminal = {
+            t["function"]["name"]
+            for t in get_tool_definitions(
+                disabled_toolsets=["terminal"], quiet_mode=True
+            )
+        }
+        assert "terminal" not in no_terminal
+
+        no_file = {
+            t["function"]["name"]
+            for t in get_tool_definitions(
+                disabled_toolsets=["file"], quiet_mode=True
+            )
+        }
+        assert "write_file" not in no_file


### PR DESCRIPTION
## Summary

Blank Slate installs (and any config with `coding` in `agent.disabled_toolsets`) no longer strip the agent's own core tools down to zero — fixed at both the setup layer (stop writing the footgun) and the runtime layer (make it harmless), salvaging PRs #57332 and #57546.

Root cause: `_blank_slate_minimal_toolsets` wrote `agent.disabled_toolsets` as "every toolset except file+terminal", which included `coding` — a posture bundle (`posture: True`) that re-lists `terminal`, `read_file`, `write_file`, `patch`, `search_files`, etc. The runtime subtraction in `model_tools.py::_compute_tool_definitions` strips disabled toolsets at tool granularity, so the shared core tools were silently removed even though `file`/`terminal` were explicitly enabled. The model received `Tools: 0` (plus stray plugin tools like cronjob/tts), across CLI, Discord, and Telegram. `hermes tools` could not heal it because the reconcile step never removes posture bundles. TUI/desktop worked because they select the coding posture directly.

Fixes #57315, fixes #58281.

## Changes

- `hermes_cli/setup.py`: blank-slate disabled computation skips `posture: True` toolsets (cherry-picked from #57332, @liuhao1024)
- `model_tools.py`: disabling a posture toolset now subtracts only its non-core delta, same protection the `hermes-*` bundles already had via #33924; atomic toolsets stay fully removable (cherry-picked from #57546, @bbopen)
- `tests/hermes_cli/test_setup_blank_slate.py`: posture-exclusion test (#57332) + overlap-invariant test from #58686 (@HexLab98)
- `tests/test_model_tools.py`: posture-preservation regression test (#57546)

## Validation

| Scenario | Before | After |
|---|---|---|
| Existing broken install (reporter's discord config, `coding` in disabled) | core tools stripped, Tools≈0 | all 6 file/terminal tools present (E2E, real imports + temp HERMES_HOME) |
| Fresh blank slate | `coding` written to disabled → zeroed | exactly `patch, process, read_file, search_files, terminal, write_file` |
| Atomic disable (`terminal`) | fully removed | still fully removed (#17309 contract holds) |
| `scripts/run_tests.sh tests/hermes_cli/test_setup_blank_slate.py tests/test_model_tools.py` | — | 43 passed |

## Credit

- @liuhao1024 (#57332, earliest fix, setup layer) — authorship preserved via cherry-pick
- @bbopen (#57546, runtime layer) — authorship preserved via cherry-pick
- @HexLab98 (#58686, independent diagnosis + the overlap-invariant test, and drove the live Discord triage that pinned this down) — test commit authored under their name

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa1141c/i90dvv_vAsHof6OAYA0gx_x7oF32B1.png)
