### PR TITLE
fix(cron): reject one-shot jobs with a past timestamp at creation time

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -978,6 +978,19 @@ def create_job(
         no_agent=normalized_no_agent,
     )
 
+    next_run = compute_next_run(parsed_schedule)
+
+    # Reject one-shot jobs whose target time is already unreachable.
+    # _recoverable_oneshot_run_at() returns None when run_at is more than
+    # ONESHOT_GRACE_SECONDS in the past — the job would be persisted with
+    # next_run_at=None, state="scheduled", and silently never fire (#59395).
+    if next_run is None and parsed_schedule.get("kind") == "once":
+        run_at = parsed_schedule.get("run_at", "unknown")
+        raise ValueError(
+            f"Requested one-shot time {run_at} is in the past "
+            f"(grace window: {ONESHOT_GRACE_SECONDS}s) and cannot be scheduled."
+        )
+
     job = {
         "id": job_id,
         "name": name or label_source[:50].strip(),
@@ -1006,7 +1019,7 @@ def create_job(
         "paused_at": None,
         "paused_reason": None,
         "created_at": now,
-        "next_run_at": compute_next_run(parsed_schedule),
+        "next_run_at": next_run,
         "last_run_at": None,
         "last_status": None,
         "last_error": None,

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -320,6 +320,33 @@ class TestJobCRUD:
         job = create_job(prompt="Test", schedule="30m")
         assert job["deliver"] == "local"
 
+    def test_reject_past_oneshot(self, tmp_cron_dir):
+        """A one-shot whose run_at is more than ONESHOT_GRACE_SECONDS in the
+        past must raise ValueError — the job would otherwise persist with
+        next_run_at=None and silently never fire (#59395)."""
+        past = (datetime.now() - timedelta(minutes=10)).isoformat()
+        with pytest.raises(ValueError, match="in the past"):
+            create_job(prompt="Past one-shot", schedule=past, deliver="local")
+
+    def test_accept_future_oneshot(self, tmp_cron_dir):
+        """A one-shot in the future must be created normally."""
+        future = (datetime.now() + timedelta(hours=1)).isoformat()
+        job = create_job(prompt="Future one-shot", schedule=future, deliver="local")
+        assert job["next_run_at"] is not None
+        assert job["state"] == "scheduled"
+
+    def test_accept_oneshot_within_grace_window(self, tmp_cron_dir, monkeypatch):
+        """A one-shot within ONESHOT_GRACE_SECONDS of now must still be
+        accepted — the grace window exists so a job created a few seconds
+        after its target minute still fires on the next tick."""
+        now = datetime(2026, 7, 6, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        # 30 seconds ago — well within the 120s grace window
+        recent = (now - timedelta(seconds=30)).isoformat()
+        job = create_job(prompt="Recent one-shot", schedule=recent, deliver="local")
+        assert job["next_run_at"] is not None
+        assert job["state"] == "scheduled"
+
 
 class TestUpdateJob:
     def test_update_name(self, tmp_cron_dir):


### PR DESCRIPTION
## What

`create_job()` silently accepted one-shot schedules whose `run_at` was more than `ONESHOT_GRACE_SECONDS` (120s) in the past. The job was persisted with `next_run_at=None`, `state="scheduled"`, and silently never fired — no warning, no error, and `cronjob action='list'` showed it as healthy.

## Root cause

`cron/jobs.py` `create_job()` L1009 called `compute_next_run(parsed_schedule)` → `_recoverable_oneshot_run_at()` → returned `None` when `run_at` was outside the 120s grace window (L482). The `None` was stored as `next_run_at` with no validation, creating an invisible ghost job.

## Fix

Three additions in `create_job()` (L981-992):

1. Hoist `compute_next_run()` result into a local `next_run` before building the job dict
2. When `next_run is None` **and** `kind == "once"`, raise `ValueError` with a clear message including the requested `run_at` and grace window
3. Use `next_run` in the dict instead of calling `compute_next_run()` inline

## Test plan

Three new tests in `tests/cron/test_jobs.py::TestJobCRUD`:

- `test_reject_past_oneshot` — 10-min-past one-shot raises `ValueError`
- `test_accept_future_oneshot` — future one-shot created normally
- `test_accept_oneshot_within_grace_window` — 30s-past one-shot still accepted

All 115 existing cron tests pass with zero changes.

## Related

Closes #59395
