### PR TITLE
feat(desktop): add refresh action to model picker

### DIFF
--- a/apps/desktop/src/components/model-picker.test.tsx
+++ b/apps/desktop/src/components/model-picker.test.tsx
@@ -1,0 +1,74 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import type { HermesGateway } from '@/hermes'
+import type { ModelOptionsResponse } from '@/types/hermes'
+
+import { ModelPickerDialog } from './model-picker'
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  vi.stubGlobal('ResizeObserver', TestResizeObserver)
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('ModelPickerDialog', () => {
+  it('requests and renders a refreshed model catalog', async () => {
+    const initial: ModelOptionsResponse = {
+      model: 'legacy-model',
+      provider: 'nous',
+      providers: [{ models: ['legacy-model'], name: 'Nous', slug: 'nous' }]
+    }
+
+    const refreshed: ModelOptionsResponse = {
+      model: 'fresh-model',
+      provider: 'nous',
+      providers: [{ models: ['fresh-model'], name: 'Nous', slug: 'nous' }]
+    }
+
+    const request = vi.fn((_method: string, params: Record<string, unknown>) =>
+      Promise.resolve(params.refresh === true ? refreshed : initial)
+    )
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+    render(
+      <QueryClientProvider client={client}>
+        <ModelPickerDialog
+          currentModel="legacy-model"
+          currentProvider="nous"
+          gw={{ request } as unknown as HermesGateway}
+          onOpenChange={vi.fn()}
+          onSelect={vi.fn()}
+          open
+          sessionId="session-1"
+        />
+      </QueryClientProvider>
+    )
+
+    expect(await screen.findByText('legacy-model')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh models' }))
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith('model.options', {
+        explicit_only: true,
+        refresh: true,
+        session_id: 'session-1'
+      })
+    )
+
+    expect(await screen.findByText('fresh-model')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -1,11 +1,12 @@
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
 
+import { Codicon } from '@/components/ui/codicon'
 import { useI18n } from '@/i18n'
 import { requestModelOptions } from '@/lib/model-options'
 import { currentPickerSelection } from '@/lib/model-status-label'
 import { normalize } from '@/lib/text'
-import type { ModelOptionProvider, ModelPricing } from '@/types/hermes'
+import type { ModelOptionProvider, ModelOptionsResponse, ModelPricing } from '@/types/hermes'
 
 import type { HermesGateway } from '../hermes'
 import { cn } from '../lib/utils'
@@ -46,15 +47,18 @@ export function ModelPickerDialog({
 }: ModelPickerDialogProps) {
   const { t } = useI18n()
   const copy = t.modelPicker
+  const queryClient = useQueryClient()
   // Own the search term so we can filter manually. cmdk's built-in
   // shouldFilter reorders items by its fuzzy-match score (≈alphabetical with
   // an empty query), which destroys the backend's curated order. We disable
   // it and do a plain substring filter that preserves array order — matching
   // the `hermes model` CLI picker, which shows the curated list verbatim.
   const [search, setSearch] = useState('')
+  const [refreshing, setRefreshing] = useState(false)
+  const queryKey = ['model-options', sessionId || 'global']
 
   const modelOptions = useQuery({
-    queryKey: ['model-options', sessionId || 'global'],
+    queryKey,
     queryFn: () => requestModelOptions({ gateway: gw, sessionId }),
     enabled: open
   })
@@ -89,6 +93,23 @@ export function ModelPickerDialog({
     onOpenChange(false)
   }
 
+  const refreshModels = async () => {
+    if (refreshing) {
+      return
+    }
+
+    setRefreshing(true)
+
+    try {
+      const next = await requestModelOptions({ gateway: gw, refresh: true, sessionId })
+      queryClient.setQueryData<ModelOptionsResponse>(queryKey, next)
+    } catch {
+      void queryClient.invalidateQueries({ queryKey: ['model-options'] })
+    } finally {
+      setRefreshing(false)
+    }
+  }
+
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
       <DialogContent className={cn('max-h-[85vh] max-w-2xl gap-0 overflow-hidden p-0', contentClassName)}>
@@ -117,6 +138,15 @@ export function ModelPickerDialog({
         </Command>
 
         <DialogFooter className="flex-row items-center justify-end gap-2 bg-card p-3">
+          <Button
+            className="mr-auto"
+            disabled={refreshing}
+            onClick={() => void refreshModels()}
+            variant="ghost"
+          >
+            <Codicon name="sync" size="0.75rem" spinning={refreshing} />
+            {copy.refreshModels}
+          </Button>
           <Button onClick={addProvider} variant="ghost">
             {copy.addProvider}
           </Button>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2038,6 +2038,7 @@ export const en: Translations = {
     unknown: '(unknown)',
     search: 'Filter providers and models...',
     noModels: 'No models found.',
+    refreshModels: 'Refresh models',
     addProvider: 'Add provider',
     loadFailed: 'Could not load models',
     noAuthenticatedProviders: 'No authenticated providers.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1958,6 +1958,7 @@ export const ja = defineLocale({
     unknown: '(不明)',
     search: 'プロバイダーとモデルをフィルター...',
     noModels: 'モデルが見つかりません。',
+    refreshModels: 'モデルを更新',
     addProvider: 'プロバイダーを追加',
     loadFailed: 'モデルを読み込めませんでした',
     noAuthenticatedProviders: '認証済みプロバイダーがありません。',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1667,6 +1667,7 @@ export interface Translations {
     unknown: string
     search: string
     noModels: string
+    refreshModels: string
     addProvider: string
     loadFailed: string
     noAuthenticatedProviders: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1893,6 +1893,7 @@ export const zhHant = defineLocale({
     unknown: '（未知）',
     search: '篩選提供方和模型...',
     noModels: '找不到模型。',
+    refreshModels: '重新整理模型',
     addProvider: '新增提供方',
     loadFailed: '無法載入模型',
     noAuthenticatedProviders: '沒有已驗證的提供方。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2203,6 +2203,7 @@ export const zh: Translations = {
     unknown: '(未知)',
     search: '筛选提供方和模型...',
     noModels: '未找到模型。',
+    refreshModels: '刷新模型',
     addProvider: '添加提供方',
     loadFailed: '无法加载模型',
     noAuthenticatedProviders: '没有已认证的提供方。',


### PR DESCRIPTION
## Summary

- add an explicit **Refresh models** action to the shared desktop model picker dialog
- call the existing `requestModelOptions({ refresh: true })` path so users can opt into live provider catalog discovery
- keep normal picker opens fast by preserving the default cached/non-probing load path
- add localized labels for the new picker action

## Context

`/api/model/options` and the gateway `model.options` RPC already support `refresh=true`, which is the path introduced after custom provider probing was moved behind explicit refresh. The shell model menu has a refresh action, but the shared modal picker did not expose one, so users opening that dialog could only see the cached/configured model list.

This complements #58183 by keeping the fast default behavior while giving the modal picker the same explicit refresh escape hatch.

## Validation

- `npm --workspace apps/desktop run typecheck`
- `npm exec eslint -- src/components/model-picker.tsx src/i18n/en.ts src/i18n/zh.ts src/i18n/ja.ts src/i18n/zh-hant.ts src/i18n/types.ts`
- `git diff --check`
