### PR TITLE
Surface approval rule keys in gateway clients

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/approval-rule-metadata-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/approval-rule-metadata-event.test.tsx
@@ -1,0 +1,87 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { clearAllPrompts, sessionApprovalRequest } from '@/store/prompts'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './index'
+
+const SID = 'session-approval'
+let handleEvent: ((event: RpcEvent) => void) | null = null
+
+function Harness() {
+  const activeSessionIdRef = useRef<string | null>(SID)
+  const sessionStateByRuntimeIdRef = useRef(new Map<string, ClientSessionState>())
+  const queryClientRef = useRef(new QueryClient())
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    sessionStateByRuntimeIdRef,
+    updateSessionState: (sessionId, updater) => {
+      const current = sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState()
+      const next = updater(current)
+      sessionStateByRuntimeIdRef.current.set(sessionId, next)
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    handleEvent = stream.handleGatewayEvent
+  }, [stream.handleGatewayEvent])
+
+  return null
+}
+
+describe('approval.request rule metadata', () => {
+  beforeEach(() => {
+    handleEvent = null
+    clearAllPrompts()
+  })
+
+  afterEach(() => {
+    cleanup()
+    clearAllPrompts()
+    vi.restoreAllMocks()
+  })
+
+  it('preserves rule metadata alongside approval capability constraints', async () => {
+    render(<Harness />)
+    await waitFor(() => expect(handleEvent).not.toBeNull())
+
+    act(() =>
+      handleEvent!({
+        payload: {
+          allow_permanent: false,
+          allowlist_key: 'plugin_rule:ext-nav',
+          choices: ['once', 'deny'],
+          command: '<browser_navigate> (plugin approval rule)',
+          description: 'external navigation',
+          pattern_key: 'plugin_rule:ext-nav',
+          pattern_keys: ['plugin_rule:ext-nav'],
+          rule_key: 'ext-nav',
+          smart_denied: true
+        },
+        session_id: SID,
+        type: 'approval.request'
+      } as RpcEvent)
+    )
+
+    expect(sessionApprovalRequest(SID).get()).toMatchObject({
+      allowPermanent: false,
+      allowlistKey: 'plugin_rule:ext-nav',
+      choices: ['once', 'deny'],
+      patternKey: 'plugin_rule:ext-nav',
+      ruleKey: 'ext-nav',
+      smartDenied: true
+    })
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -976,14 +976,25 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         const command = typeof payload?.command === 'string' ? payload.command : ''
         const description = typeof payload?.description === 'string' ? payload.description : 'dangerous command'
 
+        const allowlistKey =
+          typeof payload?.allowlist_key === 'string' && payload.allowlist_key ? payload.allowlist_key : undefined
+
+        const patternKey =
+          typeof payload?.pattern_key === 'string' && payload.pattern_key ? payload.pattern_key : undefined
+
+        const ruleKey = typeof payload?.rule_key === 'string' && payload.rule_key ? payload.rule_key : undefined
+
         setApprovalRequest({
           // false only when a tirith warning forbids it; backend omits the field otherwise.
           allowPermanent: payload?.allow_permanent !== false,
+          allowlistKey,
           choices: Array.isArray(payload?.choices)
             ? payload.choices.filter(choice => typeof choice === 'string')
             : undefined,
           command,
           description,
+          patternKey,
+          ruleKey,
           sessionId: sessionId ?? null,
           smartDenied: payload?.smart_denied === true
         })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
@@ -190,16 +190,24 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
     // surfaces once the user focuses that chat.
     const command = typeof payload?.command === 'string' ? payload.command : ''
     const description = typeof payload?.description === 'string' ? payload.description : 'dangerous command'
+    const allowlistKey =
+      typeof payload?.allowlist_key === 'string' && payload.allowlist_key ? payload.allowlist_key : undefined
+    const patternKey =
+      typeof payload?.pattern_key === 'string' && payload.pattern_key ? payload.pattern_key : undefined
+    const ruleKey = typeof payload?.rule_key === 'string' && payload.rule_key ? payload.rule_key : undefined
 
     void receiveApprovalRequest($gateway.get(), {
       // false only when a tirith warning forbids it; backend omits the field otherwise.
       allowPermanent: payload?.allow_permanent !== false,
+      allowlistKey,
       choices: Array.isArray(payload?.choices)
         ? payload.choices.filter(choice => typeof choice === 'string')
         : undefined,
       command,
       description,
       requestId: typeof payload?.request_id === 'string' ? payload.request_id : undefined,
+      patternKey,
+      ruleKey,
       sessionId: sessionId ?? null,
       smartDenied: payload?.smart_denied === true
     }).catch(() => undefined)

--- a/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import type { HermesGateway } from '@/hermes'
 import { $gateway } from '@/store/gateway'
-import { $approvalRequest, clearAllPrompts, setApprovalRequest } from '@/store/prompts'
+import { $approvalRequest, type ApprovalRequest, clearAllPrompts, setApprovalRequest } from '@/store/prompts'
 import { $activeSessionId } from '@/store/session'
 
 import { PendingApprovalFallback, PendingToolApproval } from './approval'
@@ -33,7 +33,7 @@ function part(toolName: string): ToolPart {
 function setRequest(
   command = 'rm -rf /tmp/x',
   allowPermanent?: boolean,
-  extra: { choices?: string[]; smartDenied?: boolean } = {}
+  extra: Partial<Pick<ApprovalRequest, 'allowlistKey' | 'choices' | 'patternKey' | 'ruleKey' | 'smartDenied'>> = {}
 ) {
   $activeSessionId.set('sess-1')
   setApprovalRequest({ allowPermanent, command, description: 'dangerous command', sessionId: 'sess-1', ...extra })
@@ -121,6 +121,22 @@ describe('PendingToolApproval', () => {
 
     expect(await screen.findByRole('menuitem', { name: /Always allow/ })).toBeTruthy()
     expect(screen.getByRole('menuitem', { name: /Allow this session/ })).toBeTruthy()
+  })
+
+  it('shows the approval rule and confirms the allowlist key for permanent allows', async () => {
+    setRequest('<browser_navigate> (plugin approval rule)', undefined, {
+      allowlistKey: 'plugin_rule:ext-nav',
+      ruleKey: 'ext-nav'
+    })
+    render(<PendingToolApproval part={part('terminal')} />)
+
+    expect(screen.getByText('Rule')).toBeTruthy()
+    expect(screen.getByText('ext-nav')).toBeTruthy()
+
+    fireEvent.keyDown(screen.getByRole('button', { name: /More approval options/ }), { key: 'Enter' })
+    fireEvent.click(await screen.findByRole('menuitem', { name: /Always allow/ }))
+
+    expect(await screen.findByText(/plugin_rule:ext-nav/)).toBeTruthy()
   })
 
   it('hides "Always allow" when the backend disallows a permanent allow', async () => {

--- a/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import type { HermesGateway } from '@/hermes'
 import { $gateway } from '@/store/gateway'
-import { $approvalRequest, clearAllPrompts, setApprovalRequest } from '@/store/prompts'
+import { $approvalRequest, type ApprovalRequest, clearAllPrompts, setApprovalRequest } from '@/store/prompts'
 import { $activeSessionId } from '@/store/session'
 
 import { PendingApprovalFallback, PendingToolApproval } from './approval'
@@ -33,7 +33,7 @@ function part(toolName: string): ToolPart {
 function setRequest(
   command = 'rm -rf /tmp/x',
   allowPermanent?: boolean,
-  extra: { choices?: string[]; smartDenied?: boolean } = {}
+  extra: Partial<Pick<ApprovalRequest, 'allowlistKey' | 'choices' | 'patternKey' | 'ruleKey' | 'smartDenied'>> = {}
 ) {
   $activeSessionId.set('sess-1')
   setApprovalRequest({ allowPermanent, command, description: 'dangerous command', sessionId: 'sess-1', ...extra })
@@ -129,6 +129,22 @@ describe('PendingToolApproval', () => {
 
     expect(await screen.findByRole('menuitem', { name: /Always allow/ })).toBeTruthy()
     expect(screen.getByRole('menuitem', { name: /Allow this session/ })).toBeTruthy()
+  })
+
+  it('shows the approval rule and confirms the allowlist key for permanent allows', async () => {
+    setRequest('<browser_navigate> (plugin approval rule)', undefined, {
+      allowlistKey: 'plugin_rule:ext-nav',
+      ruleKey: 'ext-nav'
+    })
+    render(<PendingToolApproval part={part('terminal')} />)
+
+    expect(screen.getByText('Rule')).toBeTruthy()
+    expect(screen.getByText('ext-nav')).toBeTruthy()
+
+    fireEvent.keyDown(screen.getByRole('button', { name: /More approval options/ }), { key: 'Enter' })
+    fireEvent.click(await screen.findByRole('menuitem', { name: /Always allow/ }))
+
+    expect(await screen.findByText(/plugin_rule:ext-nav/)).toBeTruthy()
   })
 
   it('hides "Always allow" when the backend disallows a permanent allow', async () => {

--- a/apps/desktop/src/components/assistant-ui/tool/approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.tsx
@@ -123,6 +123,8 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
   const allowAlways = choices ? choices.includes('always') : allowPermanent
   const hasMoreOptions = allowSession || allowAlways
   const hasCommand = request.command.trim().length > 0
+  const approvalRule = request.ruleKey || request.allowlistKey || request.patternKey
+  const allowlistPattern = request.allowlistKey || request.patternKey || request.ruleKey || request.description
 
   const respond = useCallback(
     async (choice: ApprovalChoice) => {
@@ -259,6 +261,19 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
         )}
       </div>
 
+      {approvalRule && (
+        <div
+          className="mt-1.5 max-w-full truncate text-[0.625rem] leading-tight text-(--ui-text-tertiary)"
+          title={approvalRule}
+        >
+          <span className="font-medium">{copy.rule}</span>
+          <span aria-hidden className="mx-1 opacity-60">
+            ·
+          </span>
+          <code className="font-mono">{approvalRule}</code>
+        </div>
+      )}
+
       {showCommand && hasCommand && (
         <pre className="mt-1.5 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-chat-surface-background) px-2.5 py-1.5 font-mono text-xs leading-snug text-foreground">
           {request.command.trim()}
@@ -269,7 +284,7 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
         <DialogContent className="max-w-md">
           <DialogHeader>
             <DialogTitle>{copy.alwaysTitle}</DialogTitle>
-            <DialogDescription>{copy.alwaysDescription(request.description)}</DialogDescription>
+            <DialogDescription>{copy.alwaysDescription(allowlistPattern)}</DialogDescription>
           </DialogHeader>
 
           {request.command.trim() && (

--- a/apps/desktop/src/components/assistant-ui/tool/approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.tsx
@@ -125,6 +125,8 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
   const allowAlways = choices ? choices.includes('always') : allowPermanent
   const hasMoreOptions = allowSession || allowAlways
   const hasCommand = request.command.trim().length > 0
+  const approvalRule = request.ruleKey || request.allowlistKey || request.patternKey
+  const allowlistPattern = request.allowlistKey || request.patternKey || request.ruleKey || request.description
 
   const respond = useCallback(
     async (choice: ApprovalChoice) => {
@@ -274,6 +276,19 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
         )}
       </div>
 
+      {approvalRule && (
+        <div
+          className="mt-1.5 max-w-full truncate text-[0.625rem] leading-tight text-(--ui-text-tertiary)"
+          title={approvalRule}
+        >
+          <span className="font-medium">{copy.rule}</span>
+          <span aria-hidden className="mx-1 opacity-60">
+            ·
+          </span>
+          <code className="font-mono">{approvalRule}</code>
+        </div>
+      )}
+
       {showCommand && hasCommand && (
         <pre className="mt-1.5 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-chat-surface-background) px-2.5 py-1.5 font-mono text-xs leading-snug text-foreground">
           {request.command.trim()}
@@ -284,7 +299,7 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
         <DialogContent className="max-w-md">
           <DialogHeader>
             <DialogTitle>{copy.alwaysTitle}</DialogTitle>
-            <DialogDescription>{copy.alwaysDescription(request.description)}</DialogDescription>
+            <DialogDescription>{copy.alwaysDescription(allowlistPattern)}</DialogDescription>
           </DialogHeader>
 
           {request.command.trim() && (

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2762,6 +2762,7 @@ export const en: Translations = {
       sendFailed: 'Could not send approval response',
       run: 'Run',
       command: 'Command',
+      rule: 'Rule',
       moreOptions: 'More approval options',
       allowSession: 'Allow this session',
       alwaysAllowMenu: 'Always allow…',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -3192,6 +3192,7 @@ export const en: Translations = {
       sendFailed: 'Could not send approval response',
       run: 'Run',
       command: 'Command',
+      rule: 'Rule',
       moreOptions: 'More approval options',
       allowSession: 'Allow this session',
       alwaysAllowMenu: 'Always allow…',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2578,6 +2578,7 @@ export const ja = defineLocale({
       sendFailed: '承認応答を送信できませんでした',
       run: '実行',
       command: 'コマンド',
+      rule: 'ルール',
       moreOptions: 'その他の承認オプション',
       allowSession: 'このセッションで許可',
       alwaysAllowMenu: '常に許可…',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2841,6 +2841,7 @@ export const ja = defineLocale({
       sendFailed: '承認応答を送信できませんでした',
       run: '実行',
       command: 'コマンド',
+      rule: 'ルール',
       moreOptions: 'その他の承認オプション',
       allowSession: 'このセッションで許可',
       alwaysAllowMenu: '常に許可…',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2352,6 +2352,7 @@ export interface Translations {
       sendFailed: string
       run: string
       command: string
+      rule: string
       moreOptions: string
       allowSession: string
       alwaysAllowMenu: string

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2751,6 +2751,7 @@ export interface Translations {
       sendFailed: string
       run: string
       command: string
+      rule: string
       moreOptions: string
       allowSession: string
       alwaysAllowMenu: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2496,6 +2496,7 @@ export const zhHant = defineLocale({
       sendFailed: '無法傳送核准回應',
       run: '執行',
       command: '指令',
+      rule: '規則',
       moreOptions: '更多核准選項',
       allowSession: '允許本工作階段',
       alwaysAllowMenu: '一律允許…',

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2747,6 +2747,7 @@ export const zhHant = defineLocale({
       sendFailed: '無法傳送核准回應',
       run: '執行',
       command: '指令',
+      rule: '規則',
       moreOptions: '更多核准選項',
       allowSession: '允許本工作階段',
       alwaysAllowMenu: '一律允許…',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2936,6 +2936,7 @@ export const zh: Translations = {
       sendFailed: '无法发送审批响应',
       run: '运行',
       command: '命令',
+      rule: '规则',
       moreOptions: '更多审批选项',
       allowSession: '允许本会话',
       alwaysAllowMenu: '始终允许…',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3351,6 +3351,7 @@ export const zh: Translations = {
       sendFailed: '无法发送审批响应',
       run: '运行',
       command: '命令',
+      rule: '规则',
       moreOptions: '更多审批选项',
       allowSession: '允许本会话',
       alwaysAllowMenu: '始终允许…',

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -74,8 +74,12 @@ export type GatewayEventPayload = {
   question?: string
   choices?: string[] | null
   // approval.request (dangerous command / execute_code) — session-keyed
+  allowlist_key?: string
   command?: string
   description?: string
+  pattern_key?: string
+  pattern_keys?: string[]
+  rule_key?: string
   // False when a tirith content-security warning forbids a permanent allow.
   allow_permanent?: boolean
   smart_denied?: boolean

--- a/apps/desktop/src/lib/chat-messages/types.ts
+++ b/apps/desktop/src/lib/chat-messages/types.ts
@@ -104,8 +104,12 @@ export type GatewayEventPayload = {
   action?: string
   reason?: string
   // approval.request (dangerous command / execute_code) — session-keyed
+  allowlist_key?: string
   command?: string
   description?: string
+  pattern_key?: string
+  pattern_keys?: string[]
+  rule_key?: string
   // False when a tirith content-security warning forbids a permanent allow.
   allow_permanent?: boolean
   smart_denied?: boolean

--- a/apps/desktop/src/store/prompts.test.ts
+++ b/apps/desktop/src/store/prompts.test.ts
@@ -67,6 +67,23 @@ describe('approval prompt store', () => {
 
     expect($approvalRequest.get()?.allowPermanent).toBe(false)
   })
+
+  it('carries approval rule metadata for desktop prompts', () => {
+    setApprovalRequest({
+      allowlistKey: 'plugin_rule:ext-nav',
+      command: '<browser_navigate> (plugin approval rule)',
+      description: 'external navigation',
+      patternKey: 'plugin_rule:ext-nav',
+      ruleKey: 'ext-nav',
+      sessionId: 's1'
+    })
+
+    expect($approvalRequest.get()).toMatchObject({
+      allowlistKey: 'plugin_rule:ext-nav',
+      patternKey: 'plugin_rule:ext-nav',
+      ruleKey: 'ext-nav'
+    })
+  })
 })
 
 describe('sudo prompt store', () => {

--- a/apps/desktop/src/store/prompts.test.ts
+++ b/apps/desktop/src/store/prompts.test.ts
@@ -111,7 +111,14 @@ describe('approval prompt store', () => {
         if (method === 'approval.pending') {
           return {
             approvals: [
-              { command: 'first', description: 'd1', request_id: 'r1' },
+              {
+                allowlist_key: 'plugin_rule:ext-nav',
+                command: 'first',
+                description: 'd1',
+                pattern_key: 'plugin_rule:ext-nav',
+                request_id: 'r1',
+                rule_key: 'ext-nav'
+              },
               { command: 'second', description: 'd2', request_id: 'r2' }
             ]
           }
@@ -124,10 +131,32 @@ describe('approval prompt store', () => {
     await replayPendingApproval(gateway, 's1')
 
     expect($approvalRequest.get()?.requestId).toBe('r1')
+    expect($approvalRequest.get()).toMatchObject({
+      allowlistKey: 'plugin_rule:ext-nav',
+      patternKey: 'plugin_rule:ext-nav',
+      ruleKey: 'ext-nav'
+    })
     expect(calls).toEqual([
       ['approval.pending', { session_id: 's1' }],
       ['approval.received', { request_id: 'r1', session_id: 's1' }]
     ])
+  })
+
+  it('carries approval rule metadata for desktop prompts', () => {
+    setApprovalRequest({
+      allowlistKey: 'plugin_rule:ext-nav',
+      command: '<browser_navigate> (plugin approval rule)',
+      description: 'external navigation',
+      patternKey: 'plugin_rule:ext-nav',
+      ruleKey: 'ext-nav',
+      sessionId: 's1'
+    })
+
+    expect($approvalRequest.get()).toMatchObject({
+      allowlistKey: 'plugin_rule:ext-nav',
+      patternKey: 'plugin_rule:ext-nav',
+      ruleKey: 'ext-nav'
+    })
   })
 })
 

--- a/apps/desktop/src/store/prompts.ts
+++ b/apps/desktop/src/store/prompts.ts
@@ -73,9 +73,12 @@ function keyedPromptStore<T extends KeyedPrompt>(): PromptStore<T> {
 export interface ApprovalRequest extends KeyedPrompt {
   // false when the backend won't honor a permanent allow (tirith warning) → hide "Always allow".
   allowPermanent?: boolean
+  allowlistKey?: string
   choices?: string[]
   command: string
   description: string
+  patternKey?: string
+  ruleKey?: string
   smartDenied?: boolean
 }
 

--- a/apps/desktop/src/store/prompts.ts
+++ b/apps/desktop/src/store/prompts.ts
@@ -73,10 +73,13 @@ function keyedPromptStore<T extends KeyedPrompt>(): PromptStore<T> {
 export interface ApprovalRequest extends KeyedPrompt {
   // false when the backend won't honor a permanent allow (tirith warning) → hide "Always allow".
   allowPermanent?: boolean
+  allowlistKey?: string
   choices?: string[]
   command: string
   description: string
   requestId?: string
+  patternKey?: string
+  ruleKey?: string
   smartDenied?: boolean
 }
 
@@ -86,10 +89,13 @@ interface ApprovalGateway {
 
 interface PendingApprovalPayload {
   allow_permanent?: boolean
+  allowlist_key?: unknown
   choices?: unknown
   command?: unknown
   description?: unknown
+  pattern_key?: unknown
   request_id?: unknown
+  rule_key?: unknown
   smart_denied?: boolean
 }
 
@@ -146,10 +152,14 @@ export async function replayPendingApproval(gateway: ApprovalGateway | null, ses
 
   await receiveApprovalRequest(gateway, {
     allowPermanent: pending.allow_permanent !== false,
+    allowlistKey:
+      typeof pending.allowlist_key === 'string' && pending.allowlist_key ? pending.allowlist_key : undefined,
     choices: Array.isArray(pending.choices) ? pending.choices.filter(choice => typeof choice === 'string') : undefined,
     command: typeof pending.command === 'string' ? pending.command : '',
     description: typeof pending.description === 'string' ? pending.description : 'dangerous command',
+    patternKey: typeof pending.pattern_key === 'string' && pending.pattern_key ? pending.pattern_key : undefined,
     requestId: pending.request_id,
+    ruleKey: typeof pending.rule_key === 'string' && pending.rule_key ? pending.rule_key : undefined,
     sessionId,
     smartDenied: pending.smart_denied === true
   })

--- a/tests/tools/test_command_guards.py
+++ b/tests/tools/test_command_guards.py
@@ -409,6 +409,8 @@ class TestGatewayApprovalAllowPermanent:
         payload = self._capture_gateway_payload("rm -rf /important", "gw-allow-perm")
         assert payload["command"] == "rm -rf /important"
         assert payload["allow_permanent"] is True
+        assert payload["allowlist_key"] == payload["pattern_key"]
+        assert payload["pattern_key"] in payload["pattern_keys"]
 
     @patch(_TIRITH_PATCH,
            return_value=_tirith_result("warn",
@@ -422,6 +424,8 @@ class TestGatewayApprovalAllowPermanent:
         # Session scope stays available — pure-tirith prompts are session-max,
         # not once-max (salvaged from PR #67312).
         assert payload["allow_session"] is True
+        assert payload["allowlist_key"] == payload["pattern_key"]
+        assert payload["pattern_key"] in payload["pattern_keys"]
 
     @patch(_TIRITH_PATCH,
            return_value=_tirith_result("warn",

--- a/tests/tools/test_request_tool_approval.py
+++ b/tests/tools/test_request_tool_approval.py
@@ -95,6 +95,59 @@ class TestRequestToolApproval:
         assert calls["session"] == ["plugin_rule:ssh-writes"]
         assert calls["permanent"] == []  # session != always
 
+    def test_gateway_path_submits_rule_metadata_and_defers(self, monkeypatch):
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: True)
+        submitted = {}
+        monkeypatch.setattr(
+            approval,
+            "submit_pending",
+            lambda sk, data: submitted.update(data),
+        )
+
+        res = request_tool_approval(
+            "browser_navigate",
+            "external URL",
+            rule_key="ext-nav",
+        )
+
+        assert res["approved"] is False
+        assert res["status"] == "approval_required"
+        assert submitted["pattern_key"] == "plugin_rule:ext-nav"
+        assert submitted["pattern_keys"] == ["plugin_rule:ext-nav"]
+        assert submitted["allowlist_key"] == "plugin_rule:ext-nav"
+        assert submitted["rule_key"] == "ext-nav"
+        assert submitted["allow_permanent"] is True
+        assert res["allowlist_key"] == "plugin_rule:ext-nav"
+        assert res["rule_key"] == "ext-nav"
+
+    def test_gateway_notify_round_trip_carries_rule_metadata(self, monkeypatch):
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: True)
+        captured = []
+
+        def notify(data):
+            captured.append(dict(data))
+            approval.resolve_gateway_approval("test-session", "once")
+
+        approval.register_gateway_notify("test-session", notify)
+        try:
+            res = request_tool_approval(
+                "browser_navigate",
+                "external URL",
+                rule_key="ext-nav",
+            )
+        finally:
+            approval.unregister_gateway_notify("test-session")
+
+        assert res == {"approved": True, "message": None}
+        assert len(captured) == 1
+        assert captured[0]["pattern_key"] == "plugin_rule:ext-nav"
+        assert captured[0]["pattern_keys"] == ["plugin_rule:ext-nav"]
+        assert captured[0]["allowlist_key"] == "plugin_rule:ext-nav"
+        assert captured[0]["rule_key"] == "ext-nav"
+        assert captured[0]["allow_permanent"] is True
+
 
     def test_cron_deny_mode_blocks(self, monkeypatch):
         monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2531,6 +2531,25 @@ def submit_pending(session_key: str, approval: dict):
         _pending[session_key] = approval
 
 
+def _approval_metadata(
+    pattern_key: str,
+    pattern_keys: Optional[list[str]] = None,
+    *,
+    allow_permanent: Optional[bool] = None,
+) -> dict:
+    """Build shared approval metadata for gateway/desktop renderers."""
+    keys = list(pattern_keys or [pattern_key])
+    metadata = {
+        "allowlist_key": pattern_key,
+        "pattern_keys": keys,
+    }
+    if allow_permanent is not None:
+        metadata["allow_permanent"] = allow_permanent
+    if pattern_key.startswith("plugin_rule:"):
+        metadata["rule_key"] = pattern_key[len("plugin_rule:"):]
+    return metadata
+
+
 def approve_session(session_key: str, pattern_key: str):
     """Approve a pattern for this session only."""
     with _lock:
@@ -3264,16 +3283,16 @@ def _run_approval_gate(
         with _lock:
             notify_cb = _gateway_notify_cbs.get(session_key)
 
+        from agent.redact import redact_sensitive_text
+        approval_data = {
+            "command": redact_sensitive_text(display_target),
+            "pattern_key": pattern_key,
+            **_approval_metadata(pattern_key, allow_permanent=True),
+            "description": redact_sensitive_text(description),
+            "allow_session": True,
+        }
+
         if notify_cb is not None:
-            from agent.redact import redact_sensitive_text
-            approval_data = {
-                "command": redact_sensitive_text(display_target),
-                "pattern_key": pattern_key,
-                "pattern_keys": [pattern_key],
-                "description": redact_sensitive_text(description),
-                "allow_permanent": True,
-                "allow_session": True,
-            }
             decision = _await_gateway_decision(
                 session_key, notify_cb, approval_data, surface="gateway"
             )
@@ -3321,17 +3340,14 @@ def _run_approval_gate(
 
         # No notify callback (e.g. API server without an attached chat):
         # queue for /approve /deny review, agent sees approval_required.
-        submit_pending(session_key, {
-            "command": display_target,
-            "pattern_key": pattern_key,
-            "description": description,
-        })
+        submit_pending(session_key, approval_data)
         return {
             "approved": False,
             "pattern_key": pattern_key,
+            **_approval_metadata(pattern_key, allow_permanent=True),
             "status": "approval_required",
-            "command": display_target,
-            "description": description,
+            "command": approval_data["command"],
+            "description": approval_data["description"],
             "message": (
                 f"⚠️ This action is potentially dangerous ({description}). "
                 f"Asking the user for approval.\n\n**Target:**\n```\n{display_target}\n```"
@@ -4020,7 +4036,7 @@ def check_all_command_guards(command: str, env_type: str,
             approval_data = {
                 "command": redact_sensitive_text(command),
                 "pattern_key": primary_key,
-                "pattern_keys": all_keys,
+                **_approval_metadata(primary_key, all_keys),
                 "description": redact_sensitive_text(combined_desc),
                 # Smart DENY overrides are one-operation decisions, so the UI
                 # must not offer a permanent scope.  Otherwise offer Always
@@ -4116,7 +4132,13 @@ def check_all_command_guards(command: str, env_type: str,
         pending_data = {
             "command": _disp_command,
             "pattern_key": primary_key,
-            "pattern_keys": all_keys,
+            **_approval_metadata(
+                primary_key,
+                all_keys,
+                allow_permanent=(
+                    has_permanent_capable and not smart_denied_for_owner
+                ),
+            ),
             "description": _disp_combined_desc,
         }
         if smart_denied_for_owner:
@@ -4125,6 +4147,13 @@ def check_all_command_guards(command: str, env_type: str,
         result = {
             "approved": False,
             "pattern_key": primary_key,
+            **_approval_metadata(
+                primary_key,
+                all_keys,
+                allow_permanent=(
+                    has_permanent_capable and not smart_denied_for_owner
+                ),
+            ),
             "status": "pending_approval",
             "approval_pending": True,
             "command": _disp_command,
@@ -4368,7 +4397,7 @@ def check_execute_code_guard(code: str, env_type: str,
         pending_data = {
             "command": display_command,
             "pattern_key": pattern_key,
-            "pattern_keys": [pattern_key],
+            **_approval_metadata(pattern_key, allow_permanent=True),
             "description": display_description,
         }
         if smart_denied_for_owner:
@@ -4377,6 +4406,7 @@ def check_execute_code_guard(code: str, env_type: str,
         result = {
             "approved": False,
             "pattern_key": pattern_key,
+            **_approval_metadata(pattern_key, allow_permanent=True),
             "status": "pending_approval",
             "approval_pending": True,
             "command": display_command,
@@ -4393,7 +4423,7 @@ def check_execute_code_guard(code: str, env_type: str,
     approval_data = {
         "command": display_command,
         "pattern_key": pattern_key,
-        "pattern_keys": [pattern_key],
+        **_approval_metadata(pattern_key, allow_permanent=True),
         "description": display_description,
         "allow_permanent": not smart_denied_for_owner,
         "allow_session": not smart_denied_for_owner,

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2907,6 +2907,32 @@ def submit_pending(session_key: str, approval: dict):
         _pending[session_key] = approval
 
 
+def _approval_metadata(
+    pattern_key: str,
+    pattern_keys: Optional[list[str]] = None,
+    *,
+    allow_permanent: Optional[bool] = None,
+) -> dict:
+    """Build shared approval metadata for gateway/desktop renderers.
+
+    ``allowlist_key`` intentionally aliases the primary ``pattern_key``: the
+    former names the exact key persisted by Session/Always decisions, while
+    ``pattern_keys`` preserves every match that contributed to the prompt.
+    Keeping the storage field explicit lets clients display what an approval
+    would persist without reconstructing that contract from the match list.
+    """
+    keys = list(pattern_keys or [pattern_key])
+    metadata = {
+        "allowlist_key": pattern_key,
+        "pattern_keys": keys,
+    }
+    if allow_permanent is not None:
+        metadata["allow_permanent"] = allow_permanent
+    if pattern_key.startswith("plugin_rule:"):
+        metadata["rule_key"] = pattern_key[len("plugin_rule:"):]
+    return metadata
+
+
 def approve_session(session_key: str, pattern_key: str):
     """Approve a pattern for this session only."""
     with _lock:
@@ -3762,16 +3788,16 @@ def _run_approval_gate(
         with _lock:
             notify_cb = _gateway_notify_cbs.get(session_key)
 
+        from agent.redact import redact_sensitive_text
+        approval_data = {
+            "command": redact_sensitive_text(display_target),
+            "pattern_key": pattern_key,
+            **_approval_metadata(pattern_key, allow_permanent=True),
+            "description": redact_sensitive_text(description),
+            "allow_session": True,
+        }
+
         if notify_cb is not None:
-            from agent.redact import redact_sensitive_text
-            approval_data = {
-                "command": redact_sensitive_text(display_target),
-                "pattern_key": pattern_key,
-                "pattern_keys": [pattern_key],
-                "description": redact_sensitive_text(description),
-                "allow_permanent": True,
-                "allow_session": True,
-            }
             decision = _await_gateway_decision(
                 session_key, notify_cb, approval_data, surface="gateway"
             )
@@ -3827,17 +3853,14 @@ def _run_approval_gate(
         ):
             # No notify callback (e.g. API server without an attached chat):
             # queue for /approve /deny review, agent sees approval_required.
-            submit_pending(session_key, {
-                "command": display_target,
-                "pattern_key": pattern_key,
-                "description": description,
-            })
+            submit_pending(session_key, approval_data)
             return {
                 "approved": False,
                 "pattern_key": pattern_key,
+                **_approval_metadata(pattern_key, allow_permanent=True),
                 "status": "approval_required",
-                "command": display_target,
-                "description": description,
+                "command": approval_data["command"],
+                "description": approval_data["description"],
                 "message": (
                     f"⚠️ This action is potentially dangerous ({description}). "
                     f"Asking the user for approval.\n\n**Target:**\n```\n{display_target}\n```"
@@ -4977,7 +5000,7 @@ def check_all_command_guards(command: str, env_type: str,
             approval_data = {
                 "command": redact_sensitive_text(command),
                 "pattern_key": primary_key,
-                "pattern_keys": all_keys,
+                **_approval_metadata(primary_key, all_keys),
                 "description": redact_sensitive_text(combined_desc),
                 # Smart DENY overrides are one-operation decisions, so the UI
                 # must not offer a permanent scope.  Otherwise offer Always
@@ -5082,7 +5105,13 @@ def check_all_command_guards(command: str, env_type: str,
             pending_data = {
                 "command": _disp_command,
                 "pattern_key": primary_key,
-                "pattern_keys": all_keys,
+                **_approval_metadata(
+                    primary_key,
+                    all_keys,
+                    allow_permanent=(
+                        has_permanent_capable and not smart_denied_for_owner
+                    ),
+                ),
                 "description": _disp_combined_desc,
             }
             if smart_denied_for_owner:
@@ -5091,6 +5120,13 @@ def check_all_command_guards(command: str, env_type: str,
             result = {
                 "approved": False,
                 "pattern_key": primary_key,
+                **_approval_metadata(
+                    primary_key,
+                    all_keys,
+                    allow_permanent=(
+                        has_permanent_capable and not smart_denied_for_owner
+                    ),
+                ),
                 "status": "pending_approval",
                 "approval_pending": True,
                 "command": _disp_command,
@@ -5514,7 +5550,7 @@ def check_execute_code_guard(code: str, env_type: str,
         pending_data = {
             "command": display_command,
             "pattern_key": pattern_key,
-            "pattern_keys": [pattern_key],
+            **_approval_metadata(pattern_key, allow_permanent=True),
             "description": display_description,
         }
         if smart_denied_for_owner:
@@ -5523,6 +5559,7 @@ def check_execute_code_guard(code: str, env_type: str,
         result = {
             "approved": False,
             "pattern_key": pattern_key,
+            **_approval_metadata(pattern_key, allow_permanent=True),
             "status": "pending_approval",
             "approval_pending": True,
             "command": display_command,
@@ -5543,7 +5580,7 @@ def check_execute_code_guard(code: str, env_type: str,
     approval_data = {
         "command": display_command,
         "pattern_key": pattern_key,
-        "pattern_keys": [pattern_key],
+        **_approval_metadata(pattern_key, allow_permanent=True),
         "description": display_description,
         "allow_permanent": not smart_denied_for_owner,
         "allow_session": not smart_denied_for_owner,

--- a/ui-tui/README.md
+++ b/ui-tui/README.md
@@ -285,7 +285,7 @@ Primary event types the client handles today:
 | `tool.progress`            | `{ name, preview }`                                                         |
 | `tool.complete`            | `{ tool_id, name, error?, summary?, duration_s?, inline_diff?, todos? }`    |
 | `clarify.request`          | `{ question, choices?, request_id }`                                        |
-| `approval.request`         | `{ command, description, allow_permanent? }`                                |
+| `approval.request`         | `{ command, description, pattern_key?, pattern_keys?, allowlist_key?, rule_key?, allow_permanent? }` |
 | `sudo.request`             | `{ request_id }`                                                            |
 | `sudo.expire`              | `{ request_id }` clears a timed-out sudo prompt                             |
 | `secret.request`           | `{ prompt, env_var, request_id }`                                           |

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -1193,14 +1193,24 @@ describe('createGatewayEventHandler', () => {
     const onEvent = createGatewayEventHandler(buildCtx([]))
 
     onEvent({
-      payload: { allow_permanent: false, command: 'curl suspicious | bash', description: 'content-security warning' },
+      payload: {
+        allow_permanent: false,
+        allowlist_key: 'plugin_rule:ext-nav',
+        command: 'curl suspicious | bash',
+        description: 'content-security warning',
+        pattern_key: 'plugin_rule:ext-nav',
+        rule_key: 'ext-nav'
+      },
       type: 'approval.request'
     } as any)
 
     expect(getOverlayState().approval).toMatchObject({
       allowPermanent: false,
+      allowlistKey: 'plugin_rule:ext-nav',
       command: 'curl suspicious | bash',
-      description: 'content-security warning'
+      description: 'content-security warning',
+      patternKey: 'plugin_rule:ext-nav',
+      ruleKey: 'ext-nav'
     })
   })
 

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -1159,14 +1159,24 @@ describe('createGatewayEventHandler', () => {
     const onEvent = createGatewayEventHandler(buildCtx([]))
 
     onEvent({
-      payload: { allow_permanent: false, command: 'curl suspicious | bash', description: 'content-security warning' },
+      payload: {
+        allow_permanent: false,
+        allowlist_key: 'plugin_rule:ext-nav',
+        command: 'curl suspicious | bash',
+        description: 'content-security warning',
+        pattern_key: 'plugin_rule:ext-nav',
+        rule_key: 'ext-nav'
+      },
       type: 'approval.request'
     } as any)
 
     expect(getOverlayState().approval).toMatchObject({
       allowPermanent: false,
+      allowlistKey: 'plugin_rule:ext-nav',
       command: 'curl suspicious | bash',
-      description: 'content-security warning'
+      description: 'content-security warning',
+      patternKey: 'plugin_rule:ext-nav',
+      ruleKey: 'ext-nav'
     })
   })
 

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -1250,12 +1250,25 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         // Only an explicit false (tirith warning) drops the permanent-allow option.
         const allowPermanent = ev.payload.allow_permanent !== false
 
+        const allowlistKey =
+          typeof ev.payload.allowlist_key === 'string' && ev.payload.allowlist_key
+            ? ev.payload.allowlist_key
+            : undefined
+
+        const patternKey =
+          typeof ev.payload.pattern_key === 'string' && ev.payload.pattern_key ? ev.payload.pattern_key : undefined
+
+        const ruleKey = typeof ev.payload.rule_key === 'string' && ev.payload.rule_key ? ev.payload.rule_key : undefined
+
         patchOverlayState({
           approval: {
             allowPermanent,
+            allowlistKey,
             choices: ev.payload.choices,
             command: String(ev.payload.command ?? ''),
             description,
+            patternKey,
+            ruleKey,
             smartDenied: ev.payload.smart_denied === true
           }
         })

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -1171,12 +1171,25 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         // Only an explicit false (tirith warning) drops the permanent-allow option.
         const allowPermanent = ev.payload.allow_permanent !== false
 
+        const allowlistKey =
+          typeof ev.payload.allowlist_key === 'string' && ev.payload.allowlist_key
+            ? ev.payload.allowlist_key
+            : undefined
+
+        const patternKey =
+          typeof ev.payload.pattern_key === 'string' && ev.payload.pattern_key ? ev.payload.pattern_key : undefined
+
+        const ruleKey = typeof ev.payload.rule_key === 'string' && ev.payload.rule_key ? ev.payload.rule_key : undefined
+
         patchOverlayState({
           approval: {
             allowPermanent,
+            allowlistKey,
             choices: ev.payload.choices,
             command: String(ev.payload.command ?? ''),
             description,
+            patternKey,
+            ruleKey,
             smartDenied: ev.payload.smart_denied === true
           }
         })

--- a/ui-tui/src/components/prompts.tsx
+++ b/ui-tui/src/components/prompts.tsx
@@ -83,6 +83,7 @@ export function approvalAction(
 export function ApprovalPrompt({ cols = 80, onChoice, req, t }: ApprovalPromptProps) {
   const [sel, setSel] = useState(0)
   const opts = approvalOptions(req)
+  const approvalRule = req.ruleKey || req.allowlistKey || req.patternKey
 
   useInput((ch, key) => {
     const action = approvalAction(ch, key, sel, opts)
@@ -111,6 +112,8 @@ export function ApprovalPrompt({ cols = 80, onChoice, req, t }: ApprovalPromptPr
       <Text bold color={t.color.warn}>
         ⚠ approval required · {req.description}
       </Text>
+
+      {approvalRule ? <Text color={t.color.muted}>rule · {approvalRule}</Text> : null}
 
       <Box flexDirection="column" paddingLeft={1}>
         {shown.map((line, i) => (

--- a/ui-tui/src/components/prompts.tsx
+++ b/ui-tui/src/components/prompts.tsx
@@ -84,6 +84,7 @@ export function approvalAction(
 export function ApprovalPrompt({ cols = 80, onChoice, req, t }: ApprovalPromptProps) {
   const [sel, setSel] = useState(0)
   const opts = approvalOptions(req)
+  const approvalRule = req.ruleKey || req.allowlistKey || req.patternKey
 
   useInput((ch, key) => {
     const action = approvalAction(ch, key, sel, opts)
@@ -112,6 +113,8 @@ export function ApprovalPrompt({ cols = 80, onChoice, req, t }: ApprovalPromptPr
       <Text bold color={t.color.warn}>
         ⚠ approval required · {req.description}
       </Text>
+
+      {approvalRule ? <Text color={t.color.muted}>rule · {approvalRule}</Text> : null}
 
       <Box flexDirection="column" paddingLeft={1}>
         {shown.map((line, i) => (

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -700,9 +700,13 @@ export type GatewayEvent =
   | {
       payload: {
         allow_permanent?: boolean
+        allowlist_key?: string
         choices?: string[]
         command: string
         description: string
+        pattern_key?: string
+        pattern_keys?: string[]
+        rule_key?: string
         smart_denied?: boolean
       }
       session_id?: string

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -717,9 +717,13 @@ export type GatewayEvent =
   | {
       payload: {
         allow_permanent?: boolean
+        allowlist_key?: string
         choices?: string[]
         command: string
         description: string
+        pattern_key?: string
+        pattern_keys?: string[]
+        rule_key?: string
         smart_denied?: boolean
       }
       session_id?: string

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -92,9 +92,12 @@ export interface DelegationStatus {
 export interface ApprovalReq {
   // false when the backend won't honor a permanent allow (tirith warning) → hide "Always allow".
   allowPermanent?: boolean
+  allowlistKey?: string
   choices?: string[]
   command: string
   description: string
+  patternKey?: string
+  ruleKey?: string
   smartDenied?: boolean
 }
 


### PR DESCRIPTION
## Summary

Rebuilt directly on current `main` after the original plugin approval base from #59163 landed through #60504.

- add shared approval metadata (`pattern_keys`, `allowlist_key`, `allow_permanent`, and plugin `rule_key`) to gateway approval payloads
- preserve the current blocking `_await_gateway_decision()` notify/response flow for plugin approvals
- carry rule metadata and Smart DENY capability constraints through command, `execute_code`, no-callback, Desktop, and TUI paths
- display the effective approval rule in Desktop and TUI prompts
- add backend round-trip, Desktop event-parsing/display, and TUI event/display coverage

## Validation

- `.venv/bin/python -m pytest tests/tools/test_request_tool_approval.py tests/tools/test_command_guards.py::TestGatewayApprovalAllowPermanent -q`
- `.venv/bin/ruff check tools/approval.py tests/tools/test_request_tool_approval.py tests/tools/test_command_guards.py`
- `npm --workspace apps/desktop run test:ui -- src/app/session/hooks/use-message-stream/approval-rule-metadata-event.test.tsx src/store/prompts.test.ts src/components/assistant-ui/tool/approval.test.tsx`
- `npm --workspace apps/desktop run typecheck`
- `npm --workspace @hermes/ink run build`
- `npm --workspace ui-tui run typecheck`
- `npm --workspace ui-tui test -- src/__tests__/createGatewayEventHandler.test.ts src/__tests__/approvalAction.test.ts`
- Prettier and `git diff --check`
- GitHub CI: all required checks pass