### PR TITLE
fix(acp): skip detect_provider_for_model when input had explicit provider prefix

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -652,7 +652,13 @@ class HermesACPAgent(acp.Agent):
             from hermes_cli.models import detect_provider_for_model, parse_model_input
 
             target_provider, new_model = parse_model_input(new_model, current_provider)
-            if target_provider == current_provider:
+            # If the input had an explicit provider:model prefix, parse_model_input
+            # already resolved the correct provider.  Do NOT re-run
+            # detect_provider_for_model — it can overwrite the explicit choice
+            # when the resolved provider happens to equal the current session
+            # provider but the model is also known to another provider.
+            _had_explicit_provider = ":" in raw_model
+            if not _had_explicit_provider and target_provider == current_provider:
                 detected = detect_provider_for_model(new_model, current_provider)
                 if detected:
                     target_provider, new_model = detected

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -649,15 +649,26 @@ class HermesACPAgent(acp.Agent):
         new_model = raw_model.strip()
 
         try:
-            from hermes_cli.models import detect_provider_for_model, parse_model_input
+            from hermes_cli.models import (
+                _KNOWN_PROVIDER_NAMES,
+                detect_provider_for_model,
+                parse_model_input,
+            )
 
             target_provider, new_model = parse_model_input(new_model, current_provider)
-            # If the input had an explicit provider:model prefix, parse_model_input
-            # already resolved the correct provider.  Do NOT re-run
-            # detect_provider_for_model — it can overwrite the explicit choice
-            # when the resolved provider happens to equal the current session
-            # provider but the model is also known to another provider.
-            _had_explicit_provider = ":" in raw_model
+            # Only skip provider detection when the raw input used a *real*
+            # provider prefix recognized by parse_model_input. Bare model ids may
+            # legally contain colons for variant tags (for example `:free`), and
+            # those still need provider detection.
+            stripped_raw_model = raw_model.strip()
+            colon = stripped_raw_model.find(":")
+            _had_explicit_provider = False
+            if colon > 0:
+                provider_part = stripped_raw_model[:colon].strip().lower()
+                model_part = stripped_raw_model[colon + 1 :].strip()
+                _had_explicit_provider = bool(
+                    provider_part and model_part and provider_part in _KNOWN_PROVIDER_NAMES
+                )
             if not _had_explicit_provider and target_provider == current_provider:
                 detected = detect_provider_for_model(new_model, current_provider)
                 if detected:

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -969,17 +969,9 @@ class TestSessionConfiguration:
             "hermes_cli.runtime_provider.resolve_runtime_provider",
             fake_resolve_runtime_provider,
         )
-        # Pin the parser so this test doesn't depend on live
-        # ``_KNOWN_PROVIDER_NAMES`` / ``_PROVIDER_ALIASES`` module state
-        # (sibling of the same hardening on
-        # ``test_model_switch_uses_requested_provider``).
-        monkeypatch.setattr(
-            "hermes_cli.models.parse_model_input",
-            lambda raw, current: ("anthropic", "claude-sonnet-4-6"),
-        )
         monkeypatch.setattr(
             "hermes_cli.models.detect_provider_for_model",
-            lambda model, current: None,
+            lambda model, current: ("openrouter", model),
         )
         manager = SessionManager(db=SessionDB(tmp_path / "state.db"))
 
@@ -996,6 +988,57 @@ class TestSessionConfiguration:
         assert state.agent.provider == "anthropic"
         assert state.agent.base_url == "https://anthropic.example/v1"
         assert runtime_calls[-1] == "anthropic"
+
+    @pytest.mark.asyncio
+    async def test_set_session_model_still_detects_provider_for_bare_variant_slug(self, tmp_path, monkeypatch):
+        runtime_calls = []
+
+        def fake_resolve_runtime_provider(requested=None, **kwargs):
+            runtime_calls.append(requested)
+            provider = requested or "anthropic"
+            return {
+                "provider": provider,
+                "api_mode": "anthropic_messages" if provider == "anthropic" else "chat_completions",
+                "base_url": f"https://{provider}.example/v1",
+                "api_key": f"{provider}-key",
+                "command": None,
+                "args": [],
+            }
+
+        def fake_agent(**kwargs):
+            return SimpleNamespace(
+                model=kwargs.get("model"),
+                provider=kwargs.get("provider"),
+                base_url=kwargs.get("base_url"),
+                api_mode=kwargs.get("api_mode"),
+            )
+
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+            "model": {"provider": "anthropic", "default": "claude-sonnet-4-6"}
+        })
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.detect_provider_for_model",
+            lambda model, current: ("openrouter", model),
+        )
+        manager = SessionManager(db=SessionDB(tmp_path / "state.db"))
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            acp_agent = HermesACPAgent(session_manager=manager)
+            state = manager.create_session(cwd="/tmp")
+            result = await acp_agent.set_session_model(
+                model_id="poolside/laguna-m.1:free",
+                session_id=state.session_id,
+            )
+
+        assert isinstance(result, SetSessionModelResponse)
+        assert state.model == "poolside/laguna-m.1:free"
+        assert state.agent.provider == "openrouter"
+        assert state.agent.base_url == "https://openrouter.example/v1"
+        assert runtime_calls[-1] == "openrouter"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -45,9 +45,10 @@ _E164_TARGET_RE = re.compile(r"^\s*\+(\d{7,15})\s*$")
 # newsletter chats. These are explicit native targets the bridge accepts
 # verbatim — they must NOT fall through to home-channel resolution.
 _WHATSAPP_JID_RE = re.compile(
-    r"^\s*[\w-]+@(?:g\.us|s\.whatsapp\.net|lid|broadcast|newsletter)\s*$",
+    r"^\s*[-\w]+@(?:g\.us|s\.whatsapp\.net|lid|broadcast|newsletter)\s*$",
     re.IGNORECASE,
 )
+_WHATSAPP_LID_RE = re.compile(r"^\s*(\d+@lid)\s*$")
 # Email addresses — a valid email like "user@domain.com" should be treated as
 # an explicit target for the email platform, not fall through to channel-name
 # resolution which has no way to resolve a raw address.
@@ -548,6 +549,10 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         if match:
             # Preserve the leading '+' — signal-cli and sms/whatsapp adapters
             # expect E.164 format for direct recipients.
+            return target_ref.strip(), None, True
+    if platform_name == "whatsapp":
+        match = _WHATSAPP_LID_RE.fullmatch(target_ref)
+        if match:
             return target_ref.strip(), None, True
     if target_ref.lstrip("-").isdigit():
         return target_ref, None, True

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -550,10 +550,6 @@ def _parse_target_ref(platform_name: str, target_ref: str):
             # Preserve the leading '+' — signal-cli and sms/whatsapp adapters
             # expect E.164 format for direct recipients.
             return target_ref.strip(), None, True
-    if platform_name == "whatsapp":
-        match = _WHATSAPP_LID_RE.fullmatch(target_ref)
-        if match:
-            return target_ref.strip(), None, True
     if target_ref.lstrip("-").isdigit():
         return target_ref, None, True
     # Matrix room IDs (start with !) and user IDs (start with @) are explicit


### PR DESCRIPTION
## Summary

`_resolve_model_selection` re-runs `detect_provider_for_model()` when the resolved provider equals the current provider, even when `parse_model_input` already resolved an explicit `provider:model` prefix. For models that newly appear in OpenRouter's catalog (or any model known to multiple providers), this overwrites the correct provider with a detected one, causing "No LLM provider configured" errors.

## Root cause

In `acp_adapter/server.py`, `_resolve_model_selection`:

1. Calls `parse_model_input(raw_model, current_provider)` which correctly resolves `openrouter:anthropic/claude-sonnet-4.5` → `("openrouter", "anthropic/claude-sonnet-4.5")`.
2. Then checks `if target_provider == current_provider`. If the current session provider happens to also be `openrouter`, it enters the branch.
3. Calls `detect_provider_for_model(new_model, current_provider)`, which detects `anthropic/claude-sonnet-4.5` as belonging to the `anthropic` provider and overwrites `target_provider` from `openrouter` → `anthropic`.

The fix skips the `detect_provider_for_model` fallback when `raw_model` contained an explicit `:` (provider prefix), since `parse_model_input` has already handled that case correctly.

## Changes

- `acp_adapter/server.py` — `_resolve_model_selection`: add `_had_explicit_provider` guard

## Testing

The fix is minimal and targeted: it only changes the condition under which `detect_provider_for_model` is called, and only for inputs where the user explicitly specified a provider prefix.

Closes #59089