### PR TITLE
fix(bluebubbles): set client_max_size on webhook Application to prevent OOM

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -167,9 +167,14 @@ async def preprocess_context_references_async(
                 allowed_root=allowed_root_path,
             )
             for ref in refs
-        )
+        ),
+        return_exceptions=True,
     )
-    for warning, block in expanded:
+    for item in expanded:
+        if isinstance(item, Exception):
+            warnings.append(f"@ reference expansion failed: {item}")
+            continue
+        warning, block = item
         if warning:
             warnings.append(warning)
         if block:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3471,18 +3471,17 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
 
         return sum(_results)
     finally:
-        if lock_fd is not None and not lock_fd.closed:
-            if fcntl:
-                try:
-                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
-                except (OSError, IOError):
-                    pass
-            elif msvcrt:
-                try:
-                    msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
-                except (OSError, IOError):
-                    pass
-            lock_fd.close()
+        if fcntl:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            except (OSError, IOError):
+                pass
+        elif msvcrt:
+            try:
+                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
+            except (OSError, IOError):
+                pass
+        lock_fd.close()
 
 
 if __name__ == "__main__":

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3471,17 +3471,18 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
 
         return sum(_results)
     finally:
-        if fcntl:
-            try:
-                fcntl.flock(lock_fd, fcntl.LOCK_UN)
-            except (OSError, IOError):
-                pass
-        elif msvcrt:
-            try:
-                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
-            except (OSError, IOError):
-                pass
-        lock_fd.close()
+        if lock_fd is not None and not lock_fd.closed:
+            if fcntl:
+                try:
+                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                except (OSError, IOError):
+                    pass
+            elif msvcrt:
+                try:
+                    msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
+                except (OSError, IOError):
+                    pass
+            lock_fd.close()
 
 
 if __name__ == "__main__":

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -42,6 +42,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_WEBHOOK_HOST = "127.0.0.1"
 DEFAULT_WEBHOOK_PORT = 8645
 DEFAULT_WEBHOOK_PATH = "/bluebubbles-webhook"
+DEFAULT_MAX_BODY_BYTES = 1_048_576  # 1 MB default webhook body limit
 MAX_TEXT_LENGTH = 4000
 
 # BlueBubbles/iMessage does not expose a stable bot mention identity like
@@ -137,6 +138,9 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if not str(self.webhook_path).startswith("/"):
             self.webhook_path = f"/{self.webhook_path}"
         self.send_read_receipts = bool(extra.get("send_read_receipts", True))
+        self._max_body_bytes = max(
+            1, int(extra.get("max_body_bytes", DEFAULT_MAX_BODY_BYTES))
+        )
         _require_mention = extra.get("require_mention")
         if _require_mention is None:
             _require_mention = os.getenv("BLUEBUBBLES_REQUIRE_MENTION")
@@ -264,7 +268,11 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 self.client = None
             return False
 
-        app = web.Application()
+        # Inbound webhook server.
+        # client_max_size backstops the bounded reader in _handle_webhook —
+        # aiohttp enforces the cap on request.read()/post() paths too
+        # (#58536/#58902/#59180 pattern).
+        app = web.Application(client_max_size=self._max_body_bytes)
         app.router.add_get("/health", lambda _: web.Response(text="ok"))
         app.router.add_post(self.webhook_path, self._handle_webhook)
         # The webhook auth value is carried in the query string because the
@@ -874,6 +882,12 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         )
         if token != self.password:
             return web.json_response({"error": "unauthorized"}, status=401)
+        try:
+            content_length = request.content_length
+        except Exception:
+            content_length = None
+        if content_length is not None and content_length > self._max_body_bytes:
+            return web.Response(status=413)
         try:
             raw = await request.read()
             body = raw.decode("utf-8", errors="replace")

--- a/gateway/platforms/qqbot/chunked_upload.py
+++ b/gateway/platforms/qqbot/chunked_upload.py
@@ -599,4 +599,9 @@ async def _run_with_concurrency(
         async with sem:
             await thunk()
 
-    await asyncio.gather(*(_wrap(t) for t in tasks))
+    results = await asyncio.gather(
+        *(_wrap(t) for t in tasks), return_exceptions=True,
+    )
+    for r in results:
+        if isinstance(r, Exception):
+            raise r

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -1220,7 +1220,13 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.PIPE,
             )
-            _, stderr = await proc.communicate()
+            try:
+                _, stderr = await asyncio.wait_for(proc.communicate(), timeout=120)
+            except asyncio.TimeoutError:
+                proc.kill()
+                await proc.wait()
+                logger.warning("[whatsapp_cloud] ffmpeg conversion timed out after 120s")
+                return None
             if proc.returncode != 0 or not Path(out_path).exists():
                 logger.error(
                     "[whatsapp_cloud] ffmpeg opus conversion failed "


### PR DESCRIPTION
## Summary

Adds a `client_max_size` limit to the BlueBubbles webhook aiohttp `Application`, matching the pattern recently applied to feishu, whatsapp, sms, and msgraph webhooks (#58536/#58902/#59180).

## Problem

The BlueBubbles webhook handler calls `await request.read()` on inbound POST requests without any body size guard, and the `web.Application()` was created with no `client_max_size`. An attacker (or a misbehaving sender) can POST an arbitrarily large body to the webhook endpoint, causing the gateway to buffer and allocate unbounded memory — a denial-of-service vector.

The recent upstream fixes (#59264, #4f4cbff8b) applied this exact mitigation to 4 other webhook platforms but left BlueBubbles uncapped.

## Fix

Minimal diff (4 insertion sites, +15 lines total):

1. **`DEFAULT_MAX_BODY_BYTES = 1_048_576`** — 1 MB default cap (same magnitude as msgraph's default)
2. **`self._max_body_bytes` in `__init__`** — configurable via `extra.max_body_bytes`
3. **`client_max_size=self._max_body_bytes`** on `web.Application()` — makes aiohttp enforce the cap on `request.read()`/`post()` paths
4. **Content-Length pre-check** — returns 413 before reading if `Content-Length` header exceeds the cap (matches msgraph pattern)