### PR TITLE
fix: redirect password dashboard auth login to login page

### DIFF
--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -193,6 +193,15 @@ async def auth_login(request: Request, provider: str, next: str = ""):
             detail=f"Provider does not support interactive login: {provider!r}",
         )
 
+    if getattr(p, "supports_password", False):
+        from urllib.parse import quote
+
+        safe_next = _validate_post_login_target(next)
+        login_url = f"{_prefix(request)}/login"
+        if safe_next:
+            login_url = f"{login_url}?next={quote(safe_next, safe='')}"
+        return RedirectResponse(url=login_url, status_code=302)
+
     try:
         ls = p.start_login(redirect_uri=_redirect_uri(request))
     except ProviderError as e:

--- a/tests/hermes_cli/test_dashboard_auth_password_login.py
+++ b/tests/hermes_cli/test_dashboard_auth_password_login.py
@@ -333,6 +333,40 @@ class TestPasswordLoginRoute:
         )
         assert resp.status_code == 200
 
+    def test_direct_auth_login_for_password_provider_redirects_to_login_page(
+        self, gated_app
+    ):
+        resp = gated_app.get(
+            "/auth/login?provider=testpw&next=%2Fsessions",
+            follow_redirects=False,
+        )
+
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/login?next=%2Fsessions"
+
+    def test_direct_auth_login_for_password_provider_drops_unsafe_next(
+        self, gated_app
+    ):
+        resp = gated_app.get(
+            "/auth/login?provider=testpw&next=https%3A%2F%2Fevil.example%2Fphish",
+            follow_redirects=False,
+        )
+
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/login"
+
+    def test_direct_auth_login_for_password_provider_respects_forwarded_prefix(
+        self, gated_app
+    ):
+        resp = gated_app.get(
+            "/auth/login?provider=testpw&next=%2Fsessions",
+            headers={"x-forwarded-prefix": "/hermes"},
+            follow_redirects=False,
+        )
+
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/hermes/login?next=%2Fsessions"
+
 
 # ---------------------------------------------------------------------------
 # Transparent refresh — expired access token, live refresh token


### PR DESCRIPTION
Password-capable dashboard auth providers render a credential form on /login and POST to /auth/password-login; they do not implement the OAuth redirect flow. This PR keeps OAuth providers unchanged but redirects direct /auth/login hits for password providers back to /login, preserving safe relative next paths and X-Forwarded-Prefix. Tests cover direct hits, unsafe next dropping, and prefixed deployments.