### PR TITLE
feat(providers): add Routstr — decentralized AI inference router

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -457,6 +457,9 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "xiaomimimo.com": "xiaomi",
     "api.gmi-serving.com": "gmi",
     "api.novita.ai": "novita",
+    "api.routstr.com": "routstr",
+    "api.nonkycai.com": "routstr",
+    "privateprovider.xyz": "routstr",
     "tokenhub.tencentmaas.com": "tencent-tokenhub",
     "ollama.com": "ollama-cloud",
 }

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -290,6 +290,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("GMI_API_KEY",),
         base_url_env_var="GMI_BASE_URL",
     ),
+    "routstr": ProviderConfig(
+        id="routstr",
+        name="Routstr",
+        auth_type="api_key",
+        inference_base_url="https://api.routstr.com/v1",
+        api_key_env_vars=("ROUTSTR_API_KEY",),
+        base_url_env_var="ROUTSTR_BASE_URL",
+    ),
     "minimax": ProviderConfig(
         id="minimax",
         name="MiniMax",

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -34,6 +34,8 @@ _PROVIDER_ENV_HINTS = (
     "OPENAI_API_KEY",
     "ANTHROPIC_API_KEY",
     "ANTHROPIC_TOKEN",
+    "ROUTSTR_API_KEY",
+    "GEMINI_API_KEY",
     "OPENAI_BASE_URL",
     "NOUS_API_KEY",
     "GLM_API_KEY",
@@ -838,6 +840,7 @@ def run_doctor(args):
             provider_policy_id = str(provider_for_policy or "").strip().lower()
             providers_accepting_vendor_slugs = {
                 "openrouter",
+                "routstr",
                 "auto",
                 "kilocode",
                 "opencode-zen",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -621,6 +621,7 @@ from hermes_cli.model_setup_flows import (
     _model_flow_api_key_provider,
     _model_flow_anthropic,
     _model_flow_moa,
+    _model_flow_routstr,
 )
 logger = logging.getLogger(__name__)
 
@@ -3115,6 +3116,8 @@ def select_provider_and_model(args=None):
         _model_flow_vertex(config, current_model)
     elif selected_provider == "azure-foundry":
         _model_flow_azure_foundry(config, current_model)
+    elif selected_provider == "routstr":
+        _model_flow_routstr(config, current_model)
     elif selected_provider in {
         "openai-api",
         "gemini",

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -2981,3 +2981,142 @@ def _model_flow_anthropic(config, current_model=""):
         print(f"Default model set to: {selected} (via Anthropic)")
     else:
         print("No change.")
+
+
+def _model_flow_routstr(config, current_model=""):
+    """Routstr provider: API key, choose base URL/node, then pick model with pricing."""
+    from hermes_cli.main import _prompt_api_key, _prompt_provider_choice
+    from hermes_cli.auth import (
+        ProviderConfig,
+        _prompt_model_selection,
+        _save_model_choice,
+        deactivate_provider,
+    )
+    from hermes_cli.config import (
+        get_env_value,
+        save_env_value,
+        load_config,
+        save_config,
+    )
+    import re as _re
+
+    from hermes_cli.models import fetch_models_with_pricing
+
+    pconfig = ProviderConfig(
+        id="routstr",
+        name="Routstr",
+        auth_type="api_key",
+        api_key_env_vars=("ROUTSTR_API_KEY",),
+        base_url_env_var="ROUTSTR_BASE_URL",
+    )
+
+    existing_key = get_env_value("ROUTSTR_API_KEY") or ""
+    if not existing_key:
+        print("Get a Routstr API key at: https://chat.routstr.com/?tab=apikeys")
+        print()
+
+    resolved_key, abort = _prompt_api_key(pconfig, existing_key, provider_id="routstr")
+    if abort:
+        return
+
+    effective_key = resolved_key or existing_key
+    if not effective_key:
+        print("No API key provided. Cancelled.")
+        return
+
+    # --- Base URL / node selection ---
+    known_nodes = [
+        ("https://api.routstr.com/v1", "Routstr official node"),
+        ("https://api.nonkycai.com/v1", "Non-KYC AI node"),
+        ("https://privateprovider.xyz/v1", "PrivateProvider node"),
+    ]
+
+    current_base = get_env_value("ROUTSTR_BASE_URL") or "https://api.routstr.com/v1"
+    print()
+    print("Select base URL for this API key:")
+    choices = [f"{url} ({label})" for url, label in known_nodes] + [
+        "Custom endpoint (enter URL manually)"
+    ]
+    default_idx = next(
+        (i for i, (u, _) in enumerate(known_nodes) if u == current_base), 0
+    )
+
+    idx = _prompt_provider_choice(
+        choices, default=default_idx, title="Select Base URL"
+    )
+    if idx is None:
+        print("No change.")
+        return
+
+    if idx < len(known_nodes):
+        effective_base = known_nodes[idx][0]
+    else:
+        try:
+            custom = input(f"Custom base URL [{current_base}]: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            print("\nCancelled.")
+            return
+        effective_base = custom or current_base
+
+    if not effective_base.startswith(("http://", "https://")):
+        print(f"Invalid URL: {effective_base} (must start with http:// or https://)")
+        return
+
+    save_env_value("ROUTSTR_API_KEY", effective_key)
+    save_env_value("ROUTSTR_BASE_URL", effective_base)
+
+    # --- Fetch models + pricing ---
+    # fetch_models_with_pricing appends /v1/models, so strip any existing
+    # /vN suffix from the base URL to avoid double paths like /v1/v1/models.
+    pricing_base = _re.sub(r"/v\d+/?$", "", effective_base.rstrip("/"))
+    print()
+    print(f"Fetching models from {effective_base}...")
+    priced = fetch_models_with_pricing(
+        api_key=effective_key,
+        base_url=pricing_base,
+        force_refresh=True,
+    )
+
+    if not priced:
+        print("Could not fetch models/pricing from this Routstr node.")
+        print("Falling back to manual model entry.")
+        try:
+            model_name = input("Model name: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            print("\nCancelled.")
+            return
+        if not model_name:
+            print("No model specified. Cancelled.")
+            return
+    else:
+        model_list = sorted(priced.keys())
+        selected = _prompt_model_selection(
+            model_list,
+            current_model=current_model,
+            pricing=priced,
+            confirm_provider="routstr",
+            confirm_base_url=effective_base,
+            confirm_api_key=effective_key,
+        )
+        if not selected:
+            print("No change.")
+            return
+        model_name = selected
+
+    # --- Persist ---
+    _save_model_choice(model_name)
+
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = "routstr"
+    model["base_url"] = effective_base
+    model["api_key"] = effective_key
+    model["api_mode"] = "chat_completions"
+    clear_model_endpoint_credentials(model, clear_api_mode=False)
+    save_config(cfg)
+    deactivate_provider()
+
+    print(f"Default model set to: {model_name} (via Routstr — {effective_base})")

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1030,6 +1030,7 @@ class ProviderEntry(NamedTuple):
 CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("nous",           "Nous Portal",              "Nous Portal (Everything your agent needs, 300+ models with bundled tool use)"),
     ProviderEntry("openrouter",     "OpenRouter",               "OpenRouter (Pay-per-use API aggregator)"),
+    ProviderEntry("routstr",        "Routstr",                  "Routstr — decentralized OpenAI-compatible AI inference router"),
     ProviderEntry("moa",            "Mixture of Agents",        "Mixture of Agents (named presets; aggregator acts after reference models)"),
     ProviderEntry("novita",         "NovitaAI",                 "NovitaAI (Cloud: Model API, Agent Sandbox, GPU Cloud)"),
     ProviderEntry("lmstudio",       "LM Studio",                "LM Studio (Local desktop app with built-in model server)"),
@@ -1558,12 +1559,25 @@ def _resolve_nous_pricing_credentials() -> tuple[str, str]:
 
 
 def get_pricing_for_provider(provider: str, *, force_refresh: bool = False) -> dict[str, dict[str, str]]:
-    """Return live pricing for providers that support it (openrouter, nous, novita)."""
+    """Return live pricing for providers that support it (openrouter, routstr, nous, novita)."""
     normalized = normalize_provider(provider)
     if normalized == "openrouter":
         return fetch_models_with_pricing(
             api_key=_resolve_openrouter_api_key(),
             base_url="https://openrouter.ai/api",
+            force_refresh=force_refresh,
+        )
+    if normalized == "routstr":
+        from hermes_cli.config import get_env_value
+
+        api_key = get_env_value("ROUTSTR_API_KEY") or ""
+        base_url = get_env_value("ROUTSTR_BASE_URL") or "https://api.routstr.com/v1"
+        # Strip /v1 suffix since fetch_models_with_pricing appends its own /v1/models
+        import re as _re2
+        base_url = _re2.sub(r"/v\d+/?$", "", base_url.rstrip("/"))
+        return fetch_models_with_pricing(
+            api_key=api_key,
+            base_url=base_url,
             force_refresh=force_refresh,
         )
     if normalized == "novita":
@@ -1804,7 +1818,7 @@ def _model_in_provider_catalog(name_lower: str, providers: set[str]) -> bool:
 
 
 _AGGREGATOR_PROVIDERS = frozenset(
-    {"nous", "openrouter", "copilot", "kilocode"}
+    {"nous", "openrouter", "routstr", "copilot", "kilocode"}
 )
 
 # Subscription/OAuth providers whose catalogs RE-EXPOSE other vendors' models

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -196,6 +196,13 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="https://api.gmi-serving.com/v1",
         base_url_env_var="GMI_BASE_URL",
     ),
+    "routstr": HermesOverlay(
+        transport="openai_chat",
+        is_aggregator=True,
+        extra_env_vars=("ROUTSTR_API_KEY",),
+        base_url_override="https://api.routstr.com/v1",
+        base_url_env_var="ROUTSTR_BASE_URL",
+    ),
     "ollama-cloud": HermesOverlay(
         transport="openai_chat",
         base_url_override="https://ollama.com/v1",
@@ -342,6 +349,9 @@ ALIASES: Dict[str, str] = {
     # gmi
     "gmi-cloud": "gmi",
     "gmicloud": "gmi",
+
+    # routstr
+    "routstr-ai": "routstr",
 
     # Local server aliases → virtual "local" concept (resolved via user config)
     "lmstudio": "lmstudio",

--- a/plugins/model-providers/routstr/__init__.py
+++ b/plugins/model-providers/routstr/__init__.py
@@ -1,0 +1,99 @@
+"""Routstr provider profile.
+
+Routstr is a decentralized OpenAI-compatible AI inference router. Users can
+point Hermes at the official Routstr node (api.routstr.com), the Non-KYC AI
+node (api.nonkycai.com), or any private Routstr-compatible endpoint. The API
+key is passed as a Bearer token and the /models endpoint returns an
+OpenRouter-shaped catalog with per-token USD pricing.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.request
+from typing import Any
+
+from hermes_cli import __version__ as _HERMES_VERSION
+from providers import register_provider
+from providers.base import ProviderProfile
+
+logger = logging.getLogger(__name__)
+
+
+def _format_price_per_mtok(per_token_str: str) -> str:
+    """Convert a per-token price string to a $/Mtok label."""
+    try:
+        val = float(per_token_str)
+    except (TypeError, ValueError):
+        return "?"
+    if val == 0:
+        return "free"
+    per_m = val * 1_000_000
+    return f"${per_m:.2f}"
+
+
+class RoutstrProfile(ProviderProfile):
+    """Routstr — decentralized OpenAI-compatible inference router."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Fetch the live model list from a Routstr node's /models endpoint."""
+        effective_base = (base_url or self.base_url or "").rstrip("/")
+        if not effective_base:
+            return None
+        url = effective_base + "/models"
+        req = urllib.request.Request(url)
+        req.add_header("Accept", "application/json")
+        req.add_header("User-Agent", f"hermes-cli/{_HERMES_VERSION}")
+        if api_key:
+            req.add_header("Authorization", f"Bearer {api_key}")
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                data = json.loads(resp.read().decode())
+            items = data if isinstance(data, list) else data.get("data", [])
+            return [m["id"] for m in items if isinstance(m, dict) and "id" in m]
+        except Exception as exc:
+            logger.debug("fetch_models(routstr, %s): %s", url, exc)
+            return None
+
+    def build_extra_body(
+        self, *, session_id: str | None = None, **context: Any
+    ) -> dict[str, Any]:
+        """Routstr-specific extra_body fields.
+
+        Routstr supports provider preference routing via extra_body.provider
+        when an upstream aggregator is used. For now we keep this minimal and
+        only forward session_id if present.
+        """
+        body: dict[str, Any] = {}
+        if session_id:
+            body["session_id"] = session_id
+        return body
+
+
+routstr = RoutstrProfile(
+    name="routstr",
+    aliases=("routstr-ai",),
+    display_name="Routstr",
+    description="Routstr — decentralized OpenAI-compatible AI inference router",
+    signup_url="https://chat.routstr.com/?tab=apikeys",
+    env_vars=("ROUTSTR_API_KEY", "ROUTSTR_BASE_URL"),
+    base_url="https://api.routstr.com/v1",
+    auth_type="api_key",
+    supports_health_check=True,
+    default_aux_model="google/gemini-3.1-flash-lite-preview",
+    fallback_models=(
+        "claude-sonnet-5",
+        "openai/gpt-5.5",
+        "deepseek/deepseek-v4-pro",
+        "google/gemini-3.5-flash",
+    ),
+)
+
+register_provider(routstr)

--- a/plugins/model-providers/routstr/plugin.yaml
+++ b/plugins/model-providers/routstr/plugin.yaml
@@ -1,0 +1,5 @@
+name: routstr-provider
+kind: model-provider
+version: 1.0.0
+description: Routstr decentralized OpenAI-compatible AI inference router
+author: Nous Research


### PR DESCRIPTION
## Summary

Add **Routstr** as a first-class model provider in Hermes Agent — enabling Hermes users to route inference through Routstr's decentralized OpenAI-compatible network of 339+ models with live pricing.

Routstr (https://routstr.com) is a decentralized AI inference protocol. This PR gives Hermes Agent users native access to the entire Routstr model catalog through the standard `hermes model` interactive flow.

## What's included

### Provider registration (7 files)
| File | Change |
|------|--------|
| `hermes_cli/providers.py` | HermesOverlay + alias |
| `hermes_cli/auth.py` | ProviderConfig in PROVIDER_REGISTRY |
| `hermes_cli/models.py` | CANONICAL_PROVIDERS entry, _AGGREGATOR_PROVIDERS, get_pricing_for_provider branch |
| `hermes_cli/model_setup_flows.py` | Full _model_flow_routstr() interactive setup |
| `hermes_cli/main.py` | Import + dispatch branch |
| `hermes_cli/doctor.py` | Routstr in vendor_slugs + env hints |
| `agent/model_metadata.py` | 3 hostname → provider mappings |

### Provider plugin (2 new files)
| File | Purpose |
|------|---------|
| `plugins/model-providers/routstr/__init__.py` | RoutstrProfile: fetch_models, build_extra_body, fallback models |
| `plugins/model-providers/routstr/plugin.yaml` | Plugin manifest |

## User experience

```
hermes model → select Routstr (positioned after OpenRouter as peer aggregator)
  → Enter ROUTSTR_API_KEY (signup: https://chat.routstr.com/?tab=apikeys)
  → Choose endpoint:
      1. https://api.routstr.com/v1 (Routstr official)
      2. https://api.nonkycai.com/v1 (Non-KYC AI)
      3. https://privateprovider.xyz/v1 (PrivateProvider)
      4. Custom endpoint
  → Browse 339 models with live $/Mtok pricing (in/out/cache columns)
  → Select model → persisted to config.yaml + .env
```

## Verified

- [x] **Live pricing**: 339 models fetched from /v1/models with `$prompt/$completion/$cache_read` per-Mtok pricing
- [x] **Interactive flow**: Full PTY walkthrough — API key → endpoint picker → model selection → config persistence
- [x] **Live inference**: claude-sonnet-5 chat completion confirmed working via Routstr API
- [x] **Auth plumbing**: `get_auth_status('routstr')` → logged_in, `resolve_api_key_provider_credentials` → api_key + base_url resolved
- [x] **Model catalog**: `provider_model_ids('routstr')` → 339 live models, `get_pricing_for_provider('routstr')` → full pricing
- [x] **Aggregator integration**: Added to `_AGGREGATOR_PROVIDERS` for proper vendor/model slug resolution
- [x] **Doctor awareness**: Added to `providers_accepting_vendor_slugs` and `_PROVIDER_ENV_HINTS`
- [x] **17/17 integration audit**: Full parity check against OpenRouter across all integration points

## Design decisions

- **Aggregator placement**: Positioned after OpenRouter (both pay-per-use API aggregators), not at the end
- **Multi-endpoint**: 3 pre-configured nodes + custom URL — Routstr is decentralized, users should choose their preferred node
- **Live pricing**: Fetches from /v1/models on each setup (not a static catalog) — matches Routstr's dynamic pricing model
- **Provider profile**: Uses the plugin system (`plugins/model-providers/routstr/`) following Hermes' standard provider profile pattern
- **No special-casing**: Routstr uses the generic api_key auth path (PROVIDER_REGISTRY), unlike OpenRouter's legacy hardcoded paths. This is cleaner and future-proof

## References

- Routstr: https://routstr.com
- Provider catalog: https://routstr.com/providers
- API keys: https://chat.routstr.com/?tab=apikeys
- GitHub: https://github.com/Routstr

---

cc @shroominic @sh1ftred @9qeklajc @fanyiy — this integration enables Hermes Agent users to route inference through Routstr's decentralized network natively