### PR TITLE
fix(desktop): ignore prototype keys in session-scoped stores (#58441)

### DIFF
--- a/apps/desktop/src/store/compaction.test.ts
+++ b/apps/desktop/src/store/compaction.test.ts
@@ -50,4 +50,14 @@ describe('compaction store', () => {
 
     expect($compactingSessions.get()).toBe(before)
   })
+
+  it('does not report a prototype-named session as active (#58441)', () => {
+    // 'toString' is on Object.prototype; an empty map must not look like it
+    // already contains it, and setting it must store an own key.
+    expect(Object.hasOwn($compactingSessions.get(), 'toString')).toBe(false)
+
+    setSessionCompacting('toString', true)
+
+    expect($compactingSessions.get().toString).toBe(true)
+  })
 })

--- a/apps/desktop/src/store/compaction.ts
+++ b/apps/desktop/src/store/compaction.ts
@@ -11,7 +11,7 @@ export const $compactingSessions = atom<Record<string, true>>({})
 
 export const $compactionActive = computed(
   [$compactingSessions, $activeSessionId],
-  (sessions, activeId) => keyFor(activeId) in sessions
+  (sessions, activeId) => Object.hasOwn(sessions, keyFor(activeId))
 )
 
 export function setSessionCompacting(sessionId: string | null | undefined, active: boolean): void {
@@ -19,7 +19,7 @@ export function setSessionCompacting(sessionId: string | null | undefined, activ
   const sessions = $compactingSessions.get()
 
   if (active) {
-    if (key in sessions) {
+    if (Object.hasOwn(sessions, key)) {
       return
     }
 
@@ -28,7 +28,7 @@ export function setSessionCompacting(sessionId: string | null | undefined, activ
     return
   }
 
-  if (!(key in sessions)) {
+  if (!Object.hasOwn(sessions, key)) {
     return
   }
 

--- a/apps/desktop/src/store/subagents.test.ts
+++ b/apps/desktop/src/store/subagents.test.ts
@@ -131,4 +131,13 @@ describe('subagent store', () => {
     expect($subagentsBySession.get().s1).toBeUndefined()
     expect($subagentsBySession.get().s2).toHaveLength(1)
   })
+
+  it('treats a prototype-named session id as an own miss (#58441)', () => {
+    // 'toString' resolves to Object.prototype.toString on a plain object;
+    // upsert must create a real array, not crash on the inherited function.
+    upsertSubagent('toString', { goal: 'proto', status: 'running', subagent_id: 'a1', task_index: 0 })
+
+    expect(listFor('toString')).toHaveLength(1)
+    expect(Array.isArray($subagentsBySession.get().toString)).toBe(true)
+  })
 })

--- a/apps/desktop/src/store/subagents.ts
+++ b/apps/desktop/src/store/subagents.ts
@@ -181,7 +181,7 @@ function toProgress(payload: SubagentPayload, prev: SubagentProgress | undefined
 export function clearSessionSubagents(sid: string) {
   const map = $subagentsBySession.get()
 
-  if (!(sid in map)) {
+  if (!Object.hasOwn(map, sid)) {
     return
   }
 
@@ -191,7 +191,7 @@ export function clearSessionSubagents(sid: string) {
 
 export function pruneDelegateFallbackSubagents(sid: string) {
   const map = $subagentsBySession.get()
-  const list = map[sid]
+  const list = Object.hasOwn(map, sid) ? map[sid] : undefined
 
   if (!list?.length) {
     return
@@ -208,7 +208,7 @@ export function pruneDelegateFallbackSubagents(sid: string) {
 
 export function upsertSubagent(sid: string, payload: SubagentPayload, createIfMissing = true, eventType?: string) {
   const map = $subagentsBySession.get()
-  const list = map[sid] ?? []
+  const list = Object.hasOwn(map, sid) ? map[sid] : []
   const id = idOf(payload)
   const idx = list.findIndex(item => item.id === id)
 

--- a/apps/desktop/src/store/todos.test.ts
+++ b/apps/desktop/src/store/todos.test.ts
@@ -102,4 +102,15 @@ describe('todosForHydration (stale-active guard on restore)', () => {
   it('returns null when there is nothing stored', () => {
     expect(todosForHydration(null)).toBeNull()
   })
+
+  it('clears a prototype-named session without a false hit (#58441)', () => {
+    // 'toString' resolves to Object.prototype.toString; clearing an empty
+    // map for it must be an own-key miss, not treat the inherited fn as a list.
+    const before = $todosBySession.get()
+
+    clearSessionTodos('toString')
+    clearActiveSessionTodos('toString')
+
+    expect($todosBySession.get()).toBe(before)
+  })
 })

--- a/apps/desktop/src/store/todos.ts
+++ b/apps/desktop/src/store/todos.ts
@@ -66,7 +66,7 @@ export function clearSessionTodos(sid: string) {
 
   const map = $todosBySession.get()
 
-  if (!(sid in map)) {
+  if (!Object.hasOwn(map, sid)) {
     return
   }
 
@@ -80,7 +80,8 @@ export function clearSessionTodos(sid: string) {
 // composer forever. A finished list is left untouched so its short linger
 // still shows the last checkmark landing.
 export function clearActiveSessionTodos(sid: string) {
-  const todos = $todosBySession.get()[sid]
+  const map = $todosBySession.get()
+  const todos = Object.hasOwn(map, sid) ? map[sid] : undefined
 
   if (!todos || !todoListActive(todos)) {
     return


### PR DESCRIPTION
## What does this PR do?

Desktop session-scoped stores keep per-session state in plain objects but tested membership with `sid in map` and read with `map[sid] ?? []` — both walk the prototype chain. A session id like `toString` collides with `Object.prototype.toString`:

- `subagents.ts` → `upsertSubagent()` reads `map[sid] ?? []`, gets the inherited **function** instead of an array, and crashes on `list.findIndex(...)`.
- `compaction.ts` / `todos.ts` → an empty map can look like it already contains the session (`in` returns true for inherited names).

Fix: treat session ids as opaque **own** keys via `Object.hasOwn` on every membership and read path. Native ES2022, no new dependency, smallest correct diff.

## Related Issue

Fixes #58441

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/store/compaction.ts` — `Object.hasOwn` for the active-computed and set/clear guards.
- `apps/desktop/src/store/todos.ts` — own-key guard in `clearSessionTodos` and `clearActiveSessionTodos`.
- `apps/desktop/src/store/subagents.ts` — own-key guard in `clearSessionSubagents`, `pruneDelegateFallbackSubagents`, and the `upsertSubagent` crash path.
- One prototype-key regression test added to each store's `*.test.ts`.

## How to Test

```
cd apps/desktop
npx vitest run --environment jsdom src/store/subagents.test.ts src/store/todos.test.ts src/store/compaction.test.ts
```

`23 passed`. Reverting any store makes its new test fail — subagents throws the exact `TypeError: list.findIndex is not a function` from the report. `tsc -p . --noEmit` clean for the touched files.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] I searched open + closed PRs/issues for duplicates — none touch these stores
- [x] Only changes related to this fix
- [x] Ran the impacted tests, all pass (23)
- [x] Added regression tests (one per store, each fails without the fix)
- [x] Tested on macOS 26.5.1, Node 22

### Documentation & Housekeeping

- [x] N/A — no docs/config/schema/tool-behavior changes
