### PR TITLE
docs: add Korean localization

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "dhhan@rideflux.com": "hdh7485",  # PR #59381 (Korean docs localization)
     "derek2000139@qq.com": "derek2000139",  # PR #57838 salvage (desktop/windows: pre-write update marker before quit dwell so the renderer's waitForUpdateToFinish gate parks instead of respawning a backend that re-locks venv .pyd files mid-update)
     "jashlee+microsoft@microsoft.com": "s905060",  # PR #57943 salvage (photon: auto-reinstall stale sidecar node_modules when lockfile is newer than npm's install marker; #59169)
     "lohinth25@proton.me": "l0h1nth",  # PR #32210 salvage (mattermost: accept leading-space slash commands from mobile clients; #25184)

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -24,10 +24,14 @@ const config: Config = {
 
   i18n: {
     defaultLocale: 'en',
-    locales: ['en', 'zh-Hans'],
+    locales: ['en', 'ko', 'zh-Hans'],
     localeConfigs: {
       en: {
         label: 'English',
+      },
+      ko: {
+        label: '한국어',
+        htmlLang: 'ko',
       },
       'zh-Hans': {
         label: '简体中文',

--- a/website/i18n/ko/code.json
+++ b/website/i18n/ko/code.json
@@ -1,0 +1,364 @@
+{
+  "theme.ErrorPageContent.title": {
+    "message": "페이지에 오류가 발생하였습니다.",
+    "description": "The title of the fallback page when the page crashed"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "맨 위로 스크롤하기",
+    "description": "The ARIA label for the back to top button"
+  },
+  "theme.blog.archive.title": {
+    "message": "게시물 목록",
+    "description": "The page & hero title of the blog archive page"
+  },
+  "theme.blog.archive.description": {
+    "message": "게시물 목록",
+    "description": "The page & hero description of the blog archive page"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "블로그 게시물 목록 탐색",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "이전 페이지",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "다음 페이지",
+    "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "블로그 게시물 탐색",
+    "description": "The ARIA label for the blog posts pagination"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "이전 게시물",
+    "description": "The blog post button label to navigate to the newer/previous post"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "다음 게시물",
+    "description": "The blog post button label to navigate to the older/next post"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "모든 태그 보기",
+    "description": "The label of the link targeting the tag list page"
+  },
+  "theme.colorToggle.ariaLabel.mode.system": {
+    "message": "시스템 모드",
+    "description": "The name for the system color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.light": {
+    "message": "밝은 모드",
+    "description": "The name for the light color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.dark": {
+    "message": "어두운 모드",
+    "description": "The name for the dark color mode"
+  },
+  "theme.colorToggle.ariaLabel": {
+    "message": "어두운 모드와 밝은 모드 전환하기 (현재 {mode})",
+    "description": "The ARIA label for the color mode toggle"
+  },
+  "theme.docs.breadcrumbs.navAriaLabel": {
+    "message": "탐색 경로",
+    "description": "The ARIA label for the breadcrumbs"
+  },
+  "theme.docs.DocCard.categoryDescription.plurals": {
+    "message": "{count} 항목",
+    "description": "The default description for a category card in the generated index about how many items this category includes"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "문서 페이지",
+    "description": "The ARIA label for the docs pagination"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "이전",
+    "description": "The label used to navigate to the previous doc"
+  },
+  "theme.docs.paginator.next": {
+    "message": "다음",
+    "description": "The label used to navigate to the next doc"
+  },
+  "theme.docs.tagDocListPageTitle.nDocsTagged": {
+    "message": "{count}개 문서가",
+    "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.tagDocListPageTitle": {
+    "message": "{nDocsTagged} \"{tagName}\" 태그에 분류되었습니다",
+    "description": "The title of the page for a docs tag"
+  },
+  "theme.docs.versionBadge.label": {
+    "message": "버전: {versionLabel}"
+  },
+  "theme.docs.versions.unreleasedVersionLabel": {
+    "message": "{siteTitle} {versionLabel} 문서는 아직 정식 공개되지 않았습니다.",
+    "description": "The label used to tell the user that he's browsing an unreleased doc version"
+  },
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "{siteTitle} {versionLabel} 문서는 더 이상 업데이트되지 않습니다.",
+    "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "최신 문서는 {latestVersionLink} ({versionLabel})을 확인하세요.",
+    "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.latestVersionLinkLabel": {
+    "message": "최신 버전",
+    "description": "The label used for the latest version suggestion link label"
+  },
+  "theme.common.editThisPage": {
+    "message": "페이지 편집",
+    "description": "The link label to edit the current page"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "{heading}에 대한 직접 링크",
+    "description": "Title for link to heading"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": " {date}에",
+    "description": "The words used to describe on which date a page has been last updated"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": " {user}가",
+    "description": "The words used to describe by who the page has been last updated"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "최종 수정: {atDate}{byUser}",
+    "description": "The sentence used to display when a page has been last updated, and by who"
+  },
+  "theme.navbar.mobileVersionsDropdown.label": {
+    "message": "버전",
+    "description": "The label for the navbar versions dropdown on mobile view"
+  },
+  "theme.NotFound.title": {
+    "message": "페이지를 찾을 수 없습니다.",
+    "description": "The title of the 404 page"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "태그:",
+    "description": "The label alongside a tag list"
+  },
+  "theme.admonition.caution": {
+    "message": "주의",
+    "description": "The default label used for the Caution admonition (:::caution)"
+  },
+  "theme.admonition.danger": {
+    "message": "위험",
+    "description": "The default label used for the Danger admonition (:::danger)"
+  },
+  "theme.admonition.info": {
+    "message": "정보",
+    "description": "The default label used for the Info admonition (:::info)"
+  },
+  "theme.admonition.note": {
+    "message": "노트",
+    "description": "The default label used for the Note admonition (:::note)"
+  },
+  "theme.admonition.tip": {
+    "message": "팁",
+    "description": "The default label used for the Tip admonition (:::tip)"
+  },
+  "theme.admonition.warning": {
+    "message": "경고",
+    "description": "The default label used for the Warning admonition (:::warning)"
+  },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "닫기",
+    "description": "The ARIA label for close button of announcement bar"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "최근 블로그 문서 둘러보기",
+    "description": "The ARIA label for recent posts in the blog sidebar"
+  },
+  "theme.DocSidebarItem.expandCategoryAriaLabel": {
+    "message": "사이드바 분류 '{label}' 펼치기",
+    "description": "The ARIA label to expand the sidebar category"
+  },
+  "theme.DocSidebarItem.collapseCategoryAriaLabel": {
+    "message": "사이드바 분류 '{label}' 접기",
+    "description": "The ARIA label to collapse the sidebar category"
+  },
+  "theme.IconExternalLink.ariaLabel": {
+    "message": "(opens in new tab)",
+    "description": "The ARIA label for the external link icon"
+  },
+  "theme.NavBar.navAriaLabel": {
+    "message": "메인",
+    "description": "The ARIA label for the main navigation"
+  },
+  "theme.navbar.mobileLanguageDropdown.label": {
+    "message": "언어",
+    "description": "The label for the mobile language switcher dropdown"
+  },
+  "theme.NotFound.p1": {
+    "message": "원하는 페이지를 찾을 수 없습니다.",
+    "description": "The first paragraph of the 404 page"
+  },
+  "theme.NotFound.p2": {
+    "message": "사이트 관리자에게 링크가 깨진 것을 알려주세요.",
+    "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "이 페이지에서",
+    "description": "The label used by the button on the collapsible TOC component"
+  },
+  "theme.blog.post.readMore": {
+    "message": "자세히 보기",
+    "description": "The label used in blog post item excerpts to link to full blog posts"
+  },
+  "theme.blog.post.readMoreLabel": {
+    "message": "{title} 에 대해 더 읽어보기",
+    "description": "The ARIA label for the link to full blog posts from excerpts"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "약 {readingTime}분",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "복사",
+    "description": "The copy button label on code blocks"
+  },
+  "theme.CodeBlock.copied": {
+    "message": "복사했습니다",
+    "description": "The copied button label on code blocks"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "클립보드에 코드 복사",
+    "description": "The ARIA label for copy code blocks button"
+  },
+  "theme.CodeBlock.wordWrapToggle": {
+    "message": "줄 바꿈 전환",
+    "description": "The title attribute for toggle word wrapping button of code block lines"
+  },
+  "theme.docs.breadcrumbs.home": {
+    "message": "홈",
+    "description": "The ARIA label for the home page in the breadcrumbs"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "사이드바 숨기기",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "사이드바 숨기기",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.navAriaLabel": {
+    "message": "문서 사이드바",
+    "description": "The ARIA label for the sidebar navigation"
+  },
+  "theme.docs.sidebar.closeSidebarButtonAriaLabel": {
+    "message": "사이드바 닫기",
+    "description": "The ARIA label for close button of mobile sidebar"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← 메인 메뉴로 돌아가기",
+    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+  },
+  "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
+    "message": "사이드바 펼치거나 접기",
+    "description": "The ARIA label for hamburger menu button of mobile navigation"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.expandAriaLabel": {
+    "message": "Expand the dropdown",
+    "description": "The ARIA label of the button to expand the mobile dropdown navbar item"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.collapseAriaLabel": {
+    "message": "Collapse the dropdown",
+    "description": "The ARIA label of the button to collapse the mobile dropdown navbar item"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "사이드바 열기",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "사이드바 열기",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.SearchBar.noResultsText": {
+    "message": "No results"
+  },
+  "theme.SearchBar.seeAllOutsideContext": {
+    "message": "See all results outside \"{context}\""
+  },
+  "theme.SearchBar.searchInContext": {
+    "message": "See all results within \"{context}\""
+  },
+  "theme.SearchBar.seeAll": {
+    "message": "See all results"
+  },
+  "theme.SearchBar.label": {
+    "message": "Search",
+    "description": "The ARIA label and placeholder for search button"
+  },
+  "theme.SearchPage.existingResultsTitle": {
+    "message": "Search results for \"{query}\"",
+    "description": "The search page title for non-empty query"
+  },
+  "theme.SearchPage.emptyResultsTitle": {
+    "message": "Search the documentation",
+    "description": "The search page title for empty query"
+  },
+  "theme.SearchPage.searchContext.everywhere": {
+    "message": "Everywhere"
+  },
+  "theme.SearchPage.documentsFound.plurals": {
+    "message": "1 document found|{count} documents found",
+    "description": "Pluralized label for \"{count} documents found\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.SearchPage.noResultsText": {
+    "message": "No documents were found",
+    "description": "The paragraph for empty search result"
+  },
+  "theme.blog.post.plurals": {
+    "message": "{count}개 게시물",
+    "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "\"{tagName}\" 태그로 연결된 {nPosts}개의 게시물이 있습니다.",
+    "description": "The title of the page for a blog tag"
+  },
+  "theme.blog.author.pageTitle": {
+    "message": "{authorName} - {nPosts}",
+    "description": "The title of the page for a blog author"
+  },
+  "theme.blog.authorsList.pageTitle": {
+    "message": "저자",
+    "description": "The title of the authors page"
+  },
+  "theme.blog.authorsList.viewAll": {
+    "message": "모든 저자 보기",
+    "description": "The label of the link targeting the blog authors page"
+  },
+  "theme.blog.author.noPosts": {
+    "message": "작성자가 아직 게시글을 작성하지 않았습니다.",
+    "description": "The text for authors with 0 blog post"
+  },
+  "theme.contentVisibility.unlistedBanner.title": {
+    "message": "색인되지 않은 문서",
+    "description": "The unlisted content banner title"
+  },
+  "theme.contentVisibility.unlistedBanner.message": {
+    "message": "이 문서는 색인되지 않습니다. 검색 엔진이 이 문서를 색인하지 않으며, 주소를 알고 있는 사용자만 접근할 수 있습니다.",
+    "description": "The unlisted content banner message"
+  },
+  "theme.contentVisibility.draftBanner.title": {
+    "message": "작성 중인 페이지",
+    "description": "The draft content banner title"
+  },
+  "theme.contentVisibility.draftBanner.message": {
+    "message": "이 페이지는 아직 작성 중입니다. 개발 환경에서만 보이며 프로덕션 빌드에서는 제외됩니다.",
+    "description": "The draft content banner message"
+  },
+  "theme.ErrorPageContent.tryAgain": {
+    "message": "다시 시도해 보세요",
+    "description": "The label of the button to try again rendering when the React error boundary captures an error"
+  },
+  "theme.common.skipToMainContent": {
+    "message": "본문으로 건너뛰기",
+    "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "theme.tags.tagsPageTitle": {
+    "message": "태그",
+    "description": "The title of the tag list page"
+  }
+}

--- a/website/i18n/ko/docusaurus-plugin-content-docs/current.json
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,250 @@
+{
+  "version.label": {
+    "message": "다음 버전",
+    "description": "The label for version current"
+  },
+  "sidebar.docs.category.Getting Started": {
+    "message": "시작하기",
+    "description": "The label for category 'Getting Started' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Using Hermes": {
+    "message": "Hermes 사용하기",
+    "description": "The label for category 'Using Hermes' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Secrets": {
+    "message": "시크릿",
+    "description": "The label for category 'Secrets' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Features": {
+    "message": "기능",
+    "description": "The label for category 'Features' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Core": {
+    "message": "핵심",
+    "description": "The label for category 'Core' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Automation": {
+    "message": "자동화",
+    "description": "The label for category 'Automation' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Media & Web": {
+    "message": "미디어와 웹",
+    "description": "The label for category 'Media & Web' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Management": {
+    "message": "관리",
+    "description": "The label for category 'Management' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Skills": {
+    "message": "스킬",
+    "description": "The label for category 'Skills' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Bundled": {
+    "message": "기본 제공",
+    "description": "The label for category 'Bundled' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-apple": {
+    "message": "apple",
+    "description": "The label for category 'apple' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-autonomous-ai-agents": {
+    "message": "autonomous-ai-agents",
+    "description": "The label for category 'autonomous-ai-agents' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-creative": {
+    "message": "creative",
+    "description": "The label for category 'creative' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-data-science": {
+    "message": "data-science",
+    "description": "The label for category 'data-science' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-dogfood": {
+    "message": "dogfood",
+    "description": "The label for category 'dogfood' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-email": {
+    "message": "email",
+    "description": "The label for category 'email' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-github": {
+    "message": "github",
+    "description": "The label for category 'github' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-media": {
+    "message": "media",
+    "description": "The label for category 'media' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-mlops": {
+    "message": "mlops",
+    "description": "The label for category 'mlops' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-note-taking": {
+    "message": "note-taking",
+    "description": "The label for category 'note-taking' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-productivity": {
+    "message": "productivity",
+    "description": "The label for category 'productivity' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-research": {
+    "message": "research",
+    "description": "The label for category 'research' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-smart-home": {
+    "message": "smart-home",
+    "description": "The label for category 'smart-home' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-social-media": {
+    "message": "social-media",
+    "description": "The label for category 'social-media' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-software-development": {
+    "message": "software-development",
+    "description": "The label for category 'software-development' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-yuanbao": {
+    "message": "yuanbao",
+    "description": "The label for category 'yuanbao' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Optional": {
+    "message": "선택 사항",
+    "description": "The label for category 'Optional' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-autonomous-ai-agents": {
+    "message": "autonomous-ai-agents",
+    "description": "The label for category 'autonomous-ai-agents' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-blockchain": {
+    "message": "blockchain",
+    "description": "The label for category 'blockchain' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-communication": {
+    "message": "communication",
+    "description": "The label for category 'communication' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-creative": {
+    "message": "creative",
+    "description": "The label for category 'creative' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-devops": {
+    "message": "devops",
+    "description": "The label for category 'devops' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-dogfood": {
+    "message": "dogfood",
+    "description": "The label for category 'dogfood' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-email": {
+    "message": "email",
+    "description": "The label for category 'email' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-finance": {
+    "message": "finance",
+    "description": "The label for category 'finance' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-gaming": {
+    "message": "gaming",
+    "description": "The label for category 'gaming' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-health": {
+    "message": "health",
+    "description": "The label for category 'health' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-mcp": {
+    "message": "mcp",
+    "description": "The label for category 'mcp' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-migration": {
+    "message": "migration",
+    "description": "The label for category 'migration' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-mlops": {
+    "message": "mlops",
+    "description": "The label for category 'mlops' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-payments": {
+    "message": "payments",
+    "description": "The label for category 'payments' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-productivity": {
+    "message": "productivity",
+    "description": "The label for category 'productivity' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-research": {
+    "message": "research",
+    "description": "The label for category 'research' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-security": {
+    "message": "security",
+    "description": "The label for category 'security' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-software-development": {
+    "message": "software-development",
+    "description": "The label for category 'software-development' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-web-development": {
+    "message": "web-development",
+    "description": "The label for category 'web-development' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Messaging Platforms": {
+    "message": "메시징 플랫폼",
+    "description": "The label for category 'Messaging Platforms' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Popular": {
+    "message": "인기",
+    "description": "The label for category 'Popular' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Microsoft 365": {
+    "message": "Microsoft 365",
+    "description": "The label for category 'Microsoft 365' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Chinese platforms": {
+    "message": "중국 플랫폼",
+    "description": "The label for category 'Chinese platforms' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Other": {
+    "message": "기타",
+    "description": "The label for category 'Other' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Integrations": {
+    "message": "통합",
+    "description": "The label for category 'Integrations' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Guides & Tutorials": {
+    "message": "가이드와 튜토리얼",
+    "description": "The label for category 'Guides & Tutorials' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Developer Guide": {
+    "message": "개발자 가이드",
+    "description": "The label for category 'Developer Guide' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Architecture": {
+    "message": "아키텍처",
+    "description": "The label for category 'Architecture' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Extending": {
+    "message": "확장하기",
+    "description": "The label for category 'Extending' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Internals": {
+    "message": "내부 구조",
+    "description": "The label for category 'Internals' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Reference": {
+    "message": "레퍼런스",
+    "description": "The label for category 'Reference' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Command Reference": {
+    "message": "명령어 레퍼런스",
+    "description": "The label for category 'Command Reference' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Configuration Reference": {
+    "message": "설정 레퍼런스",
+    "description": "The label for category 'Configuration Reference' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Tools & Skills Reference": {
+    "message": "도구와 스킬 레퍼런스",
+    "description": "The label for category 'Tools & Skills Reference' in sidebar 'docs'"
+  }
+}

--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/index.mdx
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/index.mdx
@@ -1,0 +1,141 @@
+---
+slug: /
+sidebar_position: 0
+title: "Hermes Agent 문서"
+description: "Nous Research가 만든 스스로 개선하는 AI 에이전트. 경험에서 스킬을 만들고, 사용 중 개선하며, 세션을 넘어 기억하는 내장 학습 루프를 제공합니다."
+hide_table_of_contents: true
+displayed_sidebar: docs
+---
+
+import Link from "@docusaurus/Link";
+
+# Hermes Agent
+
+[Nous Research](https://nousresearch.com)가 만든 스스로 개선하는 AI 에이전트입니다. Hermes는 경험에서 스킬을 만들고, 사용 중 스킬을 개선하며, 필요한 지식을 저장하도록 스스로를 유도하고, 여러 세션에 걸쳐 사용자를 점점 더 깊이 이해하는 내장 학습 루프를 갖춘 에이전트입니다.
+
+<div
+  style={{
+    display: "flex",
+    gap: "1rem",
+    marginBottom: "2rem",
+    flexWrap: "wrap",
+  }}
+>
+  <Link
+    to="/getting-started/installation"
+    style={{
+      display: "inline-block",
+      padding: "0.6rem 1.2rem",
+      backgroundColor: "#FFD700",
+      color: "#07070d",
+      borderRadius: "8px",
+      fontWeight: 600,
+      textDecoration: "none",
+    }}
+  >
+    시작하기 →
+  </Link>
+  <a
+    href="https://hermes-agent.nousresearch.com/"
+    style={{
+      display: "inline-block",
+      padding: "0.6rem 1.2rem",
+      border: "1px solid rgba(255,215,0,0.2)",
+      borderRadius: "8px",
+      textDecoration: "none",
+    }}
+  >
+    데스크톱 다운로드
+  </a>
+  <a
+    href="https://github.com/NousResearch/hermes-agent"
+    style={{
+      display: "inline-block",
+      padding: "0.6rem 1.2rem",
+      border: "1px solid rgba(255,215,0,0.2)",
+      borderRadius: "8px",
+      textDecoration: "none",
+    }}
+  >
+    GitHub에서 보기
+  </a>
+</div>
+
+## 설치
+
+### Windows 또는 macOS
+
+명령줄 앱과 데스크톱 앱을 쉽게 설치하려면 웹사이트에서 [Hermes Desktop 설치 프로그램](https://hermes-agent.nousresearch.com/)을 내려받아 실행하세요.
+
+### Hermes Desktop 없이 설치하기
+
+명령줄 전용으로 설치하려면 다음을 실행하세요.
+
+#### Linux / macOS / WSL2 / Android (Termux)
+
+```bash
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+```
+
+#### Windows (native)
+
+PowerShell에서 실행하세요.
+
+```powershell
+iex (irm https://hermes-agent.nousresearch.com/install.ps1)
+```
+
+설치 프로그램이 무엇을 하는지, 사용자별/루트 설치 경로가 어떻게 다른지, Windows 관련 주의점은 전체 **[설치 가이드](/getting-started/installation)**를 참고하세요. 전체 플랫폼 지원 범위는 **[플랫폼 지원](/getting-started/platform-support)**에서 볼 수 있습니다.
+
+:::tip 가장 빠르게 동작하는 에이전트 만들기
+설치 후 `hermes setup --portal`을 실행하세요. 하나의 OAuth 로그인으로 모델과 네 가지 Tool Gateway 도구(웹 검색, 이미지 생성, TTS, 브라우저)를 함께 설정합니다. 자세한 내용은 [Nous Portal](/integrations/nous-portal)을 참고하세요.
+:::
+
+## Hermes Agent란?
+
+Hermes는 IDE에 묶인 코딩 보조 도구도, 단일 API를 감싼 챗봇도 아닙니다. 오래 실행될수록 더 유능해지는 **자율 에이전트**입니다. 5달러짜리 VPS, GPU 클러스터, 혹은 유휴 상태에서는 비용이 거의 들지 않는 서버리스 인프라(Daytona, Modal) 어디에서든 실행할 수 있습니다. 직접 SSH로 접속하지 않는 클라우드 VM에서 Hermes가 작업하는 동안 Telegram으로 대화할 수도 있습니다. 노트북에 묶이지 않습니다.
+
+## 빠른 링크
+
+|                                                                         |                                                                       |
+| ----------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| 🚀 **[설치](/getting-started/installation)**                            | Linux, macOS, WSL2, Windows native, Android에서 60초 안에 설치        |
+| 📖 **[빠른 시작 튜토리얼](/getting-started/quickstart)**                | 첫 대화와 바로 써볼 핵심 기능                                         |
+| 🗺️ **[학습 경로](/getting-started/learning-path)**                       | 경험 수준에 맞는 문서 찾기                                            |
+| ⚙️ **[설정](/user-guide/configuration)**                                | 설정 파일, 제공자, 모델, 옵션                                         |
+| 💬 **[메시징 게이트웨이](/user-guide/messaging)**                       | Telegram, Discord, Slack, WhatsApp, Teams 등 연결                     |
+| 🔧 **[도구와 도구셋](/user-guide/features/tools)**                      | 60개 이상의 내장 도구와 설정 방법                                     |
+| 🧠 **[메모리 시스템](/user-guide/features/memory)**                     | 세션을 넘어 성장하는 영구 메모리                                      |
+| 📚 **[스킬 시스템](/user-guide/features/skills)**                       | 에이전트가 만들고 재사용하는 절차적 메모리                            |
+| 🔌 **[MCP 통합](/user-guide/features/mcp)**                             | MCP 서버에 연결하고 도구를 필터링하며 Hermes를 안전하게 확장          |
+| 🧭 **[Hermes에서 MCP 사용하기](/guides/use-mcp-with-hermes)**           | 실전 MCP 설정 패턴, 예제, 튜토리얼                                    |
+| 🎙️ **[음성 모드](/user-guide/features/voice-mode)**                     | CLI, Telegram, Discord, Discord VC에서 실시간 음성 상호작용           |
+| 🗣️ **[Hermes에서 음성 모드 사용하기](/guides/use-voice-mode-with-hermes)** | Hermes 음성 워크플로의 실전 설정과 사용법                         |
+| 🎭 **[Personality와 SOUL.md](/user-guide/features/personality)**        | 전역 SOUL.md로 Hermes의 기본 말투 정의                                |
+| 📄 **[컨텍스트 파일](/user-guide/features/context-files)**              | 모든 대화에 영향을 주는 프로젝트 컨텍스트 파일                        |
+| 🔒 **[보안](/user-guide/security)**                                     | 명령 승인, 권한 부여, 컨테이너 격리                                   |
+| 💡 **[팁과 모범 사례](/guides/tips)**                                  | Hermes를 더 잘 쓰기 위한 빠른 팁                                      |
+| 🏗️ **[아키텍처](/developer-guide/architecture)**                       | 내부 동작 방식                                                        |
+| ❓ **[FAQ와 문제 해결](/reference/faq)**                                | 자주 묻는 질문과 해결 방법                                            |
+
+## 핵심 기능
+
+- **닫힌 학습 루프** — 에이전트가 관리하는 메모리, 주기적 저장 유도, 자율 스킬 생성, 사용 중 스킬 개선, LLM 요약이 결합된 FTS5 세션 검색, [Honcho](https://github.com/plastic-labs/honcho) 기반 사용자 모델링
+- **노트북 밖 어디서나 실행** — local, Docker, SSH, Daytona, Singularity, Modal 등 6개 터미널 백엔드. Daytona와 Modal은 유휴 시 환경을 절전해 비용을 거의 들이지 않습니다.
+- **사용자가 있는 곳에서 동작** — CLI, Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Mattermost, Email, SMS, DingTalk, Feishu, WeCom, Weixin, QQ Bot, Yuanbao, BlueBubbles, Home Assistant, Microsoft Teams, Google Chat 등 20개 이상의 플랫폼을 하나의 게이트웨이로 지원
+- **모델 트레이너가 만든 에이전트** — Hermes, Nomos, Psyche를 만든 [Nous Research](https://nousresearch.com)가 제작. [Nous Portal](https://portal.nousresearch.com), [OpenRouter](https://openrouter.ai), OpenAI, 또는 임의의 엔드포인트와 함께 사용 가능
+- **예약 자동화** — 모든 플랫폼으로 전달할 수 있는 내장 cron
+- **위임과 병렬화** — 독립된 서브에이전트를 생성해 병렬 작업을 수행. `execute_code`를 통한 프로그래밍 방식 도구 호출로 여러 단계 파이프라인을 한 번의 추론 호출로 압축
+- **열린 표준 스킬** — [agentskills.io](https://agentskills.io)와 호환. 스킬은 이식 가능하고 공유 가능하며, Skills Hub를 통해 커뮤니티가 기여할 수 있습니다.
+- **완전한 웹 제어** — 검색, 추출, 브라우징, 비전, 이미지 생성, TTS. [Nous Portal](/integrations/nous-portal) 구독 하나로 모두 제공
+- **MCP 지원** — 모든 MCP 서버에 연결해 도구 기능 확장
+- **연구 친화적** — 배치 처리, trajectory export, Atropos 기반 RL 학습 지원. Hermes, Nomos, Psyche 모델을 만든 [Nous Research](https://nousresearch.com)가 제작
+
+## LLM과 코딩 에이전트를 위한 문서
+
+이 문서의 기계 판독용 진입점입니다.
+
+- **[`/llms.txt`](/llms.txt)** — 모든 문서 페이지의 짧은 설명이 포함된 선별 인덱스입니다. 약 17KB로 LLM 컨텍스트에 넣기 안전합니다.
+- **[`/llms-full.txt`](/llms-full.txt)** — 모든 문서 페이지를 하나의 마크다운 파일로 이어 붙인 버전입니다. 약 1.8MB입니다.
+
+두 파일은 `/docs/llms.txt`와 `/docs/llms-full.txt`에서도 접근할 수 있으며, 배포 때마다 새로 생성됩니다.

--- a/website/i18n/ko/docusaurus-theme-classic/footer.json
+++ b/website/i18n/ko/docusaurus-theme-classic/footer.json
@@ -1,0 +1,58 @@
+{
+  "link.title.Docs": {
+    "message": "문서",
+    "description": "The title of the footer links column with title=Docs in the footer"
+  },
+  "link.title.Community": {
+    "message": "커뮤니티",
+    "description": "The title of the footer links column with title=Community in the footer"
+  },
+  "link.title.More": {
+    "message": "더 보기",
+    "description": "The title of the footer links column with title=More in the footer"
+  },
+  "link.item.label.Getting Started": {
+    "message": "시작하기",
+    "description": "The label of footer link with label=Getting Started linking to /getting-started/quickstart"
+  },
+  "link.item.label.User Guide": {
+    "message": "사용자 가이드",
+    "description": "The label of footer link with label=User Guide linking to /user-guide/cli"
+  },
+  "link.item.label.Developer Guide": {
+    "message": "개발자 가이드",
+    "description": "The label of footer link with label=Developer Guide linking to /developer-guide/architecture"
+  },
+  "link.item.label.Reference": {
+    "message": "레퍼런스",
+    "description": "The label of footer link with label=Reference linking to /reference/cli-commands"
+  },
+  "link.item.label.Discord": {
+    "message": "Discord",
+    "description": "The label of footer link with label=Discord linking to https://discord.gg/NousResearch"
+  },
+  "link.item.label.GitHub Issues": {
+    "message": "GitHub 이슈",
+    "description": "The label of footer link with label=GitHub Issues linking to https://github.com/NousResearch/hermes-agent/issues"
+  },
+  "link.item.label.Skills Hub": {
+    "message": "스킬 허브",
+    "description": "The label of footer link with label=Skills Hub linking to https://agentskills.io"
+  },
+  "link.item.label.Desktop Download": {
+    "message": "데스크톱 다운로드",
+    "description": "The label of footer link with label=Desktop Download linking to https://hermes-agent.nousresearch.com/"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/NousResearch/hermes-agent"
+  },
+  "link.item.label.Nous Research": {
+    "message": "Nous Research",
+    "description": "The label of footer link with label=Nous Research linking to https://nousresearch.com"
+  },
+  "copyright": {
+    "message": "<a href=\"https://nousresearch.com\">Nous Research</a> 제작 · MIT 라이선스 · 2026",
+    "description": "The footer copyright"
+  }
+}

--- a/website/i18n/ko/docusaurus-theme-classic/navbar.json
+++ b/website/i18n/ko/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,34 @@
+{
+  "title": {
+    "message": "Hermes Agent",
+    "description": "The title in the navbar"
+  },
+  "logo.alt": {
+    "message": "Hermes Agent",
+    "description": "The alt text of navbar logo"
+  },
+  "item.label.Docs": {
+    "message": "문서",
+    "description": "Navbar item with label Docs"
+  },
+  "item.label.Skills": {
+    "message": "스킬",
+    "description": "Navbar item with label Skills"
+  },
+  "item.label.Download": {
+    "message": "다운로드",
+    "description": "Navbar item with label Download"
+  },
+  "item.label.Home": {
+    "message": "홈",
+    "description": "Navbar item with label Home"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
+  },
+  "item.label.Discord": {
+    "message": "Discord",
+    "description": "Navbar item with label Discord"
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Adds an initial Korean (`ko`) localization for the Docusaurus documentation site. This makes Korean available in the locale dropdown and provides translated UI chrome plus a Korean landing page.

## Related Issue

N/A — initial documentation localization.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `website/docusaurus.config.ts`: register the `ko` locale with Korean label and `htmlLang`.
- `website/i18n/ko/code.json`: add Korean Docusaurus/theme UI strings.
- `website/i18n/ko/docusaurus-theme-classic/navbar.json`: add Korean navbar labels.
- `website/i18n/ko/docusaurus-theme-classic/footer.json`: add Korean footer labels.
- `website/i18n/ko/docusaurus-plugin-content-docs/current.json`: add Korean docs sidebar/category labels.
- `website/i18n/ko/docusaurus-plugin-content-docs/current/index.mdx`: add a translated Korean docs landing page.
- `scripts/release.py`: map the contributor email used by this PR for the contributor attribution check.

## How to Test

1. `cd website`
2. `npm ci`
3. `npm run build`
4. Serve the built site and verify Korean pages:
   - `/ko/`
   - `/ko/getting-started/installation`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (N/A: docs-site localization only)
- [ ] I've added tests for my changes (N/A: docs-site localization only)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Verification performed locally:

- `npm run build` passes. Existing broken-link/broken-anchor warnings are still emitted for generated docs/localized skill pages.
- Served `website/build` locally and verified `/ko/` and `/ko/getting-started/installation` return Korean content.
