### PR TITLE
refactor(gateway): consolidate interruption-note builders + close WhatsApp reaction gap

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -251,7 +251,15 @@ SILENT_MARKER = "[SILENT]"
 # a marker is the entire response OR appears as its own first/last line — but
 # NOT when a token merely appears mid-sentence in a genuine report (e.g.
 # "I considered staying [SILENT] but here is the summary…" must deliver).
-_CRON_SILENCE_TOKENS = frozenset({"[SILENT]", "SILENT", "NO_REPLY", "NO REPLY"})
+#
+# The token *set* is the canonical one owned by gateway.response_filters
+# (LIVE_GATEWAY_SILENT_MARKERS); only the positional matching below is
+# cron-specific.  Imported lazily so a cron-only import path does not eagerly
+# pull in the gateway package (and so no boot-order import cycle is possible).
+def _cron_silence_tokens() -> frozenset:
+    from gateway.response_filters import LIVE_GATEWAY_SILENT_MARKERS
+
+    return LIVE_GATEWAY_SILENT_MARKERS
 
 
 def _is_cron_silence_response(text: str) -> bool:
@@ -270,7 +278,7 @@ def _is_cron_silence_response(text: str) -> bool:
         return False
 
     def _is_token(line: str) -> bool:
-        return " ".join(line.strip().upper().split()) in _CRON_SILENCE_TOKENS
+        return " ".join(line.strip().upper().split()) in _cron_silence_tokens()
 
     # Whole response is exactly a token.
     if _is_token(stripped):

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -614,6 +614,78 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     resp.status_code, code,
                 )
 
+    # ------------------------------------------------------------------ reactions
+
+    async def add_reaction(
+        self,
+        chat_id: str,
+        emoji: str,
+        message_id: Optional[str] = None,
+    ) -> bool:
+        """React to a message with an emoji via the Cloud API reaction type.
+
+        ``message_id`` is the target message's wamid; when omitted the most
+        recent inbound wamid for the chat is used (same cache as read receipts).
+        Returns True when Meta accepts the reaction.
+        """
+        return await self._post_reaction(chat_id, message_id, emoji)
+
+    async def remove_reaction(
+        self,
+        chat_id: str,
+        message_id: Optional[str] = None,
+    ) -> bool:
+        """Retract a reaction (Cloud API: send an empty-emoji reaction)."""
+        return await self._post_reaction(chat_id, message_id, "")
+
+    async def _post_reaction(
+        self,
+        chat_id: str,
+        message_id: Optional[str],
+        emoji: str,
+    ) -> bool:
+        """POST a ``type=reaction`` message to the Graph API.
+
+        An empty ``emoji`` retracts a previously-added reaction, per Meta's
+        reaction-message contract.  Best-effort: any error returns False so a
+        reaction never blocks the main reply path.
+        """
+        if self._http_client is None:
+            return False
+        target = message_id or self._last_inbound_wamid_by_chat.get(chat_id)
+        if not target:
+            return False
+
+        url = self._graph_url("messages")
+        headers = {
+            "Authorization": f"Bearer {self._access_token}",
+            "Content-Type": "application/json",
+        }
+        payload: Dict[str, Any] = {
+            "messaging_product": "whatsapp",
+            "recipient_type": "individual",
+            "to": chat_id,
+            "type": "reaction",
+            "reaction": {"message_id": target, "emoji": emoji},
+        }
+        try:
+            resp = await self._http_client.post(url, headers=headers, json=payload)
+        except Exception:
+            logger.exception("[whatsapp_cloud] reaction failed")
+            return False
+        if resp.status_code != 200:
+            try:
+                body = resp.json()
+            except Exception:
+                body = {"raw": resp.text[:500]}
+            logger.warning(
+                "[whatsapp_cloud] reaction rejected (status=%d): %s",
+                resp.status_code,
+                self._format_graph_error(body, resp.status_code),
+            )
+            return False
+        return True
+
     # ------------------------------------------------------------------ interactive messages
     #
     # WhatsApp Cloud supports two interactive primitives we use here:

--- a/gateway/response_filters.py
+++ b/gateway/response_filters.py
@@ -16,6 +16,14 @@ SILENT_REPLY_TOKEN = "NO_REPLY"
 # Exact whole-response markers that mean "the agent intentionally chose not to
 # reply".  Keep this list small and explicit; arbitrary empty output remains an
 # error/empty-response path, not silence.
+#
+# Canonical silence vocabulary: this is the single source of truth for the
+# silence-marker token set.  ``cron/scheduler.py`` imports it (lazily, to avoid
+# eagerly pulling the gateway package into cron-only import paths) rather than
+# maintaining its own copy — the two suppression paths must never drift.  The
+# *matching* rules differ (the live gateway requires an exact whole response;
+# cron also accepts a marker on its own first/last line), but the token set is
+# shared.
 LIVE_GATEWAY_SILENT_MARKERS = frozenset({
     "[SILENT]",
     "SILENT",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -952,6 +952,94 @@ def _last_transcript_timestamp(history: Optional[List[Dict[str, Any]]]) -> Any:
     return None
 
 
+def _resume_reason_phrase(reason: Optional[str]) -> str:
+    """Map a session ``resume_reason`` marker to its human-readable phrase."""
+    if reason == "restart_timeout":
+        return "a gateway restart"
+    if reason == "shutdown_timeout":
+        return "a gateway shutdown"
+    return "a gateway interruption"
+
+
+def _build_interruption_system_note(reason: Optional[str], has_new_message: bool) -> str:
+    """Build the ``[System note: ...]`` resume/recovery text.
+
+    Centralizes the two near-duplicate resume-note construction sites (the
+    primary ``resume_pending`` branch and the empty-message safety net) so a
+    future wording change or group-mode variant only needs one edit point.
+    ``reason`` is the session's ``resume_reason`` marker; ``has_new_message``
+    selects the guidance clause — address the user's new message, or (for the
+    synthesized empty auto-resume turn) report recovery and ask what's next.
+    Returns only the bracketed note; the caller appends any real message.
+    """
+    phrase = _resume_reason_phrase(reason)
+    if has_new_message:
+        guidance = (
+            "Address the user's NEW message below FIRST and focus "
+            "on what the user is asking now."
+        )
+    else:
+        guidance = (
+            "Report to the user that the session was restored "
+            "successfully and ask what they would like to do next."
+        )
+    return (
+        f"[System note: The previous turn was interrupted by "
+        f"{phrase}; the gateway is now back online. "
+        f"Any restart/shutdown command in the history has already "
+        f"run — do NOT re-execute or verify it. {guidance} "
+        f"Do NOT re-execute old tool calls — skip any unfinished "
+        f"work from the conversation history.]"
+    )
+
+
+def _build_tool_tail_system_note() -> str:
+    """Build the ``[System note: ...]`` text for the interrupted-tool-tail case.
+
+    Distinct wording from :func:`_build_interruption_system_note`: there is no
+    restart/shutdown reason, only pending tool outputs to ignore in favour of
+    the user's new message.  Returns only the bracketed note.
+    """
+    return (
+        "[System note: A new message has arrived. The conversation "
+        "history contains pending tool outputs from an interrupted turn. "
+        "IGNORE those pending results. Address the user's NEW message "
+        "below FIRST. Do NOT re-execute old tool calls from the history.]"
+    )
+
+
+def _resolve_resume_note_kind(
+    is_resume_pending: bool,
+    has_fresh_tool_tail: bool,
+    message_is_empty: bool,
+) -> str:
+    """Classify which auto-continue system note applies to an inbound turn.
+
+    Formalizes the historical ``if/elif/if`` dispatch at the inbound
+    auto-continue site into one table-testable predicate:
+
+    - ``"resume"``     — a fresh ``resume_pending`` session: emit the
+                         reason-aware resume/recovery note.
+    - ``"tool_tail"``  — no fresh resume mark, but the transcript ends in a
+                         fresh interrupted tool result.
+    - ``"safety_net"`` — neither fresh signal fired yet the turn carries an
+                         empty message; the caller still guards this on the raw
+                         ``resume_pending`` marker so a legitimately empty
+                         non-resume turn (e.g. a captionless image) is untouched.
+    - ``"none"``       — ordinary turn; no system note.
+
+    The ``safety_net`` vs ``resume`` split is the "two freshness signals
+    disagree" edge case documented inline at the call site.
+    """
+    if is_resume_pending:
+        return "resume"
+    if has_fresh_tool_tail:
+        return "tool_tail"
+    if message_is_empty:
+        return "safety_net"
+    return "none"
+
+
 # Tool results can contain literal MEDIA: examples in docs, logs, or other
 # ordinary outputs. Only tools that intentionally create deliverable media
 # artifacts should be eligible for automatic append when the model omits them
@@ -18213,48 +18301,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 and _interruption_is_fresh
             )
 
-            if _is_resume_pending:
+            _note_kind = _resolve_resume_note_kind(
+                is_resume_pending=_is_resume_pending,
+                has_fresh_tool_tail=_has_fresh_tool_tail,
+                message_is_empty=not (isinstance(message, str) and message.strip()),
+            )
+            if _note_kind == "resume":
                 _reason = getattr(_resume_entry, "resume_reason", None) or "restart_timeout"
-                _reason_phrase = (
-                    "a gateway restart"
-                    if _reason == "restart_timeout"
-                    else "a gateway shutdown"
-                    if _reason == "shutdown_timeout"
-                    else "a gateway interruption"
-                )
                 _persist_user_message_override = message
                 # The empty-message case is the auto-resume startup turn
                 # synthesized by _schedule_resume_pending_sessions — there is
                 # no NEW user message to address, so tell the model to report
                 # recovery instead of the (nonexistent) "new message".
-                if message:
-                    _resume_guidance = (
-                        "Address the user's NEW message below FIRST and focus "
-                        "on what the user is asking now."
-                    )
-                else:
-                    _resume_guidance = (
-                        "Report to the user that the session was restored "
-                        "successfully and ask what they would like to do next."
-                    )
-                message = (
-                    f"[System note: The previous turn was interrupted by "
-                    f"{_reason_phrase}; the gateway is now back online. "
-                    f"Any restart/shutdown command in the history has already "
-                    f"run — do NOT re-execute or verify it. {_resume_guidance} "
-                    f"Do NOT re-execute old tool calls — skip any unfinished "
-                    f"work from the conversation history.]"
-                    + (f"\n\n{message}" if message else "")
-                )
-            elif _has_fresh_tool_tail:
+                message = _build_interruption_system_note(
+                    _reason, has_new_message=bool(message)
+                ) + (f"\n\n{message}" if message else "")
+            elif _note_kind == "tool_tail":
                 _persist_user_message_override = message
-                message = (
-                    "[System note: A new message has arrived. The conversation "
-                    "history contains pending tool outputs from an interrupted turn. "
-                    "IGNORE those pending results. Address the user's NEW message "
-                    "below FIRST. Do NOT re-execute old tool calls from the history.]\n\n"
-                    + message
-                )
+                message = _build_tool_tail_system_note() + "\n\n" + message
 
             # Consume one-shot /reload-skills note (if the user ran
             # /reload-skills since their last turn in this session). Same
@@ -18285,22 +18349,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _sn_reason = (
                     getattr(_resume_entry, "resume_reason", None) or "restart_timeout"
                 )
-                _sn_reason_phrase = (
-                    "a gateway restart"
-                    if _sn_reason == "restart_timeout"
-                    else "a gateway shutdown"
-                    if _sn_reason == "shutdown_timeout"
-                    else "a gateway interruption"
-                )
-                message = (
-                    f"[System note: The previous turn was interrupted by "
-                    f"{_sn_reason_phrase}; the gateway is now back online. "
-                    f"Any restart/shutdown command in the history has already "
-                    f"run — do NOT re-execute or verify it. Report to the user "
-                    f"that the session was restored successfully and ask what "
-                    f"they would like to do next. Do NOT re-execute old tool "
-                    f"calls — skip any unfinished work from the conversation "
-                    f"history.]"
+                message = _build_interruption_system_note(
+                    _sn_reason, has_new_message=False
                 )
 
             _approval_session_key = session_key or ""

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1202,7 +1202,63 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 pass
         except Exception:
             pass  # Ignore typing indicator failures
-    
+
+    async def add_reaction(
+        self,
+        chat_id: str,
+        emoji: str,
+        message_id: Optional[str] = None,
+    ) -> bool:
+        """React to a message with an emoji via the bridge's ``/react`` endpoint.
+
+        ``message_id`` is the id of the message to react to; when omitted the
+        bridge targets the most recent message in the chat.  Returns True when
+        the bridge accepts the reaction.
+        """
+        return await self._post_reaction(chat_id, message_id, emoji)
+
+    async def remove_reaction(
+        self,
+        chat_id: str,
+        message_id: Optional[str] = None,
+    ) -> bool:
+        """Retract a reaction (WhatsApp: send an empty-emoji react)."""
+        return await self._post_reaction(chat_id, message_id, "")
+
+    async def _post_reaction(
+        self,
+        chat_id: str,
+        message_id: Optional[str],
+        emoji: str,
+    ) -> bool:
+        """POST a reaction to the bridge's ``/react`` endpoint.
+
+        An empty ``emoji`` retracts a previously-added reaction, matching the
+        Baileys ``{react: {text: ''}}`` protocol.  Mirrors the transport shape
+        of the other bridge calls (loopback POST, managed-bridge exit guard).
+        """
+        if not self._running or not self._http_session:
+            return False
+        if await self._check_managed_bridge_exit():
+            return False
+        try:
+            import aiohttp
+
+            payload: Dict[str, Any] = {
+                "chatId": to_whatsapp_jid(chat_id),
+                "emoji": emoji,
+            }
+            if message_id:
+                payload["messageId"] = message_id
+            async with self._http_session.post(
+                f"http://127.0.0.1:{self._bridge_port}/react",
+                json=payload,
+                timeout=aiohttp.ClientTimeout(total=15),
+            ) as resp:
+                return resp.status == 200
+        except Exception:
+            return False
+
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Get information about a WhatsApp chat."""
         if not self._running or not self._http_session:

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -944,6 +944,39 @@ app.post('/send-location', async (req, res) => {
   }
 });
 
+// React to a message with an emoji (an empty emoji retracts the reaction).
+app.post('/react', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+
+  const { chatId, messageId, emoji } = req.body;
+  if (!chatId) {
+    return res.status(400).json({ error: 'chatId is required' });
+  }
+
+  try {
+    let key;
+    if (messageId) {
+      // Prefer the full stored key (carries fromMe/participant) so a reaction
+      // on an inbound group message targets the right message; fall back to a
+      // minimal key when the message predates the bounded store.
+      const stored = messageStore.get(messageId);
+      key = stored?.key || { remoteJid: chatId, id: messageId, fromMe: false };
+    } else {
+      const latest = messageStore.latestForChat(chatId);
+      if (!latest) {
+        return res.status(404).json({ error: 'No recent message to react to in this chat' });
+      }
+      key = latest.key;
+    }
+    const sent = await sendWithTimeout(chatId, { react: { text: emoji || '', key } });
+    res.json({ success: true, messageId: sent?.key?.id });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // Typing indicator
 app.post('/typing', async (req, res) => {
   if (!sock || connectionState !== 'connected') {

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -62,7 +62,18 @@ export function createBoundedMessageStore(limit = 512) {
     return msg;
   }
 
-  return { remember, get };
+  function latestForChat(chatId) {
+    if (!chatId) return null;
+    // Map preserves insertion order; walk newest-first for the most recent
+    // remembered message in this chat (used to react without an explicit id).
+    const entries = Array.from(byId.values());
+    for (let i = entries.length - 1; i >= 0; i -= 1) {
+      if (entries[i]?.key?.remoteJid === chatId) return entries[i];
+    }
+    return null;
+  }
+
+  return { remember, get, latestForChat };
 }
 
 export function pollCreationMessageSecret(pollCreation) {

--- a/scripts/whatsapp-bridge/message_store.test.mjs
+++ b/scripts/whatsapp-bridge/message_store.test.mjs
@@ -1,0 +1,35 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createBoundedMessageStore } from './bridge_helpers.js';
+
+const msg = (id, remoteJid) => ({ key: { id, remoteJid } });
+
+test('latestForChat returns the most recent remembered message for a chat', () => {
+  const store = createBoundedMessageStore(8);
+  store.remember(msg('a1', 'chatA@s.whatsapp.net'));
+  store.remember(msg('b1', 'chatB@s.whatsapp.net'));
+  store.remember(msg('a2', 'chatA@s.whatsapp.net'));
+
+  assert.equal(store.latestForChat('chatA@s.whatsapp.net').key.id, 'a2');
+  assert.equal(store.latestForChat('chatB@s.whatsapp.net').key.id, 'b1');
+});
+
+test('latestForChat returns null for an unknown chat or falsy id', () => {
+  const store = createBoundedMessageStore(8);
+  store.remember(msg('a1', 'chatA@s.whatsapp.net'));
+
+  assert.equal(store.latestForChat('nobody@s.whatsapp.net'), null);
+  assert.equal(store.latestForChat(''), null);
+  assert.equal(store.latestForChat(undefined), null);
+});
+
+test('latestForChat follows re-remembered ordering', () => {
+  const store = createBoundedMessageStore(8);
+  store.remember(msg('a1', 'chatA@s.whatsapp.net'));
+  store.remember(msg('a2', 'chatA@s.whatsapp.net'));
+  // Re-remembering a1 moves it to the newest position (Map delete+set).
+  store.remember(msg('a1', 'chatA@s.whatsapp.net'));
+
+  assert.equal(store.latestForChat('chatA@s.whatsapp.net').key.id, 'a1');
+});

--- a/tests/gateway/test_resume_note_silence_interaction.py
+++ b/tests/gateway/test_resume_note_silence_interaction.py
@@ -1,0 +1,177 @@
+"""Resume-note refactor + silence-marker interaction.
+
+Covers three concerns for the Phase-0 auto-continue refactor in
+``gateway/run.py``:
+
+1. The extracted note builders (:func:`_build_interruption_system_note`,
+   :func:`_build_tool_tail_system_note`) reproduce the historical inline
+   f-strings **byte-for-byte** — a golden-string regression guard so a future
+   wording tweak is a deliberate, reviewed change, not an accident.
+2. The extracted dispatch predicate (:func:`_resolve_resume_note_kind`) is a
+   pure truth table, including the "two freshness signals disagree" edge case.
+3. Resume/recovery notes and the intentional-silence classifier compose
+   correctly in both directions: a recovery report is never swallowed as
+   silence, and a literal silence token on a resumed turn is still silence.
+"""
+
+import pytest
+
+from gateway.response_filters import (
+    LIVE_GATEWAY_SILENT_MARKERS,
+    is_intentional_silence_response,
+)
+from gateway.run import (
+    _build_interruption_system_note,
+    _build_tool_tail_system_note,
+    _resolve_resume_note_kind,
+)
+
+
+# --------------------------------------------------------------------------
+# 1. Golden-string guards — the note text pre-refactor, captured verbatim.
+# --------------------------------------------------------------------------
+
+
+def _golden_resume_note(reason, has_new_message):
+    """The exact inline f-string the three sites produced before extraction."""
+    reason_phrase = (
+        "a gateway restart"
+        if reason == "restart_timeout"
+        else "a gateway shutdown"
+        if reason == "shutdown_timeout"
+        else "a gateway interruption"
+    )
+    if has_new_message:
+        guidance = (
+            "Address the user's NEW message below FIRST and focus "
+            "on what the user is asking now."
+        )
+    else:
+        guidance = (
+            "Report to the user that the session was restored "
+            "successfully and ask what they would like to do next."
+        )
+    return (
+        f"[System note: The previous turn was interrupted by "
+        f"{reason_phrase}; the gateway is now back online. "
+        f"Any restart/shutdown command in the history has already "
+        f"run — do NOT re-execute or verify it. {guidance} "
+        f"Do NOT re-execute old tool calls — skip any unfinished "
+        f"work from the conversation history.]"
+    )
+
+
+_GOLDEN_TOOL_TAIL_NOTE = (
+    "[System note: A new message has arrived. The conversation "
+    "history contains pending tool outputs from an interrupted turn. "
+    "IGNORE those pending results. Address the user's NEW message "
+    "below FIRST. Do NOT re-execute old tool calls from the history.]"
+)
+
+
+@pytest.mark.parametrize(
+    "reason",
+    ["restart_timeout", "shutdown_timeout", "unknown_reason", None],
+)
+@pytest.mark.parametrize("has_new_message", [True, False])
+def test_interruption_note_is_byte_identical(reason, has_new_message):
+    assert _build_interruption_system_note(
+        reason, has_new_message
+    ) == _golden_resume_note(reason, has_new_message)
+
+
+def test_unknown_and_missing_reason_map_to_generic_interruption():
+    # Both the sentinel-default path (unmapped reason) and None resolve to the
+    # generic "a gateway interruption" phrasing.
+    assert "a gateway interruption" in _build_interruption_system_note("weird", True)
+    assert "a gateway interruption" in _build_interruption_system_note(None, True)
+
+
+def test_tool_tail_note_is_byte_identical():
+    assert _build_tool_tail_system_note() == _GOLDEN_TOOL_TAIL_NOTE
+
+
+def test_note_builders_return_only_the_bracketed_note():
+    # The builder returns just the note; the caller appends the real message.
+    note = _build_interruption_system_note("restart_timeout", True)
+    assert note.startswith("[System note:") and note.endswith("]")
+    assert "\n" not in note
+
+
+# --------------------------------------------------------------------------
+# 2. Dispatch predicate truth table.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("is_resume_pending", "has_fresh_tool_tail", "message_is_empty", "expected"),
+    [
+        # Fresh resume mark always wins, regardless of the other signals.
+        (True, True, True, "resume"),
+        (True, True, False, "resume"),
+        (True, False, True, "resume"),
+        (True, False, False, "resume"),
+        # No resume mark, fresh tool tail → tool_tail.
+        (False, True, True, "tool_tail"),
+        (False, True, False, "tool_tail"),
+        # Neither fresh signal, but an empty turn → safety net (caller also
+        # guards on the raw resume_pending marker). This IS the "two freshness
+        # signals disagree" case documented inline at the call site.
+        (False, False, True, "safety_net"),
+        # Ordinary populated turn → no note.
+        (False, False, False, "none"),
+    ],
+)
+def test_resolve_resume_note_kind_truth_table(
+    is_resume_pending, has_fresh_tool_tail, message_is_empty, expected
+):
+    assert (
+        _resolve_resume_note_kind(
+            is_resume_pending, has_fresh_tool_tail, message_is_empty
+        )
+        == expected
+    )
+
+
+# --------------------------------------------------------------------------
+# 3. Silence classifier vs. resume/recovery notes — both directions.
+# --------------------------------------------------------------------------
+
+
+def test_recovery_report_is_not_classified_as_silence():
+    # A genuine post-restart recovery report must be delivered, never swallowed
+    # as an intentional-silence marker.
+    report = (
+        "The gateway restarted and is back online now, nothing pending on my "
+        "side, what would you like to do next?"
+    )
+    assert is_intentional_silence_response(report) is False
+
+
+def test_resume_notes_are_not_silence_markers():
+    # The injected system notes themselves are substantive text, not silence.
+    assert (
+        is_intentional_silence_response(
+            _build_interruption_system_note("restart_timeout", False)
+        )
+        is False
+    )
+    assert is_intentional_silence_response(_build_tool_tail_system_note()) is False
+
+
+@pytest.mark.parametrize("marker", sorted(LIVE_GATEWAY_SILENT_MARKERS))
+def test_literal_silence_token_on_resumed_turn_is_still_silence(marker):
+    # The reverse direction: even after a resume, a model turn whose entire
+    # output is the literal silence token still classifies as silence, so the
+    # two mechanisms compose without corrupting each other.
+    assert is_intentional_silence_response(marker) is True
+
+
+def test_report_that_merely_mentions_a_marker_still_delivers():
+    # Prose that mentions a token mid-sentence is real content, not silence.
+    assert (
+        is_intentional_silence_response(
+            "I nearly stayed NO_REPLY but here's the recovery summary instead."
+        )
+        is False
+    )

--- a/tests/tools/test_send_message_react.py
+++ b/tests/tools/test_send_message_react.py
@@ -95,3 +95,152 @@ def test_react_without_live_gateway():
         )
     assert result.get("success") is not True
     assert "live" in json.dumps(result)
+
+
+# --------------------------------------------------------------------------
+# WhatsApp adapter add_reaction/remove_reaction exercised end-to-end through
+# the generic send_message(action='react') path, with the bridge HTTP call
+# mocked (no live network, no live gateway process).
+# --------------------------------------------------------------------------
+
+
+class _FakeBridgeResponse:
+    """Async-context-manager mimicking aiohttp's POST response."""
+
+    def __init__(self, status=200, payload=None):
+        self.status = status
+        self._payload = payload if payload is not None else {"success": True}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def json(self):
+        return self._payload
+
+    async def text(self):
+        return json.dumps(self._payload)
+
+
+class _FakeBridgeSession:
+    """Records POSTs and returns a canned bridge response."""
+
+    def __init__(self, status=200):
+        self._status = status
+        self.posts = []
+
+    def post(self, url, json=None, timeout=None):
+        self.posts.append({"url": url, "json": json})
+        return _FakeBridgeResponse(status=self._status)
+
+
+def _make_whatsapp_adapter(session):
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter.__new__(WhatsAppAdapter)
+    adapter._running = True
+    adapter._http_session = session
+    adapter._bridge_port = 3000
+    adapter._bridge_process = None  # no managed child → exit-check is a no-op
+    return adapter
+
+
+def _whatsapp_runner_with(adapter):
+    from gateway.config import Platform
+
+    return SimpleNamespace(adapters={Platform("whatsapp"): adapter})
+
+
+def test_whatsapp_react_posts_to_bridge_react_endpoint():
+    session = _FakeBridgeSession()
+    adapter = _make_whatsapp_adapter(session)
+    with patch("gateway.run._gateway_runner_ref", lambda: _whatsapp_runner_with(adapter)):
+        result = _call(
+            {
+                "action": "react",
+                "target": "whatsapp:1234567890@s.whatsapp.net",
+                "emoji": "❤️",
+                "message_id": "wamid-1",
+            }
+        )
+    assert result["success"] is True
+    assert len(session.posts) == 1
+    post = session.posts[0]
+    assert post["url"].endswith("/react")
+    assert post["json"] == {
+        "chatId": "1234567890@s.whatsapp.net",
+        "emoji": "❤️",
+        "messageId": "wamid-1",
+    }
+
+
+def test_whatsapp_react_without_message_id_omits_it():
+    session = _FakeBridgeSession()
+    adapter = _make_whatsapp_adapter(session)
+    with patch("gateway.run._gateway_runner_ref", lambda: _whatsapp_runner_with(adapter)):
+        result = _call(
+            {
+                "action": "react",
+                "target": "whatsapp:1234567890@s.whatsapp.net",
+                "emoji": "👍",
+            }
+        )
+    assert result["success"] is True
+    # message_id omitted so the bridge resolves the most recent message itself.
+    assert session.posts[0]["json"] == {
+        "chatId": "1234567890@s.whatsapp.net",
+        "emoji": "👍",
+    }
+
+
+def test_whatsapp_unreact_sends_empty_emoji():
+    session = _FakeBridgeSession()
+    adapter = _make_whatsapp_adapter(session)
+    with patch("gateway.run._gateway_runner_ref", lambda: _whatsapp_runner_with(adapter)):
+        result = _call(
+            {
+                "action": "unreact",
+                "target": "whatsapp:1234567890@s.whatsapp.net",
+                "message_id": "wamid-9",
+            }
+        )
+    assert result["success"] is True
+    assert session.posts[0]["url"].endswith("/react")
+    assert session.posts[0]["json"] == {
+        "chatId": "1234567890@s.whatsapp.net",
+        "emoji": "",
+        "messageId": "wamid-9",
+    }
+
+
+def test_whatsapp_react_bridge_rejection_reports_failure():
+    session = _FakeBridgeSession(status=500)
+    adapter = _make_whatsapp_adapter(session)
+    with patch("gateway.run._gateway_runner_ref", lambda: _whatsapp_runner_with(adapter)):
+        result = _call(
+            {
+                "action": "react",
+                "target": "whatsapp:1234567890@s.whatsapp.net",
+                "emoji": "👍",
+            }
+        )
+    # add_reaction returns False on a non-200 bridge response.
+    assert result["success"] is False
+
+
+def test_whatsapp_react_not_connected_reports_failure():
+    session = _FakeBridgeSession()
+    adapter = _make_whatsapp_adapter(session)
+    adapter._running = False  # bridge not connected
+    with patch("gateway.run._gateway_runner_ref", lambda: _whatsapp_runner_with(adapter)):
+        result = _call(
+            {
+                "action": "react",
+                "target": "whatsapp:1234567890@s.whatsapp.net",
+                "emoji": "👍",
+            }
+        )
+    assert result["success"] is False
+    assert session.posts == []


### PR DESCRIPTION
## Summary

Phase 0 (of 2) for a reply-gate/smart-reply architecture redesign. This PR is
**pure groundwork — zero behavior change** by design: refactors, additive
methods, vocabulary consolidation, and new regression tests only. Phase 1
(the actual tool-gated delivery mechanism, config-flagged off by default)
will follow as a separate PR once this lands.

## What changed and why

**1. Consolidate the interruption/resume system-note construction.**
`gateway/run.py` had three near-duplicate sites constructing the
`[System note: The previous turn was interrupted by ...]` bracket text — one
of them (the "safety net" fallback) was a byte-for-byte copy of another's
empty-message branch. Extracted into two pure builders
(`_build_interruption_system_note`, `_build_tool_tail_system_note`) plus one
dispatch predicate (`_resolve_resume_note_kind`) that formalizes which of the
three sites should fire. Verified byte-identical output via golden-string
tests captured from the pre-refactor text.

**2. Consolidate the silence-marker vocabulary.**
`cron/scheduler.py`'s `_CRON_SILENCE_TOKENS` was an independently-maintained
duplicate of `gateway/response_filters.py`'s `LIVE_GATEWAY_SILENT_MARKERS` —
same 4 tokens, but two separate declarations that could silently drift (and
per the inline comments, already had once). Cron now imports the canonical
set lazily (avoiding an eager gateway-package import from cron-only paths);
its own positional first/last-line matching logic is unchanged.

**3. Close a real gap in the WhatsApp reaction path.**
`tools/send_message_tool.py` already has a generic `action='react'`/`'unreact'`
path on `main` that probes for `add_reaction(chat_id, emoji, message_id)` /
`remove_reaction(chat_id, message_id)` on the platform adapter via `getattr`
— but neither WhatsApp adapter implemented these methods, and
`scripts/whatsapp-bridge/bridge.js` had no `/react` endpoint at all. Added:
- `add_reaction`/`remove_reaction` on `WhatsAppAdapter` (Baileys bridge) and
  `WhatsAppCloudAdapter` (Graph API reaction message type)
- A minimal `POST /react` endpoint on the bridge (empty emoji retracts)
- `latestForChat()` on the bridge's bounded message store, so a reaction can
  target "the most recent message in this chat" without an explicit message
  id

**4. New cross-mechanism regression tests.**
No existing test proved the interruption/resume-note mechanism and the
silence-detection mechanism compose correctly. Added:
- A realistic recovery-report string ("The gateway restarted and is back
  online now...") is never misclassified as an intentional silence marker
- A resumed turn whose model output is exactly a silence token still
  suppresses correctly
- A report that merely *mentions* a marker word mid-sentence still delivers

## How to test

```
scripts/run_tests.sh tests/gateway/test_resume_note_silence_interaction.py tests/tools/test_send_message_react.py -v
cd scripts/whatsapp-bridge && node --test *.test.mjs
```

All 37 new/modified Python tests pass; all 24 existing + new JS bridge tests
pass. Full suite run separately confirms no regressions (see verification
note below).

## What platforms tested

Linux (WSL2-adjacent dev environment). No platform-specific code paths
touched — the WhatsApp Cloud API reaction method and Baileys bridge endpoint
are both cross-platform Python/Node, no OS-specific syscalls.

## Verification note (full suite)

Ran the full test suite via `scripts/run_tests.sh` both with and without this
diff (via `git stash`) to confirm no regressions. Baseline on unmodified
`main`: 32 pre-existing test failures + 9 `tests/acp*` collection errors
(missing optional `acp` extra, `pip install hermes-agent[acp]` not run in
this dev environment) — identical failure set with or without this diff.
`ruff check` and `scripts/check-windows-footguns.py` are clean on every
touched file.

## Related / overlapping PRs (please read before reviewing)

- **#38862** (community) adds WhatsApp reactions via a *new*
  `send_message(action='react')` schema field + bridge endpoint. This PR is
  narrower and complementary: `send_message`'s react/unreact action already
  exists on `main` today — this PR only implements the two adapter methods
  that path was already trying to call via `getattr` and was silently
  failing to find. No schema changes here.
- **#21977** (`feat/whatsapp-status-reply-primitives`, our own open PR) has a
  similar `add_reaction`-style adapter method on a separate, unmerged branch.
  This PR was implemented fresh against current `main`, not derived from or
  dependent on that branch — no relationship beyond solving an adjacent
  problem.

Happy to help reconcile with whichever of these a maintainer prefers as
canonical if there's overlap concern at review time.
