### PR TITLE
fix(system-prompt): fall back to default identity when SOUL.md is blocked

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -378,18 +378,25 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # Some execution modes (cron) still want HERMES_HOME persona while keeping
     # cwd project instructions disabled.
     _soul_loaded = False
+    _blocked_soul_notice = None
     if agent.load_soul_identity or not agent.skip_context_files:
         # Scope the SOUL.md read to the agent's OWN home (see _agent_home) —
         # ambient resolution on a thread that lost the HERMES_HOME ContextVar
         # reads the launch profile's SOUL.md instead (#50233).
         _soul_content = _r.load_soul_md(_ctx_len, home_override=_agent_home(agent))
         if _soul_content:
-            stable_parts.append(_soul_content)
-            _soul_loaded = True
+            _trimmed_soul = _soul_content.strip()
+            if _trimmed_soul.startswith("[BLOCKED:"):
+                _blocked_soul_notice = _trimmed_soul
+            else:
+                stable_parts.append(_soul_content)
+                _soul_loaded = True
 
     if not _soul_loaded:
         # Fallback to hardcoded identity
         stable_parts.append(DEFAULT_AGENT_IDENTITY)
+    if _blocked_soul_notice:
+        stable_parts.append(_blocked_soul_notice)
 
     # Pointer to the hermes-agent skill + docs for user questions about Hermes itself.
     stable_parts.append(HERMES_AGENT_HELP_GUIDANCE)
@@ -793,10 +800,12 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         # gateway daemons) self-spawns into the install tree, where the
         # fallback would inject this repo's contributor AGENTS.md (#64590).
         context_files_prompt = _r.build_context_files_prompt(
-            cwd=resolve_context_cwd(), skip_soul=_soul_loaded,
+            cwd=resolve_context_cwd(),
+            skip_soul=_soul_loaded or _blocked_soul_notice is not None,
             context_length=_ctx_len,
             allow_install_tree_fallback=agent.platform in ("cli", "tui"),
-            home_override=_agent_home(agent))
+            home_override=_agent_home(agent),
+        )
         if context_files_prompt:
             context_parts.append(context_files_prompt)
 

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -190,15 +190,22 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # Some execution modes (cron) still want HERMES_HOME persona while keeping
     # cwd project instructions disabled.
     _soul_loaded = False
+    _blocked_soul_notice = None
     if agent.load_soul_identity or not agent.skip_context_files:
         _soul_content = _r.load_soul_md(_ctx_len)
         if _soul_content:
-            stable_parts.append(_soul_content)
-            _soul_loaded = True
+            _trimmed_soul = _soul_content.strip()
+            if _trimmed_soul.startswith("[BLOCKED:"):
+                _blocked_soul_notice = _trimmed_soul
+            else:
+                stable_parts.append(_soul_content)
+                _soul_loaded = True
 
     if not _soul_loaded:
         # Fallback to hardcoded identity
         stable_parts.append(DEFAULT_AGENT_IDENTITY)
+    if _blocked_soul_notice:
+        stable_parts.append(_blocked_soul_notice)
 
     # Pointer to the hermes-agent skill + docs for user questions about Hermes itself.
     stable_parts.append(HERMES_AGENT_HELP_GUIDANCE)
@@ -489,9 +496,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         # gateway daemons) self-spawns into the install tree, where the
         # fallback would inject this repo's contributor AGENTS.md (#64590).
         context_files_prompt = _r.build_context_files_prompt(
-            cwd=resolve_context_cwd(), skip_soul=_soul_loaded,
+            cwd=resolve_context_cwd(),
+            skip_soul=_soul_loaded or _blocked_soul_notice is not None,
             context_length=_ctx_len,
-            allow_install_tree_fallback=agent.platform in ("cli", "tui"))
+            allow_install_tree_fallback=agent.platform in ("cli", "tui"),
+        )
         if context_files_prompt:
             context_parts.append(context_files_prompt)
 

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -484,3 +484,68 @@ class TestSkillsInVolatileBand:
         full = _build(build_system_prompt)
         assert full.index(_CONTEXT) < full.index(_SKILLS)
         assert full.index(_SKILLS) < full.index("Conversation started:")
+
+
+class TestBlockedSoulFallback:
+    def test_blocked_soul_still_falls_back_to_default_identity(self):
+        agent = _make_agent(load_soul_identity=True, skip_context_files=True)
+
+        with (
+            patch(
+                "run_agent.load_soul_md",
+                return_value=(
+                    "[BLOCKED: SOUL.md contained potential prompt injection "
+                    "(role-hijack). Content not loaded.]"
+                ),
+            ),
+            patch("run_agent.build_nous_subscription_prompt", return_value=""),
+            patch("run_agent.build_environment_hints", return_value=""),
+            patch("run_agent.build_context_files_prompt", return_value=""),
+        ):
+            stable = build_system_prompt_parts(agent)["stable"]
+
+        from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
+
+        assert DEFAULT_AGENT_IDENTITY in stable
+
+    def test_blocked_soul_notice_is_not_duplicated_in_normal_path(self):
+        agent_home = Path("/tmp/hermes-profile-under-test")
+        agent = _make_agent(
+            load_soul_identity=True,
+            skip_context_files=False,
+            _session_db=SimpleNamespace(db_path=agent_home / "state.db"),
+        )
+        blocked = (
+            "[BLOCKED: SOUL.md contained potential prompt injection "
+            "(role-hijack). Content not loaded.]"
+        )
+
+        captured = {}
+
+        def fake_context_files(
+            cwd=None,
+            skip_soul=False,
+            context_length=None,
+            allow_install_tree_fallback=False,
+            home_override=None,
+        ):
+            captured["skip_soul"] = skip_soul
+            captured["home_override"] = home_override
+            return "" if skip_soul else blocked
+
+        with (
+            patch("run_agent.load_soul_md", return_value=blocked),
+            patch("run_agent.build_nous_subscription_prompt", return_value=""),
+            patch("run_agent.build_environment_hints", return_value=""),
+            patch("run_agent.build_context_files_prompt", side_effect=fake_context_files),
+        ):
+            parts = build_system_prompt_parts(agent)
+
+        from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
+
+        stable = parts["stable"]
+        context = parts["context"]
+        assert captured["skip_soul"] is True
+        assert captured["home_override"] == agent_home
+        assert DEFAULT_AGENT_IDENTITY in stable
+        assert stable.count("[BLOCKED:") + context.count("[BLOCKED:") == 1

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -266,3 +266,60 @@ class TestSkillsInVolatileBand:
         full = _build(build_system_prompt)
         assert full.index(_CONTEXT) < full.index(_SKILLS)
         assert full.index(_SKILLS) < full.index("Conversation started:")
+
+
+class TestBlockedSoulFallback:
+    def test_blocked_soul_still_falls_back_to_default_identity(self):
+        agent = _make_agent(load_soul_identity=True, skip_context_files=True)
+
+        with (
+            patch(
+                "run_agent.load_soul_md",
+                return_value=(
+                    "[BLOCKED: SOUL.md contained potential prompt injection "
+                    "(role-hijack). Content not loaded.]"
+                ),
+            ),
+            patch("run_agent.build_nous_subscription_prompt", return_value=""),
+            patch("run_agent.build_environment_hints", return_value=""),
+            patch("run_agent.build_context_files_prompt", return_value=""),
+        ):
+            stable = build_system_prompt_parts(agent)["stable"]
+
+        from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
+
+        assert DEFAULT_AGENT_IDENTITY in stable
+
+    def test_blocked_soul_notice_is_not_duplicated_in_normal_path(self):
+        agent = _make_agent(load_soul_identity=True, skip_context_files=False)
+        blocked = (
+            "[BLOCKED: SOUL.md contained potential prompt injection "
+            "(role-hijack). Content not loaded.]"
+        )
+
+        captured = {}
+
+        def fake_context_files(
+            cwd=None,
+            skip_soul=False,
+            context_length=None,
+            allow_install_tree_fallback=False,
+        ):
+            captured["skip_soul"] = skip_soul
+            return "" if skip_soul else blocked
+
+        with (
+            patch("run_agent.load_soul_md", return_value=blocked),
+            patch("run_agent.build_nous_subscription_prompt", return_value=""),
+            patch("run_agent.build_environment_hints", return_value=""),
+            patch("run_agent.build_context_files_prompt", side_effect=fake_context_files),
+        ):
+            parts = build_system_prompt_parts(agent)
+
+        from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
+
+        stable = parts["stable"]
+        context = parts["context"]
+        assert captured["skip_soul"] is True
+        assert DEFAULT_AGENT_IDENTITY in stable
+        assert stable.count("[BLOCKED:") + context.count("[BLOCKED:") == 1


### PR DESCRIPTION
## Summary
When `load_soul_md()` returns a `[BLOCKED: ...]` prompt-injection notice, Hermes should not treat that blocked notice as the active identity.

This patch falls back to `DEFAULT_AGENT_IDENTITY`, surfaces the blocked notice once so the agent can report what happened, and prevents the blocked SOUL from being reloaded through context-file wiring.

## Why
Right now `main` appends the blocked SOUL notice directly into the stable prompt path that normally carries agent identity. That means a blocked prompt-injection warning can displace the intended default identity even though the SOUL content was intentionally rejected.

The safer behavior is:
- keep the agent's fallback identity intact
- surface the blocked notice once so the agent can report what happened
- avoid reintroducing the blocked SOUL through later context-file loading

## Fix
- detect `[BLOCKED: ...]` SOUL results before appending identity content
- fall back to `DEFAULT_AGENT_IDENTITY` when the SOUL is blocked
- append the blocked notice separately so the agent can report what happened
- skip SOUL context-file loading when the SOUL was blocked
- add regression coverage for fallback and single-notice behavior

## Testing
Run:

```bash
python3 -m py_compile agent/system_prompt.py tests/agent/test_system_prompt.py
python3 -m pytest -q tests/agent/test_system_prompt.py
```

Result:
- `7 passed in 1.48s`

## Overlap check
No open PR or issue was found covering blocked-SOUL identity fallback or skip-soul handling, and current `main` still lacks this behavior in `agent/system_prompt.py`.

## Risk
Low. This changes only the blocked-SOUL fallback path in system-prompt construction and adds focused regression tests.