### PR TITLE
fix: suppress false cron thread loss warnings

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -549,6 +549,39 @@ def _target_matches_origin(origin: dict, platform_name: str, chat_id: str,
     return True
 
 
+def _should_warn_delivery_lost_origin_thread(job: dict, origin: dict, target: dict) -> bool:
+    """Return True only when a missing target thread is an origin-lane bug.
+
+    Cron jobs can legitimately deliver to a flat home channel or an explicit
+    ``platform:chat_id`` target even when they were created from a threaded
+    origin. Those deliveries are broadcasts, not replies to the origin thread,
+    so logging them as WARNING pollutes error logs. Keep the warning for the
+    paths that semantically promise origin-thread preservation: ``origin`` and
+    the platform shorthand when it resolves to the origin conversation.
+    """
+    if not origin or not origin.get("thread_id") or target.get("thread_id"):
+        return False
+    if str(origin.get("platform", "")).lower() != str(target.get("platform", "")).lower():
+        return False
+    if str(origin.get("chat_id", "")) != str(target.get("chat_id", "")):
+        return False
+
+    deliver = _normalize_deliver_value(job.get("deliver", "local"))
+    parts = [p.strip() for p in deliver.split(",") if p.strip()]
+    origin_platform = str(origin.get("platform", "")).lower()
+    for part in parts:
+        part_lower = part.lower()
+        if part_lower == "origin":
+            return True
+        # The shorthand ``deliver=discord`` means "the same platform as the
+        # origin" when the job has a Discord origin; it should carry the origin
+        # thread. Explicit ``discord:<chat_id>`` and fan-out tokens intentionally
+        # target delivery surfaces, so they are not warned here.
+        if ":" not in part and part_lower == origin_platform:
+            return True
+    return False
+
+
 def _maybe_mirror_cron_delivery(
     job: dict,
     platform_name: str,
@@ -1397,15 +1430,24 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         chat_id = target["chat_id"]
         thread_id = target.get("thread_id")
 
-        # Diagnostic: log thread_id for topic-aware delivery debugging
+        # Diagnostic: log thread_id for topic-aware delivery debugging. Only
+        # warn when the route semantically promised the origin thread; explicit
+        # home-channel/broadcast targets may intentionally be flat.
         origin = _resolve_origin(job) or {}
         origin_thread = origin.get("thread_id")
         if origin_thread and not thread_id:
-            logger.warning(
-                "Job '%s': origin has thread_id=%s but delivery target lost it "
-                "(deliver=%s, target=%s)",
-                job["id"], origin_thread, job.get("deliver", "local"), target,
-            )
+            if _should_warn_delivery_lost_origin_thread(job, origin, target):
+                logger.warning(
+                    "Job '%s': origin has thread_id=%s but delivery target lost it "
+                    "(deliver=%s, target=%s)",
+                    job["id"], origin_thread, job.get("deliver", "local"), target,
+                )
+            else:
+                logger.debug(
+                    "Job '%s': origin has thread_id=%s but explicit/broadcast "
+                    "delivery target is flat (deliver=%s, target=%s)",
+                    job["id"], origin_thread, job.get("deliver", "local"), target,
+                )
         elif thread_id:
             logger.debug(
                 "Job '%s': delivering to %s:%s thread_id=%s",

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -4268,6 +4268,49 @@ class TestCronDeliveryMirror:
         assert _target_matches_origin(origin, "telegram", "123", None) is False
         assert _target_matches_origin(origin, "telegram", "123", "99") is False
 
+    def test_lost_thread_warning_is_only_for_origin_lane(self):
+        from cron.scheduler import _should_warn_delivery_lost_origin_thread
+
+        origin = {"platform": "discord", "chat_id": "1516650875387514911", "thread_id": "1518758438702944498"}
+        flat_origin_chat = {"platform": "discord", "chat_id": "1516650875387514911", "thread_id": None}
+
+        assert _should_warn_delivery_lost_origin_thread(
+            {"deliver": "origin"}, origin, flat_origin_chat,
+        ) is True
+        assert _should_warn_delivery_lost_origin_thread(
+            {"deliver": "discord"}, origin, flat_origin_chat,
+        ) is True
+        assert _should_warn_delivery_lost_origin_thread(
+            {"deliver": "discord:1516650875387514911"}, origin, flat_origin_chat,
+        ) is False
+        assert _should_warn_delivery_lost_origin_thread(
+            {"deliver": "all"}, origin, flat_origin_chat,
+        ) is False
+
+    def test_explicit_discord_target_from_threaded_origin_does_not_warn(self, caplog):
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.DISCORD: pconfig}
+        job = {
+            "id": "threaded-origin-flat-home",
+            "deliver": "discord:1516650875387514911",
+            "origin": {
+                "platform": "discord",
+                "chat_id": "1516650875387514911",
+                "thread_id": "1518758438702944498",
+            },
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})), \
+             caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+            _deliver_result(job, "Here is today's summary.")
+
+        assert not any("delivery target lost it" in r.message for r in caplog.records)
+
     def test_delivery_does_not_mirror_fanout_non_origin_target(self):
         """Even with the gate ON, a delivery to a chat that is NOT the job's
         origin (explicit fan-out target) must not be mirrored — the mirror is


### PR DESCRIPTION
## Summary
- keep the cron thread-loss warning only for delivery routes that semantically promise the origin thread
- downgrade explicit flat/broadcast targets from threaded origins to debug logging
- add regression coverage for explicit Discord channel delivery from a threaded origin

## Tests
- python -m pytest tests/cron/test_scheduler.py::TestCronDeliveryMirror::test_lost_thread_warning_is_only_for_origin_lane tests/cron/test_scheduler.py::TestCronDeliveryMirror::test_explicit_discord_target_from_threaded_origin_does_not_warn -q
- python -m pytest tests/cron/test_scheduler.py -q
- python -m pytest tests/cron -q