### PR TITLE
fix(plugins): show entry-point plugins in 'hermes plugins list' (#58644)

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1020,6 +1020,18 @@ def _discover_all_plugins() -> list:
         (_plugins_dir(), "user", set()),
     ):
         _scan_level(base, source, skip, "", 0, seen)
+
+    # Pip-installed plugins registered via the ``hermes_agent.plugins``
+    # entry-point group. The real loader (PluginManager.discover_and_load)
+    # scans these; the display path must too, or an active pip plugin like
+    # rtk-hermes is invisible in `hermes plugins list`. Reuse the loader's
+    # scanner instead of duplicating the importlib.metadata logic.
+    from hermes_cli.plugins import PluginManager
+    for m in PluginManager()._scan_entry_points():
+        key = m.key or m.name
+        seen.setdefault(
+            key, (m.name, m.version, m.description, m.source, None, key)
+        )
     return list(seen.values())
 
 

--- a/tests/hermes_cli/test_plugins_cmd_list.py
+++ b/tests/hermes_cli/test_plugins_cmd_list.py
@@ -68,6 +68,45 @@ def test_cmd_list_plain_compact_output(monkeypatch, capsys):
     assert "Search" not in out  # plain mode stays compact, no descriptions
 
 
+def test_discover_all_plugins_includes_entry_points(monkeypatch):
+    """Entry-point plugins the loader sees must appear in the display path.
+
+    Regression for #58644: `hermes plugins list` scanned only bundled/user
+    dirs, so a pip-installed plugin (e.g. rtk-hermes) was loaded and active
+    but invisible in the listing.
+    """
+    from hermes_cli.plugins import PluginManager, PluginManifest
+
+    # No bundled/user dirs to scan — isolate the entry-point path.
+    monkeypatch.setattr(plugins_cmd, "_scan_level", lambda *a, **k: None)
+    monkeypatch.setattr(
+        PluginManager,
+        "_scan_entry_points",
+        lambda self: [
+            PluginManifest(
+                name="rtk-rewrite",
+                version="1.2.3",
+                description="RTK",
+                source="entrypoint",
+                path="rtk_hermes:register",
+                key="rtk-rewrite",
+            )
+        ],
+    )
+
+    entries = plugins_cmd._discover_all_plugins()
+    ep = [e for e in entries if e[3] == "entrypoint"]
+    assert ep, "entry-point plugin missing from _discover_all_plugins"
+    name, version, description, source, dir_path, key = ep[0]
+    assert (name, key, source, dir_path) == (
+        "rtk-rewrite", "rtk-rewrite", "entrypoint", None,
+    )
+    # dir_path is None for entry points — must not break resolve/render.
+    assert plugins_cmd._resolve_plugin_key_and_source("rtk-rewrite") == (
+        "rtk-rewrite", "entrypoint",
+    )
+
+
 def test_cmd_list_json_output(monkeypatch, capsys):
     entries = [("web-search-plus", "2.2.0", "Search", "git", None, "web-search-plus")]
     monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)


### PR DESCRIPTION
## What does this PR do?

`hermes plugins list` did not show pip-installed plugins registered via the
`hermes_agent.plugins` entry-point group. Those plugins are **loaded and
active** (the real loader `PluginManager.discover_and_load()` scans entry
points) — they were just invisible in the listing, including `--json` and
`--plain` output.

Root cause: two separate discovery paths. The loader scans directories **and**
entry points; the display helper `_discover_all_plugins()` in
`hermes_cli/plugins_cmd.py` scanned only bundled + user directories.

## Related Issue

Fixes #58644

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/plugins_cmd.py` — `_discover_all_plugins()` now also scans
  entry-point plugins by **reusing** `PluginManager._scan_entry_points()`
  (rather than duplicating the `importlib.metadata` logic). Entry-point
  plugins have no directory, so their tuple carries `dir_path=None`; the
  render, filter, and resolve paths already ignore that element. `setdefault`
  keeps directory plugins winning on key collision, matching
  `discover_and_load()` precedence.
- `tests/hermes_cli/test_plugins_cmd_list.py` — regression test asserting an
  entry-point plugin surfaces in the display path and resolves for
  enable/disable, with `dir_path=None`.

## How to Test

Reproduce (before fix): a pip plugin registering a `hermes_agent.plugins`
entry point (e.g. `rtk-hermes`) is loaded and rewriting commands, but absent
from `hermes plugins list` / `--json` / `--plain`.

Automated:

```
pytest tests/hermes_cli/test_plugins_cmd_list.py -q
```

The new `test_discover_all_plugins_includes_entry_points` fails on `main`
(entry points never reach the display path) and passes with this change.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the impacted tests and all pass (125 passed across the three
      `plugins_cmd` suites)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5.1, Python 3.13

### Documentation & Housekeeping

- [x] N/A — no docs/config/schema/tool-behavior changes
