### PR TITLE
fix(dashboard): raise X-Forwarded-Prefix cap to 256 chars + warn on rejection

### DIFF
--- a/hermes_cli/dashboard_auth/prefix.py
+++ b/hermes_cli/dashboard_auth/prefix.py
@@ -94,10 +94,36 @@ def normalise_prefix(raw: Optional[str]) -> str:
         or ".." in p
         or any(c in p for c in _REJECT_CHARS)
     ):
+        _warn_malformed_prefix(raw)
         return ""
-    if len(p) > 64:
+    if len(p) > 256:
+        _warn_malformed_prefix(raw)
         return ""
     return p
+
+
+def _warn_malformed_prefix(raw: str) -> None:
+    """Warn (once per distinct value) when a non-empty X-Forwarded-Prefix
+    was rejected by :func:`normalise_prefix`.
+
+    Mirrors the dedup pattern in :func:`_warn_if_malformed_public_url` so
+    a misconfigured proxy doesn't flood the logs.
+    """
+    p = raw.strip() if raw else ""
+    if not p:
+        return
+    key = p
+    if key in _warned_malformed_public_urls:
+        return
+    _warned_malformed_public_urls.add(key)
+    _log.warning(
+        "X-Forwarded-Prefix header value %r was ignored because it is "
+        "malformed (path traversal, control chars, or exceeds 256 chars). "
+        "Dashboard asset URLs and cookie paths will be unprefixed; SPA "
+        "will likely serve a blank page behind the proxy. Check your "
+        "reverse-proxy configuration.",
+        raw,
+    )
 
 
 def prefix_from_request(request) -> str:


### PR DESCRIPTION
## Summary

Fixes #59476 — Home Assistant Supervisor ingress prefixes (63 chars for `/api/hassio_ingress/<43-char-token>`) plus any proxy sub-path (e.g. `/dashboard`) exceeded the 64-char cap in `normalise_prefix()`, causing the prefix to be **silently dropped** and the dashboard to serve a blank white page (asset URLs resolved against the wrong origin).

## Changes

- **Raised the length cap from 64 → 256 characters** — covers HA Supervisor ingress + proxy sub-paths, Kubernetes ingress controllers, and other path-prefix gateways.
- **Added a warning log** when a non-empty prefix is rejected (malformed or over-length). Mirrors the existing dedup pattern in `_warn_if_malformed_public_url()` so a misconfigured proxy doesn't flood logs but the operator gets a single actionable warning explaining *why* the prefix was discarded and that the SPA will likely break behind the proxy.
- **Rejection logic now calls `_warn_malformed_prefix()`** for both the existing rejection reasons (`//`, `..`, control chars) AND the new length check — silent discards were a footgun.

## Testing

All existing dashboard auth / prefix tests pass:
- `tests/hermes_cli/test_dashboard_auth_prefix.py` — 22 tests ✓
- `tests/hermes_cli/test_dashboard_auth_gate.py` — 22 tests ✓
- `tests/hermes_cli/test_dashboard_unified_launch.py` — 9 tests ✓
- `tests/hermes_cli/test_web_server_host_header.py` — 11 tests ✓

Manual verification of the exact HA ingress case from the issue:
```python
from hermes_cli.dashboard_auth.prefix import normalise_prefix

# 73 chars — HA Supervisor ingress + proxy sub-path
normalise_prefix('/api/hassio_ingress/8AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCdEf/dashboard')
# → '/api/hassio_ingress/8AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCdEf/dashboard'  (accepted)

# 256 chars — accepted
normalise_prefix('/a' + 'b' * 254)  # → 256-char prefix

# 257 chars — rejected with warning
normalise_prefix('/a' + 'b' * 255)  # → '' + warning logged once
```