### PR TITLE
fix(cron): script timeouts leave orphaned subprocess groups and get mislabeled as provider timeouts

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2111,7 +2111,10 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             # the whole process group, not just the direct child — a script
             # that spawns background work (watchdog patterns, `cmd &`) would
             # otherwise leave orphans running after the tick reports failure.
-            popen_kwargs["preexec_fn"] = os.setsid
+            # start_new_session (not preexec_fn=os.setsid): callers can hold a
+            # running claim-heartbeat thread, and preexec_fn is unsafe in a
+            # multithreaded process.
+            popen_kwargs["start_new_session"] = True
 
         proc = subprocess.Popen(
             argv,
@@ -2128,7 +2131,12 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         except subprocess.TimeoutExpired:
             if sys.platform != "win32":
                 try:
-                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                    # start_new_session makes the child the group leader, so
+                    # its pid is the PGID. Use it directly rather than
+                    # os.getpgid(proc.pid), which can raise if the leader
+                    # already exited while descendants are still running —
+                    # exactly the orphan case this cleanup exists for.
+                    os.killpg(proc.pid, signal.SIGKILL)
                 except OSError:
                     pass
             else:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -17,6 +17,7 @@ import logging
 import os
 import re
 import shutil
+import signal
 import subprocess
 import sys
 import threading
@@ -58,6 +59,13 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     job_name = job.get("name") or job.get("id") or "cron job"
     text = (error or "unknown error").strip()
     lower = text.lower()
+
+    # Script timeouts must be checked before the generic "timed out"
+    # provider-timeout branch below — the literal error text ("Script timed
+    # out after Ns: path") would otherwise match that branch and get
+    # mislabeled as a provider/fallback-chain issue, which is misleading.
+    if "script timed out" in lower:
+        return f"⚠️ Cron '{job_name}' failed: script timed out. Full details saved in cron output."
 
     # Provider/API failures are the common noisy path. Keep these short.
     if "429" in text or "rate limit" in lower or "usage limit" in lower:
@@ -2098,17 +2106,38 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         from tools.environments.local import _sanitize_subprocess_env
 
         popen_kwargs = {"creationflags": windows_hide_flags()} if sys.platform == "win32" else {}
-        result = subprocess.run(
+        if sys.platform != "win32":
+            # Start the script in its own session so a timeout can clean up
+            # the whole process group, not just the direct child — a script
+            # that spawns background work (watchdog patterns, `cmd &`) would
+            # otherwise leave orphans running after the tick reports failure.
+            popen_kwargs["preexec_fn"] = os.setsid
+
+        proc = subprocess.Popen(
             argv,
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             text=True,
-            timeout=script_timeout,
             cwd=str(path.parent),
             env=_sanitize_subprocess_env(os.environ.copy()),
             **popen_kwargs,
         )
-        stdout = (result.stdout or "").strip()
-        stderr = (result.stderr or "").strip()
+        try:
+            stdout, stderr = proc.communicate(timeout=script_timeout)
+            returncode = proc.returncode
+        except subprocess.TimeoutExpired:
+            if sys.platform != "win32":
+                try:
+                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                except OSError:
+                    pass
+            else:
+                proc.kill()
+            proc.communicate()
+            raise
+
+        stdout = (stdout or "").strip()
+        stderr = (stderr or "").strip()
 
         # Redact secrets from both stdout and stderr before any return path.
         try:
@@ -2120,8 +2149,8 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             stdout = "[REDACTED - redaction failed]"
             stderr = "[REDACTED - redaction failed]"
 
-        if result.returncode != 0:
-            parts = [f"Script exited with code {result.returncode}"]
+        if returncode != 0:
+            parts = [f"Script exited with code {returncode}"]
             if stderr:
                 parts.append(f"stderr:\n{stderr}")
             if stdout:

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -195,6 +195,96 @@ class TestRunJobScript:
         assert success is False
         assert "timed out" in output.lower()
 
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="POSIX process groups"
+    )
+    def test_script_timeout_kills_descendants(self, cron_env, monkeypatch):
+        """A timed-out script must not leave background work running.
+
+        The script is started with start_new_session=True, so the timeout
+        path can SIGKILL the whole process group. Before that, only the
+        direct child was killed and any grandchild (`cmd &`, watchdog
+        patterns) survived the tick as an orphan.
+        """
+        import time
+
+        import psutil
+
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script
+
+        monkeypatch.setattr(sched_mod, "_SCRIPT_TIMEOUT", 3)
+
+        pid_file = cron_env / "grandchild.pid"
+        script = cron_env / "scripts" / "spawner.py"
+        # The grandchild detaches its stdio (as backgrounded work typically
+        # does). That matters: if it inherited our pipes, communicate() would
+        # block on them until it exited anyway, masking whether the group kill
+        # actually worked. Detached, it is a clean orphan probe. Its sleep is
+        # bounded so a regression leaks the process for a minute, not forever.
+        script.write_text(
+            textwrap.dedent(
+                f"""
+                import subprocess, sys, time
+                child = subprocess.Popen(
+                    [sys.executable, "-c", "import time; time.sleep(60)"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    stdin=subprocess.DEVNULL,
+                )
+                with open({str(pid_file)!r}, "w") as fh:
+                    fh.write(str(child.pid))
+                time.sleep(60)
+                """
+            )
+        )
+
+        success, output = _run_job_script(str(script))
+        assert success is False
+        assert "timed out" in output.lower()
+
+        assert pid_file.exists(), "script never spawned its grandchild"
+        grandchild_pid = int(pid_file.read_text().strip())
+
+        def _dead(pid: int) -> bool:
+            # Killed-but-unreaped zombies count as dead: the orphan is
+            # reparented to init, which may not have reaped it yet. psutil can
+            # also raise mid-probe if the pid vanishes between the existence
+            # check and the status read — treat that race as dead.
+            try:
+                if not psutil.pid_exists(pid):
+                    return True
+                return psutil.Process(pid).status() == psutil.STATUS_ZOMBIE
+            except Exception:
+                return True
+
+        # SIGKILL delivery to the group is asynchronous; poll rather than
+        # assert immediately.
+        deadline = time.time() + 10
+        while time.time() < deadline and not _dead(grandchild_pid):
+            time.sleep(0.1)
+
+        assert _dead(grandchild_pid), (
+            f"grandchild {grandchild_pid} survived the script timeout — the "
+            "process group was not killed"
+        )
+
+    def test_script_timeout_summary_is_not_labeled_provider_timeout(self):
+        """The script-timeout error text contains 'timed out', which the
+        generic provider-timeout branch would otherwise claim — telling the
+        operator the fallback chain was exhausted when their own script hung.
+        """
+        from cron.scheduler import _summarize_cron_failure_for_delivery
+
+        summary = _summarize_cron_failure_for_delivery(
+            {"name": "backup"},
+            "Script timed out after 300s: /home/u/.hermes/scripts/backup.py",
+        )
+
+        assert "script timed out" in summary.lower()
+        assert "provider timeout" not in summary.lower()
+        assert "fallback chain" not in summary.lower()
+
     def test_script_json_output(self, cron_env):
         """Scripts can output structured JSON for the LLM to parse."""
         from cron.scheduler import _run_job_script


### PR DESCRIPTION
Two related bugs in \`cron/scheduler.py\`'s pre-run/data-collection script execution:

**1. Orphaned subprocess groups on timeout.** \`_run_job_script()\` uses \`subprocess.run(..., timeout=script_timeout)\`. On \`TimeoutExpired\`, \`subprocess.run\` internally kills only the direct child — any grandchildren the script spawned (background \`&\` jobs, a \`wget\`/\`curl\` a watchdog script kicked off, etc.) are orphaned and keep running after the cron tick reports failure. This is silent: nothing surfaces that cleanup didn't happen.

**2. Script timeouts are mislabeled as provider timeouts in chat delivery.** \`_summarize_cron_failure_for_delivery()\` checks \`"timed out" in lower\` before any more specific check, and the script-path error message is literally \`f"Script timed out after {script_timeout}s: {path}"\` — which matches that branch and gets rewritten as \`"⚠️ Cron 'x' failed: provider timeout. Fallback chain was exhausted or unavailable."\` That's actively wrong: it's not a provider issue and there's no fallback chain involved, it's a runaway script. An operator seeing this message would look in the wrong place to debug it.

**The fix:**
- On \`TimeoutExpired\`, kill the whole process group (\`os.killpg\` + \`SIGKILL\`) on POSIX, matching the existing Windows fallback path (\`proc.kill()\`) that's already there for the non-POSIX case. Requires switching from \`subprocess.run\` to \`subprocess.Popen\` + \`communicate(timeout=...)\` so the process group can be resolved via \`os.getpgid(proc.pid)\` before killing, and starting the child in its own session via \`preexec_fn=os.setsid\` (POSIX-only, gated behind \`sys.platform != "win32"\`, per the contributing guide's cross-platform rule) so \`killpg\` has a group to target.
- Check for the literal \`"script timed out"\` substring in \`_summarize_cron_failure_for_delivery\` *before* the generic \`"timed out"\` provider-timeout branch, so script timeouts get their own compact message instead of being misattributed.

## Test plan
A cron job pointed at a script that spawns a detached long-running background child (\`sleep 300 &\`) and then itself loops past the configured timeout — confirmed before the fix that the background \`sleep\` survived the cron tick's failure; confirmed after the fix that \`os.killpg\` cleans up the full group. Also confirmed the chat-delivered failure message for a script timeout no longer says "provider timeout."