### PR TITLE
fix(update): treat no-op backend updates as success

### DIFF
--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -537,6 +537,32 @@ describe('applyBackendUpdate recovery', () => {
     await promise
   })
 
+  it('treats a successful no-op backend update as complete without waiting for a restart', async () => {
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'update', pid: 1 })
+    getActionStatusSpy.mockResolvedValue({
+      exit_code: 0,
+      lines: [
+        'old action line',
+        '=== hermes-update started 2026-07-05 14:48:39 ===',
+        '⚕ Updating Hermes Agent...',
+        '→ Fetching updates...',
+        '✓ Already up to date!',
+        '✓ Update complete!'
+      ],
+      name: 'update',
+      pid: 1,
+      running: false
+    })
+    checkHermesUpdateSpy.mockRejectedValue(new Error('ECONNREFUSED'))
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(1500)
+    const result = await promise
+
+    expect(result.ok).toBe(true)
+    expect($backendUpdateApply.get().stage).toBe('idle')
+  })
+
   it('surfaces an error when the backend never comes back after the restart', async () => {
     updateHermesSpy.mockResolvedValue({ ok: true, name: 'update', pid: 1 })
     getActionStatusSpy.mockRejectedValue(new Error('ECONNREFUSED'))

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -563,6 +563,58 @@ describe('applyBackendUpdate recovery', () => {
     expect($backendUpdateApply.get().stage).toBe('idle')
   })
 
+  it('treats a successful dependency repair as complete without waiting for a restart', async () => {
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'update', pid: 1 })
+    getActionStatusSpy.mockResolvedValue({
+      exit_code: 0,
+      lines: [
+        '=== hermes-update started 2026-07-05 14:48:39 ===',
+        '⚠ Checkout is current, but the venv is unhealthy:',
+        '✓ Dependencies repaired!',
+        '✓ Update complete!'
+      ],
+      name: 'update',
+      pid: 1,
+      running: false
+    })
+    checkHermesUpdateSpy.mockRejectedValue(new Error('ECONNREFUSED'))
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(1500)
+    const result = await promise
+
+    expect(result.ok).toBe(true)
+    expect(checkHermesUpdateSpy).not.toHaveBeenCalled()
+    expect($backendUpdateApply.get().stage).toBe('idle')
+  })
+
+  it('does not classify stale no-op output without the current action marker', async () => {
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'update', pid: 1 })
+    getActionStatusSpy.mockResolvedValue({
+      exit_code: 0,
+      lines: ['✓ Already up to date!', '✓ Update complete!'],
+      name: 'update',
+      pid: 1,
+      running: false
+    })
+    checkHermesUpdateSpy.mockResolvedValue({
+      install_method: 'git',
+      current_version: '0.16.0',
+      behind: 0,
+      update_available: false,
+      can_apply: true,
+      update_command: 'hermes update',
+      message: null
+    })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(6500)
+    const result = await promise
+
+    expect(result.ok).toBe(true)
+    expect(checkHermesUpdateSpy).toHaveBeenCalled()
+  })
+
   it('surfaces an error when the backend never comes back after the restart', async () => {
     updateHermesSpy.mockResolvedValue({ ok: true, name: 'update', pid: 1 })
     getActionStatusSpy.mockRejectedValue(new Error('ECONNREFUSED'))

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -555,15 +555,23 @@ function currentBackendUpdateLines(status: Awaited<ReturnType<typeof getActionSt
 
     if (line.includes('=== hermes-update started') || line.includes('=== hermes update started')) {
       start = i
+
       break
     }
   }
 
-  return start >= 0 ? status.lines.slice(start + 1) : status.lines
+  // Action status buffers can contain output from an older command. Without
+  // the current update marker, none of those lines are safe to classify.
+  return start >= 0 ? status.lines.slice(start + 1) : []
 }
 
-function isNoopBackendUpdate(status: Awaited<ReturnType<typeof getActionStatus>>): boolean {
-  return status.exit_code === 0 && currentBackendUpdateLines(status).some(line => line.includes('Already up to date'))
+function didBackendUpdateCompleteWithoutRestart(status: Awaited<ReturnType<typeof getActionStatus>>): boolean {
+  return (
+    status.exit_code === 0 &&
+    currentBackendUpdateLines(status).some(
+      line => line.includes('Already up to date') || line.includes('Dependencies repaired')
+    )
+  )
 }
 
 export async function applyBackendUpdate(): Promise<DesktopUpdateApplyResult> {
@@ -621,7 +629,7 @@ export async function applyBackendUpdate(): Promise<DesktopUpdateApplyResult> {
     const ok = !!last && (last.exit_code ?? 1) === 0
 
     if (ok) {
-      if (last && isNoopBackendUpdate(last)) {
+      if (last && didBackendUpdateCompleteWithoutRestart(last)) {
         return finishBackendApply(true)
       }
 

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -547,6 +547,25 @@ function ingestBackendActionStatus(status: Awaited<ReturnType<typeof getActionSt
   })
 }
 
+function currentBackendUpdateLines(status: Awaited<ReturnType<typeof getActionStatus>>): string[] {
+  let start = -1
+
+  for (let i = status.lines.length - 1; i >= 0; i -= 1) {
+    const line = status.lines[i] ?? ''
+
+    if (line.includes('=== hermes-update started') || line.includes('=== hermes update started')) {
+      start = i
+      break
+    }
+  }
+
+  return start >= 0 ? status.lines.slice(start + 1) : status.lines
+}
+
+function isNoopBackendUpdate(status: Awaited<ReturnType<typeof getActionStatus>>): boolean {
+  return status.exit_code === 0 && currentBackendUpdateLines(status).some(line => line.includes('Already up to date'))
+}
+
 export async function applyBackendUpdate(): Promise<DesktopUpdateApplyResult> {
   dismissNotification(UPDATE_TOAST_ID)
   $backendUpdateApply.set({
@@ -602,6 +621,10 @@ export async function applyBackendUpdate(): Promise<DesktopUpdateApplyResult> {
     const ok = !!last && (last.exit_code ?? 1) === 0
 
     if (ok) {
+      if (last && isNoopBackendUpdate(last)) {
+        return finishBackendApply(true)
+      }
+
       $backendUpdateApply.set({
         ...$backendUpdateApply.get(),
         applying: true,

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3919,6 +3919,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 healthy_after, detail_after = _venv_core_imports_healthy()
                 if healthy_after:
                     print("✓ Dependencies repaired!")
+                    if not runtime_restart_required:
+                        print("✓ Update complete!")
                 else:
                     print(f"⚠ Venv still unhealthy after repair: {detail_after}")
                     print("  Close all Hermes windows/gateways and re-run: hermes update")

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3871,6 +3871,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 (result for result in runtime_repairs if result.repaired),
                 None,
             )
+            runtime_restart_required = (
+                runtime_repaired is not None and not _m()._is_windows()
+            )
 
             # A current checkout does NOT imply a healthy install: a previous
             # dependency sync may have failed partway (classic on Windows,
@@ -3921,7 +3924,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     print("  Close all Hermes windows/gateways and re-run: hermes update")
             else:
                 print("✓ Already up to date!")
-            if runtime_repaired is not None and not _m()._is_windows():
+                if not runtime_restart_required:
+                    print("✓ Update complete!")
+            if runtime_restart_required:
                 print()
                 print(
                     "⚠ Restart required to finish the managed Python runtime repair."

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -201,6 +201,74 @@ class TestCmdUpdateTermuxUvBootstrap:
 class TestCmdUpdateBranchFallback:
     """cmd_update falls back to main when current branch has no remote counterpart."""
 
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_update_already_up_to_date(
+        self, mock_run, _mock_which, mock_args, capsys
+    ):
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="0"
+        )
+
+        with patch("hermes_cli.managed_uv.update_managed_uv") as mock_uv_update, \
+             patch(
+                 "hermes_cli.managed_uv.ensure_uv",
+                 return_value=None,
+             ) as mock_uv_ensure:
+            cmd_update(mock_args)
+
+        captured = capsys.readouterr()
+        assert "Already up to date!" in captured.out
+        assert "Update complete!" in captured.out
+        update_observer = mock_uv_update.call_args.kwargs["repair_observer"]
+        ensure_observer = mock_uv_ensure.call_args.kwargs["repair_observer"]
+        assert update_observer.__self__ is ensure_observer.__self__
+        assert update_observer.__self__ == []
+
+        commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
+        pull_cmds = [c for c in commands if "pull" in c or "merge --ff-only" in c]
+        assert len(pull_cmds) == 0
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_zero_commit_runtime_repair_requires_process_restart(
+        self, mock_run, _mock_which, mock_args, capsys, tmp_path
+    ):
+        from hermes_cli.managed_uv import RuntimeRepairResult
+
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="0"
+        )
+        backup = tmp_path / "venv.stale.runtime-test"
+        repair = RuntimeRepairResult(
+            "repaired",
+            sqlite_before="3.50.4",
+            sqlite_after="3.53.1",
+            backup_venv=backup,
+        )
+
+        def fake_update(*, repair_observer):
+            repair_observer(repair)
+            return "/managed/uv"
+
+        with patch(
+            "hermes_cli.managed_uv.update_managed_uv",
+            side_effect=fake_update,
+        ), patch(
+            "hermes_cli.managed_uv.ensure_uv",
+            return_value="/managed/uv",
+        ), patch(
+            "hermes_cli.main._is_windows",
+            return_value=False,
+        ):
+            cmd_update(mock_args)
+
+        captured = capsys.readouterr()
+        assert "Restart required to finish the managed Python runtime repair" in captured.out
+        assert "long-lived processes still use the previous runtime" in captured.out
+        assert str(backup) in captured.out
+        assert "Update complete!" not in captured.out
+
 
 
 

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -266,7 +266,7 @@ class TestCmdUpdateBranchFallback:
         captured = capsys.readouterr()
         assert "Restart required to finish the managed Python runtime repair" in captured.out
         assert "long-lived processes still use the previous runtime" in captured.out
-        assert str(backup) in captured.out
+        assert "Restart each of them to pick up the repaired runtime" in captured.out
         assert "Update complete!" not in captured.out
 
 


### PR DESCRIPTION
## Summary

- emit `✓ Update complete!` when a current checkout exits through the healthy no-op path or successfully repairs dependencies without requiring a managed-runtime restart
- let Desktop recognize an exited-0, no-restart completion only inside the current `hermes-update` action block
- fail closed when the current action marker is absent, so stale buffered output cannot be misclassified
- preserve the restart-required path for non-Windows managed-runtime repair

Fixes #58764

## Validation

- `pytest tests/hermes_cli/test_cmd_update.py -q` — 52 passed
- `ruff check hermes_cli/update_cmd.py tests/hermes_cli/test_cmd_update.py`
- from `apps/desktop`: `npm test -- --run src/store/updates.test.ts` — 33 passed
- from `apps/desktop`: `npm run typecheck`
- from `apps/desktop`: `npx prettier --check src/store/updates.ts src/store/updates.test.ts`
- `git diff --check`