### PR TITLE
feat(volcano-ark): add Volcano Ark as first-class provider

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -369,6 +369,18 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "tencent-tokenhub": [
         "hy3-preview",
     ],
+    "volcano-ark": [
+        # Coding Plan models — OpenAI-compatible endpoint at /api/coding/v3
+        "deepseek-v4-pro",
+        "deepseek-v4-flash",
+        "kimi-k2.6",
+        "kimi-k2.7-code",
+        "glm-5.2",
+        "glm-5.1",
+        "qwen3.7-max",
+        "qwen3.7-plus",
+        "minimax-m3",
+    ],
     "arcee": [
         "trinity-large-thinking",
         "trinity-large-preview",
@@ -1064,6 +1076,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("bedrock",        "AWS Bedrock",              "AWS Bedrock (Claude, Nova, Llama, DeepSeek; IAM or API key)"),
     ProviderEntry("azure-foundry",  "Azure Foundry",            "Azure Foundry (OpenAI-style or Anthropic-style endpoint, your Azure AI deployment)"),
     ProviderEntry("qwen-oauth",     "Qwen OAuth (Portal)",      "Qwen OAuth (Reuses local Qwen CLI login)"),
+    ProviderEntry("volcano-ark",    "Volcano Ark (火山方舟)",     "Volcano Ark Coding Plan — ByteDance ML platform (DeepSeek, Kimi, GLM, Qwen, MiniMax)"),
 ]
 
 # Auto-extend CANONICAL_PROVIDERS with any provider registered in providers/

--- a/plugins/model-providers/volcano-ark/__init__.py
+++ b/plugins/model-providers/volcano-ark/__init__.py
@@ -1,0 +1,40 @@
+"""Volcano Ark (火山方舟) provider profile.
+
+Volcano Ark is ByteDance's ML platform. The Coding Plan exposes an
+OpenAI-compatible chat completions endpoint at /api/coding/v3.
+
+Common models available through the Coding Plan:
+  - DeepSeek V4 Pro / Flash
+  - Kimi K2.6 / K2.7 Code
+  - GLM-5.2 / GLM-5.1
+  - Qwen3.7 Max / Plus
+  - MiniMax M3
+
+The general Ark API at /api/v3 is a different surface and returns
+"InvalidEndpointOrModel.NotFound" for Coding Plan models — always use
+/api/coding/v3 for the Coding Plan.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+volcano_ark = ProviderProfile(
+    name="volcano-ark",
+    aliases=("volcano", "ark", "volcengine", "火山", "火山方舟"),
+    env_vars=("VOLCANO_API_KEY", "ARK_API_KEY"),
+    display_name="Volcano Ark (火山方舟)",
+    description="Volcano Ark Coding Plan — ByteDance ML platform (DeepSeek, Kimi, GLM, Qwen, MiniMax)",
+    signup_url="https://www.volcengine.com/product/ark",
+    base_url="https://ark.cn-beijing.volces.com/api/coding/v3",
+    default_aux_model="deepseek-v4-flash",
+    fallback_models=(
+        "deepseek-v4-pro",
+        "deepseek-v4-flash",
+        "kimi-k2.6",
+        "kimi-k2.7-code",
+        "glm-5.2",
+        "glm-5.1",
+    ),
+)
+
+register_provider(volcano_ark)

--- a/plugins/model-providers/volcano-ark/plugin.yaml
+++ b/plugins/model-providers/volcano-ark/plugin.yaml
@@ -1,0 +1,5 @@
+name: volcano-ark-provider
+kind: model-provider
+version: 1.0.0
+description: Volcano Ark (火山方舟) — ByteDance ML platform
+author: Nous Research


### PR DESCRIPTION
## Summary

Volcano Ark (火山方舟) is ByteDance's ML platform offering a Coding Plan with an OpenAI-compatible chat completions endpoint at `/api/coding/v3`. It provides access to models from multiple vendors (DeepSeek, Kimi, GLM, Qwen, MiniMax) through a single API key.

Previously, users had to configure Volcano Ark via `custom_providers` or `model_aliases` + `providers` dict in `config.yaml` — it was not selectable from the model picker, and `/model` could not resolve it as a native provider.

## Changes

1. **`plugins/model-providers/volcano-ark/`** — new ProviderProfile plugin:
   - `base_url`: `https://ark.cn-beijing.volces.com/api/coding/v3`
   - `env_vars`: `VOLCANO_API_KEY`, `ARK_API_KEY`
   - `aliases`: `volcano`, `ark`, `volcengine`, `火山`, `火山方舟`
   - `fallback_models`: DeepSeek, Kimi, GLM, Qwen, MiniMax

2. **`hermes_cli/models.py`** — registered in `CANONICAL_PROVIDERS` for picker visibility and `_PROVIDER_MODELS` for `/model` listing

## Usage

After this change, users can select Volcano Ark directly in the model picker:

```
/model volcano-ark:glm-5.2
hermes model --provider volcano-ark
```

Environment variable: `VOLCANO_API_KEY` (or `ARK_API_KEY`)

## Model List

Models available through the Coding Plan endpoint:

| Model | Family |
|-------|--------|
| `deepseek-v4-pro` | DeepSeek |
| `deepseek-v4-flash` | DeepSeek |
| `kimi-k2.6` | Moonshot |
| `kimi-k2.7-code` | Moonshot |
| `glm-5.2` | Zhipu |
| `glm-5.1` | Zhipu |
| `qwen3.7-max` | Alibaba |
| `qwen3.7-plus` | Alibaba |
| `minimax-m3` | MiniMax |

## Test Plan

- [x] `CANONICAL_PROVIDERS` includes `volcano-ark` entry (verified via import)
- [x] `_PROVIDER_MODELS["volcano-ark"]` returns the model list (verified via import)
- [ ] `hermes model` picker shows Volcano Ark as a selectable provider
- [ ] `/model volcano-ark:glm-5.2` resolves and connects with a valid `VOLCANO_API_KEY`
- [ ] Existing provider configurations are unaffected