### PR TITLE
fix(desktop): improve prompt submit and startup resilience

### DIFF
--- a/apps/desktop/electron/backend-ready.test.cjs
+++ b/apps/desktop/electron/backend-ready.test.cjs
@@ -49,6 +49,15 @@ test('default is cold-start tolerant (> the historical 45s floor)', () => {
   )
 })
 
+test('backend status readiness uses short probes inside a longer boot budget', () => {
+  const source = fs.readFileSync(path.join(__dirname, 'main.cjs'), 'utf8').replace(/\r\n/g, '\n')
+
+  assert.match(source, /const BACKEND_READY_TIMEOUT_MS = 90_000/)
+  assert.match(source, /const BACKEND_READY_PROBE_TIMEOUT_MS = 2_000/)
+  assert.match(source, /const BACKEND_READY_POLL_MS = 500/)
+  assert.match(source, /fetchJson\(`\$\{baseUrl\}\/api\/status`, token, \{ timeoutMs: probeTimeoutMs \}\)/)
+})
+
 test('honors a valid HERMES_DESKTOP_PORT_ANNOUNCE_TIMEOUT_MS override', () => {
   const env = { HERMES_DESKTOP_PORT_ANNOUNCE_TIMEOUT_MS: '120000' }
   assert.equal(resolvePortAnnounceTimeoutMs(env), 120_000)

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -388,6 +388,13 @@ const DEFAULT_UPDATE_BRANCH = 'main'
 const DESKTOP_LOG_PATH = path.join(HERMES_HOME, 'logs', 'desktop.log')
 const DESKTOP_LOG_FLUSH_MS = 120
 const DESKTOP_LOG_BUFFER_MAX_CHARS = 64 * 1024
+// Startup readiness is different from normal API calls: after a rebuild or
+// cold Windows launch, the dashboard can bind its port before /api/status is
+// responsive. Keep the overall boot window generous, but make each probe short
+// so one slow request does not consume a third of the whole startup budget.
+const BACKEND_READY_TIMEOUT_MS = 90_000
+const BACKEND_READY_PROBE_TIMEOUT_MS = 2_000
+const BACKEND_READY_POLL_MS = 500
 // Bound desktop.log on disk. It is an append-only forensic log, so a boot loop
 // (version-skew crash -> backend exits instantly -> renderer keeps hitting
 // Retry) appends the full bootstrap transcript every attempt and grows without
@@ -3900,17 +3907,20 @@ function closePreviewWatchers() {
   }
 }
 
-async function waitForHermes(baseUrl, token) {
-  const deadline = Date.now() + 45_000
+async function waitForHermes(baseUrl, token, options = {}) {
+  const timeoutMs = options.timeoutMs ?? BACKEND_READY_TIMEOUT_MS
+  const probeTimeoutMs = options.probeTimeoutMs ?? BACKEND_READY_PROBE_TIMEOUT_MS
+  const pollMs = options.pollMs ?? BACKEND_READY_POLL_MS
+  const deadline = Date.now() + timeoutMs
   let lastError = null
 
   while (Date.now() < deadline) {
     try {
-      await fetchJson(`${baseUrl}/api/status`, token)
+      await fetchJson(`${baseUrl}/api/status`, token, { timeoutMs: probeTimeoutMs })
       return
     } catch (error) {
       lastError = error
-      await new Promise(resolve => setTimeout(resolve, 500))
+      await new Promise(resolve => setTimeout(resolve, pollMs))
     }
   }
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { textPart } from '@/lib/chat-messages'
 import { $composerAttachments, $composerDraft, type ComposerAttachment, setComposerDraft } from '@/store/composer'
+import { $notifications, clearNotifications } from '@/store/notifications'
 import { $busy, $connection, $messages, $sessions, setSessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
@@ -434,6 +435,7 @@ describe('usePromptActions desktop slash pickers', () => {
 describe('usePromptActions submit / queue drain semantics', () => {
   afterEach(() => {
     cleanup()
+    clearNotifications()
     vi.restoreAllMocks()
   })
 
@@ -576,6 +578,39 @@ describe('usePromptActions submit / queue drain semantics', () => {
     expect(seeds.some(s => Array.isArray(s.messages) && (s.messages as { error?: string }[]).some(m => m.error))).toBe(
       false
     )
+  })
+
+  it('explains prompt.submit ACK timeouts without encouraging duplicate retries', async () => {
+    const states: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.submit') {
+        throw new Error('request timed out: prompt.submit')
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => states.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    expect(await handle!.submitText('will it send twice?')).toBe(false)
+
+    const lastState = states.at(-1) as { messages?: { error?: string }[] }
+    const assistantError = lastState.messages?.find(m => m.error)?.error ?? ''
+    const notification = $notifications.get()[0]
+
+    expect(assistantError).toContain('backend may still process it')
+    expect(assistantError).toContain('avoid sending it twice')
+    expect(notification?.message).toContain('backend may still process it')
+    expect(notification?.message).toContain('avoid sending it twice')
   })
 
   it('a normal (non-queue) submit still respects the busyRef guard', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -20,10 +20,11 @@ import type { ClientSessionState } from '../../../types'
 import {
   _submitInFlight,
   type GatewayRequest,
-  inlineErrorMessage,
+  isPromptSubmitTimeoutError,
   isProviderSetupError,
   isSessionBusyError,
   isSessionNotFoundError,
+  submitErrorMessage,
   type SubmitTextOptions,
   withSessionBusyRetry
 } from './utils'
@@ -301,7 +302,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           return false
         }
 
-        const message = inlineErrorMessage(err, copy.promptFailed)
+        const message = submitErrorMessage(err, copy)
 
         updateSessionState(sessionId, state => ({
           ...state,
@@ -323,6 +324,12 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
         if (isProviderSetupError(err)) {
           requestDesktopOnboarding(copy.providerCredentialRequired)
+
+          return false
+        }
+
+        if (isPromptSubmitTimeoutError(err)) {
+          notify({ kind: 'error', title: copy.promptFailed, message })
 
           return false
         }

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -46,6 +46,20 @@ export function inlineErrorMessage(error: unknown, fallback: string): string {
   return (raw.match(/Error invoking remote method '[^']+': Error: (.+)$/)?.[1] ?? raw).replace(/^Error:\s*/, '').trim()
 }
 
+export function isPromptSubmitTimeoutError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+
+  return /request timed out:\s*prompt\.submit/i.test(message)
+}
+
+export function submitErrorMessage(error: unknown, copy: Translations['desktop']): string {
+  if (isPromptSubmitTimeoutError(error)) {
+    return copy.promptSubmitTimedOut
+  }
+
+  return inlineErrorMessage(error, copy.promptFailed)
+}
+
 export function isSessionNotFoundError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error)
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2379,6 +2379,8 @@ export const en: Translations = {
     sessionUnavailable: 'Session unavailable',
     createSessionFailed: 'Could not create a new session',
     promptFailed: 'Prompt failed',
+    promptSubmitTimedOut:
+      'Hermes did not confirm this message in time. The backend may still process it, so wait a moment before retrying to avoid sending it twice.',
     providerCredentialRequired: 'Add a provider credential before sending your first message.',
     emptySlashCommand: 'empty slash command',
     desktopCommands: 'Desktop commands',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2372,6 +2372,8 @@ export const ja = defineLocale({
     sessionUnavailable: 'セッションが利用できません',
     createSessionFailed: '新しいセッションを作成できませんでした',
     promptFailed: 'プロンプトに失敗しました',
+    promptSubmitTimedOut:
+      'Hermes はこのメッセージを時間内に確認できませんでした。バックエンドでまだ処理される可能性があるため、二重送信を避けるため少し待ってから再試行してください。',
     providerCredentialRequired: '最初のメッセージを送信する前にプロバイダー認証情報を追加してください。',
     emptySlashCommand: '空のスラッシュコマンド',
     desktopCommands: 'デスクトップコマンド',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1977,6 +1977,7 @@ export interface Translations {
     sessionUnavailable: string
     createSessionFailed: string
     promptFailed: string
+    promptSubmitTimedOut: string
     providerCredentialRequired: string
     emptySlashCommand: string
     desktopCommands: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2280,6 +2280,7 @@ export const zhHant = defineLocale({
     sessionUnavailable: '工作階段不可用',
     createSessionFailed: '無法建立新工作階段',
     promptFailed: '提示詞傳送失敗',
+    promptSubmitTimedOut: 'Hermes 未能及時確認這則訊息。後端可能仍會處理它；請稍等再重試，以免重複傳送。',
     providerCredentialRequired: '傳送第一則訊息前請先新增提供方憑證。',
     emptySlashCommand: '空的斜線指令',
     desktopCommands: '桌面端指令',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2530,6 +2530,7 @@ export const zh: Translations = {
     sessionUnavailable: '会话不可用',
     createSessionFailed: '无法创建新会话',
     promptFailed: '提示词发送失败',
+    promptSubmitTimedOut: 'Hermes 未能及时确认这条消息。后端可能仍会处理它；请稍等再重试，以免重复发送。',
     providerCredentialRequired: '发送第一条消息前请先添加提供方凭据。',
     emptySlashCommand: '空 slash 命令',
     desktopCommands: '桌面端命令',


### PR DESCRIPTION
## Summary

- Explain prompt-submit timeouts with a user-facing notification that warns the backend may still process the message.
- Add prompt-submit timeout helper coverage and localized copy updates.
- Increase Desktop backend readiness tolerance with shorter probes inside a longer boot budget.
- Add Electron backend readiness tests for the configurable readiness path.

## Verification

- `npm ci --workspace apps/desktop --include-workspace-root=false` → `found 0 vulnerabilities`
- `npm --workspace apps/desktop run test:ui -- src/app/session/hooks/use-prompt-actions/index.test.tsx` → 1 file passed, 38 tests passed
- `node --test apps/desktop/electron/backend-ready.test.cjs` → 17 tests passed
- `npm --workspace apps/desktop run typecheck` → pass
- `npm --workspace apps/desktop run build` → pass, `assert-dist-built` pass
- `git diff --check origin/main..HEAD` → pass
- added-line secret-like scan → 0 hits

## Notes

This branch is based directly on current `origin/main` to keep the PR independent of the Priority A stack. The same A3 changes were also validated on top of the Priority A refresh branch before this independent branch was created.
