### PR TITLE
fix(mcp): POST probe fallback in preflight + skip_preflight opt-out (salvage #37598, #55203)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1208,6 +1208,8 @@ AUTHOR_MAP = {
     "r2668940489@gmail.com": "r266-tech",
     "r266-tech@users.noreply.github.com": "r266-tech",  # PR #55780 salvage (dead-target not_found blast radius)
     "s5460703@gmail.com": "BlackishGreen33",
+    "84022+gnodet@users.noreply.github.com": "gnodet",  # PR #37598 salvage (MCP preflight POST probe fallback)
+    "kaishi00@users.noreply.github.com": "kaishi00",  # PR #55203 salvage (skip_preflight opt-out)
     "sberan@gmail.com": "sberan",  # PR #54494 salvage (--connect-timeout flag on hermes mcp add)
     "michaelmusser@users.noreply.github.com": "labsobsidian",  # PR #56699 salvage (MCP OAuth login connect_timeout floor)
     "saul.jj.wu@gmail.com": "SaulJWu",

--- a/tests/tools/test_mcp_preflight_content_type.py
+++ b/tests/tools/test_mcp_preflight_content_type.py
@@ -305,6 +305,41 @@ def test_run_skips_preflight_for_oauth(monkeypatch):
     )
 
 
+def test_run_skips_preflight_when_skip_preflight_set(monkeypatch):
+    """``skip_preflight: true`` in server config bypasses the probe entirely.
+
+    Escape hatch for valid Streamable HTTP servers whose HEAD/GET answers a
+    non-MCP content type (and whose POST probe still can't be validated, e.g.
+    non-OAuth auth schemes the probe headers don't satisfy).
+    """
+    import tools.mcp_tool as _mcp
+
+    preflight_calls: list[str] = []
+
+    async def _inner():
+        async def _fake_preflight(self, url, **kwargs):
+            preflight_calls.append(url)
+
+        async def _fake_run_http(self, config):
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(_mcp, "_validate_remote_mcp_url", lambda n, u: None)
+        monkeypatch.setattr(_mcp.MCPServerTask, "_preflight_content_type", _fake_preflight)
+        monkeypatch.setattr(_mcp.MCPServerTask, "_run_http", _fake_run_http)
+
+        task = _mcp.MCPServerTask("skip-preflight-test")
+        with pytest.raises(asyncio.CancelledError):
+            await task.run({
+                "url": "https://mcp.example.com/mcp",
+                "skip_preflight": True,
+            })
+
+    asyncio.run(_inner())
+    assert preflight_calls == [], (
+        "_preflight_content_type must not be called when skip_preflight is set"
+    )
+
+
 def test_ssl_verify_and_cert_forwarded(monkeypatch):
     captured: dict = {}
 

--- a/tests/tools/test_mcp_preflight_content_type.py
+++ b/tests/tools/test_mcp_preflight_content_type.py
@@ -5,8 +5,8 @@ HTTP server (via httpx's ASGI/transport plumbing through a stdlib server),
 rather than reimplementing the probe inline. That distinction matters: the
 production probe must run on its own httpx client outside the MCP SDK's anyio
 task group, and a faithful test must exercise that actual method so the
-content-type allow-list, HEAD->GET fallback, and best-effort pass-through are
-all covered as shipped.
+content-type allow-list, HEAD->GET fallback, POST probe fallback, and
+best-effort pass-through are all covered as shipped.
 
 OAuth note
 ----------
@@ -56,12 +56,19 @@ def _serve(handler_cls):
 
 def _handler(status: int = 200,
              content_type: "str | None" = "text/html; charset=utf-8",
-             body: bytes = b"<html>x</html>", head_status=None, record=None):
+             body: bytes = b"<html>x</html>", head_status=None, record=None,
+             post_content_type: "str | None" = None,
+             post_body: bytes = b"",
+             post_status: "int | None" = None):
     """Build a BaseHTTPRequestHandler that replies with the given shape.
 
     ``head_status`` lets HEAD return a different status than GET (to exercise
     the HEAD->GET fallback). ``record`` is an optional list that captures the
     HTTP methods the server actually saw.
+
+    ``post_content_type`` / ``post_body`` / ``post_status`` let POST return a
+    different response than HEAD/GET (to exercise the POST probe fallback for
+    servers that serve HTML on GET but speak MCP via POST).
     """
 
     class _H(http.server.BaseHTTPRequestHandler):
@@ -84,6 +91,18 @@ def _handler(status: int = 200,
             if record is not None:
                 record.append("GET")
             self._write(status, content_type, body)
+
+        def do_POST(self):
+            if record is not None:
+                record.append("POST")
+            # Read and discard request body to avoid broken pipe.
+            length = int(self.headers.get("Content-Length", 0))
+            if length:
+                self.rfile.read(length)
+            sc = post_status if post_status is not None else status
+            ct = post_content_type if post_content_type is not None else content_type
+            pb = post_body if post_body else body
+            self._write(sc, ct, pb)
 
         def log_message(self, format, *args):  # noqa: A002
             pass
@@ -190,6 +209,7 @@ def test_cancelled_error_is_not_swallowed():
 # ---------------------------------------------------------------------------
 
 def test_head_405_falls_back_to_get_and_rejects_html():
+    """HEAD→405, GET→html, POST probe also returns html → reject."""
     task = _make_task("fallback_srv")
     record: list[str] = []
     with _serve(_handler(
@@ -198,7 +218,8 @@ def test_head_405_falls_back_to_get_and_rejects_html():
     )) as base:
         with pytest.raises(NonMcpEndpointError):
             asyncio.run(task._preflight_content_type(f"{base}/", timeout=5.0))
-    assert record == ["HEAD", "GET"]
+    # HEAD → 405, falls back to GET (html), then POST probe (also html) → reject.
+    assert record == ["HEAD", "GET", "POST"]
 
 
 def test_head_501_falls_back_to_get_and_passes_json():
@@ -313,3 +334,78 @@ def test_ssl_verify_and_cert_forwarded(monkeypatch):
     assert captured.get("verify") is False
     assert captured.get("cert") == "/path/to/cert.pem"
     assert captured.get("follow_redirects") is True
+
+
+# ---------------------------------------------------------------------------
+# POST probe fallback for POST-only MCP servers
+# ---------------------------------------------------------------------------
+
+def test_post_probe_rescues_html_head_with_json_post():
+    """HEAD returns text/html but POST returns application/json → pass."""
+    task = _make_task()
+    record: list[str] = []
+    with _serve(_handler(
+        status=200, content_type="text/html",
+        post_content_type="application/json; charset=utf-8",
+        post_body=b'{"jsonrpc":"2.0","id":"_probe","result":{}}',
+        record=record,
+    )) as base:
+        # Must not raise — the POST probe should rescue this.
+        asyncio.run(task._preflight_content_type(f"{base}/mcp", timeout=5.0))
+    assert "HEAD" in record
+    assert "POST" in record
+
+
+def test_post_probe_rescues_html_head_with_event_stream_post():
+    """HEAD returns text/html but POST returns text/event-stream → pass."""
+    task = _make_task()
+    with _serve(_handler(
+        status=200, content_type="text/html",
+        post_content_type="text/event-stream",
+        post_body=b"data: {}\n\n",
+    )) as base:
+        asyncio.run(task._preflight_content_type(f"{base}/mcp", timeout=5.0))
+
+
+def test_post_probe_still_rejects_when_post_also_returns_html():
+    """HEAD and POST both return text/html → reject."""
+    task = _make_task("both_html")
+    with _serve(_handler(
+        status=200, content_type="text/html",
+        post_content_type="text/html",
+        post_body=b"<html>nope</html>",
+    )) as base:
+        with pytest.raises(NonMcpEndpointError):
+            asyncio.run(task._preflight_content_type(f"{base}/", timeout=5.0))
+
+
+def test_post_probe_still_rejects_when_post_returns_non_2xx():
+    """HEAD returns HTML, POST returns 401 with JSON → reject.
+
+    A non-2xx POST does not prove MCP capability; the original HEAD/GET
+    response is used and should still trigger rejection.
+    """
+    task = _make_task("post_401")
+    with _serve(_handler(
+        status=200, content_type="text/html",
+        post_content_type="application/json",
+        post_body=b'{"error":"unauthorized"}',
+        post_status=401,
+    )) as base:
+        with pytest.raises(NonMcpEndpointError):
+            asyncio.run(task._preflight_content_type(f"{base}/", timeout=5.0))
+
+
+def test_post_probe_not_attempted_for_valid_head():
+    """When HEAD already returns application/json, no POST probe is needed."""
+    task = _make_task()
+    record: list[str] = []
+    with _serve(_handler(
+        status=200, content_type="application/json", body=b"{}",
+        post_content_type="application/json",
+        post_body=b'{}',
+        record=record,
+    )) as base:
+        asyncio.run(task._preflight_content_type(f"{base}/mcp", timeout=5.0))
+    assert record == ["HEAD"]
+    assert "POST" not in record

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -34,6 +34,10 @@ Example config::
         headers:
           Authorization: "Bearer sk-..."
         timeout: 180
+        skip_preflight: true  # bypass the content-type probe for a valid
+                              # Streamable HTTP endpoint that answers HEAD/GET
+                              # with a non-MCP content type but serves real
+                              # MCP over POST. Default: false.
       searxng:
         url: "http://localhost:8000/sse"
         transport: sse       # use SSE transport instead of Streamable HTTP

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2489,7 +2489,7 @@ class MCPServerTask:
             # re-probing is a redundant round-trip. Also skip for OAuth servers:
             # without a cached token the endpoint returns HTML or 401, which
             # would incorrectly block the OAuth flow before it can run.
-            if config.get("transport") != "sse" and not self._ready.is_set() and self._auth_type != "oauth":
+            if config.get("transport") != "sse" and not config.get("skip_preflight") and not self._ready.is_set() and self._auth_type != "oauth":
                 try:
                     _probe_headers = dict(config.get("headers") or {})
                     await self._preflight_content_type(

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2067,11 +2067,17 @@ class MCPServerTask:
 
         Detection is allow-list based: a 2xx response is rejected only when it
         carries a definite content type that is NOT one an MCP endpoint uses
-        (``application/json`` / ``text/event-stream``). A missing or empty
-        content type, non-2xx status, or any network/transport error passes
-        through silently — the probe is strictly best-effort, and the real
-        handshake remains the source of truth for everything except the
-        unambiguous "this is a web page, not MCP" case.
+        (``application/json`` / ``text/event-stream``).  When HEAD/GET returns
+        a non-MCP content type (e.g. ``text/html``), a lightweight JSON-RPC
+        ``initialize`` POST is attempted before giving up — some servers
+        (e.g. DocuSeal) serve a web UI on GET but speak Streamable HTTP only
+        via POST.
+
+        A missing or empty content type, non-2xx status, or any
+        network/transport error passes through silently — the probe is
+        strictly best-effort, and the real handshake remains the source of
+        truth for everything except the unambiguous "this is a web page,
+        not MCP" case.
 
         Runs on its own httpx client OUTSIDE the SDK's anyio task group, so the
         raised error propagates as itself rather than being wrapped in an
@@ -2099,6 +2105,47 @@ class MCPServerTask:
                 resp = await client.head(url, headers=probe_headers)
                 if resp.status_code in (405, 501):
                     resp = await client.get(url, headers=probe_headers)
+
+                # Some MCP servers (e.g. DocuSeal) serve their web UI on
+                # HEAD/GET but speak Streamable HTTP only via POST.  Before
+                # rejecting the endpoint, try a lightweight JSON-RPC POST
+                # probe so we don't false-positive on POST-only servers.
+                ct = (
+                    resp.headers.get("content-type", "")
+                    .split(";")[0]
+                    .strip()
+                    .lower()
+                )
+                if (
+                    ct
+                    and ct not in self._MCP_CONTENT_TYPES
+                    and 200 <= resp.status_code < 300
+                ):
+                    post_resp = await client.post(
+                        url,
+                        headers={
+                            **probe_headers,
+                            "Content-Type": "application/json",
+                            "Accept": "application/json, text/event-stream",
+                        },
+                        content=(
+                            '{"jsonrpc":"2.0","id":"_probe",'
+                            '"method":"initialize",'
+                            '"params":{"protocolVersion":"2025-03-26",'
+                            '"capabilities":{},'
+                            '"clientInfo":{"name":"hermes-probe",'
+                            '"version":"0.1"}}}'
+                        ),
+                    )
+                    if 200 <= post_resp.status_code < 300:
+                        post_ct = (
+                            post_resp.headers.get("content-type", "")
+                            .split(";")[0]
+                            .strip()
+                            .lower()
+                        )
+                        if post_ct in self._MCP_CONTENT_TYPES:
+                            resp = post_resp
         except _httpx.HTTPError:
             return  # DNS/connect/timeout/transport error — let the SDK try.
 

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -57,6 +57,7 @@ mcp_servers:
 | `timeout` | number | both | Tool call timeout in seconds (default: `300`) |
 | `connect_timeout` | number | both | Initial connection timeout in seconds (default: `60`) |
 | `supports_parallel_tool_calls` | bool | both | Allow tools from this server to run concurrently |
+| `skip_preflight` | bool | HTTP | Bypass the fail-fast content-type probe for valid Streamable HTTP endpoints whose HEAD/GET answers a non-MCP content type (default: `false`) |
 | `tools` | mapping | both | Filtering and utility-tool policy |
 | `auth` | string | HTTP | Authentication method. Set to `oauth` to enable OAuth 2.1 with PKCE |
 | `sampling` | mapping | both | Server-initiated LLM request policy (see MCP guide) |


### PR DESCRIPTION
## Summary
The MCP preflight check no longer rejects valid Streamable HTTP servers that serve HTML/plain text on GET but real MCP over POST (Stirling-PDF, DocuSeal, SPA gateways — #57958): when the GET content-type looks like a web page, the probe now sends a JSON-RPC `initialize` POST before rejecting. A per-server `skip_preflight` flag covers exotic endpoints the probe still can't validate. Salvages #37598 (@gnodet, earliest, Jun 2) and #55203 (@kaishi00), with docs harvested from #56251 (@huangdihd).

## Root cause
`_preflight_content_type` (fail-fast guard against pointing MCP at a web-app root, which otherwise hangs the SDK for the full connect_timeout) judged the endpoint by HEAD/GET alone — but Streamable HTTP serves MCP over POST, so a server whose GET answers HTML was indistinguishable from a misconfigured URL.

## Changes
- `tools/mcp_tool.py::_preflight_content_type`: on a non-MCP GET content-type, POST a JSON-RPC `initialize` probe (same client) — 2xx accepts, failure keeps the fast rejection (from #37598, incl. 6 tests, rebased over the OAuth-skip docstring)
- `tools/mcp_tool.py::run`: honor per-server `skip_preflight: true` (from #55203) + module docstring example
- `website/docs/reference/mcp-config-reference.md`: `skip_preflight` table entry (docs from #56251)
- New test covering the `skip_preflight` bypass; AUTHOR_MAP entries

## Validation
| | Before | After |
|---|---|---|
| HTML on GET, MCP on POST | rejected (`NonMcpEndpointError`) | accepted, connects |
| HTML on GET and POST | rejected fast | still rejected fast |
| OAuth servers | skip preflight (d05cc8f4d) | unchanged |

`scripts/run_tests.sh tests/tools/test_mcp_preflight_content_type.py tests/tools/test_mcp_tool.py` — 232/232 pass. Live E2E against two real local HTTP servers: HTML-GET/MCP-POST accepted, pure-HTML server still rejected.

Fixes #57958.

## Infographic

![mcp-preflight-post-fallback](https://v3b.fal.media/files/b/0aa11ba3/1WFcCQv8s8sJ9oBs3tIsT_2qFM7i7T.png)
