### PR TITLE
fix(gateway): acquire session-store lock in _commit_memory_before_soft_evict

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15847,8 +15847,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _store = getattr(self, "session_store", None)
             if _store is None:
                 return
-            _store._ensure_loaded()
-            entry = _store._entries.get(key)
+            # Snapshot the entry under the store's own lock instead of reaching
+            # into ``_entries`` unguarded — this runs on the eviction daemon
+            # thread, concurrently with request-handling threads that mutate
+            # the store. Use ``_ensure_loaded_locked`` (not ``_ensure_loaded``)
+            # since we already hold ``_lock`` here and it is not reentrant.
+            with _store._lock:
+                _store._ensure_loaded_locked()
+                entry = _store._entries.get(key)
             if entry is None:
                 return
             # Only compensate when the watcher would otherwise expect to find


### PR DESCRIPTION
## What does this PR do?

Fixes an unguarded concurrent dict access in `_commit_memory_before_soft_evict` that violates the codebase's own locking convention for `SessionStore._entries`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

`_commit_memory_before_soft_evict` runs on the eviction daemon thread concurrently with request-handling threads that mutate `SessionStore`. The function called `_ensure_loaded()` then read `_store._entries.get(key)` without holding `_store._lock`, violating the established convention — every other `_entries` access in the codebase is wrapped in `with self._lock:`, and `peek_session_id()`'s docstring explicitly warns against unguarded access.

Fix: wrap the `_ensure_loaded` + `_entries.get` pair in `with _store._lock:` and switch to `_ensure_loaded_locked()` (the non-locking variant) to avoid re-acquiring the non-reentrant lock.

## How to Test

Under concurrent load with session eviction active, before this fix a daemon thread and a request-handling thread could race on `_entries` causing `RuntimeError: dictionary changed size during iteration` — silently caught and logged at debug level, causing the memory commit to be skipped. After this fix all `_entries` access is serialized under `_store._lock`.

## Checklist
- [x] Single focused change
- [x] No unrelated modifications
- [x] No new dependencies