### PR TITLE
fix(desktop): probe the venv python before trusting it so Repair can escape a broken venv

### DIFF
--- a/apps/desktop/electron/backend-probes.cjs
+++ b/apps/desktop/electron/backend-probes.cjs
@@ -44,7 +44,7 @@ const PROBE_TIMEOUT_MS = 5000
  * @returns {string}
  */
 function hermesRuntimeImportProbe() {
-  return 'import yaml; import hermes_cli.config'
+  return 'import yaml; import dotenv; import hermes_cli.config'
 }
 
 /**

--- a/apps/desktop/electron/backend-probes.test.cjs
+++ b/apps/desktop/electron/backend-probes.test.cjs
@@ -43,6 +43,10 @@ test('canImportHermesCli returns false when binary does not exist', () => {
 test('hermes runtime import probe checks config dependencies', () => {
   const probe = hermesRuntimeImportProbe()
   assert.match(probe, /\bimport yaml\b/)
+  // dotenv is the first third-party import on the CLI boot path
+  // (hermes_cli/env_loader.py); a mid-update venv missing python-dotenv
+  // passed the old probe and produced an unrecoverable boot loop.
+  assert.match(probe, /\bimport dotenv\b/)
   assert.match(probe, /\bimport hermes_cli\.config\b/)
 })
 

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -1338,6 +1338,28 @@ function unwrapWindowsVenvHermesCommand(command, backendArgs) {
   if (!fileExists(python)) return null
 
   const root = path.dirname(venvRoot)
+
+  // Smoke-test the venv interpreter before trusting it. A venv whose update
+  // died mid-`pip install` still has python.exe + hermes.exe on disk, but the
+  // backend dies on its first import (e.g. ModuleNotFoundError: dotenv) before
+  // the gateway ever binds. Returning it here also BYPASSED the caller's
+  // `--version` probe, so Retry/"Repair install" re-resolved the same broken
+  // venv forever instead of falling through to the bootstrap installer.
+  // Mirror isActiveRuntimeUsable(): probe with the checkout on PYTHONPATH so a
+  // healthy source-tree venv passes.
+  if (
+    !canImportHermesCli(python, {
+      env: {
+        PYTHONPATH: [...(directoryExists(root) ? [root] : []), process.env.PYTHONPATH].filter(Boolean).join(path.delimiter)
+      }
+    })
+  ) {
+    rememberLog(
+      `Ignoring venv Hermes at ${python}: runtime import probe failed (broken/partial venv); falling through to bootstrap.`
+    )
+    return null
+  }
+
   return {
     label: `existing Hermes Python at ${python}`,
     command: python,

--- a/apps/desktop/electron/windows-hermes-resolution.test.cjs
+++ b/apps/desktop/electron/windows-hermes-resolution.test.cjs
@@ -14,6 +14,11 @@
 //      shim, written at the END of venv setup and absent in interrupted
 //      states), so it escalated to a full venv recreate even on healthy
 //      installs.
+//   3. unwrapWindowsVenvHermesCommand() returned the venv python with NO
+//      runtime probe (bypassing the caller's --version check too), so a venv
+//      broken mid-update (e.g. missing python-dotenv) was re-selected forever:
+//      Retry / "Repair install" resolved the same dead interpreter instead of
+//      falling through to the bootstrap installer.
 
 const test = require('node:test')
 const assert = require('node:assert/strict')
@@ -55,5 +60,25 @@ test('Windows bootstrap recovery chooses --update when any real-install signal i
     source,
     /updaterArgs = fileExists\(venvHermes\) \?/,
     'recovery regressed to gating only on the hermes.exe shim, which forces destructive --repair'
+  )
+})
+
+test('unwrapWindowsVenvHermesCommand smoke-tests the venv python before trusting it', () => {
+  const source = readMain()
+  const fnStart = source.indexOf('function unwrapWindowsVenvHermesCommand(')
+  assert.notEqual(fnStart, -1, 'unwrapWindowsVenvHermesCommand must exist in main.cjs')
+  // Slice out just the function body (up to the next top-level function decl)
+  const fnEnd = source.indexOf('\nfunction ', fnStart + 1)
+  const body = source.slice(fnStart, fnEnd === -1 ? undefined : fnEnd)
+  assert.match(
+    body,
+    /canImportHermesCli\(python/,
+    'unwrap must probe the venv interpreter; returning it unprobed re-selects a broken venv ' +
+      'forever (Retry/Repair loop on a mid-update venv missing e.g. python-dotenv)'
+  )
+  assert.match(
+    body,
+    /return null\s*\n\s*\}\s*\n\s*return \{/,
+    'a failed probe must fall through (return null) so the resolver reaches the bootstrap rung'
   )
 })


### PR DESCRIPTION
## Summary
Windows desktop's Retry / "Repair install" recovery buttons can now actually escape a venv broken mid-update — previously they re-resolved the same dead interpreter forever.

Root cause: `unwrapWindowsVenvHermesCommand()` (main.cjs step 4 of `resolveHermesBackend`) returned the venv's `python.exe` with **no probe at all**, and its early return also bypassed the caller's `--version` smoke test. A venv whose `hermes update` died mid-`pip install` (user report: `ModuleNotFoundError: No module named 'dotenv'`) still has `python.exe` + `Scripts\hermes.exe` on disk, so every recovery action — Retry, Repair install, Use local gateway — resolved the identical broken backend and showed the identical failure overlay. "Repair install" deleted the bootstrap marker as designed, but the resolver never reached the bootstrap rung.

## Changes
- `apps/desktop/electron/main.cjs`: `unwrapWindowsVenvHermesCommand()` now runs `canImportHermesCli()` on the venv python (checkout on `PYTHONPATH`, mirroring `isActiveRuntimeUsable()`); on failure it logs and returns `null` so the resolver falls through to the bootstrap installer, which repairs the venv.
- `apps/desktop/electron/backend-probes.cjs`: `hermesRuntimeImportProbe()` adds `import dotenv` — the first third-party import on the CLI boot path (`hermes_cli/env_loader.py:9`) — so a venv missing `python-dotenv` fails the probe at every rung that uses it.
- Tests: probe-content assertion (`import dotenv`) + source assertion that the unwrap path probes and falls through (`windows-hermes-resolution.test.cjs`).

## Validation
| Check | Result |
|---|---|
| `node --test` windows-hermes-resolution + backend-probes | 11/11 pass |
| `node --check` main.cjs / backend-probes.cjs | OK |
| E2E: `canImportHermesCli` vs real venv without dotenv | `false` (falls through) |
| E2E: `canImportHermesCli` vs healthy install venv | `true` (unchanged behavior) |

User data is unaffected in all paths — the bootstrap reinstall touches only `%LOCALAPPDATA%\hermes\hermes-agent`, never `HERMES_HOME`.

## Infographic
![desktop-repair-broken-venv](https://v3b.fal.media/files/b/0aa11536/ApJb118s_vrBqrIK7IhSe_71muDfQf.png)
