### PR TITLE
fix(prompt-size): pass platform-resolved toolsets into the inspection agent

### DIFF
--- a/hermes_cli/prompt_size.py
+++ b/hermes_cli/prompt_size.py
@@ -34,10 +34,16 @@ def _build_inspection_agent(platform: str) -> Any:
     """
     from run_agent import AIAgent
     from hermes_cli.config import load_config
+    from hermes_cli.tools_config import _get_platform_tools
 
     cfg = load_config()
     model_cfg = cfg.get("model", {}) if isinstance(cfg.get("model"), dict) else {}
     model = model_cfg.get("default") or model_cfg.get("model") or ""
+
+    # Resolve platform-specific toolsets the same way the gateway does.
+    enabled_toolsets = sorted(_get_platform_tools(cfg, platform))
+    agent_cfg = cfg.get("agent") or {}
+    disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
 
     return AIAgent(
         model=model,
@@ -46,6 +52,8 @@ def _build_inspection_agent(platform: str) -> Any:
         quiet_mode=True,
         save_trajectories=False,
         platform=platform,
+        enabled_toolsets=enabled_toolsets,
+        disabled_toolsets=disabled_toolsets,
     )
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -896,6 +896,7 @@ AUTHOR_MAP = {
     "jezzahehn@gmail.com": "JezzaHehn",
     "barnacleboy.jezzahehn@agentmail.to": "JezzaHehn",
     "254021826+dodo-reach@users.noreply.github.com": "dodo-reach",
+    "edder@example.com": "EdderTalmor",  # PR #41575 salvage (prompt-size: pass platform-resolved enabled_toolsets + agent.disabled_toolsets into the inspection agent; #41445)
     "259807879+Bartok9@users.noreply.github.com": "Bartok9",
     "123342691+banditburai@users.noreply.github.com": "banditburai",
     "9063726+Kyzcreig@users.noreply.github.com": "Kyzcreig",

--- a/tests/hermes_cli/test_prompt_size.py
+++ b/tests/hermes_cli/test_prompt_size.py
@@ -1,11 +1,14 @@
 """Tests for the ``hermes prompt-size`` diagnostic (issue #34667)."""
 
 import json
+import sys
+from types import SimpleNamespace
 
 import pytest
 
 from hermes_cli.prompt_size import (
     _SKILLS_BLOCK_RE,
+    _build_inspection_agent,
     compute_prompt_breakdown,
     render_breakdown,
 )
@@ -68,6 +71,56 @@ def test_runs_offline_without_credentials(isolated_home, monkeypatch):
         monkeypatch.delenv(var, raising=False)
     data = compute_prompt_breakdown("cli")
     assert data["system_prompt"]["bytes"] > 0
+
+
+def test_inspection_agent_uses_resolved_platform_toolsets(monkeypatch):
+    """Inspection must match real CLI tool resolution, including disables."""
+    captured = {}
+
+    class FakeAIAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    cfg = {
+        "model": {"default": "test/model"},
+        "agent": {"disabled_toolsets": ["memory"]},
+    }
+
+    monkeypatch.setitem(
+        sys.modules,
+        "run_agent",
+        SimpleNamespace(AIAgent=FakeAIAgent),
+    )
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_platform_tools",
+        lambda passed_cfg, platform: {"terminal", "file"},
+    )
+
+    _build_inspection_agent("cli")
+
+    assert captured["model"] == "test/model"
+    assert captured["platform"] == "cli"
+    assert captured["enabled_toolsets"] == ["file", "terminal"]
+    assert captured["disabled_toolsets"] == ["memory"]
+
+
+def test_blank_slate_prompt_size_counts_only_minimal_tools(isolated_home):
+    """Blank Slate prompt-size should report file + terminal schemas only."""
+    from hermes_cli.config import save_config
+    from hermes_cli.setup import (
+        _blank_slate_minimal_toolsets,
+        _blank_slate_minimize_config,
+    )
+
+    cfg = {"model": {"default": "MiniMax-M2.7"}}
+    _blank_slate_minimal_toolsets(cfg)
+    _blank_slate_minimize_config(cfg)
+    save_config(cfg)
+
+    data = compute_prompt_breakdown("cli")
+
+    assert data["tools"]["count"] == 6
 
 
 def test_skills_index_reflects_installed_skills(isolated_home):


### PR DESCRIPTION
## Summary

`hermes prompt-size` now measures the tool surface the agent actually ships — it passes the platform-resolved `enabled_toolsets` and `agent.disabled_toolsets` into the inspection agent instead of letting it fall back to the default surface. Salvages the remaining valid part of #51586 and the earlier #41575.

Previously the diagnostic built its inspection `AIAgent` with no toolset arguments, so a Blank Slate profile (or any profile with per-platform toolsets / disables) got a breakdown for the wrong tool schema set. With the posture-bundle fix already on main (#59150), passing the real `disabled_toolsets` through is safe for blank-slate configs.

Fixes #41445, fixes #52032's target.

## Changes

- `hermes_cli/prompt_size.py`: `_build_inspection_agent` resolves `_get_platform_tools(cfg, platform)` and `agent.disabled_toolsets` and passes both into `AIAgent` (cherry-picked from #41575, @EdderTalmor — earliest fix, Jun 7)
- `tests/hermes_cli/test_prompt_size.py`: parity test (kwargs reach the agent) + blank-slate test (`tools.count == 6`) (salvaged from #51586, @dodo-reach)
- `scripts/release.py`: AUTHOR_MAP entry for EdderTalmor

## Validation

| | Before | After |
|---|---|---|
| Blank Slate `hermes prompt-size` tool count | default surface (dozens) | 6 (patch, process, read_file, search_files, terminal, write_file) — E2E with real imports + temp HERMES_HOME |
| `scripts/run_tests.sh tests/hermes_cli/test_prompt_size.py` | — | 9 passed |

## Credit

- @EdderTalmor (#41575, earliest fix for #41445) — authorship preserved via cherry-pick
- @dodo-reach (#51586) — regression tests authored under their name; the setup/model_tools parts of their PR were superseded by #59150

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa1155a/Q6x6gZ-ArQmJLIFOdkG2O_7JMHxg5U.png)
