### PR TITLE
fix: strip Photon iMessage attachment placeholders

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -104,6 +104,11 @@ _PHOTON_RETRYABLE_PATTERNS = (
     "upstream_unavailable",
 )
 
+# Apple inserts U+FFFC OBJECT REPLACEMENT CHARACTER into iMessage text where an
+# attachment lives. Photon forwards the real attachment metadata separately, so
+# the placeholder must not leak into the text sent to the assistant/user.
+_IMESSAGE_OBJECT_REPLACEMENT = "\uFFFC"
+
 # Minimum seconds between typing-indicator calls for the same chat.
 # iMessage is a personal channel — suppressing rapid repeats reduces
 # upstream gRPC pressure during Photon overflow events.
@@ -259,6 +264,20 @@ def _markdown_enabled() -> bool:
     return os.getenv("PHOTON_MARKDOWN", "true").strip().lower() not in {
         "false", "0", "no",
     }
+
+
+def _clean_imessage_body_text(text: str) -> str:
+    """Remove Apple's attachment placeholder from iMessage body text."""
+    if not text or _IMESSAGE_OBJECT_REPLACEMENT not in text:
+        return text
+    cleaned = text.replace(_IMESSAGE_OBJECT_REPLACEMENT, "")
+    # Removing an inline object often leaves doubled spaces or spaces dangling
+    # around line breaks. Keep this conservative and only normalize text that
+    # actually contained the placeholder.
+    cleaned = re.sub(r"[ \t]{2,}", " ", cleaned)
+    cleaned = re.sub(r"[ \t]+\n", "\n", cleaned)
+    cleaned = re.sub(r"\n[ \t]+", "\n", cleaned)
+    return cleaned.strip()
 
 
 # ---------------------------------------------------------------------------
@@ -727,6 +746,7 @@ class PhotonAdapter(BasePlatformAdapter):
             # reply_to_text comes from the sidecar (hydrated reaction target);
             # it's None for attachment/voice-only targets, and the gateway only
             # injects the pointer when both id and text are present.
+            reply_to_text = _clean_imessage_body_text(content.get("targetText") or "")
             await self.handle_message(
                 MessageEvent(
                     text=f"reaction:added:{emoji}",
@@ -734,7 +754,7 @@ class PhotonAdapter(BasePlatformAdapter):
                     source=source,
                     message_id=event.get("messageId"),
                     reply_to_message_id=target_id,
-                    reply_to_text=content.get("targetText") or None,
+                    reply_to_text=reply_to_text or None,
                     reply_to_is_own_message=True,
                     raw_message=event,
                     timestamp=timestamp,
@@ -747,7 +767,7 @@ class PhotonAdapter(BasePlatformAdapter):
         # mention gate: a reaction to a non-wake-word group message is valid.
         self._record_last_inbound(space_id, event.get("messageId"))
         if ctype == "text":
-            text = content.get("text") or ""
+            text = _clean_imessage_body_text(content.get("text") or "")
             mtype = MessageType.TEXT
         elif ctype in {"attachment", "voice"}:
             text, mtype, media_urls, media_types = _normalize_binary_payload(content)
@@ -762,7 +782,7 @@ class PhotonAdapter(BasePlatformAdapter):
                     continue
                 item_type = item_content.get("type")
                 if item_type == "text":
-                    item_text = item_content.get("text") or ""
+                    item_text = _clean_imessage_body_text(item_content.get("text") or "")
                     if item_text:
                         text_parts.append(item_text)
                     continue

--- a/tests/gateway/test_photon_inbound.py
+++ b/tests/gateway/test_photon_inbound.py
@@ -1,0 +1,100 @@
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageType
+from plugins.platforms.photon import adapter as photon_adapter
+from plugins.platforms.photon.adapter import PhotonAdapter, _clean_imessage_body_text
+
+
+@pytest.fixture
+def adapter():
+    return PhotonAdapter(PlatformConfig(enabled=True, extra={}))
+
+
+def test_clean_imessage_body_text_removes_object_replacement_placeholder():
+    placeholder = "\uFFFC"
+    assert _clean_imessage_body_text(f"Here is the file {placeholder} ") == "Here is the file"
+    assert _clean_imessage_body_text(f"before {placeholder} after") == "before after"
+    assert _clean_imessage_body_text("plain text") == "plain text"
+
+
+@pytest.mark.asyncio
+async def test_group_text_placeholder_removed_while_attachment_metadata_remains(
+    adapter, monkeypatch
+):
+    captured = []
+
+    async def capture_message(event):
+        captured.append(event)
+
+    adapter.handle_message = capture_message
+    monkeypatch.setattr(
+        photon_adapter,
+        "_cache_inbound_attachment",
+        lambda content, name, mime, force_audio=False: "/tmp/hermes-photon/photo.jpg",
+    )
+
+    await adapter._dispatch_inbound(
+        {
+            "messageId": "msg-1",
+            "space": {"id": "space-1", "type": "dm", "phone": "+15551234567"},
+            "sender": {"id": "+15557654321"},
+            "content": {
+                "type": "group",
+                "items": [
+                    {"id": "text-1", "content": {"type": "text", "text": "Here is the file \uFFFC "}},
+                    {
+                        "id": "attach-1",
+                        "content": {
+                            "type": "attachment",
+                            "id": "att-1",
+                            "name": "photo.jpg",
+                            "mimeType": "image/jpeg",
+                            "size": 123,
+                            "data": "ignored-by-test",
+                            "encoding": "base64",
+                        },
+                    },
+                ],
+            },
+            "timestamp": "2026-07-06T00:00:00.000Z",
+        }
+    )
+
+    assert len(captured) == 1
+    event = captured[0]
+    assert event.text == "Here is the file"
+    assert "\uFFFC" not in event.text
+    assert event.message_type == MessageType.PHOTO
+    assert event.media_urls == ["/tmp/hermes-photon/photo.jpg"]
+    assert event.media_types == ["image/jpeg"]
+
+
+@pytest.mark.asyncio
+async def test_reaction_target_text_placeholder_removed(adapter):
+    adapter._sent_message_ids["target-1"] = 1.0
+    captured = []
+
+    async def capture_message(event):
+        captured.append(event)
+
+    adapter.handle_message = capture_message
+
+    await adapter._dispatch_inbound(
+        {
+            "messageId": "reaction-1",
+            "space": {"id": "space-1", "type": "dm", "phone": "+15551234567"},
+            "sender": {"id": "+15557654321"},
+            "content": {
+                "type": "reaction",
+                "emoji": "❤️",
+                "targetMessageId": "target-1",
+                "targetDirection": "outbound",
+                "targetText": "Photo \uFFFC",
+            },
+            "timestamp": "2026-07-06T00:00:00.000Z",
+        }
+    )
+
+    assert len(captured) == 1
+    assert captured[0].reply_to_text == "Photo"


### PR DESCRIPTION
## Summary
- strip Apple object replacement characters (U+FFFC / \uFFFC) from Photon inbound text before user-visible delivery
- apply cleanup to plain text, mixed/group text parts, and reaction target text
- preserve attachment metadata/media URLs while removing only the inline placeholder

## Tests
- venv/bin/python -m pytest tests/gateway/test_photon_inbound.py tests/tools/test_send_message_react.py -q
- venv/bin/ruff check plugins/platforms/photon/adapter.py tests/gateway/test_photon_inbound.py
- venv/bin/ty check plugins/platforms/photon/adapter.py tests/gateway/test_photon_inbound.py
- venv/bin/python -m compileall -q plugins/platforms/photon tests/gateway/test_photon_inbound.py
- git diff --check HEAD~1..HEAD

Reported from Photon/iMessage: attachment inline placeholder appeared in chat text as ￼.