### PR TITLE
docs: clarify observer payload sanitization

### DIFF
--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -244,6 +244,11 @@ Sanitization converts provider objects to JSON-compatible structures, bounds
 large payloads, redacts sensitive keys, and avoids exposing raw response
 objects in sanitized fields.
 
+Sanitized observer payloads reduce accidental secret exposure, but they are not
+a substitute for export-side access controls. Treat telemetry sinks as sensitive
+systems, and avoid persisting legacy compatibility fields unless a plugin
+explicitly needs them.
+
 Legacy compatibility fields such as `request_messages`, `conversation_history`,
 and `assistant_message` may still be present for existing plugins. New
 observability consumers should prefer the sanitized payloads.


### PR DESCRIPTION
## Summary
- Clarifies the safety boundary for sanitized observer payloads.
- Notes that telemetry sinks should still be treated as sensitive systems.
- Advises plugins to avoid persisting legacy compatibility fields unless needed.

## Validation
- `git diff --check`
