### PR TITLE
fix(install): guard Windows desktop installs against broken web_server

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4443,14 +4443,17 @@ def _clear_bytecode_cache(root: Path) -> int:
     return removed
 
 
-# Critical files that every ``hermes`` invocation imports at startup. If any
-# of these fail to parse after a pull, the CLI is bricked — the user can't
-# even run ``hermes update`` again to roll forward. The post-pull syntax
-# guard validates these and auto-rolls-back on failure.
+# Critical files that Hermes must be able to import immediately after an
+# update/install. Most are imported on every CLI startup; ``web_server.py``
+# is the desktop/dashboard backend path that a fresh Windows install launches
+# right away. If any of these fail to parse after a pull, the user can be
+# left with a bricked CLI or desktop backend. The post-pull syntax guard
+# validates these and auto-rolls-back on failure.
 _UPDATE_CRITICAL_FILES = (
     "hermes_cli/main.py",
     "hermes_cli/config.py",
     "hermes_cli/__init__.py",
+    "hermes_cli/web_server.py",
     "cli.py",
     "run_agent.py",
     "model_tools.py",

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1995,6 +1995,7 @@ print(','.join(scripts))
     $pythonExe = if (-not $NoVenv) { "$InstallDir\venv\Scripts\python.exe" } else { (& $UvCmd python find $PythonVersion) }
     if (Test-Path $pythonExe) {
         $webOk = $false
+        $webServerSyntaxOk = $false
         # Relax EAP=Stop while running the import probe; see the matching
         # comment on the baseline-imports check above.  Python writes
         # deprecation warnings to stderr and we don't want those wrapped
@@ -2006,6 +2007,10 @@ print(','.join(scripts))
             & $pythonExe -c "import fastapi, uvicorn" 2>&1 | Out-Null
             if ($LASTEXITCODE -eq 0) { $webOk = $true }
         } catch { }
+        try {
+            & $pythonExe -m py_compile "$InstallDir\hermes_cli\web_server.py" 2>&1 | Out-Null
+            if ($LASTEXITCODE -eq 0) { $webServerSyntaxOk = $true }
+        } catch { }
         $ErrorActionPreference = $prevEAP
         if (-not $webOk) {
             Write-Warn "fastapi/uvicorn not importable -- `hermes dashboard` will not work."
@@ -2016,6 +2021,9 @@ print(','.join(scripts))
             } else {
                 Write-Warn "Could not install [web] extra. Run manually: uv pip install --python `"$pythonExe`" `"fastapi>=0.104,<1`" `"uvicorn[standard]>=0.24,<1`""
             }
+        }
+        if (-not $webServerSyntaxOk) {
+            throw "dashboard backend source failed syntax check: hermes_cli/web_server.py"
         }
     }
     

--- a/tests/hermes_cli/test_update_post_pull_syntax_guard.py
+++ b/tests/hermes_cli/test_update_post_pull_syntax_guard.py
@@ -116,6 +116,15 @@ def test_validate_critical_files_syntax_detects_break_in_main_py(tmp_path):
     assert failing_path is not None and failing_path.endswith("hermes_cli/main.py")
 
 
+def test_validate_critical_files_syntax_detects_break_in_web_server(tmp_path):
+    _populate_critical_tree(tmp_path, broken_file="hermes_cli/web_server.py")
+
+    ok, failing_path, _ = hermes_main._validate_critical_files_syntax(tmp_path)
+
+    assert ok is False
+    assert failing_path is not None and failing_path.endswith("hermes_cli/web_server.py")
+
+
 def test_validate_critical_files_syntax_tolerates_missing_files(tmp_path):
     """A refactor may legitimately remove one of the critical files — the
     guard should skip missing files, not falsely flag the install as broken."""

--- a/tests/test_install_ps1_web_server_syntax_probe.py
+++ b/tests/test_install_ps1_web_server_syntax_probe.py
@@ -1,0 +1,49 @@
+"""Regression: install.ps1 must syntax-check the dashboard backend source.
+
+Issue #59004 reported a fresh Windows desktop install crashing on launch
+because ``hermes_cli/web_server.py`` inside the installed checkout still
+contained merge-conflict markers. Import-only dependency probes (fastapi /
+uvicorn) do not catch that: the packages can be present while the backend
+source itself is unparsable.
+
+This test is source-level because Linux CI cannot execute the PowerShell
+installer. It locks the contract that install.ps1 runs ``py_compile`` against
+``hermes_cli/web_server.py`` and fails the stage when that syntax probe fails.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+
+
+def test_install_ps1_compiles_web_server_source_after_web_deps_probe() -> None:
+    text = INSTALL_PS1.read_text(encoding="utf-8")
+
+    probe = re.search(
+        r'import fastapi, uvicorn[\s\S]{0,1200}?-m py_compile "\$InstallDir\\hermes_cli\\web_server\.py"',
+        text,
+    )
+    assert probe is not None, (
+        "install.ps1 must syntax-check hermes_cli/web_server.py after the "
+        "dashboard dependency probe so a fresh desktop install fails early on "
+        "merge-conflict markers or other SyntaxErrors."
+    )
+
+
+def test_install_ps1_fails_stage_when_web_server_syntax_probe_fails() -> None:
+    text = INSTALL_PS1.read_text(encoding="utf-8")
+
+    assert "if ($LASTEXITCODE -eq 0) { $webServerSyntaxOk = $true }" in text
+    assert "if (-not $webServerSyntaxOk) {" in text
+    assert (
+        'throw "dashboard backend source failed syntax check: hermes_cli/web_server.py"'
+        in text
+    ), (
+        "install.ps1 must fail the install stage when hermes_cli/web_server.py "
+        "does not compile, instead of writing a broken desktop/backend install."
+    )


### PR DESCRIPTION
## What does this PR do?

Prevents fresh Windows desktop installs from succeeding with a broken dashboard/backend checkout when `hermes_cli/web_server.py` contains unresolved merge-conflict markers or another syntax error. The installer now syntax-checks that file before completing install, and the shared post-update syntax guard now treats `web_server.py` as a critical desktop/backend path alongside the always-imported CLI files.

## Related Issue

Fixes #59004

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `scripts/install.ps1`: after the dashboard dependency probe, run `py_compile` on `hermes_cli/web_server.py` and fail the install stage if it does not parse.
- `hermes_cli/main.py`: include `hermes_cli/web_server.py` in the shared syntax-critical file set checked after updates.
- `tests/hermes_cli/test_update_post_pull_syntax_guard.py`: add coverage for syntax failures in `hermes_cli/web_server.py`.
- `tests/test_install_ps1_web_server_syntax_probe.py`: add a source-level regression test locking the new Windows installer syntax probe.

## How to Test

1. Run `/opt/homebrew/bin/timeout -k 30 480 sh -c '$VIRTUAL_ENV/bin/pytest -q --timeout=60 "$@"' sh tests/hermes_cli/test_update_post_pull_syntax_guard.py tests/test_install_ps1_native_stderr_eap.py tests/test_install_ps1_web_server_syntax_probe.py tests/hermes_cli/test_web_server_pty_import.py tests/test_install_unmerged_index.py`
2. Run `python3 scripts/check-windows-footguns.py hermes_cli/main.py tests/hermes_cli/test_update_post_pull_syntax_guard.py tests/test_install_ps1_web_server_syntax_probe.py`
3. Run `ruff check hermes_cli/main.py tests/hermes_cli/test_update_post_pull_syntax_guard.py tests/test_install_ps1_web_server_syntax_probe.py`
4. Run `ruff format --check tests/test_install_ps1_web_server_syntax_probe.py`
5. Run `git diff --check`

## What platforms tested on

- macOS 15 / darwin-arm64 (local)
- Windows behavior covered via static `install.ps1` regression tests and `scripts/check-windows-footguns.py`; no native Windows runtime was available in this sandbox.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / darwin-arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Venv-backed broad suite attempt: stopped on unrelated pre-existing failure `tests/acp/test_approval_isolation.py::TestAcpExecAskGate::test_interactive_env_var_routes_to_callback` before it could serve as coverage for this change.
- Mechanically covering subset for the touched modules and installer guards: `22 passed, 1 skipped`.

<!-- autocontrib:worker-id=issue-new-a1f83900 kind=pr-open -->