### PR TITLE
feat(video_analyze): SSRF-filtering egress proxy for yt-dlp fetches (opt-in)

### DIFF
--- a/tests/tools/test_ssrf_proxy.py
+++ b/tests/tools/test_ssrf_proxy.py
@@ -1,0 +1,332 @@
+"""Tests for the in-process SSRF-filtering forward proxy (tools/ssrf_proxy.py).
+
+These exercise the REAL proxy over real loopback sockets — a local origin HTTP
+server, a real HTTP client speaking through the proxy — not mocks of the socket
+layer. DNS resolution is monkeypatched (via loop.getaddrinfo) so we can assert
+policy without depending on public DNS, but the connect + pipe path is real.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import resource
+
+import pytest
+
+from tools.ssrf_proxy import SsrfFilteringProxy
+
+
+# ---------------------------------------------------------------------------
+# Helpers: a minimal loopback origin server + a raw client that speaks HTTP
+# proxy (absolute-form GET) and CONNECT through the proxy.
+# ---------------------------------------------------------------------------
+
+async def _start_origin(handler):
+    """Start a loopback TCP server running `handler(reader, writer)`; return (host, port, server)."""
+    server = await asyncio.start_server(handler, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    return "127.0.0.1", port, server
+
+
+async def _http_get_via_proxy(proxy_host, proxy_port, target_host, target_port, path="/"):
+    """Send an absolute-form HTTP GET through the proxy; return (status_line, body)."""
+    reader, writer = await asyncio.open_connection(proxy_host, proxy_port)
+    req = (
+        f"GET http://{target_host}:{target_port}{path} HTTP/1.1\r\n"
+        f"Host: {target_host}:{target_port}\r\n"
+        f"Connection: close\r\n\r\n"
+    )
+    writer.write(req.encode())
+    await writer.drain()
+    data = await reader.read(-1)
+    writer.close()
+    text = data.decode("latin-1", "replace")
+    status = text.split("\r\n", 1)[0]
+    body = text.split("\r\n\r\n", 1)[1] if "\r\n\r\n" in text else ""
+    return status, body
+
+
+async def _connect_via_proxy(proxy_host, proxy_port, target_host, target_port):
+    """Send CONNECT through the proxy; return (status_line, reader, writer)."""
+    reader, writer = await asyncio.open_connection(proxy_host, proxy_port)
+    req = f"CONNECT {target_host}:{target_port} HTTP/1.1\r\nHost: {target_host}:{target_port}\r\n\r\n"
+    writer.write(req.encode())
+    await writer.drain()
+    line = await reader.readuntil(b"\r\n")
+    # consume the blank line after the status if a 200
+    try:
+        await asyncio.wait_for(reader.readuntil(b"\r\n"), timeout=0.5)
+    except Exception:
+        pass
+    return line.decode("latin-1", "replace").strip(), reader, writer
+
+
+def _patch_resolve(monkeypatch, mapping):
+    """Patch loop.getaddrinfo so host -> list of IPs (per test), real connect otherwise."""
+    async def fake_getaddrinfo(host, port, *args, **kwargs):
+        ips = mapping.get(host)
+        if ips is None:
+            raise socket.gaierror(f"no test mapping for {host}")
+        out = []
+        for ip in ips:
+            fam = socket.AF_INET6 if ":" in ip else socket.AF_INET
+            out.append((fam, socket.SOCK_STREAM, 6, "", (ip, port)))
+        return out
+    loop = asyncio.get_event_loop()
+    monkeypatch.setattr(loop, "getaddrinfo", fake_getaddrinfo)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_proxy_binds_loopback_ephemeral():
+    async with SsrfFilteringProxy() as url:
+        assert url.startswith("http://127.0.0.1:")
+        port = int(url.rsplit(":", 1)[1])
+        assert port != 0 and port > 1024
+
+
+@pytest.mark.asyncio
+async def test_proxy_allows_public_http(monkeypatch):
+    """A public host (mapped to a real loopback origin) is proxied through."""
+    async def origin(reader, writer):
+        await reader.readuntil(b"\r\n")  # request line
+        writer.write(b"HTTP/1.1 200 OK\r\nContent-Length: 3\r\nConnection: close\r\n\r\nHEY")
+        await writer.drain()
+        writer.close()
+
+    ohost, oport, oserver = await _start_origin(origin)
+    async with oserver:
+        # Map a "public" hostname to the loopback origin, but tell the policy
+        # the resolved IP is public (8.8.8.8) so it isn't blocked — then connect
+        # to the origin. To keep it real, map directly to 127.0.0.1 but disable
+        # private blocking for THIS test so loopback is allowed.
+        _patch_resolve(monkeypatch, {"public.example": ["127.0.0.1"]})
+        async with SsrfFilteringProxy(block_private=False) as url:
+            phost, pport = url[len("http://"):].split(":")
+            status, body = await _http_get_via_proxy(phost, int(pport), "public.example", oport)
+            assert "200" in status
+            assert body == "HEY"
+
+
+@pytest.mark.asyncio
+async def test_proxy_blocks_metadata(monkeypatch):
+    """A host resolving to the cloud-metadata IP is refused, even block_private=False."""
+    _patch_resolve(monkeypatch, {"evil.example": ["169.254.169.254"]})
+    async with SsrfFilteringProxy(block_private=False) as url:
+        phost, pport = url[len("http://"):].split(":")
+        status, _ = await _http_get_via_proxy(phost, int(pport), "evil.example", 80)
+        assert "403" in status
+
+
+@pytest.mark.asyncio
+async def test_proxy_blocks_private(monkeypatch):
+    """A host resolving to a private IP is refused when block_private=True."""
+    _patch_resolve(monkeypatch, {"lan.example": ["192.168.1.208"]})
+    async with SsrfFilteringProxy(block_private=True) as url:
+        phost, pport = url[len("http://"):].split(":")
+        status, _ = await _http_get_via_proxy(phost, int(pport), "lan.example", 3000)
+        assert "403" in status
+
+
+@pytest.mark.asyncio
+async def test_proxy_pins_validated_ip_mixed_answer(monkeypatch):
+    """If ANY resolved address is blocked, the whole connection is refused."""
+    _patch_resolve(monkeypatch, {"mixed.example": ["8.8.8.8", "169.254.169.254"]})
+    async with SsrfFilteringProxy(block_private=True) as url:
+        phost, pport = url[len("http://"):].split(":")
+        status, _ = await _http_get_via_proxy(phost, int(pport), "mixed.example", 80)
+        assert "403" in status
+
+
+@pytest.mark.asyncio
+async def test_proxy_connect_metadata_ip_literal_blocked(monkeypatch):
+    """CONNECT to a raw metadata IP literal is refused."""
+    _patch_resolve(monkeypatch, {"169.254.169.254": ["169.254.169.254"]})
+    async with SsrfFilteringProxy(block_private=False) as url:
+        phost, pport = url[len("http://"):].split(":")
+        status, _r, _w = await _connect_via_proxy(phost, int(pport), "169.254.169.254", 443)
+        assert "403" in status
+
+
+@pytest.mark.asyncio
+async def test_proxy_validates_port_still_blocks_private(monkeypatch):
+    """Port is carried through; a private host on any port is still blocked."""
+    _patch_resolve(monkeypatch, {"lan.example": ["10.0.0.5"]})
+    async with SsrfFilteringProxy(block_private=True) as url:
+        phost, pport = url[len("http://"):].split(":")
+        for port in (22, 6379, 8080):
+            status, _ = await _http_get_via_proxy(phost, int(pport), "lan.example", port)
+            assert "403" in status
+
+
+@pytest.mark.asyncio
+async def test_proxy_malformed_request_refused(monkeypatch):
+    """A malformed request line is refused cleanly, never an un-validated connect."""
+    async with SsrfFilteringProxy() as url:
+        phost, pport = url[len("http://"):].split(":")
+        reader, writer = await asyncio.open_connection(phost, int(pport))
+        writer.write(b"GARBAGE-NOT-HTTP\r\n\r\n")
+        await writer.drain()
+        data = await reader.read(-1)
+        writer.close()
+        assert b"400" in data
+
+
+@pytest.mark.asyncio
+async def test_proxy_connection_count_increments(monkeypatch):
+    """connection_count reflects opened validated connections; blocked_count the refusals."""
+    async def origin(reader, writer):
+        await reader.readuntil(b"\r\n")
+        writer.write(b"HTTP/1.1 200 OK\r\nContent-Length: 1\r\nConnection: close\r\n\r\nX")
+        await writer.drain()
+        writer.close()
+
+    ohost, oport, oserver = await _start_origin(origin)
+    async with oserver:
+        _patch_resolve(monkeypatch, {"pub.example": ["127.0.0.1"], "bad.example": ["169.254.169.254"]})
+        proxy = SsrfFilteringProxy(block_private=False)
+        async with proxy as url:
+            phost, pport = url[len("http://"):].split(":")
+            await _http_get_via_proxy(phost, int(pport), "pub.example", oport)
+            await _http_get_via_proxy(phost, int(pport), "pub.example", oport)
+            await _http_get_via_proxy(phost, int(pport), "bad.example", 80)
+        assert proxy.connection_count == 2
+        assert proxy.blocked_count == 1
+
+
+@pytest.mark.asyncio
+async def test_proxy_no_fd_leak(monkeypatch):
+    """N sequential proxied requests leave the process fd count flat (handler cleanup)."""
+    async def origin(reader, writer):
+        await reader.readuntil(b"\r\n")
+        writer.write(b"HTTP/1.1 200 OK\r\nContent-Length: 1\r\nConnection: close\r\n\r\nY")
+        await writer.drain()
+        writer.close()
+
+    ohost, oport, oserver = await _start_origin(origin)
+    async with oserver:
+        _patch_resolve(monkeypatch, {"pub.example": ["127.0.0.1"]})
+
+        def _open_fds():
+            import os
+            try:
+                return len(os.listdir(f"/proc/{os.getpid()}/fd"))
+            except FileNotFoundError:
+                # macOS: fall back to resource-based soft check via a dup probe.
+                return len([f for f in _list_fds_macos()])
+
+        # Warm up one full proxy lifecycle, measure, then run many more.
+        async def one():
+            async with SsrfFilteringProxy(block_private=False) as url:
+                phost, pport = url[len("http://"):].split(":")
+                await _http_get_via_proxy(phost, int(pport), "pub.example", oport)
+
+        await one()
+        before = _count_fds()
+        for _ in range(15):
+            await one()
+        after = _count_fds()
+        # Allow a small slop for interpreter/gc jitter, but no per-call leak.
+        assert after - before <= 5, f"fd leak: before={before} after={after}"
+
+
+def _count_fds():
+    import os
+    pid = os.getpid()
+    proc_fd = f"/proc/{pid}/fd"
+    try:
+        return len(os.listdir(proc_fd))
+    except FileNotFoundError:
+        pass
+    # macOS: count via lsof-free method using resource + probing is unreliable;
+    # use the psutil-free approach of scanning with os.
+    count = 0
+    soft, _hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    limit = min(soft, 4096)
+    import os as _os
+    for fd in range(limit):
+        try:
+            _os.fstat(fd)
+            count += 1
+        except OSError:
+            pass
+    return count
+
+
+def _list_fds_macos():
+    return []
+
+
+@pytest.mark.asyncio
+async def test_proxy_blocks_redirect_hop_to_metadata(monkeypatch):
+    """The whole point: a PUBLIC page that 302-redirects to a metadata IP —
+    the redirect hop (a NEW proxied request to the metadata host) is blocked,
+    not just the initial URL. Simulates a client that follows redirects by
+    issuing a second proxied request to the Location target."""
+    async def public_origin(reader, writer):
+        await reader.readuntil(b"\r\n")
+        # 302 to the metadata endpoint
+        writer.write(
+            b"HTTP/1.1 302 Found\r\n"
+            b"Location: http://metadata.evil:80/latest/meta-data/\r\n"
+            b"Content-Length: 0\r\nConnection: close\r\n\r\n"
+        )
+        await writer.drain()
+        writer.close()
+
+    ohost, oport, oserver = await _start_origin(public_origin)
+    async with oserver:
+        # public.example → loopback origin (public per policy: block_private off);
+        # metadata.evil → the cloud metadata IP (always blocked).
+        _patch_resolve(monkeypatch, {
+            "public.example": ["127.0.0.1"],
+            "metadata.evil": ["169.254.169.254"],
+        })
+        async with SsrfFilteringProxy(block_private=False) as url:
+            phost, pport = url[len("http://"):].split(":")
+            # 1) initial fetch to the public page → 302 (allowed, proxied)
+            status1, _ = await _http_get_via_proxy(phost, int(pport), "public.example", oport)
+            assert "302" in status1
+            # 2) client follows the redirect → NEW proxied request to metadata → BLOCKED
+            status2, _ = await _http_get_via_proxy(phost, int(pport), "metadata.evil", 80)
+            assert "403" in status2, "redirect hop to metadata must be blocked at the proxy"
+
+
+@pytest.mark.asyncio
+async def test_handler_tasks_registered_and_cancelled(monkeypatch):
+    """A handler task registers in _tasks while in-flight and is cancelled on
+    __aexit__ — proves the fd-leak guard is actually wired (regression for the
+    _spawn-never-called bug: start_server calls _handle_client directly)."""
+    # An origin that hangs so the handler stays in-flight (pipe never ends).
+    stop = asyncio.Event()
+
+    async def hang_origin(reader, writer):
+        await reader.readuntil(b"\r\n")
+        writer.write(b"HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\n")  # promises 100, sends 0
+        await writer.drain()
+        await stop.wait()  # hold the connection open
+        writer.close()
+
+    ohost, oport, oserver = await _start_origin(hang_origin)
+    async with oserver:
+        _patch_resolve(monkeypatch, {"pub.example": ["127.0.0.1"]})
+        proxy = SsrfFilteringProxy(block_private=False)
+        async with proxy as url:
+            phost, pport = url[len("http://"):].split(":")
+            # Kick off a request but DON'T await it — leave the handler in-flight.
+            r, w = await asyncio.open_connection(phost, int(pport))
+            w.write(
+                f"GET http://pub.example:{oport}/ HTTP/1.1\r\nHost: x\r\n\r\n".encode()
+            )
+            await w.drain()
+            # Give the proxy a moment to accept + spawn the handler task.
+            await asyncio.sleep(0.2)
+            assert len(proxy._tasks) >= 1, "handler task must be registered while in-flight"
+            w.close()
+        # After __aexit__: tasks cancelled + cleared, no leak.
+        assert len(proxy._tasks) == 0
+        stop.set()

--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -713,3 +713,51 @@ class TestRedirectTargetFromResponse:
     def test_no_location_no_next_request_returns_none(self):
         resp = _FakeResponse(is_redirect=True)
         assert redirect_target_from_response(resp) is None
+
+
+class TestIpIsBlocked:
+    """The ip_is_blocked() primitive — the single SSRF policy source reused by
+    the yt-dlp egress proxy (Phase 1 of the SSRF-proxy PRD)."""
+
+    def test_metadata_ip_blocked_regardless_of_block_private(self):
+        from tools.url_safety import ip_is_blocked
+        # Cloud metadata is ALWAYS blocked, whether or not private blocking is on.
+        assert ip_is_blocked("169.254.169.254", block_private=False) is True
+        assert ip_is_blocked("169.254.169.254", block_private=True) is True
+        assert ip_is_blocked("169.254.170.2", block_private=False) is True   # AWS ECS
+        assert ip_is_blocked("100.100.100.200", block_private=False) is True  # Alibaba
+
+    def test_private_blocked_only_when_block_private(self):
+        from tools.url_safety import ip_is_blocked
+        # RFC1918 / loopback: blocked iff block_private=True.
+        assert ip_is_blocked("192.168.1.208", block_private=True) is True
+        assert ip_is_blocked("192.168.1.208", block_private=False) is False
+        assert ip_is_blocked("127.0.0.1", block_private=True) is True
+        assert ip_is_blocked("127.0.0.1", block_private=False) is False
+        assert ip_is_blocked("10.0.0.5", block_private=True) is True
+        assert ip_is_blocked("169.254.1.1", block_private=True) is True  # link-local (non-metadata)
+
+    def test_public_allowed(self):
+        from tools.url_safety import ip_is_blocked
+        assert ip_is_blocked("8.8.8.8", block_private=True) is False
+        assert ip_is_blocked("142.250.72.206", block_private=True) is False  # a Google public IP
+
+    def test_ipv4_mapped_ipv6_normalized(self):
+        from tools.url_safety import ip_is_blocked
+        # ::ffff:x.x.x.x must be judged by the embedded IPv4 address.
+        assert ip_is_blocked("::ffff:169.254.169.254", block_private=False) is True
+        assert ip_is_blocked("::ffff:192.168.1.5", block_private=True) is True
+        assert ip_is_blocked("::ffff:192.168.1.5", block_private=False) is False
+
+    def test_cgnat_blocked_when_private(self):
+        from tools.url_safety import ip_is_blocked
+        # 100.64.0.0/10 (CGNAT) is not is_private but must block under block_private.
+        assert ip_is_blocked("100.64.0.1", block_private=True) is True
+        assert ip_is_blocked("100.64.0.1", block_private=False) is False
+
+    def test_unparseable_fails_closed(self):
+        from tools.url_safety import ip_is_blocked
+        # A non-IP string must fail closed (blocked), never allow-through.
+        assert ip_is_blocked("not-an-ip", block_private=True) is True
+        assert ip_is_blocked("not-an-ip", block_private=False) is True
+        assert ip_is_blocked("", block_private=False) is True

--- a/tests/tools/test_video_ssrf_wiring.py
+++ b/tests/tools/test_video_ssrf_wiring.py
@@ -1,0 +1,184 @@
+"""Phase-3 wiring tests: _download_video_via_ytdlp routes through the SSRF proxy.
+
+These assert the CONFIGURATION and FAIL-CLOSED behavior of the wiring without
+hitting the network: yt-dlp is monkeypatched at the subprocess boundary so we
+inspect the argv/env the tool would run, and the proxy lifecycle is exercised
+for the fail-closed and post-run-guard paths.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import tools.vision_tools as vt
+
+
+def _mk_dest(tmp_path) -> Path:
+    d = tmp_path / "vid"
+    d.mkdir()
+    return d
+
+
+def test_ssrf_proxy_disabled_by_default(monkeypatch):
+    """Config key absent → proxy OFF (v0.1 default)."""
+    monkeypatch.setattr(vt, "_cfg_get_safe", lambda *a, **k: k.get("default", ""))
+    assert vt._ssrf_proxy_enabled() is False
+
+
+def test_ssrf_proxy_enabled_when_config_true(monkeypatch):
+    def fake_cfg(*path, default=""):
+        if path == ("auxiliary", "vision", "ytdlp_ssrf_proxy"):
+            return True
+        return default
+    monkeypatch.setattr(vt, "_cfg_get_safe", fake_cfg)
+    assert vt._ssrf_proxy_enabled() is True
+
+
+def test_ffmpeg_block_shim_disables_external_downloaders(tmp_path):
+    """The shim dir provides ffmpeg/ffprobe/aria2c that fail non-zero, while the
+    real PATH (deno/node/etc.) stays reachable when prepended."""
+    import subprocess as _sp
+    shim = vt._make_ffmpeg_block_shim(tmp_path)
+    for name in ("ffmpeg", "ffprobe", "aria2c"):
+        exe = Path(shim) / name
+        assert exe.exists() and os.access(exe, os.X_OK)
+        # Running the shim binary fails (fail-closed), never a real fetch.
+        rc = _sp.run([str(exe), "-version"], capture_output=True).returncode
+        assert rc != 0
+    # The shim is a single dir to PREPEND — it does not remove real PATH entries.
+    child_path = shim + os.pathsep + "/usr/local/bin:/usr/bin"
+    assert "/usr/local/bin" in child_path and "/usr/bin" in child_path
+
+
+@pytest.mark.asyncio
+async def test_ytdlp_uses_proxy_args_when_enabled(monkeypatch, tmp_path):
+    """With the knob on, the child argv carries --proxy + --downloader native,
+    the env has *_PROXY set, and PATH excludes ffmpeg."""
+    captured = {}
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        captured["env"] = kwargs.get("env", {})
+        # Simulate yt-dlp writing a finished mp4 so _find_output succeeds.
+        # out template is argv after -o
+        oidx = argv.index("-o")
+        tmpl = argv[oidx + 1]
+        outfile = Path(tmpl.replace(".%(ext)s", ".mp4"))
+        outfile.write_bytes(b"\x00\x00\x00\x18ftypmp42")  # tiny fake mp4
+        class P:
+            returncode = 0
+            stderr = ""
+            stdout = ""
+        return P()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(vt, "_ssrf_proxy_enabled", lambda: True)
+    monkeypatch.setattr(vt, "_ytdlp_cookie_args", lambda: [])
+
+    dest = _mk_dest(tmp_path)
+    # Bump the proxy connection_count so the post-run guard passes (we're not
+    # actually connecting through it here — the argv/env is what this asserts).
+    from tools.ssrf_proxy import SsrfFilteringProxy
+    orig_aenter = SsrfFilteringProxy.__aenter__
+
+    async def patched_aenter(self):
+        url = await orig_aenter(self)
+        self.connection_count = 1  # pretend a real fetch traversed it
+        return url
+    monkeypatch.setattr(SsrfFilteringProxy, "__aenter__", patched_aenter)
+
+    out = await vt._download_video_via_ytdlp("https://youtube.com/watch?v=x", dest)
+    assert out.exists()
+    argv = captured["argv"]
+    assert "--proxy" in argv
+    pidx = argv.index("--proxy")
+    assert argv[pidx + 1].startswith("http://127.0.0.1:")
+    assert "--downloader" in argv and argv[argv.index("--downloader") + 1] == "native"
+    env = captured["env"]
+    assert env.get("HTTP_PROXY", "").startswith("http://127.0.0.1:")
+    assert env.get("HTTPS_PROXY", "").startswith("http://127.0.0.1:")
+
+
+@pytest.mark.asyncio
+async def test_ytdlp_no_proxy_args_when_disabled(monkeypatch, tmp_path):
+    """With the knob off (default), no --proxy in argv."""
+    captured = {}
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        oidx = argv.index("-o")
+        tmpl = argv[oidx + 1]
+        Path(tmpl.replace(".%(ext)s", ".mp4")).write_bytes(b"\x00\x00\x00\x18ftypmp42")
+        class P:
+            returncode = 0
+            stderr = ""
+            stdout = ""
+        return P()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(vt, "_ssrf_proxy_enabled", lambda: False)
+    monkeypatch.setattr(vt, "_ytdlp_cookie_args", lambda: [])
+
+    dest = _mk_dest(tmp_path)
+    out = await vt._download_video_via_ytdlp("https://youtube.com/watch?v=x", dest)
+    assert out.exists()
+    assert "--proxy" not in captured["argv"]
+
+
+@pytest.mark.asyncio
+async def test_ytdlp_proxy_start_failure_fails_closed(monkeypatch, tmp_path):
+    """If the proxy can't start, the tool RAISES — yt-dlp is never invoked."""
+    ran = {"called": False}
+
+    def fake_run(argv, **kwargs):
+        ran["called"] = True
+        class P:
+            returncode = 0
+            stderr = ""
+            stdout = ""
+        return P()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(vt, "_ssrf_proxy_enabled", lambda: True)
+    monkeypatch.setattr(vt, "_ytdlp_cookie_args", lambda: [])
+
+    from tools.ssrf_proxy import SsrfFilteringProxy
+
+    async def boom(self):
+        raise OSError("cannot bind")
+    monkeypatch.setattr(SsrfFilteringProxy, "__aenter__", boom)
+
+    dest = _mk_dest(tmp_path)
+    with pytest.raises(OSError):
+        await vt._download_video_via_ytdlp("https://youtube.com/watch?v=x", dest)
+    assert ran["called"] is False, "yt-dlp must NOT run when the proxy fails to start"
+
+
+@pytest.mark.asyncio
+async def test_post_run_guard_raises_on_unproxied(monkeypatch, tmp_path):
+    """Proxy on, bytes on disk, but zero proxied connections → raise + clean."""
+    def fake_run(argv, **kwargs):
+        oidx = argv.index("-o")
+        tmpl = argv[oidx + 1]
+        Path(tmpl.replace(".%(ext)s", ".mp4")).write_bytes(b"\x00\x00\x00\x18ftypmp42")
+        class P:
+            returncode = 0
+            stderr = ""
+            stdout = ""
+        return P()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(vt, "_ssrf_proxy_enabled", lambda: True)
+    monkeypatch.setattr(vt, "_ytdlp_cookie_args", lambda: [])
+    # Leave connection_count at 0 (default) — simulates external-downloader bypass.
+
+    dest = _mk_dest(tmp_path)
+    with pytest.raises(ValueError, match="no connection traversed the proxy"):
+        await vt._download_video_via_ytdlp("https://youtube.com/watch?v=x", dest)
+    # partials + the unvalidated file cleaned
+    assert list(dest.glob("*")) == []

--- a/tools/ssrf_proxy.py
+++ b/tools/ssrf_proxy.py
@@ -1,0 +1,360 @@
+"""In-process SSRF-filtering forward proxy for shelled-out fetchers (yt-dlp).
+
+Why this exists
+---------------
+``video_analyze`` fetches non-direct video URLs (YouTube/X/Vimeo/TikTok) by
+shelling out to ``yt-dlp``. A pre-flight ``is_safe_url`` check validates only the
+*initial* URL; yt-dlp then performs its own fetches (page, player JS, manifest,
+media segments) and follows redirects, any of which can target an internal /
+cloud-metadata address that is never re-validated. That is a real SSRF hole.
+
+This module stands up a tiny **in-process asyncio forward proxy** bound to
+loopback. yt-dlp is pointed at it via ``--proxy http://127.0.0.1:<port>`` (plus
+``HTTP_PROXY``/``HTTPS_PROXY`` env). Every connection yt-dlp makes — the initial
+fetch, **every redirect**, and every sub-resource — arrives at the proxy, which:
+
+  1. parses ``CONNECT host:port`` (HTTPS) or an absolute-form request (HTTP),
+  2. resolves the host (once) via the event loop's non-blocking resolver,
+  3. validates **every** resolved address (A + AAAA) against the single SSRF
+     policy source ``url_safety.ip_is_blocked`` — if ANY is blocked, refuse,
+  4. connects to a **validated IP literal** (never re-resolving — TOCTOU-safe),
+  5. for CONNECT, pipes bytes without terminating TLS (no MITM, no certs).
+
+The proxy blocks the always-metadata floor **and** private/RFC1918 addresses for
+this egress (``block_private=True``), independent of the global
+``allow_private_urls`` toggle: an attacker-controlled page URL has no legitimate
+reason to redirect to the LAN.
+
+It binds ``127.0.0.1`` on an ephemeral port, lives only for one ``async with``
+block, and tracks + cancels every per-connection handler task on exit so no
+sockets/fds leak across the fleet's high ``video_analyze`` call volume.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import socket
+from typing import Optional, Set
+
+from tools.url_safety import ip_is_blocked
+
+logger = logging.getLogger(__name__)
+
+# Bytes we shovel per pipe read. 64KiB balances throughput vs loop-time fairness.
+_PIPE_CHUNK = 65536
+# Cap the request line + headers we read before a CONNECT/absolute request so a
+# malformed client can't make us buffer unboundedly.
+_MAX_HEADER_BYTES = 16384
+
+
+class SsrfFilteringProxy:
+    """An async context manager yielding a loopback proxy URL.
+
+    Usage::
+
+        async with SsrfFilteringProxy(block_private=True) as proxy_url:
+            # proxy_url == "http://127.0.0.1:<ephemeral>"
+            ... run yt-dlp --proxy proxy_url ...
+        # on exit: server closed, all handler tasks cancelled, no leaks
+
+    ``connection_count`` records how many outbound connections were validated
+    and opened (the traffic-observing signal the acceptance gate asserts).
+    """
+
+    def __init__(self, *, block_private: bool = True) -> None:
+        self._block_private = block_private
+        self._server: Optional[asyncio.AbstractServer] = None
+        self._host = "127.0.0.1"
+        self._port: Optional[int] = None
+        self._tasks: Set[asyncio.Task] = set()
+        # Number of successfully-validated outbound connections opened. The
+        # traffic gate asserts this is > (initial + redirects) for a real
+        # segmented download, i.e. segments actually traversed the proxy.
+        self.connection_count = 0
+        # Number of refused connections (blocked by policy or malformed).
+        self.blocked_count = 0
+
+    @property
+    def proxy_url(self) -> str:
+        if self._port is None:
+            raise RuntimeError("proxy not started")
+        return f"http://{self._host}:{self._port}"
+
+    async def __aenter__(self) -> str:
+        # start_server can raise (port exhaustion, permission) — let it
+        # propagate so the caller fails CLOSED rather than running un-proxied.
+        self._server = await asyncio.start_server(
+            self._handle_client, self._host, 0
+        )
+        sock = self._server.sockets[0]
+        self._port = sock.getsockname()[1]
+        logger.debug("SSRF proxy listening on %s:%s", self._host, self._port)
+        return self.proxy_url
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        # Close the listener, then cancel + await EVERY per-connection handler
+        # task. asyncio.start_server does NOT cancel handler tasks on close, so
+        # without this, orphaned CONNECT pipes leak sockets/fds every call.
+        if self._server is not None:
+            self._server.close()
+            try:
+                await self._server.wait_closed()
+            except Exception:  # pragma: no cover - defensive
+                pass
+        tasks = list(self._tasks)
+        for t in tasks:
+            t.cancel()
+        if tasks:
+            # Give cancelled handlers a chance to unwind (close sockets) before
+            # the loop tears down, so no "Task was destroyed but pending" warning
+            # and no leaked fds.
+            await asyncio.gather(*tasks, return_exceptions=True)
+        self._tasks.clear()
+
+    async def _handle_client(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        # asyncio.start_server invokes this coroutine as its own task; register
+        # THAT task so __aexit__ can cancel any handler still piping when the
+        # context manager tears down (the fd-leak / orphaned-pipe guard). On
+        # Python <3.12, Server.wait_closed() does NOT drain handler tasks.
+        task = asyncio.current_task()
+        if task is not None:
+            self._tasks.add(task)
+            task.add_done_callback(self._tasks.discard)
+        try:
+            request_line = await self._read_request_line(reader)
+            if request_line is None:
+                await self._refuse(writer, "400 Bad Request", "malformed request")
+                return
+
+            method, target, _version = request_line
+
+            if method == "CONNECT":
+                # target == "host:port"
+                host, port = self._split_hostport(target)
+                if host is None or port is None:
+                    await self._refuse(writer, "400 Bad Request", "bad CONNECT target")
+                    return
+                # Drain the remaining request headers (up to blank line).
+                await self._drain_headers(reader)
+                await self._handle_connect(host, port, reader, writer)
+            else:
+                # Absolute-form HTTP request:  GET http://host/path HTTP/1.1
+                host, port, rest = self._split_absolute_url(target)
+                if host is None or port is None or rest is None:
+                    await self._refuse(writer, "400 Bad Request", "non-absolute HTTP request")
+                    return
+                await self._handle_http(
+                    method, host, port, rest, request_line, reader, writer
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("SSRF proxy handler error: %s", exc)
+        finally:
+            try:
+                writer.close()
+            except Exception:
+                pass
+
+    async def _read_request_line(self, reader: asyncio.StreamReader):
+        try:
+            line = await reader.readuntil(b"\r\n")
+        except (asyncio.IncompleteReadError, asyncio.LimitOverrunError, ConnectionError):
+            return None
+        text = line.decode("latin-1", "replace").strip()
+        parts = text.split(" ")
+        if len(parts) != 3:
+            return None
+        return parts[0].upper(), parts[1], parts[2]
+
+    async def _drain_headers(self, reader: asyncio.StreamReader) -> None:
+        total = 0
+        while True:
+            try:
+                line = await reader.readuntil(b"\r\n")
+            except (asyncio.IncompleteReadError, asyncio.LimitOverrunError, ConnectionError):
+                return
+            total += len(line)
+            if line in (b"\r\n", b"\n", b""):
+                return
+            if total > _MAX_HEADER_BYTES:
+                return
+
+    def _split_hostport(self, target: str):
+        if ":" not in target:
+            return None, None
+        # rsplit for IPv6-literal safety (…]:443).
+        host, _, port_s = target.rpartition(":")
+        host = host.strip("[]")
+        try:
+            port = int(port_s)
+        except ValueError:
+            return None, None
+        if not host or not (0 < port < 65536):
+            return None, None
+        return host, port
+
+    def _split_absolute_url(self, url: str):
+        # Only proxy absolute http:// forms; https always arrives via CONNECT.
+        if not url.lower().startswith("http://"):
+            return None, None, None
+        rest = url[len("http://"):]
+        slash = rest.find("/")
+        if slash == -1:
+            authority, path = rest, "/"
+        else:
+            authority, path = rest[:slash], rest[slash:]
+        if "@" in authority:
+            authority = authority.split("@", 1)[1]
+        if ":" in authority:
+            host, _, port_s = authority.rpartition(":")
+            host = host.strip("[]")
+            try:
+                port = int(port_s)
+            except ValueError:
+                return None, None, None
+        else:
+            host, port = authority.strip("[]"), 80
+        if not host or not (0 < port < 65536):
+            return None, None, None
+        return host, port, path
+
+    async def _validate_and_connect(self, host: str, port: int):
+        """Resolve host, validate EVERY address, connect to a validated literal.
+
+        Returns (reader, writer) on success or None if refused. Resolves once and
+        connects to the validated IP literal — no re-resolution between check and
+        connect (TOCTOU-safe).
+        """
+        loop = asyncio.get_running_loop()
+        try:
+            infos = await loop.getaddrinfo(
+                host, port, family=socket.AF_UNSPEC, type=socket.SOCK_STREAM
+            )
+        except (socket.gaierror, OSError) as exc:
+            logger.warning("SSRF proxy blocked %s:%s (resolve failed: %s)", host, port, exc)
+            return None
+        if not infos:
+            logger.warning("SSRF proxy blocked %s:%s (no addresses)", host, port)
+            return None
+
+        # ANY blocked address → refuse the whole connection (fail closed).
+        addrs = []
+        for family, _type, _proto, _canon, sockaddr in infos:
+            ip = str(sockaddr[0])
+            if "%" in ip:
+                ip = ip.split("%", 1)[0]
+            if ip_is_blocked(ip, block_private=self._block_private):
+                logger.warning(
+                    "SSRF proxy blocked %s:%s -> %s (policy)", host, port, ip
+                )
+                return None
+            addrs.append((family, ip))
+
+        # Connect to a validated IP literal (first that connects).
+        last_exc: Optional[Exception] = None
+        for family, ip in addrs:
+            try:
+                r, w = await asyncio.open_connection(ip, port)
+                self.connection_count += 1
+                return r, w
+            except (OSError, asyncio.TimeoutError) as exc:  # pragma: no cover - net
+                last_exc = exc
+                continue
+        logger.warning("SSRF proxy could not connect %s:%s (%s)", host, port, last_exc)
+        return None
+
+    async def _handle_connect(
+        self, host: str, port: int,
+        creader: asyncio.StreamReader, cwriter: asyncio.StreamWriter,
+    ) -> None:
+        conn = await self._validate_and_connect(host, port)
+        if conn is None:
+            self.blocked_count += 1
+            await self._refuse(cwriter, "403 Forbidden", "blocked by SSRF policy")
+            return
+        rreader, rwriter = conn
+        try:
+            cwriter.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+            await cwriter.drain()
+            await asyncio.gather(
+                self._pipe(creader, rwriter),
+                self._pipe(rreader, cwriter),
+            )
+        finally:
+            for w in (rwriter, cwriter):
+                try:
+                    w.close()
+                except Exception:
+                    pass
+
+    async def _handle_http(
+        self, method: str, host: str, port: int, path: str,
+        request_line, creader: asyncio.StreamReader, cwriter: asyncio.StreamWriter,
+    ) -> None:
+        conn = await self._validate_and_connect(host, port)
+        if conn is None:
+            self.blocked_count += 1
+            await self._refuse(cwriter, "403 Forbidden", "blocked by SSRF policy")
+            return
+        rreader, rwriter = conn
+        try:
+            # Rewrite the absolute-form request line to origin-form and forward.
+            rwriter.write(f"{method} {path} {request_line[2]}\r\n".encode("latin-1"))
+            await rwriter.drain()
+            await asyncio.gather(
+                self._pipe(creader, rwriter),
+                self._pipe(rreader, cwriter),
+            )
+        finally:
+            for w in (rwriter, cwriter):
+                try:
+                    w.close()
+                except Exception:
+                    pass
+
+    async def _pipe(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        """Copy reader→writer with backpressure (drain) + half-close on EOF."""
+        try:
+            while True:
+                chunk = await reader.read(_PIPE_CHUNK)
+                if not chunk:
+                    break
+                writer.write(chunk)
+                await writer.drain()  # backpressure — bound memory on big segments
+        except (ConnectionError, asyncio.IncompleteReadError, asyncio.CancelledError):
+            raise
+        except Exception:  # pragma: no cover - defensive
+            pass
+        finally:
+            # Half-close: signal EOF downstream so the peer's read loop ends.
+            try:
+                if writer.can_write_eof():
+                    writer.write_eof()
+            except Exception:
+                pass
+
+    async def _refuse(
+        self, writer: asyncio.StreamWriter, status: str, reason: str
+    ) -> None:
+        try:
+            body = f"SSRF proxy refused: {reason}".encode("latin-1", "replace")
+            writer.write(
+                f"HTTP/1.1 {status}\r\n"
+                f"Content-Length: {len(body)}\r\n"
+                f"Connection: close\r\n\r\n".encode("latin-1")
+                + body
+            )
+            await writer.drain()
+        except Exception:
+            pass
+        finally:
+            try:
+                writer.close()
+            except Exception:
+                pass

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -277,6 +277,55 @@ def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     return False
 
 
+def ip_is_blocked(ip_str: str, *, block_private: bool) -> bool:
+    """Return True if a resolved IP must be refused for SSRF protection.
+
+    The single SSRF policy source reused by the yt-dlp egress proxy so it never
+    defines its own IP ranges. Composes the always-blocked cloud-metadata /
+    link-local floor (enforced regardless of ``block_private``) with the private/
+    loopback/CGNAT check (enforced only when ``block_private`` is True).
+
+    Fails CLOSED: an unparseable / empty string returns True (blocked), never
+    allow-through — a resolver that hands us garbage must not become a bypass.
+
+    Args:
+        ip_str: a resolved IP literal (IPv4, IPv6, or IPv4-mapped IPv6).
+        block_private: when True, also block RFC1918/loopback/link-local/
+            reserved/multicast/unspecified/CGNAT (the full ``_is_blocked_ip``
+            policy). When False, only the always-blocked metadata floor applies.
+
+    Returns:
+        True if the IP should be refused, False if it may be connected to.
+    """
+    try:
+        ip = ipaddress.ip_address(ip_str.strip())
+    except (ValueError, AttributeError):
+        # Not a parseable IP — fail closed.
+        return True
+
+    # Always-blocked floor: cloud metadata IPs + link-local ranges. This mirrors
+    # the checks in is_safe_url()/is_always_blocked_url() and fires regardless of
+    # the block_private flag or any config toggle. Normalize IPv4-mapped IPv6 so
+    # ::ffff:169.254.169.254 is judged by its embedded IPv4 address.
+    check_ip = ip
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        check_ip = ip.ipv4_mapped
+
+    if check_ip in _ALWAYS_BLOCKED_IPS or any(
+        check_ip in net for net in _ALWAYS_BLOCKED_NETWORKS
+    ):
+        return True
+    # Also honor the mapped-form entries directly (belt-and-suspenders for the
+    # ::ffff: literals kept in the always-blocked sets).
+    if ip in _ALWAYS_BLOCKED_IPS or any(ip in net for net in _ALWAYS_BLOCKED_NETWORKS):
+        return True
+
+    if block_private and _is_blocked_ip(ip):
+        return True
+
+    return False
+
+
 def is_always_blocked_url(url: str) -> bool:
     """Return True when the URL targets an always-blocked endpoint.
 

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -36,6 +36,7 @@ from concurrent.futures import ThreadPoolExecutor
 import logging
 import os
 import uuid
+import tempfile
 from pathlib import Path
 from typing import Any, Awaitable, Dict, Optional
 from urllib.parse import urlparse
@@ -1716,6 +1717,47 @@ def _ytdlp_available() -> bool:
     return shutil.which("yt-dlp") is not None
 
 
+def _make_ffmpeg_block_shim(parent_dir: Path) -> str:
+    """Create a shim bin dir whose ffmpeg/ffprobe/aria2c immediately fail.
+
+    Prepended to the child PATH when the SSRF proxy is active so a format that
+    would force an EXTERNAL (proxy-ignoring) fetch fails CLOSED — the shim
+    binaries exit non-zero, so yt-dlp cannot use ffmpeg/aria2c to egress
+    un-proxied. Unlike stripping whole PATH directories, this leaves every other
+    executable (deno/node — yt-dlp's JS-challenge solvers, git, etc.) reachable
+    on the real PATH. yt-dlp's own native downloader needs none of the shimmed
+    tools for a progressive/single-file format.
+
+    Returns the shim directory path (to be prepended to PATH).
+    """
+    shim = parent_dir / "nofetch-bin"
+    shim.mkdir(parents=True, exist_ok=True)
+    for name in ("ffmpeg", "ffprobe", "aria2c"):
+        p = shim / name
+        p.write_text(
+            "#!/bin/sh\n"
+            "echo 'blocked by SSRF proxy: external downloaders are disabled' >&2\n"
+            "exit 127\n"
+        )
+        p.chmod(0o755)
+    return str(shim)
+
+
+def _ssrf_proxy_enabled() -> bool:
+    """Whether to route yt-dlp through the in-process SSRF-filtering proxy.
+
+    Config key auxiliary.vision.ytdlp_ssrf_proxy (bool). DEFAULT FALSE in v0.1:
+    the proxy is opt-in until proven across representative extractors, because
+    default-ON + fail-closed would break every page-URL fetch on any
+    proxy/extractor incompatibility. Read through the real config loader (not an
+    env var) so the namespace matches where video_analyze reads its config.
+    """
+    val = _cfg_get_safe("auxiliary", "vision", "ytdlp_ssrf_proxy", default="")
+    if isinstance(val, bool):
+        return val
+    return str(val).strip().lower() in ("1", "true", "yes", "on")
+
+
 def _ytdlp_cookie_args() -> list:
     """Return yt-dlp cookie args, reusing the fleet cookies jar when available.
 
@@ -1750,7 +1792,6 @@ async def _download_video_via_ytdlp(url: str, dest_dir: Path) -> Path:
     site. Caps resolution + filesize so the base64 payload stays under the API
     limit; falls back to grabbing the first 3 minutes for long videos.
     """
-    import shutil
     dest_dir.mkdir(parents=True, exist_ok=True)
     out_tmpl = str(dest_dir / f"ytdl_{uuid.uuid4().hex}.%(ext)s")
     # Single progressive file (no merge -> no hard ffmpeg dependency), <=480p.
@@ -1767,12 +1808,45 @@ async def _download_video_via_ytdlp(url: str, dest_dir: Path) -> Path:
     cookie_args = _ytdlp_cookie_args()
     base += cookie_args
 
-    def _run(extra):
+    # --- SSRF egress proxy (opt-in, default OFF) ---------------------------
+    # When enabled, route EVERY yt-dlp connection (initial fetch, redirects,
+    # sub-resources) through an in-process SSRF-filtering proxy so a page URL
+    # that redirects to an internal/metadata address is blocked at each hop.
+    # yt-dlp hands some segment/merge fetches to ffmpeg/aria2c which do NOT
+    # honor the CONNECT proxy, so we ALSO (a) force --downloader native and
+    # (b) strip ffmpeg/ffprobe/aria2c from the child PATH → a format that would
+    # force an external fetch fails closed instead of egressing un-proxied.
+    use_proxy = _ssrf_proxy_enabled()
+
+    def _child_env(proxy_url, shim_dir=None):
+        env = dict(os.environ)
+        if proxy_url:
+            env["HTTP_PROXY"] = proxy_url
+            env["HTTPS_PROXY"] = proxy_url
+            env["http_proxy"] = proxy_url
+            env["https_proxy"] = proxy_url
+            env["ALL_PROXY"] = proxy_url  # belt-only; HTTP(S)_PROXY are load-bearing
+            env.pop("NO_PROXY", None)
+            env.pop("no_proxy", None)
+            # Prepend a shim dir whose ffmpeg/ffprobe/aria2c fail, so a
+            # required-external fetch ERRORS (fails closed) rather than silently
+            # egressing un-proxied — while leaving deno/node (yt-dlp's JS
+            # challenge solvers) and everything else on the real PATH reachable.
+            if shim_dir:
+                env["PATH"] = shim_dir + os.pathsep + env.get("PATH", "")
+        return env
+
+    def _run(extra, proxy_url=None, shim_dir=None):
         import subprocess
+        argv = list(base)
+        if proxy_url:
+            argv += ["--proxy", proxy_url, "--downloader", "native"]
+        argv += extra + [url]
         proc = subprocess.run(
-            base + extra + [url],
+            argv,
             stdin=subprocess.DEVNULL,
             capture_output=True, text=True, timeout=180,
+            env=_child_env(proxy_url, shim_dir),
         )
         return proc
 
@@ -1797,31 +1871,43 @@ async def _download_video_via_ytdlp(url: str, dest_dir: Path) -> Path:
 
     import subprocess as _sp
 
-    async def _run_safe(extra):
+    async def _run_safe(extra, proxy_url=None, shim_dir=None):
         # yt-dlp timing out raises TimeoutExpired instead of returning a proc.
         # Never let that escape with partials still on disk — always clean.
         try:
-            return await asyncio.to_thread(_run, extra), None
+            return await asyncio.to_thread(_run, extra, proxy_url, shim_dir), None
         except _sp.TimeoutExpired as e:
             _clean_partials()
             return None, e
 
-    proc = None
-    try:
-        # Attempt 1: whole video within the 35M cap.
-        proc, err = await _run_safe([])
-        got = _find_output()
-        if got is None:
-            _clean_partials()
-            # Attempt 2: first 3 minutes (helps long talks that blow the cap).
-            # KEEP the 35M cap here too — a section download can still exceed
-            # the base64 payload limit at high bitrate — and force an mp4 remux
-            # so the section is finalized (not left as a .part).
-            proc, err = await _run_safe(
-                ["--download-sections", "*0-180", "--force-keyframes-at-cuts",
-                 "--remux-video", "mp4"],
-            )
+    async def _do_download(proxy_url, proxy):
+        # With the proxy on, ffmpeg is shimmed to fail (fail-closed), so DON'T
+        # use --remux-video/--force-keyframes-at-cuts (they need ffmpeg). Native
+        # section download still finalizes an mp4 for a progressive format.
+        shim_parent = Path(tempfile.mkdtemp(prefix="ssrf_shim_")) if proxy_url else None
+        shim_dir = _make_ffmpeg_block_shim(shim_parent) if shim_parent else None
+        try:
+            proc, err = await _run_safe([], proxy_url, shim_dir)
             got = _find_output()
+            if got is None:
+                _clean_partials()
+                if proxy_url:
+                    # Proxied path is ffmpeg-free (shim blocks it), so a
+                    # --download-sections fallback (which needs ffmpeg) can't run.
+                    # Instead retry with a smaller progressive format that fits
+                    # the 35M cap — still a single native download, no ffmpeg.
+                    fallback = ["-f", "b[height<=240][ext=mp4]/w[ext=mp4]/w",
+                                "--max-filesize", "35M"]
+                else:
+                    # Un-proxied path may use ffmpeg for a finalized 3-min section.
+                    fallback = ["--download-sections", "*0-180",
+                                "--force-keyframes-at-cuts", "--remux-video", "mp4"]
+                proc, err = await _run_safe(fallback, proxy_url, shim_dir)
+                got = _find_output()
+        finally:
+            if shim_parent is not None:
+                import shutil as _shutil
+                _shutil.rmtree(shim_parent, ignore_errors=True)
         if got is None:
             _clean_partials()
             stderr = (proc.stderr or "").strip()[:300] if proc is not None else "timed out"
@@ -1829,7 +1915,31 @@ async def _download_video_via_ytdlp(url: str, dest_dir: Path) -> Path:
                 "yt-dlp could not fetch a compact video from this URL. "
                 f"stderr: {stderr}"
             )
+        # Post-run runtime guard: with the proxy on, if bytes reached disk but
+        # ~0 connections traversed the proxy, an external downloader egressed
+        # un-proxied — fail closed rather than return an unvalidated file.
+        if proxy is not None and proxy.connection_count <= 0:
+            _clean_partials()
+            try:
+                got.unlink()
+            except Exception:
+                pass
+            raise ValueError(
+                "SSRF proxy guard: video bytes were fetched but no connection "
+                "traversed the proxy (an external downloader likely bypassed it). "
+                "Refusing to return an unvalidated file."
+            )
         return got
+
+    try:
+        if use_proxy:
+            from tools.ssrf_proxy import SsrfFilteringProxy
+            # Fail CLOSED: if the proxy can't start, raise — never run un-proxied.
+            proxy = SsrfFilteringProxy(block_private=True)
+            async with proxy as proxy_url:
+                return await _do_download(proxy_url, proxy)
+        else:
+            return await _do_download(None, None)
     except BaseException:
         # Any failure path (incl. cancellation): don't leak partials.
         _clean_partials()

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1627,6 +1627,191 @@ async def _download_video(video_url: str, destination: Path, max_retries: int = 
     raise last_error
 
 
+# --- Video source ingestion + video-capable provider routing -----------------
+#
+# Two bugs this block fixes:
+#  (1) The generic vision router (task="vision") tries the user's MAIN provider
+#      first. A provider can accept IMAGES but reject a `video_url` content
+#      block (Anthropic/Claude -> 400 "Input tag 'video' ... does not match").
+#      Video is a strict subset of vision backends (Gemini family today), so we
+#      resolve one explicitly instead of letting auto pick the main provider.
+#  (2) Non-direct URLs (YouTube, X/Twitter, Vimeo, TikTok, ...) are not raw
+#      video files, so a plain HTTP GET can't fetch them. Use yt-dlp.
+
+_VIDEO_CAPABLE_PROVIDER_ORDER = ("openrouter", "nous")
+_VIDEO_CAPABLE_MAIN_PROVIDERS = {
+    "gemini", "google", "google-gemini", "google-ai-studio",
+}
+_VIDEO_PROVIDER_DEFAULT_MODELS = {
+    "openrouter": "google/gemini-3-flash-preview",
+    "nous": "google/gemini-3-flash-preview",
+    "gemini": "gemini-3-flash-preview",
+    "google": "gemini-3-flash-preview",
+}
+
+
+def _cfg_get_safe(*path: str, default: str = "") -> str:
+    try:
+        from hermes_cli.config import load_config, cfg_get
+        return cfg_get(load_config(), *path, default=default)
+    except Exception:
+        return default
+
+
+def _resolve_video_provider_model(explicit_model: Optional[str] = None):
+    """Return (provider, model) for a video-capable backend.
+
+    Order: explicit config override -> video-capable main provider ->
+    first video-capable aggregator with working credentials. Returns
+    (None, explicit_model) if none resolve, so the caller can still try.
+    """
+    # 1. Operator override in config (auxiliary.vision.video_provider/model).
+    ov_provider = (_cfg_get_safe("auxiliary", "vision", "video_provider") or "").strip()
+    ov_model = (_cfg_get_safe("auxiliary", "vision", "video_model") or "").strip()
+    if ov_provider:
+        model = explicit_model or ov_model or _VIDEO_PROVIDER_DEFAULT_MODELS.get(ov_provider)
+        return ov_provider, model
+
+    # 2. Main provider, only when it's a known Gemini-family (video) backend.
+    main_provider = (_cfg_get_safe("model", "provider") or "").strip().lower()
+    if main_provider in _VIDEO_CAPABLE_MAIN_PROVIDERS:
+        main_model = (_cfg_get_safe("model", "default") or "").strip()
+        # strip a leading "provider/" prefix if present
+        if "/" in main_model:
+            main_model = main_model.split("/", 1)[1]
+        model = explicit_model or main_model or _VIDEO_PROVIDER_DEFAULT_MODELS.get(main_provider)
+        return main_provider, model
+
+    # 3. Auto: first video-capable aggregator whose client resolves.
+    try:
+        from agent.auxiliary_client import resolve_vision_provider_client
+    except Exception:
+        resolve_vision_provider_client = None
+    if resolve_vision_provider_client is not None:
+        for prov in _VIDEO_CAPABLE_PROVIDER_ORDER:
+            default_model = _VIDEO_PROVIDER_DEFAULT_MODELS.get(prov)
+            try:
+                _prov, client, final_model = resolve_vision_provider_client(
+                    provider=prov, model=explicit_model or default_model,
+                )
+            except Exception:
+                client, final_model = None, None
+            if client is not None:
+                return prov, (explicit_model or final_model or default_model)
+
+    return None, explicit_model
+
+
+def _is_direct_video_url(url: str) -> bool:
+    """True when the URL path ends in a known direct video extension."""
+    try:
+        p = urlparse(url).path.lower()
+    except Exception:
+        return False
+    return any(p.endswith(ext) for ext in _VIDEO_MIME_TYPES)
+
+
+def _ytdlp_available() -> bool:
+    import shutil
+    return shutil.which("yt-dlp") is not None
+
+
+def _ytdlp_cookie_args() -> list:
+    """Return yt-dlp cookie args, reusing the fleet cookies jar when available.
+
+    Resolution order:
+      1. auxiliary.vision.ytdlp_cookies (config) or YTNB_YTDLP_COOKIES (env)
+         -> --cookies <file>
+      2. auxiliary.vision.ytdlp_cookies_from_browser / YTNB_YTDLP_COOKIES_FROM_BROWSER
+         -> --cookies-from-browser <name>
+      3. ~/yt.cookies.txt (the fleet's canonical, cron-refreshed jar)
+    """
+    # 1. explicit cookies file
+    cfile = (_cfg_get_safe("auxiliary", "vision", "ytdlp_cookies")
+             or os.environ.get("YTNB_YTDLP_COOKIES") or "").strip()
+    if cfile and Path(os.path.expanduser(cfile)).is_file():
+        return ["--cookies", os.path.expanduser(cfile)]
+    # 2. cookies from a browser profile
+    cbrowser = (_cfg_get_safe("auxiliary", "vision", "ytdlp_cookies_from_browser")
+                or os.environ.get("YTNB_YTDLP_COOKIES_FROM_BROWSER") or "").strip()
+    if cbrowser:
+        return ["--cookies-from-browser", cbrowser]
+    # 3. fleet default jar
+    default_jar = Path(os.path.expanduser("~/yt.cookies.txt"))
+    if default_jar.is_file():
+        return ["--cookies", str(default_jar)]
+    return []
+
+
+async def _download_video_via_ytdlp(url: str, dest_dir: Path) -> Path:
+    """Fetch a compact (<=480p, size-capped) mp4 for a non-direct URL via yt-dlp.
+
+    Handles YouTube, X/Twitter, Vimeo, TikTok and any other yt-dlp-supported
+    site. Caps resolution + filesize so the base64 payload stays under the API
+    limit; falls back to grabbing the first 3 minutes for long videos.
+    """
+    import shutil
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    out_tmpl = str(dest_dir / f"ytdl_{uuid.uuid4().hex}.%(ext)s")
+    # Single progressive file (no merge -> no hard ffmpeg dependency), <=480p.
+    fmt = "b[height<=480][ext=mp4]/b[ext=mp4]/b[height<=480]/b"
+    base = [
+        "yt-dlp", "-q", "--no-warnings", "--no-playlist",
+        "-f", fmt, "--max-filesize", "45M",
+        "-o", out_tmpl,
+    ]
+    # Cookie support: many sites (YouTube especially) gate anonymous fetches
+    # behind a "confirm you're not a bot" wall. Reuse the fleet cookies jar
+    # (refreshed by the yt-cookies-refresh cron) when present.
+    cookie_args = _ytdlp_cookie_args()
+    base += cookie_args
+
+    def _run(extra):
+        import subprocess
+        proc = subprocess.run(base + extra + [url], capture_output=True, text=True, timeout=180)
+        return proc
+
+    def _find_output():
+        stem = Path(out_tmpl.replace(".%(ext)s", "")).name
+        matches = [
+            p for p in sorted(dest_dir.glob(stem + ".*"))
+            # Only completed video files — skip yt-dlp partial/temp artifacts
+            # (.part, .ytdl, .f<id> fragment files, etc.).
+            if p.suffix.lower() in _VIDEO_MIME_TYPES
+        ]
+        return matches[0] if matches else None
+
+    def _clean_partials():
+        stem = Path(out_tmpl.replace(".%(ext)s", "")).name
+        for p in dest_dir.glob(stem + ".*"):
+            if p.suffix.lower() not in _VIDEO_MIME_TYPES:
+                try:
+                    p.unlink()
+                except Exception:
+                    pass
+
+    # Attempt 1: whole video within caps.
+    proc = await asyncio.to_thread(_run, [])
+    got = _find_output()
+    if got is None:
+        _clean_partials()
+        # Attempt 2: first 3 minutes (helps long talks that blow the size cap).
+        # Drop the size cap here — 3 min @ <=480p is small — and force an mp4
+        # remux so the section is finalized (not left as a .part).
+        proc = await asyncio.to_thread(
+            _run,
+            ["--download-sections", "*0-180", "--force-keyframes-at-cuts",
+             "--remux-video", "mp4"],
+        )
+        got = _find_output()
+    if got is None:
+        raise ValueError(
+            "yt-dlp could not fetch a compact video from this URL. "
+            f"stderr: {(proc.stderr or '').strip()[:300]}"
+        )
+    return got
+
+
 async def video_analyze_tool(
     video_url: str,
     user_prompt: str,
@@ -1671,14 +1856,27 @@ async def video_analyze_tool(
             logger.info("Using local video file: %s", video_url)
             temp_video_path = local_path
             should_cleanup = False
-        elif await _validate_image_url_async(video_url):
+        elif resolved_url.startswith(("http://", "https://")):
             blocked = check_website_access(video_url)
             if blocked:
                 raise PermissionError(blocked["message"])
             temp_dir = get_hermes_dir("cache/video", "temp_video_files")
-            temp_video_path = temp_dir / f"temp_video_{uuid.uuid4()}.mp4"
-            await _download_video(video_url, temp_video_path)
-            should_cleanup = True
+            if _is_direct_video_url(resolved_url) and await _validate_image_url_async(video_url):
+                # Direct video-file URL: fetch bytes over HTTP.
+                temp_video_path = temp_dir / f"temp_video_{uuid.uuid4()}.mp4"
+                await _download_video(video_url, temp_video_path)
+                should_cleanup = True
+            elif _ytdlp_available():
+                # Page URL (YouTube, X, Vimeo, TikTok, ...): extract via yt-dlp.
+                logger.info("Non-direct video URL — fetching via yt-dlp")
+                temp_video_path = await _download_video_via_ytdlp(resolved_url, temp_dir)
+                should_cleanup = True
+            else:
+                raise ValueError(
+                    "This looks like a page URL (e.g. YouTube), not a direct video "
+                    "file, and yt-dlp is not installed. Install yt-dlp or pass a "
+                    "direct video-file URL / local path."
+                )
         else:
             raise ValueError(
                 "Invalid video source. Provide an HTTP/HTTPS URL or a valid local file path."
@@ -1750,8 +1948,21 @@ async def video_analyze_tool(
             "max_tokens": 4000,
             "timeout": vision_timeout,
         }
-        if model:
+        # Video is only accepted by a subset of vision backends (Gemini family).
+        # Resolve one explicitly so the router does not pick the main provider
+        # (e.g. Claude), which accepts images but rejects video_url blocks.
+        video_provider, video_model = _resolve_video_provider_model(model)
+        if video_provider:
+            call_kwargs["provider"] = video_provider
+        if video_model:
+            call_kwargs["model"] = video_model
+        elif model:
             call_kwargs["model"] = model
+        debug_call_data["model_used"] = video_model or model
+        logger.info(
+            "Video routing: provider=%s model=%s",
+            video_provider or "auto", video_model or model or "auto",
+        )
 
         response = await async_call_llm(**call_kwargs)
         analysis = extract_content_or_reasoning(response)

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1795,27 +1795,45 @@ async def _download_video_via_ytdlp(url: str, dest_dir: Path) -> Path:
                 except Exception:
                     pass
 
-    # Attempt 1: whole video within caps.
-    proc = await asyncio.to_thread(_run, [])
-    got = _find_output()
-    if got is None:
-        _clean_partials()
-        # Attempt 2: first 3 minutes (helps long talks that blow the size cap).
-        # Drop the size cap here — 3 min @ <=480p is small — and force an mp4
-        # remux so the section is finalized (not left as a .part).
-        proc = await asyncio.to_thread(
-            _run,
-            ["--download-sections", "*0-180", "--force-keyframes-at-cuts",
-             "--remux-video", "mp4"],
-        )
+    import subprocess as _sp
+
+    async def _run_safe(extra):
+        # yt-dlp timing out raises TimeoutExpired instead of returning a proc.
+        # Never let that escape with partials still on disk — always clean.
+        try:
+            return await asyncio.to_thread(_run, extra), None
+        except _sp.TimeoutExpired as e:
+            _clean_partials()
+            return None, e
+
+    proc = None
+    try:
+        # Attempt 1: whole video within the 35M cap.
+        proc, err = await _run_safe([])
         got = _find_output()
-    if got is None:
+        if got is None:
+            _clean_partials()
+            # Attempt 2: first 3 minutes (helps long talks that blow the cap).
+            # KEEP the 35M cap here too — a section download can still exceed
+            # the base64 payload limit at high bitrate — and force an mp4 remux
+            # so the section is finalized (not left as a .part).
+            proc, err = await _run_safe(
+                ["--download-sections", "*0-180", "--force-keyframes-at-cuts",
+                 "--remux-video", "mp4"],
+            )
+            got = _find_output()
+        if got is None:
+            _clean_partials()
+            stderr = (proc.stderr or "").strip()[:300] if proc is not None else "timed out"
+            raise ValueError(
+                "yt-dlp could not fetch a compact video from this URL. "
+                f"stderr: {stderr}"
+            )
+        return got
+    except BaseException:
+        # Any failure path (incl. cancellation): don't leak partials.
         _clean_partials()
-        raise ValueError(
-            "yt-dlp could not fetch a compact video from this URL. "
-            f"stderr: {(proc.stderr or '').strip()[:300]}"
-        )
-    return got
+        raise
 
 
 async def video_analyze_tool(
@@ -1874,6 +1892,16 @@ async def video_analyze_tool(
                 should_cleanup = True
             elif _ytdlp_available():
                 # Page URL (YouTube, X, Vimeo, TikTok, ...): extract via yt-dlp.
+                # SSRF guard: resolve DNS/IP and reject private/internal targets
+                # BEFORE handing the URL to yt-dlp (mirrors the direct-download
+                # path's _validate_image_url_async, minus the image-shape check
+                # that a page URL would fail). Blocks e.g. cloud metadata IPs.
+                from tools.url_safety import async_is_safe_url
+                if not await async_is_safe_url(resolved_url):
+                    raise PermissionError(
+                        "Refusing to fetch video from a private/internal or "
+                        "unresolvable address."
+                    )
                 logger.info("Non-direct video URL — fetching via yt-dlp")
                 temp_video_path = await _download_video_via_ytdlp(resolved_url, temp_dir)
                 should_cleanup = True

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1768,7 +1768,11 @@ async def _download_video_via_ytdlp(url: str, dest_dir: Path) -> Path:
 
     def _run(extra):
         import subprocess
-        proc = subprocess.run(base + extra + [url], capture_output=True, text=True, timeout=180)
+        proc = subprocess.run(
+            base + extra + [url],
+            stdin=subprocess.DEVNULL,
+            capture_output=True, text=True, timeout=180,
+        )
         return proc
 
     def _find_output():

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1757,7 +1757,8 @@ async def _download_video_via_ytdlp(url: str, dest_dir: Path) -> Path:
     fmt = "b[height<=480][ext=mp4]/b[ext=mp4]/b[height<=480]/b"
     base = [
         "yt-dlp", "-q", "--no-warnings", "--no-playlist",
-        "-f", fmt, "--max-filesize", "45M",
+        # 35M raw keeps the ~1.37x base64 data-URL under _MAX_VIDEO_BASE64_BYTES (50M).
+        "-f", fmt, "--max-filesize", "35M",
         "-o", out_tmpl,
     ]
     # Cookie support: many sites (YouTube especially) gate anonymous fetches
@@ -1809,6 +1810,7 @@ async def _download_video_via_ytdlp(url: str, dest_dir: Path) -> Path:
         )
         got = _find_output()
     if got is None:
+        _clean_partials()
         raise ValueError(
             "yt-dlp could not fetch a compact video from this URL. "
             f"stderr: {(proc.stderr or '').strip()[:300]}"


### PR DESCRIPTION
Reopens #59451 (auto-closed when its shared head branch was deleted after the fork merge — not a withdrawal).

Adds an in-process SSRF-filtering forward proxy so yt-dlp's own fetches (page, player JS, manifest, segments) and redirects are validated per-hop, closing the redirect-time SSRF hole where a page URL could redirect to an internal/cloud-metadata address unchecked. Opt-in via `auxiliary.vision.ytdlp_ssrf_proxy` (default OFF). CONNECT-by-IP (no TLS MITM), connect-to-validated-IP (TOCTOU-safe), single policy source (`url_safety.ip_is_blocked`), fail-closed (proxy start failure raises; external downloaders shimmed to fail-closed; post-run traffic guard). 179 tests + a live YouTube E2E through the proxy. See the fork PR Kyzcreig/hermes-agent#211 (merged).