### PR TITLE
[codex] Add Clarity dashboard theme

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1864,7 +1864,9 @@ DEFAULT_CONFIG = {
 
     # Web dashboard settings
     "dashboard": {
-        "theme": "default",  # Dashboard visual theme: "default", "midnight", "ember", "mono", "cyberpunk", "rose"
+        # Dashboard visual theme: "default", "default-large", "nous-blue",
+        # "midnight", "ember", "mono", "clarity", "cyberpunk", "rose"
+        "theme": "default",
         # Hide the token/cost analytics surfaces (Analytics page, token bars and
         # cost figures on the Models page) by default.  The numbers shown there
         # are a local debug estimate: they only count successful main-agent

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -651,7 +651,10 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "dashboard.theme": {
         "type": "select",
         "description": "Web dashboard visual theme",
-        "options": ["default", "midnight", "ember", "mono", "cyberpunk", "rose"],
+        "options": [
+            "default", "default-large", "nous-blue", "midnight", "ember",
+            "mono", "clarity", "cyberpunk", "rose",
+        ],
     },
     "display.resume_display": {
         "type": "select",
@@ -13957,10 +13960,11 @@ _BUILTIN_DASHBOARD_THEMES = [
     {"name": "default-large", "label": "Hermes Teal (Large)", "description": "Hermes Teal with bigger fonts and roomier spacing"},
     {"name": "nous-blue",     "label": "Nous Blue",           "description": "Light mode — vivid Nous-blue accents on cream canvas"},
     {"name": "midnight",      "label": "Midnight",            "description": "Deep blue-violet with cool accents"},
-    {"name": "ember",     "label": "Ember",          "description": "Warm crimson and bronze — forge vibes"},
-    {"name": "mono",      "label": "Mono",           "description": "Clean grayscale — minimal and focused"},
-    {"name": "cyberpunk", "label": "Cyberpunk",      "description": "Neon green on black — matrix terminal"},
-    {"name": "rose",      "label": "Rosé",           "description": "Soft pink and warm ivory — easy on the eyes"},
+    {"name": "ember",         "label": "Ember",               "description": "Warm crimson and bronze — forge vibes"},
+    {"name": "mono",          "label": "Mono",                "description": "Clean grayscale — minimal and focused"},
+    {"name": "clarity",       "label": "Clarity",             "description": "High-contrast teal with hyperlegible UI typography"},
+    {"name": "cyberpunk",     "label": "Cyberpunk",           "description": "Neon green on black — matrix terminal"},
+    {"name": "rose",          "label": "Rosé",                "description": "Soft pink and warm ivory — easy on the eyes"},
 ]
 
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -623,6 +623,18 @@ class TestWebServerEndpoints:
         assert config["dashboard"]["theme"] == "ember"
         assert config["dashboard"]["font"] == "jetbrains-mono"
 
+    def test_get_dashboard_themes_includes_clarity(self):
+        """The high-contrast Clarity preset is advertised to the picker."""
+        resp = self.client.get("/api/dashboard/themes")
+        assert resp.status_code == 200
+        themes = {entry["name"]: entry for entry in resp.json()["themes"]}
+
+        assert themes["clarity"] == {
+            "name": "clarity",
+            "label": "Clarity",
+            "description": "High-contrast teal with hyperlegible UI typography",
+        }
+
     def test_get_sessions_uses_only_persisted_cwd(self, monkeypatch):
         """Session rows without persisted cwd must not inherit TERMINAL_CWD.
 
@@ -2962,6 +2974,13 @@ class TestBuildSchemaFromConfig:
             assert entry["type"] == "select"
             assert "options" in entry
             assert "local" in entry["options"]
+
+    def test_dashboard_theme_options_match_builtin_themes(self):
+        from hermes_cli.web_server import CONFIG_SCHEMA, _BUILTIN_DASHBOARD_THEMES
+
+        assert CONFIG_SCHEMA["dashboard.theme"]["options"] == [
+            theme["name"] for theme in _BUILTIN_DASHBOARD_THEMES
+        ]
 
     def test_empty_prefix_produces_correct_keys(self):
         from hermes_cli.web_server import _build_schema_from_config

--- a/web/src/themes/presets.ts
+++ b/web/src/themes/presets.ts
@@ -131,6 +131,48 @@ export const monoTheme: DashboardTheme = {
   },
 };
 
+export const clarityTheme: DashboardTheme = {
+  name: "clarity",
+  label: "Clarity",
+  description: "High-contrast teal with hyperlegible UI typography",
+  palette: {
+    background: { hex: "#061214", alpha: 1 },
+    midground: { hex: "#f6f2e8", alpha: 1 },
+    foreground: { hex: "#8ee8d1", alpha: 0.2 },
+    warmGlow: "rgba(94, 234, 212, 0.16)",
+    noiseOpacity: 0.35,
+  },
+  typography: {
+    ...DEFAULT_TYPOGRAPHY,
+    fontSans: `"Atkinson Hyperlegible", ${SYSTEM_SANS}`,
+    fontMono: `"JetBrains Mono", ${SYSTEM_MONO}`,
+    fontUrl:
+      "https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;700&family=JetBrains+Mono:wght@400;500;700&display=swap",
+    baseSize: "16px",
+    lineHeight: "1.65",
+  },
+  layout: DEFAULT_LAYOUT,
+  colorOverrides: {
+    card: "#0b1b1d",
+    popover: "#0b1b1d",
+    secondary: "#102527",
+    muted: "#102527",
+    accent: "#143130",
+    border: "#315451",
+    input: "#315451",
+    ring: "#8ee8d1",
+    success: "#5eead4",
+    warning: "#facc15",
+  },
+  terminalBackground: "#050b0c",
+  terminalForeground: "#f6f2e8",
+  seriesColors: {
+    inputTokenAccent: "#f6f2e8",
+    outputTokenAccent: "#5eead4",
+  },
+  swatchColors: ["#061214", "#f6f2e8", "#5eead4"],
+};
+
 export const cyberpunkTheme: DashboardTheme = {
   name: "cyberpunk",
   label: "Cyberpunk",
@@ -235,6 +277,7 @@ export const BUILTIN_THEMES: Record<string, DashboardTheme> = {
   midnight: midnightTheme,
   ember: emberTheme,
   mono: monoTheme,
+  clarity: clarityTheme,
   cyberpunk: cyberpunkTheme,
   rose: roseTheme,
 };


### PR DESCRIPTION
## Summary

Adds a new built-in `clarity` dashboard theme focused on readability while staying close to Hermes' dark terminal aesthetic.

- Adds a high-contrast deep-teal palette with warm ivory text and teal accents.
- Uses Atkinson Hyperlegible for UI text and JetBrains Mono for code/terminal surfaces.
- Syncs the dashboard theme config options with the built-in theme list.
- Adds tests that verify the Clarity theme is exposed through `/api/dashboard/themes` and that config schema options stay aligned with built-ins.

## Validation

- `uv run --extra dev pytest tests/hermes_cli/test_web_server.py -q -k 'dashboard_theme_options_match_builtin_themes or get_dashboard_themes_includes_clarity or dashboard_font'`
- `uv run --extra dev ruff check hermes_cli/web_server.py hermes_cli/config.py tests/hermes_cli/test_web_server.py`
- `git diff --check`
- `npm ci --workspace web`
- `npm run build --workspace web`

## Manual preview

- Ran the dashboard locally with `dashboard.theme: clarity`.
- Verified the Clarity theme loads in the real dashboard at `/sessions`.
- Confirmed the page uses the high-contrast background/text colors and the hyperlegible UI font.