### PR TITLE
Redact secrets in global log records

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -1423,5 +1423,11 @@ class RedactingFormatter(logging.Formatter):
         super().__init__(fmt, datefmt, style, **kwargs)
 
     def format(self, record: logging.LogRecord) -> str:
-        original = super().format(record)
-        return redact_sensitive_text(original)
+        try:
+            original = super().format(record)
+            return redact_sensitive_text(original)
+        except Exception:
+            # Formatting is a security boundary: never let logging's default
+            # ``handleError`` path print the original record and arguments to
+            # stderr when the redactor itself is unavailable or raises.
+            return "[log content suppressed: redaction failed]"

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -163,6 +163,12 @@ _ENV_ASSIGN_LOWER_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Structured diagnostic identifiers whose ``*_key`` suffix names a lookup
+# key, not a credential. Known token prefixes are masked before assignment
+# handling, so a credential-shaped value remains protected even for these
+# fields.
+_NON_SECRET_ASSIGNMENT_KEYS = frozenset({"session_key"})
+
 # Lowercase / dotted / hyphenated config keys from config files
 # (application.properties, .env, YAML-ish dumps): ``spring.datasource.password=secret``,
 # ``app.api.key=xyz``, ``password=secret``. The uppercase _ENV_ASSIGN_RE above
@@ -851,6 +857,8 @@ def redact_sensitive_text(
                 # secret values — masking them corrupts code snippets in
                 # prose/log contexts (issue #2852): ``KEY=os.getenv('X')``.
                 if _ENV_LOOKUP_VALUE_RE.match(value):
+                    return m.group(0)
+                if name.lower() in _NON_SECRET_ASSIGNMENT_KEYS:
                     return m.group(0)
                 # Keyword must sit at a word boundary within the key —
                 # ``author=Smith`` / ``press.secretary=…`` are prose, not

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -180,14 +180,19 @@ def clear_session_context() -> None:
 # Record factory — injects session_tag and sanitizes every LogRecord at creation
 # ---------------------------------------------------------------------------
 
+def _redact_log_record_text(text: str) -> str:
+    """Redact a log text value without letting redactor failures break logging."""
+    try:
+        from agent.redact import redact_sensitive_text
+        return redact_sensitive_text(text)
+    except Exception:
+        return text
+
+
 def _redact_log_record_value(value: Any) -> Any:
     """Redact string values inside common logging payload containers."""
     if isinstance(value, str):
-        try:
-            from agent.redact import redact_sensitive_text
-            return redact_sensitive_text(value)
-        except Exception:
-            return value
+        return _redact_log_record_text(value)
     if isinstance(value, tuple):
         return tuple(_redact_log_record_value(item) for item in value)
     if isinstance(value, list):
@@ -200,6 +205,35 @@ def _redact_log_record_value(value: Any) -> Any:
     return value
 
 
+def _sanitize_log_record(record: logging.LogRecord) -> None:
+    """Redact rendered message and exception fields on a LogRecord in place."""
+    try:
+        record.msg = _redact_log_record_text(record.getMessage())
+        record.args = ()
+    except Exception:
+        try:
+            record.msg = _redact_log_record_value(record.msg)
+            record.args = _redact_log_record_value(record.args)
+        except Exception:
+            pass
+
+    try:
+        if record.exc_info:
+            record.exc_text = _redact_log_record_text(
+                logging.Formatter().formatException(record.exc_info)
+            )
+        elif record.exc_text:
+            record.exc_text = _redact_log_record_text(record.exc_text)
+    except Exception:
+        pass
+
+    try:
+        if record.stack_info:
+            record.stack_info = _redact_log_record_text(record.stack_info)
+    except Exception:
+        pass
+
+
 def _install_session_record_factory() -> None:
     """Replace the global LogRecord factory with Hermes record defaults.
 
@@ -207,8 +241,8 @@ def _install_session_record_factory() -> None:
     runs for EVERY record in the process — including records that propagate
     from child loggers and records handled by third-party handlers.  This
     guarantees ``%(session_tag)s`` is always available in format strings and
-    ensures plain non-Hermes formatters receive already-sanitized ``msg`` and
-    ``args`` payloads.
+    ensures plain non-Hermes formatters receive already-sanitized messages,
+    traceback text, and stack text.
 
     Idempotent — checks for a marker attribute to avoid double-wrapping if
     the module is reloaded.
@@ -221,11 +255,7 @@ def _install_session_record_factory() -> None:
         record = current_factory(*args, **kwargs)
         sid = getattr(_session_context, "session_id", None)
         record.session_tag = f" [{sid}]" if sid else ""  # type: ignore[attr-defined]
-        try:
-            record.msg = _redact_log_record_value(record.msg)
-            record.args = _redact_log_record_value(record.args)
-        except Exception:
-            pass
+        _sanitize_log_record(record)
         return record
 
     _session_record_factory._hermes_session_injector = True  # type: ignore[attr-defined]

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -37,7 +37,7 @@ import sys
 import threading
 from logging.handlers import QueueHandler, QueueListener
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import Any, Optional, Sequence
 
 # On Windows, stdlib ``RotatingFileHandler`` calls ``os.rename()`` in
 # ``doRollover()`` and fails with ``PermissionError [WinError 32]`` whenever
@@ -177,18 +177,38 @@ def clear_session_context() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Record factory — injects session_tag into every LogRecord at creation
+# Record factory — injects session_tag and sanitizes every LogRecord at creation
 # ---------------------------------------------------------------------------
 
+def _redact_log_record_value(value: Any) -> Any:
+    """Redact string values inside common logging payload containers."""
+    if isinstance(value, str):
+        try:
+            from agent.redact import redact_sensitive_text
+            return redact_sensitive_text(value)
+        except Exception:
+            return value
+    if isinstance(value, tuple):
+        return tuple(_redact_log_record_value(item) for item in value)
+    if isinstance(value, list):
+        return [_redact_log_record_value(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            key: _redact_log_record_value(item)
+            for key, item in value.items()
+        }
+    return value
+
+
 def _install_session_record_factory() -> None:
-    """Replace the global LogRecord factory with one that adds ``session_tag``.
+    """Replace the global LogRecord factory with Hermes record defaults.
 
     Unlike a ``logging.Filter`` on a handler or logger, the record factory
     runs for EVERY record in the process — including records that propagate
     from child loggers and records handled by third-party handlers.  This
-    guarantees ``%(session_tag)s`` is always available in format strings,
-    eliminating the KeyError that would occur if a handler used our format
-    without having a ``_SessionFilter`` attached.
+    guarantees ``%(session_tag)s`` is always available in format strings and
+    ensures plain non-Hermes formatters receive already-sanitized ``msg`` and
+    ``args`` payloads.
 
     Idempotent — checks for a marker attribute to avoid double-wrapping if
     the module is reloaded.
@@ -201,9 +221,15 @@ def _install_session_record_factory() -> None:
         record = current_factory(*args, **kwargs)
         sid = getattr(_session_context, "session_id", None)
         record.session_tag = f" [{sid}]" if sid else ""  # type: ignore[attr-defined]
+        try:
+            record.msg = _redact_log_record_value(record.msg)
+            record.args = _redact_log_record_value(record.args)
+        except Exception:
+            pass
         return record
 
     _session_record_factory._hermes_session_injector = True  # type: ignore[attr-defined]
+    _session_record_factory._hermes_record_sanitizer = True  # type: ignore[attr-defined]
     logging.setLogRecordFactory(_session_record_factory)
 
 

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -189,6 +189,17 @@ def _redact_log_record_text(text: str) -> str:
         return text
 
 
+_LOG_PRIMITIVE_TYPES = (type(None), bool, int, float, complex)
+
+
+def _safe_log_value_text(value: Any, fallback: str) -> str:
+    """Stringify a log value for redaction without letting ``__str__`` escape."""
+    try:
+        return _redact_log_record_text(str(value))
+    except Exception:
+        return fallback
+
+
 def _redact_log_record_value(value: Any) -> Any:
     """Redact string values inside common logging payload containers."""
     if isinstance(value, str):
@@ -199,21 +210,99 @@ def _redact_log_record_value(value: Any) -> Any:
         return [_redact_log_record_value(item) for item in value]
     if isinstance(value, dict):
         return {
-            key: _redact_log_record_value(item)
+            _redact_log_record_value(key): _redact_log_record_value(item)
             for key, item in value.items()
         }
-    return value
+    if isinstance(value, _LOG_PRIMITIVE_TYPES):
+        return value
+    return _safe_log_value_text(value, "<unprintable log value>")
+
+
+def _render_log_record_message(record: logging.LogRecord) -> str:
+    """Render ``record.getMessage()`` or return a safe fallback on bad format."""
+    try:
+        return record.getMessage()
+    except Exception:
+        # A malformed logging call would normally fail later in Handler.emit(),
+        # where stdlib's logging-error report prints the raw args to stderr.
+        # Drop args entirely here; the template is already the useful context.
+        template = _safe_log_value_text(record.msg, "<unprintable log message>")
+        return f"{template} [log message formatting failed]"
+
+
+def _sanitize_log_record_extra(record: logging.LogRecord, extra: object) -> None:
+    """Redact caller-supplied ``extra`` attributes after Logger merges them."""
+    if not extra:
+        return
+    try:
+        keys = list(extra.keys())  # type: ignore[union-attr]
+    except Exception:
+        return
+    for key in keys:
+        if not isinstance(key, str) or key not in record.__dict__:
+            continue
+        try:
+            record.__dict__[key] = _redact_log_record_value(record.__dict__[key])
+        except Exception:
+            record.__dict__[key] = "<unprintable log value>"
+
+
+def _sanitize_exception_value(exc: BaseException) -> BaseException:
+    """Return a shallow sanitized copy of an exception for ``record.exc_info``."""
+    try:
+        sanitized = exc.__class__.__new__(exc.__class__)
+    except Exception:
+        sanitized = Exception(_safe_log_value_text(exc, "<unprintable exception>"))
+
+    if not isinstance(sanitized, BaseException):
+        sanitized = Exception(_safe_log_value_text(exc, "<unprintable exception>"))
+
+    try:
+        sanitized.args = tuple(_redact_log_record_value(arg) for arg in exc.args)
+    except Exception:
+        sanitized.args = (_safe_log_value_text(exc, "<unprintable exception>"),)
+
+    try:
+        attrs = getattr(exc, "__dict__", None)
+        if attrs:
+            sanitized.__dict__.update(_redact_log_record_value(attrs))
+    except Exception:
+        pass
+
+    try:
+        sanitized.__cause__ = None
+        sanitized.__context__ = None
+        sanitized.__suppress_context__ = True
+    except Exception:
+        pass
+
+    return sanitized
+
+
+def _sanitize_exc_info(exc_info: object) -> object:
+    """Preserve ``exc_info`` presence while removing raw secret-bearing parts."""
+    try:
+        exc_type, exc_value, _exc_tb = exc_info  # type: ignore[misc]
+    except Exception:
+        return None
+    if not isinstance(exc_value, BaseException):
+        return None
+    sanitized_value = _sanitize_exception_value(exc_value)
+    return (type(sanitized_value) or exc_type, sanitized_value, None)
 
 
 def _sanitize_log_record(record: logging.LogRecord) -> None:
     """Redact rendered message and exception fields on a LogRecord in place."""
     try:
-        record.msg = _redact_log_record_text(record.getMessage())
+        record.msg = _redact_log_record_text(_render_log_record_message(record))
         record.args = ()
     except Exception:
         try:
-            record.msg = _redact_log_record_value(record.msg)
-            record.args = _redact_log_record_value(record.args)
+            record.msg = _safe_log_value_text(
+                record.msg,
+                "<unprintable log message>",
+            )
+            record.args = ()
         except Exception:
             pass
 
@@ -222,9 +311,12 @@ def _sanitize_log_record(record: logging.LogRecord) -> None:
             record.exc_text = _redact_log_record_text(
                 logging.Formatter().formatException(record.exc_info)
             )
+            record.exc_info = _sanitize_exc_info(record.exc_info)
         elif record.exc_text:
             record.exc_text = _redact_log_record_text(record.exc_text)
     except Exception:
+        record.exc_text = "exception traceback unavailable after redaction failure"
+        record.exc_info = _sanitize_exc_info(record.exc_info)
         pass
 
     try:
@@ -242,7 +334,7 @@ def _install_session_record_factory() -> None:
     from child loggers and records handled by third-party handlers.  This
     guarantees ``%(session_tag)s`` is always available in format strings and
     ensures plain non-Hermes formatters receive already-sanitized messages,
-    traceback text, and stack text.
+    traceback text, stack text, and caller-provided ``extra`` fields.
 
     Idempotent — checks for a marker attribute to avoid double-wrapping if
     the module is reloaded.
@@ -263,9 +355,49 @@ def _install_session_record_factory() -> None:
     logging.setLogRecordFactory(_session_record_factory)
 
 
+def _install_logger_make_record_sanitizer() -> None:
+    """Wrap ``Logger.makeRecord`` so caller-provided ``extra`` is sanitized."""
+    current_make_record = logging.Logger.makeRecord
+    if getattr(current_make_record, "_hermes_extra_sanitizer", False):
+        return
+
+    def _hermes_make_record(
+        self,
+        name,
+        level,
+        fn,
+        lno,
+        msg,
+        args,
+        exc_info,
+        func=None,
+        extra=None,
+        sinfo=None,
+    ):
+        record = current_make_record(
+            self,
+            name,
+            level,
+            fn,
+            lno,
+            msg,
+            args,
+            exc_info,
+            func=func,
+            extra=extra,
+            sinfo=sinfo,
+        )
+        _sanitize_log_record_extra(record, extra)
+        return record
+
+    _hermes_make_record._hermes_extra_sanitizer = True  # type: ignore[attr-defined]
+    logging.Logger.makeRecord = _hermes_make_record
+
+
 # Install immediately on import — session_tag is available on all records
 # from this point forward, even before setup_logging() is called.
 _install_session_record_factory()
+_install_logger_make_record_sanitizer()
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -190,6 +190,9 @@ def _redact_log_record_text(text: str) -> str:
 
 
 _LOG_PRIMITIVE_TYPES = (type(None), bool, int, float, complex)
+_LOG_RECORD_STANDARD_KEYS = frozenset(
+    logging.LogRecord("", 0, "", 0, "", (), None).__dict__
+) | {"asctime", "message"}
 
 
 def _safe_log_value_text(value: Any, fallback: str) -> str:
@@ -394,10 +397,41 @@ def _install_logger_make_record_sanitizer() -> None:
     logging.Logger.makeRecord = _hermes_make_record
 
 
+def _install_make_log_record_sanitizer() -> None:
+    """Sanitize records reconstructed from dictionaries after field updates.
+
+    ``logging.makeLogRecord`` first asks the active record factory for a
+    placeholder and then overwrites its ``__dict__``.  That second step can
+    replace the already-sanitized message, arguments, exception, and extra
+    fields, so sanitize the completed record before returning it.
+    """
+    current_make_log_record = logging.makeLogRecord
+    if getattr(current_make_log_record, "_hermes_record_sanitizer", False):
+        return
+
+    def _hermes_make_log_record(record_dict):
+        record = current_make_log_record(record_dict)
+        _sanitize_log_record(record)
+        try:
+            extras = {
+                key: value
+                for key, value in record_dict.items()
+                if key not in _LOG_RECORD_STANDARD_KEYS
+            }
+        except Exception:
+            extras = None
+        _sanitize_log_record_extra(record, extras)
+        return record
+
+    _hermes_make_log_record._hermes_record_sanitizer = True  # type: ignore[attr-defined]
+    logging.makeLogRecord = _hermes_make_log_record
+
+
 # Install immediately on import — session_tag is available on all records
 # from this point forward, even before setup_logging() is called.
 _install_session_record_factory()
 _install_logger_make_record_sanitizer()
+_install_make_log_record_sanitizer()
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -180,13 +180,22 @@ def clear_session_context() -> None:
 # Record factory — injects session_tag and sanitizes every LogRecord at creation
 # ---------------------------------------------------------------------------
 
+_LOG_REDACTION_FAILURE_TEXT = "[log content suppressed: redaction failed]"
+
+
 def _redact_log_record_text(text: str) -> str:
-    """Redact a log text value without letting redactor failures break logging."""
+    """Redact a log text value, suppressing it if the redactor fails.
+
+    This helper sits on a process-wide security boundary. Returning ``text``
+    from the exception path would turn a transient import or validator failure
+    into a credential leak through every plain logging handler in the process.
+    Logging remains available, but the unsafe payload is deliberately lost.
+    """
     try:
         from agent.redact import redact_sensitive_text
         return redact_sensitive_text(text)
     except Exception:
-        return text
+        return _LOG_REDACTION_FAILURE_TEXT
 
 
 _LOG_PRIMITIVE_TYPES = (type(None), bool, int, float, complex)

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -297,17 +297,30 @@ def _sanitize_exc_info(exc_info: object) -> object:
 def _sanitize_log_record(record: logging.LogRecord) -> None:
     """Redact rendered message and exception fields on a LogRecord in place."""
     try:
-        record.msg = _redact_log_record_text(_render_log_record_message(record))
-        record.args = ()
+        rendered_message = record.getMessage()
     except Exception:
         try:
-            record.msg = _safe_log_value_text(
-                record.msg,
-                "<unprintable log message>",
-            )
+            record.msg = _redact_log_record_text(_render_log_record_message(record))
             record.args = ()
         except Exception:
             pass
+    else:
+        try:
+            # Keep a sanitized argument container available to structured
+            # formatters such as ``uvicorn.logging.AccessFormatter``.  Final
+            # formatter output is sanitized by
+            # ``_install_formatter_output_sanitizer()``, which also covers a
+            # secret assembled only when the template and arguments join.
+            record.msg = _redact_log_record_value(record.msg)
+            record.args = _redact_log_record_value(record.args)
+            # Stringifying an unusual argument during sanitization can make a
+            # previously valid numeric template invalid.  In that rare case,
+            # preserve the old fail-closed behavior instead of letting logging
+            # print raw arguments in its error report.
+            record.getMessage()
+        except Exception:
+            record.msg = _redact_log_record_text(rendered_message)
+            record.args = ()
 
     try:
         if record.exc_info:

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -427,11 +427,33 @@ def _install_make_log_record_sanitizer() -> None:
     logging.makeLogRecord = _hermes_make_log_record
 
 
+def _install_formatter_output_sanitizer() -> None:
+    """Redact secrets assembled only when a plain formatter joins fields.
+
+    Record creation sanitizes messages and ``extra`` values independently,
+    but a format such as ``%(token_prefix)s%(token_body)s`` can combine two
+    harmless fragments into a recognizable credential.  Plain stdlib
+    formatters are the final common boundary for that assembled text, so wrap
+    their output while leaving the record-level sanitizers in place for
+    handlers and filters that inspect fields directly.
+    """
+    current_format = logging.Formatter.format
+    if getattr(current_format, "_hermes_output_sanitizer", False):
+        return
+
+    def _hermes_format(self, record):
+        return _redact_log_record_text(current_format(self, record))
+
+    _hermes_format._hermes_output_sanitizer = True  # type: ignore[attr-defined]
+    logging.Formatter.format = _hermes_format
+
+
 # Install immediately on import — session_tag is available on all records
 # from this point forward, even before setup_logging() is called.
 _install_session_record_factory()
 _install_logger_make_record_sanitizer()
 _install_make_log_record_sanitizer()
+_install_formatter_output_sanitizer()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -130,6 +130,17 @@ class TestBareSecretEnvSuffixes:
         result = redact_sensitive_text("openai_key=xyzzyplugh1234567890abcd", force=True)
         assert "xyzzyplugh1234567890abcd" not in result
 
+    def test_session_key_identifier_is_not_treated_as_a_credential(self):
+        text = "session_key=agent:main:telegram:dm:42"
+        assert redact_sensitive_text(text, force=True) == text
+
+    def test_session_key_still_masks_a_credential_shaped_value(self):
+        secret = "ghp_" + "X" * 36
+        result = redact_sensitive_text(f"session_key={secret}", force=True)
+
+        assert secret not in result
+        assert result.startswith("session_key=ghp_")
+
     def test_prose_words_with_keyword_unchanged(self):
         # KEYBOARD / PASSAGE embed the bare keyword but are prose, not creds
         for text in ("KEYBOARD=notsecret", "PASSAGE=notsecret"):

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -460,6 +460,45 @@ class TestSessionContext:
         assert github_token not in output
         assert "..." in output
 
+    @pytest.mark.parametrize(
+        ("format_string", "message"),
+        [
+            ("%(token_prefix)s%(token_body)s", "ordinary message"),
+            ("%(message)s%(token_body)s", "sk-"),
+        ],
+    )
+    def test_plain_formatter_redacts_secret_assembled_across_fields(
+        self,
+        format_string,
+        message,
+    ):
+        """Final formatter output is redacted after separate fields are joined."""
+        secret = "sk-" + "s" * 32
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(logging.Formatter(format_string))
+
+        logger = logging.getLogger("_test_plain_cross_field_redaction")
+        old_propagate = logger.propagate
+        old_level = logger.level
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+        logger.addHandler(handler)
+        try:
+            logger.info(
+                message,
+                extra={"token_prefix": "sk-", "token_body": "s" * 32},
+            )
+        finally:
+            logger.removeHandler(handler)
+            logger.propagate = old_propagate
+            logger.setLevel(old_level)
+            handler.close()
+
+        output = stream.getvalue()
+        assert secret not in output
+        assert "..." in output
+
     def test_plain_formatter_redacts_object_extra_fields(self):
         """Object extras are stringified and redacted before plain formatting."""
         secret = "sk-" + "i" * 32
@@ -685,6 +724,31 @@ class TestSessionContext:
         assert extra_secret not in output
         assert exception_secret not in output
         assert output.count("...") >= 3
+
+    def test_make_log_record_redacts_secret_assembled_across_extra_fields(self):
+        """Reconstructed records are redacted after formatter field assembly."""
+        secret = "sk-" + "t" * 32
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(logging.Formatter("%(token_prefix)s%(token_body)s"))
+        record = logging.makeLogRecord(
+            {
+                "name": "_test_make_log_record_cross_field_redaction",
+                "levelno": logging.INFO,
+                "levelname": "INFO",
+                "msg": "ordinary message",
+                "args": (),
+                "token_prefix": "sk-",
+                "token_body": "t" * 32,
+            }
+        )
+
+        handler.handle(record)
+        handler.close()
+
+        output = stream.getvalue()
+        assert secret not in output
+        assert "..." in output
 
 
 class TestComponentFilter:
@@ -1110,5 +1174,4 @@ class TestAsyncQueueLogging:
             "agent.log" in getattr(h, "baseFilename", "")
             for h in hermes_logging.rotating_file_handlers()
         )
-
 

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -312,6 +312,62 @@ class TestSessionContext:
         assert openai_key not in output
         assert "..." in output
 
+    def test_uvicorn_access_formatter_keeps_sanitized_structured_args(self, capsys):
+        """Global sanitization preserves Uvicorn's five access-log fields."""
+        from uvicorn.logging import AccessFormatter
+
+        secret = "sk-" + "u" * 32
+        stream = io.StringIO()
+        records = []
+
+        class CapturingStreamHandler(logging.StreamHandler):
+            def emit(self, record):
+                records.append(record)
+                super().emit(record)
+
+        handler = CapturingStreamHandler(stream)
+        handler.setFormatter(
+            AccessFormatter(
+                '%(client_addr)s - "%(request_line)s" %(status_code)s',
+                use_colors=False,
+            )
+        )
+
+        logger = logging.getLogger("uvicorn.access")
+        old_propagate = logger.propagate
+        old_level = logger.level
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+        logger.addHandler(handler)
+        try:
+            logger.info(
+                '%s - "%s %s HTTP/%s" %d',
+                "127.0.0.1:4321",
+                "GET",
+                f"/health?api_key={secret}",
+                "1.1",
+                200,
+            )
+        finally:
+            logger.removeHandler(handler)
+            logger.propagate = old_propagate
+            logger.setLevel(old_level)
+            handler.close()
+
+        assert len(records) == 1
+        assert records[0].args == (
+            "127.0.0.1:4321",
+            "GET",
+            "/health?api_key=***",
+            "1.1",
+            200,
+        )
+        assert stream.getvalue() == (
+            '127.0.0.1:4321 - "GET /health?api_key=*** HTTP/1.1" 200 OK\n'
+        )
+        assert secret not in stream.getvalue()
+        assert "--- Logging error ---" not in capsys.readouterr().err
+
     def test_plain_formatter_redacts_secret_assembled_by_formatting(self):
         """Format-time token assembly is redacted before plain handlers emit."""
         secret = "sk-" + "d" * 32
@@ -1174,4 +1230,3 @@ class TestAsyncQueueLogging:
             "agent.log" in getattr(h, "baseFilename", "")
             for h in hermes_logging.rotating_file_handlers()
         )
-

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -647,6 +647,45 @@ class TestSessionContext:
         assert stack_secret not in output
         assert "..." in output
 
+    def test_make_log_record_redacts_overwritten_fields_for_plain_handlers(self):
+        """Dictionary reconstruction cannot bypass the global sanitizer."""
+        message_secret = "sk-" + "p" * 32
+        extra_secret = "ghp_" + "q" * 36
+        exception_secret = "sk-" + "r" * 32
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(
+            logging.Formatter("%(message)s %(payload)s %(session_tag)s")
+        )
+
+        record = logging.makeLogRecord(
+            {
+                "name": "_test_make_log_record_redaction",
+                "levelno": logging.ERROR,
+                "levelname": "ERROR",
+                "msg": "assembled %s%s",
+                "args": ("sk-", "p" * 32),
+                "exc_info": (
+                    RuntimeError,
+                    RuntimeError(f"provider returned {exception_secret}"),
+                    None,
+                ),
+                "payload": {"Authorization": f"Bearer {extra_secret}"},
+                "session_tag": f" [{message_secret}]",
+            }
+        )
+
+        handler.handle(record)
+        handler.close()
+
+        output = stream.getvalue()
+        assert "assembled" in output
+        assert "RuntimeError" in output
+        assert message_secret not in output
+        assert extra_secret not in output
+        assert exception_secret not in output
+        assert output.count("...") >= 3
+
 
 class TestComponentFilter:
     """Unit tests for _ComponentFilter."""

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -278,6 +278,49 @@ class TestSessionContext:
         assert secret not in output
         assert "..." in output
 
+    @pytest.mark.parametrize("use_redacting_formatter", [False, True])
+    def test_redactor_failure_suppresses_log_content(
+        self,
+        capsys,
+        use_redacting_formatter,
+    ):
+        """Validator failures fail closed for plain and Hermes handlers."""
+        from agent.redact import RedactingFormatter
+
+        secret = "sk-" + "z" * 32
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        formatter_cls = RedactingFormatter if use_redacting_formatter else logging.Formatter
+        handler.setFormatter(formatter_cls("%(message)s %(payload)s"))
+
+        logger = logging.getLogger("_test_redactor_failure_suppression")
+        old_propagate = logger.propagate
+        old_level = logger.level
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+        logger.addHandler(handler)
+        try:
+            with patch(
+                "agent.redact.redact_sensitive_text",
+                side_effect=RuntimeError("redactor unavailable"),
+            ):
+                logger.info(
+                    "provider token %s",
+                    secret,
+                    extra={"payload": {"Authorization": f"Bearer {secret}"}},
+                )
+        finally:
+            logger.removeHandler(handler)
+            logger.propagate = old_propagate
+            logger.setLevel(old_level)
+            handler.close()
+
+        captured = capsys.readouterr()
+        combined = stream.getvalue() + captured.err
+        assert secret not in combined
+        assert "redaction failed" in stream.getvalue()
+        assert "--- Logging error ---" not in captured.err
+
     def test_plain_formatter_redacts_args_without_breaking_numeric_formatting(self):
         """Non-Hermes handlers receive sanitized record.args values."""
         github_token = "ghp_" + "b" * 36

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -339,6 +339,32 @@ class TestSessionContext:
         assert secret not in output
         assert "..." in output
 
+    def test_plain_formatter_redacts_secret_assembled_by_mapping_format(self):
+        """Mapping-style %-formatting gets the same rendered-message redaction."""
+        secret = "sk-" + "n" * 32
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+
+        logger = logging.getLogger("_test_plain_mapping_token_redaction")
+        old_propagate = logger.propagate
+        old_level = logger.level
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+        logger.addHandler(handler)
+        try:
+            logger.info("token %(prefix)s%(body)s", {"prefix": "sk-", "body": "n" * 32})
+        finally:
+            logger.removeHandler(handler)
+            logger.propagate = old_propagate
+            logger.setLevel(old_level)
+            handler.close()
+
+        output = stream.getvalue()
+        assert "token" in output
+        assert secret not in output
+        assert "..." in output
+
     def test_plain_formatter_redacts_non_string_message(self):
         """Object messages are stringified and redacted for plain handlers."""
         secret = "sk-" + "e" * 32
@@ -398,6 +424,227 @@ class TestSessionContext:
         assert "provider request failed" in output
         assert "RuntimeError" in output
         assert secret not in output
+        assert "..." in output
+
+    def test_plain_formatter_redacts_extra_fields(self):
+        """Plain formatters that include extra fields still receive redacted data."""
+        api_key = "sk-" + "g" * 32
+        github_token = "ghp_" + "h" * 36
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(logging.Formatter("%(message)s %(api_key)s %(payload)s"))
+
+        logger = logging.getLogger("_test_plain_extra_redaction")
+        old_propagate = logger.propagate
+        old_level = logger.level
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+        logger.addHandler(handler)
+        try:
+            logger.info(
+                "extra fields",
+                extra={
+                    "api_key": api_key,
+                    "payload": {"Authorization": f"Bearer {github_token}"},
+                },
+            )
+        finally:
+            logger.removeHandler(handler)
+            logger.propagate = old_propagate
+            logger.setLevel(old_level)
+            handler.close()
+
+        output = stream.getvalue()
+        assert "extra fields" in output
+        assert api_key not in output
+        assert github_token not in output
+        assert "..." in output
+
+    def test_plain_formatter_redacts_object_extra_fields(self):
+        """Object extras are stringified and redacted before plain formatting."""
+        secret = "sk-" + "i" * 32
+
+        class SecretExtra:
+            def __str__(self):
+                return f"extra carried {secret}"
+
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(logging.Formatter("%(message)s %(secret_extra)s"))
+
+        logger = logging.getLogger("_test_plain_object_extra_redaction")
+        old_propagate = logger.propagate
+        old_level = logger.level
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+        logger.addHandler(handler)
+        try:
+            logger.info("object extra", extra={"secret_extra": SecretExtra()})
+        finally:
+            logger.removeHandler(handler)
+            logger.propagate = old_propagate
+            logger.setLevel(old_level)
+            handler.close()
+
+        output = stream.getvalue()
+        assert "object extra" in output
+        assert "extra carried" in output
+        assert secret not in output
+        assert "..." in output
+
+    def test_bad_percent_format_does_not_leak_split_secret(self, capsys):
+        """Invalid logging templates fail closed instead of leaking arguments."""
+        secret_body = "j" * 32
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+
+        logger = logging.getLogger("_test_bad_percent_redaction")
+        old_propagate = logger.propagate
+        old_level = logger.level
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+        logger.addHandler(handler)
+        try:
+            logger.info("token %s %s", "sk-", secret_body, "unexpected-extra")
+        finally:
+            logger.removeHandler(handler)
+            logger.propagate = old_propagate
+            logger.setLevel(old_level)
+            handler.close()
+
+        captured = capsys.readouterr()
+        combined = stream.getvalue() + captured.err
+        assert "--- Logging error ---" not in captured.err
+        assert "unexpected-extra" not in combined
+        assert secret_body not in combined
+        assert "log message formatting failed" in combined
+
+    def test_plain_formatter_cannot_reformat_raw_exception_info(self):
+        """exc_info stays present but no longer carries raw secret payloads."""
+        secret = "sk-" + "k" * 32
+        records = []
+
+        class CapturingHandler(logging.Handler):
+            def emit(self, record):
+                records.append(record)
+
+        handler = CapturingHandler()
+        handler.setFormatter(logging.Formatter("%(message)s"))
+
+        logger = logging.getLogger("_test_raw_exc_info_redaction")
+        old_propagate = logger.propagate
+        old_level = logger.level
+        logger.propagate = False
+        logger.setLevel(logging.ERROR)
+        logger.addHandler(handler)
+        try:
+            try:
+                raise RuntimeError(f"provider returned {secret}")
+            except RuntimeError:
+                logger.exception("provider request failed")
+        finally:
+            logger.removeHandler(handler)
+            logger.propagate = old_propagate
+            logger.setLevel(old_level)
+            handler.close()
+
+        assert len(records) == 1
+        record = records[0]
+        assert record.exc_info is not None
+        assert record.exc_info[0] is RuntimeError
+        assert record.exc_info[2] is None
+        assert secret not in str(record.exc_info[1])
+        assert "..." in str(record.exc_info[1])
+        assert record.exc_text
+        assert secret not in record.exc_text
+        assert "..." in record.exc_text
+
+    def test_sanitized_exception_info_preserves_custom_exception_attributes(self):
+        """Filters can still inspect exception type/metadata after sanitization."""
+        secret = "sk-" + "o" * 32
+        records = []
+
+        class ProbeError(Exception):
+            def __init__(self, code, data, message):
+                super().__init__(message)
+                self.code = code
+                self.data = data
+
+        class CapturingHandler(logging.Handler):
+            def emit(self, record):
+                records.append(record)
+
+        handler = CapturingHandler()
+
+        logger = logging.getLogger("_test_custom_exception_metadata_redaction")
+        old_propagate = logger.propagate
+        old_level = logger.level
+        logger.propagate = False
+        logger.setLevel(logging.ERROR)
+        logger.addHandler(handler)
+        try:
+            try:
+                raise ProbeError(-32601, {"token": secret}, f"probe carried {secret}")
+            except ProbeError:
+                logger.exception("probe failed")
+        finally:
+            logger.removeHandler(handler)
+            logger.propagate = old_propagate
+            logger.setLevel(old_level)
+            handler.close()
+
+        assert len(records) == 1
+        record = records[0]
+        assert record.exc_info is not None
+        exc = record.exc_info[1]
+        assert isinstance(exc, ProbeError)
+        assert exc.code == -32601
+        assert secret not in str(exc)
+        assert secret not in str(exc.data)
+        assert "..." in str(exc)
+        assert "..." in str(exc.data)
+
+    def test_plain_formatter_redacts_preexisting_exception_and_stack_text(self):
+        """Pre-rendered exc_text and stack_info are sanitized on records."""
+        exc_secret = "sk-" + "l" * 32
+        stack_secret = "sk-" + "m" * 32
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+
+        logger = logging.getLogger("_test_existing_exc_stack_redaction")
+        old_propagate = logger.propagate
+        old_level = logger.level
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+        logger.addHandler(handler)
+        try:
+            record = logger.makeRecord(
+                logger.name,
+                logging.INFO,
+                __file__,
+                0,
+                "existing exception and stack",
+                (),
+                None,
+                sinfo=f"Stack with {stack_secret}",
+            )
+            record.exc_text = f"Exception carried {exc_secret}"
+            hermes_logging._sanitize_log_record(record)
+            handler.handle(record)
+        finally:
+            logger.removeHandler(handler)
+            logger.propagate = old_propagate
+            logger.setLevel(old_level)
+            handler.close()
+
+        output = stream.getvalue()
+        assert "existing exception and stack" in output
+        assert "Exception carried" in output
+        assert "Stack with" in output
+        assert exc_secret not in output
+        assert stack_secret not in output
         assert "..." in output
 
 

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -312,6 +312,94 @@ class TestSessionContext:
         assert openai_key not in output
         assert "..." in output
 
+    def test_plain_formatter_redacts_secret_assembled_by_formatting(self):
+        """Format-time token assembly is redacted before plain handlers emit."""
+        secret = "sk-" + "d" * 32
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+
+        logger = logging.getLogger("_test_plain_split_token_redaction")
+        old_propagate = logger.propagate
+        old_level = logger.level
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+        logger.addHandler(handler)
+        try:
+            logger.info("token %s%s", "sk-", "d" * 32)
+            logger.info("auth token sk-%s", "d" * 32)
+        finally:
+            logger.removeHandler(handler)
+            logger.propagate = old_propagate
+            logger.setLevel(old_level)
+            handler.close()
+
+        output = stream.getvalue()
+        assert "token" in output
+        assert secret not in output
+        assert "..." in output
+
+    def test_plain_formatter_redacts_non_string_message(self):
+        """Object messages are stringified and redacted for plain handlers."""
+        secret = "sk-" + "e" * 32
+
+        class SecretMessage:
+            def __str__(self):
+                return f"object carried {secret}"
+
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+
+        logger = logging.getLogger("_test_plain_object_message_redaction")
+        old_propagate = logger.propagate
+        old_level = logger.level
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+        logger.addHandler(handler)
+        try:
+            logger.info(SecretMessage())
+        finally:
+            logger.removeHandler(handler)
+            logger.propagate = old_propagate
+            logger.setLevel(old_level)
+            handler.close()
+
+        output = stream.getvalue()
+        assert "object carried" in output
+        assert secret not in output
+        assert "..." in output
+
+    def test_plain_formatter_redacts_exception_traceback(self):
+        """Exception text is pre-redacted before plain handlers format it."""
+        secret = "sk-" + "f" * 32
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+
+        logger = logging.getLogger("_test_plain_exception_redaction")
+        old_propagate = logger.propagate
+        old_level = logger.level
+        logger.propagate = False
+        logger.setLevel(logging.ERROR)
+        logger.addHandler(handler)
+        try:
+            try:
+                raise RuntimeError(f"provider returned {secret}")
+            except RuntimeError:
+                logger.exception("provider request failed")
+        finally:
+            logger.removeHandler(handler)
+            logger.propagate = old_propagate
+            logger.setLevel(old_level)
+            handler.close()
+
+        output = stream.getvalue()
+        assert "provider request failed" in output
+        assert "RuntimeError" in output
+        assert secret not in output
+        assert "..." in output
+
 
 class TestComponentFilter:
     """Unit tests for _ComponentFilter."""

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -252,6 +252,66 @@ class TestSessionContext:
 
 
 
+    def test_plain_formatter_redacts_literal_message_secret(self):
+        """Non-Hermes handlers receive sanitized record.msg values."""
+        secret = "sk-" + "a" * 32
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+
+        logger = logging.getLogger("_test_plain_literal_redaction")
+        old_propagate = logger.propagate
+        old_level = logger.level
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+        logger.addHandler(handler)
+        try:
+            logger.info("literal secret " + secret)
+        finally:
+            logger.removeHandler(handler)
+            logger.propagate = old_propagate
+            logger.setLevel(old_level)
+            handler.close()
+
+        output = stream.getvalue()
+        assert "literal secret" in output
+        assert secret not in output
+        assert "..." in output
+
+    def test_plain_formatter_redacts_args_without_breaking_numeric_formatting(self):
+        """Non-Hermes handlers receive sanitized record.args values."""
+        github_token = "ghp_" + "b" * 36
+        openai_key = "sk-" + "c" * 32
+        payload = {
+            "headers": {"Authorization": f"Bearer {openai_key}"},
+            "tokens": [github_token],
+            "attempt": 3,
+        }
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+
+        logger = logging.getLogger("_test_plain_args_redaction")
+        old_propagate = logger.propagate
+        old_level = logger.level
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+        logger.addHandler(handler)
+        try:
+            logger.info("payload=%s retries=%d", payload, 7)
+        finally:
+            logger.removeHandler(handler)
+            logger.propagate = old_propagate
+            logger.setLevel(old_level)
+            handler.close()
+
+        output = stream.getvalue()
+        assert "payload=" in output
+        assert "retries=7" in output
+        assert github_token not in output
+        assert openai_key not in output
+        assert "..." in output
+
 
 class TestComponentFilter:
     """Unit tests for _ComponentFilter."""


### PR DESCRIPTION
## Summary
- Sanitize `LogRecord.msg` and `LogRecord.args` in Hermes' global record factory using the existing `agent.redact.redact_sensitive_text` path.
- Walk string values inside tuple/list/dict logging args while leaving numeric values intact for `%d` and similar formatting.
- Add plain `logging.Formatter` coverage for non-Hermes handlers attached to non-propagating loggers.

Fixes #59061

## Tests
- `scripts/run_tests.sh tests/test_hermes_logging.py tests/agent/test_redact.py -q`
- `uv run ruff check hermes_logging.py tests/test_hermes_logging.py`