### PR TITLE
fix(file): block /proc-sensitive paths in search_files results (#56918)

### DIFF
--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -132,6 +132,58 @@ class TestDevicePathBlocking(unittest.TestCase):
         for path in ("/proc/cpuinfo", "/proc/meminfo", "/proc/uptime", "/proc/version"):
             self.assertFalse(_is_blocked_device(path), f"{path} should not be blocked")
 
+    @unittest.skipIf(os.name == "nt", "/proc path blocking is a Linux concept")
+    def test_search_result_read_block_error_blocks_proc(self):
+        """search_files must block /proc-sensitive paths in its output guard.
+
+        read_file already blocks these via _is_blocked_device (#56219), but
+        search_files filters through _search_result_read_block_error which
+        only applied the credential-env guard (get_read_block_error).
+        Sensitive /proc paths (maps, mem, auxv, pagemap, environ, cmdline)
+        must also be blocked in search results so they can't leak through
+        content matches, file listings, or count results (#56918).
+
+        Test _is_blocked_device_path directly — the function
+        _search_result_read_block_error delegates to it, and
+        _is_blocked_device_path is platform-agnostic (pure string match).
+        """
+        from tools.file_tools import _is_blocked_device_path
+
+        for path in (
+            "/proc/self/maps",
+            "/proc/12345/maps",
+            "/proc/self/smaps",
+            "/proc/99/smaps_rollup",
+            "/proc/self/mem",
+            "/proc/1/mem",
+            "/proc/self/auxv",
+            "/proc/12345/auxv",
+            "/proc/self/pagemap",
+            "/proc/99/pagemap",
+            "/proc/self/environ",
+            "/proc/1/environ",
+            "/proc/self/cmdline",
+            "/proc/99/cmdline",
+            "/proc/self/task/1234/maps",
+            "/proc/self/task/1234/auxv",
+        ):
+            self.assertTrue(
+                _is_blocked_device_path(path),
+                f"_is_blocked_device_path should block {path}",
+            )
+
+    @unittest.skipIf(os.name == "nt", "/proc path blocking is a Linux concept")
+    def test_search_result_read_block_error_allows_legitimate_proc(self):
+        """Top-level /proc files must not be blocked."""
+        from tools.file_tools import _is_blocked_device_path
+
+        for path in ("/proc/cpuinfo", "/proc/meminfo", "/proc/uptime",
+                      "/proc/version", "/proc/self/status"):
+            self.assertFalse(
+                _is_blocked_device_path(path),
+                f"_is_blocked_device_path should allow {path}",
+            )
+
     def test_normpath_alias_to_blocked_device_is_blocked(self):
         self.assertTrue(_is_blocked_device("/dev/../dev/zero"))
         self.assertTrue(_is_blocked_device("/dev/./urandom"))

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -559,12 +559,31 @@ def _search_result_read_block_error(path: str, task_id: str = "default") -> str 
     ``get_read_block_error`` expects an already-resolved path when the task cwd
     can differ from the Python process cwd. Mirror ``read_file_tool``'s path
     resolution before applying the shared read guard.
+
+    Also applies ``_is_blocked_device_path`` so that the same /proc-sensitive
+    paths blocked in ``read_file`` (#56219) are also blocked in
+    ``search_files`` — content matches, file listings, and count results
+    across all three output modes (#56918).
     """
     try:
         resolved = _resolve_path_for_task(path, task_id)
     except (OSError, ValueError, RuntimeError):
-        return get_read_block_error(path)
-    return get_read_block_error(str(resolved))
+        resolved = Path(path)
+    resolved_str = str(resolved)
+
+    # Credential-env guard (auth.json, .env, etc.)
+    cred_error = get_read_block_error(resolved_str)
+    if cred_error:
+        return cred_error
+
+    # Sensitive /proc guard — same blocked paths as _is_blocked_device.
+    if _is_blocked_device_path(resolved_str):
+        return (
+            f"Blocked sensitive proc path in search results: {path}\n"
+            "This file can expose ASLR layout, raw memory, or secrets."
+        )
+
+    return None
 
 
 def _filter_read_blocked_search_results(result, task_id: str = "default") -> int:


### PR DESCRIPTION
## What

`read_file` already blocks `/proc/*/maps`, `/proc/*/mem`, `/proc/*/auxv`, `/proc/*/pagemap`, and related sensitive pseudo-files via `_is_blocked_device_path` (#56219).  `search_files` applied a separate filter chain through `_search_result_read_block_error` that only guarded credential-env paths (`get_read_block_error`) — missing the proc-sensitive patterns.

This meant content matches, file listings, and count results could all leak ASLR layout, raw memory, and secrets.

## What this does

Adds `_is_blocked_device_path` to the `_search_result_read_block_error` guard so all three `search_files` output modes inherit the same `/proc`-sensitive blocking that `read_file` already enforces.

## Test plan

- Two new tests in `tests/tools/test_file_read_guards.py` verify both blocked proc paths and allowed legitimate `/proc` files. Tests are skipped on Windows (`os.name == "nt"`) where `/proc` is not a real filesystem.
- Existing `TestDevicePathBlocking` tests continue to pass.

## Related

- Closes #56918
- Follows the same pattern as #56219