### PR TITLE
fix(update-check): invalidate source cache when HEAD changes

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -294,6 +294,32 @@ def check_via_pypi() -> Optional[int]:
         return 1 if latest != VERSION else 0
 
 
+def _repo_head_cache_key(repo_dir: Path) -> Optional[str]:
+    """Return a cheap file-backed cache key for the checkout's current HEAD.
+
+    The update-check cache used to key only on embedded revision and package
+    version. Source installs commonly keep the same package version while users
+    rebase/cherry-pick local checkouts, so stale "N commits behind" counts could
+    survive for the full TTL after the repo became current. Reading .git/HEAD and
+    the pointed ref file is enough to invalidate that cache without running git
+    before the fast cache path.
+    """
+    git_dir = repo_dir / ".git"
+    head_file = git_dir / "HEAD"
+    try:
+        head = head_file.read_text().strip()
+    except Exception:
+        return None
+    if head.startswith("ref:"):
+        ref = head.split(None, 1)[1].strip() if " " in head else head[4:].strip()
+        try:
+            ref_value = (git_dir / ref).read_text().strip()
+        except Exception:
+            ref_value = ""
+        return f"{head}:{ref_value}"
+    return head
+
+
 def check_for_updates() -> Optional[int]:
     """Check whether a Hermes update is available.
 
@@ -308,6 +334,13 @@ def check_for_updates() -> Optional[int]:
     hermes_home = get_hermes_home()
     cache_file = hermes_home / ".update_check"
     embedded_rev = os.environ.get("HERMES_REVISION") or None
+    repo_cache_key = None
+    if not embedded_rev:
+        repo_dir_for_cache = Path(__file__).parent.parent.resolve()
+        if not (repo_dir_for_cache / ".git").exists():
+            repo_dir_for_cache = hermes_home / "hermes-agent"
+        if (repo_dir_for_cache / ".git").exists():
+            repo_cache_key = _repo_head_cache_key(repo_dir_for_cache)
 
     # Docker images have no working tree to count commits against — the
     # published image excludes `.git` (see .dockerignore) and sets no
@@ -337,11 +370,14 @@ def check_for_updates() -> Optional[int]:
     try:
         if cache_file.exists():
             cached = json.loads(cache_file.read_text())
-            if (
-                now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
-                and cached.get("rev") == embedded_rev
-                and cached.get("ver") == VERSION
-            ):
+            cache_fresh = now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
+            same_revision = cached.get("rev") == embedded_rev
+            same_version = cached.get("ver") == VERSION
+            same_repo_head = cached.get("repo_head") == repo_cache_key
+            # ``repo_head`` is only known for source checkouts. Old cache files
+            # without it are intentionally invalidated for source installs so a
+            # rebase/cherry-pick cannot leave a stale behind count in place.
+            if cache_fresh and same_revision and same_version and same_repo_head:
                 return cached.get("behind")
     except Exception:
         pass
@@ -362,7 +398,15 @@ def check_for_updates() -> Optional[int]:
 
     try:
         cache_file.write_text(
-            json.dumps({"ts": now, "behind": behind, "rev": embedded_rev, "ver": VERSION})
+            json.dumps(
+                {
+                    "ts": now,
+                    "behind": behind,
+                    "rev": embedded_rev,
+                    "ver": VERSION,
+                    "repo_head": repo_cache_key,
+                }
+            )
         )
     except Exception:
         pass

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -24,13 +24,32 @@ def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
     # Create a fake git repo and fresh cache
     repo_dir = tmp_path / "hermes-agent"
     repo_dir.mkdir()
-    (repo_dir / ".git").mkdir()
+    git_dir = repo_dir / ".git"
+    (git_dir / "refs" / "heads").mkdir(parents=True)
+    (git_dir / "HEAD").write_text("ref: refs/heads/main\n")
+    (git_dir / "refs" / "heads" / "main").write_text("cached-head\n")
 
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3, "ver": __version__}))
+    cache_file.write_text(
+        json.dumps(
+            {
+                "ts": time.time(),
+                "behind": 3,
+                "ver": __version__,
+                "rev": None,
+                "repo_head": "ref: refs/heads/main:cached-head",
+            }
+        )
+    )
+
+    fake_banner = repo_dir / "hermes_cli" / "banner.py"
+    fake_banner.parent.mkdir(parents=True)
+    fake_banner.touch()
+    monkeypatch.setattr("hermes_cli.banner.__file__", str(fake_banner))
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run") as mock_run:
+    with patch("hermes_cli.config.detect_install_method", return_value="git"), \
+         patch("hermes_cli.banner.subprocess.run") as mock_run:
         result = check_for_updates()
 
     assert result == 3
@@ -72,6 +91,52 @@ def test_check_for_updates_invalidates_on_version_change(tmp_path, monkeypatch):
     # Cache rewritten with the current installed version.
     written = json.loads(cache_file.read_text())
     assert written["ver"] == banner.VERSION
+
+
+def test_check_for_updates_invalidates_on_repo_head_change(tmp_path, monkeypatch):
+    """Fresh source-checkout cache must be rejected after HEAD changes.
+
+    Source installs can keep the same package VERSION across rebases/cherry-picks.
+    Without a repo-head cache key, a stale behind count can survive the 6h TTL
+    even after the checkout is up to date.
+    """
+    import hermes_cli.banner as banner
+
+    project_root = tmp_path / "project"
+    code_dir = project_root / "hermes_cli"
+    code_dir.mkdir(parents=True)
+    fake_banner = code_dir / "banner.py"
+    fake_banner.touch()
+    git_dir = project_root / ".git"
+    (git_dir / "refs" / "heads").mkdir(parents=True)
+    (git_dir / "HEAD").write_text("ref: refs/heads/main\n")
+    (git_dir / "refs" / "heads" / "main").write_text("new-head\n")
+    monkeypatch.setattr(banner, "__file__", str(fake_banner))
+
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(
+        json.dumps(
+            {
+                "ts": time.time(),
+                "behind": 411,
+                "rev": None,
+                "ver": banner.VERSION,
+                "repo_head": "ref: refs/heads/main:old-head",
+            }
+        )
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+    mock_result = MagicMock(returncode=0, stdout="0\n")
+    with patch("hermes_cli.banner.subprocess.run", return_value=mock_result) as mock_run:
+        result = banner.check_for_updates()
+
+    assert result == 0
+    assert mock_run.call_count == 2  # git fetch + git rev-list
+    written = json.loads(cache_file.read_text())
+    assert written["behind"] == 0
+    assert written["repo_head"].endswith(":new-head")
 
 
 def test_check_for_updates_expired_cache(tmp_path, monkeypatch):


### PR DESCRIPTION
The update-check source cache was keyed such that a changed HEAD did not invalidate it, so update checks could operate on stale source state after a local checkout/rebase. Invalidate the cache when HEAD changes. Includes a regression test for the upstream remote probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)