### PR TITLE
fix(plugins): refuse enable/disable on passive plugin kinds with a pointer to the real switch

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -810,6 +810,57 @@ def _set_plugin_entry_flag(plugin_id: str, key: str, value: bool) -> None:
     save_config(config)
 
 
+# Plugin kinds that the general loader does NOT gate on plugins.enabled /
+# plugins.disabled: model providers register through providers/__init__.py's
+# own discovery (selected via `hermes model` / model.provider), and exclusive
+# category plugins (memory providers) activate via `<category>.provider`.
+# `plugins enable`/`disable` used to accept these and print a success message
+# while having zero effect — the flag was written but nothing ever read it,
+# which misled users into thinking they had switched something on or off.
+_PASSIVE_PLUGIN_KINDS = {"model-provider", "exclusive"}
+
+
+def _plugin_kind(key: str) -> str:
+    """Manifest ``kind`` for a discovered plugin key (default: ``standalone``)."""
+    for entry in _discover_all_plugins():
+        # entry = (name, version, description, source, dir_path, key)
+        if entry[5] == key:
+            d = Path(entry[4])
+            for fname in ("plugin.yaml", "plugin.yml"):
+                mf = d / fname
+                if mf.exists():
+                    try:
+                        import yaml
+
+                        data = yaml.safe_load(mf.read_text(encoding="utf-8")) or {}
+                        return str(data.get("kind", "standalone"))
+                    except Exception:
+                        return "standalone"
+    return "standalone"
+
+
+def _print_passive_kind_hint(console, key: str, kind: str) -> None:
+    """Explain how a passive-kind plugin is actually controlled."""
+    if kind == "model-provider":
+        console.print(
+            f"[yellow]![/yellow] [bold]{key}[/bold] is a model provider — it is "
+            "not controlled by plugins.enabled/disabled (providers register "
+            "automatically at startup).\n"
+            "  To use it:       run [bold]hermes model[/bold] and pick it, or set "
+            "[dim]model.provider[/dim] in config.yaml.\n"
+            "  To stop using it: select a different provider; remove its API key "
+            "from ~/.hermes/.env to make it unselectable.\n"
+            "Nothing was changed."
+        )
+    else:  # exclusive
+        console.print(
+            f"[yellow]![/yellow] [bold]{key}[/bold] is an exclusive category "
+            "plugin — it is activated by its category's provider key (e.g. "
+            "[dim]memory.provider[/dim]), not by plugins.enabled/disabled.\n"
+            "Nothing was changed."
+        )
+
+
 def cmd_enable(name: str, allow_tool_override: Optional[bool] = None) -> None:
     """Add a plugin to the enabled allow-list (and remove it from disabled).
 
@@ -830,6 +881,11 @@ def cmd_enable(name: str, allow_tool_override: Optional[bool] = None) -> None:
         console.print(f"[red]Plugin '{name}' is not installed or bundled.[/red]")
         sys.exit(1)
     key, source = resolved
+
+    kind = _plugin_kind(key)
+    if kind in _PASSIVE_PLUGIN_KINDS:
+        _print_passive_kind_hint(console, key, kind)
+        return
 
     enabled = _get_enabled_set()
     disabled = _get_disabled_set()
@@ -909,6 +965,11 @@ def cmd_disable(name: str) -> None:
     if key is None:
         console.print(f"[red]Plugin '{name}' is not installed or bundled.[/red]")
         sys.exit(1)
+
+    kind = _plugin_kind(key)
+    if kind in _PASSIVE_PLUGIN_KINDS:
+        _print_passive_kind_hint(console, key, kind)
+        return
 
     enabled = _get_enabled_set()
     disabled = _get_disabled_set()

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -820,22 +820,77 @@ def _set_plugin_entry_flag(plugin_id: str, key: str, value: bool) -> None:
 _PASSIVE_PLUGIN_KINDS = {"model-provider", "exclusive"}
 
 
+def _memory_provider_names() -> set:
+    """Names of every discoverable memory provider (bundled + user-installed).
+
+    Memory providers are an ``exclusive`` category routed through the
+    ``plugins.memory`` discovery system and are deliberately skipped by
+    ``_discover_all_plugins`` (and therefore by the manifest resolver).
+    Bundled providers also typically ship WITHOUT an explicit
+    ``kind: exclusive`` in their manifest (e.g. ``plugins/memory/honcho/
+    plugin.yaml``), so asking the category's own discovery is the only
+    reliable way to recognize them.
+    """
+    try:
+        from plugins.memory import discover_memory_providers
+
+        return {name for name, _desc, _avail in discover_memory_providers()}
+    except Exception:
+        return set()
+
+
+def _match_memory_provider(name: str) -> Optional[str]:
+    """Return the memory-provider name *name* refers to, else ``None``.
+
+    Accepts a bare provider name (``honcho``) or a category-qualified key
+    (``memory/honcho``); matching is on the leaf segment.
+    """
+    providers = _memory_provider_names()
+    if not providers:
+        return None
+    if name in providers:
+        return name
+    leaf = name.split("/")[-1]
+    if leaf in providers:
+        return leaf
+    return None
+
+
 def _plugin_kind(key: str) -> str:
-    """Manifest ``kind`` for a discovered plugin key (default: ``standalone``)."""
+    """Classify *key* using the same rules the plugin loader applies.
+
+    Reuses ``PluginManager._parse_manifest`` — which folds in the
+    ``register_memory_provider`` / ``register_provider`` heuristic for
+    manifests that omit an explicit ``kind`` — instead of re-reading the raw
+    ``kind`` field, and consults ``plugins.memory`` discovery so bundled
+    memory providers (excluded from ``_discover_all_plugins`` and usually
+    lacking ``kind: exclusive``) are still recognized as passive
+    ``exclusive`` providers. Defaults to ``standalone``.
+    """
+    # Memory providers are an exclusive category handled by their own
+    # discovery, which the general scan skips. Catch them first so bundled
+    # providers without ``kind: exclusive`` aren't misread as standalone.
+    if _match_memory_provider(key):
+        return "exclusive"
+
+    from hermes_cli.plugins import get_plugin_manager
+
+    manager = get_plugin_manager()
     for entry in _discover_all_plugins():
         # entry = (name, version, description, source, dir_path, key)
         if entry[5] == key:
             d = Path(entry[4])
+            prefix = key.rsplit("/", 1)[0] if "/" in key else ""
             for fname in ("plugin.yaml", "plugin.yml"):
                 mf = d / fname
                 if mf.exists():
                     try:
-                        import yaml
-
-                        data = yaml.safe_load(mf.read_text(encoding="utf-8")) or {}
-                        return str(data.get("kind", "standalone"))
+                        manifest = manager._parse_manifest(mf, d, entry[3], prefix)
                     except Exception:
                         return "standalone"
+                    if manifest is not None:
+                        return manifest.kind
+            return "standalone"
     return "standalone"
 
 
@@ -876,6 +931,16 @@ def cmd_enable(name: str, allow_tool_override: Optional[bool] = None) -> None:
     console = Console()
     # Discover the plugin — check installed (user) AND bundled, including
     # nested category plugins — and normalize to its canonical registry key.
+    # Memory providers are an exclusive category (selected via memory.provider)
+    # and are skipped by the general resolver, so a bare `enable honcho` would
+    # otherwise fall through to a misleading "not installed" error. Intercept
+    # them here to show the same passive-kind hint the loader-classified path
+    # gives for user-installed exclusive/model-provider plugins.
+    mem = _match_memory_provider(name)
+    if mem:
+        _print_passive_kind_hint(console, mem, "exclusive")
+        return
+
     resolved = _resolve_plugin_key_and_source(name)
     if resolved is None:
         console.print(f"[red]Plugin '{name}' is not installed or bundled.[/red]")
@@ -961,6 +1026,14 @@ def cmd_disable(name: str) -> None:
     from rich.console import Console
 
     console = Console()
+    # Memory providers are skipped by the general resolver (see cmd_enable);
+    # intercept them so `disable honcho` explains memory.provider instead of
+    # failing with "not installed".
+    mem = _match_memory_provider(name)
+    if mem:
+        _print_passive_kind_hint(console, mem, "exclusive")
+        return
+
     key = _resolve_plugin_key(name)
     if key is None:
         console.print(f"[red]Plugin '{name}' is not installed or bundled.[/red]")

--- a/tests/hermes_cli/test_plugins_enable_passive_kinds.py
+++ b/tests/hermes_cli/test_plugins_enable_passive_kinds.py
@@ -1,0 +1,91 @@
+"""``hermes plugins enable/disable`` must not silently no-op on passive kinds.
+
+Model providers (``kind: model-provider``) register through
+``providers/__init__.py``'s own discovery and are selected via ``hermes model``
+/ ``model.provider``; exclusive plugins (``kind: exclusive``, e.g. memory
+providers) activate via ``<category>.provider``. The general plugin loader
+skips both kinds, so a ``plugins.enabled``/``disabled`` entry for them is dead
+config. Before this fix, ``hermes plugins enable gemini`` printed a green
+success message while changing nothing that any loader would ever read.
+"""
+import pytest
+
+
+@pytest.fixture
+def fake_plugins(tmp_path, monkeypatch):
+    """A discovery view with one plugin per kind, backed by real manifests."""
+    import hermes_cli.plugins_cmd as pc
+
+    entries = []
+    for name, kind in [
+        ("gemini", "model-provider"),
+        ("honcho", "exclusive"),
+        ("nemo_relay", "standalone"),
+    ]:
+        d = tmp_path / name
+        d.mkdir()
+        (d / "plugin.yaml").write_text(
+            f"name: {name}\nkind: {kind}\nversion: 1.0.0\n", encoding="utf-8"
+        )
+        key = f"model-providers/{name}" if kind == "model-provider" else name
+        entries.append((name, "1.0.0", "desc", "bundled", str(d), key))
+
+    monkeypatch.setattr(pc, "_discover_all_plugins", lambda: entries)
+    # config writes must land in a scratch HERMES_HOME
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import hermes_cli.config as cfg
+
+    cfg._LOAD_CONFIG_CACHE.clear()
+    cfg._RAW_CONFIG_CACHE.clear()
+    return pc
+
+
+def _enabled_disabled(pc):
+    return pc._get_enabled_set(), pc._get_disabled_set()
+
+
+def test_enable_model_provider_is_refused_with_hint(fake_plugins, capsys):
+    pc = fake_plugins
+    pc.cmd_enable("gemini")
+    out = capsys.readouterr().out
+    assert "model provider" in out
+    assert "hermes model" in out
+    assert "Nothing was changed" in out
+    enabled, disabled = _enabled_disabled(pc)
+    assert "model-providers/gemini" not in enabled
+    assert "model-providers/gemini" not in disabled
+
+
+def test_disable_model_provider_is_refused_with_hint(fake_plugins, capsys):
+    pc = fake_plugins
+    pc.cmd_disable("gemini")
+    out = capsys.readouterr().out
+    assert "model provider" in out
+    enabled, disabled = _enabled_disabled(pc)
+    assert "model-providers/gemini" not in disabled
+
+
+def test_enable_exclusive_is_refused_with_hint(fake_plugins, capsys):
+    pc = fake_plugins
+    pc.cmd_enable("honcho")
+    out = capsys.readouterr().out
+    assert "exclusive" in out
+    assert "provider" in out
+    enabled, _ = _enabled_disabled(pc)
+    assert "honcho" not in enabled
+
+
+def test_enable_standalone_still_works(fake_plugins, capsys):
+    pc = fake_plugins
+    pc.cmd_enable("nemo_relay", allow_tool_override=False)
+    out = capsys.readouterr().out
+    assert "enabled" in out
+    enabled, _ = _enabled_disabled(pc)
+    assert "nemo_relay" in enabled
+
+
+def test_plugin_kind_defaults_to_standalone(fake_plugins):
+    pc = fake_plugins
+    assert pc._plugin_kind("no-such-key") == "standalone"

--- a/tests/hermes_cli/test_plugins_enable_passive_kinds.py
+++ b/tests/hermes_cli/test_plugins_enable_passive_kinds.py
@@ -89,3 +89,103 @@ def test_enable_standalone_still_works(fake_plugins, capsys):
 def test_plugin_kind_defaults_to_standalone(fake_plugins):
     pc = fake_plugins
     assert pc._plugin_kind("no-such-key") == "standalone"
+
+
+# ---------------------------------------------------------------------------
+# Production-path coverage (not just synthetic explicit ``kind:`` manifests).
+#
+# The fixture above declares ``kind`` explicitly in each manifest. Real bundled
+# memory providers (e.g. plugins/memory/honcho/plugin.yaml) do NOT, and are
+# excluded from _discover_all_plugins() entirely; user providers rely on the
+# loader's register_memory_provider / register_provider heuristic. These tests
+# exercise both of those real paths.
+# ---------------------------------------------------------------------------
+
+
+def _scratch_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import hermes_cli.config as cfg
+
+    cfg._LOAD_CONFIG_CACHE.clear()
+    cfg._RAW_CONFIG_CACHE.clear()
+
+
+def test_bundled_memory_provider_recognized_via_memory_discovery(
+    tmp_path, monkeypatch, capsys
+):
+    """Bundled memory providers ship without ``kind: exclusive`` and are absent
+    from _discover_all_plugins(); they must still be classified exclusive via
+    plugins.memory discovery and refused (not "not installed")."""
+    import hermes_cli.plugins_cmd as pc
+    import plugins.memory as mem
+
+    # The general plugin scan does NOT surface memory providers...
+    monkeypatch.setattr(pc, "_discover_all_plugins", lambda: [])
+    # ...but the memory category's own discovery does: (name, desc, available).
+    monkeypatch.setattr(
+        mem, "discover_memory_providers", lambda: [("honcho", "Honcho memory", True)]
+    )
+
+    assert pc._plugin_kind("honcho") == "exclusive"
+    assert pc._plugin_kind("memory/honcho") == "exclusive"
+
+    _scratch_home(tmp_path, monkeypatch)
+
+    pc.cmd_enable("honcho")
+    out = capsys.readouterr().out
+    assert "exclusive" in out
+    assert "Nothing was changed" in out
+    assert "honcho" not in pc._get_enabled_set()
+
+    pc.cmd_disable("honcho")
+    out = capsys.readouterr().out
+    assert "exclusive" in out
+    assert "honcho" not in pc._get_disabled_set()
+
+
+def test_heuristic_user_memory_provider_classified_exclusive(tmp_path, monkeypatch):
+    """A user provider without explicit ``kind`` whose __init__.py registers a
+    memory provider is classified ``exclusive`` by the shared loader heuristic —
+    _plugin_kind must not fall back to ``standalone``."""
+    import hermes_cli.plugins_cmd as pc
+    import plugins.memory as mem
+
+    d = tmp_path / "mymem"
+    d.mkdir()
+    (d / "plugin.yaml").write_text("name: mymem\nversion: 1.0.0\n", encoding="utf-8")
+    (d / "__init__.py").write_text(
+        "from plugins.memory import MemoryProvider\n\n"
+        "def setup(ctx):\n"
+        "    ctx.register_memory_provider(MemoryProvider())\n",
+        encoding="utf-8",
+    )
+    entry = ("mymem", "1.0.0", "desc", "user", str(d), "providers/mymem")
+    monkeypatch.setattr(pc, "_discover_all_plugins", lambda: [entry])
+    # Force the heuristic (manifest) path, not memory discovery.
+    monkeypatch.setattr(mem, "discover_memory_providers", lambda: [])
+
+    assert pc._plugin_kind("providers/mymem") == "exclusive"
+
+
+def test_heuristic_user_model_provider_classified_model_provider(tmp_path, monkeypatch):
+    """Same shared-classification guarantee for the model-provider heuristic
+    (register_provider + ProviderProfile in __init__.py)."""
+    import hermes_cli.plugins_cmd as pc
+    import plugins.memory as mem
+
+    d = tmp_path / "myprov"
+    d.mkdir()
+    (d / "plugin.yaml").write_text("name: myprov\nversion: 1.0.0\n", encoding="utf-8")
+    (d / "__init__.py").write_text(
+        "from providers import register_provider, ProviderProfile\n\n"
+        "def setup(ctx):\n"
+        "    register_provider(ProviderProfile(name='x'))\n",
+        encoding="utf-8",
+    )
+    entry = ("myprov", "1.0.0", "desc", "user", str(d), "providers/myprov")
+    monkeypatch.setattr(pc, "_discover_all_plugins", lambda: [entry])
+    monkeypatch.setattr(mem, "discover_memory_providers", lambda: [])
+
+    assert pc._plugin_kind("providers/myprov") == "model-provider"


### PR DESCRIPTION
## What

`hermes plugins enable/disable <name>` silently did nothing for **passive** plugin kinds — kinds whose activation is controlled elsewhere, not by the enable/disable switch. The command returned success but nothing changed, leaving the user unsure why.

## Why

Passive plugin kinds (e.g. memory providers and other config-driven kinds) are switched on/off through their own config, not through `plugins enable/disable`. Invoking enable/disable on them was a no-op with no feedback. This makes the command recognize passive kinds and **refuse with a clear message pointing to the real switch**, instead of a silent no-op that looks like it worked.

## Changes

- `hermes_cli/plugins_cmd.py` — detect passive plugin kinds and refuse enable/disable with a pointer to the actual control.
- `tests/hermes_cli/test_plugins_enable_passive_kinds.py` — new coverage.

## Testing

`pytest tests/hermes_cli/test_plugins_enable_passive_kinds.py -q` -> 5 passed.

Cleanly cherry-picked onto current `main`; touches only the two files above (no unrelated changes).
