### PR TITLE
fix(acp): skip detect_provider_for_model for explicit provider input

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -651,8 +651,26 @@ class HermesACPAgent(acp.Agent):
         try:
             from hermes_cli.models import detect_provider_for_model, parse_model_input
 
+            # Track whether the caller supplied an explicit provider prefix
+            # (e.g. "anthropic:claude-sonnet-5").  When they did, we must NOT
+            # re-run detect_provider_for_model — it is a fallback for bare
+            # model names only.  Re-running it for an explicit selection can
+            # overwrite the correct provider with OpenRouter when the bare
+            # model name happens to appear in OpenRouter's live catalog.
+            # See #59089.
+            has_explicit_provider = False
+            stripped = raw_model.strip()
+            colon = stripped.find(":")
+            if colon > 0:
+                provider_part = stripped[:colon].strip().lower()
+                model_part = stripped[colon + 1:].strip()
+                if provider_part and model_part:
+                    from hermes_cli.models import _KNOWN_PROVIDER_NAMES
+                    if provider_part in _KNOWN_PROVIDER_NAMES:
+                        has_explicit_provider = True
+
             target_provider, new_model = parse_model_input(new_model, current_provider)
-            if target_provider == current_provider:
+            if target_provider == current_provider and not has_explicit_provider:
                 detected = detect_provider_for_model(new_model, current_provider)
                 if detected:
                     target_provider, new_model = detected

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -997,6 +997,80 @@ class TestSessionConfiguration:
         assert state.agent.base_url == "https://anthropic.example/v1"
         assert runtime_calls[-1] == "anthropic"
 
+    @pytest.mark.asyncio
+    async def test_set_session_model_explicit_provider_not_overridden_by_detect(self, tmp_path, monkeypatch):
+        """Regression for #59089: explicit provider must not be overridden.
+
+        When parse_model_input resolves an explicit provider prefix (e.g.
+        "anthropic:claude-sonnet-5"), detect_provider_for_model must NOT run —
+        it is a fallback for bare model names only.  Without the guard, a bare
+        model name that happens to appear in OpenRouter's catalog silently
+        overwrites the correct provider.
+        """
+        detect_calls = []
+
+        def tracking_detect(model, current):
+            detect_calls.append((model, current))
+            # Simulate the real behaviour: OpenRouter catalog finds the model
+            return ("openrouter", f"anthropic/{model}")
+
+        def fake_resolve_runtime_provider(requested=None, **kwargs):
+            return {
+                "provider": requested or "openrouter",
+                "api_mode": "anthropic_messages" if requested == "anthropic" else "chat_completions",
+                "base_url": f"https://{requested or 'openrouter'}.example/v1",
+                "api_key": f"{requested or 'openrouter'}-key",
+                "command": None,
+                "args": [],
+            }
+
+        def fake_agent(**kwargs):
+            return SimpleNamespace(
+                model=kwargs.get("model"),
+                provider=kwargs.get("provider"),
+                base_url=kwargs.get("base_url"),
+                api_mode=kwargs.get("api_mode"),
+            )
+
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+            "model": {"provider": "openrouter", "default": "openrouter/gpt-5"}
+        })
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.parse_model_input",
+            lambda raw, current: ("anthropic", "claude-sonnet-5"),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.detect_provider_for_model",
+            tracking_detect,
+        )
+        manager = SessionManager(db=SessionDB(tmp_path / "state.db"))
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            acp_agent = HermesACPAgent(session_manager=manager)
+            state = manager.create_session(cwd="/tmp")
+            result = await acp_agent.set_session_model(
+                model_id="anthropic:claude-sonnet-5",
+                session_id=state.session_id,
+            )
+
+        assert isinstance(result, SetSessionModelResponse)
+        # The explicit "anthropic" provider must be preserved, NOT overridden
+        # to "openrouter" by detect_provider_for_model.
+        assert state.agent.provider == "anthropic", (
+            f"Expected anthropic, got {state.agent.provider} — "
+            "detect_provider_for_model overrode an explicit provider"
+        )
+        assert state.model == "claude-sonnet-5"
+        # detect_provider_for_model must NOT have been called at all.
+        assert detect_calls == [], (
+            f"detect_provider_for_model should not run for explicit provider; "
+            f"but was called with {detect_calls}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # prompt


### PR DESCRIPTION
## Summary

Fixes ACP `session/set_model` silently rerouting explicit `anthropic:claude-sonnet-5` to OpenRouter, causing "No LLM provider configured" errors.

## Root Cause

`_resolve_model_selection` in `acp_adapter/server.py` runs `detect_provider_for_model` whenever `target_provider == current_provider`. But `parse_model_input("anthropic:claude-sonnet-5", "anthropic")` correctly returns `("anthropic", "claude-sonnet-5")` — the providers match because the explicit prefix IS the current provider.

The fallback then checks OpenRouter catalog, finds the bare model name, and overwrites the correct provider to `"openrouter"`.

## Fix

Track whether the raw input had an explicit provider prefix (colon syntax with a recognized provider name). When it did, skip `detect_provider_for_model` entirely — it is a fallback for bare model names only.

## Reproduction

```python
# Before fix:
detect_provider_for_model("claude-sonnet-5", "anthropic")
# -> ("openrouter", "anthropic/claude-sonnet-5")  # WRONG

# After fix: detect_provider_for_model is never called for "anthropic:claude-sonnet-5"
```

## Testing

- Added regression test `test_set_session_model_explicit_provider_not_overridden_by_detect`
- Verifies detect_provider_for_model is NOT called when explicit provider is specified
- Verifies provider stays "anthropic" (not overridden to "openrouter")

## Impact

Affects any ACP-driven agent fleet (Multica, Zed) dispatching explicit `provider:model` for new models whose bare name appears in OpenRouter catalog. Will recur for every future model release.

## Closes #59089
## Related: #48731, #16259