### PR TITLE
fix(desktop): add .ico fallback for Windows taskbar and notification icons

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -425,6 +425,13 @@ const WINDOW_BUTTON_POSITION = {
 // It's only the pre-layout fallback — the renderer measures the exact overlay
 // width live via the Window Controls Overlay API.
 const APP_ICON_PATHS = [
+  // .ico is required on Windows for taskbar + notification icons.
+  // The Apple-touch-icon.png fallback works on macOS/Linux but Windows
+  // Electron ignores PNG in BrowserWindow({ icon }) and Notification({ icon }).
+  ...(IS_WINDOWS ? [
+    path.join(APP_ROOT, 'assets', 'icon.ico'),
+    path.join(unpackedPathFor(APP_ROOT), 'assets', 'icon.ico'),
+  ] : []),
   path.join(APP_ROOT, 'public', 'apple-touch-icon.png'),
   path.join(APP_ROOT, 'dist', 'apple-touch-icon.png'),
   path.join(unpackedPathFor(APP_ROOT), 'dist', 'apple-touch-icon.png')
@@ -6573,6 +6580,7 @@ ipcMain.handle('hermes:notify', (_event, payload) => {
     title: payload?.title || 'Hermes',
     body: payload?.body || '',
     silent: Boolean(payload?.silent),
+    icon: getAppIconPath(),
     actions: actions.map(action => ({ type: 'button', text: String(action?.text || '') }))
   })
   notification.on('click', () => {


### PR DESCRIPTION
### Problem

On Windows, the Hermes Desktop app's taskbar icon and toast notification icons appear blank or generic. This is because `APP_ICON_PATHS` only contains `.png` paths (`apple-touch-icon.png`), but Windows Electron ignores PNG in `BrowserWindow({ icon })` and `Notification({ icon })`. The `.ico` file at `assets/icon.ico` is correctly stamped on `Hermes.exe` at build time but is never consulted by the window chrome or notification renderer.

### Changes

**`apps/desktop/electron/main.cjs`** — Prepend `.ico` paths to `APP_ICON_PATHS` on Windows:

```js
...(IS_WINDOWS ? [
  path.join(APP_ROOT, 'assets', 'icon.ico'),
  path.join(unpackedPathFor(APP_ROOT), 'assets', 'icon.ico'),
] : [])
```

Fallback order: `icon.ico` (Windows only) → `apple-touch-icon.png` (macOS/Linux).

Also adds the missing `icon: getAppIconPath()` to the `hermes:notify` IPC handler so Windows toast notifications show the app icon.

### Related

Closes #59400