### PR TITLE
fix(cli): guard empty message text in _display_resumed_history

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -657,20 +657,20 @@ class CLIAgentSetupMixin:
             if role == "user":
                 lines.append("  ● You: ", style=f"dim bold {_session_label_c}")
                 # Show first line inline, indent rest
-                msg_lines = text.splitlines()
+                msg_lines = text.splitlines() or [""]
                 lines.append(msg_lines[0] + "\n", style="dim")
                 for ml in msg_lines[1:]:
                     lines.append(f"         {ml}\n", style="dim")
             elif role == "assistant_last":
                 # Last assistant response shown in full, non-dim
                 lines.append("  ◆ Hermes: ", style=f"bold {_assistant_label_c}")
-                msg_lines = text.splitlines()
+                msg_lines = text.splitlines() or [""]
                 lines.append(msg_lines[0] + "\n", style="")
                 for ml in msg_lines[1:]:
                     lines.append(f"            {ml}\n", style="")
             else:
                 lines.append("  ◆ Hermes: ", style=f"dim bold {_assistant_label_c}")
-                msg_lines = text.splitlines()
+                msg_lines = text.splitlines() or [""]
                 lines.append(msg_lines[0] + "\n", style="dim")
                 for ml in msg_lines[1:]:
                     lines.append(f"            {ml}\n", style="dim")

--- a/tests/cli/test_resume_display.py
+++ b/tests/cli/test_resume_display.py
@@ -290,6 +290,37 @@ class TestDisplayResumedHistory:
 
         assert output.strip() == ""
 
+    def test_empty_message_content_does_not_crash(self):
+        """Regression: _display_resumed_history IndexError when a message has empty text.
+
+        An assistant turn that produced no text (or a blank user message)
+        makes ``text.splitlines()`` return ``[]``, crashing on ``msg_lines[0]``.
+        The fix guards with ``or [""]`` so the message renders as a blank line.
+        """
+        cli = _make_cli()
+        cli.conversation_history = [
+            {"role": "user", "content": ""},
+            {"role": "assistant", "content": ""},
+            {"role": "user", "content": "Follow-up question"},
+            {"role": "assistant", "content": "Real answer"},
+        ]
+        # Must not raise IndexError
+        output = self._capture_display(cli)
+
+        assert "Follow-up question" in output
+        assert "Real answer" in output
+
+    def test_whitespace_only_message_does_not_crash(self):
+        """Whitespace-only messages should also not crash the resume display."""
+        cli = _make_cli()
+        cli.conversation_history = [
+            {"role": "user", "content": "   "},
+            {"role": "assistant", "content": "\n\n"},
+        ]
+        output = self._capture_display(cli)
+        # Should render without error
+        assert "You:" in output
+
     def test_minimal_config_suppresses_display(self):
         cli = _make_cli(config_overrides={"display": {"resume_display": "minimal"}})
         # resume_display is captured as an instance variable during __init__


### PR DESCRIPTION
## Summary

Fixes IndexError crash in `_display_resumed_history()` when a resumed session contains a message with empty or whitespace-only text.

## Root Cause

`text.splitlines()` returns `[]` for empty strings. Accessing `msg_lines[0]` on an empty list raises `IndexError`, making the session permanently un-resumable.

This affects all three role branches: `user` (line 660), `assistant_last` (line 667), and the else/history branch (line 673).

## Fix

Added `or [""]` fallback after each `text.splitlines()` call:

```python
msg_lines = text.splitlines() or [""]
```

Empty messages now render as a blank line instead of crashing.

## Testing

- Added regression test `test_empty_message_content_does_not_crash` — verifies empty user/assistant messages dont crash
- Added `test_whitespace_only_message_does_not_crash` — verifies whitespace-only messages
- All existing tests pass

## Closes #59265