### PR TITLE
fix(raft): detect bridge child exit

### DIFF
--- a/plugins/platforms/raft/adapter.py
+++ b/plugins/platforms/raft/adapter.py
@@ -462,6 +462,7 @@ class RaftAdapter(BasePlatformAdapter):
         )
         self._runner = None
         self._bridge_process: Optional[subprocess.Popen] = None
+        self._bridge_monitor_task: Optional[asyncio.Task] = None
         self._activity_queue = ActivityQueue()
 
     @property
@@ -545,14 +546,54 @@ class RaftAdapter(BasePlatformAdapter):
         ]
         env = {**os.environ, "RAFT_CHANNEL_TOKEN": self._bridge_token}
         try:
-            self._bridge_process = subprocess.Popen(
-                cmd, env=env, stdin=subprocess.DEVNULL
+            loop = asyncio.get_running_loop()
+            proc = subprocess.Popen(cmd, env=env, stdin=subprocess.DEVNULL)
+            self._bridge_process = proc
+            self._bridge_monitor_task = loop.create_task(
+                self._monitor_bridge_process(proc)
             )
-            logger.info("[raft] Spawned bridge pid=%d profile=%s endpoint=%s", self._bridge_process.pid, profile, endpoint)
+            logger.info("[raft] Spawned bridge pid=%d profile=%s endpoint=%s", proc.pid, profile, endpoint)
         except Exception:
+            self._bridge_process = None
             logger.exception("[raft] Failed to spawn bridge")
 
+    async def _monitor_bridge_process(self, proc: subprocess.Popen) -> None:
+        try:
+            returncode = await asyncio.to_thread(proc.wait)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            if self._bridge_process is not proc:
+                return
+            self._bridge_process = None
+            message = f"Raft bridge monitor failed: {exc}"
+            logger.exception("[raft] %s", message)
+            self._set_fatal_error("raft_bridge_monitor_error", message, retryable=True)
+            await self._notify_fatal_error()
+            return
+        finally:
+            if self._bridge_monitor_task is asyncio.current_task():
+                self._bridge_monitor_task = None
+
+        if self._bridge_process is not proc:
+            return
+        self._bridge_process = None
+
+        if not self._running:
+            logger.debug("[raft] Bridge process exited during shutdown (pid=%d code=%s)", proc.pid, returncode)
+            return
+
+        message = f"Raft bridge exited unexpectedly with status {returncode}"
+        logger.error("[raft] %s (pid=%d)", message, proc.pid)
+        self._set_fatal_error("raft_bridge_exited", message, retryable=True)
+        await self._notify_fatal_error()
+
     def _stop_bridge(self) -> None:
+        monitor = self._bridge_monitor_task
+        if monitor is not None:
+            monitor.cancel()
+            self._bridge_monitor_task = None
+
         proc = self._bridge_process
         if proc is None:
             return

--- a/tests/gateway/test_raft_adapter.py
+++ b/tests/gateway/test_raft_adapter.py
@@ -81,6 +81,21 @@ def _activity_event(event_id: str, **overrides):
     return event
 
 
+class _ExitedBridgeProc:
+    def __init__(self, returncode: int = 1, pid: int = 1234):
+        self.pid = pid
+        self.returncode = returncode
+
+    def wait(self, timeout=None):
+        return self.returncode
+
+    def terminate(self):
+        return None
+
+    def kill(self):
+        return None
+
+
 class TestRaftWakePayload:
     def test_detects_content_fields(self):
         assert _has_content_field({"text": "hello"}) is True
@@ -117,6 +132,57 @@ class TestRaftWakeHttp:
 
         assert body == {"ok": False, "error": "content_not_allowed"}
         adapter.handle_message.assert_not_called()
+
+
+class TestRaftBridgeSupervision:
+    @pytest.mark.asyncio
+    async def test_bridge_exit_marks_retryable_fatal(self):
+        adapter = _make_adapter()
+        proc = _ExitedBridgeProc(returncode=7)
+        fatal_handler = AsyncMock()
+        adapter.set_fatal_error_handler(fatal_handler)
+        adapter._running = True
+        adapter._bridge_process = proc
+
+        await adapter._monitor_bridge_process(proc)
+
+        assert adapter._bridge_process is None
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_code == "raft_bridge_exited"
+        assert adapter.fatal_error_retryable is True
+        assert "status 7" in (adapter.fatal_error_message or "")
+        fatal_handler.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_planned_shutdown_bridge_exit_is_not_fatal(self):
+        adapter = _make_adapter()
+        proc = _ExitedBridgeProc(returncode=0)
+        fatal_handler = AsyncMock()
+        adapter.set_fatal_error_handler(fatal_handler)
+        adapter._running = False
+        adapter._bridge_process = proc
+
+        await adapter._monitor_bridge_process(proc)
+
+        assert adapter._bridge_process is None
+        assert adapter.has_fatal_error is False
+        fatal_handler.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_stale_bridge_monitor_does_not_mark_fatal(self):
+        adapter = _make_adapter()
+        old_proc = _ExitedBridgeProc(returncode=1, pid=111)
+        new_proc = _ExitedBridgeProc(returncode=0, pid=222)
+        fatal_handler = AsyncMock()
+        adapter.set_fatal_error_handler(fatal_handler)
+        adapter._running = True
+        adapter._bridge_process = new_proc
+
+        await adapter._monitor_bridge_process(old_proc)
+
+        assert adapter._bridge_process is new_proc
+        assert adapter.has_fatal_error is False
+        fatal_handler.assert_not_awaited()
 
 
 class TestRaftActivityHttp:


### PR DESCRIPTION
## Summary
- supervise the raft agent bridge subprocess after it is spawned
- mark the Raft adapter as retryable fatal when the bridge exits unexpectedly
- cancel the monitor during planned shutdown and ignore stale monitor completions from older bridge processes

Fixes #59046

## Validation
- uv run python -m pytest tests/gateway/test_raft_adapter.py -q
- uv run python -m pytest tests/gateway/test_platform_reconnect.py -q -k RuntimeDisconnectQueuing
- uv run ruff check plugins/platforms/raft/adapter.py tests/gateway/test_raft_adapter.py
- git diff --check