### PR TITLE
fix(cli): print '✓ Update complete!' on the Already up to date path

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9692,6 +9692,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     print("  Close all Hermes windows/gateways and re-run: hermes update")
             else:
                 print("✓ Already up to date!")
+            print("✓ Update complete!")
             _resume_windows_gateways_after_update(_windows_gateway_resume)
             return
 


### PR DESCRIPTION
Closes #58764

The Desktop's applyBackendUpdate() polls for the '✓ Update complete!'
marker to confirm success, but the no-op 'Already up to date' path returns
without printing it, causing the Desktop to show 'Backend update failed'
even though the update succeeded.

Change: hermes_cli/main.py:_cmd_update_impl()