### PR TITLE
fix(honcho): warn model away from minimal reasoning_level on multi-fact queries

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -108,13 +108,26 @@ REASONING_SCHEMA = {
                 "type": "string",
                 "description": (
                     "Override the default reasoning depth. "
-                    "Omit to use the configured default (typically low). "
-                    "Guide:\n"
-                    "- minimal: quick factual lookups (name, role, simple preference)\n"
-                    "- low: straightforward questions with clear answers\n"
-                    "- medium: multi-aspect questions requiring synthesis across observations\n"
-                    "- high: complex behavioral patterns, contradictions, deep analysis\n"
-                    "- max: thorough audit-level analysis, leave no stone unturned"
+                    "Omit to use the configured default (typically low).\n"
+                    "reasoning_level parameter guide:\n"
+                    "- minimal: use ONLY for a single quick factual lookup (e.g. "
+                    "'what is the user's name'). Honcho hard-caps this tier's output "
+                    "at 250 tokens combined with the model's own hidden reasoning "
+                    "tokens — a multi-part answer can get cut off mid-thought before "
+                    "it even reaches the final-answer phase, especially on models "
+                    "with reasoning/thinking enabled.\n"
+                    "- low/medium/high/max: use for anything requiring a synthesized, "
+                    "multi-fact, or summary-style answer (e.g. 'summarize known facts "
+                    "about this peer', 'what are their communication preferences'). "
+                    "These tiers have no output-token cap of their own (fall back to "
+                    "Honcho's 8192-token global default), so they don't have "
+                    "minimal's cutoff failure mode.\n"
+                    "  - low: straightforward questions with clear answers\n"
+                    "  - medium: multi-aspect questions requiring synthesis across observations\n"
+                    "  - high: complex behavioral patterns, contradictions, deep analysis\n"
+                    "  - max: thorough audit-level analysis, leave no stone unturned\n"
+                    "Default to at least 'low' unless the query is genuinely a single "
+                    "fact lookup."
                 ),
                 "enum": ["minimal", "low", "medium", "high", "max"],
             },


### PR DESCRIPTION
## What does this PR do?

`honcho_reasoning` exposes `reasoning_level` as a model-chosen parameter. Honcho's `minimal` tier
hard-caps output at 250 tokens shared with the model's hidden reasoning tokens, so on
reasoning-capable backends a multi-fact query at `minimal` can be cut off mid chain-of-thought before
producing any answer. The schema only described `minimal` as *"fast/cheap"*, so the model reliably
chose it for broad queries it wasn't suited to.

This expands the `reasoning_level` **parameter** description in `REASONING_SCHEMA` to document
`minimal`'s cutoff failure mode and steer the model toward `low`+ for anything beyond a single fact
lookup. Schema-string-only change — no logic change.

## Related Issue

Fixes #59470

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/honcho/__init__.py`: expand `REASONING_SCHEMA["parameters"]["properties"]["reasoning_level"]["description"]` — flag `minimal` as single-fact-lookup-only (250-token cap shared with hidden reasoning tokens; can truncate before answering), mark `low`/`medium`/`high`/`max` as the choice for synthesized/multi-fact answers, and default to at least `low` unless the query is a single fact.

## How to Test

Ask the model a broad, multi-fact memory question (e.g. *"Summarize known facts about this peer and
communication preferences."*) and let it choose `reasoning_level` freely.

- Before: model picks `minimal`; answer truncates mid chain-of-thought (Honcho `output_tokens=250`).
- After: model picks `low` (or higher) unprompted and returns a complete synthesized answer.

Verified end-to-end locally against a self-hosted Honcho backend: with the new description, the model
self-selected `low`, explicitly citing the guidance in its reasoning, and returned a full answer.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(honcho): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the honcho test slice and all tests pass
- [ ] I've added tests for my changes — N/A (schema-description-only; no logic to test)
- [x] I've tested on my platform: Windows 11 (self-hosted Honcho backend)

### Documentation & Housekeeping

- [x] I've updated tool descriptions/schemas if I changed tool behavior — this **is** the schema update
- [x] I've considered cross-platform impact — N/A (string-only change)

## Relationship to #52395

Draft PR #52395 rewrites the **tool-level** `description` of `honcho_reasoning` (and the other tools)
but does not touch the `reasoning_level` **parameter** description, and keeps the "minimal
(fast/cheap)" framing — so it doesn't address this cutoff. This change is orthogonal (parameter-level
safety guidance) and edits a non-overlapping region of the same `REASONING_SCHEMA` block, so there's
no hard merge conflict. Happy to align the "fast/cheap" wording with #52395 if preferred.

## Screenshots / Logs

_N/A — see How to Test for before/after behavior._
