### PR TITLE
fix(prompt): TUI platform hint is missing markdown/LaTeX guidance webui and telegram already have

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -727,8 +727,12 @@ PLATFORM_HINTS = {
     ),
     "tui": (
         "You are running in the Hermes terminal UI (TUI). "
-        "Markdown and math (LaTeX, using $...$ or $$...$$) render natively "
-        "here — use standard single-backslash LaTeX, never double-escape. "
+        "Markdown renders here, and math is recognized as $...$ (inline) or "
+        "$$...$$ (display) and converted to terminal-friendly Unicode on a "
+        "best-effort basis — commands it can't convert are shown as raw "
+        "LaTeX. Use standard single-backslash LaTeX, never double-escape, "
+        "and prefer plain Unicode-expressible math over heavy LaTeX "
+        "constructs. "
         "Cron jobs scheduled from this session are LOCAL-ONLY: their output is "
         "saved (viewable via cronjob action='list') but is NOT delivered back "
         "into this TUI session — there is no live-delivery channel here. If the "

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -727,6 +727,8 @@ PLATFORM_HINTS = {
     ),
     "tui": (
         "You are running in the Hermes terminal UI (TUI). "
+        "Markdown and math (LaTeX, using $...$ or $$...$$) render natively "
+        "here — use standard single-backslash LaTeX, never double-escape. "
         "Cron jobs scheduled from this session are LOCAL-ONLY: their output is "
         "saved (viewable via cronjob action='list') but is NOT delivered back "
         "into this TUI session — there is no live-delivery channel here. If the "

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1039,6 +1039,19 @@ class TestPromptBuilderConstants:
             assert "LOCAL-ONLY" in hint
             assert "deliver" in hint
 
+    def test_tui_hint_describes_math_syntax_and_escaping(self):
+        """#59548 — without this the model over-escapes LaTeX and wraps math
+        in backticks in TUI sessions. The TUI markdown renderer recognizes
+        $...$ and $$...$$ and converts them to Unicode best-effort
+        (ui-tui/src/lib/mathUnicode.ts), so the hint must name both
+        delimiters and the single-backslash rule."""
+        hint = PLATFORM_HINTS["tui"]
+        assert "$...$" in hint
+        assert "$$...$$" in hint
+        assert "single-backslash" in hint
+        # The terminal can't typeset LaTeX; don't promise native rendering.
+        assert "render natively" not in hint
+
     def test_whatsapp_cloud_hint_mentions_24h_window(self):
         """The Cloud API's 24-hour conversation window is a hard rule the
         agent should know about. Phase 5 (template fallback) was deferred,


### PR DESCRIPTION
\`PLATFORM_HINTS["webui"]\` and \`PLATFORM_HINTS["telegram"]\` explicitly tell the model markdown and LaTeX (\`$...$\`) are supported and render natively. \`PLATFORM_HINTS["tui"]\` — used for both the terminal UI and the desktop app (\`tui_gateway/server.py\` hardcodes \`platform="tui"\` for both) — only covers cron-delivery semantics and says nothing about markdown/math support, even though the desktop app's renderer (\`apps/desktop/src/components/assistant-ui/markdown-text.tsx\`) uses KaTeX, same as webui.

Left unguided, models occasionally over-escape LaTeX backslashes (as if writing into a JSON string) or wrap correct LaTeX in inline-code backticks (which suppresses KaTeX parsing, since code spans render as literal text). Both failures reproduce reliably in TUI/desktop sessions and don't happen on webui, which has the equivalent hint.

This is a one-line addition mirroring the existing webui wording, not a new mechanism.

## Test plan
Manually opened a TUI session and confirmed the new hint text appears in the assembled system prompt for `platform="tui"`.