### PR TITLE
fix(honcho): stop clipping honcho_reasoning tool results to the injection budget

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1359,6 +1359,11 @@ class HonchoMemoryProvider(MemoryProvider):
                     self._session_key, query,
                     reasoning_level=reasoning_level,
                     peer=peer,
+                    # Explicit tool call: return Honcho's full synthesized answer.
+                    # The system-prompt injection cap (dialecticMaxChars) must not
+                    # clip a result the model deliberately asked for; it's already
+                    # bounded server-side by Honcho's MAX_OUTPUT_TOKENS.
+                    apply_injection_cap=False,
                 )
                 # Update cadence tracker so auto-injection respects the gap after an explicit call
                 self._last_dialectic_turn = self._turn_count

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -331,7 +331,10 @@ class HonchoClientConfig:
     # honcho_reasoning tool param (agentic). When false, always uses
     # dialecticReasoningLevel and ignores model-provided overrides.
     dialectic_dynamic: bool = True
-    # Max chars of dialectic result to inject into Hermes system prompt
+    # Max chars of the dialectic supplement auto-injected into the Hermes system
+    # prompt each turn. Applies ONLY to auto-injection — explicit honcho_reasoning
+    # tool results return in full (bounded server-side by Honcho's MAX_OUTPUT_TOKENS),
+    # via dialectic_query(apply_injection_cap=False).
     dialectic_max_chars: int = 600
     # Dialectic depth: how many .chat() calls per dialectic cycle (1-3).
     # Depth 1: single call. Depth 2: self-audit + targeted synthesis.

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -602,6 +602,7 @@ class HonchoSessionManager:
         self, session_key: str, query: str,
         reasoning_level: str | None = None,
         peer: str = "user",
+        apply_injection_cap: bool = True,
     ) -> str:
         """
         Query Honcho's dialectic endpoint about a peer.
@@ -617,6 +618,15 @@ class HonchoSessionManager:
                              Only honored when dialecticDynamic is true.
                              If None or dialecticDynamic is false, uses the configured default.
             peer: Which peer to query — "user" (default) or "ai".
+            apply_injection_cap: When True (default), clip the result to
+                             ``dialecticMaxChars`` — the budget for the dialectic
+                             supplement auto-injected into the system prompt every
+                             turn. Set False for explicit ``honcho_reasoning`` tool
+                             calls, where the model deliberately asked for a full
+                             synthesized answer; that result is already bounded
+                             server-side by Honcho's dialectic MAX_OUTPUT_TOKENS,
+                             so clipping it to the injection budget silently
+                             discards content the caller asked for.
 
         Returns:
             Honcho's synthesized answer, or empty string on failure.
@@ -655,8 +665,17 @@ class HonchoSessionManager:
                 target_peer = self._get_or_create_peer(target_peer_id)
                 result = target_peer.chat(query, reasoning_level=level) or ""
 
-            # Apply Hermes-side char cap before caching
-            if result and self._dialectic_max_chars and len(result) > self._dialectic_max_chars:
+            # Apply the Hermes-side injection char cap before caching. This budget
+            # (dialecticMaxChars) bounds the dialectic supplement auto-injected into
+            # the system prompt every turn; it must NOT clip explicit
+            # honcho_reasoning tool results, which the model asked for in full and
+            # which Honcho already bounds server-side via MAX_OUTPUT_TOKENS.
+            if (
+                apply_injection_cap
+                and result
+                and self._dialectic_max_chars
+                and len(result) > self._dialectic_max_chars
+            ):
                 result = result[:self._dialectic_max_chars].rsplit(" ", 1)[0] + " …"
             return result
         except Exception as e:

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -503,6 +503,7 @@ class TestConcludeToolDispatch:
             "who are you",
             reasoning_level=None,
             peer="hermes",
+            apply_injection_cap=False,
         )
 
     def test_honcho_conclude_missing_both_params_returns_error(self):
@@ -890,6 +891,50 @@ class TestDialecticInputGuard:
         # The query passed to chat() should be truncated
         actual_query = mock_peer.chat.call_args[0][0]
         assert len(actual_query) <= 100
+
+
+class TestDialecticInjectionCap:
+    """dialecticMaxChars must bound the auto-injected supplement but must NOT
+    clip explicit honcho_reasoning tool results, which the model asked for in
+    full (they are already bounded server-side by Honcho's MAX_OUTPUT_TOKENS)."""
+
+    def _manager_with_long_answer(self, answer):
+        from plugins.memory.honcho.client import HonchoClientConfig
+
+        cfg = HonchoClientConfig(dialectic_max_chars=50)
+        mgr = HonchoSessionManager(config=cfg)
+        mgr._dialectic_max_chars = 50
+
+        session = HonchoSession(
+            key="test", user_peer_id="u", assistant_peer_id="a",
+            honcho_session_id="s",
+        )
+        mgr._cache["test"] = session
+
+        mock_peer = MagicMock()
+        mock_peer.chat.return_value = answer
+        mgr._get_or_create_peer = MagicMock(return_value=mock_peer)
+        return mgr
+
+    def test_injection_path_truncates(self):
+        """Default (auto-injection) path clips to dialecticMaxChars with an ellipsis."""
+        answer = "fact " * 100  # 500 chars, well over the 50-char cap
+        mgr = self._manager_with_long_answer(answer)
+
+        result = mgr.dialectic_query("test", "summarize")
+
+        assert len(result) <= 60  # cap + word-boundary slack + ellipsis
+        assert result.endswith(" …")
+
+    def test_tool_path_returns_full_answer(self):
+        """Explicit tool call (apply_injection_cap=False) returns the full answer."""
+        answer = "fact " * 100  # 500 chars, well over the 50-char cap
+        mgr = self._manager_with_long_answer(answer)
+
+        result = mgr.dialectic_query("test", "summarize", apply_injection_cap=False)
+
+        assert result == answer
+        assert not result.endswith(" …")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

`honcho_reasoning` tool results longer than `dialecticMaxChars` (default **600**) were silently
truncated mid-word with a trailing `" …"`, even though the model deliberately spent a turn asking
Honcho for a full synthesized answer. This scopes that char cap to the auto-injection path it was
designed for, so explicit tool calls return Honcho's complete answer.

`dialecticMaxChars` is documented as the budget for the dialectic supplement *auto-injected into the
system prompt every turn* — a small always-on guardrail. But `HonchoSessionManager.dialectic_query()`
applied it **unconditionally**, and that one method is shared by both the auto-injection path
(background prefetch → `_run_dialectic_depth()`) and the `honcho_reasoning` tool handler. So the tool
path inherited a budget meant only for recurring injection. The truncation is purely client-side —
Honcho returns the full answer (verified by replaying the same query with a direct HTTP call to the
backend `chat` endpoint).

Skipping the cap on the tool path is safe, not unbounded: the auto-injection path already has its own
token-based budget (`contextTokens`, enforced in `prefetch()` via `_truncate_to_budget()`), and tool
results are already bounded server-side by Honcho's dialectic `MAX_OUTPUT_TOKENS` — consistent with
sibling tools (`honcho_search`, `honcho_context`) which don't post-clip either.

## Related Issue

Fixes #59469

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/honcho/session.py`: add `apply_injection_cap: bool = True` to `dialectic_query()`; the `dialecticMaxChars` truncation now runs only when it's `True`. Default preserves current behavior for all existing callers.
- `plugins/memory/honcho/__init__.py`: the `honcho_reasoning` tool handler passes `apply_injection_cap=False`.
- `plugins/memory/honcho/client.py`: clarify the `dialectic_max_chars` field comment (injection-only).
- `tests/honcho_plugin/test_session.py`: new `TestDialecticInjectionCap` (injection path still truncates with `" …"`; tool path returns the full answer); updated the existing `honcho_reasoning` dispatch assertion for the new kwarg.

Fully backward compatible — the parameter defaults to `True`, so auto-injection is unchanged and no config migration is needed.

## How to Test

```bash
uv run --extra dev --extra messaging python -m pytest \
  tests/honcho_plugin/test_session.py::TestDialecticInjectionCap \
  tests/honcho_plugin/test_session.py -q
```

Manual: with a peer whose memory yields a >600-char synthesized answer, call `honcho_reasoning`
(e.g. *"Summarize known facts about this peer and communication preferences."*). Before: the result
ends in `" …"`, cut mid-word. After: the full answer is returned.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(honcho): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the honcho test slice and all tests pass (130 passed, 1 pre-existing skip)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (self-hosted Honcho backend)

### Documentation & Housekeeping

- [x] I've updated relevant docstrings/comments (`dialectic_query` docstring, `dialectic_max_chars` comment)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config key)
- [x] I've considered cross-platform impact — `scripts/check-windows-footguns.py` reports no footguns
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (tool contract unchanged; it now just returns the full result)

## Screenshots / Logs

_N/A — behavior is text truncation; see How to Test for before/after._

## Note for existing users

Anyone who bumped `dialecticMaxChars` in `honcho.json` as a workaround for truncated `honcho_reasoning`
answers can revert it to the default `600` after this lands — the cap no longer affects tool results.

## Open question for maintainers

The auto-injection path now has two overlapping budgets: char-based `dialecticMaxChars` (always-on
default guardrail) and token-based `contextTokens` (opt-in, enforced at the injection layer). This PR
keeps both and only fixes the mis-scoped tool-path clip. If you'd prefer the injection budget
consolidated onto a single token-based control, happy to follow up — larger change, out of scope here.
