### PR TITLE
fix(ntfy): log inbound message length, not content

### DIFF
--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -359,7 +359,7 @@ class NtfyAdapter(BasePlatformAdapter):
             timestamp=timestamp,
         )
 
-        logger.debug("[%s] Message on topic %s: %s", self.name, topic, text[:80])
+        logger.debug("[%s] Message on topic %s (%d chars)", self.name, topic, len(text))
         await self.handle_message(message_event)
 
     # -- Deduplication ------------------------------------------------------

--- a/tests/gateway/test_ntfy_plugin.py
+++ b/tests/gateway/test_ntfy_plugin.py
@@ -1019,3 +1019,22 @@ class TestTruncateHelper:
     def test_unicode_message_encoded(self):
         result = _ntfy._truncate_body("héllo 🔔", context="test")
         assert result == "héllo 🔔".encode("utf-8")
+
+
+class TestInboundLogPrivacy:
+    """`_on_message` must not copy raw message content into logs (#58477 class:
+    the merged Slack fix logs length, not a preview)."""
+
+    def test_debug_log_omits_message_text(self, caplog):
+        secret = "wire $5000 to account 12345 — private quote"
+        config = PlatformConfig(enabled=True, extra={"topic": "t"})
+        adapter = NtfyAdapter(config)
+        adapter.handle_message = AsyncMock()
+
+        with caplog.at_level("DEBUG"):
+            _run(adapter._on_message({"id": "m1", "message": secret, "topic": "t"}))
+
+        adapter.handle_message.assert_awaited_once()
+        assert secret not in caplog.text
+        assert "43 chars" in caplog.text  # length is logged instead
+


### PR DESCRIPTION
## What does this PR do?

The ntfy adapter's `_on_message()` logged the raw inbound message body at debug level:

```python
logger.debug("[%s] Message on topic %s: %s", self.name, topic, text[:80])
```

With debug logging enabled, private message content is copied into gateway logs even though the line only needs to report that a message arrived. This is the same bug class as the just-merged Slack fix (#58501 / #58477), which logs the extracted **length** instead of a content preview.

Fix: log the char count, not the text.

```python
logger.debug("[%s] Message on topic %s (%d chars)", self.name, topic, len(text))
```

## Related Issue

No existing issue — found while auditing platform adapters for the same leak class as #58477. Same fix shape as merged #58501.

## Type of Change

- [x] 🔒 Security fix (privacy: stops message content reaching logs)

## Changes Made

- `plugins/platforms/ntfy/adapter.py` — `_on_message()` logs `len(text)` instead of `text[:80]`.
- `tests/gateway/test_ntfy_plugin.py` — regression test (`TestInboundLogPrivacy`) asserting the debug log omits the message body and reports the char count.

## How to Test

```
.venv/bin/python -m pytest tests/gateway/test_ntfy_plugin.py -q
```

`83 passed`. Reverting the one-line fix makes the new test fail — the raw secret text leaks into `caplog.text`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] I searched open + closed PRs/issues — none touch the ntfy debug log
- [x] Only changes related to this fix
- [x] Ran the impacted tests, all pass (83)
- [x] Added a regression test (fails without the fix)
- [x] Tested on macOS 26.5.1, Python 3.13

### Documentation & Housekeeping

- [x] N/A — no docs/config/schema/tool-behavior changes
