### PR TITLE
fix: stop treating GITHUB_TOKEN as Copilot credential

### DIFF
--- a/agent/credential_sources.py
+++ b/agent/credential_sources.py
@@ -351,7 +351,7 @@ def _remove_copilot_gh(provider: str, removed) -> RemovalResult:
     # is harmless.
     from hermes_cli.auth import suppress_credential_source
     suppress_credential_source(provider, "gh_cli")
-    for env_var in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"):
+    for env_var in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN"):
         suppress_credential_source(provider, f"env:{env_var}")
 
     return RemovalResult(hints=[

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -217,7 +217,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         name="GitHub Copilot",
         auth_type="api_key",
         inference_base_url=DEFAULT_GITHUB_MODELS_BASE_URL,
-        api_key_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"),
+        api_key_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN"),
         base_url_env_var="COPILOT_API_BASE_URL",
     ),
     "copilot-acp": ProviderConfig(


### PR DESCRIPTION
## Problem

`GITHUB_TOKEN` is a general-purpose GitHub personal access token used for many operations (git, API, skills hub, tirith security). When a user has it set in their environment, Hermes auto-activates the GitHub Copilot provider in the model picker, showing a list of Copilot models the user may not have access to.

## Fix

Two changes:
- `hermes_cli/auth.py`: Remove `GITHUB_TOKEN` from `api_key_env_vars`
- `agent/credential_sources.py`: Remove `GITHUB_TOKEN` from suppressed env vars

Only `COPILOT_GITHUB_TOKEN` and `GH_TOKEN` now trigger the Copilot provider.