### PR TITLE
fix(computer-use): avoid Linux pixel click false success

### DIFF
--- a/tests/computer_use/test_doctor.py
+++ b/tests/computer_use/test_doctor.py
@@ -323,3 +323,47 @@ class TestDriverCmdResolution:
             doctor.run_doctor()
         # First (and only) which call should have used the env var.
         which_mock.assert_called_with("/env/path/cua-driver")
+
+
+# ── Linux desktop env discovery ─────────────────────────────────────────────
+
+
+class TestLinuxDesktopEnvDiscovery:
+    def test_discovers_gnome_wayland_and_xwayland_env(self, monkeypatch, tmp_path):
+        from tools.computer_use import doctor
+
+        runtime = tmp_path / "run-user-1000"
+        runtime.mkdir()
+        (runtime / "wayland-0").write_text("")
+        (runtime / "wayland-0.lock").write_text("")
+        xauth = runtime / ".mutter-Xwaylandauth.ABC"
+        xauth.write_text("cookie")
+        monkeypatch.setattr(doctor.sys, "platform", "linux")
+        monkeypatch.setattr(doctor.os, "getuid", lambda: 1000)
+
+        env = doctor._augment_linux_desktop_env({"XDG_RUNTIME_DIR": str(runtime)})
+
+        assert env["XDG_RUNTIME_DIR"] == str(runtime)
+        assert env["DBUS_SESSION_BUS_ADDRESS"] == f"unix:path={runtime}/bus"
+        assert env["WAYLAND_DISPLAY"] == "wayland-0"
+        assert env["DISPLAY"] == ":0"
+        assert env["XAUTHORITY"] == str(xauth)
+
+    def test_preserves_explicit_display_values(self, monkeypatch, tmp_path):
+        from tools.computer_use import doctor
+
+        runtime = tmp_path / "run-user-1000"
+        runtime.mkdir()
+        (runtime / ".mutter-Xwaylandauth.ABC").write_text("cookie")
+        monkeypatch.setattr(doctor.sys, "platform", "linux")
+
+        env = doctor._augment_linux_desktop_env({
+            "XDG_RUNTIME_DIR": str(runtime),
+            "DISPLAY": ":99",
+            "XAUTHORITY": "/custom/auth",
+            "WAYLAND_DISPLAY": "wayland-custom",
+        })
+
+        assert env["DISPLAY"] == ":99"
+        assert env["XAUTHORITY"] == "/custom/auth"
+        assert env["WAYLAND_DISPLAY"] == "wayland-custom"

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -69,8 +69,18 @@ class TestSchema:
         actions = set(COMPUTER_USE_SCHEMA["parameters"]["properties"]["action"]["enum"])
         assert actions >= {
             "capture", "click", "double_click", "right_click", "middle_click",
-            "drag", "scroll", "type", "key", "wait", "list_apps", "focus_app",
+            "drag", "scroll", "type", "key", "wait", "list_apps", "list_windows",
+            "focus_app",
         }
+
+    def test_schema_exposes_window_targeting_fields(self):
+        from tools.computer_use.schema import COMPUTER_USE_SCHEMA
+
+        props = COMPUTER_USE_SCHEMA["parameters"]["properties"]
+
+        assert props["window_title"]["type"] == "string"
+        assert props["pid"]["type"] == "integer"
+        assert props["window_id"]["type"] == "integer"
 
     def test_capture_mode_enum_has_som_vision_ax(self):
         from tools.computer_use.schema import COMPUTER_USE_SCHEMA
@@ -97,6 +107,18 @@ class TestSchema:
         prop = COMPUTER_USE_SCHEMA["parameters"]["properties"]["max_elements"]
         assert prop.get("default") == _DEFAULT_MAX_ELEMENTS
         assert prop.get("maximum") == _MAX_ALLOWED_MAX_ELEMENTS
+
+    def test_schema_exposes_delivery_mode_for_action_ladder(self):
+        """cua-driver 0.7 exposes background/foreground dispatch as a first-class
+        action-time choice; the Hermes wrapper must not hide that rung.
+        """
+        from tools.computer_use.schema import COMPUTER_USE_SCHEMA
+
+        prop = COMPUTER_USE_SCHEMA["parameters"]["properties"].get("delivery_mode")
+
+        assert prop is not None
+        assert prop["type"] == "string"
+        assert set(prop["enum"]) == {"background", "foreground"}
 
 
 class TestRegistration:
@@ -165,6 +187,15 @@ class TestDispatch:
         assert "apps" in parsed
         assert parsed["count"] == 0
 
+    def test_list_windows_returns_json(self, noop_backend):
+        from tools.computer_use.tool import handle_computer_use
+
+        out = handle_computer_use({"action": "list_windows"})
+
+        parsed = json.loads(out)
+        assert "windows" in parsed
+        assert parsed["count"] == 0
+
     def test_wait_clamps_long_waits(self, noop_backend):
         from tools.computer_use.tool import handle_computer_use
         # The backend's default wait() uses time.sleep with clamping.
@@ -211,6 +242,50 @@ class TestDispatch:
         assert "type" in call_names
         type_kw = next(c[1] for c in noop_backend.calls if c[0] == "type")
         assert type_kw["text"] == "hello"
+
+    def test_type_action_passes_target_and_delivery_mode_to_backend(self, noop_backend):
+        from tools.computer_use.tool import handle_computer_use
+
+        out = handle_computer_use({
+            "action": "type",
+            "text": "hello",
+            "element": 4,
+            "coordinate": [12, 34],
+            "delivery_mode": "foreground",
+        })
+
+        parsed = json.loads(out)
+        assert "error" not in parsed
+        type_kw = next(c[1] for c in noop_backend.calls if c[0] == "type")
+        assert type_kw == {
+            "text": "hello",
+            "element": 4,
+            "x": 12,
+            "y": 34,
+            "delivery_mode": "foreground",
+        }
+
+    def test_key_action_passes_target_and_delivery_mode_to_backend(self, noop_backend):
+        from tools.computer_use.tool import handle_computer_use
+
+        out = handle_computer_use({
+            "action": "key",
+            "keys": "ctrl+l",
+            "element": 2,
+            "coordinate": [55, 66],
+            "delivery_mode": "foreground",
+        })
+
+        parsed = json.loads(out)
+        assert "error" not in parsed
+        key_kw = next(c[1] for c in noop_backend.calls if c[0] == "key")
+        assert key_kw == {
+            "keys": "ctrl+l",
+            "element": 2,
+            "x": 55,
+            "y": 66,
+            "delivery_mode": "foreground",
+        }
 
     def test_drag_action_routes_to_backend_by_coordinate(self, noop_backend):
         """drag action must dispatch to backend.drag with coordinates (issue #24170, bug 4)."""
@@ -395,6 +470,29 @@ class TestCaptureResponse:
         assert isinstance(out["content"], list)
         assert any(p.get("type") == "image_url" for p in out["content"])
         assert any(p.get("type") == "text" for p in out["content"])
+
+    def test_capture_zero_dimension_window_returns_error_json(self):
+        """A 0x0 mutter/guard-window capture is not a valid screenshot."""
+        from tools.computer_use.backend import CaptureResult
+        from tools.computer_use import tool as cu_tool
+
+        cap = CaptureResult(
+            mode="som",
+            width=0,
+            height=0,
+            png_b64=None,
+            elements=[],
+            app="mutter-x11-frames",
+            window_title="",
+        )
+
+        out = cu_tool._capture_response(cap)
+
+        parsed = json.loads(out)
+        assert parsed["error"] == "capture returned zero-size window"
+        assert parsed["width"] == 0
+        assert parsed["height"] == 0
+        assert parsed["retry"]["action"] == "list_windows"
 
     def test_capture_tiny_image_returns_text_json(self):
         """Providers can reject <8px images, so placeholders must be omitted."""

--- a/tests/tools/test_computer_use_null_pid_windows.py
+++ b/tests/tools/test_computer_use_null_pid_windows.py
@@ -14,9 +14,10 @@ raised::
 agent could never capture the screen at all on an X11 desktop that had even
 one such window.
 
-The fix routes both ingestion sites through ``_ingest_windows``, which skips
-windows lacking a usable pid/window_id (uncapturable anyway) and coerces the
-rest, so real targetable windows survive.
+The fix routes both ingestion sites through ``_ingest_windows``, which keeps
+windows that have a usable ``window_id`` even when their PID is null. The
+backend uses cua-driver's ``pid=0`` fallback when a later call requires an
+integer pid.
 """
 
 from __future__ import annotations
@@ -36,7 +37,7 @@ _PNG_B64 = (
 # ---------------------------------------------------------------------------
 
 class TestIngestWindows:
-    def test_skips_window_with_null_pid(self):
+    def test_keeps_window_with_null_pid_when_window_id_is_present(self):
         from tools.computer_use.cua_backend import _ingest_windows
 
         raw = [
@@ -46,9 +47,11 @@ class TestIngestWindows:
 
         out = _ingest_windows(raw)
 
-        assert [w["app_name"] for w in out] == ["Firefox"]
-        assert out[0]["pid"] == 4321
-        assert out[0]["window_id"] == 77
+        assert [w["app_name"] for w in out] == ["Desktop", "Firefox"]
+        assert out[0]["pid"] is None
+        assert out[0]["window_id"] == 1
+        assert out[1]["pid"] == 4321
+        assert out[1]["window_id"] == 77
 
     def test_skips_window_with_null_window_id(self):
         from tools.computer_use.cua_backend import _ingest_windows
@@ -94,6 +97,68 @@ class TestIngestWindows:
         assert w["z_index"] == 3
 
 
+class TestSelectWindow:
+    def test_matches_app_or_window_title_substring(self):
+        from tools.computer_use.cua_backend import _select_window
+
+        windows = _ingest_fixture_windows()
+
+        assert _select_window(windows, app="chromium")["pid"] == 10
+        assert _select_window(windows, window_title="Crash")["pid"] == 10
+        assert _select_window(windows, app="python3", window_title="Hard Case")["pid"] == 20
+
+    def test_exact_pid_and_window_id_target_wins(self):
+        from tools.computer_use.cua_backend import _select_window
+
+        windows = _ingest_fixture_windows()
+
+        assert _select_window(windows, pid=20)["app_name"] == "python3"
+        assert _select_window(windows, window_id=100)["app_name"] == "Chromium"
+        assert _select_window(windows, pid=20, window_id=200)["title"] == "CUA Hard Case Test"
+        assert _select_window(windows, pid=20, window_id=999) is None
+
+    def test_skips_known_zero_size_shell_frames_when_no_filter(self):
+        from tools.computer_use.cua_backend import _select_window
+
+        windows = _ingest_fixture_windows()
+
+        assert _select_window(windows)["app_name"] == "Chromium"
+
+
+def _ingest_fixture_windows():
+    from tools.computer_use.cua_backend import _ingest_windows
+
+    return _ingest_windows([
+        {
+            "app_name": "mutter-x11-frames",
+            "pid": 1,
+            "window_id": 1,
+            "is_on_screen": True,
+            "title": "",
+            "z_index": 0,
+            "bounds": {"x": 0, "y": 0, "w": 0, "h": 0},
+        },
+        {
+            "app_name": "Chromium",
+            "pid": 10,
+            "window_id": 100,
+            "is_on_screen": True,
+            "title": "Chromium Crash Dialog",
+            "z_index": 1,
+            "bounds": {"x": 10, "y": 10, "w": 900, "h": 700},
+        },
+        {
+            "app_name": "python3",
+            "pid": 20,
+            "window_id": 200,
+            "is_on_screen": True,
+            "title": "CUA Hard Case Test",
+            "z_index": 2,
+            "bounds": {"x": 20, "y": 20, "w": 400, "h": 300},
+        },
+    ])
+
+
 # ---------------------------------------------------------------------------
 # capture(): end-to-end proof the null-pid window no longer crashes capture
 # ---------------------------------------------------------------------------
@@ -133,12 +198,125 @@ def test_capture_vision_survives_null_pid_window():
     ]
     backend = _backend_with_windows(raw)
 
-    cap = backend.capture(mode="vision")
+    cap = backend.capture(mode="vision", app="Firefox")
 
-    # The real, targetable window is selected rather than the whole capture
-    # crashing on the null-pid desktop window.
+    # The real named window is selected rather than the whole capture crashing
+    # on the null-pid desktop window.
     assert cap.app == "Firefox"
     assert cap.png_b64 == _PNG_B64
     assert backend._active_pid == 4321
     assert backend._active_window_id == 77
     assert base64.b64decode(cap.png_b64)  # decodes cleanly
+
+
+def test_capture_uses_pid_zero_driver_fallback_for_null_pid_target():
+    raw = [
+        {"app_name": "", "pid": None, "window_id": 77,
+         "is_on_screen": True, "title": "CUA Hard Case Test", "z_index": 1},
+    ]
+    backend = _backend_with_windows(raw)
+
+    cap = backend.capture(mode="vision", window_title="Hard Case")
+
+    assert cap.png_b64 == _PNG_B64
+    assert backend._active_pid == 0
+    assert backend._active_window_id == 77
+    screenshot_call = backend._session.call_tool.call_args_list[-1]  # type: ignore[attr-defined]
+    assert screenshot_call.args[0] == "screenshot"
+    assert screenshot_call.args[1]["window_id"] == 77
+
+
+def test_action_preserves_structured_outcome_fields_in_meta():
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    backend = CuaDriverBackend()
+    session = MagicMock()
+    session.supports_capability.return_value = False
+    session.call_tool.return_value = {
+        "isError": False,
+        "data": "typed text",
+        "structuredContent": {
+            "verified": False,
+            "effect": "unverifiable",
+            "escalation": {"next": "page"},
+            "path": "ax",
+        },
+    }
+    backend._session = session
+
+    result = backend._action("type_text", {"pid": 123, "text": "hello"})
+
+    assert result.ok is True
+    assert result.message == "typed text"
+    assert result.meta["verified"] is False
+    assert result.meta["effect"] == "unverifiable"
+    assert result.meta["escalation"] == {"next": "page"}
+    assert result.meta["path"] == "ax"
+
+
+def test_linux_foreground_pixel_click_marks_xtest_as_unverifiable_with_driver_hint(monkeypatch):
+    from tools.computer_use import cua_backend
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    backend = CuaDriverBackend()
+    backend._active_pid = 0
+    backend._active_window_id = 77
+    backend._active_window_bounds = {"x": 120, "y": 157, "width": 520, "height": 260}
+    session = MagicMock()
+    session.supports_capability.return_value = False
+    session.call_tool.return_value = {
+        "isError": False,
+        "data": "",
+        "structuredContent": {
+            "verified": False,
+            "effect": "unverifiable",
+            "path": "x11_xtest_fg",
+        },
+    }
+    backend._session = session
+
+    monkeypatch.setattr(cua_backend.sys, "platform", "linux")
+
+    result = backend.click(x=260, y=183, button="left", delivery_mode="foreground")
+
+    assert result.ok is True
+    assert result.meta["verified"] is False
+    assert result.meta["effect"] == "unverifiable"
+    assert "fallback" not in result.meta
+    assert result.meta["escalation"]["recommended"] == "verify_or_driver_input_backend"
+    assert "portal-libei" in " ".join(result.meta["escalation"]["next"])
+    assert "does not require ydotool" in result.meta["foreground_note"]
+    driver_call = session.call_tool.call_args
+    assert driver_call.args[0] == "click"
+    assert driver_call.args[1]["x"] == 260
+    assert driver_call.args[1]["y"] == 183
+    assert driver_call.args[1]["window_id"] == 77
+
+
+def test_linux_pixel_click_annotation_is_limited_to_unverifiable_pixel_paths(monkeypatch):
+    from tools.computer_use import cua_backend
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    backend = CuaDriverBackend()
+    backend._active_pid = 0
+    backend._active_window_id = 77
+    session = MagicMock()
+    session.supports_capability.return_value = False
+    session.call_tool.return_value = {
+        "isError": False,
+        "data": "",
+        "structuredContent": {
+            "verified": True,
+            "effect": "confirmed",
+            "path": "x11_atspi",
+        },
+    }
+    backend._session = session
+
+    monkeypatch.setattr(cua_backend.sys, "platform", "linux")
+
+    result = backend.click(x=260, y=183, button="left", delivery_mode="background")
+
+    assert result.ok is True
+    assert result.meta["effect"] == "confirmed"
+    assert "escalation" not in result.meta

--- a/tools/computer_use/backend.py
+++ b/tools/computer_use/backend.py
@@ -99,7 +99,14 @@ class ComputerUseBackend(ABC):
 
     # ── Capture ─────────────────────────────────────────────────────
     @abstractmethod
-    def capture(self, mode: str = "som", app: Optional[str] = None) -> CaptureResult: ...
+    def capture(
+        self,
+        mode: str = "som",
+        app: Optional[str] = None,
+        window_title: Optional[str] = None,
+        pid: Optional[int] = None,
+        window_id: Optional[int] = None,
+    ) -> CaptureResult: ...
 
     # ── Pointer actions ─────────────────────────────────────────────
     @abstractmethod
@@ -112,6 +119,7 @@ class ComputerUseBackend(ABC):
         button: str = "left",           # left | right | middle
         click_count: int = 1,
         modifiers: Optional[List[str]] = None,
+        delivery_mode: Optional[str] = None,
     ) -> ActionResult: ...
 
     @abstractmethod
@@ -124,6 +132,7 @@ class ComputerUseBackend(ABC):
         to_xy: Optional[Tuple[int, int]] = None,
         button: str = "left",
         modifiers: Optional[List[str]] = None,
+        delivery_mode: Optional[str] = None,
     ) -> ActionResult: ...
 
     @abstractmethod
@@ -136,14 +145,31 @@ class ComputerUseBackend(ABC):
         x: Optional[int] = None,
         y: Optional[int] = None,
         modifiers: Optional[List[str]] = None,
+        delivery_mode: Optional[str] = None,
     ) -> ActionResult: ...
 
     # ── Keyboard ────────────────────────────────────────────────────
     @abstractmethod
-    def type_text(self, text: str) -> ActionResult: ...
+    def type_text(
+        self,
+        text: str,
+        *,
+        element: Optional[int] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+        delivery_mode: Optional[str] = None,
+    ) -> ActionResult: ...
 
     @abstractmethod
-    def key(self, keys: str) -> ActionResult:
+    def key(
+        self,
+        keys: str,
+        *,
+        element: Optional[int] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+        delivery_mode: Optional[str] = None,
+    ) -> ActionResult:
         """Send a key combo, e.g. 'cmd+s', 'ctrl+alt+t', 'return'."""
 
     # ── Introspection ───────────────────────────────────────────────
@@ -152,8 +178,19 @@ class ComputerUseBackend(ABC):
         """Return running apps with bundle IDs, PIDs, window counts."""
 
     @abstractmethod
-    def focus_app(self, app: str, raise_window: bool = False) -> ActionResult:
-        """Route input to `app` (by name or bundle ID). Default: focus without raise."""
+    def list_windows(self) -> List[Dict[str, Any]]:
+        """Return targetable windows with app/title/pid/window_id/z-order."""
+
+    @abstractmethod
+    def focus_app(
+        self,
+        app: Optional[str] = None,
+        raise_window: bool = False,
+        window_title: Optional[str] = None,
+        pid: Optional[int] = None,
+        window_id: Optional[int] = None,
+    ) -> ActionResult:
+        """Route input to a window by app/title/pid/window_id without raising."""
 
     # ── Native-value mutation ────────────────────────────────────────
     @abstractmethod

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1112,27 +1112,38 @@ def _image_from_tool_result(out: Dict[str, Any]) -> tuple[Optional[str], Optiona
 def _ingest_windows(raw_windows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Normalise cua-driver ``list_windows`` entries, dropping unusable ones.
 
-    Every downstream operation needs both an integer ``pid`` (for
-    get_window_state / action tools) and ``window_id`` (for screenshot /
-    element clicks), so a window missing either is uncapturable.
+    Every downstream operation needs an integer ``window_id``. ``pid`` is
+    useful, but on X11 it is optional: cua-driver can report ``pid: null``
+    for a real, on-screen client window when ``_NET_WM_PID`` is absent. Keep
+    those rows and use the driver's ``pid=0`` fallback when a later action
+    requires an integer pid.
 
     Crucially, on X11 a window's PID comes from the *optional*
     ``_NET_WM_PID`` property — the desktop root, panels, and
     override-redirect popups routinely omit it, so the driver reports
     ``pid: null`` for them. Coercing every entry unconditionally
     (``int(w["pid"])``) let one such window abort enumeration of the real,
-    targetable windows. We skip the unusable entries instead so capture()
-    and focus_app() still find the windows that matter.
+    targetable windows. We only skip rows without a usable ``window_id``;
+    null-pid windows remain targetable by title/window_id and by coordinate.
     """
     windows: List[Dict[str, Any]] = []
     for w in raw_windows:
         pid, window_id = w.get("pid"), w.get("window_id")
-        if pid is None or window_id is None:
+        if window_id is None:
             continue
         try:
-            pid_int, window_id_int = int(pid), int(window_id)
+            window_id_int = int(window_id)
         except (TypeError, ValueError):
             continue
+        pid_int: Optional[int]
+        if pid is None:
+            pid_int = None
+        else:
+            try:
+                pid_int = int(pid)
+            except (TypeError, ValueError):
+                pid_int = None
+        bounds = w.get("bounds") or w.get("frame") or {}
         windows.append({
             "app_name": w.get("app_name", ""),
             "pid": pid_int,
@@ -1140,8 +1151,118 @@ def _ingest_windows(raw_windows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             "off_screen": not w.get("is_on_screen", True),
             "title": w.get("title", ""),
             "z_index": w.get("z_index", 0),
+            "bounds": bounds if isinstance(bounds, dict) else {},
         })
     return windows
+
+
+def _driver_pid_for_window(w: Dict[str, Any]) -> int:
+    """Return the integer pid cua-driver expects for a window row.
+
+    Linux/X11 rows can legitimately have ``pid=None`` while still being
+    capturable by ``window_id``. cua-driver's ``get_window_state`` rejects a
+    missing pid field but accepts ``pid=0`` for that case.
+    """
+    pid = w.get("pid")
+    if pid is None:
+        return 0
+    try:
+        return int(pid)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _window_text(w: Dict[str, Any]) -> str:
+    return f"{w.get('app_name', '')} {w.get('title', '')}".lower()
+
+
+def _window_is_zero_sized(w: Dict[str, Any]) -> bool:
+    bounds = w.get("bounds") or {}
+    if not isinstance(bounds, dict):
+        return False
+    try:
+        width = int(bounds.get("w", bounds.get("width", 1)))
+        height = int(bounds.get("h", bounds.get("height", 1)))
+    except (TypeError, ValueError):
+        return False
+    return width <= 0 or height <= 0
+
+
+def _window_is_known_guard_frame(w: Dict[str, Any]) -> bool:
+    haystack = _window_text(w)
+    return any(name in haystack for name in ("mutter-x11-frames", "mutter guard"))
+
+
+def _select_window(
+    windows: List[Dict[str, Any]],
+    *,
+    app: Optional[str] = None,
+    window_title: Optional[str] = None,
+    pid: Optional[int] = None,
+    window_id: Optional[int] = None,
+    desktop_only: bool = False,
+) -> Optional[Dict[str, Any]]:
+    """Choose the best targetable window from normalized list_windows rows.
+
+    Exact pid/window_id filters are authoritative. Text filters match app name
+    and/or title by case-insensitive substring. With no explicit filter, skip
+    known zero-sized shell/guard frames so a harmless Mutter frame cannot become
+    the default target just because it is frontmost in z-order.
+    """
+    candidates = [w for w in windows if not w.get("off_screen")]
+    if not candidates:
+        candidates = list(windows)
+
+    if pid is not None:
+        try:
+            pid_int = int(pid)
+        except (TypeError, ValueError):
+            return None
+        candidates = [w for w in candidates if w.get("pid") == pid_int]
+
+    if window_id is not None:
+        try:
+            window_id_int = int(window_id)
+        except (TypeError, ValueError):
+            return None
+        candidates = [w for w in candidates if w.get("window_id") == window_id_int]
+
+    if desktop_only:
+        candidates = [
+            w for w in candidates
+            if any(name in _window_text(w) for name in _DESKTOP_WINDOW_NAMES)
+        ]
+
+    if app:
+        app_lower = app.lower()
+        candidates = [w for w in candidates if app_lower in str(w.get("app_name", "")).lower()]
+
+    if window_title:
+        title_lower = window_title.lower()
+        candidates = [w for w in candidates if title_lower in str(w.get("title", "")).lower()]
+
+    if not candidates:
+        return None
+
+    def _rank(w: Dict[str, Any]) -> Tuple[int, Any]:
+        if desktop_only:
+            text = _window_text(w)
+            is_backdrop = any(
+                name in text
+                for name in ("progman", "workerw", "program manager", "finder", "desktop")
+            )
+            return (0 if is_backdrop else 1, w.get("z_index", 0))
+        return (0, w.get("z_index", 0))
+
+    if not (app or window_title or pid is not None or window_id is not None or desktop_only):
+        visible = [
+            w for w in candidates
+            if not (_window_is_known_guard_frame(w) and _window_is_zero_sized(w))
+        ]
+        if visible:
+            candidates = visible
+
+    return sorted(candidates, key=_rank)[0]
 
 
 # ---------------------------------------------------------------------------
@@ -1157,6 +1278,7 @@ class CuaDriverBackend(ComputerUseBackend):
         # Sticky context — updated by capture(), used by action tools.
         self._active_pid: Optional[int] = None
         self._active_window_id: Optional[int] = None
+        self._active_window_bounds: Optional[Dict[str, Any]] = None
         self._last_app: Optional[str] = None  # last app name targeted via capture/focus_app
         # Surface 6 of NousResearch/hermes-agent#47072: per-snapshot
         # `element_index -> element_token` map populated on capture().
@@ -1244,11 +1366,19 @@ class CuaDriverBackend(ComputerUseBackend):
         return cua_driver_binary_available()
 
     # ── Capture ────────────────────────────────────────────────────
-    def capture(self, mode: str = "som", app: Optional[str] = None) -> CaptureResult:
-        """Capture the frontmost on-screen window (optionally filtered by app name).
+    def capture(
+        self,
+        mode: str = "som",
+        app: Optional[str] = None,
+        window_title: Optional[str] = None,
+        pid: Optional[int] = None,
+        window_id: Optional[int] = None,
+    ) -> CaptureResult:
+        """Capture the frontmost on-screen window, optionally filtered by app/title/id.
 
-        Maps hermes `capture(mode, app)` → cua-driver `list_windows` +
-        `get_window_state` (ax/som) or `screenshot` (vision).
+        Maps Hermes `capture(mode, app/window_title/pid/window_id)` →
+        cua-driver `list_windows` + `get_window_state` (ax/som) or
+        `screenshot` (vision).
         """
         # Step 1: enumerate on-screen windows to find target pid/window_id.
         # Surface 3 of NousResearch/hermes-agent#47072: read the canonical
@@ -1294,73 +1424,55 @@ class CuaDriverBackend(ComputerUseBackend):
             return CaptureResult(mode=mode, width=0, height=0, png_b64=None,
                                  elements=[], app="", window_title="", png_bytes_len=0)
 
-        # Filter by app name (case-insensitive substring) if requested.
-        # When the filter matches nothing, surface that explicitly instead of
-        # silently capturing the frontmost window — on macOS the `app_name`
-        # returned by list_windows is the localized name (e.g. "計算機"), so
-        # `app="Calculator"` legitimately matches no windows on a non-English
-        # system and the caller needs to retry with the localized name.
-        if app and app.strip().lower() in _SCREEN_CAPTURE_SENTINELS:
-            # Whole-screen / desktop request. cua-driver has no virtual-desktop
-            # capture tool, so resolve to the OS shell/desktop window (the
-            # desktop backdrop or the taskbar/menu-bar), which list_windows
-            # does surface. This makes "show me my screen" and "click the
-            # taskbar" work; a single image still can't span multiple monitors
-            # — that's a driver limitation, not a wrapper one.
-            def _is_desktop_window(w: Dict[str, Any]) -> bool:
-                haystack = f"{w.get('app_name', '')} {w.get('title', '')}".lower()
-                return any(name in haystack for name in _DESKTOP_WINDOW_NAMES)
-
-            desktop = [w for w in windows if _is_desktop_window(w)]
-            if not desktop:
-                return CaptureResult(
-                    mode=mode, width=0, height=0, png_b64=None,
-                    elements=[], app="",
-                    window_title=(
-                        f"<no desktop/shell window found for app={app!r}; "
-                        f"cua-driver captures one window at a time and exposes "
-                        f"no whole-virtual-desktop or per-monitor capture. "
-                        f"Call list_apps / capture(app='<AppName>') to target a "
-                        f"specific window instead. On Windows the taskbar is "
-                        f"'Shell_TrayWnd' and the desktop is 'Progman'.>"
-                    ),
-                    png_bytes_len=0,
+        desktop_only = bool(app and app.strip().lower() in _SCREEN_CAPTURE_SENTINELS)
+        target = _select_window(
+            windows,
+            app=None if desktop_only else app,
+            window_title=window_title,
+            pid=pid,
+            window_id=window_id,
+            desktop_only=desktop_only,
+        )
+        if target is None:
+            selector_bits = []
+            if app:
+                selector_bits.append(f"app={app!r}")
+            if window_title:
+                selector_bits.append(f"window_title={window_title!r}")
+            if pid is not None:
+                selector_bits.append(f"pid={pid!r}")
+            if window_id is not None:
+                selector_bits.append(f"window_id={window_id!r}")
+            selector = ", ".join(selector_bits) or "frontmost window"
+            if desktop_only:
+                detail = (
+                    f"<no desktop/shell window found for app={app!r}; "
+                    f"cua-driver captures one window at a time and exposes "
+                    f"no whole-virtual-desktop or per-monitor capture. "
+                    f"Call list_apps/list_windows or capture(app='<AppName>') "
+                    f"to target a specific window instead. On Windows the "
+                    f"taskbar is 'Shell_TrayWnd' and the desktop is 'Progman'.>"
                 )
-            # Prefer the desktop backdrop (Progman/WorkerW/Finder) over the
-            # taskbar when both are present, so a bare "screen" capture shows
-            # the full desktop rather than just the task strip.
-            windows = sorted(
-                desktop,
-                key=lambda w: 0 if any(
-                    n in f"{w.get('app_name', '')} {w.get('title', '')}".lower()
-                    for n in ("progman", "workerw", "program manager", "finder", "desktop")
-                ) else 1,
+            else:
+                detail = (
+                    f"<no on-screen window matched {selector}; call "
+                    f"list_apps/list_windows and retry with app, window_title, "
+                    f"pid, or window_id>"
+                )
+            return CaptureResult(
+                mode=mode, width=0, height=0, png_b64=None,
+                elements=[], app="",
+                window_title=detail,
+                png_bytes_len=0,
             )
-        elif app:
-            app_lower = app.lower()
-            filtered = [w for w in windows if app_lower in w["app_name"].lower()]
-            if not filtered:
-                return CaptureResult(
-                    mode=mode, width=0, height=0, png_b64=None,
-                    elements=[], app="",
-                    window_title=(
-                        f"<no on-screen window matched app={app!r}; "
-                        f"call list_apps to see available app names "
-                        f"(macOS reports localized names, e.g. '計算機' "
-                        f"instead of 'Calculator')>"
-                    ),
-                    png_bytes_len=0,
-                )
-            windows = filtered
 
-        # Pick first on-screen window (sorted by z_index / z-order above).
-        target = next((w for w in windows if not w["off_screen"]), windows[0])
-        self._active_pid = target["pid"]
+        self._active_pid = _driver_pid_for_window(target)
         self._active_window_id = target["window_id"]
+        self._active_window_bounds = target.get("bounds") if isinstance(target.get("bounds"), dict) else None
         app_name = target["app_name"]
         # Record the resolved app name so capture_after= follow-ups can re-target
         # the same app rather than falling back to the frontmost window.
-        if app or not self._last_app:
+        if app or window_title or pid is not None or window_id is not None or not self._last_app:
             self._last_app = app_name
 
         # Step 2: capture.
@@ -1563,7 +1675,7 @@ class CuaDriverBackend(ComputerUseBackend):
             png_b64=png_b64,
             elements=elements,
             app=app_name,
-            window_title=window_title,
+            window_title=window_title or "",
             png_bytes_len=png_bytes_len,
             image_mime_type=image_mime_type,
         )
@@ -1578,6 +1690,7 @@ class CuaDriverBackend(ComputerUseBackend):
         button: str = "left",
         click_count: int = 1,
         modifiers: Optional[List[str]] = None,
+        delivery_mode: Optional[str] = None,
     ) -> ActionResult:
         pid = self._active_pid
         if pid is None:
@@ -1599,6 +1712,8 @@ class CuaDriverBackend(ComputerUseBackend):
         tool = "double_click" if click_count == 2 else "click"
 
         args: Dict[str, Any] = {"pid": pid, "button": button_norm}
+        if delivery_mode:
+            args["delivery_mode"] = delivery_mode
         if element is not None:
             if self._active_window_id is None:
                 return ActionResult(ok=False, action=tool,
@@ -1608,13 +1723,86 @@ class CuaDriverBackend(ComputerUseBackend):
         elif x is not None and y is not None:
             args["x"] = x
             args["y"] = y
+            if self._active_window_id is not None:
+                args["window_id"] = self._active_window_id
         else:
             return ActionResult(ok=False, action=tool,
                                 message="click requires element= or x/y.")
         if modifiers:
             args["modifier"] = modifiers
 
-        return self._action(tool, args)
+        result = self._action(tool, args)
+        return self._annotate_linux_unverifiable_click(
+            result,
+            delivery_mode=delivery_mode,
+            element=element,
+            x=x,
+            y=y,
+            button=button_norm,
+            click_count=click_count,
+            modifiers=modifiers,
+        )
+
+    def _annotate_linux_unverifiable_click(
+        self,
+        result: ActionResult,
+        *,
+        delivery_mode: Optional[str],
+        element: Optional[int],
+        x: Optional[int],
+        y: Optional[int],
+        button: str,
+        click_count: int,
+        modifiers: Optional[List[str]],
+    ) -> ActionResult:
+        """Surface a concrete next step for Linux XTest/XSendEvent no-op risk.
+
+        cua-driver's Linux pixel paths correctly report ``verified:false`` when
+        they cannot prove that the click changed app state. On GNOME/Xwayland,
+        those paths can be real no-ops: background MPX/uinput may be denied,
+        and foreground XTest/XSendEvent may be filtered by the compositor/app.
+
+        Do not add a Hermes-side real-input dependency here. The non-ydotool
+        fix is a cua-driver build/runtime with a real compositor input backend
+        (portal/libei on GNOME/KDE, or wlroots virtual-pointer), or an AX/AT-SPI
+        element action when the target exposes one. Hermes should make that
+        limitation explicit instead of reporting a false success.
+        """
+        if sys.platform != "linux" or not result.ok:
+            return result
+        if element is not None or x is None or y is None:
+            return result
+        if button != "left" or click_count != 1 or modifiers:
+            return result
+        path = str(result.meta.get("path") or "")
+        effect = str(result.meta.get("effect") or "")
+        if path not in {"x11_xtest_fg", "xtest_desktop", "x11_pixel"}:
+            return result
+        if effect not in {"unverifiable", "suspected_noop", ""}:
+            return result
+
+        meta = dict(result.meta)
+        meta.setdefault("verified", False)
+        meta["effect"] = "unverifiable"
+        meta["escalation"] = {
+            "recommended": "verify_or_driver_input_backend",
+            "reason": (
+                "Linux pixel click used an unverifiable X11/XTest path. On "
+                "GNOME/Xwayland this may be a real no-op; verify by recapture "
+                "or app-state readback before treating it as successful."
+            ),
+            "next": [
+                "Prefer an element/AT-SPI action when the target exposes one.",
+                "For GNOME/KDE Wayland real pointer input, use a cua-driver build with portal-libei enabled.",
+                "Run hermes computer-use doctor / cua-driver health_report to confirm the Linux input backend.",
+            ],
+        }
+        if delivery_mode == "foreground":
+            meta["foreground_note"] = (
+                "Foreground XTest was dispatched but is still unverifiable; "
+                "Hermes does not require ydotool or another evdev helper."
+            )
+        return ActionResult(ok=result.ok, action=result.action, message=result.message, meta=meta)
 
     def drag(
         self,
@@ -1625,12 +1813,15 @@ class CuaDriverBackend(ComputerUseBackend):
         to_xy: Optional[Tuple[int, int]] = None,
         button: str = "left",
         modifiers: Optional[List[str]] = None,
+        delivery_mode: Optional[str] = None,
     ) -> ActionResult:
         pid = self._active_pid
         if pid is None:
             return ActionResult(ok=False, action="drag",
                                 message="No active window — call capture() first.")
         args: Dict[str, Any] = {"pid": pid}
+        if delivery_mode:
+            args["delivery_mode"] = delivery_mode
         if from_element is not None and to_element is not None:
             if self._active_window_id is None:
                 return ActionResult(ok=False, action="drag",
@@ -1641,6 +1832,8 @@ class CuaDriverBackend(ComputerUseBackend):
         elif from_xy is not None and to_xy is not None:
             args["from_x"], args["from_y"] = int(from_xy[0]), int(from_xy[1])
             args["to_x"], args["to_y"] = int(to_xy[0]), int(to_xy[1])
+            if self._active_window_id is not None:
+                args["window_id"] = self._active_window_id
         else:
             return ActionResult(ok=False, action="drag",
                                 message="drag requires from_element/to_element or from_coordinate/to_coordinate.")
@@ -1655,6 +1848,7 @@ class CuaDriverBackend(ComputerUseBackend):
         x: Optional[int] = None,
         y: Optional[int] = None,
         modifiers: Optional[List[str]] = None,
+        delivery_mode: Optional[str] = None,
     ) -> ActionResult:
         pid = self._active_pid
         if pid is None:
@@ -1665,23 +1859,57 @@ class CuaDriverBackend(ComputerUseBackend):
             "direction": direction,
             "amount": max(1, min(50, amount)),
         }
+        if delivery_mode:
+            args["delivery_mode"] = delivery_mode
         if element is not None and self._active_window_id is not None:
             args["element_index"] = element
             args["window_id"] = self._active_window_id
         elif x is not None and y is not None:
             args["x"] = x
             args["y"] = y
+            if self._active_window_id is not None:
+                args["window_id"] = self._active_window_id
         return self._action("scroll", args)
 
     # ── Keyboard ───────────────────────────────────────────────────
-    def type_text(self, text: str) -> ActionResult:
+    def type_text(
+        self,
+        text: str,
+        *,
+        element: Optional[int] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+        delivery_mode: Optional[str] = None,
+    ) -> ActionResult:
         pid = self._active_pid
         if pid is None:
             return ActionResult(ok=False, action="type_text",
                                 message="No active window — call capture() first.")
-        return self._action("type_text", {"pid": pid, "text": text})
+        args: Dict[str, Any] = {"pid": pid, "text": text}
+        if delivery_mode:
+            args["delivery_mode"] = delivery_mode
+        if element is not None:
+            if self._active_window_id is None:
+                return ActionResult(ok=False, action="type_text",
+                                    message="No active window_id for element_index type.")
+            args["element_index"] = element
+            args["window_id"] = self._active_window_id
+        elif x is not None and y is not None:
+            args["x"] = x
+            args["y"] = y
+            if self._active_window_id is not None:
+                args["window_id"] = self._active_window_id
+        return self._action("type_text", args)
 
-    def key(self, keys: str) -> ActionResult:
+    def key(
+        self,
+        keys: str,
+        *,
+        element: Optional[int] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+        delivery_mode: Optional[str] = None,
+    ) -> ActionResult:
         pid = self._active_pid
         if pid is None:
             return ActionResult(ok=False, action="key",
@@ -1692,11 +1920,28 @@ class CuaDriverBackend(ComputerUseBackend):
             return ActionResult(ok=False, action="key",
                                 message=f"Could not parse key from '{keys}'.")
 
+        common: Dict[str, Any] = {"pid": pid}
+        if delivery_mode:
+            common["delivery_mode"] = delivery_mode
+        if element is not None:
+            if self._active_window_id is None:
+                return ActionResult(ok=False, action="key",
+                                    message="No active window_id for element_index key.")
+            common["element_index"] = element
+            common["window_id"] = self._active_window_id
+        elif x is not None and y is not None:
+            common["x"] = x
+            common["y"] = y
+            if self._active_window_id is not None:
+                common["window_id"] = self._active_window_id
+
         if modifiers:
             # hotkey requires at least one modifier + one key.
-            return self._action("hotkey", {"pid": pid, "keys": modifiers + [key_name]})
+            common["keys"] = modifiers + [key_name]
+            return self._action("hotkey", common)
         else:
-            return self._action("press_key", {"pid": pid, "key": key_name})
+            common["key"] = key_name
+            return self._action("press_key", common)
 
     # ── Value setter ────────────────────────────────────────────────
     def set_value(self, value: str, element: Optional[int] = None) -> ActionResult:
@@ -1735,7 +1980,23 @@ class CuaDriverBackend(ComputerUseBackend):
             return apps
         return []
 
-    def focus_app(self, app: str, raise_window: bool = False) -> ActionResult:
+    def list_windows(self) -> List[Dict[str, Any]]:
+        out = self._session.call_tool(
+            "list_windows",
+            {"on_screen_only": True, "session": self._session_id},
+        )
+        raw_windows = (out.get("structuredContent") or {}).get("windows") or []
+        windows = _ingest_windows(raw_windows)
+        return sorted(windows, key=lambda w: w.get("z_index", 0))
+
+    def focus_app(
+        self,
+        app: Optional[str] = None,
+        raise_window: bool = False,
+        window_title: Optional[str] = None,
+        pid: Optional[int] = None,
+        window_id: Optional[int] = None,
+    ) -> ActionResult:
         """Target an app for subsequent actions without stealing system focus.
 
         cua-driver background-automation never needs to bring a window to the
@@ -1756,24 +2017,38 @@ class CuaDriverBackend(ComputerUseBackend):
         windows = _ingest_windows(raw_windows)
         windows.sort(key=lambda w: w["z_index"])
 
-        app_lower = app.lower()
-        matched = [w for w in windows if app_lower in w["app_name"].lower()]
-        # Don't silently fall back to the frontmost window when the filter
-        # matches nothing — that hides the real failure (often a localized
-        # macOS app name mismatch, e.g. caller passed "Calculator" but
-        # list_windows returns "計算機").
-        target = matched[0] if matched else None
+        desktop_only = bool(app and app.strip().lower() in _SCREEN_CAPTURE_SENTINELS)
+        target = _select_window(
+            windows,
+            app=None if desktop_only else app,
+            window_title=window_title,
+            pid=pid,
+            window_id=window_id,
+            desktop_only=desktop_only,
+        )
         if target:
-            self._active_pid = target["pid"]
+            self._active_pid = _driver_pid_for_window(target)
             self._active_window_id = target["window_id"]
+            self._active_window_bounds = target.get("bounds") if isinstance(target.get("bounds"), dict) else None
             self._last_app = target["app_name"]  # preserve for capture_after= follow-ups
             return ActionResult(
                 ok=True, action="focus_app",
                 message=f"Targeted {target['app_name']} (pid {self._active_pid}, "
                         f"window {self._active_window_id}) without raising window.",
+                meta={"window": target, "raise_window_ignored": bool(raise_window)},
             )
+        selector_bits = []
+        if app:
+            selector_bits.append(f"app={app!r}")
+        if window_title:
+            selector_bits.append(f"window_title={window_title!r}")
+        if pid is not None:
+            selector_bits.append(f"pid={pid!r}")
+        if window_id is not None:
+            selector_bits.append(f"window_id={window_id!r}")
+        selector = ", ".join(selector_bits) or "window"
         return ActionResult(ok=False, action="focus_app",
-                            message=f"No on-screen window found for app '{app}'.")
+                            message=f"No on-screen window found for {selector}.")
 
     # ── App lifecycle ────────────────────────────────────────────────
     #
@@ -2094,9 +2369,13 @@ class CuaDriverBackend(ComputerUseBackend):
         ok = not out["isError"]
         message = ""
         data = out["data"]
+        meta: Dict[str, Any] = {}
         if isinstance(data, dict):
             message = str(data.get("message", ""))
+            meta.update(data)
         elif isinstance(data, str):
             message = data
-        return ActionResult(ok=ok, action=name, message=message,
-                            meta=data if isinstance(data, dict) else {})
+        structured = out.get("structuredContent")
+        if isinstance(structured, dict):
+            meta.update(structured)
+        return ActionResult(ok=ok, action=name, message=message, meta=meta)

--- a/tools/computer_use/doctor.py
+++ b/tools/computer_use/doctor.py
@@ -15,6 +15,7 @@ Exit code conventions:
 
 from __future__ import annotations
 
+import glob
 import json
 import os
 import shutil
@@ -52,6 +53,46 @@ def _cua_child_env() -> Dict[str, str]:
         return dict(os.environ)
 
 
+def _augment_linux_desktop_env(env: Dict[str, str]) -> Dict[str, str]:
+    """Best-effort desktop env discovery for `hermes computer-use doctor`.
+
+    Users often run the CLI from shells that did not inherit the graphical
+    session variables, which makes cua-driver report "X11 is not reachable"
+    even though the same user owns a live GNOME/Xwayland session. The runtime
+    backend already runs inside Hermes with the right env; doctor should make
+    the same safe local discovery before spawning the driver.
+    """
+    if sys.platform != "linux":
+        return env
+    out = dict(env)
+    runtime_dir = out.get("XDG_RUNTIME_DIR") or f"/run/user/{os.getuid()}"
+    out.setdefault("XDG_RUNTIME_DIR", runtime_dir)
+    out.setdefault("DBUS_SESSION_BUS_ADDRESS", f"unix:path={runtime_dir}/bus")
+
+    if not out.get("WAYLAND_DISPLAY"):
+        wayland_sockets = sorted(
+            p for p in glob.glob(os.path.join(runtime_dir, "wayland-*"))
+            if not p.endswith(".lock") and os.path.exists(p)
+        )
+        if wayland_sockets:
+            out["WAYLAND_DISPLAY"] = os.path.basename(wayland_sockets[0])
+
+    if not out.get("DISPLAY"):
+        # GNOME Wayland's Xwayland bridge is conventionally :0 and exposes its
+        # auth cookie under the runtime dir. Only set DISPLAY when the cookie is
+        # discoverable; otherwise cua-driver's existing health hint is clearer.
+        xauth_candidates = sorted(glob.glob(os.path.join(runtime_dir, ".mutter-Xwaylandauth.*")))
+        if xauth_candidates:
+            out["DISPLAY"] = ":0"
+            out.setdefault("XAUTHORITY", xauth_candidates[0])
+    elif not out.get("XAUTHORITY"):
+        xauth_candidates = sorted(glob.glob(os.path.join(runtime_dir, ".mutter-Xwaylandauth.*")))
+        if xauth_candidates:
+            out["XAUTHORITY"] = xauth_candidates[0]
+
+    return out
+
+
 def _sanitized_cua_env() -> Dict[str, str]:
     """Telemetry-policy env with Hermes provider secrets stripped.
 
@@ -64,9 +105,10 @@ def _sanitized_cua_env() -> Dict[str, str]:
     try:
         from tools.environments.local import _sanitize_subprocess_env
 
-        return _sanitize_subprocess_env(env)
+        env = _sanitize_subprocess_env(env)
     except Exception:
-        return env
+        pass
+    return _augment_linux_desktop_env(env)
 
 
 def _drive_health_report(

--- a/tools/computer_use/doctor.py
+++ b/tools/computer_use/doctor.py
@@ -65,7 +65,11 @@ def _augment_linux_desktop_env(env: Dict[str, str]) -> Dict[str, str]:
     if sys.platform != "linux":
         return env
     out = dict(env)
-    runtime_dir = out.get("XDG_RUNTIME_DIR") or f"/run/user/{os.getuid()}"
+    getuid = getattr(os, "getuid", None)
+    uid = getuid() if getuid is not None else None
+    runtime_dir = out.get("XDG_RUNTIME_DIR") or (f"/run/user/{uid}" if uid is not None else "")
+    if not runtime_dir:
+        return out
     out.setdefault("XDG_RUNTIME_DIR", runtime_dir)
     out.setdefault("DBUS_SESSION_BUS_ADDRESS", f"unix:path={runtime_dir}/bus")
 

--- a/tools/computer_use/schema.py
+++ b/tools/computer_use/schema.py
@@ -44,6 +44,7 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
                     "set_value",
                     "wait",
                     "list_apps",
+                    "list_windows",
                     "focus_app",
                 ],
                 "description": (
@@ -79,6 +80,31 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
                     "capture is per-window; a single image cannot span "
                     "multiple monitors, so on a multi-screen setup capture "
                     "one window or display at a time."
+                ),
+            },
+            "window_title": {
+                "type": "string",
+                "description": (
+                    "Optional. Target a window by case-insensitive title "
+                    "substring. Works with action='capture' and "
+                    "action='focus_app'. Use action='list_windows' first "
+                    "when app-name matching is ambiguous."
+                ),
+            },
+            "pid": {
+                "type": "integer",
+                "description": (
+                    "Optional. Target an exact OS process id for "
+                    "action='capture' or action='focus_app'. Prefer pairing "
+                    "with window_id when multiple windows share a pid."
+                ),
+            },
+            "window_id": {
+                "type": "integer",
+                "description": (
+                    "Optional. Target an exact native window id for "
+                    "action='capture' or action='focus_app'. Get ids from "
+                    "action='list_windows'."
                 ),
             },
             "max_elements": {
@@ -138,6 +164,17 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
                     ],
                 },
                 "description": "Modifier keys held during the action.",
+            },
+            "delivery_mode": {
+                "type": "string",
+                "enum": ["background", "foreground"],
+                "description": (
+                    "Optional input delivery rung for cua-driver action tools. "
+                    "`background` (default) routes without raising/activating "
+                    "the target window. `foreground` is the explicit escalation "
+                    "for focus-sensitive pixel/keyboard paths after a background "
+                    "attempt is observed not to land."
+                ),
             },
             # ── drag ───────────────────────────────────────────────
             "from_element": {"type": "integer",

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -193,8 +193,21 @@ class _NoopBackend(ComputerUseBackend):  # pragma: no cover
     def stop(self) -> None: self._started = False
     def is_available(self) -> bool: return True
 
-    def capture(self, mode: str = "som", app: Optional[str] = None) -> CaptureResult:
-        self.calls.append(("capture", {"mode": mode, "app": app}))
+    def capture(
+        self,
+        mode: str = "som",
+        app: Optional[str] = None,
+        window_title: Optional[str] = None,
+        pid: Optional[int] = None,
+        window_id: Optional[int] = None,
+    ) -> CaptureResult:
+        self.calls.append(("capture", {
+            "mode": mode,
+            "app": app,
+            "window_title": window_title,
+            "pid": pid,
+            "window_id": window_id,
+        }))
         return CaptureResult(mode=mode, width=1024, height=768, png_b64=None,
                              elements=[], app=app or "", window_title="")
 
@@ -210,20 +223,41 @@ class _NoopBackend(ComputerUseBackend):  # pragma: no cover
         self.calls.append(("scroll", kw))
         return ActionResult(ok=True, action="scroll")
 
-    def type_text(self, text: str) -> ActionResult:
-        self.calls.append(("type", {"text": text}))
+    def type_text(self, text: str, **kw) -> ActionResult:
+        payload = {"text": text}
+        payload.update(kw)
+        self.calls.append(("type", payload))
         return ActionResult(ok=True, action="type")
 
-    def key(self, keys: str) -> ActionResult:
-        self.calls.append(("key", {"keys": keys}))
+    def key(self, keys: str, **kw) -> ActionResult:
+        payload = {"keys": keys}
+        payload.update(kw)
+        self.calls.append(("key", payload))
         return ActionResult(ok=True, action="key")
 
     def list_apps(self) -> List[Dict[str, Any]]:
         self.calls.append(("list_apps", {}))
         return []
 
-    def focus_app(self, app: str, raise_window: bool = False) -> ActionResult:
-        self.calls.append(("focus_app", {"app": app, "raise": raise_window}))
+    def list_windows(self) -> List[Dict[str, Any]]:
+        self.calls.append(("list_windows", {}))
+        return []
+
+    def focus_app(
+        self,
+        app: Optional[str] = None,
+        raise_window: bool = False,
+        window_title: Optional[str] = None,
+        pid: Optional[int] = None,
+        window_id: Optional[int] = None,
+    ) -> ActionResult:
+        self.calls.append(("focus_app", {
+            "app": app,
+            "raise": raise_window,
+            "window_title": window_title,
+            "pid": pid,
+            "window_id": window_id,
+        }))
         return ActionResult(ok=True, action="focus_app")
 
     def set_value(self, value: str, element: Optional[int] = None) -> ActionResult:
@@ -347,7 +381,14 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
         mode = str(args.get("mode", "som"))
         if mode not in {"som", "vision", "ax"}:
             return json.dumps({"error": f"bad mode {mode!r}; use som|vision|ax"})
-        cap = backend.capture(mode=mode, app=args.get("app"))
+        capture_kwargs = {"mode": mode, "app": args.get("app")}
+        if args.get("window_title") is not None:
+            capture_kwargs["window_title"] = args.get("window_title")
+        if args.get("pid") is not None:
+            capture_kwargs["pid"] = args.get("pid")
+        if args.get("window_id") is not None:
+            capture_kwargs["window_id"] = args.get("window_id")
+        cap = backend.capture(**capture_kwargs)
         return _capture_response(cap, max_elements=_coerce_max_elements(args.get("max_elements")))
 
     if action == "wait":
@@ -359,11 +400,21 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
         apps = backend.list_apps()
         return json.dumps({"apps": apps, "count": len(apps)})
 
+    if action == "list_windows":
+        windows = backend.list_windows()
+        return json.dumps({"windows": windows, "count": len(windows)})
+
     if action == "focus_app":
         app = args.get("app")
-        if not app:
-            return json.dumps({"error": "focus_app requires `app`"})
-        res = backend.focus_app(app, raise_window=bool(args.get("raise_window")))
+        if not app and not args.get("window_title") and args.get("pid") is None and args.get("window_id") is None:
+            return json.dumps({"error": "focus_app requires app, window_title, pid, or window_id"})
+        res = backend.focus_app(
+            app=app,
+            raise_window=bool(args.get("raise_window")),
+            window_title=args.get("window_title"),
+            pid=args.get("pid"),
+            window_id=args.get("window_id"),
+        )
         return _maybe_follow_capture(backend, res, capture_after)
 
     if action in {"click", "double_click", "right_click", "middle_click"}:
@@ -384,6 +435,7 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             element=element if element is not None else None,
             x=x, y=y, button=button or "left", click_count=click_count,
             modifiers=args.get("modifiers"),
+            delivery_mode=args.get("delivery_mode"),
         )
         return _maybe_follow_capture(backend, res, capture_after)
 
@@ -401,6 +453,7 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             to_xy=tuple(args["to_coordinate"]) if args.get("to_coordinate") else None,
             button=args.get("button", "left"),
             modifiers=args.get("modifiers"),
+            delivery_mode=args.get("delivery_mode"),
         )
         return _maybe_follow_capture(backend, res, capture_after)
 
@@ -413,15 +466,30 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             x=coord[0] if coord and coord[0] is not None else None,
             y=coord[1] if coord and coord[1] is not None else None,
             modifiers=args.get("modifiers"),
+            delivery_mode=args.get("delivery_mode"),
         )
         return _maybe_follow_capture(backend, res, capture_after)
 
     if action == "type":
-        res = backend.type_text(args.get("text", ""))
+        coord = args.get("coordinate") or (None, None)
+        res = backend.type_text(
+            args.get("text", ""),
+            element=args.get("element"),
+            x=coord[0] if coord and coord[0] is not None else None,
+            y=coord[1] if coord and coord[1] is not None else None,
+            delivery_mode=args.get("delivery_mode"),
+        )
         return _maybe_follow_capture(backend, res, capture_after)
 
     if action == "key":
-        res = backend.key(args.get("keys", ""))
+        coord = args.get("coordinate") or (None, None)
+        res = backend.key(
+            args.get("keys", ""),
+            element=args.get("element"),
+            x=coord[0] if coord and coord[0] is not None else None,
+            y=coord[1] if coord and coord[1] is not None else None,
+            delivery_mode=args.get("delivery_mode"),
+        )
         return _maybe_follow_capture(backend, res, capture_after)
 
     if action == "set_value":
@@ -542,6 +610,23 @@ def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEME
     image_dimensions = _image_dimensions_from_b64(cap.png_b64 or "") if cap.png_b64 else None
     response_width = image_dimensions[0] if image_dimensions else cap.width
     response_height = image_dimensions[1] if image_dimensions else cap.height
+    if response_width <= 0 or response_height <= 0:
+        return json.dumps({
+            "error": "capture returned zero-size window",
+            "mode": cap.mode,
+            "width": response_width,
+            "height": response_height,
+            "app": cap.app,
+            "window_title": cap.window_title,
+            "elements": total_elements,
+            "hint": (
+                "The selected native window has no visible capture surface "
+                "(common with mutter-x11-frames/guard windows on GNOME). "
+                "Call list_windows and retry capture with window_title, pid, "
+                "or window_id."
+            ),
+            "retry": {"action": "list_windows"},
+        })
     image_too_small = bool(
         image_dimensions
         and (


### PR DESCRIPTION
## Summary

- Align Hermes computer_use with cua-driver 0.7.0 window targeting: delivery_mode, targeted type/key, structured action metadata, list_windows, null-PID X11 windows, and 0x0 capture failure handling.
- Remove the Hermes-side ydotool recovery lane. Linux foreground pixel clicks now keep cua-driver's `verified:false` contract and add a concrete escalation hint instead of requiring an evdev helper or reporting a false success.
- Make `hermes computer-use doctor` best-effort discover the local Linux desktop session env (`XDG_RUNTIME_DIR`, `DBUS_SESSION_BUS_ADDRESS`, `WAYLAND_DISPLAY`, Mutter Xwayland auth) before spawning cua-driver, so shell-launched doctor reports the real backend state instead of a misleading "X11 not reachable".

## Root cause / upstream reconnaissance

- `cua-driver` reports X11 windows without `_NET_WM_PID` as `pid:null`; Hermes previously discarded those windows or produced 0x0 captures. Keeping the window when `window_id` is valid fixes targeting/capture for those surfaces.
- For the Tk/Xwayland hard case, coordinates were correct. Background MPX/uinput fell back with permission denied, and foreground XTest dispatched but did not affect app state. AT-SPI saw only the toplevel window, so element action was not available.
- Upstream `trycua/cua` already identifies the non-ydotool solution class: a Linux driver build with a real compositor input backend (`portal-libei` on GNOME/KDE, or wlroots virtual-pointer). The installed 0.7.0 build reports that it was compiled without libei/portal support, so Hermes must not mask that limitation with an external ydotool dependency.

## Test plan

- `scripts/run_tests.sh tests/tools/test_computer_use.py tests/tools/test_computer_use_null_pid_windows.py tests/computer_use/test_doctor.py -q`
- `python -m py_compile tools/computer_use/cua_backend.py tools/computer_use/doctor.py tests/tools/test_computer_use_null_pid_windows.py tests/computer_use/test_doctor.py`
- `git diff --check`
- Live doctor smoke: `env -u DISPLAY -u WAYLAND_DISPLAY -u XAUTHORITY -u XDG_SESSION_TYPE uv run hermes computer-use doctor` now discovers the desktop env and reports the real `portal-libei`/Wayland backend limitation.
- Live Tk hardcase smoke: capture succeeds (`520x260`, `window_id` valid, `pid:null` retained); foreground pixel click remains `verified:false` with escalation metadata, and app state stays unchanged (`clicked=0`) rather than being falsely reported as confirmed.
