### PR TITLE
docs: recommend consolidating related tool verbs into one action-dispatch tool

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,9 +58,10 @@ This is the most common question for new contributors. The answer is almost alwa
 
 When a capability needs several related operations on the same resource
 (create/read/update/delete, or a handful of sibling queries), prefer a
-single tool with an `action` or `resource` parameter that dispatches
-internally, rather than registering a separate tool per verb. `memory_tool`
-(`action: add | replace | remove`) and the cron tool follow this pattern
+single tool with an `action` parameter, optionally paired with a resource
+selector, that dispatches internally, rather than registering a separate
+tool per verb. `memory` (`action: add | replace | remove` selects the verb,
+`target: memory | user` selects the store) and `cronjob` follow this pattern
 already — it keeps the tool list (and the token cost of every tool's
 schema/description in every request) from growing linearly with the
 number of operations a feature needs. Reach for multiple tools only when

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,19 @@ This is the most common question for new contributors. The answer is almost alwa
 - It handles binary data, streaming, or real-time events that can't go through the terminal
 - Examples: browser automation (Browserbase session management), TTS (audio encoding + platform delivery), vision analysis (base64 image handling)
 
+### One tool, many actions — don't add a tool per verb
+
+When a capability needs several related operations on the same resource
+(create/read/update/delete, or a handful of sibling queries), prefer a
+single tool with an `action` or `resource` parameter that dispatches
+internally, rather than registering a separate tool per verb. `memory_tool`
+(`action: add | replace | remove`) and the cron tool follow this pattern
+already — it keeps the tool list (and the token cost of every tool's
+schema/description in every request) from growing linearly with the
+number of operations a feature needs. Reach for multiple tools only when
+the operations genuinely have different input/output shapes, not just
+different verbs on the same resource.
+
 ### Should the Skill be bundled?
 
 Bundled skills (in `skills/`) ship with every Hermes install. They should be **broadly useful to most users**:


### PR DESCRIPTION
CONTRIBUTING.md already tells contributors new tools are rarely needed and most capabilities should be skills, but it doesn't say what to do when a tool genuinely is warranted for a *family* of related operations (e.g. CRUD on one resource type). Left unstated, the natural default is one tool per verb, which is exactly the tool-count sprawl the "rarely needed" guidance is trying to avoid.

The codebase already has the answer in practice — `memory_tool.py`'s single `action` enum (`add`/`replace`/`remove`) and the cron tool's `action`-based dispatch both consolidate what would otherwise be 3+ separate tools into one. This PR just writes that convention down in the same section that already discusses the skill-vs-tool decision, so new contributors have a concrete pattern to reach for instead of guessing.

No code changes, no tests needed — docs only.

## Test plan
N/A — documentation change.