### PR TITLE
test(cli): gate only the POSIX mode-bit assertion on Windows

### DIFF
--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -2693,8 +2693,9 @@ class TestMemoryProviderExternalPaths:
         restored = dst_home / ".honcho" / "config.json"
         assert restored.exists()
         assert restored.read_text() == '{"peer":"bob"}'
-        # Credential-shaped file tightened.
-        assert (restored.stat().st_mode & 0o777) == 0o600
+        # Credential-shaped file tightened where POSIX mode bits are supported.
+        if os.name != "nt":
+            assert (restored.stat().st_mode & 0o777) == 0o600
         # External state did NOT leak into HERMES_HOME.
         assert not (hermes_home / "_external").exists()
 


### PR DESCRIPTION
## What & why

Native Windows does not expose POSIX permission bits from `os.chmod(..., 0o600)`, so the credential-shaped restore test failed on `st_mode` even though restoration was correct.

## Change

Keep the test enabled on every platform and gate only the POSIX-specific `0o600` assertion. Windows still verifies the restored home-relative path, file contents, and absence of `_external` leakage under `HERMES_HOME`.

## Validation

- The focused external-restore test passes on native Windows.
- `ruff` and `git diff --check` pass.

This follows the reviewer-requested assertion-level scope and the repository precedent in #60888.