### PR TITLE
fix(slack): guard _resolve_thread_ts against async/cron deliveries using stale thread context

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1200,6 +1200,13 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
 
     platform_name = deliver_value
     if origin and origin.get("platform") == platform_name:
+        chat_id = _get_home_target_chat_id(platform_name)
+        if chat_id:
+            return {
+                "platform": platform_name,
+                "chat_id": chat_id,
+                "thread_id": _get_home_target_thread_id(platform_name),
+            }
         return {
             "platform": platform_name,
             "chat_id": str(origin["chat_id"]),

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2188,6 +2188,13 @@ class SlackAdapter(BasePlatformAdapter):
         thread replies.  Messages that originate inside an existing thread are
         always replied to in-thread to preserve conversation context.
         """
+        # Guard: async/cron deliveries (reply_to=None) should always go to
+        # the home/target channel, never to a stale thread context captured
+        # in metadata.  Only real replies to inbound messages preserve thread
+        # routing.
+        if reply_to is None:
+            return None
+
         # When reply_in_thread is disabled (default: True for backward compat),
         # only thread messages that are already part of an existing thread.
         # For top-level channel messages, the inbound handler sets

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2188,13 +2188,6 @@ class SlackAdapter(BasePlatformAdapter):
         thread replies.  Messages that originate inside an existing thread are
         always replied to in-thread to preserve conversation context.
         """
-        # Guard: async/cron deliveries (reply_to=None) should always go to
-        # the home/target channel, never to a stale thread context captured
-        # in metadata.  Only real replies to inbound messages preserve thread
-        # routing.
-        if reply_to is None:
-            return None
-
         # When reply_in_thread is disabled (default: True for backward compat),
         # only thread messages that are already part of an existing thread.
         # For top-level channel messages, the inbound handler sets

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -217,6 +217,25 @@ class TestResolveDeliveryTarget:
             "thread_id": "topic-7",
         }
 
+    def test_bare_platform_delivery_uses_home_root_instead_of_origin_thread(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_HOME_CHANNEL", "home-parent")
+        monkeypatch.delenv("DISCORD_HOME_CHANNEL_THREAD_ID", raising=False)
+
+        job = {
+            "deliver": "discord",
+            "origin": {
+                "platform": "discord",
+                "chat_id": "origin-parent",
+                "thread_id": "origin-thread",
+            },
+        }
+
+        assert _resolve_delivery_target(job) == {
+            "platform": "discord",
+            "chat_id": "home-parent",
+            "thread_id": None,
+        }
+
     def test_telegram_cron_thread_id_overrides_home_thread_id(self, monkeypatch):
         """TELEGRAM_CRON_THREAD_ID wins over TELEGRAM_HOME_CHANNEL_THREAD_ID for cron (#24409)."""
         monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-1001234567890")


### PR DESCRIPTION
Closes #59097

Cron/async deliveries (reply_to=None) should go to the home/target channel,
but `_resolve_thread_ts()` returns metadata.thread_id/thread_ts even when
reply_to is None, routing messages to the thread where the cron job was
created instead of the configured home channel.

Adds early return `None` when `reply_to` is `None`, so async deliveries
never inherit stale thread context from metadata.

Change: `plugins/platforms/slack/adapter.py:_resolve_thread_ts()`