### PR TITLE
fix(approval): gate security config CLI mutations

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -612,6 +612,51 @@ class TestHermesConfigWriteProtection:
         dangerous, key, desc = detect_dangerous_command("cp /tmp/evil.yaml ~/.hermes/config.yaml")
         assert dangerous is True
 
+    def test_cli_config_set_approval_mode(self):
+        dangerous, key, desc = detect_dangerous_command("hermes config set approvals.mode off")
+        assert dangerous is True
+        assert key is not None
+        assert "security config" in desc.lower()
+
+    def test_cli_config_set_yolo(self):
+        dangerous, key, desc = detect_dangerous_command("hermes config set yolo true")
+        assert dangerous is True
+        assert "security config" in desc.lower()
+
+    def test_cli_config_set_approval_deny_with_profile_flag(self):
+        dangerous, key, desc = detect_dangerous_command(
+            "hermes --profile prod config set approvals.deny '[\"python *\"]'"
+        )
+        assert dangerous is True
+        assert "security config" in desc.lower()
+
+    def test_cli_config_set_security_key_with_short_profile_flag(self):
+        dangerous, key, desc = detect_dangerous_command(
+            "hermes -p prod config set security.tirith_enabled false"
+        )
+        assert dangerous is True
+        assert "security config" in desc.lower()
+
+    def test_cli_config_set_display_key_safe(self):
+        dangerous, key, desc = detect_dangerous_command(
+            "hermes config set display.show_cost true"
+        )
+        assert dangerous is False
+        assert key is None
+
+    def test_security_config_key_ignores_preexisting_cached_scopes(self):
+        _, key, _ = detect_dangerous_command(
+            "hermes config set security.tirith_enabled false"
+        )
+        session_key = "legacy-security-config-approval"
+        approval_module.load_permanent({key})
+        assert key not in approval_module._permanent_approved
+
+        approval_module._session_approved[session_key] = {key}
+        approval_module._permanent_approved.add(key)
+
+        assert is_approved(session_key, key) is False
+
     def test_sed_in_place(self):
         # The gap the pairing closes: sed -i mutates the file directly,
         # bypassing the redirection/tee patterns.

--- a/tests/tools/test_command_guards.py
+++ b/tests/tools/test_command_guards.py
@@ -144,6 +144,78 @@ class TestTirithAllowDangerous:
         # allow_permanent should be True (no tirith warning)
         assert cb.call_args[1]["allow_permanent"] is True
 
+    @patch(_TIRITH_PATCH, return_value=_tirith_result("allow"))
+    @patch("hermes_cli.config.load_config", return_value={"approvals": {"mode": "manual"}})
+    def test_security_config_cli_set_prompts(self, mock_config, mock_tirith):
+        os.environ["HERMES_INTERACTIVE"] = "1"
+        cb = MagicMock(return_value="deny")
+        result = check_all_command_guards(
+            "hermes config set approvals.mode off",
+            "local",
+            approval_callback=cb,
+        )
+
+        assert result["approved"] is False
+        cb.assert_called_once()
+        assert "security config" in cb.call_args.args[1].lower()
+        assert cb.call_args.kwargs["allow_permanent"] is False
+
+    @pytest.mark.parametrize("legacy_choice", ["session", "always"])
+    def test_security_config_cli_approval_is_one_shot(
+        self, monkeypatch, legacy_choice
+    ):
+        os.environ["HERMES_INTERACTIVE"] = "1"
+        session_key = f"cli-security-config-{legacy_choice}"
+        token = set_current_session_key(session_key)
+        cb = MagicMock(side_effect=[legacy_choice, "deny"])
+        monkeypatch.setattr(
+            approval_module, "save_permanent_allowlist", lambda _patterns: None
+        )
+
+        try:
+            with patch(_TIRITH_PATCH, return_value=_tirith_result("allow")), patch(
+                "hermes_cli.config.load_config",
+                return_value={"approvals": {"mode": "manual"}},
+            ):
+                first = check_all_command_guards(
+                    "hermes config set security.tirith_enabled false",
+                    "local",
+                    approval_callback=cb,
+                )
+                second = check_all_command_guards(
+                    "hermes config set approvals.mode off",
+                    "local",
+                    approval_callback=cb,
+                )
+        finally:
+            reset_current_session_key(token)
+
+        assert first["approved"] is True
+        assert second["approved"] is False
+        assert cb.call_count == 2
+        assert all(
+            call.kwargs["allow_permanent"] is False
+            for call in cb.call_args_list
+        )
+        _, pattern_key, _ = approval_module.detect_dangerous_command(
+            "hermes config set approvals.mode off"
+        )
+        assert is_approved(session_key, pattern_key) is False
+
+    @patch(_TIRITH_PATCH, return_value=_tirith_result("allow"))
+    @patch("hermes_cli.config.load_config", return_value={"approvals": {"mode": "manual"}})
+    def test_non_security_config_cli_set_stays_auto_approved(self, mock_config, mock_tirith):
+        os.environ["HERMES_INTERACTIVE"] = "1"
+        cb = MagicMock(return_value="deny")
+        result = check_all_command_guards(
+            "hermes config set display.show_cost true",
+            "local",
+            approval_callback=cb,
+        )
+
+        assert result["approved"] is True
+        cb.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # tirith warn + safe command
@@ -417,3 +489,57 @@ class TestGatewayApprovalAllowPermanent:
         renderer hides "Always allow"."""
         payload = self._capture_gateway_payload("curl https://bit.ly/abc", "gw-no-perm")
         assert payload["allow_permanent"] is False
+
+    @pytest.mark.parametrize("legacy_choice", ["session", "always"])
+    def test_security_config_gateway_approval_is_one_shot(
+        self, monkeypatch, legacy_choice
+    ):
+        from tools.approval import (
+            register_gateway_notify,
+            resolve_gateway_approval,
+            unregister_gateway_notify,
+        )
+
+        session_key = f"gw-security-config-{legacy_choice}"
+        choices = iter([legacy_choice, "deny"])
+        captured = []
+
+        def notify(data):
+            captured.append(dict(data))
+            resolve_gateway_approval(session_key, next(choices))
+
+        monkeypatch.setattr(
+            approval_module, "save_permanent_allowlist", lambda _patterns: None
+        )
+        register_gateway_notify(session_key, notify)
+        token = set_current_session_key(session_key)
+        os.environ["HERMES_GATEWAY_SESSION"] = "1"
+        os.environ["HERMES_EXEC_ASK"] = "1"
+        os.environ["HERMES_SESSION_KEY"] = session_key
+        try:
+            with patch(_TIRITH_PATCH, return_value=_tirith_result("allow")), patch(
+                "hermes_cli.config.load_config",
+                return_value={"approvals": {"mode": "manual"}},
+            ):
+                first = check_all_command_guards(
+                    "hermes config set security.tirith_enabled false", "local"
+                )
+                second = check_all_command_guards(
+                    "hermes config set approvals.mode off", "local"
+                )
+        finally:
+            os.environ.pop("HERMES_GATEWAY_SESSION", None)
+            os.environ.pop("HERMES_EXEC_ASK", None)
+            os.environ.pop("HERMES_SESSION_KEY", None)
+            reset_current_session_key(token)
+            unregister_gateway_notify(session_key)
+
+        assert first["approved"] is True
+        assert second["approved"] is False
+        assert len(captured) == 2
+        assert captured[0]["allow_permanent"] is False
+        assert captured[0]["choices"] == ["once", "deny"]
+        _, pattern_key, _ = approval_module.detect_dangerous_command(
+            "hermes config set approvals.mode off"
+        )
+        assert is_approved(session_key, pattern_key) is False

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -273,6 +273,14 @@ _HERMES_CONFIG_PATH = (
     r'(?:\$hermes_home|\$\{hermes_home\})/)'
     r'config\.yaml\b'
 )
+_HERMES_SECURITY_CONFIG_KEY = (
+    r'(?:approvals(?:\.[^\s"\'`]+)?|'
+    r'yolo|'
+    r'command_allowlist(?:\.[^\s"\'`]+)?|'
+    r'security(?:\.[^\s"\'`]+)?)'
+)
+_HERMES_SECURITY_CONFIG_APPROVAL_KEY = "modify Hermes security config via CLI"
+_ONE_SHOT_APPROVAL_KEYS = frozenset({_HERMES_SECURITY_CONFIG_APPROVAL_KEY})
 _PROJECT_ENV_PATH = r'(?:(?:/|\.{1,2}/)?(?:[^\s/"\'`]+/)*\.env(?:\.[^/\s"\'`]+)*)'
 _PROJECT_CONFIG_PATH = r'(?:(?:/|\.{1,2}/)?(?:[^\s/"\'`]+/)*config\.yaml)'
 _SHELL_RC_FILES = (
@@ -685,6 +693,14 @@ DANGEROUS_PATTERNS = [
     # profile flag can't slip the agent past the guard.
     (r'\bhermes\s+(?:-{1,2}\S+(?:\s+\S+)?\s+)*gateway\s+(stop|restart)\b', "stop/restart hermes gateway (kills running agents)"),
     (r'\bhermes\s+update\b', "hermes update (restarts gateway, kills running agents)"),
+    # `~/.hermes/config.yaml` is already protected against direct shell writes
+    # above, but `hermes config set` is the documented front door to the same
+    # security policy. Gate only approval/security keys so ordinary display or
+    # UX config edits remain usable.
+    (
+        rf'\bhermes\s+(?:-{{1,2}}\S+(?:\s+\S+)?\s+)*config\s+set\s+["\']?{_HERMES_SECURITY_CONFIG_KEY}["\']?(?:\s|$)',
+        _HERMES_SECURITY_CONFIG_APPROVAL_KEY,
+    ),
     # Docker container lifecycle — any user with docker.sock mounted (a common
     # Docker Compose pattern) gives the agent the ability to restart/stop/kill
     # containers without approval.  These are agent-initiated lifecycle operations
@@ -857,6 +873,11 @@ def _approval_key_aliases(pattern_key: str) -> set[str]:
     historical regex-derived key.
     """
     return _PATTERN_KEY_ALIASES.get(pattern_key, {pattern_key})
+
+
+def _is_one_shot_approval_key(pattern_key: str) -> bool:
+    """Return whether an approval key must never be cached or persisted."""
+    return bool(_approval_key_aliases(pattern_key) & _ONE_SHOT_APPROVAL_KEYS)
 
 
 # =========================================================================
@@ -2120,6 +2141,8 @@ def submit_pending(session_key: str, approval: dict):
 
 def approve_session(session_key: str, pattern_key: str):
     """Approve a pattern for this session only."""
+    if _is_one_shot_approval_key(pattern_key):
+        return
     with _lock:
         _session_approved.setdefault(session_key, set()).add(pattern_key)
 
@@ -2175,6 +2198,8 @@ def is_approved(session_key: str, pattern_key: str) -> bool:
     Accept both the current canonical key and the legacy regex-derived key so
     existing command_allowlist entries continue to work after key migrations.
     """
+    if _is_one_shot_approval_key(pattern_key):
+        return False
     aliases = _approval_key_aliases(pattern_key)
     with _lock:
         if any(alias in _permanent_approved for alias in aliases):
@@ -2185,6 +2210,8 @@ def is_approved(session_key: str, pattern_key: str) -> bool:
 
 def approve_permanent(pattern_key: str):
     """Add a pattern to the permanent allowlist."""
+    if _is_one_shot_approval_key(pattern_key):
+        return
     with _lock:
         _permanent_approved.add(pattern_key)
 
@@ -2192,7 +2219,10 @@ def approve_permanent(pattern_key: str):
 def load_permanent(patterns: set):
     """Bulk-load permanent allowlist entries from config."""
     with _lock:
-        _permanent_approved.update(patterns)
+        _permanent_approved.update(
+            pattern for pattern in patterns
+            if not _is_one_shot_approval_key(pattern)
+        )
 
 
 _ALLOWLIST_SHELL_OPERATOR_RE = re.compile(r"(?:\n|&&|\|\||[;&|<>`]|\$\()")
@@ -2693,6 +2723,7 @@ def _run_approval_gate(
         return {"approved": True, "message": None}
 
     session_key = get_current_session_key()
+    one_shot_only = _is_one_shot_approval_key(pattern_key)
     if is_approved(session_key, pattern_key):
         return {"approved": True, "message": None}
 
@@ -2762,8 +2793,10 @@ def _run_approval_gate(
                 "pattern_key": pattern_key,
                 "pattern_keys": [pattern_key],
                 "description": redact_sensitive_text(description),
-                "allow_permanent": True,
+                "allow_permanent": not one_shot_only,
             }
+            if one_shot_only:
+                approval_data["choices"] = ["once", "deny"]
             decision = _await_gateway_decision(
                 session_key, notify_cb, approval_data, surface="gateway"
             )
@@ -2811,12 +2844,18 @@ def _run_approval_gate(
 
         # No notify callback (e.g. API server without an attached chat):
         # queue for /approve /deny review, agent sees approval_required.
-        submit_pending(session_key, {
+        pending_data = {
             "command": display_target,
             "pattern_key": pattern_key,
             "description": description,
-        })
-        return {
+        }
+        if one_shot_only:
+            pending_data.update(
+                allow_permanent=False,
+                choices=["once", "deny"],
+            )
+        submit_pending(session_key, pending_data)
+        result = {
             "approved": False,
             "pattern_key": pattern_key,
             "status": "approval_required",
@@ -2827,8 +2866,15 @@ def _run_approval_gate(
                 f"Asking the user for approval.\n\n**Target:**\n```\n{display_target}\n```"
             ),
         }
+        if one_shot_only:
+            result.update(
+                allow_permanent=False,
+                choices=["once", "deny"],
+            )
+        return result
 
     choice = prompt_dangerous_approval(display_target, description,
+                                       allow_permanent=not one_shot_only,
                                        approval_callback=approval_callback)
 
     if choice == "deny":
@@ -3417,6 +3463,7 @@ def check_all_command_guards(command: str, env_type: str,
     primary_key = warnings[0][0]
     all_keys = [key for key, _, _ in warnings]
     has_tirith = any(is_t for _, _, is_t in warnings)
+    one_shot_only = any(_is_one_shot_approval_key(key) for key in all_keys)
 
     # Gateway/async approval — block the agent thread until the user
     # responds with /approve or /deny, mirroring the CLI's synchronous
@@ -3445,10 +3492,16 @@ def check_all_command_guards(command: str, env_type: str,
                 "pattern_key": primary_key,
                 "pattern_keys": all_keys,
                 "description": redact_sensitive_text(combined_desc),
-                # Smart DENY overrides are one-operation decisions, so the UI
+                # Smart DENY overrides and non-persistable security mutations
                 # must not offer a permanent scope.
-                "allow_permanent": not has_tirith and not smart_denied_for_owner,
+                "allow_permanent": (
+                    not has_tirith
+                    and not smart_denied_for_owner
+                    and not one_shot_only
+                ),
             }
+            if one_shot_only:
+                approval_data["choices"] = ["once", "deny"]
             if smart_denied_for_owner:
                 approval_data["smart_denied"] = True
             decision = _await_gateway_decision(
@@ -3503,9 +3556,9 @@ def check_all_command_guards(command: str, env_type: str,
                     "deny_reason": deny_reason,
                 }
 
-            # A smart-DENY owner override is always one operation, even if an
-            # older client returns "session" or "always". Manual and ESCALATE
-            # choices retain their existing persistence semantics.
+            # A smart-DENY owner override is always one operation. The
+            # approve_* helpers also reject one-shot keys, so an older client
+            # returning "session" or "always" cannot cache those decisions.
             if not smart_denied_for_owner:
                 for key, _, is_tirith in warnings:
                     if choice == "session" or (choice == "always" and is_tirith):
@@ -3531,6 +3584,11 @@ def check_all_command_guards(command: str, env_type: str,
             "pattern_keys": all_keys,
             "description": _disp_combined_desc,
         }
+        if one_shot_only:
+            pending_data.update(
+                allow_permanent=False,
+                choices=["once", "deny"],
+            )
         if smart_denied_for_owner:
             pending_data.update(smart_denied=True, allow_permanent=False)
         submit_pending(session_key, pending_data)
@@ -3545,6 +3603,11 @@ def check_all_command_guards(command: str, env_type: str,
                 f"⚠️ {_disp_combined_desc}. Asking the user for approval.\n\n**Command:**\n```\n{_disp_command}\n```"
             ),
         }
+        if one_shot_only:
+            result.update(
+                allow_permanent=False,
+                choices=["once", "deny"],
+            )
         if smart_denied_for_owner:
             result.update(smart_denied=True, allow_permanent=False)
         return result
@@ -3563,7 +3626,11 @@ def check_all_command_guards(command: str, env_type: str,
     choice = prompt_dangerous_approval(
         command,
         combined_desc,
-        allow_permanent=not has_tirith and not smart_denied_for_owner,
+        allow_permanent=(
+            not has_tirith
+            and not smart_denied_for_owner
+            and not one_shot_only
+        ),
         smart_denied=smart_denied_for_owner,
         approval_callback=approval_callback,
     )
@@ -3595,8 +3662,9 @@ def check_all_command_guards(command: str, env_type: str,
             "user_consent": False,
         }
 
-    # Smart-DENY owner overrides are one-operation scoped. Preserve existing
-    # persistence for manual mode and smart ESCALATE.
+    # Smart-DENY owner overrides are one-operation scoped. For manual mode and
+    # smart ESCALATE, approve_* preserves normal scopes while rejecting keys
+    # declared one-shot, including legacy callbacks that return a broad scope.
     if not smart_denied_for_owner:
         for key, _, is_tirith in warnings:
             if choice == "session" or (choice == "always" and is_tirith):


### PR DESCRIPTION
## What does this PR do?

Closes the approval-layer gap where terminal access could run `hermes config set approvals.mode off` or `hermes config set yolo true` without triggering the same approval guard that already protects direct writes to `~/.hermes/config.yaml`.

`config.yaml` is the approval/security policy store, and `hermes config set` is the documented front door to mutate it. This PR adds a narrow dangerous-command pattern for security-sensitive `hermes config set` keys while leaving ordinary config edits such as `display.*` alone.

## Related Issue

Fixes #59293

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/approval.py`
  - Adds a security-config key fragment for `approvals.*`, `yolo`, `command_allowlist.*`, and `security.*`.
  - Flags `hermes [global flags] config set <security-key> ...` as `modify Hermes security config via CLI`.
  - Keeps non-security config writes outside the dangerous-command gate.
- `tests/tools/test_approval.py`
  - Covers detector-level matches for `approvals.mode`, `yolo`, `approvals.deny`, and `security.*` CLI mutations.
  - Covers a negative case for `display.show_cost`.
- `tests/tools/test_command_guards.py`
  - Covers the end-to-end command guard prompting path for `hermes config set approvals.mode off`.
  - Confirms ordinary `hermes config set display.show_cost true` remains auto-approved.

## How to Test

1. Reproduce the old gap on `upstream/main`:
   ```text
   detect_dangerous_command('hermes config set approvals.mode off') -> (False, None, None)
   detect_dangerous_command('hermes config set yolo true') -> (False, None, None)
   detect_dangerous_command('echo x >> ~/.hermes/config.yaml') -> (True, ...)
   ```
2. Verify this branch:
   ```bash
   ./.venv/bin/python -m pytest tests/tools/test_approval.py tests/tools/test_command_guards.py -q -o 'addopts='
   ./.venv/bin/ruff check tools/approval.py tests/tools/test_approval.py tests/tools/test_command_guards.py
   ./.venv/bin/python -m py_compile tools/approval.py tests/tools/test_approval.py tests/tools/test_command_guards.py
   git diff --check
   ```
3. Result:
   ```text
   336 passed
   All checks passed!
   py_compile passed
   git diff --check passed
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 / Python 3.11 venv

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
./.venv/bin/python -m pytest tests/tools/test_approval.py tests/tools/test_command_guards.py -q -o 'addopts='
336 passed in 8.61s

./.venv/bin/ruff check tools/approval.py tests/tools/test_approval.py tests/tools/test_command_guards.py
All checks passed!
```
