### PR TITLE
fix(tools): preserve large integer tool args

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -929,6 +929,16 @@ def _coerce_json(value: str, expected_python_type: type):
 
 def _coerce_number(value: str, integer_only: bool = False):
     """Try to parse *value* as a number.  Returns original string on failure."""
+    stripped = value.strip()
+    # Parse integer literals directly so values outside IEEE-754's exact
+    # integer range (for example 2^53 + 1) do not round through float().
+    if re.fullmatch(r"[+-]?\d+", stripped):
+        try:
+            return int(stripped)
+        except ValueError:
+            # Extremely long digit strings can trip Python's int digit limit.
+            return value
+
     try:
         f = float(value)
     except (ValueError, OverflowError):

--- a/tests/run_agent/test_tool_arg_coercion.py
+++ b/tests/run_agent/test_tool_arg_coercion.py
@@ -62,6 +62,20 @@ class TestCoerceNumber:
     def test_large_number(self):
         assert _coerce_number("1000000") == 1000000
 
+    def test_large_integer_string_preserves_precision(self):
+        """Integer literals must not round through float() before int()."""
+        value = "9007199254740993"
+        result = _coerce_number(value)
+        assert result == 9007199254740993
+        assert isinstance(result, int)
+
+    def test_large_integer_only_string_preserves_precision(self):
+        """Schema integer coercion should preserve values above 2^53 exactly."""
+        value = "9007199254740993"
+        result = _coerce_number(value, integer_only=True)
+        assert result == 9007199254740993
+        assert isinstance(result, int)
+
     def test_scientific_notation(self):
         assert _coerce_number("1e5") == 100000
 
@@ -410,6 +424,14 @@ class TestCoerceToolArgs:
         assert isinstance(result["offset"], int)
         assert result["limit"] == 100
         assert isinstance(result["limit"], int)
+
+    def test_real_read_file_schema_preserves_large_integer_string(self):
+        """Regression for #59186: offset must not lose precision via float()."""
+        large_offset = 9007199254740993
+        args = {"path": "foo.py", "offset": str(large_offset), "limit": "100"}
+        result = coerce_tool_args("read_file", args)
+        assert result["offset"] == large_offset
+        assert isinstance(result["offset"], int)
 
 
 # ── Schema-guided nested JSON-string normalization (cline/cline#11803) ─────


### PR DESCRIPTION
## What changed

This fixes tool argument coercion for large integer strings. Integer literals are now parsed with `int()` before falling back to `float()`, so values above JavaScript's exact integer range do not get rounded before a tool sees them.

I also added regression coverage for both the low-level number coercion helper and the real `read_file` schema path.

Fixes #59186.

## Why

Hermes often receives tool arguments as strings from models. Before this change, a value like `"9007199254740993"` was parsed through `float()` first, which rounded it to `9007199254740992`. That can make a tool call look successful while running with the wrong offset, limit, repeat count, or other integer argument.

## How I tested

- `scripts/run_tests.sh tests/run_agent/test_tool_arg_coercion.py -q`
- `$HOME/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_model_tools.py tests/run_agent/test_tool_arg_coercion.py -q -o 'addopts='`
- `$HOME/.hermes/hermes-agent/venv/bin/python -m compileall -q model_tools.py`
- `$HOME/.hermes/hermes-agent/venv/bin/python scripts/check-windows-footguns.py --diff upstream/main --all`
- `scripts/run_tests.sh` was also attempted. It timed out after 600 seconds at 78.7 percent complete. The failures shown before timeout were unrelated macOS or environment issues in `tests/agent/lsp/test_client_e2e.py`, `tests/test_live_system_guard_self_test.py`, and `tests/tools/test_base_environment.py`.

Tested on macOS 26.5.1 with Python 3.11.11 from the Hermes managed venv.
