### PR TITLE
fix(telegram): avoid lingering typing after review notice

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -229,6 +229,26 @@ def _non_conversational_metadata(
     return merged
 
 
+def _post_delivery_status_metadata(
+    metadata: Optional[Dict[str, Any]] = None,
+    *,
+    platform: Any = None,
+) -> Dict[str, Any]:
+    """Metadata for status notices sent after the main reply.
+
+    Telegram's Bot API has no explicit "stop typing" call.  The Telegram
+    adapter therefore treats metadata["notify"] as the final-send marker and
+    avoids re-arming the ~5s typing timer after that send.  Post-delivery
+    background-review notices are sent after the main reply and after the
+    typing loop has been stopped, so they must carry the same marker; otherwise
+    a small "Self-improvement review" notice can leave the chat header showing
+    "bot is typing" even though no agent work remains.
+    """
+    merged = dict(_non_conversational_metadata(metadata, platform=platform) or {})
+    merged["notify"] = True
+    return merged
+
+
 def _is_transient_network_error(exc: BaseException) -> bool:
     """Return True for transient network errors safe to log + swallow.
 
@@ -18404,7 +18424,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _status_adapter.send(
                         _status_chat_id,
                         message,
-                        metadata=_non_conversational_metadata(_status_thread_metadata, platform=source.platform),
+                        metadata=_post_delivery_status_metadata(
+                            _status_thread_metadata,
+                            platform=source.platform,
+                        ),
                     ),
                     _loop_for_step,
                     logger=logger,

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "raymaylee@gmail.com": "raymaylee",  # PR #59326 (telegram: avoid lingering typing after review notice)
     "iganapolsky@gmail.com": "IgorGanapolsky",  # PR #62125 salvage (compaction anti-thrash threshold verification)
     "tturney1@gmail.com": "TheTom",  # PR #62696 salvage (gateway: expand @ context references under runtime/session model resolution)
     "wilsonkinyuam@gmail.com": "WilsonKinyua",  # PR #62052 (tui: persist unflushed conversations on disconnect/restart)

--- a/tests/gateway/test_post_delivery_status_metadata.py
+++ b/tests/gateway/test_post_delivery_status_metadata.py
@@ -1,0 +1,20 @@
+from gateway.run import _post_delivery_status_metadata
+
+
+def test_post_delivery_status_metadata_marks_notify_for_telegram():
+    metadata = {"message_thread_id": 23}
+
+    result = _post_delivery_status_metadata(metadata, platform="telegram")
+
+    assert result == {"message_thread_id": 23, "notify": True}
+    assert metadata == {"message_thread_id": 23}
+
+
+def test_post_delivery_status_metadata_preserves_discord_non_conversational_marker():
+    result = _post_delivery_status_metadata({"channel_id": "c1"}, platform="discord")
+
+    assert result == {
+        "channel_id": "c1",
+        "non_conversational": True,
+        "notify": True,
+    }


### PR DESCRIPTION
## Summary
- mark post-delivery background-review/status notices as final `notify` sends
- preserve Discord's non-conversational status metadata while avoiding Telegram typing re-arming
- add a regression test for the post-delivery status metadata helper

## Why
Telegram has no explicit stop-typing Bot API call. The Telegram adapter already uses `metadata["notify"]` to avoid re-triggering typing on final replies, but post-delivery background review/status notices are sent after the main reply and after the typing loop is stopped. Without the same marker, those notices can re-arm Telegram's typing timer and leave the chat header showing the bot as typing even though no work remains.

## Test Plan
- `python -m pytest tests/gateway/test_post_delivery_status_metadata.py tests/gateway/test_keep_typing_timeout.py -q -o 'addopts='`
- Result: `7 passed in 7.02s`
