### PR TITLE
fix(qqbot): accept is_reconnect kwarg in connect() to match base class signature

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,7 +278,7 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"


### PR DESCRIPTION
## Problem

QQ bot fails to reconnect after gateway restart with error:

```
QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'
```

All other platform adapters accept the `is_reconnect` parameter (from `BasePlatformAdapter.connect`), but QQ adapter was missed when this parameter was added to the base class.

## Fix

Add `*, is_reconnect: bool = False` to `QQAdapter.connect()` signature to match the base class contract.

## Verification

- Gateway restart: QQ bot reconnects successfully (state goes from `retrying` to `connected`)
- All other platforms already have this parameter — no regression risk