### PR TITLE
fix(cli): resolve streaming deadlock when show_reasoning is on

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5747,13 +5747,22 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             return
 
         # When show_reasoning is on and reasoning is still rendering,
-        # defer content until the reasoning box closes.  This ensures the
-        # reasoning block always appears BEFORE the response in the terminal.
+        # close the reasoning box first so the response appears below it.
+        # Previously this deferred content until _close_reasoning_box() was
+        # called externally, but _close_reasoning_box() is only reachable
+        # through this very method (line below) or _flush_stream (end of
+        # turn) — so the defer created a self-locking deadlock: the
+        # reasoning box never closed because the close call was blocked by
+        # the defer, and the defer was never released because the box never
+        # closed.  Calling _close_reasoning_box() here breaks the cycle:
+        # it sets _reasoning_box_opened=False and recursively emits any
+        # previously-deferred content, then we fall through to render the
+        # current text normally.
         if self.show_reasoning and getattr(self, "_reasoning_box_opened", False):
-            self._deferred_content = getattr(self, "_deferred_content", "") + text
-            return
+            self._close_reasoning_box()
 
         # Close the live reasoning box before opening the response box
+        # (no-op if already closed by the branch above)
         self._close_reasoning_box()
 
         # Open the response box header on the very first visible text


### PR DESCRIPTION
Fixes #47116

## Problem

When `display.show_reasoning: true` and `display.streaming: true` are both enabled, the CLI streams reasoning content correctly but the response body never renders until the agent thread exits. This only affects models that emit reasoning as a separate field (`reasoning_content`), not inline `<think>` tags.

## Root Cause

In `_emit_stream_text`, when `_reasoning_box_opened=True`, content was deferred into `_deferred_content` and `return`ed early. For inline-tag models, `</think>` triggers `_close_reasoning_box()` mid-stream. For separate-field models, no such trigger exists — the only path to close the reasoning box is through `_flush_stream()` at end-of-turn. Result: all content tokens are buffered until the turn ends.

## Fix

Instead of deferring, call `_close_reasoning_box()` eagerly when reasoning is still rendering. The first content token acts as the "reasoning done" signal. `_close_reasoning_box()` recursively emits any previously-deferred content, then we fall through to render the current text normally. The existing `_close_reasoning_box()` call below becomes a no-op.

## Testing

Tested locally with `display.show_reasoning: true` + `display.streaming: true`. Response body now renders inline during streaming instead of only after the agent thread exits.

---

> **Note:** I'm not a developer, just a Hermes user. The root cause and fix were identified by AI. I only handled the submission. Please review carefully.