### PR TITLE
fix(qqbot): accept gateway reconnect flag

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,8 +278,13 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
-        """Authenticate, obtain gateway URL, and open the WebSocket."""
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        """Authenticate, obtain gateway URL, and open the WebSocket.
+
+        ``is_reconnect`` is accepted for compatibility with the gateway's
+        common PlatformAdapter.connect() contract. QQBot manages resume vs.
+        cold identify internally from its stored session state.
+        """
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"
             self._set_fatal_error("qq_missing_dependency", message, retryable=True)

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -190,6 +190,20 @@ class TestVoiceAttachmentSSRFProtection:
         assert kwargs.get("follow_redirects") is True
         assert kwargs.get("event_hooks", {}).get("response") == [_ssrf_redirect_guard]
 
+    def test_connect_accepts_gateway_reconnect_flag(self):
+        """QQBot must match BasePlatformAdapter.connect(is_reconnect=...)."""
+        from gateway.platforms.qqbot import QQAdapter
+
+        adapter = QQAdapter(_make_config(app_id="a", client_secret="b"))
+        adapter._ensure_token = mock.AsyncMock(side_effect=RuntimeError("stop after client creation"))
+
+        # Regression guard: gateway.run calls this exact keyword during cold
+        # boot and reconnect. QQBot may ignore the flag internally, but it must
+        # accept it to satisfy the platform adapter contract.
+        connected = asyncio.run(adapter.connect(is_reconnect=True))
+
+        assert connected is False
+
 
 # ---------------------------------------------------------------------------
 # WebSocket proxy handling


### PR DESCRIPTION
## Summary
- update QQBot adapter to accept the gateway's `connect(is_reconnect=...)` keyword argument
- document that QQBot manages resume vs identify internally and can ignore the flag
- add a regression test that calls `QQAdapter.connect(is_reconnect=True)`

## Why
GatewayRunner now forwards `is_reconnect` through `_connect_adapter_with_timeout()` to every adapter. QQBot still exposed `connect(self)`, so gateway startup/reconnect failed before it could open the QQ websocket:

```text
QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'
```

## Test Plan
- `python3 -m pytest tests/gateway/test_qqbot.py::TestVoiceAttachmentSSRFProtection::test_connect_accepts_gateway_reconnect_flag -q -o 'addopts='`
- `python3 -m pytest tests/gateway/test_qqbot.py -q -o 'addopts='`
