### PR TITLE
Remove stale noqa directives from mcp_servers/ files

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -21,7 +21,7 @@ from hermes_cli.config import (
     save_config,
     get_env_value,
     save_env_value,
-    get_hermes_home,  # noqa: F401 — used by test mocks
+    get_hermes_home,
 )
 from hermes_cli.colors import Colors, color
 from hermes_constants import display_hermes_home

--- a/tests/tools/test_mcp_dynamic_discovery.py
+++ b/tests/tools/test_mcp_dynamic_discovery.py
@@ -125,7 +125,7 @@ class TestDeregister:
 
     def test_cleans_up_toolset_check(self):
         reg = ToolRegistry()
-        check = lambda: True  # noqa: E731
+        check = lambda: True
         reg.register(name="foo", toolset="ts1", schema={}, handler=lambda x: x, check_fn=check)
         assert reg.is_toolset_available("ts1")
         reg.deregister("foo")
@@ -134,7 +134,7 @@ class TestDeregister:
 
     def test_preserves_toolset_check_if_other_tools_remain(self):
         reg = ToolRegistry()
-        check = lambda: True  # noqa: E731
+        check = lambda: True
         reg.register(name="foo", toolset="ts1", schema={}, handler=lambda x: x, check_fn=check)
         reg.register(name="bar", toolset="ts1", schema={}, handler=lambda x: x)
         reg.deregister("foo")

--- a/tests/tools/test_mcp_elicitation.py
+++ b/tests/tools/test_mcp_elicitation.py
@@ -16,9 +16,9 @@ import pytest
 
 pytest.importorskip("mcp.types")
 
-from mcp.types import ElicitResult  # noqa: E402  -- after importorskip
+from mcp.types import ElicitResult
 
-from tools.mcp_tool import (  # noqa: E402
+from tools.mcp_tool import (
     ElicitationHandler,
     _format_elicitation_schema_summary,
 )

--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -156,7 +156,7 @@ async def test_handle_401_tracks_inflight_task_to_prevent_gc(tmp_path, monkeypat
             super().__init__()
             self.ever_added: list = []
 
-        def add(self, item):  # noqa: A003
+        def add(self, item):
             self.ever_added.append(item)
             super().add(item)
 

--- a/tests/tools/test_mcp_preflight_content_type.py
+++ b/tests/tools/test_mcp_preflight_content_type.py
@@ -85,7 +85,7 @@ def _handler(status: int = 200,
                 record.append("GET")
             self._write(status, content_type, body)
 
-        def log_message(self, format, *args):  # noqa: A002
+        def log_message(self, format, *args):
             pass
 
     return _H

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -505,7 +505,7 @@ def _make_callback_handler() -> tuple[type, dict]:
     result: dict[str, Any] = {"auth_code": None, "state": None, "error": None}
 
     class _Handler(BaseHTTPRequestHandler):
-        def do_GET(self) -> None:  # noqa: N802
+        def do_GET(self) -> None:
             params = parse_qs(urlparse(self.path).query)
             code = params.get("code", [None])[0]
             state = params.get("state", [None])[0]

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -603,7 +603,7 @@ class MCPOAuthManager:
                 # on its next auth flow. `_initialized` is private API but
                 # stable across the MCP SDK versions we pin (>=1.26.0).
                 if hasattr(entry.provider, "_initialized"):
-                    entry.provider._initialized = False  # noqa: SLF001
+                    entry.provider._initialized = False
                 logger.info(
                     "MCP OAuth '%s': tokens file changed (mtime %d -> %d), "
                     "forcing reload",


### PR DESCRIPTION
Ran Found 769 errors (769 fixed, 0 remaining). to remove unused noqa
directives for non-enabled rules across MCP server-related Python files.

Affected files:
- hermes_cli/mcp_config.py (F401)
- tests/tools/test_mcp_dynamic_discovery.py (E731)
- tests/tools/test_mcp_elicitation.py (E402)
- tests/tools/test_mcp_oauth_manager.py (A003)
- tests/tools/test_mcp_preflight_content_type.py (A002)
- tools/mcp_oauth.py (N802)
- tools/mcp_oauth_manager.py (SLF001)
