### PR TITLE
feat(gateway): tool-gated reply delivery for free-response WhatsApp groups

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -251,7 +251,15 @@ SILENT_MARKER = "[SILENT]"
 # a marker is the entire response OR appears as its own first/last line — but
 # NOT when a token merely appears mid-sentence in a genuine report (e.g.
 # "I considered staying [SILENT] but here is the summary…" must deliver).
-_CRON_SILENCE_TOKENS = frozenset({"[SILENT]", "SILENT", "NO_REPLY", "NO REPLY"})
+#
+# The token *set* is the canonical one owned by gateway.response_filters
+# (LIVE_GATEWAY_SILENT_MARKERS); only the positional matching below is
+# cron-specific.  Imported lazily so a cron-only import path does not eagerly
+# pull in the gateway package (and so no boot-order import cycle is possible).
+def _cron_silence_tokens() -> frozenset:
+    from gateway.response_filters import LIVE_GATEWAY_SILENT_MARKERS
+
+    return LIVE_GATEWAY_SILENT_MARKERS
 
 
 def _is_cron_silence_response(text: str) -> bool:
@@ -270,7 +278,7 @@ def _is_cron_silence_response(text: str) -> bool:
         return False
 
     def _is_token(line: str) -> bool:
-        return " ".join(line.strip().upper().split()) in _CRON_SILENCE_TOKENS
+        return " ".join(line.strip().upper().split()) in _cron_silence_tokens()
 
     # Whole response is exactly a token.
     if _is_token(stripped):

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -102,6 +102,21 @@ def _normalize_unauthorized_dm_behavior(value: Any, default: str = "pair") -> st
     return default
 
 
+def _normalize_reply_gate_mode(value: Any, default: str = "prompt") -> str:
+    """Normalize the reply-gate mode to a supported value.
+
+    ``"prompt"`` (default) preserves today's deliver-by-default behavior;
+    ``"tool"`` opts a deployment into tool-gated delivery for free-response
+    group turns. Any unrecognized value falls back to ``"prompt"`` so a bad
+    config edit can never silently break delivery.
+    """
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"prompt", "tool"}:
+            return normalized
+    return default
+
+
 def _normalize_notice_delivery(value: Any, default: str = "public") -> str:
     """Normalize notice delivery mode to a supported value."""
     if isinstance(value, str):
@@ -642,6 +657,23 @@ class GatewayConfig:
     # raw passthrough.
     filter_silence_narration: bool = True
 
+    # Reply-gate mode for free-response GROUP turns (see gateway/reply_policy.py
+    # + the reply-gate redesign). "prompt" (default) is today's behavior,
+    # byte-identical: the agent's final free text is delivered unless it matches
+    # a silence marker. "tool" inverts the contract for free-response groups —
+    # the free-text tail is NOT auto-delivered; delivery happens only when the
+    # model calls send_message(target="current"). DMs and mention-gated groups
+    # are unaffected in either mode. config.yaml-only; no HERMES_* env var.
+    reply_gate_mode: str = "prompt"  # "prompt" | "tool"
+    # Fallback ratchet for "tool" mode: while True (default during burn-in), a
+    # tool-mode turn that made zero current-chat tool sends AND whose final text
+    # is a substantive (non-silence-marker) answer still delivers that text —
+    # today's behavior as a safety net so the feature can only remove duplicate/
+    # leaked text, never silently swallow a real answer. Flipping to False (a
+    # deliberate operator decision, out of scope for this change) makes
+    # silence-by-default real.
+    reply_gate_tool_fallback: bool = True
+
     # STT settings
     stt_enabled: bool = True  # Whether to auto-transcribe inbound voice messages
     stt_echo_transcripts: bool = True  # Whether to echo raw STT transcripts back to the user
@@ -768,6 +800,8 @@ class GatewayConfig:
             "write_sessions_json": self.write_sessions_json,
             "always_log_local": self.always_log_local,
             "filter_silence_narration": self.filter_silence_narration,
+            "reply_gate_mode": self.reply_gate_mode,
+            "reply_gate_tool_fallback": self.reply_gate_tool_fallback,
             "stt_enabled": self.stt_enabled,
             "stt_echo_transcripts": self.stt_echo_transcripts,
             "group_sessions_per_user": self.group_sessions_per_user,
@@ -865,6 +899,12 @@ class GatewayConfig:
             always_log_local=_coerce_bool(data.get("always_log_local"), True),
             filter_silence_narration=_coerce_bool(
                 data.get("filter_silence_narration"), True
+            ),
+            reply_gate_mode=_normalize_reply_gate_mode(
+                data.get("reply_gate_mode"), "prompt"
+            ),
+            reply_gate_tool_fallback=_coerce_bool(
+                data.get("reply_gate_tool_fallback"), True
             ),
             stt_enabled=_coerce_bool(stt_enabled, True),
             stt_echo_transcripts=_coerce_bool(stt_echo_transcripts, True),
@@ -1021,6 +1061,13 @@ def load_gateway_config() -> GatewayConfig:
             if "filter_silence_narration" in yaml_cfg:
                 gw_data["filter_silence_narration"] = yaml_cfg[
                     "filter_silence_narration"
+                ]
+
+            if "reply_gate_mode" in yaml_cfg:
+                gw_data["reply_gate_mode"] = yaml_cfg["reply_gate_mode"]
+            if "reply_gate_tool_fallback" in yaml_cfg:
+                gw_data["reply_gate_tool_fallback"] = yaml_cfg[
+                    "reply_gate_tool_fallback"
                 ]
 
             if "unauthorized_dm_behavior" in yaml_cfg:

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -614,6 +614,78 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     resp.status_code, code,
                 )
 
+    # ------------------------------------------------------------------ reactions
+
+    async def add_reaction(
+        self,
+        chat_id: str,
+        emoji: str,
+        message_id: Optional[str] = None,
+    ) -> bool:
+        """React to a message with an emoji via the Cloud API reaction type.
+
+        ``message_id`` is the target message's wamid; when omitted the most
+        recent inbound wamid for the chat is used (same cache as read receipts).
+        Returns True when Meta accepts the reaction.
+        """
+        return await self._post_reaction(chat_id, message_id, emoji)
+
+    async def remove_reaction(
+        self,
+        chat_id: str,
+        message_id: Optional[str] = None,
+    ) -> bool:
+        """Retract a reaction (Cloud API: send an empty-emoji reaction)."""
+        return await self._post_reaction(chat_id, message_id, "")
+
+    async def _post_reaction(
+        self,
+        chat_id: str,
+        message_id: Optional[str],
+        emoji: str,
+    ) -> bool:
+        """POST a ``type=reaction`` message to the Graph API.
+
+        An empty ``emoji`` retracts a previously-added reaction, per Meta's
+        reaction-message contract.  Best-effort: any error returns False so a
+        reaction never blocks the main reply path.
+        """
+        if self._http_client is None:
+            return False
+        target = message_id or self._last_inbound_wamid_by_chat.get(chat_id)
+        if not target:
+            return False
+
+        url = self._graph_url("messages")
+        headers = {
+            "Authorization": f"Bearer {self._access_token}",
+            "Content-Type": "application/json",
+        }
+        payload: Dict[str, Any] = {
+            "messaging_product": "whatsapp",
+            "recipient_type": "individual",
+            "to": chat_id,
+            "type": "reaction",
+            "reaction": {"message_id": target, "emoji": emoji},
+        }
+        try:
+            resp = await self._http_client.post(url, headers=headers, json=payload)
+        except Exception:
+            logger.exception("[whatsapp_cloud] reaction failed")
+            return False
+        if resp.status_code != 200:
+            try:
+                body = resp.json()
+            except Exception:
+                body = {"raw": resp.text[:500]}
+            logger.warning(
+                "[whatsapp_cloud] reaction rejected (status=%d): %s",
+                resp.status_code,
+                self._format_graph_error(body, resp.status_code),
+            )
+            return False
+        return True
+
     # ------------------------------------------------------------------ interactive messages
     #
     # WhatsApp Cloud supports two interactive primitives we use here:

--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -125,6 +125,26 @@ class WhatsAppBehaviorMixin:
             return {str(part).strip() for part in raw if str(part).strip()}
         return {part.strip() for part in str(raw).split(",") if part.strip()}
 
+    def _resolve_whatsapp_reply_policy(self, data: Dict[str, Any]):
+        """Classify the inbound event's reply policy (read-only, for delivery).
+
+        Reads the SAME two config knobs the group branch of
+        ``_should_process_message`` consults — ``free_response_chats`` membership
+        and ``require_mention`` — and returns a :class:`ReplyPolicy`. Does not
+        affect ingestion; the ingestion gate is untouched. Stamped onto the
+        outbound event's ``SessionSource`` so the post-turn delivery block can
+        decide whether the tool-gated inversion applies.
+        """
+        from gateway.reply_policy import resolve_reply_policy
+
+        is_group = bool(data.get("isGroup", False))
+        chat_id = str(data.get("chatId") or "")
+        return resolve_reply_policy(
+            is_group=is_group,
+            in_free_response_set=chat_id in self._whatsapp_free_response_chats(),
+            require_mention=self._whatsapp_require_mention(),
+        )
+
     @staticmethod
     def _coerce_allow_list(raw) -> set[str]:
         """Parse allow_from / group_allow_from from config or env var."""

--- a/gateway/reply_policy.py
+++ b/gateway/reply_policy.py
@@ -1,0 +1,60 @@
+"""Platform-agnostic reply-policy classification for gateway turns.
+
+A single enum-valued policy, resolved once per inbound event from the same
+config knobs each adapter's ``_should_process_message`` ingestion gate already
+consults (``require_mention`` / ``free_response_*``), and carried on the
+event's :class:`~gateway.session.SessionSource` metadata into the post-turn
+delivery block.
+
+This is a READ-ONLY classification for the *delivery* layer — it does not
+touch any adapter's ingestion gate. The default (no group signal) is
+:attr:`ReplyPolicy.DM`, the safe value that makes partial platform rollout
+non-breaking: an unstamped event never triggers the tool-gated delivery
+inversion.
+"""
+
+from enum import Enum
+
+
+class ReplyPolicy(str, Enum):
+    """How the delivery layer should treat an inbound turn.
+
+    - ``DM``            — a direct message (or any non-group turn). Deliver by
+                          default; never gated.
+    - ``MENTION_GATED`` — a group that only processes messages that mention the
+                          bot. Ingestion already gated it, so there is no
+                          reply-ambiguity to solve; deliver by default.
+    - ``FREE_RESPONSE`` — a group the bot listens to freely (``require_mention``
+                          off, or the chat is in the platform's
+                          ``free_response_*`` set). The ambiguous class the
+                          reply gate targets.
+    """
+
+    DM = "dm"
+    MENTION_GATED = "mention_gated"
+    FREE_RESPONSE = "free_response"
+
+
+def resolve_reply_policy(
+    *,
+    is_group: bool,
+    in_free_response_set: bool,
+    require_mention: bool,
+) -> ReplyPolicy:
+    """Classify a turn from the three inputs every mention/free-response gate reads.
+
+    Mirrors the group branch of the adapters' ``_should_process_message`` as a
+    value instead of a control-flow decision:
+
+    - not a group                         -> ``DM``
+    - group, in the free-response set      -> ``FREE_RESPONSE``
+    - group, ``require_mention`` is false  -> ``FREE_RESPONSE``
+    - group, ``require_mention`` is true   -> ``MENTION_GATED``
+    """
+    if not is_group:
+        return ReplyPolicy.DM
+    if in_free_response_set:
+        return ReplyPolicy.FREE_RESPONSE
+    if not require_mention:
+        return ReplyPolicy.FREE_RESPONSE
+    return ReplyPolicy.MENTION_GATED

--- a/gateway/response_filters.py
+++ b/gateway/response_filters.py
@@ -16,6 +16,14 @@ SILENT_REPLY_TOKEN = "NO_REPLY"
 # Exact whole-response markers that mean "the agent intentionally chose not to
 # reply".  Keep this list small and explicit; arbitrary empty output remains an
 # error/empty-response path, not silence.
+#
+# Canonical silence vocabulary: this is the single source of truth for the
+# silence-marker token set.  ``cron/scheduler.py`` imports it (lazily, to avoid
+# eagerly pulling the gateway package into cron-only import paths) rather than
+# maintaining its own copy — the two suppression paths must never drift.  The
+# *matching* rules differ (the live gateway requires an exact whole response;
+# cron also accepts a marker on its own first/last line), but the token set is
+# shared.
 LIVE_GATEWAY_SILENT_MARKERS = frozenset({
     "[SILENT]",
     "SILENT",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -961,7 +961,11 @@ def _resume_reason_phrase(reason: Optional[str]) -> str:
     return "a gateway interruption"
 
 
-def _build_interruption_system_note(reason: Optional[str], has_new_message: bool) -> str:
+def _build_interruption_system_note(
+    reason: Optional[str],
+    has_new_message: bool,
+    group_mode: bool = False,
+) -> str:
     """Build the ``[System note: ...]`` resume/recovery text.
 
     Centralizes the two near-duplicate resume-note construction sites (the
@@ -970,10 +974,24 @@ def _build_interruption_system_note(reason: Optional[str], has_new_message: bool
     ``reason`` is the session's ``resume_reason`` marker; ``has_new_message``
     selects the guidance clause — address the user's new message, or (for the
     synthesized empty auto-resume turn) report recovery and ask what's next.
+
+    ``group_mode`` (True when the turn's reply policy is not ``dm``) swaps the
+    recovery guidance for owner-routing guidance: the model must NOT narrate the
+    restart/interruption into a shared group; any recovery/status report goes to
+    the owner's private channel via ``send_message``. Defaults to False so DM
+    output is byte-identical to before this variant existed.
+
     Returns only the bracketed note; the caller appends any real message.
     """
     phrase = _resume_reason_phrase(reason)
-    if has_new_message:
+    if group_mode:
+        guidance = (
+            "Recovery context only — do NOT narrate this restart/interruption "
+            "into the group. If the new message below needs a substantive "
+            "reply, answer it normally; send any recovery/status report to the "
+            "owner's private channel via send_message if needed."
+        )
+    elif has_new_message:
         guidance = (
             "Address the user's NEW message below FIRST and focus "
             "on what the user is asking now."
@@ -11369,12 +11387,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 _intentional_silence = False
 
+            # Reply-gate (tool mode): in free-response GROUP turns under
+            # reply_gate_mode="tool", the agent's free-text tail is NOT
+            # auto-delivered — delivery happens only via a
+            # send_message(target="current") tool call during the turn (see
+            # gateway/reply_policy.py + the reply-gate redesign). Computed once
+            # here; consumed by the delivery-suppression branch below and by the
+            # `and not tool_gated` guards on the normalizer/footer/voice paths.
+            # DMs, mention-gated groups, and prompt mode all leave `tool_gated`
+            # False, so the entire branch is inert (default-OFF, byte-identical
+            # to today) for anyone who has not opted in.
+            _reply_policy = getattr(source, "reply_policy", None)
+            tool_gated = self._is_reply_tool_gated(source)
+            # Turn-scoped count of current-chat tool deliveries (send_message
+            # target="current"); read back off the shared source object the tool
+            # mutated during the turn. Drives dedup regardless of tool_gated.
+            _tool_send_count = int(getattr(source, "reply_gate_tool_sends", 0) or 0)
+            _delivered_via_tool = _tool_send_count > 0
+            # Was the RAW final text (before empty-normalization) a substantive
+            # answer? Gates the fallback ratchet so it never rescues an empty
+            # tail into a manufactured placeholder.
+            _had_substantive_tail = bool(response.strip()) and not _intentional_silence
+
             # Convert the agent's internal "(empty)" sentinel into a
             # user-friendly message.  "(empty)" means the model failed to
             # produce visible content after exhausting all retries (nudge,
             # prefill, empty-retry, fallback).  Sending the raw sentinel
             # looks like a bug; a short explanation is more helpful.
-            if response == "(empty)" and not _intentional_silence:
+            if response == "(empty)" and not _intentional_silence and not tool_gated:
                 response = (
                     "⚠️ The model returned no response after processing tool "
                     "results. This can happen with some models — try again or "
@@ -11418,9 +11458,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Normalize empty responses: surface errors, partial failures, and
             # the case where agent did work but returned no text. Fix for #18765.
             if not _intentional_silence:
-                response = _normalize_empty_agent_response(
-                    agent_result, response, history_len=len(history),
-                )
+                # Skip the empty→placeholder normalizer for tool-gated turns so a
+                # suppressed tail is never turned into a visible "no response"
+                # message; sanitization still runs so any fallback-delivered tail
+                # is cleaned exactly as in prompt mode.
+                if not tool_gated:
+                    response = _normalize_empty_agent_response(
+                        agent_result, response, history_len=len(history),
+                    )
                 response = _sanitize_gateway_final_response(source.platform, response)
 
             # Ordering contract: the agent thread already updated the contextvar
@@ -11522,7 +11567,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)
                 _footer_line = ""
-            if _footer_line and response and not agent_result.get("already_sent") and not _intentional_silence:
+            if _footer_line and response and not agent_result.get("already_sent") and not _intentional_silence and not tool_gated:
                 response = f"{response}\n\n{_footer_line}"
 
             # Emit agent:end hook
@@ -11842,9 +11887,51 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 response = ""
 
+            # Reply-gate tool-mode delivery decision. Fires only for
+            # free-response group turns under reply_gate_mode="tool"
+            # (`tool_gated`), OR whenever a current-chat tool send already
+            # delivered this turn (`_delivered_via_tool` — the dedup guard, which
+            # applies independently of the mode). This runs AFTER transcript
+            # persistence (above) and only suppresses platform delivery, never
+            # the transcript — mirroring the intentional-silence contract.
+            if tool_gated or _delivered_via_tool:
+                if _delivered_via_tool:
+                    # Dedup (defense in depth): a tool-driven send already
+                    # delivered to this chat, so the free-text tail must never
+                    # ALSO auto-deliver — a duplicate is always wrong.
+                    _reply_gate_suppress = True
+                    _reply_gate_fallback = False
+                elif not _had_substantive_tail:
+                    # Empty or silence-marker tail with no tool send — nothing to
+                    # deliver (a marker was already wiped just above).
+                    _reply_gate_suppress = True
+                    _reply_gate_fallback = False
+                elif getattr(self.config, "reply_gate_tool_fallback", True):
+                    # Fallback ratchet (Phase-1 safety): a substantive answer was
+                    # produced but no tool send happened — still deliver it
+                    # (today's behavior) so the feature can only remove duplicate/
+                    # leaked text, never silently swallow a real reply.
+                    _reply_gate_suppress = False
+                    _reply_gate_fallback = True
+                else:
+                    _reply_gate_suppress = True
+                    _reply_gate_fallback = False
+                logger.info(
+                    "reply_gate: tool-mode session=%s policy=%s chars=%d "
+                    "tool_sends=%d suppressed=%s fallback=%d",
+                    session_entry.session_id,
+                    getattr(_reply_policy, "value", _reply_policy),
+                    len(response),
+                    _tool_send_count,
+                    _reply_gate_suppress,
+                    int(_reply_gate_fallback),
+                )
+                if _reply_gate_suppress:
+                    response = ""
+
             # Auto voice reply: send TTS audio before the text response
             _already_sent = bool(agent_result.get("already_sent"))
-            if self._should_send_voice_reply(event, response, agent_messages, already_sent=_already_sent):
+            if not tool_gated and self._should_send_voice_reply(event, response, agent_messages, already_sent=_already_sent):
                 await self._send_voice_reply(event, response)
 
             # If streaming already delivered the response, extract and
@@ -12746,6 +12833,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
 
         await adapter.handle_message(event)
+
+    def _is_reply_tool_gated(self, source) -> bool:
+        """True when the tool-gated delivery inversion applies to this turn.
+
+        The single predicate: ``reply_gate_mode == "tool"`` AND the turn is a
+        free-response group (``source.reply_policy == FREE_RESPONSE``). In that
+        case the agent's free-text tail is NOT auto-delivered — delivery happens
+        only via ``send_message(target="current")``. False for DMs, mention-gated
+        groups, and prompt mode (the default), so the mechanism is inert unless a
+        deployment opts in. Consumed by both the post-turn delivery block and the
+        streaming-eligibility gate (streamed text IS delivery).
+        """
+        if getattr(self.config, "reply_gate_mode", "prompt") != "tool":
+            return False
+        from gateway.reply_policy import ReplyPolicy
+        return getattr(source, "reply_policy", None) == ReplyPolicy.FREE_RESPONSE
 
     def _should_send_voice_reply(
         self,
@@ -16289,6 +16392,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _plat_streaming is None
             else bool(_plat_streaming)
         )
+        # Tool-gated free-response group turns must not stream (streamed text IS
+        # delivery, bypassing the reply gate).
+        if _streaming_enabled and self._is_reply_tool_gated(source):
+            _streaming_enabled = False
 
         _thread_metadata: Optional[Dict[str, Any]] = self._thread_metadata_for_source(source, event_message_id)
 
@@ -17612,6 +17719,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if _plat_streaming is None
                 else bool(_plat_streaming)
             )
+            # Tool-gated free-response group turns must not stream the final text
+            # — streamed text IS delivery, which would bypass the reply gate.
+            if _streaming_enabled and self._is_reply_tool_gated(source):
+                _streaming_enabled = False
             _want_stream_deltas = _streaming_enabled
             _want_interim_messages = interim_assistant_messages_enabled
             _want_interim_consumer = _want_interim_messages
@@ -18131,7 +18242,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # to the user immediately.
             from tools.approval import (
                 register_gateway_notify,
+                reset_current_message_source,
                 reset_current_session_key,
+                set_current_message_source,
                 set_current_session_key,
                 unregister_gateway_notify,
             )
@@ -18306,6 +18419,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 has_fresh_tool_tail=_has_fresh_tool_tail,
                 message_is_empty=not (isinstance(message, str) and message.strip()),
             )
+            # Group turns (reply policy != dm) must not narrate recovery into the
+            # shared chat — route the recovery report to the owner instead.
+            from gateway.reply_policy import ReplyPolicy as _ReplyPolicy
+            _group_recovery = (
+                getattr(source, "reply_policy", _ReplyPolicy.DM) != _ReplyPolicy.DM
+            )
             if _note_kind == "resume":
                 _reason = getattr(_resume_entry, "resume_reason", None) or "restart_timeout"
                 _persist_user_message_override = message
@@ -18314,7 +18433,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # no NEW user message to address, so tell the model to report
                 # recovery instead of the (nonexistent) "new message".
                 message = _build_interruption_system_note(
-                    _reason, has_new_message=bool(message)
+                    _reason, has_new_message=bool(message), group_mode=_group_recovery,
                 ) + (f"\n\n{message}" if message else "")
             elif _note_kind == "tool_tail":
                 _persist_user_message_override = message
@@ -18350,11 +18469,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     getattr(_resume_entry, "resume_reason", None) or "restart_timeout"
                 )
                 message = _build_interruption_system_note(
-                    _sn_reason, has_new_message=False
+                    _sn_reason, has_new_message=False, group_mode=_group_recovery,
                 )
 
             _approval_session_key = session_key or ""
             _approval_session_token = set_current_session_key(_approval_session_key)
+            # Bind the inbound source for this turn so send_message(target="current")
+            # can resolve the originating chat. Same lifetime + crash-safety as the
+            # session-key registration (reset in the finally below). Zero the
+            # per-turn tool-send counter first so a reused source object never
+            # carries a stale count into a new turn.
+            try:
+                source.reply_gate_tool_sends = 0
+            except Exception:
+                pass
+            _message_source_token = set_current_message_source(source)
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
             try:
                 # If _prepare_inbound_message_text buffered image paths for native
@@ -18416,6 +18545,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 except Exception:
                     pass
                 reset_current_session_key(_approval_session_token)
+                reset_current_message_source(_message_source_token)
             result_holder[0] = result
 
             # Signal the stream consumer that the agent is done

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -952,6 +952,94 @@ def _last_transcript_timestamp(history: Optional[List[Dict[str, Any]]]) -> Any:
     return None
 
 
+def _resume_reason_phrase(reason: Optional[str]) -> str:
+    """Map a session ``resume_reason`` marker to its human-readable phrase."""
+    if reason == "restart_timeout":
+        return "a gateway restart"
+    if reason == "shutdown_timeout":
+        return "a gateway shutdown"
+    return "a gateway interruption"
+
+
+def _build_interruption_system_note(reason: Optional[str], has_new_message: bool) -> str:
+    """Build the ``[System note: ...]`` resume/recovery text.
+
+    Centralizes the two near-duplicate resume-note construction sites (the
+    primary ``resume_pending`` branch and the empty-message safety net) so a
+    future wording change or group-mode variant only needs one edit point.
+    ``reason`` is the session's ``resume_reason`` marker; ``has_new_message``
+    selects the guidance clause — address the user's new message, or (for the
+    synthesized empty auto-resume turn) report recovery and ask what's next.
+    Returns only the bracketed note; the caller appends any real message.
+    """
+    phrase = _resume_reason_phrase(reason)
+    if has_new_message:
+        guidance = (
+            "Address the user's NEW message below FIRST and focus "
+            "on what the user is asking now."
+        )
+    else:
+        guidance = (
+            "Report to the user that the session was restored "
+            "successfully and ask what they would like to do next."
+        )
+    return (
+        f"[System note: The previous turn was interrupted by "
+        f"{phrase}; the gateway is now back online. "
+        f"Any restart/shutdown command in the history has already "
+        f"run — do NOT re-execute or verify it. {guidance} "
+        f"Do NOT re-execute old tool calls — skip any unfinished "
+        f"work from the conversation history.]"
+    )
+
+
+def _build_tool_tail_system_note() -> str:
+    """Build the ``[System note: ...]`` text for the interrupted-tool-tail case.
+
+    Distinct wording from :func:`_build_interruption_system_note`: there is no
+    restart/shutdown reason, only pending tool outputs to ignore in favour of
+    the user's new message.  Returns only the bracketed note.
+    """
+    return (
+        "[System note: A new message has arrived. The conversation "
+        "history contains pending tool outputs from an interrupted turn. "
+        "IGNORE those pending results. Address the user's NEW message "
+        "below FIRST. Do NOT re-execute old tool calls from the history.]"
+    )
+
+
+def _resolve_resume_note_kind(
+    is_resume_pending: bool,
+    has_fresh_tool_tail: bool,
+    message_is_empty: bool,
+) -> str:
+    """Classify which auto-continue system note applies to an inbound turn.
+
+    Formalizes the historical ``if/elif/if`` dispatch at the inbound
+    auto-continue site into one table-testable predicate:
+
+    - ``"resume"``     — a fresh ``resume_pending`` session: emit the
+                         reason-aware resume/recovery note.
+    - ``"tool_tail"``  — no fresh resume mark, but the transcript ends in a
+                         fresh interrupted tool result.
+    - ``"safety_net"`` — neither fresh signal fired yet the turn carries an
+                         empty message; the caller still guards this on the raw
+                         ``resume_pending`` marker so a legitimately empty
+                         non-resume turn (e.g. a captionless image) is untouched.
+    - ``"none"``       — ordinary turn; no system note.
+
+    The ``safety_net`` vs ``resume`` split is the "two freshness signals
+    disagree" edge case documented inline at the call site.
+    """
+    if is_resume_pending:
+        return "resume"
+    if has_fresh_tool_tail:
+        return "tool_tail"
+    if message_is_empty:
+        return "safety_net"
+    return "none"
+
+
 # Tool results can contain literal MEDIA: examples in docs, logs, or other
 # ordinary outputs. Only tools that intentionally create deliverable media
 # artifacts should be eligible for automatic append when the model omits them
@@ -18213,48 +18301,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 and _interruption_is_fresh
             )
 
-            if _is_resume_pending:
+            _note_kind = _resolve_resume_note_kind(
+                is_resume_pending=_is_resume_pending,
+                has_fresh_tool_tail=_has_fresh_tool_tail,
+                message_is_empty=not (isinstance(message, str) and message.strip()),
+            )
+            if _note_kind == "resume":
                 _reason = getattr(_resume_entry, "resume_reason", None) or "restart_timeout"
-                _reason_phrase = (
-                    "a gateway restart"
-                    if _reason == "restart_timeout"
-                    else "a gateway shutdown"
-                    if _reason == "shutdown_timeout"
-                    else "a gateway interruption"
-                )
                 _persist_user_message_override = message
                 # The empty-message case is the auto-resume startup turn
                 # synthesized by _schedule_resume_pending_sessions — there is
                 # no NEW user message to address, so tell the model to report
                 # recovery instead of the (nonexistent) "new message".
-                if message:
-                    _resume_guidance = (
-                        "Address the user's NEW message below FIRST and focus "
-                        "on what the user is asking now."
-                    )
-                else:
-                    _resume_guidance = (
-                        "Report to the user that the session was restored "
-                        "successfully and ask what they would like to do next."
-                    )
-                message = (
-                    f"[System note: The previous turn was interrupted by "
-                    f"{_reason_phrase}; the gateway is now back online. "
-                    f"Any restart/shutdown command in the history has already "
-                    f"run — do NOT re-execute or verify it. {_resume_guidance} "
-                    f"Do NOT re-execute old tool calls — skip any unfinished "
-                    f"work from the conversation history.]"
-                    + (f"\n\n{message}" if message else "")
-                )
-            elif _has_fresh_tool_tail:
+                message = _build_interruption_system_note(
+                    _reason, has_new_message=bool(message)
+                ) + (f"\n\n{message}" if message else "")
+            elif _note_kind == "tool_tail":
                 _persist_user_message_override = message
-                message = (
-                    "[System note: A new message has arrived. The conversation "
-                    "history contains pending tool outputs from an interrupted turn. "
-                    "IGNORE those pending results. Address the user's NEW message "
-                    "below FIRST. Do NOT re-execute old tool calls from the history.]\n\n"
-                    + message
-                )
+                message = _build_tool_tail_system_note() + "\n\n" + message
 
             # Consume one-shot /reload-skills note (if the user ran
             # /reload-skills since their last turn in this session). Same
@@ -18285,22 +18349,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _sn_reason = (
                     getattr(_resume_entry, "resume_reason", None) or "restart_timeout"
                 )
-                _sn_reason_phrase = (
-                    "a gateway restart"
-                    if _sn_reason == "restart_timeout"
-                    else "a gateway shutdown"
-                    if _sn_reason == "shutdown_timeout"
-                    else "a gateway interruption"
-                )
-                message = (
-                    f"[System note: The previous turn was interrupted by "
-                    f"{_sn_reason_phrase}; the gateway is now back online. "
-                    f"Any restart/shutdown command in the history has already "
-                    f"run — do NOT re-execute or verify it. Report to the user "
-                    f"that the session was restored successfully and ask what "
-                    f"they would like to do next. Do NOT re-execute old tool "
-                    f"calls — skip any unfinished work from the conversation "
-                    f"history.]"
+                message = _build_interruption_system_note(
+                    _sn_reason, has_new_message=False
                 )
 
             _approval_session_key = session_key or ""

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -19,6 +19,8 @@ from datetime import datetime, timedelta
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Any
 
+from gateway.reply_policy import ReplyPolicy
+
 logger = logging.getLogger(__name__)
 
 
@@ -168,6 +170,18 @@ class SessionSource:
     # deliberately excluded from ``to_dict``/``from_dict`` so a peer can never
     # forge it across the wire or have it restored from persistence.
     delivered_via_upstream_relay: bool = False
+
+    # Reply-gate metadata (wire-INVISIBLE; deliberately excluded from
+    # to_dict/from_dict). `reply_policy` is stamped once per inbound event by
+    # the platform adapter (default DM = the safe value for unstamped events /
+    # partial platform rollout) and read by the post-turn delivery block to
+    # decide whether the tool-gated delivery inversion applies.
+    # `reply_gate_tool_sends` is a turn-scoped counter incremented when the
+    # agent delivers to THIS chat via send_message(target="current"); the
+    # post-turn block reads it to dedup the free-text tail. Both are per-turn
+    # runtime state, never persisted or sent across the wire.
+    reply_policy: ReplyPolicy = ReplyPolicy.DM
+    reply_gate_tool_sends: int = 0
 
     def __post_init__(self) -> None:
         # D-Q2.5 dual-field reconciliation: `scope_id` is canonical, `guild_id`

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1419,7 +1419,10 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 user_id=data.get("senderId"),
                 user_name=data.get("senderName"),
             )
-            
+            # Stamp the reply policy for the delivery layer (read-only classification
+            # mirroring the ingestion gate's mention/free-response knobs).
+            source.reply_policy = self._resolve_whatsapp_reply_policy(data)
+
             # Download media URLs to the local cache so agent tools
             # can access them reliably regardless of URL expiration.
             raw_urls = data.get("mediaUrls", [])

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1202,7 +1202,63 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 pass
         except Exception:
             pass  # Ignore typing indicator failures
-    
+
+    async def add_reaction(
+        self,
+        chat_id: str,
+        emoji: str,
+        message_id: Optional[str] = None,
+    ) -> bool:
+        """React to a message with an emoji via the bridge's ``/react`` endpoint.
+
+        ``message_id`` is the id of the message to react to; when omitted the
+        bridge targets the most recent message in the chat.  Returns True when
+        the bridge accepts the reaction.
+        """
+        return await self._post_reaction(chat_id, message_id, emoji)
+
+    async def remove_reaction(
+        self,
+        chat_id: str,
+        message_id: Optional[str] = None,
+    ) -> bool:
+        """Retract a reaction (WhatsApp: send an empty-emoji react)."""
+        return await self._post_reaction(chat_id, message_id, "")
+
+    async def _post_reaction(
+        self,
+        chat_id: str,
+        message_id: Optional[str],
+        emoji: str,
+    ) -> bool:
+        """POST a reaction to the bridge's ``/react`` endpoint.
+
+        An empty ``emoji`` retracts a previously-added reaction, matching the
+        Baileys ``{react: {text: ''}}`` protocol.  Mirrors the transport shape
+        of the other bridge calls (loopback POST, managed-bridge exit guard).
+        """
+        if not self._running or not self._http_session:
+            return False
+        if await self._check_managed_bridge_exit():
+            return False
+        try:
+            import aiohttp
+
+            payload: Dict[str, Any] = {
+                "chatId": to_whatsapp_jid(chat_id),
+                "emoji": emoji,
+            }
+            if message_id:
+                payload["messageId"] = message_id
+            async with self._http_session.post(
+                f"http://127.0.0.1:{self._bridge_port}/react",
+                json=payload,
+                timeout=aiohttp.ClientTimeout(total=15),
+            ) as resp:
+                return resp.status == 200
+        except Exception:
+            return False
+
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Get information about a WhatsApp chat."""
         if not self._running or not self._http_session:

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -944,6 +944,39 @@ app.post('/send-location', async (req, res) => {
   }
 });
 
+// React to a message with an emoji (an empty emoji retracts the reaction).
+app.post('/react', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+
+  const { chatId, messageId, emoji } = req.body;
+  if (!chatId) {
+    return res.status(400).json({ error: 'chatId is required' });
+  }
+
+  try {
+    let key;
+    if (messageId) {
+      // Prefer the full stored key (carries fromMe/participant) so a reaction
+      // on an inbound group message targets the right message; fall back to a
+      // minimal key when the message predates the bounded store.
+      const stored = messageStore.get(messageId);
+      key = stored?.key || { remoteJid: chatId, id: messageId, fromMe: false };
+    } else {
+      const latest = messageStore.latestForChat(chatId);
+      if (!latest) {
+        return res.status(404).json({ error: 'No recent message to react to in this chat' });
+      }
+      key = latest.key;
+    }
+    const sent = await sendWithTimeout(chatId, { react: { text: emoji || '', key } });
+    res.json({ success: true, messageId: sent?.key?.id });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // Typing indicator
 app.post('/typing', async (req, res) => {
   if (!sock || connectionState !== 'connected') {

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -62,7 +62,18 @@ export function createBoundedMessageStore(limit = 512) {
     return msg;
   }
 
-  return { remember, get };
+  function latestForChat(chatId) {
+    if (!chatId) return null;
+    // Map preserves insertion order; walk newest-first for the most recent
+    // remembered message in this chat (used to react without an explicit id).
+    const entries = Array.from(byId.values());
+    for (let i = entries.length - 1; i >= 0; i -= 1) {
+      if (entries[i]?.key?.remoteJid === chatId) return entries[i];
+    }
+    return null;
+  }
+
+  return { remember, get, latestForChat };
 }
 
 export function pollCreationMessageSecret(pollCreation) {

--- a/scripts/whatsapp-bridge/message_store.test.mjs
+++ b/scripts/whatsapp-bridge/message_store.test.mjs
@@ -1,0 +1,35 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createBoundedMessageStore } from './bridge_helpers.js';
+
+const msg = (id, remoteJid) => ({ key: { id, remoteJid } });
+
+test('latestForChat returns the most recent remembered message for a chat', () => {
+  const store = createBoundedMessageStore(8);
+  store.remember(msg('a1', 'chatA@s.whatsapp.net'));
+  store.remember(msg('b1', 'chatB@s.whatsapp.net'));
+  store.remember(msg('a2', 'chatA@s.whatsapp.net'));
+
+  assert.equal(store.latestForChat('chatA@s.whatsapp.net').key.id, 'a2');
+  assert.equal(store.latestForChat('chatB@s.whatsapp.net').key.id, 'b1');
+});
+
+test('latestForChat returns null for an unknown chat or falsy id', () => {
+  const store = createBoundedMessageStore(8);
+  store.remember(msg('a1', 'chatA@s.whatsapp.net'));
+
+  assert.equal(store.latestForChat('nobody@s.whatsapp.net'), null);
+  assert.equal(store.latestForChat(''), null);
+  assert.equal(store.latestForChat(undefined), null);
+});
+
+test('latestForChat follows re-remembered ordering', () => {
+  const store = createBoundedMessageStore(8);
+  store.remember(msg('a1', 'chatA@s.whatsapp.net'));
+  store.remember(msg('a2', 'chatA@s.whatsapp.net'));
+  // Re-remembering a1 moves it to the newest position (Map delete+set).
+  store.remember(msg('a1', 'chatA@s.whatsapp.net'));
+
+  assert.equal(store.latestForChat('chatA@s.whatsapp.net').key.id, 'a1');
+});

--- a/tests/gateway/test_reply_gate_tool_mode.py
+++ b/tests/gateway/test_reply_gate_tool_mode.py
@@ -1,0 +1,366 @@
+"""Reply-gate tool-mode delivery inversion (Phase 1).
+
+Covers the tool-gated delivery mechanism, the fallback ratchet, the
+ReplyPolicy resolver, target="current" addressing, and the group-mode
+interruption note. The feature is config-flagged OFF by default
+(reply_gate_mode="prompt"); these tests assert that opting in flips delivery
+only for free-response GROUP turns and leaves DMs / mention-gated groups /
+prompt mode byte-identical.
+"""
+
+import json
+import logging
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin
+from gateway.reply_policy import ReplyPolicy, resolve_reply_policy
+from gateway.run import _build_interruption_system_note
+from gateway.session import SessionEntry, SessionSource
+from tools import approval
+from tools.send_message_tool import _handle_send
+
+
+# --------------------------------------------------------------------------- #
+# ReplyPolicy resolver (T-POL)
+# --------------------------------------------------------------------------- #
+
+
+class _FakeWhatsApp(WhatsAppBehaviorMixin):
+    """Minimal mixin host driven by a real PlatformConfig (config-propagation)."""
+
+    def __init__(self, extra):
+        self.config = PlatformConfig(enabled=True, extra=extra)
+
+
+def _wa_reply_policy(extra, data):
+    return _FakeWhatsApp(extra)._resolve_whatsapp_reply_policy(data)
+
+
+def test_resolver_pure_matrix():
+    assert resolve_reply_policy(
+        is_group=False, in_free_response_set=False, require_mention=True
+    ) == ReplyPolicy.DM
+    assert resolve_reply_policy(
+        is_group=True, in_free_response_set=True, require_mention=True
+    ) == ReplyPolicy.FREE_RESPONSE
+    assert resolve_reply_policy(
+        is_group=True, in_free_response_set=False, require_mention=False
+    ) == ReplyPolicy.FREE_RESPONSE
+    assert resolve_reply_policy(
+        is_group=True, in_free_response_set=False, require_mention=True
+    ) == ReplyPolicy.MENTION_GATED
+
+
+def test_whatsapp_matrix_via_real_config():
+    # T-POL-1: free_response_chats member (even with require_mention on) →
+    # FREE_RESPONSE. Driven through the real mixin config parsers, not a mock.
+    assert _wa_reply_policy(
+        {"require_mention": True, "free_response_chats": "123@g.us,999@g.us"},
+        {"isGroup": True, "chatId": "123@g.us"},
+    ) == ReplyPolicy.FREE_RESPONSE
+    # require_mention false → FREE_RESPONSE
+    assert _wa_reply_policy(
+        {"require_mention": False},
+        {"isGroup": True, "chatId": "555@g.us"},
+    ) == ReplyPolicy.FREE_RESPONSE
+    # require_mention true, not in the set → MENTION_GATED
+    assert _wa_reply_policy(
+        {"require_mention": True, "free_response_chats": ["123@g.us"]},
+        {"isGroup": True, "chatId": "555@g.us"},
+    ) == ReplyPolicy.MENTION_GATED
+    # DM → DM
+    assert _wa_reply_policy(
+        {"require_mention": True},
+        {"isGroup": False, "chatId": "111@s.whatsapp.net"},
+    ) == ReplyPolicy.DM
+
+
+def test_unstamped_event_defaults_to_dm():
+    # T-POL-2: a freshly-built source (platform not yet wired) defaults DM, so
+    # the inversion never applies — partial platform rollout is safe.
+    src = SessionSource(platform=Platform.TELEGRAM, chat_id="-1", chat_type="group")
+    assert src.reply_policy == ReplyPolicy.DM
+
+
+# --------------------------------------------------------------------------- #
+# Config flag (T-GATE-5 groundwork)
+# --------------------------------------------------------------------------- #
+
+
+def test_config_defaults_and_coercion():
+    c = GatewayConfig()
+    assert c.reply_gate_mode == "prompt"
+    assert c.reply_gate_tool_fallback is True
+    # garbage → prompt (never raise on bad config)
+    assert GatewayConfig.from_dict({"reply_gate_mode": "bogus"}).reply_gate_mode == "prompt"
+    assert GatewayConfig.from_dict({"reply_gate_mode": "TOOL"}).reply_gate_mode == "tool"
+    rt = GatewayConfig.from_dict(
+        {"reply_gate_mode": "tool", "reply_gate_tool_fallback": False}
+    )
+    assert (rt.reply_gate_mode, rt.reply_gate_tool_fallback) == ("tool", False)
+    # to_dict round-trip preserves values
+    assert GatewayConfig.from_dict(rt.to_dict()).reply_gate_mode == "tool"
+
+
+# --------------------------------------------------------------------------- #
+# target="current" resolution (T-GATE-6)
+# --------------------------------------------------------------------------- #
+
+
+def test_target_current_errors_outside_gateway_turn():
+    for args in ({"target": "current", "message": "hi"}, {"message": "hi"}):
+        r = json.loads(_handle_send(args))
+        assert "error" in r
+        assert "live gateway turn" in r["error"]
+
+
+def test_target_current_resolves_registered_turn(monkeypatch):
+    src = SessionSource(platform=Platform.WHATSAPP, chat_id="123@g.us", chat_type="group")
+    captured = {}
+
+    async def _fake_send_to_platform(platform, pconfig, chat_id, message, **kw):
+        captured["platform"] = platform
+        captured["chat_id"] = chat_id
+        captured["message"] = message
+        return {"success": True, "message_id": "m1"}
+
+    monkeypatch.setattr("tools.send_message_tool._send_to_platform", _fake_send_to_platform)
+    monkeypatch.setattr("model_tools._run_async", lambda coro: __import__("asyncio").get_event_loop().run_until_complete(coro))
+    # A configured, enabled WhatsApp platform so _handle_send passes the pconfig gate.
+    cfg = GatewayConfig()
+    cfg.platforms[Platform.WHATSAPP] = PlatformConfig(enabled=True, token="x")
+    monkeypatch.setattr("gateway.config.load_gateway_config", lambda: cfg)
+
+    tok = approval.set_current_message_source(src)
+    try:
+        r = json.loads(_handle_send({"target": "current", "message": "hello there"}))
+    finally:
+        approval.reset_current_message_source(tok)
+
+    assert r.get("success") is True
+    assert captured["chat_id"] == "123@g.us"
+    assert captured["message"] == "hello there"
+    # Marker recorded so the post-turn block can dedup.
+    assert src.reply_gate_tool_sends == 1
+
+
+# --------------------------------------------------------------------------- #
+# Interruption note group-mode variant (T-COLL-3 companion)
+# --------------------------------------------------------------------------- #
+
+
+def test_interruption_note_group_vs_dm():
+    dm = _build_interruption_system_note("restart_timeout", has_new_message=False)
+    grp = _build_interruption_system_note(
+        "restart_timeout", has_new_message=False, group_mode=True
+    )
+    assert "Report to the user that the session was restored" in dm
+    assert "do NOT narrate this restart/interruption into the group" in grp
+    assert "Report to the user that the session was restored" not in grp
+    # DM default output unchanged (byte-identical to pre-variant behavior).
+    assert _build_interruption_system_note("restart_timeout", has_new_message=False) == dm
+
+
+# --------------------------------------------------------------------------- #
+# Post-turn delivery inversion (T-GATE / T-FALL) — E2E through the runner
+# --------------------------------------------------------------------------- #
+
+_SESSION_KEY = "agent:main:whatsapp:group:123@g.us:u1"
+
+
+def _source(reply_policy=ReplyPolicy.FREE_RESPONSE, chat_type="group", tool_sends=0):
+    src = SessionSource(
+        platform=Platform.WHATSAPP,
+        chat_id="123@g.us",
+        chat_type=chat_type,
+        user_id="u1",
+    )
+    src.reply_policy = reply_policy
+    src.reply_gate_tool_sends = tool_sends
+    return src
+
+
+def _event(src):
+    return MessageEvent(text="side chatter", source=src, message_id="msg-1")
+
+
+def _runner(monkeypatch, tmp_path, config):
+    runner = gateway_run.GatewayRunner(config)
+    runner.adapters = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._is_user_authorized = lambda _s: True
+    runner._set_session_env = lambda _c: None
+    runner._handle_active_session_busy_message = AsyncMock(return_value=False)
+    runner._session_db = MagicMock()
+    runner._recover_telegram_topic_thread_id = lambda _s: None
+    runner._cache_session_source = lambda _k, _s: None
+    runner._is_session_run_current = lambda _k, _g: True
+    runner._reply_anchor_for_event = lambda _e: None
+    runner._get_guild_id = lambda _e: None
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key=_SESSION_KEY,
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.WHATSAPP,
+        chat_type="group",
+    )
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"}
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_a, **_kw: 100_000,
+    )
+    return runner
+
+
+def _agent_result(text):
+    return {
+        "final_response": text,
+        "messages": [
+            {"role": "user", "content": "side chatter"},
+            {"role": "assistant", "content": text},
+        ],
+        "tools": [],
+        "history_offset": 0,
+        "last_prompt_tokens": 0,
+        "api_calls": 1,
+        "failed": False,
+    }
+
+
+async def _run(runner, src, text):
+    runner._run_agent = AsyncMock(return_value=_agent_result(text))
+    return await runner._handle_message_with_agent(_event(src), src, _SESSION_KEY, 1)
+
+
+@pytest.mark.asyncio
+async def test_tool_gated_silence_is_non_event(monkeypatch, tmp_path, caplog):
+    # T-GATE-1: tool mode, free-response group, chatty tail, zero tool sends,
+    # ratchet OFF → nothing delivered; transcript still persisted; telemetry.
+    runner = _runner(
+        monkeypatch, tmp_path,
+        GatewayConfig(reply_gate_mode="tool", reply_gate_tool_fallback=False),
+    )
+    src = _source()
+    with caplog.at_level(logging.INFO, logger="gateway.run"):
+        response = await _run(runner, src, "just some banter, nothing to do here")
+    assert response == ""
+    appended = [c.args[1] for c in runner.session_store.append_to_transcript.call_args_list]
+    assert any(m.get("role") == "assistant" for m in appended)
+    assert any("reply_gate: tool-mode" in r.message and "tool_sends=0" in r.message
+               for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_tool_send_dedup_suppresses_tail(monkeypatch, tmp_path):
+    # T-GATE-2 / T-FALL-3: a current-target tool send happened this turn → the
+    # free-text tail is NOT also delivered (dedup), even with fallback ON.
+    runner = _runner(
+        monkeypatch, tmp_path,
+        GatewayConfig(reply_gate_mode="tool", reply_gate_tool_fallback=True),
+    )
+    src = _source(tool_sends=1)
+    response = await _run(runner, src, "and here is a chatty tail too")
+    assert response == ""
+
+
+@pytest.mark.asyncio
+async def test_dm_byte_identical_regardless_of_mode(monkeypatch, tmp_path):
+    # T-GATE-3: DM policy bypasses the inversion in both modes.
+    text = "here is your answer"
+    for mode in ("prompt", "tool"):
+        runner = _runner(monkeypatch, tmp_path, GatewayConfig(reply_gate_mode=mode))
+        src = _source(reply_policy=ReplyPolicy.DM, chat_type="dm")
+        assert await _run(runner, src, text) == text
+
+
+@pytest.mark.asyncio
+async def test_mention_gated_byte_identical(monkeypatch, tmp_path):
+    # T-GATE-4: mention-gated groups bypass the inversion in both modes.
+    text = "here is your answer"
+    for mode in ("prompt", "tool"):
+        runner = _runner(monkeypatch, tmp_path, GatewayConfig(reply_gate_mode=mode))
+        src = _source(reply_policy=ReplyPolicy.MENTION_GATED)
+        assert await _run(runner, src, text) == text
+
+
+@pytest.mark.asyncio
+async def test_prompt_mode_branch_inert(monkeypatch, tmp_path):
+    # T-GATE-5: default prompt mode → free-response group tail delivers as today.
+    runner = _runner(monkeypatch, tmp_path, GatewayConfig())  # reply_gate_mode="prompt"
+    src = _source()
+    text = "a normal free-response reply"
+    assert await _run(runner, src, text) == text
+
+
+@pytest.mark.asyncio
+async def test_fallback_ratchet_delivers_substantive_tail(monkeypatch, tmp_path, caplog):
+    # T-FALL-1: ratchet ON, zero tool sends, substantive non-marker tail →
+    # delivered (old behavior), telemetry marks fallback=1.
+    runner = _runner(
+        monkeypatch, tmp_path,
+        GatewayConfig(reply_gate_mode="tool", reply_gate_tool_fallback=True),
+    )
+    src = _source()
+    text = "the real answer the model forgot to send via tool"
+    with caplog.at_level(logging.INFO, logger="gateway.run"):
+        response = await _run(runner, src, text)
+    assert response == text
+    assert any("reply_gate: tool-mode" in r.message and "fallback=1" in r.message
+               for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_fallback_ratchet_still_suppresses_marker(monkeypatch, tmp_path):
+    # T-FALL-2: ratchet ON, zero tool sends, tail IS a silence marker →
+    # suppressed (the ratchet only rescues substantive answers).
+    runner = _runner(
+        monkeypatch, tmp_path,
+        GatewayConfig(reply_gate_mode="tool", reply_gate_tool_fallback=True),
+    )
+    src = _source()
+    assert await _run(runner, src, "NO_REPLY") == ""
+
+
+@pytest.mark.asyncio
+async def test_fallback_off_suppresses_substantive_tail(monkeypatch, tmp_path):
+    # T-FALL-4: ratchet OFF → the same substantive tail delivers nothing.
+    runner = _runner(
+        monkeypatch, tmp_path,
+        GatewayConfig(reply_gate_mode="tool", reply_gate_tool_fallback=False),
+    )
+    src = _source()
+    assert await _run(runner, src, "the real answer") == ""
+
+
+@pytest.mark.asyncio
+async def test_tool_gated_empty_tail_not_normalized(monkeypatch, tmp_path):
+    # T-GATE-7 (partial): a tool-gated turn with an empty tail is NOT turned
+    # into a "no response" placeholder by the empty-response normalizer.
+    runner = _runner(
+        monkeypatch, tmp_path,
+        GatewayConfig(reply_gate_mode="tool", reply_gate_tool_fallback=True),
+    )
+    src = _source()
+    response = await _run(runner, src, "")
+    assert response == ""

--- a/tests/gateway/test_resume_note_silence_interaction.py
+++ b/tests/gateway/test_resume_note_silence_interaction.py
@@ -1,0 +1,177 @@
+"""Resume-note refactor + silence-marker interaction.
+
+Covers three concerns for the Phase-0 auto-continue refactor in
+``gateway/run.py``:
+
+1. The extracted note builders (:func:`_build_interruption_system_note`,
+   :func:`_build_tool_tail_system_note`) reproduce the historical inline
+   f-strings **byte-for-byte** — a golden-string regression guard so a future
+   wording tweak is a deliberate, reviewed change, not an accident.
+2. The extracted dispatch predicate (:func:`_resolve_resume_note_kind`) is a
+   pure truth table, including the "two freshness signals disagree" edge case.
+3. Resume/recovery notes and the intentional-silence classifier compose
+   correctly in both directions: a recovery report is never swallowed as
+   silence, and a literal silence token on a resumed turn is still silence.
+"""
+
+import pytest
+
+from gateway.response_filters import (
+    LIVE_GATEWAY_SILENT_MARKERS,
+    is_intentional_silence_response,
+)
+from gateway.run import (
+    _build_interruption_system_note,
+    _build_tool_tail_system_note,
+    _resolve_resume_note_kind,
+)
+
+
+# --------------------------------------------------------------------------
+# 1. Golden-string guards — the note text pre-refactor, captured verbatim.
+# --------------------------------------------------------------------------
+
+
+def _golden_resume_note(reason, has_new_message):
+    """The exact inline f-string the three sites produced before extraction."""
+    reason_phrase = (
+        "a gateway restart"
+        if reason == "restart_timeout"
+        else "a gateway shutdown"
+        if reason == "shutdown_timeout"
+        else "a gateway interruption"
+    )
+    if has_new_message:
+        guidance = (
+            "Address the user's NEW message below FIRST and focus "
+            "on what the user is asking now."
+        )
+    else:
+        guidance = (
+            "Report to the user that the session was restored "
+            "successfully and ask what they would like to do next."
+        )
+    return (
+        f"[System note: The previous turn was interrupted by "
+        f"{reason_phrase}; the gateway is now back online. "
+        f"Any restart/shutdown command in the history has already "
+        f"run — do NOT re-execute or verify it. {guidance} "
+        f"Do NOT re-execute old tool calls — skip any unfinished "
+        f"work from the conversation history.]"
+    )
+
+
+_GOLDEN_TOOL_TAIL_NOTE = (
+    "[System note: A new message has arrived. The conversation "
+    "history contains pending tool outputs from an interrupted turn. "
+    "IGNORE those pending results. Address the user's NEW message "
+    "below FIRST. Do NOT re-execute old tool calls from the history.]"
+)
+
+
+@pytest.mark.parametrize(
+    "reason",
+    ["restart_timeout", "shutdown_timeout", "unknown_reason", None],
+)
+@pytest.mark.parametrize("has_new_message", [True, False])
+def test_interruption_note_is_byte_identical(reason, has_new_message):
+    assert _build_interruption_system_note(
+        reason, has_new_message
+    ) == _golden_resume_note(reason, has_new_message)
+
+
+def test_unknown_and_missing_reason_map_to_generic_interruption():
+    # Both the sentinel-default path (unmapped reason) and None resolve to the
+    # generic "a gateway interruption" phrasing.
+    assert "a gateway interruption" in _build_interruption_system_note("weird", True)
+    assert "a gateway interruption" in _build_interruption_system_note(None, True)
+
+
+def test_tool_tail_note_is_byte_identical():
+    assert _build_tool_tail_system_note() == _GOLDEN_TOOL_TAIL_NOTE
+
+
+def test_note_builders_return_only_the_bracketed_note():
+    # The builder returns just the note; the caller appends the real message.
+    note = _build_interruption_system_note("restart_timeout", True)
+    assert note.startswith("[System note:") and note.endswith("]")
+    assert "\n" not in note
+
+
+# --------------------------------------------------------------------------
+# 2. Dispatch predicate truth table.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("is_resume_pending", "has_fresh_tool_tail", "message_is_empty", "expected"),
+    [
+        # Fresh resume mark always wins, regardless of the other signals.
+        (True, True, True, "resume"),
+        (True, True, False, "resume"),
+        (True, False, True, "resume"),
+        (True, False, False, "resume"),
+        # No resume mark, fresh tool tail → tool_tail.
+        (False, True, True, "tool_tail"),
+        (False, True, False, "tool_tail"),
+        # Neither fresh signal, but an empty turn → safety net (caller also
+        # guards on the raw resume_pending marker). This IS the "two freshness
+        # signals disagree" case documented inline at the call site.
+        (False, False, True, "safety_net"),
+        # Ordinary populated turn → no note.
+        (False, False, False, "none"),
+    ],
+)
+def test_resolve_resume_note_kind_truth_table(
+    is_resume_pending, has_fresh_tool_tail, message_is_empty, expected
+):
+    assert (
+        _resolve_resume_note_kind(
+            is_resume_pending, has_fresh_tool_tail, message_is_empty
+        )
+        == expected
+    )
+
+
+# --------------------------------------------------------------------------
+# 3. Silence classifier vs. resume/recovery notes — both directions.
+# --------------------------------------------------------------------------
+
+
+def test_recovery_report_is_not_classified_as_silence():
+    # A genuine post-restart recovery report must be delivered, never swallowed
+    # as an intentional-silence marker.
+    report = (
+        "The gateway restarted and is back online now, nothing pending on my "
+        "side, what would you like to do next?"
+    )
+    assert is_intentional_silence_response(report) is False
+
+
+def test_resume_notes_are_not_silence_markers():
+    # The injected system notes themselves are substantive text, not silence.
+    assert (
+        is_intentional_silence_response(
+            _build_interruption_system_note("restart_timeout", False)
+        )
+        is False
+    )
+    assert is_intentional_silence_response(_build_tool_tail_system_note()) is False
+
+
+@pytest.mark.parametrize("marker", sorted(LIVE_GATEWAY_SILENT_MARKERS))
+def test_literal_silence_token_on_resumed_turn_is_still_silence(marker):
+    # The reverse direction: even after a resume, a model turn whose entire
+    # output is the literal silence token still classifies as silence, so the
+    # two mechanisms compose without corrupting each other.
+    assert is_intentional_silence_response(marker) is True
+
+
+def test_report_that_merely_mentions_a_marker_still_delivers():
+    # Prose that mentions a token mid-sentence is real content, not silence.
+    assert (
+        is_intentional_silence_response(
+            "I nearly stayed NO_REPLY but here's the recovery summary instead."
+        )
+        is False
+    )

--- a/tests/tools/test_send_message_react.py
+++ b/tests/tools/test_send_message_react.py
@@ -95,3 +95,152 @@ def test_react_without_live_gateway():
         )
     assert result.get("success") is not True
     assert "live" in json.dumps(result)
+
+
+# --------------------------------------------------------------------------
+# WhatsApp adapter add_reaction/remove_reaction exercised end-to-end through
+# the generic send_message(action='react') path, with the bridge HTTP call
+# mocked (no live network, no live gateway process).
+# --------------------------------------------------------------------------
+
+
+class _FakeBridgeResponse:
+    """Async-context-manager mimicking aiohttp's POST response."""
+
+    def __init__(self, status=200, payload=None):
+        self.status = status
+        self._payload = payload if payload is not None else {"success": True}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def json(self):
+        return self._payload
+
+    async def text(self):
+        return json.dumps(self._payload)
+
+
+class _FakeBridgeSession:
+    """Records POSTs and returns a canned bridge response."""
+
+    def __init__(self, status=200):
+        self._status = status
+        self.posts = []
+
+    def post(self, url, json=None, timeout=None):
+        self.posts.append({"url": url, "json": json})
+        return _FakeBridgeResponse(status=self._status)
+
+
+def _make_whatsapp_adapter(session):
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter.__new__(WhatsAppAdapter)
+    adapter._running = True
+    adapter._http_session = session
+    adapter._bridge_port = 3000
+    adapter._bridge_process = None  # no managed child → exit-check is a no-op
+    return adapter
+
+
+def _whatsapp_runner_with(adapter):
+    from gateway.config import Platform
+
+    return SimpleNamespace(adapters={Platform("whatsapp"): adapter})
+
+
+def test_whatsapp_react_posts_to_bridge_react_endpoint():
+    session = _FakeBridgeSession()
+    adapter = _make_whatsapp_adapter(session)
+    with patch("gateway.run._gateway_runner_ref", lambda: _whatsapp_runner_with(adapter)):
+        result = _call(
+            {
+                "action": "react",
+                "target": "whatsapp:1234567890@s.whatsapp.net",
+                "emoji": "❤️",
+                "message_id": "wamid-1",
+            }
+        )
+    assert result["success"] is True
+    assert len(session.posts) == 1
+    post = session.posts[0]
+    assert post["url"].endswith("/react")
+    assert post["json"] == {
+        "chatId": "1234567890@s.whatsapp.net",
+        "emoji": "❤️",
+        "messageId": "wamid-1",
+    }
+
+
+def test_whatsapp_react_without_message_id_omits_it():
+    session = _FakeBridgeSession()
+    adapter = _make_whatsapp_adapter(session)
+    with patch("gateway.run._gateway_runner_ref", lambda: _whatsapp_runner_with(adapter)):
+        result = _call(
+            {
+                "action": "react",
+                "target": "whatsapp:1234567890@s.whatsapp.net",
+                "emoji": "👍",
+            }
+        )
+    assert result["success"] is True
+    # message_id omitted so the bridge resolves the most recent message itself.
+    assert session.posts[0]["json"] == {
+        "chatId": "1234567890@s.whatsapp.net",
+        "emoji": "👍",
+    }
+
+
+def test_whatsapp_unreact_sends_empty_emoji():
+    session = _FakeBridgeSession()
+    adapter = _make_whatsapp_adapter(session)
+    with patch("gateway.run._gateway_runner_ref", lambda: _whatsapp_runner_with(adapter)):
+        result = _call(
+            {
+                "action": "unreact",
+                "target": "whatsapp:1234567890@s.whatsapp.net",
+                "message_id": "wamid-9",
+            }
+        )
+    assert result["success"] is True
+    assert session.posts[0]["url"].endswith("/react")
+    assert session.posts[0]["json"] == {
+        "chatId": "1234567890@s.whatsapp.net",
+        "emoji": "",
+        "messageId": "wamid-9",
+    }
+
+
+def test_whatsapp_react_bridge_rejection_reports_failure():
+    session = _FakeBridgeSession(status=500)
+    adapter = _make_whatsapp_adapter(session)
+    with patch("gateway.run._gateway_runner_ref", lambda: _whatsapp_runner_with(adapter)):
+        result = _call(
+            {
+                "action": "react",
+                "target": "whatsapp:1234567890@s.whatsapp.net",
+                "emoji": "👍",
+            }
+        )
+    # add_reaction returns False on a non-200 bridge response.
+    assert result["success"] is False
+
+
+def test_whatsapp_react_not_connected_reports_failure():
+    session = _FakeBridgeSession()
+    adapter = _make_whatsapp_adapter(session)
+    adapter._running = False  # bridge not connected
+    with patch("gateway.run._gateway_runner_ref", lambda: _whatsapp_runner_with(adapter)):
+        result = _call(
+            {
+                "action": "react",
+                "target": "whatsapp:1234567890@s.whatsapp.net",
+                "emoji": "👍",
+            }
+        )
+    assert result["success"] is False
+    assert session.posts == []

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -19,7 +19,7 @@ import sys
 import threading
 import time
 import unicodedata
-from typing import Optional
+from typing import Any, Optional
 from hermes_cli.config import cfg_get
 
 from tools.interrupt import is_interrupted
@@ -148,6 +148,62 @@ def reset_current_observability_context(
     turn_token, tool_token = tokens
     _approval_tool_call_id.reset(tool_token)
     _approval_turn_id.reset(turn_token)
+
+
+# Turn-scoped "current message source" — the inbound SessionSource-like object
+# for the gateway turn currently executing in this context. Mirrors the
+# session-key contextvar lifecycle (set at turn start, reset in the same
+# try/finally) so tools running inside the turn can resolve
+# send_message(target="current") back to the originating chat without knowing
+# platform/chat_id plumbing. Lives here beside the other turn-scoped gateway
+# contextvars because it shares their exact lifecycle and crash-safety story.
+_current_message_source: contextvars.ContextVar[Optional[Any]] = contextvars.ContextVar(
+    "current_message_source",
+    default=None,
+)
+
+
+def set_current_message_source(source: Any) -> contextvars.Token:
+    """Bind the current gateway turn's inbound message source to this context."""
+    return _current_message_source.set(source)
+
+
+def get_current_message_source() -> Optional[Any]:
+    """Return the current gateway turn's inbound message source, or None.
+
+    None outside a live gateway turn (CLI, cron, subagent) — callers that need
+    a message source (e.g. send_message(target="current")) must surface a clear
+    error rather than guess.
+    """
+    return _current_message_source.get()
+
+
+def reset_current_message_source(token: contextvars.Token) -> None:
+    """Restore the prior message-source context."""
+    _current_message_source.reset(token)
+
+
+def note_current_message_delivered() -> None:
+    """Record that the current turn delivered to its originating chat via a tool.
+
+    Increments a turn-scoped counter ON the current message source object (the
+    same object the async post-turn delivery block holds a reference to), so the
+    post-turn block can dedup — a tool-driven send to the current chat means the
+    free-text tail must never also auto-deliver. The counter rides the source
+    object rather than a contextvar because the tool runs in the agent's
+    executor-thread context (a copy) while the post-turn block reads it back on
+    the asyncio loop; mutating the shared object crosses that boundary, a
+    contextvar reset would not. No-op outside a gateway turn.
+    """
+    src = _current_message_source.get()
+    if src is None:
+        return
+    try:
+        src.reply_gate_tool_sends = int(getattr(src, "reply_gate_tool_sends", 0) or 0) + 1
+    except Exception:
+        # Source object may be an unexpected shape (defensive: never let a
+        # bookkeeping write break a successful delivery).
+        pass
 
 
 def get_current_session_key(default: str = "default") -> str:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -158,7 +158,7 @@ SEND_MESSAGE_SCHEMA = {
             },
             "target": {
                 "type": "string",
-                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics and Discord threads. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org', 'ntfy:alerts-channel' (explicit ntfy topic), 'yuanbao:direct:<account_id>' (DM), 'yuanbao:group:<group_code>' (group chat)"
+                "description": "Delivery target. Use 'current' (or omit target) to reply in the chat this turn came from — the current conversation. Cross-channel format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics and Discord threads. Examples: 'current', 'telegram', 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org', 'ntfy:alerts-channel' (explicit ntfy topic), 'yuanbao:direct:<account_id>' (DM), 'yuanbao:group:<group_code>' (group chat)"
             },
             "message": {
                 "type": "string",
@@ -297,39 +297,67 @@ def _handle_react(args, remove=False):
 
 def _handle_send(args):
     """Send a message to a platform target."""
-    target = args.get("target", "")
+    target = (args.get("target") or "").strip()
     message = args.get("message", "")
-    if not target or not message:
-        return tool_error("Both 'target' and 'message' are required when action='send'")
+    if not message:
+        return tool_error("'message' is required when action='send'")
 
-    parts = target.split(":", 1)
-    platform_name = parts[0].strip().lower()
-    target_ref = parts[1].strip() if len(parts) > 1 else None
-    chat_id = None
-    thread_id = None
-
-    if target_ref:
-        chat_id, thread_id, is_explicit = _parse_target_ref(platform_name, target_ref)
-    else:
-        is_explicit = False
-
-    # Resolve human-friendly channel names to numeric IDs
-    if target_ref and not is_explicit:
+    # target="current" (or an omitted target during a live gateway turn) means
+    # "reply in the chat this turn came from" — resolved via the turn-scoped
+    # message-source registered by the gateway runner (tools/approval.py).
+    # Outside any gateway turn (CLI, cron, subagent) no source is registered, so
+    # this is a CLEAR tool error rather than a silent guess.
+    _current_source = None
+    if target in ("", "current"):
+        from tools.approval import get_current_message_source
+        _current_source = get_current_message_source()
+        if _current_source is None:
+            return tool_error(
+                "target='current' is only valid during a live gateway turn "
+                "(the chat this message came from). No inbound message source is "
+                "registered in this context — specify an explicit target such as "
+                "'platform:chat_id' instead."
+            )
         try:
-            from gateway.channel_directory import resolve_channel_name
-            resolved = resolve_channel_name(platform_name, target_ref)
-            if resolved:
-                chat_id, thread_id, _ = _parse_target_ref(platform_name, resolved)
-            else:
+            platform_name = _current_source.platform.value
+        except Exception:
+            platform_name = str(getattr(_current_source, "platform", "")).strip().lower()
+        chat_id = str(getattr(_current_source, "chat_id", "") or "")
+        thread_id = getattr(_current_source, "thread_id", None) or None
+        if not platform_name or not chat_id:
+            return tool_error(
+                "target='current' could not resolve the originating chat "
+                "(missing platform/chat id on the message source)."
+            )
+    else:
+        parts = target.split(":", 1)
+        platform_name = parts[0].strip().lower()
+        target_ref = parts[1].strip() if len(parts) > 1 else None
+        chat_id = None
+        thread_id = None
+
+        if target_ref:
+            chat_id, thread_id, is_explicit = _parse_target_ref(platform_name, target_ref)
+        else:
+            is_explicit = False
+
+        # Resolve human-friendly channel names to numeric IDs
+        if target_ref and not is_explicit:
+            try:
+                from gateway.channel_directory import resolve_channel_name
+                resolved = resolve_channel_name(platform_name, target_ref)
+                if resolved:
+                    chat_id, thread_id, _ = _parse_target_ref(platform_name, resolved)
+                else:
+                    return json.dumps({
+                        "error": f"Could not resolve '{target_ref}' on {platform_name}. "
+                        f"Use send_message(action='list') to see available targets."
+                    })
+            except Exception:
                 return json.dumps({
                     "error": f"Could not resolve '{target_ref}' on {platform_name}. "
-                    f"Use send_message(action='list') to see available targets."
+                    f"Try using a numeric channel ID instead."
                 })
-        except Exception:
-            return json.dumps({
-                "error": f"Could not resolve '{target_ref}' on {platform_name}. "
-                f"Try using a numeric channel ID instead."
-            })
 
     from tools.interrupt import is_interrupted
     if is_interrupted():
@@ -467,6 +495,19 @@ def _handle_send(args):
 
         if isinstance(result, dict) and "error" in result:
             result["error"] = _sanitize_error_text(result["error"])
+        # Record a successful current-chat delivery so the post-turn block can
+        # dedup the free-text tail (and, under reply_gate_mode="tool", know a
+        # tool-driven delivery happened this turn).
+        if (
+            _current_source is not None
+            and isinstance(result, dict)
+            and result.get("success")
+        ):
+            try:
+                from tools.approval import note_current_message_delivered
+                note_current_message_delivered()
+            except Exception:
+                pass
         return json.dumps(result)
     except Exception as e:
         return json.dumps(_error(f"Send failed: {e}"))


### PR DESCRIPTION
## Summary

Phase 1 (of 2) for the reply-gate/smart-reply architecture redesign. **This
PR depends on #59318 (Phase 0) and should merge after it** — the branch is
stacked on Phase 0's commit so it can be reviewed/tested independently, but
GitHub will show Phase 0's diff too until #59318 lands.

**Config-flagged, default OFF.** `reply_gate_mode` defaults to `"prompt"` —
today's deliver-by-default behavior, byte-identical for every deployment that
doesn't explicitly opt in via `config.yaml`.

## The problem this fixes

When a WhatsApp group has `require_mention: false`, every allowlisted message
today spawns a full paid agent turn, and the model's only way to say "I'm
choosing not to reply" is emitting a magic string (`NO_REPLY`/`[SILENT]`) that
the gateway then has to pattern-match out of the response **after** the
(already-paid-for) turn ran. Free text is being asked to double as a control
signal, which is why this repo has ended up with several independently-tuned
silence-detection regexes across different files, each catching leaks the
others miss.

## The fix

For free-response group turns under `reply_gate_mode: "tool"`, the model's
final free-text tail is **never auto-delivered**. Delivery happens only via
`send_message(target="current", ...)` — silence becomes the absence of a tool
call, a finite and testable control-flow branch, instead of a string parsed
out of infinite free text. DMs and mention-gated groups are completely
unaffected; the ingestion gate (`_should_process_message`) is untouched in
every adapter.

## What changed

- **`gateway/reply_policy.py`** (new) — a platform-agnostic `ReplyPolicy`
  enum (`dm | mention_gated | free_response`), resolved read-only from the
  same `require_mention`/`free_response_*` config knobs each adapter's
  ingestion gate already consults. An unstamped event (platform not yet
  wired) defaults to `dm` — the safe value that makes partial rollout
  non-breaking by construction. **WhatsApp is wired end-to-end**; other
  platforms are left unstamped in this PR (see Non-goals).
- **`gateway/config.py`** — `reply_gate_mode` (`"prompt"`/`"tool"`, default
  `"prompt"`) and `reply_gate_tool_fallback` (bool, default `true`), following
  the existing `filter_silence_narration` four-touch-point pattern exactly.
  Bad config values fall back to `"prompt"`, never raise.
- **`tools/approval.py`** — a turn-scoped current-message-source registry
  (`set_current_message_source`/`get_current_message_source`/
  `reset_current_message_source`), mirroring the existing
  `set_current_session_key` contextvar-with-token lifecycle exactly.
- **`tools/send_message_tool.py`** — `target="current"` (or an omitted
  target during a live gateway turn) resolves via the registry above.
  Outside any gateway turn (CLI/cron/subagent), this is a clear tool error,
  never a silent guess. Additive to the existing `target` field — no new
  tool, no new required schema field.
- **`gateway/run.py`** — the actual delivery-inversion branch. Computed once
  beside the existing `_intentional_silence` check. A current-chat tool send
  this turn always wins (dedup, independent of mode — a duplicate is always
  wrong). Otherwise: nothing to suppress if the tail is empty/already a
  silence marker; the **fallback ratchet** delivers a substantive tail
  anyway when no tool send happened (so this mechanism can only reduce
  duplicate/leaked text during burn-in, never silently swallow a real
  answer); with the ratchet off, a substantive tail with no tool call is
  suppressed. Guards added to the empty-response normalizer, the footer
  line, the voice-reply check, and both streaming-eligibility call sites
  (streamed text IS delivery, so streaming is disabled for tool-gated turns).
- **Group-mode interruption-note variant** (built on Phase 0's
  `_build_interruption_system_note`) — a resume/safety-net note in a
  non-DM session now tells the model not to narrate the restart/interruption
  into the group, instead of "report to the user."
- **16 new tests** in `tests/gateway/test_reply_gate_tool_mode.py`: silence
  as a non-event, tool-send delivery + dedup, DM/mention-gated turns
  byte-identical regardless of mode, prompt-mode (the default) fully inert,
  `target="current"` resolution in/out of a gateway turn, both
  fallback-ratchet states, the WhatsApp `ReplyPolicy` matrix driven by real
  config parsing (not mocks, per this repo's E2E-over-mocks guidance), an
  unstamped event defaulting to `dm`, and the group-mode note variant.

## How to test

```
scripts/run_tests.sh tests/gateway/test_reply_gate_tool_mode.py tests/gateway/test_resume_note_silence_interaction.py tests/tools/test_send_message_react.py -v
```

## Verification

Ran the full suite twice — with this diff and with it `git stash`ed — to
separate pre-existing failures from real regressions. Baseline: 30 failures
across 11 files (missing optional `acp` extra not installed in this dev
environment, plus a handful of environment/path-sensitive tests — git-repo
detection, audio-environment detection — that behave differently depending
on whether the checkout is a plain clone or a git worktree). Identical set
with or without this diff. **Zero regressions.** `ruff check` and
`scripts/check-windows-footguns.py` clean on every touched file.

## What platforms tested

Linux dev environment. WhatsApp is the platform fully wired end-to-end in
this PR; no adapter-specific OS syscalls touched.

## Known naming collision (please read before reviewing)

`send_message`'s new `target="current"` addressing solves the exact same
problem as two other open PRs, using different sentinel names:
- **#33010** uses `target="origin"`
- **#11521** uses `platform:current`/`session`/`__session__`

This PR needed the capability for its own tool-gated delivery mechanism and
implemented it independently under the name `"current"` for internal
consistency, rather than depending on either unmerged PR. **A maintainer
should pick one canonical name across all three at merge/review time** — this
PR does not attempt to resolve that collision itself.

## Non-goals (explicit)

- Cron's own silence contract (`cron/scheduler.py`) — unchanged, different
  contract (single-shot, no conversational ambiguity).
- `gateway/delivery.py`'s bot-to-bot silence-narration filter — unchanged,
  different failure mode (mirror loops on non-native channels).
- Rewriting any platform's `_should_process_message` ingestion gate — this
  PR adds a read-only classification alongside it, doesn't touch its control
  flow.
- Wiring `ReplyPolicy` onto Telegram/Discord/DingTalk/other adapters —
  WhatsApp is the platform being burned in first; others stay unstamped
  (safely defaulting to `dm`) until there's real operational data from
  WhatsApp to justify wider rollout.
- Flipping `reply_gate_mode`'s default — a separate, later, data-driven
  decision after a burn-in period on a live deployment, not part of this PR.

Related design doc (not part of this repo, shared for context if useful):
happy to share on request.
