### PR TITLE
fix(mcp): honor per-server connect_timeout in CLI/GUI probes (salvage #34276, #56699, #54494)

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -781,8 +781,19 @@ def _reauth_oauth_server(name: str, server_config: dict) -> bool:
     _info(f"Starting OAuth flow for '{name}'...")
 
     # Probe triggers the OAuth flow (browser redirect + callback capture).
+    # Honor the server's configured connect_timeout so a human has enough
+    # time to complete the browser sign-in; the 30s default is too tight for
+    # an interactive OAuth round-trip. Give at least 180s for the login path.
     try:
-        tools = _probe_single_server(name, server_config)
+        _login_connect_timeout = server_config.get("connect_timeout")
+        try:
+            _login_connect_timeout = float(_login_connect_timeout)
+        except (TypeError, ValueError):
+            _login_connect_timeout = 0.0
+        _login_connect_timeout = max(_login_connect_timeout, 180.0)
+        tools = _probe_single_server(
+            name, server_config, connect_timeout=_login_connect_timeout
+        )
         # A clean probe is NOT proof of authentication. Some MCP servers
         # (notably Google's official Drive server) serve initialize +
         # tools/list WITHOUT auth, so the probe lists tools even when the

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -397,6 +397,7 @@ def cmd_mcp_add(args):
     auth_type = getattr(args, "auth", None)
     preset_name = getattr(args, "preset", None)
     raw_env = getattr(args, "env", None)
+    raw_connect_timeout = getattr(args, "connect_timeout", None)
 
     server_config: Dict[str, Any] = {}
     try:
@@ -442,6 +443,8 @@ def cmd_mcp_add(args):
             server_config["args"] = cmd_args
         if explicit_env:
             server_config["env"] = explicit_env
+    if raw_connect_timeout is not None:
+        server_config["connect_timeout"] = raw_connect_timeout
 
     issues = validate_mcp_server_entry(name, server_config)
     if issues:

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -247,7 +247,7 @@ def _resolve_mcp_server_config(config: dict) -> dict:
 
 
 def _probe_single_server(
-    name: str, config: dict, connect_timeout: float = 30, *, details: Optional[dict] = None
+    name: str, config: dict, connect_timeout: Optional[float] = None, *, details: Optional[dict] = None
 ) -> List[Tuple[str, str]]:
     """Temporarily connect to one MCP server, list its tools, disconnect.
 
@@ -271,9 +271,14 @@ def _probe_single_server(
     )
 
     config = _resolve_mcp_server_config(config)
+    if connect_timeout is None:
+        raw_timeout = config.get("connect_timeout", 30)
+        try:
+            connect_timeout = max(1.0, float(raw_timeout))
+        except (TypeError, ValueError):
+            connect_timeout = 30.0
 
     _ensure_mcp_loop()
-
     tools_found: List[Tuple[str, str]] = []
 
     async def _probe():

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -786,14 +786,16 @@ def _reauth_oauth_server(name: str, server_config: dict) -> bool:
     # Probe triggers the OAuth flow (browser redirect + callback capture).
     # Honor the server's configured connect_timeout so a human has enough
     # time to complete the browser sign-in; the 30s default is too tight for
-    # an interactive OAuth round-trip. Give at least 180s for the login path.
+    # an interactive OAuth round-trip. Floor at 315s — the OAuth callback
+    # window (300s in mcp_oauth) plus headroom — matching the GUI re-auth
+    # path in web_server.py so CLI and dashboard behave identically.
     try:
         _login_connect_timeout = server_config.get("connect_timeout")
         try:
             _login_connect_timeout = float(_login_connect_timeout)
         except (TypeError, ValueError):
             _login_connect_timeout = 0.0
-        _login_connect_timeout = max(_login_connect_timeout, 180.0)
+        _login_connect_timeout = max(_login_connect_timeout, 315.0)
         tools = _probe_single_server(
             name, server_config, connect_timeout=_login_connect_timeout
         )

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -61,6 +61,11 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
     mcp_add_p.add_argument("--auth", choices=["oauth", "header"], help="Auth method")
     mcp_add_p.add_argument("--preset", help="Known MCP preset name")
     mcp_add_p.add_argument(
+        "--connect-timeout",
+        type=float,
+        help="Timeout in seconds for initial connection and tool discovery",
+    )
+    mcp_add_p.add_argument(
         "--env",
         nargs="*",
         default=[],

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -9152,8 +9152,15 @@ async def auth_mcp_server(name: str, profile: Optional[str] = None):
                 # The default 30s connect timeout would kill the flow while the
                 # user is still on the consent screen — give the browser
                 # round-trip the full callback window (300s in mcp_oauth) plus
-                # headroom so the connect wrapper can't pre-empt it.
-                tools = _probe_single_server(name, cfg, connect_timeout=315)
+                # headroom so the connect wrapper can't pre-empt it. Honor a
+                # larger configured connect_timeout when the user set one.
+                try:
+                    _cfg_timeout = float(cfg.get("connect_timeout", 0))
+                except (TypeError, ValueError):
+                    _cfg_timeout = 0.0
+                tools = _probe_single_server(
+                    name, cfg, connect_timeout=max(_cfg_timeout, 315)
+                )
             except Exception:
                 storage.restore(backup)
                 raise

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1204,6 +1204,8 @@ AUTHOR_MAP = {
     "r2668940489@gmail.com": "r266-tech",
     "r266-tech@users.noreply.github.com": "r266-tech",  # PR #55780 salvage (dead-target not_found blast radius)
     "s5460703@gmail.com": "BlackishGreen33",
+    "sberan@gmail.com": "sberan",  # PR #54494 salvage (--connect-timeout flag on hermes mcp add)
+    "michaelmusser@users.noreply.github.com": "labsobsidian",  # PR #56699 salvage (MCP OAuth login connect_timeout floor)
     "saul.jj.wu@gmail.com": "SaulJWu",
     "shenhaocheng19990111@gmail.com": "hcshen0111",
     "sjtuwbh@gmail.com": "Cygra",

--- a/tests/hermes_cli/test_mcp_add_command_dest.py
+++ b/tests/hermes_cli/test_mcp_add_command_dest.py
@@ -41,6 +41,7 @@ def _build_parser():
     mcp_add.add_argument("name")
     mcp_add.add_argument("--url")
     mcp_add.add_argument("--command", dest="mcp_command")
+    mcp_add.add_argument("--connect-timeout", type=float)
     mcp_add.add_argument("--args", nargs=argparse.REMAINDER, default=[])
 
     return parser
@@ -86,6 +87,25 @@ class TestMcpAddCommandDest:
         assert args.command == "mcp"
         assert args.mcp_command is None
         assert args.url is None
+
+    def test_connect_timeout_flag_sets_probe_timeout(self):
+        """`--connect-timeout` exposes the per-server discovery timeout."""
+        parser = _build_parser()
+        args = parser.parse_args(
+            [
+                "mcp",
+                "add",
+                "slow",
+                "--url",
+                "https://example.com/mcp",
+                "--connect-timeout",
+                "180",
+            ]
+        )
+
+        assert args.command == "mcp"
+        assert args.mcp_action == "add"
+        assert args.connect_timeout == 180
 
     def test_args_passthrough_keeps_nested_option_flags(self):
         """`--args` must keep command flags like Docker MCP's --profile."""

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -868,7 +868,9 @@ class TestMcpLogin:
         # Probe returns tools even though auth never completed.
         monkeypatch.setattr(
             "hermes_cli.mcp_config._probe_single_server",
-            lambda name, cfg: [("search_files", "d"), ("read_file_content", "d")],
+            lambda name, cfg, connect_timeout=30: [
+                ("search_files", "d"), ("read_file_content", "d"),
+            ],
         )
         # No token file is created → _oauth_tokens_present() returns False.
         from hermes_cli.mcp_config import cmd_mcp_login
@@ -890,7 +892,10 @@ class TestMcpLogin:
         # cmd_mcp_login wipes tokens before probing, then the real OAuth flow
         # writes a fresh token during the probe. Simulate that: the mocked
         # probe drops a token file, mirroring a successful authorization.
-        def mock_probe(name, cfg):
+        seen = {}
+
+        def mock_probe(name, cfg, connect_timeout=30):
+            seen["connect_timeout"] = connect_timeout
             token_dir.mkdir(exist_ok=True)
             (token_dir / "realserver.json").write_text('{"access_token": "x"}')
             return [("a", "d"), ("b", "d"), ("c", "d")]
@@ -906,6 +911,9 @@ class TestMcpLogin:
 
         assert "Authenticated — 3 tool(s) available" in out
         assert "no OAuth token" not in out
+        # The login path must grant a human enough time to finish the browser
+        # OAuth round-trip — far longer than the 30s probe default.
+        assert seen["connect_timeout"] >= 180
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -445,6 +445,44 @@ class TestMcpTest:
         assert "Connected" in out
         assert "Tools discovered: 2" in out
 
+    def test_probe_uses_configured_connect_timeout(self, monkeypatch):
+        """OAuth-capable probes must not hard-code a short 30s timeout."""
+        import asyncio
+        from hermes_cli import mcp_config
+        import tools.mcp_tool as mcp_tool
+
+        captured = {}
+
+        class FakeServer:
+            _tools = []
+
+            async def shutdown(self):
+                captured["shutdown"] = True
+
+        async def fake_connect(name, config):
+            return FakeServer()
+
+        def fake_run_on_mcp_loop(coro, timeout):
+            captured["outer_timeout"] = timeout
+            return asyncio.run(coro)
+
+        async def fake_wait_for(awaitable, timeout):
+            captured["inner_timeout"] = timeout
+            return await awaitable
+
+        monkeypatch.setattr(mcp_tool, "_ensure_mcp_loop", lambda: None)
+        monkeypatch.setattr(mcp_tool, "_stop_mcp_loop_if_idle", lambda: None)
+        monkeypatch.setattr(mcp_tool, "_connect_server", fake_connect)
+        monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", fake_run_on_mcp_loop)
+        monkeypatch.setattr(mcp_config.asyncio, "wait_for", fake_wait_for)
+
+        assert mcp_config._probe_single_server(
+            "supabase", {"connect_timeout": 300}
+        ) == []
+        assert captured["inner_timeout"] == 300.0
+        assert captured["outer_timeout"] == 310.0
+        assert captured["shutdown"] is True
+
 
 # ---------------------------------------------------------------------------
 # Tests: env var interpolation


### PR DESCRIPTION
## Summary
CLI/GUI MCP probes now honor each server's configured `connect_timeout` — previously all six probe call sites hard-coded 30s, so slow servers and interactive OAuth logins timed out regardless of config. Salvages #34276 (@stephenschoettler, earliest, fixes #24097), #56699 (@labsobsidian), and the `--connect-timeout` flag from #54494 (@sberan), authorship preserved per-commit.

## Changes
- `hermes_cli/mcp_config.py::_probe_single_server`: `connect_timeout` defaults to `None`; when unset, resolves `config["connect_timeout"]` (fallback 30, floor 1.0) after env interpolation — fixes all 6 broken call sites (`mcp add`, `mcp test`, `mcp login`/reauth, `mcp configure`, catalog install, dashboard probe) with zero caller churn (from #34276, rebased over #58824's capability gating)
- `hermes_cli/mcp_config.py::_reauth_oauth_server`: OAuth login floor raised to `max(configured, 315s)` — full callback window + headroom (from #56699, floor aligned from 180s to web_server's 315s)
- `hermes_cli/web_server.py` GUI re-auth: honors a configured `connect_timeout` larger than the 315s floor
- `hermes_cli/subcommands/mcp.py`: `hermes mcp add --connect-timeout <s>` persists into server config (from #54494; its probe-wrapper approach superseded by the choke-point fix)
- AUTHOR_MAP entries for sberan / labsobsidian

## Validation
| | Before | After |
|---|---|---|
| Probe with `connect_timeout: 200` | 30s hard-coded | 200s inner / 210s outer |
| `hermes mcp login` (OAuth) | 30s (killed mid-consent) | ≥315s, config can raise |
| Explicit caller override (GUI 315) | works | still works (arg wins) |
| Garbage/absent config value | n/a | falls back to 30s |

`scripts/run_tests.sh tests/hermes_cli/test_mcp_config.py tests/hermes_cli/test_mcp_add_command_dest.py tests/hermes_cli/test_mcp_security.py` — 81/81 pass. E2E with real imports against temp HERMES_HOME: 6/6 cases pass, including coexistence with #58824's capability-gating `details` out-param.

Fixes #24097.

## Infographic

![mcp-probe-connect-timeout](https://v3b.fal.media/files/b/0aa115cb/206HUfr6Q9oCkPVgHOw3J_YypxTbln.png)
