### PR TITLE
fix(cron): reject one-shot jobs with a past timestamp at create + update (#59395)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -988,7 +988,8 @@ def create_job(
             ONESHOT_GRACE_SECONDS,
         )
         raise ValueError(
-            f"Requested one-shot time {run_at} is in the past and cannot be scheduled."
+            f"Requested one-shot time {run_at} is more than "
+            f"{ONESHOT_GRACE_SECONDS}s in the past and cannot be scheduled."
         )
 
     job = {
@@ -1150,7 +1151,29 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updated_schedule.get("display", updated.get("schedule_display")),
                 )
                 if updated.get("state") != "paused":
-                    updated["next_run_at"] = compute_next_run(updated_schedule)
+                    updated_next_run = compute_next_run(updated_schedule)
+                    # Same guard as create_job: an UPDATE that sets a one-shot
+                    # to a time >ONESHOT_GRACE_SECONDS in the past would store
+                    # next_run_at=None with state="scheduled", re-creating the
+                    # ghost job that never fires (#59395). Reject it here too so
+                    # the bug can't re-enter through the update door.
+                    if (
+                        updated_next_run is None
+                        and updated_schedule.get("kind") == "once"
+                    ):
+                        run_at = updated_schedule.get("run_at") or updated_schedule
+                        logger.warning(
+                            "Rejecting one-shot cron job update '%s': run_at %s "
+                            "is outside the %ss grace window",
+                            updated.get("name", job_id),
+                            run_at,
+                            ONESHOT_GRACE_SECONDS,
+                        )
+                        raise ValueError(
+                            f"Requested one-shot time {run_at} is more than "
+                            f"{ONESHOT_GRACE_SECONDS}s in the past and cannot be scheduled."
+                        )
+                    updated["next_run_at"] = updated_next_run
 
             if inference_fields_changed:
                 provider_snapshot, model_snapshot = _compute_provider_model_snapshots(

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -978,6 +978,19 @@ def create_job(
         no_agent=normalized_no_agent,
     )
 
+    next_run_at = compute_next_run(parsed_schedule)
+    if parsed_schedule.get("kind") == "once" and next_run_at is None:
+        run_at = parsed_schedule.get("run_at") or schedule
+        logger.warning(
+            "Rejecting one-shot cron job '%s': run_at %s is outside the %ss grace window",
+            name or label_source[:50].strip(),
+            run_at,
+            ONESHOT_GRACE_SECONDS,
+        )
+        raise ValueError(
+            f"Requested one-shot time {run_at} is in the past and cannot be scheduled."
+        )
+
     job = {
         "id": job_id,
         "name": name or label_source[:50].strip(),
@@ -1006,7 +1019,7 @@ def create_job(
         "paused_at": None,
         "paused_reason": None,
         "created_at": now,
-        "next_run_at": compute_next_run(parsed_schedule),
+        "next_run_at": next_run_at,
         "last_run_at": None,
         "last_status": None,
         "last_error": None,

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -11,6 +11,7 @@ import json
 import os
 import sys
 import textwrap
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -84,6 +85,19 @@ class TestJobScriptField:
 
         updated = update_job(job["id"], {"script": None})
         assert updated.get("script") is None
+
+
+def test_cronjob_tool_rejects_stale_past_one_shot(cron_env, monkeypatch):
+    from tools.cronjob_tools import cronjob
+
+    now = datetime(2026, 3, 18, 4, 30, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+    stale = (now - timedelta(minutes=5)).isoformat()
+
+    result = json.loads(cronjob(action="create", prompt="Too late", schedule=stale))
+
+    assert result["success"] is False
+    assert "past and cannot be scheduled" in result["error"]
 
 
 class TestRunJobScript:

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -374,6 +374,33 @@ class TestUpdateJob:
         assert fetched["schedule"]["minutes"] == 120
         assert fetched["schedule_display"] == "every 120m"
 
+    def test_update_to_past_oneshot_rejected(self, tmp_cron_dir, monkeypatch):
+        """Updating a job's schedule to a one-shot >ONESHOT_GRACE_SECONDS in the
+        past must raise ValueError — otherwise the ghost-job bug (#59395) re-enters
+        through the update door (next_run_at=None stored with state='scheduled').
+        The original job must be left unchanged on disk."""
+        now = datetime(2026, 7, 6, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = create_job(prompt="Recurring", schedule="every 1h", deliver="local")
+        past = parse_schedule((now - timedelta(minutes=10)).isoformat())
+        with pytest.raises(ValueError, match="past and cannot be scheduled"):
+            update_job(job["id"], {"schedule": past})
+        # Original job unchanged — still the recurring interval, still scheduled.
+        fetched = get_job(job["id"])
+        assert fetched["schedule"]["kind"] == "interval"
+        assert fetched["next_run_at"] is not None
+
+    def test_update_to_future_oneshot_accepted(self, tmp_cron_dir, monkeypatch):
+        """Updating to a FUTURE one-shot still works — only past ones are rejected."""
+        now = datetime(2026, 7, 6, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = create_job(prompt="Recurring", schedule="every 1h", deliver="local")
+        future = parse_schedule((now + timedelta(hours=2)).isoformat())
+        updated = update_job(job["id"], {"schedule": future})
+        assert updated is not None
+        assert updated["schedule"]["kind"] == "once"
+        assert updated["next_run_at"] is not None
+
     def test_update_enable_disable(self, tmp_cron_dir):
         job = create_job(prompt="Toggle me", schedule="every 1h")
         assert job["enabled"] is True

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -305,6 +305,26 @@ class TestJobCRUD:
         job = create_job(prompt="One-shot", schedule="1h")
         assert job["repeat"]["times"] == 1
 
+    def test_rejects_stale_past_one_shot_at_creation(self, tmp_cron_dir, monkeypatch):
+        now = datetime(2026, 3, 18, 4, 30, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        stale = (now - timedelta(minutes=5)).isoformat()
+
+        with pytest.raises(ValueError, match="past and cannot be scheduled"):
+            create_job(prompt="Too late", schedule=stale)
+
+        assert load_jobs() == []
+
+    def test_recent_past_one_shot_within_grace_still_creates(self, tmp_cron_dir, monkeypatch):
+        now = datetime(2026, 3, 18, 4, 30, 30, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        recent = (now - timedelta(seconds=30)).isoformat()
+
+        job = create_job(prompt="Still valid", schedule=recent)
+
+        assert job["next_run_at"] == recent
+        assert load_jobs()[0]["id"] == job["id"]
+
     def test_interval_no_auto_repeat(self, tmp_cron_dir):
         job = create_job(prompt="Recurring", schedule="every 1h")
         assert job["repeat"]["times"] is None


### PR DESCRIPTION
## Summary

`create_job()` now rejects one-shot jobs whose target time is already unreachable, instead of silently persisting a ghost job that never fires. Fixes #59395.

**Root cause:** for a `once` schedule, `compute_next_run()` → `_recoverable_oneshot_run_at()` returns `None` when `run_at` is more than `ONESHOT_GRACE_SECONDS` (120s) in the past. `create_job()` stored that `None` as `next_run_at` with `state="scheduled"` and no validation — the job looked healthy in `cronjob list` but never ran, with no warning or error. A caller who miscomputed "tomorrow 9am" into a past absolute timestamp got a confident success and a reminder that silently never arrived.

## Changes

- `cron/jobs.py` — `create_job()`: hoist `compute_next_run()` into a local; when it returns `None` and `kind == "once"`, log a warning and raise `ValueError` (with the grace-window seconds) before the job dict is built or persisted. Reuse the local in the dict (also removes a redundant second `compute_next_run()` call).
- `cron/jobs.py` — `update_job()`: **same guard on the schedule-change path** (whole-bug-class fix). The `schedule_changed` branch had the identical unguarded `compute_next_run → next_run_at` pattern, so updating a job's schedule to a past one-shot would re-create the ghost job through the update door. The guard raises before any disk write, leaving the original job intact. (`resume`/`trigger`/re-arm paths are unaffected — their `None` is the semantically-valid "exhausted one-shot" case, not a user-supplied past time.)
- `tests/cron/test_jobs.py` — create: past raises + no ghost job; future and within-grace still create. update: past-one-shot update rejected (original left unchanged) + future-one-shot update accepted.
- `tests/cron/test_cron_script.py` — E2E through the `cronjob` tool: a stale past one-shot returns `{success: false, error: "...past and cannot be scheduled"}`.

## Validation

| | Before (main) | After |
|---|---|---|
| create one-shot >120s past | persisted, `next_run_at=None`, `state=scheduled`, never fires (silent) | `ValueError`, nothing persisted |
| **update schedule → past one-shot** | **ghost job re-created (same bug)** | **`ValueError`, original job unchanged** |
| within-grace / future one-shot | created | created (unchanged) |
| `cronjob` tool on stale one-shot | `success: true` + ghost job | `success: false` + clear error |
| `tests/cron/` full suite | — | 635 passed, 0 failed |

Verified via E2E with a temp `HERMES_HOME`: past one-shot raises with the grace-window message, `load_jobs()` stays empty (no ghost file), future + within-grace still create. ruff clean, ty 3==3 (zero net-new).

## Credit

Based on #59412 by @itsflownium — cherry-picked to preserve authorship (fix + tests, including the tool-boundary E2E test). A competing PR #59410 by @isheng-eqi (submitted a few minutes earlier) fixed the same issue with an identical guard; its richer error message (surfacing the grace-window seconds) was folded in via a follow-up commit crediting @isheng-eqi (Co-authored-by). Both contributors correctly identified the ghost-job root cause; #59412 was chosen for its broader test coverage (tool-boundary E2E + persistence assertion). #59410 closed as duplicate with credit.
