### PR TITLE
fix(agent): prevent stale moa://local base_url from surviving model s…

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -359,6 +359,21 @@ def init_agent(
     else:
         agent.api_mode = "chat_completions"
 
+    # ── Safety check: moa://local is a virtual endpoint used ONLY by the
+    # MoA virtual provider.  If a non-moa provider somehow has this URL set
+    # (e.g. leaked from a stale config or model switch), clear it so the
+    # real provider's default endpoint is used instead.  Without this guard
+    # the agent creates a real HTTP client targeting moa://local, which has
+    # no server listening and always returns APIConnectionError.
+    if agent.provider != "moa" and agent.base_url and "moa://" in agent.base_url:
+        logger.warning(
+            "Defense-in-depth: cleared moa://local base_url for provider %s "
+            "(moa:// URLs are only valid for the moa virtual provider). "
+            "Falling back to provider-default endpoint.",
+            agent.provider,
+        )
+        agent.base_url = ""
+
     # Eagerly warm the transport cache so import errors surface at init,
     # not mid-conversation.  Also validates the api_mode is registered.
     try:

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -996,6 +996,17 @@ def try_recover_primary_transport(
         agent.model = rt["model"]
         agent.provider = rt["provider"]
         agent.base_url = rt["base_url"]
+        # Defense-in-depth: if the primary snapshot carries a moa://local
+        # base_url for a non-moa provider, clear it so the real provider's
+        # default endpoint is re-resolved.  Same pattern as
+        # restore_primary_runtime() and init_agent().
+        if agent.provider != "moa" and "moa://" in (agent.base_url or ""):
+            logger.warning(
+                "Defense-in-depth: cleared moa://local base_url for provider %s "
+                "on primary recovery (moa:// URLs are only valid for "
+                "the moa virtual provider).", agent.provider,
+            )
+            agent.base_url = ""
         agent.api_mode = rt["api_mode"]
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
@@ -1159,6 +1170,17 @@ def restore_primary_runtime(agent) -> bool:
         agent.model = rt["model"]
         agent.provider = rt["provider"]
         agent.base_url = rt["base_url"]           # setter updates _base_url_lower
+        # Defense-in-depth: if the restored primary runtime carries a
+        # moa://local base_url for a non-moa provider (e.g. from a stale
+        # config or a previous session), clear it so the real provider's
+        # default endpoint is re-resolved.
+        if agent.provider != "moa" and "moa://" in (agent.base_url or ""):
+            logger.warning(
+                "Defense-in-depth: cleared moa://local base_url for provider %s "
+                "on primary runtime restore (moa:// URLs are only valid for "
+                "the moa virtual provider).", agent.provider,
+            )
+            agent.base_url = ""
         agent.api_mode = rt["api_mode"]
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
@@ -1792,13 +1814,25 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         # ── Swap core runtime fields ──
         agent.model = new_model
         agent.provider = new_provider
-        # Use new base_url when provided; only fall back to current when the
-        # new provider genuinely has no endpoint (e.g. native SDK providers).
-        # Without this guard the old provider's URL (e.g. Ollama's localhost
-        # address) would persist silently after switching to a cloud provider
-        # that returns an empty base_url string.
-        if base_url:
-            agent.base_url = base_url
+        # Always apply the resolved base_url (even when empty) so that a
+        # stale value from a previous provider or a corrupted value like
+        # moa://local leaking into a non-moa provider is overwritten.
+        # The old `if base_url:` guard meant an empty-string result from the
+        # model switch resolver would leave the old base_url in place, letting
+        # a corrupted value (moa://local) survive across model switches and
+        # be restored from _primary_runtime on every turn.
+        agent.base_url = base_url
+        # Defense-in-depth: moa://local is a virtual endpoint used ONLY by
+        # the MoA virtual provider.  If a non-moa provider somehow ends up
+        # with this URL, clear it so the real provider's default endpoint
+        # is used.
+        if agent.provider != "moa" and "moa://" in (agent.base_url or ""):
+            logger.warning(
+                "Defense-in-depth: cleared moa://local base_url for provider %s "
+                "on model switch (moa:// URLs are only valid for the moa "
+                "virtual provider).", agent.provider,
+            )
+            agent.base_url = ""
         agent.api_mode = api_mode
         # Invalidate transport cache — new api_mode may need a different transport
         if hasattr(agent, "_transport_cache"):

--- a/cli.py
+++ b/cli.py
@@ -8071,8 +8071,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self._explicit_base_url = result.base_url
         if result.api_key:
             self.api_key = result.api_key
-        if result.base_url:
-            self.base_url = result.base_url
+        # Always apply the resolved base_url (even when empty) so a stale
+        # value from a previous provider (e.g. moa://local leaking into
+        # opencode-go) is overwritten.  On the next turn, credential
+        # resolution re-derives the canonical URL from the provider profile.
+        self.base_url = result.base_url
         if result.api_mode:
             self.api_mode = result.api_mode
 


### PR DESCRIPTION
## Problem

Setting `model.base_url: moa://local` in config.yaml (or switching to MoA then
back to a non-MoA provider) leaves the stale `moa://local` URL stuck on the
agent. Three mechanisms prevent it from being cleared:

1. `if base_url:` guards in `switch_model()` and `_handle_model_switch()`
   skip the update when the resolved base_url is empty, leaving the stale
   value in place
2. `_primary_runtime` snapshot captures the corrupted value at agent init,
   and `restore_primary_runtime()` re-applies it on every subsequent turn
3. No defense-in-depth guard exists to reject `moa://local` for non-moa
   providers

## Fix

- Remove `if base_url:` guards — always apply resolved base_url on model
  switch, even when empty
- Add `moa://local` clearing guards at all 4 `_primary_runtime` read/write
  sites: `init_agent`, `switch_model`, `restore_primary_runtime`, and
  `recover_with_primary_runtime`
- Each guard uses `agent.provider != "moa"` — MoA itself is unaffected

## Files changed

| File | Lines | Change |
|------|-------|--------|
| `agent/agent_init.py` | +15 | moa://local clearing guard in init_agent |
| `agent/agent_runtime_helpers.py` | +48/-9 | Unconditional base_url in switch_model + 3 defense-in-depth guards |
| `cli.py` | +7/-2 | Unconditional base_url in _handle_model_switch |

## Related

- Closes #56158 — stale base_url persists after /model switch
- Addresses residual from #54669 — moa://local poisons non-moa providers
