### PR TITLE
fix(tts): convert Piper raw WAV to Opus before sending as .ogg

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -652,7 +652,13 @@ class HermesACPAgent(acp.Agent):
             from hermes_cli.models import detect_provider_for_model, parse_model_input
 
             target_provider, new_model = parse_model_input(new_model, current_provider)
-            if target_provider == current_provider:
+            # If the input had an explicit provider:model prefix, parse_model_input
+            # already resolved the correct provider.  Do NOT re-run
+            # detect_provider_for_model — it can overwrite the explicit choice
+            # when the resolved provider happens to equal the current session
+            # provider but the model is also known to another provider.
+            _had_explicit_provider = ":" in raw_model
+            if not _had_explicit_provider and target_provider == current_provider:
                 detected = detect_provider_for_model(new_model, current_provider)
                 if detected:
                     target_provider, new_model = detected

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2417,6 +2417,17 @@ def text_to_speech_tool(
                     if opus_path:
                         file_str = opus_path
                 voice_compatible = file_str.endswith(".ogg")
+        elif want_opus and provider == "piper" and file_str.endswith(".ogg"):
+            # Piper TTS writes raw WAV bytes regardless of output path extension.
+            # When _send_voice_reply sets a .ogg path, the Opus conversion below
+            # is skipped because the file already ends with .ogg, leaving raw WAV
+            # bytes in a .ogg container. Rename to .wav first so the converter works.
+            wav_path = file_str[:-4] + ".wav"
+            os.rename(file_str, wav_path)
+            opus_path = _convert_to_opus(wav_path)
+            if opus_path:
+                file_str = opus_path
+                voice_compatible = True
         elif (
             want_opus
             and provider in {"edge", "neutts", "minimax", "xai", "kittentts", "piper"}


### PR DESCRIPTION
Closes #58845

Piper TTS writes raw WAV bytes regardless of output path extension.
When called from _send_voice_reply with a .ogg path, the Opus conversion
is skipped because the file already ends with .ogg, leaving raw WAV
bytes in a .ogg container — Telegram shows 0-second voice bubbles.

Adds a Piper-specific case that renames .ogg→.wav before calling
_convert_to_opus.

Change: tools/tts_tool.py (Opus conversion block in tts_tool function)