### PR TITLE
fix(fuzzy_match): preserve indentation in file edits

### DIFF
--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -148,7 +148,7 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
                 )
             new_content = _apply_replacements(
                 content, matches, effective_new,
-                old_string=old_string if strategy_name != "exact" else None,
+                old_string=old_string,
             )
             return new_content, len(matches), strategy_name, None
 


### PR DESCRIPTION
## Problem

LLMs often fall back to fuzzy match strategies when the exact string lookup fails — typically because the agent supplied the snippet with slightly different whitespace/indentation than what is on disk.  
In these cases the replacement text was emitted verbatim, so the patch lost the file’s actual leading whitespace and produced mis-indented source. When the `patch` tool retried, it loaded the corrupted contents into context, compounding the issue across turns.

## Root cause

`fuzzy_find_and_replace` unconditionally suppressed reindentation for the `exact` strategy:

```python
old_string=old_string if strategy_name != "exact" else None
```

The downstream `_apply_replacements/_reindent_replacement` path only runs when `old_string` is not `None`. Because exact matches passed `None`, the tool could never detect that the surrounding context had leading whitespace that needed to be preserved on the replacement lines.

## Why this guard was originally there

The code comment at lines 111-133 in `tools/fuzzy_match.py` assumed:
> "When the matched strategy is NOT `exact`, the file's indentation may differ from what the LLM sent…"

The intent was: if we matched *exactly*, the LLM’s text and the file’s text must already align, so no reindentation is needed.

However, in practice the LLM often **includes surrounding context** in its old_string to guarantee uniqueness. That context already carries the file’s leading whitespace, so even an exact match still needs to anchor new_string to the same indent depth.

## Fix

Always forward `old_string=old_string` to `_apply_replacements`. The reindent helper (`_reindent_replacement`) is already idempotent when indents match, so the no-op fast-path stays fast while the exact-match case now correctly adapts `new_string` to the file’s real indent style.

```diff
@@ -148,7 +148,7 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
  effective_new = _maybe_unescape_new_string(
  new_string, content, matches,
  )
  new_content = _apply_replacements(
  content, matches, effective_new,
 - old_string=old_string if strategy_name != "exact" else None,
 + old_string=old_string,
  )
  return new_content, len(matches), strategy_name, None
```

## Verification

- `tests/tools/test_fuzzy_match.py` — 47 tests pass.  
- No new dependencies, no public API change.  
- Block indentation and tab preservation remain unchanged; this only affects how `new_string` is anchored to the file’s existing indent depth.
- `_reindent_replacement` is already idempotent (returns `new_string` unchanged when file and LLM base indents match), so exact matches that already align remain zero-overhead.
- The separate escape-drift guard (lines 106-109) is untouched and still gated on `strategy_name != "exact"`.

## Related

- Likely downstream of the fuzzy-edit fallback path added to `patch`.  
- Closely related to indentation-preservation work in #32273.  
- May help reduce retry churn when exact match succeeds with leading whitespace captured in context.
