### PR TITLE
fix(line): keep full code-fence info string out of stripped output

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -166,7 +166,7 @@ _MD_LINK_RE = re.compile(r"\[([^\]]+)\]\((https?://[^\s)]+)\)")
 _MD_BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
 _MD_ITAL_RE = re.compile(r"(?<!\*)\*(?!\s)(.+?)(?<!\s)\*(?!\*)")
 _MD_CODE_INLINE_RE = re.compile(r"`([^`]+)`")
-_MD_CODE_BLOCK_RE = re.compile(r"```[a-zA-Z0-9_+-]*\n?(.*?)```", re.DOTALL)
+_MD_CODE_BLOCK_RE = re.compile(r"```[^\n]*\n?(.*?)```", re.DOTALL)
 _MD_HEADING_RE = re.compile(r"^#{1,6}\s+", re.MULTILINE)
 _MD_BULLET_RE = re.compile(r"^[\s]*[-*+]\s+", re.MULTILINE)
 

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -280,6 +280,13 @@ class TestMarkdownAndChunking:
         assert "print('hi')" in out
         assert "```" not in out
 
+    def test_code_fence_dotted_language_tag_kept(self):
+        # A fence info string containing '.' or '#' (html.erb, python3.11, c#)
+        # must be consumed whole — the old [a-zA-Z0-9_+-]* class stopped at the
+        # dot and leaked the suffix (".erb") into the plain-text bubble.
+        md = "```html.erb\nprint('hi')\n```"
+        assert strip_markdown_preserving_urls(md) == "print('hi')"
+
     def test_split_short_returns_single_chunk(self):
         assert split_for_line("hi") == ["hi"]
 


### PR DESCRIPTION
## What does this PR do?

Fixes a deterministic, user-visible LINE formatting bug: an agent reply containing a code block whose language tag has a `.` or `#` (e.g. `html.erb`, `python3.11`, `c#`) gets garbage (`.erb`) prepended to its plain-text bubble.

LINE's text bubble has zero Markdown support, so `strip_markdown_preserving_urls()` (`plugins/platforms/line/adapter.py`) rewrites fenced code blocks to bare content via `_MD_CODE_BLOCK_RE`. That regex matched the fence info string with the class `[a-zA-Z0-9_+-]*`, which excludes `.` and `#`. For a fence like ` ```html.erb `, the tag regex stops at the dot; the unmatched suffix `.erb\n…` falls into the `(.*?)` content group and leaks into the stripped output:

```
strip_markdown_preserving_urls("```html.erb\nprint('hi')\n```")
# BEFORE:  ".erb\nprint('hi')"   ← ".erb" leaks as a plain-text line
# AFTER:   "print('hi')"
```

The fix consumes the whole info string to end-of-line (`[^\n]*`), per CommonMark (a fence info string runs to the end of the opening line). Plain `python` and no-language fences are unaffected.

## Related Issue

No filed issue — code-originated formatting bug.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/line/adapter.py`: widen `_MD_CODE_BLOCK_RE`'s language-tag class from `[a-zA-Z0-9_+-]*` to `[^\n]*` so a dotted/hashed info string is consumed whole instead of leaking its suffix into the content group.
- `tests/gateway/test_line_plugin.py`: add `test_code_fence_dotted_language_tag_kept`. The existing `test_code_fence_content_kept` only covered plain `python`, which masked this.

## How to Test

Regression guard (verified both directions):

1. **Before the fix:** `strip_markdown_preserving_urls("```html.erb\nprint('hi')\n```")` returns `".erb\nprint('hi')"` — new test fails.
2. **After the fix:** returns `"print('hi')"` — new test passes; plain `python` and no-language fences stay green.

```
uv run --with pytest --with pytest-asyncio python3 -m pytest tests/gateway/test_line_plugin.py -q
# 78 passed
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the touched-area suite and all tests pass (78 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A (internal Markdown-stripping regex)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture — or N/A
- [x] I've considered cross-platform impact — or N/A (pure regex logic)