### PR TITLE
fix(gateway): mark bg-process completion consumed after injection to stop duplicate notifications

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14676,72 +14676,81 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # poll() is read-only and intentionally does NOT mark consumed
                 # (#10156) — a status check must not suppress this delivery turn.
                 from tools.process_registry import format_process_notification, process_registry as _pr_check
-                if agent_notify and not _pr_check.is_completion_consumed(session_id):
-                    from tools.ansi_strip import strip_ansi
-                    _raw = strip_ansi(session.output_buffer) if session.output_buffer else ""
-                    # Truncate at line boundaries so notifications never start
-                    # mid-line (fixes #23284). Keep the last ~2000 chars but
-                    # snap to the nearest preceding newline, then prepend a
-                    # truncation marker when output was cut.
-                    _LIMIT = 2000
-                    if len(_raw) > _LIMIT:
-                        _tail = _raw[-_LIMIT:]
-                        _nl = _tail.find("\n")
-                        _tail = _tail[_nl + 1:] if _nl != -1 else _tail
-                        _out = f"[… output truncated — showing last {len(_tail)} chars]\n{_tail}"
-                    else:
-                        _out = _raw
-                    synth_text = format_process_notification({
-                        "type": "completion",
-                        "session_id": session_id,
-                        "command": session.command,
-                        "exit_code": session.exit_code,
-                        "completion_reason": getattr(session, "completion_reason", "exited"),
-                        "termination_source": getattr(session, "termination_source", ""),
-                        "output": _out,
-                    })
-                    if not synth_text:
+                if agent_notify:
+                    if not _pr_check.claim_completion_delivery(session_id):
                         break
-                    source = self._build_process_event_source({
-                        "session_id": session_id,
-                        "session_key": session_key,
-                        "platform": platform_name,
-                        "chat_id": chat_id,
-                        "thread_id": thread_id,
-                        "user_id": user_id,
-                        "user_name": user_name,
-                    })
-                    if not source:
-                        logger.warning(
-                            "Dropping completion notification with no routing metadata for process %s",
-                            session_id,
-                        )
-                        break
-
-                    adapter = None
-                    for p, a in self.adapters.items():
-                        if p == source.platform:
-                            adapter = a
+                    delivery_succeeded = False
+                    try:
+                        from tools.ansi_strip import strip_ansi
+                        _raw = strip_ansi(session.output_buffer) if session.output_buffer else ""
+                        # Truncate at line boundaries so notifications never start
+                        # mid-line (fixes #23284). Keep the last ~2000 chars but
+                        # snap to the nearest preceding newline, then prepend a
+                        # truncation marker when output was cut.
+                        _LIMIT = 2000
+                        if len(_raw) > _LIMIT:
+                            _tail = _raw[-_LIMIT:]
+                            _nl = _tail.find("\n")
+                            _tail = _tail[_nl + 1:] if _nl != -1 else _tail
+                            _out = f"[… output truncated — showing last {len(_tail)} chars]\n{_tail}"
+                        else:
+                            _out = _raw
+                        synth_text = format_process_notification({
+                            "type": "completion",
+                            "session_id": session_id,
+                            "command": session.command,
+                            "exit_code": session.exit_code,
+                            "completion_reason": getattr(session, "completion_reason", "exited"),
+                            "termination_source": getattr(session, "termination_source", ""),
+                            "output": _out,
+                        })
+                        if not synth_text:
                             break
-                    if adapter and source.chat_id:
-                        try:
-                            synth_event = MessageEvent(
-                                text=synth_text,
-                                message_type=MessageType.TEXT,
-                                source=source,
-                                internal=True,
-                                message_id=message_id,
-                            )
-                            logger.info(
-                                "Process %s finished — injecting agent notification for session %s chat=%s thread=%s",
+                        source = self._build_process_event_source({
+                            "session_id": session_id,
+                            "session_key": session_key,
+                            "platform": platform_name,
+                            "chat_id": chat_id,
+                            "thread_id": thread_id,
+                            "user_id": user_id,
+                            "user_name": user_name,
+                        })
+                        if not source:
+                            logger.warning(
+                                "Dropping completion notification with no routing metadata for process %s",
                                 session_id,
-                                session_key,
-                                source.chat_id,
-                                source.thread_id,
                             )
-                            await adapter.handle_message(synth_event)
-                        except Exception as e:
-                            logger.error("Agent notify injection error: %s", e)
+                            break
+
+                        adapter = None
+                        for p, a in self.adapters.items():
+                            if p == source.platform:
+                                adapter = a
+                                break
+                        if adapter and source.chat_id:
+                            try:
+                                synth_event = MessageEvent(
+                                    text=synth_text,
+                                    message_type=MessageType.TEXT,
+                                    source=source,
+                                    internal=True,
+                                    message_id=message_id,
+                                )
+                                logger.info(
+                                    "Process %s finished — injecting agent notification for session %s chat=%s thread=%s",
+                                    session_id,
+                                    session_key,
+                                    source.chat_id,
+                                    source.thread_id,
+                                )
+                                await adapter.handle_message(synth_event)
+                                _pr_check.mark_completion_consumed(session_id)
+                                delivery_succeeded = True
+                            except Exception as e:
+                                logger.error("Agent notify injection error: %s", e)
+                    finally:
+                        if not delivery_succeeded:
+                            _pr_check.release_completion_delivery(session_id)
                     break
 
                 # --- Normal text-only notification ---

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -26,6 +26,8 @@ class _FakeRegistry:
 
     def __init__(self, sessions):
         self._sessions = list(sessions)
+        self._consumed = set()
+        self._claimed = set()
 
     def get(self, session_id):
         if self._sessions:
@@ -33,7 +35,20 @@ class _FakeRegistry:
         return None
 
     def is_completion_consumed(self, session_id):
-        return False
+        return session_id in self._consumed
+
+    def claim_completion_delivery(self, session_id):
+        if session_id in self._consumed or session_id in self._claimed:
+            return False
+        self._claimed.add(session_id)
+        return True
+
+    def release_completion_delivery(self, session_id):
+        self._claimed.discard(session_id)
+
+    def mark_completion_consumed(self, session_id):
+        self._consumed.add(session_id)
+        self.release_completion_delivery(session_id)
 
 
 def _build_runner(monkeypatch, tmp_path, mode: str) -> GatewayRunner:
@@ -321,6 +336,151 @@ async def test_agent_notification_carries_message_id_reply_anchor(monkeypatch, t
     assert synth_event.internal is True
     assert synth_event.message_id == "555"
     assert synth_event.source.thread_id == "24296"
+
+
+@pytest.mark.asyncio
+async def test_agent_notify_watcher_marks_completion_consumed_after_success(monkeypatch, tmp_path):
+    import tools.process_registry as pr_module
+
+    session = SimpleNamespace(
+        id="proc_notify_dedup",
+        output_buffer="SMOKE_OK\n",
+        exited=True,
+        exit_code=0,
+        command="sleep 1",
+    )
+    registry = _FakeRegistry([session, session])
+    monkeypatch.setattr(pr_module, "process_registry", registry)
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    watcher = {
+        "session_id": session.id,
+        "check_interval": 0,
+        "session_key": "agent:main:telegram:dm:123:24296",
+        "platform": "telegram",
+        "chat_id": "123",
+        "thread_id": "24296",
+        "message_id": "555",
+        "notify_on_complete": True,
+    }
+
+    await runner._run_process_watcher(watcher)
+
+    handle_message = getattr(adapter, "handle_message")
+    handle_message.assert_awaited_once()
+    assert registry.is_completion_consumed(session.id)
+
+    await runner._run_process_watcher(watcher)
+
+    handle_message.assert_awaited_once()
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_agent_notify_watcher_retries_after_injection_error(monkeypatch, tmp_path):
+    import tools.process_registry as pr_module
+
+    session = SimpleNamespace(
+        id="proc_notify_retry_after_error",
+        output_buffer="SMOKE_OK\n",
+        exited=True,
+        exit_code=0,
+        command="sleep 1",
+    )
+    registry = _FakeRegistry([session, session])
+    monkeypatch.setattr(pr_module, "process_registry", registry)
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    handle_message = getattr(adapter, "handle_message")
+    handle_message.side_effect = RuntimeError("boom")
+    watcher = {
+        "session_id": session.id,
+        "check_interval": 0,
+        "session_key": "agent:main:telegram:dm:123:24296",
+        "platform": "telegram",
+        "chat_id": "123",
+        "thread_id": "24296",
+        "message_id": "555",
+        "notify_on_complete": True,
+    }
+
+    await runner._run_process_watcher(watcher)
+
+    assert not registry.is_completion_consumed(session.id)
+
+    handle_message.side_effect = None
+    handle_message.reset_mock()
+    await runner._run_process_watcher(watcher)
+
+    handle_message.assert_awaited_once()
+    assert registry.is_completion_consumed(session.id)
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_agent_notify_watcher_claims_completion_before_await(monkeypatch, tmp_path):
+    import tools.process_registry as pr_module
+
+    session = SimpleNamespace(
+        id="proc_notify_concurrent_dedup",
+        output_buffer="SMOKE_OK\n",
+        exited=True,
+        exit_code=0,
+        command="sleep 1",
+    )
+    registry = _FakeRegistry([session, session])
+    monkeypatch.setattr(pr_module, "process_registry", registry)
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    entered_first_delivery = asyncio.Event()
+    release_first_delivery = asyncio.Event()
+    delivered_events = []
+
+    async def _handle_message(event):
+        delivered_events.append(event)
+        if len(delivered_events) == 1:
+            entered_first_delivery.set()
+            await release_first_delivery.wait()
+
+    adapter.handle_message.side_effect = _handle_message
+    watcher = {
+        "session_id": session.id,
+        "check_interval": 0,
+        "session_key": "agent:main:telegram:dm:123:24296",
+        "platform": "telegram",
+        "chat_id": "123",
+        "thread_id": "24296",
+        "message_id": "555",
+        "notify_on_complete": True,
+    }
+
+    first_watcher = asyncio.create_task(runner._run_process_watcher(watcher))
+    await asyncio.wait_for(entered_first_delivery.wait(), timeout=1)
+
+    await runner._run_process_watcher(watcher)
+    assert len(delivered_events) == 1
+
+    release_first_delivery.set()
+    await first_watcher
+
+    assert registry.is_completion_consumed(session.id)
+    adapter.handle_message.assert_awaited_once()
+    adapter.send.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_internal_event_bypass_pairing.py
+++ b/tests/gateway/test_internal_event_bypass_pairing.py
@@ -29,7 +29,8 @@ class _FakeRegistry:
 
     def __init__(self, sessions):
         self._sessions = list(sessions)
-        self._completion_consumed: set = set()
+        self._completion_consumed: set[str] = set()
+        self._completion_delivery_claimed: set[str] = set()
 
     def get(self, session_id):
         if self._sessions:
@@ -38,6 +39,22 @@ class _FakeRegistry:
 
     def is_completion_consumed(self, session_id):
         return session_id in self._completion_consumed
+
+    def claim_completion_delivery(self, session_id):
+        if (
+            session_id in self._completion_consumed
+            or session_id in self._completion_delivery_claimed
+        ):
+            return False
+        self._completion_delivery_claimed.add(session_id)
+        return True
+
+    def release_completion_delivery(self, session_id):
+        self._completion_delivery_claimed.discard(session_id)
+
+    def mark_completion_consumed(self, session_id):
+        self._completion_consumed.add(session_id)
+        self.release_completion_delivery(session_id)
 
 
 def _build_runner(monkeypatch, tmp_path) -> GatewayRunner:

--- a/tests/gateway/test_scale_to_zero_watcher.py
+++ b/tests/gateway/test_scale_to_zero_watcher.py
@@ -144,7 +144,11 @@ def test_real_inbound_after_dormancy_restores_running_status(monkeypatch):
     assert status_updates == ["running"]
 
 
-def test_bg_work_false_when_quiet():
+def test_bg_work_false_when_quiet(monkeypatch):
+    from tools.process_registry import ProcessRegistry
+
+    monkeypatch.setattr("tools.async_delegation.active_count", lambda: 0)
+    monkeypatch.setattr("tools.process_registry.process_registry", ProcessRegistry())
     r = GatewayRunner.__new__(GatewayRunner)
     r._background_tasks = set()
     # No background tasks, no active processes in this fresh process.

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -176,7 +176,8 @@ class ProcessRegistry:
         # via wait/log.  Drain loops AND gateway/tui watchers skip notifications
         # for these — a blocking wait() or a full read_log() means the agent
         # has the output in hand and is acting on it this turn.
-        self._completion_consumed: set = set()
+        self._completion_consumed: set[str] = set()
+        self._completion_delivery_claimed: set[str] = set()
 
         # Track sessions the agent merely *observed* exited via poll().  poll()
         # is a read-only status check, so it does NOT mark _completion_consumed
@@ -1099,6 +1100,34 @@ class ProcessRegistry:
         """Check if a completion notification was already consumed via wait/log."""
         return session_id in self._completion_consumed
 
+    def claim_completion_delivery(self, session_id: str) -> bool:
+        """Reserve one autonomous completion delivery for a session."""
+        if not session_id:
+            return False
+        with self._lock:
+            if (
+                session_id in self._completion_consumed
+                or session_id in self._completion_delivery_claimed
+            ):
+                return False
+            self._completion_delivery_claimed.add(session_id)
+            return True
+
+    def release_completion_delivery(self, session_id: str) -> None:
+        """Release a delivery reservation when notification injection fails."""
+        if not session_id:
+            return
+        with self._lock:
+            self._completion_delivery_claimed.discard(session_id)
+
+    def mark_completion_consumed(self, session_id: str) -> None:
+        """Mark a session completion as delivered by an autonomous watcher."""
+        if not session_id:
+            return
+        with self._lock:
+            self._completion_consumed.add(session_id)
+            self._completion_delivery_claimed.discard(session_id)
+
     def is_session_waiting(self, session_id: str) -> bool:
         """Whether a goal loop parked on this session should still be parked.
 
@@ -1727,6 +1756,7 @@ class ProcessRegistry:
         for sid in expired:
             del self._finished[sid]
             self._completion_consumed.discard(sid)
+            self._completion_delivery_claimed.discard(sid)
             self._poll_observed.discard(sid)
 
         # If still over limit, remove oldest finished
@@ -1735,6 +1765,7 @@ class ProcessRegistry:
             oldest_id = min(self._finished, key=lambda sid: self._finished[sid].started_at)
             del self._finished[oldest_id]
             self._completion_consumed.discard(oldest_id)
+            self._completion_delivery_claimed.discard(oldest_id)
             self._poll_observed.discard(oldest_id)
 
         # Drop any _completion_consumed / _poll_observed entries whose sessions
@@ -1745,6 +1776,9 @@ class ProcessRegistry:
         stale = self._completion_consumed - tracked
         if stale:
             self._completion_consumed -= stale
+        stale_claims = self._completion_delivery_claimed - tracked
+        if stale_claims:
+            self._completion_delivery_claimed -= stale_claims
         stale_polls = self._poll_observed - tracked
         if stale_polls:
             self._poll_observed -= stale_polls


### PR DESCRIPTION
## Symptom

Background process completion notifications with `notify_on_complete=True` could be delivered more than once when duplicate watcher tasks observed the same finished session.

## Root Cause

The gateway watcher injected the synthetic completion `MessageEvent`, but it did not mark the process completion as consumed in `ProcessRegistry`. A sequential duplicate watcher could reinject the same completion. A concurrent duplicate watcher could also pass the consumed check before the first `handle_message` call returned.

## Fix

- Added lock-protected completion delivery claim/release state to `ProcessRegistry`.
- Added `ProcessRegistry.mark_completion_consumed(session_id)` and call it only after successful `await adapter.handle_message(synth_event)`.
- Release the in-flight delivery claim on failed injection so the completion remains retryable.
- Skip duplicate agent-notify watchers before the plain text fallback path.
- Updated gateway tests and fakes for sequential dedupe, failed-injection retry, and concurrent watcher suppression.
- Isolated the scale-to-zero quiet test from leaked global background-process state so the required filtered pytest command is stable.

## Test Evidence

```text
python3 -c "import ast; ast.parse(open('gateway/run.py').read()); ast.parse(open('tools/process_registry.py').read()); print('AST OK')"
AST OK
```

```text
python3 -m pytest tests/gateway/test_background_process_notifications.py::test_agent_notify_watcher_marks_completion_consumed_after_success tests/gateway/test_background_process_notifications.py::test_agent_notify_watcher_retries_after_injection_error tests/gateway/test_background_process_notifications.py::test_agent_notify_watcher_claims_completion_before_await -q --tb=short
...                                                                      [100%]
3 passed in 0.85s
```

```text
python3 -m pytest tests/ -k "process_registry or notification or watcher or completion" -q --tb=short
677 passed, 5 skipped, 37469 deselected, 33 warnings in 36.13s
```

```text
python3 -m ruff check gateway/run.py tools/process_registry.py tests/gateway/test_background_process_notifications.py tests/gateway/test_internal_event_bypass_pairing.py tests/gateway/test_scale_to_zero_watcher.py
All checks passed!
```

Manual concurrent watcher harness:

```json
{"pass": true, "delivered_count": 1, "during_concurrent_count": 1, "send_count": 0, "consumed": true, "event_internal": true, "message_id": "555"}
```

Review gates:

- Code review: APPROVE, blockers none.
- QA: PASS, blockers none.
- Gate review: PASS, blockers none.
