### PR TITLE
fix(proxy): support CIDR notation in no_proxy for custom provider routing

### DIFF
--- a/agent/process_bootstrap.py
+++ b/agent/process_bootstrap.py
@@ -23,7 +23,9 @@ unchanged.
 
 from __future__ import annotations
 
+import ipaddress
 import os
+import socket
 import sys
 import urllib.request
 from typing import Any, Optional
@@ -139,7 +141,57 @@ def _get_proxy_for_base_url(base_url: Optional[str]) -> Optional[str]:
     except Exception:
         pass
 
+    # urllib.request.proxy_bypass_environment() does NOT support CIDR
+    # notation in no_proxy (e.g., 10.0.0.0/8). Parse no_proxy entries
+    # ourselves for CIDR ranges and bypass the proxy when the target
+    # host resolves to an IP inside an excluded subnet (#59465).
+    if _no_proxy_cidr_match(host):
+        return None
+
     return proxy
+
+
+def _no_proxy_cidr_match(host: str) -> bool:
+    """Return True if *host* resolves to an IP inside a no_proxy CIDR range.
+
+    ``urllib.request.proxy_bypass_environment()`` matches hostnames and
+    domain suffixes but does NOT support CIDR notation (e.g., ``10.0.0.0/8``
+    or ``192.168.1.0/24``). This function parses ``no_proxy`` entries as
+    ``ipaddress.ip_network()`` and checks whether the resolved IP falls
+    inside any excluded subnet (#59465).
+
+    Fail-open: any error (DNS resolution failure, invalid CIDR entry,
+    missing no_proxy) returns False so the proxy is used as fallback.
+    """
+    no_proxy = os.environ.get("no_proxy", "") or os.environ.get("NO_PROXY", "")
+    if not no_proxy:
+        return False
+
+    # Resolve hostname → IP. Use the first AF_INET address.
+    try:
+        addrs = socket.getaddrinfo(host, None, socket.AF_INET, socket.SOCK_STREAM)
+        host_ip = addrs[0][4][0] if addrs else None
+    except Exception:
+        return False
+    if not host_ip:
+        return False
+
+    # Check each no_proxy entry for CIDR notation.
+    for entry in no_proxy.replace(" ", "").split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        try:
+            network = ipaddress.ip_network(entry, strict=False)
+        except ValueError:
+            continue  # not a valid network — host/suffix matching handles this
+        try:
+            if ipaddress.ip_address(host_ip) in network:
+                return True
+        except ValueError:
+            continue
+
+    return False
 
 
 def build_keepalive_http_client(

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -64,6 +64,7 @@ AUTHOR_MAP = {
     "wyuebei@gmail.com": "wyuebei-cloud",  # PR #56640 salvage (hermes journey: replace GNU-only %-d strftime with dt.day for Windows)
     "yingwaizhiying@gmail.com": "msh01",  # PR #58250 salvage (telegram: wall-clock init timeout via daemon-thread deadline + abandon the shielded initialize task on timeout so the retry ladder advances instead of hanging on attempt 1/8 under s6 supervision; #58236). Also covers PR #58276 salvage (compression: preserve a real user turn after compaction; #55677).
     "danilo@falcao.org": "danilofalcao",  # PR #56674 salvage (update: skip unsupported platform.matrix lazy refresh on native Windows — python-olm has no Windows wheel)
+    "ishengeqi@163.com": "isheng-eqi",
     "huanshan5195@users.noreply.github.com": "huanshan5195",  # PR #57601 salvage (custom-provider: emit reasoning_effort at the live CustomProfile path so GLM-5.2/ARK/vLLM/Ollama endpoints receive it; + "max" reasoning level)
     "infinitycrew39@gmail.com": "infinitycrew39",  # PR #56431 salvage (honor live vLLM context limits on local endpoints)
     "jonathan.kovacs999@gmail.com": "CocaKova",  # PR #57692 salvage (cron: run jobs under the profile secret scope so get_secret does not fail-close with UnscopedSecretError under profile isolation)

--- a/tests/agent/test_auxiliary_client_proxy_env.py
+++ b/tests/agent/test_auxiliary_client_proxy_env.py
@@ -96,3 +96,43 @@ def test_openai_http_client_kwargs_async_mode():
         async_mode=True,
     )
     assert isinstance(kwargs["http_client"], httpx.AsyncClient)
+
+
+# ── no_proxy CIDR matching ──────────────────────────────────────────────
+
+def test_no_proxy_cidr_bypass(monkeypatch):
+    from agent.process_bootstrap import _get_proxy_for_base_url
+
+    for key in ("HTTPS_PROXY", "NO_PROXY", "no_proxy"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7897")
+    monkeypatch.setenv("NO_PROXY", "localhost,127.0.0.1,10.0.0.0/8")
+
+    # 10.0.0.0/8 includes private-range IPs like 10.10.10.101
+    # socket.getaddrinfo won't resolve random names, so test with a
+    # host that is already an IP — CIDR matching works on IPs directly.
+    assert _get_proxy_for_base_url("https://10.10.10.101/v1") is None
+
+
+def test_no_proxy_cidr_no_match(monkeypatch):
+    from agent.process_bootstrap import _get_proxy_for_base_url
+
+    for key in ("HTTPS_PROXY", "NO_PROXY", "no_proxy"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7897")
+    monkeypatch.setenv("NO_PROXY", "10.0.0.0/8")
+
+    # 1.2.3.4 is outside the excluded subnet — proxy should apply.
+    assert _get_proxy_for_base_url("https://1.2.3.4/v1") == "http://127.0.0.1:7897"
+
+
+def test_no_proxy_cidr_invalid_entry_ignored(monkeypatch):
+    from agent.process_bootstrap import _get_proxy_for_base_url
+
+    for key in ("HTTPS_PROXY", "NO_PROXY", "no_proxy"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7897")
+    monkeypatch.setenv("NO_PROXY", "not-a-cidr,not/a/network,192.168.1.0/24")
+
+    # Invalid entries are ignored; 192.168.1.0/24 still works.
+    assert _get_proxy_for_base_url("https://192.168.1.50/v1") is None


### PR DESCRIPTION
## What

`no_proxy` entries with CIDR notation (e.g., `10.0.0.0/8`, `192.168.1.0/24`) were silently ignored. Custom providers whose `base_url` fell inside a no_proxy subnet were routed through the proxy, producing hard-to-diagnose 503 errors.

## Root cause

`urllib.request.proxy_bypass_environment()` matches hostnames and domain suffixes but does **not** support CIDR notation. Many other tools (curl, browsers) do, so an operator's `no_proxy` setting that works everywhere else silently breaks for Hermes' Python HTTP clients.

## Fix

Added `_no_proxy_cidr_match(host)` in `agent/process_bootstrap.py` which:

1. Reads `NO_PROXY` / `no_proxy` from the environment
2. For each entry, tries to parse as `ipaddress.ip_network()`
3. Resolves the target hostname to an IP via `socket.getaddrinfo()`
4. If the IP falls inside any excluded subnet, bypasses the proxy

Fail-open: any error (DNS failure, invalid CIDR) returns False so the proxy is still used as fallback.

## Test plan

Three new tests in `tests/agent/test_auxiliary_client_proxy_env.py`:

- `test_no_proxy_cidr_bypass` — IP inside CIDR subnet bypasses proxy
- `test_no_proxy_cidr_no_match` — IP outside subnet uses proxy  
- `test_no_proxy_cidr_invalid_entry_ignored` — malformed entries skipped; valid ones still work

All 8 proxy tests pass.

## Related

Closes #59465