### PR TITLE
fix: prevent no_agent one-shot cron jobs from re-firing on gateway re…

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1254,9 +1254,17 @@ def advance_next_run(job_id: str) -> bool:
     scheduler from at-least-once to at-most-once for recurring jobs — missing
     one run is far better than firing dozens of times in a crash loop.
 
-    One-shot jobs are left unchanged so they can still retry on restart.
+    One-shot LLM-backed jobs are left unchanged so they can still retry on
+    restart (the LLM may have been mid-response).  One-shot no_agent script
+    jobs are treated like recurring jobs: ``last_run_at`` is persisted BEFORE
+    the script runs so a script that restarts the gateway (e.g. reboot-gw.sh
+    calling ``systemctl restart hermes-gateway``) does not re-fire on restart.
+    The script has no intermediate LLM state to retry — it either runs or it
+    doesn't — and the retry guarantee is actively harmful when the script is a
+    gateway lifecycle action (#30719).
 
-    Returns True if next_run_at was advanced, False otherwise.
+    Returns True if next_run_at was advanced (or last_run_at was pre-set for a
+    no_agent one-shot), False otherwise.
     """
     with _jobs_lock():
         jobs = load_jobs()
@@ -1264,6 +1272,13 @@ def advance_next_run(job_id: str) -> bool:
             if job["id"] == job_id:
                 kind = job.get("schedule", {}).get("kind")
                 if kind not in {"cron", "interval"}:
+                    # One-shot job: persist execution marker for no_agent
+                    # scripts so they cannot re-fire on gateway restart.
+                    if kind == "once" and job.get("no_agent"):
+                        now = _hermes_now().isoformat()
+                        job["last_run_at"] = now
+                        save_jobs(jobs)
+                        return True
                     return False
                 now = _hermes_now().isoformat()
                 new_next = compute_next_run(job["schedule"], now)

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -685,6 +685,58 @@ class TestAdvanceNextRun:
         updated = get_job(job["id"])
         assert updated["next_run_at"] == original_next, "one-shot next_run_at should be unchanged"
 
+    def test_persists_last_run_at_for_no_agent_oneshot(self, tmp_cron_dir):
+        """no_agent one-shot jobs should have last_run_at set BEFORE execution.
+
+        LLM-backed one-shots retain their retry-on-restart semantics (the
+        LLM may have been mid-response).  But no_agent script jobs have
+        no intermediate state to retry, and a script that restarts the
+        gateway (e.g. reboot-gw.sh calling ``systemctl restart``) must
+        NOT re-fire on restart — that creates an infinite restart loop
+        (#30719).
+        """
+        job = create_job(
+            prompt="Restart gateway", schedule="30m",
+            no_agent=True, script="reboot-gw.sh",
+        )
+
+        result = advance_next_run(job["id"])
+        assert result is True
+
+        updated = get_job(job["id"])
+        assert updated["last_run_at"] is not None, (
+            "no_agent one-shot must have last_run_at set before execution "
+            "to prevent re-fire on gateway restart"
+        )
+
+        # After advance, the job should NOT be due (simulates restart)
+        due_after = get_due_jobs()
+        assert len(due_after) == 0, (
+            "no_agent one-shot should not be due after advance_next_run"
+        )
+
+    def test_llm_oneshot_still_retries(self, tmp_cron_dir):
+        """LLM-backed one-shots must still retry on restart (unchanged)."""
+        job = create_job(prompt="LLM task", schedule="30m")
+
+        result = advance_next_run(job["id"])
+        assert result is False
+
+        updated = get_job(job["id"])
+        assert updated["last_run_at"] is None, (
+            "LLM one-shot must retain None last_run_at for retry-on-restart"
+        )
+
+        # Force next_run_at to the past so it's due
+        jobs = load_jobs()
+        jobs[0]["next_run_at"] = (datetime.now() - timedelta(minutes=1)).isoformat()
+        save_jobs(jobs)
+
+        # LLM one-shot should still be due (for retry)
+        due = get_due_jobs()
+        assert len(due) == 1
+        assert due[0]["id"] == job["id"]
+
     def test_nonexistent_job_returns_false(self, tmp_cron_dir):
         result = advance_next_run("nonexistent-id")
         assert result is False


### PR DESCRIPTION
**What does this PR do?**

Fixes a bug where `no_agent=true` one-shot cron jobs that restart the gateway (e.g. a script calling `systemctl restart
hermes-gateway`) cause an infinite restart loop.

The root cause: `advance_next_run()` intentionally skips one-shot jobs to allow retry-on-restart. But `no_agent` script
jobs have no LLM mid-response state to retry — the script either runs or doesn't. When the script kills the gateway
process, `mark_job_run()` (which persists `last_run_at`) is never reached. On restart, `last_run_at` is still None → the
job fires again → infinite loop.

The fix: `advance_next_run()` now pre-persists `last_run_at` for `no_agent=true` one-shot jobs before the script
executes, preventing re-fire. LLM-backed one-shots retain their retry-on-restart behavior unchanged.

**Related Issue**

Fixes #30719

**Type of Change**

- [x] 🐛 Bug fix

**Changes Made**

- `cron/jobs.py`: `advance_next_run()` — for `no_agent` one-shot jobs, persist `last_run_at` before script execution
(previously skipped all one-shots)
- `tests/cron/test_jobs.py`: added `test_persists_last_run_at_for_no_agent_oneshot` (verifies no_agent one-shot has
last_run_at set before execution and is not re-due after) and `test_llm_oneshot_still_retries` (verifies LLM one-shot
retains None last_run_at for retry)

**How to Test**

```
pytest tests/cron/test_jobs.py::TestAdvanceNextRun -v
```

All 8 tests pass including the 2 new ones, no regressions. Full cron suite: 560/561 pass (1 pre-existing unrelated
failure).

**Checklist**

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs
- [x] PR contains only related changes
- [x] All tests pass (`pytest tests/cron/ -q`: 560/561)
- [x] Tests added for the fix
- [x] Tested on: Ubuntu 24.04 (Linux)