### PR TITLE
fix(gateway): honor top-level stt_enabled config.yaml key

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -927,6 +927,8 @@ def load_gateway_config() -> GatewayConfig:
             stt_cfg = yaml_cfg.get("stt")
             if isinstance(stt_cfg, dict):
                 gw_data["stt"] = stt_cfg
+            if "stt_enabled" in yaml_cfg:
+                gw_data["stt_enabled"] = yaml_cfg["stt_enabled"]
             if "stt_echo_transcripts" in yaml_cfg:
                 gw_data["stt_echo_transcripts"] = yaml_cfg["stt_echo_transcripts"]
 

--- a/tests/gateway/test_stt_transcript_echo_config.py
+++ b/tests/gateway/test_stt_transcript_echo_config.py
@@ -41,6 +41,18 @@ def test_load_gateway_config_honors_top_level_stt_echo_transcripts(monkeypatch, 
     assert cfg.stt_echo_transcripts is False
 
 
+def test_load_gateway_config_honors_top_level_stt_enabled(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "stt:\n  enabled: true\nstt_enabled: false\n",
+        encoding="utf-8",
+    )
+
+    cfg = load_gateway_config()
+
+    assert cfg.stt_enabled is False
+
+
 def test_gateway_runner_uses_stt_echo_transcripts_flag():
     runner = GatewayRunner.__new__(GatewayRunner)
 


### PR DESCRIPTION
## This is a sibling follow-up to commit `4be749d15`

- **What the parent covered:** `4be749d15` ("honor top-level STT transcript echo config") bridged the top-level `stt_echo_transcripts` key from `config.yaml` into the `gw_data` dict that feeds `GatewayConfig.from_dict()`.
- **What the parent did NOT touch:** the older sibling top-level `stt_enabled` key. It stayed unbridged in `load_gateway_config()`.
- **What this adds:** the one missing bridge line so `stt_enabled` reaches `from_dict()` exactly like `stt_echo_transcripts` and `group_sessions_per_user` do.

## What does this PR do?

`load_gateway_config()` selectively copies `config.yaml` keys into `gw_data` before handing it to `GatewayConfig.from_dict()`. `from_dict()` already resolves the top-level `stt_enabled` key with precedence over nested `stt.enabled` (config.py:774-776), but that precedence is unreachable via the real `config.yaml` path: the loader copies the `stt` sub-dict and top-level `stt_echo_transcripts`, but never the top-level `stt_enabled`.

As a result a documented top-level `stt_enabled: false` (see `website/docs/user-guide/messaging/slack.md`, which instructs users to set exactly that at the top level) is silently dropped, so inbound voice keeps being auto-transcribed against the user's explicit intent.

The fix mirrors the adjacent `stt_echo_transcripts` surfacing line — a single conditional copy.

## Related Issue

No filed issue — code-originated sibling-miss of `4be749d15`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/config.py`: in `load_gateway_config()`, bridge the top-level `stt_enabled` key from `config.yaml` into `gw_data`, immediately alongside the existing `stt_echo_transcripts` bridge.
- `tests/gateway/test_stt_transcript_echo_config.py`: add `test_load_gateway_config_honors_top_level_stt_enabled`, mirroring the existing `test_load_gateway_config_honors_top_level_stt_echo_transcripts` fixture.

## How to Test

Regression guard (verified both directions):

1. Write `config.yaml` with `stt:\n  enabled: true\nstt_enabled: false`.
2. **Before the fix:** `load_gateway_config().stt_enabled` returns `True` — the top-level key is dropped, nested `stt.enabled: true` wins. New test fails (`assert True is False`).
3. **After the fix:** `load_gateway_config().stt_enabled` returns `False` — top-level precedence honored. New test passes.

```
uv run --with pytest --with pytest-asyncio python3 -m pytest tests/gateway/test_stt_transcript_echo_config.py -v
# 7 passed
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the touched-area suite and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A (behavior now matches the already-documented `stt_enabled` key)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new key; wires an existing documented one)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture — or N/A
- [x] I've considered cross-platform impact — or N/A (pure config-parsing logic)