### PR TITLE
fix(telegram): bound webhook startup deadline

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3209,18 +3209,48 @@ class TelegramAdapter(BasePlatformAdapter):
                 from urllib.parse import urlparse
                 webhook_path = urlparse(webhook_url).path or "/telegram"
 
-                await self._app.updater.start_webhook(
-                    listen="0.0.0.0",
-                    port=webhook_port,
-                    url_path=webhook_path,
-                    webhook_url=webhook_url,
-                    secret_token=webhook_secret,
-                    allowed_updates=Update.ALL_TYPES,
-                    # Webhooks are push-based — Telegram does not hold a
-                    # server-side getUpdates queue, so this flag is a no-op
-                    # in practice. Mirror the polling path's reconnect
-                    # semantics for consistency.
-                    drop_pending_updates=not is_reconnect,
+                async def _cleanup_abandoned_webhook_start(app=self._app):
+                    try:
+                        updater = getattr(app, "updater", None) if app else None
+                        if updater and getattr(updater, "running", False):
+                            try:
+                                await asyncio.wait_for(
+                                    updater.stop(), timeout=_UPDATER_STOP_TIMEOUT
+                                )
+                            except asyncio.TimeoutError:
+                                logger.warning(
+                                    "[%s] updater.stop() timed out during webhook "
+                                    "startup cleanup; forcing app shutdown",
+                                    self.name,
+                                )
+                            except Exception as stop_error:
+                                logger.warning(
+                                    "[%s] updater.stop() failed during webhook "
+                                    "startup cleanup: %s",
+                                    self.name,
+                                    _redact_telegram_error_text(stop_error),
+                                )
+                        if app and getattr(app, "running", False):
+                            await app.stop()
+                    finally:
+                        await _shutdown_abandoned_app(app)
+
+                await _await_with_thread_deadline(
+                    self._app.updater.start_webhook(
+                        listen="0.0.0.0",
+                        port=webhook_port,
+                        url_path=webhook_path,
+                        webhook_url=webhook_url,
+                        secret_token=webhook_secret,
+                        allowed_updates=Update.ALL_TYPES,
+                        # Webhooks are push-based — Telegram does not hold a
+                        # server-side getUpdates queue, so this flag is a no-op
+                        # in practice. Mirror the polling path's reconnect
+                        # semantics for consistency.
+                        drop_pending_updates=not is_reconnect,
+                    ),
+                    timeout=_init_timeout,
+                    on_abandon=_cleanup_abandoned_webhook_start,
                 )
                 self._webhook_mode = True
                 logger.info(

--- a/tests/gateway/test_telegram_init_deadline.py
+++ b/tests/gateway/test_telegram_init_deadline.py
@@ -82,6 +82,99 @@ async def test_connect_retries_when_initialize_wall_deadline_expires(monkeypatch
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("stop_failure", [None, "timeout", "error"])
+async def test_connect_bounds_webhook_start_with_wall_deadline(
+    monkeypatch, caplog, stop_failure
+):
+    """Webhook bootstrap must not wedge connect() after app.start() succeeds."""
+    lifecycle = []
+    stop_timeouts = []
+
+    async def _stop_updater():
+        lifecycle.append("updater.stop")
+        if stop_failure == "error":
+            raise RuntimeError("updater stop failed")
+
+    async def _stop_app():
+        lifecycle.append("app.stop")
+
+    async def _shutdown_app():
+        lifecycle.append("app.shutdown")
+
+    real_wait_for = tg_adapter.asyncio.wait_for
+
+    async def _recording_wait_for(awaitable, timeout):
+        stop_timeouts.append(timeout)
+        result = await real_wait_for(awaitable, timeout)
+        if stop_failure == "timeout":
+            raise tg_adapter.asyncio.TimeoutError()
+        return result
+
+    fake_updater = MagicMock()
+    fake_updater.start_webhook = AsyncMock(return_value=None)
+    fake_updater.stop = AsyncMock(side_effect=_stop_updater)
+    fake_updater.running = True
+    fake_app = MagicMock()
+    fake_app.bot = MagicMock()
+    fake_app.initialize = AsyncMock(return_value=None)
+    fake_app.start = AsyncMock(return_value=None)
+    fake_app.stop = AsyncMock(side_effect=_stop_app)
+    fake_app.shutdown = AsyncMock(side_effect=_shutdown_app)
+    fake_app.add_handler = MagicMock()
+    fake_app.running = True
+    fake_app.updater = fake_updater
+
+    chainable = MagicMock()
+    chainable.token.return_value = chainable
+    chainable.request.return_value = chainable
+    chainable.get_updates_request.return_value = chainable
+    chainable.build.return_value = fake_app
+
+    builder_root = MagicMock()
+    builder_root.builder.return_value = chainable
+    monkeypatch.setattr(tg_adapter, "Application", builder_root)
+    monkeypatch.setattr(tg_adapter, "HTTPXRequest", MagicMock)
+    monkeypatch.setattr(tg_adapter, "discover_fallback_ips", AsyncMock(return_value=[]))
+    monkeypatch.setattr(tg_adapter, "resolve_proxy_url", lambda *a, **k: None)
+    monkeypatch.setattr(tg_adapter.asyncio, "wait_for", _recording_wait_for)
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_URL", "https://example.com/telegram")
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "secret")
+
+    deadline_calls = 0
+
+    async def _fake_deadline(awaitable, timeout, *, on_abandon=None):
+        nonlocal deadline_calls
+        deadline_calls += 1
+        if deadline_calls == 1:
+            return await awaitable
+        awaitable.close()
+        assert on_abandon is not None
+        await on_abandon()
+        raise tg_adapter.asyncio.TimeoutError()
+
+    monkeypatch.setattr(tg_adapter, "_await_with_thread_deadline", _fake_deadline)
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    monkeypatch.setattr(adapter, "_acquire_platform_lock", lambda *a, **k: True)
+    monkeypatch.setattr(adapter, "_fallback_ips", lambda: [])
+    monkeypatch.setattr(adapter, "_start_post_connect_housekeeping", MagicMock())
+
+    assert await adapter.connect() is False
+
+    assert deadline_calls == 2
+    fake_app.initialize.assert_awaited_once()
+    fake_app.start.assert_awaited_once()
+    fake_updater.start_webhook.assert_called_once()
+    fake_updater.stop.assert_awaited_once()
+    fake_app.stop.assert_awaited_once()
+    fake_app.shutdown.assert_awaited_once()
+    assert stop_timeouts == [tg_adapter._UPDATER_STOP_TIMEOUT]
+    assert lifecycle == ["updater.stop", "app.stop", "app.shutdown"]
+    if stop_failure:
+        assert "webhook startup cleanup" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_await_with_thread_deadline_returns_value_on_happy_path():
     """The real helper returns the awaited result and raises no timeout."""
     async def _ok():


### PR DESCRIPTION
## What does this PR do?

Bounds Telegram webhook startup with the same wall-clock deadline helper already used for `Application.initialize()`.

Current `main` already prevents `initialize()` from wedging the Telegram `connect()` path, but webhook mode still awaited `updater.start_webhook()` directly after `app.start()` succeeds. If PTB/httpcore wedges there, the gateway process remains alive while Telegram delivery never becomes active and `connect()` never returns.

This wraps the webhook start await in `_await_with_thread_deadline(..., timeout=_init_timeout)`. On timeout, it best-effort stops/shuts down the already-started app so a failed connect does not leave a half-started webhook app behind.

## Related Issue

Related to #59202. The reported `initialize()` path appears covered on current `main`; this PR handles the adjacent webhook-mode startup await in the same Telegram connect flow.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/telegram/adapter.py`
  - Wrap `self._app.updater.start_webhook(...)` in `_await_with_thread_deadline(...)`.
  - Reuse `_init_timeout` for the webhook bootstrap deadline.
  - On abandonment, best-effort stop/shutdown the already-started app.
- `tests/gateway/test_telegram_init_deadline.py`
  - Add a focused regression test for webhook startup timing out after `app.start()` succeeds.

## How to Test

1. Ran the Telegram init-deadline regression suite:

```bash
uv run pytest tests/gateway/test_telegram_init_deadline.py -q
```

Result:

```text
7 passed
```

2. Ran the adjacent Telegram reconnect test with the deadline suite:

```bash
uv run pytest tests/gateway/test_telegram_init_deadline.py tests/gateway/test_telegram_network_reconnect.py::test_polling_bootstrap_network_error_schedules_background_recovery -q
```

Result:

```text
8 passed
```

3. Ran targeted lint:

```bash
uv run ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_init_deadline.py
```

Result:

```text
All checks passed!
```

4. Ran targeted type check:

```bash
uv run ty check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_init_deadline.py
```

This still reports pre-existing Telegram SDK/stub diagnostics in the adapter. The PR's GitHub `ruff + ty diff` check passes, confirming no net-new type diagnostics from this diff.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
