### PR TITLE
fix(tools): preserve explicitly-enabled tools when disabling composite toolsets

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -423,13 +423,38 @@ def _compute_tool_definitions(
                             ", ".join(resolved) if resolved else "none",
                         )
                 else:
-                    resolved = resolve_toolset(toolset_name)
-                    tools_to_include.difference_update(resolved)
+                    resolved = set(resolve_toolset(toolset_name))
+                    if enabled_toolsets is not None:
+                        # When explicitly-enabled toolsets are set, only
+                        # subtract the tools of the disabled composite that
+                        # are NOT also contributed by an enabled toolset.
+                        # Otherwise disabling a composite like "coding"
+                        # strips every terminal + file tool and the model
+                        # receives zero tools with no warning (#58281).
+                        exclusive = resolved - tools_to_include
+                        if exclusive != resolved and not quiet_mode:
+                            preserved = resolved - exclusive
+                            logger.info(
+                                "disabled_toolsets includes '%s' which overlaps "
+                                "with enabled toolsets; %d tools are preserved "
+                                "because they are provided by enabled toolsets: %s",
+                                toolset_name, len(preserved),
+                                ", ".join(sorted(preserved)),
+                            )
+                        tools_to_include.difference_update(exclusive)
+                    else:
+                        tools_to_include.difference_update(resolved)
+                resolved_display = sorted(resolved)
                 if not quiet_mode:
-                    print(f"🚫 Disabled toolset '{toolset_name}': {', '.join(resolved) if resolved else 'no tools'}")
+                    print(f"🚫 Disabled toolset '{toolset_name}': {', '.join(resolved_display) if resolved_display else 'no tools'}")
             elif toolset_name in _LEGACY_TOOLSET_MAP:
                 legacy_tools = _LEGACY_TOOLSET_MAP[toolset_name]
-                tools_to_include.difference_update(legacy_tools)
+                if enabled_toolsets is not None:
+                    legacy_set = set(legacy_tools)
+                    exclusive = legacy_set - tools_to_include
+                    tools_to_include.difference_update(exclusive)
+                else:
+                    tools_to_include.difference_update(legacy_tools)
                 if not quiet_mode:
                     print(f"🚫 Disabled legacy toolset '{toolset_name}': {', '.join(legacy_tools)}")
             elif not quiet_mode:

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -587,3 +587,126 @@ class TestDisabledToolsetsPostureToolset:
             )
         }
         assert "write_file" not in no_file
+
+class TestDisabledCompositeToolsetOverlap:
+    """Regression for #58281: disabling a composite toolset like ``coding``
+    must preserve tools belonging to explicitly-enabled subtoolsets."""
+
+    def test_disabling_coding_preserves_terminal_and_file_tools(self):
+        """With terminal + file enabled, disabling coding keeps terminal/file tools."""
+        from model_tools import get_tool_definitions
+
+        tools_before = get_tool_definitions(
+            enabled_toolsets=["terminal", "file"],
+            quiet_mode=True,
+        )
+        tools_after = get_tool_definitions(
+            enabled_toolsets=["terminal", "file"],
+            disabled_toolsets=["coding"],
+            quiet_mode=True,
+        )
+        names_before = {t["function"]["name"] for t in tools_before}
+        names_after = {t["function"]["name"] for t in tools_after}
+
+        # Should not lose any terminal or file tools
+        assert names_before == names_after, (
+            f"Tools lost when disabling coding: {names_before - names_after}"
+        )
+
+    def test_disabling_coding_removes_coding_only_tools(self):
+        """Tools exclusive to 'coding' (not in terminal/file) are still removed."""
+        from model_tools import get_tool_definitions
+
+        tools_all = get_tool_definitions(
+            enabled_toolsets=["terminal", "file", "coding"],
+            quiet_mode=True,
+        )
+        tools_no_coding = get_tool_definitions(
+            enabled_toolsets=["terminal", "file"],
+            disabled_toolsets=["coding"],
+            quiet_mode=True,
+        )
+        names_all = {t["function"]["name"] for t in tools_all}
+        names_no_coding = {t["function"]["name"] for t in tools_no_coding}
+
+        # coding-only tools should NOT appear
+        coding_only = names_all - names_no_coding
+        assert coding_only, "expected coding to contribute exclusive tools"
+        assert not (coding_only & names_no_coding), (
+            f"coding-only tools leaked: {coding_only & names_no_coding}"
+        )
+
+    def test_disabling_safe_preserves_enabled_overlap(self):
+        """Disabling 'safe' preserves tools from explicitly enabled terminal/file."""
+        from model_tools import get_tool_definitions
+
+        tools = get_tool_definitions(
+            enabled_toolsets=["terminal", "file"],
+            disabled_toolsets=["safe"],
+            quiet_mode=True,
+        )
+        names = {t["function"]["name"] for t in tools}
+        assert "terminal" in names
+        assert "read_file" in names
+
+    def test_disabling_debugging_preserves_enabled_overlap(self):
+        """Disabling 'debugging' preserves tools from explicitly enabled terminal/file."""
+        from model_tools import get_tool_definitions
+
+        tools = get_tool_definitions(
+            enabled_toolsets=["terminal", "file"],
+            disabled_toolsets=["debugging"],
+            quiet_mode=True,
+        )
+        names = {t["function"]["name"] for t in tools}
+        assert "terminal" in names
+        assert "read_file" in names
+
+    def test_default_enabled_toolsets_full_subtraction_still_works(self):
+        """When enabled_toolsets is None (default=all), full subtraction still works."""
+        from model_tools import get_tool_definitions
+
+        tools_all = get_tool_definitions(quiet_mode=True)
+        tools_no_coding = get_tool_definitions(
+            disabled_toolsets=["coding"],
+            quiet_mode=True,
+        )
+        names_all = {t["function"]["name"] for t in tools_all}
+        names_no_coding = {t["function"]["name"] for t in tools_no_coding}
+
+        removed = names_all - names_no_coding
+        assert removed, "expected tools to be removed when all toolsets are enabled"
+
+    def test_legacy_toolset_disabled_preserves_enabled_overlap(self):
+        """Disabling legacy 'file_tools' preserves file tools from enabled 'terminal' + 'file'."""
+        from model_tools import get_tool_definitions
+
+        tools = get_tool_definitions(
+            enabled_toolsets=["terminal", "file"],
+            disabled_toolsets=["file_tools"],
+            quiet_mode=True,
+        )
+        names = {t["function"]["name"] for t in tools}
+        # file tools should still be present because "file" toolset is explicitly enabled
+        for file_tool in ("read_file", "write_file", "patch", "search_files"):
+            assert file_tool in names, f"{file_tool} lost when disabling legacy file_tools"
+
+    def test_hermes_bundle_regression_unchanged(self):
+        """hermes-* bundle protection (#33924) is unchanged by the new logic."""
+        from model_tools import get_tool_definitions
+
+        tools_telegram = get_tool_definitions(
+            enabled_toolsets=["hermes-telegram"],
+            quiet_mode=True,
+        )
+        tools_telegram_no_yuanbao = get_tool_definitions(
+            enabled_toolsets=["hermes-telegram"],
+            disabled_toolsets=["hermes-yuanbao"],
+            quiet_mode=True,
+        )
+        names_telegram = {t["function"]["name"] for t in tools_telegram}
+        names_no_yuanbao = {t["function"]["name"] for t in tools_telegram_no_yuanbao}
+
+        assert names_telegram == names_no_yuanbao, (
+            f"Tools lost from telegram bundle: {names_telegram - names_no_yuanbao}"
+        )

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -663,19 +663,29 @@ class TestDisabledCompositeToolsetOverlap:
         assert "read_file" in names
 
     def test_default_enabled_toolsets_full_subtraction_still_works(self):
-        """When enabled_toolsets is None (default=all), full subtraction still works."""
+        """When enabled_toolsets is None (default=all), the default
+        full-subtraction path still removes a disabled toolset's tools.
+
+        This intentionally disables an *atomic* toolset (``file``) rather than
+        the ``coding`` posture toolset: every ``coding`` tool is also a shared
+        core tool, so disabling ``coding`` correctly preserves them (#57315,
+        TestDisabledToolsetsPostureToolset) and removes nothing -- it cannot
+        exercise the full-subtraction path this test guards."""
         from model_tools import get_tool_definitions
 
         tools_all = get_tool_definitions(quiet_mode=True)
-        tools_no_coding = get_tool_definitions(
-            disabled_toolsets=["coding"],
+        tools_no_file = get_tool_definitions(
+            disabled_toolsets=["file"],
             quiet_mode=True,
         )
         names_all = {t["function"]["name"] for t in tools_all}
-        names_no_coding = {t["function"]["name"] for t in tools_no_coding}
+        names_no_file = {t["function"]["name"] for t in tools_no_file}
 
-        removed = names_all - names_no_coding
+        removed = names_all - names_no_file
         assert removed, "expected tools to be removed when all toolsets are enabled"
+        # file tools are atomic (not shared posture/core re-lists), so the
+        # default (enabled_toolsets=None) path fully subtracts them.
+        assert "write_file" not in names_no_file
 
     def test_legacy_toolset_disabled_preserves_enabled_overlap(self):
         """Disabling legacy 'file_tools' preserves file tools from enabled 'terminal' + 'file'."""


### PR DESCRIPTION
## What Problem This Solves

Fixes #58281. When a composite toolset like `coding` is listed in `disabled_toolsets` while individual subtoolsets like `terminal` + `file` are explicitly enabled, the old code subtracted **all** tools in the composite — including tools that overlap with the enabled subtoolsets. The model receives zero tools with no warning.

## Root Cause

In `_compute_tool_definitions()`, the `disabled_toolsets` loop calls `tools_to_include.difference_update(resolved)` unconditionally. For composite toolsets like `coding` (which bundles terminal + file + coding-only tools), this strips every tool from all overlapping subtoolsets.

## Fix

When `enabled_toolsets` is explicitly set, compute the **exclusive** set of tools (those NOT also contributed by an enabled toolset) and subtract only those. Log a message noting how many tools were preserved and why.

Same logic applies to legacy toolset aliases (`file_tools` → `file`, etc.).

## Evidence

All 7 new regression tests in `TestDisabledCompositeToolsetOverlap` pass:

```
tests/test_model_tools.py::TestDisabledCompositeToolsetOverlap::test_disabling_coding_preserves_terminal_and_file_tools PASSED
tests/test_model_tools.py::TestDisabledCompositeToolsetOverlap::test_disabling_coding_removes_coding_only_tools PASSED
tests/test_model_tools.py::TestDisabledCompositeToolsetOverlap::test_disabling_safe_preserves_enabled_overlap PASSED
tests/test_model_tools.py::TestDisabledCompositeToolsetOverlap::test_disabling_debugging_preserves_enabled_overlap PASSED
tests/test_model_tools.py::TestDisabledCompositeToolsetOverlap::test_default_enabled_toolsets_full_subtraction_still_works PASSED
tests/test_model_tools.py::TestDisabledCompositeToolsetOverlap::test_legacy_toolset_disabled_preserves_enabled_overlap PASSED
tests/test_model_tools.py::TestDisabledCompositeToolsetOverlap::test_hermes_bundle_regression_unchanged PASSED
```

---

*Split from #58805 — this is the standalone model_tools.py bug fix, separated so it can be reviewed on its own merits.*