### PR TITLE
feat(tools): add delegate_completion one-shot completion tool

### DIFF
--- a/tests/tools/test_delegate_completion_tool.py
+++ b/tests/tools/test_delegate_completion_tool.py
@@ -27,16 +27,36 @@ from tools.delegate_completion_tool import (
 def _fake_response(text: str):
     """Return a duck-typed auxiliary_client response.
 
-    ``_extract_aux_response_text`` first looks for ``output_text`` on the
-    top-level response. Setting that field is the smallest surface that
-    exercises the helper's primary branch, which is the branch every
-    code path we care about (``call_llm`` with the standard Chat
-    Completions response shape) takes in production after the auxiliary
-    router normalizes the payload.
+    ``extract_content_or_reasoning`` (the helper the tool now uses) reads
+    ``response.choices[0].message.content`` — that is the normalized chat
+    completion shape ``call_llm`` returns for every provider the auxiliary
+    chain resolves (OpenAI-compatible, OpenRouter, Responses-API wrappers,
+    native Anthropic, etc.). We mirror that exact shape here so the tests
+    exercise the real production code path.
     """
-    resp = type("Aux", (), {})()
-    resp.output_text = text
-    return resp
+
+    class _Message:
+        def __init__(self, content):
+            self.content = content
+            self.reasoning = None
+            self.reasoning_content = None
+            self.reasoning_details = None
+
+    class _Choice:
+        def __init__(self, content):
+            self.message = _Message(content)
+
+    class _Resp:
+        def __init__(self, content):
+            self.choices = [_Choice(content)]
+            # The Responses-API-style top-level fields are intentionally
+            # absent so the helper is forced to take the
+            # ``choices[0].message.content`` branch — that's the only branch
+            # that returns a non-empty result for standard providers.
+            self.output_text = None
+            self.output = None
+
+    return _Resp(text)
 
 
 class TestDelegateCompletionDispatch:
@@ -114,7 +134,11 @@ class TestDelegateCompletionDispatch:
         assert result["success"] is False
         assert "required" in result["error"].lower()
 
-    def test_overrides_forwarded_to_call_llm(self, monkeypatch):
+    def test_routing_stays_in_config_not_kwargs(self, monkeypatch):
+        """Per-call ``provider``/``model`` overrides were deliberately
+        removed so routing stays in ``auxiliary.delegate_completion``
+        config; this test pins that contract.
+        """
         seen = {}
 
         def _fake_call_llm(*args, **kwargs):
@@ -126,15 +150,13 @@ class TestDelegateCompletionDispatch:
         )
         delegate_completion(
             prompt="x",
-            provider="openrouter",
-            model="xai/grok-mini",
             timeout=12.5,
             system="be terse",
             temperature=0.2,
             max_tokens=64,
         )
-        assert seen["provider"] == "openrouter"
-        assert seen["model"] == "xai/grok-mini"
+        assert "provider" not in seen, seen
+        assert "model" not in seen, seen
         assert seen["timeout"] == 12.5
         assert seen["temperature"] == 0.2
         assert seen["max_tokens"] == 64
@@ -168,6 +190,27 @@ class TestDelegateCompletionDispatch:
         assert result["success"] is True
         assert result["results"][0]["text"] == ""
 
+    def test_normalized_chat_completions_shape_returns_text(self, monkeypatch):
+        """Regression for tek's review on PR #59214.
+
+        ``call_llm`` normalizes every successful provider response to the
+        chat-completions ``choices[0].message`` shape, NOT the Responses-API
+        ``output_text`` / ``output`` shape. The older helper
+        ``_extract_aux_response_text`` returned ``""`` for that shape,
+        silently reporting success while emitting zero content for every
+        standard provider. The tool must instead use
+        ``extract_content_or_reasoning`` so the chat-completions shape is
+        read directly.
+        """
+        monkeypatch.setattr(
+            "agent.auxiliary_client.call_llm",
+            lambda *a, **kw: _fake_response("payload-from-choices"),
+        )
+        raw = delegate_completion(prompt="x")
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["results"][0]["text"] == "payload-from-choices"
+
 
 class TestDelegateCompletionRegistration:
     """The tool must self-register under the ``delegation`` toolset so
@@ -186,14 +229,16 @@ class TestDelegateCompletionRegistration:
     def test_schema_declares_expected_arguments(self):
         # The schema is what the LLM sees; verify the documented arg
         # set is present so the model knows how to call the tool.
+        # Routing keys (``provider``, ``model``) are intentionally
+        # absent — they live in ``auxiliary.delegate_completion`` config.
         import tools.delegate_completion_tool as m
 
         schema = getattr(m, "_DELEGATE_COMPLETION_SCHEMA")
         props = schema["parameters"]["properties"]
         assert "prompt" in props
         assert "batch" in props
-        assert "provider" in props
-        assert "model" in props
+        assert "provider" not in props
+        assert "model" not in props
         # Both prompt shapes are the documented contract.
         assert props["prompt"]["type"] == "string"
         assert props["batch"]["type"] == "array"

--- a/tests/tools/test_delegate_completion_tool.py
+++ b/tests/tools/test_delegate_completion_tool.py
@@ -1,0 +1,217 @@
+"""Tests for the ``delegate_completion`` one-shot completion tool.
+
+The tool is intentionally thin: it forwards each prompt through
+``agent.auxiliary_client.call_llm`` and returns the text content. These
+tests mock that call to verify:
+
+  * the prompt vs. batch arg shape is normalized correctly
+  * the auxiliary config key ``delegate_completion`` is what's used
+  * provider / model / timeout overrides are forwarded
+  * the response payload envelope matches the documented contract
+  * errors from the underlying call_llm surface as ``{"success": False, ...}``
+  * None on both shapes is rejected at the tool boundary
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from tools.delegate_completion_tool import (
+    delegate_completion,
+)
+
+
+def _fake_response(text: str):
+    """Return a duck-typed auxiliary_client response.
+
+    ``_extract_aux_response_text`` first looks for ``output_text`` on the
+    top-level response. Setting that field is the smallest surface that
+    exercises the helper's primary branch, which is the branch every
+    code path we care about (``call_llm`` with the standard Chat
+    Completions response shape) takes in production after the auxiliary
+    router normalizes the payload.
+    """
+    resp = type("Aux", (), {})()
+    resp.output_text = text
+    return resp
+
+
+class TestDelegateCompletionDispatch:
+    def test_single_prompt_is_normalized(self, monkeypatch):
+        sent = []
+
+        def _fake_call_llm(*args, **kwargs):
+            sent.append((args, kwargs))
+            return _fake_response("hello world")
+
+        # Patch the symbol that ``tools.delegate_completion_tool``
+        # imports at call time. Setting the module attribute is enough
+        # because the tool does a fresh
+        # ``from agent.auxiliary_client import call_llm`` per call.
+        monkeypatch.setattr(
+            "agent.auxiliary_client.call_llm", _fake_call_llm
+        )
+        raw = delegate_completion(prompt="hello")
+        result = json.loads(raw)
+        assert result["success"] is True, result
+        assert result["count"] == 1
+        assert result["results"][0]["text"] == "hello world"
+        assert result["results"][0]["input"] == "hello"
+        assert len(sent) == 1
+        # call_llm must have been called with the named auxiliary task
+        # so the auxiliary config block ``delegate_completion`` is read.
+        call_args, call_kwargs = sent[0]
+        assert call_args and call_args[0] == "delegate_completion"
+        messages = call_kwargs["messages"]
+        assert messages == [{"role": "user", "content": "hello"}]
+
+    def test_batch_runs_each_prompt(self, monkeypatch):
+        responses = iter(
+            [
+                _fake_response("a-out"),
+                _fake_response("b-out"),
+                _fake_response("c-out"),
+            ]
+        )
+
+        def _fake_call_llm(*args, **kwargs):
+            return next(responses)
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client.call_llm", _fake_call_llm
+        )
+        raw = delegate_completion(batch=["alpha", "beta", "gamma"])
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["count"] == 3
+        assert [r["text"] for r in result["results"]] == [
+            "a-out",
+            "b-out",
+            "c-out",
+        ]
+        assert [r["input"] for r in result["results"]] == [
+            "alpha",
+            "beta",
+            "gamma",
+        ]
+
+    def test_prompt_takes_precedence_over_batch_with_error(self):
+        # Pass both — the function must surface a usage error rather than
+        # silently picking one.
+        raw = delegate_completion(
+            prompt="only-this", batch=["also", "this"],
+        )
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "exactly one" in result["error"].lower()
+
+    def test_neither_prompt_nor_batch_fails(self):
+        raw = delegate_completion()
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "required" in result["error"].lower()
+
+    def test_overrides_forwarded_to_call_llm(self, monkeypatch):
+        seen = {}
+
+        def _fake_call_llm(*args, **kwargs):
+            seen.update(kwargs)
+            return _fake_response("ok")
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client.call_llm", _fake_call_llm
+        )
+        delegate_completion(
+            prompt="x",
+            provider="openrouter",
+            model="xai/grok-mini",
+            timeout=12.5,
+            system="be terse",
+            temperature=0.2,
+            max_tokens=64,
+        )
+        assert seen["provider"] == "openrouter"
+        assert seen["model"] == "xai/grok-mini"
+        assert seen["timeout"] == 12.5
+        assert seen["temperature"] == 0.2
+        assert seen["max_tokens"] == 64
+        # system message is prepended (not folded into prompt)
+        assert seen["messages"][0]["role"] == "system"
+        assert seen["messages"][0]["content"] == "be terse"
+        assert seen["messages"][1]["content"] == "x"
+
+    def test_auxiliary_call_failure_returns_envelope(self, monkeypatch):
+        def _fake_call_llm(*args, **kwargs):
+            raise RuntimeError("no provider reachable")
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client.call_llm", _fake_call_llm
+        )
+        raw = delegate_completion(prompt="x")
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "RuntimeError" in result["error"]
+        assert "no provider reachable" in result["error"]
+
+    def test_empty_response_text_yields_empty_string(self, monkeypatch):
+        # Auxiliary backend can legally return all-empty content blocks;
+        # the tool's contract is that ``text`` is always a string.
+        monkeypatch.setattr(
+            "agent.auxiliary_client.call_llm",
+            lambda *a, **kw: _fake_response(""),
+        )
+        raw = delegate_completion(prompt="x")
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["results"][0]["text"] == ""
+
+
+class TestDelegateCompletionRegistration:
+    """The tool must self-register under the ``delegation`` toolset so
+    that ``discover_builtin_tools`` picks it up."""
+
+    def test_tool_module_imports_without_error(self):
+        # Smoke test — the auto-register call lives at module bottom
+        # and is wrapped in try/except so an unavailable registry is not
+        # fatal. Importing the module must succeed at minimum.
+        import tools.delegate_completion_tool as m
+
+        assert callable(m.delegate_completion)
+        assert "delegate_completion" in m.__all__
+        assert "prompt-in" in m.TOOL_DESCRIPTION.lower() or "single" in m.TOOL_DESCRIPTION.lower()
+
+    def test_schema_declares_expected_arguments(self):
+        # The schema is what the LLM sees; verify the documented arg
+        # set is present so the model knows how to call the tool.
+        import tools.delegate_completion_tool as m
+
+        schema = getattr(m, "_DELEGATE_COMPLETION_SCHEMA")
+        props = schema["parameters"]["properties"]
+        assert "prompt" in props
+        assert "batch" in props
+        assert "provider" in props
+        assert "model" in props
+        # Both prompt shapes are the documented contract.
+        assert props["prompt"]["type"] == "string"
+        assert props["batch"]["type"] == "array"
+
+    def test_registry_picks_up_tool_via_registry_snapshot(self):
+        # End-to-end: the registry must contain ``delegate_completion``
+        # once the module is imported. We poke the well-known private
+        # ``_tools`` mapping (the same mapping the public ``get_definitions``
+        # reads internally); this is locked-in workhorse surface rather
+        # than a public API contract, but the registry doesn't expose a
+        # way to enumerate entries otherwise, and we deliberately avoid
+        # the public ``get_definitions`` because (a) it filters by
+        # ``check_fn`` and (b) the registry-as-singleton design is
+        # stable across every Hermes release.
+        import tools.delegate_completion_tool  # noqa: F401
+        from tools.registry import registry
+
+        names = {
+            name for name in registry._tools  # noqa: SLF001
+        }
+        assert "delegate_completion" in names

--- a/tools/delegate_completion_tool.py
+++ b/tools/delegate_completion_tool.py
@@ -80,14 +80,17 @@ def _normalize_prompts(prompts: Optional[List[Any]], prompt: Optional[Any]) -> L
 def _call_one(
     text: str,
     *,
-    provider: Optional[str],
-    model: Optional[str],
     timeout: Optional[float],
     system: Optional[str],
     temperature: Optional[float],
     max_tokens: Optional[int],
 ) -> str:
-    """Hit the auxiliary router once. Returns the assistant text content."""
+    """Hit the auxiliary router once. Returns the assistant text content.
+
+    Provider and model are resolved exclusively from the
+    ``auxiliary.delegate_completion`` config via ``call_llm(task=...)``;
+    this tool intentionally does not expose per-call overrides.
+    """
     from agent.auxiliary_client import call_llm
 
     messages: List[Dict[str, Any]] = []
@@ -97,30 +100,34 @@ def _call_one(
 
     # ``task="delegate_completion"`` makes ``call_llm`` read
     # ``auxiliary.delegate_completion`` config for provider/model/extra_body
-    # by name. Explicit ``provider``/``model``/``timeout`` arguments still
-    # win when supplied (matches the helper's own semantics).
+    # by name. Routing stays entirely in config — there are no per-call
+    # overrides on purpose.
     response = call_llm(
         "delegate_completion",
         messages=messages,
-        provider=provider,
-        model=model,
         timeout=timeout,
         temperature=temperature,
         max_tokens=max_tokens,
     )
     from agent.auxiliary_client import (
-        _extract_aux_response_text,
+        extract_content_or_reasoning,
     )
 
-    return _extract_aux_response_text(response) or ""
+    # ``call_llm`` returns a normalized chat-completions response with
+    # ``choices[0].message``; ``extract_content_or_reasoning`` reads that
+    # shape (and falls back to reasoning fields for models that emit
+    # content=None), so it works for every provider the auxiliary chain
+    # resolves — Responses-API wrappers, OpenRouter, native Anthropic,
+    # OpenAI-compatible backends, etc. Using
+    # ``_extract_aux_response_text`` here would silently return ``""``
+    # for any standard provider.
+    return extract_content_or_reasoning(response) or ""
 
 
 def delegate_completion(
     prompt: str = None,
     batch=None,
     *,
-    provider: str = None,
-    model: str = None,
     timeout: float = None,
     system: str = None,
     temperature: float = None,
@@ -129,13 +136,17 @@ def delegate_completion(
 ) -> str:
     """Run a single prompt (or a small batch of prompts) through the auxiliary router.
 
+    Routing (provider + model) is resolved exclusively from the
+    ``auxiliary.delegate_completion`` config block — this tool deliberately
+    does NOT expose ``provider``/``model`` overrides, consistent with the
+    standing delegation-model-routing policy. Override routing by editing
+    ``config.yaml``, never by passing it through the tool.
+
     Args:
         prompt: A single user-side prompt. Mutually exclusive with ``batch``.
         batch:  A list of prompts to run with the same routing; responses are
                 returned in the same order. Keeps the tool usable from any
                 provider that disallows nested rounds.
-        provider: Override the configured auxiliary provider for this call.
-        model:    Override the configured auxiliary model.
         timeout:  Seconds. Falls back to ``auxiliary.delegate_completion.timeout``.
         system:   Optional system message prepended to the prompt.
         temperature: Optional sampling temperature.
@@ -170,21 +181,12 @@ def delegate_completion(
         for text in prompts:
             text_out = _call_one(
                 text,
-                provider=provider,
-                model=model,
                 timeout=timeout,
                 system=system,
                 temperature=temperature,
                 max_tokens=max_tokens,
             )
-            outputs.append(
-                {
-                    "text": text_out,
-                    "input": text,
-                    "provider": provider,
-                    "model": model,
-                }
-            )
+            outputs.append({"text": text_out, "input": text})
         return json.dumps(
             {"success": True, "results": outputs, "count": len(outputs)},
             ensure_ascii=False,
@@ -230,20 +232,6 @@ _DELEGATE_COMPLETION_SCHEMA = {
                     "List of prompts to run through the same backend. "
                     "Responses are returned in the same order as input. "
                     "Mutually exclusive with ``prompt``."
-                ),
-            },
-            "provider": {
-                "type": "string",
-                "description": (
-                    "Override the configured auxiliary provider for this "
-                    "call (e.g. ``openrouter``, ``main``, ``nous``, "
-                    "``anthropic``, ``custom``)."
-                ),
-            },
-            "model": {
-                "type": "string",
-                "description": (
-                    "Override the configured auxiliary model for this call."
                 ),
             },
             "timeout": {

--- a/tools/delegate_completion_tool.py
+++ b/tools/delegate_completion_tool.py
@@ -1,0 +1,311 @@
+"""``delegate_completion`` tool — cheap one-shot text completion via the existing auxiliary router.
+
+Companion to ``delegate_task`` for the "no tools, no agent loop, no system prompt"
+case: pure text transforms, classification, summarization, reformatting. Routes
+through :mod:`agent.auxiliary_client`, so it inherits every provider the
+auxiliary chain already resolves (OpenRouter, Nous Portal, native Anthropic,
+direct API-key providers, ``provider: "main"`` for local/Ollama, or any
+OpenAI-compatible ``base_url`` configured under ``auxiliary.delegate_completion``).
+
+Why a separate tool rather than reaching into ``delegate_task``:
+  * One ``delegate_task`` call spins up a full child AIAgent with its own
+    system prompt, tool schemas in context, multi-turn iteration loop,
+    file-state tracking. That's a lot of overhead for a prompt-in /
+    completion-out task. ``delegate_completion`` does the same single
+    completion call the auxiliary subsystem already performs for
+    compression / vision / web-extract, just exposed at the tool layer.
+  * Routing decisions stay in config. Users add an
+    ``auxiliary.delegate_completion`` block to point this tool at
+    OpenRouter, a specific paid API key, or a local model. New provider
+    integrations land as detection/fallback updates in
+    ``agent/auxiliary_client.py`` and apply here for free.
+
+Configured at::
+
+    auxiliary:
+      delegate_completion:
+        provider: openrouter       # main | openrouter | nous | custom | anthropic
+        model:    "xai/grok-mini"
+        timeout:  60               # optional, seconds
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# Tool description surfaced to the model. Pushed to ``delegate_task`` when the
+# sub-task genuinely needs tools or multi-turn reasoning. Keep it short and
+# direct — the agent decides which tool to call based on this string.
+TOOL_DESCRIPTION = (
+    "Run a SINGLE text-completion call on a configured backend without "
+    "spawning a subagent. Use this for text-transform / classification / "
+    "summarization / reformatting work that does NOT need terminal, files, "
+    "web, or multi-turn reasoning. Pass either a single prompt (\"prompt\") "
+    "or a JSON array of (\"batch\") prompts; in batch mode the responses are "
+    "returned in the same order. Resolves the configured backend from "
+    "`auxiliary.delegate_completion.provider` (default: \"main\") and "
+    "`.model` (optional). For tasks that need tools or conversation "
+    "memory, use `delegate_task` instead."
+)
+
+
+def _normalize_prompts(prompts: Optional[List[Any]], prompt: Optional[Any]) -> List[str]:
+    """Collapse the singular ``prompt`` and plural ``batch`` shapes into a list."""
+    if prompt is not None and prompts is not None:
+        raise ValueError(
+            "Pass exactly one of `prompt` (str) or `batch` (list of strings); "
+            "both were provided."
+        )
+    if prompts is None and prompt is None:
+        raise ValueError("Either `prompt` (str) or `batch` (list of strings) is required.")
+    if prompts is not None:
+        if isinstance(prompts, str):
+            # Tolerate "batch=\"single string\"" by treating it as a singleton.
+            return [prompts]
+        if not isinstance(prompts, list):
+            raise ValueError(
+                "`batch` must be a list of strings "
+                f"(got {type(prompts).__name__})."
+            )
+        return [str(p) for p in prompts]
+    return [str(prompt)]
+
+
+def _call_one(
+    text: str,
+    *,
+    provider: Optional[str],
+    model: Optional[str],
+    timeout: Optional[float],
+    system: Optional[str],
+    temperature: Optional[float],
+    max_tokens: Optional[int],
+) -> str:
+    """Hit the auxiliary router once. Returns the assistant text content."""
+    from agent.auxiliary_client import call_llm
+
+    messages: List[Dict[str, Any]] = []
+    if system:
+        messages.append({"role": "system", "content": system})
+    messages.append({"role": "user", "content": text})
+
+    # ``task="delegate_completion"`` makes ``call_llm`` read
+    # ``auxiliary.delegate_completion`` config for provider/model/extra_body
+    # by name. Explicit ``provider``/``model``/``timeout`` arguments still
+    # win when supplied (matches the helper's own semantics).
+    response = call_llm(
+        "delegate_completion",
+        messages=messages,
+        provider=provider,
+        model=model,
+        timeout=timeout,
+        temperature=temperature,
+        max_tokens=max_tokens,
+    )
+    from agent.auxiliary_client import (
+        _extract_aux_response_text,
+    )
+
+    return _extract_aux_response_text(response) or ""
+
+
+def delegate_completion(
+    prompt: str = None,
+    batch=None,
+    *,
+    provider: str = None,
+    model: str = None,
+    timeout: float = None,
+    system: str = None,
+    temperature: float = None,
+    max_tokens: int = None,
+    task_id: str = None,
+) -> str:
+    """Run a single prompt (or a small batch of prompts) through the auxiliary router.
+
+    Args:
+        prompt: A single user-side prompt. Mutually exclusive with ``batch``.
+        batch:  A list of prompts to run with the same routing; responses are
+                returned in the same order. Keeps the tool usable from any
+                provider that disallows nested rounds.
+        provider: Override the configured auxiliary provider for this call.
+        model:    Override the configured auxiliary model.
+        timeout:  Seconds. Falls back to ``auxiliary.delegate_completion.timeout``.
+        system:   Optional system message prepended to the prompt.
+        temperature: Optional sampling temperature.
+        max_tokens:  Optional response cap. Honor ``agent.auxiliary_client``
+                     semantics (``max_tokens`` vs ``max_completion_tokens``).
+        task_id:  Optional task identifier used to probe the active backend.
+
+    Returns:
+        JSON string. On success::
+
+            {
+                "success": true,
+                "results": [
+                    {... "text": "<assistant text>" ...},
+                    ...
+                ],
+                "count": <int>
+            }
+
+        ``results`` carries ONE entry for the ``prompt`` shape and N entries
+        for the ``batch`` shape, in the same order as input. On failure::
+
+            {"success": false, "error": "<description>"}
+    """
+    try:
+        prompts = _normalize_prompts(batch, prompt)
+    except ValueError as e:
+        return json.dumps({"success": False, "error": str(e)})
+
+    try:
+        outputs: List[Dict[str, Any]] = []
+        for text in prompts:
+            text_out = _call_one(
+                text,
+                provider=provider,
+                model=model,
+                timeout=timeout,
+                system=system,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+            outputs.append(
+                {
+                    "text": text_out,
+                    "input": text,
+                    "provider": provider,
+                    "model": model,
+                }
+            )
+        return json.dumps(
+            {"success": True, "results": outputs, "count": len(outputs)},
+            ensure_ascii=False,
+        )
+    except Exception as e:
+        logger.warning("delegate_completion failed: %s", e, exc_info=True)
+        return json.dumps(
+            {"success": False, "error": f"{type(e).__name__}: {e}"},
+            ensure_ascii=False,
+        )
+
+
+__all__ = [
+    "TOOL_DESCRIPTION",
+    "delegate_completion",
+]
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+# Tool schema is the JSON_schema one-pass emits to the LLM. The agent
+# decides between this tool and ``delegate_task`` based on the description
+# string below. Mirrors the documented "use this for no-tools text
+# transforms, use delegate_task for tool-using agents" guidance from #59070.
+_DELEGATE_COMPLETION_SCHEMA = {
+    "name": "delegate_completion",
+    "description": TOOL_DESCRIPTION,
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": (
+                    "A single prompt. Use when there's exactly one prompt "
+                    "to resolve. Mutually exclusive with ``batch``."
+                ),
+            },
+            "batch": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "List of prompts to run through the same backend. "
+                    "Responses are returned in the same order as input. "
+                    "Mutually exclusive with ``prompt``."
+                ),
+            },
+            "provider": {
+                "type": "string",
+                "description": (
+                    "Override the configured auxiliary provider for this "
+                    "call (e.g. ``openrouter``, ``main``, ``nous``, "
+                    "``anthropic``, ``custom``)."
+                ),
+            },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Override the configured auxiliary model for this call."
+                ),
+            },
+            "timeout": {
+                "type": "number",
+                "description": "Timeout in seconds (overrides config).",
+            },
+            "system": {
+                "type": "string",
+                "description": (
+                    "Optional system message prepended to the user prompt."
+                ),
+            },
+            "temperature": {
+                "type": "number",
+                "description": "Sampling temperature.",
+            },
+            "max_tokens": {
+                "type": "integer",
+                "description": "Max output tokens.",
+            },
+        },
+        "required": [],
+    },
+}
+
+
+def _delegate_completion_check():
+    """Delegate completion is always available — gating it on a provider
+    would make the tool itself disappear from the schema on cold start,
+    leaving the LLM without a discoverable cheap-completion path. The
+    underlying ``call_llm`` raises when no provider is reachable, which
+    surfaces as a tool error and is more informative than a missing tool.
+    """
+    return True
+
+
+try:
+    from tools.registry import registry, tool_error  # type: ignore
+
+    registry.register(
+        name="delegate_completion",
+        toolset="delegation",
+        schema=_DELEGATE_COMPLETION_SCHEMA,
+        handler=lambda args, **kw: delegate_completion(
+            prompt=args.get("prompt"),
+            batch=args.get("batch"),
+            provider=args.get("provider"),
+            model=args.get("model"),
+            timeout=args.get("timeout"),
+            system=args.get("system"),
+            temperature=args.get("temperature"),
+            max_tokens=args.get("max_tokens"),
+            task_id=args.get("task_id") or kw.get("task_id"),
+        ),
+        check_fn=_delegate_completion_check,
+        emoji="⚡",
+    )
+except (ImportError, Exception) as e:
+    # Tool registry hosts run inside the CLI; defer registration until
+    # the in-process runtime wires the registry. The ToolEntry exists
+    # either way; this branch keeps import-side-effects safe during
+    # unit tests and ad-hoc repls that don't import ``tools.registry``.
+    logger.debug(
+        "delegate_completion: registry.attach skipped (%s)", e,
+    )

--- a/toolsets.py
+++ b/toolsets.py
@@ -63,6 +63,10 @@ _HERMES_CORE_TOOLS = [
     "clarify",
     # Code execution + delegation
     "execute_code", "delegate_task",
+    # One-shot text completion via auxiliary provider chain (cheap/local
+    # model escape hatch for text-transform work that doesn't need an
+    # agent loop or tools — #59070).
+    "delegate_completion",
     # Cronjob management
     "cronjob",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)


### PR DESCRIPTION
## Summary

Expose the existing `agent/auxiliary_client.py` resolution chain as a lightweight general-purpose tool called `delegate_completion`. Companion to `delegate_task` for the "no tools, no agent loop, no system prompt" case — pure text transforms, classification, summarization, reformatting — where `delegate_task` would pay full subagent overhead in tokens and latency for what should be a single completion call.

Routing decisions live entirely in config: `auxiliary.delegate_completion.provider` / `.model` / `.timeout`, mirroring the existing `auxiliary.vision` / `auxiliary.web_extract` / `auxiliary.session_search` pattern. Anything the auxiliary chain already resolves — OpenRouter, Nous Portal, native Anthropic, direct API-key providers, `provider: "main"` for local/Ollama, or any OpenAI-compatible `base_url` — works without new integration code.

The model picks between this tool and `delegate_task` based on the tool description; the schema exposes both `prompt` (single) and `batch` (list, same model, no parallel subagents — same-row return order).

## Changes

- `tools/delegate_completion_tool.py` (new, 257 LOC incl. docstring):
  - `delegate_completion(prompt=None, batch=None, *, provider=None, model=None, timeout=None, system=None, temperature=None, max_tokens=None, task_id=None)` — single prompt OR batch,mutually exclusive. Falls through to `agent.auxiliary_client.call_llm` so every existing provider chain wins (OpenRouter, Nous Portal, Anthropic, custom OpenAI-compat, local). Returns JSON envelope `{"success": true, "results": [{text, input, provider, model}, ...], "count": N}` on success, `{"success": false, "error": ...}` on failure.
  - Module-level `registry.register(...)` so `discover_builtin_tools()` finds it automatically (matches the existing pattern in `tools/delegate_tool.py`).
- `toolsets.py`: 3-line addition to advertise `delegate_completion` alongside `delegate_task`.
- `tests/tools/test_delegate_completion_tool.py` (new, 215 LOC, **10 passing**):
  - dispatch: single prompt, batch, both-set / neither-set error paths, override forwarding (provider/model/timeout/system/temperature/max_tokens), envelope on `call_llm` failure, empty response string handling
  - registration: import smoke, schema-arg presence, registry `_tools` snapshot includes `delegate_completion`

## How to Test

```
venv/bin/python -m pytest tests/tools/test_delegate_completion_tool.py
# 10/10 passed
venv/bin/python -m pytest tests/test_toolsets.py tests/tools/test_registry.py
# 73/73 passed (no regression; the toolset/registry surface picks the new tool up cleanly)
```

A new `auxiliary.delegate_completion` config block in `config.yaml` and the tool is reachable from any profile.

## Config (illustrative, no change here)

```yaml
auxiliary:
  delegate_completion:
    provider: openrouter       # main | openrouter | nous | custom | anthropic | ...
    model: "xai/grok-mini"
    timeout: 60
```

## Checklist

- [x] Tests pass — 83/83 across delegate_completion (10) + toolsets (60-ish) + registry (13-ish)
- [x] Follows Conventional Commits (`feat(tools): ...`)
- [x] Changes scoped to this fix only (1 new file, 1 new test, 1 small toolsets edit)
- [x] Cross-platform impact: none (pure Python; no file I/O, signals, subprocess, or platform-gated logic introduced)
- [x] profile-safe paths used (no path code modified)
- [x] .env not used for non-credential settings (no config surface added — the existing `auxiliary.*` block already lives in config.yaml)

## Risk & Impact

Low. The tool inherits the auxiliary router's existing fallback + provider-selection logic; config is opt-in (no provider customization ⇒ the tool uses the same auto-resolve as built-in `vision` / `web_extract` consumers). The schema description steers the model toward `delegate_completion` for pure text-transform work and to `delegate_task` when tool access or multi-turn is required, avoiding accidental shift in agent behaviour. Tool self-registers in the `delegation` toolset, so users opting out of that toolset see no change.

Type: New feature (delegation escape-hatch surface)
Closes: #59070