### PR TITLE
fix(whatsapp): hide bridge console window on Windows

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -638,6 +638,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             bridge_env["HERMES_AUDIO_CACHE_DIR"] = str(_get_audio_dir())
             bridge_env["HERMES_DOCUMENT_CACHE_DIR"] = str(_get_doc_dir())
 
+            from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
+
             self._bridge_process = subprocess.Popen(
                 [
                     find_node_executable("node") or "node",
@@ -648,8 +650,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 ],
                 stdout=bridge_log_fh,
                 stderr=bridge_log_fh,
-                start_new_session=True,
                 env=bridge_env,
+                **windows_detach_popen_kwargs(),
             )
             _write_bridge_pidfile(self._session_path, self._bridge_process.pid)
             


### PR DESCRIPTION
## What changed and why

The WhatsApp bridge (`scripts/whatsapp-bridge/bridge.js`) is spawned via
`subprocess.Popen(..., start_new_session=True)` in
`plugins/platforms/whatsapp/adapter.py`. `start_new_session` maps to
`os.setsid()` on POSIX but is a silent no-op on Windows, so the Node.js
child stayed attached to whatever console launched the gateway:

- The bridge got a visible cmd window with no way to suppress it.
- Closing that window killed the bridge process (still attached to that
  console), which `_check_managed_bridge_exit()` then reported as an
  unexpected crash (`retryable=True`) — so the gateway reconnected the
  WhatsApp platform a few seconds later, spawning a fresh visible window
  each time. Net effect: an un-closeable, self-healing console window on
  every native Windows install with WhatsApp enabled.

This swaps to `windows_detach_popen_kwargs()` from
`hermes_cli._subprocess_compat` — the project's existing helper for this
exact situation, documented in CONTRIBUTING.md's Cross-Platform
Compatibility rule #10 and already used as the reference pattern in
`gateway_windows.py::_spawn_detached`. It applies `CREATE_NO_WINDOW |
DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_BREAKAWAY_FROM_JOB`
on Windows and falls back to `start_new_session=True` on POSIX, so POSIX
behavior is unchanged.

## How to test

1. On Windows, enable WhatsApp (`hermes whatsapp` to pair) and run
   `hermes gateway restart`.
2. Before this fix: a visible `node.exe` console window appears; closing
   it kills the bridge, and the gateway respawns a new visible window
   within ~10s.
3. After this fix: `Get-CimInstance Win32_Process -Filter "Name='node.exe'"`
   shows the bridge running, but it has no window
   (`Get-Process node | select MainWindowHandle` is `0`) and nothing
   flashes on screen.
4. `python scripts/check-windows-footguns.py` (staged diff) reports no
   footguns.
5. `scripts/run_tests.sh tests/test_windows_subprocess_no_window_flags.py
   tests/gateway/test_whatsapp_connect.py
   tests/gateway/test_whatsapp_stale_bridge.py
   tests/gateway/test_whatsapp_bridge_pidfile.py
   tests/gateway/test_whatsapp_bridge_dir_resolution.py
   tests/gateway/test_whatsapp_formatting.py` — 78 passed, 1 skipped
   (pre-existing, unrelated).

## Platforms tested

- Windows 11 (native install) — manually verified the window disappears
  and the bridge survives what previously killed it.
- Not tested on macOS/Linux, but the change is a no-op there
  (`windows_detach_popen_kwargs()` returns `{"start_new_session": True}`
  on non-Windows, identical to the code being replaced).

## Related issues

None found — searched open/closed issues and PRs for
"whatsapp bridge window" / "CREATE_NO_WINDOW" with no matches.