### PR TITLE
fix(cron): deliver to home channel instead of stale origin thread

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1030,13 +1030,12 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
         }
 
     platform_name = deliver_value
-    if origin and origin.get("platform") == platform_name:
-        return {
-            "platform": platform_name,
-            "chat_id": str(origin["chat_id"]),
-            "thread_id": origin.get("thread_id"),
-        }
-
+    # When delivering to a specific platform (not "origin"), prefer the
+    # configured home channel over the origin's thread context.  The origin
+    # thread_id is only meaningful for deliver=origin (above) — using it
+    # for platform-named deliveries causes cron results to land in the
+    # stale thread where the job was created instead of the home channel
+    # the user configured with /sethome (#59097).
     if not _is_known_delivery_platform(platform_name):
         return None
     chat_id = _get_home_target_chat_id(platform_name)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -358,7 +358,13 @@ class TestResolveDeliveryTarget:
             "thread_id": None,
         }
 
-    def test_bare_platform_uses_matching_origin_chat(self):
+    def test_bare_platform_uses_home_channel_not_stale_origin_thread(self, monkeypatch):
+        """Platform-named delivery (deliver=telegram) should use the configured
+        home channel, not the origin's thread context.  Using the origin
+        thread_id for platform deliveries caused cron results to land in
+        the stale thread where the job was created instead of the home
+        channel the user configured with /sethome (#59097)."""
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-2002")
         job = {
             "deliver": "telegram",
             "origin": {
@@ -370,8 +376,8 @@ class TestResolveDeliveryTarget:
 
         assert _resolve_delivery_target(job) == {
             "platform": "telegram",
-            "chat_id": "-1001",
-            "thread_id": "17585",
+            "chat_id": "-2002",
+            "thread_id": None,
         }
 
     def test_bare_platform_falls_back_to_home_channel(self, monkeypatch):


### PR DESCRIPTION
## Summary

Fix cron delivery routing so platform-named deliveries (e.g. `deliver=slack`, `deliver=all`) route to the configured home channel instead of the stale origin thread where the job was created.

## Problem

When a cron job was created from a Slack thread with `deliver=all`, the delivery was routed to the origin's `thread_id` instead of the configured home channel. This meant cron results appeared in the stale thread where the job was created, ignoring the user's `/sethome` configuration.

The root cause was in `_resolve_single_delivery_target()`: when `deliver=<platform>` matched the origin's platform, the function returned the origin's `chat_id` and `thread_id` instead of the home channel.

## Fix

Remove the origin-fallback path for platform-named deliveries. Only `deliver=origin` uses the origin's thread context; platform-named deliveries now always resolve to the configured home channel.

**Before:** `deliver=slack` with origin on Slack → deliver to origin's thread  
**After:** `deliver=slack` → deliver to `SLACK_HOME_CHANNEL`

## Changes

- `cron/scheduler.py`: Removed origin-thread fallback for platform-named deliveries in `_resolve_single_delivery_target()`
- `tests/cron/test_scheduler.py`: Updated test to verify platform deliveries use home channel, not stale origin thread

## Testing

All 212 cron scheduler tests pass.

Fixes #59097