### PR TITLE
fix(cli): guard _display_resumed_history against empty messages (#59265)

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -654,6 +654,8 @@ class CLIAgentSetupMixin:
             )
 
         for i, (role, text) in enumerate(entries):
+            if not text:
+                continue
             if role == "user":
                 lines.append("  ● You: ", style=f"dim bold {_session_label_c}")
                 # Show first line inline, indent rest


### PR DESCRIPTION
## Summary

`hermes chat --resume <id>` (and `--continue`) crashes with `IndexError: list index out of range` when the resumed session contains a message whose text is empty or whitespace-only.

## Root cause

`_display_resumed_history` calls `text.splitlines()` on each entry's text, then accesses `msg_lines[0]` unconditionally. When `text` is empty, `splitlines()` returns `[]`, causing the crash.

### Traceback
```
File ".../hermes_cli/cli_agent_setup_mixin.py", line 661, in _display_resumed_history
    lines.append(msg_lines[0] + "\n", style="dim")
IndexError: list index out of range
```

## Fix

Guard the loop iteration with `if not text: continue`, skipping empty entries entirely. Two lines added.

## Changes

| File | Δ |
|------|---|
| `hermes_cli/cli_agent_setup_mixin.py` | +2 lines |

Closes #59265