### PR TITLE
fix: honor no_proxy CIDR for provider clients

### DIFF
--- a/agent/process_bootstrap.py
+++ b/agent/process_bootstrap.py
@@ -25,10 +25,9 @@ from __future__ import annotations
 
 import os
 import sys
-import urllib.request
 from typing import Any, Optional
 
-from utils import base_url_hostname, normalize_proxy_url
+from utils import base_url_hostname, normalize_proxy_url, should_bypass_proxy
 
 
 # Cached at module level so we only pay the OpenAI SDK import cost once
@@ -134,7 +133,7 @@ def _get_proxy_for_base_url(base_url: Optional[str]) -> Optional[str]:
         return proxy
 
     try:
-        if urllib.request.proxy_bypass_environment(host):
+        if should_bypass_proxy([base_url, host]):
             return None
     except Exception:
         pass

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -20,7 +20,7 @@ import uuid
 from abc import ABC, abstractmethod
 from urllib.parse import urlsplit
 
-from utils import normalize_proxy_url
+from utils import normalize_proxy_url, should_bypass_proxy
 
 logger = logging.getLogger(__name__)
 
@@ -253,96 +253,6 @@ def _detect_macos_system_proxy() -> str | None:
                 return f"http://{host}:{port}"
     return None
 
-
-def _split_host_port(value: str) -> tuple[str, int | None]:
-    raw = str(value or "").strip()
-    if not raw:
-        return "", None
-    if "://" in raw:
-        parsed = urlsplit(raw)
-        return (parsed.hostname or "").lower().rstrip("."), parsed.port
-    if raw.startswith("[") and "]" in raw:
-        host, _, rest = raw[1:].partition("]")
-        port = None
-        if rest.startswith(":") and rest[1:].isdigit():
-            port = int(rest[1:])
-        return host.lower().rstrip("."), port
-    if raw.count(":") == 1:
-        host, _, maybe_port = raw.rpartition(":")
-        if maybe_port.isdigit():
-            return host.lower().rstrip("."), int(maybe_port)
-    return raw.lower().strip("[]").rstrip("."), None
-
-
-def _no_proxy_entries() -> list[str]:
-    entries: list[str] = []
-    for key in ("NO_PROXY", "no_proxy"):
-        raw = os.environ.get(key, "")
-        entries.extend(part.strip() for part in raw.split(",") if part.strip())
-    return entries
-
-
-def _no_proxy_entry_matches(entry: str, host: str, port: int | None = None) -> bool:
-    token = str(entry or "").strip().lower()
-    if not token:
-        return False
-    if token == "*":
-        return True
-
-    token_host, token_port = _split_host_port(token)
-    if token_port is not None and port is not None and token_port != port:
-        return False
-    if token_port is not None and port is None:
-        return False
-    if not token_host:
-        return False
-
-    try:
-        network = ipaddress.ip_network(token_host, strict=False)
-        try:
-            return ipaddress.ip_address(host) in network
-        except ValueError:
-            return False
-    except ValueError:
-        pass
-
-    try:
-        token_ip = ipaddress.ip_address(token_host)
-        try:
-            return ipaddress.ip_address(host) == token_ip
-        except ValueError:
-            return False
-    except ValueError:
-        pass
-
-    if token_host.startswith("*."):
-        suffix = token_host[1:]
-        return host.endswith(suffix)
-    if token_host.startswith("."):
-        return host == token_host[1:] or host.endswith(token_host)
-    return host == token_host or host.endswith(f".{token_host}")
-
-
-def should_bypass_proxy(target_hosts: str | list[str] | tuple[str, ...] | set[str] | None) -> bool:
-    """Return True when NO_PROXY/no_proxy matches at least one target host.
-
-    Supports exact hosts, domain suffixes, wildcard suffixes, IP literals,
-    CIDR ranges, optional host:port entries, and ``*``.
-    """
-    entries = _no_proxy_entries()
-    if not entries or not target_hosts:
-        return False
-    if isinstance(target_hosts, str):
-        candidates = [target_hosts]
-    else:
-        candidates = list(target_hosts)
-    for candidate in candidates:
-        host, port = _split_host_port(str(candidate))
-        if not host:
-            continue
-        if any(_no_proxy_entry_matches(entry, host, port) for entry in entries):
-            return True
-    return False
 
 
 def resolve_proxy_url(

--- a/tests/run_agent/test_create_openai_client_proxy_env.py
+++ b/tests/run_agent/test_create_openai_client_proxy_env.py
@@ -179,8 +179,26 @@ def test_get_proxy_for_base_url_returns_none_when_host_bypassed(monkeypatch):
     assert _get_proxy_for_base_url("http://127.0.0.1:11434/v1") is None
     assert _get_proxy_for_base_url("http://localhost:1234/v1") is None
 
+    # CIDR endpoint: must bypass the proxy too.  stdlib
+    # proxy_bypass_environment() does not understand this shape, but users
+    # reasonably expect curl-style NO_PROXY CIDR entries to work for internal
+    # OpenAI-compatible providers (#59465).
+    assert _get_proxy_for_base_url("http://192.168.44.10:4001/v1") is None
+
     # Non-local endpoint — proxy still applies.
     assert _get_proxy_for_base_url("https://api.openai.com/v1") == "http://127.0.0.1:7897"
+
+
+def test_get_proxy_for_base_url_bypasses_ipv6_cidr_no_proxy(monkeypatch):
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy",
+                "NO_PROXY", "no_proxy"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HTTPS_PROXY", "http://corp:8080")
+    monkeypatch.setenv("NO_PROXY", "fd00::/8")
+
+    assert _get_proxy_for_base_url("http://[fd00::1234]:4001/v1") is None
+    assert _get_proxy_for_base_url("http://[fe80::1234]:4001/v1") == "http://corp:8080"
 
 
 def test_get_proxy_for_base_url_returns_proxy_when_no_proxy_unset(monkeypatch):
@@ -230,5 +248,36 @@ def test_create_openai_client_bypasses_proxy_for_no_proxy_host(mock_openai, monk
     ]
     assert "HTTPProxy" not in pool_types, (
         "NO_PROXY host must not route through HTTPProxy; pools were %r" % (pool_types,)
+    )
+    http_client.close()
+
+
+@patch("run_agent.OpenAI")
+def test_create_openai_client_bypasses_proxy_for_no_proxy_cidr(mock_openai, monkeypatch):
+    """E2E: a private custom provider inside a NO_PROXY CIDR must not be proxied."""
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy",
+                "NO_PROXY", "no_proxy"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HTTPS_PROXY", "http://corp-proxy:8080")
+    monkeypatch.setenv("NO_PROXY", "10.10.10.0/24")
+
+    agent = _make_agent()
+    kwargs = {
+        "api_key": "***",
+        "base_url": "http://10.10.10.101:4001/v1",
+    }
+    agent._create_openai_client(kwargs, reason="test", shared=False)
+
+    forwarded = mock_openai.call_args.kwargs
+    http_client = _extract_http_client(forwarded)
+    assert isinstance(http_client, httpx.Client)
+    pool_types = [
+        type(mount._pool).__name__
+        for mount in http_client._mounts.values()
+        if mount is not None and hasattr(mount, "_pool")
+    ]
+    assert "HTTPProxy" not in pool_types, (
+        "NO_PROXY CIDR target must not route through HTTPProxy; pools were %r" % (pool_types,)
     )
     http_client.close()

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,7 @@
 """Shared utility functions for hermes-agent."""
 
 import errno
+import ipaddress
 import json
 import logging
 import os
@@ -442,6 +443,8 @@ _PROXY_ENV_KEYS = (
     "https_proxy", "http_proxy", "all_proxy",
 )
 
+_NO_PROXY_ENV_KEYS = ("NO_PROXY", "no_proxy")
+
 
 def normalize_proxy_url(proxy_url: str | None) -> str | None:
     """Normalize proxy URLs for httpx/aiohttp compatibility.
@@ -465,6 +468,116 @@ def normalize_proxy_env_vars() -> None:
         normalized = normalize_proxy_url(value)
         if normalized and normalized != value:
             os.environ[key] = normalized
+
+
+def _split_no_proxy_host_port(value: str) -> tuple[str, int | None]:
+    """Return a normalized host/network token and optional port.
+
+    ``NO_PROXY`` accepts a mix of bare hosts, ``host:port`` entries, URLs,
+    bracketed IPv6 literals, domain suffixes, and CIDR networks.  Keep this
+    parser deliberately small and permissive: if a value does not clearly carry
+    a port, return the stripped token as the host side so the CIDR/IP/domain
+    matchers below can decide what it means.
+    """
+    raw = str(value or "").strip()
+    if not raw:
+        return "", None
+    if "://" in raw:
+        parsed = urlparse(raw)
+        return (parsed.hostname or "").lower().rstrip("."), parsed.port
+    if raw.startswith("[") and "]" in raw:
+        host, _, rest = raw[1:].partition("]")
+        port = None
+        if rest.startswith(":") and rest[1:].isdigit():
+            port = int(rest[1:])
+        return host.lower().rstrip("."), port
+    if raw.count(":") == 1:
+        host, _, maybe_port = raw.rpartition(":")
+        if maybe_port.isdigit():
+            return host.lower().rstrip("."), int(maybe_port)
+    return raw.lower().strip("[]").rstrip("."), None
+
+
+def _no_proxy_entries() -> list[str]:
+    entries: list[str] = []
+    for key in _NO_PROXY_ENV_KEYS:
+        raw = os.environ.get(key, "")
+        entries.extend(part.strip() for part in raw.split(",") if part.strip())
+    return entries
+
+
+def _no_proxy_entry_matches(entry: str, host: str, port: int | None = None) -> bool:
+    """Return True when one ``NO_PROXY`` token excludes ``host``.
+
+    The stdlib's ``urllib.request.proxy_bypass_environment`` handles hosts and
+    suffixes but not CIDR notation.  Operators commonly use curl/browser-style
+    CIDR ranges for private model gateways, so Hermes handles those locally and
+    keeps the same hostname/suffix behavior for non-IP entries.
+    """
+    token = str(entry or "").strip().lower()
+    if not token:
+        return False
+    if token == "*":
+        return True
+
+    token_host, token_port = _split_no_proxy_host_port(token)
+    if token_port is not None and port is not None and token_port != port:
+        return False
+    if token_port is not None and port is None:
+        return False
+    if not token_host:
+        return False
+
+    try:
+        network = ipaddress.ip_network(token_host, strict=False)
+        try:
+            return ipaddress.ip_address(host) in network
+        except ValueError:
+            return False
+    except ValueError:
+        pass
+
+    try:
+        token_ip = ipaddress.ip_address(token_host)
+        try:
+            return ipaddress.ip_address(host) == token_ip
+        except ValueError:
+            return False
+    except ValueError:
+        pass
+
+    if token_host.startswith("*."):
+        suffix = token_host[1:]
+        return host.endswith(suffix)
+    if token_host.startswith("."):
+        return host == token_host[1:] or host.endswith(token_host)
+    return host == token_host or host.endswith(f".{token_host}")
+
+
+def should_bypass_proxy(
+    target_hosts: str | list[str] | tuple[str, ...] | set[str] | None,
+) -> bool:
+    """Return True when ``NO_PROXY``/``no_proxy`` matches a target.
+
+    Supports exact hosts, domain suffixes, wildcard suffixes, IP literals,
+    CIDR ranges, optional host:port entries, URLs, and ``*``.  This is shared by
+    provider HTTP clients and gateway platform adapters so global proxy bypass
+    behavior stays consistent across Hermes.
+    """
+    entries = _no_proxy_entries()
+    if not entries or not target_hosts:
+        return False
+    if isinstance(target_hosts, str):
+        candidates = [target_hosts]
+    else:
+        candidates = list(target_hosts)
+    for candidate in candidates:
+        host, port = _split_no_proxy_host_port(str(candidate))
+        if not host:
+            continue
+        if any(_no_proxy_entry_matches(entry, host, port) for entry in entries):
+            return True
+    return False
 
 
 # ─── URL Parsing Helpers ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #59465.

Hermes was still using the stdlib NO_PROXY matcher for OpenAI-compatible provider clients. That matcher does not understand CIDR entries, so a base_url like `http://10.10.10.101:4001/v1` could still be sent through `HTTPS_PROXY` even when `NO_PROXY=10.10.10.0/24` was set.

This change:

- Adds one shared proxy bypass helper in `utils.py` with CIDR, IPv6, wildcard, suffix, host, and host:port support.
- Uses that helper in the provider keepalive client path.
- Reuses the same helper in gateway platform proxy resolution so gateway and provider traffic follow the same bypass rules.
- Adds regression coverage for IPv4 CIDR, IPv6 CIDR, and the full `AIAgent._create_openai_client` path that used to mount an `HTTPProxy` pool.

## Testing

- `scripts/run_tests.sh tests/run_agent/test_create_openai_client_proxy_env.py tests/gateway/test_proxy_mode.py tests/gateway/test_telegram_network.py -q`
- `$HOME/.hermes/hermes-agent/venv/bin/python -m ruff check utils.py agent/process_bootstrap.py gateway/platforms/base.py tests/run_agent/test_create_openai_client_proxy_env.py`
- `git diff --check`
- `scripts/run_tests.sh -j 8` was attempted locally. It reached the full-suite summary but failed in unrelated local macOS service, system guard, path normalization, and API server collection tests outside this change. The focused proxy coverage above passes.
