### PR TITLE
fix: stop validating session_key as filesystem path (#59322)

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -741,12 +741,15 @@ class SessionEntry:
         session_key = data["session_key"]
         session_id = data["session_id"]
 
-        # Validate path-sensitive fields to prevent directory traversal (CWE-22)
-        for _field, _val in (("session_key", session_key), ("session_id", session_id)):
-            if _is_path_unsafe(_val):
-                raise ValueError(
-                    f"Invalid {_field}: potential directory traversal detected"
-                )
+        # Validate path-sensitive fields to prevent directory traversal (CWE-22).
+        # Only session_id is used as a filesystem filename (sessions_dir / f"{session_id}.json"),
+        # so only it needs the strict path-un safety guard.  session_key is a logical
+        # routing key that may legitimately contain "/" (e.g. Google Chat
+        # "spaces/<id>/threads/<id>") and is never touched on-disk.
+        if _is_path_unsafe(session_id):
+            raise ValueError(
+                "Invalid session_id: potential directory traversal detected"
+            )
 
         return cls(
             session_key=session_key,

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1160,10 +1160,13 @@ class TestSessionEntryFromDictTraversalValidation:
         with pytest.raises(ValueError, match="session_id"):
             SessionEntry.from_dict(self._entry(session_id="../../etc/passwd"))
 
-    def test_session_key_dotdot_raises(self):
+    def test_session_key_dotdot_allowed(self):
+        """session_key is a logical routing key, never a filesystem path —
+        traversal sequences in session_key are harmless and must not cause
+        load failures (see #59322)."""
         from gateway.session import SessionEntry
-        with pytest.raises(ValueError, match="session_key"):
-            SessionEntry.from_dict(self._entry(session_key="agent:main:../../secret"))
+        entry = SessionEntry.from_dict(self._entry(session_key="agent:main:../../secret"))
+        assert entry.session_key == "agent:main:../../secret"
 
     def test_session_id_absolute_unix_raises(self):
         from gateway.session import SessionEntry
@@ -1191,8 +1194,9 @@ class TestSessionEntryFromDictTraversalValidation:
         from gateway.session import SessionEntry
         with pytest.raises(ValueError, match="session_id"):
             SessionEntry.from_dict(self._entry(session_id="good\\..\\bad"))
-        with pytest.raises(ValueError, match="session_key"):
-            SessionEntry.from_dict(self._entry(session_key="agent:main:good/sub"))
+        # session_key with "/" is legitimate (e.g. Google Chat spaces/X/threads/Y)
+        entry = SessionEntry.from_dict(self._entry(session_key="agent:main:good/sub"))
+        assert entry.session_key == "agent:main:good/sub"
 
 
 class TestEnsureLoadedSkipsInvalidEntries:


### PR DESCRIPTION
## Problem

`SessionEntry.from_dict` validates **both** `session_key` and `session_id` with the `_is_path_unsafe()` traversal guard. But only `session_id` is used as a filesystem filename (`sessions_dir / f"{session_id}.json"`). `session_key` is a logical routing key that may legitimately contain `/`.

**Google Chat** session keys are `spaces/<id>/threads/<id>` — they all contain `/`, so every Google Chat session is silently dropped on gateway restart. Conversational continuity is lost, and startup logs are flooded with warnings:

```
WARNING gateway.session: Skipping invalid session entry
'agent:main:google_chat:group:spaces/AAAAEVvy5RY:...':
Invalid session_key: potential directory traversal detected
```

## Fix

Validate only `session_id` with the path-un safety guard. `session_key` is never touched on-disk, so path validation is a false positive.

## Testing

Updated 2 existing tests in `tests/gateway/test_session.py`:
- `test_session_key_dotdot_allowed`: session_key with `..` now accepted (harmless — never used as path)
- `test_session_id_non_leading_separator_raises`: session_key with `/` now accepted

All 8 traversal-validation tests pass. `session_id` traversal variants (`..`, `/`, `\`, drive letters) remain correctly rejected.

Fixes #59322