### PR TITLE
fix(cli): use termux-all group in venv repair path on Termux

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9677,11 +9677,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 if repair_uv:
                     repair_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
                     _install_python_dependencies_with_optional_fallback(
-                        [repair_uv, "pip"], env=repair_env, group="all"
+                        [repair_uv, "pip"], env=repair_env, group="termux-all" if _is_termux_env(repair_env) else "all"
                     )
                 else:
                     _install_python_dependencies_with_optional_fallback(
-                        [sys.executable, "-m", "pip"], group="all"
+                        [sys.executable, "-m", "pip"], group="termux-all" if _is_termux_env() else "all"
                     )
                 _clear_update_incomplete_marker()
                 healthy_after, detail_after = _venv_core_imports_healthy()


### PR DESCRIPTION
## What does this PR do?

Fixes the venv repair path in `_cmd_update_impl` to use the correct dependency group on Termux.

## Related Issue

No existing PR found for this bug.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

The venv repair branch hardcoded `group='all'` for both the `uv` and `pip` install paths, unlike the normal update path (~L9866, ~L9894) which checks `_is_termux_env()` and uses `group='termux-all'` with the curated Android-compatible profile.

On Termux this caused the repair to install the full `all` extras profile instead of the Termux-safe one, likely failing to build native extensions that Termux cannot compile.

Fix: detect Termux the same way as the rest of `_cmd_update_impl` and pass `group='termux-all'` in both repair branches when running on Termux.

## How to Test

On a Termux environment, trigger a broken venv (e.g. remove a core package) and run `hermes update`. Before: installs `all` group and likely fails. After: installs `termux-all` group correctly.

## Checklist
- [x] Single focused change
- [x] No unrelated modifications
- [x] No new dependencies