### PR TITLE
test(gateway): pin random tip in topic-mode /new test (1-in-380 flake)

### DIFF
--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -340,6 +340,12 @@ async def test_group_new_keeps_existing_reset_semantics_when_dm_topic_mode_enabl
     monkeypatch.setattr(
         gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
     )
+    # /new appends a random tip from hermes_cli.tips; one tip's text contains
+    # the phrase "parallel work", which collides with the negative assertion
+    # below (observed as a 1-in-N CI flake). Pin the tip.
+    monkeypatch.setattr(
+        "hermes_cli.tips.get_random_tip", lambda: "pinned tip for test"
+    )
 
     result = await runner._handle_message(_make_group_event("/new", thread_id="555"))
 


### PR DESCRIPTION
## Summary
Kills a 1-in-380 CI flake: `test_group_new_keeps_existing_reset_semantics_when_dm_topic_mode_enabled` asserts `"parallel work" not in` the `/new` reply, but `/new` appends a random tip from `hermes_cli.tips` (380 entries) and the delegate_task concurrency tip contains exactly that phrase. When the dice landed on it, the assertion failed (observed on PR #59331, test slice 2/8). The test now pins `get_random_tip`.

## Changes
- `tests/gateway/test_telegram_topic_mode.py`: monkeypatch `hermes_cli.tips.get_random_tip` to a fixed string in the affected test

## Validation
| | Before | After |
|---|---|---|
| Flake odds per run | 1/380 (random tip collision) | 0 (tip pinned) |

Audited the other negative assertions in the suite ("All Messages", "Started a new Hermes session in this topic", `test_title_command`'s "New session started: Dup") against all 380 tips — no other collisions exist.

## Infographic

![telegram-topic-test-tip-flake](https://v3b.fal.media/files/b/0aa11eb5/9gALpaNXYXrrf0xbmjCfu_9lMQZ35o.png)
