### PR TITLE
fix(mcp): scale tool-probe outer timeout to the largest configured connect_timeout

### DIFF
--- a/tests/tools/test_mcp_probe.py
+++ b/tests/tools/test_mcp_probe.py
@@ -111,6 +111,79 @@ class TestProbeMcpServerTools:
         # Outer bound must scale to the configured connect_timeout: max(120, 300 + 10).
         assert captured.get("timeout", 0) >= 310
 
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            float("nan"),   # YAML `.nan` -> Python float nan
+            float("inf"),   # YAML `.inf` -> Python float inf
+            float("-inf"),  # YAML `-.inf`
+            0,              # non-positive
+            -5,             # negative
+        ],
+        ids=["nan", "inf", "-inf", "zero", "negative"],
+    )
+    def test_outer_timeout_finite_for_non_finite_connect_timeout(self, bad_value):
+        """A YAML ``.nan``/``.inf`` (or non-positive) connect_timeout must not
+        poison the outer probe bound.
+
+        A YAML loader parses ``.nan``/``.inf`` into real Python ``float('nan')``/
+        ``float('inf')`` values, so they reach ``cfg.get('connect_timeout')`` as
+        finite-passing floats. ``float(nan)`` raises no ``TypeError``/``ValueError``,
+        so the old guard let them through and ``max(connect_timeouts) + 10``
+        became non-finite — a non-finite outer deadline never trips
+        ``_run_on_mcp_loop``'s ``remaining <= 0`` branch, so the probe would
+        never time out. The poisoned value must be sanitized to the default
+        while a legitimately-large peer server still drives the bound.
+
+        A second, valid ``connect_timeout=300`` server is co-configured so the
+        correct outer bound is ``max(120, 300 + 10) = 310``. Pre-fix, an ``inf``
+        member makes ``max()`` return ``inf`` and a ``nan`` member silently
+        collapses the bound back to the ``120`` floor — both distinguishable
+        from the sanitized 310.
+        """
+        import math as _math
+
+        config = {
+            "poisoned": {"command": "npx", "connect_timeout": bad_value},
+            "slow": {"command": "npx", "connect_timeout": 300},
+        }
+        mock_tool = SimpleNamespace(name="do_thing", description="Do a thing")
+        mock_server = MagicMock()
+        mock_server._tools = [mock_tool]
+        mock_server.shutdown = AsyncMock()
+
+        async def fake_connect(name, cfg):
+            return mock_server
+
+        captured = {}
+
+        with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+             patch("tools.mcp_tool._load_mcp_config", return_value=config), \
+             patch("tools.mcp_tool._connect_server", side_effect=fake_connect), \
+             patch("tools.mcp_tool._ensure_mcp_loop"), \
+             patch("tools.mcp_tool._run_on_mcp_loop") as mock_run, \
+             patch("tools.mcp_tool._stop_mcp_loop"):
+
+            def run_coro(coro_or_factory, timeout=120):
+                captured["timeout"] = timeout
+                coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+                loop = asyncio.new_event_loop()
+                try:
+                    return loop.run_until_complete(coro)
+                finally:
+                    loop.close()
+
+            mock_run.side_effect = run_coro
+
+            from tools.mcp_tool import probe_mcp_server_tools
+            probe_mcp_server_tools()
+
+        outer = captured.get("timeout")
+        assert outer is not None
+        assert _math.isfinite(outer), f"outer_timeout was non-finite: {outer!r}"
+        # Sanitized poisoned value drops out; the valid 300s peer drives the bound.
+        assert outer == max(120.0, 300.0 + 10.0)
+
     def test_skips_disabled_servers(self):
         """Disabled servers are not probed."""
         config = {

--- a/tests/tools/test_mcp_probe.py
+++ b/tests/tools/test_mcp_probe.py
@@ -71,6 +71,46 @@ class TestProbeMcpServerTools:
         assert "broken" not in result
 
 
+    def test_outer_timeout_respects_large_connect_timeout(self):
+        """A server with connect_timeout > 120 must not be cancelled by the
+        outer probe bound before its own inner wait_for budget elapses."""
+        config = {
+            "slow": {"command": "npx", "connect_timeout": 300},
+        }
+        mock_tool = SimpleNamespace(name="do_thing", description="Do a thing")
+        mock_server = MagicMock()
+        mock_server._tools = [mock_tool]
+        mock_server.shutdown = AsyncMock()
+
+        async def fake_connect(name, cfg):
+            return mock_server
+
+        captured = {}
+
+        with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+             patch("tools.mcp_tool._load_mcp_config", return_value=config), \
+             patch("tools.mcp_tool._connect_server", side_effect=fake_connect), \
+             patch("tools.mcp_tool._ensure_mcp_loop"), \
+             patch("tools.mcp_tool._run_on_mcp_loop") as mock_run, \
+             patch("tools.mcp_tool._stop_mcp_loop"):
+
+            def run_coro(coro_or_factory, timeout=120):
+                captured["timeout"] = timeout
+                coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+                loop = asyncio.new_event_loop()
+                try:
+                    return loop.run_until_complete(coro)
+                finally:
+                    loop.close()
+
+            mock_run.side_effect = run_coro
+
+            from tools.mcp_tool import probe_mcp_server_tools
+            probe_mcp_server_tools()
+
+        # Outer bound must scale to the configured connect_timeout: max(120, 300 + 10).
+        assert captured.get("timeout", 0) >= 310
+
     def test_skips_disabled_servers(self):
         """Disabled servers are not probed."""
         config = {

--- a/tests/tools/test_mcp_probe.py
+++ b/tests/tools/test_mcp_probe.py
@@ -1,4 +1,11 @@
-"""Tests for probe_mcp_server_tools() in tools.mcp_tool."""
+"""Tests for the parallel-discovery outer-timeout policy in tools.mcp_tool.
+
+Covers ``probe_mcp_server_tools()`` and the sibling site in
+``register_mcp_servers()``: both gather per-server connects in parallel under
+an enclosing ``_run_on_mcp_loop`` bound, and both must scale that bound off the
+largest *sanitized* ``connect_timeout`` so a slow-but-legitimately-configured
+server is not cancelled before its own budget elapses.
+"""
 
 import asyncio
 from types import SimpleNamespace
@@ -224,3 +231,136 @@ class TestProbeMcpServerTools:
         assert "github" in result
         assert "disabled_one" not in result
         assert "disabled_one" not in connect_calls
+
+
+class TestRegisterMcpServersOuterTimeout:
+    """``register_mcp_servers`` runs the same parallel-discovery shape as the
+    probe, so it needs the same largest-configured-timeout outer bound.
+
+    Its inner per-server budget lives in ``_discover_and_register_server``,
+    which honors each server's ``connect_timeout``; the enclosing
+    ``_run_on_mcp_loop`` call was hard-capped at 120s, so a server configured
+    above that floor was cancelled by the outer cap before its own connect
+    budget elapsed and was silently dropped from discovery.
+    """
+
+    @staticmethod
+    def _register(config, captured):
+        """Drive ``register_mcp_servers`` with the real ``_discover_all``
+        coroutine, recording the outer timeout it was handed."""
+        import tools.mcp_tool as mcp
+
+        async def fake_discover(name, cfg):
+            return [f"mcp__{name}__tool_a"]
+
+        def run_coro(coro_or_factory, timeout=120):
+            captured["timeout"] = timeout
+            coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+            loop = asyncio.new_event_loop()
+            try:
+                return loop.run_until_complete(coro)
+            finally:
+                loop.close()
+
+        with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+             patch("tools.mcp_tool._discover_and_register_server", side_effect=fake_discover), \
+             patch("tools.mcp_tool._ensure_mcp_loop"), \
+             patch("tools.mcp_tool._run_on_mcp_loop", side_effect=run_coro), \
+             patch("tools.mcp_tool._existing_tool_names", return_value=[]):
+            mcp.register_mcp_servers(config)
+
+    def test_outer_timeout_respects_large_connect_timeout(self):
+        """A server with ``connect_timeout`` above the 120s floor drives the bound."""
+        captured = {}
+        self._register({"slow": {"command": "npx", "connect_timeout": 300}}, captured)
+
+        assert captured.get("timeout") == max(120.0, 300.0 + 10.0)
+
+    def test_outer_timeout_keeps_120s_floor_for_small_timeouts(self):
+        """Many small servers keep the generous 120s floor — the bound only grows."""
+        captured = {}
+        self._register(
+            {
+                "a": {"command": "npx", "connect_timeout": 5},
+                "b": {"command": "npx", "connect_timeout": 10},
+            },
+            captured,
+        )
+
+        assert captured.get("timeout") == 120.0
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            float("nan"),   # YAML `.nan` -> Python float nan
+            float("inf"),   # YAML `.inf` -> Python float inf
+            float("-inf"),  # YAML `-.inf`
+            0,              # non-positive
+            -5,             # negative
+            "not-a-number",  # unparseable
+        ],
+        ids=["nan", "inf", "-inf", "zero", "negative", "unparseable"],
+    )
+    def test_outer_timeout_finite_for_bad_connect_timeout(self, bad_value):
+        """A poisoned ``connect_timeout`` must not make the outer bound
+        non-finite (``nan``/``inf`` deadlines never trip ``_run_on_mcp_loop``'s
+        ``remaining <= 0`` branch, so discovery would never time out).
+
+        A valid 300s peer is co-configured so the sanitized bound is a
+        distinguishable 310: an ``inf`` member would otherwise return ``inf``
+        from ``max()`` and a ``nan`` member would collapse it to the floor.
+        """
+        import math as _math
+
+        captured = {}
+        self._register(
+            {
+                "poisoned": {"command": "npx", "connect_timeout": bad_value},
+                "slow": {"command": "npx", "connect_timeout": 300},
+            },
+            captured,
+        )
+
+        outer = captured.get("timeout")
+        assert outer is not None
+        assert _math.isfinite(outer), f"outer_timeout was non-finite: {outer!r}"
+        assert outer == max(120.0, 300.0 + 10.0)
+
+class TestSanitizedConnectTimeout:
+    """``_sanitized_connect_timeout`` is the single source both the inner
+    ``asyncio.wait_for`` budgets and the outer bound read, so the two can never
+    disagree about what a server's connect budget is."""
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            float("nan"),
+            float("inf"),
+            float("-inf"),
+            0,
+            -5,
+            "not-a-number",
+            None,
+            [30],
+        ],
+        ids=["nan", "inf", "-inf", "zero", "negative", "unparseable", "none", "list"],
+    )
+    def test_unusable_values_fall_back_to_the_default(self, bad_value):
+        import tools.mcp_tool as mcp
+
+        assert mcp._sanitized_connect_timeout({"connect_timeout": bad_value}) == float(
+            mcp._DEFAULT_CONNECT_TIMEOUT
+        )
+
+    def test_missing_value_uses_the_default(self):
+        import tools.mcp_tool as mcp
+
+        assert mcp._sanitized_connect_timeout({}) == float(mcp._DEFAULT_CONNECT_TIMEOUT)
+
+    @pytest.mark.parametrize("good_value", [1, 5, 30.5, 300, "45"])
+    def test_usable_values_pass_through_as_floats(self, good_value):
+        import tools.mcp_tool as mcp
+
+        result = mcp._sanitized_connect_timeout({"connect_timeout": good_value})
+        assert result == float(good_value)
+        assert isinstance(result, float)

--- a/tests/tools/test_mcp_probe.py
+++ b/tests/tools/test_mcp_probe.py
@@ -1,10 +1,18 @@
-"""Tests for the parallel-discovery outer-timeout policy in tools.mcp_tool.
+"""Tests for the ``connect_timeout`` policy in tools.mcp_tool.
 
 Covers ``probe_mcp_server_tools()`` and the sibling site in
 ``register_mcp_servers()``: both gather per-server connects in parallel under
 an enclosing ``_run_on_mcp_loop`` bound, and both must scale that bound off the
 largest *sanitized* ``connect_timeout`` so a slow-but-legitimately-configured
 server is not cancelled before its own budget elapses.
+
+Also covers the two *transport* connect paths that consume the same setting —
+``MCPServerTask._run_http`` and ``MCPServerTask._run_stdio``. They read
+``connect_timeout`` once and feed it to the transport's client timeout and to
+the ``asyncio.wait_for`` that bounds the ``initialize()`` handshake, so they
+must read it through ``_sanitized_connect_timeout`` too: the outer bound and
+the inner deadlines are only consistent if every reader applies the same
+policy.
 """
 
 import asyncio
@@ -364,3 +372,232 @@ class TestSanitizedConnectTimeout:
         result = mcp._sanitized_connect_timeout({"connect_timeout": good_value})
         assert result == float(good_value)
         assert isinstance(result, float)
+
+
+# --- transport connect paths -------------------------------------------------
+#
+# ``_run_http`` and ``_run_stdio`` each read ``connect_timeout`` once and hand
+# it to the transport client AND to the ``asyncio.wait_for`` bounding
+# ``session.initialize()``. The helpers below drive the real coroutines against
+# fake transports and report the value that read resolved to, so every
+# assertion is a bounded value check — no test ever awaits a real deadline.
+
+_UNUSABLE_CONNECT_TIMEOUTS = [
+    float("nan"),    # YAML `.nan`  -> a deadline that is not a deadline
+    float("inf"),    # YAML `.inf`  -> a deadline that never elapses
+    float("-inf"),   # YAML `-.inf`
+    0,               # non-positive: connect can never succeed
+    -5,              # negative
+    "not-a-number",  # unparseable
+    None,            # explicit null in config.yaml
+    [30],            # wrong YAML shape
+]
+
+_UNUSABLE_IDS = [
+    "nan", "inf", "-inf", "zero", "negative", "unparseable", "none", "list",
+]
+
+
+class _ProbeStop(Exception):
+    """Raised by a fake transport once it has recorded the resolved timeout.
+
+    Unwinding immediately keeps these tests to a pure value comparison: a
+    regression shows up as a wrong number, never as a hung suite.
+    """
+
+
+class _FakeAsyncCM:
+    """Minimal async context manager yielding a fixed value."""
+
+    def __init__(self, value):
+        self._value = value
+
+    async def __aenter__(self):
+        return self._value
+
+    async def __aexit__(self, *_exc):
+        return False
+
+
+class _RecordingAsyncio:
+    """Delegating ``asyncio`` stand-in that records ``wait_for`` deadlines.
+
+    ``tools.mcp_tool`` reaches ``wait_for`` through its own module-level
+    ``asyncio`` binding, so replacing that binding captures the deadline the
+    stdio connect path resolved without patching the global module. The call
+    at index ``stop_at`` is short-circuited with ``_ProbeStop`` instead of
+    being awaited.
+    """
+
+    def __init__(self, recorded, stop_at):
+        self._recorded = recorded
+        self._stop_at = stop_at
+
+    def wait_for(self, awaitable, timeout=None):
+        self._recorded.append(timeout)
+        if len(self._recorded) != self._stop_at:
+            return asyncio.wait_for(awaitable, timeout)
+        close = getattr(awaitable, "close", None)
+        if close is not None:
+            close()  # never-awaited coroutine would warn otherwise
+        raise _ProbeStop
+
+    def __getattr__(self, name):
+        return getattr(asyncio, name)
+
+
+def _resolved_http_connect_timeout(config, branch):
+    """Return the connect timeout ``_run_http`` handed to its transport.
+
+    ``branch`` picks which of the three transports the single
+    ``connect_timeout`` read feeds: ``"sse"``, ``"streamable_http"``
+    (mcp >= 1.24) or ``"legacy_http"`` (mcp < 1.24).
+    """
+    pytest.importorskip("mcp")
+    import tools.mcp_tool as mcp
+
+    captured = {}
+
+    def fake_sse_client(**kwargs):
+        captured["timeout"] = kwargs.get("timeout")
+        raise _ProbeStop
+
+    def fake_streamable_http_client(_url, http_client=None, **_kwargs):
+        captured["timeout"] = http_client.timeout.connect
+        raise _ProbeStop
+
+    def fake_streamablehttp_client(_url, **kwargs):
+        captured["timeout"] = kwargs.get("timeout")
+        raise _ProbeStop
+
+    server = mcp.MCPServerTask("connect-timeout-probe")
+    full_config = dict(config, url="https://example.invalid/mcp")
+    if branch == "sse":
+        full_config["transport"] = "sse"
+
+    async def drive():
+        with patch.object(mcp, "_MCP_HTTP_AVAILABLE", True), \
+             patch.object(mcp, "_MCP_NEW_HTTP", branch != "legacy_http"), \
+             patch.object(mcp, "sse_client", fake_sse_client), \
+             patch.object(mcp, "streamable_http_client",
+                          fake_streamable_http_client, create=True), \
+             patch.object(mcp, "streamablehttp_client",
+                          fake_streamablehttp_client, create=True):
+            with pytest.raises(_ProbeStop):
+                await server._run_http(full_config)
+
+    asyncio.run(drive())
+    return captured["timeout"]
+
+
+def _resolved_stdio_connect_timeout(config):
+    """Return the deadline ``_run_stdio`` handed to the handshake ``wait_for``."""
+    pytest.importorskip("mcp")
+    import tools.mcp_tool as mcp
+
+    recorded = []
+    server = mcp.MCPServerTask("connect-timeout-probe")
+    full_config = dict(config, command="fake-mcp", args=[])
+
+    def fake_stdio_client(*_args, **_kwargs):
+        return _FakeAsyncCM((object(), object()))
+
+    def fake_client_session(*_args, **_kwargs):
+        session = MagicMock()
+        session.initialize = AsyncMock()
+        return _FakeAsyncCM(session)
+
+    async def drive():
+        with patch.object(mcp, "stdio_client", fake_stdio_client), \
+             patch.object(mcp, "ClientSession", fake_client_session), \
+             patch.object(mcp, "_resolve_stdio_command", lambda c, e: (c, e)), \
+             patch.object(mcp, "_write_stderr_log_header", lambda *_a, **_k: None), \
+             patch.object(mcp, "_get_mcp_stderr_log", lambda: None), \
+             patch("tools.osv_check.check_package_for_malware", lambda *_a, **_k: None), \
+             patch.object(mcp, "asyncio", _RecordingAsyncio(recorded, stop_at=2)):
+            with pytest.raises(_ProbeStop):
+                await server._run_stdio(full_config)
+
+    asyncio.run(drive())
+    # recorded[0] is the OSV malware preflight bound; recorded[1] is the
+    # handshake deadline under test.
+    return recorded[1]
+
+
+class TestHttpTransportConnectTimeout:
+    """``_run_http``'s ``connect_timeout`` read feeds the transport's client
+    timeout and the ``initialize()`` ``wait_for`` on all three branches.
+
+    Left unsanitized, a YAML ``.inf`` yields a handshake deadline that never
+    elapses — the server accepts the connection, never answers ``initialize``,
+    and the connect coroutine parks forever; ``.nan`` yields a deadline that is
+    not a deadline at all (the loop's timer heap trips it on an arbitrary
+    wake-up, killing a healthy handshake); ``0``/negative can never connect;
+    and an unparseable value raises out of the middle of the transport setup
+    instead of falling back. All four are the same defect: the value never
+    passed through ``_sanitized_connect_timeout``.
+    """
+
+    @pytest.mark.parametrize("branch", ["sse", "streamable_http", "legacy_http"])
+    @pytest.mark.parametrize(
+        "bad_value", _UNUSABLE_CONNECT_TIMEOUTS, ids=_UNUSABLE_IDS
+    )
+    def test_unusable_value_falls_back_to_the_default(self, branch, bad_value):
+        import tools.mcp_tool as mcp
+
+        resolved = _resolved_http_connect_timeout(
+            {"connect_timeout": bad_value}, branch
+        )
+
+        assert resolved == float(mcp._DEFAULT_CONNECT_TIMEOUT), (
+            f"{branch} transport resolved connect_timeout={bad_value!r} to "
+            f"{resolved!r} — an unusable deadline reached the transport"
+        )
+
+    @pytest.mark.parametrize("branch", ["sse", "streamable_http", "legacy_http"])
+    def test_valid_value_is_still_honoured(self, branch):
+        """Sanitizing must not flatten every server to the default."""
+        resolved = _resolved_http_connect_timeout({"connect_timeout": 300}, branch)
+
+        assert resolved == 300.0
+
+    @pytest.mark.parametrize("branch", ["sse", "streamable_http", "legacy_http"])
+    def test_missing_value_uses_the_default(self, branch):
+        import tools.mcp_tool as mcp
+
+        resolved = _resolved_http_connect_timeout({}, branch)
+
+        assert resolved == float(mcp._DEFAULT_CONNECT_TIMEOUT)
+
+
+class TestStdioTransportConnectTimeout:
+    """``_run_stdio`` bounds its ``initialize()`` handshake with the same
+    setting (#59349), so it needs the same sanitization: an ``.inf`` deadline
+    never elapses, which is precisely the hang that bound was added to stop,
+    and the spawned child is only reaped when the connect unwinds.
+    """
+
+    @pytest.mark.parametrize(
+        "bad_value", _UNUSABLE_CONNECT_TIMEOUTS, ids=_UNUSABLE_IDS
+    )
+    def test_unusable_value_falls_back_to_the_default(self, bad_value):
+        import tools.mcp_tool as mcp
+
+        resolved = _resolved_stdio_connect_timeout({"connect_timeout": bad_value})
+
+        assert resolved == float(mcp._DEFAULT_CONNECT_TIMEOUT), (
+            f"stdio transport resolved connect_timeout={bad_value!r} to "
+            f"{resolved!r} — an unusable handshake deadline was applied"
+        )
+
+    def test_valid_value_is_still_honoured(self):
+        resolved = _resolved_stdio_connect_timeout({"connect_timeout": 300})
+
+        assert resolved == 300.0
+
+    def test_missing_value_uses_the_default(self):
+        import tools.mcp_tool as mcp
+
+        resolved = _resolved_stdio_connect_timeout({})
+
+        assert resolved == float(mcp._DEFAULT_CONNECT_TIMEOUT)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6324,11 +6324,28 @@ def probe_mcp_server_tools() -> Dict[str, List[tuple]]:
     result: Dict[str, List[tuple]] = {}
     probed_servers: List[MCPServerTask] = []
 
+    # Sanitize each server's connect_timeout to a finite, positive float ONCE.
+    # YAML admits ``.nan``/``.inf``, which ``float()`` accepts silently — an
+    # earlier ``except (TypeError, ValueError)`` guard does not reject them.
+    # A non-finite value would poison both the inner ``wait_for`` (a ``nan``
+    # deadline never elapses) and ``max(connect_timeouts)`` below (making the
+    # outer probe bound non-finite, so it never times out). Fall back to the
+    # default whenever the configured value isn't a usable finite positive.
+    connect_timeouts: Dict[str, float] = {}
+    for name, cfg in enabled.items():
+        try:
+            ct = float(cfg.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT))
+        except (TypeError, ValueError):
+            ct = float(_DEFAULT_CONNECT_TIMEOUT)
+        if not math.isfinite(ct) or ct <= 0:
+            ct = float(_DEFAULT_CONNECT_TIMEOUT)
+        connect_timeouts[name] = ct
+
     async def _probe_all():
         names = list(enabled.keys())
         coros = []
         for name, cfg in enabled.items():
-            ct = cfg.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
+            ct = connect_timeouts[name]
             coros.append(asyncio.wait_for(_connect_server(name, cfg), timeout=ct))
 
         outcomes = await asyncio.gather(*coros, return_exceptions=True)
@@ -6354,15 +6371,10 @@ def probe_mcp_server_tools() -> Dict[str, List[tuple]]:
     # budget, or a server with connect_timeout > 120 is cancelled by the outer
     # cap before its inner wait_for elapses and is silently dropped from the
     # result. Mirror _probe_single_server's `connect_timeout + 10`, keeping 120s
-    # as a floor for the common many-small-servers case. Coerce defensively so a
-    # non-numeric connect_timeout can't crash the outer bound.
-    connect_timeouts = []
-    for cfg in enabled.values():
-        try:
-            connect_timeouts.append(float(cfg.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)))
-        except (TypeError, ValueError):
-            connect_timeouts.append(float(_DEFAULT_CONNECT_TIMEOUT))
-    outer_timeout = max(120.0, max(connect_timeouts) + 10.0)
+    # as a floor for the common many-small-servers case. Reuse the sanitized
+    # per-server values so a non-finite/non-numeric connect_timeout can't make
+    # the outer bound non-finite (which would defeat the timeout entirely).
+    outer_timeout = max(120.0, max(connect_timeouts.values()) + 10.0)
 
     try:
         _run_on_mcp_loop(_probe_all, timeout=outer_timeout)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6350,8 +6350,22 @@ def probe_mcp_server_tools() -> Dict[str, List[tuple]]:
             return_exceptions=True,
         )
 
+    # The outer probe bound must not undercut any server's own connect_timeout
+    # budget, or a server with connect_timeout > 120 is cancelled by the outer
+    # cap before its inner wait_for elapses and is silently dropped from the
+    # result. Mirror _probe_single_server's `connect_timeout + 10`, keeping 120s
+    # as a floor for the common many-small-servers case. Coerce defensively so a
+    # non-numeric connect_timeout can't crash the outer bound.
+    connect_timeouts = []
+    for cfg in enabled.values():
+        try:
+            connect_timeouts.append(float(cfg.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)))
+        except (TypeError, ValueError):
+            connect_timeouts.append(float(_DEFAULT_CONNECT_TIMEOUT))
+    outer_timeout = max(120.0, max(connect_timeouts) + 10.0)
+
     try:
-        _run_on_mcp_loop(_probe_all, timeout=120)
+        _run_on_mcp_loop(_probe_all, timeout=outer_timeout)
     except Exception as exc:
         logger.debug("MCP probe failed: %s", exc)
     finally:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -108,7 +108,7 @@ import time
 from types import SimpleNamespace
 from typing import Callable
 from datetime import datetime
-from typing import Any, Coroutine, Dict, List, Optional, Set, Tuple
+from typing import Any, Coroutine, Dict, Iterable, List, Optional, Set, Tuple
 from urllib.parse import urlparse
 
 from tools.registry import tool_error
@@ -5882,12 +5882,52 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
 
     return registered_names
 
+
+def _sanitized_connect_timeout(config: dict) -> float:
+    """Return a server's ``connect_timeout`` as a finite, positive float.
+
+    YAML admits ``.nan``/``.inf``, which ``float()`` accepts silently — a
+    ``try/except (TypeError, ValueError)`` guard alone does not reject them.
+    A non-finite value poisons both the inner ``asyncio.wait_for`` (a ``nan``
+    deadline never elapses) and any outer bound derived from it. Fall back to
+    the default whenever the configured value isn't a usable finite positive.
+    """
+    try:
+        timeout = float(config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT))
+    except (TypeError, ValueError):
+        return float(_DEFAULT_CONNECT_TIMEOUT)
+
+    if not math.isfinite(timeout) or timeout <= 0:
+        return float(_DEFAULT_CONNECT_TIMEOUT)
+
+    return timeout
+
+
+def _outer_discovery_timeout(connect_timeouts: Iterable[float]) -> float:
+    """Outer bound for a parallel discovery/probe gather.
+
+    The enclosing bound must not undercut any individual server's own
+    ``connect_timeout`` budget, or a server configured above the floor is
+    cancelled by the outer cap before its inner ``wait_for`` elapses and is
+    silently dropped from the results. Add 10s of headroom over the largest
+    per-server budget so the inner ``wait_for`` is always the one that fires,
+    keeping 120s as a floor for the common many-small-servers case.
+
+    Callers pass already-sanitized values (see ``_sanitized_connect_timeout``)
+    so the bound can never come out non-finite, which would defeat the timeout
+    entirely.
+    """
+    timeouts = list(connect_timeouts)
+
+    return max(120.0, max(timeouts) + 10.0) if timeouts else 120.0
+
+
 async def _discover_and_register_server(name: str, config: dict) -> List[str]:
     """Connect to a single MCP server, discover tools, and register them.
 
     Returns list of registered tool names.
     """
-    connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
+    connect_timeout = _sanitized_connect_timeout(config)
     # List-based claim (not a ``nonlocal`` rebind): the claim callback runs
     # inside ``_connect_server`` while this frame is suspended, and appending
     # keeps type narrowing intact for the module's other ``server`` locals.
@@ -6053,9 +6093,15 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
                     _server_connect_errors.pop(name, None)
                     _clear_connect_failure(name)
 
-    # Per-server timeouts are handled inside _discover_and_register_server.
-    # The outer timeout is generous: 120s total for parallel discovery.
-    #
+    # Per-server timeouts are handled inside _discover_and_register_server,
+    # which sanitizes each server's connect_timeout the same way. Scale the
+    # enclosing bound off those same sanitized values so a server configured
+    # above the 120s floor isn't cancelled by the outer cap before its own
+    # connect budget elapses (which silently dropped it from discovery).
+    outer_timeout = _outer_discovery_timeout(
+        _sanitized_connect_timeout(cfg) for cfg in new_servers.values()
+    )
+
     # Temporarily clear the interrupt flag on the current thread so that MCP
     # discovery is never cancelled by a stale interrupt from a prior agent
     # session (executor threads get reused and may carry old interrupt state).
@@ -6064,7 +6110,7 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
     if _was_interrupted:
         _set_interrupt(False)
     try:
-        _run_on_mcp_loop(_discover_all, timeout=120)
+        _run_on_mcp_loop(_discover_all, timeout=outer_timeout)
     except (TimeoutError, InterruptedError) as _e:
         # When the outer timeout fires or the user interrupts,
         # _discover_all's gather may not have finished, leaving
@@ -6324,22 +6370,12 @@ def probe_mcp_server_tools() -> Dict[str, List[tuple]]:
     result: Dict[str, List[tuple]] = {}
     probed_servers: List[MCPServerTask] = []
 
-    # Sanitize each server's connect_timeout to a finite, positive float ONCE.
-    # YAML admits ``.nan``/``.inf``, which ``float()`` accepts silently — an
-    # earlier ``except (TypeError, ValueError)`` guard does not reject them.
-    # A non-finite value would poison both the inner ``wait_for`` (a ``nan``
-    # deadline never elapses) and ``max(connect_timeouts)`` below (making the
-    # outer probe bound non-finite, so it never times out). Fall back to the
-    # default whenever the configured value isn't a usable finite positive.
-    connect_timeouts: Dict[str, float] = {}
-    for name, cfg in enabled.items():
-        try:
-            ct = float(cfg.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT))
-        except (TypeError, ValueError):
-            ct = float(_DEFAULT_CONNECT_TIMEOUT)
-        if not math.isfinite(ct) or ct <= 0:
-            ct = float(_DEFAULT_CONNECT_TIMEOUT)
-        connect_timeouts[name] = ct
+    # Sanitize each server's connect_timeout to a finite, positive float ONCE,
+    # then reuse those values for both the inner ``wait_for`` budgets and the
+    # outer probe bound below.
+    connect_timeouts: Dict[str, float] = {
+        name: _sanitized_connect_timeout(cfg) for name, cfg in enabled.items()
+    }
 
     async def _probe_all():
         names = list(enabled.keys())
@@ -6367,14 +6403,7 @@ def probe_mcp_server_tools() -> Dict[str, List[tuple]]:
             return_exceptions=True,
         )
 
-    # The outer probe bound must not undercut any server's own connect_timeout
-    # budget, or a server with connect_timeout > 120 is cancelled by the outer
-    # cap before its inner wait_for elapses and is silently dropped from the
-    # result. Mirror _probe_single_server's `connect_timeout + 10`, keeping 120s
-    # as a floor for the common many-small-servers case. Reuse the sanitized
-    # per-server values so a non-finite/non-numeric connect_timeout can't make
-    # the outer bound non-finite (which would defeat the timeout entirely).
-    outer_timeout = max(120.0, max(connect_timeouts.values()) + 10.0)
+    outer_timeout = _outer_discovery_timeout(connect_timeouts.values())
 
     try:
         _run_on_mcp_loop(_probe_all, timeout=outer_timeout)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3110,9 +3110,15 @@ class MCPServerTask:
                     # until the gateway hits EMFILE. Timing out here converts the
                     # hang into a normal failure, letting the ``finally`` reap the
                     # child. See #59349.
-                    connect_timeout = float(
-                        config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
-                    )
+                    #
+                    # A bare ``float()`` is not enough to make that bound real:
+                    # it accepts YAML's ``.inf``/``.nan`` silently, and an
+                    # ``.inf`` deadline never elapses — the child leaks exactly
+                    # as it did before the bound existed — while a ``.nan`` one
+                    # trips on an arbitrary loop wake-up. It also raises on a
+                    # non-numeric value instead of falling back. Use the same
+                    # sanitizer the discovery/probe bound is derived from.
+                    connect_timeout = _sanitized_connect_timeout(config)
                     self.initialize_result = await self._negotiate_session(
                         session, connect_timeout
                     )

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -7622,8 +7622,22 @@ def probe_mcp_server_tools() -> Dict[str, List[tuple]]:
             return_exceptions=True,
         )
 
+    # The outer probe bound must not undercut any server's own connect_timeout
+    # budget, or a server with connect_timeout > 120 is cancelled by the outer
+    # cap before its inner wait_for elapses and is silently dropped from the
+    # result. Mirror _probe_single_server's `connect_timeout + 10`, keeping 120s
+    # as a floor for the common many-small-servers case. Coerce defensively so a
+    # non-numeric connect_timeout can't crash the outer bound.
+    connect_timeouts = []
+    for cfg in enabled.values():
+        try:
+            connect_timeouts.append(float(cfg.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)))
+        except (TypeError, ValueError):
+            connect_timeouts.append(float(_DEFAULT_CONNECT_TIMEOUT))
+    outer_timeout = max(120.0, max(connect_timeouts) + 10.0)
+
     try:
-        _run_on_mcp_loop(_probe_all, timeout=120)
+        _run_on_mcp_loop(_probe_all, timeout=outer_timeout)
     except Exception as exc:
         logger.debug("MCP probe failed: %s", exc)
     finally:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -113,7 +113,7 @@ import time
 from types import SimpleNamespace
 from typing import Callable
 from datetime import datetime
-from typing import Any, Coroutine, Dict, List, Optional, Set, Tuple
+from typing import Any, Coroutine, Dict, Iterable, List, Optional, Set, Tuple
 from urllib.parse import urlparse
 
 from tools.registry import tool_error
@@ -7102,12 +7102,52 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
         )
     return registered_names
 
+
+def _sanitized_connect_timeout(config: dict) -> float:
+    """Return a server's ``connect_timeout`` as a finite, positive float.
+
+    YAML admits ``.nan``/``.inf``, which ``float()`` accepts silently — a
+    ``try/except (TypeError, ValueError)`` guard alone does not reject them.
+    A non-finite value poisons both the inner ``asyncio.wait_for`` (a ``nan``
+    deadline never elapses) and any outer bound derived from it. Fall back to
+    the default whenever the configured value isn't a usable finite positive.
+    """
+    try:
+        timeout = float(config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT))
+    except (TypeError, ValueError):
+        return float(_DEFAULT_CONNECT_TIMEOUT)
+
+    if not math.isfinite(timeout) or timeout <= 0:
+        return float(_DEFAULT_CONNECT_TIMEOUT)
+
+    return timeout
+
+
+def _outer_discovery_timeout(connect_timeouts: Iterable[float]) -> float:
+    """Outer bound for a parallel discovery/probe gather.
+
+    The enclosing bound must not undercut any individual server's own
+    ``connect_timeout`` budget, or a server configured above the floor is
+    cancelled by the outer cap before its inner ``wait_for`` elapses and is
+    silently dropped from the results. Add 10s of headroom over the largest
+    per-server budget so the inner ``wait_for`` is always the one that fires,
+    keeping 120s as a floor for the common many-small-servers case.
+
+    Callers pass already-sanitized values (see ``_sanitized_connect_timeout``)
+    so the bound can never come out non-finite, which would defeat the timeout
+    entirely.
+    """
+    timeouts = list(connect_timeouts)
+
+    return max(120.0, max(timeouts) + 10.0) if timeouts else 120.0
+
+
 async def _discover_and_register_server(name: str, config: dict) -> List[str]:
     """Connect to a single MCP server, discover tools, and register them.
 
     Returns list of registered tool names.
     """
-    connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
+    connect_timeout = _sanitized_connect_timeout(config)
     # List-based claim (not a ``nonlocal`` rebind): the claim callback runs
     # inside ``_connect_server`` while this frame is suspended, and appending
     # keeps type narrowing intact for the module's other ``server`` locals.
@@ -7321,9 +7361,15 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
                     _server_connect_errors.pop(name, None)
                     _clear_connect_failure(name)
 
-    # Per-server timeouts are handled inside _discover_and_register_server.
-    # The outer timeout is generous: 120s total for parallel discovery.
-    #
+    # Per-server timeouts are handled inside _discover_and_register_server,
+    # which sanitizes each server's connect_timeout the same way. Scale the
+    # enclosing bound off those same sanitized values so a server configured
+    # above the 120s floor isn't cancelled by the outer cap before its own
+    # connect budget elapses (which silently dropped it from discovery).
+    outer_timeout = _outer_discovery_timeout(
+        _sanitized_connect_timeout(cfg) for cfg in new_servers.values()
+    )
+
     # Temporarily clear the interrupt flag on the current thread so that MCP
     # discovery is never cancelled by a stale interrupt from a prior agent
     # session (executor threads get reused and may carry old interrupt state).
@@ -7332,7 +7378,7 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
     if _was_interrupted:
         _set_interrupt(False)
     try:
-        _run_on_mcp_loop(_discover_all, timeout=120)
+        _run_on_mcp_loop(_discover_all, timeout=outer_timeout)
     except (TimeoutError, InterruptedError) as _e:
         # When the outer timeout fires or the user interrupts,
         # _discover_all's gather may not have finished, leaving
@@ -7596,22 +7642,12 @@ def probe_mcp_server_tools() -> Dict[str, List[tuple]]:
     result: Dict[str, List[tuple]] = {}
     probed_servers: List[MCPServerTask] = []
 
-    # Sanitize each server's connect_timeout to a finite, positive float ONCE.
-    # YAML admits ``.nan``/``.inf``, which ``float()`` accepts silently — an
-    # earlier ``except (TypeError, ValueError)`` guard does not reject them.
-    # A non-finite value would poison both the inner ``wait_for`` (a ``nan``
-    # deadline never elapses) and ``max(connect_timeouts)`` below (making the
-    # outer probe bound non-finite, so it never times out). Fall back to the
-    # default whenever the configured value isn't a usable finite positive.
-    connect_timeouts: Dict[str, float] = {}
-    for name, cfg in enabled.items():
-        try:
-            ct = float(cfg.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT))
-        except (TypeError, ValueError):
-            ct = float(_DEFAULT_CONNECT_TIMEOUT)
-        if not math.isfinite(ct) or ct <= 0:
-            ct = float(_DEFAULT_CONNECT_TIMEOUT)
-        connect_timeouts[name] = ct
+    # Sanitize each server's connect_timeout to a finite, positive float ONCE,
+    # then reuse those values for both the inner ``wait_for`` budgets and the
+    # outer probe bound below.
+    connect_timeouts: Dict[str, float] = {
+        name: _sanitized_connect_timeout(cfg) for name, cfg in enabled.items()
+    }
 
     async def _probe_all():
         names = list(enabled.keys())
@@ -7639,14 +7675,7 @@ def probe_mcp_server_tools() -> Dict[str, List[tuple]]:
             return_exceptions=True,
         )
 
-    # The outer probe bound must not undercut any server's own connect_timeout
-    # budget, or a server with connect_timeout > 120 is cancelled by the outer
-    # cap before its inner wait_for elapses and is silently dropped from the
-    # result. Mirror _probe_single_server's `connect_timeout + 10`, keeping 120s
-    # as a floor for the common many-small-servers case. Reuse the sanitized
-    # per-server values so a non-finite/non-numeric connect_timeout can't make
-    # the outer bound non-finite (which would defeat the timeout entirely).
-    outer_timeout = max(120.0, max(connect_timeouts.values()) + 10.0)
+    outer_timeout = _outer_discovery_timeout(connect_timeouts.values())
 
     try:
         _run_on_mcp_loop(_probe_all, timeout=outer_timeout)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3377,7 +3377,15 @@ class MCPServerTask:
         # agree with what the body actually speaks.
         if not any(key.lower() == "mcp-protocol-version" for key in headers):
             headers["mcp-protocol-version"] = LATEST_HANDSHAKE_VERSION
-        connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
+        # Sanitize once, here: this single read feeds the transport's client
+        # timeout AND the ``initialize()`` ``wait_for`` deadline on all three
+        # branches below (SSE, Streamable HTTP, legacy Streamable HTTP). Taken
+        # raw, a YAML ``.inf`` produces a deadline that never elapses, so a
+        # server that accepts the connection but never answers ``initialize``
+        # parks this coroutine forever — the same hang the bound exists to
+        # prevent (#59349). ``.nan`` is no better: the loop's timer heap trips
+        # it on an arbitrary wake-up, so it is not a deadline at all.
+        connect_timeout = _sanitized_connect_timeout(config)
         ssl_verify = config.get("ssl_verify", True)
         client_cert = _resolve_client_cert(self.name, config)
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -7596,11 +7596,28 @@ def probe_mcp_server_tools() -> Dict[str, List[tuple]]:
     result: Dict[str, List[tuple]] = {}
     probed_servers: List[MCPServerTask] = []
 
+    # Sanitize each server's connect_timeout to a finite, positive float ONCE.
+    # YAML admits ``.nan``/``.inf``, which ``float()`` accepts silently — an
+    # earlier ``except (TypeError, ValueError)`` guard does not reject them.
+    # A non-finite value would poison both the inner ``wait_for`` (a ``nan``
+    # deadline never elapses) and ``max(connect_timeouts)`` below (making the
+    # outer probe bound non-finite, so it never times out). Fall back to the
+    # default whenever the configured value isn't a usable finite positive.
+    connect_timeouts: Dict[str, float] = {}
+    for name, cfg in enabled.items():
+        try:
+            ct = float(cfg.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT))
+        except (TypeError, ValueError):
+            ct = float(_DEFAULT_CONNECT_TIMEOUT)
+        if not math.isfinite(ct) or ct <= 0:
+            ct = float(_DEFAULT_CONNECT_TIMEOUT)
+        connect_timeouts[name] = ct
+
     async def _probe_all():
         names = list(enabled.keys())
         coros = []
         for name, cfg in enabled.items():
-            ct = cfg.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
+            ct = connect_timeouts[name]
             coros.append(asyncio.wait_for(_connect_server(name, cfg), timeout=ct))
 
         outcomes = await asyncio.gather(*coros, return_exceptions=True)
@@ -7626,15 +7643,10 @@ def probe_mcp_server_tools() -> Dict[str, List[tuple]]:
     # budget, or a server with connect_timeout > 120 is cancelled by the outer
     # cap before its inner wait_for elapses and is silently dropped from the
     # result. Mirror _probe_single_server's `connect_timeout + 10`, keeping 120s
-    # as a floor for the common many-small-servers case. Coerce defensively so a
-    # non-numeric connect_timeout can't crash the outer bound.
-    connect_timeouts = []
-    for cfg in enabled.values():
-        try:
-            connect_timeouts.append(float(cfg.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)))
-        except (TypeError, ValueError):
-            connect_timeouts.append(float(_DEFAULT_CONNECT_TIMEOUT))
-    outer_timeout = max(120.0, max(connect_timeouts) + 10.0)
+    # as a floor for the common many-small-servers case. Reuse the sanitized
+    # per-server values so a non-finite/non-numeric connect_timeout can't make
+    # the outer bound non-finite (which would defeat the timeout entirely).
+    outer_timeout = max(120.0, max(connect_timeouts.values()) + 10.0)
 
     try:
         _run_on_mcp_loop(_probe_all, timeout=outer_timeout)


### PR DESCRIPTION
## What does this PR do?

`hermes tools` interactive tool-discovery (`probe_mcp_server_tools` in `tools/mcp_tool.py`) waits on each MCP server for its configured `connect_timeout`, but drives the whole probe under a hard-coded 120 s outer bound. Any server with `connect_timeout > 120` is cancelled by the outer cap before its own inner `wait_for` budget elapses — it lands in the exception branch and is silently dropped from the returned tool dict.

The single-server path (`_probe_single_server` in `hermes_cli/mcp_config.py`) already does this correctly, deriving its outer bound as `connect_timeout + 10`. This brings the multi-server probe into line: it scales the outer timeout to the largest configured `connect_timeout` (floored at 120 s for the common many-small-servers case).

> Mirrors `_probe_single_server`'s outer-bound precedence: `connect_timeout + 10`, floored at 120 s.

## Related Issue

Code-originated (no filed issue).

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py`: in `probe_mcp_server_tools`, replace the literal outer `timeout=120` with `max(120.0, max(connect_timeout) + 10.0)` over the enabled servers, coercing each `connect_timeout` defensively so a non-numeric value can't crash the outer bound. `enabled` is guaranteed non-empty here (the function early-returns `{}` otherwise), so `max(...)` is safe.
- `tests/tools/test_mcp_probe.py`: add `test_outer_timeout_respects_large_connect_timeout`, which captures the outer timeout passed to the probe loop for a `connect_timeout: 300` server and asserts it is `>= 310`.

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/tools/test_mcp_probe.py -v` — 9 passed.
2. Regression guard: with the production hunk reverted to the literal `timeout=120`, the new test fails with `assert 120 >= 310` (captured timeout is exactly 120); restoring the fix makes it pass. Fails-before / passes-after.
3. Real-world repro: configure an MCP server with `connect_timeout: 300` (e.g. a slow OAuth cold-start server). Before this change it appears via `hermes mcp test` (outer = ct + 10) but is silently missing from `hermes tools`; after, both agree.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tools/test_mcp_probe.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A (timeout arithmetic, platform-independent)