### PR TITLE
fix: improve kanban mobile cleanup UX

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -2432,6 +2432,7 @@
                       toggleSelected: props.toggleSelected,
                       toggleRange: props.toggleRange,
                       onOpen: props.onOpen,
+                      onDelete: props.onDelete,
                     });
                   }),
                 );
@@ -2446,6 +2447,7 @@
                   toggleSelected: props.toggleSelected,
                   toggleRange: props.toggleRange,
                   onOpen: props.onOpen,
+                  onDelete: props.onDelete,
                 });
               }),
       ),
@@ -2606,6 +2608,20 @@
                   className: "hermes-kanban-needs-assignee",
                   title: tx(i18n, "needsAssigneeHint", "Dependencies are satisfied, but the dispatcher skips this task until you assign a profile."),
                 }, tx(i18n, "needsAssignee", "Needs assignee"))
+              : null,
+            t.status === "done" && props.onDelete
+              ? h("button", {
+                  type: "button",
+                  className: "hermes-kanban-card-delete-done",
+                  title: tx(i18n, "deleteDoneTask", "Delete completed task"),
+                  "aria-label": tx(i18n, "deleteDoneTask", "Delete completed task"),
+                  onClick: function (e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    props.onDelete(t.id);
+                  },
+                }, "🗑", h("span", { className: "hermes-kanban-card-delete-done-text" },
+                  tx(i18n, "delete", "Delete")))
               : null,
           ),
           h("div", { className: "hermes-kanban-card-title" },

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -291,6 +291,27 @@
   color: var(--color-foreground);
 }
 
+.hermes-kanban-card-delete-done {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  min-height: 1.6rem;
+  padding: 0.15rem 0.45rem;
+  border-radius: var(--radius-sm, 0.25rem);
+  border: 1px solid color-mix(in srgb, var(--color-destructive, #d14a4a) 45%, var(--color-border));
+  background: color-mix(in srgb, var(--color-destructive, #d14a4a) 8%, transparent);
+  color: var(--color-destructive, #d14a4a);
+  font-size: 0.68rem;
+  line-height: 1;
+  cursor: pointer;
+}
+.hermes-kanban-card-delete-done:hover,
+.hermes-kanban-card-delete-done:focus-visible {
+  background: color-mix(in srgb, var(--color-destructive, #d14a4a) 16%, transparent);
+  outline: none;
+}
+
 .hermes-kanban-assignee {
   font-weight: 500;
   color: color-mix(in srgb, var(--color-foreground) 80%, var(--color-muted-foreground));
@@ -1580,4 +1601,73 @@
 
 .hermes-kanban-trash-label {
   font-weight: 500;
+}
+
+/* ---- Mobile board ergonomics ----------------------------------------- */
+@media (max-width: 768px) {
+  .hermes-kanban {
+    gap: 0.75rem;
+  }
+
+  .hermes-kanban-columns {
+    gap: 0.65rem;
+    padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .hermes-kanban-column {
+    flex-basis: min(86vw, 360px);
+    max-height: none;
+    min-height: 56vh;
+    scroll-snap-align: start;
+  }
+
+  .hermes-kanban-column-body {
+    max-height: none;
+    overflow-y: visible;
+  }
+
+  .hermes-kanban-card-content {
+    padding: 0.65rem 0.7rem !important;
+    gap: 0.42rem;
+  }
+
+  .hermes-kanban-card-title {
+    font-size: 0.92rem;
+  }
+
+  .hermes-kanban-card-delete-done {
+    min-height: 2rem;
+    padding: 0.25rem 0.55rem;
+    font-size: 0.72rem;
+  }
+
+  .hermes-kanban-trash {
+    flex: 0 0 min(42vw, 180px);
+    min-height: 56vh;
+    position: sticky;
+    right: 0;
+    z-index: 2;
+  }
+
+  .hermes-kanban-bulk {
+    position: sticky;
+    bottom: max(0.5rem, env(safe-area-inset-bottom));
+    z-index: 40;
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    align-items: center;
+    padding: 0.5rem;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .hermes-kanban-bulk > * {
+    flex: 0 0 auto;
+  }
+
+  .hermes-kanban .flex.flex-wrap.items-end.gap-3 > .flex.flex-col.gap-1,
+  .hermes-kanban .flex.flex-wrap.items-end.gap-3 input.w-56 {
+    width: 100%;
+  }
 }

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -260,6 +260,33 @@ def test_dashboard_markdown_html_is_sanitized_before_render():
     assert "dangerouslySetInnerHTML: { __html: renderMarkdown(props.source || \"\") }" not in js
 
 
+def test_dashboard_done_cards_have_explicit_delete_action_for_mobile():
+    """Done cards need a visible delete affordance; drag-to-trash is weak on phones."""
+
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    js = bundle.read_text()
+
+    assert "onDelete: props.onDelete" in js
+    assert 't.status === "done" && props.onDelete' in js
+    assert 'className: "hermes-kanban-card-delete-done"' in js
+    assert 'props.onDelete(t.id);' in js
+
+
+def test_dashboard_mobile_kanban_css_is_present():
+    """The plugin should present phone-sized columns instead of a desktop-only grid."""
+
+    repo_root = Path(__file__).resolve().parents[2]
+    styles = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "style.css"
+    css = styles.read_text()
+
+    assert "Mobile board ergonomics" in css
+    assert "@media (max-width: 768px)" in css
+    assert "scroll-snap-type: x mandatory" in css
+    assert "flex-basis: min(86vw, 360px)" in css
+    assert ".hermes-kanban-card-delete-done" in css
+
+
 # ---------------------------------------------------------------------------
 # GET /tasks/:id returns body + comments + events + links
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Make the Kanban dashboard friendlier on phones with horizontal snap columns and mobile bulk actions
- Add a visible delete button on completed/done task cards
- Add regression coverage for the mobile CSS and done-card delete affordance

## Test Plan
- scripts/run_tests.sh tests/plugins/test_kanban_dashboard_plugin.py -q