### PR TITLE
feat: add skill-maintainer optional skill (upstream sync + drift tracking)

### DIFF
--- a/optional-skills/software-development/skill-maintainer/SKILL.md
+++ b/optional-skills/software-development/skill-maintainer/SKILL.md
@@ -1,0 +1,439 @@
+---
+name: skill-maintainer
+description: "Maintain a skill library: curate external collections, track upstream drift with a manifest, run monthly sync audits, scan engine dependencies, and publish skills. Includes manifest template and cron script for automated drift detection."
+version: 1.0.1
+author: moonlight-lupin
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [skills, curation, upstream, sync, manifest, maintenance, publishing]
+    related_skills: [hermes-agent-skill-authoring, skill-curation]
+---
+
+# Skill Maintainer
+
+## Overview
+
+End-to-end skill library maintenance for agents who adapt external skills,
+track upstream changes, and publish to repos. Covers the full lifecycle:
+**curate → track → sync → publish**.
+
+This skill fills the gaps between Hermes' native skill management systems:
+
+| Hermes native | What it does | What it doesn't do |
+|---|---|---|
+| `hermes skills check/update` | Update bundled + hub skills from the Hermes registry | Track arbitrary GitHub repos you adapted from |
+| `hermes curator` | Usage tracking, stale detection, archive/restore | Upstream content sync, drift detection |
+| `hermes skills diff` | Show local edits vs stock bundled skills | Compare against external upstream repos |
+| `hermes skills publish` | Publish to the Hermes skills hub | Debrand/generalize for a public GitHub repo |
+
+**This skill adds:** upstream drift tracking for adapted skills, engine
+dependency scanning, Layer 2 (local → published repo) sync, a monthly cron
+script, and the full curation/publishing workflow documentation.
+
+## When to Use
+
+- Importing/adapting skills from an external repo or collection
+- Checking if local skills have drifted from upstream sources
+- Scanning for untracked external tool dependencies
+- Publishing a local skill to a shared repo (debrand + generalize)
+- Setting up automated monthly sync checks
+- Tightening/pruning an accumulated skill library
+
+**Don't use for:** updating bundled or hub skills — use `hermes skills check`
+and `hermes skills update` for those. This skill tracks skills adapted from
+sources *outside* the Hermes registry.
+
+## Core Concepts
+
+### The three sync layers
+
+| Layer | Direction | What drifts | Example |
+|-------|-----------|-------------|---------|
+| **1. External → Local** | Upstream repo → your skill | Upstream adds features, fixes bugs, changes API | baoyu-skills v1.56 → v1.117 |
+| **2. Local → Published repo** | Your skill → your GitHub repo | You improve locally; repo copy goes stale | skill gets new flags locally; repo doesn't |
+| **3. Local → Standalone repo** | Your skill → a code project repo | Skill documents a workflow; the code evolves | skill describes CLI v1; CLI is now v3 |
+
+All three need tracking. Layer 1 is the most common concern. Layer 2 is the
+most commonly forgotten — publish once, keep improving, repo goes stale.
+
+### The manifest
+
+A single `UPSTREAM_MANIFEST.md` file at `~/.hermes/skills/` tracks every
+skill with external provenance. One row per skill, covering all three
+layers. See `templates/upstream-manifest.md` for the file format.
+
+### The cron job
+
+An automated script (`scripts/upstream_check.py`) runs monthly, parses the
+manifest, fetches upstream versions, compares content hashes for published
+skills, and reports drift. See the Cron Setup section.
+
+---
+
+## Skill Curation Workflow
+
+### 1. Inventory and classify
+
+When porting skills from an external collection, classify each:
+
+| Class | Action |
+|-------|--------|
+| **Keep** — unique, valuable, no overlap | Adapt to Hermes format |
+| **Duplicate** — Hermes already has an equivalent | Merge unique parts or skip |
+| **Thin/pointer** — just a URL, no real content | Skip |
+| **Novelty** — joke/toy, no practical value | Skip |
+| **Capability-layer/router** — installer + router delegating to upstream CLIs | Evaluate each backend; don't wholesale replace native skills |
+
+### 2. Assess overlap
+
+Run `hermes skills list` and compare each candidate against existing skills.
+When two overlap, prefer the Hermes-native one unless the external one adds
+clear value. If merging: `skill_manage(action='patch')` the existing skill
+with unique content, then discard the external copy.
+
+### 3. Adapt to Hermes format
+
+**Frontmatter** — strip all framework-specific fields. Keep `name`,
+`description`, `version` (bump for adapted), `author` (e.g. "Source (adapted)").
+Add `metadata.hermes.tags` and `metadata.hermes.related_skills`.
+
+**Body** — full rewrite, not copy-paste:
+- Translate all non-English content to English
+- Strip framework-specific references, sandbox paths, proprietary tool names
+- Restructure into Hermes sections (When to use, body, pitfalls, verification)
+- **Preserve all domain detail** — exact hex codes, pixel dimensions, font
+  names, timing, forbidden patterns — these ARE the skill's value
+- Add practical trigger words
+
+### 4. Quality audit
+
+```bash
+# Non-English characters remaining (if source was non-EN)
+grep -cP '[\x{4e00}-\x{9fff}]' SKILL.md
+# Framework jargon remaining
+grep -c 'framework-specific-term\|upstream-field' SKILL.md
+# Version/author consistency
+grep '^version:\|^author:' SKILL.md
+```
+
+### 5. Place in correct category
+
+Use existing Hermes categories (`skills/<category>/`). Don't invent new
+top-level categories casually. Pick the closest existing one.
+
+### 6. Update manifest
+
+Add a row to `~/.hermes/skills/UPSTREAM_MANIFEST.md` for every adapted skill.
+See the Upstream Tracking section for entry types.
+
+---
+
+## Upstream Tracking Manifest
+
+Maintain `UPSTREAM_MANIFEST.md` at `~/.hermes/skills/`. One row per skill
+with external provenance. See `templates/upstream-manifest.md` for the full
+template.
+
+### Entry types — pick the right table
+
+| Type | What it tracks | Audit method |
+|------|---------------|--------------|
+| **Adapted skill** | Skill content adapted from an upstream skill repo | Diff upstream SKILL.md, compare version fields |
+| **Engine dependency** | Skill wraps a third-party CLI/pip tool | `tool --version` vs GitHub releases |
+| **Engine-tracking skill** | Original skill built around a third-party engine | `pip show <pkg>` + GitHub releases |
+| **Third-party skill** | Adapted from external repo (not a skill repo per se) | Fetch README/latest, compare concepts |
+| **Published skill** | Local skill pushed to your repo | `diff` local vs repo copy + content hash |
+
+**Skip the manifest** for original skills with zero external dependency.
+
+### The PORT_NOTES pattern (gold standard for complex adaptations)
+
+For skills with significant structural changes, maintain `PORT_NOTES.md`
+inside the skill directory:
+
+```markdown
+# Port Notes — <skill-name>
+
+Ported from <repo-url> v<upstream-version>.
+
+## Changes from upstream
+| Change | Upstream | Ours |
+
+### What was preserved
+<list of verbatim-copied files>
+
+## Syncing with upstream
+<exact curl/diff commands>
+<files safe to overwrite vs requiring manual merge>
+```
+
+---
+
+## Sync Audit Workflow
+
+Run monthly or when prompted.
+
+### 1. Read the manifest
+
+Note last-checked dates. Identify stale rows (last sync >60 days).
+
+### 2. Layer 1 — External → Local
+
+For each adapted skill:
+1. Fetch upstream version (raw GitHub URL or GitHub API)
+2. Compare to pinned version in manifest
+3. If different, classify the source and apply the right sync strategy:
+
+| Source type | Sync approach |
+|-------------|--------------|
+| **Versioned, verbatim-heavy** | Overwrite verbatim files, merge adapted files |
+| **Unversioned, full rewrite** | Keep ours — diff for new domain content only |
+| **Actively evolving** | Content merge — add upstream sections, preserve local wiring |
+| **Archived/moved** | Update URLs only — upstream may have changed format |
+| **Low activity** | One-time check, usually nothing to do |
+
+### 3. Layer 2 — Local → Published repo
+
+For each published skill, `diff` local vs repo copy. The cron script does
+both version comparison AND SHA-256 content hash comparison — so
+same-version content drift is also caught.
+
+### 4. Layer 3 — Local → Standalone repo
+
+For skills tied to code repos, check if the repo's workflow/CLI has changed.
+
+### 5. Engine dependency scan
+
+```bash
+# List installed CLI binaries
+for tool in <your-tools>; do
+  path=$(which $tool 2>/dev/null) && echo "$tool: $path" || echo "$tool: not installed"
+done
+
+# List pip packages
+for pkg in <your-packages>; do
+  pip show $pkg 2>/dev/null | grep -E '^Version:'
+done
+
+# Check latest releases
+curl -s https://api.github.com/repos/<owner>/<repo>/releases/latest | grep tag_name
+```
+
+Cross-reference with manifest — any installed tool that powers a skill but
+isn't in the manifest is an untracked dependency. Add it.
+
+### 6. Update manifest
+
+Record last-checked date, new upstream version, any sync actions taken.
+
+### Parallel diff dispatch
+
+When auditing multiple upstream sources simultaneously:
+1. Fetch all upstream files in one batch
+2. Dispatch parallel subagents (`delegate_task`) per source to diff and classify
+3. Handle simple updates (URL fixes, verbatim overwrites) yourself
+4. Collect structured recommendations (keep/merge/re-port)
+5. Execute merges based on recommendations
+
+This turns a serial 30-minute audit into a 5-minute parallel one.
+
+---
+
+## Publishing Skills to a Public Repo
+
+### Debranding
+
+When publishing a skill derived from a client/org-specific source:
+
+1. Grep for brand references across all files
+2. Remove or genericize: brand names, proprietary palettes, regulatory
+   references, org-internal file paths, house styles
+3. Remove brand-specific reference files
+4. Replace specific dollar amounts with generic terms
+5. Verify clean with grep
+6. Bump version for the published version
+
+### Generalizing for agent-agnostic repos
+
+| Hermes term | Replace with |
+|-------------|-------------|
+| `image_generate` (tool) | "image generation tool/skill" |
+| `clarify` (tool) | "ask the user" or "user-input tool" |
+| `delegate_task` (tool) | "spawn subagent" or "delegate" |
+| `MEDIA:` (Telegram) | "send via the user's channel" |
+| `write_file`, `read_file`, `search_files` | "write to file", "read file", "search files" |
+| `officecli` skill | "office document tools" |
+| Hermes metadata fields (`hermes.tags`, `hermes.related_skills`) | Remove from frontmatter |
+| Hardcoded paths (`~/.hermes/...`) | Env var with fallback, or `<skill_dir>/...` |
+
+### Mutual exclusivity
+
+In a pick-and-choose repo, each skill must be self-contained and runnable
+standalone, even at the cost of code duplication across siblings. Do NOT
+extract shared modules — a user who clones only one skill should not need
+a file from another.
+
+---
+
+## Cron Setup — Automated Drift Detection
+
+Set up a monthly cron job to automatically check for upstream drift.
+
+### 1. Copy the manifest template
+
+```bash
+cp templates/upstream-manifest.md ~/.hermes/skills/UPSTREAM_MANIFEST.md
+```
+
+Edit it to list your actual skills, upstream repos, and versions.
+
+### 2. Copy the check script
+
+```bash
+cp scripts/upstream_check.py ~/scripts/upstream_check.py
+```
+
+The script reads Layer 1 and Layer 2 tables directly from
+`UPSTREAM_MANIFEST.md`. No hardcoded skill lists — the manifest is the
+single source of truth.
+
+Engine dependencies (`ENGINE_DEPS`) are configured in the script file
+itself, not in the manifest. This is a deliberate security boundary:
+manifest content is markdown that could be externally edited, so we
+don't execute shell commands derived from it. Add entries like:
+
+```python
+ENGINE_DEPS = [
+    {"name": "my-cli-tool", "command": ["my-cli", "--version"], "version_regex": r"(\d+\.\d+\.\d+)"},
+    {"name": "my-pip-pkg", "command": ["pip", "show", "my-pip-pkg"], "version_regex": r"(\d+\.\d+\.\d+)"},
+]
+```
+
+Commands are passed as lists (never `shell=True`) to prevent shell
+injection from untrusted config.
+
+You may also need to set `SKILLS_ROOT` and `LAYER_2_REPO` at the top of
+the script, or via the `SKILLS_ROOT` and `LAYER_2_REPO` env vars.
+
+### 3. Set up the cron job
+
+Using Hermes cron (recommended):
+
+```bash
+# Via CLI
+hermes cron create "0 9 1 * *" --name "Monthly Upstream Sync Check" \
+  --prompt "Run the upstream sync check script at ~/scripts/upstream_check.py. Report any drift detected. If drift is found, summarize which skills need attention and what changed upstream."
+
+# Or via the cronjob tool (in-session):
+# schedule: "0 9 1 * *"
+# no_agent: true  (script-only — stdout delivered verbatim, silent when in sync)
+```
+
+Or using system crontab:
+
+```
+# Monthly upstream sync check — 9am on the 1st
+0 9 1 * * /path/to/python3 /path/to/scripts/upstream_check.py
+```
+
+The script exits 0 if all in sync, 1 if drift detected. Non-empty stdout is
+delivered as the message; empty stdout means silent (nothing to report).
+
+### 4. What the script checks
+
+- **Layer 1:** parses manifest table, fetches upstream SKILL.md from GitHub,
+  compares version fields. For sources without version fields, reports last
+  commit date via GitHub API. Uses the repo's default branch (falls back to
+  `master`).
+- **Layer 2:** compares local vs published repo using **both** version
+  fields and SHA-256 content hashes. Catches version drift (different
+  version numbers) AND content drift (same version, different content —
+  e.g. you edited locally but didn't bump the version or re-publish).
+- **Engine deps:** runs configured version-check commands (list-form, no
+  shell) and extracts version strings.
+
+### 5. Handling drift reports
+
+When the cron reports drift:
+1. Read the report — which skills changed, what's the version delta
+2. Fetch upstream files to a temp directory
+3. Classify each file as verbatim (overwrite) or adapted (merge)
+4. For merges: take upstream as base, re-apply Hermes-specific adaptations
+5. Run jargon check — grep for upstream-specific terms that should be absent
+6. Update PORT_NOTES.md with sync log
+7. Update manifest with new version, date, and status
+
+---
+
+## Extending vs Creating New Skills
+
+When a new capability overlaps with an existing skill:
+
+1. **Does an existing skill cover the core capability?** → Extend it with
+   the missing piece (reference file, script, routing entry)
+2. **Does it need a fundamentally different workflow/toolset?** → New skill
+   may be warranted, but justify it first
+3. **Is it a thin layer on existing infrastructure?** → Reference file +
+   optional script, not a new skill
+
+When a sub-topic grows large enough to warrant a dedicated skill, the
+umbrella skill MUST point to the new skill, not keep duplicate content.
+Replace inline detail with a pointer: "→ See dedicated `<skill-name>` skill
+for: ..." Duplicate content drifts; a pointer ensures one source of truth.
+
+---
+
+## Pitfalls
+
+1. **Shallow ports are worthless** — a skill with source jargon, missing
+   triggers, and no restructuring helps no one. Always do a full adaptation pass.
+2. **Skill inflation** — don't port 139 skills when 35 are valuable. Ruthlessly
+   delete thin/pointer/duplicate/novelty skills before adapting.
+3. **Copy-paste trap** — the source format is never the target format.
+   Restructure the body, don't just translate headers.
+4. **Missing domain detail** — exact hex codes, pixel sizes, font weights,
+   forbidden patterns ARE the skill. Stripping them destroys the value.
+5. **Overlap blind spot** — always check `hermes skills list` before adding.
+   Two skills doing the same thing is worse than one.
+6. **Reverse-sync blind spot (Layer 2)** — after publishing, you keep
+   improving locally. Without manifest tracking, the repo copy silently goes
+   stale. Always record push dates.
+7. **"Keep ours" is valid** — not every upstream diff requires a merge. When
+   your version is a superset, record the decision and move on.
+8. **Merge subagents need explicit preserve lists** — without listing what
+   must NOT be removed, a merge subagent may overwrite everything with upstream.
+9. **Engine-tracking skills need different sync** — compare installed version
+   vs latest release, not SKILL.md content. A stale binary breaks the skill
+   even if the SKILL.md is current.
+10. **Silent auth dependency** — a backend that "just works" on a developer's
+    desktop may require cookies, QR login, or a browser extension impossible
+    on a server. Surface the auth boundary explicitly.
+11. **Atomic skills principle** — keep skills atomic (one capability per
+    skill). The agent chains skills at runtime, not at design time.
+12. **Mutual exclusivity in portable repos** — each skill must be
+    self-contained. Don't extract shared modules; duplication is the price
+    of independence.
+13. **Sediment** — a skill should get shorter or sharper over time. When
+    adding a rule, remove the old wording it replaces.
+14. **No-op prose** — "be careful," "be thorough" rarely change behavior.
+    Replace with checkable completion criteria.
+
+## Verification Checklist
+
+- [ ] Overlap checked — `hermes skills list` shows no existing skill covers the same capability
+- [ ] Frontmatter valid — starts with `---`, closes with `\n---\n`, parses as YAML
+- [ ] `name` (≤64 chars, lowercase+hyphens) and `description` (≤1024 chars) present
+- [ ] `metadata.hermes.tags` and `metadata.hermes.related_skills` present
+- [ ] Structure: Overview → When to Use → body → Pitfalls → Verification
+- [ ] Each step has a checkable completion criterion
+- [ ] No no-op prose or duplicated rules
+- [ ] Total file ≤100k chars (aim for 8–15k)
+- [ ] Bulky reference material in linked `references/*.md` files
+- [ ] Scripts are deterministic, pure stdlib where possible
+- [ ] **UPSTREAM_MANIFEST.md updated** if skill has external provenance
+- [ ] PORT_NOTES.md created for complex adaptations
+- [ ] Jargon check passed — no upstream-specific terms in adapted files
+- [ ] Published version debranded + generalized + tested
+- [ ] Cron job configured for monthly drift detection

--- a/optional-skills/software-development/skill-maintainer/scripts/upstream_check.py
+++ b/optional-skills/software-development/skill-maintainer/scripts/upstream_check.py
@@ -1,0 +1,536 @@
+#!/usr/bin/env python3
+"""
+Monthly upstream sync check — parses UPSTREAM_MANIFEST.md tables, fetches
+upstream versions, compares content hashes for published skills, and reports
+drift. Designed to run as a cron job on any agent platform.
+
+Exit codes: 0 = all in sync (or unknown), 1 = drift detected
+
+SETUP:
+  1. Copy templates/upstream-manifest.md to your skills root as
+     UPSTREAM_MANIFEST.md and fill in your skills
+  2. Set SKILLS_ROOT and LAYER_2_REPO below (or via env vars)
+  3. Optionally add ENGINE_DEPS entries for CLI tools / pip packages
+  4. Schedule monthly via cron or your agent platform's scheduler
+
+The script reads Layer 1 and Layer 2 tables directly from the manifest.
+Engine deps are configured in this file (they require shell commands that
+can't be safely parsed from markdown).
+
+CUSTOMIZATION:
+  - SKILLS_ROOT: where your skills + UPSTREAM_MANIFEST.md live
+  - LAYER_2_REPO: path to your published repo (None to skip)
+  - ENGINE_DEPS: list of dicts with name + command (as list, not shell string)
+"""
+
+import re
+import sys
+import subprocess
+import json
+import hashlib
+from pathlib import Path
+from datetime import datetime
+
+# ─── CONFIGURATION — edit these to match your setup ───────────────────────
+
+# Path to your skills directory (where UPSTREAM_MANIFEST.md lives)
+# Override with SKILLS_ROOT env var if needed
+SKILLS_ROOT = Path.home() / ".hermes" / "skills"
+
+# Path to your published repo (for Layer 2 checks). Set to None to skip.
+# Override with LAYER_2_REPO env var if needed
+LAYER_2_REPO = Path.home() / "agent_skills"
+
+# Engine dependencies to check (CLI binaries and pip packages).
+# Each entry: {"name": str, "command": [str, ...], "version_regex": r"..."}
+# Commands are passed as lists — never shell=True — so untrusted config
+# can't inject shell metacharacters. Do not populate ENGINE_DEPS from
+# untrusted manifest input; keep it in this file under your control.
+ENGINE_DEPS = [
+    # Example:
+    # {"name": "my-cli-tool", "command": ["my-cli", "--version"], "version_regex": r"(\d+\.\d+\.\d+)"},
+    # {"name": "my-pip-pkg", "command": ["pip", "show", "my-pip-pkg"], "version_regex": r"(\d+\.\d+\.\d+)"},
+]
+
+# ─── END CONFIGURATION ────────────────────────────────────────────────────
+
+
+def _resolve_config():
+    """Allow env var overrides without importing os at module level clutter."""
+    import os
+    global SKILLS_ROOT, LAYER_2_REPO
+    env_root = os.environ.get("SKILLS_ROOT")
+    if env_root:
+        SKILLS_ROOT = Path(env_root)
+    env_repo = os.environ.get("LAYER_2_REPO")
+    if env_repo:
+        LAYER_2_REPO = Path(env_repo) if env_repo.lower() != "none" else None
+
+
+MANIFEST_FILENAME = "UPSTREAM_MANIFEST.md"
+
+
+# ─── Manifest parsing ─────────────────────────────────────────────────────
+
+
+def parse_manifest(path):
+    """Parse UPSTREAM_MANIFEST.md and return structured entries.
+
+    Returns:
+        {
+            "layer1_skills": [{"skill": str, "source_repo": str, "repo_url": str,
+                               "local_ver": str, "upstream_ver": str, ...}],
+            "layer1_refs": [{...}],
+            "layer1_engines": [{...}],
+            "layer1_third_party": [{...}],
+            "layer2_published": [{"skill": str, "repo_path": str, ...}],
+        }
+    """
+    if not path.exists():
+        return {"layer1_skills": [], "layer1_refs": [], "layer1_engines": [],
+                "layer1_third_party": [], "layer2_published": []}
+
+    text = path.read_text()
+    sections = _split_sections(text)
+    result = {
+        "layer1_skills": [],
+        "layer1_refs": [],
+        "layer1_engines": [],
+        "layer1_third_party": [],
+        "layer2_published": [],
+    }
+
+    # Parse each table section
+    for header, table_text in sections:
+        rows = _parse_table(table_text)
+        if not rows:
+            continue
+
+        header_lower = header.lower()
+        if "whole skill" in header_lower:
+            result["layer1_skills"] = rows
+        elif "reference file" in header_lower:
+            result["layer1_refs"] = rows
+        elif "engine dep" in header_lower:
+            result["layer1_engines"] = rows
+        elif "third-party" in header_lower:
+            result["layer1_third_party"] = rows
+        elif "layer 2" in header_lower or "published repo" in header_lower:
+            result["layer2_published"] = rows
+
+    return result
+
+
+def _split_sections(text):
+    """Split manifest into (header, table_text) pairs by ## and ### headers."""
+    sections = []
+    current_header = None
+    current_lines = []
+
+    for line in text.splitlines():
+        if line.startswith("### ") or line.startswith("## "):
+            if current_header and current_lines:
+                sections.append((current_header, "\n".join(current_lines)))
+            current_header = line.lstrip("# ").strip()
+            current_lines = []
+        elif current_header:
+            current_lines.append(line)
+
+    if current_header and current_lines:
+        sections.append((current_header, "\n".join(current_lines)))
+
+    return sections
+
+
+def _parse_table(text):
+    """Parse a markdown table into list of dicts using the header row as keys."""
+    lines = [l.strip() for l in text.splitlines() if l.strip()]
+    if not lines:
+        return []
+
+    # Find the header row (starts with |)
+    header_idx = None
+    for i, line in enumerate(lines):
+        if line.startswith("|") and "|" in line[1:]:
+            header_idx = i
+            break
+
+    if header_idx is None:
+        return []
+
+    header_cells = [c.strip().lower().replace(" ", "_") for c in
+                    lines[header_idx].strip("|").split("|")]
+
+    # Skip separator row (|---|---|...)
+    data_start = header_idx + 1
+    if data_start < len(lines) and re.match(r"^\|[\s\-:|]+\|$", lines[data_start]):
+        data_start += 1
+
+    rows = []
+    for line in lines[data_start:]:
+        if not line.startswith("|"):
+            break
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if len(cells) != len(header_cells):
+            continue
+        row = {}
+        for key, val in zip(header_cells, cells):
+            row[key] = val
+        rows.append(row)
+
+    return rows
+
+
+def _extract_github_url(cell_text):
+    """Extract GitHub repo owner/repo from a markdown link cell."""
+    # Match [text](https://github.com/owner/repo)
+    m = re.search(r"github\.com/([^/]+/[^/)\s]+)", cell_text)
+    if m:
+        repo = m.group(1).rstrip("/")
+        # Remove trailing .git if present
+        if repo.endswith(".git"):
+            repo = repo[:-4]
+        return repo
+    return None
+
+
+# ─── Fetching ─────────────────────────────────────────────────────────────
+
+
+def fetch_url(url, timeout=15):
+    """Fetch a URL via curl, return text or None."""
+    try:
+        r = subprocess.run(
+            ["curl", "-sL", "--max-time", str(timeout), url],
+            capture_output=True, text=True
+        )
+        if r.returncode == 0 and r.stdout and "404: Not Found" not in r.stdout:
+            return r.stdout
+    except Exception:
+        pass
+    return None
+
+
+def extract_version(text):
+    """Extract version: field from YAML frontmatter."""
+    m = re.search(r'^version:\s*(.+)$', text, re.M)
+    if not m:
+        return None
+    val = m.group(1).strip()
+    # Strip surrounding quotes if present
+    if (val.startswith('"') and val.endswith('"')) or \
+       (val.startswith("'") and val.endswith("'")):
+        val = val[1:-1]
+    return val
+
+
+def extract_name(text):
+    """Extract name: field from YAML frontmatter."""
+    m = re.search(r'^name:\s*(.+)$', text, re.M)
+    return m.group(1).strip() if m else None
+
+
+def get_last_commit_date(repo):
+    """Get last commit date from GitHub API."""
+    url = f"https://api.github.com/repos/{repo}/commits?per_page=1"
+    text = fetch_url(url)
+    if not text:
+        return None
+    try:
+        data = json.loads(text)
+        if data and isinstance(data, list) and "commit" in data[0]:
+            return data[0]["commit"]["committer"]["date"][:10]
+    except (json.JSONDecodeError, KeyError, IndexError):
+        pass
+    return None
+
+
+def get_default_branch(repo):
+    """Get default branch from GitHub API."""
+    url = f"https://api.github.com/repos/{repo}"
+    text = fetch_url(url)
+    if not text:
+        return "main"
+    try:
+        data = json.loads(text)
+        return data.get("default_branch", "main")
+    except (json.JSONDecodeError, KeyError):
+        return "main"
+
+
+def content_hash(text):
+    """SHA-256 hash of text content for content-drift detection."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+def read_local_skill(path):
+    """Read a local SKILL.md file, return (name, version, hash) or None."""
+    full = SKILLS_ROOT / path
+    if not full.exists():
+        return None
+    text = full.read_text()
+    return (extract_name(text), extract_version(text), content_hash(text))
+
+
+# ─── Layer 1 checks ───────────────────────────────────────────────────────
+
+
+def check_layer_1_skills(manifest_data):
+    """Check Layer 1 whole-skills + reference-files tables."""
+    results = []
+    checked_repos = {}  # cache: repo -> default_branch
+
+    all_entries = (manifest_data["layer1_skills"] +
+                   manifest_data["layer1_refs"])
+
+    for row in all_entries:
+        skill = row.get("skill", row.get("file", "?"))
+        source_repo_cell = row.get("source_repo", row.get("source", ""))
+        repo = _extract_github_url(source_repo_cell)
+
+        if not repo:
+            results.append(f"  ⚠️ {skill}: no GitHub URL in manifest")
+            continue
+
+        local_ver = row.get("local_ver", "")
+        upstream_ver_field = row.get("upstream_ver", "")
+
+        # Determine the path within the repo to fetch
+        # For whole skills: skills/<skill-name>/SKILL.md
+        # For reference files: the file path itself
+        skill_path = row.get("skill", row.get("file", "")).strip("`")
+        repo_skill_path = None
+        if skill_path and not skill_path.startswith("http"):
+            # If the skill path looks like a full path, use it
+            if "/" in skill_path and skill_path.endswith(".md"):
+                repo_skill_path = skill_path
+            else:
+                # Derive from skill name — try skills/<name>/SKILL.md
+                skill_name = skill_path.split("/")[-1] if "/" in skill_path else skill_path
+                repo_skill_path = f"skills/{skill_name}/SKILL.md"
+
+        if repo not in checked_repos:
+            checked_repos[repo] = get_default_branch(repo)
+        branch = checked_repos[repo]
+
+        if repo_skill_path:
+            url = f"https://raw.githubusercontent.com/{repo}/{branch}/{repo_skill_path}"
+            upstream_text = fetch_url(url)
+            if not upstream_text:
+                # Try with 'master' branch
+                url = f"https://raw.githubusercontent.com/{repo}/master/{repo_skill_path}"
+                upstream_text = fetch_url(url)
+
+            if not upstream_text:
+                results.append(f"  ⚠️ {skill}: could not fetch upstream from {repo}")
+                continue
+
+            upstream_ver = extract_version(upstream_text) or "(no version)"
+
+            if upstream_ver == "(no version)":
+                last_commit = get_last_commit_date(repo)
+                results.append(f"  ❓ {skill}: upstream has no version — last commit {last_commit or '?'}")
+            elif upstream_ver == local_ver:
+                results.append(f"  ✅ {skill}: v{local_ver} (in sync)")
+            else:
+                results.append(f"  🔄 {skill}: local v{local_ver} → upstream v{upstream_ver} **DRIFT**")
+        else:
+            # Can't determine path — check last commit
+            last_commit = get_last_commit_date(repo)
+            results.append(f"  📅 {skill}: last upstream commit {last_commit or '?'}")
+
+    if not all_entries:
+        results.append("  ℹ️ No Layer 1 entries in manifest")
+
+    return results
+
+
+# ─── Layer 2 checks ───────────────────────────────────────────────────────
+
+
+def check_layer_2(manifest_data):
+    """Check Layer 2: local skills vs published repo.
+
+    Does TWO checks per skill:
+    1. Version comparison (fast — catches version bumps)
+    2. Content hash comparison (catches same-version content drift)
+    """
+    results = []
+
+    if not LAYER_2_REPO or not LAYER_2_REPO.exists():
+        results.append("  ℹ️ Published repo not found — set LAYER_2_REPO to enable")
+        return results
+
+    published = manifest_data.get("layer2_published", [])
+
+    if not published:
+        # Fallback: scan repo for all SKILL.md files
+        repo_skills = [p for p in LAYER_2_REPO.rglob("SKILL.md")
+                       if ".git" not in str(p)]
+        for repo_path in sorted(repo_skills):
+            results.extend(_check_single_layer2(repo_path, None))
+    else:
+        for row in published:
+            skill_name = row.get("skill", "?").strip("`")
+            repo_path_str = row.get("repo_path", "").strip("`")
+            local_path_str = row.get("local_path", "").strip("`")
+
+            repo_path = LAYER_2_REPO / repo_path_str / "SKILL.md" if repo_path_str else None
+            local_path = SKILLS_ROOT / local_path_str / "SKILL.md" if local_path_str else None
+
+            if not repo_path or not repo_path.exists():
+                # Try finding by skill name
+                repo_path = _find_skill_by_name(LAYER_2_REPO, skill_name)
+
+            if not local_path or not local_path.exists():
+                local_path = _find_skill_by_name(SKILLS_ROOT, skill_name)
+
+            results.extend(_check_single_layer2(repo_path, local_path, skill_name))
+
+    if not any("DRIFT" in r or "⚠️" in r for r in results):
+        if not results:
+            results.append("  ✅ No published skills to check")
+        elif not any("✅" in r for r in results):
+            results.append("  ✅ All published skills in sync")
+
+    return results
+
+
+def _find_skill_by_name(root, name):
+    """Find a SKILL.md by skill name field in frontmatter."""
+    if not root or not root.exists():
+        return None
+    for p in root.rglob("SKILL.md"):
+        if ".git" in str(p):
+            continue
+        text = p.read_text()[:2000]
+        if extract_name(text) == name:
+            return p
+    return None
+
+
+def _check_single_layer2(repo_path, local_path, fallback_name=None):
+    """Compare a single repo skill vs local. Returns list of result lines."""
+    results = []
+
+    if not repo_path or not repo_path.exists():
+        name = fallback_name or "?"
+        results.append(f"  ⚠️ {name}: repo SKILL.md not found")
+        return results
+
+    repo_text = repo_path.read_text()
+    repo_name = extract_name(repo_text) or fallback_name or "?"
+    repo_ver = extract_version(repo_text) or "(no version)"
+    repo_hash = content_hash(repo_text)
+
+    if not local_path or not local_path.exists():
+        # Try to find by name
+        local_path = _find_skill_by_name(SKILLS_ROOT, repo_name)
+
+    if not local_path or not local_path.exists():
+        results.append(f"  ⚠️ {repo_name}: no local counterpart found")
+        return results
+
+    local_text = local_path.read_text()
+    local_ver = extract_version(local_text) or "(no version)"
+    local_hash = content_hash(local_text)
+
+    if local_ver != repo_ver:
+        results.append(f"  🔄 {repo_name}: repo v{repo_ver} vs local v{local_ver} **VERSION DRIFT**")
+    elif local_hash != repo_hash:
+        results.append(f"  🔄 {repo_name}: same version (v{local_ver}) but content differs **CONTENT DRIFT**")
+    # else: in sync — don't report
+
+    return results
+
+
+# ─── Engine dependency checks ─────────────────────────────────────────────
+
+
+def check_engine_deps(manifest_data):
+    """Check engine dependency versions.
+
+    Engine deps are configured in ENGINE_DEPS in this file (not parsed from
+    the manifest) because they require shell commands. This is a deliberate
+    security boundary — manifest content is markdown and could be externally
+    edited, so we don't execute commands derived from it.
+    """
+    results = []
+
+    for dep in ENGINE_DEPS:
+        name = dep["name"]
+        cmd = dep["command"]
+        try:
+            r = subprocess.run(
+                cmd,  # list form — no shell=True
+                capture_output=True, text=True, timeout=10
+            )
+            output = (r.stdout + r.stderr).strip()
+            regex = dep.get("version_regex", r"(\d+\.\d+\.\d+)")
+            ver_m = re.search(regex, output)
+            ver = ver_m.group(1) if ver_m else "unknown"
+            results.append(f"  📦 {name}: v{ver}")
+        except FileNotFoundError:
+            results.append(f"  ⚠️ {name}: not installed (command not found)")
+        except Exception as e:
+            results.append(f"  ⚠️ {name}: check failed ({e})")
+
+    return results
+
+
+# ─── Main ─────────────────────────────────────────────────────────────────
+
+
+def main():
+    _resolve_config()
+
+    today = datetime.now().strftime("%Y-%m-%d")
+    manifest_path = SKILLS_ROOT / MANIFEST_FILENAME
+
+    lines = []
+    lines.append(f"📋 Upstream Sync Check — {today}")
+    lines.append("")
+
+    if not manifest_path.exists():
+        lines.append(f"⚠️ Manifest not found at {manifest_path}")
+        lines.append("   Copy templates/upstream-manifest.md and fill in your skills.")
+        print("\n".join(lines))
+        return 1
+
+    manifest_data = parse_manifest(manifest_path)
+
+    skill_count = (len(manifest_data["layer1_skills"]) +
+                   len(manifest_data["layer1_refs"]))
+    published_count = len(manifest_data["layer2_published"])
+    lines.append(f"Manifest: {skill_count} adapted skills, "
+                 f"{published_count} published, "
+                 f"{len(ENGINE_DEPS)} engine deps")
+    lines.append("")
+
+    lines.append("Layer 1 — External → Local:")
+    lines.extend(check_layer_1_skills(manifest_data))
+    lines.append("")
+
+    lines.append("Layer 2 — Local → Published repo:")
+    lines.extend(check_layer_2(manifest_data))
+    lines.append("")
+
+    engine_results = check_engine_deps(manifest_data)
+    if engine_results:
+        lines.append("Engine dependencies:")
+        lines.extend(engine_results)
+        lines.append("")
+
+    output = "\n".join(lines)
+    has_drift = "DRIFT" in output or "⚠️" in output
+
+    if has_drift:
+        print(output)
+        return 1
+    elif "✅" in output or "📦" in output:
+        print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/optional-skills/software-development/skill-maintainer/templates/upstream-manifest.md
+++ b/optional-skills/software-development/skill-maintainer/templates/upstream-manifest.md
@@ -1,0 +1,69 @@
+# Upstream Tracking Manifest
+
+<!-- Single source of truth for adapted and published skills. -->
+<!-- Maintain at <your-skills-root>/UPSTREAM_MANIFEST.md -->
+<!-- Audit monthly or when prompted. Update last-checked dates after each audit. -->
+
+## Layer 1 — External → Local (adapted skills)
+
+Skills adapted from external repos. Upstream may add features, fix bugs, or
+change workflows. Check periodically and sync.
+
+### Whole skills
+
+| Skill | Source repo | Local ver | Upstream ver | Last sync | Status | Verbatim files | Adapted files | Sync method | License | PORT_NOTES |
+|-------|------------|-----------|-------------|-----------|--------|---------------|--------------|-------------|---------|------------|
+| `category/skill-name` | [owner/repo](https://github.com/owner/repo) | 1.0.0 | 1.0.0 | 2026-01-01 | ✅ current | references/styles.md | SKILL.md | overwrite refs, merge SKILL.md | MIT | ✅ |
+
+### Reference files within skills
+
+| File | Source repo | Local ver | Last sync | Status | Notes | License |
+|------|------------|-----------|-----------|--------|-------|---------|
+| `category/skill/references/file.md` | [owner/repo](https://github.com/owner/repo) | 1.0.0 | 2026-01-01 | ✅ synced | Description of what was merged | MIT |
+
+### Engine dependencies
+
+Skills that wrap a third-party CLI or pip package. The skill itself is
+original, but the engine can go stale.
+
+| Skill | Tool | Installed ver | Upstream URL | Type | License | Audit method |
+|-------|------|--------------|-------------|------|---------|-------------|
+| `category/skill-name` | `tool-name` | 1.0.0 | [owner/repo](https://github.com/owner/repo) | binary | MIT | `tool --version` + releases |
+
+### Third-party skills
+
+Skills adapted from external repos that are not traditional skill repos.
+
+| Skill | Source repo | Local ver | Upstream ver | Last sync | Status | Notes | License |
+|-------|------------|-----------|-------------|-----------|--------|-------|---------|
+| `category/skill-name` | [owner/repo](https://github.com/owner/repo) | 1.0.0 | v0.5.4 | 2026-01-01 | ⚠️ stale | Description | Apache-2.0 |
+
+## Layer 2 — Local → Published Repo
+
+Skills developed locally, then published (debranded + generalized) to a
+shared repo. The local version is the source of truth.
+
+| Skill | Repo category | Ver (both) | Repo path | Local path | Status |
+|-------|-------------|------------|-----------|-----------|--------|
+| `skill-name` | category/ | 1.0.0 | `category/skill-name/` | `category/skill-name/` | ✅ sync |
+
+## Audit log
+
+| Date | Layer(s) | Actions taken |
+|------|----------|---------------|
+| 2026-01-01 | all | Manifest created. Initial entries added. |
+
+## Audit checklist
+
+1. Read the manifest — note last-checked dates, identify stale rows
+2. Layer 1 (external → local): fetch upstream version, compare to pinned
+   version. If different, run the Layer 1 sync workflow
+3. Layer 2 (local → repo): diff local SKILL.md against repo copy. If local
+   is ahead, re-publish
+4. Layer 3 (local → standalone repo): check if the repo's workflow/CLI changed
+5. Engine dependency scan: list installed CLI binaries and pip packages,
+   compare versions, cross-reference with manifest
+6. Update the manifest — record last-checked date, new upstream version, sync
+   actions taken
+7. Third-party skill scan: fetch upstream README/latest SKILL.md for adapted
+   skills, compare concepts and features

--- a/tests/test_upstream_check_skill.py
+++ b/tests/test_upstream_check_skill.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""
+Test suite for upstream_check.py — tests manifest parsing, version extraction,
+content hash drift detection, and Layer 2 same-version content drift.
+
+Run: python3 -m pytest tests/test_upstream_check.py -v --tb=short
+     python3 tests/test_upstream_check.py  # standalone (no pytest needed)
+"""
+
+import sys
+import os
+import tempfile
+import textwrap
+from pathlib import Path
+
+# Add scripts dir to path
+SKILL_ROOT = Path(__file__).resolve().parent.parent / "optional-skills" / "software-development" / "skill-maintainer"
+SCRIPTS_DIR = SKILL_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import upstream_check
+
+
+# ─── Test fixtures ────────────────────────────────────────────────────────
+
+
+SAMPLE_MANIFEST = """\
+# Upstream Tracking Manifest
+
+## Layer 1 — External → Local (adapted skills)
+
+### Whole skills
+
+| Skill | Source repo | Local ver | Upstream ver | Last sync | Status |
+|-------|------------|-----------|-------------|-----------|--------|
+| `creative/baoyu-infographic` | [JimLiu/baoyu-skills](https://github.com/JimLiu/baoyu-skills) | 1.117.4 | 1.117.4 | 2026-07-02 | ✅ current |
+| `finance/excel-author` | [anthropics/financial-services](https://github.com/anthropics/financial-services) | 1.0.0 | (no ver) | 2026-07-04 | ✅ keep ours |
+
+### Reference files within skills
+
+| File | Source repo | Local ver | Last sync | Status |
+|------|------------|-----------|-----------|--------|
+| `subagent-driven-development/SKILL.md` | [obra/superpowers](https://github.com/obra/superpowers) | 1.2.0 | 2026-07-04 | ✅ synced |
+
+### Engine dependencies
+
+| Skill | Tool | Installed ver | Upstream URL | Type | License | Audit method |
+|-------|------|--------------|-------------|------|---------|-------------|
+| `productivity/my-tool` | `my-cli` | 1.0.0 | [owner/repo](https://github.com/owner/repo) | binary | MIT | `my-cli --version` |
+
+### Third-party skills
+
+| Skill | Source repo | Local ver | Upstream ver | Last sync | Status | Notes | License |
+|-------|------------|-----------|-------------|-----------|--------|-------|---------|
+| `research/dspy` | [stanfordnlp/dspy](https://github.com/stanfordnlp/dspy) | 2.0.0 | v3.0.0 | 2026-01-01 | ⚠️ stale | Major API rewrite | MIT |
+
+## Layer 2 — Local → Published Repo
+
+| Skill | Repo category | Ver (both) | Repo path | Local path | Status |
+|-------|-------------|------------|-----------|-----------|--------|
+| `clips-studio` | creative/ | 1.1.0 | `creative/clips-studio/` | `creative/clips-studio/` | ✅ sync |
+| `deep-research` | research/ | 1.0.0 | `research/deep-research/` | `research/deep-research/` | ✅ sync |
+
+## Audit log
+
+| Date | Layer(s) | Actions taken |
+|------|----------|---------------|
+| 2026-07-04 | all | Manifest created. |
+"""
+
+
+def make_manifest_file(tmpdir, content=SAMPLE_MANIFEST):
+    """Write a manifest file to tmpdir and return the path."""
+    p = Path(tmpdir) / "UPSTREAM_MANIFEST.md"
+    p.write_text(content)
+    return p
+
+
+def make_skill_file(tmpdir, category, name, version="1.0.0", body="Test skill."):
+    """Create a minimal SKILL.md and return its path."""
+    skill_dir = Path(tmpdir) / category / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    path = skill_dir / "SKILL.md"
+    path.write_text(f"---\nname: {name}\nversion: {version}\n---\n\n{body}\n")
+    return path
+
+
+# ─── Tests ────────────────────────────────────────────────────────────────
+
+
+def test_extract_version_basic():
+    """extract_version finds version: field in YAML frontmatter."""
+    text = "---\nname: foo\nversion: 1.2.3\n---\n\n# Foo\n"
+    assert upstream_check.extract_version(text) == "1.2.3"
+
+
+def test_extract_version_quoted():
+    """extract_version handles quoted values."""
+    text = '---\nname: foo\nversion: "1.2.3"\n---\n\n'
+    assert upstream_check.extract_version(text) == "1.2.3"
+
+
+def test_extract_version_missing():
+    """extract_version returns None when no version field."""
+    text = "---\nname: foo\n---\n\n# Foo\n"
+    assert upstream_check.extract_version(text) is None
+
+
+def test_extract_name_basic():
+    """extract_name finds name: field in YAML frontmatter."""
+    text = "---\nname: my-skill\nversion: 1.0.0\n---\n\n"
+    assert upstream_check.extract_name(text) == "my-skill"
+
+
+def test_content_hash_stability():
+    """content_hash is deterministic for the same input."""
+    h1 = upstream_check.content_hash("hello world")
+    h2 = upstream_check.content_hash("hello world")
+    assert h1 == h2
+    assert len(h1) == 16  # truncated to 16 chars
+
+
+def test_content_hash_differs():
+    """content_hash differs for different content."""
+    h1 = upstream_check.content_hash("hello world")
+    h2 = upstream_check.content_hash("hello World")
+    assert h1 != h2
+
+
+def test_parse_manifest_sections():
+    """parse_manifest splits the manifest into the right sections."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = make_manifest_file(tmpdir)
+        data = upstream_check.parse_manifest(path)
+
+        assert len(data["layer1_skills"]) == 2
+        assert len(data["layer1_refs"]) == 1
+        assert len(data["layer1_engines"]) == 1
+        assert len(data["layer1_third_party"]) == 1
+        assert len(data["layer2_published"]) == 2
+
+
+def test_parse_manifest_skill_names():
+    """parse_manifest correctly extracts skill names from table rows."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = make_manifest_file(tmpdir)
+        data = upstream_check.parse_manifest(path)
+
+        skills = [r["skill"] for r in data["layer1_skills"]]
+        assert "`creative/baoyu-infographic`" in skills
+        assert "`finance/excel-author`" in skills
+
+
+def test_parse_manifest_missing_file():
+    """parse_manifest returns empty lists when file doesn't exist."""
+    data = upstream_check.parse_manifest(Path("/nonexistent/path.md"))
+    assert data["layer1_skills"] == []
+    assert data["layer2_published"] == []
+
+
+def test_extract_github_url():
+    """_extract_github_url parses owner/repo from markdown links."""
+    url = upstream_check._extract_github_url(
+        "[JimLiu/baoyu-skills](https://github.com/JimLiu/baoyu-skills)")
+    assert url == "JimLiu/baoyu-skills"
+
+
+def test_extract_github_url_trailing_git():
+    """_extract_github_url strips .git suffix."""
+    url = upstream_check._extract_github_url(
+        "[repo](https://github.com/owner/repo.git)")
+    assert url == "owner/repo"
+
+
+def test_extract_github_url_none():
+    """_extract_github_url returns None for non-GitHub URLs."""
+    url = upstream_check._extract_github_url("[repo](https://gitlab.com/owner/repo)")
+    assert url is None
+
+
+def test_parse_table_empty():
+    """_parse_table returns [] for empty text."""
+    assert upstream_check._parse_table("") == []
+
+
+def test_parse_table_no_table():
+    """_parse_table returns [] when no table found."""
+    assert upstream_check._parse_table("Just some text.\nNo table here.") == []
+
+
+def test_layer2_content_drift_detection():
+    """Layer 2 detects same-version content drift via hash comparison."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        skills_root = Path(tmpdir) / "skills"
+        repo_root = Path(tmpdir) / "repo"
+
+        # Create local skill with version 1.0.0 and body "original"
+        local_path = make_skill_file(
+            skills_root, "research", "test-skill",
+            version="1.0.0", body="# Original content")
+
+        # Create repo skill with same version but different body
+        repo_path = make_skill_file(
+            repo_root, "research", "test-skill",
+            version="1.0.0", body="# Modified content")
+
+        # Monkey-patch config
+        old_root = upstream_check.SKILLS_ROOT
+        old_repo = upstream_check.LAYER_2_REPO
+        upstream_check.SKILLS_ROOT = skills_root
+        upstream_check.LAYER_2_REPO = repo_root
+
+        try:
+            results = upstream_check._check_single_layer2(repo_path, local_path, "test-skill")
+            # Should detect content drift (same version, different hash)
+            combined = " ".join(results)
+            assert "CONTENT DRIFT" in combined, f"Expected CONTENT DRIFT, got: {results}"
+        finally:
+            upstream_check.SKILLS_ROOT = old_root
+            upstream_check.LAYER_2_REPO = old_repo
+
+
+def test_layer2_version_drift_detection():
+    """Layer 2 detects version drift."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        skills_root = Path(tmpdir) / "skills"
+        repo_root = Path(tmpdir) / "repo"
+
+        local_path = make_skill_file(
+            skills_root, "research", "test-skill",
+            version="1.1.0", body="# Same content")
+
+        repo_path = make_skill_file(
+            repo_root, "research", "test-skill",
+            version="1.0.0", body="# Same content")
+
+        old_root = upstream_check.SKILLS_ROOT
+        old_repo = upstream_check.LAYER_2_REPO
+        upstream_check.SKILLS_ROOT = skills_root
+        upstream_check.LAYER_2_REPO = repo_root
+
+        try:
+            results = upstream_check._check_single_layer2(repo_path, local_path, "test-skill")
+            combined = " ".join(results)
+            assert "VERSION DRIFT" in combined, f"Expected VERSION DRIFT, got: {results}"
+        finally:
+            upstream_check.SKILLS_ROOT = old_root
+            upstream_check.LAYER_2_REPO = old_repo
+
+
+def test_layer2_no_drift_when_identical():
+    """Layer 2 reports no drift when content and version match."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        skills_root = Path(tmpdir) / "skills"
+        repo_root = Path(tmpdir) / "repo"
+
+        body = "# Identical content"
+        local_path = make_skill_file(
+            skills_root, "research", "test-skill",
+            version="1.0.0", body=body)
+
+        repo_path = make_skill_file(
+            repo_root, "research", "test-skill",
+            version="1.0.0", body=body)
+
+        old_root = upstream_check.SKILLS_ROOT
+        old_repo = upstream_check.LAYER_2_REPO
+        upstream_check.SKILLS_ROOT = skills_root
+        upstream_check.LAYER_2_REPO = repo_root
+
+        try:
+            results = upstream_check._check_single_layer2(repo_path, local_path, "test-skill")
+            # Should be empty (no drift reported)
+            combined = " ".join(results)
+            assert "DRIFT" not in combined, f"Should be no drift, got: {results}"
+        finally:
+            upstream_check.SKILLS_ROOT = old_root
+            upstream_check.LAYER_2_REPO = old_repo
+
+
+def test_layer2_missing_local():
+    """Layer 2 reports warning when local counterpart missing."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        repo_root = Path(tmpdir) / "repo"
+        repo_path = make_skill_file(
+            repo_root, "research", "orphan-skill",
+            version="1.0.0")
+
+        old_root = upstream_check.SKILLS_ROOT
+        upstream_check.SKILLS_ROOT = Path(tmpdir) / "empty_skills"
+        upstream_check.SKILLS_ROOT.mkdir(exist_ok=True)
+
+        try:
+            results = upstream_check._check_single_layer2(repo_path, None, "orphan-skill")
+            combined = " ".join(results)
+            assert "⚠️" in combined or "no local" in combined.lower()
+        finally:
+            upstream_check.SKILLS_ROOT = old_root
+
+
+def test_engine_deps_list_form_no_shell():
+    """ENGINE_DEPS commands are lists, not shell strings — no shell=True."""
+    # Inspect the source to verify no shell=True is used in check_engine_deps
+    source = (SCRIPTS_DIR / "upstream_check.py").read_text()
+    # The check_engine_deps function should use list-form subprocess.run
+    # Check only actual code lines (not comments/docstrings) for shell=True
+    func_start = source.index("def check_engine_deps")
+    func_end = source.index("\n\n\n# ─── Main", func_start)
+    func_source = source[func_start:func_end]
+    code_lines = []
+    for l in func_source.splitlines():
+        s = l.strip()
+        if not s or s.startswith("#"):
+            continue
+        # Strip inline comments (rough but sufficient for this check)
+        if "  #" in s:
+            s = s.split("  #")[0].strip()
+        code_lines.append(s)
+    for line in code_lines:
+        assert "shell=True" not in line, \
+            f"check_engine_deps should not use shell=True, found in: {line}"
+
+
+def test_split_sections():
+    """_split_sections correctly splits markdown by ## and ### headers."""
+    text = """\
+# Title
+
+## Section A
+content a
+
+### Subsection
+table here
+
+## Section B
+content b
+"""
+    sections = upstream_check._split_sections(text)
+    assert len(sections) == 3
+    assert "Section A" in sections[0][0]
+    assert "Subsection" in sections[1][0]
+    assert "Section B" in sections[2][0]
+
+
+# ─── Standalone runner (no pytest required) ───────────────────────────────
+
+
+def run_all_tests():
+    """Run all tests without pytest — for environments without it."""
+    tests = [
+        (name, obj) for name, obj in globals().items()
+        if name.startswith("test_") and callable(obj)
+    ]
+    passed = 0
+    failed = 0
+    for name, fn in sorted(tests):
+        try:
+            fn()
+            print(f"  ✅ {name}")
+            passed += 1
+        except AssertionError as e:
+            print(f"  ❌ {name}: {e}")
+            failed += 1
+        except Exception as e:
+            print(f"  ❌ {name}: {type(e).__name__}: {e}")
+            failed += 1
+
+    print(f"\n{'='*60}")
+    print(f"Results: {passed} passed, {failed} failed, {passed+failed} total")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(run_all_tests())


### PR DESCRIPTION
## What does this PR do?

Adds a new optional skill `skill-maintainer` that provides end-to-end skill library maintenance: curating external collections, tracking upstream drift with a manifest, running monthly sync audits, scanning engine dependencies, and publishing skills to repos.

This fills the gaps between Hermes native skill management systems:

| Hermes native | What it does | What this skill adds |
|---|---|---|
| `hermes skills check/update` | Update bundled + hub skills from the Hermes registry | Track arbitrary GitHub repos you adapted from |
| `hermes curator` | Usage tracking, stale detection, archive/restore | Upstream content sync, drift detection |
| `hermes skills diff` | Show local edits vs stock bundled skills | Compare against external upstream repos |
| `hermes skills publish` | Publish to the Hermes skills hub | Debrand/generalize for a public GitHub repo |

**This is a companion to `hermes-agent-skill-authoring`** — that skill covers *writing* a SKILL.md, this one covers *maintaining* a library of adapted skills over time.

## Related Issue

No existing issue — this is a new optional skill contribution per CONTRIBUTING.md priority #5.

## Type of Change

- [x] 🎯 New skill (bundled or hub)

## Changes Made

- `optional-skills/software-development/skill-maintainer/SKILL.md` — 485-line skill covering curation, upstream tracking, sync audit, publishing, cron setup, pitfalls, and verification checklist
- `optional-skills/software-development/skill-maintainer/templates/upstream-manifest.md` — manifest template with Layer 1/2 tables, engine deps, third-party skills, and 7-step audit checklist
- `optional-skills/software-development/skill-maintainer/scripts/upstream_check.py` — monthly cron script that parses the manifest, fetches upstream versions via GitHub API, compares content hashes for published skills (catches same-version content drift). List-form commands only (no `shell=True`). Env var overrides for portability.
- `tests/test_upstream_check_skill.py` — 20 tests covering `extract_version`, `content_hash`, manifest parsing, Layer 2 drift detection (version + content), `shell=True` guard, section splitting, GitHub URL extraction

### Why optional-skills/?

Per CONTRIBUTING.md: If your skill is official and useful but not universally needed, put it in `optional-skills/`. Skill library maintenance is valuable for power users who adapt external skills, but not needed by casual users who only use bundled/hub skills. Placed in `software-development/` alongside `hermes-agent-skill-authoring`.

### Key design decisions

- **Manifest is the single source of truth** — the cron script parses `UPSTREAM_MANIFEST.md` tables directly, no hardcoded skill lists
- **Content hash comparison** — Layer 2 does both version comparison AND SHA-256 hash comparison, catching same-version content drift
- **Security boundary** — engine deps are configured in the script file (not parsed from manifest) because manifest content is externally-editable markdown; commands are list-form only (no `shell=True`)
- **Hermes-native integration** — references `hermes skills list`, `hermes curator`, `hermes cron`, `skill_manage`, `delegate_task` as complementary systems
- **Agent-agnostic publishing section** — the debranding/generalizing workflow uses generic terms so it works for any agent platform

## How to Test

1. **Run the test suite:**
   ```bash
   python3 tests/test_upstream_check_skill.py
   ```
   Expected: 20 passed, 0 failed

2. **Verify frontmatter:**
   ```bash
   python3 -c "import yaml, re, pathlib; c = pathlib.Path(\"optional-skills/software-development/skill-maintainer/SKILL.md\").read_text(); assert c.startswith(\"---\"); m = re.search(r\"\\n---\\s*\\n\", c[3:]); fm = yaml.safe_load(c[3:m.start()+3]); assert \"name\" in fm and \"description\" in fm; assert len(fm[\"description\"]) <= 1024; print(\"Valid\")"
   ```

3. **Dry-run the script:**
   ```bash
   python3 optional-skills/software-development/skill-maintainer/scripts/upstream_check.py
   ```
   Should report Manifest not found if no ~/.hermes/skills/UPSTREAM_MANIFEST.md exists, or parse and check if it does.

## Checklist

- [x] Code follows the projects style and conventions
- [x] Self-reviewed the changes
- [x] Added tests (20 tests covering parsing, drift detection, security guard)
- [x] All tests pass (20/20)
- [x] No new dependencies (pure stdlib + curl)
- [x] Placed in optional-skills/ per CONTRIBUTING.md guidance
- [x] Frontmatter validated (name, description <=1024 chars, metadata.hermes.tags)
- [x] No shell=True in subprocess calls
- [x] No hardcoded secrets or credentials