### PR TITLE
fix(memory): substring replace preserves surrounding entry content

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -321,10 +321,21 @@ class TestMemoryStoreAdd:
 class TestMemoryStoreReplace:
     def test_replace_entry(self, store):
         store.add("memory", "Python 3.11 project")
-        result = store.replace("memory", "3.11", "Python 3.12 project")
+        result = store.replace("memory", "3.11", "3.12")
         assert result["success"] is True
         assert "Python 3.12 project" in store.memory_entries
         assert "Python 3.11 project" not in store.memory_entries
+
+    def test_replace_substring_preserves_context(self, store):
+        """Substring replacement within an entry preserves surrounding content."""
+        store.add("memory", "Section A\ncontent A\n\nSection B\ncontent B\n\nSection C\ncontent C")
+        result = store.replace("memory", "Section B\ncontent B", "Section B\nupdated B")
+        assert result["success"] is True
+        entry = store.memory_entries[0]
+        assert "Section A" in entry
+        assert "Section C" in entry
+        assert "updated B" in entry
+        assert "content B" not in entry
 
     def test_replace_no_match(self, store):
         store.add("memory", "fact A")

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -386,7 +386,13 @@ class MemoryStore:
         return self._success_response(target, "Entry added.")
 
     def replace(self, target: str, old_text: str, new_content: str) -> Dict[str, Any]:
-        """Find entry containing old_text substring, replace it with new_content."""
+        """Find entry containing old_text substring, replace that substring with new_content.
+
+        The replacement is a substring substitution within the matched entry —
+        only the portion matching *old_text* is replaced; surrounding content
+        in the same entry is preserved.  This lets callers surgically update
+        one section of a multi-section entry without losing the rest.
+        """
         old_text = old_text.strip()
         new_content = new_content.strip()
         if not old_text:
@@ -429,9 +435,13 @@ class MemoryStore:
             idx = matches[0][0]
             limit = self._char_limit(target)
 
+            # Substring replacement: only the matching portion is swapped out,
+            # preserving the rest of the entry.
+            updated_entry = entries[idx].replace(old_text, new_content, 1)
+
             # Check that replacement doesn't blow the budget
             test_entries = entries.copy()
-            test_entries[idx] = new_content
+            test_entries[idx] = updated_entry
             new_total = len(ENTRY_DELIMITER.join(test_entries))
 
             if new_total > limit:
@@ -448,7 +458,7 @@ class MemoryStore:
                     "usage": f"{current:,}/{limit:,}",
                 })
 
-            entries[idx] = new_content
+            entries[idx] = updated_entry
             self._set_entries(target, entries)
             self.save_to_disk(target)
 


### PR DESCRIPTION
## Summary

The memory tool's  action previously swapped the **entire** matched entry with , discarding any content before and after the matched substring. This caused data loss on composite (multi-section) entries where only a single section needed updating.

## Problem

When a user had a memory entry with multiple sections:



And called  with  and , the result was:



Sections A and C were silently lost.

## Fix

 now performs a substring substitution within the matched entry using , so only the matching portion is swapped out and surrounding content is preserved:



## Changes

- : Updated  to use  instead of 
- : Updated  to reflect new substring semantics, added  regression test

## Testing

All 84 memory tool tests pass. Verified with manual test that multi-section entries preserve surrounding content after partial replacement.

Fixes #59184