### PR TITLE
Route gateway approvals to configured operator target

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -839,6 +839,36 @@ def _send_approval_escalated_origin_notice_sync(
         logger.debug("Failed to send approval escalation origin notice: %s", exc)
 
 
+def _send_exec_approval_prompt_sync(
+    route: _ApprovalPromptRoute,
+    approval_data: Dict[str, Any],
+    *,
+    command: str,
+    description: str,
+    session_key: str,
+    loop: Any,
+) -> str:
+    """Send an interactive approval while preserving its capability contract."""
+    approval_fut = safe_schedule_threadsafe(
+        route.adapter.send_exec_approval(
+            chat_id=route.chat_id,
+            command=command,
+            session_key=session_key,
+            description=description,
+            metadata=route.metadata,
+            allow_permanent=approval_data.get("allow_permanent", True),
+            allow_session=approval_data.get("allow_session", True),
+            smart_denied=approval_data.get("smart_denied", False),
+        ),
+        loop,
+        logger=logger,
+        log_message="send_exec_approval scheduling error",
+    )
+    if approval_fut is None:
+        raise RuntimeError("send_exec_approval: loop unavailable")
+    return _approval_send_outcome(approval_fut, timeout=15)
+
+
 def _gateway_provider_error_reply(text: str) -> str:
     """Map raw provider/API errors to a short user-safe Telegram reply."""
     if _GATEWAY_AUTH_ERROR_RE.search(text):
@@ -6271,24 +6301,14 @@ class TurnRunner:
             # false positives from MagicMock auto-attribute creation in tests.
             if getattr(type(approval_route.adapter), "send_exec_approval", None) is not None:
                 try:
-                    _approval_fut = safe_schedule_threadsafe(
-                        approval_route.adapter.send_exec_approval(
-                            chat_id=approval_route.chat_id,
-                            command=cmd,
-                            session_key=_approval_session_key,
-                            description=desc,
-                            metadata=approval_route.metadata,
-                            allow_permanent=approval_data.get("allow_permanent", True),
-                            allow_session=approval_data.get("allow_session", True),
-                            smart_denied=approval_data.get("smart_denied", False),
-                        ),
-                        ctx._loop_for_step,
-                        logger=logger,
-                        log_message="send_exec_approval scheduling error",
+                    _outcome = _send_exec_approval_prompt_sync(
+                        approval_route,
+                        approval_data,
+                        command=cmd,
+                        description=desc,
+                        session_key=_approval_session_key,
+                        loop=ctx._loop_for_step,
                     )
-                    if _approval_fut is None:
-                        raise RuntimeError("send_exec_approval: loop unavailable")
-                    _outcome = _approval_send_outcome(_approval_fut, timeout=15)
                     if _outcome == "sent":
                         return
                     if _outcome == "ambiguous":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -727,6 +727,118 @@ def _format_exec_approval_fallback(
         + ", ".join(choices[:-1]) + f", or {choices[-1]}."
     )
 
+_APPROVAL_ESCALATED_ORIGIN_NOTICE = "I've flagged this for review."
+
+
+@dataclasses.dataclass(frozen=True)
+class _ApprovalPromptRoute:
+    adapter: Any
+    chat_id: str
+    metadata: Optional[Dict[str, Any]]
+    escalated: bool = False
+
+
+def _approval_escalate_to_target(
+    user_config: Any,
+) -> Optional[tuple["Platform", str]]:
+    """Parse approvals.escalate_to as a platform:chat_id target."""
+    approvals = user_config.get("approvals") if isinstance(user_config, dict) else None
+    if not isinstance(approvals, dict) or "escalate_to" not in approvals:
+        return None
+
+    raw = approvals.get("escalate_to")
+    if raw is None or raw == "":
+        return None
+    if not isinstance(raw, str):
+        raise ValueError("approvals.escalate_to must be a platform:chat_id string")
+
+    platform_name, sep, chat_id = raw.partition(":")
+    platform_name = platform_name.strip().lower()
+    chat_id = chat_id.strip()
+    if not sep or not platform_name or not chat_id:
+        raise ValueError("approvals.escalate_to must be a platform:chat_id string")
+
+    try:
+        platform = Platform(platform_name)
+    except Exception as exc:
+        raise ValueError("approvals.escalate_to references an unknown platform") from exc
+    return platform, chat_id
+
+
+def _resolve_approval_prompt_route(
+    user_config: Any,
+    adapters: Dict[Any, Any],
+    *,
+    source: Any,
+    origin_adapter: Any,
+    origin_chat_id: str,
+    origin_metadata: Optional[Dict[str, Any]],
+) -> _ApprovalPromptRoute:
+    """Resolve where a gateway dangerous-command approval prompt should go."""
+    configured_target = _approval_escalate_to_target(user_config)
+    if configured_target is None:
+        return _ApprovalPromptRoute(
+            adapter=origin_adapter,
+            chat_id=origin_chat_id,
+            metadata=origin_metadata,
+            escalated=False,
+        )
+
+    target_platform, target_chat_id = configured_target
+    target_adapter = adapters.get(target_platform) if isinstance(adapters, dict) else None
+    if target_adapter is None:
+        raise RuntimeError("approvals.escalate_to target adapter is not connected")
+
+    origin_platform = getattr(source, "platform", None)
+    origin_has_thread = bool(
+        getattr(source, "thread_id", None)
+        or (isinstance(origin_metadata, dict) and origin_metadata.get("thread_id"))
+    )
+    escalated = (
+        target_platform != origin_platform
+        or str(target_chat_id) != str(origin_chat_id)
+        or origin_has_thread
+    )
+
+    if escalated and getattr(type(target_adapter), "send_exec_approval", None) is None:
+        raise RuntimeError(
+            "approvals.escalate_to target must support interactive exec approvals"
+        )
+
+    return _ApprovalPromptRoute(
+        adapter=target_adapter,
+        chat_id=target_chat_id,
+        metadata=None if escalated else origin_metadata,
+        escalated=escalated,
+    )
+
+
+def _send_approval_escalated_origin_notice_sync(
+    origin_adapter: Any,
+    origin_chat_id: str,
+    origin_metadata: Optional[Dict[str, Any]],
+    loop: Any,
+) -> None:
+    """Send the neutral origin notice for escalated approval prompts."""
+    if origin_adapter is None:
+        return
+    try:
+        notice_fut = safe_schedule_threadsafe(
+            origin_adapter.send(
+                origin_chat_id,
+                _APPROVAL_ESCALATED_ORIGIN_NOTICE,
+                metadata=origin_metadata,
+            ),
+            loop,
+            logger=logger,
+            log_message="Approval escalation origin notice scheduling error",
+        )
+        if notice_fut is not None:
+            notice_fut.result(timeout=15)
+    except Exception as exc:
+        logger.debug("Failed to send approval escalation origin notice: %s", exc)
+
+
 def _gateway_provider_error_reply(text: str) -> str:
     """Map raw provider/API errors to a short user-safe Telegram reply."""
     if _GATEWAY_AUTH_ERROR_RE.search(text):
@@ -6114,11 +6226,11 @@ class TurnRunner:
         def _approval_notify_sync(approval_data: dict) -> None:
             """Send the approval request to the user from the agent thread.
 
-                If the adapter supports interactive button-based approvals
-                (e.g. Discord's ``send_exec_approval``), use that for a richer
-                UX.  Otherwise fall back to a plain text message with
-                ``/approve`` instructions.
-                """
+            If the adapter supports interactive button-based approvals
+            (e.g. Discord's ``send_exec_approval``), use that for a richer
+            UX. Otherwise fall back to a plain text message with ``/approve``
+            instructions.
+            """
             # Pause the typing indicator while the agent waits for
             # user approval.  Critical for Slack's Assistant API where
             # assistant_threads_setStatus disables the compose box — the

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6126,7 +6126,22 @@ class TurnRunner:
             # is active.  The approval message send auto-clears the Slack
             # status; pausing prevents _keep_typing from re-setting it.
             # Typing resumes in _handle_approve_command/_handle_deny_command.
-            ctx._status_adapter.pause_typing_for_chat(ctx._status_chat_id)
+            approval_route = _resolve_approval_prompt_route(
+                ctx.user_config,
+                self._runner.adapters,
+                source=ctx.source,
+                origin_adapter=ctx._status_adapter,
+                origin_chat_id=ctx._status_chat_id,
+                origin_metadata=ctx._status_thread_metadata,
+            )
+            if approval_route.escalated:
+                _send_approval_escalated_origin_notice_sync(
+                    ctx._status_adapter,
+                    ctx._status_chat_id,
+                    ctx._status_thread_metadata,
+                    ctx._loop_for_step,
+                )
+            approval_route.adapter.pause_typing_for_chat(approval_route.chat_id)
 
             cmd = approval_data.get("command", "")
             desc = approval_data.get("description", "dangerous command")
@@ -6142,15 +6157,15 @@ class TurnRunner:
             # Prefer button-based approval when the adapter supports it.
             # Check the *class* for the method, not the instance — avoids
             # false positives from MagicMock auto-attribute creation in tests.
-            if getattr(type(ctx._status_adapter), "send_exec_approval", None) is not None:
+            if getattr(type(approval_route.adapter), "send_exec_approval", None) is not None:
                 try:
                     _approval_fut = safe_schedule_threadsafe(
-                        ctx._status_adapter.send_exec_approval(
-                            chat_id=ctx._status_chat_id,
+                        approval_route.adapter.send_exec_approval(
+                            chat_id=approval_route.chat_id,
                             command=cmd,
                             session_key=_approval_session_key,
                             description=desc,
-                            metadata=ctx._status_thread_metadata,
+                            metadata=approval_route.metadata,
                             allow_permanent=approval_data.get("allow_permanent", True),
                             allow_session=approval_data.get("allow_session", True),
                             smart_denied=approval_data.get("smart_denied", False),
@@ -6179,19 +6194,32 @@ class TurnRunner:
                             "stays armed for a late tap)"
                         )
                         return
-                    logger.warning(
-                        "Button-based approval failed (send returned error), falling back to text"
-                    )
+                    if approval_route.escalated:
+                        logger.warning(
+                            "Escalated approval prompt failed (send returned error)"
+                        )
+                    else:
+                        logger.warning(
+                            "Button-based approval failed (send returned error), falling back to text"
+                        )
                 except Exception as _e:
-                    logger.warning(
-                        "Button-based approval failed, falling back to text: %s", _e
-                    )
+                    if approval_route.escalated:
+                        logger.warning("Escalated approval prompt failed: %s", _e)
+                    else:
+                        logger.warning(
+                            "Button-based approval failed, falling back to text: %s", _e
+                        )
+
+            if approval_route.escalated:
+                raise RuntimeError(
+                    "escalated approval prompt could not be delivered with interactive buttons"
+                )
 
             # Fallback: plain text approval prompt.  Use the adapter's
             # typed prefix so Slack/Matrix users are told the form they
             # can actually type (`!approve`) — typed "/" is blocked in
             # Slack threads and reserved by Matrix clients.
-            _p = getattr(ctx._status_adapter, "typed_command_prefix", "/")
+            _p = getattr(approval_route.adapter, "typed_command_prefix", "/")
             msg = _format_exec_approval_fallback(
                 cmd,
                 desc,
@@ -6202,10 +6230,10 @@ class TurnRunner:
             )
             try:
                 _approval_send_fut = safe_schedule_threadsafe(
-                    ctx._status_adapter.send(
-                        ctx._status_chat_id,
+                    approval_route.adapter.send(
+                        approval_route.chat_id,
                         msg,
-                        metadata=_interim_metadata(ctx._status_thread_metadata),
+                        metadata=_interim_metadata(approval_route.metadata),
                     ),
                     ctx._loop_for_step,
                     logger=logger,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -644,6 +644,118 @@ def _format_exec_approval_fallback(
     )
 
 
+_APPROVAL_ESCALATED_ORIGIN_NOTICE = "I've flagged this for review."
+
+
+@dataclasses.dataclass(frozen=True)
+class _ApprovalPromptRoute:
+    adapter: Any
+    chat_id: str
+    metadata: Optional[Dict[str, Any]]
+    escalated: bool = False
+
+
+def _approval_escalate_to_target(
+    user_config: Any,
+) -> Optional[tuple["Platform", str]]:
+    """Parse approvals.escalate_to as a platform:chat_id target."""
+    approvals = user_config.get("approvals") if isinstance(user_config, dict) else None
+    if not isinstance(approvals, dict) or "escalate_to" not in approvals:
+        return None
+
+    raw = approvals.get("escalate_to")
+    if raw is None or raw == "":
+        return None
+    if not isinstance(raw, str):
+        raise ValueError("approvals.escalate_to must be a platform:chat_id string")
+
+    platform_name, sep, chat_id = raw.partition(":")
+    platform_name = platform_name.strip().lower()
+    chat_id = chat_id.strip()
+    if not sep or not platform_name or not chat_id:
+        raise ValueError("approvals.escalate_to must be a platform:chat_id string")
+
+    try:
+        platform = Platform(platform_name)
+    except Exception as exc:
+        raise ValueError("approvals.escalate_to references an unknown platform") from exc
+    return platform, chat_id
+
+
+def _resolve_approval_prompt_route(
+    user_config: Any,
+    adapters: Dict[Any, Any],
+    *,
+    source: Any,
+    origin_adapter: Any,
+    origin_chat_id: str,
+    origin_metadata: Optional[Dict[str, Any]],
+) -> _ApprovalPromptRoute:
+    """Resolve where a gateway dangerous-command approval prompt should go."""
+    configured_target = _approval_escalate_to_target(user_config)
+    if configured_target is None:
+        return _ApprovalPromptRoute(
+            adapter=origin_adapter,
+            chat_id=origin_chat_id,
+            metadata=origin_metadata,
+            escalated=False,
+        )
+
+    target_platform, target_chat_id = configured_target
+    target_adapter = adapters.get(target_platform) if isinstance(adapters, dict) else None
+    if target_adapter is None:
+        raise RuntimeError("approvals.escalate_to target adapter is not connected")
+
+    origin_platform = getattr(source, "platform", None)
+    origin_has_thread = bool(
+        getattr(source, "thread_id", None)
+        or (isinstance(origin_metadata, dict) and origin_metadata.get("thread_id"))
+    )
+    escalated = (
+        target_platform != origin_platform
+        or str(target_chat_id) != str(origin_chat_id)
+        or origin_has_thread
+    )
+
+    if escalated and getattr(type(target_adapter), "send_exec_approval", None) is None:
+        raise RuntimeError(
+            "approvals.escalate_to target must support interactive exec approvals"
+        )
+
+    return _ApprovalPromptRoute(
+        adapter=target_adapter,
+        chat_id=target_chat_id,
+        metadata=None if escalated else origin_metadata,
+        escalated=escalated,
+    )
+
+
+def _send_approval_escalated_origin_notice_sync(
+    origin_adapter: Any,
+    origin_chat_id: str,
+    origin_metadata: Optional[Dict[str, Any]],
+    loop: Any,
+) -> None:
+    """Send the neutral origin notice for escalated approval prompts."""
+    if origin_adapter is None:
+        return
+    try:
+        notice_fut = safe_schedule_threadsafe(
+            origin_adapter.send(
+                origin_chat_id,
+                _APPROVAL_ESCALATED_ORIGIN_NOTICE,
+                metadata=origin_metadata,
+            ),
+            loop,
+            logger=logger,
+            log_message="Approval escalation origin notice scheduling error",
+        )
+        if notice_fut is not None:
+            notice_fut.result(timeout=15)
+    except Exception as exc:
+        logger.debug("Failed to send approval escalation origin notice: %s", exc)
+
+
 def _gateway_provider_error_reply(text: str) -> str:
     """Map raw provider/API errors to a short user-safe Telegram reply."""
     if _GATEWAY_AUTH_ERROR_RE.search(text):
@@ -5211,11 +5323,11 @@ class TurnRunner:
         def _approval_notify_sync(approval_data: dict) -> None:
             """Send the approval request to the user from the agent thread.
 
-                If the adapter supports interactive button-based approvals
-                (e.g. Discord's ``send_exec_approval``), use that for a richer
-                UX.  Otherwise fall back to a plain text message with
-                ``/approve`` instructions.
-                """
+            If the adapter supports interactive button-based approvals
+            (e.g. Discord's ``send_exec_approval``), use that for a richer
+            UX. Otherwise fall back to a plain text message with ``/approve``
+            instructions.
+            """
             # Pause the typing indicator while the agent waits for
             # user approval.  Critical for Slack's Assistant API where
             # assistant_threads_setStatus disables the compose box — the

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5223,7 +5223,22 @@ class TurnRunner:
             # is active.  The approval message send auto-clears the Slack
             # status; pausing prevents _keep_typing from re-setting it.
             # Typing resumes in _handle_approve_command/_handle_deny_command.
-            ctx._status_adapter.pause_typing_for_chat(ctx._status_chat_id)
+            approval_route = _resolve_approval_prompt_route(
+                ctx.user_config,
+                self._runner.adapters,
+                source=ctx.source,
+                origin_adapter=ctx._status_adapter,
+                origin_chat_id=ctx._status_chat_id,
+                origin_metadata=ctx._status_thread_metadata,
+            )
+            if approval_route.escalated:
+                _send_approval_escalated_origin_notice_sync(
+                    ctx._status_adapter,
+                    ctx._status_chat_id,
+                    ctx._status_thread_metadata,
+                    ctx._loop_for_step,
+                )
+            approval_route.adapter.pause_typing_for_chat(approval_route.chat_id)
 
             cmd = approval_data.get("command", "")
             desc = approval_data.get("description", "dangerous command")
@@ -5239,15 +5254,15 @@ class TurnRunner:
             # Prefer button-based approval when the adapter supports it.
             # Check the *class* for the method, not the instance — avoids
             # false positives from MagicMock auto-attribute creation in tests.
-            if getattr(type(ctx._status_adapter), "send_exec_approval", None) is not None:
+            if getattr(type(approval_route.adapter), "send_exec_approval", None) is not None:
                 try:
                     _approval_fut = safe_schedule_threadsafe(
-                        ctx._status_adapter.send_exec_approval(
-                            chat_id=ctx._status_chat_id,
+                        approval_route.adapter.send_exec_approval(
+                            chat_id=approval_route.chat_id,
                             command=cmd,
                             session_key=_approval_session_key,
                             description=desc,
-                            metadata=ctx._status_thread_metadata,
+                            metadata=approval_route.metadata,
                             allow_permanent=approval_data.get("allow_permanent", True),
                             allow_session=approval_data.get("allow_session", True),
                             smart_denied=approval_data.get("smart_denied", False),
@@ -5261,20 +5276,34 @@ class TurnRunner:
                     _approval_result = _approval_fut.result(timeout=15)
                     if _approval_result.success:
                         return
-                    logger.warning(
-                        "Button-based approval failed (send returned error), falling back to text: %s",
-                        _approval_result.error,
-                    )
+                    if approval_route.escalated:
+                        logger.warning(
+                            "Escalated approval prompt failed (send returned error): %s",
+                            _approval_result.error,
+                        )
+                    else:
+                        logger.warning(
+                            "Button-based approval failed (send returned error), falling back to text: %s",
+                            _approval_result.error,
+                        )
                 except Exception as _e:
-                    logger.warning(
-                        "Button-based approval failed, falling back to text: %s", _e
-                    )
+                    if approval_route.escalated:
+                        logger.warning("Escalated approval prompt failed: %s", _e)
+                    else:
+                        logger.warning(
+                            "Button-based approval failed, falling back to text: %s", _e
+                        )
+
+            if approval_route.escalated:
+                raise RuntimeError(
+                    "escalated approval prompt could not be delivered with interactive buttons"
+                )
 
             # Fallback: plain text approval prompt.  Use the adapter's
             # typed prefix so Slack/Matrix users are told the form they
             # can actually type (`!approve`) — typed "/" is blocked in
             # Slack threads and reserved by Matrix clients.
-            _p = getattr(ctx._status_adapter, "typed_command_prefix", "/")
+            _p = getattr(approval_route.adapter, "typed_command_prefix", "/")
             msg = _format_exec_approval_fallback(
                 cmd,
                 desc,
@@ -5285,10 +5314,10 @@ class TurnRunner:
             )
             try:
                 _approval_send_fut = safe_schedule_threadsafe(
-                    ctx._status_adapter.send(
-                        ctx._status_chat_id,
+                    approval_route.adapter.send(
+                        approval_route.chat_id,
                         msg,
-                        metadata=ctx._status_thread_metadata,
+                        metadata=approval_route.metadata,
                     ),
                     ctx._loop_for_step,
                     logger=logger,

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2122,6 +2122,12 @@ DEFAULT_CONFIG = {
         #     - "git push --force*"
         #     - "*curl*|*sh*"
         "deny": [],
+        # Optional operator escalation target for gateway dangerous-command
+        # prompts, formatted as "platform:chat_id" (for example,
+        # "telegram:7042601176"). When set, prompts from non-operator gateway
+        # sessions route to that target; the originating session only receives
+        # a neutral review notice.
+        "escalate_to": "",
         # When true, /reload-mcp asks the user to confirm before rebuilding
         # the MCP tool set for the active session.  Reloading invalidates
         # the provider prompt cache (tool schemas are baked into the system

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2436,6 +2436,12 @@ DEFAULT_CONFIG = {
         #     - "git push --force*"
         #     - "*curl*|*sh*"
         "deny": [],
+        # Optional operator escalation target for gateway dangerous-command
+        # prompts, formatted as "platform:chat_id" (for example,
+        # "telegram:7042601176"). When set, prompts from non-operator gateway
+        # sessions route to that target; the originating session only receives
+        # a neutral review notice.
+        "escalate_to": "",
         # When true, /reload-mcp asks the user to confirm before rebuilding
         # the MCP tool set for the active session.  Reloading invalidates
         # the provider prompt cache (tool schemas are baked into the system

--- a/tests/gateway/test_approval_escalation_routing.py
+++ b/tests/gateway/test_approval_escalation_routing.py
@@ -9,6 +9,7 @@ import pytest
 from gateway.config import Platform
 from gateway.run import (
     _APPROVAL_ESCALATED_ORIGIN_NOTICE,
+    _approval_escalate_to_target,
     _resolve_approval_prompt_route,
     _send_approval_escalated_origin_notice_sync,
 )
@@ -82,6 +83,32 @@ def test_approval_prompt_route_defaults_to_origin_when_key_missing():
     assert route.escalated is False
 
 
+@pytest.mark.parametrize(
+    "user_config",
+    [
+        {"approvals": {"escalate_to": ""}},
+        {"approvals": {"escalate_to": None}},
+        {"approvals": {}},
+        {},
+    ],
+)
+def test_approval_escalate_to_target_allows_disabled_config(user_config):
+    assert _approval_escalate_to_target(user_config) is None
+
+
+def test_approval_escalate_to_target_rejects_non_string_value():
+    with pytest.raises(ValueError, match="platform:chat_id"):
+        _approval_escalate_to_target({"approvals": {"escalate_to": 123}})
+
+
+def test_approval_escalate_to_target_preserves_colons_in_chat_id():
+    target = _approval_escalate_to_target(
+        {"approvals": {"escalate_to": " telegram : team:approval:room "}}
+    )
+
+    assert target == (Platform.TELEGRAM, "team:approval:room")
+
+
 def test_approval_prompt_route_uses_configured_interactive_target():
     origin = _OriginAdapter()
     operator = _ButtonApprovalAdapter()
@@ -101,6 +128,48 @@ def test_approval_prompt_route_uses_configured_interactive_target():
     assert route.escalated is True
 
 
+def test_approval_prompt_route_keeps_metadata_for_same_chat_without_thread():
+    origin = _ButtonApprovalAdapter()
+    metadata = {"delivery": "dm"}
+
+    route = _resolve_approval_prompt_route(
+        {"approvals": {"escalate_to": "bluebubbles:origin-chat"}},
+        {Platform.BLUEBUBBLES: origin},
+        source=_source(platform=Platform.BLUEBUBBLES, chat_id="origin-chat"),
+        origin_adapter=origin,
+        origin_chat_id="origin-chat",
+        origin_metadata=metadata,
+    )
+
+    assert route.adapter is origin
+    assert route.chat_id == "origin-chat"
+    assert route.metadata is metadata
+    assert route.escalated is False
+
+
+def test_approval_prompt_route_strips_thread_metadata_for_same_chat_thread():
+    origin = _ButtonApprovalAdapter()
+    metadata = {"thread_id": "origin-thread"}
+
+    route = _resolve_approval_prompt_route(
+        {"approvals": {"escalate_to": "bluebubbles:origin-chat"}},
+        {Platform.BLUEBUBBLES: origin},
+        source=_source(
+            platform=Platform.BLUEBUBBLES,
+            chat_id="origin-chat",
+            thread_id="origin-thread",
+        ),
+        origin_adapter=origin,
+        origin_chat_id="origin-chat",
+        origin_metadata=metadata,
+    )
+
+    assert route.adapter is origin
+    assert route.chat_id == "origin-chat"
+    assert route.metadata is None
+    assert route.escalated is True
+
+
 def test_approval_prompt_route_rejects_cross_session_text_only_target():
     origin = _OriginAdapter()
     text_only_operator = _OriginAdapter()
@@ -116,10 +185,36 @@ def test_approval_prompt_route_rejects_cross_session_text_only_target():
         )
 
 
+def test_approval_prompt_route_rejects_disconnected_target():
+    origin = _OriginAdapter()
+
+    with pytest.raises(RuntimeError, match="target adapter is not connected"):
+        _resolve_approval_prompt_route(
+            {"approvals": {"escalate_to": "telegram:operator-chat"}},
+            {Platform.BLUEBUBBLES: origin},
+            source=_source(platform=Platform.BLUEBUBBLES, chat_id="origin-chat"),
+            origin_adapter=origin,
+            origin_chat_id="origin-chat",
+            origin_metadata=None,
+        )
+
+
 def test_approval_prompt_route_rejects_malformed_configured_target():
     with pytest.raises(ValueError, match="platform:chat_id"):
         _resolve_approval_prompt_route(
             {"approvals": {"escalate_to": "telegram"}},
+            {},
+            source=_source(),
+            origin_adapter=_OriginAdapter(),
+            origin_chat_id="origin-chat",
+            origin_metadata=None,
+        )
+
+
+def test_approval_prompt_route_rejects_unknown_target_platform():
+    with pytest.raises(ValueError, match="unknown platform"):
+        _resolve_approval_prompt_route(
+            {"approvals": {"escalate_to": "carrier:operator-chat"}},
             {},
             source=_source(),
             origin_adapter=_OriginAdapter(),

--- a/tests/gateway/test_approval_escalation_routing.py
+++ b/tests/gateway/test_approval_escalation_routing.py
@@ -1,0 +1,167 @@
+"""Tests for approvals.escalate_to gateway approval routing."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform
+from gateway.run import (
+    _APPROVAL_ESCALATED_ORIGIN_NOTICE,
+    _resolve_approval_prompt_route,
+    _send_approval_escalated_origin_notice_sync,
+)
+from gateway.session import SessionSource
+
+
+class _OriginAdapter:
+    typed_command_prefix = "/"
+
+    def __init__(self) -> None:
+        self.sent = []
+
+    async def send(self, chat_id, content, metadata=None):
+        self.sent.append(
+            {"chat_id": chat_id, "content": content, "metadata": metadata}
+        )
+        return SimpleNamespace(success=True)
+
+    def pause_typing_for_chat(self, chat_id):
+        return None
+
+
+class _ButtonApprovalAdapter(_OriginAdapter):
+    async def send_exec_approval(
+        self, chat_id, command, session_key, description="", metadata=None
+    ):
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "command": command,
+                "session_key": session_key,
+                "description": description,
+                "metadata": metadata,
+            }
+        )
+        return SimpleNamespace(success=True)
+
+
+def _source(
+    *,
+    platform: Platform = Platform.BLUEBUBBLES,
+    chat_id: str = "origin-chat",
+    thread_id: str | None = None,
+) -> SessionSource:
+    return SessionSource(
+        platform=platform,
+        user_id="origin-user",
+        chat_id=chat_id,
+        user_name="Origin",
+        chat_type="dm",
+        thread_id=thread_id,
+    )
+
+
+def test_approval_prompt_route_defaults_to_origin_when_key_missing():
+    origin = _OriginAdapter()
+    metadata = {"thread_id": "origin-thread"}
+
+    route = _resolve_approval_prompt_route(
+        {},
+        {Platform.BLUEBUBBLES: origin},
+        source=_source(platform=Platform.BLUEBUBBLES),
+        origin_adapter=origin,
+        origin_chat_id="origin-chat",
+        origin_metadata=metadata,
+    )
+
+    assert route.adapter is origin
+    assert route.chat_id == "origin-chat"
+    assert route.metadata is metadata
+    assert route.escalated is False
+
+
+def test_approval_prompt_route_uses_configured_interactive_target():
+    origin = _OriginAdapter()
+    operator = _ButtonApprovalAdapter()
+
+    route = _resolve_approval_prompt_route(
+        {"approvals": {"escalate_to": "telegram:operator-chat"}},
+        {Platform.BLUEBUBBLES: origin, Platform.TELEGRAM: operator},
+        source=_source(platform=Platform.BLUEBUBBLES, chat_id="origin-chat"),
+        origin_adapter=origin,
+        origin_chat_id="origin-chat",
+        origin_metadata={"thread_id": "origin-thread"},
+    )
+
+    assert route.adapter is operator
+    assert route.chat_id == "operator-chat"
+    assert route.metadata is None
+    assert route.escalated is True
+
+
+def test_approval_prompt_route_rejects_cross_session_text_only_target():
+    origin = _OriginAdapter()
+    text_only_operator = _OriginAdapter()
+
+    with pytest.raises(RuntimeError, match="interactive exec approvals"):
+        _resolve_approval_prompt_route(
+            {"approvals": {"escalate_to": "sms:operator-chat"}},
+            {Platform.BLUEBUBBLES: origin, Platform.SMS: text_only_operator},
+            source=_source(platform=Platform.BLUEBUBBLES, chat_id="origin-chat"),
+            origin_adapter=origin,
+            origin_chat_id="origin-chat",
+            origin_metadata=None,
+        )
+
+
+def test_approval_prompt_route_rejects_malformed_configured_target():
+    with pytest.raises(ValueError, match="platform:chat_id"):
+        _resolve_approval_prompt_route(
+            {"approvals": {"escalate_to": "telegram"}},
+            {},
+            source=_source(),
+            origin_adapter=_OriginAdapter(),
+            origin_chat_id="origin-chat",
+            origin_metadata=None,
+        )
+
+
+def test_escalated_origin_notice_is_neutral_and_bounded(monkeypatch):
+    origin = _OriginAdapter()
+    scheduled = []
+
+    def fake_schedule(coro, loop, **kwargs):
+        import asyncio
+
+        scheduled.append(kwargs)
+        result = asyncio.run(coro)
+
+        class _Future:
+            def result(self, timeout=None):
+                return result
+
+        return _Future()
+
+    monkeypatch.setattr("gateway.run.safe_schedule_threadsafe", fake_schedule)
+
+    _send_approval_escalated_origin_notice_sync(
+        origin,
+        "origin-chat",
+        {"thread_id": "origin-thread"},
+        loop=object(),
+    )
+
+    assert origin.sent == [
+        {
+            "chat_id": "origin-chat",
+            "content": _APPROVAL_ESCALATED_ORIGIN_NOTICE,
+            "metadata": {"thread_id": "origin-thread"},
+        }
+    ]
+    notice = origin.sent[0]["content"]
+    assert "rm -rf" not in notice
+    assert "/approve" not in notice
+    assert "flagged" in notice
+    assert scheduled

--- a/tests/gateway/test_approval_escalation_routing.py
+++ b/tests/gateway/test_approval_escalation_routing.py
@@ -12,6 +12,7 @@ from gateway.run import (
     _approval_escalate_to_target,
     _resolve_approval_prompt_route,
     _send_approval_escalated_origin_notice_sync,
+    _send_exec_approval_prompt_sync,
 )
 from gateway.session import SessionSource
 
@@ -34,7 +35,16 @@ class _OriginAdapter:
 
 class _ButtonApprovalAdapter(_OriginAdapter):
     async def send_exec_approval(
-        self, chat_id, command, session_key, description="", metadata=None
+        self,
+        chat_id,
+        command,
+        session_key,
+        description="",
+        metadata=None,
+        *,
+        allow_permanent=True,
+        allow_session=True,
+        smart_denied=False,
     ):
         self.sent.append(
             {
@@ -43,6 +53,9 @@ class _ButtonApprovalAdapter(_OriginAdapter):
                 "session_key": session_key,
                 "description": description,
                 "metadata": metadata,
+                "allow_permanent": allow_permanent,
+                "allow_session": allow_session,
+                "smart_denied": smart_denied,
             }
         )
         return SimpleNamespace(success=True)
@@ -126,6 +139,59 @@ def test_approval_prompt_route_uses_configured_interactive_target():
     assert route.chat_id == "operator-chat"
     assert route.metadata is None
     assert route.escalated is True
+
+
+def test_escalated_approval_preserves_smart_deny_capabilities(monkeypatch):
+    origin = _OriginAdapter()
+    operator = _ButtonApprovalAdapter()
+    route = _resolve_approval_prompt_route(
+        {"approvals": {"escalate_to": "telegram:operator-chat"}},
+        {Platform.BLUEBUBBLES: origin, Platform.TELEGRAM: operator},
+        source=_source(platform=Platform.BLUEBUBBLES, chat_id="origin-chat"),
+        origin_adapter=origin,
+        origin_chat_id="origin-chat",
+        origin_metadata={"thread_id": "origin-thread"},
+    )
+
+    def fake_schedule(coro, loop, **kwargs):
+        import asyncio
+
+        result = asyncio.run(coro)
+
+        class _Future:
+            def result(self, timeout=None):
+                return result
+
+        return _Future()
+
+    monkeypatch.setattr("gateway.run.safe_schedule_threadsafe", fake_schedule)
+
+    outcome = _send_exec_approval_prompt_sync(
+        route,
+        {
+            "allow_permanent": False,
+            "allow_session": False,
+            "smart_denied": True,
+        },
+        command="rm -rf /tmp/example",
+        description="dangerous deletion",
+        session_key="bluebubbles:origin-chat",
+        loop=object(),
+    )
+
+    assert outcome == "sent"
+    assert operator.sent == [
+        {
+            "chat_id": "operator-chat",
+            "command": "rm -rf /tmp/example",
+            "session_key": "bluebubbles:origin-chat",
+            "description": "dangerous deletion",
+            "metadata": None,
+            "allow_permanent": False,
+            "allow_session": False,
+            "smart_denied": True,
+        }
+    ]
 
 
 def test_approval_prompt_route_keeps_metadata_for_same_chat_without_thread():

--- a/tests/hermes_cli/test_approval_escalate_to_config.py
+++ b/tests/hermes_cli/test_approval_escalate_to_config.py
@@ -1,0 +1,73 @@
+"""Tests for the approvals.escalate_to config key."""
+
+from __future__ import annotations
+
+from hermes_cli.config import DEFAULT_CONFIG
+
+
+class TestApprovalEscalateToDefault:
+    def test_default_config_has_the_key(self):
+        approvals = DEFAULT_CONFIG.get("approvals")
+        assert isinstance(approvals, dict)
+        assert "escalate_to" in approvals
+
+    def test_default_is_empty_string(self):
+        assert DEFAULT_CONFIG["approvals"]["escalate_to"] == ""
+
+    def test_shape_matches_other_approval_keys(self):
+        approvals = DEFAULT_CONFIG["approvals"]
+        assert isinstance(approvals.get("mode"), str)
+        assert isinstance(approvals.get("timeout"), int)
+        assert isinstance(approvals.get("cron_mode"), str)
+        assert isinstance(approvals.get("escalate_to"), str)
+
+
+class TestUserConfigMerge:
+    def test_existing_user_config_without_key_gets_default(
+        self, tmp_path, monkeypatch
+    ):
+        import importlib
+        import yaml
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        cfg_path = home / "config.yaml"
+        legacy = {
+            "approvals": {"mode": "manual", "timeout": 60, "cron_mode": "deny"},
+        }
+        cfg_path.write_text(yaml.safe_dump(legacy))
+
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        import hermes_cli.config as cfg_mod
+
+        importlib.reload(cfg_mod)
+
+        cfg = cfg_mod.load_config()
+        assert cfg["approvals"]["escalate_to"] == ""
+
+    def test_existing_user_config_with_target_survives_merge(
+        self, tmp_path, monkeypatch
+    ):
+        import importlib
+        import yaml
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        cfg_path = home / "config.yaml"
+        user_cfg = {
+            "approvals": {
+                "mode": "manual",
+                "timeout": 60,
+                "cron_mode": "deny",
+                "escalate_to": "telegram:operator-chat",
+            },
+        }
+        cfg_path.write_text(yaml.safe_dump(user_cfg))
+
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        import hermes_cli.config as cfg_mod
+
+        importlib.reload(cfg_mod)
+
+        cfg = cfg_mod.load_config()
+        assert cfg["approvals"]["escalate_to"] == "telegram:operator-chat"

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2425,6 +2425,7 @@ Control how Hermes handles potentially dangerous commands:
 ```yaml
 approvals:
   mode: smart   # smart | manual | off
+  escalate_to: ""  # optional platform:chat_id operator target for gateway prompts
 ```
 
 | Mode | Behavior |
@@ -2434,6 +2435,16 @@ approvals:
 | `off` | Skip all approval checks. Equivalent to `HERMES_YOLO_MODE=true`. **Use with caution.** |
 
 Smart mode is particularly useful for reducing approval fatigue — it lets the agent work more autonomously on safe operations while still catching genuinely destructive commands.
+
+For messaging gateways, set `approvals.escalate_to` to route dangerous-command approval prompts to an operator chat instead of the originating conversation:
+
+```yaml
+approvals:
+  mode: manual
+  escalate_to: telegram:7042601176
+```
+
+When `escalate_to` is set, the originating gateway session only receives a neutral review notice. Full command text and approval controls are sent to the configured operator target when that target supports interactive exec approvals.
 
 :::warning
 Setting `approvals.mode: off` disables all safety checks for terminal commands. Only use this in trusted, sandboxed environments.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2246,6 +2246,7 @@ Control how Hermes handles potentially dangerous commands:
 ```yaml
 approvals:
   mode: smart   # smart | manual | off
+  escalate_to: ""  # optional platform:chat_id operator target for gateway prompts
 ```
 
 | Mode | Behavior |
@@ -2255,6 +2256,16 @@ approvals:
 | `off` | Skip all approval checks. Equivalent to `HERMES_YOLO_MODE=true`. **Use with caution.** |
 
 Smart mode is particularly useful for reducing approval fatigue — it lets the agent work more autonomously on safe operations while still catching genuinely destructive commands.
+
+For messaging gateways, set `approvals.escalate_to` to route dangerous-command approval prompts to an operator chat instead of the originating conversation:
+
+```yaml
+approvals:
+  mode: manual
+  escalate_to: telegram:7042601176
+```
+
+When `escalate_to` is set, the originating gateway session only receives a neutral review notice. Full command text and approval controls are sent to the configured operator target when that target supports interactive exec approvals.
 
 :::warning
 Setting `approvals.mode: off` disables all safety checks for terminal commands. Only use this in trusted, sandboxed environments.


### PR DESCRIPTION
## Summary

- add `approvals.escalate_to` support for `platform:chat_id` gateway approval routing
- send escalated prompts to the configured interactive operator target and only a neutral notice to the originating session
- fail closed for malformed, unavailable, or text-only cross-session targets instead of leaking command details back to the origin
- preserve current approval capabilities (`allow_permanent`, `allow_session`, and `smart_denied`) through the routed interactive send
- define the behavioral setting in `hermes_cli/config_defaults.py`, document it, and cover config merge/routing behavior

Fixes #58887

## Validation

- focused escalation/config tests — 20 passed
- broader gateway approval/button/redaction/interrupt selection — 179 passed
- `ruff check` on touched Python files
- `git diff --check`