### PR TITLE
fix(qqbot): accept is_reconnect kwarg in QQAdapter.connect()

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,8 +278,15 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
-        """Authenticate, obtain gateway URL, and open the WebSocket."""
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        """Authenticate, obtain gateway URL, and open the WebSocket.
+
+        ``is_reconnect`` is part of the ``BasePlatformAdapter.connect`` contract
+        (the gateway forwards it on retry). QQ does not need to branch on it
+        currently, but the kwarg MUST be accepted or the reconnect loop dies
+        with ``TypeError: got an unexpected keyword argument 'is_reconnect'``.
+        """
+        del is_reconnect  # accepted for contract compliance; unused today
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"
             self._set_fatal_error("qq_missing_dependency", message, retryable=True)


### PR DESCRIPTION
## Symptom

After the QQ WebSocket receives its first `code=4009 Session timed out` close (which happens routinely, ~every 30 min per QQ's own docs), the gateway reconnect loop dies with:

```
ERROR gateway.run: ✗ qqbot error: QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'
WARNING gateway.run: Reconnect qqbot error: QQAdapter.connect() got an unexpected keyword argument 'is_reconnect', next retry in 120s
```

…and never recovers. QQ silently stops delivering messages to the agent until the gateway is manually restarted (and even then, the next 4009 close kills it again). Nothing on the QQ side surfaces the failure — users just notice their agent has stopped responding on QQ.

## Root cause

`gateway/run.py` forwards `is_reconnect=True` to `adapter.connect()` on every retry (line 7724 → `_call_adapter_connect` at 3383). All ~30 other adapters — Telegram, Discord, Slack, Feishu, WhatsApp, Signal, WeChat, Matrix, Teams, LINE, Email, IRC, SMS, DingTalk, WeCom, Homeassistant, Google Chat, Mattermost, Ntfy, Photon, Raft, Simplex, Yuanbao, API Server, BlueBubbles, Webhook, MSGraph Webhook, Relay — accept `*, is_reconnect: bool = False` per the `BasePlatformAdapter.connect()` contract (see `gateway/platforms/base.py:2864`).

`QQAdapter.connect()` was the lone holdout with a bare `async def connect(self) -> bool:` signature.

## Fix

Add the `*, is_reconnect: bool = False` kwarg to `QQAdapter.connect()`. QQ's connection flow does not need to branch on cold-boot vs. reconnect today (unlike Telegram, which uses it to drive `drop_pending_updates`), so the parameter is accepted-and-ignored with a `del is_reconnect` and a docstring pointer explaining why it must nonetheless be accepted.

## Verification

On the affected host, before this patch: qqbot cycled through 30-min timeout → TypeError → 60s → 120s retry backoff, permanently disconnected.

After this patch: `systemctl --user restart hermes-gateway` → qqbot connects → user confirmed message delivery restored end-to-end.

## Notes

- One-line contract fix, no behavior change beyond accepting the kwarg.
- Consistent with the existing pattern used by every other adapter in the tree.
- Would recommend a follow-up test that iterates every adapter class and asserts `connect` accepts `is_reconnect` to catch regressions of this exact class, but out of scope for this fix.