### PR TITLE
test: isolate node/tui, delegation, and vision/resume test state

### DIFF
--- a/tests/agent/test_subagent_stop_hook.py
+++ b/tests/agent/test_subagent_stop_hook.py
@@ -56,8 +56,8 @@ def _fresh_plugin_manager():
 @pytest.fixture(autouse=True)
 def _stub_child_builder(monkeypatch):
     """Replace _build_child_agent with a MagicMock factory so delegate_task
-    never transitively imports run_agent / openai.  Keeps the test runnable
-    in environments without heavyweight runtime deps installed."""
+    never transitively imports run_agent / openai, and isolate delegation
+    routing from the user's persistent config."""
     def _fake_build_child(task_index, **kwargs):
         child = MagicMock()
         child._delegate_saved_tool_names = []
@@ -67,6 +67,7 @@ def _stub_child_builder(monkeypatch):
     monkeypatch.setattr(
         "tools.delegate_tool._build_child_agent", _fake_build_child,
     )
+    monkeypatch.setattr("tools.delegate_tool._load_config", lambda: {})
 
 
 def _register_capturing_hook():

--- a/tests/cli/test_resume_quiet_stderr.py
+++ b/tests/cli/test_resume_quiet_stderr.py
@@ -63,13 +63,21 @@ class TestResumeQuietStderr:
         db.get_session.return_value = None
         cli = _make_cli(quiet=False, db=db)
 
-        with patch("cli._prepare_deferred_agent_startup"):
+        with (
+            patch("cli._prepare_deferred_agent_startup"),
+            patch("cli._cprint") as cprint,
+        ):
             result = cli._init_agent()
 
         captured = capsys.readouterr()
         assert result is False
-        # Interactive mode keeps the existing _cprint path → stdout.
-        assert "Session not found" in captured.out
+        # Interactive mode keeps the existing _cprint path. Observe that
+        # boundary directly because prompt_toolkit may bind stdout before
+        # pytest's per-test capture stream is installed.
+        assert "Session not found" in " ".join(
+            call.args[0] for call in cprint.call_args_list
+        )
+        assert captured.err == ""
 
     def test_resumed_banner_goes_to_stderr_in_quiet_mode(self, capsys):
         db = MagicMock()

--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -14,6 +14,7 @@
     "fmt": "prettier --write 'src/**/*.{ts,tsx}' 'packages/**/*.{ts,tsx}'",
     "fix": "npm run lint:fix && npm run fmt",
     "check": "npm run build:ink && npm run typecheck && npm run test",
+    "pretest": "npm run build:ink",
     "test": "vitest run",
     "test:watch": "vitest"
   },


### PR DESCRIPTION
Test-hygiene batch that removes cross-test state leakage:
- `fix(node)`: resolve audit and stabilize TUI tests
- `test(delegation)`: isolate persistent provider config between tests
- `test`: isolate vision and resume output state

No production-code behavior change; these make the affected suites deterministic in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)