### PR TITLE
fix(voice): honor PipeWire forwarding under WSL

### DIFF
--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -243,6 +243,33 @@ class TestDetectAudioEnvironment:
         assert result["warnings"] == []
         assert any("WSL" in n for n in result.get("notices", []))
 
+    def test_wsl_with_pipewire_allows_voice(self, monkeypatch, tmp_path):
+        """WSL with PIPEWIRE_REMOTE set should NOT block voice mode."""
+        monkeypatch.delenv("SSH_CLIENT", raising=False)
+        monkeypatch.delenv("SSH_TTY", raising=False)
+        monkeypatch.delenv("SSH_CONNECTION", raising=False)
+        monkeypatch.delenv("PULSE_SERVER", raising=False)
+        monkeypatch.setenv("PIPEWIRE_REMOTE", "/run/user/1000/pipewire-0")
+        monkeypatch.setattr("tools.voice_mode._import_audio",
+                            lambda: (MagicMock(), MagicMock()))
+
+        proc_version = tmp_path / "proc_version"
+        proc_version.write_text("Linux 5.15.0-microsoft-standard-WSL2")
+
+        _real_open = open
+        def _fake_open(f, *a, **kw):
+            if f == "/proc/version":
+                return _real_open(str(proc_version), *a, **kw)
+            return _real_open(f, *a, **kw)
+
+        with patch("builtins.open", side_effect=_fake_open):
+            from tools.voice_mode import detect_audio_environment
+            result = detect_audio_environment()
+
+        assert result["available"] is True
+        assert result["warnings"] == []
+        assert any("WSL" in n for n in result.get("notices", []))
+
     def test_wsl_device_query_fails_with_pulse_continues(self, monkeypatch, tmp_path):
         """WSL device query failure should not block if PULSE_SERVER is set."""
         monkeypatch.delenv("SSH_CLIENT", raising=False)

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -190,16 +190,16 @@ def detect_audio_environment() -> dict:
                 "    PipeWire:    -e PIPEWIRE_REMOTE=$XDG_RUNTIME_DIR/pipewire-0"
             )
 
-    # WSL detection — PulseAudio bridge makes audio work in WSL.
-    # Only block if PULSE_SERVER is not configured.
+    # WSL detection — PulseAudio/PipeWire forwarding makes audio work in WSL.
+    # Only block if no forwarded sound server is configured or reachable.
     try:
         with open('/proc/version', 'r', encoding="utf-8") as f:
             if 'microsoft' in f.read().lower():
-                if os.environ.get('PULSE_SERVER'):
-                    notices.append("Running in WSL with PulseAudio bridge")
+                if has_forwarded_audio:
+                    notices.append("Running in WSL with PulseAudio/PipeWire audio forwarding")
                 else:
                     warnings.append(
-                        "Running in WSL -- audio requires PulseAudio bridge.\n"
+                        "Running in WSL -- audio requires PulseAudio/PipeWire forwarding.\n"
                         "  1. Set PULSE_SERVER=unix:/mnt/wslg/PulseServer\n"
                         "  2. Create ~/.asoundrc pointing ALSA at PulseAudio\n"
                         "  3. Verify with: arecord -d 3 /tmp/test.wav && aplay /tmp/test.wav"


### PR DESCRIPTION
Voice did not honor PipeWire audio forwarding when running under WSL, breaking audio in that environment. Detect and honor the PipeWire forwarding path so voice works under WSL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)