### PR TITLE
Fix crash when context_length_cache.yaml has empty context_lengths key

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1007,7 +1007,7 @@ def _load_context_cache() -> Dict[str, int]:
     try:
         with open(path, encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
-        return data.get("context_lengths", {})
+        return data.get("context_lengths") or {}
     except Exception as e:
         logger.debug("Failed to load context length cache: %s", e)
         return {}

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -438,6 +438,7 @@ class CLIAgentSetupMixin:
                     # Keep _pending_title so it can be retried after row creation succeeds
             return True
         except Exception as e:
+            logger.exception("Agent initialization failed")
             ChatConsole().print(f"[bold red]Failed to initialize agent: {e}[/]")
             return False
 


### PR DESCRIPTION
## Problem

When `~/.hermes/context_length_cache.yaml` contains a key with no value, e.g.:

```yaml
context_lengths:
```

YAML parses this as `context_lengths: None` (the key **exists**, but its value is `None`, not missing).

In `agent/model_metadata.py::_load_context_cache()`:

```python
return data.get("context_lengths", {})
```

`dict.get(key, default)` only returns `default` when the key is **absent**. Since the key is present with value `None`, this returns `None` instead of `{}`. That `None` then propagates into `get_cached_context_length()`:

```python
cache = _load_context_cache()
return cache.get(key)  # crashes: 'NoneType' object has no attribute 'get'
```

This is called from `get_model_context_length()`, which is invoked by `ContextCompressor.__init__()` during **every** `AIAgent` construction (`agent/agent_init.py`). So a single malformed cache entry breaks every `hermes chat`/TUI session with:

```
Failed to initialize agent: 'NoneType' object has no attribute 'get'
```

The real error was masked because `hermes_cli/cli_agent_setup_mixin.py::_init_agent()` wraps agent construction in a broad `try/except Exception as e` and only prints `str(e)`, discarding the traceback.

## Fix

- `agent/model_metadata.py`: use `data.get("context_lengths") or {}` so a `None` value falls back to `{}` regardless of whether the key is missing or present-but-empty.
- `hermes_cli/cli_agent_setup_mixin.py`: log the full traceback (`logger.exception`) on agent init failure so future issues are easier to diagnose instead of only surfacing `str(e)`.

## Repro

```bash
echo 'context_lengths:' > ~/.hermes/context_length_cache.yaml
hermes chat
# Failed to initialize agent: 'NoneType' object has no attribute 'get'
```

Manual workaround for affected users in the meantime:

```bash
echo 'context_lengths: {}' > ~/.hermes/context_length_cache.yaml
```

## Testing

Verified directly by constructing `AIAgent(...)` with the malformed cache file present:
- **Before fix**: raises `AttributeError: 'NoneType' object has no attribute 'get'`
- **After fix**: initializes successfully, prints `📊 Context limit: 200,000 tokens (compress at 50% = 100,000)`