### PR TITLE
fix(file-sync): re-deliver deferred Ctrl+C via raise_signal, not os.kill (Windows hard-kill) (#57599)

### DIFF
--- a/tests/tools/test_file_sync_sigint.py
+++ b/tests/tools/test_file_sync_sigint.py
@@ -1,0 +1,56 @@
+"""Cross-platform regression for the deferred-SIGINT re-delivery in sync-back.
+
+``_sync_back_once`` defers a Ctrl+C that lands mid-sync, then re-delivers it once
+the sync completes. It must do so via ``signal.raise_signal`` — which invokes the
+handler through C ``raise()`` on every platform — and NOT via
+``os.kill(os.getpid(), signal.SIGINT)``: on Windows the latter routes SIGINT (2)
+to ``TerminateProcess`` and hard-kills the whole CLI instead of raising
+``KeyboardInterrupt``.
+
+Unlike ``test_file_sync_back.py`` this module does not depend on ``fcntl`` (the
+locked sync body is stubbed), so it runs on Windows too — the platform the bug
+actually manifests on.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+
+from tools.environments.file_sync import FileSyncManager
+
+
+def _make_manager() -> FileSyncManager:
+    return FileSyncManager(
+        get_files_fn=lambda: {},
+        upload_fn=lambda *a, **k: None,
+        delete_fn=lambda *a, **k: None,
+    )
+
+
+def test_deferred_sigint_redelivered_via_raise_signal(tmp_path, monkeypatch):
+    mgr = _make_manager()
+
+    # Simulate a Ctrl+C arriving during the sync body: invoke the deferring
+    # handler that _sync_back_once installed, so `deferred_sigint` is populated.
+    def fake_locked(lock_path):
+        signal.getsignal(signal.SIGINT)(signal.SIGINT, None)
+
+    monkeypatch.setattr(mgr, "_sync_back_locked", fake_locked)
+
+    raised: list[int] = []
+    killed: list[tuple[int, int]] = []
+    monkeypatch.setattr(
+        "tools.environments.file_sync.signal.raise_signal", raised.append
+    )
+    monkeypatch.setattr(
+        "tools.environments.file_sync.os.kill",
+        lambda pid, sig: killed.append((pid, sig)),
+    )
+
+    mgr._sync_back_once(tmp_path / "sync.lock")
+
+    # The deferred Ctrl+C is re-delivered cross-platform via raise_signal,
+    assert raised == [signal.SIGINT]
+    # and never through os.kill(getpid, SIGINT) (which hard-kills on Windows).
+    assert (os.getpid(), signal.SIGINT) not in killed

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -302,7 +302,17 @@ class FileSyncManager:
             if on_main_thread and original_handler is not None:
                 signal.signal(signal.SIGINT, original_handler)
                 if deferred_sigint:
-                    os.kill(os.getpid(), signal.SIGINT)
+                    # Re-deliver the deferred Ctrl+C to the just-restored
+                    # handler. ``os.kill(os.getpid(), signal.SIGINT)`` is NOT a
+                    # graceful signal on Windows: os.kill only treats
+                    # CTRL_C_EVENT(0)/CTRL_BREAK_EVENT(1) as console events; any
+                    # other value (SIGINT == 2) routes to TerminateProcess(sig),
+                    # hard-killing the CLI (exit code 2) instead of raising
+                    # KeyboardInterrupt — so a Ctrl+C during a remote-backend
+                    # sync-back would kill the whole session on Windows.
+                    # ``signal.raise_signal`` (3.8+) invokes the handler via C
+                    # ``raise()`` on every platform.
+                    signal.raise_signal(signal.SIGINT)
 
     def _sync_back_locked(self, lock_path: Path) -> None:
         """Sync-back under file lock (serializes concurrent gateways)."""


### PR DESCRIPTION
## Summary
A Ctrl+C deferred during remote-backend sync-back no longer hard-kills the whole CLI on Windows — the deferred interrupt is re-delivered via `signal.raise_signal(SIGINT)` instead of `os.kill(os.getpid(), SIGINT)`.

Root cause: on Windows, `os.kill` only treats CTRL_C_EVENT(0)/CTRL_BREAK_EVENT(1) as console events; SIGINT (2) routes to `TerminateProcess(pid, 2)`, destroying the session instead of raising `KeyboardInterrupt`. `signal.raise_signal` goes through C `raise()` in-process on every platform — no console event, no process-group broadcast, so it is also consistent with the earlier Windows `os.kill` cleanup (`_pid_exists`, PR #22752 lineage).

Salvage of #57599 by @Frowtek — cherry-picked with authorship preserved. This was the last remaining `os.kill(getpid(), SIGINT)` site outside tests.

## Changes
- `tools/environments/file_sync.py`: re-deliver deferred SIGINT via `signal.raise_signal` (1-line fix + explanatory comment)
- `tests/tools/test_file_sync_sigint.py`: new fcntl-free regression test (runs on Windows, the platform the bug manifests on)

## Validation
| | Before | After |
|---|---|---|
| Ctrl+C mid-sync on Windows | TerminateProcess, exit code 2, session destroyed | KeyboardInterrupt via restored handler |
| `scripts/run_tests.sh tests/tools/test_file_sync_sigint.py tests/tools/test_file_sync_back.py` | — | pass |
| E2E (real `FileSyncManager`, deferred handler invoked mid-sync) | — | `KeyboardInterrupt` raised in-process |

Closes #57599.

## Infographic

![filesync-raise-signal](https://v3b.fal.media/files/b/0aa123d2/Oc6eiaEuYoQVBo0OX7CKp_XnDIjO6z.png)
