### PR TITLE
fix(dashboard): skip auto-sso for password auth providers

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -177,9 +177,16 @@ def _auto_sso_response(request: Request) -> Response | None:
 
     # list_session_providers() already filters on supports_session=True, so
     # token-only credentials (drain/service providers) are never candidates.
-    providers = list_session_providers()
+    # Password-only providers render the /login credential form; they do not
+    # have an OAuth redirect flow for /auth/login to start.
+    providers = [
+        provider
+        for provider in list_session_providers()
+        if not getattr(provider, "supports_password", False)
+    ]
     if len(providers) != 1:
-        # Zero → nothing to redirect to. Two+ → user must choose at /login.
+        # Zero → nothing to redirect to (or only password forms to render).
+        # Two+ → user must choose at /login.
         return None
 
     from hermes_cli.dashboard_auth.prefix import prefix_from_request

--- a/tests/hermes_cli/test_dashboard_auth_401_reauth.py
+++ b/tests/hermes_cli/test_dashboard_auth_401_reauth.py
@@ -406,6 +406,29 @@ class TestAutoSsoRedirect:
         assert r.headers["location"].startswith("/login")
         assert "/auth/login" not in r.headers["location"]
 
+    def test_single_password_provider_renders_login_not_auto_sso(
+        self, gated_app
+    ):
+        """Password-only providers do not have an OAuth redirect flow, so a
+        basic-auth-only deployment must render /login instead of auto-starting
+        /auth/login for the single registered provider."""
+        from hermes_cli.dashboard_auth import clear_providers, register_provider
+        from plugins.dashboard_auth.basic import BasicAuthProvider, hash_password
+
+        clear_providers()
+        register_provider(
+            BasicAuthProvider(
+                username="admin",
+                password_hash=hash_password("hunter2"),
+                secret=b"test-secret-for-basic-auth-provider",
+            )
+        )
+
+        r = gated_app.get("/sessions", follow_redirects=False)
+        assert r.status_code == 302
+        assert r.headers["location"].startswith("/login")
+        assert "/auth/login" not in r.headers["location"]
+
 
 # ---------------------------------------------------------------------------
 # Gate middleware: same-origin next= validation


### PR DESCRIPTION
## Summary

Dashboard auto-SSO currently auto-starts `/auth/login` whenever exactly one interactive session provider is registered. That works for OAuth-style providers but breaks password-only deployments using the basic dashboard auth provider: `BasicAuthProvider.start_login()` intentionally raises `NotImplementedError` because basic auth should render `/login` and submit to `/auth/password-login`.

This change filters password-capable providers out of the auto-SSO candidate list. With only basic auth configured, unauthenticated HTML navigations fall back to the login interstitial instead of attempting an OAuth redirect. OAuth-only single-provider deployments keep the existing auto-SSO behavior.

## Verification

- Added regression: `TestAutoSsoRedirect::test_single_password_provider_renders_login_not_auto_sso`
- Observed the regression fail before the fix: `/auth/login?provider=basic&next=%2Fsessions`
- `PYTHONPATH="$PWD" /home/scoobydoo/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_dashboard_auth_401_reauth.py::TestAutoSsoRedirect -q -o addopts= --tb=short`
  - `6 passed`
- `PYTHONPATH="$PWD" /home/scoobydoo/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_dashboard_auth_401_reauth.py tests/plugins/dashboard_auth/test_basic_provider.py tests/hermes_cli/test_web_server.py -q -o addopts= --tb=short`
  - `408 passed, 11 warnings`
- `/home/scoobydoo/.hermes/hermes-agent/venv/bin/python -m py_compile hermes_cli/dashboard_auth/middleware.py tests/hermes_cli/test_dashboard_auth_401_reauth.py`
- `git diff --check`
