### PR TITLE
fix(approval): deny unattended gateway jobs via cron mode

### DIFF
--- a/tests/tools/test_cron_approval_mode.py
+++ b/tests/tools/test_cron_approval_mode.py
@@ -8,6 +8,7 @@ from tools.approval import (
     _get_cron_approval_mode,
     check_all_command_guards,
     check_dangerous_command,
+    check_execute_code_guard,
     detect_dangerous_command,
 )
 
@@ -15,14 +16,24 @@ from tools.approval import (
 @pytest.fixture(autouse=True)
 def _clear_approval_state():
     approval_module._permanent_approved.clear()
+    approval_module._gateway_queues.clear()
+    approval_module._gateway_notify_cbs.clear()
+    approval_module._pending.clear()
     approval_module.clear_session("default")
     approval_module.clear_session("test-session")
     reset_session_vars()
+    approval_module.clear_session("gateway-kanban-test")
+    approval_module.clear_session("interactive-gateway-test")
     yield
     approval_module._permanent_approved.clear()
+    approval_module._gateway_queues.clear()
+    approval_module._gateway_notify_cbs.clear()
+    approval_module._pending.clear()
     approval_module.clear_session("default")
     approval_module.clear_session("test-session")
     reset_session_vars()
+    approval_module.clear_session("gateway-kanban-test")
+    approval_module.clear_session("interactive-gateway-test")
 
 
 # ---------------------------------------------------------------------------
@@ -455,6 +466,179 @@ class TestCronWithGatewayOrigin:
         finally:
             clear_session_vars(tokens)
 
+
+class TestCronModeGatewayHostedUnattended:
+    """Gateway-hosted unattended jobs must fail closed on cron_mode=deny."""
+
+    @pytest.mark.parametrize(
+        ("marker", "value"),
+        [
+            ("HERMES_CRON_SESSION", "1"),
+            ("HERMES_KANBAN_TASK", "task-42"),
+        ],
+    )
+    def test_gateway_hosted_unattended_job_denies_without_gateway_wait(
+        self,
+        monkeypatch,
+        marker,
+        value,
+    ):
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+        monkeypatch.setenv(marker, value)
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+        if marker != "HERMES_CRON_SESSION":
+            monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        if marker != "HERMES_KANBAN_TASK":
+            monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+        session_key = "gateway-kanban-test"
+        token = approval_module.set_current_session_key(session_key)
+        notified = []
+
+        def notify(_approval_data):
+            notified.append(_approval_data)
+            raise AssertionError("unattended jobs must not enter gateway approval")
+
+        approval_module.register_gateway_notify(session_key, notify)
+        try:
+            from unittest.mock import patch as mock_patch
+
+            with (
+                mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"),
+                mock_patch("tools.approval._get_approval_mode", return_value="manual"),
+                mock_patch("tools.approval._get_approval_config",
+                           return_value={"gateway_timeout": 30}),
+            ):
+                result = check_all_command_guards("rm -rf /tmp/stuff", "local")
+        finally:
+            approval_module.reset_current_session_key(token)
+            approval_module.unregister_gateway_notify(session_key)
+
+        assert not result["approved"]
+        assert "BLOCKED" in result["message"]
+        assert "cron_mode" in result["message"]
+        assert result.get("status") != "pending_approval"
+        assert result.get("outcome") != "timeout"
+        assert notified == []
+
+    def test_gateway_hosted_kanban_execute_code_denies_without_gateway_wait(
+        self,
+        monkeypatch,
+    ):
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "task-42")
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+
+        session_key = "gateway-kanban-test"
+        token = approval_module.set_current_session_key(session_key)
+        notified = []
+
+        def notify(_approval_data):
+            notified.append(_approval_data)
+            raise AssertionError("unattended jobs must not enter gateway approval")
+
+        approval_module.register_gateway_notify(session_key, notify)
+        try:
+            from unittest.mock import patch as mock_patch
+
+            with (
+                mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"),
+                mock_patch("tools.approval._get_approval_mode", return_value="manual"),
+                mock_patch("tools.approval._get_approval_config",
+                           return_value={"gateway_timeout": 30}),
+            ):
+                result = check_execute_code_guard("import os", "local")
+        finally:
+            approval_module.reset_current_session_key(token)
+            approval_module.unregister_gateway_notify(session_key)
+
+        assert not result["approved"]
+        assert result["outcome"] == "blocked"
+        assert result["pattern_key"] == "execute_code"
+        assert "cron_mode" in result["message"]
+        assert notified == []
+
+    def test_interactive_gateway_still_uses_gateway_approval_flow(self, monkeypatch):
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+
+        session_key = "interactive-gateway-test"
+        token = approval_module.set_current_session_key(session_key)
+        notified = []
+
+        def notify(approval_data):
+            notified.append(approval_data)
+            with approval_module._lock:
+                entry = approval_module._gateway_queues[session_key][-1]
+                entry.result = "once"
+                entry.event.set()
+
+        approval_module.register_gateway_notify(session_key, notify)
+        try:
+            from unittest.mock import patch as mock_patch
+
+            with (
+                mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"),
+                mock_patch("tools.approval._get_approval_mode", return_value="manual"),
+            ):
+                result = check_all_command_guards("rm -rf /tmp/stuff", "local")
+        finally:
+            approval_module.reset_current_session_key(token)
+            approval_module.unregister_gateway_notify(session_key)
+
+        assert result["approved"]
+        assert result.get("user_approved") is True
+        assert len(notified) == 1
+        assert notified[0]["command"] == "rm -rf /tmp/stuff"
+
+    def test_non_gateway_cron_deny_behavior_is_unchanged(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+
+        from unittest.mock import patch as mock_patch
+        with mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"):
+            result = check_all_command_guards("rm -rf /tmp/stuff", "local")
+
+        assert not result["approved"]
+        assert "BLOCKED" in result["message"]
+        assert "cron_mode" in result["message"]
+        assert result.get("status") != "pending_approval"
+
+    def test_exec_ask_does_not_override_unattended_deny(self, monkeypatch):
+        """A host ask-mode marker must not create an unanswerable job prompt."""
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+
+        from unittest.mock import patch as mock_patch
+
+        with mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"):
+            result = check_all_command_guards("rm -rf /tmp/stuff", "local")
+
+        assert not result["approved"]
+        assert "cron_mode" in result["message"]
+        assert result.get("status") != "pending_approval"
+
+
+class TestCronWithGatewayOriginAdditional:
+    """Additional cron jobs from gateway-origin delivery routing checks."""
+
     def test_cron_with_telegram_origin_approve_mode_allows(self, monkeypatch):
         """Cron + contextvar platform=telegram + cron_mode=approve → allowed via cron path."""
         monkeypatch.setenv("HERMES_CRON_SESSION", "1")
@@ -474,4 +658,3 @@ class TestCronWithGatewayOrigin:
                 assert result.get("status") != "approval_required"
         finally:
             clear_session_vars(tokens)
-

--- a/tests/tools/test_request_tool_approval.py
+++ b/tests/tools/test_request_tool_approval.py
@@ -99,7 +99,9 @@ class TestRequestToolApproval:
     def test_cron_deny_mode_blocks(self, monkeypatch):
         monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)
         monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
-        monkeypatch.setattr(approval, "_is_cron_approval_context", lambda: True)
+        monkeypatch.setattr(
+            approval, "_is_unattended_approval_context", lambda: True
+        )
         monkeypatch.setattr(approval, "_get_cron_approval_mode", lambda: "deny")
         res = request_tool_approval("terminal", "smtp send")
         assert res["approved"] is False
@@ -108,7 +110,9 @@ class TestRequestToolApproval:
     def test_cron_approve_mode_allows(self, monkeypatch):
         monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)
         monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
-        monkeypatch.setattr(approval, "_is_cron_approval_context", lambda: True)
+        monkeypatch.setattr(
+            approval, "_is_unattended_approval_context", lambda: True
+        )
         monkeypatch.setattr(approval, "_get_cron_approval_mode", lambda: "approve")
         res = request_tool_approval("terminal", "smtp send")
         assert res["approved"] is True

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -225,20 +225,34 @@ def _get_session_platform() -> str:
         return os.getenv("HERMES_SESSION_PLATFORM", "") or ""
 
 
-def _is_cron_approval_context() -> bool:
-    """True when the current approval decision is running inside cron.
-
-    Prefer the session ContextVar so one cron job cannot taint unrelated
-    gateway/API/TUI turns in the same process. If the session context layer is
-    not engaged or unavailable, fall back to the legacy process env var for CLI
-    tests and older entrypoints.
-    """
+def _get_session_marker(name: str) -> str:
+    """Read an approval context marker, preferring session-local state."""
     try:
         from gateway.session_context import get_session_env
 
-        return is_truthy_value(get_session_env("HERMES_CRON_SESSION", ""))
+        return get_session_env(name, "") or ""
     except Exception:
-        return env_var_enabled("HERMES_CRON_SESSION")
+        return os.getenv(name, "") or ""
+
+
+def _is_cron_session() -> bool:
+    """True when the current tool call is running inside a cron job."""
+    return is_truthy_value(_get_session_marker("HERMES_CRON_SESSION"))
+
+
+def _is_cron_approval_context() -> bool:
+    """Compatibility name for cron approval-context detection."""
+    return _is_cron_session()
+
+
+def _is_kanban_worker_session() -> bool:
+    """True when the current tool call is running inside a kanban worker."""
+    return bool(_get_session_marker("HERMES_KANBAN_TASK").strip())
+
+
+def _is_unattended_approval_context() -> bool:
+    """True for job contexts that cannot receive live approval responses."""
+    return _is_cron_approval_context() or _is_kanban_worker_session()
 
 
 def _is_gateway_approval_context() -> bool:
@@ -248,14 +262,13 @@ def _is_gateway_approval_context() -> bool:
     Newer concurrent gateway paths bind HERMES_SESSION_PLATFORM via
     contextvars so approval mode does not depend on process-global flags.
 
-    Cron jobs are NEVER gateway-approval contexts even when they originate
-    from a gateway platform (cron binds HERMES_SESSION_PLATFORM via
-    contextvars for delivery routing). Cron approvals are governed by
-    ``approvals.cron_mode`` config, not interactive resolve — letting cron
-    fall through to the gateway branch would submit a pending approval
-    with no listener and block the job indefinitely.
+    Unattended cron/kanban jobs are NEVER gateway-approval contexts even
+    when they originate from a gateway process or inherit gateway env. Their
+    approvals are governed by ``approvals.cron_mode`` config, not interactive
+    resolve — letting them fall through to the gateway branch would submit a
+    pending approval with no listener and block the job indefinitely.
     """
-    if _is_cron_approval_context():
+    if _is_unattended_approval_context():
         return False
     if env_var_enabled("HERMES_GATEWAY_SESSION"):
         return True
@@ -3216,8 +3229,11 @@ def _run_approval_gate(
     is_gateway = _is_gateway_approval_context()
 
     if not is_cli and not is_gateway:
-        # Cron sessions: respect cron_mode config
-        if _is_cron_approval_context():
+        # Unattended cron/kanban sessions: respect cron_mode config even when
+        # they inherit process-wide gateway or ask-mode markers. There is no
+        # live user on these paths, so entering an interactive approval wait
+        # would only time out.
+        if _is_unattended_approval_context():
             if _get_cron_approval_mode() == "deny":
                 return {
                     "approved": False,
@@ -3792,72 +3808,78 @@ def check_all_command_guards(command: str, env_type: str,
     is_gateway = _is_gateway_approval_context()
     is_ask = env_var_enabled("HERMES_EXEC_ASK")
 
-    # Preserve the existing non-interactive behavior: outside CLI/gateway/ask
-    # flows, we do not block on approvals and we skip external guard work.
-    if not is_cli and not is_gateway and not is_ask:
-        # Cron sessions: respect cron_mode config
-        if _is_cron_approval_context():
-            if _get_cron_approval_mode() == "deny":
-                # Run detection to get a description for the block message
-                is_dangerous, _pk, description = detect_dangerous_command(command)
-                if is_dangerous:
+    # Unattended jobs have no live approval responder. Resolve their policy
+    # before consulting HERMES_EXEC_ASK, which can be inherited from the host
+    # process and must not turn a cron/kanban job into a pending human prompt.
+    if _is_unattended_approval_context():
+        # Unattended cron/kanban sessions: respect cron_mode config.
+        if _get_cron_approval_mode() == "deny":
+            # Run detection to get a description for the block message
+            is_dangerous, _pk, description = detect_dangerous_command(command)
+            if is_dangerous:
+                return {
+                    "approved": False,
+                    "message": (
+                        f"BLOCKED: Command flagged as dangerous ({description}) "
+                        "but unattended cron/kanban jobs run without a user "
+                        "present to approve it. "
+                        "Find an alternative approach that avoids this command. "
+                        "To allow dangerous commands in unattended jobs, set "
+                        "approvals.cron_mode: approve in config.yaml."
+                    ),
+                }
+            # Also run tirith check in cron-deny mode so content-level threats
+            # are caught even when pattern-based detection does not match.
+            try:
+                from tools.tirith_security import check_command_security
+                _cron_tirith = check_command_security(command)
+                if _cron_tirith.get("action") in ("block", "warn"):
+                    _cron_desc = _format_tirith_description(_cron_tirith)
                     return {
                         "approved": False,
                         "message": (
-                            f"BLOCKED: Command flagged as dangerous ({description}) "
-                            "but cron jobs run without a user present to approve it. "
+                            f"BLOCKED: {_cron_desc} "
+                            "but unattended cron/kanban jobs run without a user "
+                            "present to approve it. "
                             "Find an alternative approach that avoids this command. "
-                            "To allow dangerous commands in cron jobs, set "
+                            "To allow dangerous commands in unattended jobs, set "
                             "approvals.cron_mode: approve in config.yaml."
                         ),
                     }
-                # Also run tirith check in cron-deny mode so content-level
-                # threats (homograph URLs, pipe-to-interpreter, terminal
-                # injection, etc.) are caught even when they do not match
-                # the pattern-based detection above.
+            except ImportError:
+                # Tirith not installed. Honour security.tirith_fail_open:
+                # the default (True) allows as before, but when an operator
+                # has explicitly opted into fail-closed the command cannot
+                # be silently allowed — and a cron session has no user to
+                # approve it, so fail-closed means block (mirrors the
+                # fail-closed synthesis in the main flow below; see #20733).
+                _cron_fail_open = True  # safe default if config is unreadable
                 try:
-                    from tools.tirith_security import check_command_security
-                    _cron_tirith = check_command_security(command)
-                    if _cron_tirith.get("action") in ("block", "warn"):
-                        _cron_desc = _format_tirith_description(_cron_tirith)
-                        return {
-                            "approved": False,
-                            "message": (
-                                f"BLOCKED: {_cron_desc} "
-                                "but cron jobs run without a user present to approve it. "
-                                "Find an alternative approach that avoids this command. "
-                                "To allow dangerous commands in cron jobs, set "
-                                "approvals.cron_mode: approve in config.yaml."
-                            ),
-                        }
-                except ImportError:
-                    # Tirith not installed. Honour security.tirith_fail_open:
-                    # the default (True) allows as before, but when an operator
-                    # has explicitly opted into fail-closed the command cannot
-                    # be silently allowed — and a cron session has no user to
-                    # approve it, so fail-closed means block (mirrors the
-                    # fail-closed synthesis in the main flow below; see #20733).
-                    _cron_fail_open = True  # safe default if config is unreadable
-                    try:
-                        from hermes_cli.config import load_config_readonly as _load_cfg
-                        _sec = (_load_cfg() or {}).get("security", {}) or {}
-                        if _sec.get("tirith_enabled", True):
-                            _cron_fail_open = _sec.get("tirith_fail_open", True)
-                    except Exception:
-                        pass
-                    if not _cron_fail_open:
-                        return {
-                            "approved": False,
-                            "message": (
-                                "BLOCKED: the Tirith security scanner could not be "
-                                "imported and security.tirith_fail_open is false, "
-                                "so this command cannot be silently allowed — and "
-                                "cron jobs run without a user present to approve it. "
-                                "Find an alternative approach, install tirith, or set "
-                                "approvals.cron_mode: approve in config.yaml."
-                            ),
-                        }
-                    # else: tirith_fail_open is True — allow as before
+                    from hermes_cli.config import load_config_readonly as _load_cfg
+                    _sec = (_load_cfg() or {}).get("security", {}) or {}
+                    if _sec.get("tirith_enabled", True):
+                        _cron_fail_open = _sec.get("tirith_fail_open", True)
+                except Exception:
+                    pass
+                if not _cron_fail_open:
+                    return {
+                        "approved": False,
+                        "message": (
+                            "BLOCKED: the Tirith security scanner could not be "
+                            "imported and security.tirith_fail_open is false, "
+                            "so this command cannot be silently allowed — and "
+                            "unattended cron/kanban jobs run without a user "
+                            "present to approve it. "
+                            "Find an alternative approach, install tirith, or set "
+                            "approvals.cron_mode: approve in config.yaml."
+                        ),
+                    }
+                # else: tirith_fail_open is True — allow as before
+        return {"approved": True, "message": None}
+
+    # Preserve the existing non-interactive behavior: outside CLI/gateway/ask
+    # flows, we do not block on approvals and we skip external guard work.
+    if not is_cli and not is_gateway and not is_ask:
         return {"approved": True, "message": None}
 
     # --- Phase 1: Gather findings from both checks ---
@@ -4265,17 +4287,17 @@ def check_execute_code_guard(code: str, env_type: str,
     is_gateway = _is_gateway_approval_context()
     is_ask = env_var_enabled("HERMES_EXEC_ASK")
 
-    # Cron: no user is present to approve arbitrary code.
-    if _is_cron_approval_context():
+    # Unattended cron/kanban sessions: no user is present to approve arbitrary code.
+    if _is_unattended_approval_context():
         if _get_cron_approval_mode() == "deny":
             return {
                 "approved": False,
                 "message": (
                     "BLOCKED: execute_code runs arbitrary local Python "
                     "(including subprocess calls that bypass shell-string "
-                    "approval checks). Cron jobs run without a user present "
-                    "to approve it. Use normal tools instead, or set "
-                    "approvals.cron_mode: approve only if this cron profile "
+                    "approval checks). Unattended cron/kanban jobs run without "
+                    "a user present to approve it. Use normal tools instead, or set "
+                    "approvals.cron_mode: approve only if this unattended profile "
                     "is intentionally trusted."
                 ),
                 "pattern_key": pattern_key,

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -249,20 +249,34 @@ def _get_session_platform() -> str:
         return os.getenv("HERMES_SESSION_PLATFORM", "") or ""
 
 
-def _is_cron_approval_context() -> bool:
-    """True when the current approval decision is running inside cron.
-
-    Prefer the session ContextVar so one cron job cannot taint unrelated
-    gateway/API/TUI turns in the same process. If the session context layer is
-    not engaged or unavailable, fall back to the legacy process env var for CLI
-    tests and older entrypoints.
-    """
+def _get_session_marker(name: str) -> str:
+    """Read an approval context marker, preferring session-local state."""
     try:
         from gateway.session_context import get_session_env
 
-        return is_truthy_value(get_session_env("HERMES_CRON_SESSION", ""))
+        return get_session_env(name, "") or ""
     except Exception:
-        return env_var_enabled("HERMES_CRON_SESSION")
+        return os.getenv(name, "") or ""
+
+
+def _is_cron_session() -> bool:
+    """True when the current tool call is running inside a cron job."""
+    return is_truthy_value(_get_session_marker("HERMES_CRON_SESSION"))
+
+
+def _is_cron_approval_context() -> bool:
+    """Compatibility name for cron approval-context detection."""
+    return _is_cron_session()
+
+
+def _is_kanban_worker_session() -> bool:
+    """True when the current tool call is running inside a kanban worker."""
+    return bool(_get_session_marker("HERMES_KANBAN_TASK").strip())
+
+
+def _is_unattended_approval_context() -> bool:
+    """True for job contexts that cannot receive live approval responses."""
+    return _is_cron_approval_context() or _is_kanban_worker_session()
 
 
 def _is_single_query_approval_context() -> bool:
@@ -297,14 +311,13 @@ def _is_gateway_approval_context() -> bool:
     Newer concurrent gateway paths bind HERMES_SESSION_PLATFORM via
     contextvars so approval mode does not depend on process-global flags.
 
-    Cron jobs are NEVER gateway-approval contexts even when they originate
-    from a gateway platform (cron binds HERMES_SESSION_PLATFORM via
-    contextvars for delivery routing). Cron approvals are governed by
-    ``approvals.cron_mode`` config, not interactive resolve — letting cron
-    fall through to the gateway branch would submit a pending approval
-    with no listener and block the job indefinitely.
+    Unattended cron/kanban jobs are NEVER gateway-approval contexts even
+    when they originate from a gateway process or inherit gateway env. Their
+    approvals are governed by ``approvals.cron_mode`` config, not interactive
+    resolve — letting them fall through to the gateway branch would submit a
+    pending approval with no listener and block the job indefinitely.
     """
-    if _is_cron_approval_context():
+    if _is_unattended_approval_context():
         return False
     if env_var_enabled("HERMES_GATEWAY_SESSION"):
         return True
@@ -3714,8 +3727,11 @@ def _run_approval_gate(
                 autoapprove_log_prefix, pattern_key, description,
             )
             return {"approved": True, "message": None}
-        # Cron sessions: respect cron_mode config
-        if _is_cron_approval_context():
+        # Unattended cron/kanban sessions: respect cron_mode config even when
+        # they inherit process-wide gateway or ask-mode markers. There is no
+        # live user on these paths, so entering an interactive approval wait
+        # would only time out.
+        if _is_unattended_approval_context():
             if _get_cron_approval_mode() == "deny":
                 return {
                     "approved": False,
@@ -4688,69 +4704,78 @@ def check_all_command_guards(command: str, env_type: str,
                         }
                     # else: tirith_fail_open is True — allow as before
             # single_query_mode: approve — fall through to auto-approve below.
-        # Cron sessions: respect cron_mode config
-        if _is_cron_approval_context():
-            if _get_cron_approval_mode() == "deny":
-                # Run detection to get a description for the block message
-                is_dangerous, _pk, description = detect_dangerous_command(command)
-                if is_dangerous:
+    # Unattended jobs have no live approval responder. Resolve their policy
+    # before consulting HERMES_EXEC_ASK, which can be inherited from the host
+    # process and must not turn a cron/kanban job into a pending human prompt.
+    if _is_unattended_approval_context():
+        # Unattended cron/kanban sessions: respect cron_mode config.
+        if _get_cron_approval_mode() == "deny":
+            # Run detection to get a description for the block message
+            is_dangerous, _pk, description = detect_dangerous_command(command)
+            if is_dangerous:
+                return {
+                    "approved": False,
+                    "message": (
+                        f"BLOCKED: Command flagged as dangerous ({description}) "
+                        "but unattended cron/kanban jobs run without a user "
+                        "present to approve it. "
+                        "Find an alternative approach that avoids this command. "
+                        "To allow dangerous commands in unattended jobs, set "
+                        "approvals.cron_mode: approve in config.yaml."
+                    ),
+                }
+            # Also run tirith check in cron-deny mode so content-level threats
+            # are caught even when pattern-based detection does not match.
+            try:
+                from tools.tirith_security import check_command_security
+                _cron_tirith = check_command_security(command)
+                if _cron_tirith.get("action") in ("block", "warn"):
+                    _cron_desc = _format_tirith_description(_cron_tirith)
                     return {
                         "approved": False,
                         "message": (
-                            f"BLOCKED: Command flagged as dangerous ({description}) "
-                            "but cron jobs run without a user present to approve it. "
+                            f"BLOCKED: {_cron_desc} "
+                            "but unattended cron/kanban jobs run without a user "
+                            "present to approve it. "
                             "Find an alternative approach that avoids this command. "
-                            "To allow dangerous commands in cron jobs, set "
+                            "To allow dangerous commands in unattended jobs, set "
                             "approvals.cron_mode: approve in config.yaml."
                         ),
                     }
-                # Also run tirith check in cron-deny mode so content-level
-                # threats (homograph URLs, pipe-to-interpreter, terminal
-                # injection, etc.) are caught even when they do not match
-                # the pattern-based detection above.
+            except ImportError:
+                # Tirith not installed. Honour security.tirith_fail_open:
+                # the default (True) allows as before, but when an operator
+                # has explicitly opted into fail-closed the command cannot
+                # be silently allowed — and a cron session has no user to
+                # approve it, so fail-closed means block (mirrors the
+                # fail-closed synthesis in the main flow below; see #20733).
+                _cron_fail_open = True  # safe default if config is unreadable
                 try:
-                    from tools.tirith_security import check_command_security
-                    _cron_tirith = check_command_security(command)
-                    if _cron_tirith.get("action") in ("block", "warn"):
-                        _cron_desc = _format_tirith_description(_cron_tirith)
-                        return {
-                            "approved": False,
-                            "message": (
-                                f"BLOCKED: {_cron_desc} "
-                                "but cron jobs run without a user present to approve it. "
-                                "Find an alternative approach that avoids this command. "
-                                "To allow dangerous commands in cron jobs, set "
-                                "approvals.cron_mode: approve in config.yaml."
-                            ),
-                        }
-                except ImportError:
-                    # Tirith not installed. Honour security.tirith_fail_open:
-                    # the default (True) allows as before, but when an operator
-                    # has explicitly opted into fail-closed the command cannot
-                    # be silently allowed — and a cron session has no user to
-                    # approve it, so fail-closed means block (mirrors the
-                    # fail-closed synthesis in the main flow below; see #20733).
-                    _cron_fail_open = True  # safe default if config is unreadable
-                    try:
-                        from hermes_cli.config import load_config_readonly as _load_cfg
-                        _sec = (_load_cfg() or {}).get("security", {}) or {}
-                        if _sec.get("tirith_enabled", True):
-                            _cron_fail_open = _sec.get("tirith_fail_open", True)
-                    except Exception:
-                        pass
-                    if not _cron_fail_open:
-                        return {
-                            "approved": False,
-                            "message": (
-                                "BLOCKED: the Tirith security scanner could not be "
-                                "imported and security.tirith_fail_open is false, "
-                                "so this command cannot be silently allowed — and "
-                                "cron jobs run without a user present to approve it. "
-                                "Find an alternative approach, install tirith, or set "
-                                "approvals.cron_mode: approve in config.yaml."
-                            ),
-                        }
-                    # else: tirith_fail_open is True — allow as before
+                    from hermes_cli.config import load_config_readonly as _load_cfg
+                    _sec = (_load_cfg() or {}).get("security", {}) or {}
+                    if _sec.get("tirith_enabled", True):
+                        _cron_fail_open = _sec.get("tirith_fail_open", True)
+                except Exception:
+                    pass
+                if not _cron_fail_open:
+                    return {
+                        "approved": False,
+                        "message": (
+                            "BLOCKED: the Tirith security scanner could not be "
+                            "imported and security.tirith_fail_open is false, "
+                            "so this command cannot be silently allowed — and "
+                            "unattended cron/kanban jobs run without a user "
+                            "present to approve it. "
+                            "Find an alternative approach, install tirith, or set "
+                            "approvals.cron_mode: approve in config.yaml."
+                        ),
+                    }
+                # else: tirith_fail_open is True — allow as before
+        return {"approved": True, "message": None}
+
+    # Preserve the existing non-interactive behavior: outside CLI/gateway/ask
+    # flows, we do not block on approvals and we skip external guard work.
+    if not is_cli and not is_gateway and not is_ask:
         return {"approved": True, "message": None}
 
     # --- Phase 1: Gather findings from both checks ---
@@ -5258,17 +5283,17 @@ def check_execute_code_guard(code: str, env_type: str,
             }
         return {"approved": True, "message": None}
 
-    # Cron: no user is present to approve arbitrary code.
-    if _is_cron_approval_context():
+    # Unattended cron/kanban sessions: no user is present to approve arbitrary code.
+    if _is_unattended_approval_context():
         if _get_cron_approval_mode() == "deny":
             return {
                 "approved": False,
                 "message": (
                     "BLOCKED: execute_code runs arbitrary local Python "
                     "(including subprocess calls that bypass shell-string "
-                    "approval checks). Cron jobs run without a user present "
-                    "to approve it. Use normal tools instead, or set "
-                    "approvals.cron_mode: approve only if this cron profile "
+                    "approval checks). Unattended cron/kanban jobs run without "
+                    "a user present to approve it. Use normal tools instead, or set "
+                    "approvals.cron_mode: approve only if this unattended profile "
                     "is intentionally trusted."
                 ),
                 "pattern_key": pattern_key,


### PR DESCRIPTION
## Summary

- Treat existing cron and kanban worker markers as unattended before gateway approval classification.
- Route dangerous-command, combined guard, and execute_code approval checks through `approvals.cron_mode` for unattended gateway-hosted jobs.
- Preserve the normal interactive gateway approval flow when no unattended job marker is present.

## Root Cause

Gateway-hosted unattended work can inherit gateway approval context, especially kanban worker subprocesses launched from the gateway dispatcher. Without checking the existing unattended markers first, `approvals.cron_mode: deny` is skipped and the guard falls into gateway approval/pending behavior even though no live user is attached to that job.

Fixes #58673

## Tests

- `uv run --extra dev pytest tests/tools/test_approval.py tests/tools/test_approval_interrupt.py tests/tools/test_execute_code_approval_cluster.py tests/tools/test_cron_approval_mode.py -q`
- `uv run --extra dev pytest tests/tools/test_cron_approval_mode.py -q`
- `uv run --extra dev python -m py_compile tools/approval.py tests/tools/test_cron_approval_mode.py`
- `uv run --extra dev ruff check tools/approval.py tests/tools/test_cron_approval_mode.py`
- `git diff --check`
