### PR TITLE
fix(cron): clean up HERMES_CRON_SESSION env var after each job run (#59236)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3184,6 +3184,9 @@ def run_job(
             _terminal_cwd_lock.release_write()
         else:
             _terminal_cwd_lock.release_read()
+        # Clean up HERMES_CRON_SESSION so interactive gateway sessions sharing
+        # this process don't inherit cron-mode approval behavior (#59236).
+        os.environ.pop("HERMES_CRON_SESSION", None)
         # Clean up ContextVar session/delivery state for this job.
         clear_session_vars(_ctx_tokens)
         for _var_name in _cron_delivery_vars:


### PR DESCRIPTION
## Summary

Follow-up to #59179 review feedback: the in-process cron scheduler sets `os.environ["HERMES_CRON_SESSION"] = "1"` process-wide but never clears it, causing the cron-mode approval behavior to leak into interactive gateway sessions.

## Problem

When `InProcessCronScheduler` fires a job inside the gateway process, `HERMES_CRON_SESSION=1` persists in `os.environ` for the lifetime of the process. Every subsequent interactive session (Telegram, Discord, etc.) inherits this marker, so:

- `cron_mode: deny` (default): `execute_code` and dangerous commands are hard-blocked with "cron jobs run without a user present"
- `cron_mode: approve`: dangerous commands are auto-approved without user prompt

## Fix

**1 line added** in `cron/scheduler.py:run_job()` finally block (line 3187):

```python
os.environ.pop("HERMES_CRON_SESSION", None)
```

Placed alongside the existing `TERMINAL_CWD` cleanup and ContextVar clear — the marker is now only present while a cron job is actively running.

## Why this approach

The scheduler already has a well-established finally block for exactly this kind of cleanup (TERMINAL_CWD restore, ContextVar clear, lock release). Adding the `pop` here is:
- **Consistent** with the existing cleanup patterns
- **Minimal** — 1 line, no new imports or APIs
- **Backward compatible** — the env var is still set before each job and cleared after

Closes #59236