### PR TITLE
fix(agent): recover leaked clarify JSON envelopes

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -25,6 +25,7 @@ import ssl
 import threading
 import time
 import uuid
+from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
@@ -46,6 +47,7 @@ from agent.message_sanitization import (
     _sanitize_tools_non_ascii,
     _strip_images_from_messages,
     _strip_non_ascii,
+    recover_plaintext_tool_call,
 )
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
@@ -4234,6 +4236,32 @@ def run_conversation(
                     assistant_message.content = "\n".join(parts)
                 else:
                     assistant_message.content = str(raw)
+
+            if not getattr(assistant_message, "tool_calls", None):
+                recovered_tool_call = recover_plaintext_tool_call(
+                    assistant_message.content or "",
+                    agent.tools,
+                )
+                if recovered_tool_call:
+                    tool_name = recovered_tool_call["name"]
+                    assistant_message.tool_calls = [
+                        SimpleNamespace(
+                            id=f"call_recovered_{uuid.uuid4().hex[:12]}",
+                            type="function",
+                            function=SimpleNamespace(
+                                name=tool_name,
+                                arguments=recovered_tool_call["arguments"],
+                            ),
+                        )
+                    ]
+                    assistant_message.content = None
+                    finish_reason = "tool_calls"
+                    logger.warning(
+                        "Recovered plaintext JSON envelope as %s tool_call "
+                        "(session=%s)",
+                        tool_name,
+                        agent.session_id or "none",
+                    )
 
             try:
                 from hermes_cli.plugins import (

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -26,6 +26,8 @@ logger = logging.getLogger(__name__)
 # below as well as by run_agent and the CLI for paste-from-clipboard
 # scrubbing.
 _SURROGATE_RE = re.compile(r'[\ud800-\udfff]')
+_TOOL_NAME_KEYS = ("action", "tool", "tool_name", "name", "function", "function_name")
+_PLAINTEXT_TOOL_RECOVERY_ALLOWLIST = frozenset({"clarify"})
 
 
 def _sanitize_surrogates(text: str) -> str:
@@ -277,6 +279,134 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
         tool_name, raw_stripped[:80],
     )
     return "{}"
+
+
+def _strip_json_code_fence(content: str) -> str:
+    stripped = content.strip()
+    if not stripped.startswith("```") or not stripped.endswith("```"):
+        return stripped
+
+    lines = stripped.splitlines()
+    if len(lines) < 2:
+        return stripped
+    opener = lines[0].strip().lower()
+    if opener not in {"```", "```json", "```javascript", "```js"}:
+        return stripped
+    if lines[-1].strip() != "```":
+        return stripped
+    return "\n".join(lines[1:-1]).strip()
+
+
+def _load_plaintext_json_object(content: str) -> dict[str, Any] | None:
+    if not isinstance(content, str) or not content.strip():
+        return None
+    stripped = _strip_json_code_fence(content)
+    try:
+        parsed = json.loads(stripped)
+    except (TypeError, ValueError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _tool_schema_by_name(tools: list | None) -> dict[str, dict[str, Any]]:
+    schemas: dict[str, dict[str, Any]] = {}
+    for tool in tools or []:
+        if not isinstance(tool, dict):
+            continue
+        function = tool.get("function")
+        if not isinstance(function, dict):
+            continue
+        name = function.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        parameters = function.get("parameters")
+        schemas[name] = parameters if isinstance(parameters, dict) else {}
+    return schemas
+
+
+def _explicit_tool_name(payload: dict[str, Any], valid_names: set[str]) -> str | None:
+    for key in _TOOL_NAME_KEYS:
+        value = payload.get(key)
+        if isinstance(value, str) and value in valid_names:
+            return value
+        if key == "function" and isinstance(value, dict):
+            nested_name = value.get("name")
+            if isinstance(nested_name, str) and nested_name in valid_names:
+                return nested_name
+    return None
+
+
+def _arguments_for_tool(
+    payload: dict[str, Any],
+    tool_name: str,
+    schema: dict[str, Any],
+) -> dict[str, Any] | None:
+    source = payload
+    function_value = payload.get("function")
+    if isinstance(function_value, dict) and function_value.get("name") == tool_name:
+        nested_args = function_value.get("arguments")
+        if isinstance(nested_args, dict):
+            source = nested_args
+
+    properties = schema.get("properties")
+    property_names = set(properties) if isinstance(properties, dict) else set()
+    required = schema.get("required")
+    required_names = {
+        item for item in required
+        if isinstance(item, str)
+    } if isinstance(required, list) else set()
+
+    if property_names:
+        arguments = {
+            key: value
+            for key, value in source.items()
+            if key in property_names
+        }
+    else:
+        arguments = {
+            key: value
+            for key, value in source.items()
+            if key not in _TOOL_NAME_KEYS
+        }
+
+    if not required_names.issubset(arguments):
+        return None
+    return arguments
+
+
+def recover_plaintext_tool_call(content: str, tools: list | None) -> dict[str, str] | None:
+    """Recover an explicit tool-call JSON envelope emitted as assistant text.
+
+    Weak local models can occasionally print a JSON object like
+    ``{"action":"clarify","question":"...","choices":[...]}`` in assistant
+    content instead of using the structured ``tool_calls`` field.  This guard
+    is intentionally conservative: the visible content must be a complete JSON
+    object (or a fenced JSON object), that object must name a real enabled tool
+    via a tool-name field, and the tool must be safe-listed for plaintext
+    recovery.  Extra envelope keys such as ``action`` are not forwarded as tool
+    arguments.
+    """
+    payload = _load_plaintext_json_object(content)
+    if not payload:
+        return None
+
+    schemas = {
+        name: schema
+        for name, schema in _tool_schema_by_name(tools).items()
+        if name in _PLAINTEXT_TOOL_RECOVERY_ALLOWLIST
+    }
+    tool_name = _explicit_tool_name(payload, set(schemas))
+    if not tool_name:
+        return None
+
+    arguments = _arguments_for_tool(payload, tool_name, schemas.get(tool_name, {}))
+    if arguments is None:
+        return None
+
+    return {
+        "name": tool_name,
+        "arguments": json.dumps(arguments, ensure_ascii=False, separators=(",", ":")),
+    }
 
 
 def close_interrupted_tool_sequence(messages: list, final_response: Any = None) -> bool:

--- a/tests/run_agent/test_plaintext_tool_call_recovery.py
+++ b/tests/run_agent/test_plaintext_tool_call_recovery.py
@@ -1,0 +1,142 @@
+"""Tests for recovering tool-call-shaped JSON emitted as assistant text."""
+
+import json
+from types import SimpleNamespace
+
+from agent.message_sanitization import recover_plaintext_tool_call
+
+
+CLARIFY_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "clarify",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "question": {"type": "string"},
+                "choices": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": ["question"],
+        },
+    },
+}
+
+TERMINAL_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "terminal",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "command": {"type": "string"},
+            },
+            "required": ["command"],
+        },
+    },
+}
+
+
+def test_recovers_explicit_action_envelope_as_tool_call():
+    recovered = recover_plaintext_tool_call(
+        '{"action":"clarify","question":"Pick one","choices":["A","B"]}',
+        [CLARIFY_TOOL],
+    )
+
+    assert recovered is not None
+    assert recovered["name"] == "clarify"
+    assert json.loads(recovered["arguments"]) == {
+        "question": "Pick one",
+        "choices": ["A", "B"],
+    }
+
+
+def test_recovers_fenced_action_envelope():
+    recovered = recover_plaintext_tool_call(
+        '```json\n{"action":"clarify","question":"Pick one"}\n```',
+        [CLARIFY_TOOL],
+    )
+
+    assert recovered is not None
+    assert recovered["name"] == "clarify"
+    assert json.loads(recovered["arguments"]) == {"question": "Pick one"}
+
+
+def test_does_not_recover_unmarked_json_answer():
+    assert recover_plaintext_tool_call(
+        '{"question":"What did the report ask?","answer":"Pick A"}',
+        [CLARIFY_TOOL],
+    ) is None
+
+
+def test_does_not_recover_when_required_arguments_missing():
+    assert recover_plaintext_tool_call(
+        '{"action":"clarify","choices":["A","B"]}',
+        [CLARIFY_TOOL],
+    ) is None
+
+
+def test_does_not_recover_non_allowlisted_tool_envelope():
+    assert recover_plaintext_tool_call(
+        '{"action":"terminal","command":"echo should-not-run"}',
+        [TERMINAL_TOOL],
+    ) is None
+
+
+def _response(content: str, *, finish_reason: str = "stop"):
+    assistant = SimpleNamespace(content=content, reasoning=None, tool_calls=[])
+    choice = SimpleNamespace(message=assistant, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], usage=None, model="test/model")
+
+
+class _FakeChatCompletions:
+    def __init__(self):
+        self.calls = 0
+
+    def create(self, **kwargs):
+        self.calls += 1
+        if self.calls == 1:
+            return _response(
+                '{"action":"clarify","question":"Pick one","choices":["A","B"]}'
+            )
+        return _response("Thanks, continuing with A.")
+
+
+class _FakeClient:
+    def __init__(self):
+        self.chat = SimpleNamespace(completions=_FakeChatCompletions())
+
+
+def test_loop_dispatches_recovered_plaintext_tool_call(monkeypatch):
+    from run_agent import AIAgent
+
+    clarify_calls = []
+
+    def _clarify(question, choices):
+        clarify_calls.append((question, choices))
+        return "A"
+
+    fake_client = _FakeClient()
+    monkeypatch.setattr("run_agent.OpenAI", lambda **kwargs: fake_client)
+    monkeypatch.setattr(
+        "run_agent.get_tool_definitions",
+        lambda *args, **kwargs: [CLARIFY_TOOL],
+    )
+
+    agent = AIAgent(
+        model="test-model",
+        api_key="test-key",
+        base_url="http://localhost:8080/v1",
+        platform="telegram",
+        max_iterations=3,
+        quiet_mode=True,
+        skip_memory=True,
+        skip_context_files=True,
+        clarify_callback=_clarify,
+    )
+    agent._disable_streaming = True
+
+    result = agent.run_conversation("ambiguous request")
+
+    assert clarify_calls == [("Pick one", ["A", "B"])]
+    assert result["final_response"].startswith("Thanks")
+    assert '{"action":"clarify"' not in result["final_response"]


### PR DESCRIPTION
## What does this PR do?

Recovers a narrow local-model failure mode where the model emits a clarify-shaped JSON envelope as assistant text instead of a structured tool call, for example:

```json
{"action":"clarify","question":"...","choices":[...]}
```

When that exact class appears as a complete JSON object or fenced JSON object, Hermes now converts it back into a normal `clarify` tool call before assistant text is displayed or returned to messaging gateways. The recovery is intentionally allowlisted to `clarify` so arbitrary tool-shaped JSON cannot become terminal/file/etc. execution.

## Related Issue

Fixes #59291

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/message_sanitization.py`: add conservative plaintext JSON recovery for explicit `clarify` envelopes, filtering arguments through the enabled tool schema.
- `agent/conversation_loop.py`: recover the envelope before visible assistant output, synthesize a normal tool call, and reuse existing tool validation/execution.
- `tests/run_agent/test_plaintext_tool_call_recovery.py`: cover recovered clarify envelopes, fenced JSON, non-matching JSON, missing required fields, non-allowlisted tools, and the loop dispatch path.

## How to Test

1. Run `pytest tests/run_agent/test_plaintext_tool_call_recovery.py tests/run_agent/test_repair_tool_call_arguments.py -q`.
2. Run `python -m py_compile agent/message_sanitization.py agent/conversation_loop.py tests/run_agent/test_plaintext_tool_call_recovery.py`.
3. Run `ruff check agent/message_sanitization.py agent/conversation_loop.py tests/run_agent/test_plaintext_tool_call_recovery.py`.
4. Run `git diff --check`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS local test lane

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted validation:

```text
pytest tests/run_agent/test_plaintext_tool_call_recovery.py tests/run_agent/test_repair_tool_call_arguments.py -q
27 passed in 33.78s
```

Also passed:

```text
python -m py_compile agent/message_sanitization.py agent/conversation_loop.py tests/run_agent/test_plaintext_tool_call_recovery.py
ruff check agent/message_sanitization.py agent/conversation_loop.py tests/run_agent/test_plaintext_tool_call_recovery.py
git diff --check
```