### PR TITLE
fix(cli): show all source sessions in /resume listing (#59224)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6757,9 +6757,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
             return query_session_listing(
                 self._session_db,
-                source="cli",
+                source=None,
                 current_session_id=self.session_id,
-                include_all_sources=False,
+                include_all_sources=True,
                 include_unnamed=True,
                 limit=limit,
                 exclude_sources=["tool"],


### PR DESCRIPTION
## Summary

Classic CLI `/resume` (`hermes` without `--tui`) only shows sessions tagged `source="cli"`, hiding sessions created by the Desktop app (`source="tui"`) and WebUI (`source="webui"`). Users must know the session ID in advance to resume cross-source sessions.

## Change

**1 line changed** in `cli.py:_list_recent_sessions()`:

| Before | After |
|---|---|
| `source="cli"` | `source=None` |
| `include_all_sources=False` | `include_all_sources=True` |

This matches the TUI gateway's deny-list approach (filter out only `tool` sub-agent runs) — the same pattern already proven in `tui_gateway/server.py:5066`.

## Why it matters

- Desktop app users can now discover and resume sessions from the terminal
- WebUI sessions appear in `hermes` CLI `/resume` listing
- Asymmetric visibility (TUI shows CLI sessions but CLI hides TUI sessions) is resolved
- Cross-source resume by ID/title already worked — this fixes the listing and numeric-index paths

## Prior art

- TUI gateway (`tui_gateway/server.py:5066`) already uses deny-list semantics with `source=None`
- PR #15746 — fixed the same class of bug for `hermes --tui` by adding `"webui"` to an allow-list

Closes #59224