### PR TITLE
fix(auxiliary): reuse main_runtime credentials for named custom providers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4307,6 +4307,8 @@ def resolve_provider_client(
 
     # ── Custom endpoint (OPENAI_BASE_URL + OPENAI_API_KEY) ───────────
     if provider == "custom":
+        custom_base = ""
+        custom_key = ""
         if explicit_base_url:
             custom_base = _to_openai_base_url(explicit_base_url).strip()
             custom_key = (
@@ -4321,6 +4323,19 @@ def resolve_provider_client(
                     "but base_url is empty"
                 )
                 return None, None
+        elif main_runtime:
+            # When main_runtime carries a concrete base_url + api_key for a
+            # named custom provider (custom:<name>), use it directly instead
+            # of re-resolving from the bare "custom" provider name.
+            # Re-resolution loses the provider name and falls back to
+            # OpenRouter or a wrong API-key provider — the main agent already
+            # solved this, we just need to reuse its answer. (#45472)
+            _main_base = str(main_runtime.get("base_url") or "").strip().rstrip("/")
+            _main_key = str(main_runtime.get("api_key") or "").strip()
+            if _main_base and _main_key:
+                custom_base = _main_base
+                custom_key = _main_key
+        if custom_base and custom_key:
             final_model = _normalize_resolved_model(
                 model or (main_runtime.get("model") if main_runtime else None) or "gpt-4o-mini",
                 provider,
@@ -4357,49 +4372,6 @@ def resolve_provider_client(
                     else (client, final_model))
         # Try custom first, then API-key providers (Codex excluded here:
         # falling through to Codex with no model is a stale-constant trap).
-        #
-        # When main_runtime carries a concrete base_url + api_key for a
-        # named custom provider (custom:<name>), use it directly instead of
-        # re-resolving from the bare "custom" provider name.  Re-resolution
-        # loses the provider name and falls back to OpenRouter or a wrong
-        # API-key provider — the main agent already solved this, we just
-        # need to reuse its answer. (#45472)
-        if main_runtime:
-            main_base = str(main_runtime.get("base_url") or "").strip().rstrip("/")
-            main_key = str(main_runtime.get("api_key") or "").strip()
-            if main_base and main_key:
-                final_model = _normalize_resolved_model(
-                    model or main_runtime.get("model") or "gpt-4o-mini",
-                    provider,
-                )
-                extra = {}
-                _clean_base, _dq = _extract_url_query_params(main_base)
-                if _dq:
-                    extra["default_query"] = _dq
-                if base_url_host_matches(main_base, "api.kimi.com"):
-                    extra["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
-                elif base_url_host_matches(main_base, "api.githubcopilot.com"):
-                    from hermes_cli.copilot_auth import copilot_request_headers
-                    extra["default_headers"] = copilot_request_headers(
-                        is_agent_turn=True, is_vision=is_vision
-                    )
-                elif base_url_host_matches(main_base, "integrate.api.nvidia.com"):
-                    extra["default_headers"] = build_nvidia_nim_headers(main_base)
-                else:
-                    try:
-                        from providers import get_provider_profile as _gpf_main
-                        _ph_main = _gpf_main(provider)
-                        if _ph_main and _ph_main.default_headers:
-                            extra["default_headers"] = dict(_ph_main.default_headers)
-                    except Exception:
-                        pass
-                _merged_main = _apply_user_default_headers(extra.get("default_headers"))
-                if _merged_main:
-                    extra["default_headers"] = _merged_main
-                client = OpenAI(api_key=main_key, base_url=_clean_base, **extra)
-                client = _wrap_if_needed(client, final_model, main_base, main_key)
-                return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
-                        else (client, final_model))
         for try_fn in (_try_custom_endpoint, _resolve_api_key_provider):
             client, default = try_fn()
             if client is not None:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4357,6 +4357,49 @@ def resolve_provider_client(
                     else (client, final_model))
         # Try custom first, then API-key providers (Codex excluded here:
         # falling through to Codex with no model is a stale-constant trap).
+        #
+        # When main_runtime carries a concrete base_url + api_key for a
+        # named custom provider (custom:<name>), use it directly instead of
+        # re-resolving from the bare "custom" provider name.  Re-resolution
+        # loses the provider name and falls back to OpenRouter or a wrong
+        # API-key provider — the main agent already solved this, we just
+        # need to reuse its answer. (#45472)
+        if main_runtime:
+            main_base = str(main_runtime.get("base_url") or "").strip().rstrip("/")
+            main_key = str(main_runtime.get("api_key") or "").strip()
+            if main_base and main_key:
+                final_model = _normalize_resolved_model(
+                    model or main_runtime.get("model") or "gpt-4o-mini",
+                    provider,
+                )
+                extra = {}
+                _clean_base, _dq = _extract_url_query_params(main_base)
+                if _dq:
+                    extra["default_query"] = _dq
+                if base_url_host_matches(main_base, "api.kimi.com"):
+                    extra["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+                elif base_url_host_matches(main_base, "api.githubcopilot.com"):
+                    from hermes_cli.copilot_auth import copilot_request_headers
+                    extra["default_headers"] = copilot_request_headers(
+                        is_agent_turn=True, is_vision=is_vision
+                    )
+                elif base_url_host_matches(main_base, "integrate.api.nvidia.com"):
+                    extra["default_headers"] = build_nvidia_nim_headers(main_base)
+                else:
+                    try:
+                        from providers import get_provider_profile as _gpf_main
+                        _ph_main = _gpf_main(provider)
+                        if _ph_main and _ph_main.default_headers:
+                            extra["default_headers"] = dict(_ph_main.default_headers)
+                    except Exception:
+                        pass
+                _merged_main = _apply_user_default_headers(extra.get("default_headers"))
+                if _merged_main:
+                    extra["default_headers"] = _merged_main
+                client = OpenAI(api_key=main_key, base_url=_clean_base, **extra)
+                client = _wrap_if_needed(client, final_model, main_base, main_key)
+                return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                        else (client, final_model))
         for try_fn in (_try_custom_endpoint, _resolve_api_key_provider):
             client, default = try_fn()
             if client is not None:

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -491,3 +491,73 @@ class TestCustomProviderAliasCollision:
         assert isinstance(client, OpenAI)
         assert "override.example.com" in str(client.base_url)
         assert client.api_key == "override-key"
+
+
+class TestResolveProviderClientMainRuntimeCustom:
+    """When the main agent uses a named custom provider (custom:<name>),
+    resolve_provider_client('custom', ..., main_runtime=...) must reuse the
+    main_runtime's base_url + api_key instead of re-resolving from the bare
+    'custom' provider name.  Re-resolution loses the provider name and falls
+    back to OpenRouter or a wrong API-key provider. (#45472)"""
+
+    def test_custom_provider_main_runtime_used_directly(self, tmp_path, monkeypatch):
+        """main_runtime with base_url + api_key for a named custom provider
+        is used directly, bypassing the _try_custom_endpoint / API-key
+        fallback chain."""
+        from agent.auxiliary_client import resolve_provider_client
+        main_runtime = {
+            "provider": "custom",
+            "base_url": "https://my-gateway.example.com/v1",
+            "api_key": "***",
+            "model": "glm-5.1",
+        }
+        client, model = resolve_provider_client(
+            "custom",
+            model="explicit-glm-5.1",
+            main_runtime=main_runtime,
+        )
+        assert client is not None
+        assert model == "explicit-glm-5.1"
+        assert "my-gateway.example.com" in str(client.base_url)
+        assert client.api_key == "***"
+
+    def test_custom_provider_main_runtime_no_credentials_falls_through(self, tmp_path, monkeypatch):
+        """When main_runtime has no base_url or no api_key, the existing
+        _try_custom_endpoint / _resolve_api_key_provider fallback chain is
+        still tried."""
+        # Ensure no env-provided credentials interfere
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        from agent.auxiliary_client import resolve_provider_client
+        # main_runtime with key but no base_url → must fall through
+        client, model = resolve_provider_client(
+            "custom",
+            main_runtime={"api_key": "k", "base_url": ""},
+        )
+        # Should fall through to _try_custom_endpoint → return None,None
+        # because no OPENAI_BASE_URL is set and no custom endpoint is configured
+        assert client is None
+
+    def test_custom_provider_main_runtime_respects_explicit_base_url(self, tmp_path):
+        """explicit_base_url still wins over main_runtime — the caller's
+        explicit argument is the strongest signal."""
+        from agent.auxiliary_client import resolve_provider_client
+        main_runtime = {
+            "base_url": "https://main-runtime.example.com/v1",
+            "api_key": "sk-main",
+            "model": "ignored-model",
+        }
+        client, model = resolve_provider_client(
+            "custom",
+            model="explicit-model",
+            explicit_base_url="https://explicit.example.com/v1",
+            explicit_api_key="sk-explicit",
+            main_runtime=main_runtime,
+        )
+        assert client is not None
+        assert model == "explicit-model"
+        assert "explicit.example.com" in str(client.base_url)
+        assert client.api_key == "sk-explicit"


### PR DESCRIPTION
## Summary
Auxiliary tasks (vision, compression, title generation, …) now work when the main model uses a named custom provider (`custom:<name>`): `resolve_provider_client("custom", ...)` reuses the `main_runtime` base_url + api_key the main agent already resolved, instead of re-resolving from the bare `"custom"` name — which lost the provider name and fell back to OpenRouter or a wrong credential-pool provider. Fixes #45472.

Salvage of #45545 by @rayjun, cherry-picked onto current main with authorship preserved, plus a dedupe follow-up: the cherry-picked fix duplicated the ~35-line header-shaping block (kimi UA, copilot headers, nvidia NIM, provider-profile defaults, query params) from the `explicit_base_url` branch; the follow-up routes the `main_runtime` case through that same shared block, so there is one client-build path and no drift risk.

## Changes
- `agent/auxiliary_client.py`: bare-`custom` branch resolves `custom_base`/`custom_key` from `explicit_base_url` (unchanged) or, failing that, from `main_runtime` (#45472); single shared client-build block for both
- `tests/agent/test_auxiliary_named_custom_providers.py`: contributor's 3 tests (direct reuse, credential-less fallthrough, explicit args win)

## Validation
| call | Before | After |
|---|---|---|
| bare `custom` + main_runtime (named custom provider) | no client / wrong provider | main gateway + key reused |
| explicit base_url + api_key | wins | wins (unchanged) |
| main_runtime without base_url | fallthrough chain | unchanged |
| env-based custom endpoint | `_try_custom_endpoint` | unchanged |

`scripts/run_tests.sh tests/agent/test_auxiliary_named_custom_providers.py tests/agent/test_auxiliary_client.py`: 325/325 green. E2E with real imports + the exact #45472 config: main_runtime reuse, explicit-wins, no-credential fallthrough, and async mode all verified.

## Infographic

![custom-provider-reuse](https://v3b.fal.media/files/b/0aa11b0c/aeVs33QeYIQtnxCCPHTKH_DNmmsFYm.png)
