### PR TITLE
fix(qqbot): accept is_reconnect kwarg in connect() matching base-class contract (#59272)

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,7 +278,7 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -191,6 +191,51 @@ class TestVoiceAttachmentSSRFProtection:
         assert kwargs.get("event_hooks", {}).get("response") == [_ssrf_redirect_guard]
 
 
+class TestQQConnectSignature:
+    """Regression for issue #59272 — QQAdapter.connect() must accept is_reconnect kwarg.
+
+    After commit 43b8ba418 (fix telemetry), the base class signature became
+    ``async def connect(self, *, is_reconnect: bool = False) -> bool:``.
+    Every other adapter was updated to match — QQAdapter was missed,
+    causing a TypeError on every first connect and an exponential-backoff
+    reconnect loop for QQ.
+    """
+
+    def _make(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b", **extra))
+
+    def test_connect_accepts_is_reconnect_true(self):
+        """Reconnect path — is_reconnect=True must not raise TypeError."""
+        adapter = self._make()
+        adapter._ensure_token = mock.AsyncMock(side_effect=RuntimeError("stop"))
+        try:
+            asyncio.run(adapter.connect(is_reconnect=True))
+        except RuntimeError:
+            pass
+        assert adapter._ensure_token.call_count == 1
+
+    def test_connect_accepts_is_reconnect_false(self):
+        """Cold-boot path — is_reconnect=False must not raise TypeError."""
+        adapter = self._make()
+        adapter._ensure_token = mock.AsyncMock(side_effect=RuntimeError("stop"))
+        try:
+            asyncio.run(adapter.connect(is_reconnect=False))
+        except RuntimeError:
+            pass
+        assert adapter._ensure_token.call_count == 1
+
+    def test_connect_no_keyword_still_works(self):
+        """Position-only call with no kwargs must still work (default is_reconnect=False)."""
+        adapter = self._make()
+        adapter._ensure_token = mock.AsyncMock(side_effect=RuntimeError("stop"))
+        try:
+            asyncio.run(adapter.connect())
+        except RuntimeError:
+            pass
+        assert adapter._ensure_token.call_count == 1
+
+
 # ---------------------------------------------------------------------------
 # WebSocket proxy handling
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #59272 — `QQAdapter.connect()` raises `TypeError: QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'` on every first connect, sending QQ into a permanent exponential-backoff reconnect loop (60s → 120s → 240s → 300s) until the platform is patched locally.

## Root Cause

Commit `43b8ba418` (fix(telegram): preserve Bot API update queue on watcher reconnect) changed the abstract base class signature in `gateway/platforms/base.py`:

```python
async def connect(self, *, is_reconnect: bool = False) -> bool:
```

Every other platform adapter (bluebubbles, signal, webhook, weixin, whatsapp_cloud, yuanbao, msgraph_webhook, api_server) was updated to match. `QQAdapter` was missed:

```python
# gateway/platforms/qqbot/adapter.py:281
async def connect(self) -> bool:  # ← missing is_reconnect parameter
```

The gateway call sites at `gateway/run.py:3395` and `:3398` pass `connect(is_reconnect=...)`, so QQAdapter raises `TypeError` immediately and never starts.

## Fix

One-line signature change in `gateway/platforms/qqbot/adapter.py:281`:

```diff
- async def connect(self) -> bool:
+ async def connect(self, *, is_reconnect: bool = False) -> bool:
```

QQ is a stateless adapter — every connect performs a full fresh auth + WebSocket. Accepting and ignoring `is_reconnect` is the documented safe choice, identical to the WhatsApp / WeChat pattern.

## Verification

- **Reproduce (RED)** on `upstream/main` @ 6133285596: `TypeError: QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'` ✓
- **Cherry-picked** onto current `upstream/main` @ 18e840469f. `git rev-list --left-right --count upstream/main...HEAD` = `0 1` ✓
- **All 168 tests** in `tests/gateway/test_qqbot.py` pass on the rebased branch, including 3 new regression tests in `TestQQConnectSignature`:
  - `test_connect_accepts_is_reconnect_true` (reconnect path)
  - `test_connect_accepts_is_reconnect_false` (cold-boot path)
  - `test_connect_no_keyword_still_works` (backward-compat / default value)
- **No same-author PR** exists in Tranquil-Flow's open PRs for this issue.
- **No competing PRs** found via `QQAdapter`, `qqbot connect`, or `is_reconnect kwarg` keyword searches against the open PR set.
- The related "duplicate" issues (#52914, #53443, #54410) all describe the same TypeError on QQAdapter; this PR closes the root cause for all of them.

## Files Changed

```
 gateway/platforms/qqbot/adapter.py |  2 +-
 tests/gateway/test_qqbot.py        | 45 ++++++++++++++++++++++++++++++++++++++
 2 files changed, 46 insertions(+), 1 deletion(-)
```

Auto-published by Moonsong via Path B automated pipeline.
