### PR TITLE
fix(kanban): goal-gate judge unpack matches judge_goal's 4-tuple (completes #38367)

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -621,7 +621,9 @@ def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
     # Mock the judge to reject the completion. The gate only runs when a
     # judge is reachable, so force the availability probe True as well.
     def mock_judge_goal(goal, last_response, *, timeout=30.0, subgoals=None):
-        return "continue", "missing verification evidence", False
+        # Must match the REAL judge_goal arity (4-tuple) — a 3-tuple mock
+        # is exactly the drift that let the broken unpack pass tests.
+        return "continue", "missing verification evidence", False, None
 
     monkeypatch.setattr("tools.kanban_tools.judge_goal", mock_judge_goal)
     monkeypatch.setattr("tools.kanban_tools._goal_judge_available", lambda: True)

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -602,7 +602,12 @@ def _handle_complete(args: dict, **kw) -> str:
                 verdict = "done"
                 reason = ""
                 try:
-                    verdict, reason, _ = judge_goal(
+                    # judge_goal returns a 4-tuple (verdict, reason,
+                    # parse_failed, wait_directive); unpacking into three
+                    # names raised ValueError on every call, which the
+                    # defensive except below swallowed — silently allowing
+                    # every goal_mode completion through the gate (#38367).
+                    verdict, reason, _parse_failed, _wait = judge_goal(
                         goal=f"{task.title}\n\n{task.body or ''}".strip(),
                         last_response=(summary or result or "").strip(),
                     )


### PR DESCRIPTION
## The bug

The goal-mode completion gate added in 0b33bc539 ("Fixes #38367") has been fail-open-by-crash since it landed. `judge_goal` returns a 4-tuple — `hermes_cli/goals.py:836`: `Tuple[str, str, bool, Optional[Dict[str, Any]]]` — but the gate call site unpacks three names:

```python
# tools/kanban_tools.py:605 (current main)
verdict, reason, _ = judge_goal(...)
```

Every call raises `ValueError: too many values to unpack (expected 3)`, the defensive `except Exception` at :609 swallows it, `verdict` keeps its pre-set default `"done"`, and every goal_mode completion passes the gate unjudged. The follow-up commits (b3c1b3b3f review feedback, 14c4a849b true fail-open probe) never touched the unpack.

Reproduction on current main: correct the test mock's arity (below) and `test_complete_goal_mode_rejected_by_judge` fails with the production log line visible:

```
WARNING tools.kanban_tools: goal judge check failed, allowing completion: too many values to unpack (expected 3)
```

## Why tests never caught it

The gate test's judge mock had drifted to a 3-tuple (`tests/tools/test_kanban_tools.py:623`) — matching the broken unpack instead of the real signature, so the mocked path passed while the real path crashed.

## The fix (whole class)

- `tools/kanban_tools.py:605` — unpack all four values (the only broken site; `goals.py:1444` and `:1698` already unpack four correctly).
- `tests/tools/test_kanban_tools.py:623` — mock returns the real 4-tuple, so the existing rejection test now pins the arity contract and fails if the shapes ever drift apart again.

Verified: `tests/tools/test_kanban_tools.py` 97/97, `tests/hermes_cli/test_goals.py` 101/101 (mock fix watched fail first, then green after the one-line unpack fix).