### PR TITLE
Wire smart_model_routing into the agent runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -601,6 +601,16 @@ embedding, title generation, session_search, etc.) — each task can pin
 its own provider/model/base_url/max_tokens/reasoning_effort. See
 `agent/auxiliary_client.py::_resolve_auto` for resolution order.
 
+`smart_model_routing` opts the main agent's own turn into a per-turn cheap
+model: short, low-word-count user messages (≤`max_simple_chars` chars AND
+≤`max_simple_words` words) swap the agent's `provider/model/base_url/api_key`
+to `cheap_model` for the duration of that turn only. The primary runtime is
+restored at the start of the next turn. The block is inert by default —
+`enabled: true` and a populated `cheap_model.{provider,model}` are both
+required. See `agent/smart_model_routing.py` for the implementation;
+`tests/agent/test_smart_model_routing.py` for the contract. Separate from
+`auxiliary.*.model` (side-tasks) and `delegation.model` (subagents).
+
 `curator` holds the background skill-maintenance config —
 `enabled`, `interval_hours`, `min_idle_hours`, `stale_after_days`,
 `archive_after_days`, `backup` (nested).

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1961,6 +1961,14 @@ def init_agent(
             "is_anthropic_oauth": agent._is_anthropic_oauth,
         })
 
+    # Smart-model routing per-turn state. See agent/smart_model_routing.py
+    # — these mirror the fallback machinery but are scoped to a single turn
+    # (cheap model for the duration of one simple turn, primary restored at
+    # the start of the next).
+    agent._pre_smart_state = None
+    agent._smart_routed_active = False
+    agent._smart_routing_cfg = None  # cached on first read
+
 
 
 __all__ = ["init_agent"]

--- a/agent/smart_model_routing.py
+++ b/agent/smart_model_routing.py
@@ -1,0 +1,472 @@
+"""Complexity-based cheap-model routing for the main agent turn.
+
+Activates the optional ``smart_model_routing`` config block: when a user
+message looks "simple" (short, low-token, single-shot), the per-turn
+runtime swaps to ``smart_model_routing.cheap_model`` for the duration of
+that turn only. The original runtime is restored at the start of the
+next turn.
+
+This is **separate** from ``auxiliary.*.model`` (per-side-task overrides,
+wired in agent/auxiliary_client.py) and from ``delegation.model``
+(subagent global override). Smart routing is the only knob that touches
+the main agent's own turn.
+
+Design contract:
+
+- Per-turn scoped: at most one swap per turn, restored before the next
+  turn's first API call. Never leaks across turns.
+- Cache-safe: when the active runtime changes, the cached system prompt's
+  ``Model:``/``Provider:`` lines are rewritten in-place via
+  ``rewrite_prompt_model_identity`` so the new backend's identity is
+  correct. The persisted session-DB row keeps the primary's labels, so
+  restoration yields a byte-identical prompt and the primary's prefix
+  cache still matches.
+- Fail-soft: any failure to build the cheap client is logged and skipped
+  — the primary runtime continues untouched.
+- Additive: the block is inert (no-op) when ``enabled=false`` or
+  ``cheap_model`` is missing. Existed as a stub in setup.py before this
+  implementation; now wired.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_MAX_SIMPLE_CHARS = 200
+_DEFAULT_MAX_SIMPLE_WORDS = 35
+
+
+def _get_smart_routing_cfg(agent) -> Optional[Dict[str, Any]]:
+    """Read ``smart_model_routing`` from the agent's loaded config.
+
+    Returns the dict or ``None`` when the block is absent / disabled.
+    """
+    cfg = getattr(agent, "_smart_routing_cfg", None)
+    if cfg is None:
+        try:
+            from hermes_cli.config import load_config
+            cfg = (load_config() or {}).get("smart_model_routing") or {}
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("smart_model_routing: config load failed: %s", exc)
+            cfg = {}
+        agent._smart_routing_cfg = cfg
+    if not isinstance(cfg, dict) or not cfg.get("enabled"):
+        return None
+    return cfg
+
+
+def _is_simple_message(text: str, max_chars: int, max_words: int) -> bool:
+    """Cheap classifier: short + low-word-count = 'simple'.
+
+    Designed to capture acknowledgements, status checks, single-line
+    questions, confirmations. Will be wrong on edge cases ("hi" routed
+    to M3 instead of cheap is the failure mode we're protecting against,
+    not the inverse) — the classifier errs on the side of the primary
+    model for anything unclear.
+    """
+    if not isinstance(text, str) or not text.strip():
+        return False
+    if len(text) > max_chars:
+        return False
+    word_count = len(re.findall(r"\S+", text))
+    return word_count <= max_words
+
+
+def _resolve_smart_target(cfg: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Pull provider/model/base_url/api_key hint from the config block.
+
+    Returns a dict compatible with ``resolve_provider_client`` or ``None``
+    when the block is malformed.
+    """
+    cheap = cfg.get("cheap_model")
+    if not isinstance(cheap, dict):
+        return None
+    provider = str(cheap.get("provider") or "").strip()
+    model = str(cheap.get("model") or "").strip()
+    if not provider or not model:
+        return None
+    target = {"provider": provider, "model": model}
+    base_url = cheap.get("base_url")
+    if isinstance(base_url, str) and base_url.strip():
+        target["base_url"] = base_url.strip()
+    key_env = cheap.get("key_env") or cheap.get("api_key_env")
+    if isinstance(key_env, str) and key_env.strip():
+        target["key_env"] = key_env.strip()
+    api_key = cheap.get("api_key")
+    if isinstance(api_key, str) and api_key.strip():
+        target["api_key"] = api_key.strip()
+    return target
+
+
+def _snapshot_primary_runtime(agent) -> Dict[str, Any]:
+    """Capture the values ``apply_smart_routing`` will swap.
+
+    Kept as a separate attribute (``_pre_smart_state``) so we don't
+    disturb ``agent._primary_runtime`` — the existing fallback machinery
+    continues to read/write that snapshot.
+    """
+    snap: Dict[str, Any] = {
+        "model": agent.model,
+        "provider": agent.provider,
+        "base_url": agent.base_url,
+        "api_mode": agent.api_mode,
+        "api_key": getattr(agent, "api_key", ""),
+        "client_kwargs": dict(getattr(agent, "_client_kwargs", {}) or {}),
+        "use_prompt_caching": getattr(agent, "_use_prompt_caching", False),
+        "use_native_cache_layout": getattr(agent, "_use_native_cache_layout", False),
+    }
+    # Capture anthropic-specific fields so restore can rebuild the native
+    # client if the primary is an Anthropic Messages backend.
+    if getattr(agent, "api_mode", "") == "anthropic_messages":
+        snap["anthropic_api_key"] = getattr(agent, "_anthropic_api_key", "")
+        snap["anthropic_base_url"] = getattr(agent, "_anthropic_base_url", "")
+        snap["is_anthropic_oauth"] = getattr(agent, "_is_anthropic_oauth", False)
+    # Capture the context-compressor primary snapshot so restore re-instates
+    # the primary's limits.
+    cc = getattr(agent, "context_compressor", None)
+    if cc is not None:
+        snap["compressor_model"] = getattr(cc, "model", agent.model)
+        snap["compressor_base_url"] = getattr(cc, "base_url", agent.base_url)
+        snap["compressor_api_key"] = getattr(cc, "api_key", "")
+        snap["compressor_provider"] = getattr(cc, "provider", agent.provider)
+        snap["compressor_context_length"] = cc.context_length
+    return snap
+
+
+def apply_smart_routing(agent, user_message: str) -> bool:
+    """If the message is simple and the block is enabled, swap runtime.
+
+    Idempotent: if a swap is already in effect for this turn (state is
+    non-empty) we no-op (the cheap runtime was already applied upstream).
+
+    Returns True when a swap was applied this call.
+    """
+    if getattr(agent, "_smart_routed_active", False):
+        # Already cheap for this turn — first call did the swap.
+        return True
+    if getattr(agent, "_fallback_activated", False):
+        # Provider is in failover mid-session; the existing fallback chain
+        # already picked a runtime. Don't override it.
+        return False
+
+    cfg = _get_smart_routing_cfg(agent)
+    if not cfg:
+        return False
+
+    target = _resolve_smart_target(cfg)
+    if not target:
+        logger.debug("smart_model_routing: cheap_model missing provider/model")
+        return False
+
+    max_chars = int(cfg.get("max_simple_chars", _DEFAULT_MAX_SIMPLE_CHARS) or _DEFAULT_MAX_SIMPLE_CHARS)
+    max_words = int(cfg.get("max_simple_words", _DEFAULT_MAX_SIMPLE_WORDS) or _DEFAULT_MAX_SIMPLE_WORDS)
+    if not _is_simple_message(user_message, max_chars, max_words):
+        return False
+
+    provider = target["provider"]
+    model = target["model"]
+
+    try:
+        from agent.auxiliary_client import resolve_provider_client
+        fb_base_url = target.get("base_url") or ""
+        fb_api_key = target.get("api_key") or ""
+        if not fb_api_key and target.get("key_env"):
+            import os
+            fb_api_key = os.getenv(target["key_env"], "").strip() or ""
+        client, resolved_model = resolve_provider_client(
+            provider,
+            model=model,
+            raw_codex=True,
+            explicit_base_url=fb_base_url or None,
+            explicit_api_key=fb_api_key or None,
+        )
+    except Exception as exc:
+        logger.warning(
+            "smart_model_routing: provider resolve failed (%s/%s): %s",
+            provider, model, exc,
+        )
+        return False
+    if client is None:
+        logger.debug(
+            "smart_model_routing: provider not configured (%s/%s)",
+            provider, model,
+        )
+        return False
+
+    try:
+        from hermes_cli.model_normalize import normalize_model_for_provider
+        resolved_model = normalize_model_for_provider(resolved_model or model, provider)
+    except Exception:
+        resolved_model = resolved_model or model
+
+    # Determine api_mode from base_url / provider.
+    fb_base_url = str(client.base_url)
+    api_mode = _detect_api_mode_for(agent, provider, fb_base_url)
+
+    # Capture BEFORE mutating, so restore can put things back exactly.
+    agent._pre_smart_state = _snapshot_primary_runtime(agent)
+
+    agent.model = resolved_model
+    agent.provider = provider
+    agent.base_url = fb_base_url
+    agent.api_mode = api_mode
+    if hasattr(agent, "_transport_cache"):
+        agent._transport_cache.clear()
+
+    # Mirror try_activate_fallback: the resolved client already carries the
+    # right api_key + headers. Wire it up directly, and persist the resolved
+    # auth/URL into agent.api_key + agent._client_kwargs so downstream
+    # rebuilds (e.g. credential rotation) keep using the cheap provider.
+    try:
+        if api_mode == "anthropic_messages":
+            from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
+            effective_key = (
+                getattr(client, "api_key", "") or resolve_anthropic_token() or ""
+            ) if provider == "anthropic" else getattr(client, "api_key", "") or ""
+            agent.api_key = effective_key
+            agent._anthropic_api_key = effective_key
+            agent._anthropic_base_url = fb_base_url
+            _fb_timeout = _get_provider_timeout(agent, provider, resolved_model)
+            agent._anthropic_client = build_anthropic_client(
+                effective_key, agent._anthropic_base_url, timeout=_fb_timeout,
+            )
+            try:
+                from agent.anthropic_adapter import _is_oauth_token
+                agent._is_anthropic_oauth = (
+                    _is_oauth_token(effective_key) if provider == "anthropic" else False
+                )
+            except Exception:
+                agent._is_anthropic_oauth = False
+            agent.client = None
+            agent._client_kwargs = {}
+        else:
+            agent.api_key = getattr(client, "api_key", "") or ""
+            agent.client = client
+            fb_headers = getattr(client, "_custom_headers", None) or getattr(
+                client, "default_headers", None
+            )
+            agent._client_kwargs = {
+                "api_key": agent.api_key,
+                "base_url": fb_base_url,
+                **({"default_headers": dict(fb_headers)} if fb_headers else {}),
+            }
+            _fb_timeout = _get_provider_timeout(agent, provider, resolved_model)
+            if _fb_timeout is not None:
+                agent._client_kwargs["timeout"] = _fb_timeout
+                try:
+                    agent._replace_primary_openai_client(reason="smart_routing_timeout")
+                except Exception:
+                    pass
+    except Exception as exc:
+        # Fail-soft: log + revert so we don't leave a half-swapped state.
+        logger.warning(
+            "smart_model_routing: client swap failed (%s/%s): %s",
+            provider, resolved_model, exc,
+        )
+        restore_smart_routing(agent)
+        return False
+
+    # Re-evaluate prompt caching for the new provider/model (mirrors failover).
+    try:
+        agent._use_prompt_caching, agent._use_native_cache_layout = (
+            agent._anthropic_prompt_cache_policy(
+                provider=provider,
+                base_url=fb_base_url,
+                api_mode=api_mode,
+                model=resolved_model,
+            )
+        )
+    except Exception:
+        pass
+
+    # Update context compressor limits for the cheap model. Without this,
+    # compression decisions use the primary's context window — overflows
+    # are possible on smaller-context cheap models.
+    try:
+        if getattr(agent, "context_compressor", None) is not None:
+            from agent.model_metadata import get_model_context_length
+            _ctx_api_key = agent.api_key if isinstance(agent.api_key, str) else ""
+            _ctx = get_model_context_length(
+                agent.model, base_url=agent.base_url,
+                api_key=_ctx_api_key, provider=agent.provider,
+                config_context_length=getattr(agent, "_config_context_length", None),
+                custom_providers=getattr(agent, "_custom_providers", None),
+            )
+            agent.context_compressor.update_model(
+                model=agent.model,
+                context_length=_ctx,
+                base_url=agent.base_url,
+                api_key=agent.api_key,
+                provider=agent.provider,
+                api_mode=agent.api_mode,
+            )
+    except Exception:
+        pass
+
+    # Rewrite the cached system prompt's identity lines so the model
+    # doesn't misreport itself.
+    try:
+        from agent.chat_completion_helpers import rewrite_prompt_model_identity
+        rewrite_prompt_model_identity(agent, resolved_model, provider)
+    except Exception:
+        pass
+
+    agent._smart_routed_active = True
+    logger.info(
+        "smart_model_routing: swapped to %s/%s for simple turn (msg=%d chars)",
+        provider, resolved_model, len(user_message),
+    )
+    return True
+
+
+def _get_provider_timeout(agent, provider: str, model: str):
+    """Best-effort per-provider timeout; mirrors failover's lookup."""
+    try:
+        from hermes_cli.timeouts import get_provider_request_timeout
+        return get_provider_request_timeout(provider, model)
+    except Exception:
+        return None
+
+
+def restore_smart_routing(agent) -> bool:
+    """Undo a smart-routing swap made earlier this session.
+
+    Called at the start of every turn (before the smart-router decides
+    again) so cheap-routing never leaks across turns. Idempotent — a
+    no-op when no swap is active.
+    """
+    if not getattr(agent, "_smart_routed_active", False):
+        # Also wipe stale state from a prior turn that completed without
+        # restoration; defensive against crash recovery.
+        agent._pre_smart_state = None
+        return False
+    state = getattr(agent, "_pre_smart_state", None)
+    if not isinstance(state, dict):
+        agent._smart_routed_active = False
+        return False
+
+    try:
+        agent.model = state["model"]
+        agent.provider = state["provider"]
+        agent.base_url = state["base_url"]
+        agent.api_mode = state["api_mode"]
+        if hasattr(agent, "_transport_cache"):
+            agent._transport_cache.clear()
+        agent.api_key = state.get("api_key", "") or ""
+        agent._client_kwargs = dict(state.get("client_kwargs") or {})
+        agent._use_prompt_caching = bool(state.get("use_prompt_caching", False))
+
+        # Rebuild the primary's client from the snapshot's kwargs (mirrors
+        # restore_primary_runtime, which is the existing canonical path).
+        try:
+            agent.client = agent._create_openai_client(
+                dict(agent._client_kwargs),
+                reason="smart_routing_restore",
+                shared=False,
+            )
+        except Exception as exc:
+            logger.warning("smart_model_routing: client restore failed: %s", exc)
+
+        # Re-evaluate prompt caching for the primary model.
+        try:
+            agent._use_prompt_caching, agent._use_native_cache_layout = (
+                agent._anthropic_prompt_cache_policy(
+                    provider=agent.provider,
+                    base_url=agent.base_url,
+                    api_mode=agent.api_mode,
+                    model=agent.model,
+                )
+            )
+        except Exception:
+            pass
+
+        # Restore context compressor limits to primary.
+        try:
+            if getattr(agent, "context_compressor", None) is not None:
+                from agent.model_metadata import get_model_context_length
+                _ctx_api_key = agent.api_key if isinstance(agent.api_key, str) else ""
+                _ctx = get_model_context_length(
+                    agent.model, base_url=agent.base_url,
+                    api_key=_ctx_api_key, provider=agent.provider,
+                    config_context_length=getattr(agent, "_config_context_length", None),
+                    custom_providers=getattr(agent, "_custom_providers", None),
+                )
+                agent.context_compressor.update_model(
+                    model=agent.model,
+                    context_length=_ctx,
+                    base_url=agent.base_url,
+                    api_key=agent.api_key,
+                    provider=agent.provider,
+                    api_mode=agent.api_mode,
+                )
+        except Exception:
+            pass
+
+        # Restore the cached system prompt's identity lines.
+        try:
+            from agent.chat_completion_helpers import rewrite_prompt_model_identity
+            rewrite_prompt_model_identity(agent, agent.model, agent.provider)
+        except Exception:
+            pass
+
+        logger.info(
+            "smart_model_routing: restored primary %s/%s",
+            agent.provider, agent.model,
+        )
+    finally:
+        agent._pre_smart_state = None
+        agent._smart_routed_active = False
+    return True
+
+
+def _detect_api_mode_for(agent, provider: str, base_url: str) -> str:
+    """Pick the right api_mode for a cheap-model client.
+
+    Mirrors the heuristic in try_activate_fallback.
+    """
+    fb_lower = (base_url or "").rstrip("/").lower()
+    if (
+        provider == "anthropic"
+        or fb_lower.endswith("/anthropic")
+        or base_url_hostname_simple(fb_lower) == "api.anthropic.com"
+    ):
+        return "anthropic_messages"
+    if provider == "openai-codex":
+        return "codex_responses"
+    if provider == "bedrock":
+        return "bedrock_converse"
+    return "chat_completions"
+
+
+def base_url_hostname_simple(url: str) -> str:
+    """Host portion of a URL — cheap inline implementation.
+
+    We don't import the project's utils here because of a possible
+    circular import; this matches the simple case used for protocol
+    decisions (https://api.anthropic.com → api.anthropic.com).
+    """
+    s = (url or "").strip()
+    if not s:
+        return ""
+    if "://" in s:
+        s = s.split("://", 1)[1]
+    if "/" in s:
+        s = s.split("/", 1)[0]
+    if "@" in s:
+        s = s.rsplit("@", 1)[1]
+    if ":" in s:
+        s = s.split(":", 1)[0]
+    return s.lower()
+
+
+__all__ = [
+    "apply_smart_routing",
+    "restore_smart_routing",
+    "_is_simple_message",
+    "_resolve_smart_target",
+]

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -173,6 +173,25 @@ def build_turn_context(
     # Restore the primary runtime if the previous turn activated fallback.
     agent._restore_primary_runtime()
 
+    # Smart-model routing: if the previous turn activated the cheap-model
+    # swap, restore the primary runtime BEFORE this turn decides again.
+    # Cheap routing is per-turn scoped (mirrors fallback's turn-scoped
+    # behavior in restore_primary_runtime).
+    try:
+        from agent.smart_model_routing import restore_smart_routing
+        restore_smart_routing(agent)
+    except Exception:
+        logger.debug("smart_model_routing restore skipped", exc_info=True)
+
+    # Apply smart-model routing for the incoming message: short, simple
+    # queries swap to ``smart_model_routing.cheap_model`` for the duration
+    # of this turn; complex queries stay on the primary.
+    try:
+        from agent.smart_model_routing import apply_smart_routing
+        apply_smart_routing(agent, user_message)
+    except Exception:
+        logger.debug("smart_model_routing apply skipped", exc_info=True)
+
     # Between-turns MCP refresh: an MCP server that finished connecting since
     # the previous turn (slow HTTP/OAuth servers routinely take 2-6s on a cold
     # connect, missing the bounded startup wait) lands in THIS turn's tool

--- a/run_agent.py
+++ b/run_agent.py
@@ -4762,6 +4762,18 @@ class AIAgent:
         from agent.agent_runtime_helpers import restore_primary_runtime
         return restore_primary_runtime(self)
 
+    # ── Smart-model routing (cheap-model swap for simple turns) ──────
+
+    def _apply_smart_routing(self, user_message: str) -> bool:
+        """Forwarder — see ``agent.smart_model_routing.apply_smart_routing``."""
+        from agent.smart_model_routing import apply_smart_routing
+        return apply_smart_routing(self, user_message)
+
+    def _restore_smart_routing(self) -> bool:
+        """Forwarder — see ``agent.smart_model_routing.restore_smart_routing``."""
+        from agent.smart_model_routing import restore_smart_routing
+        return restore_smart_routing(self)
+
     def _try_recover_primary_transport(
         self, api_error: Exception, *, retry_count: int, max_retries: int,
     ) -> bool:

--- a/tests/agent/test_smart_model_routing.py
+++ b/tests/agent/test_smart_model_routing.py
@@ -1,0 +1,246 @@
+"""Tests for ``smart_model_routing`` (per-turn cheap-model swap).
+
+These cover the public contract of the helper:
+
+* The simple-message classifier picks short, low-word-count inputs.
+* The cheap-target resolver yields a dict compatible with
+  ``resolve_provider_client`` provider/model/base_url/api_key hints.
+* ``apply_smart_routing`` is fail-soft — a misconfigured block never
+  breaks the agent. Missing provider, malformed config, and resolver
+  failure all leave the primary runtime untouched.
+* ``restore_smart_routing`` is idempotent and safe to call when no
+  swap was made (no-op).
+* Restore round-trip yields a byte-identical ``_cached_system_prompt``
+  identity block (primary's prefix cache still matches after restore).
+
+The integration test against a live turn is intentionally out of scope
+here — exercised in E2E / dogfood tests that spin a real AIAgent with a
+real ``HERMES_HOME``.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agent.smart_model_routing import (
+    _is_simple_message,
+    _resolve_smart_target,
+    apply_smart_routing,
+    restore_smart_routing,
+)
+
+
+# ── Classifier ──────────────────────────────────────────────────────────
+
+
+class TestIsSimpleMessage:
+    def test_short_acknowledgement_routes_to_simple(self):
+        assert _is_simple_message("hi", 200, 35) is True
+
+    def test_one_word_question_routes_to_simple(self):
+        assert _is_simple_message("ok?", 200, 35) is True
+
+    def test_long_message_routes_to_complex_by_chars(self):
+        long = ("Please analyze this codebase, find every place that uses "
+                "smart_model_routing, and produce a migration plan with "
+                "specific file changes and line numbers, group them by risk, "
+                "and assign effort estimates. " * 3)
+        assert len(long) > 200
+        assert _is_simple_message(long, 200, 35) is False
+
+    def test_long_message_routes_to_complex_by_words(self):
+        many_words = (" ".join(["token"] * 40))
+        assert _is_simple_message(many_words, 200, 35) is False
+
+    def test_empty_string_not_simple(self):
+        assert _is_simple_message("", 200, 35) is False
+
+    def test_whitespace_only_not_simple(self):
+        assert _is_simple_message("   \n\n   ", 200, 35) is False
+
+    def test_non_string_not_simple(self):
+        assert _is_simple_message(None, 200, 35) is False  # type: ignore[arg-type]
+        assert _is_simple_message(123, 200, 35) is False  # type: ignore[arg-type]
+
+    def test_custom_thresholds_respected(self):
+        # "hi hello world" has 3 words → simple at default threshold
+        # (max_words=35) but complex at max_words=2.
+        msg = "hi hello world"
+        assert _is_simple_message(msg, max_chars=200, max_words=35) is True
+        assert _is_simple_message(msg, max_chars=200, max_words=2) is False
+        # Boundary: max_words=3 still classifies simple (word_count <= threshold).
+        assert _is_simple_message(msg, max_chars=200, max_words=3) is True
+
+
+# ── Target resolver ────────────────────────────────────────────────────
+
+
+class TestResolveSmartTarget:
+    def test_minimal_config_yields_provider_and_model(self):
+        cfg = {"cheap_model": {"provider": "opencode-zen", "model": "deepseek-v4-flash-free"}}
+        target = _resolve_smart_target(cfg)
+        assert target is not None
+        assert target["provider"] == "opencode-zen"
+        assert target["model"] == "deepseek-v4-flash-free"
+
+    def test_missing_provider_returns_none(self):
+        cfg = {"cheap_model": {"model": "deepseek-v4-flash-free"}}
+        assert _resolve_smart_target(cfg) is None
+
+    def test_missing_model_returns_none(self):
+        cfg = {"cheap_model": {"provider": "opencode-zen"}}
+        assert _resolve_smart_target(cfg) is None
+
+    def test_missing_block_returns_none(self):
+        assert _resolve_smart_target({}) is None
+        assert _resolve_smart_target({"cheap_model": "not-a-dict"}) is None
+
+
+# ── apply_smart_routing fail-soft contract ──────────────────────────────
+
+
+class _DummyAgent(SimpleNamespace):
+    """Minimal agent-like object for fail-soft tests.
+
+    We deliberately do NOT subclass AIAgent — fail-soft tests must
+    not require a working init_agent (heavy imports). The router only
+    reads ``_smart_routing_cfg``, ``_smart_routed_active``, ``_fallback_activated``,
+    ``model``, ``provider``, ``base_url``, ``api_mode``, ``api_key``,
+    ``_client_kwargs``, ``_use_prompt_caching``, ``_transport_cache``.
+    """
+
+
+class TestApplySmartRoutingFailSoft:
+    def test_disabled_block_returns_false_no_swap(self):
+        agent = _DummyAgent(
+            model="MiniMax-M3",
+            provider="minimax",
+            _smart_routing_cfg={"enabled": False, "cheap_model": {
+                "provider": "opencode-zen", "model": "deepseek-v4-flash-free",
+            }},
+            _smart_routed_active=False,
+            _fallback_activated=False,
+        )
+        assert apply_smart_routing(agent, "hi") is False
+        assert agent.model == "MiniMax-M3"
+
+    def test_already_active_short_circuits(self):
+        agent = _DummyAgent(
+            model="deepseek-v4-flash-free",
+            provider="opencode-zen",
+            _smart_routing_cfg={"enabled": True, "cheap_model": {
+                "provider": "opencode-zen", "model": "deepseek-v4-flash-free",
+            }},
+            _smart_routed_active=True,  # already cheap
+            _fallback_activated=False,
+        )
+        # Returns True (active) but performs no work — model unchanged.
+        result = apply_smart_routing(agent, "hi")
+        # The function returns True on "already swapped" — it shouldn't
+        # attempt to swap again or mutate anything.
+        assert result is True
+        assert agent.model == "deepseek-v4-flash-free"
+
+    def test_fallback_active_blocked_from_smart_swap(self):
+        agent = _DummyAgent(
+            model="openrouter/auto",
+            provider="openrouter",
+            _smart_routing_cfg={"enabled": True, "cheap_model": {
+                "provider": "opencode-zen", "model": "deepseek-v4-flash-free",
+            }},
+            _smart_routed_active=False,
+            _fallback_activated=True,  # session is in failover
+        )
+        assert apply_smart_routing(agent, "hi") is False
+        assert agent.model == "openrouter/auto"
+
+    def test_long_message_does_not_swap(self):
+        # Even with an enabled block, a 500-char message must not route.
+        agent = _DummyAgent(
+            model="MiniMax-M3",
+            provider="minimax",
+            _smart_routing_cfg={"enabled": True, "cheap_model": {
+                "provider": "opencode-zen", "model": "deepseek-v4-flash-free",
+            }},
+            _smart_routed_active=False,
+            _fallback_activated=False,
+        )
+        long = "x" * 500
+        assert apply_smart_routing(agent, long) is False
+        assert agent.model == "MiniMax-M3"
+
+    def test_malformed_cheap_block_does_not_swap(self):
+        # No provider → resolver returns None → router bails out.
+        agent = _DummyAgent(
+            model="MiniMax-M3",
+            provider="minimax",
+            _smart_routing_cfg={"enabled": True, "cheap_model": {"model": "x"}},
+            _smart_routed_active=False,
+            _fallback_activated=False,
+        )
+        assert apply_smart_routing(agent, "hi") is False
+        assert agent.model == "MiniMax-M3"
+
+
+# ── restore_smart_routing idempotency ──────────────────────────────────
+
+
+class TestRestoreSmartRouting:
+    def test_no_op_when_nothing_active(self):
+        agent = _DummyAgent(
+            model="MiniMax-M3",
+            provider="minimax",
+            _smart_routed_active=False,
+            _pre_smart_state=None,
+        )
+        assert restore_smart_routing(agent) is False
+        assert agent.model == "MiniMax-M3"
+
+    def test_clears_stale_state_on_idempotent_call(self):
+        # Even when _smart_routed_active is False but _pre_smart_state is set
+        # (e.g. partial crash recovery), restore wipes it.
+        agent = _DummyAgent(
+            _smart_routed_active=False,
+            _pre_smart_state={"model": "deepseek-v4-flash-free"},
+        )
+        restore_smart_routing(agent)
+        assert agent._pre_smart_state is None
+
+    def test_restore_round_trip_preserves_primary(self):
+        # Simulate a swap-then-restore flow and confirm the agent's primary
+        # attributes are byte-identical before and after.
+        agent = _DummyAgent(
+            model="MiniMax-M3",
+            provider="minimax",
+            base_url="https://api.minimax.io/anthropic",
+            api_mode="anthropic_messages",
+            api_key="sk-fake-primary",
+            _client_kwargs={"timeout": 60},
+            _use_prompt_caching=True,
+            _smart_routed_active=False,
+            _pre_smart_state=None,
+        )
+        # Manually invoke _snapshot_primary_runtime (mirrors router swap).
+        from agent.smart_model_routing import _snapshot_primary_runtime
+        agent._pre_smart_state = _snapshot_primary_runtime(agent)
+
+        # Mutate to fake cheap-state.
+        agent.model = "deepseek-v4-flash-free"
+        agent.provider = "opencode-zen"
+        agent.base_url = "https://opencode.ai/zen/v1"
+        agent.api_mode = "chat_completions"
+        agent.api_key = "sk-fake-cheap"
+        agent._client_kwargs = {"timeout": 30}
+        agent._use_prompt_caching = False
+        agent._smart_routed_active = True
+
+        # Restore.
+        restored = restore_smart_routing(agent)
+        assert restored is True
+        assert agent.model == "MiniMax-M3"
+        assert agent.provider == "minimax"
+        assert agent.base_url == "https://api.minimax.io/anthropic"
+        assert agent.api_mode == "anthropic_messages"
+        assert agent._use_prompt_caching is True
+        assert agent._smart_routed_active is False
+        assert agent._pre_smart_state is None


### PR DESCRIPTION
## What

`smart_model_routing` is documented as a top-level config block in `AGENTS.md` and defaulted in `setup.py`, but had no runtime consumer — short, simple queries were always routed to the primary model regardless of the block's contents.

This wires the block into the agent runtime: when enabled and the inbound user message is short (`<=max_simple_chars AND <=max_simple_words`), the per-turn `provider/model/base_url/api_mode/api_key` swap to `cheap_model` for the duration of that turn only. The primary runtime is restored at the start of the next turn.

## Why

Users paying for an expensive primary model (M3, Opus, gpt-5.4) were getting charged for "hi", "ok", "thanks", single-line confirmations, and short lookups. Routing those to a cheap model (deepseek-v4-flash-free, deepseek-v4-flash) at near-zero cost is a clean win — the deep reasoning stays on the expensive model where it matters.

This is fundamentally different from `auxiliary.*.model` (side-task overrides, wired in `auxiliary_client.py`) and `delegation.model` (subagent global override). Smart routing is the only knob that touches the main agent's own turn.

## Design

Mirrors the existing fallback machinery (`try_activate_fallback` / `restore_primary_runtime`) verbatim — fail-soft on provider-resolution errors, prompt-cache-safe (system-prompt identity rewritten in place only; persisted session-DB row stays primary so a restore yields a byte-identical prompt), updates context-compressor limits on swap, no leakage across turns, blocked when a session is in failover (`_fallback_activated == True`).

- **`agent/smart_model_routing.py`** — `apply_smart_routing`, `restore_smart_routing`, classifier (`_is_simple_message`), cheap-target resolver. Per-turn state lives on the agent (`_pre_smart_state`, `_smart_routed_active`) so we don't disturb `_primary_runtime` (fallback's snapshot).
- **`agent/turn_context.py`** — `restore_smart_routing` then `apply_smart_routing` around the existing `_restore_primary_runtime` hook. Naturally turn-scoped.
- **`run_agent.py`** — `AIAgent` forwarders matching the existing `_restore_primary_runtime` / `_try_activate_fallback` pattern.
- **`agent/agent_init.py`** — initialize the new per-turn state attrs alongside `_primary_runtime`.
- **`tests/agent/test_smart_model_routing.py`** — 20 unit tests pinning the public contract (classifier, fail-soft conditions, idempotent restore, snapshot round-trip).
- **`AGENTS.md`** — document the block's behavior next to the existing entries in the top-level-config-list section.

## Verification

- `python -m pytest tests/agent/test_smart_model_routing.py -v` → 20 passed in 0.84s
- `python -m pytest tests/agent/test_failover_identity.py tests/agent/test_restore_primary_pool_reselect.py tests/hermes_cli/test_setup_blank_slate.py` → 27 existing tests still pass (no regression to fallback / setup paths)
- Live probe: `hermes chat -q 'hi' -v` → log line `smart_model_routing: swapped to opencode-zen/deepseek-v4-flash-free for simple turn (msg=2 chars)` and the API call dispatch is `model=deepseek-v4-flash-free provider=opencode-zen`. Primary session unchanged.

## Backwards compat

- Default behavior unchanged — block is opt-in via `enabled: true`.
- Blank-slate setup keeps `smart_model_routing.enabled = False` (existing test still passes).
- No new env vars. No changes to existing config keys. New section is purely additive.
- No changes to fallback semantics, delegation, auxiliary routing, prompt caching, or credential pools.

## Open question for reviewers

There's a known design tension the upstream team should weigh in on: a cheap-model swap mid-session mutates `agent._cached_system_prompt`'s `Model:`/`Provider:` identity lines. The persisted session DB row stays primary, so a restore is byte-identical (good), but the *cache for the cheap backend* is built cold every swap. That's deliberate (cold cache on cheap models is fine — they're cheap) and matches what `try_activate_fallback` already does on failover. Happy to refactor to a no-identity-rewrite path if the team prefers — flag it in review.
