### PR TITLE
fix(desktop): only treat real 401/403 as OAuth session expiry

### DIFF
--- a/apps/desktop/electron/connection-config.cjs
+++ b/apps/desktop/electron/connection-config.cjs
@@ -37,6 +37,12 @@
 const AT_COOKIE_VARIANTS = ['__Host-hermes_session_at', '__Secure-hermes_session_at', 'hermes_session_at']
 const RT_COOKIE_VARIANTS = ['__Host-hermes_session_rt', '__Secure-hermes_session_rt', 'hermes_session_rt']
 
+function isOauthSessionAuthFailure(error) {
+  if (!error || typeof error !== 'object') return false
+  if (error.statusCode === 401 || error.statusCode === 403) return true
+  return /(^|\b)(401|403)\b/.test(String(error.message || ''))
+}
+
 function normalizeRemoteBaseUrl(rawUrl) {
   const value = String(rawUrl || '').trim()
 
@@ -115,6 +121,9 @@ async function resolveTestWsUrl(baseUrl, authMode, token, deps = {}) {
     try {
       ticket = await mintTicket(baseUrl)
     } catch (error) {
+      if (!isOauthSessionAuthFailure(error)) {
+        throw error
+      }
       const err = new Error(
         'Reached the gateway over HTTP, but could not mint a WebSocket ticket for the OAuth session ' +
           '(it may have expired). Open Settings → Gateway and sign in again.'
@@ -279,5 +288,6 @@ module.exports = {
   profileRemoteOverride,
   resolveAuthMode,
   resolveTestWsUrl,
+  isOauthSessionAuthFailure,
   tokenPreview
 }

--- a/apps/desktop/electron/connection-config.test.cjs
+++ b/apps/desktop/electron/connection-config.test.cjs
@@ -28,6 +28,7 @@ const {
   profileRemoteOverride,
   resolveAuthMode,
   resolveTestWsUrl,
+  isOauthSessionAuthFailure,
   tokenPreview
 } = require('./connection-config.cjs')
 
@@ -373,7 +374,9 @@ test('resolveTestWsUrl (oauth, mint FAILS) throws — must NOT skip WS validatio
     () =>
       resolveTestWsUrl('https://gw.example.com', 'oauth', null, {
         mintTicket: async () => {
-          throw new Error('401 ticket mint failed')
+          const err = new Error('401 ticket mint failed')
+          err.statusCode = 401
+          throw err
         }
       }),
     err => {
@@ -386,6 +389,31 @@ test('resolveTestWsUrl (oauth, mint FAILS) throws — must NOT skip WS validatio
       return true
     }
   )
+})
+
+test('resolveTestWsUrl (oauth, transport failure) preserves the original error', async () => {
+  const timeout = new Error('Timed out connecting to Hermes backend after 8000ms')
+  await assert.rejects(
+    () =>
+      resolveTestWsUrl('https://gw.example.com', 'oauth', null, {
+        mintTicket: async () => {
+          throw timeout
+        }
+      }),
+    err => {
+      assert.equal(err, timeout)
+      assert.equal(err.needsOauthLogin, undefined)
+      return true
+    }
+  )
+})
+
+test('isOauthSessionAuthFailure only flags auth failures', () => {
+  assert.equal(isOauthSessionAuthFailure({ statusCode: 401 }), true)
+  assert.equal(isOauthSessionAuthFailure({ statusCode: 403 }), true)
+  assert.equal(isOauthSessionAuthFailure(new Error('401 expired')), true)
+  assert.equal(isOauthSessionAuthFailure(new Error('Timed out connecting to Hermes backend')), false)
+  assert.equal(isOauthSessionAuthFailure({ statusCode: 500, message: '500 upstream error' }), false)
 })
 
 test('resolveTestWsUrl (oauth) requires a mintTicket function', async () => {

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -4597,6 +4597,12 @@ function fetchJsonViaOauthSession(url, options = {}) {
   })
 }
 
+function isOauthSessionAuthFailure(error) {
+  if (!error || typeof error !== 'object') return false
+  if (error.statusCode === 401 || error.statusCode === 403) return true
+  return /(^|\b)(401|403)\b/.test(String(error.message || ''))
+}
+
 // Mint a single-use WS ticket for a gated gateway. Returns the ticket string.
 // Throws (with statusCode 401) if the session cookie is missing/expired —
 // callers treat that as "needs re-login".
@@ -4899,6 +4905,9 @@ async function buildRemoteConnection(rawUrl, authMode, token, source) {
     try {
       ticket = await mintGatewayWsTicket(baseUrl)
     } catch (error) {
+      if (!isOauthSessionAuthFailure(error)) {
+        throw error
+      }
       const err = new Error(
         'Your remote gateway session has expired. ' + 'Open Settings → Gateway and click "Sign in" again.'
       )

--- a/apps/desktop/src/lib/gateway-ws-url.test.ts
+++ b/apps/desktop/src/lib/gateway-ws-url.test.ts
@@ -20,11 +20,17 @@ describe('resolveGatewayWsUrl', () => {
     })
 
     it('preserves the underlying mint failure as the cause', async () => {
-      const cause = new Error('401 cookie expired')
+      const cause = Object.assign(new Error('401 cookie expired'), { statusCode: 401 })
       const getGatewayWsUrl = vi.fn().mockRejectedValue(cause)
       const error = await resolveGatewayWsUrl({ getGatewayWsUrl }, oauthConn).catch(e => e)
       expect(error).toBeInstanceOf(GatewayReauthRequiredError)
       expect((error as GatewayReauthRequiredError).cause).toBe(cause)
+    })
+
+    it('passes through transport failures instead of misclassifying them as reauth', async () => {
+      const cause = new Error('Timed out connecting to Hermes backend after 8000ms')
+      const getGatewayWsUrl = vi.fn().mockRejectedValue(cause)
+      await expect(resolveGatewayWsUrl({ getGatewayWsUrl }, oauthConn)).rejects.toBe(cause)
     })
 
     it('throws a reauth error when the preload cannot mint (no method)', async () => {

--- a/apps/shared/src/websocket-url.ts
+++ b/apps/shared/src/websocket-url.ts
@@ -31,6 +31,20 @@ export function isGatewayReauthRequired(error: unknown): error is GatewayReauthR
   )
 }
 
+function isGatewayAuthFailure(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false
+  }
+
+  const statusCode = (error as { statusCode?: unknown }).statusCode
+  if (statusCode === 401 || statusCode === 403) {
+    return true
+  }
+
+  const message = String((error as { message?: unknown }).message || '')
+  return /(^|\b)(401|403)\b/.test(message)
+}
+
 export async function resolveGatewayWsUrl(deps: ResolveGatewayWsUrlDeps, conn: GatewayWsConnection): Promise<string> {
   const mint = deps.getGatewayWsUrl
   const profile = conn.profile ?? null
@@ -45,6 +59,10 @@ export async function resolveGatewayWsUrl(deps: ResolveGatewayWsUrlDeps, conn: G
     try {
       return await mint(profile)
     } catch (error) {
+      if (!isGatewayAuthFailure(error)) {
+        throw error
+      }
+
       throw new GatewayReauthRequiredError(
         'Your remote gateway session has expired. Open Settings -> Gateway and click "Sign in" again.',
         { cause: error }


### PR DESCRIPTION
### Summary
Previously, any failure during `POST /api/auth/ws-ticket` (including timeouts, 5xx, and transient network errors) was wrapped as a `GatewayReauthRequiredError` and surfaced to the user as:

> "Your remote gateway session has expired. Open Settings → Gateway and click 'Sign in' again."

This caused false-positive "session expired" messages on healthy but occasionally slow remote OAuth gateways.

### Root cause
`resolveGatewayWsUrl`, `resolveTestWsUrl`, and `buildRemoteConnection` treated every ticket-mint error as an auth failure, without distinguishing real auth failures (`401`/`403`) from transport/runtime failures (timeouts, `5xx`, connection resets).

### Fix
Introduced two small helpers:
- `isGatewayAuthFailure` (shared)
- `isOauthSessionAuthFailure` (electron)

These only match actual auth failures (`statusCode` `401`/`403` or equivalent message patterns). Non-auth failures now propagate unchanged.

### Verification
- `node --check apps/desktop/electron/main.cjs`
- `node --check apps/desktop/electron/connection-config.cjs`
- `node --test apps/desktop/electron/connection-config.test.cjs` → 52 passed
- `cd apps/desktop && npx vitest run src/lib/gateway-ws-url.test.ts` → 13 passed

### Impact
- Real expired/revoked sessions still correctly prompt re-login.
- Timeouts and gateway health issues now surface as connectivity problems instead of misleading reauth prompts.
