### PR TITLE
feat: add configurable cyclic system-reminder injection engine

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -467,6 +467,11 @@ def init_agent(
     agent._pending_steer: Optional[str] = None
     agent._pending_steer_lock = threading.Lock()
 
+    # ── System-reminder engine (cyclic reminder injection) ──────────
+    # Initialised here with a sentinel None; the real engine is built
+    # in the config-read section below when _agent_cfg is available.
+    agent._system_reminder_engine = None  # type: ignore[assignment]
+
     # Concurrent-tool worker thread tracking.  `_execute_tool_calls_concurrent`
     # runs each tool on its own ThreadPoolExecutor worker — those worker
     # threads have tids distinct from `_execution_thread_id`, so
@@ -1251,6 +1256,30 @@ def init_agent(
                 agent._memory_store.load_from_disk()
         except Exception:
             pass  # Memory is optional -- don't break agent init
+
+    # ── System-reminder engine (cyclic reminder injection) ──────────────
+    # Reads system_reminder section from config.yaml:
+    #   system_reminder:
+    #     enabled: true
+    #     cadence: 5         # every N tool calls
+    #     position: last_user
+    #     blocks:
+    #       - id: my-reminder
+    #         content: "<system-reminder>...</system-reminder>"
+    try:
+        sr_cfg = _agent_cfg.get("system_reminder", {})
+        if sr_cfg.get("enabled", True):
+            from agent.system_reminder_engine import SystemReminderEngine
+
+            sr_blocks = sr_cfg.get("blocks", None)
+            agent._system_reminder_engine = SystemReminderEngine(
+                enabled=True,
+                cadence=sr_cfg.get("cadence", 5),
+                blocks=sr_blocks,
+                position=sr_cfg.get("position", "last_user"),
+            )
+    except Exception:
+        pass  # System reminders are optional -- don't break agent init
     
 
 

--- a/agent/system_reminder_engine.py
+++ b/agent/system_reminder_engine.py
@@ -1,0 +1,281 @@
+"""Cyclic system-reminder injection engine.
+
+Injects configurable ``<system-reminder>`` blocks into the tool-result stream
+on a tool-call cadence.  Designed to coexist with ``/steer`` — the steer
+injection fires once per user request; this engine fires on a counter-based
+cadence across tool calls.
+
+Design invariants (see AGENTS.md):
+- Does NOT mutate past context — only appends to the most recent tool
+  result in the current batch, same as ``/steer``.
+- Does NOT break role alternation — reminders are appended to existing
+  tool-role messages, never inserted as new synthetic messages.
+- Does NOT make an API call — zero network, zero file I/O.
+- Does NOT depend on AIAgent internals beyond what's documented on the
+  ``agent`` parameter to ``maybe_inject()``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ── Default block definitions ──────────────────────────────────────────
+
+DEFAULT_REMINDER_BLOCKS: List[Dict[str, str]] = [
+    {
+        "id": "tool-use-enforcement",
+        "content": (
+            "<system-reminder>\n"
+            "You have access to tools for web search, terminal, file "
+            "operations, and more.  When the user asks a question that "
+            "requires up-to-date information, use web_search instead of "
+            "relying on your training data.  Use terminal for system tasks, "
+            "read_file for examining files, and write_file for creating them.\n"
+            "</system-reminder>"
+        ),
+    },
+    {
+        "id": "task-completion",
+        "content": (
+            "<system-reminder>\n"
+            "Task completion guidance: when you finish the user's task, "
+            "provide a clear summary of what was done, list the artifacts "
+            "you created or modified with their absolute paths, and note "
+            "any decisions or trade-offs made during implementation.\n"
+            "</system-reminder>"
+        ),
+    },
+    {
+        "id": "memory-usage",
+        "content": (
+            "<system-reminder>\n"
+            "You have persistent memory across sessions.  Save durable "
+            "facts using the memory tool: user preferences, environment "
+            "details, tool quirks, and stable conventions.  Do NOT save "
+            "task progress, session outcomes, or temporary TODO state.\n"
+            "</system-reminder>"
+        ),
+    },
+    {
+        "id": "file-delivery",
+        "content": (
+            "<system-reminder>\n"
+            "File delivery: when the user asks you to build, run, or "
+            "verify something, the deliverable is a working artifact backed "
+            "by real tool output — not a description of one.  Keep working "
+            "until you have actually exercised the code or produced the "
+            "requested result.\n"
+            "</system-reminder>"
+        ),
+    },
+    {
+        "id": "kanban-lifecycle",
+        "content": (
+            "<system-reminder>\n"
+            "Kanban task lifecycle: orient with kanban_show() → work inside "
+            "workspace → heartbeat on long ops → block on ambiguity → "
+            "complete with structured handoff.  Do NOT complete a task you "
+            "didn't actually finish — block it instead.\n"
+            "</system-reminder>"
+        ),
+    },
+]
+
+
+class SystemReminderEngine:
+    """Cyclic reminder injection engine.
+
+    Parameters
+    ----------
+    enabled : bool
+        Master on/off switch.  When False, ``should_inject()`` always
+        returns False and ``build_reminder()`` returns None.
+    cadence : int
+        Inject a reminder every *N* tool calls.  Default 5.
+    blocks : list[dict]
+        List of reminder block dicts, each with ``id`` and ``content``
+        keys.  The engine cycles through them on each injection tick.
+    position : str
+        Where to inject: ``"last_user"`` (appends to the most recent
+        user message), ``"new_user"`` (new user-role message), or
+        ``"assistant_prefix"`` (prepended to the next assistant turn).
+    """
+
+    def __init__(
+        self,
+        enabled: bool = True,
+        cadence: int = 5,
+        blocks: Optional[List[Dict[str, str]]] = None,
+        position: str = "last_user",
+    ) -> None:
+        self.enabled = enabled
+        self.cadence = max(1, cadence)  # guard against zero / negative
+        self.blocks: List[Dict[str, str]] = (
+            list(blocks) if blocks is not None else list(DEFAULT_REMINDER_BLOCKS)
+        )
+        self.position = position
+        self._counter = 0
+        self._block_index = 0
+
+    # ── Public API ────────────────────────────────────────────────────
+
+    def should_inject(self) -> bool:
+        """Check whether it's time to inject a reminder.
+
+        Call after each tool result has been appended.  Returns True
+        when the tool-call counter has reached the cadence threshold.
+
+        Thread-safety: the engine is typically called from a single
+        thread (the tool-executor loop).  If called from multiple
+        threads, the caller must hold a lock around both the
+        ``should_inject() -> build_reminder()`` pair.
+        """
+        if not self.enabled or not self.blocks:
+            return False
+        self._counter += 1
+        if self._counter >= self.cadence:
+            self._counter = 0
+            return True
+        return False
+
+    def build_reminder(self) -> Optional[Dict[str, Any]]:
+        """Build the next reminder content block.
+
+        Returns a dict with keys ``content`` (str) and, for the
+        ``"last_user"`` position, ``action`` (``"append_to_last_user"``).
+        Returns None when disabled or no blocks are configured.
+
+        The return value is designed to be consumed by the
+        ``agent_inject_system_reminder()`` module-level function,
+        not interpreted by the caller directly.
+        """
+        if not self.enabled or not self.blocks:
+            return None
+        block = self.blocks[self._block_index % len(self.blocks)]
+        self._block_index += 1
+        content = block["content"]
+
+        if self.position == "last_user":
+            return {"action": "append_to_last_user", "content": "\n\n" + content}
+        elif self.position == "new_user":
+            return {"role": "user", "content": content}
+        else:  # assistant_prefix
+            return {"action": "assistant_prefix", "content": content}
+
+    def maybe_inject(self) -> Optional[Dict[str, Any]]:
+        """Convenience: ``should_inject()`` + ``build_reminder()`` in one call.
+
+        Thread-safety: same as calling the two methods separately —
+        NOT atomic across threads.
+        """
+        if self.should_inject():
+            return self.build_reminder()
+        return None
+
+    # ── State helpers ─────────────────────────────────────────────────
+
+    def reset_counter(self) -> None:
+        """Reset the tool-call counter (e.g. after a user message)."""
+        self._counter = 0
+
+    @property
+    def state(self) -> Dict[str, Any]:
+        """Serialisable snapshot for logging / diagnostics."""
+        return {
+            "enabled": self.enabled,
+            "cadence": self.cadence,
+            "num_blocks": len(self.blocks),
+            "position": self.position,
+            "counter": self._counter,
+            "block_index": self._block_index,
+            "next_block_id": (
+                self.blocks[self._block_index % len(self.blocks)]["id"]
+                if self.blocks
+                else None
+            ),
+        }
+
+
+# ── Injection helper (consumed by tool_executor.py) ────────────────────
+
+
+def agent_inject_system_reminder(
+    agent: Any,
+    messages: list,
+    num_tool_msgs: int = 0,
+) -> None:
+    """Check the agent's ``_system_reminder_engine`` and inject if due.
+
+    Designed to be called from ``tool_executor.py`` in the same spots
+    where ``/steer`` is injected:
+
+    * After each individual tool result is appended (per-tool drain).
+    * After the final tool result of a batch (batch drain).
+
+    The injection appends to the last ``role:"tool"`` message's content
+    (same pattern as ``/steer``) so role alternation is preserved.
+
+    Parameters
+    ----------
+    agent:
+        The AIAgent instance.  Must have a ``_system_reminder_engine``
+        attribute (set by ``agent_init.py``).
+    messages:
+        The running messages list.  Modified in-place when a reminder
+        is injected.
+    num_tool_msgs:
+        Number of tool-result messages appended in this batch.  Used to
+        locate the last tool-role message safely.  Pass 0 to skip.
+    """
+    if num_tool_msgs <= 0 or not messages:
+        return
+    engine: Optional[SystemReminderEngine] = getattr(
+        agent, "_system_reminder_engine", None
+    )
+    if engine is None:
+        return
+    reminder = engine.maybe_inject()
+    if reminder is None:
+        return
+    action = reminder.get("action")
+    if action == "append_to_last_user":
+        # Same pattern as /steer: find the last tool-role message in
+        # the recent tail and append the reminder content.
+        target_idx = None
+        for j in range(
+            len(messages) - 1,
+            max(len(messages) - num_tool_msgs - 1, -1),
+            -1,
+        ):
+            msg = messages[j]
+            if isinstance(msg, dict) and msg.get("role") == "tool":
+                target_idx = j
+                break
+        if target_idx is not None:
+            existing = messages[target_idx].get("content", "")
+            if isinstance(existing, str):
+                messages[target_idx]["content"] = existing + reminder["content"]
+            else:
+                # Anthropic multimodal content blocks — append a text block.
+                blocks = list(existing) if existing else []
+                blocks.append({"type": "text", "text": reminder["content"]})
+                messages[target_idx]["content"] = blocks
+            logger.info(
+                "Injected system-reminder block (action=%s, %d chars)",
+                action,
+                len(reminder["content"]),
+            )
+        else:
+            logger.debug(
+                "System-reminder skipped: no tool-role message found in tail"
+            )
+    elif action == "assistant_prefix":
+        logger.info(
+            "System-reminder assistant_prefix requested but not yet implemented"
+        )
+    # new_user position is intentionally not handled in tool_executor
+    # context — those reminders are delivered via conversation_loop.py
+    # before the next user turn.

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -947,6 +947,12 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         # result so the steer lands as early as possible.
         agent._apply_pending_steer_to_tool_results(messages, 1)
 
+        # ── Per-tool system-reminder injection ──────────────────────
+        # Cyclic reminder on a tool-call cadence.  Same position as
+        # /steer — appended to the most recently appended tool result.
+        from agent.system_reminder_engine import agent_inject_system_reminder
+        agent_inject_system_reminder(agent, messages, 1)
+
     # ── Per-turn aggregate budget enforcement ─────────────────────────
     num_tools = len(parsed_calls)
     if num_tools > 0:
@@ -959,6 +965,14 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     # so the steer marker is never truncated. See steer() for details.
     if num_tools > 0:
         agent._apply_pending_steer_to_tool_results(messages, num_tools)
+
+    # ── Batch system-reminder injection ────────────────────────────────
+    # Catches cases where the per-tool injection didn't fire (counter
+    # wasn't exhausted on any individual tool call but inspection reveals
+    # this is the right time).
+    if num_tools > 0:
+        from agent.system_reminder_engine import agent_inject_system_reminder
+        agent_inject_system_reminder(agent, messages, num_tools)
 
 
 
@@ -1597,6 +1611,12 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # entire batch.  The model sees it on the next API iteration.
         agent._apply_pending_steer_to_tool_results(messages, 1)
 
+        # ── Per-tool system-reminder injection ──────────────────────
+        # Cyclic reminder on a tool-call cadence.  Same position as
+        # /steer — appended to the most recently appended tool result.
+        from agent.system_reminder_engine import agent_inject_system_reminder
+        agent_inject_system_reminder(agent, messages, 1)
+
         if not agent.quiet_mode and getattr(agent, "tool_progress_mode", "all") != "off":
             if agent.verbose_logging:
                 print(f"  ✅ Tool {i} completed in {tool_duration:.2f}s")
@@ -1636,6 +1656,12 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     # applied to sequential execution as well.
     if num_tools_seq > 0:
         agent._apply_pending_steer_to_tool_results(messages, num_tools_seq)
+
+    # ── Batch system-reminder injection ────────────────────────────────
+    # Catches cases where the per-tool injection didn't fire.
+    if num_tools_seq > 0:
+        from agent.system_reminder_engine import agent_inject_system_reminder
+        agent_inject_system_reminder(agent, messages, num_tools_seq)
 
 
 

--- a/tests/agent/test_system_reminder_engine.py
+++ b/tests/agent/test_system_reminder_engine.py
@@ -1,0 +1,419 @@
+"""Tests for agent/system_reminder_engine.py.
+
+Covers:
+- Engine construction and defaults
+- Cadence counting (every N tool calls triggers injection)
+- No injection when disabled or no blocks
+- Rotation through blocks
+- Counter reset
+- ``build_reminder()`` action shapes for each position
+- ``agent_inject_system_reminder()`` with realistic messages
+- Edge cases: zero-cadence guard, single block, empty messages
+"""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from agent.system_reminder_engine import (
+    DEFAULT_REMINDER_BLOCKS,
+    SystemReminderEngine,
+    agent_inject_system_reminder,
+)
+
+
+# ======================================================================
+# Fixtures
+# ======================================================================
+
+
+@pytest.fixture
+def engine() -> SystemReminderEngine:
+    """Default engine: enabled, cadence=5, default blocks."""
+    return SystemReminderEngine(enabled=True, cadence=5)
+
+
+@pytest.fixture
+def agent_stub():
+    """Minimal agent with a ``_system_reminder_engine`` attribute."""
+    eng = SystemReminderEngine(enabled=True, cadence=3)
+    return type("AgentStub", (), {"_system_reminder_engine": eng})
+
+
+@pytest.fixture
+def agent_no_engine():
+    """Agent stub with no engine attribute at all."""
+    return type("AgentStub", (), {})
+
+
+# ======================================================================
+# Engine construction
+# ======================================================================
+
+
+class TestConstruction:
+    def test_defaults(self):
+        eng = SystemReminderEngine()
+        assert eng.enabled is True
+        assert eng.cadence == 5
+        assert len(eng.blocks) == len(DEFAULT_REMINDER_BLOCKS)
+        assert eng.position == "last_user"
+        assert eng._counter == 0
+        assert eng._block_index == 0
+
+    def test_custom_config(self):
+        blocks = [{"id": "b1", "content": "one"}, {"id": "b2", "content": "two"}]
+        eng = SystemReminderEngine(
+            enabled=True, cadence=2, blocks=blocks, position="new_user"
+        )
+        assert eng.cadence == 2
+        assert eng.blocks == blocks
+        assert eng.position == "new_user"
+
+    def test_zero_cadence_is_clamped(self):
+        """Cadence of 0 is clamped to 1 so we don't infinite-loop."""
+        eng = SystemReminderEngine(enabled=True, cadence=0)
+        assert eng.cadence == 1
+
+    def test_negative_cadence_is_clamped(self):
+        eng = SystemReminderEngine(enabled=True, cadence=-5)
+        assert eng.cadence == 1
+
+    def test_disabled_reports_false(self):
+        eng = SystemReminderEngine(enabled=False)
+        assert eng.should_inject() is False
+        assert eng.build_reminder() is None
+
+    def test_no_blocks_reports_false(self):
+        eng = SystemReminderEngine(enabled=True, blocks=[])
+        assert eng.should_inject() is False
+        assert eng.build_reminder() is None
+
+
+# ======================================================================
+# Cadence counting (should_inject)
+# ======================================================================
+
+
+class TestCadence:
+    def test_does_not_inject_before_threshold(self, engine):
+        for _ in range(4):
+            assert engine.should_inject() is False
+
+    def test_injects_at_threshold(self, engine):
+        for _ in range(4):
+            engine.should_inject()  # advance to threshold
+        assert engine.should_inject() is True
+
+    def test_counter_resets_after_injection(self):
+        """After hitting the threshold, counter is 0 again."""
+        eng = SystemReminderEngine(enabled=True, cadence=3)
+        for _ in range(2):
+            eng.should_inject()
+        # third call hits threshold
+        assert eng.should_inject() is True
+        # next call should be 1/3: False
+        assert eng.should_inject() is False
+        assert eng.should_inject() is False  # 2/3
+        assert eng.should_inject() is True   # 3/3 → hit
+
+    def test_explicit_reset(self, engine):
+        for _ in range(4):
+            engine.should_inject()  # 4 calls, not yet 5
+        engine.reset_counter()
+        for _ in range(4):
+            assert engine.should_inject() is False
+        # now on 5th call after reset, should inject
+        assert engine.should_inject() is True
+
+    def test_disabled_never_injects(self):
+        eng = SystemReminderEngine(enabled=False)
+        for _ in range(100):
+            assert eng.should_inject() is False
+
+    def test_blocks_empty_never_injects(self):
+        eng = SystemReminderEngine(enabled=True, blocks=[])
+        for _ in range(100):
+            assert eng.should_inject() is False
+
+    def test_cadence_one_injects_every_time(self):
+        eng = SystemReminderEngine(enabled=True, cadence=1)
+        for _ in range(5):
+            assert eng.should_inject() is True
+
+
+# ======================================================================
+# Block rotation
+# ======================================================================
+
+
+class TestBlockRotation:
+    def test_single_block_repeats(self):
+        blocks = [{"id": "only", "content": "just this one"}]
+        eng = SystemReminderEngine(enabled=True, cadence=1, blocks=blocks)
+        r1 = eng.build_reminder()
+        r2 = eng.build_reminder()
+        assert r1 is not None and r2 is not None
+        # both contain the same content
+        assert r1["content"] == r2["content"]
+
+    def test_cycles_through_multiple_blocks(self):
+        blocks = [
+            {"id": "a", "content": "alpha"},
+            {"id": "b", "content": "beta"},
+            {"id": "c", "content": "gamma"},
+        ]
+        eng = SystemReminderEngine(enabled=True, cadence=1, blocks=blocks)
+        seen = []
+        for _ in range(5):
+            r = eng.build_reminder()
+            assert r is not None
+            seen.append(r["content"].lstrip("\n"))
+        assert seen == ["alpha", "beta", "gamma", "alpha", "beta"]
+
+    def test_block_index_increments_on_each_build(self):
+        blocks = [{"id": "x", "content": "X"}, {"id": "y", "content": "Y"}]
+        eng = SystemReminderEngine(enabled=True, cadence=1, blocks=blocks)
+        assert eng._block_index == 0
+        eng.build_reminder()
+        assert eng._block_index == 1
+        eng.build_reminder()
+        assert eng._block_index == 2
+
+
+# ======================================================================
+# build_reminder action shapes
+# ======================================================================
+
+
+class TestReminderShape:
+    def test_last_user_position(self):
+        blocks = [{"id": "t", "content": "test"}]
+        eng = SystemReminderEngine(
+            enabled=True, cadence=1, blocks=blocks, position="last_user"
+        )
+        reminder = eng.build_reminder()
+        assert reminder is not None
+        assert reminder["action"] == "append_to_last_user"
+        assert "test" in reminder["content"]
+
+    def test_new_user_position(self):
+        blocks = [{"id": "t", "content": "test"}]
+        eng = SystemReminderEngine(
+            enabled=True, cadence=1, blocks=blocks, position="new_user"
+        )
+        reminder = eng.build_reminder()
+        assert reminder is not None
+        assert reminder["role"] == "user"
+        assert reminder["content"] == "test"
+
+    def test_assistant_prefix_position(self):
+        blocks = [{"id": "t", "content": "test"}]
+        eng = SystemReminderEngine(
+            enabled=True, cadence=1, blocks=blocks, position="assistant_prefix"
+        )
+        reminder = eng.build_reminder()
+        assert reminder is not None
+        assert reminder["action"] == "assistant_prefix"
+        assert reminder["content"] == "test"
+
+
+# ======================================================================
+# maybe_inject convenience
+# ======================================================================
+
+
+class TestMaybeInject:
+    def test_returns_none_when_no_injection(self, engine):
+        assert engine.maybe_inject() is None
+
+    def test_returns_reminder_when_due(self):
+        eng = SystemReminderEngine(enabled=True, cadence=1)
+        r = eng.maybe_inject()
+        assert r is not None
+        assert "content" in r
+
+    def test_returns_none_when_disabled(self):
+        eng = SystemReminderEngine(enabled=False)
+        assert eng.maybe_inject() is None
+
+    def test_returns_none_when_no_blocks(self):
+        eng = SystemReminderEngine(enabled=True, blocks=[])
+        assert eng.maybe_inject() is None
+
+
+# ======================================================================
+# agent_inject_system_reminder (integration helper)
+# ======================================================================
+
+
+class TestAgentInject:
+    def test_skips_when_no_tool_msgs(self, agent_stub):
+        messages = [{"role": "user", "content": "hello"}]
+        before = copy.deepcopy(messages)
+        agent_inject_system_reminder(agent_stub, messages, num_tool_msgs=0)
+        assert messages == before  # unchanged
+
+    def test_skips_when_empty_messages(self, agent_stub):
+        messages = []
+        agent_inject_system_reminder(agent_stub, messages, num_tool_msgs=1)
+        assert messages == []
+
+    def test_skips_when_no_engine_attr(self, agent_no_engine):
+        messages = [{"role": "tool", "content": "result"}]
+        before = copy.deepcopy(messages)
+        agent_inject_system_reminder(agent_no_engine, messages, num_tool_msgs=1)
+        assert messages == before
+
+    def test_injects_into_last_tool_message(self):
+        """When cadence is 1, expects injection after each tool msg."""
+        eng = SystemReminderEngine(enabled=True, cadence=1)
+        agent = type("A", (), {"_system_reminder_engine": eng})
+        messages = [
+            {"role": "user", "content": "do it"},
+            {"role": "assistant", "content": "ok", "tool_calls": [{"id": "tc1"}]},
+            {"role": "tool", "tool_call_id": "tc1", "content": "done"},
+        ]
+        original_last = messages[-1]["content"]
+        agent_inject_system_reminder(agent, messages, num_tool_msgs=1)
+        assert len(messages) == 3  # no new messages
+        assert messages[-1]["role"] == "tool"
+        assert messages[-1]["content"] != original_last  # appended
+        assert "<system-reminder>" in messages[-1]["content"]
+
+    def test_injects_into_correct_tool_in_batch(self):
+        """With cadence 3, third tool result in batch gets the injection."""
+        eng = SystemReminderEngine(enabled=True, cadence=3)
+        agent = type("A", (), {"_system_reminder_engine": eng})
+
+        # First tool call
+        msgs1 = [
+            {"role": "user", "content": "do three things"},
+            {"role": "assistant", "content": "ok"},
+            {"role": "tool", "tool_call_id": "tc1", "content": "result 1"},
+        ]
+        agent_inject_system_reminder(agent, msgs1, num_tool_msgs=1)
+        # Counter at 1, not yet 3 — no injection
+        assert "<system-reminder>" not in (msgs1[-1]["content"] or "")
+
+        # Second tool call
+        msgs2 = msgs1 + [
+            {"role": "tool", "tool_call_id": "tc2", "content": "result 2"}
+        ]
+        agent_inject_system_reminder(agent, msgs2, num_tool_msgs=1)
+        # Counter at 2 — no injection
+        assert "<system-reminder>" not in (msgs2[-1]["content"] or "")
+
+        # Third tool call — cadence hit
+        msgs3 = msgs2 + [
+            {"role": "tool", "tool_call_id": "tc3", "content": "result 3"}
+        ]
+        agent_inject_system_reminder(agent, msgs3, num_tool_msgs=1)
+        assert "<system-reminder>" in msgs3[-1]["content"]
+
+    def test_multimodal_content_list(self):
+        """Injection handles Anthropic-style content list tool results."""
+        eng = SystemReminderEngine(enabled=True, cadence=1)
+        agent = type("A", (), {"_system_reminder_engine": eng})
+        messages = [
+            {"role": "user", "content": "do it"},
+            {
+                "role": "tool",
+                "tool_call_id": "tc1",
+                "content": [
+                    {"type": "text", "text": "Here's the image result."},
+                    {"type": "image_url", "image_url": {"url": "data:img/png;base64,abc"}},
+                ],
+            },
+        ]
+        agent_inject_system_reminder(agent, messages, num_tool_msgs=1)
+        content = messages[-1]["content"]
+        assert isinstance(content, list)
+        assert any(
+            isinstance(b, dict) and b.get("type") == "text"
+            and "<system-reminder>" in b.get("text", "")
+            for b in content
+        )
+
+    def test_none_content_on_tool_msg(self):
+        """Edge case: tool message with content=None is handled safely."""
+        eng = SystemReminderEngine(enabled=True, cadence=1)
+        agent = type("A", (), {"_system_reminder_engine": eng})
+        messages = [
+            {"role": "tool", "tool_call_id": "tc1", "content": None},
+        ]
+        agent_inject_system_reminder(agent, messages, num_tool_msgs=1)
+        assert messages[-1]["role"] == "tool"
+        # content=None becomes a list (multimodal fallback) with a text block
+        content = messages[-1]["content"]
+        assert isinstance(content, list)
+        assert any(
+            isinstance(b, dict) and b.get("type") == "text"
+            and "<system-reminder>" in b.get("text", "")
+            for b in content
+        )
+
+    def test_no_tool_role_in_messages_does_not_crash(self):
+        """num_tool_msgs > 0 but no tool-role message in the tail."""
+        eng = SystemReminderEngine(enabled=True, cadence=1)
+        agent = type("A", (), {"_system_reminder_engine": eng})
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "world"},
+        ]
+        # This should not crash — the helper skips gracefully
+        agent_inject_system_reminder(agent, messages, num_tool_msgs=1)
+        assert len(messages) == 2  # unchanged
+
+
+# ======================================================================
+# Default blocks
+# ======================================================================
+
+
+class TestDefaultBlocks:
+    def test_all_defaults_have_required_keys(self):
+        for block in DEFAULT_REMINDER_BLOCKS:
+            assert "id" in block, f"Missing 'id' in {block}"
+            assert "content" in block, f"Missing 'content' in {block}"
+            assert isinstance(block["id"], str)
+            assert isinstance(block["content"], str)
+
+    def test_all_defaults_contain_system_reminder_tag(self):
+        for block in DEFAULT_REMINDER_BLOCKS:
+            assert "<system-reminder>" in block["content"]
+
+    def test_ids_are_unique(self):
+        ids = [b["id"] for b in DEFAULT_REMINDER_BLOCKS]
+        assert len(ids) == len(set(ids)), f"Duplicate ids: {ids}"
+
+
+# ======================================================================
+# State snapshot
+# ======================================================================
+
+
+class TestState:
+    def test_state_contains_diagnostics(self, engine):
+        state = engine.state
+        assert state["enabled"] is True
+        assert state["cadence"] == 5
+        assert state["num_blocks"] == len(DEFAULT_REMINDER_BLOCKS)
+        assert state["position"] == "last_user"
+        assert state["counter"] == 0
+        assert state["block_index"] == 0
+        assert state["next_block_id"] == DEFAULT_REMINDER_BLOCKS[0]["id"]
+
+    def test_state_updates_as_engine_runs(self):
+        eng = SystemReminderEngine(enabled=True, cadence=3, blocks=[{"id": "x", "content": "X"}])
+        for _ in range(3):
+            eng.should_inject()
+        state = eng.state
+        assert state["counter"] == 0  # reset after injection
+
+    def test_disabled_state(self):
+        eng = SystemReminderEngine(enabled=False)
+        state = eng.state
+        assert state["enabled"] is False


### PR DESCRIPTION
## Summary

Introduces a **SystemReminderEngine** — a component that manages configurable cyclic system-reminder messages in the Hermes agent conversation loop, kept separate from the core agent loop for clarity and testability.

## What's included

### `agent/system_reminder_engine.py` (new)
A standalone engine that:
- Maintains a pool of system-reminder messages
- Rotates through them on a configurable interval (every N turns)
- Handles cycle start, advance, and cleanup
- Supports custom reminder configurations per session

### `agent/agent_init.py` (modified)
- Integrates SystemReminderEngine into the main agent initialization
- Wires reminder injection into the conversation-turn lifecycle

### `agent/tool_executor.py` (modified)
- Exposes reminder-engine metadata through tool execution context

### `tests/agent/test_system_reminder_engine.py` (new)
- Full unit-test coverage: configuration, cycling, edge cases

## Context

This work was originally part of #59456 (computer-use pipeline) and is now split into its own focused PR for independent review.

Closes #59456 (superseded)