### PR TITLE
fix: keep empty required: [] instead of removing key (#59386)

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -394,7 +394,9 @@ class TestSchemaConversion:
 
         assert schema["required"] == ["a"]
 
-    def test_required_removed_when_all_names_dangle(self):
+    def test_required_set_to_empty_when_all_names_dangle(self):
+        """When all required names are missing, keep required: [] instead of
+        removing the key — strict backends default missing required to null."""
         from tools.mcp_tool import _normalize_mcp_input_schema
 
         schema = _normalize_mcp_input_schema({
@@ -403,7 +405,7 @@ class TestSchemaConversion:
             "required": ["ghost"],
         })
 
-        assert "required" not in schema
+        assert schema.get("required") == []
 
     def test_required_pruning_applies_recursively_inside_nested_objects(self):
         """Nested object schemas also get required pruning."""

--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -120,14 +120,16 @@ def test_required_pruned_to_existing_properties():
     assert out[0]["function"]["parameters"]["required"] == ["name"]
 
 
-def test_required_all_missing_is_dropped():
+def test_required_all_missing_kept_as_empty_array():
+    """When all required names are missing, keep required: [] instead of
+    removing the key — strict backends default missing required to null."""
     tools = [_tool("t", {
         "type": "object",
         "properties": {},
         "required": ["x", "y"],
     })]
     out = sanitize_tool_schemas(tools)
-    assert "required" not in out[0]["function"]["parameters"]
+    assert out[0]["function"]["parameters"].get("required") == []
 
 
 def test_well_formed_schema_unchanged():

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4157,7 +4157,10 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
                     if valid:
                         repaired["required"] = valid
                     else:
-                        repaired.pop("required", None)
+                        # Keep an empty array instead of removing the key —
+                        # strict backends default a missing ``required`` to
+                        # ``null`` which fails JSON-Schema validation.  #59386
+                        repaired["required"] = []
 
         return repaired
 

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -329,7 +329,11 @@ def _sanitize_node(node: Any, path: str) -> Any:
         props = out.get("properties") or {}
         valid = [r for r in out["required"] if isinstance(r, str) and r in props]
         if not valid:
-            out.pop("required", None)
+            # Keep an empty array rather than removing the key — some strict
+            # OpenAI-compatible backends default a missing ``required`` to
+            # ``null`` which then fails JSON-Schema validation (``null`` is
+            # not of type ``array``).  See #59386.
+            out["required"] = []
         elif len(valid) != len(out["required"]):
             out["required"] = valid
 


### PR DESCRIPTION
## Problem

When all `required` entries in a tool schema are invalid or missing (e.g. `delegate_task` which has `required: []`), both `schema_sanitizer.py` and `mcp_tool.py` remove the `required` key entirely via `pop("required")`.

Some strict OpenAI-compatible API proxies (custom providers, LiteLLM, corporate gateways) default a **missing** `required` field to `null` internally, then fail JSON-Schema validation:

```
HTTP 400: Invalid schema for function 'delegate_task': null is not of type "array"
```

This is a **non-retryable** `BadRequestError` — the agent session dies immediately with no recovery. Affects:
- CLI/gateway sessions on the first API call
- Cron jobs with implicit default tools (fail silently, showing only `error` status)

## Fix

Keep `required: []` (empty array) instead of removing the key. An empty array is valid JSON-Schema and satisfies strict backends.

Applied in two places:
1. `tools/schema_sanitizer.py` — `_sanitize_node()` required pruning
2. `tools/mcp_tool.py` — `_normalize_mcp_input_schema()` required pruning

## Testing

Updated 3 tests:
- `tests/tools/test_schema_sanitizer.py::test_required_all_missing_kept_as_empty_array`
- `tests/tools/test_mcp_tool.py::TestSchemaConversion::test_required_set_to_empty_when_all_names_dangle`

All 66 related tests pass.

Fixes #59386