### PR TITLE
fix(skills): order bundle content hash by path components to prevent phantom updates

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1168,6 +1168,29 @@ class TestCheckForSkillUpdates:
 
         assert bundle_content_hash(bundle) == content_hash(skill_dir)
 
+    def test_bundle_content_hash_matches_path_order_with_file_directory_prefix(self, tmp_path):
+        """A sibling file and directory sharing a prefix must not cause false updates."""
+        from tools.skills_guard import content_hash
+
+        bundle = SkillBundle(
+            name="demo-skill",
+            files={
+                "SKILL.md": "same content",
+                "references/styles.md": "style index\n",
+                "references/styles/warm.md": "warm style\n",
+            },
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+        )
+        skill_dir = tmp_path / "demo-skill"
+        (skill_dir / "references" / "styles").mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("same content")
+        (skill_dir / "references" / "styles.md").write_text("style index\n")
+        (skill_dir / "references" / "styles" / "warm.md").write_text("warm style\n")
+
+        assert bundle_content_hash(bundle) == content_hash(skill_dir)
+
     def test_bundle_content_hash_accepts_binary_files(self):
         bundle = SkillBundle(
             name="demo-binary-skill",

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3571,9 +3571,17 @@ def uninstall_skill(skill_name: str) -> Tuple[bool, str]:
 
 
 def bundle_content_hash(bundle: SkillBundle) -> str:
-    """Compute a deterministic hash for an in-memory skill bundle."""
+    """Compute a deterministic hash for an in-memory skill bundle.
+
+    Keep the traversal order symmetric with ``tools.skills_guard.content_hash``.
+    That function sorts ``Path`` objects, not raw relative strings, so a file and
+    directory with the same prefix (for example ``references/styles.md`` and
+    ``references/styles/foo.md``) must be ordered by path components here too.
+    Otherwise ``hermes skills check`` reports a permanent update even immediately
+    after installing the skill.
+    """
     h = hashlib.sha256()
-    for rel_path in sorted(bundle.files):
+    for rel_path in sorted(bundle.files, key=lambda p: PurePosixPath(p).parts):
         # Include the path so swapping file contents between two paths
         # changes the hash (avoids filename-swap evading update detection).
         h.update(rel_path.encode("utf-8"))


### PR DESCRIPTION
`bundle_content_hash` sorted raw relative-path strings while `tools.skills_guard.content_hash` sorts `Path` objects. A file and directory sharing a prefix (e.g. `references/styles.md` vs `references/styles/foo.md`) therefore hashed in a different order between the two functions, so `hermes skills check` reported a permanent "update available" immediately after installing a skill.

Sort by `PurePosixPath(p).parts` here so the traversal order matches `skills_guard`.

Test coverage added in `tests/tools/test_skills_hub.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)