### PR TITLE
fix(gateway): detect config-held token credential collisions (#51064 salvage)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8432,6 +8432,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 token = val.strip()
                 break
         if not token:
+            config = getattr(adapter, "config", None)
+            val = getattr(config, "token", None)
+            if isinstance(val, str) and val.strip():
+                token = val.strip()
+        if not token:
             return None
         import hashlib
         return hashlib.sha256(("hermes-mux:" + token).encode("utf-8")).hexdigest()[:16]

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -5,8 +5,9 @@ from gateway.run import GatewayRunner
 
 
 class _FakeAdapter:
-    def __init__(self, token=None):
+    def __init__(self, token=None, config=None):
         self.token = token
+        self.config = config
 
 
 class TestCredentialFingerprint:
@@ -31,6 +32,17 @@ class TestCredentialFingerprint:
             def __init__(self):
                 self.bot_token = "alt-token"
         assert GatewayRunner._adapter_credential_fingerprint(_AltAdapter()) is not None
+
+    def test_reads_platform_config_token(self):
+        class _Config:
+            token = "config-token"
+
+        fp = GatewayRunner._adapter_credential_fingerprint(
+            _FakeAdapter(token=None, config=_Config())
+        )
+
+        assert fp is not None
+        assert "config-token" not in fp
 
 
 class TestProfileMessageHandler:
@@ -127,10 +139,57 @@ class TestPortBindingHardError:
         connected = await runner._start_one_profile_adapters("reviewer", "/tmp/x", {})
         assert connected == 0  # nothing connected, but no MultiplexConfigError
 
+    @pytest.mark.asyncio
+    async def test_secondary_same_config_token_is_refused(self, monkeypatch):
+        """Adapters that keep their token on config still trip the mux guard."""
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+        class _ConfigTokenAdapter:
+            def __init__(self, token):
+                self.config = PlatformConfig(enabled=True, token=token)
+                self.disconnected = False
+
+            async def connect(self):
+                raise AssertionError("duplicate adapter must not connect")
+
+            async def disconnect(self):
+                self.disconnected = True
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._profile_adapters = {}
+
+        reviewer_cfg = GatewayConfig(multiplex_profiles=True)
+        reviewer_cfg.platforms = {
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="same-token"),
+        }
+        duplicate = _ConfigTokenAdapter("same-token")
+        claimed = {
+            (
+                Platform.TELEGRAM,
+                GatewayRunner._adapter_credential_fingerprint(
+                    _ConfigTokenAdapter("same-token")
+                ),
+            ): "default"
+        }
+
+        monkeypatch.setattr(
+            "gateway.config.load_gateway_config", lambda: reviewer_cfg
+        )
+        monkeypatch.setattr(runner, "_create_adapter", lambda p, c: duplicate)
+        monkeypatch.setattr(runner, "_adapter_disconnect_timeout_secs", lambda: 0)
+
+        connected = await runner._start_one_profile_adapters(
+            "reviewer", "/tmp/x", claimed
+        )
+
+        assert connected == 0
+        assert duplicate.disconnected is True
+        assert runner._profile_adapters["reviewer"] == {}
+
     def test_port_binding_set_covers_known_listeners(self):
         from gateway.run import _PORT_BINDING_PLATFORM_VALUES
         # Every adapter that binds a TCP port must be in the guard set.
         for p in ("webhook", "api_server", "msgraph_webhook", "feishu",
                   "wecom_callback", "bluebubbles", "sms"):
             assert p in _PORT_BINDING_PLATFORM_VALUES
-


### PR DESCRIPTION
## Summary
Same-token collision detection now actually works for Telegram (and any adapter that keeps its token on `adapter.config`): `_adapter_credential_fingerprint` falls back to `adapter.config.token` when no direct token attribute exists.

Salvages #51064 by @markoub (clean cherry-pick, authorship preserved). Fixes #51030.

Root cause: the fingerprint helper probed only direct attributes (`token`/`bot_token`/`_token`/`api_token`/`_bot_token`), but the Telegram adapter stores its token exclusively on `self.config.token`. Fingerprint was always `None`, so both the `claimed` seeding and the duplicate-refusal branch in the multiplex adapter registry were dead code — two profiles configured with the same bot token started two competing adapters (getUpdates conflict, messages split between profiles).

## Changes
- `gateway/run.py`: `adapter.config.token` fallback in `_adapter_credential_fingerprint` (hash-not-token property preserved)
- `tests/gateway/test_multiplex_adapter_registry.py`: end-to-end duplicate-refusal test for config-held tokens

## Validation
| | Before | After |
|---|---|---|
| Two profiles, same Telegram token | both connect, getUpdates conflict | second refused with conflict log |
| tests/gateway/test_multiplex_adapter_registry.py | — | 11/11 pass |

Fourth PR in the multiplex isolation cluster (#59310, #59315, #59320).

## Infographic

![token-collision-detection](https://v3b.fal.media/files/b/0aa11be5/YCJIGcOJvEtXGiTzR-X3G_aNmtLBow.png)
