### PR TITLE
fix(mcp): bound stdio initialize handshake to stop subprocess/FD leak

### DIFF
--- a/tests/tools/test_mcp_stdio_init_timeout.py
+++ b/tests/tools/test_mcp_stdio_init_timeout.py
@@ -1,0 +1,94 @@
+"""Regression test for the stdio-MCP subprocess/FD leak (#59349).
+
+A stdio MCP server that never completes ``initialize`` (e.g. emits a
+non-JSON-RPC frame and then blocks on stdin) used to hang ``_run_stdio``
+forever on the background event loop: ``connect_timeout`` bounded only the
+*caller's* ``.result()`` wait, not the coroutine itself. Because the connect
+never unwound, the cleanup ``finally`` in ``_run_stdio`` never ran, so the
+spawned child process and its stdio pipes / pidfd leaked on *every* discovery
+retry — unbounded, until the gateway hit EMFILE.
+
+The fix wraps ``session.initialize()`` in
+``asyncio.wait_for(..., timeout=connect_timeout)`` so a stalled handshake fails
+instead of hanging, which lets the existing ``finally`` reap the child.
+
+This test drives the *real* ``_run_stdio`` with a fake transport whose
+``initialize()`` hangs, and asserts the connect is bounded by
+``connect_timeout`` rather than blocking forever. It is fully hermetic — no real
+subprocess, no network (the drain-to-zero behaviour was additionally verified
+manually against the reporter's live repro).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("mcp")
+
+
+class _HangingSession:
+    """Stand-in ClientSession whose handshake never completes."""
+
+    async def initialize(self):
+        await asyncio.sleep(3600)
+
+
+class _FakeAsyncCM:
+    """Minimal async context manager yielding a fixed value; spawns nothing."""
+
+    def __init__(self, value):
+        self._value = value
+
+    async def __aenter__(self):
+        return self._value
+
+    async def __aexit__(self, *_exc):
+        return False
+
+
+def _fake_stdio_client(*_args, **_kwargs):
+    # `async with stdio_client(...) as (read, write)` — no subprocess spawned.
+    return _FakeAsyncCM((object(), object()))
+
+
+def _fake_client_session(*_args, **_kwargs):
+    # `async with ClientSession(...) as session` -> a session that hangs.
+    return _FakeAsyncCM(_HangingSession())
+
+
+class TestStdioInitializeTimeout:
+    def test_hanging_initialize_is_bounded_not_leaked(self):
+        """A stdio server that hangs at ``initialize`` must fail within
+        ``connect_timeout`` — not block ``_run_stdio`` forever (#59349)."""
+        from tools import mcp_tool
+
+        server = mcp_tool.MCPServerTask("leak-guard")
+        config = {"command": "fake-mcp", "args": [], "connect_timeout": 0.2}
+
+        async def drive():
+            with patch.object(mcp_tool, "stdio_client", _fake_stdio_client), \
+                 patch.object(mcp_tool, "ClientSession", _fake_client_session), \
+                 patch.object(mcp_tool, "_resolve_stdio_command", lambda c, e: (c, e)), \
+                 patch.object(mcp_tool, "_write_stderr_log_header", lambda *_a, **_k: None), \
+                 patch.object(mcp_tool, "_get_mcp_stderr_log", lambda: None), \
+                 patch("tools.osv_check.check_package_for_malware",
+                       lambda *_a, **_k: None):
+                start = time.monotonic()
+                # The outer 5s guard exists ONLY so a regression can't hang the
+                # whole suite. With the fix, the inner connect_timeout (0.2s)
+                # fires first; the elapsed assertion below is what actually
+                # distinguishes "bounded" (fixed) from "hung" (regressed).
+                with pytest.raises(asyncio.TimeoutError):
+                    await asyncio.wait_for(server._run_stdio(config), timeout=5.0)
+                return time.monotonic() - start
+
+        elapsed = asyncio.run(drive())
+        assert elapsed < 2.0, (
+            f"_run_stdio blocked {elapsed:.1f}s on a hanging initialize() — the "
+            f"connect_timeout ({config['connect_timeout']}s) bound was not applied; "
+            f"the #59349 subprocess/FD leak has regressed."
+        )

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1995,7 +1995,23 @@ class MCPServerTask:
                 async with ClientSession(
                     read_stream, write_stream, **sampling_kwargs
                 ) as session:
-                    self.initialize_result = await session.initialize()
+                    # Bound the MCP handshake. A stdio server that never
+                    # completes ``initialize`` (e.g. emits a non-JSON-RPC frame
+                    # and then blocks on stdin) otherwise hangs this coroutine
+                    # forever on the background loop: ``connect_timeout`` only
+                    # bounds the caller's ``.result()`` wait, not the coroutine
+                    # itself. Because the connect never unwinds, the cleanup
+                    # ``finally`` below never runs, so the spawned child and its
+                    # stdio pipes/pidfd leak on every discovery retry — unbounded
+                    # until the gateway hits EMFILE. Timing out here converts the
+                    # hang into a normal failure, letting the ``finally`` reap the
+                    # child. See #59349.
+                    connect_timeout = float(
+                        config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
+                    )
+                    self.initialize_result = await asyncio.wait_for(
+                        session.initialize(), timeout=connect_timeout
+                    )
                     self.session = session
                     await self._discover_tools()
                     self._ready.set()


### PR DESCRIPTION
## What does this PR do?

Fixes the unbounded stdio-MCP subprocess + FD leak that ends in `EMFILE`. A stdio MCP server that never completes `initialize` (e.g. emits a non-JSON-RPC frame, then blocks on stdin) is re-spawned by the discovery-retry loop every cycle; each spawned child is never reaped, so the gateway leaks a child + its pipes/pidfd per attempt until it hits the open-file limit and every new `open()`/spawn fails.

## Related Issue

Fixes #59349

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Root cause (confirmed by instrumentation — and it differs from the issue's hypothesis)

I reproduced the leak and instrumented the actual code path rather than guess:

- The spawned child **is** captured (`new_pids` is populated, `_stdio_pids` gets the entry). So the report's candidate #2 ("`new_pids` empty at finally time") is **not** the cause.
- Polling the module globals shows `_stdio_pids` is never popped and `_orphan_stdio_pids` stays empty over time → **`_run_stdio`'s `finally` never runs**.
- Real cause: **`session.initialize()` hangs forever** on the garbage stream. `connect_timeout` only bounds the *caller's* `.result()` wait on the foreground thread — it does **not** cancel the coroutine on the background MCP loop. So `_run_stdio` is stuck at `await session.initialize()` permanently, its cleanup `finally` never executes, and the child stays invisible to the orphan-reaper (whose `_orphan_stdio_pids` set is never populated).

## The fix

Wrap the handshake in a timeout so a stalled `initialize` fails instead of hanging:

```python
connect_timeout = float(config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT))
self.initialize_result = await asyncio.wait_for(session.initialize(), timeout=connect_timeout)
```

The `TimeoutError` unwinds through the SDK context managers (closing the child's stdin → EOF → child exits) and lets the existing `finally` reap any straggler. Cross-platform — `asyncio.wait_for`, no signals/`pgid`/`/proc`.

I deliberately did **not** take the report's suggested fixes (hard-reap child / circuit-breaker / close stdin) — those treat symptoms. Making the connect *fail instead of hang* lets the existing, already-correct cleanup machinery run.

**Scope:** stdio only. The HTTP path has the same `await session.initialize()` shape but spawns no subprocess (so it can't cause this leak) and already has httpx transport timeouts.

## How to Test

Automated (hermetic — no subprocess/network):
```bash
scripts/run_tests.sh tests/tools/test_mcp_stdio_init_timeout.py
```
The added test drives the real `_run_stdio` with a fake transport whose `initialize()` hangs and asserts the connect is bounded by `connect_timeout`. It **fails on the pre-fix code** (blocks ~5s) and **passes on the fix** (~0.2s) — a genuine regression guard.

Manual (the reporter's repro): register a stdio server that prints a non-JSON-RPC frame then blocks on stdin, drive discovery repeatedly. Before: child + FD count grow unbounded. After: bounded — the reconnect loop retries a few times, then parks, and the children **drain to zero**.

Verified locally: reproduced the unbounded leak → confirmed drain-to-zero after the fix; the new regression test passes with the fix / fails without; **566 existing MCP tests pass**; ruff clean.

> Platform note: I reproduced on **macOS**, where the leak shows as pipe FDs + live children (not the Linux `pidfd` count in the report) — same mechanism. @xclusivesystems offered to validate on Linux against the original repro.

## Checklist

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] I searched existing PRs to make sure this isn't a duplicate (distinct from #11202 / #12430, which targeted the *reconnect* path; this is the *discovery* path)
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant tests and they pass (MCP suite: 566 + new regression test)
- [x] I've added tests for my changes (required for bug fixes)
- [x] Tested on my platform: macOS

### Documentation & Housekeeping
- [x] No docs/config-key/tool-schema changes needed — N/A (internal lifecycle fix)
- [x] Cross-platform impact considered — `asyncio.wait_for`, no POSIX-only primitives