### PR TITLE
fix(kanban): accept a list of statuses in list_tasks + normalize blank assignee

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2378,6 +2378,8 @@ def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
     """Lowercase-assignee normalization for Kanban rows (dashboard/CLI parity)."""
     if assignee is None:
         return None
+    if isinstance(assignee, str) and not assignee.strip():
+        return None
     from hermes_cli.profiles import normalize_profile_name
 
     return normalize_profile_name(assignee)
@@ -2740,10 +2742,18 @@ def list_tasks(
         query += " AND assignee = ?"
         params.append(_canonical_assignee(assignee))
     if status is not None:
-        if status not in VALID_STATUSES:
-            raise ValueError(f"status must be one of {sorted(VALID_STATUSES)}")
-        query += " AND status = ?"
-        params.append(status)
+        if isinstance(status, (list, tuple)):
+            for s in status:
+                if s not in VALID_STATUSES:
+                    raise ValueError(f"status must be one of {sorted(VALID_STATUSES)}")
+            if status:
+                query += f" AND status IN ({','.join(['?' for _ in status])})"
+                params.extend(status)
+        else:
+            if status not in VALID_STATUSES:
+                raise ValueError(f"status must be one of {sorted(VALID_STATUSES)}")
+            query += " AND status = ?"
+            params.append(status)
     if tenant is not None:
         query += " AND tenant = ?"
         params.append(tenant)


### PR DESCRIPTION
## Summary
- `list_tasks(status=...)` now also accepts a **list/tuple of statuses** (rendered as a SQL `IN (...)` clause), while keeping the existing single-string behavior. Each entry is validated against `VALID_STATUSES` as before.
- `_canonical_assignee()` now normalizes **empty/whitespace-only assignee strings to `None`** instead of passing them into `normalize_profile_name()`.

## Motivation
Filtering a board on multiple statuses (e.g. `ready` + `running` for "active work") currently requires N separate queries or client-side filtering. We've been running this patch locally on an edge deployment (dashboard/CLI parity for a Jetson-based ops board) and it keeps getting re-applied across `hermes update` runs, so upstreaming it.

Backwards compatible: single-string `status` behaves exactly as before, invalid entries still raise `ValueError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)