### PR TITLE
feat(desktop): add workspace path status action

### DIFF
--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -8,15 +8,18 @@ import { GatewayMenuPanel } from '@/app/shell/gateway-menu-panel'
 import { Codicon } from '@/components/ui/codicon'
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'
 import { useI18n } from '@/i18n'
-import { Activity, AlertCircle, Clock, Command, Hash, Loader2, Terminal, Zap, ZapFilled } from '@/lib/icons'
+import { Activity, AlertCircle, Clock, Command, CopyIcon, FolderOpen, Hash, Loader2, Terminal, Zap, ZapFilled } from '@/lib/icons'
 import type { RuntimeReadinessResult } from '@/lib/runtime-readiness'
 import { contextBarLabel, LiveDuration, usageContextLabel } from '@/lib/statusbar'
 import { cn } from '@/lib/utils'
 import { setGlobalYolo, setSessionYolo } from '@/lib/yolo-session'
+import { copyFilePath, revealFile } from '@/store/file-actions'
+import { revealFileInTree } from '@/store/layout'
 import {
   $activeSessionId,
   $busy,
   $connection,
+  $currentCwd,
   $currentUsage,
   $sessionStartedAt,
   $turnStartedAt,
@@ -37,6 +40,13 @@ import type { StatusResponse } from '@/types/hermes'
 
 import { CRON_ROUTE } from '../../routes'
 import type { StatusbarItem, StatusbarSelectModifiers } from '../statusbar-controls'
+
+function workspaceLabel(cwd: string): string {
+  const normalized = cwd.replace(/[\\/]+$/, '')
+  const leaf = normalized.split(/[\\/]/).filter(Boolean).pop()
+
+  return leaf || cwd
+}
 
 interface StatusbarItemsOptions {
   agentsOpen: boolean
@@ -71,10 +81,12 @@ export function useStatusbarItems({
 }: StatusbarItemsOptions) {
   const { t } = useI18n()
   const copy = t.shell.statusbar
+  const fileMenu = t.fileMenu
   const activeSessionId = useStore($activeSessionId)
   const terminalTakeover = useStore($terminalTakeover)
   const yoloActive = useStore($yoloActive)
   const busy = useStore($busy)
+  const currentCwd = useStore($currentCwd)
   const currentUsage = useStore($currentUsage)
   const gatewayRestarting = useStore($gatewayRestarting)
   const sessionStartedAt = useStore($sessionStartedAt)
@@ -300,6 +312,39 @@ export function useStatusbarItems({
         variant: 'menu'
       },
       {
+        hidden: !currentCwd,
+        icon: <FolderOpen className="size-3" />,
+        id: 'workspace-cwd',
+        label: currentCwd ? workspaceLabel(currentCwd) : undefined,
+        menuItems: currentCwd
+          ? [
+              {
+                icon: <CopyIcon className="size-4" />,
+                id: 'copy-workspace-path',
+                label: fileMenu.copyPath,
+                onSelect: () => void copyFilePath(currentCwd),
+                title: currentCwd
+              },
+              {
+                icon: <FolderOpen className="size-4" />,
+                id: 'reveal-workspace-finder',
+                label: fileMenu.revealFileManager,
+                onSelect: () => void revealFile(currentCwd),
+                title: currentCwd
+              },
+              {
+                icon: <Codicon name="go-to-file" size="1rem" />,
+                id: 'reveal-workspace-sidebar',
+                label: fileMenu.revealInSidebar,
+                onSelect: () => revealFileInTree(currentCwd),
+                title: currentCwd
+              }
+            ]
+          : undefined,
+        title: currentCwd || undefined,
+        variant: 'menu'
+      },
+      {
         className: cn(
           agentsOpen && 'bg-accent/55 text-foreground',
           subagentsFailed > 0 && 'text-destructive hover:text-destructive'
@@ -337,6 +382,10 @@ export function useStatusbarItems({
       agentsOpen,
       commandCenterOpen,
       copy,
+      currentCwd,
+      fileMenu.copyPath,
+      fileMenu.revealFileManager,
+      fileMenu.revealInSidebar,
       gatewayMenuContent,
       gatewayClassName,
       gatewayDetail,


### PR DESCRIPTION
## Summary

Adds a workspace path item to the desktop status bar with quick path actions.

## Why

The current working directory is one of the most important pieces of context in an agentic coding session. If users have to manually infer the folder, copy a path from text, switch to Finder, or hunt through the tree, a simple orientation task becomes a repeated context switch.

This makes the active workspace a visible, actionable object.

## Changes

- Shows the active workspace folder name in the left status bar when a cwd is attached.
- Adds a menu with:
  - Copy workspace path
  - Reveal workspace in the system file manager
  - Reveal workspace in the Hermes file tree
- Reuses existing file actions and file-menu translations.
- Keeps the item hidden when no workspace cwd is attached.

## Validation

- `cd apps/desktop && npm run typecheck`
- `cd apps/desktop && npx eslint src/app/shell/hooks/use-statusbar-items.tsx`
