### PR TITLE
feat(tui): show runtime details in status bar

### DIFF
--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -243,6 +243,39 @@ describe('StatusRule session count click target', () => {
   })
 })
 
+
+describe('StatusRule runtime detail readout', () => {
+  it('labels non-default reasoning effort explicitly in the model segment', () => {
+    const element = StatusRule({
+      ...baseProps,
+      model: 'openai-codex/gpt-5.5',
+      modelReasoningEffort: 'xhigh'
+    })
+
+    expect(textContent(element)).toContain('R:xhigh')
+  })
+
+  it('renders provider, tool-call count, and cost as budgeted status segments on a wide terminal', () => {
+    const element = StatusRule({
+      ...baseProps,
+      cols: 140,
+      model: 'openai-codex/gpt-5.5',
+      modelProvider: 'openai-codex',
+      usage: {
+        ...baseProps.usage,
+        calls: 12,
+        cost_status: 'estimated',
+        cost_usd: 0.0421
+      }
+    })
+
+    const rendered = textContent(element)
+    expect(rendered).toContain('via openai-codex')
+    expect(rendered).toContain('tools 12')
+    expect(rendered).toContain('~$0.042')
+  })
+})
+
 describe('StatusRule credits notice render priority', () => {
   it('replaces the idle status with the notice text and keeps model + context', () => {
     const element = StatusRule({

--- a/ui-tui/src/__tests__/statusRule.test.ts
+++ b/ui-tui/src/__tests__/statusRule.test.ts
@@ -69,6 +69,8 @@ describe('statusBarSegments', () => {
       voice: true,
       bg: true,
       subagents: true,
+      tools: true,
+      provider: true,
       cost: true
     })
   })
@@ -83,7 +85,7 @@ describe('statusBarSegments', () => {
   })
 
   it('sheds tail segments in priority order as the terminal narrows', () => {
-    // cost is the first to go, the context bar the last of the tail.
+    // provider/cost/tools are the first to go, the context bar the last of the tail.
     const order: (keyof ReturnType<typeof statusBarSegments>)[] = [
       'bar',
       'duration',
@@ -91,7 +93,9 @@ describe('statusBarSegments', () => {
       'voice',
       'bg',
       'subagents',
-      'cost'
+      'tools',
+      'cost',
+      'provider'
     ]
 
     let prevCount = Infinity

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -248,8 +248,11 @@ export interface StatusBarSegments {
   bg: boolean
   compactCtx: boolean
   compressions: boolean
+  cost: boolean
   duration: boolean
+  provider: boolean
   subagents: boolean
+  tools: boolean
   voice: boolean
 }
 
@@ -263,7 +266,10 @@ export function statusBarSegments(cols: number): StatusBarSegments {
     compressions: w >= 80,
     voice: w >= 84,
     bg: w >= 88,
-    subagents: w >= 92
+    subagents: w >= 92,
+    tools: w >= 96,
+    cost: w >= 104,
+    provider: w >= 112
   }
 }
 
@@ -361,7 +367,23 @@ const effortLabel = (effort?: string) => {
     .trim()
     .toLowerCase()
 
-  return value && value !== 'medium' && value !== 'normal' && value !== 'default' ? value : ''
+  return value && value !== 'medium' && value !== 'normal' && value !== 'default' ? `R:${value}` : ''
+}
+
+const providerLabel = (provider?: string) => {
+  const value = String(provider ?? '').trim()
+
+  return value ? `via ${value}` : ''
+}
+
+const costLabel = (usage: Usage) => {
+  if (typeof usage.cost_usd !== 'number' || !Number.isFinite(usage.cost_usd) || usage.cost_usd <= 0) {
+    return ''
+  }
+
+  const prefix = usage.cost_status === 'estimated' ? '~' : ''
+
+  return `${prefix}$${usage.cost_usd.toFixed(3)}`
 }
 
 const shortModelLabel = (model: string) =>
@@ -409,6 +431,7 @@ export function StatusRule({
   status,
   statusColor,
   model,
+  modelProvider,
   modelFast,
   modelReasoningEffort,
   indicatorStyle = 'kaomoji',
@@ -492,6 +515,10 @@ export function StatusRule({
 
   const sessionCountText = liveSessionCount > 0 ? statusSessionCountLabel(liveSessionCount) : ''
   const compressions = typeof usage.compressions === 'number' ? usage.compressions : 0
+  const toolCalls = typeof usage.calls === 'number' ? usage.calls : 0
+  const toolCallsText = toolCalls > 0 ? `tools ${toolCalls}` : ''
+  const costText = costLabel(usage)
+  const providerText = providerLabel(modelProvider)
 
   // Dev-only readout (HERMES_DEV_CREDITS). The server omits the key entirely unless the
   // flag is on, so this segment self-hides for normal users. micros→cents is allowed money
@@ -517,6 +544,9 @@ export function StatusRule({
   const showBg = segs.bg && bgCount > 0 && fits(SEP + stringWidth(`${bgCount} bg`))
   const subagentCount = typeof usage.active_subagents === 'number' ? usage.active_subagents : 0
   const showSubagents = segs.subagents && subagentCount > 0 && fits(SEP + stringWidth(`⛓ ${subagentCount}`))
+  const showTools = segs.tools && !!toolCallsText && fits(SEP + stringWidth(toolCallsText))
+  const showCost = segs.cost && !!costText && fits(SEP + stringWidth(costText))
+  const showProvider = segs.provider && !!providerText && fits(SEP + stringWidth(providerText))
 
   // Parked-background reassurance: a top-level delegate_task runs in the
   // background, so the turn ends (idle) while the subagent keeps working and its
@@ -637,6 +667,24 @@ export function StatusRule({
         {showSubagents ? (
           <Text color={t.color.muted} wrap="truncate-end">
             {' │ '}⛓ {subagentCount}
+          </Text>
+        ) : null}
+        {showTools ? (
+          <Text color={t.color.muted} wrap="truncate-end">
+            {' │ '}
+            {toolCallsText}
+          </Text>
+        ) : null}
+        {showCost ? (
+          <Text color={usage.cost_status === 'exact' ? t.color.statusGood : t.color.muted} wrap="truncate-end">
+            {' │ '}
+            {costText}
+          </Text>
+        ) : null}
+        {showProvider ? (
+          <Text color={t.color.muted} wrap="truncate-end">
+            {' │ '}
+            {providerText}
           </Text>
         ) : null}
         {showResumeHint ? (
@@ -777,6 +825,7 @@ interface StatusRuleProps {
   cols: number
   cwdLabel: string
   model: string
+  modelProvider?: string
   modelFast?: boolean
   modelReasoningEffort?: string
   indicatorStyle?: IndicatorStyle

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -475,6 +475,7 @@ const StatusRulePane = memo(function StatusRulePane({
         liveSessionCount={ui.liveSessionCount}
         model={ui.info?.model ?? ''}
         modelFast={ui.info?.fast || ui.info?.service_tier === 'priority'}
+        modelProvider={ui.info?.provider}
         modelReasoningEffort={ui.info?.reasoning_effort}
         notice={ui.notice}
         onSessionCountClick={() => patchOverlayState({ sessions: true })}

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -154,6 +154,7 @@ export interface SessionInfo {
   mcp_servers?: McpServerStatus[]
   model: string
   profile_name?: string
+  provider?: string
   reasoning_effort?: string
   release_date?: string
   service_tier?: string


### PR DESCRIPTION
## Summary
- Make non-default TUI reasoning effort explicit as `R:<level>` in the model segment.
- Add budgeted status-bar tail segments for provider (`via ...`), tool-call count (`tools N`), and cost (`~$...` for estimated costs).
- Wire `SessionInfo.provider` through `StatusRule` and add regression coverage for the new readouts.

## Test Plan
- `npm test -- --run src/__tests__/appChromeStatusRule.test.tsx` (RED before implementation: 2 expected failures)
- `npm test -- --run src/__tests__/appChromeStatusRule.test.tsx src/__tests__/appChromeStatusRuleDevCredits.test.tsx src/__tests__/statusRule.test.ts` ✅
- `npm run typecheck` ✅
- `npx eslint src/components/appChrome.tsx src/components/appLayout.tsx src/types.ts src/__tests__/appChromeStatusRule.test.tsx src/__tests__/statusRule.test.ts` ✅
- `npm run build` ✅

## Notes
- Full `npm test -- --run` currently has an unrelated pre-existing failure in `src/__tests__/virtualHeights.test.ts`; verified it reproduces after stashing this change.
- `src/__tests__/cursorDriftRegression.test.ts` timed out once in the full run but passed when rerun with the focused pristine check.
