### PR TITLE
fix(send_message): accept WhatsApp LID targets

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -266,6 +266,40 @@ class TestSendMessageTool:
             force_document=False,
         )
 
+    def test_whatsapp_lid_target_bypasses_home_channel_resolution(self):
+        whatsapp_cfg = SimpleNamespace(enabled=True, token=None, extra={"bridge_port": 3000})
+        config = SimpleNamespace(
+            platforms={Platform.WHATSAPP: whatsapp_cfg},
+            get_home_channel=lambda _platform: None,
+        )
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("gateway.channel_directory.resolve_channel_name", side_effect=AssertionError("should not resolve WhatsApp LID targets")), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "whatsapp:37576702443707@lid",
+                        "message": "Test",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        send_mock.assert_awaited_once_with(
+            Platform.WHATSAPP,
+            whatsapp_cfg,
+            "37576702443707@lid",
+            "Test",
+            thread_id=None,
+            media_files=[],
+            force_document=False,
+        )
+
     def test_cron_duplicate_target_is_skipped_and_explained(self):
         home = SimpleNamespace(chat_id="-1001")
         config, _telegram_cfg = _make_config()
@@ -1539,9 +1573,9 @@ class TestParseTargetRefWhatsAppJID:
 
     def test_lid_jid_is_explicit(self):
         chat_id, _, is_explicit = _parse_target_ref(
-            "whatsapp", "149606612619433@lid"
+            "whatsapp", "37576702443707@lid"
         )
-        assert chat_id == "149606612619433@lid"
+        assert chat_id == "37576702443707@lid"
         assert is_explicit is True
 
     def test_broadcast_and_newsletter_jids_are_explicit(self):
@@ -1557,7 +1591,16 @@ class TestParseTargetRefWhatsAppJID:
     def test_jid_suffix_only_matches_whatsapp(self):
         """WhatsApp JID suffixes must NOT be treated as explicit elsewhere."""
         assert _parse_target_ref("telegram", "120363408391911677@g.us")[2] is False
-        assert _parse_target_ref("signal", "149606612619433@lid")[2] is False
+
+    def test_lid_suffix_only_matches_whatsapp_phone_platform(self):
+        """WhatsApp LID targets must not broaden other phone platforms."""
+        for platform_name in ("photon", "signal", "sms"):
+            chat_id, thread_id, is_explicit = _parse_target_ref(
+                platform_name, "37576702443707@lid"
+            )
+            assert chat_id is None
+            assert thread_id is None
+            assert is_explicit is False
 
     def test_non_jid_whatsapp_target_falls_through(self):
         """A bare friendly name is not a JID — it must fall through to

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -41,13 +41,13 @@ _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
 _PHONE_PLATFORMS = frozenset({"photon", "signal", "sms", "whatsapp"})
 _E164_TARGET_RE = re.compile(r"^\s*\+(\d{7,15})\s*$")
 # WhatsApp JIDs: group chats (<digits>@g.us), individual users
-# (<phone>@s.whatsapp.net), linked identities (<id>@lid), and broadcast /
-# newsletter chats. These are explicit native targets the bridge accepts
-# verbatim — they must NOT fall through to home-channel resolution.
+# (<phone>@s.whatsapp.net), and broadcast / newsletter chats. Linked-identity
+# IDs use their own conservative parser below so support stays WhatsApp-only.
 _WHATSAPP_JID_RE = re.compile(
-    r"^\s*[\w-]+@(?:g\.us|s\.whatsapp\.net|lid|broadcast|newsletter)\s*$",
+    r"^\s*[\w-]+@(?:g\.us|s\.whatsapp\.net|broadcast|newsletter)\s*$",
     re.IGNORECASE,
 )
+_WHATSAPP_LID_RE = re.compile(r"^\s*\d+@lid\s*$")
 # Email addresses — a valid email like "user@domain.com" should be treated as
 # an explicit target for the email platform, not fall through to channel-name
 # resolution which has no way to resolve a raw address.
@@ -532,9 +532,9 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         if match:
             return target_ref.strip(), None, True
     if platform_name == "whatsapp":
-        # Native WhatsApp JIDs (group @g.us, user @s.whatsapp.net, @lid, etc.)
-        # are explicit targets — pass through verbatim. E.164 '+' numbers fall
-        # through to the _PHONE_PLATFORMS handler below.
+        # Native WhatsApp JIDs are explicit targets — pass through verbatim.
+        # E.164 '+' numbers and LID targets fall through to the phone-platform
+        # handler below.
         if _WHATSAPP_JID_RE.fullmatch(target_ref):
             return target_ref.strip(), None, True
     stripped_target = target_ref.strip()
@@ -548,6 +548,8 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         if match:
             # Preserve the leading '+' — signal-cli and sms/whatsapp adapters
             # expect E.164 format for direct recipients.
+            return target_ref.strip(), None, True
+        if platform_name == "whatsapp" and _WHATSAPP_LID_RE.fullmatch(target_ref):
             return target_ref.strip(), None, True
     if target_ref.lstrip("-").isdigit():
         return target_ref, None, True


### PR DESCRIPTION
## Summary
- recognize WhatsApp `digits@lid` targets as explicit direct targets via a WhatsApp-only parser branch
- keep LID handling from broadening Signal/SMS/Photon target parsing
- add parser and send_message_tool regression coverage for `whatsapp:37576702443707@lid` without home-channel fallback

Fixes #59136

## Tests
- `python -m py_compile tools/send_message_tool.py tests/tools/test_send_message_tool.py`
- `uv run --extra dev --extra messaging python -m pytest tests/tools/test_send_message_tool.py -q` (152 passed, 1 warning: `discord.py` `audioop` deprecation)
- `uv run --extra dev ruff check tools/send_message_tool.py tests/tools/test_send_message_tool.py`
- `uv run --extra dev --extra messaging python -m py_compile tools/send_message_tool.py tests/tools/test_send_message_tool.py`