### PR TITLE
fix: enable ANSI rendering on Windows consoles

### DIFF
--- a/hermes_bootstrap.py
+++ b/hermes_bootstrap.py
@@ -28,6 +28,9 @@ What this module does on Windows:
   - Reconfigures ``sys.stdout`` / ``sys.stderr`` to UTF-8 in the current
     process, using the ``reconfigure()`` API (Python 3.7+).  This fixes
     ``print("café")`` in the parent without a re-exec.
+  - Enables Windows virtual-terminal processing for stdout/stderr console
+    handles so ANSI color/style escapes render instead of printing literally
+    in Windows 10 CMD / PowerShell hosts.
 
 What this module does NOT do:
 
@@ -49,11 +52,62 @@ against double-reconfigure.
 
 from __future__ import annotations
 
+import ctypes
 import os
 import sys
 
 _IS_WINDOWS = sys.platform == "win32"
 _bootstrap_applied = False
+
+_STD_OUTPUT_HANDLE = -11
+_STD_ERROR_HANDLE = -12
+_INVALID_HANDLE_VALUE = ctypes.c_void_p(-1).value
+_ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
+
+
+def _enable_windows_virtual_terminal_processing() -> bool:
+    """Enable ANSI escape rendering for Windows console stdout/stderr."""
+    if not _IS_WINDOWS:
+        return False
+
+    try:
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+    except Exception:
+        return False
+
+    # ctypes assumes C ``int`` arguments and return values when signatures are
+    # omitted.  A Windows HANDLE is pointer-sized, so that default truncates
+    # valid console handles in 64-bit processes before GetConsoleMode sees them.
+    dword = ctypes.c_ulong
+    handle_type = ctypes.c_void_p
+    get_std_handle = kernel32.GetStdHandle
+    get_console_mode = kernel32.GetConsoleMode
+    set_console_mode = kernel32.SetConsoleMode
+    get_std_handle.argtypes = [dword]
+    get_std_handle.restype = handle_type
+    get_console_mode.argtypes = [handle_type, ctypes.POINTER(dword)]
+    get_console_mode.restype = ctypes.c_int
+    set_console_mode.argtypes = [handle_type, dword]
+    set_console_mode.restype = ctypes.c_int
+
+    enabled = False
+    for std_handle in (_STD_OUTPUT_HANDLE, _STD_ERROR_HANDLE):
+        try:
+            handle = get_std_handle(std_handle)
+            if handle in (None, 0, _INVALID_HANDLE_VALUE):
+                continue
+
+            mode = dword()
+            if not get_console_mode(handle, ctypes.byref(mode)):
+                continue
+
+            new_mode = mode.value | _ENABLE_VIRTUAL_TERMINAL_PROCESSING
+            if set_console_mode(handle, new_mode):
+                enabled = True
+        except Exception:
+            continue
+
+    return enabled
 
 
 def apply_windows_utf8_bootstrap() -> bool:
@@ -117,6 +171,8 @@ def apply_windows_utf8_bootstrap() -> bool:
                 reconfigure(encoding="utf-8", errors="replace")
             except (OSError, ValueError):
                 pass
+
+    _enable_windows_virtual_terminal_processing()
 
     _bootstrap_applied = True
     return True

--- a/tests/test_hermes_bootstrap.py
+++ b/tests/test_hermes_bootstrap.py
@@ -114,6 +114,108 @@ class TestWindowsBehavior:
         assert "\U0001f680" in decoded
 
 
+class TestWindowsAnsiConsoleMode:
+    """Windows console hosts must be switched into ANSI rendering mode."""
+
+    class _FakeFunction:
+        def __init__(self, callback):
+            self.callback = callback
+            self.argtypes = None
+            self.restype = None
+
+        def __call__(self, *args):
+            return self.callback(*args)
+
+    @classmethod
+    def _fake_kernel32(cls, hb, *, redirect_stderr=False, output_handle=None):
+        class _FakeKernel32:
+            def __init__(self):
+                self.modes = {
+                    hb._STD_OUTPUT_HANDLE: 0x0001,
+                    hb._STD_ERROR_HANDLE: 0x0001,
+                }
+                self.set_modes = []
+                self.seen_handles = []
+                self.GetStdHandle = cls._FakeFunction(self._get_std_handle)
+                self.GetConsoleMode = cls._FakeFunction(self._get_console_mode)
+                self.SetConsoleMode = cls._FakeFunction(self._set_console_mode)
+
+            def _get_std_handle(self, std_handle):
+                if std_handle == hb._STD_OUTPUT_HANDLE and output_handle is not None:
+                    return output_handle
+                return std_handle
+
+            def _get_console_mode(self, handle, mode_ptr):
+                self.seen_handles.append(handle)
+                if redirect_stderr and handle == hb._STD_ERROR_HANDLE:
+                    return 0
+                mode_ptr._obj.value = self.modes.get(handle, 0x0001)
+                return 1
+
+            def _set_console_mode(self, handle, mode):
+                self.set_modes.append((handle, mode))
+                return 1
+
+        return _FakeKernel32()
+
+    def test_virtual_terminal_processing_enabled(self, monkeypatch):
+        hb = _fresh_import()
+        hb._IS_WINDOWS = True
+        hb._bootstrap_applied = False
+
+        fake_kernel32 = self._fake_kernel32(hb)
+
+        class _FakeWindll:
+            kernel32 = fake_kernel32
+
+        monkeypatch.setattr(hb.ctypes, "windll", _FakeWindll(), raising=False)
+
+        assert hb.apply_windows_utf8_bootstrap() is True
+        assert fake_kernel32.set_modes == [
+            (hb._STD_OUTPUT_HANDLE, 0x0005),
+            (hb._STD_ERROR_HANDLE, 0x0005),
+        ]
+
+    def test_kernel32_functions_use_pointer_safe_signatures(self, monkeypatch):
+        hb = _fresh_import()
+        hb._IS_WINDOWS = True
+        large_handle = 0x1_0000_0001
+        fake_kernel32 = self._fake_kernel32(hb, output_handle=large_handle)
+
+        class _FakeWindll:
+            kernel32 = fake_kernel32
+
+        monkeypatch.setattr(hb.ctypes, "windll", _FakeWindll(), raising=False)
+
+        assert hb._enable_windows_virtual_terminal_processing() is True
+        assert fake_kernel32.GetStdHandle.argtypes == [hb.ctypes.c_ulong]
+        assert fake_kernel32.GetStdHandle.restype is hb.ctypes.c_void_p
+        assert fake_kernel32.GetConsoleMode.argtypes == [
+            hb.ctypes.c_void_p,
+            hb.ctypes.POINTER(hb.ctypes.c_ulong),
+        ]
+        assert fake_kernel32.SetConsoleMode.argtypes == [
+            hb.ctypes.c_void_p,
+            hb.ctypes.c_ulong,
+        ]
+        assert large_handle in fake_kernel32.seen_handles
+
+    def test_redirected_console_handle_is_ignored(self, monkeypatch):
+        hb = _fresh_import()
+        hb._IS_WINDOWS = True
+        hb._bootstrap_applied = False
+
+        fake_kernel32 = self._fake_kernel32(hb, redirect_stderr=True)
+
+        class _FakeWindll:
+            kernel32 = fake_kernel32
+
+        monkeypatch.setattr(hb.ctypes, "windll", _FakeWindll(), raising=False)
+
+        assert hb.apply_windows_utf8_bootstrap() is True
+        assert fake_kernel32.set_modes == [(hb._STD_OUTPUT_HANDLE, 0x0005)]
+
+
 class TestUserOptOut:
     """If the user has explicitly set PYTHONUTF8 / PYTHONIOENCODING in
     their environment, we respect that (setdefault, not overwrite)."""


### PR DESCRIPTION
## Summary
- Enable Windows virtual-terminal processing for stdout and stderr in the shared bootstrap.
- Declare pointer-safe Kernel32 signatures for `GetStdHandle`, `GetConsoleMode`, and `SetConsoleMode`.
- Ignore redirected or invalid handles and cover the 64-bit handle boundary with simulated tests.

## Problem
Hermes configured UTF-8 streams on Windows but did not enable the console mode that interprets ANSI style sequences. The first implementation also called Kernel32 without ctypes signatures, so 64-bit console handles could be truncated to `c_int`.

## Validation
- `python -m pytest -q tests/test_hermes_bootstrap.py` (21 passed, 5 skipped)
- `python -m ruff check hermes_bootstrap.py tests/test_hermes_bootstrap.py`

Fixes #59397