### PR TITLE
fix(gemini): clarify OpenAI compat SDK request shape

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1547,6 +1547,7 @@ def dump_api_request_debug(
             "request": {
                 "method": "POST",
                 "url": f"{agent.base_url.rstrip('/')}{'/responses' if agent.api_mode == 'codex_responses' else '/chat/completions'}",
+                "body_format": "openai_sdk_create_kwargs",
                 "headers": {
                     "Authorization": f"Bearer {agent._mask_api_key_for_logs(api_key)}",
                     "Content-Type": "application/json",

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1515,6 +1515,32 @@ def extract_reasoning(agent, assistant_message) -> Optional[str]:
 
 
 
+def _request_dump_body_format(agent) -> str:
+    """Describe the serializer that consumes a debug dump's request body."""
+    api_mode = str(getattr(agent, "api_mode", "") or "")
+    provider = str(getattr(agent, "provider", "") or "").strip().lower()
+    base_url = str(getattr(agent, "base_url", "") or "")
+
+    if api_mode == "anthropic_messages":
+        return "anthropic_sdk_create_kwargs"
+    if api_mode == "bedrock_converse":
+        return "bedrock_converse_kwargs"
+
+    if provider == "gemini":
+        from agent.gemini_native_adapter import is_native_gemini_base_url
+
+        if is_native_gemini_base_url(base_url):
+            return "gemini_native_create_kwargs"
+    if provider == "moa":
+        return "moa_client_create_kwargs"
+    if provider == "copilot-acp" or base_url.startswith("acp://"):
+        return "copilot_acp_create_kwargs"
+
+    if api_mode in {"chat_completions", "codex_responses"}:
+        return "openai_sdk_create_kwargs"
+    return "transport_create_kwargs"
+
+
 def dump_api_request_debug(
     agent,
     api_kwargs: Dict[str, Any],
@@ -1547,7 +1573,7 @@ def dump_api_request_debug(
             "request": {
                 "method": "POST",
                 "url": f"{agent.base_url.rstrip('/')}{'/responses' if agent.api_mode == 'codex_responses' else '/chat/completions'}",
-                "body_format": "openai_sdk_create_kwargs",
+                "body_format": _request_dump_body_format(agent),
                 "headers": {
                     "Authorization": f"Bearer {agent._mask_api_key_for_logs(api_key)}",
                     "Content-Type": "application/json",

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -1,7 +1,9 @@
 """Tests for the ChatCompletionsTransport."""
 
-import pytest
+import json
 from types import SimpleNamespace
+
+import pytest
 
 from agent.transports import get_transport
 from agent.transports.types import NormalizedResponse
@@ -469,6 +471,69 @@ class TestChatCompletionsBuildKwargs:
         )
         assert "thinking_config" not in kw["extra_body"]
         assert kw["extra_body"]["extra_body"]["google"]["thinking_config"] == {
+            "include_thoughts": True,
+            "thinking_level": "high",
+        }
+
+    def test_gemini_openai_compat_sdk_kwargs_serialize_to_single_wire_extra_body(self, transport):
+        """The nested SDK kwarg becomes wire-level extra_body.google.
+
+        OpenAI's Python SDK treats its ``extra_body`` parameter as fields to
+        merge into the JSON request body. Hermes therefore must pass
+        ``extra_body={"extra_body": {"google": ...}}`` as SDK kwargs so the
+        actual HTTP body contains ``extra_body.google``. Flattening the SDK
+        kwargs to ``extra_body={"google": ...}`` would send top-level
+        ``google`` instead.
+        """
+        import httpx
+        from openai import OpenAI
+
+        bodies = []
+
+        def handler(request):
+            bodies.append(json.loads(request.content.decode("utf-8")))
+            return httpx.Response(
+                200,
+                json={
+                    "id": "chatcmpl-test",
+                    "object": "chat.completion",
+                    "created": 0,
+                    "model": "gemini-3-flash-preview",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "ok"},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                },
+            )
+
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gemini-3-flash-preview",
+            messages=msgs,
+            provider_name="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        http_client = httpx.Client(transport=httpx.MockTransport(handler))
+        client = OpenAI(
+            api_key="test-key",
+            base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+            http_client=http_client,
+        )
+
+        try:
+            client.chat.completions.create(**kw)
+        finally:
+            client.close()
+
+        assert len(bodies) == 1
+        wire_body = bodies[0]
+        assert "google" not in wire_body
+        assert "extra_body" not in wire_body["extra_body"]
+        assert wire_body["extra_body"]["google"]["thinking_config"] == {
             "include_thoughts": True,
             "thinking_level": "high",
         }

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -2823,6 +2823,7 @@ def test_dump_api_request_debug_uses_responses_url(monkeypatch, tmp_path):
 
     payload = json.loads(dump_file.read_text())
     assert payload["request"]["url"] == "http://127.0.0.1:9208/v1/responses"
+    assert payload["request"]["body_format"] == "openai_sdk_create_kwargs"
 
 
 def test_dump_api_request_debug_uses_chat_completions_url(monkeypatch, tmp_path):
@@ -2848,6 +2849,56 @@ def test_dump_api_request_debug_uses_chat_completions_url(monkeypatch, tmp_path)
     payload = json.loads(dump_file.read_text())
     assert payload["request"]["url"] == "http://127.0.0.1:9208/v1/chat/completions"
     assert payload["request"]["body_format"] == "openai_sdk_create_kwargs"
+
+
+@pytest.mark.parametrize(
+    ("api_mode", "provider", "base_url", "expected_format"),
+    [
+        (
+            "anthropic_messages",
+            "anthropic",
+            "https://api.anthropic.com/v1",
+            "anthropic_sdk_create_kwargs",
+        ),
+        (
+            "bedrock_converse",
+            "bedrock",
+            "https://bedrock-runtime.us-east-1.amazonaws.com",
+            "bedrock_converse_kwargs",
+        ),
+        (
+            "chat_completions",
+            "gemini",
+            "https://generativelanguage.googleapis.com/v1beta",
+            "gemini_native_create_kwargs",
+        ),
+    ],
+)
+def test_dump_api_request_debug_labels_non_openai_serializers(
+    monkeypatch,
+    tmp_path,
+    api_mode,
+    provider,
+    base_url,
+    expected_format,
+):
+    """Request dumps must describe the serializer that consumes the kwargs."""
+    import json
+
+    agent = _build_agent(monkeypatch)
+    agent.api_mode = api_mode
+    agent.provider = provider
+    agent.base_url = base_url
+    agent.logs_dir = tmp_path
+
+    dump_file = agent._dump_api_request_debug(
+        {"model": agent.model, "messages": []},
+        reason="preflight",
+    )
+
+    payload = json.loads(dump_file.read_text())
+    assert payload["request"]["body_format"] == expected_format
+    assert payload["request"]["body_format"] != "openai_sdk_create_kwargs"
 
 
 def test_dump_api_request_debug_redacts_request_and_error_secrets(monkeypatch, tmp_path, capsys):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -2847,6 +2847,7 @@ def test_dump_api_request_debug_uses_chat_completions_url(monkeypatch, tmp_path)
 
     payload = json.loads(dump_file.read_text())
     assert payload["request"]["url"] == "http://127.0.0.1:9208/v1/chat/completions"
+    assert payload["request"]["body_format"] == "openai_sdk_create_kwargs"
 
 
 def test_dump_api_request_debug_redacts_request_and_error_secrets(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
## What does this PR do?

This PR clarifies the boundary between Hermes request dumps and the final HTTP JSON generated by the OpenAI Python SDK for Gemini OpenAI-compatible requests.

For Gemini thinking config, Hermes intentionally passes nested SDK kwargs:

```python
extra_body={"extra_body": {"google": {"thinking_config": ...}}}
```

That looks double-nested in `HERMES_DUMP_REQUESTS`, but `extra_body` is a special OpenAI SDK parameter. The SDK merges it into the JSON request body, so the wire payload becomes the Google-compatible shape:

```json
{"extra_body": {"google": {"thinking_config": {}}}}
```

Flattening the Hermes SDK kwargs to `extra_body={"google": ...}` would instead make the SDK send a top-level `google` field, which is not the documented OpenAI-compatible Google shape.

The fix therefore does not change the production Gemini builder. Instead, it:

- marks request dumps with `body_format: openai_sdk_create_kwargs` so they are not mistaken for curl-ready wire JSON
- adds a regression test using `httpx.MockTransport` and the real OpenAI SDK client to capture the final serialized HTTP body
- keeps the existing nested SDK kwarg behavior protected from accidental flattening

## Related Issue

Related to #59283

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/agent_runtime_helpers.py`: adds `body_format: openai_sdk_create_kwargs` to request debug dumps.
- `tests/agent/transports/test_chat_completions.py`: adds an SDK-level regression test proving Gemini OpenAI-compatible kwargs serialize to wire-level `extra_body.google.thinking_config`, with no `extra_body.extra_body` in the final HTTP body.
- `tests/run_agent/test_run_agent_codex_responses.py`: asserts the new request dump body-format marker.

## How to Test

1. `pytest tests/agent/transports/test_chat_completions.py -q`
2. `pytest tests/agent/transports/test_chat_completions.py::TestChatCompletionsBuildKwargs::test_gemini_openai_compat_sdk_kwargs_serialize_to_single_wire_extra_body tests/agent/transports/test_chat_completions.py::TestChatCompletionsBuildKwargs::test_gemini_openai_compat_flash_reasoning_maps_to_nested_google_thinking_config -q`
3. `pytest tests/run_agent/test_run_agent_codex_responses.py::test_dump_api_request_debug_uses_chat_completions_url -q`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs/issues context before changing the Gemini request shape
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS, Python venv

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — test-only plus JSON dump metadata
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Targeted validation passed locally:

```text
pytest tests/agent/transports/test_chat_completions.py -q
83 passed in 1.60s

pytest tests/agent/transports/test_chat_completions.py::TestChatCompletionsBuildKwargs::test_gemini_openai_compat_sdk_kwargs_serialize_to_single_wire_extra_body tests/agent/transports/test_chat_completions.py::TestChatCompletionsBuildKwargs::test_gemini_openai_compat_flash_reasoning_maps_to_nested_google_thinking_config -q
2 passed in 0.71s

pytest tests/run_agent/test_run_agent_codex_responses.py::test_dump_api_request_debug_uses_chat_completions_url -q
1 passed in 32.72s
```

Not tested: live Gemini API call.