### PR TITLE
optional-mcps: add HealthClaw Guardrails (guardrailed FHIR health records)

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -77,6 +77,7 @@ class TransportSpec:
     args: List[str] = field(default_factory=list)
     url: Optional[str] = None
     version: Optional[str] = None  # informational, pinned
+    headers: Dict[str, str] = field(default_factory=dict)  # http only
 
 
 @dataclass
@@ -147,6 +148,35 @@ def _parse_env_spec(raw: Any) -> EnvVarSpec:
     )
 
 
+# RFC 7230 token — the legal character set for an HTTP header field name.
+_HEADER_NAME_RE = re.compile(r"^[A-Za-z0-9!#$%&'*+.^_`|~-]+$")
+
+
+def _parse_transport_headers(raw: Any, path: Path) -> Dict[str, str]:
+    """Validate ``transport.headers`` into a str->str mapping.
+
+    Static HTTP headers a client must send to the server (e.g. a demo
+    ``X-Tenant-Id``). Keys must be valid header names; values are coerced to
+    strings. Newlines are rejected to prevent header injection.
+    """
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise CatalogError(f"{path}: transport.headers must be a mapping")
+    headers: Dict[str, str] = {}
+    for key, value in raw.items():
+        if not isinstance(key, str) or not _HEADER_NAME_RE.match(key):
+            raise CatalogError(f"{path}: invalid header name {key!r}")
+        if not isinstance(value, (str, int, float, bool)):
+            raise CatalogError(
+                f"{path}: header {key!r} value must be a string or number")
+        text = str(value)
+        if "\n" in text or "\r" in text:
+            raise CatalogError(f"{path}: header {key!r} value may not contain newlines")
+        headers[key] = text
+    return headers
+
+
 def _parse_manifest(path: Path) -> CatalogEntry:
     """Read and validate a manifest.yaml. Raise CatalogError on any problem."""
     try:
@@ -184,12 +214,16 @@ def _parse_manifest(path: Path) -> CatalogEntry:
     args = transport_raw.get("args") or []
     if not isinstance(args, list):
         raise CatalogError(f"{path}: transport.args must be a list")
+    headers = _parse_transport_headers(transport_raw.get("headers"), path)
+    if headers and t_type != "http":
+        raise CatalogError(f"{path}: transport.headers is only valid for http")
     transport = TransportSpec(
         type=t_type,
         command=transport_raw.get("command"),
         args=[str(a) for a in args],
         url=transport_raw.get("url"),
         version=transport_raw.get("version"),
+        headers=headers,
     )
     if t_type == "stdio" and not transport.command:
         raise CatalogError(f"{path}: stdio transport requires 'command'")
@@ -470,6 +504,8 @@ def _build_server_config(
             cfg["args"] = [_expand_install_dir(a, install_dir) for a in t.args]
     elif t.type == "http":
         cfg["url"] = t.url
+        if t.headers:
+            cfg["headers"] = dict(t.headers)
         if entry.auth.type == "oauth":
             cfg["auth"] = "oauth"
     return cfg

--- a/optional-mcps/healthclaw/manifest.yaml
+++ b/optional-mcps/healthclaw/manifest.yaml
@@ -1,0 +1,64 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: healthclaw
+description: >
+  Guardrailed access to FHIR health records — PHI redaction, immutable audit,
+  step-up authorization, and human-in-the-loop enforced server-side. Interpret
+  labs, check quality measures, fill intake forms, and share records via
+  encrypted SMART Health Links. Decision support, never diagnosis.
+source: https://github.com/aks129/HealthClawGuardrails
+
+# HealthClaw ships a remote MCP server (Streamable HTTP). The guardrails run
+# server-side, so no client configuration can bypass them. The public
+# `desktop-demo` tenant carries synthetic data only and needs no credentials —
+# zero-setup trial. For real records, users set their own tenant + token
+# headers (see post_install).
+transport:
+  type: http
+  url: https://mcp-server-production-5112.up.railway.app/mcp
+  headers:
+    X-Tenant-Id: desktop-demo
+
+# No auth for the synthetic demo tenant. Real tenants authenticate with a
+# tenant-bound step-up token header (X-Step-Up-Token) — write-tier tools
+# additionally require explicit human confirmation, enforced by the server
+# (HTTP 428 otherwise).
+
+# Curated default: the read-tier tools. Write tools (fhir_commit_write,
+# action_commit, shl_generate, questionnaire_extract, ...) stay opt-in at the
+# install checklist — they are proposal->human-confirm->commit flows by design.
+tools:
+  default_enabled:
+    - search
+    - fetch
+    - context_get
+    - fhir_read
+    - fhir_search
+    - fhir_validate
+    - fhir_stats
+    - fhir_lastn
+    - fhir_interpret_labs
+    - fhir_compiled_truth
+    - questionnaire_populate
+    - curatr_evaluate
+    - sources_check
+    - guardrail_conformance
+
+post_install: |
+  The default connection uses the public `desktop-demo` tenant — synthetic
+  records only, no credentials needed. Try:
+    "Search my health records for lab results and explain them in plain language."
+    "Run the guardrail conformance check and show me the scorecard."
+
+  To connect real records, self-host or use your own tenant, then set:
+    headers:
+      X-Tenant-Id: <your-tenant>
+      X-Step-Up-Token: <tenant-bound token>
+  Docs: https://github.com/aks129/HealthClawGuardrails#quick-start
+
+  The guardrails are verifiable, not asserted — the `guardrail_conformance`
+  tool (or GET /r6/fhir/$conformance on the backend) returns a graded A-F
+  scorecard across PHI redaction, audit, step-up auth, human-in-the-loop,
+  tenant isolation, and medical disclaimers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -334,6 +334,7 @@ locales = ["locales/*.yaml"]
 # entry; tests/test_packaging_metadata.py enforces an entry per optional-mcps/<name>.
 "optional-mcps/linear" = ["optional-mcps/linear/manifest.yaml"]
 "optional-mcps/n8n" = ["optional-mcps/n8n/manifest.yaml"]
+"optional-mcps/healthclaw" = ["optional-mcps/healthclaw/manifest.yaml"]
 
 [tool.setuptools.package-data]
 hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -307,6 +307,81 @@ class TestInstall:
         assert server["url"] == "https://mcp.example.com/sse"
         assert server["auth"] == "oauth"
 
+    def test_install_http_headers_written_to_config(self, catalog_dir):
+        """Static transport.headers must survive into the installed server
+        config — else a manifest's demo tenant header is silently dropped."""
+        body = _basic_manifest(
+            transport={
+                "type": "http",
+                "url": "https://mcp.example.com/mcp",
+                "headers": {"X-Tenant-Id": "desktop-demo"},
+            },
+            auth={"type": "none"},
+        )
+        _write_manifest(catalog_dir, "demo", body)
+
+        from hermes_cli.mcp_catalog import install_entry
+        from hermes_cli.config import load_config
+
+        install_entry(_entry("demo"), enable=True)
+
+        server = load_config()["mcp_servers"]["demo"]
+        assert server["url"] == "https://mcp.example.com/mcp"
+        assert server["headers"] == {"X-Tenant-Id": "desktop-demo"}
+
+    def test_manifest_http_header_value_coerced_to_string(self, catalog_dir):
+        body = _basic_manifest(
+            transport={
+                "type": "http",
+                "url": "https://mcp.example.com/mcp",
+                "headers": {"X-Api-Version": 6},
+            },
+        )
+        _write_manifest(catalog_dir, "demo", body)
+        assert _entry("demo").transport.headers == {"X-Api-Version": "6"}
+
+    def test_manifest_invalid_header_name_skipped(self, catalog_dir):
+        # Invalid manifests are skipped by the loader (see
+        # test_missing_transport_command_rejected), not surfaced.
+        from hermes_cli.mcp_catalog import get_entry
+
+        body = _basic_manifest(
+            transport={
+                "type": "http",
+                "url": "https://mcp.example.com/mcp",
+                "headers": {"Bad Header": "x"},
+            },
+        )
+        _write_manifest(catalog_dir, "demo", body)
+        assert get_entry("demo") is None
+
+    def test_manifest_header_injection_newline_skipped(self, catalog_dir):
+        from hermes_cli.mcp_catalog import get_entry
+
+        body = _basic_manifest(
+            transport={
+                "type": "http",
+                "url": "https://mcp.example.com/mcp",
+                "headers": {"X-Tenant-Id": "demo\r\nX-Evil: 1"},
+            },
+        )
+        _write_manifest(catalog_dir, "demo", body)
+        assert get_entry("demo") is None
+
+    def test_manifest_headers_on_stdio_skipped(self, catalog_dir):
+        from hermes_cli.mcp_catalog import get_entry
+
+        body = _basic_manifest(
+            transport={
+                "type": "stdio",
+                "command": "npx",
+                "args": ["-y", "demo-mcp"],
+                "headers": {"X-Tenant-Id": "demo"},
+            },
+        )
+        _write_manifest(catalog_dir, "demo", body)
+        assert get_entry("demo") is None
+
     def test_install_required_env_missing_raises(self, catalog_dir, monkeypatch):
         body = _basic_manifest(
             auth={


### PR DESCRIPTION
## What

Adds `optional-mcps/healthclaw/manifest.yaml` — a remote Streamable HTTP MCP server for **FHIR health records with the safety layer built in**: PHI redaction on every read, an immutable audit trail, step-up authorization + explicit human confirmation for writes (HTTP 428 without it), tenant isolation, and medical disclaimers. All enforced **server-side**, so no client configuration can bypass them.

## Why it fits the catalog

- **Zero-setup trial**: the manifest defaults to a public synthetic-data tenant (`desktop-demo`) — no credentials, works the moment it's installed. Try: *"Search my health records for lab results and explain them in plain language."*
- **Curated tool surface**: 14 read-tier tools default-enabled (including ChatGPT-connector-style `search`/`fetch`, lab interpretation with plain-language summaries, an NQF 0018 blood-pressure quality measure, and SDC form population). Write tools stay opt-in at the checklist — they are proposal → human-confirm → commit flows by design.
- **Verifiable, not asserted**: the `guardrail_conformance` tool returns a graded A–F scorecard across all six guardrail properties, computed live against the deployment ([currently Grade A](https://app.healthclaw.io/r6/fhir/$conformance?format=text)). Post-ClawHavoc, we think health-data tools should have to *prove* their safety posture.
- **Health-data posture**: decision support, never diagnosis — flagged labs say "worth discussing with your clinician," and every clinical response carries a disclaimer. Synthetic demo data throughout; real tenants are self-hosted or token-bound.

Works with Hermes's MCP client unmodified (Streamable HTTP + `headers:` mapping; verified against the `mcp-config-reference` shape). MIT, open source: https://github.com/aks129/HealthClawGuardrails (900+ tests, active).

Happy to adjust the default tool list or manifest shape to whatever the catalog prefers.