### PR TITLE
fix(daemon_pool): guard against missing _initializer attr on Python 3.14

### DIFF
--- a/tools/daemon_pool.py
+++ b/tools/daemon_pool.py
@@ -55,8 +55,8 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
                 args=(
                     weakref.ref(self, weakref_cb),
                     self._work_queue,
-                    self._initializer,
-                    self._initargs,
+                    getattr(self, '_initializer', None),
+                    getattr(self, '_initargs', ()),
                 ),
                 daemon=True,
             )


### PR DESCRIPTION
Python 3.14 removed the private _initializer attribute from
ThreadPoolExecutor. Direct access via self._initializer crashes
DaemonThreadPoolExecutor._adjust_thread_count with AttributeError.

Use getattr with a safe default (None / empty tuple) so the class
works transparently on both CPython 3.8-3.13 and 3.14+.

Closes #58596.
