### PR TITLE
fix(gateway): fall back to self.config for home-channel prompt

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11118,7 +11118,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK:
             platform_name = source.platform.value
             env_key = _home_target_env_var(platform_name)
-            if not os.getenv(env_key):
+            # Fix #10581: /sethome persists to .env + self.config, but .env only
+            # enters os.environ after a restart, so os.getenv() missed it and the
+            # "No home channel" prompt refired every new session. Fall back to
+            # self.config (updated immediately by sethome). (@Mason-zy)
+            _home_set = bool(os.getenv(env_key))
+            if not _home_set:
+                _pcfg = None
+                try:
+                    _pcfg = self.config.platforms.get(source.platform)
+                except Exception:
+                    _pcfg = None
+                if _pcfg and getattr(_pcfg, "home_channel", None):
+                    _home_set = True
+            if not _home_set:
                 # Slack dispatches all Hermes commands through a single
                 # parent slash command `/hermes`; bare `/sethome` is not
                 # registered and would fail with "app did not respond".


### PR DESCRIPTION
## Problem

The "📬 No home channel is set..." prompt keeps refiring on every new session even **after the user has run `/sethome`**. Tracked in #10581.

## Root cause

The prompt check in `gateway/run.py` only reads the env var:

```python
if not os.getenv(env_key):
    # shows "No home channel is set..." prompt
```

But `_handle_set_home_command` persists the home channel to **`.env` + `self.config`**, not to `os.environ`. The `.env` value only enters `os.environ` after a gateway restart, so within a running process `os.getenv()` never sees it — and the prompt refires on every fresh session (`not history`).

`/sethome` already updates `self.config.platforms[platform].home_channel` in-memory immediately, but the prompt check ignores it.

## Fix

Also consult `self.config` before deciding to show the prompt:

```python
_home_set = bool(os.getenv(env_key))
if not _home_set:
    pcfg = self.config.platforms.get(source.platform)
    if pcfg and getattr(pcfg, "home_channel", None):
        _home_set = True
if not _home_set:
    # show the prompt
```

Now the prompt respects whichever source `/sethome` actually wrote to, and stops refiring once a home channel is set — without requiring a restart.

Closes #10581.