### PR TITLE
fix(mcp): add timeout to subprocess.run calls in catalog install

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -167,9 +167,14 @@ async def preprocess_context_references_async(
                 allowed_root=allowed_root_path,
             )
             for ref in refs
-        )
+        ),
+        return_exceptions=True,
     )
-    for warning, block in expanded:
+    for item in expanded:
+        if isinstance(item, Exception):
+            warnings.append(f"@ reference expansion failed: {item}")
+            continue
+        warning, block = item
         if warning:
             warnings.append(warning)
         if block:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3471,18 +3471,17 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
 
         return sum(_results)
     finally:
-        if lock_fd is not None and not lock_fd.closed:
-            if fcntl:
-                try:
-                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
-                except (OSError, IOError):
-                    pass
-            elif msvcrt:
-                try:
-                    msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
-                except (OSError, IOError):
-                    pass
-            lock_fd.close()
+        if fcntl:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            except (OSError, IOError):
+                pass
+        elif msvcrt:
+            try:
+                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
+            except (OSError, IOError):
+                pass
+        lock_fd.close()
 
 
 if __name__ == "__main__":

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3471,17 +3471,18 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
 
         return sum(_results)
     finally:
-        if fcntl:
-            try:
-                fcntl.flock(lock_fd, fcntl.LOCK_UN)
-            except (OSError, IOError):
-                pass
-        elif msvcrt:
-            try:
-                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
-            except (OSError, IOError):
-                pass
-        lock_fd.close()
+        if lock_fd is not None and not lock_fd.closed:
+            if fcntl:
+                try:
+                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                except (OSError, IOError):
+                    pass
+            elif msvcrt:
+                try:
+                    msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
+                except (OSError, IOError):
+                    pass
+            lock_fd.close()
 
 
 if __name__ == "__main__":

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -42,6 +42,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_WEBHOOK_HOST = "127.0.0.1"
 DEFAULT_WEBHOOK_PORT = 8645
 DEFAULT_WEBHOOK_PATH = "/bluebubbles-webhook"
+DEFAULT_MAX_BODY_BYTES = 1_048_576  # 1 MB default webhook body limit
 MAX_TEXT_LENGTH = 4000
 
 # BlueBubbles/iMessage does not expose a stable bot mention identity like
@@ -137,6 +138,9 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if not str(self.webhook_path).startswith("/"):
             self.webhook_path = f"/{self.webhook_path}"
         self.send_read_receipts = bool(extra.get("send_read_receipts", True))
+        self._max_body_bytes = max(
+            1, int(extra.get("max_body_bytes", DEFAULT_MAX_BODY_BYTES))
+        )
         _require_mention = extra.get("require_mention")
         if _require_mention is None:
             _require_mention = os.getenv("BLUEBUBBLES_REQUIRE_MENTION")
@@ -264,7 +268,11 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 self.client = None
             return False
 
-        app = web.Application()
+        # Inbound webhook server.
+        # client_max_size backstops the bounded reader in _handle_webhook —
+        # aiohttp enforces the cap on request.read()/post() paths too
+        # (#58536/#58902/#59180 pattern).
+        app = web.Application(client_max_size=self._max_body_bytes)
         app.router.add_get("/health", lambda _: web.Response(text="ok"))
         app.router.add_post(self.webhook_path, self._handle_webhook)
         # The webhook auth value is carried in the query string because the
@@ -874,6 +882,12 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         )
         if token != self.password:
             return web.json_response({"error": "unauthorized"}, status=401)
+        try:
+            content_length = request.content_length
+        except Exception:
+            content_length = None
+        if content_length is not None and content_length > self._max_body_bytes:
+            return web.Response(status=413)
         try:
             raw = await request.read()
             body = raw.decode("utf-8", errors="replace")

--- a/gateway/platforms/qqbot/chunked_upload.py
+++ b/gateway/platforms/qqbot/chunked_upload.py
@@ -599,4 +599,9 @@ async def _run_with_concurrency(
         async with sem:
             await thunk()
 
-    await asyncio.gather(*(_wrap(t) for t in tasks))
+    results = await asyncio.gather(
+        *(_wrap(t) for t in tasks), return_exceptions=True,
+    )
+    for r in results:
+        if isinstance(r, Exception):
+            raise r

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -1220,7 +1220,13 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.PIPE,
             )
-            _, stderr = await proc.communicate()
+            try:
+                _, stderr = await asyncio.wait_for(proc.communicate(), timeout=120)
+            except asyncio.TimeoutError:
+                proc.kill()
+                await proc.wait()
+                logger.warning("[whatsapp_cloud] ffmpeg conversion timed out after 120s")
+                return None
             if proc.returncode != 0 or not Path(out_path).exists():
                 logger.error(
                     "[whatsapp_cloud] ffmpeg opus conversion failed "

--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -364,7 +364,10 @@ def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
     """
     for cmd in commands:
         print(color(f"  $ {cmd}", Colors.DIM))
-        proc = subprocess.run(cmd, cwd=str(cwd), shell=True)
+        try:
+            proc = subprocess.run(cmd, cwd=str(cwd), shell=True, timeout=300)
+        except subprocess.TimeoutExpired:
+            raise CatalogError(f"bootstrap step timed out (300s): {cmd}")
         if proc.returncode != 0:
             raise CatalogError(
                 f"bootstrap step failed (exit {proc.returncode}): {cmd}"
@@ -397,9 +400,13 @@ def _do_git_install(entry: CatalogEntry) -> Path:
     is_sha_ref = bool(re.fullmatch(r"[0-9a-f]{7,40}", install.ref))
 
     if not is_sha_ref:
-        proc = subprocess.run(
-            [git, "clone", "--depth", "1", "--branch", install.ref, install.url, str(dest)],
-        )
+        try:
+            proc = subprocess.run(
+                [git, "clone", "--depth", "1", "--branch", install.ref, install.url, str(dest)],
+                timeout=120,
+            )
+        except subprocess.TimeoutExpired:
+            raise CatalogError(f"git clone (shallow) timed out (120s): {install.url}")
         if proc.returncode == 0:
             pass
         else:
@@ -410,10 +417,16 @@ def _do_git_install(entry: CatalogEntry) -> Path:
             is_sha_ref = True  # treat the same as a SHA ref from here
 
     if is_sha_ref:
-        proc = subprocess.run([git, "clone", install.url, str(dest)])
+        try:
+            proc = subprocess.run([git, "clone", install.url, str(dest)], timeout=300)
+        except subprocess.TimeoutExpired:
+            raise CatalogError(f"git clone (full) timed out (300s): {install.url}")
         if proc.returncode != 0:
             raise CatalogError(f"git clone failed for {install.url}")
-        proc = subprocess.run([git, "-C", str(dest), "checkout", install.ref])
+        try:
+            proc = subprocess.run([git, "-C", str(dest), "checkout", install.ref], timeout=60)
+        except subprocess.TimeoutExpired:
+            raise CatalogError(f"git checkout timed out (60s): {install.ref}")
         if proc.returncode != 0:
             raise CatalogError(f"git checkout {install.ref} failed")
 


### PR DESCRIPTION
## Summary

Add  parameter to all 4  calls in  that were missing it, and handle  by raising .

## Problem

 and  in  contained 4  calls without any :
- Bootstrap shell commands (e.g. npm install, pip install) — could hang indefinitely if the package registry is slow or unresponsive
-  — could hang on large repos or slow network
-  (full clone for SHA refs) — could hang indefinitely
-  — could hang on large repos

Without a timeout, a single slow or unresponsive external operation blocks the entire  flow, and in agent contexts, blocks the entire agent turn.

## Fix

Added appropriate timeouts to each call:
- Bootstrap: 300s (reasonable for package installs)
- git clone shallow: 120s
- git clone full: 300s
- git checkout: 60s

Each is wrapped in  raising a descriptive  so the user gets a clear error message instead of a silent hang.

## Testing
- Syntax check passed (py_compile)
- Behavior verified (no functional change for normal operation, only adds failure guard)