### PR TITLE
fix(openviking): match tenant-header errors structurally instead of hard-coding strings

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -268,12 +268,25 @@ class _VikingClient:
 
     @staticmethod
     def _needs_trusted_identity_retry(exc: Exception) -> bool:
+        """Detect errors that indicate missing tenant-scoped identity headers.
+
+        OpenViking raises these when a ROOT or trusted-mode request lacks
+        ``X-OpenViking-Account`` / ``X-OpenViking-User``.  Instead of
+        hard-coding each server-side error string (which changes across
+        releases), match on the structural signature: the message mentions
+        one of the tenant headers **and** the error is a 400-class failure.
+
+        The 400 status guard avoids false-positives on 403 errors such as
+        ``"USER API keys cannot override X-OpenViking-User"``, which must not
+        trigger a retry.
+        """
         message = str(exc)
-        return (
-            "Trusted mode requests must include X-OpenViking-Account" in message
-            or "Trusted mode requests must include X-OpenViking-User" in message
-            or "Trusted mode requests must include X-OpenViking-Account or explicit account_id" in message
-        )
+        if "X-OpenViking-Account" not in message and "X-OpenViking-User" not in message:
+            return False
+        status_code = getattr(exc, "status_code", None)
+        if status_code is not None and status_code != 400:
+            return False
+        return True
 
     def _send_with_trusted_identity_retry(self, send, *, multipart: bool = False) -> dict:
         try:


### PR DESCRIPTION
## Problem

`_needs_trusted_identity_retry` was hard-coding specific server-side error strings to detect when a request failed due to missing `X-OpenViking-Account` / `X-OpenViking-User` headers. Each new server-side error variant (e.g. ROOT-key tenant checks added in multi-tenant mode) required another string added to the client-side match list.

This caused a real bug: when OpenViking server added the `"ROOT requests to tenant-scoped APIs must include X-OpenViking-Account and X-OpenViking-User headers"` error for API-key-mode ROOT requests, the Hermes client did not recognise it and never retried with tenant headers, causing all memory operations to fail silently.

## Fix

Replace the string enumeration with a **structural match**:

1. The error message mentions `X-OpenViking-Account` or `X-OpenViking-User`
2. The HTTP status code is 400 (if available)

This covers all current and future tenant-header-missing variants without client-side changes.

### Why the 400 guard?

The 403 error `"USER API keys cannot override X-OpenViking-User"` also mentions `X-OpenViking-User` but must **not** trigger a retry — it's a permission denial, not a missing-header issue. The status code guard filters this out.

## Testing

All 176 existing tests pass:
```
tests/plugins/memory/test_openviking_provider.py  133 passed
tests/openviking_plugin/test_openviking.py         43 passed
```

## Changes

- `plugins/memory/openviking/__init__.py`: `_needs_trusted_identity_retry` rewritten (+18 −5)