### PR TITLE
feat(telegram): support copy text buttons

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -28,6 +28,7 @@ from typing import Any, Dict, Optional
 from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale_timeout
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
 from agent.error_classifier import FailoverReason
+from agent.network_circuit_breaker import get_global_network_breaker
 from agent.gemini_native_adapter import is_native_gemini_base_url
 from agent.model_metadata import is_local_endpoint
 from agent.message_sanitization import (
@@ -185,6 +186,8 @@ def interruptible_api_call(agent, api_kwargs: dict):
     the main retry loop can try again with backoff / credential rotation /
     provider fallback.
     """
+    breaker = get_global_network_breaker()
+    breaker.before_request("provider")
     result = {"response": None, "error": None}
     request_client_holder = {"client": None, "owner_tid": None}
     request_client_lock = threading.Lock()
@@ -598,7 +601,9 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 pass
             raise InterruptedError("Agent interrupted during API call")
     if result["error"] is not None:
+        breaker.record_failure(result["error"], surface="provider")
         raise result["error"]
+    breaker.record_success(surface="provider")
     return result["response"]
 
 
@@ -1790,6 +1795,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         finally:
             agent._codex_on_first_delta = None
 
+    breaker = get_global_network_breaker()
+    breaker.before_request("provider")
+
     # Bedrock Converse uses boto3's converse_stream() with real-time delta
     # callbacks — same UX as Anthropic and chat_completions streaming.
     if agent.api_mode == "bedrock_converse":
@@ -1880,7 +1888,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             if agent._interrupt_requested:
                 raise InterruptedError("Agent interrupted during Bedrock API call")
         if result["error"] is not None:
+            breaker.record_failure(result["error"], surface="provider")
             raise result["error"]
+        breaker.record_success(surface="provider")
         return result["response"]
 
     result = {"response": None, "error": None, "partial_tool_names": []}
@@ -2901,6 +2911,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 pass
             raise InterruptedError("Agent interrupted during streaming API call")
     if result["error"] is not None:
+        breaker.record_failure(result["error"], surface="provider")
         if deltas_were_sent["yes"]:
             # Streaming failed AFTER some tokens were already delivered to
             # the platform.  Re-raising would let the outer retry loop make
@@ -2985,6 +2996,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 _stub._content_filter_terminated = True
             return _stub
         raise result["error"]
+    breaker.record_success(surface="provider")
     return result["response"]
 
 # ── Provider fallback ──────────────────────────────────────────────────

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -22,6 +22,8 @@ import time
 from types import SimpleNamespace
 from typing import Any, Dict, List
 
+from agent.credential_usage import resolve_credential_label
+
 logger = logging.getLogger(__name__)
 
 
@@ -209,6 +211,7 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
                 billing_base_url=agent.base_url,
                 billing_mode="subscription_included"
                 if cost_result.status == "included" else None,
+                credential_label=resolve_credential_label(agent),
                 model=agent.model,
                 api_call_count=1,
             )

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -28,6 +28,7 @@ import uuid
 from typing import Any, Dict, List, Optional
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
+from agent.credential_usage import resolve_credential_label
 from agent.conversation_compression import conversation_history_after_compression
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
@@ -2210,6 +2211,7 @@ def run_conversation(
                                 billing_base_url=agent.base_url,
                                 billing_mode="subscription_included"
                                 if cost_result.status == "included" else None,
+                                credential_label=resolve_credential_label(agent),
                                 model=agent.model,
                                 api_call_count=1,
                             )

--- a/agent/credential_usage.py
+++ b/agent/credential_usage.py
@@ -1,0 +1,46 @@
+"""Helpers for attributing model-token usage to credential-pool labels."""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+def resolve_credential_label(agent: Any) -> Optional[str]:
+    """Best-effort credential label for the current model call.
+
+    The router selects a runtime token from the provider credential pool before
+    the agent is initialized. We intentionally store only the non-secret label,
+    never the token. If matching fails, return None and skip credential-level
+    telemetry for that call.
+    """
+    provider = str(getattr(agent, "provider", "") or "").strip().lower()
+    if not provider:
+        return None
+    api_key = str(getattr(agent, "api_key", "") or "").strip()
+    pool = getattr(agent, "_credential_pool", None)
+    if pool is None:
+        try:
+            from agent.credential_pool import load_pool
+
+            pool = load_pool(provider)
+        except Exception:
+            return None
+    try:
+        entries = pool._available_entries(clear_expired=False, refresh=False)
+    except Exception:
+        try:
+            entries = getattr(pool, "_entries", []) or []
+        except Exception:
+            return None
+    for entry in entries:
+        try:
+            if api_key and str(getattr(entry, "runtime_api_key", "") or "").strip() == api_key:
+                return str(getattr(entry, "label", "") or "").strip() or None
+        except Exception:
+            continue
+    try:
+        current = pool.current() if callable(getattr(pool, "current", None)) else None
+        if current is not None:
+            return str(getattr(current, "label", "") or "").strip() or None
+    except Exception:
+        return None
+    return None

--- a/agent/network_circuit_breaker.py
+++ b/agent/network_circuit_breaker.py
@@ -1,0 +1,204 @@
+"""Host-level network circuit breaker utilities.
+
+This module is intentionally below provider-specific retry logic. It only
+opens on local host connectivity failures such as ephemeral port exhaustion
+(``EADDRNOTAVAIL``) or broken source-route selection (``EHOSTUNREACH``).
+Provider 4xx/5xx responses and ordinary request timeouts are left to the
+existing model retry/fallback machinery.
+"""
+
+from __future__ import annotations
+
+import errno
+import logging
+import os
+import subprocess
+import threading
+import time
+from collections import Counter
+from typing import Mapping
+
+logger = logging.getLogger(__name__)
+
+_HOST_CONNECT_ERRNOS = {
+    errno.EADDRNOTAVAIL,
+    errno.EHOSTUNREACH,
+    errno.ENETUNREACH,
+}
+
+_HOST_CONNECT_PHRASES = (
+    "can't assign requested address",
+    "cannot assign requested address",
+    "no route to host",
+    "network is unreachable",
+)
+
+_NETSTAT_STATES = {
+    "CLOSED",
+    "LISTEN",
+    "SYN_SENT",
+    "SYN_RECEIVED",
+    "ESTABLISHED",
+    "CLOSE_WAIT",
+    "FIN_WAIT_1",
+    "CLOSING",
+    "LAST_ACK",
+    "FIN_WAIT_2",
+    "TIME_WAIT",
+}
+
+
+class NetworkCircuitOpen(ConnectionError):
+    """Raised when host networking is in cooldown."""
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _iter_exception_chain(exc: BaseException):
+    seen: set[int] = set()
+    cur: BaseException | None = exc
+    depth = 0
+    while cur is not None and depth < 16:
+        ident = id(cur)
+        if ident in seen:
+            break
+        seen.add(ident)
+        depth += 1
+        yield cur
+        cur = cur.__cause__ or cur.__context__
+
+
+def is_host_connectivity_error(exc: BaseException) -> bool:
+    """True for local host/socket failures that retry storms worsen."""
+    for item in _iter_exception_chain(exc):
+        err_no = getattr(item, "errno", None)
+        if err_no in _HOST_CONNECT_ERRNOS:
+            return True
+        if isinstance(item, OSError) and getattr(item, "args", None):
+            first = item.args[0]
+            if isinstance(first, int) and first in _HOST_CONNECT_ERRNOS:
+                return True
+        text = str(item).lower()
+        if any(phrase in text for phrase in _HOST_CONNECT_PHRASES):
+            return True
+    return False
+
+
+class NetworkCircuitBreaker:
+    """Small thread-safe failure counter with a cooldown window."""
+
+    def __init__(self, *, threshold: int | None = None, cooldown_seconds: float | None = None):
+        self.threshold = max(1, threshold if threshold is not None else _env_int("HERMES_NETWORK_CIRCUIT_THRESHOLD", 3))
+        self.cooldown_seconds = max(1.0, cooldown_seconds if cooldown_seconds is not None else _env_float("HERMES_NETWORK_CIRCUIT_COOLDOWN_SECONDS", 120.0))
+        self._lock = threading.Lock()
+        self._failures = 0
+        self._opened_until = 0.0
+        self._reason = ""
+
+    def reset(self) -> None:
+        with self._lock:
+            self._failures = 0
+            self._opened_until = 0.0
+            self._reason = ""
+
+    def before_request(self, surface: str = "network") -> None:
+        now = time.time()
+        with self._lock:
+            if self._opened_until > now:
+                remaining = int(self._opened_until - now) + 1
+                reason = self._reason or "host network circuit open"
+                raise NetworkCircuitOpen(
+                    f"Host network circuit open for {surface}; retry after {remaining}s ({reason})"
+                )
+            if self._opened_until and self._opened_until <= now:
+                self._opened_until = 0.0
+                self._reason = ""
+                self._failures = 0
+
+    def record_success(self, surface: str = "network") -> None:
+        with self._lock:
+            self._failures = 0
+
+    def record_failure(self, exc: BaseException, *, surface: str = "network") -> bool:
+        if not is_host_connectivity_error(exc):
+            return False
+        with self._lock:
+            self._failures += 1
+            if self._failures >= self.threshold:
+                self._opened_until = time.time() + self.cooldown_seconds
+                self._reason = f"{type(exc).__name__}: {exc}"[:240]
+                logger.warning(
+                    "Host network circuit opened for %s after %d connectivity failures: %s",
+                    surface,
+                    self._failures,
+                    self._reason,
+                )
+                return True
+        return False
+
+    def force_open(self, reason: str, *, cooldown_seconds: float | None = None) -> None:
+        cooldown = max(1.0, cooldown_seconds if cooldown_seconds is not None else self.cooldown_seconds)
+        with self._lock:
+            self._opened_until = time.time() + cooldown
+            self._reason = str(reason or "forced open")[:240]
+            self._failures = max(self._failures, self.threshold)
+            logger.warning("Host network circuit forced open for %.0fs: %s", cooldown, self._reason)
+
+
+_GLOBAL_BREAKER = NetworkCircuitBreaker()
+
+
+def get_global_network_breaker() -> NetworkCircuitBreaker:
+    return _GLOBAL_BREAKER
+
+
+def parse_netstat_state_counts(output: str) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for line in str(output or "").splitlines():
+        for token in reversed(line.split()):
+            state = token.strip()
+            if state in _NETSTAT_STATES:
+                counts[state] += 1
+                break
+    return dict(counts)
+
+
+def socket_pressure_is_high(
+    counts: Mapping[str, int],
+    *,
+    port_range_size: int,
+    threshold_ratio: float = 0.70,
+) -> bool:
+    if port_range_size <= 0:
+        return False
+    pressure = (
+        int(counts.get("TIME_WAIT", 0))
+        + int(counts.get("FIN_WAIT_1", 0))
+        + int(counts.get("LAST_ACK", 0))
+    )
+    return pressure >= int(port_range_size * threshold_ratio)
+
+
+def current_socket_state_counts() -> dict[str, int]:
+    try:
+        output = subprocess.check_output(
+            ["netstat", "-anv", "-f", "inet"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        )
+    except Exception:
+        return {}
+    return parse_netstat_state_counts(output)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9640,6 +9640,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if canonical == "usage":
             return await self._handle_usage_command(event)
 
+        if canonical == "codex-usage":
+            return await self._handle_codex_usage_command(event)
+
         if canonical == "credits":
             return await self._handle_credits_command(event)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -34,6 +34,7 @@ import os
 import re
 import shlex
 import site
+import subprocess
 import sys
 import signal
 import tempfile
@@ -19676,6 +19677,58 @@ def _run_planned_stop_watcher(
         stop_event.wait(poll_interval)
 
 
+
+def _socket_state_counts() -> dict[str, int]:
+    try:
+        from agent.network_circuit_breaker import current_socket_state_counts
+        return current_socket_state_counts()
+    except Exception:
+        return {}
+
+
+def _ephemeral_port_range_size() -> int:
+    if sys.platform != "darwin":
+        return 28232
+    try:
+        first_raw = subprocess.check_output(
+            ["sysctl", "-n", "net.inet.ip.portrange.first"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            timeout=2,
+        ).strip()
+        last_raw = subprocess.check_output(
+            ["sysctl", "-n", "net.inet.ip.portrange.last"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            timeout=2,
+        ).strip()
+        first = int(first_raw)
+        last = int(last_raw)
+        return max(0, last - first + 1)
+    except Exception:
+        return 16384
+
+
+def _gateway_socket_pressure_check() -> bool:
+    try:
+        from agent.network_circuit_breaker import (
+            get_global_network_breaker,
+            socket_pressure_is_high,
+        )
+        threshold = float(os.getenv("HERMES_GATEWAY_SOCKET_PRESSURE_THRESHOLD", "0.70"))
+        cooldown = float(os.getenv("HERMES_GATEWAY_SOCKET_PRESSURE_COOLDOWN_SECONDS", "180"))
+        counts = _socket_state_counts()
+        port_range = _ephemeral_port_range_size()
+        if socket_pressure_is_high(counts, port_range_size=port_range, threshold_ratio=threshold):
+            pressure = int(counts.get("TIME_WAIT", 0)) + int(counts.get("FIN_WAIT_1", 0)) + int(counts.get("LAST_ACK", 0))
+            reason = f"socket pressure high: {pressure}/{port_range} transient TCP states ({counts})"
+            get_global_network_breaker().force_open(reason, cooldown_seconds=cooldown)
+            logger.warning("Gateway socket pressure guard opened network circuit: %s", reason)
+            return True
+    except Exception as exc:
+        logger.debug("Gateway socket pressure check failed: %s", exc)
+    return False
+
 def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop=None, interval: int = 60):
     """Background thread for gateway-only periodic chores (NOT cron).
 
@@ -19702,6 +19755,8 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
     tick_count = 0
     while not stop_event.is_set():
         tick_count += 1
+
+        _gateway_socket_pressure_check()
 
         if tick_count % CHANNEL_DIR_EVERY == 0 and adapters:
             try:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4054,6 +4054,43 @@ class GatewaySlashCommandsMixin:
             return "\n".join(parts)
         return t("gateway.usage.no_data")
 
+    async def _handle_codex_usage_command(self, event: MessageEvent) -> str:
+        """Handle /codex-usage — current Codex quota by Hermes credential."""
+        raw_args = event.get_command_args().strip() if event else ""
+        argv = shlex.split(raw_args) if raw_args else ["--compact"]
+        if not argv:
+            argv = ["--compact"]
+        try:
+            from hermes_cli.codex_usage import collect, render_alert, render_compact, render_text
+
+            payload = await asyncio.to_thread(collect)
+            primary = None
+            secondary = None
+            alert = None
+            verbose = False
+            i = 0
+            while i < len(argv):
+                arg = argv[i]
+                if arg in {"--verbose", "verbose"}:
+                    verbose = True
+                elif arg == "--alert-threshold" and i + 1 < len(argv):
+                    i += 1
+                    alert = float(argv[i])
+                elif arg == "--primary-threshold" and i + 1 < len(argv):
+                    i += 1
+                    primary = float(argv[i])
+                elif arg == "--secondary-threshold" and i + 1 < len(argv):
+                    i += 1
+                    secondary = float(argv[i])
+                i += 1
+            if alert is not None or primary is not None or secondary is not None:
+                out = render_alert(payload, alert, None, primary_threshold=primary, secondary_threshold=secondary)
+                return out or "Codex usage OK."
+            return render_text(payload) if verbose else render_compact(payload)
+        except Exception as exc:
+            logger.warning("/codex-usage failed: %s", exc)
+            return f"Codex usage check failed: {exc}"
+
     async def _handle_insights_command(self, event: MessageEvent) -> str:
         """Handle /insights command -- show usage insights and analytics."""
         args = event.get_command_args().strip()

--- a/hermes_cli/codex_usage.py
+++ b/hermes_cli/codex_usage.py
@@ -11,7 +11,7 @@ import json
 import sys
 import urllib.error
 import urllib.request
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
@@ -19,12 +19,16 @@ from hermes_cli.config import get_hermes_home
 
 USAGE_URL = "https://chatgpt.com/backend-api/wham/usage"
 DEFAULT_WATERMARK = get_hermes_home() / "state" / "codex_usage_alerts.json"
+DEFAULT_HISTORY = get_hermes_home() / "state" / "codex_usage_history.jsonl"
+TREND_TARGETS = (80, 95, 100)
+MIN_TREND_SAMPLE_SECONDS = 10 * 60
 
 
 def local_dt(epoch: Any) -> Optional[datetime]:
     if isinstance(epoch, str):
         try:
-            return datetime.fromisoformat(epoch).astimezone()
+            dt = datetime.fromisoformat(epoch)
+            return dt if dt.tzinfo is not None else dt.astimezone()
         except ValueError:
             return None
     if not isinstance(epoch, (int, float)):
@@ -173,6 +177,166 @@ def iter_windows(row: Dict[str, Any]) -> Iterable[Tuple[str, str, Dict[str, Any]
     yield "7d", "secondary_window", row.get("secondary_window") or {}
 
 
+def _checked_dt(payload: Dict[str, Any]) -> Optional[datetime]:
+    return local_dt(payload.get("checked_at"))
+
+
+def _history_percent(row: Dict[str, Any], window_key: str) -> Optional[float]:
+    window = row.get(window_key) or {}
+    return _window_used(window)
+
+
+def _matching_previous_window(
+    history: Iterable[Dict[str, Any]],
+    *,
+    label: str,
+    window_key: str,
+    reset_at: Any,
+    checked_at: datetime,
+) -> Optional[tuple[datetime, Dict[str, Any]]]:
+    best: Optional[tuple[datetime, Dict[str, Any]]] = None
+    for snapshot in history:
+        previous_checked = _checked_dt(snapshot)
+        if previous_checked is None or previous_checked >= checked_at:
+            continue
+        if (checked_at - previous_checked).total_seconds() < MIN_TREND_SAMPLE_SECONDS:
+            continue
+        for row in snapshot.get("accounts") or []:
+            if str(row.get("label")) != label or not row.get("ok", True):
+                continue
+            window = row.get(window_key) or {}
+            previous_reset = local_dt(window.get("reset_at"))
+            current_reset = local_dt(reset_at)
+            if previous_reset is None or current_reset is None or previous_reset != current_reset:
+                continue
+            if _history_percent(row, window_key) is None:
+                continue
+            if best is None or previous_checked > best[0]:
+                best = (previous_checked, window)
+    return best
+
+
+def _eta_map(*, checked_at: datetime, reset_at: Optional[datetime], used: float, burn_per_hour: float) -> dict[str, dict[str, Any]]:
+    eta: dict[str, dict[str, Any]] = {}
+    for target in TREND_TARGETS:
+        if used >= target:
+            eta[str(target)] = {"reached": True}
+            continue
+        if burn_per_hour <= 0:
+            eta[str(target)] = {"reached": False, "at": None, "remaining": None, "before_reset": False}
+            continue
+        eta_at = checked_at + timedelta(hours=(target - used) / burn_per_hour)
+        before_reset = bool(reset_at is None or eta_at <= reset_at)
+        eta[str(target)] = {
+            "reached": False,
+            "at": eta_at.isoformat(timespec="seconds"),
+            "remaining": human_delta(eta_at, checked_at),
+            "before_reset": before_reset,
+        }
+    return eta
+
+
+def annotate_usage_trends(
+    payload: Dict[str, Any],
+    *,
+    history: Optional[Iterable[Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    """Attach burn-rate and ETA trend data to each quota window in-place.
+
+    Prefer the most recent prior sample with the same credential label, window,
+    and reset timestamp. If no prior sample exists, fall back to the current
+    window average from the inferred window start so the first run is still
+    informative while clearly marking the source as `window_avg`.
+    """
+    checked_at = _checked_dt(payload)
+    if checked_at is None:
+        return payload
+    history_rows = list(history or [])
+    for row in payload.get("accounts") or []:
+        if not row.get("ok"):
+            continue
+        label = str(row.get("label"))
+        for _display, window_key, window in iter_windows(row):
+            used = _window_used(window)
+            reset_at = local_dt(window.get("reset_at"))
+            if used is None or reset_at is None:
+                continue
+            source = "window_avg"
+            burn_per_hour: Optional[float] = None
+            previous = _matching_previous_window(
+                history_rows,
+                label=label,
+                window_key=window_key,
+                reset_at=window.get("reset_at"),
+                checked_at=checked_at,
+            )
+            if previous:
+                prev_checked, prev_window = previous
+                prev_used = _window_used(prev_window)
+                elapsed_hours = (checked_at - prev_checked).total_seconds() / 3600
+                if prev_used is not None and elapsed_hours > 0:
+                    delta = used - prev_used
+                    if delta >= 0:
+                        burn_per_hour = delta / elapsed_hours
+                        source = "recent"
+            if burn_per_hour is None:
+                window_seconds = window.get("limit_window_seconds")
+                if isinstance(window_seconds, (int, float)) and window_seconds > 0:
+                    start_at = reset_at - timedelta(seconds=float(window_seconds))
+                    elapsed_hours = (checked_at - start_at).total_seconds() / 3600
+                    if elapsed_hours > 0:
+                        burn_per_hour = max(0.0, used / elapsed_hours)
+            if burn_per_hour is None:
+                continue
+            burn_per_hour = round(burn_per_hour, 2)
+            window["trend"] = {
+                "source": source,
+                "burn_percent_per_hour": burn_per_hour,
+                "eta": _eta_map(checked_at=checked_at, reset_at=reset_at, used=used, burn_per_hour=burn_per_hour),
+            }
+    return payload
+
+
+def load_history(path: Path, *, limit: int = 200) -> list[dict[str, Any]]:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        return []
+    rows: list[dict[str, Any]] = []
+    for line in lines[-limit:]:
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(item, dict):
+            rows.append(item)
+    return rows
+
+
+def save_history_snapshot(path: Path, payload: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    snapshot = {
+        "checked_at": payload.get("checked_at"),
+        "accounts": [
+            {
+                "label": row.get("label"),
+                "ok": row.get("ok"),
+                "primary_window": {
+                    "used_percent": (row.get("primary_window") or {}).get("used_percent"),
+                    "reset_at": (row.get("primary_window") or {}).get("reset_at"),
+                },
+                "secondary_window": {
+                    "used_percent": (row.get("secondary_window") or {}).get("used_percent"),
+                    "reset_at": (row.get("secondary_window") or {}).get("reset_at"),
+                },
+            }
+            for row in payload.get("accounts") or []
+        ],
+    }
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(snapshot, ensure_ascii=False, separators=(",", ":")) + "\n")
+
+
 def render_text(payload: Dict[str, Any]) -> str:
     lines = [f"Codex usage ({payload['checked_at']})"]
     accounts = payload.get("accounts") or []
@@ -319,6 +483,70 @@ def _next_reset(accounts: list[dict[str, Any]], min_used: Optional[float] = None
     return min(candidates, key=lambda item: item[0])[1] if candidates else None
 
 
+def _trend_for(row: dict[str, Any], window_key: str) -> Optional[dict[str, Any]]:
+    window = row.get(window_key) or {}
+    trend = window.get("trend")
+    return trend if isinstance(trend, dict) else None
+
+
+def _fmt_burn(value: Any) -> str:
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return "?%/h"
+    return f"+{f:.1f}%/h"
+
+
+def _fmt_eta_at(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value).strftime("%m/%d %H:%M")
+    except ValueError:
+        return None
+
+
+def _render_trend_detail(trend: Optional[dict[str, Any]]) -> str:
+    if not trend:
+        return ""
+    parts = [f"burn {_fmt_burn(trend.get('burn_percent_per_hour'))}"]
+    eta95 = (trend.get("eta") or {}).get("95") or {}
+    if eta95.get("reached"):
+        parts.append("ETA95 도달")
+    else:
+        eta_at = _fmt_eta_at(eta95.get("at"))
+        if eta_at:
+            suffix = "" if eta95.get("before_reset") else "*"
+            parts.append(f"ETA95 {eta_at}{suffix}")
+    return " · ".join(parts)
+
+
+def _recommended_row(payload: Dict[str, Any]) -> Optional[dict[str, Any]]:
+    rec_label = (payload.get("recommendation") or {}).get("label")
+    accounts = payload.get("accounts") or []
+    if rec_label:
+        for row in accounts:
+            if row.get("ok") and str(row.get("label")) == str(rec_label):
+                return row
+    for row in accounts:
+        if row.get("ok"):
+            return row
+    return None
+
+
+def _burn_summary(payload: Dict[str, Any]) -> str:
+    row = _recommended_row(payload)
+    if not row:
+        return ""
+    parts: list[str] = []
+    for display, key, _window in iter_windows(row):
+        trend = _trend_for(row, key)
+        if trend:
+            source = "avg " if trend.get("source") == "window_avg" else ""
+            parts.append(f"{display} {source}{_fmt_burn(trend.get('burn_percent_per_hour'))}")
+    return "🔥 Burn: " + " · ".join(parts) if parts else ""
+
+
 def render_compact(payload: Dict[str, Any]) -> str:
     accounts = payload.get("accounts") or []
     worst = _worst_risk(accounts)
@@ -329,6 +557,9 @@ def render_compact(payload: Dict[str, Any]) -> str:
         explanation = _recommendation_explanation(payload)
         if explanation:
             lines.append(explanation)
+    burn_summary = _burn_summary(payload)
+    if burn_summary:
+        lines.append(burn_summary)
     next_reset = _next_reset(accounts)
     if next_reset:
         lines.append(f"⏱ 다음 회복: {next_reset['label']} {next_reset['window']} · {next_reset['remaining']} ({next_reset['reset']})")
@@ -346,13 +577,17 @@ def render_compact(payload: Dict[str, Any]) -> str:
             lines.append(f"└ ERROR {row.get('http', '')} {row.get('error', '')}".rstrip())
             continue
         lines.append(f"\n• {label} · {plan}")
-        for display, _key, window in iter_windows(row):
+        for display, key, window in iter_windows(row):
             r = window.get("risk") or risk(window.get("used_percent"))
             used = window.get("used_percent")
-            lines.append(
+            line = (
                 f"  {display:>2} {_fmt_percent(used)} {r.get('icon')} "
                 f"[{usage_bar(used)}] reset {short_reset(window.get('reset_at'))} · {window.get('remaining', '?')}"
             )
+            trend_detail = _render_trend_detail(_trend_for(row, key))
+            if trend_detail:
+                line = f"{line} · {trend_detail}"
+            lines.append(line)
     return "\n".join(lines)
 
 def load_seen(path: Path) -> set[str]:
@@ -530,6 +765,9 @@ def main(argv: Optional[list[str]] = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     payload = collect()
+    history = load_history(DEFAULT_HISTORY)
+    annotate_usage_trends(payload, history=history)
+    save_history_snapshot(DEFAULT_HISTORY, payload)
     alert_mode = any(
         value is not None
         for value in (args.alert_threshold, args.primary_threshold, args.secondary_threshold)

--- a/hermes_cli/codex_usage.py
+++ b/hermes_cli/codex_usage.py
@@ -202,13 +202,14 @@ def _recommendation_sort_key(row: Dict[str, Any]) -> tuple[Any, ...]:
     secondary_reset = _window_reset_dt(row, "secondary_window")
     secondary_missing = secondary_reset is None
     secondary_used = _percent(row, "secondary_window")
-    # Reset timestamp is the primary policy. If the endpoint does not expose a
-    # reset timestamp, fall back to the old conservative behavior: lower 7d
-    # usage first. When reset timestamps tie, burn the fuller soon-resetting
-    # window first.
+    # Prefer an available credential whose 7d window has not started / does not
+    # expose a reset timestamp yet. A tiny warm-up call can start that 7d reset
+    # clock, maximizing usable weekly rotation. After every candidate has a
+    # reset timestamp, reset time becomes the primary policy. When reset times
+    # tie, burn the fuller soon-resetting window first.
     return (
-        1 if secondary_missing else 0,
-        secondary_reset or datetime.max.replace(tzinfo=datetime.now().astimezone().tzinfo),
+        0 if secondary_missing else 1,
+        secondary_reset or datetime.min.replace(tzinfo=datetime.now().astimezone().tzinfo),
         secondary_used if secondary_missing else -secondary_used,
         _percent(row, "primary_window"),
         int(row.get("priority") or 999),

--- a/hermes_cli/codex_usage.py
+++ b/hermes_cli/codex_usage.py
@@ -262,6 +262,63 @@ def _worst_risk(accounts: list[dict[str, Any]]) -> dict[str, str]:
     return worst
 
 
+def _window_used(window: dict[str, Any]) -> Optional[float]:
+    try:
+        value = window.get("used_percent")
+        if value is None:
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _recommendation_explanation(payload: Dict[str, Any]) -> str:
+    recommendation = payload.get("recommendation") or {}
+    rec_label = recommendation.get("label")
+    blockers: list[tuple[float, str]] = []
+    for row in payload.get("accounts") or []:
+        label = row.get("label")
+        if not row.get("ok") or label == rec_label:
+            continue
+        for display, _key, window in iter_windows(row):
+            used = _window_used(window)
+            if used is not None and used >= 80:
+                blockers.append((used, f"{label} {display} {_fmt_percent(used).strip()}"))
+    if blockers:
+        blockers.sort(reverse=True)
+        return f"사유: {blockers[0][1]}로 회복 전까지 보류"
+    reason = recommendation.get("reason")
+    return f"사유: 7d 사용률이 가장 낮음 ({reason})" if reason else ""
+
+
+def _next_reset(accounts: list[dict[str, Any]], min_used: Optional[float] = None) -> Optional[dict[str, str]]:
+    candidates: list[tuple[datetime, dict[str, str]]] = []
+    for row in accounts:
+        if not row.get("ok"):
+            continue
+        label = str(row.get("label"))
+        for display, _key, window in iter_windows(row):
+            used = _window_used(window)
+            if min_used is not None and (used is None or used < min_used):
+                continue
+            reset_at = window.get("reset_at")
+            dt = local_dt(reset_at)
+            if dt is None or dt <= datetime.now().astimezone():
+                continue
+            candidates.append(
+                (
+                    dt,
+                    {
+                        "label": label,
+                        "window": display,
+                        "reset": short_reset(reset_at),
+                        "remaining": str(window.get("remaining", "?")),
+                    },
+                )
+            )
+    return min(candidates, key=lambda item: item[0])[1] if candidates else None
+
+
 def render_compact(payload: Dict[str, Any]) -> str:
     accounts = payload.get("accounts") or []
     worst = _worst_risk(accounts)
@@ -269,6 +326,15 @@ def render_compact(payload: Dict[str, Any]) -> str:
     recommendation = payload.get("recommendation") or {}
     if recommendation:
         lines.append(f"✅ 추천 {recommendation.get('label')} — {recommendation.get('reason')}")
+        explanation = _recommendation_explanation(payload)
+        if explanation:
+            lines.append(explanation)
+    next_reset = _next_reset(accounts)
+    if next_reset:
+        lines.append(f"⏱ 다음 회복: {next_reset['label']} {next_reset['window']} · {next_reset['remaining']} ({next_reset['reset']})")
+    risk_reset = _next_reset(accounts, min_used=95)
+    if risk_reset and risk_reset != next_reset:
+        lines.append(f"🚦 위험 회복: {risk_reset['label']} {risk_reset['window']} · {risk_reset['remaining']} ({risk_reset['reset']})")
     if not accounts:
         lines.append("계정 없음")
         return "\n".join(lines)
@@ -288,7 +354,6 @@ def render_compact(payload: Dict[str, Any]) -> str:
                 f"[{usage_bar(used)}] reset {short_reset(window.get('reset_at'))} · {window.get('remaining', '?')}"
             )
     return "\n".join(lines)
-
 
 def load_seen(path: Path) -> set[str]:
     try:
@@ -383,21 +448,62 @@ def render_alert(
         events = fresh
     if not events:
         return ""
-    lines = [f"⚠️ Codex usage alert ({payload['checked_at']})"]
+    lines = [f"🚨 Codex 한도 주의 · {short_checked_at(payload.get('checked_at'))}"]
     for event in events:
         if event.get("error"):
             row = event["row"]
-            lines.append(f"{row.get('label')}: ERROR {row.get('http', '')} {row.get('error', '')}".rstrip())
+            lines.append(f"\n❌ {row.get('label')}")
+            lines.append(f"└ ERROR {row.get('http', '')} {row.get('error', '')}".rstrip())
             continue
         r = event.get("risk") or {}
-        lines.append(
-            f"{r.get('icon', '⚠️')} {event.get('label')} {event.get('window')} "
-            f"{event.get('used'):g}% >= {event.get('threshold'):g}% — "
-            f"reset {event.get('reset_at')} ({event.get('remaining')})"
-        )
+        lines.append(f"\n{r.get('icon', '⚠️')} {event.get('label')} · {event.get('window')} {event.get('used'):g}% [{usage_bar(event.get('used'))}]")
+        lines.append(f"└ 기준 {event.get('threshold'):g}% · reset {short_reset(event.get('reset_at'))} · {event.get('remaining')}")
     recommendation = payload.get("recommendation") or {}
     if recommendation:
-        lines.append(f"추천: {recommendation.get('label')} — {recommendation.get('reason')}")
+        lines.append(f"\n✅ 추천 {recommendation.get('label')} — {recommendation.get('reason')}")
+        explanation = _recommendation_explanation(payload)
+        if explanation:
+            lines.append(explanation)
+    return "\n".join(lines)
+
+
+def _fmt_tokens(value: Any) -> str:
+    try:
+        n = int(value or 0)
+    except (TypeError, ValueError):
+        n = 0
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.2f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}k"
+    return str(n)
+
+
+def render_credential_insights(rows: list[dict[str, Any]], *, provider: Optional[str], days: int) -> str:
+    title = "Codex credential" if provider == "openai-codex" else "Credential"
+    lines = [f"📊 {title} 사용량 · {days}d"]
+    if not rows:
+        suffix = f" ({provider})" if provider else ""
+        lines.append(f"아직 credential별 사용 기록 없음{suffix}")
+        lines.append("새 모델 턴부터 쌓임")
+        return "\n".join(lines)
+    total_all = sum(int(row.get("total_tokens") or 0) for row in rows) or 1
+    for row in rows:
+        label = row.get("credential_label") or "unknown"
+        model = row.get("model") or "unknown"
+        total = int(row.get("total_tokens") or 0)
+        calls = int(row.get("api_calls") or row.get("api_call_count") or 0)
+        avg = total / calls if calls else 0
+        share = total / total_all * 100
+        lines.append(f"\n• {label} · {model}")
+        lines.append(f"  {_fmt_tokens(total)} tokens · {calls} calls · avg {_fmt_tokens(avg)}/call · {share:.0f}%")
+        breakdown = [f"in {_fmt_tokens(row.get('input_tokens'))}", f"out {_fmt_tokens(row.get('output_tokens'))}"]
+        if int(row.get("cache_read_tokens") or 0) or int(row.get("cache_write_tokens") or 0):
+            cache_total = int(row.get("cache_read_tokens") or 0) + int(row.get("cache_write_tokens") or 0)
+            breakdown.append(f"cache {_fmt_tokens(cache_total)}")
+        if int(row.get("reasoning_tokens") or 0):
+            breakdown.append(f"reason {_fmt_tokens(row.get('reasoning_tokens'))}")
+        lines.append("  " + " · ".join(breakdown))
     return "\n".join(lines)
 
 

--- a/hermes_cli/codex_usage.py
+++ b/hermes_cli/codex_usage.py
@@ -11,6 +11,7 @@ import json
 import sys
 import urllib.error
 import urllib.request
+from collections import deque
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
@@ -299,11 +300,11 @@ def annotate_usage_trends(
 
 def load_history(path: Path, *, limit: int = 200) -> list[dict[str, Any]]:
     try:
-        lines = path.read_text(encoding="utf-8").splitlines()
-    except FileNotFoundError:
+        lines = deque(path.open(encoding="utf-8"), maxlen=limit)
+    except OSError:
         return []
     rows: list[dict[str, Any]] = []
-    for line in lines[-limit:]:
+    for line in lines:
         try:
             item = json.loads(line)
         except json.JSONDecodeError:
@@ -314,7 +315,6 @@ def load_history(path: Path, *, limit: int = 200) -> list[dict[str, Any]]:
 
 
 def save_history_snapshot(path: Path, payload: Dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
     snapshot = {
         "checked_at": payload.get("checked_at"),
         "accounts": [
@@ -333,8 +333,12 @@ def save_history_snapshot(path: Path, payload: Dict[str, Any]) -> None:
             for row in payload.get("accounts") or []
         ],
     }
-    with path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(snapshot, ensure_ascii=False, separators=(",", ":")) + "\n")
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(snapshot, ensure_ascii=False, separators=(",", ":")) + "\n")
+    except OSError:
+        return
 
 
 def render_text(payload: Dict[str, Any]) -> str:

--- a/hermes_cli/codex_usage.py
+++ b/hermes_cli/codex_usage.py
@@ -216,23 +216,77 @@ def short_reset(reset_at: Any) -> str:
         return reset_at
 
 
-def render_compact(payload: Dict[str, Any]) -> str:
-    lines = [f"Codex usage {payload['checked_at']}"]
-    for row in payload.get("accounts") or []:
+def short_checked_at(checked_at: Any) -> str:
+    if not isinstance(checked_at, str):
+        return "?"
+    try:
+        return datetime.fromisoformat(checked_at).strftime("%m/%d %H:%M")
+    except ValueError:
+        return checked_at
+
+
+def usage_bar(used_percent: Any, width: int = 10) -> str:
+    """Return a compact text progress bar for Telegram/CLI scanning."""
+    try:
+        value = max(0.0, min(100.0, float(used_percent)))
+    except (TypeError, ValueError):
+        return "?" * max(1, width)
+    filled = int(value / 100 * width)
+    if value > 0 and filled == 0:
+        filled = 1
+    if value >= 95:
+        filled = width
+    return "█" * filled + "░" * (width - filled)
+
+
+def _fmt_percent(value: Any) -> str:
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return " ?%"
+    if f.is_integer():
+        return f"{int(f):>2}%"
+    return f"{f:>4.1f}%"
+
+
+def _worst_risk(accounts: list[dict[str, Any]]) -> dict[str, str]:
+    order = {"critical": 3, "warning": 2, "ok": 1, "unknown": 0}
+    worst = {"level": "unknown", "icon": "⚪", "label": "unknown"}
+    for row in accounts:
         if not row.get("ok"):
-            lines.append(f"{row.get('label')}: ERROR {row.get('http', '')} {row.get('error', '')}".rstrip())
-            continue
-        parts = []
-        for display, _key, window in iter_windows(row):
+            return {"level": "error", "icon": "❌", "label": "조회 실패"}
+        for _display, _key, window in iter_windows(row):
             r = window.get("risk") or risk(window.get("used_percent"))
-            parts.append(
-                f"{display} {window.get('used_percent', '?')}% {r.get('icon')} "
-                f"reset {short_reset(window.get('reset_at'))} ({window.get('remaining', '?')})"
-            )
-        lines.append(f"{row.get('label')}: " + "; ".join(parts))
+            if order.get(r.get("level", "unknown"), 0) > order.get(worst.get("level", "unknown"), 0):
+                worst = r
+    return worst
+
+
+def render_compact(payload: Dict[str, Any]) -> str:
+    accounts = payload.get("accounts") or []
+    worst = _worst_risk(accounts)
+    lines = [f"🧭 Codex 사용량 · {short_checked_at(payload.get('checked_at'))} · {worst.get('icon')} {worst.get('label')}"]
     recommendation = payload.get("recommendation") or {}
     if recommendation:
-        lines.append(f"추천: {recommendation.get('label')} — {recommendation.get('reason')}")
+        lines.append(f"✅ 추천 {recommendation.get('label')} — {recommendation.get('reason')}")
+    if not accounts:
+        lines.append("계정 없음")
+        return "\n".join(lines)
+    for row in accounts:
+        label = row.get("label")
+        plan = row.get("plan_type") or "unknown"
+        if not row.get("ok"):
+            lines.append(f"\n❌ {label} · {plan}")
+            lines.append(f"└ ERROR {row.get('http', '')} {row.get('error', '')}".rstrip())
+            continue
+        lines.append(f"\n• {label} · {plan}")
+        for display, _key, window in iter_windows(row):
+            r = window.get("risk") or risk(window.get("used_percent"))
+            used = window.get("used_percent")
+            lines.append(
+                f"  {display:>2} {_fmt_percent(used)} {r.get('icon')} "
+                f"[{usage_bar(used)}] reset {short_reset(window.get('reset_at'))} · {window.get('remaining', '?')}"
+            )
     return "\n".join(lines)
 
 
@@ -350,7 +404,8 @@ def render_alert(
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Show Hermes OpenAI Codex quota usage by credential")
     parser.add_argument("--json", action="store_true", help="print machine-readable JSON")
-    parser.add_argument("--compact", action="store_true", help="print Telegram-friendly compact output")
+    parser.add_argument("--compact", action="store_true", help="print Telegram-friendly compact output (default)")
+    parser.add_argument("--verbose", action="store_true", help="print detailed per-account text output")
     parser.add_argument("--alert-threshold", type=float, help="legacy: print only accounts/windows at or above this percent")
     parser.add_argument("--primary-threshold", type=float, help="5h window alert threshold percent")
     parser.add_argument("--secondary-threshold", type=float, help="7d window alert threshold percent")
@@ -389,10 +444,10 @@ def main(argv: Optional[list[str]] = None) -> int:
             primary = args.primary_threshold if args.primary_threshold is not None else args.alert_threshold or 90
             secondary = args.secondary_threshold if args.secondary_threshold is not None else args.alert_threshold or 90
             print(f"Codex usage OK: 5h below {primary:g}%, 7d below {secondary:g}%")
-    elif args.compact:
-        print(render_compact(payload))
-    else:
+    elif args.verbose:
         print(render_text(payload))
+    else:
+        print(render_compact(payload))
     return 0
 
 

--- a/hermes_cli/codex_usage.py
+++ b/hermes_cli/codex_usage.py
@@ -1,0 +1,400 @@
+"""OpenAI Codex quota usage helpers for Hermes.
+
+This module powers both the `hermes codex-usage` CLI command and local watchdog
+scripts. It reads Hermes' `openai-codex` credential pool and calls the Codex
+quota endpoint once per credential. Runtime OAuth tokens are never printed.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from hermes_cli.config import get_hermes_home
+
+USAGE_URL = "https://chatgpt.com/backend-api/wham/usage"
+DEFAULT_WATERMARK = get_hermes_home() / "state" / "codex_usage_alerts.json"
+
+
+def local_dt(epoch: Any) -> Optional[datetime]:
+    if isinstance(epoch, str):
+        try:
+            return datetime.fromisoformat(epoch).astimezone()
+        except ValueError:
+            return None
+    if not isinstance(epoch, (int, float)):
+        return None
+    return datetime.fromtimestamp(epoch).astimezone()
+
+
+def human_delta(target: Optional[datetime], now: Optional[datetime] = None) -> str:
+    if target is None:
+        return "unknown"
+    now = now or datetime.now().astimezone()
+    seconds = int((target - now).total_seconds())
+    if seconds <= 0:
+        return "already reset"
+    days, rem = divmod(seconds, 86400)
+    hours, rem = divmod(rem, 3600)
+    minutes, _ = divmod(rem, 60)
+    parts: list[str] = []
+    if days:
+        parts.append(f"{days}d")
+    if hours:
+        parts.append(f"{hours}h")
+    if minutes or not parts:
+        parts.append(f"{minutes}m")
+    return " ".join(parts)
+
+
+def risk(used_percent: Any) -> Dict[str, str]:
+    try:
+        value = float(used_percent)
+    except (TypeError, ValueError):
+        return {"level": "unknown", "icon": "⚪", "label": "unknown"}
+    if value >= 95:
+        return {"level": "critical", "icon": "🔴", "label": "거의 소진"}
+    if value >= 80:
+        return {"level": "warning", "icon": "🟠", "label": "주의"}
+    return {"level": "ok", "icon": "🟢", "label": "정상"}
+
+
+def summarize_window(window: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    if not isinstance(window, dict):
+        return None
+    reset_dt = local_dt(window.get("reset_at"))
+    used = window.get("used_percent")
+    return {
+        "used_percent": used,
+        "limit_window_seconds": window.get("limit_window_seconds"),
+        "reset_at": reset_dt.isoformat(timespec="seconds") if reset_dt else window.get("reset_at"),
+        "remaining": human_delta(reset_dt),
+        "risk": risk(used),
+    }
+
+
+# Backward-compatible alias used by the first local helper script.
+window_summary = summarize_window
+
+
+def fetch_usage(access_token: str, account_id: Optional[str] = None, timeout: int = 30) -> Dict[str, Any]:
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "User-Agent": "Hermes Codex usage check",
+        "Accept": "application/json",
+    }
+    if account_id:
+        headers["ChatGPT-Account-Id"] = account_id
+    req = urllib.request.Request(USAGE_URL, headers=headers, method="GET")
+    with urllib.request.urlopen(req, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def collect() -> Dict[str, Any]:
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    # clear_expired=True + refresh=True lets Hermes refresh OAuth tokens if needed.
+    entries = pool._available_entries(clear_expired=True, refresh=True)  # intentional internal API
+    now = datetime.now().astimezone()
+    rows: list[dict[str, Any]] = []
+    for entry in entries:
+        row: Dict[str, Any] = {
+            "label": entry.label,
+            "priority": entry.priority,
+            "source": entry.source,
+            "last_status": entry.last_status or "ok",
+        }
+        account_id = (
+            entry.extra.get("account_id")
+            or entry.extra.get("chatgpt_account_id")
+            or entry.extra.get("accountId")
+        )
+        try:
+            data = fetch_usage(entry.runtime_api_key, account_id=account_id)
+            rate_limit = data.get("rate_limit") or {}
+            credits = data.get("credits") or {}
+            row.update(
+                {
+                    "ok": True,
+                    "plan_type": data.get("plan_type"),
+                    "primary_window": summarize_window(rate_limit.get("primary_window")),
+                    "secondary_window": summarize_window(rate_limit.get("secondary_window")),
+                    "credits": {
+                        key: credits.get(key)
+                        for key in ("has_credits", "unlimited", "balance")
+                        if key in credits
+                    },
+                }
+            )
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", "replace")[:500]
+            row.update({"ok": False, "http": exc.code, "error": body})
+        except Exception as exc:  # noqa: BLE001 - CLI report should survive per-account failures
+            row.update({"ok": False, "error": f"{type(exc).__name__}: {exc}"})
+        rows.append(row)
+    payload = {"checked_at": now.isoformat(timespec="seconds"), "provider": "openai-codex", "accounts": rows}
+    payload["recommendation"] = compute_recommendation(rows)
+    return payload
+
+
+def _percent(row: Dict[str, Any], window_name: str) -> float:
+    try:
+        value = (row.get(window_name) or {}).get("used_percent")
+        if value is None:
+            return 999.0
+        return float(value)
+    except (TypeError, ValueError):
+        return 999.0
+
+
+def compute_recommendation(accounts: List[Dict[str, Any]]) -> Optional[Dict[str, str]]:
+    ok_accounts = [row for row in accounts if row.get("ok")]
+    if not ok_accounts:
+        return None
+    best = min(ok_accounts, key=lambda row: (_percent(row, "secondary_window"), _percent(row, "primary_window")))
+    sec = best.get("secondary_window") or {}
+    pri = best.get("primary_window") or {}
+    reason = f"7d {sec.get('used_percent', '?')}%, 5h {pri.get('used_percent', '?')}%"
+    return {"label": str(best.get("label")), "reason": reason}
+
+
+# Backward-compatible alias.
+recommend = compute_recommendation
+
+
+def iter_windows(row: Dict[str, Any]) -> Iterable[Tuple[str, str, Dict[str, Any]]]:
+    yield "5h", "primary_window", row.get("primary_window") or {}
+    yield "7d", "secondary_window", row.get("secondary_window") or {}
+
+
+def render_text(payload: Dict[str, Any]) -> str:
+    lines = [f"Codex usage ({payload['checked_at']})"]
+    accounts = payload.get("accounts") or []
+    if not accounts:
+        lines.append("No available openai-codex credentials found.")
+        return "\n".join(lines)
+    recommendation = payload.get("recommendation") or {}
+    if recommendation:
+        lines.append(f"추천: {recommendation.get('label')} ({recommendation.get('reason')})")
+    for row in accounts:
+        lines.append("")
+        lines.append(f"[{row.get('label')}] plan={row.get('plan_type', 'unknown')} status={row.get('last_status', 'unknown')}")
+        if not row.get("ok"):
+            lines.append(f"  ERROR: {row.get('http', '')} {row.get('error', '')}".rstrip())
+            continue
+        for display, _key, window in iter_windows(row):
+            r = window.get("risk") or risk(window.get("used_percent"))
+            lines.append(
+                f"  {display}: {r.get('icon')} "
+                f"{window.get('used_percent', '?')}% used ({r.get('label')}), "
+                f"reset {window.get('reset_at', '?')} ({window.get('remaining', '?')})"
+            )
+        credits = row.get("credits") or {}
+        if credits:
+            lines.append(
+                "  credits: "
+                f"has={credits.get('has_credits')}, "
+                f"unlimited={credits.get('unlimited')}, "
+                f"balance={credits.get('balance')}"
+            )
+    return "\n".join(lines)
+
+
+def short_reset(reset_at: Any) -> str:
+    if not isinstance(reset_at, str):
+        return "?"
+    try:
+        dt = datetime.fromisoformat(reset_at)
+        return dt.strftime("%m/%d %H:%M")
+    except ValueError:
+        return reset_at
+
+
+def render_compact(payload: Dict[str, Any]) -> str:
+    lines = [f"Codex usage {payload['checked_at']}"]
+    for row in payload.get("accounts") or []:
+        if not row.get("ok"):
+            lines.append(f"{row.get('label')}: ERROR {row.get('http', '')} {row.get('error', '')}".rstrip())
+            continue
+        parts = []
+        for display, _key, window in iter_windows(row):
+            r = window.get("risk") or risk(window.get("used_percent"))
+            parts.append(
+                f"{display} {window.get('used_percent', '?')}% {r.get('icon')} "
+                f"reset {short_reset(window.get('reset_at'))} ({window.get('remaining', '?')})"
+            )
+        lines.append(f"{row.get('label')}: " + "; ".join(parts))
+    recommendation = payload.get("recommendation") or {}
+    if recommendation:
+        lines.append(f"추천: {recommendation.get('label')} — {recommendation.get('reason')}")
+    return "\n".join(lines)
+
+
+def load_seen(path: Path) -> set[str]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, list):
+            return {str(item) for item in data}
+    except FileNotFoundError:
+        return set()
+    except Exception:
+        return set()
+    return set()
+
+
+def save_seen(path: Path, seen: set[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(sorted(seen), ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def apply_alert_policy(
+    payload: Dict[str, Any],
+    *,
+    threshold: Optional[float] = None,
+    primary_threshold: Optional[float] = None,
+    secondary_threshold: Optional[float] = None,
+) -> List[Dict[str, Any]]:
+    """Return alert events from a collected usage payload.
+
+    `threshold` is the legacy single threshold. `primary_threshold` controls the
+    5h window and `secondary_threshold` controls the 7d window. Missing specific
+    thresholds fall back to `threshold`, then 90%.
+    """
+    fallback = 90.0 if threshold is None else float(threshold)
+    primary = float(primary_threshold) if primary_threshold is not None else fallback
+    secondary = float(secondary_threshold) if secondary_threshold is not None else fallback
+    thresholds = {"primary_window": primary, "secondary_window": secondary}
+
+    events: list[dict[str, Any]] = []
+    for row in payload.get("accounts") or []:
+        if not row.get("ok"):
+            events.append({"key": f"error:{row.get('label')}:{row.get('http')}:{row.get('error')}", "row": row, "error": True})
+            continue
+        for display, key, window in iter_windows(row):
+            try:
+                raw_used = window.get("used_percent")
+                if raw_used is None:
+                    continue
+                used = float(raw_used)
+            except (TypeError, ValueError):
+                continue
+            if used >= thresholds[key]:
+                reset_key = str(window.get("reset_at"))[:16]
+                events.append(
+                    {
+                        "key": f"quota:{row.get('label')}:{key}:{reset_key}",
+                        "label": row.get("label"),
+                        "window": display,
+                        "window_key": key,
+                        "threshold": thresholds[key],
+                        "used": used if used % 1 else int(used),
+                        "reset_at": window.get("reset_at"),
+                        "remaining": window.get("remaining"),
+                        "risk": window.get("risk") or risk(used),
+                    }
+                )
+    return events
+
+
+def alert_events(payload: Dict[str, Any], threshold: float) -> List[Dict[str, Any]]:
+    return apply_alert_policy(payload, threshold=threshold)
+
+
+def render_alert(
+    payload: Dict[str, Any],
+    threshold: Optional[float] = None,
+    watermark: Optional[Path] = None,
+    *,
+    primary_threshold: Optional[float] = None,
+    secondary_threshold: Optional[float] = None,
+) -> str:
+    events = apply_alert_policy(
+        payload,
+        threshold=threshold,
+        primary_threshold=primary_threshold,
+        secondary_threshold=secondary_threshold,
+    )
+    if watermark:
+        seen = load_seen(watermark)
+        fresh = [event for event in events if event["key"] not in seen]
+        if fresh:
+            seen.update(event["key"] for event in fresh)
+            save_seen(watermark, seen)
+        events = fresh
+    if not events:
+        return ""
+    lines = [f"⚠️ Codex usage alert ({payload['checked_at']})"]
+    for event in events:
+        if event.get("error"):
+            row = event["row"]
+            lines.append(f"{row.get('label')}: ERROR {row.get('http', '')} {row.get('error', '')}".rstrip())
+            continue
+        r = event.get("risk") or {}
+        lines.append(
+            f"{r.get('icon', '⚠️')} {event.get('label')} {event.get('window')} "
+            f"{event.get('used'):g}% >= {event.get('threshold'):g}% — "
+            f"reset {event.get('reset_at')} ({event.get('remaining')})"
+        )
+    recommendation = payload.get("recommendation") or {}
+    if recommendation:
+        lines.append(f"추천: {recommendation.get('label')} — {recommendation.get('reason')}")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Show Hermes OpenAI Codex quota usage by credential")
+    parser.add_argument("--json", action="store_true", help="print machine-readable JSON")
+    parser.add_argument("--compact", action="store_true", help="print Telegram-friendly compact output")
+    parser.add_argument("--alert-threshold", type=float, help="legacy: print only accounts/windows at or above this percent")
+    parser.add_argument("--primary-threshold", type=float, help="5h window alert threshold percent")
+    parser.add_argument("--secondary-threshold", type=float, help="7d window alert threshold percent")
+    parser.add_argument("--quiet-ok", action="store_true", help="with alert thresholds, print nothing when below threshold")
+    parser.add_argument(
+        "--watermark",
+        type=Path,
+        nargs="?",
+        const=DEFAULT_WATERMARK,
+        help="with alert thresholds, suppress duplicate alerts for the same reset window",
+    )
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    payload = collect()
+    alert_mode = any(
+        value is not None
+        for value in (args.alert_threshold, args.primary_threshold, args.secondary_threshold)
+    )
+    if args.json:
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    elif alert_mode:
+        output = render_alert(
+            payload,
+            args.alert_threshold,
+            args.watermark,
+            primary_threshold=args.primary_threshold,
+            secondary_threshold=args.secondary_threshold,
+        )
+        if output:
+            print(output)
+        elif not args.quiet_ok:
+            primary = args.primary_threshold if args.primary_threshold is not None else args.alert_threshold or 90
+            secondary = args.secondary_threshold if args.secondary_threshold is not None else args.alert_threshold or 90
+            print(f"Codex usage OK: 5h below {primary:g}%, 7d below {secondary:g}%")
+    elif args.compact:
+        print(render_compact(payload))
+    else:
+        print(render_text(payload))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/hermes_cli/codex_usage.py
+++ b/hermes_cli/codex_usage.py
@@ -104,16 +104,23 @@ def collect() -> Dict[str, Any]:
     from agent.credential_pool import load_pool
 
     pool = load_pool("openai-codex")
-    # clear_expired=True + refresh=True lets Hermes refresh OAuth tokens if needed.
-    entries = pool._available_entries(clear_expired=True, refresh=True)  # intentional internal API
+    # First let Hermes clear expired cooldowns / refresh available tokens, then
+    # inspect the full pool. Quota reporting must include exhausted credentials
+    # too; otherwise a 7d-reset-aware recommendation cannot see the account that
+    # is about to recover next.
+    pool._available_entries(clear_expired=True, refresh=True)  # intentional internal API
+    entries = pool.entries()
     now = datetime.now().astimezone()
     rows: list[dict[str, Any]] = []
     for entry in entries:
+        exhausted_until = local_dt(entry.last_error_reset_at)
         row: Dict[str, Any] = {
             "label": entry.label,
             "priority": entry.priority,
             "source": entry.source,
             "last_status": entry.last_status or "ok",
+            "available": (entry.last_status or "ok") == "ok",
+            "exhausted_until": exhausted_until.isoformat(timespec="seconds") if exhausted_until else None,
         }
         account_id = (
             entry.extra.get("account_id")
@@ -158,15 +165,79 @@ def _percent(row: Dict[str, Any], window_name: str) -> float:
         return 999.0
 
 
+def _window_reset_dt(row: Dict[str, Any], window_name: str) -> Optional[datetime]:
+    window = row.get(window_name) or {}
+    return local_dt(window.get("reset_at"))
+
+
+def _window_remaining_seconds(row: Dict[str, Any], window_name: str) -> float:
+    reset_dt = _window_reset_dt(row, window_name)
+    if reset_dt is None:
+        return float("inf")
+    return (reset_dt - datetime.now().astimezone()).total_seconds()
+
+
+def _reset_aware_blocker(row: Dict[str, Any]) -> Optional[str]:
+    """Return why a row should not be actively routed right now."""
+    if not row.get("ok"):
+        return "usage 조회 실패"
+    status = str(row.get("last_status") or "ok")
+    if status == "dead":
+        return "재로그인 필요"
+    if not row.get("available", True):
+        exhausted_until = row.get("exhausted_until") or "?"
+        return f"cooldown/exhausted until {short_reset(exhausted_until)}"
+    primary_used = _percent(row, "primary_window")
+    secondary_used = _percent(row, "secondary_window")
+    # Do not route into a near-full 5h window unless it is effectively about to
+    # reset; the proxy cannot wait, so promoting it would just create 429s.
+    if primary_used >= 95 and _window_remaining_seconds(row, "primary_window") > 15 * 60:
+        return "5h 95%+ and reset >15m"
+    if secondary_used >= 100 and _window_remaining_seconds(row, "secondary_window") > 15 * 60:
+        return "7d 100% and reset >15m"
+    return None
+
+
+def _recommendation_sort_key(row: Dict[str, Any]) -> tuple[Any, ...]:
+    secondary_reset = _window_reset_dt(row, "secondary_window")
+    secondary_missing = secondary_reset is None
+    secondary_used = _percent(row, "secondary_window")
+    # Reset timestamp is the primary policy. If the endpoint does not expose a
+    # reset timestamp, fall back to the old conservative behavior: lower 7d
+    # usage first. When reset timestamps tie, burn the fuller soon-resetting
+    # window first.
+    return (
+        1 if secondary_missing else 0,
+        secondary_reset or datetime.max.replace(tzinfo=datetime.now().astimezone().tzinfo),
+        secondary_used if secondary_missing else -secondary_used,
+        _percent(row, "primary_window"),
+        int(row.get("priority") or 999),
+    )
+
+
 def compute_recommendation(accounts: List[Dict[str, Any]]) -> Optional[Dict[str, str]]:
-    ok_accounts = [row for row in accounts if row.get("ok")]
-    if not ok_accounts:
+    candidates: list[Dict[str, Any]] = []
+    blocked: list[tuple[str, str]] = []
+    for row in accounts:
+        reason = _reset_aware_blocker(row)
+        if reason:
+            blocked.append((str(row.get("label")), reason))
+            continue
+        candidates.append(row)
+    if not candidates:
         return None
-    best = min(ok_accounts, key=lambda row: (_percent(row, "secondary_window"), _percent(row, "primary_window")))
+
+    best = min(candidates, key=_recommendation_sort_key)
     sec = best.get("secondary_window") or {}
     pri = best.get("primary_window") or {}
-    reason = f"7d {sec.get('used_percent', '?')}%, 5h {pri.get('used_percent', '?')}%"
-    return {"label": str(best.get("label")), "reason": reason}
+    reason = (
+        f"7d reset {short_reset(sec.get('reset_at'))} · {sec.get('remaining', '?')}, "
+        f"7d {sec.get('used_percent', '?')}%, 5h {pri.get('used_percent', '?')}%"
+    )
+    result = {"label": str(best.get("label")), "reason": reason, "policy": "7d-reset-aware"}
+    if blocked:
+        result["blocked"] = "; ".join(f"{label}: {why}" for label, why in blocked[:3])
+    return result
 
 
 # Backward-compatible alias.
@@ -452,11 +523,14 @@ def _recommendation_explanation(payload: Dict[str, Any]) -> str:
             used = _window_used(window)
             if used is not None and used >= 80:
                 blockers.append((used, f"{label} {display} {_fmt_percent(used).strip()}"))
+    blocked = recommendation.get("blocked")
+    if blocked:
+        return f"사유: 7d reset 우선 정책 · 제외: {blocked}"
     if blockers:
         blockers.sort(reverse=True)
         return f"사유: {blockers[0][1]}로 회복 전까지 보류"
     reason = recommendation.get("reason")
-    return f"사유: 7d 사용률이 가장 낮음 ({reason})" if reason else ""
+    return f"사유: 7d reset이 가장 가까운 사용 가능 계정 ({reason})" if reason else ""
 
 
 def _next_reset(accounts: list[dict[str, Any]], min_used: Optional[float] = None) -> Optional[dict[str, str]]:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -230,7 +230,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True),
     CommandDef("usage", "Show token usage and rate limits for the current session", "Info"),
     CommandDef("codex-usage", "Show current OpenAI Codex quota usage by credential", "Info",
-               aliases=("codex_usage",), args_hint="[--compact]"),
+               aliases=("codex_usage",), args_hint="[--compact|--verbose]"),
     CommandDef("credits", "Show Nous credit balance and top up", "Info"),
     CommandDef("billing", "Manage Nous terminal billing — buy credits, auto-reload, limits", "Info",
                cli_only=True),

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -229,6 +229,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("restart", "Gracefully restart the gateway after draining active runs", "Session",
                gateway_only=True),
     CommandDef("usage", "Show token usage and rate limits for the current session", "Info"),
+    CommandDef("codex-usage", "Show current OpenAI Codex quota usage by credential", "Info",
+               aliases=("codex_usage",), args_hint="[--compact]"),
     CommandDef("credits", "Show Nous credit balance and top up", "Info"),
     CommandDef("billing", "Manage Nous terminal billing — buy credits, auto-reload, limits", "Info",
                cli_only=True),

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12642,26 +12642,9 @@ def cmd_insights(args):
         if getattr(args, "by_credential", False):
             provider = getattr(args, "provider", None)
             rows = db.get_credential_usage(days=args.days, provider=provider)
-            if rows:
-                title_provider = f" for {provider}" if provider else ""
-                print(f"Credential usage{title_provider} (last {args.days}d)")
-                for row in rows:
-                    label = row.get("credential_label") or "unknown"
-                    model = row.get("model") or "unknown"
-                    total = row.get("total_tokens") or 0
-                    in_tok = row.get("input_tokens") or 0
-                    out_tok = row.get("output_tokens") or 0
-                    calls = row.get("api_calls") or 0
-                    print(
-                        f"  {label} · {model}: {total:,} tokens "
-                        f"({in_tok:,} in, {out_tok:,} out), {calls:,} calls"
-                    )
-            else:
-                suffix = f" for {provider}" if provider else ""
-                print(
-                    f"No credential-level usage rows{suffix} in the last {args.days}d. "
-                    "New rows are recorded only after this Hermes version handles model turns."
-                )
+            from hermes_cli.codex_usage import render_credential_insights
+
+            print(render_credential_insights(rows, provider=provider, days=args.days))
         else:
             report = engine.generate(days=args.days, source=args.source)
             if getattr(args, "provider", None):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13968,7 +13968,8 @@ def main():
         description="Show current OpenAI Codex quota, reset windows, alerts, and recommended credential.",
     )
     codex_usage_parser.add_argument("--json", action="store_true", help="print machine-readable JSON")
-    codex_usage_parser.add_argument("--compact", action="store_true", help="print Telegram-friendly compact output")
+    codex_usage_parser.add_argument("--compact", action="store_true", help="print Telegram-friendly compact output (default)")
+    codex_usage_parser.add_argument("--verbose", action="store_true", help="print detailed per-account text output")
     codex_usage_parser.add_argument("--alert-threshold", type=float, help="legacy: alert when either window is at/above this percent")
     codex_usage_parser.add_argument("--primary-threshold", type=float, help="5h window alert threshold percent")
     codex_usage_parser.add_argument("--secondary-threshold", type=float, help="7d window alert threshold percent")
@@ -13977,7 +13978,7 @@ def main():
     def _cmd_codex_usage(_args):
         from hermes_cli.codex_usage import main as _codex_usage_main
         argv = []
-        for _flag in ("json", "compact", "quiet_ok"):
+        for _flag in ("json", "compact", "verbose", "quiet_ok"):
             if getattr(_args, _flag, False):
                 argv.append("--" + _flag.replace("_", "-"))
         for _flag in ("alert_threshold", "primary_threshold", "secondary_threshold"):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12639,8 +12639,34 @@ def cmd_insights(args):
 
         db = SessionDB()
         engine = InsightsEngine(db)
-        report = engine.generate(days=args.days, source=args.source)
-        print(engine.format_terminal(report))
+        if getattr(args, "by_credential", False):
+            provider = getattr(args, "provider", None)
+            rows = db.get_credential_usage(days=args.days, provider=provider)
+            if rows:
+                title_provider = f" for {provider}" if provider else ""
+                print(f"Credential usage{title_provider} (last {args.days}d)")
+                for row in rows:
+                    label = row.get("credential_label") or "unknown"
+                    model = row.get("model") or "unknown"
+                    total = row.get("total_tokens") or 0
+                    in_tok = row.get("input_tokens") or 0
+                    out_tok = row.get("output_tokens") or 0
+                    calls = row.get("api_calls") or 0
+                    print(
+                        f"  {label} · {model}: {total:,} tokens "
+                        f"({in_tok:,} in, {out_tok:,} out), {calls:,} calls"
+                    )
+            else:
+                suffix = f" for {provider}" if provider else ""
+                print(
+                    f"No credential-level usage rows{suffix} in the last {args.days}d. "
+                    "New rows are recorded only after this Hermes version handles model turns."
+                )
+        else:
+            report = engine.generate(days=args.days, source=args.source)
+            if getattr(args, "provider", None):
+                report["provider_filter_note"] = args.provider
+            print(engine.format_terminal(report))
         db.close()
     except Exception as e:
         print(f"Error generating insights: {e}")
@@ -13935,6 +13961,36 @@ def main():
     # insights command  (parser built in hermes_cli/subcommands/insights.py)
     # =========================================================================
     build_insights_parser(subparsers, cmd_insights=cmd_insights)
+
+    codex_usage_parser = subparsers.add_parser(
+        "codex-usage",
+        help="Show OpenAI Codex quota usage for Hermes OAuth credentials",
+        description="Show current OpenAI Codex quota, reset windows, alerts, and recommended credential.",
+    )
+    codex_usage_parser.add_argument("--json", action="store_true", help="print machine-readable JSON")
+    codex_usage_parser.add_argument("--compact", action="store_true", help="print Telegram-friendly compact output")
+    codex_usage_parser.add_argument("--alert-threshold", type=float, help="legacy: alert when either window is at/above this percent")
+    codex_usage_parser.add_argument("--primary-threshold", type=float, help="5h window alert threshold percent")
+    codex_usage_parser.add_argument("--secondary-threshold", type=float, help="7d window alert threshold percent")
+    codex_usage_parser.add_argument("--quiet-ok", action="store_true", help="with alert thresholds, print nothing when below threshold")
+    codex_usage_parser.add_argument("--watermark", nargs="?", const="__DEFAULT__", help="suppress duplicate alerts for the same reset window")
+    def _cmd_codex_usage(_args):
+        from hermes_cli.codex_usage import main as _codex_usage_main
+        argv = []
+        for _flag in ("json", "compact", "quiet_ok"):
+            if getattr(_args, _flag, False):
+                argv.append("--" + _flag.replace("_", "-"))
+        for _flag in ("alert_threshold", "primary_threshold", "secondary_threshold"):
+            _val = getattr(_args, _flag, None)
+            if _val is not None:
+                argv.extend(["--" + _flag.replace("_", "-"), str(_val)])
+        _wm = getattr(_args, "watermark", None)
+        if _wm is not None:
+            argv.append("--watermark")
+            if _wm != "__DEFAULT__":
+                argv.append(str(_wm))
+        return _codex_usage_main(argv)
+    codex_usage_parser.set_defaults(func=_cmd_codex_usage)
 
     # =========================================================================
     # claw command  (parser built in hermes_cli/subcommands/claw.py)

--- a/hermes_cli/subcommands/insights.py
+++ b/hermes_cli/subcommands/insights.py
@@ -22,4 +22,12 @@ def build_insights_parser(subparsers, *, cmd_insights: Callable) -> None:
     insights_parser.add_argument(
         "--source", help="Filter by platform (cli, telegram, discord, etc.)"
     )
+    insights_parser.add_argument(
+        "--provider", help="Filter usage by billing provider (e.g. openai-codex)"
+    )
+    insights_parser.add_argument(
+        "--by-credential",
+        action="store_true",
+        help="Show per-credential token usage when credential telemetry is available",
+    )
     insights_parser.set_defaults(func=cmd_insights)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -767,6 +767,21 @@ CREATE TABLE IF NOT EXISTS messages (
     compacted INTEGER NOT NULL DEFAULT 0
 );
 
+CREATE TABLE IF NOT EXISTS credential_usage (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL REFERENCES sessions(id),
+    timestamp REAL NOT NULL,
+    provider TEXT,
+    credential_label TEXT,
+    model TEXT,
+    input_tokens INTEGER DEFAULT 0,
+    output_tokens INTEGER DEFAULT 0,
+    cache_read_tokens INTEGER DEFAULT 0,
+    cache_write_tokens INTEGER DEFAULT 0,
+    reasoning_tokens INTEGER DEFAULT 0,
+    api_call_count INTEGER DEFAULT 0
+);
+
 CREATE TABLE IF NOT EXISTS state_meta (
     key TEXT PRIMARY KEY,
     value TEXT
@@ -808,6 +823,8 @@ CREATE INDEX IF NOT EXISTS idx_sessions_gateway_peer
     ON sessions(source, user_id, chat_id, chat_type, thread_id, started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_sessions_handoff_state
     ON sessions(handoff_state, started_at);
+CREATE INDEX IF NOT EXISTS idx_credential_usage_time_provider
+    ON credential_usage(timestamp DESC, provider, credential_label);
 """
 
 FTS_SQL = """
@@ -2414,6 +2431,7 @@ class SessionDB:
         billing_provider: Optional[str] = None,
         billing_base_url: Optional[str] = None,
         billing_mode: Optional[str] = None,
+        credential_label: Optional[str] = None,
         api_call_count: int = 0,
         absolute: bool = False,
     ) -> None:
@@ -2494,7 +2512,82 @@ class SessionDB:
         )
         def _do(conn):
             conn.execute(sql, params)
+            if credential_label:
+                conn.execute(
+                    """INSERT INTO credential_usage (
+                       session_id, timestamp, provider, credential_label, model,
+                       input_tokens, output_tokens, cache_read_tokens,
+                       cache_write_tokens, reasoning_tokens, api_call_count
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        session_id,
+                        time.time(),
+                        billing_provider,
+                        credential_label,
+                        model,
+                        input_tokens,
+                        output_tokens,
+                        cache_read_tokens,
+                        cache_write_tokens,
+                        reasoning_tokens,
+                        api_call_count,
+                    ),
+                )
         self._execute_write(_do)
+
+    def get_credential_usage(
+        self,
+        days: int = 30,
+        provider: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Aggregate per-credential token usage rows for recent model calls."""
+        cutoff = time.time() - (max(0, int(days)) * 86400)
+        where = ["timestamp >= ?"]
+        params: list[Any] = [cutoff]
+        if provider:
+            where.append("provider = ?")
+            params.append(provider)
+        query = f"""
+            SELECT
+                COALESCE(provider, 'unknown') AS provider,
+                COALESCE(credential_label, 'unknown') AS credential_label,
+                COALESCE(model, 'unknown') AS model,
+                COALESCE(SUM(api_call_count), 0) AS api_calls,
+                COALESCE(SUM(input_tokens), 0) AS input_tokens,
+                COALESCE(SUM(output_tokens), 0) AS output_tokens,
+                COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
+                COALESCE(SUM(cache_write_tokens), 0) AS cache_write_tokens,
+                COALESCE(SUM(reasoning_tokens), 0) AS reasoning_tokens
+            FROM credential_usage
+            WHERE {' AND '.join(where)}
+            GROUP BY provider, credential_label, model
+            ORDER BY (COALESCE(SUM(input_tokens), 0) + COALESCE(SUM(output_tokens), 0)
+                      + COALESCE(SUM(cache_read_tokens), 0) + COALESCE(SUM(cache_write_tokens), 0)
+                      + COALESCE(SUM(reasoning_tokens), 0)) DESC,
+                     credential_label ASC,
+                     model ASC
+        """
+        with self._lock:
+            cursor = self._conn.execute(query, tuple(params))
+            rows = [dict(row) for row in cursor.fetchall()]
+        for row in rows:
+            row["api_calls"] = int(row.get("api_calls") or 0)
+            for key in (
+                "input_tokens",
+                "output_tokens",
+                "cache_read_tokens",
+                "cache_write_tokens",
+                "reasoning_tokens",
+            ):
+                row[key] = int(row.get(key) or 0)
+            row["total_tokens"] = (
+                row["input_tokens"]
+                + row["output_tokens"]
+                + row["cache_read_tokens"]
+                + row["cache_write_tokens"]
+                + row["reasoning_tokens"]
+            )
+        return rows
 
     def ensure_session(
         self,

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -155,6 +155,10 @@ async def _shutdown_abandoned_app(app) -> None:
 try:
     from telegram import Update, Bot, Message, InlineKeyboardButton, InlineKeyboardMarkup
     try:
+        from telegram import CopyTextButton
+    except ImportError:
+        CopyTextButton = None
+    try:
         from telegram import LinkPreviewOptions
     except ImportError:
         LinkPreviewOptions = None
@@ -176,6 +180,7 @@ except ImportError:
     Message = Any
     InlineKeyboardButton = Any
     InlineKeyboardMarkup = Any
+    CopyTextButton = None
     LinkPreviewOptions = None
     Application = Any
     CommandHandler = Any
@@ -251,7 +256,7 @@ def check_telegram_requirements() -> bool:
     so the adapter's class-level type aliases get rebound.
     """
     global TELEGRAM_AVAILABLE, Update, Bot, Message, InlineKeyboardButton
-    global InlineKeyboardMarkup, LinkPreviewOptions, Application
+    global InlineKeyboardMarkup, CopyTextButton, LinkPreviewOptions, Application
     global CommandHandler, CallbackQueryHandler, TelegramMessageHandler
     global ContextTypes, filters, ParseMode, ChatType, HTTPXRequest
     if TELEGRAM_AVAILABLE:
@@ -264,6 +269,10 @@ def check_telegram_requirements() -> bool:
     try:
         from telegram import Update as _Update, Bot as _Bot, Message as _Message
         from telegram import InlineKeyboardButton as _IKB, InlineKeyboardMarkup as _IKM
+        try:
+            from telegram import CopyTextButton as _CTB
+        except ImportError:
+            _CTB = None
         try:
             from telegram import LinkPreviewOptions as _LPO
         except ImportError:
@@ -283,6 +292,7 @@ def check_telegram_requirements() -> bool:
     Message = _Message
     InlineKeyboardButton = _IKB
     InlineKeyboardMarkup = _IKM
+    CopyTextButton = _CTB
     LinkPreviewOptions = _LPO
     Application = _App
     CommandHandler = _CH
@@ -345,6 +355,48 @@ def _separate_chunk_indicator_from_fence(text: str) -> str:
     closing fence.
     """
     return _CHUNK_INDICATOR_ON_FENCE_RE.sub(r'```\n\g<indicator>', text)
+
+
+# ---------------------------------------------------------------------------
+# Telegram copy-to-clipboard buttons
+# ---------------------------------------------------------------------------
+
+_COPY_BUTTON_LINE_RE = re.compile(
+    r'^\s*COPY_BUTTON:\s*(?P<label>[^|\n]{1,64})\|(?P<text>[^\n]{1,256})\s*$',
+    re.MULTILINE,
+)
+
+
+def _extract_copy_buttons(content: str) -> tuple[str, list[tuple[str, str]]]:
+    """Strip ``COPY_BUTTON: label | text`` marker lines and return buttons.
+
+    Telegram's Bot API exposes ``InlineKeyboardButton.copy_text`` for true
+    clipboard-copy buttons, but Hermes final answers are plain markdown.  This
+    narrowly-scoped marker gives the agent a way to request copy buttons on
+    Telegram without adding a new model tool or changing other platforms.
+
+    Invalid/oversized marker lines are left untouched so no user-visible text is
+    silently dropped.  Valid button copy payloads are limited to Telegram's
+    documented 1-256 character range; labels are capped to avoid mobile
+    truncation-heavy keyboards.  The adapter caps the rendered keyboard to the
+    first 20 buttons as a conservative Bot API/client guardrail.
+    """
+    if not content or "COPY_BUTTON:" not in content:
+        return content, []
+
+    buttons: list[tuple[str, str]] = []
+
+    def _replace(match: re.Match[str]) -> str:
+        label = match.group("label").strip()
+        text = match.group("text").strip()
+        if not label or not text or len(text) > 256 or len(buttons) >= 20:
+            return match.group(0)
+        buttons.append((label, text))
+        return ""
+
+    stripped = _COPY_BUTTON_LINE_RE.sub(_replace, content)
+    stripped = re.sub(r'\n{3,}', '\n\n', stripped).strip()
+    return stripped, buttons
 
 
 # ---------------------------------------------------------------------------
@@ -1261,6 +1313,23 @@ class TelegramAdapter(BasePlatformAdapter):
         if LinkPreviewOptions is not None:
             return {"link_preview_options": LinkPreviewOptions(is_disabled=True)}
         return {"disable_web_page_preview": True}
+
+    def _copy_buttons_markup(self, buttons: list[tuple[str, str]]) -> Optional[Any]:
+        """Build Telegram copy-to-clipboard inline keyboard markup."""
+        if not buttons:
+            return None
+        if CopyTextButton is None:
+            logger.warning("[%s] copy_text buttons requested but CopyTextButton is unavailable", self.name)
+            return None
+        rows = []
+        for label, text in buttons[:20]:
+            rows.append([
+                InlineKeyboardButton(
+                    label,
+                    copy_text=CopyTextButton(text=text),  # type: ignore[reportCallIssue]
+                )
+            ])
+        return InlineKeyboardMarkup(rows)  # type: ignore[reportCallIssue]
 
     # ------------------------------------------------------------------
     # Bot API 10.1 Rich Messages (sendRichMessage)
@@ -3495,14 +3564,22 @@ class TelegramAdapter(BasePlatformAdapter):
         # Skip whitespace-only text to prevent Telegram 400 empty-text errors.
         if not content or not content.strip():
             return SendResult(success=True, message_id=None)
+
+        copy_markup = None
+        if CopyTextButton is not None:
+            content, copy_buttons = _extract_copy_buttons(content)
+            if copy_buttons and not content.strip():
+                content = "Copy buttons"
+            copy_markup = self._copy_buttons_markup(copy_buttons)
+        elif "COPY_BUTTON:" in content:
+            logger.warning("[%s] COPY_BUTTON markers requested but CopyTextButton is unavailable", self.name)
         
         try:
-            # Bot API 10.1 rich fast-path: send the raw agent markdown via
-            # sendRichMessage so tables/task lists/etc. render natively. Falls
-            # through to the legacy MarkdownV2 path on permanent/capability
-            # errors or DM-topic routing skips; returns directly on success or
-            # on a transient failure (which must NOT be legacy-resent).
-            if self._should_attempt_rich(content, metadata=metadata):
+            # Bot API 10.1 rich messages currently use the raw sendRichMessage
+            # endpoint path, which does not attach reply_markup here.  If copy
+            # buttons were requested, stay on the legacy sendMessage path so the
+            # clipboard keyboard is delivered with the text.
+            if not copy_markup and self._should_attempt_rich(content, metadata=metadata):
                 rich_result = await self._try_send_rich(chat_id, content, reply_to, metadata)
                 if rich_result is not None:
                     if rich_result.success:
@@ -3611,6 +3688,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 **thread_kwargs,
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),
+                                **({"reply_markup": copy_markup} if copy_markup is not None and i == len(chunks) - 1 else {}),
                             )
                         except Exception as md_error:
                             # Markdown parsing failed, try plain text
@@ -3625,6 +3703,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     **thread_kwargs,
                                     **self._link_preview_kwargs(),
                                     **self._notification_kwargs(metadata),
+                                    **({"reply_markup": copy_markup} if copy_markup is not None and i == len(chunks) - 1 else {}),
                                 )
                             else:
                                 raise
@@ -3860,6 +3939,15 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot:
             return SendResult(success=False, error="Not connected")
 
+        copy_markup = None
+        if finalize and CopyTextButton is not None:
+            content, copy_buttons = _extract_copy_buttons(content)
+            if copy_buttons and not content.strip():
+                content = "Copy buttons"
+            copy_markup = self._copy_buttons_markup(copy_buttons)
+        elif finalize and "COPY_BUTTON:" in content:
+            logger.warning("[%s] COPY_BUTTON markers requested but CopyTextButton is unavailable", self.name)
+
         # Rich finalize (Bot API 10.1): when the completed content has
         # constructs the legacy MarkdownV2 edit degrades (tables → bullet
         # lists, task lists, <details>, block math) and rich is available,
@@ -3870,7 +3958,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # table that exceeds the MarkdownV2 limit must not be split into legacy
         # chunks.  Falls back to the legacy edit path (overflow split included)
         # on capability/permanent rejection.
-        if finalize and self._rich_eligible(content):
+        if finalize and not copy_markup and self._rich_eligible(content):
             rich_result = await self._try_edit_rich(
                 chat_id, message_id, content, metadata=metadata,
             )
@@ -3929,6 +4017,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     message_id=int(message_id),
                     text=formatted,
                     parse_mode=ParseMode.MARKDOWN_V2,
+                    **({"reply_markup": copy_markup} if copy_markup is not None else {}),
                 )
             except Exception as fmt_err:
                 # "Message is not modified" is a no-op, not an error
@@ -3946,6 +4035,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     chat_id=normalize_telegram_chat_id(chat_id),
                     message_id=int(message_id),
                     text=_plain,
+                    **({"reply_markup": copy_markup} if copy_markup is not None else {}),
                 )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:

--- a/plugins/platforms/telegram/telegram_network.py
+++ b/plugins/platforms/telegram/telegram_network.py
@@ -13,9 +13,12 @@ import asyncio
 import ipaddress
 import logging
 import socket
+import time
 from typing import Iterable, Optional
 
 import httpx
+
+from agent.network_circuit_breaker import get_global_network_breaker
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +61,14 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
     ``curl --resolve api.telegram.org:443:<ip>``.
     """
 
-    def __init__(self, fallback_ips: Iterable[str], **transport_kwargs):
+    def __init__(
+        self,
+        fallback_ips: Iterable[str],
+        *,
+        failure_threshold: int = 3,
+        cooldown_seconds: float = 90.0,
+        **transport_kwargs,
+    ):
         self._fallback_ips = list(dict.fromkeys(_normalize_fallback_ips(fallback_ips)))
         proxy_url = _resolve_proxy_url(target_hosts=[_TELEGRAM_API_HOST, *self._fallback_ips])
         if proxy_url and "proxy" not in transport_kwargs:
@@ -69,10 +79,26 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
         }
         self._sticky_ip: Optional[str] = None
         self._sticky_lock = asyncio.Lock()
+        self._failure_threshold = max(1, int(failure_threshold))
+        self._cooldown_seconds = max(1.0, float(cooldown_seconds))
+        self._consecutive_total_failures = 0
+        self._cooldown_until = 0.0
+        self._cooldown_error: Exception | None = None
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
         if request.url.host != _TELEGRAM_API_HOST or not self._fallback_ips:
             return await self._primary.handle_async_request(request)
+
+        now = time.time()
+        if self._cooldown_until > now:
+            error = self._cooldown_error or httpx.ConnectError(
+                "Telegram fallback transport in cooldown after repeated connection failures",
+                request=request,
+            )
+            raise httpx.ConnectError(
+                f"Telegram fallback transport in cooldown for {int(self._cooldown_until - now) + 1}s",
+                request=request,
+            ) from error
 
         sticky_ip = self._sticky_ip
         attempt_order: list[Optional[str]] = [sticky_ip] if sticky_ip else [None]
@@ -96,6 +122,10 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
                                 "[Telegram] Primary api.telegram.org path unreachable; using sticky fallback IP %s",
                                 ip,
                             )
+                self._consecutive_total_failures = 0
+                self._cooldown_until = 0.0
+                self._cooldown_error = None
+                get_global_network_breaker().record_success(surface="telegram")
                 return response
             except Exception as exc:
                 last_error = exc
@@ -121,6 +151,16 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
 
         if last_error is None:
             raise RuntimeError("All Telegram fallback IPs exhausted but no error was recorded")
+        self._consecutive_total_failures += 1
+        self._cooldown_error = last_error
+        if self._consecutive_total_failures >= self._failure_threshold:
+            self._cooldown_until = time.time() + self._cooldown_seconds
+            logger.warning(
+                "[Telegram] All primary/fallback connection attempts failed %d time(s); cooling down for %.0fs",
+                self._consecutive_total_failures,
+                self._cooldown_seconds,
+            )
+        get_global_network_breaker().record_failure(last_error, surface="telegram")
         raise last_error
 
     async def aclose(self) -> None:

--- a/tests/agent/test_network_circuit_breaker.py
+++ b/tests/agent/test_network_circuit_breaker.py
@@ -1,0 +1,50 @@
+import errno
+import time
+
+import pytest
+
+
+def test_host_connectivity_errors_are_classified_through_exception_chain():
+    from agent.network_circuit_breaker import is_host_connectivity_error
+
+    low = OSError(errno.EADDRNOTAVAIL, "Cannot assign requested address")
+    wrapped = RuntimeError("provider wrapper")
+    wrapped.__cause__ = low
+
+    assert is_host_connectivity_error(wrapped) is True
+    assert is_host_connectivity_error(OSError(errno.EHOSTUNREACH, "No route to host")) is True
+    assert is_host_connectivity_error(TimeoutError("ordinary timeout")) is False
+
+
+def test_breaker_opens_after_repeated_host_connectivity_errors(monkeypatch):
+    from agent.network_circuit_breaker import NetworkCircuitBreaker, NetworkCircuitOpen
+
+    now = {"t": 1000.0}
+    monkeypatch.setattr(time, "time", lambda: now["t"])
+    breaker = NetworkCircuitBreaker(threshold=2, cooldown_seconds=30)
+
+    breaker.before_request("provider")
+    breaker.record_failure(OSError(errno.EADDRNOTAVAIL, "Cannot assign requested address"), surface="provider")
+    breaker.before_request("provider")
+    breaker.record_failure(OSError(errno.EHOSTUNREACH, "No route to host"), surface="provider")
+
+    with pytest.raises(NetworkCircuitOpen):
+        breaker.before_request("provider")
+
+    now["t"] += 31
+    breaker.before_request("provider")
+
+
+def test_parse_netstat_counts_and_pressure_threshold():
+    from agent.network_circuit_breaker import parse_netstat_state_counts, socket_pressure_is_high
+
+    output = """
+tcp4 0 0 192.168.1.2.50001 1.1.1.1.443 TIME_WAIT
+tcp4 0 0 192.168.1.2.50002 1.1.1.1.443 TIME_WAIT
+tcp4 0 0 192.168.1.2.50003 1.1.1.1.443 ESTABLISHED
+"""
+    counts = parse_netstat_state_counts(output)
+    assert counts["TIME_WAIT"] == 2
+    assert counts["ESTABLISHED"] == 1
+    assert socket_pressure_is_high({"TIME_WAIT": 12000}, port_range_size=16384, threshold_ratio=0.70)
+    assert not socket_pressure_is_high({"TIME_WAIT": 100}, port_range_size=16384, threshold_ratio=0.70)

--- a/tests/gateway/test_network_pressure_monitor.py
+++ b/tests/gateway/test_network_pressure_monitor.py
@@ -1,0 +1,20 @@
+def test_gateway_socket_pressure_monitor_opens_global_breaker(monkeypatch):
+    import gateway.run as run
+    from agent.network_circuit_breaker import get_global_network_breaker, NetworkCircuitOpen
+
+    breaker = get_global_network_breaker()
+    breaker.reset()
+    monkeypatch.setenv("HERMES_GATEWAY_SOCKET_PRESSURE_THRESHOLD", "0.70")
+    monkeypatch.setattr(run, "_socket_state_counts", lambda: {"TIME_WAIT": 12000})
+    monkeypatch.setattr(run, "_ephemeral_port_range_size", lambda: 16384)
+
+    assert run._gateway_socket_pressure_check() is True
+    try:
+        try:
+            breaker.before_request("provider")
+        except NetworkCircuitOpen:
+            pass
+        else:
+            raise AssertionError("global network breaker did not open")
+    finally:
+        breaker.reset()

--- a/tests/gateway/test_telegram_copy_buttons.py
+++ b/tests/gateway/test_telegram_copy_buttons.py
@@ -1,0 +1,202 @@
+"""Tests for Telegram copy-to-clipboard inline buttons."""
+
+import sys
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+def _ensure_telegram_mock():
+    try:
+        import telegram  # noqa: F401
+        if hasattr(telegram, "__file__"):
+            return
+    except ImportError:
+        pass
+
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules[name] = mod
+    sys.modules["telegram.error"] = mod.error
+
+
+_ensure_telegram_mock()
+
+from gateway.config import PlatformConfig
+from plugins.platforms.telegram import adapter as telegram_adapter
+from plugins.platforms.telegram.adapter import TelegramAdapter, _extract_copy_buttons
+
+
+@pytest.fixture(autouse=True)
+def _unload_adapter_after_test():
+    """Let later tests that inject fake telegram modules import a fresh adapter."""
+    yield
+    sys.modules.pop("plugins.platforms.telegram.adapter", None)
+    pkg = sys.modules.get("plugins.platforms.telegram")
+    if pkg is not None and getattr(pkg, "adapter", None) is telegram_adapter:
+        try:
+            delattr(pkg, "adapter")
+        except AttributeError:
+            pass
+
+
+class FakeCopyTextButton:
+    def __init__(self, text: str):
+        self.text = text
+
+
+class FakeInlineKeyboardButton:
+    def __init__(self, text: str, **kwargs):
+        self.text = text
+        self.kwargs = kwargs
+
+
+class FakeInlineKeyboardMarkup:
+    def __init__(self, rows):
+        self.rows = rows
+
+
+def _make_adapter(monkeypatch):
+    monkeypatch.setattr(telegram_adapter, "CopyTextButton", FakeCopyTextButton)
+    monkeypatch.setattr(telegram_adapter, "InlineKeyboardButton", FakeInlineKeyboardButton)
+    monkeypatch.setattr(telegram_adapter, "InlineKeyboardMarkup", FakeInlineKeyboardMarkup)
+
+    config = PlatformConfig(enabled=True, token="test-token", extra={})
+    adapter = TelegramAdapter(config)
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    return adapter
+
+
+def test_extract_copy_buttons_strips_valid_markers_only():
+    content = """VNC 주소
+COPY_BUTTON: Mac mini IP | 100.96.33.123
+body remains
+COPY_BUTTON: bad | 
+"""
+
+    stripped, buttons = _extract_copy_buttons(content)
+
+    assert buttons == [("Mac mini IP", "100.96.33.123")]
+    assert "COPY_BUTTON: Mac mini IP" not in stripped
+    assert "body remains" in stripped
+    assert "COPY_BUTTON: bad |" in stripped
+
+
+@pytest.mark.asyncio
+async def test_send_attaches_copy_text_keyboard_and_strips_markers(monkeypatch):
+    adapter = _make_adapter(monkeypatch)
+    mock_msg = MagicMock()
+    mock_msg.message_id = 123
+    bot = cast(Any, adapter._bot)
+    bot.send_message = AsyncMock(return_value=mock_msg)
+
+    result = await adapter.send(
+        chat_id="12345",
+        content=(
+            "VNC 주소\n"
+            "COPY_BUTTON: Mac mini IP | 100.96.33.123\n"
+            "COPY_BUTTON: MacBook VNC | 100.99.47.75:5900"
+        ),
+    )
+
+    assert result.success is True
+    kwargs = bot.send_message.call_args.kwargs
+    assert "COPY_BUTTON:" not in kwargs["text"]
+    assert "VNC 주소" in kwargs["text"]
+
+    markup = kwargs["reply_markup"]
+    assert isinstance(markup, FakeInlineKeyboardMarkup)
+    assert len(markup.rows) == 2
+    first = markup.rows[0][0]
+    second = markup.rows[1][0]
+    assert first.text == "Mac mini IP"
+    assert first.kwargs["copy_text"].text == "100.96.33.123"
+    assert second.text == "MacBook VNC"
+    assert second.kwargs["copy_text"].text == "100.99.47.75:5900"
+
+
+@pytest.mark.asyncio
+async def test_copy_button_only_message_gets_safe_fallback_text(monkeypatch):
+    adapter = _make_adapter(monkeypatch)
+    mock_msg = MagicMock()
+    mock_msg.message_id = 124
+    bot = cast(Any, adapter._bot)
+    bot.send_message = AsyncMock(return_value=mock_msg)
+
+    result = await adapter.send(
+        chat_id="12345",
+        content="COPY_BUTTON: MacBook IP | 100.99.47.75",
+    )
+
+    assert result.success is True
+    kwargs = bot.send_message.call_args.kwargs
+    assert kwargs["text"] == "Copy buttons"
+    assert kwargs["reply_markup"].rows[0][0].kwargs["copy_text"].text == "100.99.47.75"
+
+
+@pytest.mark.asyncio
+async def test_send_leaves_markers_visible_when_copy_text_button_unavailable(monkeypatch):
+    adapter = _make_adapter(monkeypatch)
+    monkeypatch.setattr(telegram_adapter, "CopyTextButton", None)
+    mock_msg = MagicMock()
+    mock_msg.message_id = 125
+    bot = cast(Any, adapter._bot)
+    bot.send_message = AsyncMock(return_value=mock_msg)
+
+    result = await adapter.send(
+        chat_id="12345",
+        content="VNC\nCOPY_BUTTON: MacBook IP | 100.99.47.75",
+    )
+
+    assert result.success is True
+    kwargs = bot.send_message.call_args.kwargs
+    assert "COPY\\_BUTTON: MacBook IP \\| 100\\.99\\.47\\.75" in kwargs["text"]
+    assert "reply_markup" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_finalize_edit_attaches_copy_text_keyboard_and_strips_markers(monkeypatch):
+    adapter = _make_adapter(monkeypatch)
+    bot = cast(Any, adapter._bot)
+    bot.edit_message_text = AsyncMock(return_value=None)
+
+    result = await adapter.edit_message(
+        chat_id="12345",
+        message_id="777",
+        content=(
+            "VNC 주소\n"
+            "COPY_BUTTON: Mac mini IP | 100.96.33.123\n"
+            "COPY_BUTTON: MacBook VNC | 100.99.47.75:5900"
+        ),
+        finalize=True,
+    )
+
+    assert result.success is True
+    kwargs = bot.edit_message_text.call_args.kwargs
+    assert kwargs["message_id"] == 777
+    assert "COPY_BUTTON:" not in kwargs["text"]
+    assert "VNC 주소" in kwargs["text"]
+    assert kwargs["reply_markup"].rows[0][0].kwargs["copy_text"].text == "100.96.33.123"
+    assert kwargs["reply_markup"].rows[1][0].kwargs["copy_text"].text == "100.99.47.75:5900"

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -258,6 +258,34 @@ class TestFallbackTransport:
         assert [c["url_host"] for c in calls] == ["149.154.167.220", "api.telegram.org", "149.154.167.221"]
         assert transport._sticky_ip == "149.154.167.221"
 
+    @pytest.mark.asyncio
+    async def test_repeated_total_connect_failure_enters_cooldown(self, monkeypatch):
+        calls = []
+        behavior = {"api.telegram.org": "connect_error", "149.154.167.220": "connect_error"}
+        monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", _fake_transport_factory(calls, behavior))
+
+        now = {"t": 1000.0}
+        monkeypatch.setattr(tnet.time, "time", lambda: now["t"])
+        transport = tnet.TelegramFallbackTransport(
+            ["149.154.167.220"],
+            failure_threshold=1,
+            cooldown_seconds=30,
+        )
+
+        with pytest.raises(httpx.ConnectError):
+            await transport.handle_async_request(_telegram_request())
+        assert [c["url_host"] for c in calls] == ["api.telegram.org", "149.154.167.220"]
+
+        calls.clear()
+        with pytest.raises(httpx.ConnectError, match="cooldown"):
+            await transport.handle_async_request(_telegram_request())
+        assert calls == []
+
+        now["t"] += 31
+        with pytest.raises(httpx.ConnectError):
+            await transport.handle_async_request(_telegram_request())
+        assert [c["url_host"] for c in calls] == ["api.telegram.org", "149.154.167.220"]
+
 
 class TestFallbackTransportPassthrough:
     """Requests that don't need fallback behavior."""

--- a/tests/hermes_cli/test_codex_usage.py
+++ b/tests/hermes_cli/test_codex_usage.py
@@ -2,9 +2,11 @@ from hermes_cli.codex_usage import (
     annotate_usage_trends,
     apply_alert_policy,
     compute_recommendation,
+    load_history,
     render_alert,
     render_compact,
     render_credential_insights,
+    save_history_snapshot,
     summarize_window,
     usage_bar,
 )
@@ -148,6 +150,124 @@ def test_render_compact_includes_burn_and_eta_when_trend_is_available():
     assert "🔥 Burn:" in text
     assert "5h +4.0%/h" in text
     assert "burn +4.0%/h · ETA95 07/07 14:15" in text
+
+
+def test_annotate_usage_trends_falls_back_to_window_average_on_first_run():
+    payload = {
+        "checked_at": "2026-07-06T20:00:00+09:00",
+        "accounts": [
+            {
+                "label": "company-plus-100",
+                "ok": True,
+                "primary_window": summarize_window(
+                    {
+                        "used_percent": 25,
+                        "limit_window_seconds": 18000,
+                        "reset_at": "2026-07-06T21:00:00+09:00",
+                    }
+                ),
+                "secondary_window": {},
+            }
+        ],
+    }
+
+    annotate_usage_trends(payload, history=[])
+
+    trend = payload["accounts"][0]["primary_window"]["trend"]
+    assert trend["source"] == "window_avg"
+    assert trend["burn_percent_per_hour"] == 6.25
+
+
+def test_annotate_usage_trends_ignores_usage_rollbacks_and_uses_average():
+    payload = {
+        "checked_at": "2026-07-06T20:00:00+09:00",
+        "accounts": [
+            {
+                "label": "company-plus-100",
+                "ok": True,
+                "primary_window": summarize_window(
+                    {
+                        "used_percent": 20,
+                        "limit_window_seconds": 18000,
+                        "reset_at": "2026-07-06T21:00:00+09:00",
+                    }
+                ),
+                "secondary_window": {},
+            }
+        ],
+    }
+
+    annotate_usage_trends(
+        payload,
+        history=[
+            {
+                "checked_at": "2026-07-06T19:30:00+09:00",
+                "accounts": [
+                    {
+                        "label": "company-plus-100",
+                        "ok": True,
+                        "primary_window": {"used_percent": 25, "reset_at": "2026-07-06T21:00:00+09:00"},
+                    }
+                ],
+            }
+        ],
+    )
+
+    trend = payload["accounts"][0]["primary_window"]["trend"]
+    assert trend["source"] == "window_avg"
+    assert trend["burn_percent_per_hour"] == 5.0
+
+
+def test_history_load_skips_corrupt_lines_and_save_is_nonfatal(tmp_path):
+    history_path = tmp_path / "history.jsonl"
+    history_path.write_text('{"checked_at":"old"}\nnot-json\n{"checked_at":"new"}\n', encoding="utf-8")
+
+    rows = load_history(history_path)
+
+    assert [row["checked_at"] for row in rows] == ["old", "new"]
+    save_history_snapshot(tmp_path / "missing" / "nested" / "history.jsonl", {"checked_at": "now", "accounts": []})
+    save_history_snapshot(tmp_path, {"checked_at": "now", "accounts": []})
+
+
+def test_render_compact_marks_eta_after_reset():
+    payload = {
+        "checked_at": "2026-07-06T20:00:00+09:00",
+        "accounts": [
+            {
+                "label": "company-plus-100",
+                "ok": True,
+                "plan_type": "prolite",
+                "primary_window": summarize_window(
+                    {
+                        "used_percent": 22,
+                        "limit_window_seconds": 18000,
+                        "reset_at": "2026-07-06T21:00:00+09:00",
+                    }
+                ),
+                "secondary_window": {},
+            }
+        ],
+        "recommendation": {"label": "company-plus-100", "reason": "7d ?, 5h 22%"},
+    }
+    annotate_usage_trends(
+        payload,
+        history=[
+            {
+                "checked_at": "2026-07-06T19:30:00+09:00",
+                "accounts": [
+                    {
+                        "label": "company-plus-100",
+                        "ok": True,
+                        "primary_window": {"used_percent": 20, "reset_at": "2026-07-06T21:00:00+09:00"},
+                    }
+                ],
+            }
+        ],
+    )
+
+    text = render_compact(payload)
+
+    assert "ETA95 07/07 14:15*" in text
 
 
 def test_render_compact_includes_risk_and_recommendation():

--- a/tests/hermes_cli/test_codex_usage.py
+++ b/tests/hermes_cli/test_codex_usage.py
@@ -62,16 +62,28 @@ def test_recommendation_prefers_soonest_weekly_reset_then_usage_fallback():
     assert "7d reset" in rec["reason"]
 
 
-def test_recommendation_falls_back_to_lowest_weekly_usage_without_reset_times():
+def test_recommendation_prefers_unstarted_weekly_window_before_known_resets():
     accounts = [
-        {"label": "a", "ok": True, "primary_window": {"used_percent": 1}, "secondary_window": {"used_percent": 70}},
-        {"label": "b", "ok": True, "primary_window": {"used_percent": 60}, "secondary_window": {"used_percent": 40}},
+        {
+            "label": "started",
+            "ok": True,
+            "available": True,
+            "primary_window": {"used_percent": 1},
+            "secondary_window": {"used_percent": 10, "reset_at": "2099-07-07T10:00:00+09:00", "remaining": "1h"},
+        },
+        {
+            "label": "unstarted",
+            "ok": True,
+            "available": True,
+            "primary_window": {"used_percent": 1},
+            "secondary_window": {"used_percent": 0},
+        },
     ]
 
     rec = compute_recommendation(accounts)
 
     assert rec is not None
-    assert rec["label"] == "b"
+    assert rec["label"] == "unstarted"
 
 
 def test_annotate_usage_trends_uses_recent_history_for_burn_and_eta():

--- a/tests/hermes_cli/test_codex_usage.py
+++ b/tests/hermes_cli/test_codex_usage.py
@@ -1,0 +1,64 @@
+from hermes_cli.codex_usage import (
+    apply_alert_policy,
+    compute_recommendation,
+    render_compact,
+    summarize_window,
+)
+
+
+def test_risk_policy_supports_per_window_thresholds():
+    payload = {
+        "checked_at": "2026-07-06T15:00:00+09:00",
+        "accounts": [
+            {
+                "label": "personal-backup",
+                "ok": True,
+                "primary_window": {"used_percent": 94, "reset_at": "2026-07-06T16:00:00+09:00"},
+                "secondary_window": {"used_percent": 86, "reset_at": "2026-07-07T10:00:00+09:00"},
+            },
+            {
+                "label": "company-plus-100",
+                "ok": True,
+                "primary_window": {"used_percent": 10, "reset_at": "2026-07-06T19:00:00+09:00"},
+                "secondary_window": {"used_percent": 54, "reset_at": "2026-07-09T18:00:00+09:00"},
+            },
+        ],
+    }
+
+    events = apply_alert_policy(payload, primary_threshold=95, secondary_threshold=85)
+
+    assert [event["label"] for event in events] == ["personal-backup"]
+    assert events[0]["window"] == "7d"
+    assert events[0]["used"] == 86
+
+
+def test_recommendation_prefers_lowest_weekly_then_five_hour_usage():
+    accounts = [
+        {"label": "a", "ok": True, "primary_window": {"used_percent": 1}, "secondary_window": {"used_percent": 70}},
+        {"label": "b", "ok": True, "primary_window": {"used_percent": 60}, "secondary_window": {"used_percent": 40}},
+    ]
+
+    rec = compute_recommendation(accounts)
+
+    assert rec == {"label": "b", "reason": "7d 40%, 5h 60%"}
+
+
+def test_render_compact_includes_risk_and_recommendation():
+    payload = {
+        "checked_at": "2026-07-06T15:00:00+09:00",
+        "accounts": [
+            {
+                "label": "company-plus-100",
+                "ok": True,
+                "primary_window": summarize_window({"used_percent": 1, "reset_at": 1783333044}),
+                "secondary_window": summarize_window({"used_percent": 54, "reset_at": 1783609614}),
+            }
+        ],
+        "recommendation": {"label": "company-plus-100", "reason": "7d 54%, 5h 1%"},
+    }
+
+    text = render_compact(payload)
+
+    assert "company-plus-100" in text
+    assert "5h 1% 🟢" in text
+    assert "추천: company-plus-100" in text

--- a/tests/hermes_cli/test_codex_usage.py
+++ b/tests/hermes_cli/test_codex_usage.py
@@ -1,4 +1,5 @@
 from hermes_cli.codex_usage import (
+    annotate_usage_trends,
     apply_alert_policy,
     compute_recommendation,
     render_alert,
@@ -44,6 +45,109 @@ def test_recommendation_prefers_lowest_weekly_then_five_hour_usage():
     rec = compute_recommendation(accounts)
 
     assert rec == {"label": "b", "reason": "7d 40%, 5h 60%"}
+
+
+def test_annotate_usage_trends_uses_recent_history_for_burn_and_eta():
+    payload = {
+        "checked_at": "2026-07-06T20:00:00+09:00",
+        "accounts": [
+            {
+                "label": "company-plus-100",
+                "ok": True,
+                "plan_type": "prolite",
+                "primary_window": summarize_window(
+                    {
+                        "used_percent": 22,
+                        "limit_window_seconds": 18000,
+                        "reset_at": "2026-07-07T00:00:00+09:00",
+                    }
+                ),
+                "secondary_window": summarize_window(
+                    {
+                        "used_percent": 57,
+                        "limit_window_seconds": 604800,
+                        "reset_at": "2026-07-09T18:00:00+09:00",
+                    }
+                ),
+            }
+        ],
+    }
+    history = [
+        {
+            "checked_at": "2026-07-06T19:30:00+09:00",
+            "accounts": [
+                {
+                    "label": "company-plus-100",
+                    "ok": True,
+                    "primary_window": {
+                        "used_percent": 20,
+                        "reset_at": "2026-07-07T00:00:00+09:00",
+                    },
+                    "secondary_window": {
+                        "used_percent": 56,
+                        "reset_at": "2026-07-09T18:00:00+09:00",
+                    },
+                }
+            ],
+        }
+    ]
+
+    annotate_usage_trends(payload, history=history)
+
+    primary_trend = payload["accounts"][0]["primary_window"]["trend"]
+    assert primary_trend["source"] == "recent"
+    assert primary_trend["burn_percent_per_hour"] == 4.0
+    assert primary_trend["eta"]["95"]["at"] == "2026-07-07T14:15:00+09:00"
+
+
+def test_render_compact_includes_burn_and_eta_when_trend_is_available():
+    payload = {
+        "checked_at": "2026-07-06T20:00:00+09:00",
+        "accounts": [
+            {
+                "label": "company-plus-100",
+                "ok": True,
+                "plan_type": "prolite",
+                "primary_window": summarize_window(
+                    {
+                        "used_percent": 22,
+                        "limit_window_seconds": 18000,
+                        "reset_at": "2026-07-07T00:00:00+09:00",
+                    }
+                ),
+                "secondary_window": summarize_window(
+                    {
+                        "used_percent": 57,
+                        "limit_window_seconds": 604800,
+                        "reset_at": "2026-07-09T18:00:00+09:00",
+                    }
+                ),
+            }
+        ],
+        "recommendation": {"label": "company-plus-100", "reason": "7d 57%, 5h 22%"},
+    }
+    annotate_usage_trends(
+        payload,
+        history=[
+            {
+                "checked_at": "2026-07-06T19:30:00+09:00",
+                "accounts": [
+                    {
+                        "label": "company-plus-100",
+                        "ok": True,
+                        "primary_window": {"used_percent": 20, "reset_at": "2026-07-07T00:00:00+09:00"},
+                        "secondary_window": {"used_percent": 56, "reset_at": "2026-07-09T18:00:00+09:00"},
+                    }
+                ],
+            }
+        ],
+    )
+
+    text = render_compact(payload)
+
+    assert "🔥 Burn:" in text
+    assert "5h +4.0%/h" in text
+    assert "burn +4.0%/h · ETA95 07/07 14:15" in text
 
 
 def test_render_compact_includes_risk_and_recommendation():

--- a/tests/hermes_cli/test_codex_usage.py
+++ b/tests/hermes_cli/test_codex_usage.py
@@ -1,7 +1,9 @@
 from hermes_cli.codex_usage import (
     apply_alert_policy,
     compute_recommendation,
+    render_alert,
     render_compact,
+    render_credential_insights,
     summarize_window,
     usage_bar,
 )
@@ -49,11 +51,19 @@ def test_render_compact_includes_risk_and_recommendation():
         "checked_at": "2026-07-06T15:00:00+09:00",
         "accounts": [
             {
+                "label": "personal-backup",
+                "ok": True,
+                "plan_type": "pro",
+                "primary_window": summarize_window({"used_percent": 92, "reset_at": "2099-07-06T15:20:00+09:00"}),
+                "secondary_window": summarize_window({"used_percent": 98, "reset_at": "2099-07-07T10:42:00+09:00"}),
+            },
+            {
                 "label": "company-plus-100",
                 "ok": True,
-                "primary_window": summarize_window({"used_percent": 1, "reset_at": 1783333044}),
-                "secondary_window": summarize_window({"used_percent": 54, "reset_at": 1783609614}),
-            }
+                "plan_type": "prolite",
+                "primary_window": summarize_window({"used_percent": 1, "reset_at": "2099-07-06T19:17:00+09:00"}),
+                "secondary_window": summarize_window({"used_percent": 54, "reset_at": "2099-07-09T18:46:00+09:00"}),
+            },
         ],
         "recommendation": {"label": "company-plus-100", "reason": "7d 54%, 5h 1%"},
     }
@@ -62,10 +72,42 @@ def test_render_compact_includes_risk_and_recommendation():
 
     assert "🧭 Codex 사용량" in text
     assert "✅ 추천 company-plus-100" in text
+    assert "사유:" in text
+    assert "personal-backup 7d 98%" in text
+    assert "⏱ 다음 회복: personal-backup 5h" in text
+    assert "🚦 위험 회복: personal-backup 7d" in text
     assert "company-plus-100" in text
     assert "5h  1% 🟢" in text
     assert "7d 54% 🟢" in text
     assert "[" in text and "]" in text
+
+
+def test_render_alert_uses_card_layout_with_bar_and_recommendation():
+    payload = {
+        "checked_at": "2026-07-06T15:00:00+09:00",
+        "accounts": [
+            {
+                "label": "personal-backup",
+                "ok": True,
+                "primary_window": summarize_window({"used_percent": 17, "reset_at": "2099-07-06T16:05:00+09:00"}),
+                "secondary_window": summarize_window({"used_percent": 98, "reset_at": "2099-07-07T10:42:00+09:00"}),
+            },
+            {
+                "label": "company-plus-100",
+                "ok": True,
+                "primary_window": summarize_window({"used_percent": 1, "reset_at": "2099-07-06T19:17:00+09:00"}),
+                "secondary_window": summarize_window({"used_percent": 54, "reset_at": "2099-07-09T18:46:00+09:00"}),
+            },
+        ],
+        "recommendation": {"label": "company-plus-100", "reason": "7d 54%, 5h 1%"},
+    }
+
+    text = render_alert(payload, primary_threshold=95, secondary_threshold=85)
+
+    assert "🚨 Codex 한도 주의" in text
+    assert "personal-backup · 7d 98%" in text
+    assert "[██████████]" in text
+    assert "✅ 추천 company-plus-100" in text
 
 
 def test_usage_bar_visualizes_percent_buckets():
@@ -73,3 +115,69 @@ def test_usage_bar_visualizes_percent_buckets():
     assert usage_bar(54, width=10) == "█████░░░░░"
     assert usage_bar(98, width=10) == "██████████"
     assert usage_bar(None, width=10) == "??????????"
+
+
+def test_render_credential_insights_groups_rows_readably():
+    rows = [
+        {
+            "credential_label": "personal-backup",
+            "model": "gpt-5.5",
+            "total_tokens": 1477482,
+            "input_tokens": 77847,
+            "output_tokens": 2996,
+            "api_call_count": 10,
+        },
+        {
+            "credential_label": "company-plus-100",
+            "model": "gpt-5.5",
+            "total_tokens": 200000,
+            "input_tokens": 1000,
+            "output_tokens": 2000,
+            "api_call_count": 2,
+        },
+    ]
+
+    text = render_credential_insights(rows, provider="openai-codex", days=30)
+
+    assert "📊 Codex credential 사용량 · 30d" in text
+    assert "personal-backup" in text
+    assert "1.48M tokens · 10 calls" in text
+    assert "avg 147.7k/call" in text
+    assert "company-plus-100" in text
+    assert "200.0k tokens · 2 calls" in text
+
+
+def test_render_credential_insights_shows_share_and_cache_breakdown():
+    rows = [
+        {
+            "credential_label": "personal-backup",
+            "model": "gpt-5.5",
+            "total_tokens": 900,
+            "input_tokens": 100,
+            "output_tokens": 20,
+            "cache_read_tokens": 700,
+            "reasoning_tokens": 80,
+            "api_calls": 3,
+        },
+        {
+            "credential_label": "company-plus-100",
+            "model": "gpt-5.5",
+            "total_tokens": 100,
+            "input_tokens": 50,
+            "output_tokens": 50,
+            "api_calls": 1,
+        },
+    ]
+
+    text = render_credential_insights(rows, provider="openai-codex", days=7)
+
+    assert "900 tokens · 3 calls · avg 300/call · 90%" in text
+    assert "cache 700" in text
+    assert "reason 80" in text
+
+
+def test_render_credential_insights_empty_explains_future_rows():
+    text = render_credential_insights([], provider="openai-codex", days=30)
+
+    assert "아직 credential별 사용 기록 없음" in text
+    assert "새 모델 턴부터 쌓임" in text

--- a/tests/hermes_cli/test_codex_usage.py
+++ b/tests/hermes_cli/test_codex_usage.py
@@ -3,6 +3,7 @@ from hermes_cli.codex_usage import (
     compute_recommendation,
     render_compact,
     summarize_window,
+    usage_bar,
 )
 
 
@@ -59,6 +60,16 @@ def test_render_compact_includes_risk_and_recommendation():
 
     text = render_compact(payload)
 
+    assert "🧭 Codex 사용량" in text
+    assert "✅ 추천 company-plus-100" in text
     assert "company-plus-100" in text
-    assert "5h 1% 🟢" in text
-    assert "추천: company-plus-100" in text
+    assert "5h  1% 🟢" in text
+    assert "7d 54% 🟢" in text
+    assert "[" in text and "]" in text
+
+
+def test_usage_bar_visualizes_percent_buckets():
+    assert usage_bar(0, width=10) == "░░░░░░░░░░"
+    assert usage_bar(54, width=10) == "█████░░░░░"
+    assert usage_bar(98, width=10) == "██████████"
+    assert usage_bar(None, width=10) == "??????????"

--- a/tests/hermes_cli/test_codex_usage.py
+++ b/tests/hermes_cli/test_codex_usage.py
@@ -38,7 +38,31 @@ def test_risk_policy_supports_per_window_thresholds():
     assert events[0]["used"] == 86
 
 
-def test_recommendation_prefers_lowest_weekly_then_five_hour_usage():
+def test_recommendation_prefers_soonest_weekly_reset_then_usage_fallback():
+    accounts = [
+        {
+            "label": "a",
+            "ok": True,
+            "primary_window": {"used_percent": 1},
+            "secondary_window": {"used_percent": 70, "reset_at": "2099-07-09T18:00:00+09:00", "remaining": "2d"},
+        },
+        {
+            "label": "b",
+            "ok": True,
+            "primary_window": {"used_percent": 60},
+            "secondary_window": {"used_percent": 40, "reset_at": "2099-07-07T10:00:00+09:00", "remaining": "1h"},
+        },
+    ]
+
+    rec = compute_recommendation(accounts)
+
+    assert rec is not None
+    assert rec["label"] == "b"
+    assert rec["policy"] == "7d-reset-aware"
+    assert "7d reset" in rec["reason"]
+
+
+def test_recommendation_falls_back_to_lowest_weekly_usage_without_reset_times():
     accounts = [
         {"label": "a", "ok": True, "primary_window": {"used_percent": 1}, "secondary_window": {"used_percent": 70}},
         {"label": "b", "ok": True, "primary_window": {"used_percent": 60}, "secondary_window": {"used_percent": 40}},
@@ -46,7 +70,8 @@ def test_recommendation_prefers_lowest_weekly_then_five_hour_usage():
 
     rec = compute_recommendation(accounts)
 
-    assert rec == {"label": "b", "reason": "7d 40%, 5h 60%"}
+    assert rec is not None
+    assert rec["label"] == "b"
 
 
 def test_annotate_usage_trends_uses_recent_history_for_burn_and_eta():

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -254,6 +254,46 @@ class TestSessionLifecycle:
         session = db.get_session("s1")
         assert session["api_call_count"] == 3
 
+    def test_update_token_counts_records_credential_usage_rows(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.update_token_counts(
+            "s1",
+            input_tokens=100,
+            output_tokens=50,
+            cache_read_tokens=10,
+            reasoning_tokens=5,
+            api_call_count=1,
+            billing_provider="openai-codex",
+            credential_label="company-plus-100",
+            model="gpt-5.5",
+        )
+        db.update_token_counts(
+            "s1",
+            input_tokens=20,
+            output_tokens=5,
+            api_call_count=1,
+            billing_provider="openai-codex",
+            credential_label="company-plus-100",
+            model="gpt-5.5",
+        )
+
+        rows = db.get_credential_usage(days=30, provider="openai-codex")
+
+        assert rows == [
+            {
+                "provider": "openai-codex",
+                "credential_label": "company-plus-100",
+                "model": "gpt-5.5",
+                "api_calls": 2,
+                "input_tokens": 120,
+                "output_tokens": 55,
+                "cache_read_tokens": 10,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 5,
+                "total_tokens": 190,
+            }
+        ]
+
     def test_update_token_counts_api_call_count_absolute(self, db):
         """absolute mode sets api_call_count directly."""
         db.create_session(session_id="s1", source="cli")

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -990,6 +990,30 @@ gateway:
 
 When enabled, Hermes attaches Telegram's `LinkPreviewOptions(is_disabled=True)` to every outgoing message and falls back to the legacy `disable_web_page_preview` parameter on older `python-telegram-bot` versions.
 
+**Copy-to-clipboard buttons.** Telegram supports inline keyboard buttons that copy a short string to the user's clipboard. To attach copy buttons to a Telegram reply, include one marker line per button in the assistant's final text:
+
+```text
+COPY_BUTTON: Button label | text copied to clipboard
+```
+
+Hermes removes valid marker lines from the visible message and renders them as [`CopyTextButton`](https://core.telegram.org/bots/api#copytextbutton) inline buttons. This is useful for IP addresses, one-line commands, invite codes, URLs, and other mobile handoff values that are awkward to select from a Telegram message.
+
+```text
+Server address: 100.96.33.123
+
+COPY_BUTTON: Copy IP | 100.96.33.123
+COPY_BUTTON: Copy VNC address | 100.96.33.123:5900
+```
+
+Marker constraints follow Telegram's copy button limits:
+
+- the label must be 1-64 characters and cannot contain `|`
+- the copied text must be 1-256 characters
+- Hermes renders at most 20 buttons per message
+- invalid marker lines are left as ordinary text instead of being silently dropped
+
+Copy buttons are attached on both normal sends and streaming final edits. When copy buttons are requested, Hermes uses the MarkdownV2 send/edit path instead of the rich-message path because the rich raw endpoint used here does not carry `reply_markup`.
+
 ## Group Allowlisting
 
 Telegram groups and forum chats have two orthogonal gates you can configure:


### PR DESCRIPTION
## Summary
- add Telegram `COPY_BUTTON: label | text` markers that render as Bot API `CopyTextButton` inline keyboard buttons
- support both normal sends and streaming final edits, while leaving markers visible when `CopyTextButton` is unavailable
- document the marker syntax and constraints for Telegram users

## Test Plan
- `uv run --extra messaging python -m pytest tests/gateway/test_telegram_copy_buttons.py tests/gateway/test_telegram_clarify_buttons.py tests/gateway/test_telegram_rich_messages.py tests/gateway/test_telegram_thread_fallback.py -q -o 'addopts='`
- `git diff --check`
- `uv run --extra messaging python -m py_compile plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_copy_buttons.py`