### PR TITLE
fix(patch): normalize newline escapes in fuzzy replacements

### DIFF
--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -563,8 +563,8 @@ class TestEscapeNormalizedNewString:
 
     The fix unescapes ``\\t`` -> tab and ``\\r`` -> CR in new_string when
     the matched file region actually contains those control characters,
-    regardless of which match strategy fired. ``\\n`` is excluded because
-    newlines serialize correctly through JSON.
+    regardless of which match strategy fired. ``\\n`` is only unescaped when
+    escape-normalized matching proved old_string needed the same conversion.
     """
 
     def test_tab_in_new_string_unescaped_under_escape_normalized(self):
@@ -626,6 +626,34 @@ class TestEscapeNormalizedNewString:
         # And there should be no real newline added where ``\\n`` sat.
         assert "alpha\nbeta" not in new
 
+    def test_newline_in_new_string_unescaped_under_escape_normalized(self):
+        content = "line1\nline2\nline3\n"
+        old_string = "line1\\nline2"
+        new_string = "lineA\\nlineB"
+
+        new, count, strategy, err = fuzzy_find_and_replace(content, old_string, new_string)
+
+        assert err is None, f"Unexpected error: {err}"
+        assert count == 1
+        assert strategy == "escape_normalized"
+        assert new == "lineA\nlineB\nline3\n"
+
+    def test_tab_only_escape_normalized_preserves_literal_newline_escape(self):
+        """If only tabs caused escape-normalized matching, source string
+        literals containing ``\\n`` must not be converted to real newlines.
+        """
+        content = 'def f():\n\tvalue = "old"\n\treturn value\n'
+        old_string = 'def f():\n\\tvalue = "old"\n\\treturn value\n'
+        new_string = 'def f():\n\\tvalue = "line1\\nline2"\n\\treturn value\n'
+
+        new, count, strategy, err = fuzzy_find_and_replace(content, old_string, new_string)
+
+        assert err is None, f"Unexpected error: {err}"
+        assert count == 1
+        assert strategy == "escape_normalized"
+        assert '\tvalue = "line1\\nline2"' in new
+        assert '"line1\nline2"' not in new
+
     def test_mixed_tab_and_newline_only_tab_unescaped(self):
         """When new_string contains both \\t and \\n, only \\t is converted."""
         content = "def foo():\n\tpass\n"
@@ -665,4 +693,3 @@ class TestEscapeNormalizedNewString:
         assert err is None
         assert count == 1
         assert "return 2" in new
-

--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -654,6 +654,60 @@ class TestEscapeNormalizedNewString:
         assert '\tvalue = "line1\\nline2"' in new
         assert '"line1\nline2"' not in new
 
+    def test_newline_escape_match_preserves_inserted_string_literal_escape(self):
+        """Structural ``\\n`` separators are unescaped, but inserted string
+        literal escapes remain literal.
+        """
+        content = 'def f():\n    value = "old"\n    return value\n'
+        old_string = 'def f():\\n    value = "old"\\n    return value\\n'
+        new_string = 'def f():\\n    value = "line1\\nline2"\\n    return value\\n'
+
+        new, count, strategy, err = fuzzy_find_and_replace(content, old_string, new_string)
+
+        assert err is None, f"Unexpected error: {err}"
+        assert count == 1
+        assert strategy == "escape_normalized"
+        assert new == 'def f():\n    value = "line1\\nline2"\n    return value\n'
+        assert '"line1\nline2"' not in new
+
+    def test_newline_escape_after_word_apostrophe_is_structural(self):
+        content = "It's fine\nsecond\n"
+        old_string = "It's fine\\nsecond"
+        new_string = "It's great\\nsecond"
+
+        new, count, strategy, err = fuzzy_find_and_replace(content, old_string, new_string)
+
+        assert err is None, f"Unexpected error: {err}"
+        assert count == 1
+        assert strategy == "escape_normalized"
+        assert new == "It's great\nsecond\n"
+        assert "great\\nsecond" not in new
+
+    def test_newline_escape_after_unbalanced_apostrophe_is_structural(self):
+        content = "don't forget\nsecond line\n"
+        old_string = "don't forget\\nsecond line"
+        new_string = "don't forget\\nsecond line updated"
+
+        new, count, strategy, err = fuzzy_find_and_replace(content, old_string, new_string)
+
+        assert err is None, f"Unexpected error: {err}"
+        assert count == 1
+        assert strategy == "escape_normalized"
+        assert new == "don't forget\nsecond line updated\n"
+        assert "forget\\nsecond" not in new
+
+    def test_unbalanced_quote_does_not_protect_later_newline_escape(self):
+        content = 'quote starts here\nnext line\n'
+        old_string = 'quote starts here\\nnext line'
+        new_string = '"quote starts here\\nnext line'
+
+        new, count, strategy, err = fuzzy_find_and_replace(content, old_string, new_string)
+
+        assert err is None, f"Unexpected error: {err}"
+        assert count == 1
+        assert strategy == "escape_normalized"
+        assert new == '"quote starts here\nnext line\n'
+
     def test_mixed_tab_and_newline_only_tab_unescaped(self):
         """When new_string contains both \\t and \\n, only \\t is converted."""
         content = "def foo():\n\tpass\n"

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -128,11 +128,19 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
             # untouched — those files have a backslash+t in the matched
             # region, not a real tab, so we leave new_string alone.
             #
-            # ``\n`` is intentionally excluded: newlines serialize correctly
-            # through JSON, and rewriting backslash-n would mangle escape
-            # sequences in source code constants far more often than help.
+            # ``\n`` is only unescaped when the escape-normalized strategy
+            # matched because old_string's newline escapes were needed.
+            # Escape-normalized also handles tabs/CRs; treating every
+            # escape-normalized multiline match as permission to rewrite
+            # backslash-n would corrupt source-code string literals.
             effective_new = _maybe_unescape_new_string(
                 new_string, content, matches,
+                unescape_newlines=(
+                    strategy_name == "escape_normalized"
+                    and _escape_normalized_used_newline_escape(
+                        content, old_string, matches,
+                    )
+                ),
             )
             # Unicode-preservation guard: when strategy 7 (unicode_normalized)
             # matched, the file has Unicode characters (em-dashes, smart quotes,
@@ -282,8 +290,10 @@ def _reindent_replacement(file_region: str, old_string: str, new_string: str) ->
 
 def _maybe_unescape_new_string(new_string: str,
                                content: str,
-                               matches: List[Tuple[int, int]]) -> str:
-    """Conditionally unescape ``\\t``/``\\r`` in new_string.
+                               matches: List[Tuple[int, int]],
+                               *,
+                               unescape_newlines: bool = False) -> str:
+    """Conditionally unescape common control sequences in new_string.
 
     LLMs frequently send the two-character sequences ``\\t`` (backslash + t)
     and ``\\r`` (backslash + r) inside JSON tool-call arguments where they
@@ -298,22 +308,47 @@ def _maybe_unescape_new_string(new_string: str,
     ``sep = "\\t"``) get a backslash+t in the matched region instead of a
     tab, so we leave new_string alone.
 
-    ``\\n`` is intentionally excluded: newlines serialize correctly through
-    JSON and rewriting backslash-n would corrupt escape sequences in
+    ``\\n`` is only unescaped when the caller knows the matching strategy
+    unescaped ``old_string`` the same way. Rewriting backslash-n for exact or
+    unrelated fuzzy matches would corrupt source-code escape sequences in
     string literals far more often than it would help.
     """
     # Cheap pre-check — bail out unless new_string actually contains one of
     # the suspect sequences. Keeps the common case free.
-    if "\\t" not in new_string and "\\r" not in new_string:
+    if (
+        "\\t" not in new_string
+        and "\\r" not in new_string
+        and (not unescape_newlines or "\\n" not in new_string)
+    ):
         return new_string
 
     matched_regions = "".join(content[start:end] for start, end in matches)
     out = new_string
+    if unescape_newlines and "\\n" in out and "\n" in matched_regions:
+        out = out.replace("\\n", "\n")
     if "\\t" in out and "\t" in matched_regions:
         out = out.replace("\\t", "\t")
     if "\\r" in out and "\r" in matched_regions:
         out = out.replace("\\r", "\r")
     return out
+
+
+def _escape_normalized_used_newline_escape(
+    content: str,
+    pattern: str,
+    matches: List[Tuple[int, int]],
+) -> bool:
+    """Return True when escape-normalized matching needed ``\\n`` conversion."""
+    if "\\n" not in pattern:
+        return False
+
+    pattern_without_newline_unescape = (
+        pattern.replace("\\t", "\t").replace("\\r", "\r")
+    )
+    matches_without_newline_unescape = set(
+        _strategy_exact(content, pattern_without_newline_unescape)
+    )
+    return bool(set(matches) - matches_without_newline_unescape)
 
 
 def _preserve_unicode_in_replacement(

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -309,9 +309,9 @@ def _maybe_unescape_new_string(new_string: str,
     tab, so we leave new_string alone.
 
     ``\\n`` is only unescaped when the caller knows the matching strategy
-    unescaped ``old_string`` the same way. Rewriting backslash-n for exact or
-    unrelated fuzzy matches would corrupt source-code escape sequences in
-    string literals far more often than it would help.
+    needed newline escape conversion for ``old_string``. Even then, only
+    backslash-n sequences outside quoted string literals are converted; literal
+    source escapes such as ``"line1\\nline2"`` must survive.
     """
     # Cheap pre-check — bail out unless new_string actually contains one of
     # the suspect sequences. Keeps the common case free.
@@ -325,12 +325,90 @@ def _maybe_unescape_new_string(new_string: str,
     matched_regions = "".join(content[start:end] for start, end in matches)
     out = new_string
     if unescape_newlines and "\\n" in out and "\n" in matched_regions:
-        out = out.replace("\\n", "\n")
+        out = _unescape_newlines_outside_quotes(out)
     if "\\t" in out and "\t" in matched_regions:
         out = out.replace("\\t", "\t")
     if "\\r" in out and "\r" in matched_regions:
         out = out.replace("\\r", "\r")
     return out
+
+
+def _unescape_newlines_outside_quotes(value: str) -> str:
+    """Convert structural ``\\n`` separators while preserving string literals.
+
+    This is a heuristic for replacement text, not a full language parser:
+    only balanced quote spans are protected, apostrophes inside words do not
+    start single-quoted spans, and unbalanced quotes are treated as ordinary
+    text so one stray quote cannot suppress later structural newline fixes.
+    """
+    protected_spans = _balanced_quote_spans(value)
+    out: List[str] = []
+    i = 0
+    span_idx = 0
+    while i < len(value):
+        if (
+            span_idx < len(protected_spans)
+            and i == protected_spans[span_idx][0]
+        ):
+            start, end = protected_spans[span_idx]
+            out.append(value[start:end])
+            i = end
+            span_idx += 1
+            continue
+
+        ch = value[i]
+        nxt = value[i + 1] if i + 1 < len(value) else ""
+
+        if ch == "\\" and nxt == "n":
+            out.append("\n")
+            i += 2
+            continue
+
+        out.append(ch)
+        i += 1
+
+    return "".join(out)
+
+
+def _balanced_quote_spans(value: str) -> List[Tuple[int, int]]:
+    """Return balanced single/double-quoted spans to leave untouched."""
+    spans: List[Tuple[int, int]] = []
+    i = 0
+    while i < len(value):
+        quote = value[i]
+        if quote not in {"'", '"'} or _is_word_apostrophe(value, i):
+            i += 1
+            continue
+
+        start = i
+        i += 1
+        while i < len(value):
+            ch = value[i]
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == quote:
+                spans.append((start, i + 1))
+                i += 1
+                break
+            i += 1
+        else:
+            # No closing quote: do not protect the rest of the replacement.
+            # Resume after the opener so later balanced spans can still count.
+            i = start + 1
+
+    return spans
+
+
+def _is_word_apostrophe(value: str, index: int) -> bool:
+    """Return True for apostrophes in words like ``It's`` or ``don't``."""
+    return (
+        value[index] == "'"
+        and index > 0
+        and index + 1 < len(value)
+        and value[index - 1].isalnum()
+        and value[index + 1].isalnum()
+    )
 
 
 def _escape_normalized_used_newline_escape(


### PR DESCRIPTION
## What does this PR do?

Fixes the escape-normalized fuzzy replacement path so a patch can match multiline content sent with literal `\n` escapes and write the replacement with real structural newlines instead of literal backslash-n text.

Exact-match replacements still preserve literal `\n` sequences. For escape-normalized matches, newline unescaping is limited to structural separators: balanced quoted spans such as `"line1\nline2"` are preserved, word apostrophes like `It's` / `don't` do not suppress structural newline conversion, and unbalanced quotes are documented as ordinary text so one stray quote cannot leave later `\n` escapes literal.

## Related Issue

Closes #59188.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `tools/fuzzy_match.py`: pass strategy context into `_maybe_unescape_new_string()` and unescape `\n` only for `escape_normalized` matches that needed newline escape conversion.
- `tools/fuzzy_match.py`: preserve balanced quoted string-literal escapes while treating word apostrophes and unbalanced quotes as ordinary replacement text.
- `tests/tools/test_fuzzy_match.py`: add regression coverage for structural newline replacement, quoted literal preservation, word apostrophes (`It's`, `don't`), and unbalanced quotes.

## How to Test

```bash
scripts/run_tests.sh tests/tools/test_fuzzy_match.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] `cli-config.yaml.example` update: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A
- [x] Cross-platform impact considered: pure Python string handling
- [x] Tool descriptions/schemas update: N/A

## Screenshots / Logs

N/A.
