### PR TITLE
docs: document gateway status phrases

### DIFF
--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1828,6 +1828,7 @@ display:
   runtime_footer:         # Gateway: append a runtime-context footer to final replies
     enabled: false
     fields: ["model", "context_pct", "cwd"]
+  status_phrases: {}      # Gateway: customize generic long-running status phrases
   file_mutation_verifier: true    # Append an advisory footer when write_file/patch calls failed this turn
   credits_notices: true   # Nous credits status-bar notices (usage bands, grant-spent, depleted). false = silence them; /usage still works
   cli_rebuild_scrollback_on_redraw: false  # Classic CLI: also wipe terminal scrollback (CSI 3J) on /redraw / Ctrl+L / width-change resize recovery. Enable when a terminal/tmux stack stamps stale prompt chrome into scrollback on maximize/restore.
@@ -1959,6 +1960,69 @@ Example footer appended to a Telegram/Discord/Slack reply:
 ```
 
 Only the **final** message of a turn gets the footer; interim updates stay clean.
+
+### Gateway status phrases
+
+Messaging gateways use short generic phrases for long-running status updates instead of echoing raw tool arguments, command previews, or model scratch text. You can customize those phrase catalogs globally or per platform.
+
+Hermes always starts with the built-in defaults, then loads these sources in order:
+
+1. `~/.hermes/status_phrases.yaml`
+2. every `.yaml` or `.yml` file in `~/.hermes/status_phrases/`
+3. `display.status_phrases` in `config.yaml`
+4. `display.platforms.<platform>.status_phrases`
+
+```yaml
+display:
+  status_phrases:
+    mode: append                    # append (default) | replace
+    phrases:
+      status:
+        - still working through it
+        - waiting for the result
+      generic:
+        - on it
+        - checking that now
+```
+
+Use `mode: replace` when your catalog should fully replace the built-ins for any surface you define. Use `mode: append` to add your phrases after the defaults.
+
+You can also load profile-relative files or directories. Paths are resolved under `HERMES_HOME`; absolute paths and `..` escapes are ignored so profile configs stay portable.
+
+```yaml
+display:
+  status_phrases:
+    path: status_phrases/team.yaml
+    paths:
+      - status_phrases/slack.yaml
+      - status_phrases/ops
+```
+
+Phrase files use the same shape:
+
+```yaml
+mode: append
+phrases:
+  status:
+    - still checking
+  generic:
+    - one moment
+```
+
+For platform-specific wording, put the same block under a platform override:
+
+```yaml
+display:
+  platforms:
+    slack:
+      status_phrases:
+        mode: append
+        phrases:
+          status:
+            - still working on this thread
+```
+
+The supported phrase surfaces are `status` for long-running/waiting updates and `generic` as the fallback bucket. Hermes keeps only non-empty phrase strings, caps each phrase at 160 characters, and caps each custom surface at 80 phrases.
 
 ### Per-platform progress overrides
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1828,6 +1828,7 @@ display:
   runtime_footer:         # Gateway: append a runtime-context footer to final replies
     enabled: false
     fields: ["model", "context_pct", "cwd"]
+  long_running_notifications: generic  # Use generic phrases for heartbeat updates
   status_phrases: {}      # Gateway: customize generic long-running status phrases
   file_mutation_verifier: true    # Append an advisory footer when write_file/patch calls failed this turn
   credits_notices: true   # Nous credits status-bar notices (usage bands, grant-spent, depleted). false = silence them; /usage still works
@@ -1963,7 +1964,12 @@ Only the **final** message of a turn gets the footer; interim updates stay clean
 
 ### Gateway status phrases
 
-Messaging gateways use short generic phrases for long-running status updates instead of echoing raw tool arguments, command previews, or model scratch text. You can customize those phrase catalogs globally or per platform.
+Messaging gateways can use short generic phrases for periodic long-running
+heartbeat updates instead of the default raw heartbeat. Set
+`long_running_notifications: generic` to activate the catalog; defining
+`status_phrases` alone only customizes the available phrases and does not
+change the notification mode. You can customize the catalogs globally or per
+platform.
 
 Hermes always starts with the built-in defaults, then loads these sources in order:
 
@@ -1974,6 +1980,7 @@ Hermes always starts with the built-in defaults, then loads these sources in ord
 
 ```yaml
 display:
+  long_running_notifications: generic
   status_phrases:
     mode: append                    # append (default) | replace
     phrases:
@@ -2015,6 +2022,7 @@ For platform-specific wording, put the same block under a platform override:
 display:
   platforms:
     slack:
+      long_running_notifications: generic
       status_phrases:
         mode: append
         phrases:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1701,6 +1701,7 @@ display:
   runtime_footer:         # Gateway: append a runtime-context footer to final replies
     enabled: false
     fields: ["model", "context_pct", "cwd"]
+  status_phrases: {}      # Gateway: customize generic long-running status phrases
   file_mutation_verifier: true    # Append an advisory footer when write_file/patch calls failed this turn
   credits_notices: true   # Nous credits status-bar notices (usage bands, grant-spent, depleted). false = silence them; /usage still works
   language: en            # UI language for static messages (approval prompts, some gateway replies). en | zh | zh-hant | ja | de | es | fr | tr | uk | af | ko | it | ga | pt | ru | hu
@@ -1831,6 +1832,69 @@ Example footer appended to a Telegram/Discord/Slack reply:
 ```
 
 Only the **final** message of a turn gets the footer; interim updates stay clean.
+
+### Gateway status phrases
+
+Messaging gateways use short generic phrases for long-running status updates instead of echoing raw tool arguments, command previews, or model scratch text. You can customize those phrase catalogs globally or per platform.
+
+Hermes always starts with the built-in defaults, then loads these sources in order:
+
+1. `~/.hermes/status_phrases.yaml`
+2. every `.yaml` or `.yml` file in `~/.hermes/status_phrases/`
+3. `display.status_phrases` in `config.yaml`
+4. `display.platforms.<platform>.status_phrases`
+
+```yaml
+display:
+  status_phrases:
+    mode: append                    # append (default) | replace
+    phrases:
+      status:
+        - still working through it
+        - waiting for the result
+      generic:
+        - on it
+        - checking that now
+```
+
+Use `mode: replace` when your catalog should fully replace the built-ins for any surface you define. Use `mode: append` to add your phrases after the defaults.
+
+You can also load profile-relative files or directories. Paths are resolved under `HERMES_HOME`; absolute paths and `..` escapes are ignored so profile configs stay portable.
+
+```yaml
+display:
+  status_phrases:
+    path: status_phrases/team.yaml
+    paths:
+      - status_phrases/slack.yaml
+      - status_phrases/ops
+```
+
+Phrase files use the same shape:
+
+```yaml
+mode: append
+phrases:
+  status:
+    - still checking
+  generic:
+    - one moment
+```
+
+For platform-specific wording, put the same block under a platform override:
+
+```yaml
+display:
+  platforms:
+    slack:
+      status_phrases:
+        mode: append
+        phrases:
+          status:
+            - still working on this thread
+```
+
+The supported phrase surfaces are `status` for long-running/waiting updates and `generic` as the fallback bucket. Hermes keeps only non-empty phrase strings, caps each phrase at 160 characters, and caps each custom surface at 80 phrases.
 
 ### Per-platform progress overrides
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1701,6 +1701,7 @@ display:
   runtime_footer:         # Gateway: append a runtime-context footer to final replies
     enabled: false
     fields: ["model", "context_pct", "cwd"]
+  long_running_notifications: generic  # Use generic phrases for heartbeat updates
   status_phrases: {}      # Gateway: customize generic long-running status phrases
   file_mutation_verifier: true    # Append an advisory footer when write_file/patch calls failed this turn
   credits_notices: true   # Nous credits status-bar notices (usage bands, grant-spent, depleted). false = silence them; /usage still works
@@ -1835,7 +1836,12 @@ Only the **final** message of a turn gets the footer; interim updates stay clean
 
 ### Gateway status phrases
 
-Messaging gateways use short generic phrases for long-running status updates instead of echoing raw tool arguments, command previews, or model scratch text. You can customize those phrase catalogs globally or per platform.
+Messaging gateways can use short generic phrases for periodic long-running
+heartbeat updates instead of the default raw heartbeat. Set
+`long_running_notifications: generic` to activate the catalog; defining
+`status_phrases` alone only customizes the available phrases and does not
+change the notification mode. You can customize the catalogs globally or per
+platform.
 
 Hermes always starts with the built-in defaults, then loads these sources in order:
 
@@ -1846,6 +1852,7 @@ Hermes always starts with the built-in defaults, then loads these sources in ord
 
 ```yaml
 display:
+  long_running_notifications: generic
   status_phrases:
     mode: append                    # append (default) | replace
     phrases:
@@ -1887,6 +1894,7 @@ For platform-specific wording, put the same block under a platform override:
 display:
   platforms:
     slack:
+      long_running_notifications: generic
       status_phrases:
         mode: append
         phrases:

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -490,6 +490,8 @@ When enabled, the bot sends status messages as it works:
 🐍 execute_code...
 ```
 
+For long-running gateway status updates, Hermes can use generic status phrase catalogs instead of relaying raw tool details. Configure them with `display.status_phrases` globally or `display.platforms.<platform>.status_phrases` per channel; see [Gateway status phrases](/user-guide/configuration#gateway-status-phrases).
+
 ## Background Sessions
 
 Run a prompt in a separate background session so the agent works on it independently while your main chat stays responsive:

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -490,7 +490,12 @@ When enabled, the bot sends status messages as it works:
 🐍 execute_code...
 ```
 
-For long-running gateway status updates, Hermes can use generic status phrase catalogs instead of relaying raw tool details. Configure them with `display.status_phrases` globally or `display.platforms.<platform>.status_phrases` per channel; see [Gateway status phrases](/user-guide/configuration#gateway-status-phrases).
+For periodic long-running heartbeat updates, Hermes can use generic status
+phrase catalogs instead of the default raw heartbeat. Enable the generic mode
+with `display.long_running_notifications: generic` globally, or with
+`display.platforms.<platform>.long_running_notifications: generic` per
+channel, then configure the matching `status_phrases` catalog; see
+[Gateway status phrases](/user-guide/configuration#gateway-status-phrases).
 
 ## Background Sessions
 


### PR DESCRIPTION
## Summary
- document display.status_phrases loading order and supported YAML shapes
- add examples for append vs replace, profile-relative files/directories, and per-platform overrides
- cross-link the messaging guide to the new configuration section

## Validation
- npm run build (website) passes; Docusaurus still reports existing broken-link warnings outside the touched pages
- git diff --check

## Note
- npm run lint:diagrams is currently not runnable from a clean website install because ascii-guard is referenced by the script but is not present in website/package-lock.json