### PR TITLE
fix(dashboard): let CORS preflights bypass token gate

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -344,6 +344,14 @@ def _has_valid_query_token(request: Request, path: str) -> bool:
     return bool(token) and hmac.compare_digest(token.encode(), _SESSION_TOKEN.encode())
 
 
+def _is_cors_preflight(request: Request) -> bool:
+    return (
+        request.method == "OPTIONS"
+        and bool(request.headers.get("origin"))
+        and bool(request.headers.get("access-control-request-method"))
+    )
+
+
 def _require_token(request: Request) -> None:
     """Authorize a sensitive endpoint, raising 401 if the caller isn't allowed.
 
@@ -575,6 +583,11 @@ async def auth_middleware(request: Request, call_next):
     # above) is authoritative.  The legacy _SESSION_TOKEN path is loopback-only
     # and is skipped here so the gate's session attachment isn't overridden.
     if getattr(request.app.state, "auth_required", False):
+        return await call_next(request)
+    # Browser CORS preflights never carry the dashboard session token. Let the
+    # inner CORSMiddleware answer them according to the configured origin/method
+    # policy; the real follow-up request still goes through the token gate.
+    if _is_cors_preflight(request):
         return await call_next(request)
     path = request.url.path
     if path.startswith("/api/") and path not in _PUBLIC_API_PATHS:

--- a/tests/hermes_cli/test_dashboard_auth_gate.py
+++ b/tests/hermes_cli/test_dashboard_auth_gate.py
@@ -46,6 +46,22 @@ def test_loopback_protected_route_requires_token(client_loopback):
     assert r.status_code == 401
 
 
+def test_loopback_cors_preflight_to_protected_api_uses_cors_policy(client_loopback):
+    """CORS preflights are tokenless by design, so auth must not 401 them."""
+    origin = "http://127.0.0.1:8092"
+    r = client_loopback.options(
+        "/api/skills",
+        headers={
+            "Origin": origin,
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "x-hermes-session-token",
+        },
+    )
+    assert r.status_code == 200
+    assert r.headers["access-control-allow-origin"] == origin
+    assert "x-hermes-session-token" in r.headers["access-control-allow-headers"].lower()
+
+
 def test_loopback_protected_route_accepts_session_token(client_loopback):
     """The injected SPA token unlocks protected /api/ routes."""
     r = client_loopback.get(


### PR DESCRIPTION
## Problem

Fixes #59052.

Loopback dashboard CORS allows localhost origins, but token-protected `/api/*` preflight requests never reached `CORSMiddleware`. A cross-port localhost SPA that sends `X-Hermes-Session-Token` triggers `OPTIONS /api/...` first; browsers do not include that token on preflight, so the legacy dashboard token middleware returned `401` with no CORS headers and the real request was never sent.

## Root Cause

`auth_middleware` wraps the earlier-registered `CORSMiddleware` in loopback mode. It treated tokenless CORS preflights exactly like real protected API calls, even though preflights are only asking whether the configured CORS policy allows the follow-up request.

## Fix

Detect true browser CORS preflights (`OPTIONS` + `Origin` + `Access-Control-Request-Method`) in the loopback token gate and pass them through to `CORSMiddleware`. The actual follow-up request still has to carry `X-Hermes-Session-Token` or the legacy bearer token.

## Tests

- `$HOME/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_dashboard_auth_gate.py::test_loopback_cors_preflight_to_protected_api_uses_cors_policy -q`
- `$HOME/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_dashboard_auth_gate.py -q`
- `scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_gate.py`
- `$HOME/.hermes/hermes-agent/venv/bin/python -m ruff check hermes_cli/web_server.py tests/hermes_cli/test_dashboard_auth_gate.py`

Duplicate check: searched open/all PRs for `#59052`, CORS, preflight, and OPTIONS preflight before implementation; no competing PR found.
