### PR TITLE
fix(feishu): ignore @所有人/@everyone mentions in group chats

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4329,10 +4329,9 @@ class FeishuAdapter(BasePlatformAdapter):
     # --- Mention detection ----------------------------------------------------
 
     def _mentions_self(self, message: Any) -> bool:
-        # @_all is Feishu's @everyone placeholder.
+        # Fix #33723: @_all (@everyone) no longer treated as self-mention —
+        # stops the bot replying to every @所有人 group announcement. (@Mason-zy)
         raw_content = getattr(message, "content", "") or ""
-        if "@_all" in raw_content:
-            return True
         mentions = getattr(message, "mentions", None) or []
         if mentions and self._message_mentions_bot(mentions):
             return True


### PR DESCRIPTION
## Problem

In Feishu group chats, the bot **always replies when someone uses @所有人 (`@everyone`)**, even though the bot itself is not mentioned. This creates noise in enterprise groups where @所有人 is routinely used for announcements. Tracked in #33723.

## Root cause

`_mentions_self()` in `plugins/platforms/feishu/adapter.py` treats `@_all` (Feishu's `@everyone` placeholder) as a self-mention:

```python
def _mentions_self(self, message):
    # @_all is Feishu's @everyone placeholder.
    raw_content = getattr(message, "content", "") or ""
    if "@_all" in raw_content:
        return True            # ← always triggers the bot
```

Combined with the `require_mention` gate (`@_all` returns True → gate passes → bot replies), this means every @所有人 announcement triggers a response.

## Fix

Drop the `@_all → return True` branch so @所有人 no longer counts as a self-mention. The bot will still respond to explicit `@botname` mentions.

This change is safe because the other two mention-detection paths already handle the case correctly:
- `_message_mentions_bot()` matches by bot open_id/user_id/name (an @everyone tag has no bot ID)
- `_post_mentions_bot()` checks `m.is_self` (an @everyone tag is `is_all=True`, never `is_self`)

So removing this branch only stops @所有人 from triggering the bot; real @bot mentions are unaffected.

## Behavior contrast

| Message | Before | After |
|---|---|---|
| `@所有人 please review` | bot replies | bot ignores (no @bot) |
| `@botname what's up` | bot replies | bot replies |
| `@所有人 @botname hey` | bot replies | bot replies (bot explicitly mentioned) |

Closes #33723.