### PR TITLE
security(gateway): complete the webhook body-cap sweep (salvages #54620, #25296, #54944, #54938)

### DIFF
--- a/gateway/platforms/msgraph_webhook.py
+++ b/gateway/platforms/msgraph_webhook.py
@@ -34,6 +34,7 @@ DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = 8646
 DEFAULT_WEBHOOK_PATH = "/msgraph/webhook"
 DEFAULT_MAX_SEEN_RECEIPTS = 5000
+DEFAULT_MAX_BODY_BYTES = 1_048_576
 NotificationScheduler = Callable[[Dict[str, Any], MessageEvent], Awaitable[None] | None]
 
 
@@ -62,6 +63,9 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
         self._client_state: Optional[str] = self._string_or_none(extra.get("client_state"))
         self._max_seen_receipts = max(
             1, int(extra.get("max_seen_receipts", DEFAULT_MAX_SEEN_RECEIPTS))
+        )
+        self._max_body_bytes = max(
+            1, int(extra.get("max_body_bytes", DEFAULT_MAX_BODY_BYTES))
         )
         self._allowed_source_networks: list[ipaddress._BaseNetwork] = (
             self._parse_allowed_source_cidrs(extra.get("allowed_source_cidrs"))
@@ -152,7 +156,7 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
             )
             return False
 
-        app = web.Application()
+        app = web.Application(client_max_size=self._max_body_bytes)
         app.router.add_get(self._health_path, self._handle_health)
         app.router.add_get(self._webhook_path, self._handle_validation)
         app.router.add_post(self._webhook_path, self._handle_notification)
@@ -229,8 +233,24 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
             return web.Response(text=validation_token, content_type="text/plain")
 
         try:
-            body = await request.json()
+            content_length = request.content_length
         except Exception:
+            content_length = None
+        if content_length is not None and content_length > self._max_body_bytes:
+            return web.Response(status=413)
+
+        try:
+            raw_body = await request.read()
+        except Exception:
+            return web.Response(status=400)
+        if len(raw_body) > self._max_body_bytes:
+            return web.Response(status=413)
+
+        try:
+            body = json.loads(raw_body.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return web.Response(status=400)
+        if not isinstance(body, dict):
             return web.Response(status=400)
 
         notifications = body.get("value")

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -90,6 +90,7 @@ DEFAULT_WEBHOOK_HOST = "0.0.0.0"
 DEFAULT_WEBHOOK_PORT = 8090
 DEFAULT_WEBHOOK_PATH = "/whatsapp/webhook"
 GRAPH_API_BASE = "https://graph.facebook.com"
+WEBHOOK_MAX_BODY_BYTES = 3 * 1024 * 1024
 # Meta retries failed webhooks for up to 7 days. We don't need to remember
 # every wamid for the full retry window — the practical risk is duplicate
 # delivery within minutes, not days. 5000 entries with FIFO eviction is
@@ -142,6 +143,17 @@ _WHATSAPP_MIME_EXTENSION_OVERRIDES: Dict[str, str] = {
     # of .jpg, which trips up tools that switch on extension.
     "image/jpeg": ".jpg",
 }
+
+
+async def _read_limited_request_body(request: Any, max_bytes: int) -> bytes:
+    """Read at most ``max_bytes`` from an aiohttp request body."""
+    try:
+        body = await request.content.readexactly(max_bytes + 1)
+    except asyncio.IncompleteReadError as exc:
+        body = exc.partial
+    if len(body) > max_bytes:
+        raise ValueError("payload too large")
+    return body
 
 
 def _ext_for_mime(mime: str) -> Optional[str]:
@@ -1405,15 +1417,17 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
              multiply downstream agent work because of a transient bug
              during dispatch.
         """
+        # Meta's documented max payload is 3MB. Read one byte past the limit
+        # so oversized chunked bodies are rejected before buffering the rest.
         try:
-            raw = await request.read()
+            raw = await _read_limited_request_body(
+                request,
+                WEBHOOK_MAX_BODY_BYTES,
+            )
+        except ValueError:
+            return web.Response(status=413)
         except Exception:
             return web.Response(status=400)
-
-        # Meta's documented max payload is 3MB. Reject earlier than aiohttp
-        # would so we don't even compute HMAC over giant junk.
-        if len(raw) > 3 * 1024 * 1024:
-            return web.Response(status=413)
 
         # Refuse to accept anything if app_secret isn't configured. Without
         # it we can't authenticate the sender, and the handler would be a

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -415,7 +415,10 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         )
 
         # Inbound webhook server.
-        app = web.Application()
+        # client_max_size backstops the bounded reader in _handle_webhook —
+        # aiohttp enforces the cap on request.read()/post() paths too
+        # (#58536/#58902/#59180 pattern).
+        app = web.Application(client_max_size=WEBHOOK_MAX_BODY_BYTES)
         app.router.add_get(self._health_path, self._handle_health)
         app.router.add_get(self._webhook_path, self._handle_verify)
         app.router.add_post(self._webhook_path, self._handle_webhook)

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -228,6 +228,19 @@ _APPROVAL_LABEL_MAP: Dict[str, str] = {
     "always": "Approved permanently",
     "deny": "Denied",
 }
+
+
+async def _read_limited_feishu_webhook_body(request: Any, max_bytes: int) -> bytes:
+    """Read at most ``max_bytes`` from an aiohttp request body."""
+    try:
+        body = await request.content.readexactly(max_bytes + 1)
+    except asyncio.IncompleteReadError as exc:
+        body = exc.partial
+    if len(body) > max_bytes:
+        raise ValueError("payload too large")
+    return body
+
+
 _FEISHU_BOT_MSG_TRACK_SIZE = 512                   # LRU size for tracking sent message IDs
 _FEISHU_REPLY_FALLBACK_CODES = frozenset({230011, 231003})  # reply target withdrawn/missing → create fallback
 
@@ -3467,9 +3480,16 @@ class FeishuAdapter(BasePlatformAdapter):
 
         try:
             body_bytes: bytes = await asyncio.wait_for(
-                request.read(),
+                _read_limited_feishu_webhook_body(
+                    request,
+                    _FEISHU_WEBHOOK_MAX_BODY_BYTES,
+                ),
                 timeout=_FEISHU_WEBHOOK_BODY_TIMEOUT_SECONDS,
             )
+        except ValueError:
+            logger.warning("[Feishu] Webhook body exceeds limit from %s", remote_ip)
+            self._record_webhook_anomaly(remote_ip, "413")
+            return web.Response(status=413, text="Request body too large")
         except asyncio.TimeoutError:
             logger.warning("[Feishu] Webhook body read timed out after %ds from %s", _FEISHU_WEBHOOK_BODY_TIMEOUT_SECONDS, remote_ip)
             self._record_webhook_anomaly(remote_ip, "408")
@@ -3477,11 +3497,6 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception:
             self._record_webhook_anomaly(remote_ip, "400")
             return web.json_response({"code": 400, "msg": "failed to read body"}, status=400)
-
-        if len(body_bytes) > _FEISHU_WEBHOOK_MAX_BODY_BYTES:
-            logger.warning("[Feishu] Webhook body exceeds limit (%d bytes) from %s", len(body_bytes), remote_ip)
-            self._record_webhook_anomaly(remote_ip, "413")
-            return web.Response(status=413, text="Request body too large")
 
         try:
             payload = json.loads(body_bytes.decode("utf-8"))

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4747,7 +4747,10 @@ class FeishuAdapter(BasePlatformAdapter):
         if self._event_handler is None:
             raise RuntimeError("failed to build Feishu event handler")
         await self._hydrate_bot_identity()
-        app = web.Application()
+        # client_max_size backstops the bounded reader in
+        # _handle_webhook_request; aiohttp then enforces the same cap on
+        # every read path (#58536/#58902/#59180 pattern).
+        app = web.Application(client_max_size=_FEISHU_WEBHOOK_MAX_BODY_BYTES)
         app.router.add_post(self._webhook_path, self._handle_webhook_request)
         self._webhook_runner = web.AppRunner(app)
         await self._webhook_runner.setup()

--- a/plugins/platforms/sms/adapter.py
+++ b/plugins/platforms/sms/adapter.py
@@ -119,7 +119,10 @@ class SmsAdapter(BasePlatformAdapter):
                 self._webhook_port,
             )
 
-        app = web.Application()
+        # client_max_size bounds every read path — including chunked bodies
+        # with no Content-Length — before the handler's own 413 checks run
+        # (#58536/#58902/#59180 pattern).
+        app = web.Application(client_max_size=_TWILIO_WEBHOOK_MAX_BODY_BYTES)
         app.router.add_post("/webhooks/twilio", self._handle_webhook)
         app.router.add_get("/health", lambda _: web.Response(text="ok"))
 

--- a/plugins/platforms/sms/adapter.py
+++ b/plugins/platforms/sms/adapter.py
@@ -42,6 +42,7 @@ TWILIO_API_BASE = "https://api.twilio.com/2010-04-01/Accounts"
 MAX_SMS_LENGTH = 1600  # ~10 SMS segments
 DEFAULT_WEBHOOK_PORT = 8080
 DEFAULT_WEBHOOK_HOST = "127.0.0.1"
+_TWILIO_WEBHOOK_MAX_BODY_BYTES = 65_536  # 64 KiB — Twilio payloads are small
 
 
 def check_sms_requirements() -> bool:
@@ -293,7 +294,20 @@ class SmsAdapter(BasePlatformAdapter):
         from aiohttp import web
 
         try:
+            content_length = request.content_length
+            if content_length is not None and content_length > _TWILIO_WEBHOOK_MAX_BODY_BYTES:
+                return web.Response(
+                    text='<?xml version="1.0" encoding="UTF-8"?><Response></Response>',
+                    content_type="application/xml",
+                    status=413,
+                )
             raw = await request.read()
+            if len(raw) > _TWILIO_WEBHOOK_MAX_BODY_BYTES:
+                return web.Response(
+                    text='<?xml version="1.0" encoding="UTF-8"?><Response></Response>',
+                    content_type="application/xml",
+                    status=413,
+                )
             # Twilio sends form-encoded data, not JSON
             form = urllib.parse.parse_qs(raw.decode("utf-8"), keep_blank_values=True)
         except Exception as e:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -730,6 +730,7 @@ AUTHOR_MAP = {
     "hypnus.yuan@gmail.com": "Hypnus-Yuan",
     "15558128926@qq.com": "xsfX20",
     "binhnt.ht.92@gmail.com": "binhnt92",
+    "li.long15@xydigit.com": "Alix-007",  # PR #54620 salvage (sms: bound Twilio webhook body reads)
     "johnny@Jons-MBA-M4.local": "acesjohnny",
     "1581133593@qq.com": "liu-collab",
     "haidaoe@proton.me": "haidao1919",

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -21,6 +21,18 @@ except ImportError:
     _HAS_LARK_OAPI = False
 
 
+class _FakeRequestContent:
+    def __init__(self, body: bytes):
+        self.body = body
+        self.read_sizes: list[int] = []
+
+    async def readexactly(self, size: int) -> bytes:
+        self.read_sizes.append(size)
+        if len(self.body) < size:
+            raise asyncio.IncompleteReadError(self.body, size)
+        return self.body[:size]
+
+
 def _mock_event_dispatcher_builder(mock_handler_class):
     mock_builder = Mock()
     mock_builder.register_p2_im_message_message_read_v1 = Mock(return_value=mock_builder)
@@ -1604,7 +1616,7 @@ class TestAdapterBehavior(unittest.TestCase):
             remote="127.0.0.1",
             content_length=None,
             headers={},
-            read=AsyncMock(return_value=body),
+            content=_FakeRequestContent(body),
         )
 
         response = asyncio.run(adapter._handle_webhook_request(request))
@@ -1633,7 +1645,7 @@ class TestAdapterBehavior(unittest.TestCase):
             remote="203.0.113.10",
             content_length=None,
             headers={},
-            read=AsyncMock(return_value=body),
+            content=_FakeRequestContent(body),
         )
 
         response = asyncio.run(adapter._handle_webhook_request(request))
@@ -3261,6 +3273,30 @@ class TestWebhookSecurity(unittest.TestCase):
         response = asyncio.run(adapter._handle_webhook_request(request))
         self.assertEqual(response.status, 413)
 
+    def test_webhook_request_rejects_oversized_chunked_body_while_reading(self):
+        from gateway.config import PlatformConfig
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+        from plugins.platforms.feishu.adapter import FeishuAdapter, _FEISHU_WEBHOOK_MAX_BODY_BYTES
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            token = set_hermes_home_override(tmpdir)
+            try:
+                adapter = FeishuAdapter(PlatformConfig())
+            finally:
+                reset_hermes_home_override(token)
+            content = _FakeRequestContent(b"A" * (_FEISHU_WEBHOOK_MAX_BODY_BYTES + 2))
+            request = SimpleNamespace(
+                remote="127.0.0.1",
+                content_length=None,
+                headers={},
+                content=content,
+            )
+
+            response = asyncio.run(adapter._handle_webhook_request(request))
+
+            self.assertEqual(response.status, 413)
+            self.assertEqual(content.read_sizes, [_FEISHU_WEBHOOK_MAX_BODY_BYTES + 1])
+
     @patch.dict(os.environ, {}, clear=True)
     def test_webhook_request_rejects_invalid_json(self):
         from gateway.config import PlatformConfig
@@ -3270,7 +3306,7 @@ class TestWebhookSecurity(unittest.TestCase):
         request = SimpleNamespace(
             remote="127.0.0.1",
             content_length=None,
-            read=AsyncMock(return_value=b"not-json"),
+            content=_FakeRequestContent(b"not-json"),
         )
         response = asyncio.run(adapter._handle_webhook_request(request))
         self.assertEqual(response.status, 400)
@@ -3286,7 +3322,7 @@ class TestWebhookSecurity(unittest.TestCase):
             remote="127.0.0.1",
             content_length=None,
             headers={"x-lark-request-timestamp": "123", "x-lark-request-nonce": "abc", "x-lark-signature": "bad"},
-            read=AsyncMock(return_value=body),
+            content=_FakeRequestContent(body),
         )
         response = asyncio.run(adapter._handle_webhook_request(request))
         self.assertEqual(response.status, 401)
@@ -3335,7 +3371,7 @@ class TestWebhookSecurity(unittest.TestCase):
         request = SimpleNamespace(
             remote="127.0.0.1",
             content_length=None,
-            read=AsyncMock(return_value=body),
+            content=_FakeRequestContent(body),
         )
         response = asyncio.run(adapter._handle_webhook_request(request))
         self.assertEqual(response.status, 200)

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -190,7 +190,7 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         runner = AsyncMock()
         site = AsyncMock()
         web_module = SimpleNamespace(
-            Application=lambda: SimpleNamespace(router=SimpleNamespace(add_post=lambda *_args, **_kwargs: None)),
+            Application=lambda **_kwargs: SimpleNamespace(router=SimpleNamespace(add_post=lambda *_args, **_kwargs: None)),
             AppRunner=lambda _app: runner,
             TCPSite=lambda _runner, host, port: SimpleNamespace(start=site.start, host=host, port=port),
         )

--- a/tests/gateway/test_msgraph_webhook.py
+++ b/tests/gateway/test_msgraph_webhook.py
@@ -1,6 +1,7 @@
 """Tests for the Microsoft Graph webhook adapter."""
 
 import asyncio
+import json
 
 import pytest
 

--- a/tests/gateway/test_msgraph_webhook.py
+++ b/tests/gateway/test_msgraph_webhook.py
@@ -19,15 +19,30 @@ def _make_adapter(**extra_overrides) -> MSGraphWebhookAdapter:
 
 
 class _FakeRequest:
-    def __init__(self, *, query=None, json_payload=None, remote="127.0.0.1"):
+    def __init__(
+        self,
+        *,
+        query=None,
+        json_payload=None,
+        raw_body: bytes | None = None,
+        content_length: int | None = None,
+        remote="127.0.0.1",
+    ):
         self.query = query or {}
         self._json_payload = json_payload
+        self._raw_body = raw_body
+        self.content_length = content_length
         self.remote = remote
 
     async def json(self):
         if isinstance(self._json_payload, Exception):
             raise self._json_payload
         return self._json_payload
+
+    async def read(self):
+        if self._raw_body is not None:
+            return self._raw_body
+        return json.dumps(self._json_payload or {}).encode("utf-8")
 
 
 class TestMSGraphWebhookConfig:
@@ -182,6 +197,62 @@ class TestMSGraphNotifications:
         assert event.source.platform == Platform.MSGRAPH_WEBHOOK
         assert event.source.chat_type == "webhook"
         assert event.message_id == "id:notif-1"
+
+    @pytest.mark.anyio
+    async def test_oversized_notification_rejected_by_content_length(self):
+        adapter = _make_adapter(max_body_bytes=100)
+        payload = {
+            "value": [
+                {
+                    "id": "notif-oversized",
+                    "subscriptionId": "sub-1",
+                    "changeType": "updated",
+                    "resource": "communications/onlineMeetings/meeting-1",
+                    "clientState": "expected-client-state",
+                }
+            ]
+        }
+
+        resp = await adapter._handle_notification(
+            _FakeRequest(json_payload=payload, content_length=101)
+        )
+
+        assert resp.status == 413
+
+    @pytest.mark.anyio
+    async def test_chunked_oversized_notification_rejected_after_read(self):
+        adapter = _make_adapter(max_body_bytes=100)
+        payload = {
+            "value": [
+                {
+                    "id": "notif-chunked-oversized",
+                    "subscriptionId": "sub-1",
+                    "changeType": "updated",
+                    "resource": "communications/onlineMeetings/meeting-1",
+                    "clientState": "expected-client-state",
+                }
+            ]
+        }
+
+        resp = await adapter._handle_notification(
+            _FakeRequest(
+                json_payload=payload,
+                raw_body=b"x" * 101,
+                content_length=None,
+            )
+        )
+
+        assert resp.status == 413
+
+    @pytest.mark.anyio
+    async def test_non_object_notification_body_rejected(self):
+        adapter = _make_adapter()
+
+        resp = await adapter._handle_notification(
+            _FakeRequest(json_payload=[], raw_body=b"[]")
+        )
+
+        assert resp.status == 400
 
     @pytest.mark.anyio
     async def test_bad_client_state_rejected_as_auth_failure(self):

--- a/tests/gateway/test_sms.py
+++ b/tests/gateway/test_sms.py
@@ -459,10 +459,11 @@ class TestWebhookSignatureEnforcement:
         adapter._message_handler = AsyncMock()
         return adapter
 
-    def _mock_request(self, body, headers=None):
+    def _mock_request(self, body, headers=None, content_length=None):
         request = MagicMock()
         request.read = AsyncMock(return_value=body)
         request.headers = headers or {}
+        request.content_length = content_length
         return request
 
     @pytest.mark.asyncio
@@ -536,3 +537,27 @@ class TestWebhookSignatureEnforcement:
         request = self._mock_request(body, headers={"X-Twilio-Signature": sig})
         resp = await adapter._handle_webhook(request)
         assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_webhook_rejects_oversized_body_via_content_length(self):
+        """POST with Content-Length exceeding 64 KiB returns 413 before reading."""
+        adapter = self._make_adapter(webhook_url="")
+        body = b"From=%2B15551234567&To=%2B15550001111&Body=hello&MessageSid=SM123"
+        request = self._mock_request(body, content_length=65_537)
+        resp = await adapter._handle_webhook(request)
+        assert resp.status == 413
+        # request.read must NOT have been called — we bailed on Content-Length
+        request.read.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_webhook_rejects_oversized_body_via_read_length(self):
+        """POST whose actual read size exceeds 64 KiB returns 413.
+
+        Covers the case where Content-Length is absent (chunked transfer) but
+        the body still exceeds the cap.
+        """
+        adapter = self._make_adapter(webhook_url="")
+        oversized = b"x" * 65_537
+        request = self._mock_request(oversized, content_length=None)
+        resp = await adapter._handle_webhook(request)
+        assert resp.status == 413

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -12,6 +12,7 @@ exercised with synthetic ``Request`` objects.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock
 
@@ -405,10 +406,22 @@ def _sign(secret: str, body: bytes) -> str:
     return f"sha256={digest}"
 
 
+class _FakeRequestContent:
+    def __init__(self, body: bytes):
+        self.body = body
+        self.read_sizes: list[int] = []
+
+    async def readexactly(self, size: int) -> bytes:
+        self.read_sizes.append(size)
+        if len(self.body) < size:
+            raise asyncio.IncompleteReadError(self.body, size)
+        return self.body[:size]
+
+
 def _post_request(body: bytes, headers: dict | None = None):
     """Build a minimal aiohttp.web.Request stub for POST tests."""
     request = MagicMock()
-    request.read = AsyncMock(return_value=body)
+    request.content = _FakeRequestContent(body)
     request.headers = headers or {}
     return request
 
@@ -539,20 +552,23 @@ class TestWebhookSignature:
     @pytest.mark.asyncio
     async def test_oversize_body_rejected_before_signature(self):
         """3MB cap per Meta — refuse without computing HMAC over giant junk."""
+        from gateway.platforms.whatsapp_cloud import WEBHOOK_MAX_BODY_BYTES
+
         adapter = _make_adapter(app_secret="key")
         adapter._dispatch_payload = AsyncMock()
-        body = b"x" * (4 * 1024 * 1024)
+        body = b"x" * (WEBHOOK_MAX_BODY_BYTES + 2)
         request = _post_request(body, {"X-Hub-Signature-256": "sha256=ignored"})
 
         response = await adapter._handle_webhook(request)
         assert response.status == 413
+        assert request.content.read_sizes == [WEBHOOK_MAX_BODY_BYTES + 1]
         adapter._dispatch_payload.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_unreadable_body_rejected(self):
         adapter = _make_adapter(app_secret="key")
         request = MagicMock()
-        request.read = AsyncMock(side_effect=RuntimeError("read failed"))
+        request.content.readexactly = AsyncMock(side_effect=RuntimeError("read failed"))
         request.headers = {}
 
         response = await adapter._handle_webhook(request)
@@ -2436,4 +2452,3 @@ class TestReplyContextResolution:
             rich_sent_store.lookup("15551234567", "wamid.OUT")
             == "here is your answer"
         )
-


### PR DESCRIPTION
## Summary
Completes the webhook body-cap sweep: SMS, msgraph, WhatsApp Cloud, and Feishu listeners now all enforce their intended body limits on every read path, salvaging three community PRs with authorship preserved.

Salvaged (cherry-picked, contributor authorship intact):
- **#54620** (@Alix-007) — SMS/Twilio: 64 KiB cap, Content-Length pre-check + post-read 413 with empty TwiML
- **#25296** (@binhnt92) — msgraph: configurable `max_body_bytes` (default 1 MiB), `client_max_size` + pre/post-read 413; rebased across the `connect(is_reconnect=)` signature change
- **#54944** (@luyifan) — WhatsApp Cloud: bounded reader honoring Meta's documented 3 MB limit (previously dead code — aiohttp's implicit 1 MiB tripped first)
- **#54938** (@luyifan) — Feishu: bounded reader with 413 + anomaly telemetry for oversized chunked bodies

Our follow-up commits on top:
- `client_max_size` set on the SMS, WhatsApp, and Feishu Applications so aiohttp enforces the same caps mid-read on every path (#58536/#58902/#59180 pattern; the bounded readers remain as defense-in-depth with proper 413/telemetry)
- missing `json` import in the salvaged msgraph test fixture (NameError was swallowed to 400, failing 10 tests)
- AUTHOR_MAP entry for @Alix-007

## Validation
| Suite | Result |
|---|---|
| test_sms.py + test_msgraph_webhook.py + test_whatsapp_cloud.py + test_feishu.py | 389 passed, 0 failed |

Closed as redundant during review (already covered on main): #54931 (LINE), #54934 (WeCom).

## Infographic

![webhook-body-caps-sweep-complete](https://v3b.fal.media/files/b/0aa1158d/_xpMepPMX2vaXGG-hL6yd_eERyqKoM.png)
