### PR TITLE
fix(gateway): judge empty internal auto-resume turns on original event text so group-channel restarts don't leak blank turns

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10453,6 +10453,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _msg_start_time = time.time()
         _platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
         _msg_preview = (event.text or "")[:80].replace("\n", " ")
+        _orig_empty_internal = (
+            bool(getattr(event, "internal", False))
+            and not (getattr(event, "text", "") or "").strip()
+            and not getattr(event, "media_urls", None)
+        )
         _reply_id = getattr(event, "reply_to_message_id", None)
         _reply_txt = (getattr(event, "reply_to_text", None) or "")[:80].replace("\n", " ")
         logger.info(
@@ -11246,7 +11251,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 moa_config=getattr(event, "_moa_config", None),
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                event_internal=bool(getattr(event, "internal", False)),
+                event_has_media=bool(getattr(event, "media_urls", None)),
+                orig_empty_internal=_orig_empty_internal,
             )
+            if agent_result.get("_dropped_empty_internal_auto_resume"):
+                return None
 
             # Stop persistent typing indicator now that the agent is done
             try:
@@ -16411,6 +16421,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[str] = None,
         persist_user_timestamp: Optional[float] = None,
+        event_internal: bool = False,
+        event_has_media: bool = False,
+        orig_empty_internal: bool = False,
     ) -> Dict[str, Any]:
         """Profile-scoping wrapper around the agent run.
 
@@ -16429,6 +16442,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                event_internal=event_internal,
+                event_has_media=event_has_media,
+                orig_empty_internal=orig_empty_internal,
             )
 
         profile_home = self._resolve_profile_home_for_source(source)
@@ -16440,6 +16456,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                event_internal=event_internal,
+                event_has_media=event_has_media,
+                orig_empty_internal=orig_empty_internal,
             )
 
     def _resolve_profile_home_for_source(self, source: SessionSource) -> "Path":
@@ -16472,6 +16491,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[str] = None,
         persist_user_timestamp: Optional[float] = None,
+        event_internal: bool = False,
+        event_has_media: bool = False,
+        orig_empty_internal: bool = False,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -18141,6 +18163,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # message so stale guidance never replays as user-authored text.
             _persist_user_message_override: Optional[Any] = persist_user_message
             _persist_user_timestamp_override: Optional[float] = persist_user_timestamp
+            _empty_internal_auto_resume = bool(
+                event_internal
+                and not event_has_media
+                and (
+                    orig_empty_internal
+                    or (isinstance(message, str) and not message.strip())
+                )
+            )
+            _empty_internal_auto_resume_message = (
+                message if _empty_internal_auto_resume else None
+            )
 
             # Prepend pending model switch note so the model knows about the switch
             _pending_notes = getattr(self, '_pending_model_notes', {})
@@ -18222,12 +18255,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if _reason == "shutdown_timeout"
                     else "a gateway interruption"
                 )
-                _persist_user_message_override = message
+                _persist_user_message_override = "" if _empty_internal_auto_resume else message
+                _has_resume_user_message = bool(
+                    isinstance(message, str)
+                    and message.strip()
+                    and not _empty_internal_auto_resume
+                )
                 # The empty-message case is the auto-resume startup turn
                 # synthesized by _schedule_resume_pending_sessions — there is
                 # no NEW user message to address, so tell the model to report
                 # recovery instead of the (nonexistent) "new message".
-                if message:
+                if _has_resume_user_message:
                     _resume_guidance = (
                         "Address the user's NEW message below FIRST and focus "
                         "on what the user is asking now."
@@ -18244,7 +18282,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     f"run — do NOT re-execute or verify it. {_resume_guidance} "
                     f"Do NOT re-execute old tool calls — skip any unfinished "
                     f"work from the conversation history.]"
-                    + (f"\n\n{message}" if message else "")
+                    + (f"\n\n{message}" if _has_resume_user_message else "")
                 )
             elif _has_fresh_tool_tail:
                 _persist_user_message_override = message
@@ -18278,10 +18316,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # wrapped as native content below) are untouched.
             if (
                 isinstance(message, str)
-                and not message.strip()
+                and (
+                    not message.strip()
+                    or (
+                        _empty_internal_auto_resume
+                        and message == _empty_internal_auto_resume_message
+                    )
+                )
                 and _resume_entry is not None
                 and getattr(_resume_entry, "resume_pending", False)
             ):
+                if _empty_internal_auto_resume:
+                    _persist_user_message_override = ""
                 _sn_reason = (
                     getattr(_resume_entry, "resume_reason", None) or "restart_timeout"
                 )
@@ -18302,6 +18348,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     f"calls — skip any unfinished work from the conversation "
                     f"history.]"
                 )
+
+            if (
+                event_internal
+                and isinstance(message, str)
+                and not event_has_media
+                and (
+                    not message.strip()
+                    or (
+                        _empty_internal_auto_resume
+                        and message == _empty_internal_auto_resume_message
+                    )
+                )
+            ):
+                logger.debug(
+                    "Dropping empty internal auto-resume turn for session %s "
+                    "(resume note did not apply)",
+                    session_key or "",
+                )
+                return {
+                    "final_response": "",
+                    "messages": [],
+                    "api_calls": 0,
+                    "completed": False,
+                    "interrupted": True,
+                    "tools": tools_holder[0] or [],
+                    "history_offset": len(agent_history),
+                    "session_id": session_id,
+                    "_dropped_empty_internal_auto_resume": True,
+                }
 
             _approval_session_key = session_key or ""
             _approval_session_token = set_current_session_key(_approval_session_key)

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -26,13 +26,17 @@ PRs #9850, #9934, #7536):
 """
 
 import asyncio
+import sys
 import time
+import types
 from datetime import datetime, timedelta
+from typing import ClassVar, List
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from gateway.config import GatewayConfig, HomeChannel, Platform
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, MessageType, SendResult
 from gateway.run import (
     _AGENT_PENDING_SENTINEL,
@@ -77,6 +81,88 @@ def _make_source(platform=Platform.TELEGRAM, chat_id="123", user_id="u1"):
 
 def _make_store(tmp_path):
     return SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+
+
+class _CapturingAutoResumeAgent:
+    run_messages: ClassVar[List[str]] = []
+
+    def __init__(self, *args, **kwargs):
+        self.tools = []
+        self.session_id = kwargs.get("session_id", "session-1")
+        self.model = kwargs.get("model", "test-model")
+        self.provider = kwargs.get("provider")
+        self.max_iterations = kwargs.get("max_iterations", 1)
+
+    def run_conversation(self, user_message, **kwargs):
+        type(self).run_messages.append(user_message)
+        return {
+            "final_response": "agent ok",
+            "messages": [
+                {"role": "user", "content": user_message},
+                {"role": "assistant", "content": "agent ok"},
+            ],
+            "api_calls": 1,
+            "completed": True,
+            "history_offset": len(kwargs.get("conversation_history") or []),
+            "session_id": self.session_id,
+        }
+
+
+def _install_capturing_auto_resume_agent(monkeypatch):
+    fake_run_agent = types.ModuleType("run_agent")
+    setattr(fake_run_agent, "AIAgent", _CapturingAutoResumeAgent)
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    _CapturingAutoResumeAgent.run_messages = []
+
+
+def _make_auto_resume_handler_runner(monkeypatch, tmp_path):
+    runner = gateway_run.GatewayRunner(
+        GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")},
+            sessions_dir=tmp_path / "sessions",
+            group_sessions_per_user=False,
+        )
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    adapter.stop_typing = AsyncMock()
+    adapter.get_pending_message.return_value = None
+    adapter.has_pending_interrupt.return_value = False
+    adapter.SUPPORTS_MESSAGE_EDITING = False
+    adapter._pending_messages = {}
+    adapter._active_sessions = {}
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.hooks.loaded_hooks = False
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._session_run_generation = {}
+    monkeypatch.setattr(runner, "_is_user_authorized", lambda source: True)
+    monkeypatch.setattr(runner, "_set_session_env", lambda context: [])
+    monkeypatch.setattr(runner, "_recover_telegram_topic_thread_id", lambda source: None)
+    monkeypatch.setattr(runner, "_cache_session_source", lambda session_key, source: None)
+    monkeypatch.setattr(runner, "_is_session_run_current", lambda session_key, generation: True)
+    monkeypatch.setattr(runner, "_reply_anchor_for_event", lambda event: None)
+    monkeypatch.setattr(runner, "_get_guild_id", lambda event: None)
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    monkeypatch.setattr(
+        runner,
+        "_resolve_session_agent_runtime",
+        lambda **kwargs: ("test-model", {"api_key": "fake", "provider": "test"}),
+    )
+    monkeypatch.setattr(runner, "_resolve_session_reasoning_config", lambda **kwargs: None)
+    monkeypatch.setattr(runner, "_load_service_tier", lambda: None)
+
+    async def _run_inline(func, *args):
+        return func(*args)
+
+    monkeypatch.setattr(runner, "_run_in_executor_with_context", _run_inline)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "phantom-empty-chat")
+    return runner, adapter
 
 
 def _build_agent_history(history: list) -> list:
@@ -651,6 +737,187 @@ class TestResumePendingSystemNote:
             resume_entry=None,
         )
         assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_group_prefixed_empty_internal_turn_is_flagged_and_dropped(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        runner, adapter = _make_auto_resume_handler_runner(monkeypatch, tmp_path)
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="phantom-empty-chat",
+            chat_name="Restart Group",
+            chat_type="group",
+            user_id="u1",
+            user_name="민서",
+        )
+        session_entry = runner.session_store.get_or_create_session(source)
+        session_key = session_entry.session_key
+        captured = {}
+
+        async def _fake_run_agent(**kwargs):
+            captured.clear()
+            captured.update(kwargs)
+            if kwargs.get("orig_empty_internal"):
+                return {
+                    "final_response": "",
+                    "messages": [],
+                    "api_calls": 0,
+                    "completed": False,
+                    "interrupted": True,
+                    "tools": [],
+                    "history_offset": 0,
+                    "session_id": session_entry.session_id,
+                    "_dropped_empty_internal_auto_resume": True,
+                }
+            return {
+                "final_response": "agent ok",
+                "messages": [
+                    {"role": "user", "content": kwargs["message"]},
+                    {"role": "assistant", "content": "agent ok"},
+                ],
+                "api_calls": 1,
+                "completed": True,
+                "tools": [],
+                "history_offset": 0,
+                "session_id": session_entry.session_id,
+            }
+
+        monkeypatch.setattr(runner, "_run_agent", _fake_run_agent)
+
+        empty_internal = MessageEvent(
+            text="",
+            message_type=MessageType.TEXT,
+            source=source,
+            internal=True,
+            message_id="auto-resume-empty",
+        )
+        dropped = await runner._handle_message_with_agent(
+            empty_internal,
+            source,
+            session_key,
+            0,
+        )
+
+        assert dropped is None
+        assert captured["message"] == "[민서] "
+        assert captured["event_internal"] is True
+        assert captured["event_has_media"] is False
+        assert captured["orig_empty_internal"] is True
+        adapter.send.assert_not_awaited()
+
+        normal_event = MessageEvent(
+            text="hello",
+            message_type=MessageType.TEXT,
+            source=source,
+            internal=False,
+            message_id="normal-message",
+        )
+        normal = await runner._handle_message_with_agent(
+            normal_event,
+            source,
+            session_key,
+            0,
+        )
+
+        assert normal == "agent ok"
+        assert captured["message"] == "[민서] hello"
+        assert captured["event_internal"] is False
+        assert captured["event_has_media"] is False
+        assert captured["orig_empty_internal"] is False
+
+    @pytest.mark.asyncio
+    async def test_group_prefixed_empty_internal_turn_drops_before_agent_invocation(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        _install_capturing_auto_resume_agent(monkeypatch)
+        runner, _adapter = _make_auto_resume_handler_runner(monkeypatch, tmp_path)
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="phantom-empty-chat",
+            chat_name="Restart Group",
+            chat_type="group",
+            user_id="u1",
+            user_name="민서",
+        )
+        session_key = runner._session_key_for_source(source)
+
+        result = await runner._run_agent_inner(
+            message="[민서] ",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id="sid-cleared-resume",
+            session_key=session_key,
+            run_generation=0,
+            event_internal=True,
+            event_has_media=False,
+            orig_empty_internal=True,
+        )
+
+        assert result["_dropped_empty_internal_auto_resume"] is True
+        assert _CapturingAutoResumeAgent.run_messages == []
+
+    @pytest.mark.asyncio
+    async def test_group_prefixed_empty_internal_resume_pending_reports_recovery(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        _install_capturing_auto_resume_agent(monkeypatch)
+        runner, _adapter = _make_auto_resume_handler_runner(monkeypatch, tmp_path)
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="phantom-empty-chat",
+            chat_name="Restart Group",
+            chat_type="group",
+            user_id="u1",
+            user_name="민서",
+        )
+        session_key = runner._session_key_for_source(source)
+        now = datetime.now()
+        runner.session_store._entries[session_key] = SessionEntry(
+            session_key=session_key,
+            session_id="sid-fresh-resume",
+            created_at=now,
+            updated_at=now,
+            origin=source,
+            platform=Platform.TELEGRAM,
+            chat_type="group",
+            resume_pending=True,
+            resume_reason="restart_timeout",
+            last_resume_marked_at=now,
+        )
+
+        result = await runner._run_agent_inner(
+            message="[민서] ",
+            context_prompt="",
+            history=[
+                {
+                    "role": "assistant",
+                    "content": "interrupted",
+                    "timestamp": time.time(),
+                },
+            ],
+            source=source,
+            session_id="sid-fresh-resume",
+            session_key=session_key,
+            run_generation=0,
+            event_internal=True,
+            event_has_media=False,
+            orig_empty_internal=True,
+        )
+
+        assert not result.get("_dropped_empty_internal_auto_resume")
+        assert _CapturingAutoResumeAgent.run_messages
+        run_message = _CapturingAutoResumeAgent.run_messages[-1]
+        assert "restored successfully" in run_message
+        assert "NEW message" not in run_message
+        assert "[민서]" not in run_message
 
     def test_fresh_tool_tail_preserves_auto_continue_note(self):
         history = [


### PR DESCRIPTION
## Problem

On gateway restart, `_schedule_resume_pending_sessions()` injects one internal `MessageEvent` per interrupted session with `text=""`, `internal=True`. The intent is that `_run_agent_inner`'s resume-pending branch rewrites that blank turn into a recovery "[System note: ...]" instead of handing the model an empty user turn.

This works for **DMs / single-user channels**, but **leaks on shared multi-user (group) channels**: `_prepare_inbound_message_text` prepends a sender prefix (`[Alice] `) to the message when the session is a shared multi-user session. So the empty `""` becomes `"[Alice] "`, which is **non-empty after `.strip()`** (`"[Alice]"`). Every downstream guard that tests `not message.strip()` — the resume-note safety net and the empty-internal drop guard — is bypassed, and the model receives a bare `"[Alice] "` user turn and replies with confused "the message came through blank" noise. This only reproduces on group channels.

## Root cause

The "is this an empty auto-resume turn?" decision was made on the **post-prefix** `message_text`, not on the **original** `event.text`. The sender prefix defeats the empty check.

## Fix

Compute an `orig_empty_internal` signal from the **original** `MessageEvent` (before `_prepare_inbound_message_text` mutates the text):

```python
_orig_empty_internal = (
    bool(getattr(event, "internal", False))
    and not (getattr(event, "text", "") or "").strip()
    and not getattr(event, "media_urls", None)
)
```

Thread it through `_run_agent` / `_run_agent_inner` and treat it as a **semantic-empty override**: the resume recovery-note branch, the safety net, and the final empty-internal drop sentinel now fire when `orig_empty_internal` is true **even if** the prefixed `message.strip()` is non-empty. Real group messages like `"[Alice] hello"` are untouched because `event.text` was non-empty there (so `orig_empty_internal` is `False`).

Default for callers not passing the new kwarg is unchanged.

## Tests

`tests/gateway/test_restart_resume_pending.py` adds group-prefix regression coverage:
- an internal empty-text turn on a shared multi-user session (prefixed to `"[user] "`) is flagged/dropped and does not reach the model
- when `resume_pending` is fresh it produces a recovery note instead
- a real group message `"[user] hello"` still runs normally

`83 passed` for the file; no regressions in neighboring gateway/session suites.
