### PR TITLE
fix(gateway): honor nested gateway.multiplex_profiles in load_gateway_config (#51372 salvage)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -980,15 +980,18 @@ def load_gateway_config() -> GatewayConfig:
                 gw_data["thread_sessions_per_user"] = yaml_cfg["thread_sessions_per_user"]
 
             # Multiplexing flag: accept both the top-level key and the nested
-            # gateway.multiplex_profiles form (from_dict resolves the nested
-            # fallback, but surface the top-level key here for parity with the
-            # other session-scope flags above).
+            # gateway.multiplex_profiles form (written by
+            # ``hermes config set gateway.multiplex_profiles true``).
             if "multiplex_profiles" in yaml_cfg:
                 gw_data["multiplex_profiles"] = yaml_cfg["multiplex_profiles"]
 
             gateway_section = yaml_cfg.get("gateway")
-            if isinstance(gateway_section, dict) and "max_concurrent_sessions" in gateway_section:
-                gw_data["max_concurrent_sessions"] = gateway_section["max_concurrent_sessions"]
+            if isinstance(gateway_section, dict):
+                if "multiplex_profiles" in gateway_section and "multiplex_profiles" not in gw_data:
+                    # gateway.multiplex_profiles written by `hermes config set gateway.multiplex_profiles true`
+                    gw_data["multiplex_profiles"] = gateway_section["multiplex_profiles"]
+                if "max_concurrent_sessions" in gateway_section:
+                    gw_data["max_concurrent_sessions"] = gateway_section["max_concurrent_sessions"]
 
             if "max_concurrent_sessions" in yaml_cfg:
                 gw_data["max_concurrent_sessions"] = yaml_cfg["max_concurrent_sessions"]

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -405,6 +405,32 @@ class TestLoadGatewayConfig:
 
         assert config.quick_commands == {"limits": {"type": "exec", "command": "echo ok"}}
 
+    def test_multiplex_profiles_from_nested_gateway_section(self, tmp_path, monkeypatch):
+        """``gateway.multiplex_profiles: true`` (the nested form written by
+        ``hermes config set gateway.multiplex_profiles true``) must enable
+        multiplexing when loaded via load_gateway_config().
+
+        Regression: load_gateway_config() only surfaced the *top-level*
+        ``multiplex_profiles`` key into gw_data, so a config.yaml that pinned
+        the flag under the nested ``gateway:`` section silently loaded with
+        multiplex_profiles=False. (from_dict honors the nested fallback, but
+        load_gateway_config builds gw_data from the top-level keys before
+        calling from_dict, so the nested value never reached it.)
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n  multiplex_profiles: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.multiplex_profiles is True
+
     def test_relay_platform_enabled_from_env_url(self, tmp_path, monkeypatch):
         """GATEWAY_RELAY_URL must enable Platform.RELAY in config.platforms so
         start_gateway()'s connect loop actually dials the connector. Registering


### PR DESCRIPTION
## Summary
`gateway.multiplex_profiles: true` in config.yaml — the exact form written by `hermes config set gateway.multiplex_profiles true` — now actually enables multiplexing; previously `load_gateway_config()` only surfaced the top-level key, so the documented path silently loaded `multiplex_profiles=False`.

Salvages #51372 by @davidgut1982 (clean cherry-pick, authorship preserved).

Root cause: `from_dict()` honors the nested fallback, but `load_gateway_config()` builds `gw_data` as a synthesized dict from top-level keys, so the nested `gateway:` section never reached it. Mirrors the existing nested handling for `max_concurrent_sessions`/`streaming`.

## Changes
- `gateway/config.py`: read `gateway.multiplex_profiles` into `gw_data` when the top-level key is absent
- `tests/gateway/test_config.py`: regression test (fails without the fix)

## Validation
| | Before | After |
|---|---|---|
| `gateway:\n  multiplex_profiles: true` | flag ignored, multiplexing off | flag honored |
| tests/gateway/test_config.py | — | 84/84 pass |

Third PR in the multiplex isolation cluster (#59310, #59315). The empirical premise check was re-verified today: `from_dict` resolves the nested form, the loader does not.

## Infographic

![nested-flag-fix](https://v3b.fal.media/files/b/0aa11bb5/niiYBLskfdOUqBMbPEcrA_5U890akJ.png)
