### PR TITLE
Allow per-profile kanban guidance overrides

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1605,9 +1605,9 @@ def init_agent(
     # Resolving the ~835-token block once here avoids re-running the
     # membership test + reference on every system-prompt rebuild
     # (init + each context compression).
-    from agent.prompt_builder import KANBAN_GUIDANCE
+    from agent.prompt_builder import resolve_kanban_guidance
     agent._kanban_worker_guidance = (
-        KANBAN_GUIDANCE if "kanban_show" in agent.valid_tool_names else ""
+        resolve_kanban_guidance() if "kanban_show" in agent.valid_tool_names else ""
     )
 
     # Check tool requirements

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1466,9 +1466,9 @@ def init_agent(
     # Resolving the ~835-token block once here avoids re-running the
     # membership test + reference on every system-prompt rebuild
     # (init + each context compression).
-    from agent.prompt_builder import KANBAN_GUIDANCE
+    from agent.prompt_builder import resolve_kanban_guidance
     agent._kanban_worker_guidance = (
-        KANBAN_GUIDANCE if "kanban_show" in agent.valid_tool_names else ""
+        resolve_kanban_guidance() if "kanban_show" in agent.valid_tool_names else ""
     )
 
     # Check tool requirements

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -356,24 +356,16 @@ KANBAN_GUIDANCE = (
 
 
 def resolve_kanban_guidance(
-    profile_name: Optional[str] = None,
     config: Optional[dict] = None,
 ) -> str:
-    """Return kanban worker guidance for *profile_name*.
+    """Return the active profile's configured kanban worker guidance.
 
-    ``kanban.guidance_override.<profile>`` may append to or replace the built-in
-    guidance. Malformed config is ignored so existing prompt behavior remains
-    unchanged unless a profile has a valid inline override.
+    Each profile owns an isolated ``config.yaml``, so
+    ``kanban.guidance_override`` applies only to the worker whose
+    ``HERMES_HOME`` loaded that config.  It may append to or replace the
+    built-in guidance. Malformed config is ignored so existing prompt behavior
+    remains unchanged unless the active profile has a valid inline override.
     """
-    if profile_name is None:
-        try:
-            from hermes_cli.profiles import get_active_profile_name
-
-            profile_name = get_active_profile_name()
-        except Exception as exc:
-            logger.debug("Could not resolve active profile for kanban guidance: %s", exc)
-            profile_name = "default"
-
     if config is None:
         try:
             from hermes_cli.config import load_config
@@ -383,8 +375,6 @@ def resolve_kanban_guidance(
             logger.debug("Could not read kanban guidance override config: %s", exc)
             return KANBAN_GUIDANCE
 
-    if not isinstance(profile_name, str) or not profile_name.strip():
-        return KANBAN_GUIDANCE
     if not isinstance(config, dict):
         return KANBAN_GUIDANCE
 
@@ -392,11 +382,7 @@ def resolve_kanban_guidance(
     if not isinstance(kanban_config, dict):
         return KANBAN_GUIDANCE
 
-    overrides = kanban_config.get("guidance_override", {})
-    if not isinstance(overrides, dict):
-        return KANBAN_GUIDANCE
-
-    override = overrides.get(profile_name.strip())
+    override = kanban_config.get("guidance_override", {})
     if not isinstance(override, dict):
         return KANBAN_GUIDANCE
 

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -354,6 +354,62 @@ KANBAN_GUIDANCE = (
     "cross-agent handoffs that outlive one API loop."
 )
 
+
+def resolve_kanban_guidance(
+    profile_name: Optional[str] = None,
+    config: Optional[dict] = None,
+) -> str:
+    """Return kanban worker guidance for *profile_name*.
+
+    ``kanban.guidance_override.<profile>`` may append to or replace the built-in
+    guidance. Malformed config is ignored so existing prompt behavior remains
+    unchanged unless a profile has a valid inline override.
+    """
+    if profile_name is None:
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+
+            profile_name = get_active_profile_name()
+        except Exception as exc:
+            logger.debug("Could not resolve active profile for kanban guidance: %s", exc)
+            profile_name = "default"
+
+    if config is None:
+        try:
+            from hermes_cli.config import load_config
+
+            config = load_config()
+        except Exception as exc:
+            logger.debug("Could not read kanban guidance override config: %s", exc)
+            return KANBAN_GUIDANCE
+
+    if not isinstance(profile_name, str) or not profile_name.strip():
+        return KANBAN_GUIDANCE
+    if not isinstance(config, dict):
+        return KANBAN_GUIDANCE
+
+    kanban_config = config.get("kanban", {})
+    if not isinstance(kanban_config, dict):
+        return KANBAN_GUIDANCE
+
+    overrides = kanban_config.get("guidance_override", {})
+    if not isinstance(overrides, dict):
+        return KANBAN_GUIDANCE
+
+    override = overrides.get(profile_name.strip())
+    if not isinstance(override, dict):
+        return KANBAN_GUIDANCE
+
+    text = override.get("text")
+    if not isinstance(text, str) or not text.strip():
+        return KANBAN_GUIDANCE
+    text = text.strip()
+
+    mode = override.get("mode", "append")
+    if isinstance(mode, str) and mode.strip().lower() == "replace":
+        return text
+    return f"{KANBAN_GUIDANCE}\n\n{text}"
+
 TOOL_USE_ENFORCEMENT_GUIDANCE = (
     "# Tool-use enforcement\n"
     "You MUST use your tools to take action — do not describe what you would do "

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -308,24 +308,16 @@ KANBAN_GUIDANCE = (
 
 
 def resolve_kanban_guidance(
-    profile_name: Optional[str] = None,
     config: Optional[dict] = None,
 ) -> str:
-    """Return kanban worker guidance for *profile_name*.
+    """Return the active profile's configured kanban worker guidance.
 
-    ``kanban.guidance_override.<profile>`` may append to or replace the built-in
-    guidance. Malformed config is ignored so existing prompt behavior remains
-    unchanged unless a profile has a valid inline override.
+    Each profile owns an isolated ``config.yaml``, so
+    ``kanban.guidance_override`` applies only to the worker whose
+    ``HERMES_HOME`` loaded that config.  It may append to or replace the
+    built-in guidance. Malformed config is ignored so existing prompt behavior
+    remains unchanged unless the active profile has a valid inline override.
     """
-    if profile_name is None:
-        try:
-            from hermes_cli.profiles import get_active_profile_name
-
-            profile_name = get_active_profile_name()
-        except Exception as exc:
-            logger.debug("Could not resolve active profile for kanban guidance: %s", exc)
-            profile_name = "default"
-
     if config is None:
         try:
             from hermes_cli.config import load_config
@@ -335,8 +327,6 @@ def resolve_kanban_guidance(
             logger.debug("Could not read kanban guidance override config: %s", exc)
             return KANBAN_GUIDANCE
 
-    if not isinstance(profile_name, str) or not profile_name.strip():
-        return KANBAN_GUIDANCE
     if not isinstance(config, dict):
         return KANBAN_GUIDANCE
 
@@ -344,11 +334,7 @@ def resolve_kanban_guidance(
     if not isinstance(kanban_config, dict):
         return KANBAN_GUIDANCE
 
-    overrides = kanban_config.get("guidance_override", {})
-    if not isinstance(overrides, dict):
-        return KANBAN_GUIDANCE
-
-    override = overrides.get(profile_name.strip())
+    override = kanban_config.get("guidance_override", {})
     if not isinstance(override, dict):
         return KANBAN_GUIDANCE
 

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -306,6 +306,62 @@ KANBAN_GUIDANCE = (
     "cross-agent handoffs that outlive one API loop."
 )
 
+
+def resolve_kanban_guidance(
+    profile_name: Optional[str] = None,
+    config: Optional[dict] = None,
+) -> str:
+    """Return kanban worker guidance for *profile_name*.
+
+    ``kanban.guidance_override.<profile>`` may append to or replace the built-in
+    guidance. Malformed config is ignored so existing prompt behavior remains
+    unchanged unless a profile has a valid inline override.
+    """
+    if profile_name is None:
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+
+            profile_name = get_active_profile_name()
+        except Exception as exc:
+            logger.debug("Could not resolve active profile for kanban guidance: %s", exc)
+            profile_name = "default"
+
+    if config is None:
+        try:
+            from hermes_cli.config import load_config
+
+            config = load_config()
+        except Exception as exc:
+            logger.debug("Could not read kanban guidance override config: %s", exc)
+            return KANBAN_GUIDANCE
+
+    if not isinstance(profile_name, str) or not profile_name.strip():
+        return KANBAN_GUIDANCE
+    if not isinstance(config, dict):
+        return KANBAN_GUIDANCE
+
+    kanban_config = config.get("kanban", {})
+    if not isinstance(kanban_config, dict):
+        return KANBAN_GUIDANCE
+
+    overrides = kanban_config.get("guidance_override", {})
+    if not isinstance(overrides, dict):
+        return KANBAN_GUIDANCE
+
+    override = overrides.get(profile_name.strip())
+    if not isinstance(override, dict):
+        return KANBAN_GUIDANCE
+
+    text = override.get("text")
+    if not isinstance(text, str) or not text.strip():
+        return KANBAN_GUIDANCE
+    text = text.strip()
+
+    mode = override.get("mode", "append")
+    if isinstance(mode, str) and mode.strip().lower() == "replace":
+        return text
+    return f"{KANBAN_GUIDANCE}\n\n{text}"
+
 TOOL_USE_ENFORCEMENT_GUIDANCE = (
     "# Tool-use enforcement\n"
     "You MUST use your tools to take action — do not describe what you would do "

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2324,6 +2324,15 @@ DEFAULT_CONFIG = {
         # behaviour — e.g. for a profile that prefers explicit
         # ``kanban_notify-subscribe`` calls per task.
         "auto_subscribe_on_create": True,
+        # Profile-local worker prompt customization. Each named profile reads
+        # this from its own config.yaml under its HERMES_HOME; it is not a
+        # root-level map of profile names. Empty text preserves the built-in
+        # lifecycle guidance. "append" is the safe default; advanced users
+        # may choose "replace" to substitute the complete guidance block.
+        "guidance_override": {
+            "mode": "append",
+            "text": "",
+        },
         # Run the dispatcher inside the gateway process. On by default —
         # the cost is ~300µs every `dispatch_interval_seconds` when idle,
         # and gateway is the supervisor users already have. Set to false

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2672,6 +2672,15 @@ DEFAULT_CONFIG = {
         # behaviour — e.g. for a profile that prefers explicit
         # ``kanban_notify-subscribe`` calls per task.
         "auto_subscribe_on_create": True,
+        # Profile-local worker prompt customization. Each named profile reads
+        # this from its own config.yaml under its HERMES_HOME; it is not a
+        # root-level map of profile names. Empty text preserves the built-in
+        # lifecycle guidance. "append" is the safe default; advanced users
+        # may choose "replace" to substitute the complete guidance block.
+        "guidance_override": {
+            "mode": "append",
+            "text": "",
+        },
         # Run the dispatcher inside the gateway process. On by default —
         # the cost is ~300µs every `dispatch_interval_seconds` when idle,
         # and gateway is the supervisor users already have. Set to false

--- a/tests/agent/test_prompt_builder_kanban_guidance.py
+++ b/tests/agent/test_prompt_builder_kanban_guidance.py
@@ -1,0 +1,149 @@
+from unittest.mock import MagicMock, patch
+
+from agent.prompt_builder import KANBAN_GUIDANCE, resolve_kanban_guidance
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def test_kanban_guidance_default_unchanged():
+    assert (
+        resolve_kanban_guidance(profile_name="custom-orchestrator", config={})
+        == KANBAN_GUIDANCE
+    )
+
+
+def test_kanban_guidance_append_for_matching_profile():
+    custom_text = "Always create analyst then coder tasks."
+    config = {
+        "kanban": {
+            "guidance_override": {
+                "custom-orchestrator": {
+                    "mode": "append",
+                    "text": custom_text,
+                },
+            },
+        },
+    }
+
+    guidance = resolve_kanban_guidance(
+        profile_name="custom-orchestrator",
+        config=config,
+    )
+
+    assert KANBAN_GUIDANCE in guidance
+    assert custom_text in guidance
+
+
+def test_kanban_guidance_replace_for_matching_profile():
+    custom_text = "Use the exact deterministic decomposition pipeline."
+    config = {
+        "kanban": {
+            "guidance_override": {
+                "custom-orchestrator": {
+                    "mode": "replace",
+                    "text": custom_text,
+                },
+            },
+        },
+    }
+
+    guidance = resolve_kanban_guidance(
+        profile_name="custom-orchestrator",
+        config=config,
+    )
+
+    assert guidance == custom_text
+    assert KANBAN_GUIDANCE not in guidance
+
+
+def test_kanban_guidance_non_matching_profile_falls_back():
+    config = {
+        "kanban": {
+            "guidance_override": {
+                "custom-orchestrator": {
+                    "mode": "replace",
+                    "text": "Only custom orchestrators should see this.",
+                },
+            },
+        },
+    }
+
+    assert (
+        resolve_kanban_guidance(profile_name="coder", config=config)
+        == KANBAN_GUIDANCE
+    )
+
+
+def test_kanban_guidance_invalid_mode_defaults_to_append():
+    custom_text = "Invalid mode should still append this valid text."
+    config = {
+        "kanban": {
+            "guidance_override": {
+                "custom-orchestrator": {
+                    "mode": "sideways",
+                    "text": custom_text,
+                },
+            },
+        },
+    }
+
+    guidance = resolve_kanban_guidance(
+        profile_name="custom-orchestrator",
+        config=config,
+    )
+
+    assert KANBAN_GUIDANCE in guidance
+    assert custom_text in guidance
+
+
+def test_kanban_worker_agent_uses_profile_override():
+    custom_text = "Always create analyst then coder tasks."
+    config = {
+        "kanban": {
+            "guidance_override": {
+                "custom-orchestrator": {
+                    "mode": "append",
+                    "text": custom_text,
+                },
+            },
+        },
+    }
+
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("kanban_show"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("hermes_cli.config.load_config", return_value=config),
+        patch(
+            "hermes_cli.profiles.get_active_profile_name",
+            return_value="custom-orchestrator",
+        ),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.client = MagicMock()
+
+    prompt = agent._build_system_prompt()
+    assert KANBAN_GUIDANCE in prompt
+    assert custom_text in prompt

--- a/tests/agent/test_prompt_builder_kanban_guidance.py
+++ b/tests/agent/test_prompt_builder_kanban_guidance.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 from agent.prompt_builder import KANBAN_GUIDANCE, resolve_kanban_guidance
+from hermes_cli.config import DEFAULT_CONFIG
 from run_agent import AIAgent
 
 
@@ -18,109 +19,100 @@ def _make_tool_defs(*names: str) -> list:
     ]
 
 
-def test_kanban_guidance_default_unchanged():
-    assert (
-        resolve_kanban_guidance(profile_name="custom-orchestrator", config={})
-        == KANBAN_GUIDANCE
-    )
-
-
-def test_kanban_guidance_append_for_matching_profile():
-    custom_text = "Always create analyst then coder tasks."
-    config = {
+def _override_config(text: str, *, mode: str = "append") -> dict:
+    return {
         "kanban": {
             "guidance_override": {
-                "custom-orchestrator": {
-                    "mode": "append",
-                    "text": custom_text,
-                },
+                "mode": mode,
+                "text": text,
             },
         },
     }
 
-    guidance = resolve_kanban_guidance(
-        profile_name="custom-orchestrator",
-        config=config,
-    )
+
+def test_kanban_guidance_default_unchanged():
+    assert resolve_kanban_guidance(config={}) == KANBAN_GUIDANCE
+    assert DEFAULT_CONFIG["kanban"]["guidance_override"] == {
+        "mode": "append",
+        "text": "",
+    }
+
+
+def test_kanban_guidance_appends_profile_local_text():
+    custom_text = "Always create analyst then coder tasks."
+
+    guidance = resolve_kanban_guidance(config=_override_config(custom_text))
 
     assert KANBAN_GUIDANCE in guidance
     assert custom_text in guidance
 
 
-def test_kanban_guidance_replace_for_matching_profile():
+def test_kanban_guidance_replaces_for_profile_local_config():
     custom_text = "Use the exact deterministic decomposition pipeline."
-    config = {
-        "kanban": {
-            "guidance_override": {
-                "custom-orchestrator": {
-                    "mode": "replace",
-                    "text": custom_text,
-                },
-            },
-        },
-    }
 
     guidance = resolve_kanban_guidance(
-        profile_name="custom-orchestrator",
-        config=config,
+        config=_override_config(custom_text, mode="replace")
     )
 
     assert guidance == custom_text
     assert KANBAN_GUIDANCE not in guidance
 
 
-def test_kanban_guidance_non_matching_profile_falls_back():
+def test_kanban_guidance_old_profile_map_shape_falls_back():
     config = {
         "kanban": {
             "guidance_override": {
                 "custom-orchestrator": {
                     "mode": "replace",
-                    "text": "Only custom orchestrators should see this.",
+                    "text": "This map belongs to a different profile.",
                 },
             },
         },
     }
 
-    assert (
-        resolve_kanban_guidance(profile_name="coder", config=config)
-        == KANBAN_GUIDANCE
-    )
+    assert resolve_kanban_guidance(config=config) == KANBAN_GUIDANCE
 
 
 def test_kanban_guidance_invalid_mode_defaults_to_append():
     custom_text = "Invalid mode should still append this valid text."
-    config = {
-        "kanban": {
-            "guidance_override": {
-                "custom-orchestrator": {
-                    "mode": "sideways",
-                    "text": custom_text,
-                },
-            },
-        },
-    }
 
     guidance = resolve_kanban_guidance(
-        profile_name="custom-orchestrator",
-        config=config,
+        config=_override_config(custom_text, mode="sideways")
     )
 
     assert KANBAN_GUIDANCE in guidance
     assert custom_text in guidance
 
 
-def test_kanban_worker_agent_uses_profile_override():
+def test_kanban_guidance_loads_only_active_profile_home(monkeypatch, tmp_path):
+    root_home = tmp_path / ".hermes"
+    profile_home = root_home / "profiles" / "custom-orchestrator"
+    profile_home.mkdir(parents=True)
+    root_home.joinpath("config.yaml").write_text(
+        "kanban:\n"
+        "  guidance_override:\n"
+        "    mode: append\n"
+        "    text: Root guidance must not leak.\n",
+        encoding="utf-8",
+    )
+    profile_home.joinpath("config.yaml").write_text(
+        "kanban:\n"
+        "  guidance_override:\n"
+        "    mode: append\n"
+        "    text: Profile-local verification pipeline.\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    guidance = resolve_kanban_guidance()
+
+    assert "Profile-local verification pipeline." in guidance
+    assert "Root guidance must not leak." not in guidance
+
+
+def test_kanban_worker_agent_uses_profile_local_override():
     custom_text = "Always create analyst then coder tasks."
-    config = {
-        "kanban": {
-            "guidance_override": {
-                "custom-orchestrator": {
-                    "mode": "append",
-                    "text": custom_text,
-                },
-            },
-        },
-    }
+    config = _override_config(custom_text)
 
     with (
         patch(
@@ -130,10 +122,6 @@ def test_kanban_worker_agent_uses_profile_override():
         patch("run_agent.check_toolset_requirements", return_value={}),
         patch("run_agent.OpenAI"),
         patch("hermes_cli.config.load_config", return_value=config),
-        patch(
-            "hermes_cli.profiles.get_active_profile_name",
-            return_value="custom-orchestrator",
-        ),
     ):
         agent = AIAgent(
             api_key="test-key-1234567890",

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -605,7 +605,9 @@ The decomposer's routing decisions depend on profile descriptions, which is a pe
 
 `kanban.orchestrator_profile` does not load that profile's prompt, skills, or custom logic into the decomposition call. It controls who owns the root/orchestration task after fan-out. To change the decomposer's model/provider, configure `auxiliary.kanban_decomposer`. To use a profile's custom task-splitting logic instead of the built-in decomposer, switch to Manual mode and have that profile create or decompose tasks explicitly.
 
-Config knobs (all under `kanban:` in `~/.hermes/config.yaml`):
+Config knobs (all under `kanban:` in the active profile's `config.yaml`; the
+default profile uses `~/.hermes/config.yaml`, while named workers use their
+isolated profile config):
 
 | Key | Default | Purpose |
 |---|---|---|
@@ -615,6 +617,22 @@ Config knobs (all under `kanban:` in `~/.hermes/config.yaml`):
 | `default_assignee` | `""` | Where a child task lands when the LLM picks an unknown profile. Empty = fall back to active default. |
 | `auto_subscribe_on_create` | `true` | When `kanban_create` runs inside a persistent gateway/TUI session, terminal events resume that originating agent with a synthetic status turn. Set to `false` for passive completion or to require explicit `kanban_notify-subscribe` calls. Independent of `auto_decompose`. |
 | `done_sub_retention_days` | `30` | Notify subscriptions survive `done` (reopen-safe) and are removed on `archived`. The notifier GC purges subscriptions whose task has been `done` with no new events for this many days, bounding sub-table growth on boards that never archive. `0` disables the sweep. |
+| `guidance_override.mode` | `append` | `append` keeps the built-in worker lifecycle and adds the profile's text; `replace` substitutes the complete block. |
+| `guidance_override.text` | `""` | Profile-local worker guidance. Empty or invalid values preserve the built-in guidance. |
+
+For a named profile, put the override in that profile's own `config.yaml`:
+
+```yaml
+kanban:
+  guidance_override:
+    mode: append
+    text: |
+      Create an explicit verification task after every implementation task.
+```
+
+The dispatcher launches named workers with that profile's `HERMES_HOME`, so a
+profile never reads another profile's override. The text is resolved once at
+worker initialization and remains session-static across prompt rebuilds.
 
 And the two auxiliary LLM slots:
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -575,7 +575,9 @@ The decomposer's routing decisions depend on profile descriptions, which is a pe
 
 `kanban.orchestrator_profile` does not load that profile's prompt, skills, or custom logic into the decomposition call. It controls who owns the root/orchestration task after fan-out. To change the decomposer's model/provider, configure `auxiliary.kanban_decomposer`. To use a profile's custom task-splitting logic instead of the built-in decomposer, switch to Manual mode and have that profile create or decompose tasks explicitly.
 
-Config knobs (all under `kanban:` in `~/.hermes/config.yaml`):
+Config knobs (all under `kanban:` in the active profile's `config.yaml`; the
+default profile uses `~/.hermes/config.yaml`, while named workers use their
+isolated profile config):
 
 | Key | Default | Purpose |
 |---|---|---|
@@ -584,6 +586,22 @@ Config knobs (all under `kanban:` in `~/.hermes/config.yaml`):
 | `orchestrator_profile` | `""` | Profile assigned to the root/orchestration task after decomposition. Empty = fall back to active default profile. |
 | `default_assignee` | `""` | Where a child task lands when the LLM picks an unknown profile. Empty = fall back to active default. |
 | `auto_subscribe_on_create` | `true` | When a worker calls `kanban_create` from inside a session with a persistent delivery channel (messaging gateway or TUI), the originating session is auto-subscribed to the new task's completion/block events. The dispatcher still drives the delivery — this only changes whether the caller's chat/key shows up in the notify-sub table. Set to `false` to require explicit `kanban_notify-subscribe` calls per task. |
+| `guidance_override.mode` | `append` | `append` keeps the built-in worker lifecycle and adds the profile's text; `replace` substitutes the complete block. |
+| `guidance_override.text` | `""` | Profile-local worker guidance. Empty or invalid values preserve the built-in guidance. |
+
+For a named profile, put the override in that profile's own `config.yaml`:
+
+```yaml
+kanban:
+  guidance_override:
+    mode: append
+    text: |
+      Create an explicit verification task after every implementation task.
+```
+
+The dispatcher launches named workers with that profile's `HERMES_HOME`, so a
+profile never reads another profile's override. The text is resolved once at
+worker initialization and remains session-static across prompt rebuilds.
 
 And the two auxiliary LLM slots:
 


### PR DESCRIPTION
## Summary

- add a profile-local `kanban.guidance_override` block with `append` and `replace` modes
- resolve worker guidance once at agent initialization, preserving prompt-cache stability and built-in guidance for missing or malformed config
- keep profile isolation intact: each named worker reads only its own `HERMES_HOME/config.yaml`
- document the ownership contract and cover it with a real isolated-`HERMES_HOME` integration test

Closes #59126

## Validation

- prompt/system guidance suite — 17 passed
- config-loader profile-isolation integration — 2 passed
- `ruff check` on touched Python files
- `git diff --check`