### PR TITLE
fix(qqbot): accept is_reconnect kwarg in QQAdapter.connect()

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,8 +278,15 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
-        """Authenticate, obtain gateway URL, and open the WebSocket."""
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        """Authenticate, obtain gateway URL, and open the WebSocket.
+
+        ``is_reconnect`` is accepted for interface compatibility with
+        ``BasePlatformAdapter.connect()`` (see ``_connect_adapter_with_timeout``).
+        The QQ adapter does not currently differentiate cold boot from
+        reconnect, but the parameter is accepted to prevent a ``TypeError``
+        when the gateway calls ``adapter.connect(is_reconnect=...)``.
+        """
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"
             self._set_fatal_error("qq_missing_dependency", message, retryable=True)


### PR DESCRIPTION
## Problem

`QQAdapter.connect()` was defined without the `is_reconnect` keyword argument:

```python
async def connect(self) -> bool:
```

But the gateway calls it with `is_reconnect` (in `_connect_adapter_with_timeout`, `gateway/run.py:3395`):

```python
return await adapter.connect(is_reconnect=is_reconnect)
```

Every other platform adapter (`base.py`, `signal.py`, `webhook.py`, `yuanbao.py`, `msgraph_webhook.py`, `api_server.py`, `bluebubbles.py`, `whatsapp_cloud.py`, `weixin.py`) accepts this parameter:

```python
async def connect(self, *, is_reconnect: bool = False) -> bool:
```

This causes a `TypeError` on every connection attempt:

```
QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'
```

The QQ bot can never connect — every reconnect attempt (every 5 min by the watcher) fails with the same error. The adapter enters a retry loop that can never succeed.

## Fix

Add `*, is_reconnect: bool = False` to `QQAdapter.connect()`, matching the `BasePlatformAdapter.connect()` contract. The parameter is accepted but not yet used internally (the QQ adapter does not currently differentiate cold boot from reconnect), which is the same approach other adapters take when they accept the kwarg without acting on it.

## Reproduction

1. Configure a QQ bot with valid `QQ_APP_ID` and `QQ_CLIENT_SECRET`
2. Start the gateway: `hermes gateway run --replace`
3. Observe the error in `gateway_state.json`:
   ```json
   "qqbot": {
     "state": "retrying",
     "error_message": "QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'"
   }
   ```
4. Logs show endless retry loop (every 300s) with the same TypeError

## Test Plan

- [ ] QQ bot connects successfully after this change
- [ ] `gateway_state.json` shows `qqbot.state: "connected"` after gateway start
- [ ] No regression in other platform adapters (they already accept this kwarg)