### PR TITLE
fix: harden Windows agent CLI tests

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -420,6 +420,75 @@ def _parse_single_entry(
 _TOP_LEVEL_PAYLOAD_KEYS = {"tool_name", "args", "session_id", "parent_session_id"}
 
 
+def _split_windows_command(command: str) -> List[str]:
+    """Split a Windows command line without treating backslashes as escapes.
+
+    Python's POSIX ``shlex`` corrupts native paths (``C:\\tmp`` -> ``C:tmp``),
+    while ``shlex(..., posix=False)`` preserves quote characters and splits
+    ``--flag=\"C:\\Program Files\\x\"`` in the middle. Hooks only need a
+    shell-style argv split; this small parser keeps backslashes literal and uses
+    quotes solely for grouping/removal.
+    """
+    argv: List[str] = []
+    current: List[str] = []
+    in_quotes = False
+    quote_char = ""
+    for ch in command:
+        if ch in {'"', "'"}:
+            if in_quotes and ch == quote_char:
+                in_quotes = False
+                quote_char = ""
+            elif not in_quotes:
+                in_quotes = True
+                quote_char = ch
+            else:
+                current.append(ch)
+            continue
+        if ch.isspace() and not in_quotes:
+            if current:
+                argv.append("".join(current))
+                current = []
+            continue
+        current.append(ch)
+    if in_quotes:
+        raise ValueError("No closing quotation")
+    if current:
+        argv.append("".join(current))
+    return argv
+
+
+def _split_command(command: str) -> List[str]:
+    """Split a hook command while preserving native Windows paths."""
+    if os.name != "nt":
+        return shlex.split(command)
+    return _split_windows_command(command)
+
+
+def _expand_user_path(path: str) -> str:
+    if path.startswith("~"):
+        home = os.environ.get("HOME")
+        if home:
+            if path == "~":
+                return home
+            if path.startswith(("~/", "~\\")):
+                return os.path.join(home, path[2:])
+    return os.path.expanduser(path)
+
+
+def _argv_for_spawn(command: str) -> List[str]:
+    argv = [_expand_user_path(part) for part in _split_command(command)]
+    if (
+        os.name == "nt"
+        and argv
+        and argv[0].lower().endswith((".sh", ".bash"))
+    ):
+        # Windows cannot CreateProcess a shebang script directly. Git/MSYS
+        # provides ``sh.exe`` reliably in the Hermes runtime; invoking via sh
+        # mirrors what a POSIX shebang would do without shell=True.
+        return ["sh", *argv]
+    return argv
+
+
 def _spawn(spec: ShellHookSpec, stdin_json: str) -> Dict[str, Any]:
     """Run ``spec.command`` as a subprocess with ``stdin_json`` on stdin.
 
@@ -439,7 +508,7 @@ def _spawn(spec: ShellHookSpec, stdin_json: str) -> Dict[str, Any]:
         "error": None,
     }
     try:
-        argv = shlex.split(os.path.expanduser(spec.command))
+        argv = _argv_for_spawn(spec.command)
     except ValueError as exc:
         result["error"] = f"command {spec.command!r} cannot be parsed: {exc}"
         return result
@@ -804,7 +873,7 @@ def _command_script_path(command: str) -> str:
     common bare-path form.
     """
     try:
-        parts = shlex.split(command)
+        parts = _split_command(command)
     except ValueError:
         return command
     if not parts:
@@ -868,7 +937,7 @@ def script_mtime_iso(command: str) -> Optional[str]:
     if not path:
         return None
     try:
-        expanded = os.path.expanduser(path)
+        expanded = _expand_user_path(path)
         return datetime.fromtimestamp(
             os.path.getmtime(expanded), tz=timezone.utc,
         ).isoformat().replace("+00:00", "Z")
@@ -887,14 +956,18 @@ def script_is_executable(command: str) -> bool:
     path = _command_script_path(command)
     if not path:
         return False
-    expanded = os.path.expanduser(path)
+    expanded = _expand_user_path(path)
     if not os.path.isfile(expanded):
         return False
     try:
-        argv = shlex.split(command)
+        argv = _split_command(command)
     except ValueError:
         return False
     is_bare_invocation = bool(argv) and argv[0] == path
+    if os.name == "nt" and is_bare_invocation and expanded.lower().endswith((".py", ".pyw")):
+        return False
+    if os.name == "nt" and is_bare_invocation and expanded.lower().endswith((".sh", ".bash")):
+        return os.access(expanded, os.R_OK)
     required = os.X_OK if is_bare_invocation else os.R_OK
     return os.access(expanded, required)
 

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -327,7 +327,9 @@ def _build_skill_message(
         parts.append("")
         parts.append("[This skill has supporting files:]")
         for sf in supporting:
-            parts.append(f"- {sf}  ->  {skill_dir / sf}")
+            sf_display = str(sf).replace("\\", "/")
+            sf_path = skill_dir / sf
+            parts.append(f"- {sf_display}  ->  {sf_path}")
         parts.append(
             f'\nLoad any of these with skill_view(name="{skill_view_target}", '
             f'file_path="<path>"), or run scripts directly by absolute path '

--- a/agent/skill_preprocessing.py
+++ b/agent/skill_preprocessing.py
@@ -1,6 +1,7 @@
 """Shared SKILL.md preprocessing helpers."""
 
 import logging
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -62,45 +63,100 @@ def substitute_template_vars(
     return _SKILL_TEMPLATE_RE.sub(_replace, content)
 
 
+def _shell_candidates() -> list[str]:
+    """Return shell executables to try for inline snippets.
+
+    Windows may expose a broken WSL ``bash.exe`` ahead of Git Bash in clean
+    subprocess environments. Trying ``sh`` as a fallback keeps simple POSIX
+    snippets working when ``bash`` only prints the WSL relay error.
+    """
+    if os.name == "nt":
+        return ["bash", "sh"]
+    return ["bash"]
+
+
+def _normalize_inline_shell_output(output: str, cwd: Path | None) -> str:
+    """Normalize shell cwd echoes back to the native skill directory path."""
+    if not output or not cwd:
+        return output
+    native_cwd = str(cwd)
+    aliases = {native_cwd, native_cwd.replace("\\", "/")}
+    try:
+        resolved = str(cwd.resolve())
+        aliases.add(resolved)
+        aliases.add(resolved.replace("\\", "/"))
+    except Exception:
+        pass
+    try:
+        _popen_kwargs = {"creationflags": windows_hide_flags()} if IS_WINDOWS else {}
+        cyg = subprocess.run(
+            ["sh", "-c", "pwd"],
+            cwd=native_cwd,
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+            stdin=subprocess.DEVNULL,
+            **_popen_kwargs,
+        )
+        if cyg.stdout:
+            aliases.add(cyg.stdout.strip())
+    except Exception:
+        pass
+    for alias in sorted((a for a in aliases if a), key=len, reverse=True):
+        output = output.replace(alias, native_cwd)
+    return output
+
+
 def run_inline_shell(command: str, cwd: Path | None, timeout: int) -> str:
     """Execute a single inline-shell snippet and return its stdout (trimmed).
 
     Failures return a short ``[inline-shell error: ...]`` marker instead of
     raising, so one bad snippet can't wreck the whole skill message.
     """
+    last_error = "bash not found"
     _popen_kwargs = {"creationflags": windows_hide_flags()} if IS_WINDOWS else {}
-    try:
-        completed = subprocess.run(
-            ["bash", "-c", command],
-            cwd=str(cwd) if cwd else None,
-            capture_output=True,
-            text=True,
-            timeout=max(1, int(timeout)),
-            check=False,
-            stdin=subprocess.DEVNULL,
-            **_popen_kwargs,
-        )
-    except subprocess.TimeoutExpired:
-        return f"[inline-shell timeout after {timeout}s: {command}]"
-    except FileNotFoundError:
-        return "[inline-shell error: bash not found]"
-    except RuntimeError as exc:
-        # tests/conftest.py installs a live-system guard that blocks real
-        # os.kill on out-of-tree PIDs. subprocess.run(timeout=...) may trip
-        # that guard while trying to clean up the timed-out shell; treat that
-        # as the same timeout outcome instead of surfacing the guard error.
-        if "live-system guard: blocked os.kill" in str(exc):
+    for shell in _shell_candidates():
+        try:
+            completed = subprocess.run(
+                [shell, "-c", command],
+                cwd=str(cwd) if cwd else None,
+                capture_output=True,
+                text=True,
+                timeout=max(1, int(timeout)),
+                check=False,
+                stdin=subprocess.DEVNULL,
+                **_popen_kwargs,
+            )
+        except subprocess.TimeoutExpired:
             return f"[inline-shell timeout after {timeout}s: {command}]"
-        return f"[inline-shell error: {exc}]"
-    except Exception as exc:
-        return f"[inline-shell error: {exc}]"
+        except FileNotFoundError:
+            last_error = f"{shell} not found"
+            continue
+        except RuntimeError as exc:
+            # tests/conftest.py installs a live-system guard that blocks real
+            # os.kill on out-of-tree PIDs. subprocess.run(timeout=...) may trip
+            # that guard while trying to clean up the timed-out shell; treat it
+            # as the same timeout outcome instead of surfacing the guard error.
+            if "live-system guard: blocked os.kill" in str(exc):
+                return f"[inline-shell timeout after {timeout}s: {command}]"
+            return f"[inline-shell error: {exc}]"
+        except Exception as exc:
+            return f"[inline-shell error: {exc}]"
 
-    output = (completed.stdout or "").rstrip("\n")
-    if not output and completed.stderr:
-        output = completed.stderr.rstrip("\n")
-    if len(output) > _INLINE_SHELL_MAX_OUTPUT:
-        output = output[:_INLINE_SHELL_MAX_OUTPUT] + "...[truncated]"
-    return output
+        output = (completed.stdout or "").rstrip("\n")
+        stderr = (completed.stderr or "").rstrip("\n")
+        combined = "\n".join(part for part in (output, stderr) if part)
+        if completed.returncode != 0 and "execvpe(/bin/bash) failed" in combined:
+            last_error = combined
+            continue
+        if not output and stderr:
+            output = stderr
+        output = _normalize_inline_shell_output(output, cwd)
+        if len(output) > _INLINE_SHELL_MAX_OUTPUT:
+            output = output[:_INLINE_SHELL_MAX_OUTPUT] + "...[truncated]"
+        return output
+    return f"[inline-shell error: {last_error}]"
 
 
 def expand_inline_shell(

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -9,6 +9,7 @@ covered in ``test_shell_hooks_consent.py``.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -356,10 +357,11 @@ class TestCallbackSubprocess:
     def test_matcher_regex_filters_callback(self, tmp_path, monkeypatch):
         """A matcher set to 'terminal' must not fire for 'web_search'."""
         calls = tmp_path / "calls.log"
+        calls_for_sh = calls.as_posix()
         script = _write_script(
             tmp_path, "log.sh",
             f"#!/usr/bin/env bash\n"
-            f"echo \"$(cat -)\" >> {calls}\n"
+            f"echo \"$(cat -)\" >> {calls_for_sh}\n"
             f"printf '{{}}\\n'\n",
         )
         spec = shell_hooks.ShellHookSpec(
@@ -377,9 +379,10 @@ class TestCallbackSubprocess:
 
     def test_payload_schema_delivered(self, tmp_path):
         capture = tmp_path / "payload.json"
+        capture_for_sh = capture.as_posix()
         script = _write_script(
             tmp_path, "capture.sh",
-            f"#!/usr/bin/env bash\ncat - > {capture}\nprintf '{{}}\\n'\n",
+            f"#!/usr/bin/env bash\ncat - > {capture_for_sh}\nprintf '{{}}\\n'\n",
         )
         spec = shell_hooks.ShellHookSpec(
             event="pre_tool_call", command=str(script),
@@ -431,6 +434,20 @@ class TestCallbackSubprocess:
         cb = shell_hooks._make_callback(spec)
         # No crash = shlex parsed it correctly.
         assert cb(tool_name="terminal") is None  # empty object parses to None
+
+    def test_windows_bare_shell_script_with_args_routes_through_sh(self, monkeypatch):
+        monkeypatch.setattr(shell_hooks.os, "name", "nt", raising=False)
+
+        argv = shell_hooks._argv_for_spawn(r'"C:\tmp\hook.sh" --flag x')
+
+        assert argv == ["sh", r"C:\tmp\hook.sh", "--flag", "x"]
+
+    def test_windows_split_preserves_quoted_path_in_flag_value(self, monkeypatch):
+        monkeypatch.setattr(shell_hooks.os, "name", "nt", raising=False)
+
+        argv = shell_hooks._argv_for_spawn(r'hook.exe --config="C:\Program Files\Hermes\cfg.json"')
+
+        assert argv == ["hook.exe", r"--config=C:\Program Files\Hermes\cfg.json"]
 
     def test_missing_binary_logged_not_raised(self, tmp_path):
         spec = shell_hooks.ShellHookSpec(
@@ -693,9 +710,12 @@ class TestAllowlistConcurrency:
         # Bare invocation on the same non-X_OK file: not runnable.
         assert not shell_hooks.script_is_executable(str(script))
 
-        # Flip +x; bare invocation is now runnable too.
+        # Flip +x; bare invocation is now runnable too on platforms that
+        # preserve executable mode bits. Windows cannot run a bare .py script
+        # via CreateProcess even after chmod, so the doctor check should keep
+        # reporting it as not directly executable there.
         script.chmod(0o755)
-        assert shell_hooks.script_is_executable(str(script))
+        assert shell_hooks.script_is_executable(str(script)) is (os.name != "nt")
 
     def test_command_script_path_resolution(self):
         """Regression: ``_command_script_path`` used to return the first

--- a/tests/hermes_cli/test_skills_config.py
+++ b/tests/hermes_cli/test_skills_config.py
@@ -206,7 +206,10 @@ class TestGetDisabledSkillNames:
         monkeypatch.delenv("HERMES_PLATFORM", raising=False)
         monkeypatch.setenv("HERMES_SESSION_PLATFORM", "discord")
 
+        from gateway.session_context import reset_session_vars
         from agent.skill_utils import get_disabled_skill_names
+
+        reset_session_vars()
         result = get_disabled_skill_names()
         assert result == {"discord-skill", "global-skill"}
 

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -203,6 +203,11 @@ def skill_matches_environment(frontmatter: Dict[str, Any]) -> bool:
     return _impl(frontmatter)
 
 
+def _display_relpath(path: Path) -> str:
+    """Return a stable slash-separated relative path for tool JSON output."""
+    return path.as_posix()
+
+
 def _normalize_prerequisite_values(value: Any) -> List[str]:
     if not value:
         return []
@@ -1082,7 +1087,7 @@ def skill_view(
                     _record(None, found_md)
 
         if len(candidates) > 1:
-            paths = [str(smd) for _, smd in candidates]
+            paths = [str(smd).replace("\\", "/") for _, smd in candidates]
             logging.getLogger(__name__).warning(
                 "Skill name collision for '%s': %d candidates — %s",
                 name, len(candidates), "; ".join(paths),
@@ -1232,7 +1237,7 @@ def skill_view(
                 # Scan for all readable files
                 for f in skill_dir.rglob("*"):
                     if f.is_file() and f.name != "SKILL.md":
-                        rel = str(f.relative_to(skill_dir))
+                        rel = _display_relpath(f.relative_to(skill_dir))
                         if rel.startswith("references/"):
                             available_files["references"].append(rel)
                         elif rel.startswith("templates/"):
@@ -1316,7 +1321,7 @@ def skill_view(
             references_dir = skill_dir / "references"
             if references_dir.exists():
                 reference_files = [
-                    str(f.relative_to(skill_dir)) for f in references_dir.glob("*.md")
+                    _display_relpath(f.relative_to(skill_dir)) for f in references_dir.glob("*.md")
                 ]
 
             templates_dir = skill_dir / "templates"
@@ -1332,7 +1337,7 @@ def skill_view(
                 ]:
                     template_files.extend(
                         [
-                            str(f.relative_to(skill_dir))
+                            _display_relpath(f.relative_to(skill_dir))
                             for f in templates_dir.rglob(ext)
                         ]
                     )
@@ -1342,13 +1347,13 @@ def skill_view(
             if assets_dir.exists():
                 for f in assets_dir.rglob("*"):
                     if f.is_file():
-                        asset_files.append(str(f.relative_to(skill_dir)))
+                        asset_files.append(_display_relpath(f.relative_to(skill_dir)))
 
             scripts_dir = skill_dir / "scripts"
             if scripts_dir.exists():
                 for ext in ["*.py", "*.sh", "*.bash", "*.js", "*.ts", "*.rb"]:
                     script_files.extend(
-                        [str(f.relative_to(skill_dir)) for f in scripts_dir.glob(ext)]
+                        [_display_relpath(f.relative_to(skill_dir)) for f in scripts_dir.glob(ext)]
                     )
 
         # Read tags/related_skills with backward compat:
@@ -1375,10 +1380,10 @@ def skill_view(
             linked_files["scripts"] = script_files
 
         try:
-            rel_path = str(skill_md.relative_to(SKILLS_DIR))
+            rel_path = _display_relpath(skill_md.relative_to(SKILLS_DIR))
         except ValueError:
             # External skill — use path relative to the skill's own parent dir
-            rel_path = str(skill_md.relative_to(skill_md.parent.parent)) if skill_md.parent.parent else skill_md.name
+            rel_path = _display_relpath(skill_md.relative_to(skill_md.parent.parent)) if skill_md.parent.parent else skill_md.name
         skill_name = frontmatter.get(
             "name", skill_md.stem if not skill_dir else skill_dir.name
         )


### PR DESCRIPTION
## Summary
- harden Windows agent CLI handling around shell hook flag/path parsing
- keep session platform resolution on the get_session_env()/ContextVar path instead of bypassing via raw env reads
- add regression coverage for the Windows quoted flag path and skills config behavior

## Tests
- `uv run pytest tests/agent/test_shell_hooks.py tests/hermes_cli/test_skills_config.py -q` → 88 passed in 65.11s
- prior target suite from approval package: 249 passed
- `git diff --check` passed
- `python -m py_compile ...` passed

## Risk / rollback
- Scope is limited to 6 files in agent/skills/tooling test paths.
- No credentials, production entrypoints, Gateway/Cron runtime config, or external delivery paths changed.
- Rollback: revert commit `34a7b9e` if regressions appear.
