### PR TITLE
fix(mcp): return schema content for approval elicitations

### DIFF
--- a/tests/tools/test_mcp_elicitation.py
+++ b/tests/tools/test_mcp_elicitation.py
@@ -20,6 +20,7 @@ from mcp.types import ElicitResult  # noqa: E402  -- after importorskip
 
 from tools.mcp_tool import (  # noqa: E402
     ElicitationHandler,
+    _accepted_elicitation_content,
     _format_elicitation_schema_summary,
 )
 
@@ -85,6 +86,48 @@ class TestElicitationHandlerFormMode:
         assert handler.metrics["accepted"] == 1
         assert handler.metrics["declined"] == 0
 
+    def test_accept_required_boolean_approval_returns_schema_content(self):
+        handler = ElicitationHandler("singularity", {"timeout": 5})
+        params = _form_params(
+            "Approve Singularity write operation?",
+            {
+                "type": "object",
+                "properties": {
+                    "approved": {
+                        "type": "boolean",
+                        "description": "Approve this write operation.",
+                    }
+                },
+                "required": ["approved"],
+            },
+        )
+
+        with patch("tools.approval.request_elicitation_consent", return_value="accept"):
+            result = asyncio.run(handler(context=None, params=params))
+
+        assert result.action == "accept"
+        assert result.content == {"approved": True}
+        assert handler.metrics["accepted"] == 1
+        assert handler.metrics["declined"] == 0
+
+    def test_accept_unsupported_required_form_field_declines_fail_closed(self):
+        handler = ElicitationHandler("pay", {"timeout": 5})
+        params = _form_params(
+            "Provide payment metadata",
+            {
+                "type": "object",
+                "properties": {"memo": {"type": "string"}},
+                "required": ["memo"],
+            },
+        )
+
+        with patch("tools.approval.request_elicitation_consent", return_value="accept"):
+            result = asyncio.run(handler(context=None, params=params))
+
+        assert result.action == "decline"
+        assert handler.metrics["accepted"] == 0
+        assert handler.metrics["declined"] == 1
+
     def test_user_denies_returns_decline(self):
         handler = ElicitationHandler("pay", {"timeout": 5})
         params = _form_params()
@@ -109,6 +152,25 @@ class TestElicitationHandlerFormMode:
 
         assert result.action == "cancel"
         assert handler.metrics["errors"] == 1
+
+
+class TestAcceptedElicitationContent:
+    def test_single_value_enum_and_const_are_synthesized(self):
+        assert _accepted_elicitation_content({
+            "type": "object",
+            "properties": {
+                "mode": {"enum": ["approve"]},
+                "confirmed": {"const": True},
+            },
+            "required": ["mode", "confirmed"],
+        }) == {"mode": "approve", "confirmed": True}
+
+    def test_non_approval_boolean_name_is_not_guessed(self):
+        assert _accepted_elicitation_content({
+            "type": "object",
+            "properties": {"remember": {"type": "boolean"}},
+            "required": ["remember"],
+        }) is None
 
 
 class TestElicitationHandlerFailureModes:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1295,6 +1295,75 @@ def _format_elicitation_schema_summary(schema: dict, server_name: str) -> str:
     return "\n".join(lines)
 
 
+_ELICITATION_BOOLEAN_APPROVAL_FIELDS = frozenset({
+    "accept",
+    "accepted",
+    "approve",
+    "approved",
+    "authorize",
+    "authorized",
+    "confirm",
+    "confirmed",
+    "consent",
+    "consented",
+})
+
+
+def _accepted_elicitation_content(schema: dict) -> Optional[dict]:
+    """Build schema-compatible content for approval-only form elicitations.
+
+    Hermes approval surfaces currently collect a yes/no decision, not arbitrary
+    form fields. Returning ``accept`` with invalid empty content is worse than
+    failing closed, so synthesize only values that are unambiguous from an
+    approval click.
+    """
+    if not isinstance(schema, dict) or not schema:
+        return {}
+
+    props = schema.get("properties")
+    if props is None:
+        return {}
+    if not isinstance(props, dict):
+        return None
+
+    required_raw = schema.get("required") or []
+    if not isinstance(required_raw, list):
+        return None
+    required = [field for field in required_raw if isinstance(field, str)]
+    if len(required) != len(required_raw):
+        return None
+    if not required:
+        return {}
+
+    content: dict = {}
+    for field in required:
+        spec = props.get(field)
+        if not isinstance(spec, dict):
+            return None
+
+        if "const" in spec:
+            content[field] = spec["const"]
+            continue
+
+        enum = spec.get("enum")
+        if isinstance(enum, list) and len(enum) == 1:
+            content[field] = enum[0]
+            continue
+
+        if "default" in spec:
+            content[field] = spec["default"]
+            continue
+
+        field_type = spec.get("type")
+        if field_type == "boolean" and field.lower() in _ELICITATION_BOOLEAN_APPROVAL_FIELDS:
+            content[field] = True
+            continue
+
+        return None
+
+    return content
+
+
 class ElicitationHandler:
     """Handles ``elicitation/create`` requests for a single MCP server.
 
@@ -1443,8 +1512,18 @@ class ElicitationHandler:
             return ElicitResult(action="decline")
 
         if answer == "accept":
+            content = _accepted_elicitation_content(schema)
+            if content is None:
+                logger.warning(
+                    "MCP server '%s' elicitation accepted by user, but "
+                    "requested schema requires form content Hermes cannot "
+                    "collect on this approval surface; declining fail-closed",
+                    self.server_name,
+                )
+                self.metrics["declined"] += 1
+                return ElicitResult(action="decline")
             self.metrics["accepted"] += 1
-            return ElicitResult(action="accept", content={})
+            return ElicitResult(action="accept", content=content)
         if answer == "cancel":
             self.metrics["errors"] += 1
             return ElicitResult(action="cancel")


### PR DESCRIPTION
## Problem

Fixes #58778.

MCP form-mode elicitation currently returns `ElicitResult(action="accept", content={})` after a user approves through Hermes' yes/no approval surfaces. For schemas with required fields, that makes the accepted response schema-invalid; `singularity-mcp` expects `{"approved": true}` and fails closed when it receives `{}`.

## Root Cause

`ElicitationHandler.__call__` treated every accepted form elicitation as content-free, even though the MCP form contract uses `content` for submitted form data. Hermes does not collect arbitrary form fields on gateway/CLI approval surfaces, so returning `accept` with empty content was not a valid fallback for required schemas.

## Fix

- Add a small schema-content builder for approval-only form elicitations.
- Synthesize unambiguous required values from an approval click: approval-named required booleans become `true`, and single-value `const` / one-item `enum` / `default` fields are preserved.
- Fail closed with `decline` when the requested schema requires arbitrary form content Hermes cannot collect, instead of returning a schema-invalid accept.

## Tests

- `scripts/run_tests.sh tests/tools/test_mcp_elicitation.py`
- `$HOME/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_mcp_elicitation.py -q`
- `$HOME/.hermes/hermes-agent/venv/bin/python -m ruff check tools/mcp_tool.py tests/tools/test_mcp_elicitation.py`
