### PR TITLE
fix: normalize empty tool-call assistant content

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -150,6 +150,12 @@ class ChatCompletionsTransport(ProviderTransport):
           ``Extra inputs are not permitted, field: 'messages[N].tool_name'``.
           Permissive providers (OpenRouter, MiniMax) silently ignore the
           field, which masked the bug for months.
+        - Empty-string assistant ``content`` on tool-call turns — Bedrock-backed
+          OpenAI-compatible Claude gateways translate ``content: ""`` into an
+          empty Anthropic text block and reject it with
+          ``messages: text content blocks must be non-empty``.  ``content: None``
+          is the canonical strict Chat Completions representation for an
+          assistant message that contains only ``tool_calls``.
         - Hermes-internal scaffolding markers — any top-level message key
           starting with ``_`` (e.g. ``_empty_recovery_synthetic``,
           ``_empty_terminal_sentinel``, ``_thinking_prefill``). These are
@@ -181,6 +187,9 @@ class ChatCompletionsTransport(ProviderTransport):
                 break
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
+                if msg.get("role") == "assistant" and msg.get("content") == "":
+                    needs_sanitize = True
+                    break
                 for tc in tool_calls:
                     if isinstance(tc, dict) and (
                         "call_id" in tc
@@ -199,6 +208,12 @@ class ChatCompletionsTransport(ProviderTransport):
         for msg in sanitized:
             if not isinstance(msg, dict):
                 continue
+            if (
+                msg.get("role") == "assistant"
+                and isinstance(msg.get("tool_calls"), list)
+                and msg.get("content") == ""
+            ):
+                msg["content"] = None
             msg.pop("codex_reasoning_items", None)
             msg.pop("codex_message_items", None)
             msg.pop("tool_name", None)

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -104,6 +104,46 @@ class TestChatCompletionsBasic:
         # Original list untouched (deepcopy-on-demand)
         assert msgs[2]["tool_name"] == "execute_code"
 
+    def test_convert_messages_normalizes_empty_tool_call_content(self, transport):
+        """Assistant tool-call turns with ``content: ""`` are legal on
+        permissive OpenAI-compatible routes, but Bedrock-backed Claude gateways
+        translate them into empty Anthropic text blocks and reject them with
+        HTTP 400 "messages: text content blocks must be non-empty".  Use
+        ``None`` for the strict Chat Completions representation of an assistant
+        message that contains only tool calls.
+        """
+        msgs = [
+            {"role": "user", "content": "run a tool"},
+            {"role": "assistant", "content": "",
+             "tool_calls": [{"id": "call_1", "type": "function",
+                             "function": {"name": "terminal", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+        ]
+        result = transport.convert_messages(msgs, model="claude-sonnet-5")
+        assert result[1]["content"] is None
+        assert result[1]["tool_calls"][0]["id"] == "call_1"
+        # Original list untouched (deepcopy-on-demand)
+        assert msgs[1]["content"] == ""
+
+    def test_convert_messages_keeps_empty_text_response_content(self, transport):
+        """Only tool-call assistant messages are normalized; a text-only empty
+        assistant message follows the existing no-copy behavior.
+        """
+        msgs = [{"role": "assistant", "content": ""}]
+        assert transport.convert_messages(msgs) is msgs
+        assert msgs[0]["content"] == ""
+
+    def test_build_kwargs_normalizes_empty_tool_call_content(self, transport):
+        msgs = [
+            {"role": "user", "content": "run a tool"},
+            {"role": "assistant", "content": "",
+             "tool_calls": [{"id": "call_1", "type": "function",
+                             "function": {"name": "terminal", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+        ]
+        kw = transport.build_kwargs(model="claude-sonnet-5", messages=msgs)
+        assert kw["messages"][1]["content"] is None
+
     def test_convert_messages_strips_timestamp(self, transport):
         """Internal per-message ``timestamp`` metadata (stamped by
         ``_apply_persist_user_message_override`` to preserve platform event


### PR DESCRIPTION
## Summary

Normalize assistant tool-call messages with empty-string `content` to `None` before sending Chat Completions requests.

Some OpenAI-compatible Claude gateways backed by AWS Bedrock translate assistant tool-call turns like:

```json
{"role": "assistant", "content": "", "tool_calls": [...]}
```

into an Anthropic/Bedrock empty text block, which Bedrock rejects with:

```text
ValidationException: messages: text content blocks must be non-empty
```

`content: null` is the strict Chat Completions representation for an assistant message that contains only tool calls, and avoids the empty text block while preserving the tool-call history.

## Changes

- Detect assistant messages with `tool_calls` and `content == ""` in `ChatCompletionsTransport.convert_messages()`.
- Deep-copy on demand and normalize that content to `None` before API replay.
- Add regression tests for:
  - conversion-level normalization
  - `build_kwargs()` normalization
  - preserving empty content on text-only assistant messages
  - preserving the original message list

## Test plan

```bash
PYTHONPATH=/tmp/hermes-agent-sonnet5-empty-content-pr python -m pytest tests/agent/transports/test_chat_completions.py -q -o 'addopts='
```

Result:

```text
85 passed in 0.81s
```

## Real-world repro

Against a Bedrock-backed OpenAI-compatible Claude/Sonnet endpoint:

- Assistant tool-call history with `content: ""` failed with HTTP 400:
  `messages: text content blocks must be non-empty`
- The same request with `content: null` succeeded.
