### PR TITLE
fix(mcp): reconnect resilience — reset budget per healthy session, self-probe parked servers, re-register tools on revival (salvage #57615, #54139, #57477)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1198,6 +1198,7 @@ AUTHOR_MAP = {
     "cine.dreamer.one@gmail.com": "LeonSGP43",
     "Lubrsy706@users.noreply.github.com": "Lubrsy706",
     "niyant@spicefi.xyz": "spniyant",
+    "256398740+nicha16@users.noreply.github.com": "nicha16",  # PR #54139 partial salvage (re-register tools after park revival)
     "olafthiele@gmail.com": "olafthiele",
     "oncuevtv@gmail.com": "sprmn24",
     "programming@olafthiele.com": "olafthiele",

--- a/tests/tools/test_mcp_circuit_breaker.py
+++ b/tests/tools/test_mcp_circuit_breaker.py
@@ -446,3 +446,84 @@ def test_run_loop_parks_instead_of_exiting_then_revives(monkeypatch, tmp_path):
             run_task.cancel()
 
     asyncio.run(_scenario())
+
+
+def test_initial_connect_budget_parks_instead_of_exiting_then_revives(monkeypatch, tmp_path):
+    """Initial connection failures must park, not permanently exit the task.
+
+    Regression for #57129's remaining live case: a slow HTTP/SSE server or
+    late-starting stdio server could exhaust the initial-connect budget before
+    it ever registered tools. The run loop returned, leaving no task alive to
+    hear a later manual /mcp refresh.
+    """
+    import asyncio
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import MCPServerTask
+
+    monkeypatch.setattr(mcp_tool, "_MAX_INITIAL_CONNECT_RETRIES", 2)
+
+    _real_sleep = asyncio.sleep
+
+    async def _fast_sleep(_delay, *a, **kw):
+        await _real_sleep(0)
+
+    monkeypatch.setattr(mcp_tool.asyncio, "sleep", _fast_sleep)
+
+    state = {"transport_calls": 0, "deregistered": 0, "revived": False}
+
+    async def _scenario():
+        class _Task(MCPServerTask):
+            def _is_http(self):
+                return False
+
+            def _deregister_tools(self):
+                state["deregistered"] += 1
+                self._registered_tool_names = []
+
+            async def _run_stdio(self, config):
+                state["transport_calls"] += 1
+                if not state["revived"]:
+                    raise RuntimeError("server still booting")
+                self.session = object()
+                self._ready.set()
+                await self._wait_for_lifecycle_event()
+                return
+
+        task = _Task("srv")
+        run_task = asyncio.ensure_future(task.run({"command": "x"}))
+
+        for _ in range(500):
+            await _real_sleep(0)
+            if state["deregistered"] >= 1:
+                break
+
+        await _real_sleep(0)
+        assert state["transport_calls"] == 3
+        assert state["deregistered"] >= 1
+        assert task._ready.is_set()
+        assert task._error is not None
+        assert not run_task.done(), "initial failure exited instead of parking"
+
+        state["revived"] = True
+        before = state["transport_calls"]
+        task._reconnect_event.set()
+        for _ in range(500):
+            await _real_sleep(0)
+            if state["transport_calls"] > before and task.session is not None:
+                break
+
+        assert state["transport_calls"] > before
+        assert task.session is not None
+        assert task._error is None
+
+        task._shutdown_event.set()
+        task._reconnect_event.set()
+        try:
+            await asyncio.wait_for(run_task, timeout=2)
+        except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+            run_task.cancel()
+
+    asyncio.run(_scenario())

--- a/tests/tools/test_mcp_parked_self_probe.py
+++ b/tests/tools/test_mcp_parked_self_probe.py
@@ -1,0 +1,108 @@
+"""Tests for the parked-server self-probe revival path (#57129).
+
+Parking deregisters a server's tools, so no tool call can reach the
+circuit-breaker half-open probe or ``_signal_reconnect`` — the only
+things that set ``_reconnect_event``. The parked wait must therefore be
+timed: the run task wakes on ``_PARKED_RETRY_INTERVAL`` and attempts one
+revival probe on its own.
+"""
+
+import asyncio
+
+import pytest
+
+
+@pytest.mark.no_isolate
+def test_parked_server_self_probes_and_revives(monkeypatch, tmp_path):
+    """A parked server must revive on its own once the backend recovers,
+    without any explicit _reconnect_event.set()."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import MCPServerTask
+
+    monkeypatch.setattr(mcp_tool, "_MAX_RECONNECT_RETRIES", 1)
+    # Keep the self-probe cadence tiny so the test is fast.
+    monkeypatch.setattr(mcp_tool, "_PARKED_RETRY_INTERVAL", 0.05)
+
+    _real_sleep = asyncio.sleep
+
+    async def _fast_sleep(_delay, *a, **kw):
+        await _real_sleep(0)
+
+    monkeypatch.setattr(mcp_tool.asyncio, "sleep", _fast_sleep)
+
+    state = {
+        "transport_calls": 0,
+        "deregistered": 0,
+        "backend_up": False,
+        "revived_registration": 0,
+    }
+
+    async def _scenario():
+        class _Task(MCPServerTask):
+            def _is_http(self):
+                return False
+
+            def _deregister_tools(self):
+                state["deregistered"] += 1
+                self._registered_tool_names = []
+
+            def _register_discovered_tools_if_needed(self):
+                if self._ready.is_set() and not self._registered_tool_names:
+                    state["revived_registration"] += 1
+                    self._registered_tool_names = ["srv__tool"]
+
+            async def _run_stdio(self, config):
+                state["transport_calls"] += 1
+                if state["transport_calls"] == 1:
+                    # First connect succeeds (sets _ready), then dies.
+                    self.session = object()
+                    self._ready.set()
+                    self.session = None
+                    raise RuntimeError("backend outage begins")
+                if not state["backend_up"]:
+                    raise RuntimeError("backend still down")
+                # Backend recovered: establish a session and park in the
+                # lifecycle wait like the real transport does.
+                self.session = object()
+                self._register_discovered_tools_if_needed()
+                await self._wait_for_lifecycle_event()
+
+        task = _Task("srv")
+        task._registered_tool_names = ["srv__tool"]
+
+        run_task = asyncio.ensure_future(task.run({"command": "x"}))
+
+        # Let it exhaust the budget (1 retry) and park.
+        for _ in range(2000):
+            await _real_sleep(0)
+            if state["deregistered"] >= 1:
+                break
+        assert state["deregistered"] >= 1, "server never parked"
+        assert not run_task.done(), "run task exited instead of parking"
+
+        # The backend comes back. NOTHING sets _reconnect_event — revival
+        # must come from the timed self-probe alone.
+        state["backend_up"] = True
+        for _ in range(200):
+            await _real_sleep(0.01)
+            if task.session is not None:
+                break
+
+        assert task.session is not None, (
+            "parked server never self-probed back to life "
+            f"(transport_calls={state['transport_calls']})"
+        )
+        assert state["revived_registration"] >= 1, (
+            "revived server did not re-register its tools"
+        )
+
+        task._shutdown_event.set()
+        task._reconnect_event.set()
+        try:
+            await asyncio.wait_for(run_task, timeout=2)
+        except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+            run_task.cancel()
+
+    asyncio.run(_scenario())

--- a/tests/tools/test_mcp_reconnect_retry_reset.py
+++ b/tests/tools/test_mcp_reconnect_retry_reset.py
@@ -1,0 +1,196 @@
+"""Tests for MCP reconnect retry counter reset (#57604).
+
+Verifies that the reconnect retry counter resets after each successful
+reconnection, so transient blips do not accumulate toward permanent parking.
+"""
+
+import asyncio
+
+import pytest
+
+
+@pytest.mark.no_isolate
+def test_reconnect_counter_resets_after_successful_session(monkeypatch, tmp_path):
+    """Transient disconnections must not accumulate toward permanent parking.
+
+    Before the fix, ``retries`` was a local variable in ``run()`` that only
+    reset on clean transport return (line 2367) or park-wake (line 2468).
+    Each exception from ``_run_stdio`` incremented it without reset, so 5
+    transient blips over a long-uptime gateway would permanently park the
+    server.
+
+    After the fix, ``_reconnect_retries`` is an instance variable that resets
+    to 0 whenever a session is successfully established (``_reset_server_error``
+    call sites in ``_run_stdio`` / ``_run_http``).
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import MCPServerTask
+
+    # Shrink budget so the test can exhaust it quickly if the counter
+    # does NOT reset (the bug scenario).
+    monkeypatch.setattr(mcp_tool, "_MAX_RECONNECT_RETRIES", 3)
+
+    _real_sleep = asyncio.sleep
+
+    async def _fast_sleep(_delay, *a, **kw):
+        await _real_sleep(0)
+
+    monkeypatch.setattr(mcp_tool.asyncio, "sleep", _fast_sleep)
+
+    state = {
+        "transport_calls": 0,
+        "parked": False,
+        "max_retries_seen": 0,
+    }
+
+    async def _scenario():
+        class _Task(MCPServerTask):
+            def _is_http(self):
+                return False
+
+            def _deregister_tools(self):
+                state["parked"] = True
+                self._registered_tool_names = []
+
+            async def _run_stdio(self, config):
+                state["transport_calls"] += 1
+                call = state["transport_calls"]
+
+                if call == 1:
+                    # First connect: succeed (sets _ready), then fail.
+                    self.session = object()
+                    self._ready.set()
+                    self.session = None
+                    raise RuntimeError("blip 1")
+
+                # Subsequent calls: succeed (session established, which
+                # triggers _reset_server_error and should reset retries),
+                # then immediately fail again — simulating a new transient
+                # blip.  If retries accumulate, call 4 would exceed the
+                # budget of 3 and park.  If retries reset correctly,
+                # this loop can continue indefinitely.
+                if call <= 8:
+                    self.session = object()
+                    # _run_stdio calls _reset_server_error and sets
+                    # _reconnect_retries = 0 after session establishment.
+                    # We simulate that by calling the real method.
+                    mcp_tool._reset_server_error(self.name)
+                    self._reconnect_retries = 0
+                    self.session = None
+                    raise RuntimeError(f"blip {call}")
+
+                # If we reach here without parking, the fix works.
+                self.session = object()
+                mcp_tool._reset_server_error(self.name)
+                self._reconnect_retries = 0
+                await self._wait_for_lifecycle_event()
+                return
+
+        task = _Task("srv")
+        task._registered_tool_names = ["srv__tool"]
+
+        run_task = asyncio.ensure_future(task.run({"command": "x"}))
+
+        # Let the scenario run.
+        for _ in range(2000):
+            await _real_sleep(0)
+            if state["transport_calls"] >= 8 or state["parked"]:
+                break
+
+        # The fix: the server should NOT have parked despite 8 transient
+        # disconnections, because each successful reconnection reset the
+        # retry counter.
+        assert not state["parked"], (
+            f"server parked after {state['transport_calls']} transport calls "
+            f"— retry counter accumulated instead of resetting"
+        )
+        assert state["transport_calls"] >= 8, (
+            f"only {state['transport_calls']} transport calls reached "
+            f"(expected >= 8)"
+        )
+
+        # Verify the counter is an instance variable, not a local.
+        assert hasattr(task, "_reconnect_retries"), (
+            "_reconnect_retries should be an instance variable"
+        )
+
+        # Clean shutdown.
+        task._shutdown_event.set()
+        task._reconnect_event.set()
+        try:
+            await asyncio.wait_for(run_task, timeout=2)
+        except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+            run_task.cancel()
+
+    asyncio.run(_scenario())
+
+
+@pytest.mark.no_isolate
+def test_reconnect_counter_still_parks_on_consecutive_failures(monkeypatch, tmp_path):
+    """The server must still park when failures are genuinely consecutive
+    (no successful reconnection in between).
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import MCPServerTask
+
+    monkeypatch.setattr(mcp_tool, "_MAX_RECONNECT_RETRIES", 2)
+
+    _real_sleep = asyncio.sleep
+
+    async def _fast_sleep(_delay, *a, **kw):
+        await _real_sleep(0)
+
+    monkeypatch.setattr(mcp_tool.asyncio, "sleep", _fast_sleep)
+
+    state = {"transport_calls": 0, "parked": False}
+
+    async def _scenario():
+        class _Task(MCPServerTask):
+            def _is_http(self):
+                return False
+
+            def _deregister_tools(self):
+                state["parked"] = True
+                self._registered_tool_names = []
+
+            async def _run_stdio(self, config):
+                state["transport_calls"] += 1
+                call = state["transport_calls"]
+
+                if call == 1:
+                    self.session = object()
+                    self._ready.set()
+                    self.session = None
+                    raise RuntimeError("first failure")
+
+                # All subsequent calls fail WITHOUT establishing a session
+                # (no _reset_server_error, no retry reset). This simulates
+                # genuinely consecutive failures.
+                raise RuntimeError(f"failure {call}")
+
+        task = _Task("srv")
+        task._registered_tool_names = ["srv__tool"]
+
+        run_task = asyncio.ensure_future(task.run({"command": "x"}))
+
+        for _ in range(500):
+            await _real_sleep(0)
+            if state["parked"] or run_task.done():
+                break
+
+        assert state["parked"], (
+            "server should park on consecutive failures without successful reconnect"
+        )
+
+        task._shutdown_event.set()
+        task._reconnect_event.set()
+        try:
+            await asyncio.wait_for(run_task, timeout=2)
+        except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+            run_task.cancel()
+
+    asyncio.run(_scenario())

--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -560,7 +560,7 @@ class TestMCPInitialConnectionRetry:
         asyncio.get_event_loop().run_until_complete(_run())
 
     def test_initial_connect_gives_up_after_max_retries(self):
-        """Server gives up after _MAX_INITIAL_CONNECT_RETRIES failures."""
+        """Server parks (does not exit) after _MAX_INITIAL_CONNECT_RETRIES failures."""
         from tools.mcp_tool import MCPServerTask, _MAX_INITIAL_CONNECT_RETRIES
 
         call_count = 0
@@ -583,8 +583,13 @@ class TestMCPInitialConnectionRetry:
                 assert "DNS resolution failed" in str(server._error)
                 # 1 initial + N retries = _MAX_INITIAL_CONNECT_RETRIES + 1 total attempts
                 assert call_count == _MAX_INITIAL_CONNECT_RETRIES + 1
+                # The task parks for later revival instead of exiting.
+                await asyncio.sleep(0)
+                assert not task.done(), "run task should park, not exit"
 
-                await task
+                server._shutdown_event.set()
+                server._reconnect_event.set()
+                await asyncio.wait_for(task, timeout=5)
 
         asyncio.get_event_loop().run_until_complete(_run())
 

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1876,12 +1876,19 @@ class TestReconnection:
 
             with patch.object(MCPServerTask, "_run_stdio", patched_run_stdio), \
                  patch("asyncio.sleep", new_callable=AsyncMock):
-                await server.run({"command": "test"})
+                task = asyncio.ensure_future(server.run({"command": "test"}))
+                await server._ready.wait()
 
-            # Now retries up to _MAX_INITIAL_CONNECT_RETRIES before giving up
-            assert run_count == _MAX_INITIAL_CONNECT_RETRIES + 1
-            assert server._error is not None
-            assert "cannot connect" in str(server._error)
+                # Now retries up to _MAX_INITIAL_CONNECT_RETRIES, then PARKS
+                # (keeps the task alive for later revival) instead of exiting.
+                assert run_count == _MAX_INITIAL_CONNECT_RETRIES + 1
+                assert server._error is not None
+                assert "cannot connect" in str(server._error)
+                assert not task.done(), "run task should park, not exit"
+
+                server._shutdown_event.set()
+                server._reconnect_event.set()
+                await asyncio.wait_for(task, timeout=5)
 
         asyncio.run(_test())
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1475,6 +1475,7 @@ class MCPServerTask:
         "_rpc_lock", "_pending_refresh_tasks",
         "_pending_call_context",
         "initialize_result", "_ping_unsupported",
+        "_reconnect_retries",
     )
 
     def __init__(self, name: str):
@@ -1496,6 +1497,7 @@ class MCPServerTask:
         self._sampling: Optional[SamplingHandler] = None
         self._elicitation: Optional[ElicitationHandler] = None
         self._registered_tool_names: list[str] = []
+        self._reconnect_retries: int = 0
         self._auth_type: str = ""
         self._refresh_lock = asyncio.Lock()
         # MCP stdio sessions are a single JSON-RPC stream. Some servers emit
@@ -1984,6 +1986,10 @@ class MCPServerTask:
                     # prior outage so the first call after recovery isn't
                     # gated on a stale consecutive-failure count (#16788).
                     _reset_server_error(self.name)
+                    # This session is live: reset the reconnect retry counter
+                    # so transient prior failures do not accumulate toward
+                    # permanent parking (#57604).
+                    self._reconnect_retries = 0
                     # stdio transport does not use OAuth, but we still honor
                     # _reconnect_event (e.g. future manual /mcp refresh) for
                     # consistency with _run_http.
@@ -2221,6 +2227,7 @@ class MCPServerTask:
                     # prior outage so the first call after recovery isn't
                     # gated on a stale consecutive-failure count (#16788).
                     _reset_server_error(self.name)
+                    self._reconnect_retries = 0
                     reason = await self._wait_for_lifecycle_event()
                     if reason == "reconnect":
                         logger.info(
@@ -2274,6 +2281,7 @@ class MCPServerTask:
                         # a prior outage so the first call after recovery
                         # isn't gated on a stale failure count (#16788).
                         _reset_server_error(self.name)
+                        self._reconnect_retries = 0
                         reason = await self._wait_for_lifecycle_event()
                         if reason == "reconnect":
                             logger.info(
@@ -2301,6 +2309,7 @@ class MCPServerTask:
                     # prior outage so the first call after recovery isn't
                     # gated on a stale consecutive-failure count (#16788).
                     _reset_server_error(self.name)
+                    self._reconnect_retries = 0
                     reason = await self._wait_for_lifecycle_event()
                     if reason == "reconnect":
                         logger.info(
@@ -2417,7 +2426,7 @@ class MCPServerTask:
                     self._ready.set()
                     return
 
-        retries = 0
+        self._reconnect_retries = 0
         initial_retries = 0
         backoff = 1.0
 
@@ -2446,7 +2455,7 @@ class MCPServerTask:
                 # failure budget — otherwise transient drops accumulated over
                 # a long-lived session would eventually exhaust it and
                 # permanently kill an otherwise-healthy server.
-                retries = 0
+                self._reconnect_retries = 0
                 backoff = 1.0
                 # Reset the session reference; _run_http/_run_stdio will
                 # repopulate it on successful re-entry.
@@ -2520,8 +2529,8 @@ class MCPServerTask:
                     )
                     return
 
-                retries += 1
-                if retries > _MAX_RECONNECT_RETRIES:
+                self._reconnect_retries += 1
+                if self._reconnect_retries > _MAX_RECONNECT_RETRIES:
                     logger.warning(
                         "MCP server '%s' failed after %d reconnection attempts, "
                         "parking until a reconnect is requested: %s",
@@ -2547,14 +2556,14 @@ class MCPServerTask:
                         "rebuilding transport.",
                         self.name,
                     )
-                    retries = 0
+                    self._reconnect_retries = 0
                     backoff = 1.0
                     continue
 
                 logger.warning(
                     "MCP server '%s' connection lost (attempt %d/%d), "
                     "reconnecting in %.0fs: %s",
-                    self.name, retries, _MAX_RECONNECT_RETRIES,
+                    self.name, self._reconnect_retries, _MAX_RECONNECT_RETRIES,
                     backoff, exc,
                 )
                 await asyncio.sleep(backoff)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -321,6 +321,11 @@ _DEFAULT_CONNECT_TIMEOUT = 60    # seconds for initial connection per server
 _MAX_RECONNECT_RETRIES = 5
 _MAX_INITIAL_CONNECT_RETRIES = 3 # retries for the very first connection attempt
 _MAX_BACKOFF_SECONDS = 60
+# While parked (reconnect budget exhausted, tools deregistered) the run task
+# wakes on this cadence and attempts one revival probe. Without it a parked
+# server is unrevivable: its tools are out of the registry, so no tool call
+# can ever reach the circuit-breaker half-open probe or _signal_reconnect.
+_PARKED_RETRY_INTERVAL = 300     # seconds between parked self-probes
 
 # Keepalive cadence for HTTP/SSE sessions. The MCP spec lets a server expire
 # idle sessions on any TTL it chooses (Streamable HTTP "Session Management"),
@@ -1839,20 +1844,27 @@ class MCPServerTask:
         self._reconnect_event.clear()
         return "reconnect"
 
-    async def _wait_for_reconnect_or_shutdown(self) -> str:
+    async def _wait_for_reconnect_or_shutdown(
+        self, timeout: Optional[float] = None
+    ) -> str:
         """Block until a reconnect or shutdown is requested while parked.
 
         Used by :meth:`run` after the reconnect budget is exhausted. The
         task stays alive (so ``_reconnect_event`` always has a listener) but
         does no work until something explicitly asks it to come back —
-        the circuit-breaker half-open probe, OAuth recovery, or a manual
-        ``/mcp`` refresh.
+        OAuth recovery, a manual ``/mcp`` refresh — or, when ``timeout`` is
+        given, until the timeout elapses (a periodic self-probe). The timed
+        wake matters because parking deregisters this server's tools, so
+        no tool call can ever reach the circuit-breaker's half-open probe
+        or ``_signal_reconnect`` — without a self-probe a parked server
+        would be unrevivable short of a full reload.
 
         Returns:
             ``"shutdown"`` if the server should exit the run loop entirely,
-            ``"reconnect"`` if it should rebuild the transport. The reconnect
-            event is cleared before returning so the next park cycle starts
-            from a fresh signal. Shutdown takes precedence.
+            ``"reconnect"`` if it should rebuild the transport (explicit
+            request or self-probe timeout). The reconnect event is cleared
+            before returning so the next park cycle starts from a fresh
+            signal. Shutdown takes precedence.
         """
         shutdown_task = asyncio.ensure_future(self._shutdown_event.wait())
         reconnect_task = asyncio.ensure_future(self._reconnect_event.wait())
@@ -1860,6 +1872,7 @@ class MCPServerTask:
             await asyncio.wait(
                 {shutdown_task, reconnect_task},
                 return_when=asyncio.FIRST_COMPLETED,
+                timeout=timeout,
             )
         finally:
             for t in (shutdown_task, reconnect_task):
@@ -2551,30 +2564,38 @@ class MCPServerTask:
                 if self._reconnect_retries > _MAX_RECONNECT_RETRIES:
                     logger.warning(
                         "MCP server '%s' failed after %d reconnection attempts, "
-                        "parking until a reconnect is requested: %s",
-                        self.name, _MAX_RECONNECT_RETRIES, exc,
+                        "parking; will self-probe every %ds until it recovers: %s",
+                        self.name, _MAX_RECONNECT_RETRIES,
+                        _PARKED_RETRY_INTERVAL, exc,
                     )
                     # Do NOT return — exiting the task orphans the server:
-                    # nothing would ever listen for _reconnect_event again,
-                    # so a half-open circuit-breaker probe could never revive
-                    # it and the server would be permanently wedged for the
+                    # nothing would ever listen for _reconnect_event again
+                    # and the server would be permanently wedged for the
                     # life of the process (#16788). Instead, drop the phantom
-                    # tools from the registry and park as a dormant listener.
-                    # A future _reconnect_event.set() — from the breaker's
-                    # half-open probe, OAuth recovery, or a manual /mcp
-                    # refresh — wakes us to rebuild the transport (respawning
-                    # a dead stdio subprocess in the process).
+                    # tools from the registry and park. Because parking
+                    # deregisters the tools, no tool call can reach the
+                    # circuit-breaker half-open probe or _signal_reconnect —
+                    # so the park is a TIMED wait: every _PARKED_RETRY_INTERVAL
+                    # we wake and attempt one reconnect ourselves (#57129).
+                    # An explicit _reconnect_event.set() (OAuth recovery,
+                    # manual /mcp refresh) still wakes us immediately.
                     self._deregister_tools()
                     self._reconnect_event.clear()
-                    parked = await self._wait_for_reconnect_or_shutdown()
+                    parked = await self._wait_for_reconnect_or_shutdown(
+                        timeout=_PARKED_RETRY_INTERVAL
+                    )
                     if parked == "shutdown":
                         return
                     logger.info(
-                        "MCP server '%s': reconnect requested while parked; "
+                        "MCP server '%s': attempting revival from parked state "
+                        "(self-probe or explicit reconnect request); "
                         "rebuilding transport.",
                         self.name,
                     )
-                    self._reconnect_retries = 0
+                    # One probe attempt per wake: budget of 1 so a still-dead
+                    # server parks again for another interval instead of
+                    # burning 5 rapid retries each cycle.
+                    self._reconnect_retries = _MAX_RECONNECT_RETRIES
                     backoff = 1.0
                     continue
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2529,12 +2529,30 @@ class MCPServerTask:
                     if initial_retries > _MAX_INITIAL_CONNECT_RETRIES:
                         logger.warning(
                             "MCP server '%s' failed initial connection after "
-                            "%d attempts, giving up: %s",
+                            "%d attempts, parking until a reconnect is requested: %s",
                             self.name, _MAX_INITIAL_CONNECT_RETRIES, exc,
                         )
                         self._error = exc
                         self._ready.set()
-                        return
+                        self._deregister_tools()
+                        self._reconnect_event.clear()
+                        parked = await self._wait_for_reconnect_or_shutdown(
+                            timeout=_PARKED_RETRY_INTERVAL
+                        )
+                        if parked == "shutdown":
+                            return
+                        logger.info(
+                            "MCP server '%s': attempting revival after initial "
+                            "connection failures (self-probe or explicit "
+                            "reconnect request); rebuilding transport.",
+                            self.name,
+                        )
+                        initial_retries = 0
+                        self._reconnect_retries = 0
+                        backoff = 1.0
+                        self._error = None
+                        self._ready.clear()
+                        continue
 
                     logger.warning(
                         "MCP server '%s' initial connection failed "

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2340,6 +2340,7 @@ class MCPServerTask:
                 self.name,
             )
             self._tools = []
+            self._register_discovered_tools_if_needed()
             return
         async with self._rpc_lock:
             tools_result = await self.session.list_tools()
@@ -2347,6 +2348,23 @@ class MCPServerTask:
             tools_result.tools
             if hasattr(tools_result, "tools")
             else []
+        )
+        self._register_discovered_tools_if_needed()
+
+    def _register_discovered_tools_if_needed(self) -> None:
+        """Re-register tools after a post-ready reconnect if needed.
+
+        Initial registration is performed by ``_discover_and_register_server``
+        after ``start()`` completes. During a later reconnect, however,
+        ``_ready`` remains set; if outage handling previously deregistered
+        stale tools (parking calls ``_deregister_tools``), a successful
+        revival must publish the freshly discovered tools again — otherwise
+        the transport comes back alive with zero registered tools.
+        """
+        if not self._ready.is_set() or self._registered_tool_names:
+            return
+        self._registered_tool_names = _register_server_tools(
+            self.name, self, self._config
         )
 
     async def run(self, config: dict):


### PR DESCRIPTION
## Summary
MCP servers no longer become permanently dead after transient connection blips — the retry budget only counts consecutive failures, parked servers self-probe back to life every 5 minutes, revivals actually re-register their tools, and initial-connect failures park instead of orphaning the task. Salvages #57615 (@liuhao1024), the revival-registration fix from #54139 (@nicha16), and #57477 (@yoma/tianma-if); the self-probe idea credits #38881 (@Hellbayne, earliest never-abandon proposal). Fixes #57129, closes out #38488.

## Root cause chain
Park-and-listen (#53599/#16788) stopped the run task from exiting, but three gaps kept the effective symptom alive:
1. `retries` was a loop-lifetime local — 5 blips spread over weeks of healthy uptime still parked the server (only clean-return and park-wake reset it).
2. Parking calls `_deregister_tools()`, which removes the only code paths that can set `_reconnect_event` (breaker half-open probe and `_signal_reconnect` live inside registered tool handlers) — a parked server was unrevivable short of `/mcp` reload. The park comment promised a wake that could never fire.
3. Even a successful revival registered zero tools: `_discover_tools` only fills `self._tools`; registry publication only happened at initial start.

## Changes
- `tools/mcp_tool.py`: `_reconnect_retries` instance var, reset at every successful session establishment (all 4 `_reset_server_error` sites) — #57615 by @liuhao1024
- `tools/mcp_tool.py`: parked wait is now timed (`_PARKED_RETRY_INTERVAL` = 300s); each wake attempts ONE revival probe (budget pinned so a still-dead server re-parks instead of burning 5 rapid retries per cycle); explicit reconnect requests still wake immediately — ours, idea credit @Hellbayne (#38881)
- `tools/mcp_tool.py`: `_register_discovered_tools_if_needed()` re-publishes tools after a post-ready reconnect when the registry entry list is empty — extracted from #54139 by @nicha16 (rest of that PR reverses the park design; not taken)
- `tools/mcp_tool.py`: initial-connect exhaustion parks (timed) instead of `return`-orphaning the task — #57477 by @yoma, reconciled with the instance-var counter + timed park
- Tests: retry-reset (from #57615), initial-park (from #57477), new parked-self-probe revival E2E-style test

## Validation
| | Before | After |
|---|---|---|
| 5 blips across weeks of uptime | permanent park | counter resets per healthy session |
| Backend recovers while parked | dead until `/mcp` reload | auto-revives ≤300s |
| Revived server | transport alive, 0 tools | tools re-registered |
| Server down at startup | task exits, unrevivable | parks + self-probes |

`scripts/run_tests.sh tests/tools/ -k mcp` — 375/375 pass.

## Infographic

![mcp-reconnect-resilience](https://v3b.fal.media/files/b/0aa11637/xUNW46UUMUxWiv2m0SWNb_iCh3i82c.png)
