### PR TITLE
fix: drop malformed required schema values

### DIFF
--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -130,6 +130,36 @@ def test_required_all_missing_is_dropped():
     assert "required" not in out[0]["function"]["parameters"]
 
 
+def test_required_null_is_dropped():
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": None,
+    })]
+
+    out = sanitize_tool_schemas(tools)
+
+    assert "required" not in out[0]["function"]["parameters"]
+
+
+def test_nested_required_null_is_dropped():
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "task": {
+                "type": "object",
+                "properties": {"goal": {"type": "string"}},
+                "required": None,
+            },
+        },
+    })]
+
+    out = sanitize_tool_schemas(tools)
+
+    task_schema = out[0]["function"]["parameters"]["properties"]["task"]
+    assert "required" not in task_schema
+
+
 def test_well_formed_schema_unchanged():
     schema = {
         "type": "object",

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -313,6 +313,13 @@ def _sanitize_node(node: Any, path: str) -> Any:
             # Recursing into these with _sanitize_node() would mis-interpret
             # literal strings like "path" as bare-string schemas and replace
             # them with {"type": "object"} dicts. Pass through unchanged.
+            if key == "required" and not isinstance(value, list):
+                logger.debug(
+                    "schema_sanitizer[%s]: dropping non-list required=%r "
+                    "(strict-backend compat)",
+                    path, value,
+                )
+                continue
             out[key] = copy.deepcopy(value) if isinstance(value, (list, dict)) else value
         else:
             out[key] = _sanitize_node(value, f"{path}.{key}") if isinstance(value, (dict, list)) else value


### PR DESCRIPTION
Summary
- Drop non-list `required` values while sanitizing tool JSON schemas.
- Preserve existing required-field pruning for valid arrays.
- Add regression coverage for top-level and nested `required: null` schemas.

Problem
Strict OpenAI-compatible backends can reject a whole tool payload when any tool schema contains `required: null`. Hermes already sanitized several strict-backend schema hazards, but non-list `required` values passed through unchanged and could surface as HTTP 400 before the agent loop produced a useful response.

Validation
- `/Users/arhaandesai/.hermes/hermes-agent/venv/bin/pytest -q tests/tools/test_schema_sanitizer.py`
- `/Users/arhaandesai/.hermes/hermes-agent/venv/bin/python -m py_compile tools/schema_sanitizer.py tests/tools/test_schema_sanitizer.py`
- `/Users/arhaandesai/.hermes/hermes-agent/venv/bin/python -m ruff check tools/schema_sanitizer.py tests/tools/test_schema_sanitizer.py`

Fixes #59386