### PR TITLE
fix(qqbot): accept base-class is_reconnect kwarg in connect() (#57671)

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,8 +278,15 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
-        """Authenticate, obtain gateway URL, and open the WebSocket."""
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        """Authenticate, obtain gateway URL, and open the WebSocket.
+
+        Accepts the base-class ``is_reconnect`` keyword so the gateway's
+        reconnect watcher can re-establish this platform without raising
+        ``TypeError: connect() got an unexpected keyword argument
+        'is_reconnect'``. QQ has no server-side update queue to preserve
+        across an outage, so the flag is accepted and ignored.
+        """
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"
             self._set_fatal_error("qq_missing_dependency", message, retryable=True)

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -97,6 +97,49 @@ class TestQQAdapterInit:
 
 
 # ---------------------------------------------------------------------------
+# QQAdapter.connect signature — must accept base-class is_reconnect kwarg
+# (regression for #57671: connect() got an unexpected keyword argument
+# 'is_reconnect' when the reconnect watcher re-establishes the platform)
+# ---------------------------------------------------------------------------
+
+class TestQQConnectSignature:
+    def test_connect_accepts_is_reconnect_keyword(self):
+        import inspect
+        from gateway.platforms.qqbot import QQAdapter
+
+        sig = inspect.signature(QQAdapter.connect)
+        assert "is_reconnect" in sig.parameters, (
+            "QQAdapter.connect must accept is_reconnect to match "
+            "BasePlatformAdapter.connect (see #57671)"
+        )
+        param = sig.parameters["is_reconnect"]
+        assert param.kind is inspect.Parameter.KEYWORD_ONLY
+        assert param.default is False
+
+    def test_connect_signature_matches_base(self):
+        import inspect
+        from gateway.platforms.base import BasePlatformAdapter
+        from gateway.platforms.qqbot import QQAdapter
+
+        base_kw = {
+            name for name, p in inspect.signature(
+                BasePlatformAdapter.connect
+            ).parameters.items()
+            if p.kind is inspect.Parameter.KEYWORD_ONLY
+        }
+        qq_kw = {
+            name for name, p in inspect.signature(
+                QQAdapter.connect
+            ).parameters.items()
+            if p.kind is inspect.Parameter.KEYWORD_ONLY
+        }
+        assert base_kw <= qq_kw, (
+            f"QQAdapter.connect missing base keyword-only params: "
+            f"{base_kw - qq_kw}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # _coerce_list
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- QQ Bot adapter now accepts the base-class `is_reconnect` keyword in `connect()`.
- QQ Bot can start and be re-established by the reconnect watcher instead of crash-looping offline.

## Motivation

Closes #57671.

`BasePlatformAdapter.connect` is declared as `connect(self, *, is_reconnect: bool = False)`, and `gateway/run.py` always calls `adapter.connect(is_reconnect=...)` — on cold boot (`is_reconnect=False`) and from the reconnect watcher (`is_reconnect=True`). `QQAdapter.connect` was defined as `connect(self)`, so every start raised:

```
QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'
```

and the QQ Bot stayed offline, retrying with the same error.

## Fix

Widen the signature to `connect(self, *, is_reconnect: bool = False)`, matching the base class. QQ has no server-side update queue to preserve across an outage, so the flag is accepted and ignored — the same approach used by `msgraph_webhook`, `webhook`, `signal`, `weixin`, `whatsapp_cloud`, and `bluebubbles`.

Diff: `+1` line of real code (plus docstring) in `gateway/platforms/qqbot/adapter.py`.

## Verification

- `python3 -m pytest tests/gateway/test_qqbot.py::TestQQConnectSignature` — 2 passed
- Both new tests **fail without the fix** (`Extra items in the left set: 'is_reconnect'`) and pass with it.
- `python3 -m pytest tests/gateway/test_qqbot.py` — 167 passed (pre-existing async-close warnings unrelated to this change).

New tests assert `connect()` accepts the keyword-only `is_reconnect` param (default `False`) and that its keyword-only params are a superset of `BasePlatformAdapter.connect`, guarding against future drift.
