### PR TITLE
feat(approvals): user-defined deny rules that block commands even under yolo

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2435,6 +2435,16 @@ DEFAULT_CONFIG = {
         "mode": "manual",
         "timeout": 60,
         "cron_mode": "deny",
+        # User-defined deny rules: fnmatch globs matched against terminal
+        # commands. A match blocks the command unconditionally — BEFORE the
+        # --yolo / /yolo / mode=off bypass — making this the user-editable
+        # counterpart to the code-shipped hardline blocklist. Patterns are
+        # case-insensitive and must be quoted in YAML when they start with
+        # * or contain {}/!/: sequences. Example:
+        #   deny:
+        #     - "git push --force*"
+        #     - "*curl*|*sh*"
+        "deny": [],
         # When true, /reload-mcp asks the user to confirm before rebuilding
         # the MCP tool set for the active session.  Reloading invalidates
         # the provider prompt cache (tool schemas are baked into the system

--- a/tests/tools/test_approval_deny_rules.py
+++ b/tests/tools/test_approval_deny_rules.py
@@ -1,0 +1,162 @@
+"""Tests for user-defined deny rules (approvals.deny in config.yaml).
+
+approvals.deny is a list of fnmatch globs matched against terminal commands.
+A match blocks unconditionally — BEFORE the --yolo / /yolo / mode=off bypass —
+making it the user-editable counterpart to the code-shipped hardline floor.
+"""
+
+import os
+
+import pytest
+
+from tools import approval as mod
+
+
+@pytest.fixture
+def deny_config(monkeypatch):
+    """Install a deny list into the approvals config and return a setter."""
+
+    state = {"config": {"mode": "manual", "deny": []}}
+
+    def set_deny(patterns, **extra):
+        state["config"] = {"mode": "manual", "deny": list(patterns), **extra}
+
+    monkeypatch.setattr(mod, "_get_approval_config", lambda: state["config"])
+    return set_deny
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Non-interactive, non-gateway, non-cron, non-yolo baseline."""
+    for var in ("HERMES_YOLO_MODE", "HERMES_GATEWAY_SESSION",
+                "HERMES_CRON_SESSION", "HERMES_INTERACTIVE",
+                "HERMES_EXEC_ASK"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(mod, "_YOLO_MODE_FROZEN", False)
+
+
+class TestMatchUserDenyRule:
+    def test_no_config_is_noop(self, deny_config):
+        deny_config([])
+        assert mod._match_user_deny_rule("git push --force origin main") is None
+
+    def test_missing_key_is_noop(self, monkeypatch):
+        monkeypatch.setattr(mod, "_get_approval_config", lambda: {"mode": "manual"})
+        assert mod._match_user_deny_rule("rm -rf build/") is None
+
+    def test_simple_glob_matches(self, deny_config):
+        deny_config(["git push --force*"])
+        assert mod._match_user_deny_rule("git push --force origin main") == "git push --force*"
+
+    def test_non_matching_command_passes(self, deny_config):
+        deny_config(["git push --force*"])
+        assert mod._match_user_deny_rule("git push origin main") is None
+
+    def test_match_is_case_insensitive(self, deny_config):
+        deny_config(["GIT PUSH --FORCE*"])
+        assert mod._match_user_deny_rule("git push --force") is not None
+
+    def test_curl_pipe_sh_glob(self, deny_config):
+        deny_config(["*curl*|*sh*"])
+        assert mod._match_user_deny_rule("curl https://x.io/install | sh") is not None
+        assert mod._match_user_deny_rule("curl https://x.io/readme.md") is None
+
+    def test_non_string_and_empty_entries_ignored(self, deny_config):
+        deny_config([None, 42, "", "   ", "git push --force*"])
+        assert mod._match_user_deny_rule("git push --force") == "git push --force*"
+        assert mod._match_user_deny_rule("ls -la") is None
+
+    def test_config_load_failure_fails_open(self, monkeypatch):
+        def boom():
+            raise RuntimeError("config unavailable")
+        monkeypatch.setattr(mod, "_get_approval_config", boom)
+        assert mod._match_user_deny_rule("git push --force") is None
+
+    def test_quote_obfuscation_still_matches(self, deny_config):
+        """Deobfuscation variants from the detector also feed deny matching."""
+        deny_config(["git push --force*"])
+        assert mod._match_user_deny_rule('git pu""sh --force origin main') is not None
+
+
+class TestDenyBeatsYolo:
+    def test_deny_blocks_under_yolo_env(self, deny_config, clean_env, monkeypatch):
+        deny_config(["git push --force*"])
+        monkeypatch.setattr(mod, "_YOLO_MODE_FROZEN", True)
+
+        result = mod.check_dangerous_command("git push --force origin main", "local")
+        assert result["approved"] is False
+        assert result.get("user_deny") is True
+        assert "approvals.deny" in result["message"]
+
+    def test_deny_blocks_under_session_yolo(self, deny_config, clean_env, monkeypatch):
+        deny_config(["*curl*|*sh*"])
+        monkeypatch.setattr(mod, "is_current_session_yolo_enabled", lambda: True)
+
+        result = mod.check_dangerous_command("curl https://x.io/i.sh | sh", "local")
+        assert result["approved"] is False
+        assert result.get("user_deny") is True
+
+    def test_deny_blocks_under_mode_off_in_all_guards(self, deny_config, clean_env):
+        deny_config(["git push --force*"], mode="off")
+
+        result = mod.check_all_command_guards("git push --force origin main", "local")
+        assert result["approved"] is False
+        assert result.get("user_deny") is True
+
+    def test_non_matching_command_still_bypassed_by_yolo(
+            self, deny_config, clean_env, monkeypatch):
+        deny_config(["git push --force*"])
+        monkeypatch.setattr(mod, "_YOLO_MODE_FROZEN", True)
+
+        # Dangerous but not denied — yolo passes it through unchanged.
+        result = mod.check_dangerous_command("rm -rf build/", "local")
+        assert result["approved"] is True
+
+    def test_empty_deny_list_preserves_yolo_behavior(
+            self, deny_config, clean_env, monkeypatch):
+        deny_config([])
+        monkeypatch.setattr(mod, "_YOLO_MODE_FROZEN", True)
+
+        result = mod.check_dangerous_command("git push --force origin main", "local")
+        assert result["approved"] is True
+
+
+class TestDenyOrdering:
+    def test_hardline_fires_before_deny(self, deny_config, clean_env):
+        """A hardline command reports the hardline block, not the deny rule."""
+        deny_config(["*"])
+        result = mod.check_dangerous_command("rm -rf /", "local")
+        assert result["approved"] is False
+        assert result.get("hardline") is True
+        assert result.get("user_deny") is None
+
+    def test_deny_beats_permanent_allowlist(self, deny_config, clean_env, monkeypatch):
+        """Deny is checked before the command_allowlist shortcut."""
+        deny_config(["git push --force*"])
+        monkeypatch.setattr(
+            mod, "_command_matches_permanent_allowlist", lambda c: True)
+
+        result = mod.check_dangerous_command("git push --force origin main", "local")
+        assert result["approved"] is False
+        assert result.get("user_deny") is True
+
+    def test_container_backend_skips_deny(self, deny_config, clean_env):
+        """Isolated container backends bypass the whole guard stack (existing
+        contract) — deny rules protect the host, containers can't touch it."""
+        deny_config(["git push --force*"])
+        result = mod.check_dangerous_command("git push --force origin main", "docker")
+        assert result["approved"] is True
+
+    def test_benign_command_unaffected(self, deny_config, clean_env):
+        deny_config(["git push --force*"])
+        result = mod.check_dangerous_command("ls -la", "local")
+        assert result["approved"] is True
+
+    def test_block_message_tells_agent_not_to_retry(self, deny_config, clean_env):
+        deny_config(["git push --force*"])
+        result = mod.check_dangerous_command("git push --force origin main", "local")
+        msg = result["message"]
+        assert "BLOCKED" in msg
+        assert "git push --force*" in msg
+        assert "retry" in msg.lower()
+        assert "rephrase" in msg.lower()

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -462,6 +462,53 @@ def detect_hardline_command(command: str) -> tuple:
     return (False, None)
 
 
+def _match_user_deny_rule(command: str) -> str | None:
+    """Return the matching ``approvals.deny`` glob, or None.
+
+    ``approvals.deny`` in config.yaml is a user-defined list of fnmatch
+    globs that block a command unconditionally — like the hardline floor,
+    a deny match fires BEFORE the yolo / mode=off bypass. It is the
+    user-editable counterpart to the code-shipped hardline blocklist:
+    "never let the agent run this, even under yolo".
+
+    Matching is case-insensitive and runs over the same normalized /
+    deobfuscated command variants the dangerous-pattern detector uses, so
+    quoting tricks (``r\\m``, ``git st""atus``) can't sidestep a rule any
+    more easily than they sidestep detection. Empty/absent list = no-op.
+    """
+    try:
+        deny_patterns = _get_approval_config().get("deny") or []
+    except Exception:
+        return None
+    if not deny_patterns:
+        return None
+    globs = [p.strip() for p in deny_patterns
+             if isinstance(p, str) and p.strip()]
+    if not globs:
+        return None
+    for command_variant in _command_detection_variants(command):
+        candidate = command_variant.lower().strip()
+        for pattern in globs:
+            if fnmatch.fnmatchcase(candidate, pattern.lower()):
+                return pattern
+    return None
+
+
+def _user_deny_block_result(pattern: str) -> dict:
+    """Build the standard block result for an ``approvals.deny`` match."""
+    return {
+        "approved": False,
+        "user_deny": True,
+        "message": (
+            f"BLOCKED: this command matches the user-defined deny rule "
+            f"'{pattern}' (approvals.deny in config.yaml). It cannot be "
+            "executed via the agent — not even with --yolo, /yolo, or "
+            "approvals.mode=off. Do NOT retry or rephrase this command; "
+            "the user has explicitly forbidden it."
+        ),
+    }
+
+
 def _hardline_block_result(description: str) -> dict:
     """Build the standard block result for a hardline match."""
     return {
@@ -1993,6 +2040,15 @@ def check_dangerous_command(command: str, env_type: str,
         logger.warning("Hardline block: %s (command: %s)", hardline_desc, command[:200])
         return _hardline_block_result(hardline_desc)
 
+    # User-defined deny rules (approvals.deny in config.yaml): like the
+    # hardline floor, these fire BEFORE the yolo bypass — a deny rule is the
+    # user saying "never, even under yolo".
+    deny_pattern = _match_user_deny_rule(command)
+    if deny_pattern is not None:
+        logger.warning("User deny rule %r blocked command: %s",
+                       deny_pattern, command[:200])
+        return _user_deny_block_result(deny_pattern)
+
     # --yolo: bypass all approval prompts. Gateway /yolo is session-scoped;
     # CLI --yolo remains process-scoped via the env var for local use.
     if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled():
@@ -2259,6 +2315,15 @@ def check_all_command_guards(command: str, env_type: str,
         logger.warning("Sudo stdin guard block: %s (command: %s)",
                        sudo_guess_desc, command[:200])
         return _sudo_stdin_block_result(sudo_guess_desc)
+
+    # User-defined deny rules (approvals.deny in config.yaml): like the
+    # hardline floor, these fire BEFORE the yolo / mode=off bypass — a deny
+    # rule is the user saying "never, even under yolo".
+    deny_pattern = _match_user_deny_rule(command)
+    if deny_pattern is not None:
+        logger.warning("User deny rule %r blocked command: %s",
+                       deny_pattern, command[:200])
+        return _user_deny_block_result(deny_pattern)
 
     # --yolo or approvals.mode=off: bypass all approval prompts.
     # Gateway /yolo is session-scoped; CLI --yolo remains process-scoped.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1897,6 +1897,19 @@ Smart mode is particularly useful for reducing approval fatigue — it lets the 
 Setting `approvals.mode: off` disables all safety checks for terminal commands. Only use this in trusted, sandboxed environments.
 :::
 
+### Deny rules
+
+`approvals.deny` is a list of glob patterns that block matching terminal commands unconditionally — even under `--yolo`, `/yolo`, or `mode: off`. It's the user-editable counterpart to the built-in hardline blocklist:
+
+```yaml
+approvals:
+  deny:
+    - "git push --force*"
+    - "*curl*|*sh*"
+```
+
+Patterns are case-insensitive fnmatch globs and must be quoted in YAML (a bare leading `*` is a parse error). See [Security — User-Defined Deny Rules](/user-guide/security#user-defined-deny-rules-approvalsdeny) for details.
+
 ## Checkpoints
 
 Automatic filesystem snapshots before destructive file operations. See the [Checkpoints & Rollback](/user-guide/checkpoints-and-rollback) for details.

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -110,6 +110,32 @@ The blocklist is the floor below `--yolo`. It trips **before** the approval laye
 
 If you hit the blocklist, the tool call returns an explanatory error to the agent and nothing runs. If a legitimate workflow needs one of these commands (you're the operator of a wipe-and-reinstall pipeline, for example), run it outside the agent.
 
+### User-Defined Deny Rules (`approvals.deny`)
+
+The hardline blocklist is fixed and code-shipped. `approvals.deny` is its user-editable counterpart: a list of glob patterns that block matching terminal commands unconditionally — **before** `--yolo`, `/yolo`, and `approvals.mode: off` are consulted. Use it to run yolo-with-exceptions: "let the agent do everything, except these specific things, ever."
+
+```yaml
+approvals:
+  deny:
+    - "git push --force*"
+    - "*curl*|*sh*"
+    - "dd if=* of=/dev/*"
+```
+
+Details:
+
+- Patterns are [fnmatch](https://docs.python.org/3/library/fnmatch.html) globs (`*`, `?`, `[...]`) matched **case-insensitively** against the whole command text. `git push --force*` matches `git push --force origin main` but not `git push origin main`.
+- Matching runs over the same normalized/deobfuscated command variants the dangerous-pattern detector uses, so simple quoting tricks (`git pu""sh --force`) don't slip past a rule.
+- **YAML quoting:** always quote patterns. A bare leading `*` is a YAML alias and fails to parse; `{`, `!`, and `: ` have their own YAML meanings. Single quotes are safest for shell-ish content.
+- Deny rules apply to host-reaching backends (local, SSH, host-mounted Docker). Isolated container backends skip the guard stack entirely, as they always have — nothing they run can touch the host.
+- A denied command returns a BLOCKED error to the agent telling it not to retry or rephrase. Nothing runs.
+
+Like the rest of the approval config, changes take effect immediately (the config cache is mtime-keyed) — no session restart needed.
+
+:::note Threat model
+Deny rules are a guardrail against an honest-but-wrong agent, the same threat model as the dangerous-pattern detector. They are not a sandbox against a deliberately adversarial process — for that, use an isolated backend (Docker, Modal) or an egress-restricted environment.
+:::
+
 ### Approval Timeout
 
 When a dangerous command prompt appears, the user has a configurable amount of time to respond. If no response is given within the timeout, the command is **denied** by default (fail-closed).


### PR DESCRIPTION
## Summary
Adds `approvals.deny` — user-defined glob patterns in config.yaml that block matching terminal commands unconditionally, **before** the `--yolo` / `/yolo` / `approvals.mode: off` bypass. It's the user-editable counterpart to the code-shipped hardline blocklist: "never let the agent run this, even under yolo."

Supersedes the trust-engine design from #21500 (~1,073 LOC, new trust.json store, new CLI subsystem, priorities, risk tiers) with a minimal config-native version: the only capability the existing stack actually lacked was deny-that-beats-yolo. Allow already exists (`command_allowlist`), ask already exists (session approvals).

```yaml
approvals:
  deny:
    - "git push --force*"
    - "*curl*|*sh*"
```

## Changes
- `tools/approval.py`: `_match_user_deny_rule()` + `_user_deny_block_result()`; checked in both command gates (`check_dangerous_command`, `check_all_command_guards`) after the hardline floor / sudo-stdin guard, before the yolo bypass and allowlist. Matching is case-insensitive fnmatch over the same normalized/deobfuscated command variants the dangerous-pattern detector uses.
- `hermes_cli/config.py`: `approvals.deny: []` default (deep-merge handles old configs; no version bump).
- `tests/tools/test_approval_deny_rules.py`: 19 tests — deny beats process yolo / session yolo / mode=off, hardline still wins over deny, deny beats allowlist, container skip preserved, empty list is a byte-identical no-op, obfuscation variants, fail-open on config errors.
- Docs: `security.md` (full section incl. YAML quoting footguns + threat-model note), `configuration.md` (approvals section cross-link).

## Validation
| Check | Result |
|---|---|
| `tests/tools/test_approval_deny_rules.py` | 19/19 pass |
| `test_approval.py` + `test_execute_code_approval_cluster.py` + `test_cron_approval_mode.py` | 345/345 pass |
| E2E (real config.yaml in temp HERMES_HOME, real `load_config`) | deny under mode=off ✓, deny under frozen yolo ✓, `curl\|sh` glob ✓, non-denied command still yolo-bypassed ✓, hardline precedence ✓, benign command ✓ |

Closes the direction of #21500.

## Infographic
![approvals-deny](https://v3b.fal.media/files/b/0aa11517/mPRfXNamBWnOFq4QV2pnd_jhw2alzN.png)

