### PR TITLE
fix(config): preserve model.context_length on same-model re-pick

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1073,6 +1073,7 @@ def _apply_main_model_assignment(
     if not isinstance(model_cfg, dict):
         model_cfg = {}
     prev_provider = str(model_cfg.get("provider") or "").strip().lower()
+    prev_model = str(model_cfg.get("default") or "").strip()
     new_provider = provider.strip().lower()
     model_cfg["provider"] = provider
     model_cfg["default"] = model
@@ -1094,7 +1095,12 @@ def _apply_main_model_assignment(
         clear_model_endpoint_credentials(model_cfg, clear_api_mode=False)
     if new_provider != prev_provider:
         clear_model_endpoint_credentials(model_cfg, clear_api_key=False)
-    model_cfg.pop("context_length", None)
+    # Preserve context_length on a same-model/same-provider re-pick so
+    # re-selecting a model in the dashboard doesn't silently drop a user's
+    # manually-set override.  Only clear it when the model or provider
+    # actually changed — the new model may have a different context window.
+    if new_provider != prev_provider or model != prev_model:
+        model_cfg.pop("context_length", None)
     return model_cfg
 
 


### PR DESCRIPTION
Closes #59050

`_apply_main_model_assignment()` unconditionally drops `context_length`
on every call, even when the model and provider are unchanged.  For
self-hosted OpenAI-compatible endpoints, auto-detection is unreliable
and the lost override leaves users with a wrong context window.

This captures `prev_model` before overwriting it and only pops
`context_length` when the model or provider actually changed, mirroring
the same-provider preserve behavior already used for `base_url` and
`api_key` in the same function.

Changes:
- `hermes_cli/web_server.py:_apply_main_model_assignment()`