### PR TITLE
fix(dashboard): accept HA ingress prefix paths

### DIFF
--- a/hermes_cli/dashboard_auth/prefix.py
+++ b/hermes_cli/dashboard_auth/prefix.py
@@ -26,6 +26,11 @@ from typing import Optional
 
 _log = logging.getLogger(__name__)
 
+# Home Assistant Supervisor ingress prefixes are already 63 chars before
+# deployments add their own sub-path. Keep a bounded header budget, but leave
+# room for mainstream reverse-proxy path mounts.
+_MAX_PREFIX_LENGTH = 256
+
 # Characters that, if present in a public_url or prefix value, indicate
 # either a typo or a header-injection attempt. Reject the whole value
 # rather than try to sanitise — the operator can fix their config.
@@ -37,6 +42,7 @@ _REJECT_CHARS = frozenset(('"', "'", "<", ">", " ", "\n", "\r", "\t"))
 # misconfigured deploy. Keyed on the raw value too, so changing the
 # config and reloading surfaces a fresh warning.
 _warned_malformed_public_urls: set = set()
+_warned_malformed_prefixes: set = set()
 
 
 def _warn_if_malformed(source: str, raw: str) -> None:
@@ -72,6 +78,23 @@ def _warn_if_malformed(source: str, raw: str) -> None:
     )
 
 
+def _warn_if_malformed_prefix(raw: Optional[str], reason: str) -> None:
+    """Warn once when a non-empty X-Forwarded-Prefix value is rejected."""
+    cleaned = raw.strip() if raw else ""
+    if not cleaned:
+        return
+    key = (cleaned, reason)
+    if key in _warned_malformed_prefixes:
+        return
+    _warned_malformed_prefixes.add(key)
+    _log.warning(
+        "X-Forwarded-Prefix header %r was ignored because %s. "
+        "Dashboard URLs will be generated without a reverse-proxy path prefix.",
+        cleaned,
+        reason,
+    )
+
+
 def normalise_prefix(raw: Optional[str]) -> str:
     """Normalise an X-Forwarded-Prefix header value.
 
@@ -94,8 +117,16 @@ def normalise_prefix(raw: Optional[str]) -> str:
         or ".." in p
         or any(c in p for c in _REJECT_CHARS)
     ):
+        _warn_if_malformed_prefix(
+            raw,
+            "it contains a disallowed character or path sequence",
+        )
         return ""
-    if len(p) > 64:
+    if len(p) > _MAX_PREFIX_LENGTH:
+        _warn_if_malformed_prefix(
+            raw,
+            f"it is longer than {_MAX_PREFIX_LENGTH} characters",
+        )
         return ""
     return p
 

--- a/tests/hermes_cli/test_dashboard_auth_prefix.py
+++ b/tests/hermes_cli/test_dashboard_auth_prefix.py
@@ -30,13 +30,22 @@ those rules surfaces before a Mission Control deploy.
 """
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 from fastapi.testclient import TestClient
 
 from hermes_cli import web_server
 from hermes_cli.dashboard_auth import clear_providers, register_provider
+from hermes_cli.dashboard_auth import prefix as prefix_mod
 from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+
+
+HA_INGRESS_DASHBOARD_PREFIX = (
+    "/api/hassio_ingress/8AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCdEf"
+    "/dashboard"
+)
 
 
 @pytest.fixture
@@ -90,6 +99,53 @@ def gated_app_direct():
     web_server.app.state.bound_host = prev_host
     web_server.app.state.bound_port = prev_port
     web_server.app.state.auth_required = prev_required
+
+
+# ---------------------------------------------------------------------------
+# X-Forwarded-Prefix normalisation
+# ---------------------------------------------------------------------------
+
+
+class TestForwardedPrefixNormalisation:
+    def test_home_assistant_ingress_prefix_with_subpath_is_accepted(
+        self, caplog
+    ):
+        """Home Assistant Supervisor ingress prefixes are 63 chars before
+        add-ons append their own mount path. They must survive validation so
+        the SPA receives the correct __HERMES_BASE_PATH__ and asset prefix."""
+        prefix_mod._warned_malformed_prefixes.clear()
+        assert len(HA_INGRESS_DASHBOARD_PREFIX) > 64
+
+        with caplog.at_level(logging.WARNING, logger=prefix_mod.__name__):
+            result = prefix_mod.normalise_prefix(HA_INGRESS_DASHBOARD_PREFIX)
+
+        assert result == HA_INGRESS_DASHBOARD_PREFIX
+        assert not [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "X-Forwarded-Prefix" in r.getMessage()
+        ]
+
+    def test_overlong_prefix_is_rejected_with_deduplicated_warning(
+        self, caplog
+    ):
+        """Keep a bounded header budget, but make rejected non-empty
+        prefixes diagnosable instead of silently producing root-relative
+        dashboard URLs."""
+        prefix_mod._warned_malformed_prefixes.clear()
+        too_long = "/" + ("a" * 257)
+
+        with caplog.at_level(logging.WARNING, logger=prefix_mod.__name__):
+            for _ in range(3):
+                assert prefix_mod.normalise_prefix(too_long) == ""
+
+        warnings = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "X-Forwarded-Prefix" in r.getMessage()
+        ]
+        assert len(warnings) == 1
+        assert "longer than 256 characters" in warnings[0].getMessage()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes a dashboard reverse-proxy bug where valid Home Assistant Supervisor ingress prefixes were silently discarded by the `X-Forwarded-Prefix` normalizer.

HA Supervisor ingress prefixes have the shape `/api/hassio_ingress/<43-char-token>`, which is already 63 characters. When an add-on or proxy appends a mount path such as `/dashboard`, the prefix exceeds the old 64-character cap and normalized to `""`. The dashboard then injected an empty `window.__HERMES_BASE_PATH__` and left SPA asset URLs root-relative, so browsers behind HA ingress fetched the wrong origin paths and the dashboard could boot as a blank page.

This raises the bounded prefix budget to 256 characters, keeps the existing path/character rejection rules, and adds a deduplicated warning when a non-empty prefix is rejected so future proxy misconfigurations are diagnosable.

## Related Issue

Fixes #59476

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/dashboard_auth/prefix.py`: raise the `X-Forwarded-Prefix` length cap from 64 to 256 and warn once for rejected non-empty prefixes.
- `tests/hermes_cli/test_dashboard_auth_prefix.py`: add a HA ingress + `/dashboard` regression case and lock the overlong-prefix warning dedup behavior.

## How to Test

Reproduction on `upstream/main`:

```python
from hermes_cli.dashboard_auth.prefix import normalise_prefix
prefix = "/api/hassio_ingress/8AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCdEf/dashboard"
print(len(prefix), repr(normalise_prefix(prefix)))
# before: 73 ''
# after:  73 '/api/hassio_ingress/.../dashboard'
```

Validated locally:

1. `scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_prefix.py -q` -> 24 passed
2. `.venv/bin/python -m pytest tests/hermes_cli/test_web_server.py -k 'spa_assets_are_read_as_utf8' -q` -> 1 passed
3. `python -m ruff check hermes_cli/dashboard_auth/prefix.py tests/hermes_cli/test_dashboard_auth_prefix.py` -> all checks passed
4. `git diff --check` -> clean

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS / local Hermes worktree

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure Python header normalization
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A — path-prefix normalization and SPA bootstrap behavior are covered by tests.
