### PR TITLE
fix(mattermost): normalize rich markdown safely

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2561,6 +2561,7 @@ DEFAULT_CONFIG = {
         "require_mention": True,       # Require @mention to respond in channels
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
+        "rich_markdown": False,        # Normalize unsupported rich HTML into Mattermost Markdown
         "channel_prompts": {},         # Per-channel ephemeral system prompts
     },
 

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -14,6 +14,7 @@ Environment variables:
 from __future__ import annotations
 
 import asyncio
+import html
 import json
 import logging
 import os
@@ -50,6 +51,20 @@ _RECONNECT_MAX_DELAY = 60.0
 _RECONNECT_JITTER = 0.2
 
 
+def _as_bool(value: Any, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return bool(value)
+
+
 def check_mattermost_requirements() -> bool:
     """Return True if the Mattermost adapter can be used."""
     token = os.getenv("MATTERMOST_TOKEN", "")
@@ -66,6 +81,29 @@ def check_mattermost_requirements() -> bool:
     except ImportError:
         logger.warning("Mattermost: aiohttp not installed")
         return False
+
+
+_HTML_DETAILS_RE = re.compile(
+    r"<details>\s*<summary>(?P<summary>.*?)</summary>\s*(?P<body>.*?)\s*</details>",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _format_mattermost_rich_markdown(content: str) -> str:
+    """Normalize generic rich content into documented Mattermost Markdown."""
+
+    def _replace_details(match: re.Match[str]) -> str:
+        summary = html.unescape(match.group("summary"))
+        summary = re.sub(r"\s+", " ", summary).strip() or "Details"
+        body = html.unescape(match.group("body")).strip()
+        if not body:
+            return f"**{summary}**"
+        quoted_body = "\n".join(
+            f"> {line}" if line else ">" for line in body.splitlines()
+        )
+        return f"**{summary}**\n{quoted_body}"
+
+    return _HTML_DETAILS_RE.sub(_replace_details, content)
 
 
 class MattermostAdapter(BasePlatformAdapter):
@@ -97,6 +135,7 @@ class MattermostAdapter(BasePlatformAdapter):
             config.extra.get("reply_mode", "")
             or os.getenv("MATTERMOST_REPLY_MODE", "off")
         ).lower()
+        self._rich_markdown: bool = _as_bool(config.extra.get("rich_markdown"))
 
         self._last_post_status: Optional[int] = None
         self._last_post_error: str = ""
@@ -474,13 +513,17 @@ class MattermostAdapter(BasePlatformAdapter):
         )
 
     def format_message(self, content: str) -> str:
-        """Mattermost uses standard Markdown — mostly pass through.
+        """Mattermost uses Markdown — pass through, with optional normalization.
 
         Strip image markdown into plain links (files are uploaded separately).
+        Mattermost-native mentions, task lists, emoji, math, and plugin code
+        fences already work without the option and remain untouched.
         """
         # Convert ![alt](url) to just the URL — Mattermost renders
         # image URLs as inline previews automatically.
         content = re.sub(r"!\[([^\]]*)\]\(([^)]+)\)", r"\2", content)
+        if self._rich_markdown:
+            content = _format_mattermost_rich_markdown(content)
         return content
 
     # ------------------------------------------------------------------
@@ -1189,11 +1232,12 @@ def _apply_yaml_config(yaml_cfg: dict, mattermost_cfg: dict) -> dict | None:
     model and merely owns the YAML→env translation here, next to the
     adapter that consumes it.
 
-    Env vars take precedence over YAML — every assignment is guarded
+    Env vars take precedence over YAML — every env assignment is guarded
     by ``not os.getenv(...)`` so an explicit env var survives a config.yaml
-    update.  Returns ``None`` because no extras are seeded into
-    ``PlatformConfig.extra`` directly (everything flows through env).
+    update.  ``rich_markdown`` is returned as ``PlatformConfig.extra`` because
+    it is adapter-local formatting behavior rather than an env-driven gate.
     """
+    seeded: dict[str, Any] = {}
     if "require_mention" in mattermost_cfg and not os.getenv("MATTERMOST_REQUIRE_MENTION"):
         os.environ["MATTERMOST_REQUIRE_MENTION"] = str(mattermost_cfg["require_mention"]).lower()
     frc = mattermost_cfg.get("free_response_channels")
@@ -1207,7 +1251,9 @@ def _apply_yaml_config(yaml_cfg: dict, mattermost_cfg: dict) -> dict | None:
         if isinstance(ac, list):
             ac = ",".join(str(v) for v in ac)
         os.environ["MATTERMOST_ALLOWED_CHANNELS"] = str(ac)
-    return None  # all settings flow through env; nothing to merge into extras
+    if "rich_markdown" in mattermost_cfg:
+        seeded["rich_markdown"] = _as_bool(mattermost_cfg.get("rich_markdown"))
+    return seeded or None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -183,18 +183,65 @@ class TestMattermostConfigLoading:
         assert Platform.MATTERMOST in config.platforms
         assert config.platforms[Platform.MATTERMOST].extra.get("url") == ""
 
+    def test_apply_yaml_config_returns_rich_markdown_extra(self, monkeypatch):
+        monkeypatch.delenv("MATTERMOST_REQUIRE_MENTION", raising=False)
+        from plugins.platforms.mattermost.adapter import _apply_yaml_config
+
+        seeded = _apply_yaml_config(
+            {"mattermost": {"rich_markdown": True}},
+            {"rich_markdown": True},
+        )
+
+        assert seeded == {"rich_markdown": True}
+
+    def test_apply_yaml_config_parses_rich_markdown_string(self):
+        from plugins.platforms.mattermost.adapter import _apply_yaml_config
+
+        seeded = _apply_yaml_config(
+            {"mattermost": {"rich_markdown": "false"}},
+            {"rich_markdown": "false"},
+        )
+
+        assert seeded == {"rich_markdown": False}
+
+    def test_load_gateway_config_resolves_registered_rich_markdown_extra(
+        self, monkeypatch, tmp_path
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "mattermost:\n  rich_markdown: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("MATTERMOST_TOKEN", "test-token")
+        monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
+
+        from gateway.config import load_gateway_config
+        from gateway.platform_registry import platform_registry
+
+        config = load_gateway_config()
+
+        entry = platform_registry.get("mattermost")
+        assert entry is not None
+        assert entry.apply_yaml_config_fn is not None
+        assert config.platforms[Platform.MATTERMOST].extra["rich_markdown"] is True
+
 
 # ---------------------------------------------------------------------------
 # Adapter format / truncate
 # ---------------------------------------------------------------------------
 
-def _make_adapter():
+def _make_adapter(extra=None):
     """Create a MattermostAdapter with mocked config."""
     from plugins.platforms.mattermost.adapter import MattermostAdapter
+    adapter_extra = {"url": "https://mm.example.com"}
+    if extra:
+        adapter_extra.update(extra)
     config = PlatformConfig(
         enabled=True,
         token="test-token",
-        extra={"url": "https://mm.example.com"},
+        extra=adapter_extra,
     )
     adapter = MattermostAdapter(config)
     return adapter
@@ -234,6 +281,34 @@ class TestMattermostFormatMessage:
         assert "![" not in result
         assert "http://a.com/1.png" in result
         assert "http://b.com/2.png" in result
+
+    def test_rich_markdown_disabled_preserves_html_details(self):
+        content = "<details><summary>Plan</summary>Do the thing</details>"
+        assert self.adapter.format_message(content) == content
+
+    def test_rich_markdown_preserves_mattermost_extensions(self):
+        adapter = _make_adapter({"rich_markdown": True})
+        content = (
+            "@alice check ~town-square :thumbsup:\n"
+            "- [ ] task\n"
+            "```mermaid\nflowchart TD\nA-->B\n```"
+        )
+
+        assert adapter.format_message(content) == content
+
+    def test_rich_markdown_expands_html_details_with_supported_markdown(self):
+        adapter = _make_adapter({"rich_markdown": True})
+        content = (
+            "<details>\n"
+            "<summary>Plan &amp; risks</summary>\n"
+            "\n"
+            "- [x] shipped\n"
+            "</details>"
+        )
+
+        assert adapter.format_message(content) == (
+            "**Plan & risks**\n> - [x] shipped"
+        )
 
 
 class TestMattermostTruncateMessage:

--- a/website/docs/user-guide/messaging/mattermost.md
+++ b/website/docs/user-guide/messaging/mattermost.md
@@ -161,9 +161,12 @@ Optional behavior settings in `~/.hermes/config.yaml`:
 
 ```yaml
 group_sessions_per_user: true
+mattermost:
+  rich_markdown: true
 ```
 
 - `group_sessions_per_user: true` keeps each participant's context isolated inside shared channels and threads
+- `mattermost.rich_markdown: true` converts unsupported HTML disclosure blocks into expanded, readable Mattermost Markdown. Native Mattermost features such as mentions, task lists, emoji, math, and plugin-provided code fences are always passed through and do not require this option. Mattermost does not document a collapsible `::: details` fence, so Hermes does not emit one.
 
 ### Start the Gateway
 


### PR DESCRIPTION
## Summary
- Route `mattermost.rich_markdown` through registered plugin discovery and the real gateway config loader.
- Preserve native Mattermost mentions, task lists, emoji, math, and plugin code fences unchanged.
- Convert HTML disclosure blocks to documented bold and blockquote Markdown instead of emitting an unsupported details fence.
- Document the option around its actual formatting behavior.

## Problem
Mattermost already renders its native Markdown without a flag. The previous implementation overstated what the option enabled and converted HTML details into an undocumented `::: details` fence that could be displayed literally.

## Validation
- `python -m pytest -q tests/gateway/test_mattermost.py` (66 passed)
- `python -m ruff check hermes_cli/config.py plugins/platforms/mattermost/adapter.py tests/gateway/test_mattermost.py`

Refs #59401