### PR TITLE
fix(feishu): route topic sends via reply API; remove invalid thread_id receive_id

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15332,12 +15332,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             parent_session_id = str(evt.get("parent_session_id") or "").strip()
             if parent_session_id:
                 metadata["gateway_session_id"] = parent_session_id
+            # Resolve a reply anchor for the synthetic event. Prefer the event's
+            # explicit message_id (terminal watchers and async-delegation
+            # completions carry the triggering ``om_`` anchor from the
+            # session context). When that's missing (older background
+            # processes dispatched before the anchor was captured, or a
+            # session origin whose message_id wasn't populated), fall back to
+            # the persisted session-store origin's message_id — e.g. a Feishu
+            # thread root. This keeps topic/thread-capable platforms routing
+            # the re-entry message via the reply API instead of an invalid
+            # create-by-thread-id path.
+            _synth_msg_id = str(evt.get("message_id") or "").strip() or getattr(source, "message_id", None) or None
             synth_event = MessageEvent(
                 text=synth_text,
                 message_type=MessageType.TEXT,
                 source=source,
                 internal=True,
-                message_id=str(evt.get("message_id") or "").strip() or None,
+                message_id=_synth_msg_id,
                 metadata=metadata,
             )
             logger.info(
@@ -15573,6 +15584,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             await adapter.send(
                                 chat_id,
                                 message_text,
+                                reply_to=message_id,
                                 metadata=_non_conversational_metadata(send_meta, platform=platform_name),
                             )
                         except Exception as e:
@@ -15603,6 +15615,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         await adapter.send(
                             chat_id,
                             message_text,
+                            reply_to=message_id,
                             metadata=_non_conversational_metadata(send_meta, platform=platform_name),
                         )
                     except Exception as e:

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3249,14 +3249,29 @@ class FeishuAdapter(BasePlatformAdapter):
             if hint:
                 text = f"{hint}\n\n{text}" if text else hint
 
-        thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
+        root_id = getattr(message, "root_id", None)
+        thread_id = getattr(message, "thread_id", None) or root_id or None
         reply_to_message_id = (
             getattr(message, "parent_id", None)
             or getattr(message, "upper_message_id", None)
-            or getattr(message, "root_id", None)
+            or root_id
             or None
         )
         reply_to_text = await self._fetch_message_text(reply_to_message_id) if reply_to_message_id else None
+        # Feishu has no "send by thread_id" API — a message lands in a topic
+        # only via the reply API with reply_in_thread=true against an ``om_``
+        # message id.  Thread replies on real inbound messages route off
+        # ``event.reply_to_message_id``; synthetic / resumed sends (async
+        # delegation completions, terminal background notifications, cron
+        # deliveries) only see ``event.message_id`` plus ``source.message_id``
+        # (the latter is persisted on the session origin and rehydrated by the
+        # gateway).  Populate ``source.message_id`` with a stable thread anchor
+        # — the topic root when present, otherwise the message itself (which
+        # IS the root for a seed message) — so every downstream path that
+        # resolves a reply anchor for a Feishu thread can find a valid ``om_``
+        # id instead of falling into an invalid ``receive_id_type=thread_id``
+        # create branch.
+        thread_reply_anchor = root_id or message_id
 
         sender_primary = (
             getattr(sender_id, "open_id", None)
@@ -3288,6 +3303,7 @@ class FeishuAdapter(BasePlatformAdapter):
             thread_id=thread_id,
             user_id_alt=sender_profile["user_id_alt"],
             is_bot=is_bot,
+            message_id=thread_reply_anchor,
         )
         normalized = MessageEvent(
             text=text,
@@ -4620,34 +4636,45 @@ class FeishuAdapter(BasePlatformAdapter):
             request = self._build_reply_message_request(effective_reply_to, body)
             return await self._run_blocking(self._client.im.v1.message.reply, request)
 
-        # For topic/thread messages that fell back from reply→create, use
-        # thread_id as receive_id so the message lands in the topic instead of
-        # the main chat.
-        _thread_id = (metadata or {}).get("thread_id")
-        if _thread_id:
-            body = self._build_create_message_body(
-                receive_id=_thread_id,
-                msg_type=msg_type,
-                content=payload,
-                uuid_value=str(uuid.uuid4()),
+        # No reply anchor available.  Feishu's create-message API only
+        # accepts receive_id_type in {open_id, union_id, user_id, email,
+        # chat_id} — there is NO ``thread_id`` receive_id_type, so a topic
+        # message cannot be created by threading off the ``omt_`` thread id.
+        # Landing in a topic requires the reply API above against a real
+        # ``om_`` message id.  When a threaded send reaches this point anyway
+        # (a synthetic / resumed event whose source.message_id and metadata
+        # both lacked an anchor), fall back to a top-level chat create and
+        # warn loudly rather than emitting an invalid ``receive_id_type=
+        # thread_id`` request that the server rejects with
+        # ``[99992402] field validation failed``.  Thread context is lost on
+        # this fallback, which is strictly better than a hard send failure —
+        # the routing layer is expected to keep source.message_id populated
+        # so this branch stays unreached in normal operation.
+        if (metadata or {}).get("thread_id") and not effective_reply_to:
+            logger.warning(
+                "[Feishu] Thread send with no reply anchor for chat %s thread %s; "
+                "falling back to top-level chat send (thread context will be lost). "
+                "Ensure the inbound source.message_id and async-delegation / "
+                "terminal notification message_id are populated so threaded "
+                "sends route via the reply API.",
+                chat_id,
+                (metadata or {}).get("thread_id"),
             )
-            request = self._build_create_message_request("thread_id", body)
-        else:
-            receive_id = chat_id
-            receive_id_type = "chat_id"
-            if chat_id.startswith("feishu_user_id:"):
-                receive_id = chat_id.split(":", 1)[1]
-                receive_id_type = "user_id"
-            elif chat_id.startswith("ou_"):
-                receive_id_type = "open_id"
+        receive_id = chat_id
+        receive_id_type = "chat_id"
+        if chat_id.startswith("feishu_user_id:"):
+            receive_id = chat_id.split(":", 1)[1]
+            receive_id_type = "user_id"
+        elif chat_id.startswith("ou_"):
+            receive_id_type = "open_id"
 
-            body = self._build_create_message_body(
-                receive_id=receive_id,
-                msg_type=msg_type,
-                content=payload,
-                uuid_value=str(uuid.uuid4()),
-            )
-            request = self._build_create_message_request(receive_id_type, body)
+        body = self._build_create_message_body(
+            receive_id=receive_id,
+            msg_type=msg_type,
+            content=payload,
+            uuid_value=str(uuid.uuid4()),
+        )
+        request = self._build_create_message_request(receive_id_type, body)
         return await self._run_blocking(self._client.im.v1.message.create, request)
 
     @staticmethod

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1547,6 +1547,93 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(event.message_type.value, "command")
         self.assertEqual(event.text, "/help test")
 
+    def test_inbound_thread_message_populates_source_message_id_anchor(self):
+        """A topic/thread inbound message must populate source.message_id
+        with a stable om_ thread anchor (the topic root) so synthetic /
+        resumed sends (async-delegation completions, terminal background
+        notifications) route into the topic via the reply API instead of an
+        invalid create-by-thread-id path."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_chat", "name": "Group", "type": "group"}
+        )
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "ou_user", "user_name": "张三", "user_id_alt": None}
+        )
+        adapter._fetch_message_text = AsyncMock(return_value=None)
+        message = SimpleNamespace(
+            chat_id="oc_chat",
+            thread_id="omt_topic_abc",
+            root_id="om_root_msg",
+            parent_id=None,
+            upper_message_id=None,
+            message_type="text",
+            content='{"text":"hi in topic"}',
+            message_id="om_user_msg",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_user", user_id=None, union_id=None),
+                is_bot=False,
+                chat_type="group",
+                message_id="om_user_msg",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        # source.message_id carries the topic root, not the omt_ thread id.
+        self.assertEqual(event.source.thread_id, "omt_topic_abc")
+        self.assertEqual(event.source.message_id, "om_root_msg")
+        # event.reply_to_message_id is unchanged — still the root for context.
+        self.assertEqual(event.reply_to_message_id, "om_root_msg")
+
+    def test_inbound_thread_seed_message_populates_source_message_id_self(self):
+        """A seed message (the first message of a new topic, no root_id yet)
+        populates source.message_id with the message itself — it IS the root."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_chat", "name": "Group", "type": "group"}
+        )
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "ou_user", "user_name": "张三", "user_id_alt": None}
+        )
+        adapter._fetch_message_text = AsyncMock(return_value=None)
+        message = SimpleNamespace(
+            chat_id="oc_chat",
+            thread_id="omt_topic_new",
+            root_id=None,
+            parent_id=None,
+            upper_message_id=None,
+            message_type="text",
+            content='{"text":"new topic"}',
+            message_id="om_seed_msg",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_user", user_id=None, union_id=None),
+                is_bot=False,
+                chat_type="group",
+                message_id="om_seed_msg",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        self.assertEqual(event.source.message_id, "om_seed_msg")
+
     @patch.dict(os.environ, {}, clear=True)
     def test_extract_text_file_injects_content(self):
         from gateway.config import PlatformConfig

--- a/tests/gateway/test_stream_consumer_thread_routing.py
+++ b/tests/gateway/test_stream_consumer_thread_routing.py
@@ -174,39 +174,119 @@ class TestOverflowFirstMessage:
 
 
 class TestFeishuFallbackThreadRouting:
-    """Verify FeishuAdapter._send_raw_message routes to topic on fallback."""
+    """Verify FeishuAdapter._send_raw_message routes thread sends via reply API.
+
+    Feishu's create-message API only accepts receive_id_type in
+    {open_id, union_id, user_id, email, chat_id} — there is NO ``thread_id``
+    receive_id_type, so a topic message can only land in a topic through the
+    reply API (``reply_in_thread=true``) against a real ``om_`` message id.
+    These tests assert that contract: a thread send with an anchor uses the
+    reply API, and a thread send with no anchor falls back to a top-level
+    chat create (never an invalid ``receive_id_type=thread_id``).
+    """
 
     @pytest.mark.asyncio
-    async def test_create_uses_thread_id_when_available(self):
-        """When reply_to=None and metadata has thread_id, message.create
-        should use receive_id_type='thread_id'."""
+    async def test_thread_send_with_anchor_uses_reply_api(self):
+        """When reply_to is set and metadata has thread_id, the reply API is
+        used with reply_in_thread=True so the message lands in the topic."""
         from plugins.platforms.feishu.adapter import FeishuAdapter
 
-        # We test the _send_raw_message method directly by mocking the client
-        adapter = MagicMock(spec=FeishuAdapter)
+        mock_client = MagicMock()
+        mock_reply_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="new_msg_1"),
+        )
+        mock_client.im.v1.message.reply = MagicMock(return_value=mock_reply_response)
+        mock_client.im.v1.message.create = MagicMock()
 
-        # Set up the real _send_raw_message logic manually
+        adapter = MagicMock(spec=FeishuAdapter)
+        adapter._client = mock_client
+        adapter._build_reply_message_body = FeishuAdapter._build_reply_message_body
+        adapter._build_reply_message_request = FeishuAdapter._build_reply_message_request
+        async def _run_blocking_passthrough(func, *args):
+            return func(*args)
+        adapter._run_blocking = _run_blocking_passthrough
+
+        import json
+        await FeishuAdapter._send_raw_message(
+            adapter,
+            chat_id="oc_main_chat",
+            msg_type="text",
+            payload=json.dumps({"text": "hello"}),
+            reply_to="om_thread_root",
+            metadata={"thread_id": "omt_topic_abc"},
+        )
+
+        # Reply API is the path that lands a message in a topic.
+        mock_client.im.v1.message.reply.assert_called_once()
+        mock_client.im.v1.message.create.assert_not_called()
+        # request must target the supplied om_ message id.
+        reply_request = mock_client.im.v1.message.reply.call_args[0][0]
+        assert getattr(reply_request, "message_id", None) == "om_thread_root"
+
+    @pytest.mark.asyncio
+    async def test_thread_send_with_metadata_reply_to_uses_reply_api(self):
+        """When reply_to is None but metadata carries reply_to_message_id
+        (the Feishu status-metadata fallback), the reply API is still used."""
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        mock_client = MagicMock()
+        mock_reply_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="new_msg_1"),
+        )
+        mock_client.im.v1.message.reply = MagicMock(return_value=mock_reply_response)
+        mock_client.im.v1.message.create = MagicMock()
+
+        adapter = MagicMock(spec=FeishuAdapter)
+        adapter._client = mock_client
+        adapter._build_reply_message_body = FeishuAdapter._build_reply_message_body
+        adapter._build_reply_message_request = FeishuAdapter._build_reply_message_request
+        async def _run_blocking_passthrough(func, *args):
+            return func(*args)
+        adapter._run_blocking = _run_blocking_passthrough
+
+        import json
+        await FeishuAdapter._send_raw_message(
+            adapter,
+            chat_id="oc_main_chat",
+            msg_type="text",
+            payload=json.dumps({"text": "hello"}),
+            reply_to=None,
+            metadata={
+                "thread_id": "omt_topic_abc",
+                "reply_to_message_id": "om_thread_root",
+            },
+        )
+
+        mock_client.im.v1.message.reply.assert_called_once()
+        mock_client.im.v1.message.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_thread_send_without_anchor_falls_back_to_chat_create(self):
+        """When reply_to is None and metadata has thread_id but no anchor,
+        fall back to a top-level chat create — NOT an invalid
+        receive_id_type=thread_id. The Feishu API rejects thread_id."""
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
         mock_client = MagicMock()
         mock_create_response = SimpleNamespace(
             success=lambda: True,
             data=SimpleNamespace(message_id="new_msg_1"),
         )
         mock_client.im.v1.message.create = MagicMock(return_value=mock_create_response)
+        mock_client.im.v1.message.reply = MagicMock()
 
-        # Use the real implementation path
+        adapter = MagicMock(spec=FeishuAdapter)
         adapter._client = mock_client
         adapter._build_create_message_body = FeishuAdapter._build_create_message_body
         adapter._build_create_message_request = FeishuAdapter._build_create_message_request
-        # _send_raw_message routes blocking SDK calls through _run_blocking
-        # (adapter-owned executor). On a MagicMock(spec=...) that method is
-        # auto-mocked and would swallow the real call, so wire a passthrough.
         async def _run_blocking_passthrough(func, *args):
             return func(*args)
         adapter._run_blocking = _run_blocking_passthrough
 
-        # Call _send_raw_message with reply_to=None and thread_id in metadata
         import json
-        result = await FeishuAdapter._send_raw_message(
+        await FeishuAdapter._send_raw_message(
             adapter,
             chat_id="oc_main_chat",
             msg_type="text",
@@ -215,28 +295,26 @@ class TestFeishuFallbackThreadRouting:
             metadata={"thread_id": "omt_topic_abc"},
         )
 
-        # Verify message.create was called (not message.reply)
         mock_client.im.v1.message.create.assert_called_once()
-
-        # The request should have receive_id_type="thread_id"
+        mock_client.im.v1.message.reply.assert_not_called()
         call_args = mock_client.im.v1.message.create.call_args[0][0]
-        # Lark SDK builder exposes .body; the in-tree fallback exposes .request_body.
-        # The contributor's branch had the lark SDK installed, the test environment
-        # may not — handle both shapes.
+        receive_id_type = getattr(call_args, "receive_id_type", None)
+        assert receive_id_type != "thread_id", (
+            f"receive_id_type must NOT be 'thread_id' (Feishu rejects it); "
+            f"got '{receive_id_type}'"
+        )
+        assert receive_id_type == "chat_id", (
+            f"Expected top-level fallback receive_id_type='chat_id', "
+            f"got '{receive_id_type}'"
+        )
+        # receive_id must be the chat_id, never the omt_ thread id.
         body = getattr(call_args, "body", None) or getattr(call_args, "request_body", None)
-        assert body is not None, "request has neither .body nor .request_body"
-        # receive_id should be the thread_id, not the chat_id
         receive_id = getattr(body, "receive_id", None)
         if receive_id is None and isinstance(body, str):
             import json as _json
             receive_id = _json.loads(body).get("receive_id")
-        assert receive_id == "omt_topic_abc", (
-            f"Expected receive_id='omt_topic_abc', got '{receive_id}'"
-        )
-        # And receive_id_type must be 'thread_id', not 'chat_id'
-        receive_id_type = getattr(call_args, "receive_id_type", None)
-        assert receive_id_type == "thread_id", (
-            f"Expected receive_id_type='thread_id', got '{receive_id_type}'"
+        assert receive_id == "oc_main_chat", (
+            f"Expected receive_id='oc_main_chat', got '{receive_id}'"
         )
 
     @pytest.mark.asyncio
@@ -261,7 +339,7 @@ class TestFeishuFallbackThreadRouting:
         adapter._run_blocking = _run_blocking_passthrough
 
         import json
-        result = await FeishuAdapter._send_raw_message(
+        await FeishuAdapter._send_raw_message(
             adapter,
             chat_id="oc_main_chat",
             msg_type="text",
@@ -271,3 +349,6 @@ class TestFeishuFallbackThreadRouting:
         )
 
         mock_client.im.v1.message.create.assert_called_once()
+        call_args = mock_client.im.v1.message.create.call_args[0][0]
+        receive_id_type = getattr(call_args, "receive_id_type", None)
+        assert receive_id_type == "chat_id"

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -113,6 +113,65 @@ def test_completion_event_lands_on_shared_queue_with_session_key():
     assert evt["delegation_id"] == res["delegation_id"]
 
 
+def test_completion_event_carries_message_id_single():
+    """Single-task dispatch threads message_id onto the completion event so
+    the synthetic re-entry routes into the original topic/thread via the
+    platform reply API."""
+    def runner():
+        return {"status": "completed", "summary": "ok", "api_calls": 1,
+                "duration_seconds": 1.0, "model": "m"}
+
+    res = ad.dispatch_async_delegation(
+        goal="g", context=None, toolsets=None, role="leaf", model="m",
+        session_key="agent:main:feishu:group:oc_chat:omt_topic",
+        message_id="om_thread_root",
+        runner=runner, max_async_children=3,
+    )
+    assert res["status"] == "dispatched"
+
+    evt = _drain_one()
+    assert evt is not None
+    assert evt.get("message_id") == "om_thread_root"
+
+
+def test_completion_event_carries_message_id_batch():
+    """Batch dispatch threads message_id onto the combined completion event."""
+    def runner():
+        return {"results": [{"status": "completed", "summary": "ok"}],
+                "total_duration_seconds": 1.0}
+
+    res = ad.dispatch_async_delegation_batch(
+        goals=["g1", "g2"], context=None, toolsets=None, role="orchestrator",
+        model="m", session_key="agent:main:feishu:group:oc_chat:omt_topic",
+        message_id="om_thread_root",
+        runner=runner, max_async_children=3,
+    )
+    assert res["status"] == "dispatched"
+
+    evt = _drain_one()
+    assert evt is not None
+    assert evt.get("is_batch") is True
+    assert evt.get("message_id") == "om_thread_root"
+
+
+def test_completion_event_message_id_defaults_empty():
+    """When no message_id is supplied (CLI / cron / pre-anchor sessions),
+    the event carries an empty string, not a missing key — the gateway reads
+    it unconditionally and an absent key would raise."""
+    def runner():
+        return {"status": "completed", "summary": "ok", "api_calls": 0,
+                "duration_seconds": 0.0, "model": "m"}
+
+    ad.dispatch_async_delegation(
+        goal="g", context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=runner, max_async_children=3,
+    )
+    evt = _drain_one()
+    assert evt is not None
+    assert "message_id" in evt
+    assert evt["message_id"] == ""
+
+
 def test_rich_reinjection_block_is_self_contained():
     def runner():
         return {"status": "completed", "summary": "The answer is 42.",

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -166,6 +166,27 @@ def get_current_session_key(default: str = "default") -> str:
     return get_session_env("HERMES_SESSION_KEY", default)
 
 
+def get_current_session_message_id(default: str = "") -> str:
+    """Return the triggering message id for the active session.
+
+    Mirrors :func:`get_current_session_key` but reads
+    ``HERMES_SESSION_MESSAGE_ID``.  Gateway adapters populate this from
+    ``source.message_id`` (per-turn inbound origin), so background dispatch
+    paths (``delegate_task(background=True)``, ``terminal notify_on_complete``)
+    can capture a stable ``om_``-style reply anchor BEFORE detaching onto the
+    daemon worker thread, where the contextvar is no longer carried.  The
+    anchor is threaded back into the completion event so the synthetic
+    re-entry message routes into the original topic/thread via the platform
+    reply API instead of an invalid create-by-thread-id path.
+
+    Resolution order mirrors :func:`get_current_session_key`: contextvars
+    first, ``os.environ`` fallback last.  Returns ``default`` when no
+    session context is active (CLI / cron / tests without a pinned id).
+    """
+    from gateway.session_context import get_session_env
+    return get_session_env("HERMES_SESSION_MESSAGE_ID", default)
+
+
 def _get_session_platform() -> str:
     """Return the current gateway platform from contextvars/env fallback."""
     try:

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -130,6 +130,7 @@ def dispatch_async_delegation(
     model: Optional[str],
     session_key: str,
     parent_session_id: Optional[str] = None,
+    message_id: str = "",
     runner: Callable[[], Dict[str, Any]],
     origin_ui_session_id: str = "",
     interrupt_fn: Optional[Callable[[], None]] = None,
@@ -152,6 +153,14 @@ def dispatch_async_delegation(
         the delegation. Carried on the completion event so the gateway can
         pin routing to the spawning session instead of recovering the latest
         ``ended_at IS NULL`` row for the peer tuple (#57498).
+    message_id
+        The triggering platform message id (from
+        ``tools.approval.get_current_session_message_id``), captured on the
+        parent thread BEFORE dispatch. Carried into the completion event so
+        the synthetic re-entry message routes into the original topic/thread
+        via the platform reply API. Feishu has no create-by-thread-id path
+        and would otherwise reject the send; empty for CLI / cron / sessions
+        with no anchor (the gateway falls back per platform).
     runner
         Zero-arg callable that builds + runs the child and returns the same
         result dict ``_run_single_child`` produces. Runs on the worker thread.
@@ -159,9 +168,9 @@ def dispatch_async_delegation(
         Optional callable to signal the child to stop (used on shutdown /
         explicit cancel).
     max_async_children
-        Concurrency cap. When at capacity the dispatch is REJECTED (the caller
-        should fall back to sync or tell the user) rather than queued, so a
-        runaway model can't pile up unbounded background work.
+        Concurrency cap. When at capacity the dispatch is REJECTED (the
+        caller should fall back to sync or tell the user) rather than queued,
+        so a runaway model can't pile up unbounded background work.
 
     Returns
     -------
@@ -181,6 +190,7 @@ def dispatch_async_delegation(
         "session_key": session_key,
         "origin_ui_session_id": origin_ui_session_id,
         "parent_session_id": parent_session_id,
+        "message_id": message_id,
         "status": "running",
         "dispatched_at": dispatched_at,
         "completed_at": None,
@@ -293,6 +303,10 @@ def _push_completion_event(
         "session_key": record.get("session_key", ""),
         "origin_ui_session_id": record.get("origin_ui_session_id", ""),
         "parent_session_id": record.get("parent_session_id"),
+        # message_id carries the triggering message id back onto the
+        # synthetic re-entry event so topic/thread-capable platforms route
+        # the result via the reply API instead of an invalid create path.
+        "message_id": record.get("message_id", ""),
         "goal": record.get("goal", ""),
         "context": record.get("context"),
         "toolsets": record.get("toolsets"),
@@ -328,6 +342,7 @@ def dispatch_async_delegation_batch(
     model: Optional[str],
     session_key: str,
     parent_session_id: Optional[str] = None,
+    message_id: str = "",
     runner: Callable[[], Dict[str, Any]],
     origin_ui_session_id: str = "",
     interrupt_fn: Optional[Callable[[], None]] = None,
@@ -348,6 +363,11 @@ def dispatch_async_delegation_batch(
     ``results`` list, so the consolidated summaries re-enter the conversation
     as one message once every child is done — the chat is never blocked while
     they run.
+
+    ``message_id`` mirrors ``session_key``: the triggering platform message id
+    captured on the parent thread BEFORE dispatch, carried onto the completion
+    event so the synthetic re-entry routes into the original topic/thread via
+    the reply API on platforms that have no create-by-thread-id path (Feishu).
 
     Returns ``{"status": "dispatched", "delegation_id": ...}`` on success or
     ``{"status": "rejected", "error": ...}`` when the async pool is at
@@ -371,6 +391,7 @@ def dispatch_async_delegation_batch(
         "session_key": session_key,
         "origin_ui_session_id": origin_ui_session_id,
         "parent_session_id": parent_session_id,
+        "message_id": message_id,
         "status": "running",
         "dispatched_at": dispatched_at,
         "completed_at": None,
@@ -470,6 +491,10 @@ def _finalize_batch(
         "session_key": event_record.get("session_key", ""),
         "origin_ui_session_id": event_record.get("origin_ui_session_id", ""),
         "parent_session_id": event_record.get("parent_session_id"),
+        # message_id routes the synthetic re-entry message into the original
+        # topic/thread via the platform reply API; empty when the dispatching
+        # session had no anchor (CLI / cron / stateless HTTP).
+        "message_id": event_record.get("message_id", ""),
         "goal": event_record.get("goal", ""),
         "goals": event_record.get("goals"),
         "context": event_record.get("context"),

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2765,7 +2765,10 @@ def delegate_task(
     # keep chatting, get the combined summaries back together at the end.
     if background:
         from tools.async_delegation import dispatch_async_delegation_batch
-        from tools.approval import get_current_session_key
+        from tools.approval import (
+            get_current_session_key,
+            get_current_session_message_id,
+        )
 
         # Stateless request/response sessions (the API server / WebUI path)
         # cannot route a detached subagent result back to the agent after the
@@ -2816,6 +2819,12 @@ def delegate_task(
         except Exception:
             _origin_ui_session_id = ""
         _parent_session_id = getattr(parent_agent, "session_id", None)
+        # Capture the triggering message id BEFORE detaching onto the daemon
+        # worker thread (the contextvar won't be carried there). This anchors
+        # the completion re-entry message so it routes into the original
+        # topic/thread via the platform reply API — Feishu in particular has
+        # no create-by-thread-id path and would otherwise reject the send.
+        _message_id = get_current_session_message_id(default="")
         _child_agents = [c for (_, _, c) in children]
 
         # Detach every child from the parent's interrupt-propagation list — the
@@ -2858,6 +2867,7 @@ def delegate_task(
             session_key=_session_key,
             origin_ui_session_id=_origin_ui_session_id,
             parent_session_id=_parent_session_id,
+            message_id=_message_id,
             runner=_batch_runner,
             interrupt_fn=_batch_interrupt,
             max_async_children=_get_max_async_children(),


### PR DESCRIPTION
## What does this PR do?

Fixes a Feishu send failure where the agent's reply after an async-delegation completion (and other background-notification synthetic events) is rejected by the Feishu API with `[99992402] field validation failed`, because the adapter emits an invalid `receive_id_type=thread_id` on the create-message API.

**Root cause.** A message can only land in a Feishu topic via the **reply API** (`reply_in_thread=true`) against a real `om_` message id. There is no "send by thread_id" path — the create-message API's `receive_id_type` accepts only `open_id/union_id/user_id/email/chat_id`, **not `thread_id`** (per the [create-message docs](https://open.feishu.cn/document/server-docs/im-v1/message/create) and [message field docs](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/intro), which define `thread_id` as a topic identifier distinct from `message_id`'s `om_` prefix).

The broken branch was added in #13077 (`ff14666cd`) to route "reply→create fallback" messages into a topic. Its regression test (`tests/gateway/test_stream_consumer_thread_routing.py::TestFeishuFallbackThreadRouting::test_create_uses_thread_id_when_available`) was a pure mock that only asserted the request was *shaped* as `receive_id_type=thread_id` and the client returned `success()` — it never exercised the real Feishu API, so the server rejection never surfaced. This is a green-unit-mock-hides-integration-bug case.

**When it triggers.** Real inbound messages route fine — they carry `event.reply_to_message_id` (the topic root `om_`), so the adapter uses the reply API. The broken branch is only reached when a **synthetic / resumed send** has no reply anchor:
- `delegate_task(background=true)` completions — the async-delegation event carries `session_key` but no `message_id`.
- `terminal(background=True, notify_on_complete=True)` agent re-entry — `watcher_message_id` was sourced from `source.message_id`, which Feishu never populated.
- `terminal` text-only notifications and `watch_pattern` events in a topic.

All of these hit the invalid `thread_id` create path and fail with `[99992402]`.

**Why this approach.** The fix keeps the existing "reply API lands the message in a topic" contract and makes the routing layer guarantee a stable `om_` anchor end-to-end, so every path that needs to send into a topic reaches the reply API with a valid id. The adapter's illegal branch is removed and replaced with a defensive top-level fallback (strictly better than a hard send failure), which stays unreached in normal operation once anchors are threaded through.

## Related Issue

No existing issue found. Searched open/closed issues and PRs for `thread_id receive_id`, `field validation failed`, `feishu topic send`, `async delegation send`.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

End-to-end anchor threading so a stable `om_` reply id reaches every topic send, plus removal of the invalid `receive_id_type=thread_id` create branch.

**Routing layer — populate the anchor and carry it to synthetic events:**
- `plugins/platforms/feishu/adapter.py` (inbound): extract `root_id`, set `thread_reply_anchor = root_id or message_id`, and pass it as `message_id=` to `build_source`. This populates `source.message_id` (previously always `None` for Feishu), which flows into `_SESSION_MESSAGE_ID` and is captured by background watchers at spawn time.
- `tools/approval.py`: add `get_current_session_message_id()` helper mirroring `get_current_session_key()`, reading `HERMES_SESSION_MESSAGE_ID`.
- `tools/delegate_tool.py`: capture `_message_id` before detaching onto the daemon worker thread (mirrors `_session_key` capture) and pass it to `dispatch_async_delegation_batch(message_id=...)`.
- `tools/async_delegation.py`: both `dispatch_async_delegation` and `dispatch_async_delegation_batch` accept `message_id: str = ""`, store it on the record, and carry it onto the completion event (`"message_id": ...`).
- `gateway/run.py` (terminal text notifications): pass `reply_to=message_id` on the two `adapter.send()` call sites (completion + running-update) so topic-capable platforms route via the reply API.
- `gateway/run.py` (`_inject_watch_notification`): fall back to `source.message_id` (persisted session origin) when the event lacks an explicit `message_id` — covers in-flight background processes dispatched before the anchor was captured.

**Adapter — remove the invalid branch:**
- `plugins/platforms/feishu/adapter.py` (`_send_raw_message`): delete the `receive_id_type="thread_id"` create branch. When a threaded send reaches the no-anchor point anyway, fall back to a top-level `chat_id` create with a `logger.warning` (thread context lost, but no hard failure). The `_feishu_send_with_retry` 230011/231003 topic guard is untouched (preserves PR #13077's intentional fail-closed for revoked-root cases).

## How to Test

**Unit tests** (hermetic):
```bash
scripts/run_tests.sh tests/gateway/test_stream_consumer_thread_routing.py tests/tools/test_async_delegation.py tests/gateway/test_feishu.py
```

**The old test that froze the bug is replaced.** `test_create_uses_thread_id_when_available` (asserted `receive_id_type == "thread_id"`) is replaced by:
- `test_thread_send_with_anchor_uses_reply_api` — reply API + `reply_in_thread=True`
- `test_thread_send_with_metadata_reply_to_uses_reply_api` — metadata-anchor path
- `test_thread_send_without_anchor_falls_back_to_chat_create` — asserts `receive_id_type != "thread_id"` and `== "chat_id"`

**New tests added:**
- `tests/gateway/test_feishu.py`: `test_inbound_thread_message_populates_source_message_id_anchor` (topic root → `source.message_id`), `test_inbound_thread_seed_message_populates_source_message_id_self` (seed message → self as root).
- `tests/tools/test_async_delegation.py`: `test_completion_event_carries_message_id_single`, `test_completion_event_carries_message_id_batch`, `test_completion_event_message_id_defaults_empty` (invariant: key always present, empty when no anchor).

**End-to-end reproduction (the original failure scenario):**
1. In a Feishu group topic, message the agent asking it to dispatch a subagent (which internally calls `delegate_task(background=true)`).
2. Continue chatting while the subagent runs in the background.
3. When the async-delegation completion re-enters the session, the agent's reply must **land in the topic** (not fail, not land in the main chat).

Before the fix, the gateway log showed:
```
WARNING gateway.platforms.base: [Feishu] Send failed: [99992402] field validation failed — trying plain-text fallback
ERROR gateway.platforms.base: [Feishu] Fallback send also failed: [99992402] field validation failed
```
After the fix: no `[99992402]`; the reply API is used and the message appears in the topic.

**Cross-platform regression** (other IM platforms unaffected):
```bash
scripts/run_tests.sh tests/gateway/test_stream_consumer_thread_routing.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Feishu gateway, end-to-end async-delegation scenario)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (no user-facing config/schema change; inline docstrings added)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys added)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (no architecture/workflow change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (changes are platform-neutral; `scripts/check-windows-footguns.py --diff` reports 0 issues)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no tool schema changes; `delegate_task` signature unchanged at the model-facing level)

## Screenshots / Logs

**Before** (async-delegation completion reply fails — IDs redacted):
```
WARNING gateway.platforms.base: [Feishu] Send failed: [99992402] field validation failed — trying plain-text fallback
ERROR gateway.platforms.base: [Feishu] Fallback send also failed: [99992402] field validation failed
```

**After** (reply routes into the topic via the reply API — no `[99992402]`).
