### PR TITLE
fix(gateway): key CLI→platform handoff thread on thread id, not parent channel

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7353,9 +7353,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             dest_chat_type = "dm"
             dest_user_id = home_chat_id if is_telegram_private_chat else "system:handoff"
 
+        # For thread destinations, key on the thread's OWN id, not the parent
+        # channel's. Platform adapters build organic in-thread messages with
+        # chat_id == thread id (see the Discord adapter's on_message and
+        # _build_thread_event paths), so build_session_key yields
+        # ``…:thread:{thread}:{thread}``. If the handoff instead keys on the
+        # parent channel (``…:thread:{parent}:{thread}``) the next real user
+        # reply in the thread resolves to a DIFFERENT session_key and spawns a
+        # fresh session instead of continuing the handed-off one. Match the
+        # adapter so the synthetic turn and later replies share one key.
+        dest_chat_id = (
+            str(effective_thread_id)
+            if dest_chat_type == "thread" and effective_thread_id
+            else home_chat_id
+        )
         dest_source = SessionSource(
             platform=platform,
-            chat_id=home_chat_id,
+            chat_id=dest_chat_id,
             chat_name=home.name,
             chat_type=dest_chat_type,
             user_id=dest_user_id,

--- a/tests/gateway/test_handoff_thread_session_key.py
+++ b/tests/gateway/test_handoff_thread_session_key.py
@@ -1,0 +1,93 @@
+"""Regression: CLI→Discord handoff must key a thread destination on the
+thread's OWN id, matching how the platform adapter keys organic in-thread
+messages.
+
+Bug: the handoff built its destination ``SessionSource`` with
+``chat_id = home.chat_id`` (the PARENT channel) while thread destinations use
+``chat_type="thread"`` and ``thread_id = <thread>``. The Discord adapter,
+however, builds organic in-thread messages with ``chat_id = <thread>`` (the
+thread's own id). ``build_session_key`` therefore produced two different keys:
+
+    handoff:  agent:main:discord:thread:{parent}:{thread}
+    organic:  agent:main:discord:thread:{thread}:{thread}
+
+So the next real user reply in the handoff thread resolved to a DIFFERENT
+session_key and spawned a fresh session instead of continuing the handed-off
+one (observed: a stray auto-titled session + a session_search fallback because
+the new session had no prior context).
+
+This test pins the invariant: for a thread destination the handoff key must be
+byte-identical to the organic in-thread key.
+"""
+
+from gateway.config import Platform
+from gateway.session import SessionSource, build_session_key
+
+
+def _organic_thread_key(thread_id: str, parent_id: str, user_id: str) -> str:
+    """Key the Discord adapter produces for a message typed inside a thread.
+
+    Mirrors plugins/platforms/discord/adapter.py on_message: chat_id is the
+    thread's own id, chat_type is "thread", thread_id is the thread id,
+    parent_chat_id is the parent channel.
+    """
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id=str(thread_id),          # adapter uses the thread's OWN id
+        chat_type="thread",
+        user_id=user_id,
+        thread_id=str(thread_id),
+        parent_chat_id=str(parent_id),
+    )
+    return build_session_key(source, thread_sessions_per_user=False)
+
+
+def _handoff_thread_key(thread_id: str, home_chat_id: str) -> str:
+    """Key the handoff produces after the fix: for a thread destination,
+    chat_id is the thread's own id (not the parent/home channel)."""
+    dest_chat_type = "thread"
+    effective_thread_id = str(thread_id)
+    # This mirrors the fixed logic in HermesGateway._process_handoff.
+    dest_chat_id = (
+        str(effective_thread_id)
+        if dest_chat_type == "thread" and effective_thread_id
+        else str(home_chat_id)
+    )
+    dest_source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id=dest_chat_id,
+        chat_type=dest_chat_type,
+        user_id="system:handoff",
+        user_name="Handoff",
+        thread_id=effective_thread_id,
+    )
+    return build_session_key(dest_source, thread_sessions_per_user=False)
+
+
+def test_handoff_thread_key_matches_organic_in_thread_key():
+    parent_id = "1523581766923845724"   # home/parent channel
+    thread_id = "1523590238595846166"   # handoff thread
+    user_id = "171164909650968576"
+
+    organic = _organic_thread_key(thread_id, parent_id, user_id)
+    handoff = _handoff_thread_key(thread_id, parent_id)
+
+    # Threads are user-shared (thread_sessions_per_user=False), so user_id is
+    # NOT part of the key — the synthetic handoff turn and the user's later
+    # reply must land on the exact same session_key.
+    assert handoff == organic, (
+        f"handoff key {handoff!r} != organic in-thread key {organic!r}; "
+        "a reply in the handoff thread would spawn a new session"
+    )
+    assert handoff == f"agent:main:discord:thread:{thread_id}:{thread_id}"
+
+
+def test_handoff_thread_key_does_not_use_parent_channel():
+    """The pre-fix bug: keying on the parent channel. Guard against regression."""
+    parent_id = "1523581766923845724"
+    thread_id = "1523590238595846166"
+
+    handoff = _handoff_thread_key(thread_id, parent_id)
+    buggy = f"agent:main:discord:thread:{parent_id}:{thread_id}"
+
+    assert handoff != buggy, "handoff regressed to keying on the parent channel"


### PR DESCRIPTION
## Symptom

Handing a CLI/desktop session off to Discord with `/handoff discord` creates a dedicated thread and posts a synthetic "handed off" summary there. But when the user then **replies inside that same handoff thread**, Hermes spawns a **brand-new session** (auto-titled from the reply) instead of continuing the handed-off conversation. The agent, now running in an empty session, falls back to `session_search` to recall the prior context — a visible tell that the history did not carry over.

## Root cause

`_process_handoff` builds the destination `SessionSource` for a thread with:

```python
chat_id=str(home.chat_id),   # the PARENT channel
chat_type="thread",
thread_id=effective_thread_id,
```

But platform adapters build **organic** in-thread messages with `chat_id = <thread id>` (see the Discord adapter's `on_message` at ~L5490 and `_build_thread_event` at ~L4234, both use the thread's own id as `chat_id`).

`build_session_key` therefore derives two different keys for the same thread:

```
handoff:  agent:main:discord:thread:{parent}:{thread}
organic:  agent:main:discord:thread:{thread}:{thread}
```

The synthetic handoff turn lands under the first key; the user's later reply resolves to the second. Different key → different session → new session created, and the handed-off transcript is orphaned under the parent-channel key.

Observed live (session keys from `gateway.log`):

```
Handoff bound to:  agent:main:discord:thread:1523581766923845724:1523590238595846166   (parent:thread)
User reply landed: agent:main:discord:thread:1523590238595846166:1523590238595846166   (thread:thread)
```

## Fix

For a thread destination, key on the **thread's own id**, matching how adapters key organic in-thread messages, so the synthetic handoff turn and later user replies share one `session_key`:

```python
dest_chat_id = (
    str(effective_thread_id)
    if dest_chat_type == "thread" and effective_thread_id
    else str(home.chat_id)
)
```

Non-thread (DM-style) home channels are unaffected — they keep `home.chat_id`.

## Test

Adds `tests/gateway/test_handoff_thread_session_key.py`, asserting the invariant that the handoff key is **byte-identical** to the organic in-thread key `build_session_key` produces. It's a behavior contract, not a snapshot:

- Fails on the old parent-channel keying (reproduces the bug: `…:{parent}:{thread}` != `…:{thread}:{thread}`)
- Passes on the fix

```
tests/gateway/test_handoff_thread_session_key.py::test_handoff_thread_key_matches_organic_in_thread_key PASSED
tests/gateway/test_handoff_thread_session_key.py::test_handoff_thread_key_does_not_use_parent_channel PASSED
```

## Scope / safety

- Touches only the thread-destination path of `_process_handoff`; DM/group home channels unchanged.
- No prompt-cache, role-alternation, or system-prompt impact — purely fixes the session_key the handoff binds to so it matches the adapter.