### PR TITLE
fix(telegram): respect explicit private thread routing

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -902,13 +902,6 @@ class TelegramAdapter(BasePlatformAdapter):
         reply_to = metadata.get("telegram_reply_to_message_id")
         return int(reply_to) if reply_to is not None else None
 
-    @staticmethod
-    def _looks_like_private_chat_id(chat_id: str) -> bool:
-        try:
-            return int(chat_id) > 0
-        except (TypeError, ValueError):
-            return False
-
     @classmethod
     def _is_private_dm_topic_send(
         cls,
@@ -926,10 +919,8 @@ class TelegramAdapter(BasePlatformAdapter):
             return False
         return bool(
             thread_id
-            and (
-                metadata and metadata.get("telegram_dm_topic_reply_fallback")
-                or cls._looks_like_private_chat_id(chat_id)
-            )
+            and metadata
+            and metadata.get("telegram_dm_topic_reply_fallback")
         )
 
     @staticmethod

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -458,6 +458,81 @@ async def test_send_private_dm_topic_uses_direct_messages_topic_id():
     assert call_log[0]["direct_messages_topic_id"] == 99999
 
 
+@pytest.mark.asyncio
+async def test_private_chat_explicit_thread_id_uses_message_thread_id_without_anchor():
+    """Cron-resolved private-chat forum topics route by message_thread_id."""
+    adapter = _make_adapter()
+    call_log = []
+
+    async def mock_send_message(**kwargs):
+        call_log.append(dict(kwargs))
+        return SimpleNamespace(message_id=270454)
+
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+
+    result = await adapter.send(
+        chat_id="775566675",
+        content="cron topic delivery",
+        metadata={"thread_id": "270453"},
+    )
+
+    assert result.success is True
+    assert call_log[0]["reply_to_message_id"] is None
+    assert call_log[0]["message_thread_id"] == 270453
+    assert "direct_messages_topic_id" not in call_log[0]
+
+
+@pytest.mark.asyncio
+async def test_private_chat_explicit_direct_messages_topic_id_uses_direct_topic_without_anchor():
+    """Explicit Bot API Direct Messages topics do not need a reply anchor."""
+    adapter = _make_adapter()
+    call_log = []
+
+    async def mock_send_message(**kwargs):
+        call_log.append(dict(kwargs))
+        return SimpleNamespace(message_id=270454)
+
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+
+    result = await adapter.send(
+        chat_id="775566675",
+        content="direct topic delivery",
+        metadata={"direct_messages_topic_id": "270453"},
+    )
+
+    assert result.success is True
+    assert call_log[0]["reply_to_message_id"] is None
+    assert call_log[0]["message_thread_id"] is None
+    assert call_log[0]["direct_messages_topic_id"] == 270453
+
+
+@pytest.mark.asyncio
+async def test_private_dm_topic_reply_fallback_without_anchor_fails_loud():
+    """Anchor-required DM topic fallback must not silently send elsewhere."""
+    adapter = _make_adapter()
+    call_log = []
+
+    async def mock_send_message(**kwargs):
+        call_log.append(dict(kwargs))
+        return SimpleNamespace(message_id=270454)
+
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+
+    result = await adapter.send(
+        chat_id="775566675",
+        content="missing anchor",
+        metadata={
+            "thread_id": "270453",
+            "telegram_dm_topic_reply_fallback": True,
+        },
+    )
+
+    assert result.success is False
+    assert result.retryable is False
+    assert result.error == adapter._dm_topic_missing_anchor_error()
+    assert call_log == []
+
+
 def test_base_gateway_metadata_marks_telegram_dm_topics_as_reply_fallback():
     source = SimpleNamespace(
         platform=Platform.TELEGRAM,


### PR DESCRIPTION
## Problem

Companion to #58165.

#58165 fixed cron delivery for ambiguous Telegram targets shaped like `telegram:<positive_chat_id>:<numeric_thread_id>` by probing the chat and routing private/forum-style topics via `message_thread_id` instead of `direct_messages_topic_id`.

That scheduler-side fix is correct, but the Telegram adapter still had a broader private-DM-topic heuristic: any positive private chat plus `thread_id` was treated as anchor-required DM-topic fallback. Cron sends then logged a false live-adapter failure:

```text
Telegram DM topic delivery requires a reply anchor; refusing to send outside the requested topic
```

before falling back to standalone delivery.

## Root cause

`TelegramAdapter._is_private_dm_topic_send()` classified `thread_id + positive chat_id` as private DM-topic fallback, even when the caller explicitly supplied `metadata["thread_id"]` / `metadata["message_thread_id"]` for ordinary Bot API `message_thread_id` routing.

## Fix

Remove the positive-chat-id heuristic from `_is_private_dm_topic_send()` and keep the anchor-required path gated on explicit `telegram_dm_topic_reply_fallback` metadata.

Preserved behavior:
- explicit `direct_messages_topic_id` still routes through `direct_messages_topic_id` without an anchor
- explicit `telegram_dm_topic_reply_fallback` still fails loud without an anchor
- explicit `thread_id` / `message_thread_id` now routes via `message_thread_id` without the false DM-topic refusal

## Tests

```text
python3 -m pytest -q tests/gateway/test_telegram_thread_fallback.py
# 50 passed

python3 -m pytest -q tests/gateway/test_telegram_reply_mode.py tests/gateway/test_telegram_rich_messages.py tests/gateway/test_delivery.py
# 137 passed

git diff --check
# clean
```
