### PR TITLE
feat(optional-skills): squish-video — read a local video as timestamped contact sheets

### DIFF
--- a/optional-skills/media/DESCRIPTION.md
+++ b/optional-skills/media/DESCRIPTION.md
@@ -1,0 +1,3 @@
+---
+description: Optional media skills — video understanding and heavier media tooling that not every install needs.
+---

--- a/optional-skills/media/squish-video/SKILL.md
+++ b/optional-skills/media/squish-video/SKILL.md
@@ -1,86 +1,113 @@
 ---
 name: squish-video
-description: "See what happens in a local video via timestamped frames. Turns video into contact sheets you can vision_analyze — use for 'what happens in this clip', finding a moment, or citing timecodes."
+description: Read a local video as timestamped contact sheets.
 version: 1.0.0
-author: Squish (getsquish.app)
+author: Natthawut Phurahong (v1b3x0r), Squish (getsquish.app)
 license: MIT
 platforms: [linux, macos]
 prerequisites:
-  commands: [node, ffmpeg]
+  commands: [npx, ffmpeg]
 metadata:
   hermes:
     tags: [Video, Vision, Timestamps, Contact-Sheet, FFmpeg, MCP]
     homepage: https://getsquish.app
 ---
 
-# Squish: video → timestamped contact sheet → your eyes
+# Squish Video Skill
 
-You have vision but cannot ingest video. When a user asks about a **local video file**, do not
-guess and do not refuse — compress it into **timestamped contact sheets** (frames sampled evenly
-across the clip, laid out as a grid, each cell stamped with its timecode) and read those.
+Compresses a local video file into timestamped contact sheets — frame grids where every
+cell carries its absolute timecode — so `vision_analyze` can read the clip with the main
+model's own vision. Visual content only: no audio is decoded, and nothing is uploaded.
+Complements the built-in `video_analyze` tool, which sends the whole clip to an auxiliary
+model and returns text.
 
-The reasoning primitive: **video → contact sheet → look at the grid → answer with timestamps.**
-
-## When to use
+## When to Use
 
 - "What happens in this video / screen recording?" — and the file is on this machine.
 - The question spans time: before/after, a scene change, progress, "find the moment when…".
 - The answer needs precise citations ("at 0:07 the press comes down").
 
-Skip it when the user needs one specific frame only, or the question isn't about the video's
-visual content. Scope: **local video file paths** — if the video lives elsewhere, get a local
-copy first. (This complements the built-in `video_analyze` tool: that sends the whole clip to an
-auxiliary model and returns text; Squish gives *your own* vision the actual frames.)
+Skip it when only one known frame matters, when the question isn't about visual content
+(speech, music — no audio is read), or when the video isn't a local file (get a local
+copy first).
 
-## How (terminal — zero setup)
+## Prerequisites
+
+- `npx` (ships with Node.js ≥ 20, the engine's floor) and `ffmpeg` on PATH. The helper script shells out to
+  the open-source Squish CLI (`@getsquish/squish`, Apache-2.0 —
+  [github.com/getsquish/squish](https://github.com/getsquish/squish)), fetched by `npx`
+  on first use; frames are extracted locally by ffmpeg.
+- Helper script: `~/.hermes/skills/media/squish-video/scripts/squish_video.py`
+  (stdlib only).
+- Optional persistent alternative — the same engine speaks MCP. One block in
+  `~/.hermes/config.yaml` exposes the tool `squish_video` (same contract plus
+  `timecodes[][]` per sheet):
+
+  ```yaml
+  mcp_servers:
+    squish:
+      command: npx
+      args: ["-y", "@getsquish/squish", "mcp"]
+  ```
+
+## How to Run
+
+Invoke through the `terminal` tool. The script passes the path as a single argument, so
+whitespace in filenames is safe:
 
 ```bash
-npx -y @getsquish/squish <video> --json
+python3 ~/.hermes/skills/media/squish-video/scripts/squish_video.py "<video-path>"
 ```
 
-stdout is one JSON object (contract `squish-cli-v0`): parse `files[]` — absolute paths to
-`.sheet-N.jpg` in time order — then `vision_analyze` each sheet **in order**; each covers a
+stdout is one JSON object (contract `squish-cli-v0`); `files[]` lists absolute sheet
+paths in time order. Then `vision_analyze` each sheet **in order** — each covers a
 consecutive window of the clip.
 
-`--density 4x4|5x5|6x6` packs more frames per sheet: use for long or fast-moving clips, or
-"how exactly did X happen" questions (default `3x3` recovers *what* happened).
-`--out <dir>` controls where sheets land. Everything runs on this machine — nothing is uploaded.
+## Quick Reference
 
-## Reading a sheet
-
-- Cells run in time order, left→right, top→bottom.
-- The pill in each cell's corner is that frame's timecode — cite those exact values.
-- Adjacent cells that look alike = little changed in that window; a hard visual break between
-  cells is where an event happened. Zoom your attention there.
-
-## Answer shape
-
-Never answer with just a file path. Give the user:
-
-1. **Summary** — what the clip shows, one or two sentences.
-2. **Key moments with timestamps** — the events that matter, each cited to a cell's timecode.
-3. **Notable frames / anomalies** — anything odd or worth a second look (with its timecode), or
-   say there were none.
-
-If the question was specific ("find the moment when…"), lead with that answer + timestamp.
-
-## Optional: register it as an MCP tool
-
-For a persistent setup, one config block in `~/.hermes/config.yaml` exposes the same engine as
-the `squish_video` tool (returns the contract above **plus** `timecodes[][]` per sheet):
-
-```yaml
-mcp_servers:
-  squish:
-    command: npx
-    args: ["-y", "@getsquish/squish", "mcp"]
-    env: {}
+```bash
+squish_video.py <video>                          # 3x3 overview: WHAT happened
+squish_video.py <video> --density 5x5            # denser grid: HOW it happened, long clips
+squish_video.py <video> --start 1:00 --end 1:30  # zoom into a range
+squish_video.py <video> --out <dir>              # choose where sheets land
 ```
 
-## No node/ffmpeg on this machine?
+- `--density`: `3x3` (default) · `4x4` · `5x5` · `6x6`.
+- `--start` / `--end`: seconds (`90`) or a timecode exactly as stamped on a sheet
+  (`1:30`, `1:07.3`). Timecodes stay **absolute to the source video** at every depth.
 
-The hosted API does the same job remotely (this **uploads the video** — say so to the user
-first; the upload is deleted when the job ends): `POST https://api.getsquish.app/v1/squish`
-with `Authorization: Bearer $SQUISH_API_KEY`. Keys are self-serve at
-https://getsquish.app/api-keys — accounts that never purchased get a free daily allowance on
-the first request. Agent-facing details: https://getsquish.app/llms.txt
+## Procedure
+
+1. **Overview.** Run the script with defaults; `vision_analyze` every sheet in `files[]`,
+   in order.
+2. **Read the grid.** Cells run in time order, left→right, top→bottom; the pill in each
+   cell's corner is that frame's timecode. Adjacent near-identical cells mean little
+   changed; a hard visual break between cells is where an event happened.
+3. **Zoom when the question needs precision.** Re-run with `--start`/`--end` bracketing
+   the timecodes around the event (add a denser `--density` for fast motion); repeat
+   until the moment is pinned.
+4. **Answer.** Lead with the asked-for moment and its timestamp, then: a one-two sentence
+   summary · key moments, each cited to a cell's timecode · anomalies worth a second look
+   (or say there were none). Never answer with just a file path.
+
+## Pitfalls
+
+- **No audio.** Sheets carry visuals only — say so if the user asks about speech or sound.
+- **Cite pill timecodes only**; never claim precision finer than the spacing between cells.
+- Long clips emit multiple sheets — read all of them before concluding.
+- A too-narrow window is rejected with a teaching error (addressable floor ~2 ms/cell) —
+  widen the range instead of retrying.
+- No `npx`/`ffmpeg` on this machine: the hosted API does the same job remotely
+  (`POST https://api.getsquish.app/v1/squish`, self-serve keys at
+  https://getsquish.app/api-keys), but it **uploads the video** — tell the user before
+  using it. Agent-facing details: https://getsquish.app/llms.txt
+
+## Verification
+
+- The script on a short clip exits `0` and prints JSON with
+  `"contract": "squish-cli-v0"` and a non-empty `files[]`.
+- Every path in `files[]` exists (`search_files target='files'`) and renders in
+  `vision_analyze` with readable timecode pills.
+- With prerequisites missing, the script fails fast with an actionable message
+  (`npx not found…`), not a stack trace.
+- Hermetic tests: `scripts/run_tests.sh tests/skills/test_squish_video_skill.py -q`.

--- a/optional-skills/media/squish-video/SKILL.md
+++ b/optional-skills/media/squish-video/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: squish-video
+description: "See what happens in a local video via timestamped frames. Turns video into contact sheets you can vision_analyze — use for 'what happens in this clip', finding a moment, or citing timecodes."
+version: 1.0.0
+author: Squish (getsquish.app)
+license: MIT
+platforms: [linux, macos]
+prerequisites:
+  commands: [node, ffmpeg]
+metadata:
+  hermes:
+    tags: [Video, Vision, Timestamps, Contact-Sheet, FFmpeg, MCP]
+    homepage: https://getsquish.app
+---
+
+# Squish: video → timestamped contact sheet → your eyes
+
+You have vision but cannot ingest video. When a user asks about a **local video file**, do not
+guess and do not refuse — compress it into **timestamped contact sheets** (frames sampled evenly
+across the clip, laid out as a grid, each cell stamped with its timecode) and read those.
+
+The reasoning primitive: **video → contact sheet → look at the grid → answer with timestamps.**
+
+## When to use
+
+- "What happens in this video / screen recording?" — and the file is on this machine.
+- The question spans time: before/after, a scene change, progress, "find the moment when…".
+- The answer needs precise citations ("at 0:07 the press comes down").
+
+Skip it when the user needs one specific frame only, or the question isn't about the video's
+visual content. Scope: **local video file paths** — if the video lives elsewhere, get a local
+copy first. (This complements the built-in `video_analyze` tool: that sends the whole clip to an
+auxiliary model and returns text; Squish gives *your own* vision the actual frames.)
+
+## How (terminal — zero setup)
+
+```bash
+npx -y @getsquish/squish <video> --json
+```
+
+stdout is one JSON object (contract `squish-cli-v0`): parse `files[]` — absolute paths to
+`.sheet-N.jpg` in time order — then `vision_analyze` each sheet **in order**; each covers a
+consecutive window of the clip.
+
+`--density 4x4|5x5|6x6` packs more frames per sheet: use for long or fast-moving clips, or
+"how exactly did X happen" questions (default `3x3` recovers *what* happened).
+`--out <dir>` controls where sheets land. Everything runs on this machine — nothing is uploaded.
+
+## Reading a sheet
+
+- Cells run in time order, left→right, top→bottom.
+- The pill in each cell's corner is that frame's timecode — cite those exact values.
+- Adjacent cells that look alike = little changed in that window; a hard visual break between
+  cells is where an event happened. Zoom your attention there.
+
+## Answer shape
+
+Never answer with just a file path. Give the user:
+
+1. **Summary** — what the clip shows, one or two sentences.
+2. **Key moments with timestamps** — the events that matter, each cited to a cell's timecode.
+3. **Notable frames / anomalies** — anything odd or worth a second look (with its timecode), or
+   say there were none.
+
+If the question was specific ("find the moment when…"), lead with that answer + timestamp.
+
+## Optional: register it as an MCP tool
+
+For a persistent setup, one config block in `~/.hermes/config.yaml` exposes the same engine as
+the `squish_video` tool (returns the contract above **plus** `timecodes[][]` per sheet):
+
+```yaml
+mcp_servers:
+  squish:
+    command: npx
+    args: ["-y", "@getsquish/squish", "mcp"]
+    env: {}
+```
+
+## No node/ffmpeg on this machine?
+
+The hosted API does the same job remotely (this **uploads the video** — say so to the user
+first; the upload is deleted when the job ends): `POST https://api.getsquish.app/v1/squish`
+with `Authorization: Bearer $SQUISH_API_KEY`. Keys are self-serve at
+https://getsquish.app/api-keys — accounts that never purchased get a free daily allowance on
+the first request. Agent-facing details: https://getsquish.app/llms.txt

--- a/optional-skills/media/squish-video/scripts/squish_video.py
+++ b/optional-skills/media/squish-video/scripts/squish_video.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Run the Squish CLI on a local video and print its JSON contract.
+
+Thin wrapper around ``npx -y @getsquish/squish`` (Apache-2.0,
+github.com/getsquish/squish). The subprocess receives an argument list --
+never a shell string -- so paths containing whitespace stay intact.
+Stdlib only; no network access of its own (npx handles the package fetch).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+PACKAGE = "@getsquish/squish"
+CONTRACT = "squish-cli-v0"
+DENSITIES = ("3x3", "4x4", "5x5", "6x6")
+
+
+def build_command(
+    video: str,
+    density: str | None = None,
+    start: str | None = None,
+    end: str | None = None,
+    out: str | None = None,
+) -> list[str]:
+    """Build the npx argument list. The video path is one argv element."""
+    if density is not None and density not in DENSITIES:
+        raise ValueError(f"--density must be one of: {', '.join(DENSITIES)}")
+    cmd = ["npx", "-y", PACKAGE, video, "--json"]
+    if density is not None:
+        cmd += ["--density", density]
+    if start is not None:
+        cmd += ["--start", start]
+    if end is not None:
+        cmd += ["--end", end]
+    if out is not None:
+        cmd += ["--out", out]
+    return cmd
+
+
+def parse_contract(stdout: str) -> dict:
+    """Validate the CLI's JSON output against the frozen contract."""
+    payload = json.loads(stdout)
+    if payload.get("contract") != CONTRACT:
+        raise ValueError(
+            f"unexpected contract {payload.get('contract')!r} (want {CONTRACT!r})"
+        )
+    files = payload.get("files")
+    if not isinstance(files, list) or not files:
+        raise ValueError("output contains no contact sheets (files[] is empty)")
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Turn a local video into timestamped contact sheets."
+    )
+    parser.add_argument("video", help="path to a local video file")
+    parser.add_argument("--density", help="grid density: 3x3 (default), 4x4, 5x5, 6x6")
+    parser.add_argument("--start", help="window start: seconds (90) or timecode (1:30)")
+    parser.add_argument("--end", help="window end: seconds or timecode")
+    parser.add_argument("--out", help="directory where sheets are written")
+    args = parser.parse_args(argv)
+
+    if shutil.which("npx") is None:
+        print(
+            "error: `npx` not found -- install Node.js >= 20 "
+            "(ffmpeg is also required).",
+            file=sys.stderr,
+        )
+        return 1
+    video = Path(args.video)
+    if not video.is_file():
+        print(f"error: no such video file: {video}", file=sys.stderr)
+        return 1
+
+    try:
+        cmd = build_command(str(video), args.density, args.start, args.end, args.out)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr)
+        return proc.returncode or 1
+
+    try:
+        payload = parse_contract(proc.stdout)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    json.dump(payload, sys.stdout, indent=2)
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/skills/test_squish_video_skill.py
+++ b/tests/skills/test_squish_video_skill.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "media"
+    / "squish-video"
+)
+SKILL_MD = SKILL_DIR / "SKILL.md"
+SCRIPT_PATH = SKILL_DIR / "scripts" / "squish_video.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("squish_video_skill", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def contract_payload(video: str) -> dict:
+    return {
+        "input": video,
+        "duration": 20.275,
+        "frames": 9,
+        "sheets": 1,
+        "files": ["/abs/path/clip.sheet-1.jpg"],
+        "warnings": [],
+        "contract": "squish-cli-v0",
+    }
+
+
+# --- SKILL.md authoring standards ---
+
+
+def test_description_is_one_sentence_max_60_chars():
+    m = re.search(r"^description: (.*)$", SKILL_MD.read_text(), re.MULTILINE)
+    assert m is not None
+    desc = m.group(1).strip().strip('"')
+    assert len(desc) <= 60, len(desc)
+    assert desc.endswith(".")
+
+
+def test_body_uses_modern_section_order():
+    text = SKILL_MD.read_text()
+    headings = [
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ]
+    positions = [text.index(h) for h in headings]
+    assert positions == sorted(positions)
+
+
+# --- command construction (whitespace-safe by design) ---
+
+
+def test_build_command_keeps_whitespace_path_as_single_argument():
+    mod = load_module()
+    path = "/tmp/My Clips/screen recording.mov"
+    cmd = mod.build_command(path)
+    assert cmd[:3] == ["npx", "-y", "@getsquish/squish"]
+    assert cmd[3] == path
+    assert "--json" in cmd
+
+
+def test_build_command_appends_density_window_and_out():
+    mod = load_module()
+    cmd = mod.build_command(
+        "clip.mov", density="5x5", start="1:00", end="1:30", out="/tmp/out"
+    )
+    for pair in (
+        ["--density", "5x5"],
+        ["--start", "1:00"],
+        ["--end", "1:30"],
+        ["--out", "/tmp/out"],
+    ):
+        i = cmd.index(pair[0])
+        assert cmd[i + 1] == pair[1]
+
+
+def test_build_command_rejects_unknown_density():
+    mod = load_module()
+    with pytest.raises(ValueError):
+        mod.build_command("clip.mov", density="9x9")
+
+
+# --- contract parsing ---
+
+
+def test_parse_contract_accepts_v0_payload():
+    mod = load_module()
+    payload = mod.parse_contract(json.dumps(contract_payload("clip.mov")))
+    assert payload["files"] == ["/abs/path/clip.sheet-1.jpg"]
+
+
+def test_parse_contract_rejects_wrong_contract():
+    mod = load_module()
+    bad = contract_payload("clip.mov") | {"contract": "squish-cli-v999"}
+    with pytest.raises(ValueError):
+        mod.parse_contract(json.dumps(bad))
+
+
+def test_parse_contract_rejects_empty_files():
+    mod = load_module()
+    bad = contract_payload("clip.mov") | {"files": []}
+    with pytest.raises(ValueError):
+        mod.parse_contract(json.dumps(bad))
+
+
+# --- main(), fully hermetic ---
+
+
+def test_main_passes_video_as_single_argv_and_prints_contract(tmp_path, capsys):
+    mod = load_module()
+    video = tmp_path / "clip with spaces.mov"
+    video.write_bytes(b"\x00")
+    fake = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=json.dumps(contract_payload(str(video))),
+        stderr="",
+    )
+    with patch.object(mod.shutil, "which", return_value="/usr/bin/npx"), patch.object(
+        mod.subprocess, "run", return_value=fake
+    ) as run:
+        rc = mod.main([str(video)])
+
+    assert rc == 0
+    sent = run.call_args[0][0]
+    assert sent[3] == str(video)  # one argv element, whitespace intact
+    out = json.loads(capsys.readouterr().out)
+    assert out["contract"] == "squish-cli-v0"
+    assert out["files"]
+
+
+def test_main_errors_when_npx_is_missing(tmp_path, capsys):
+    mod = load_module()
+    video = tmp_path / "clip.mov"
+    video.write_bytes(b"\x00")
+    with patch.object(mod.shutil, "which", return_value=None), patch.object(
+        mod.subprocess, "run"
+    ) as run:
+        rc = mod.main([str(video)])
+
+    assert rc == 1
+    run.assert_not_called()
+    assert "npx" in capsys.readouterr().err
+
+
+def test_main_errors_on_missing_video_without_running_npx(tmp_path, capsys):
+    mod = load_module()
+    with patch.object(mod.shutil, "which", return_value="/usr/bin/npx"), patch.object(
+        mod.subprocess, "run"
+    ) as run:
+        rc = mod.main([str(tmp_path / "nope.mov")])
+
+    assert rc == 1
+    run.assert_not_called()
+    assert "no such video" in capsys.readouterr().err
+
+
+def test_main_relays_cli_failure(tmp_path, capsys):
+    mod = load_module()
+    video = tmp_path / "clip.mov"
+    video.write_bytes(b"\x00")
+    fake = subprocess.CompletedProcess(
+        args=[], returncode=2, stdout="", stderr="ffmpeg exploded\n"
+    )
+    with patch.object(mod.shutil, "which", return_value="/usr/bin/npx"), patch.object(
+        mod.subprocess, "run", return_value=fake
+    ):
+        rc = mod.main([str(video)])
+
+    assert rc == 2
+    assert "ffmpeg exploded" in capsys.readouterr().err


### PR DESCRIPTION
## What

An optional media skill that lets the agent **see inside a local video**: it turns the clip into timestamped contact sheets (frames sampled evenly, grid-composed, each cell stamped with its timecode) and reads them with its own vision — so answers cite real timestamps ("at 0:07 the press comes down").

## Why it complements (not duplicates) `video_analyze`

The built-in `video_analyze` tool ships the whole clip (≤50 MB) to an auxiliary model and returns *text*. This skill gives the **main model's own vision** the actual frames. Different failure modes, different strengths: no clip-size ceiling from base64, no second model in the loop, and the evidence (the sheet) is inspectable by the user.

## Zero new dependencies for this repo

The skill is instructions + one CLI call the agent runs via `terminal`:

```bash
npx -y @getsquish/squish <video> --json
```

The package ([`@getsquish/squish`](https://www.npmjs.com/package/@getsquish/squish)) is Apache-2.0, processes everything locally (no upload), needs Node ≥ 20 + ffmpeg, and is e2e-tested from the packed tarball on clean ubuntu + macos runners (frozen JSON contract `squish-cli-v0`). An optional MCP registration block is included in the skill for persistent setups.

## Placement

`optional-skills/media/` (new category, mirrors `skills/media/`) — per CONTRIBUTING: useful but not universally needed (Node + ffmpeg dependency; an optional hosted fallback exists and the skill discloses it as an upload before use).

## Field evidence

In a stock Hermes session (gemini-3.5-flash), the agent chose the tool from its description alone and narrated a real clip with correct timecodes — terminal and Telegram DM both (the Telegram bridge lands the attachment as a local file; the skill needs nothing platform-specific).

---

Happy to move this to the Skills Hub instead if you'd rather keep third-party-adjacent skills out of the tree — placement guidance welcome.