### PR TITLE
[codex] Fix Bengali shaping in dashboard chat

### DIFF
--- a/web/src/lib/bengali-shaping.test.ts
+++ b/web/src/lib/bengali-shaping.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  type CharacterJoinRange,
+  DASHBOARD_CHAT_TERMINAL_FONT_FAMILY,
+  getBengaliCharacterJoinRanges,
+  registerBengaliCharacterJoiner,
+} from "./bengali-shaping";
+
+describe("DASHBOARD_CHAT_TERMINAL_FONT_FAMILY", () => {
+  it("keeps Bengali-capable fonts ahead of generic monospace fallback", () => {
+    expect(DASHBOARD_CHAT_TERMINAL_FONT_FAMILY).toContain(
+      "'Noto Sans Bengali'",
+    );
+    expect(
+      DASHBOARD_CHAT_TERMINAL_FONT_FAMILY.indexOf("'Noto Sans Bengali'"),
+    ).toBeLessThan(DASHBOARD_CHAT_TERMINAL_FONT_FAMILY.indexOf("monospace"));
+  });
+});
+
+describe("getBengaliCharacterJoinRanges", () => {
+  it("joins Bengali conjunct samples as script runs", () => {
+    const text =
+      "প্রযুক্তি ক্লিপবোর্ড যুক্তাক্ষর শ্রদ্ধা কর্তৃপক্ষ";
+
+    const joined = getBengaliCharacterJoinRanges(text).map(([start, end]) =>
+      text.slice(start, end),
+    );
+
+    expect(joined).toEqual([
+      "প্রযুক্তি",
+      "ক্লিপবোর্ড",
+      "যুক্তাক্ষর",
+      "শ্রদ্ধা",
+      "কর্তৃপক্ষ",
+    ]);
+  });
+
+  it("does not join Latin text or isolated Bengali characters", () => {
+    const text = "run ক test বাংলা";
+
+    const joined = getBengaliCharacterJoinRanges(text).map(([start, end]) =>
+      text.slice(start, end),
+    );
+
+    expect(joined).toEqual(["বাংলা"]);
+  });
+});
+
+describe("registerBengaliCharacterJoiner", () => {
+  it("registers and deregisters the Bengali joiner", () => {
+    let registeredHandler: (text: string) => CharacterJoinRange[] = () => [];
+    const term = {
+      registerCharacterJoiner: vi.fn(
+        (handler: (text: string) => CharacterJoinRange[]) => {
+          registeredHandler = handler;
+          return 17;
+        },
+      ),
+      deregisterCharacterJoiner: vi.fn(),
+    };
+
+    const dispose = registerBengaliCharacterJoiner(term);
+
+    expect(registeredHandler("প্রযুক্তি")).toEqual([
+      [0, "প্রযুক্তি".length],
+    ]);
+
+    dispose();
+
+    expect(term.deregisterCharacterJoiner).toHaveBeenCalledWith(17);
+  });
+});

--- a/web/src/lib/bengali-shaping.test.ts
+++ b/web/src/lib/bengali-shaping.test.ts
@@ -19,7 +19,7 @@ describe("DASHBOARD_CHAT_TERMINAL_FONT_FAMILY", () => {
 });
 
 describe("getBengaliCharacterJoinRanges", () => {
-  it("joins Bengali conjunct samples as script runs", () => {
+  it("joins only conjunct clusters within Bengali words", () => {
     const text =
       "প্রযুক্তি ক্লিপবোর্ড যুক্তাক্ষর শ্রদ্ধা কর্তৃপক্ষ";
 
@@ -28,22 +28,37 @@ describe("getBengaliCharacterJoinRanges", () => {
     );
 
     expect(joined).toEqual([
-      "প্রযুক্তি",
-      "ক্লিপবোর্ড",
-      "যুক্তাক্ষর",
-      "শ্রদ্ধা",
-      "কর্তৃপক্ষ",
+      "প্র",
+      "ক্তি",
+      "ক্লি",
+      "র্ড",
+      "ক্তা",
+      "ক্ষ",
+      "শ্র",
+      "দ্ধা",
+      "র্তৃ",
+      "ক্ষ",
     ]);
   });
 
-  it("does not join Latin text or isolated Bengali characters", () => {
+  it("does not join Latin text or Bengali text without a conjunct", () => {
     const text = "run ক test বাংলা";
 
     const joined = getBengaliCharacterJoinRanges(text).map(([start, end]) =>
       text.slice(start, end),
     );
 
-    expect(joined).toEqual(["বাংলা"]);
+    expect(joined).toEqual([]);
+  });
+
+  it("keeps long Bengali runs split at conjunct boundaries", () => {
+    const text = "বাংলাপ্রযুক্তিবাংলাক্লিপবোর্ডবাংলা";
+
+    const joined = getBengaliCharacterJoinRanges(text).map(([start, end]) =>
+      text.slice(start, end),
+    );
+
+    expect(joined).toEqual(["প্র", "ক্তি", "ক্লি", "র্ড"]);
   });
 });
 
@@ -63,7 +78,8 @@ describe("registerBengaliCharacterJoiner", () => {
     const dispose = registerBengaliCharacterJoiner(term);
 
     expect(registeredHandler("প্রযুক্তি")).toEqual([
-      [0, "প্রযুক্তি".length],
+      [0, "প্র".length],
+      [5, "প্রযুক্তি".length],
     ]);
 
     dispose();

--- a/web/src/lib/bengali-shaping.ts
+++ b/web/src/lib/bengali-shaping.ts
@@ -1,0 +1,57 @@
+export type CharacterJoinRange = [number, number];
+
+interface CharacterJoinerTerminal {
+  registerCharacterJoiner(
+    handler: (text: string) => CharacterJoinRange[],
+  ): number;
+  deregisterCharacterJoiner(joinerId: number): void;
+}
+
+const BENGALI_BLOCK_RE = /[\u0980-\u09ff]/u;
+const BENGALI_JOINABLE_RUN_RE = /[\u0980-\u09ff\u200c\u200d]+/gu;
+
+export const DASHBOARD_CHAT_TERMINAL_FONT_FAMILY = [
+  "'JetBrains Mono'",
+  "'Noto Sans Bengali'",
+  "'Noto Serif Bengali'",
+  "'Nirmala UI'",
+  "'Bangla Sangam MN'",
+  "'Bangla MN'",
+  "'Kohinoor Bangla'",
+  "'Vrinda'",
+  "'Mukti'",
+  "'SolaimanLipi'",
+  "'Cascadia Mono'",
+  "'Fira Code'",
+  "'MesloLGS NF'",
+  "'Source Code Pro'",
+  "Menlo",
+  "Consolas",
+  "'DejaVu Sans Mono'",
+  "monospace",
+].join(", ");
+
+export function getBengaliCharacterJoinRanges(
+  text: string,
+): CharacterJoinRange[] {
+  const ranges: CharacterJoinRange[] = [];
+
+  for (const match of text.matchAll(BENGALI_JOINABLE_RUN_RE)) {
+    const value = match[0];
+    if (value.length <= 1 || !BENGALI_BLOCK_RE.test(value)) {
+      continue;
+    }
+
+    const start = match.index;
+    ranges.push([start, start + value.length]);
+  }
+
+  return ranges;
+}
+
+export function registerBengaliCharacterJoiner(
+  term: CharacterJoinerTerminal,
+): () => void {
+  const joinerId = term.registerCharacterJoiner(getBengaliCharacterJoinRanges);
+  return () => term.deregisterCharacterJoiner(joinerId);
+}

--- a/web/src/lib/bengali-shaping.ts
+++ b/web/src/lib/bengali-shaping.ts
@@ -7,8 +7,11 @@ interface CharacterJoinerTerminal {
   deregisterCharacterJoiner(joinerId: number): void;
 }
 
-const BENGALI_BLOCK_RE = /[\u0980-\u09ff]/u;
-const BENGALI_JOINABLE_RUN_RE = /[\u0980-\u09ff\u200c\u200d]+/gu;
+// Join only virama-linked consonant clusters (plus their final vowel mark).
+// Joining whole Bengali runs makes xterm cursor movement and selection treat
+// an entire word or pasted paragraph as one unit.
+const BENGALI_CONJUNCT_RE =
+  /[\u0995-\u09b9\u09dc-\u09df]\u09bc?(?:\u09cd[\u200c\u200d]?[\u0995-\u09b9\u09dc-\u09df]\u09bc?)+(?:[\u0981-\u0983\u09be-\u09c4\u09c7\u09c8\u09cb\u09cc\u09d7])*/gu;
 
 export const DASHBOARD_CHAT_TERMINAL_FONT_FAMILY = [
   "'JetBrains Mono'",
@@ -36,12 +39,8 @@ export function getBengaliCharacterJoinRanges(
 ): CharacterJoinRange[] {
   const ranges: CharacterJoinRange[] = [];
 
-  for (const match of text.matchAll(BENGALI_JOINABLE_RUN_RE)) {
+  for (const match of text.matchAll(BENGALI_CONJUNCT_RE)) {
     const value = match[0];
-    if (value.length <= 1 || !BENGALI_BLOCK_RE.test(value)) {
-      continue;
-    }
-
     const start = match.index;
     ranges.push([start, start + value.length]);
   }

--- a/web/src/pages/ChatPage.test.tsx
+++ b/web/src/pages/ChatPage.test.tsx
@@ -75,6 +75,12 @@ class FakeTerminal {
 
   refresh() {}
 
+  registerCharacterJoiner() {
+    return 1;
+  }
+
+  deregisterCharacterJoiner() {}
+
   write() {}
 }
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -35,6 +35,10 @@ import { ChatSessionList } from "@/components/ChatSessionList";
 import { usePageHeader } from "@/contexts/usePageHeader";
 import { useI18n } from "@/i18n";
 import { api } from "@/lib/api";
+import {
+  DASHBOARD_CHAT_TERMINAL_FONT_FAMILY,
+  registerBengaliCharacterJoiner,
+} from "@/lib/bengali-shaping";
 import { latchChatActivation } from "@/lib/chat-activation";
 import { normalizeSessionTitle } from "@/lib/chat-title";
 import { PtyResumeSanitizer } from "@/lib/pty-resume-sanitizer";
@@ -493,8 +497,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     const term = new Terminal({
       allowProposedApi: true,
       cursorBlink: true,
-      fontFamily:
-        "'JetBrains Mono', 'Cascadia Mono', 'Fira Code', 'MesloLGS NF', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace",
+      fontFamily: DASHBOARD_CHAT_TERMINAL_FONT_FAMILY,
       fontSize: terminalFontSizeForWidth(tierW0),
       lineHeight: terminalLineHeightForWidth(tierW0),
       letterSpacing: 0,
@@ -782,11 +785,13 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     // The canvas/DOM renderer tracks `fontSize` faithfully; use it for narrow
     // hosts.  Wide layouts still get WebGL for crisp box-drawing.
     const useWebgl = terminalTierWidthPx(host) >= 768;
+    let deregisterBengaliJoiner: (() => void) | null = null;
     if (useWebgl) {
       try {
         const webgl = new WebglAddon();
         webgl.onContextLoss(() => webgl.dispose());
         term.loadAddon(webgl);
+        deregisterBengaliJoiner = registerBengaliCharacterJoiner(term);
       } catch (err) {
         console.warn(
           "[hermes-chat] WebGL renderer unavailable; falling back to default",
@@ -1258,6 +1263,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // the ticket fetch resolves and ``wsRef.current`` was never assigned.
       wsRef.current?.close();
       wsRef.current = null;
+      deregisterBengaliJoiner?.();
       term.dispose();
       termRef.current = null;
       fitRef.current = null;

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -891,13 +891,12 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     // The canvas/DOM renderer tracks `fontSize` faithfully; use it for narrow
     // hosts.  Wide layouts still get WebGL for crisp box-drawing.
     const useWebgl = terminalTierWidthPx(host) >= 768;
-    let deregisterBengaliJoiner: (() => void) | null = null;
+    const deregisterBengaliJoiner = registerBengaliCharacterJoiner(term);
     if (useWebgl) {
       try {
         const webgl = new WebglAddon();
         webgl.onContextLoss(() => webgl.dispose());
         term.loadAddon(webgl);
-        deregisterBengaliJoiner = registerBengaliCharacterJoiner(term);
       } catch (err) {
         console.warn(
           "[hermes-chat] WebGL renderer unavailable; falling back to default",
@@ -1540,7 +1539,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       wsRef.current?.close();
       wsRef.current = null;
       host.removeEventListener("keydown", _imeCompositionGuard, true);
-      deregisterBengaliJoiner?.();
+      deregisterBengaliJoiner();
       term.dispose();
       termRef.current = null;
       fitRef.current = null;

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -35,6 +35,10 @@ import { ChatSessionList } from "@/components/ChatSessionList";
 import { usePageHeader } from "@/contexts/usePageHeader";
 import { useI18n } from "@/i18n";
 import { api } from "@/lib/api";
+import {
+  DASHBOARD_CHAT_TERMINAL_FONT_FAMILY,
+  registerBengaliCharacterJoiner,
+} from "@/lib/bengali-shaping";
 import { latchChatActivation } from "@/lib/chat-activation";
 import { copyTextToClipboard } from "@/lib/clipboard";
 import { normalizeSessionTitle } from "@/lib/chat-title";
@@ -532,8 +536,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     const term = new Terminal({
       allowProposedApi: true,
       cursorBlink: true,
-      fontFamily:
-        "'JetBrains Mono', 'Cascadia Mono', 'Fira Code', 'MesloLGS NF', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace",
+      fontFamily: DASHBOARD_CHAT_TERMINAL_FONT_FAMILY,
       fontSize: terminalFontSizeForWidth(tierW0),
       lineHeight: terminalLineHeightForWidth(tierW0),
       letterSpacing: 0,
@@ -888,11 +891,13 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     // The canvas/DOM renderer tracks `fontSize` faithfully; use it for narrow
     // hosts.  Wide layouts still get WebGL for crisp box-drawing.
     const useWebgl = terminalTierWidthPx(host) >= 768;
+    let deregisterBengaliJoiner: (() => void) | null = null;
     if (useWebgl) {
       try {
         const webgl = new WebglAddon();
         webgl.onContextLoss(() => webgl.dispose());
         term.loadAddon(webgl);
+        deregisterBengaliJoiner = registerBengaliCharacterJoiner(term);
       } catch (err) {
         console.warn(
           "[hermes-chat] WebGL renderer unavailable; falling back to default",
@@ -1535,6 +1540,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       wsRef.current?.close();
       wsRef.current = null;
       host.removeEventListener("keydown", _imeCompositionGuard, true);
+      deregisterBengaliJoiner?.();
       term.dispose();
       termRef.current = null;
       fitRef.current = null;


### PR DESCRIPTION
## Summary
- Add Bengali-capable system font fallbacks to the dashboard `/chat` xterm font stack.
- Register an xterm WebGL character joiner for Bengali script runs so conjunct sequences are rendered as one shaped unit instead of isolated terminal cells.
- Add focused regression coverage for the Bengali samples from #58685.

Addresses #58685.

## Testing
- `npm test --workspace web -- bengali-shaping.test.ts`
- `npm run typecheck --workspace web`
- `npm run build --workspace web` (passes; Vite reports the existing large chunk warning)
- `cd web && npx eslint src/pages/ChatPage.tsx src/lib/bengali-shaping.ts src/lib/bengali-shaping.test.ts` (0 errors; existing `ChatPage.tsx` exhaustive-deps warning remains)

## Notes
- Full `npm run lint --workspace web` is still blocked by existing unrelated lint errors in files outside this diff (React hook/ref rules and i18n escape warnings).