### PR TITLE
fix(tools): forward allowlisted env vars to Daytona sandbox exec

### DIFF
--- a/tests/tools/test_daytona_environment.py
+++ b/tests/tools/test_daytona_environment.py
@@ -462,6 +462,13 @@ class TestEnvPassthroughForwarding:
         )
 
         clear_env_passthrough()
+        # Pin the process-global config allowlist empty: is_env_passthrough
+        # also consults config.yaml's terminal.env_passthrough (cached, and
+        # NOT reset by clear_env_passthrough), so a dev/CI machine that lists
+        # one of these names would otherwise make the assertions flaky.
+        monkeypatch.setattr(
+            "tools.env_passthrough._config_passthrough", frozenset()
+        )
         monkeypatch.setenv("PCLOUD_S3_TOKEN", "sekret")
         monkeypatch.setenv("UNRELATED_VAR", "nope")
         register_env_passthrough(["PCLOUD_S3_TOKEN"])
@@ -473,6 +480,44 @@ class TestEnvPassthroughForwarding:
         assert collected.get("PCLOUD_S3_TOKEN") == "sekret"
         # Non-allowlisted vars must not leak into the isolated sandbox.
         assert "UNRELATED_VAR" not in collected
+
+    def test_collect_denies_always_strip_keys_on_remote_boundary(
+        self, monkeypatch
+    ):
+        """Tier-1 secrets must never be forwarded to the remote sandbox.
+
+        ``SLACK_SIGNING_SECRET`` sits in local.py's ``_ALWAYS_STRIP_KEYS``
+        ("stripped from EVERY spawned subprocess unconditionally") but is NOT
+        in the provider-credential blocklist, so ``register_env_passthrough``
+        accepts it. Without a remote-boundary deny in _collect_passthrough_env,
+        it would be tunneled off-host to Daytona's third-party cloud. Enforce
+        the strip here regardless of registration.
+        """
+        from tools.environments.daytona import DaytonaEnvironment
+        from tools.env_passthrough import (
+            register_env_passthrough,
+            clear_env_passthrough,
+            is_env_passthrough,
+        )
+
+        clear_env_passthrough()
+        monkeypatch.setattr(
+            "tools.env_passthrough._config_passthrough", frozenset()
+        )
+        monkeypatch.setenv("SLACK_SIGNING_SECRET", "8f00b204e9800998")
+        monkeypatch.setenv("PCLOUD_S3_TOKEN", "sekret")
+        register_env_passthrough(["SLACK_SIGNING_SECRET", "PCLOUD_S3_TOKEN"])
+        try:
+            # Precondition: registration did NOT refuse the Tier-1 name, so the
+            # deny below is what actually protects the remote boundary.
+            assert is_env_passthrough("SLACK_SIGNING_SECRET")
+            collected = DaytonaEnvironment._collect_passthrough_env()
+        finally:
+            clear_env_passthrough()
+
+        assert "SLACK_SIGNING_SECRET" not in collected
+        # A legitimately allowlisted non-Tier-1 var is still forwarded.
+        assert collected.get("PCLOUD_S3_TOKEN") == "sekret"
 
     def test_run_bash_passes_env_to_exec(self, make_env, monkeypatch):
         from tools.env_passthrough import (
@@ -492,5 +537,37 @@ class TestEnvPassthroughForwarding:
         finally:
             clear_env_passthrough()
 
+        # Fail loudly if the worker hung rather than passing on a stale call.
+        assert handle._done.is_set()
         _, kwargs = sandbox.process.exec.call_args
         assert kwargs.get("env", {}).get("PCLOUD_S3_TOKEN") == "sekret"
+
+    def test_run_bash_forwards_empty_string_value(self, make_env, monkeypatch):
+        """An allowlisted var explicitly set to "" must still be forwarded.
+
+        Regression: _collect_passthrough_env filtered with ``if v``, silently
+        dropping empty-string values that the local backend's sanitizer
+        preserves — the two backends would disagree on a valid env state.
+        """
+        from tools.env_passthrough import (
+            register_env_passthrough,
+            clear_env_passthrough,
+        )
+
+        clear_env_passthrough()
+        monkeypatch.setenv("PCLOUD_S3_TOKEN", "")
+        register_env_passthrough(["PCLOUD_S3_TOKEN"])
+        env = make_env()
+        sandbox = env._sandbox
+        sandbox.process.exec.reset_mock()  # drop the $HOME-detection call
+        try:
+            handle = env._run_bash("echo hi")
+            handle._done.wait(timeout=5)
+        finally:
+            clear_env_passthrough()
+
+        assert handle._done.is_set()
+        _, kwargs = sandbox.process.exec.call_args
+        env_arg = kwargs.get("env")
+        assert env_arg is not None
+        assert env_arg.get("PCLOUD_S3_TOKEN") == ""

--- a/tests/tools/test_daytona_environment.py
+++ b/tests/tools/test_daytona_environment.py
@@ -440,3 +440,57 @@ class TestSyncSafety:
         assert "; touch" not in mkdir_cmd.replace(
             "'/root/.hermes/skills/evil; touch /tmp/daytona-owned'", ""
         )
+
+
+# ---------------------------------------------------------------------------
+# env_passthrough forwarding (regression)
+# ---------------------------------------------------------------------------
+class TestEnvPassthroughForwarding:
+    """The Daytona backend must forward allowlisted env vars to sandbox exec.
+
+    Regression: daytona.py previously called ``sandbox.process.exec`` without
+    ``env=`` and never consulted ``is_env_passthrough`` (unlike local.py), so a
+    skill's ``required_environment_variables`` / ``terminal.env_passthrough``
+    silently never reached commands run on the Daytona backend.
+    """
+
+    def test_collect_only_forwards_allowlisted(self, monkeypatch):
+        from tools.environments.daytona import DaytonaEnvironment
+        from tools.env_passthrough import (
+            register_env_passthrough,
+            clear_env_passthrough,
+        )
+
+        clear_env_passthrough()
+        monkeypatch.setenv("PCLOUD_S3_TOKEN", "sekret")
+        monkeypatch.setenv("UNRELATED_VAR", "nope")
+        register_env_passthrough(["PCLOUD_S3_TOKEN"])
+        try:
+            collected = DaytonaEnvironment._collect_passthrough_env()
+        finally:
+            clear_env_passthrough()
+
+        assert collected.get("PCLOUD_S3_TOKEN") == "sekret"
+        # Non-allowlisted vars must not leak into the isolated sandbox.
+        assert "UNRELATED_VAR" not in collected
+
+    def test_run_bash_passes_env_to_exec(self, make_env, monkeypatch):
+        from tools.env_passthrough import (
+            register_env_passthrough,
+            clear_env_passthrough,
+        )
+
+        clear_env_passthrough()
+        monkeypatch.setenv("PCLOUD_S3_TOKEN", "sekret")
+        register_env_passthrough(["PCLOUD_S3_TOKEN"])
+        env = make_env()
+        sandbox = env._sandbox
+        sandbox.process.exec.reset_mock()  # drop the $HOME-detection call
+        try:
+            handle = env._run_bash("echo hi")
+            handle._done.wait(timeout=5)
+        finally:
+            clear_env_passthrough()
+
+        _, kwargs = sandbox.process.exec.call_args
+        assert kwargs.get("env", {}).get("PCLOUD_S3_TOKEN") == "sekret"

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -259,14 +259,33 @@ class DaytonaEnvironment(BaseEnvironment):
         ``required_environment_variables`` or ``terminal.env_passthrough``) are
         forwarded — never the full host environment — so the remote sandbox
         stays isolated by default. ``is_env_passthrough`` already refuses Hermes
-        provider credentials (GHSA-rhgp-j443-p4rf)."""
+        provider credentials (GHSA-rhgp-j443-p4rf).
+
+        Remote boundary hardening: this backend ships env vars to a
+        *third-party cloud* sandbox over the network, so we additionally honor
+        the local backend's ``_ALWAYS_STRIP_KEYS`` invariant ("stripped from
+        EVERY spawned subprocess unconditionally") and refuse dynamically
+        generated Hermes-internal secrets — even if a skill or operator managed
+        to allowlist such a name. ``SLACK_SIGNING_SECRET`` in particular sits in
+        ``_ALWAYS_STRIP_KEYS`` but not in the provider blocklist, so without
+        this deny it would be registerable and tunneled off-host.
+
+        Allowlisted values are preserved as-is, including empty strings — an
+        explicitly-set ``VAR=""`` is a valid environment state and the local
+        backend's sanitizer keeps it too."""
         try:
             from tools.env_passthrough import is_env_passthrough
+            from tools.environments.local import (
+                _ALWAYS_STRIP_KEYS,
+                _is_hermes_internal_secret,
+            )
         except Exception:
             return {}
         return {
             k: v for k, v in os.environ.items()
-            if v and is_env_passthrough(k)
+            if is_env_passthrough(k)
+            and k not in _ALWAYS_STRIP_KEYS
+            and not _is_hermes_internal_secret(k)
         }
 
     def cleanup(self):

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -235,11 +235,39 @@ class DaytonaEnvironment(BaseEnvironment):
         else:
             shell_cmd = f"bash -c {shlex.quote(cmd_string)}"
 
+        # Forward explicitly-allowlisted env vars into the remote sandbox.
+        # env_passthrough is otherwise only honored by the local / execute_code
+        # backends, so skill (``required_environment_variables``) and config
+        # (``terminal.env_passthrough``) declarations never reached commands run
+        # on the Daytona backend. Resolve the allowlist HERE in the calling
+        # context: ContextVar-based skill declarations do not propagate into the
+        # _ThreadedProcessHandle worker thread below.
+        sandbox_env = self._collect_passthrough_env()
+
         def exec_fn() -> tuple[str, int]:
-            response = sandbox.process.exec(shell_cmd, timeout=timeout)
+            response = sandbox.process.exec(
+                shell_cmd, env=sandbox_env or None, timeout=timeout)
             return (response.result or "", response.exit_code)
 
         return _ThreadedProcessHandle(exec_fn, cancel_fn=cancel)
+
+    @staticmethod
+    def _collect_passthrough_env() -> dict[str, str]:
+        """Env vars explicitly allowlisted for sandbox passthrough.
+
+        Only names allowed by ``is_env_passthrough`` (a skill's
+        ``required_environment_variables`` or ``terminal.env_passthrough``) are
+        forwarded — never the full host environment — so the remote sandbox
+        stays isolated by default. ``is_env_passthrough`` already refuses Hermes
+        provider credentials (GHSA-rhgp-j443-p4rf)."""
+        try:
+            from tools.env_passthrough import is_env_passthrough
+        except Exception:
+            return {}
+        return {
+            k: v for k, v in os.environ.items()
+            if v and is_env_passthrough(k)
+        }
 
     def cleanup(self):
         with self._lock:


### PR DESCRIPTION
Fixes #59286

## What & why
The Daytona backend never honored `env_passthrough`: `_run_bash` called
`sandbox.process.exec(...)` without `env=`, and `daytona.py` never consulted
`is_env_passthrough`. So a skill's `required_environment_variables` and
`terminal.env_passthrough` silently never reached commands on the Daytona
backend — even though they work on the `local` / `execute_code` backends.

## Fix
Resolve the allowlisted subset of `os.environ` in the calling context (skill
declarations live in a ContextVar that does not propagate into the
`_ThreadedProcessHandle` worker thread) and pass it as `env=` to
`process.exec`. Only explicitly-allowlisted names are forwarded, so the remote
sandbox stays isolated by default; `is_env_passthrough` already refuses Hermes
provider credentials (GHSA-rhgp-j443-p4rf).

## How to test
- New unit tests in `tests/tools/test_daytona_environment.py`:
  - `_collect_passthrough_env` forwards only allowlisted vars (non-allowlisted excluded)
  - `_run_bash` passes `env=` containing the allowlisted var to `process.exec`
- `scripts/run_tests.sh tests/tools/test_daytona_environment.py` → 29 passed, ruff clean
- Also verified end-to-end on a live Daytona (DinD) sandbox: an allowlisted
  credential now reaches sandbox commands; previously empty.

## Platforms tested
- Linux (Ubuntu 24.04, Python 3.13)
