### PR TITLE
fix(review): include active memory provider's tools in review whitelist

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -760,6 +760,40 @@ def _run_review_in_thread(
                     quiet_mode=True,
                 )
             }
+
+            # Active memory provider (e.g. ``mnemosyne``, ``honcho``, ``hindsight``)
+            # exposes its own write tools via ``MemoryProvider.get_tool_schemas()``;
+            # those tools are what we actually want the review fork to call so
+            # distilled memories land in the configured backend instead of the
+            # legacy MEMORY.md file. ``skip_memory=True`` above prevents the
+            # review agent's own transcript from autosaving into the provider,
+            # but it does NOT give the review LLM a path to call the provider's
+            # explicit write tools either — the toolset whitelist built here
+            # would only include the legacy ``memory`` tool at that point. Add
+            # the active provider's tool schemas (read-only schema names only;
+            # we do not re-import the schemas themselves) to the whitelist so
+            # memory reviews honour ``memory.provider`` (#59244).
+            try:
+                from plugins.memory import (
+                    _get_active_memory_provider,
+                    load_memory_provider,
+                )
+
+                _active_name = _get_active_memory_provider()
+                if _active_name:
+                    _provider = load_memory_provider(_active_name)
+                    if _provider is not None:
+                        for _schema in _provider.get_tool_schemas() or []:
+                            _name = (_schema or {}).get("name")
+                            if _name:
+                                review_whitelist.add(_name)
+            except Exception as _exc:
+                # Provider-discovery failure must not break the review fork.
+                # The legacy memory path remains the safer default fallback.
+                logger.debug(
+                    "background_review: provider-aware whitelist skip (%s)",
+                    _exc,
+                )
             set_thread_tool_whitelist(
                 review_whitelist,
                 deny_msg_fmt=(

--- a/tests/run_agent/test_background_review_toolset_restriction.py
+++ b/tests/run_agent/test_background_review_toolset_restriction.py
@@ -220,10 +220,132 @@ def test_background_review_includes_memory_when_user_profile_enabled():
     with patch.object(run_agent.AIAgent, "__init__", _no_init), \
          patch.object(_plugins, "set_thread_tool_whitelist", _capture_whitelist), \
          patch("threading.Thread", _SyncThread):
-        agent._spawn_background_review(
-            messages_snapshot=[],
-            review_memory=True,
-            review_skills=False,
-        )
+        try:
+            agent._spawn_background_review(
+                messages_snapshot=[],
+                review_memory=True,
+                review_skills=False,
+            )
+        except RuntimeError:
+            pass
 
     assert "memory" in captured["whitelist"]
+
+
+def test_background_review_whitelist_includes_active_provider_tools():
+    """Active memory provider's write tools must be reachable from the
+    review fork so distilled memories land in the configured backend
+    instead of the legacy short ``MEMORY.md`` file (#59244).
+
+    The bug we pin: ``_spawn_background_review`` builds a whitelist from
+    ``review_toolsets`` (currently just ``[\"skills\", \"memory\"]``),
+    ``skip_memory=True`` disables the provider surface in the fork, so
+    the legacy ``memory`` tool remains the only path. Live provider
+    write tools (``mnemosyne_remember`` etc.) are never whitelisted,
+    so the review writes distilled facts to MEMORY.md even when
+    ``memory.provider`` is set to e.g. mnemosyne.
+    """
+    import run_agent
+    from hermes_cli import plugins as _plugins
+
+    captured = {}
+
+    def _capture_whitelist(whitelist, deny_msg_fmt=None):
+        captured["whitelist"] = set(whitelist)
+        raise RuntimeError("stop after capturing whitelist")
+
+    class _FakeProvider:
+        name = "mnemosyne"
+
+        def get_tool_schemas(self):
+            # The provider advertises two write tools and one read tool.
+            # ALL of them must end up in the whitelist — the review LLM
+            # may legitimately need any of them to write a distilled
+            # memory or summarize recalled context.
+            return [
+                {"name": "mnemosyne_remember", "description": "...", "parameters": {}},
+                {"name": "mnemosyne_recall", "description": "...", "parameters": {}},
+                {"name": "mnemosyne_sleep", "description": "...", "parameters": {}},
+            ]
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+    agent._memory_enabled = True
+    agent._user_profile_enabled = False
+
+    def _no_init(self, *args, **kwargs):
+        return None
+
+    with patch.object(run_agent.AIAgent, "__init__", _no_init), \
+         patch.object(_plugins, "set_thread_tool_whitelist", _capture_whitelist), \
+         patch("plugins.memory._get_active_memory_provider", return_value="mnemosyne"), \
+         patch("plugins.memory.load_memory_provider", return_value=_FakeProvider()), \
+         patch("threading.Thread", _SyncThread):
+        try:
+            agent._spawn_background_review(
+                messages_snapshot=[],
+                review_memory=True,
+                review_skills=False,
+            )
+        except RuntimeError:
+            pass
+
+    # Provider tool names must be in the whitelist alongside the legacy
+    # ``memory`` tool. None of the listed tools are part of the
+    # ``[\"skills\", \"memory\"]`` default toolsets, so they only arrive
+    # through our new provider-aware path.
+    for name in ("mnemosyne_remember", "mnemosyne_recall", "mnemosyne_sleep"):
+        assert name in captured["whitelist"], (
+            f"{name!r} missing from review whitelist — provider-aware "
+            "whitelist extension from #59244 regressed"
+        )
+    # Built-in legacy memory tool still whitelisted
+    # when ``_memory_enabled`` is True.
+    assert "memory" in captured["whitelist"]
+
+
+def test_background_review_whitelist_no_provider_unchanged():
+    """When no provider is configured, the whitelist must still contain
+    exactly the legacy ``memory`` + ``skills`` entries — the new
+    provider-aware path must be a no-op in that case (#59244).
+
+    Stash-regression companion: with the fix removed, this test still
+    passes (makes sure we didn't break the no-provider path while
+    adding the provider-aware one). With the fix removed AND a provider
+    configured, the corresponding test above fails. Pair them to pin
+    both halves of the contract.
+    """
+    import run_agent
+    from hermes_cli import plugins as _plugins
+
+    captured = {}
+
+    def _capture_whitelist(whitelist, deny_msg_fmt=None):
+        captured["whitelist"] = set(whitelist)
+        raise RuntimeError("stop after capturing whitelist")
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+    agent._memory_enabled = True
+    agent._user_profile_enabled = False
+
+    def _no_init(self, *args, **kwargs):
+        return None
+
+    with patch.object(run_agent.AIAgent, "__init__", _no_init), \
+         patch.object(_plugins, "set_thread_tool_whitelist", _capture_whitelist), \
+         patch("plugins.memory._get_active_memory_provider", return_value=None), \
+         patch("threading.Thread", _SyncThread):
+        try:
+            agent._spawn_background_review(
+                messages_snapshot=[],
+                review_memory=True,
+                review_skills=False,
+            )
+        except RuntimeError:
+            pass
+
+    # Same default contract as before — provider-aware path MUST NOT add
+    # any extra entries when no provider is configured.
+    assert "memory" in captured["whitelist"]
+    # ``skills`` shows up only when ``review_skills=True``; with the
+    # call above we passed ``review_skills=False``, so it MUST be absent.
+    assert "skills" not in captured["whitelist"]


### PR DESCRIPTION
## Summary

When ``memory.provider`` is set to ``mnemosyne`` (or any other active external provider), the background review/distillation loop still writes to the legacy ``memory`` tool's short ``MEMORY.md`` file instead of the provider's write tools (``mnemosyne_remember`` etc.). Two root causes:

1. ``agent/background_review.py::_spawn_background_review`` builds ``review_whitelist`` from ``review_toolsets = ["skills", "memory"]`` — the registered memory toolset only contains the legacy ``memory`` tool. The active provider's write tools are not part of those toolsets.
2. ``skip_memory=True`` is intentionally passed into ``AIAgent(...)`` so the review fork's *own* transcript does not autosave into the provider. That's correct, but it does NOT give the review LLM a way to call the provider's write tools either — so the legacy ``memory`` tool remained the only dispatchable option.

The fix adds the active provider's tool names to the existing ``review_whitelist`` after the legacy ``memory`` toolset has populated it. The provider-discovery call goes through the same ``plugins.memory._get_active_memory_provider()`` / ``load_memory_provider()`` helpers the rest of the runtime uses, so this works uniformly for every configured provider (``mnemosyne``, ``honcho``, ``hindsight``, ``holographic``, ``mem0``, ``supermemory``, ``byterover``, ``openviking``, ``retaindb``, …). Provider-discovery failure falls back to the legacy ``memory`` path, so this can never break the review fork.

Keeps ``skip_memory=True`` intact so the review fork prompt itself never autosaves into the provider — only the explicitly-called provider tools do.

## Changes

- ``agent/background_review.py``: read the active provider via ``plugins.memory._get_active_memory_provider()`` / ``load_memory_provider()``, query ``provider.get_tool_schemas()`` for the names, and add them to ``review_whitelist`` around the existing legacy-memory whitelist. All in a structured ``try/except`` so provider-discovery failure is a warning-level debug log, never a fork-failing exception.
- ``tests/run_agent/test_background_review_toolset_restriction.py``:
  - ``test_background_review_whitelist_includes_active_provider_tools`` — provider-aware path adds the provider's advertised tool names (e.g. ``mnemosyne_remember``, ``mnemosyne_recall``, ``mnemosyne_sleep``).
  - ``test_background_review_whitelist_no_provider_unchanged`` — companion: without a provider, the whitelist is unchanged (pins that the new path is opt-in).

## How to Test

```
venv/bin/python -m pytest tests/run_agent/test_background_review_toolset_restriction.py -v
# 7/7 passed (5 pre-existing + 2 new for #59244)

venv/bin/python -m pytest tests/run_agent/test_background_review.py tests/run_agent/test_background_review_cache_parity.py tests/run_agent/test_background_review_cost_controls.py tests/run_agent/test_background_review_summary.py tests/run_agent/test_background_review_toolset_restriction.py tests/test_background_review_session_isolation.py
# 52/52 passed (regression sweep)
```

Stash-regression verified: with ``agent/background_review.py`` reverted, the provider-aware test correctly fails with
``AssertionError: 'mnemosyne_remember' missing from review whitelist`` and the no-provider test still passes — pinning the contract from both sides.

## Checklist

- [x] Tests pass — 52/52 across the full background-review suite
- [x] Follows Conventional Commits
- [x] Cross-platform impact: pure Python, no platform-specific paths
- [x] profile-safe paths used (no path code modified)
- [x] `.env` not used for non-credential settings (config surface unchanged; provider discovery reuses existing helpers)

## Risk & Impact

Low. The legacy ``memory`` tool remains in ``review_whitelist`` when ``_memory_enabled`` is True, so any profile that was working through that path keeps working. A provider-discovery ``try/except`` ensures provider-load failures degrade gracefully to the legacy path. ``skip_memory=True`` is preserved, so the review fork prompt is no longer a source of unintended autosaves into the provider; only the review LLM's *explicit* write calls reach the provider.

Type: Bug fix (provider-aware review + existing memory mirror preserved)
Closes: #59244