### PR TITLE
fix(dashboard): normalize absolute-form websocket paths

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -253,6 +253,31 @@ def _get_pty_active_session_files(app: "FastAPI") -> dict[str, Path]:
 
 app = FastAPI(title="Hermes Agent", version=__version__, lifespan=_lifespan)
 
+
+class _WsAbsoluteUriMiddleware:
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope.get("type") == "websocket":
+            path = str(scope.get("path", "") or "")
+            if path.startswith(("ws://", "wss://")):
+                parsed = urllib.parse.urlsplit(path)
+                normalised_path = parsed.path or "/"
+                scope = dict(scope)
+                scope["path"] = normalised_path
+                scope["raw_path"] = normalised_path.encode("ascii", "surrogateescape")
+                _log.debug(
+                    "websocket absolute-uri normalised peer=%s:%s from=%s to=%s",
+                    *((scope.get("client") or ("?", "?"))[:2]),
+                    path,
+                    normalised_path,
+                )
+        await self.app(scope, receive, send)
+
+
+app.add_middleware(_WsAbsoluteUriMiddleware)
+
 # Memory-provider OAuth connect routes live in the memory layer, not here.
 from hermes_cli.memory_oauth import router as _memory_oauth_router  # noqa: E402
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -267,6 +267,10 @@ class _WsAbsoluteUriMiddleware:
                 scope = dict(scope)
                 scope["path"] = normalised_path
                 scope["raw_path"] = normalised_path.encode("ascii", "surrogateescape")
+                if parsed.query and not scope.get("query_string"):
+                    scope["query_string"] = parsed.query.encode(
+                        "ascii", "surrogateescape"
+                    )
                 _log.debug(
                     "websocket absolute-uri normalised peer=%s:%s from=%s to=%s",
                     *((scope.get("client") or ("?", "?"))[:2]),

--- a/tests/hermes_cli/test_web_server_ws_absolute_uri.py
+++ b/tests/hermes_cli/test_web_server_ws_absolute_uri.py
@@ -1,5 +1,6 @@
 import pytest
 
+from hermes_cli.dashboard_auth.ws_tickets import mint_ticket
 from hermes_cli.web_server import _WsAbsoluteUriMiddleware
 
 
@@ -13,8 +14,9 @@ async def test_ws_absolute_uri_path_is_normalized_before_routing():
     middleware = _WsAbsoluteUriMiddleware(downstream)
     scope = {
         "type": "websocket",
-        "path": "ws://192.168.1.15:9119/api/ws",
-        "raw_path": b"ws://192.168.1.15:9119/api/ws",
+        "path": "ws://192.168.1.15:9119/api/ws?ticket=abc123",
+        "raw_path": b"ws://192.168.1.15:9119/api/ws?ticket=abc123",
+        "query_string": b"",
         "client": ("192.168.1.9", 62493),
         "headers": [],
     }
@@ -29,7 +31,8 @@ async def test_ws_absolute_uri_path_is_normalized_before_routing():
 
     assert captured_scope["path"] == "/api/ws"
     assert captured_scope["raw_path"] == b"/api/ws"
-    assert scope["path"] == "ws://192.168.1.15:9119/api/ws"
+    assert captured_scope["query_string"] == b"ticket=abc123"
+    assert scope["path"] == "ws://192.168.1.15:9119/api/ws?ticket=abc123"
 
 
 @pytest.mark.asyncio
@@ -58,3 +61,94 @@ async def test_ws_origin_form_path_is_left_unchanged():
 
     assert captured_scope["path"] == "/api/events"
     assert captured_scope["raw_path"] == b"/api/events"
+
+
+def _make_scope(path: str) -> dict:
+    return {
+        "type": "websocket",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "scheme": "ws",
+        "http_version": "1.1",
+        "path": path,
+        "raw_path": path.encode("ascii"),
+        "query_string": b"",
+        "root_path": "",
+        "client": ("192.168.1.24", 53142),
+        "server": ("192.168.1.15", 9119),
+        "headers": [
+            (b"host", b"192.168.1.15:9119"),
+            (b"origin", b"http://192.168.1.15:9119"),
+        ],
+        "subprotocols": [],
+    }
+
+
+async def _drive_app(app, scope: dict) -> list[dict]:
+    sent: list[dict] = []
+    received = iter(
+        [
+            {"type": "websocket.connect"},
+            {"type": "websocket.disconnect", "code": 1000},
+        ]
+    )
+
+    async def receive():
+        try:
+            return next(received)
+        except StopIteration:
+            return {"type": "websocket.disconnect", "code": 1000}
+
+    async def send(message):
+        sent.append(message)
+
+    await app(scope, receive, send)
+    return sent
+
+
+@pytest.mark.asyncio
+async def test_absolute_form_ws_route_accepts_ticket(monkeypatch):
+    import hermes_cli.web_server as web_server
+
+    async def fake_handle_ws(ws):
+        await ws.accept()
+        await ws.close(code=1000)
+
+    monkeypatch.setattr(web_server.app.state, "auth_required", True, raising=False)
+    monkeypatch.setattr(
+        web_server.app.state, "bound_host", "192.168.1.15", raising=False
+    )
+    monkeypatch.setattr("tui_gateway.ws.handle_ws", fake_handle_ws)
+
+    ticket = mint_ticket(user_id="pytest", provider="pytest")
+    sent = await _drive_app(
+        web_server.app,
+        _make_scope(f"ws://192.168.1.15:9119/api/ws?ticket={ticket}"),
+    )
+
+    assert any(msg["type"] == "websocket.accept" for msg in sent)
+    assert sent[-1]["type"] == "websocket.close"
+    assert sent[-1]["code"] == 1000
+    assert all(msg.get("code") not in {4401, 4403, 4408} for msg in sent)
+
+
+@pytest.mark.asyncio
+async def test_absolute_form_pty_route_accepts_ticket(monkeypatch):
+    import hermes_cli.web_server as web_server
+
+    monkeypatch.setattr(web_server.app.state, "auth_required", True, raising=False)
+    monkeypatch.setattr(
+        web_server.app.state, "bound_host", "192.168.1.15", raising=False
+    )
+    monkeypatch.setattr(web_server, "_PTY_BRIDGE_AVAILABLE", False)
+
+    ticket = mint_ticket(user_id="pytest", provider="pytest")
+    sent = await _drive_app(
+        web_server.app,
+        _make_scope(f"ws://192.168.1.15:9119/api/pty?ticket={ticket}"),
+    )
+
+    assert any(msg["type"] == "websocket.accept" for msg in sent)
+    assert any(msg["type"] == "websocket.send" for msg in sent)
+    assert sent[-1]["type"] == "websocket.close"
+    assert sent[-1]["code"] == 1011
+    assert all(msg.get("code") not in {4401, 4403, 4408} for msg in sent)

--- a/tests/hermes_cli/test_web_server_ws_absolute_uri.py
+++ b/tests/hermes_cli/test_web_server_ws_absolute_uri.py
@@ -1,0 +1,60 @@
+import pytest
+
+from hermes_cli.web_server import _WsAbsoluteUriMiddleware
+
+
+@pytest.mark.asyncio
+async def test_ws_absolute_uri_path_is_normalized_before_routing():
+    captured_scope = {}
+
+    async def downstream(scope, receive, send):
+        captured_scope.update(scope)
+
+    middleware = _WsAbsoluteUriMiddleware(downstream)
+    scope = {
+        "type": "websocket",
+        "path": "ws://192.168.1.15:9119/api/ws",
+        "raw_path": b"ws://192.168.1.15:9119/api/ws",
+        "client": ("192.168.1.9", 62493),
+        "headers": [],
+    }
+
+    async def receive():
+        return {"type": "websocket.disconnect"}
+
+    async def send(message):
+        return None
+
+    await middleware(scope, receive, send)
+
+    assert captured_scope["path"] == "/api/ws"
+    assert captured_scope["raw_path"] == b"/api/ws"
+    assert scope["path"] == "ws://192.168.1.15:9119/api/ws"
+
+
+@pytest.mark.asyncio
+async def test_ws_origin_form_path_is_left_unchanged():
+    captured_scope = {}
+
+    async def downstream(scope, receive, send):
+        captured_scope.update(scope)
+
+    middleware = _WsAbsoluteUriMiddleware(downstream)
+    scope = {
+        "type": "websocket",
+        "path": "/api/events",
+        "raw_path": b"/api/events",
+        "client": ("127.0.0.1", 12345),
+        "headers": [],
+    }
+
+    async def receive():
+        return {"type": "websocket.disconnect"}
+
+    async def send(message):
+        return None
+
+    await middleware(scope, receive, send)
+
+    assert captured_scope["path"] == "/api/events"
+    assert captured_scope["raw_path"] == b"/api/events"


### PR DESCRIPTION
## What does this PR do?

Fixes dashboard chat WebSocket routing for LAN/iPhone Safari clients that provide an absolute-form WebSocket path in the ASGI scope, for example:

`ws://192.168.1.15:9119/api/ws`

instead of the origin-form path expected by FastAPI routing:

`/api/ws`

When this happens, `/api/ws`, `/api/events`, and `/api/pty` do not dispatch, even though the dashboard auth cookie and `/api/auth/ws-ticket` request succeed. The visible symptoms are `closed`, `Chat connection interrupted (code 1006)`, or `events feed disconnected` in the dashboard chat.

The fix adds a small ASGI middleware that normalizes only WebSocket paths beginning with `ws://` or `wss://` before route matching. Normal origin-form paths are left unchanged.

## Related Issue

Related: #15731, #32615

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Added WebSocket absolute URI path normalization in `hermes_cli/web_server.py`.
- Added regression coverage in `tests/hermes_cli/test_web_server_ws_absolute_uri.py`.

## How to Test

1. Run the targeted regression tests:
   `./venv/bin/python -m pytest tests/hermes_cli/test_web_server_ws_absolute_uri.py -q`
2. Run existing dashboard websocket auth coverage:
   `./venv/bin/python -m pytest tests/hermes_cli/test_dashboard_auth_ws_auth.py -q`
3. Manual LAN verification:
   - Start dashboard with `hermes dashboard --host 0.0.0.0 --port 9119 --no-open`
   - Open `http://<mac-lan-ip>:9119/chat` from iPhone Safari
   - Confirm `/api/ws`, `/api/events`, and `/api/pty` connect and chat no longer loops on `closed` / `1006` / `events feed disconnected`

## Screenshots / Logs

Observed before the fix: iPhone Safari opened WebSocket scopes whose path was an absolute URI such as `ws://192.168.1.15:9119/api/ws`, which missed FastAPI route matching.

Observed after the fix: the absolute URI path is normalized to `/api/ws`, `/api/events`, or `/api/pty`, and the dashboard chat WebSocket routes are accepted.
