### PR TITLE
fix(desktop): guard IME composition Enter key on macOS Chromium edge case

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -121,6 +121,7 @@ export function ChatBar({
   // engine writes it — an explicit shared handle, not a back-reference.
   const queueEditRef = useRef<QueueEditState | null>(null)
   const composingRef = useRef(false) // true during IME composition (CJK input)
+  const recentCompositionRef = useRef(false) // true briefly after compositionend — catches Enter keydowns that Chromium dispatches without isComposing=true
 
   const { availableThemes, themeName } = useTheme()
   const at = useAtCompletions({ gateway: gateway ?? null, sessionId: sessionId ?? null, cwd: cwd ?? null })
@@ -363,11 +364,14 @@ export function ChatBar({
 
   const handleEditorKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     // IME composition: Enter confirms composed text, not a message submission.
-    // We check both composingRef (set by compositionstart/compositionend, robust
-    // across browsers) and nativeEvent.isComposing (Chromium fallback).  Without
-    // this guard, pressing Enter to finalise a Korean/Japanese/Chinese IME
-    // preedit fires submitDraft() and splits the message mid-word.
-    if (composingRef.current || event.nativeEvent.isComposing) {
+    // We check composingRef (set by compositionstart/compositionend, robust
+    // across browsers), nativeEvent.isComposing (Chromium fallback), and
+    // recentCompositionRef (catches Enter keydowns that Chromium dispatches
+    // *after* compositionend without isComposing=true — a known macOS Chinese
+    // IME edge case).  Without this guard, pressing Enter to finalise a
+    // Korean/Japanese/Chinese IME preedit fires submitDraft() and splits the
+    // message mid-word.
+    if (composingRef.current || event.nativeEvent.isComposing || recentCompositionRef.current) {
       return
     }
 
@@ -727,11 +731,20 @@ export function ChatBar({
         onCompositionEnd={event => {
           composingRef.current = false
 
+          // Chromium on macOS sometimes dispatches the Enter keydown event
+          // *after* compositionend, without setting isComposing=true on the
+          // native event.  The brief guard window prevents that Enter from
+          // submitting the draft instead of committing the IME candidate.
+          recentCompositionRef.current = true
+          setTimeout(() => {
+            recentCompositionRef.current = false
+          }, 100)
+
           // The input events fired *during* composition were skipped (they
           // carried uncommitted preedit text), and Chromium does NOT reliably
           // emit a trailing input event after compositionend on Windows IMEs.
           // Without flushing here, committed multi-character IME input (e.g.
-          // Chinese "你好", Japanese, Korean) never reaches composer state, so
+          // Chinese 你好, Japanese, Korean) never reaches composer state, so
           // `hasComposerPayload` stays false and the send button stays hidden
           // until an unrelated edit forces a sync (#39614).
           flushEditorToDraft(event.currentTarget)


### PR DESCRIPTION
## Problem

When using a Chinese IME on macOS (e.g. macOS Pinyin), pressing Enter to confirm an IME candidate sometimes submits the draft message instead of committing the composed text.

## Root Cause

The existing IME guards check `composingRef.current` (set by compositionstart/compositionend) and `event.nativeEvent.isComposing`. However, macOS Chinese IMEs trigger a known Chromium edge case where the Enter keydown event is dispatched **after** compositionend without `isComposing=true`. Both guards miss this window, so Enter reaches `submitDraft()`.

## Fix

Introduce `recentCompositionRef`, set to `true` on compositionend and cleared after a 100ms timeout. The keydown handler now checks `composingRef.current || event.nativeEvent.isComposing || recentCompositionRef.current`, which covers all IME timing scenarios.

## Testing

1. Open Hermes Desktop
2. Switch to Chinese Pinyin IME
3. Type English (or Pinyin) characters
4. Press Enter to confirm the IME candidate
5. Press Enter again (empty draft to submit) — should submit, not compose