### PR TITLE
fix(desktop): keep model picker switches session-scoped

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -109,7 +109,7 @@ describe('useModelControls', () => {
     expect($currentProvider.get()).toBe('deepseek')
   })
 
-  it('routes active-session picker changes through config.set with an explicit provider', async () => {
+  it('routes active-session picker changes through config.set with an explicit session-scoped provider', async () => {
     const requestGateway = vi.fn(async () => ({ key: 'model', value: 'claude-sonnet-4.6' }) as never)
     let controls!: Controls
 
@@ -127,9 +127,31 @@ describe('useModelControls', () => {
     expect(requestGateway).toHaveBeenCalledWith('config.set', {
       session_id: 'session-1',
       key: 'model',
-      value: 'claude-sonnet-4.6 --provider anthropic'
+      value: 'claude-sonnet-4.6 --provider anthropic --session'
     })
     expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
+  })
+
+  it('session-scopes MoA preset selections so they cannot persist as the global gateway default', async () => {
+    const requestGateway = vi.fn(async () => ({ key: 'model', value: 'BeastMode' }) as never)
+    let controls!: Controls
+
+    render(
+      <Harness activeSessionId="session-1" onReady={value => (controls = value)} requestGateway={requestGateway} />
+    )
+
+    await expect(
+      controls.selectModel({
+        model: 'BeastMode',
+        provider: 'moa'
+      })
+    ).resolves.toBe(true)
+
+    expect(requestGateway).toHaveBeenCalledWith('config.set', {
+      session_id: 'session-1',
+      key: 'model',
+      value: 'BeastMode --provider moa --session'
+    })
   })
 
   it('stores a no-session pick as UI state with no gateway or global write', async () => {

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -96,7 +96,7 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
         await requestGateway('config.set', {
           session_id: activeSessionId,
           key: 'model',
-          value: `${selection.model} --provider ${selection.provider}`
+          value: `${selection.model} --provider ${selection.provider} --session`
         })
 
         void queryClient.invalidateQueries({ queryKey: ['model-options', activeSessionId] })

--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -61,8 +61,8 @@ describe('ModelMenuPanel MoA presets', () => {
     fireEvent.click(row)
 
     // #54670: must route through the persistent model-switch path
-    // (config.set model="<preset> --provider moa"), i.e. onSelectModel with
-    // provider 'moa', NOT a one-shot command.dispatch that reverts after a turn.
+    // i.e. onSelectModel with provider 'moa' (which session-scopes live-session
+    // switches), NOT a one-shot command.dispatch that reverts after a turn.
     expect(onSelectModel).toHaveBeenCalledWith({ model: 'BeastMode', provider: 'moa' })
   })
 

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -180,8 +180,8 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
   }
 
   // Selecting a MoA preset switches the session to it PERSISTENTLY, using the
-  // same path real provider selections use (config.set model="<preset>
-  // --provider moa" via onSelectModel → the gateway's persistent switch_model).
+  // same path real provider selections use (onSelectModel → config.set with
+  // --session for live sessions → the gateway's persistent switch_model).
   // Previously this dispatched the one-shot `/moa` command, which ran a single
   // turn through MoA and then silently reverted to the prior model (#54670) —
   // the dropdown presented presets like persistent selections but they weren't.


### PR DESCRIPTION
## What does this PR do?

Fixes the desktop model picker path for live sessions so selecting a model, including a MoA preset, stays session-scoped instead of falling through to the global `config.yaml` persist path.

The desktop hook was already sending `session_id` to `config.set`, but the gateway decides global persistence from the parsed model flags. Without `--session`, `resolve_persist_behavior(False, False)` can still persist the switch globally when `model.persist_switch_by_default` is enabled. This PR appends `--session` for active desktop sessions and adds coverage for both normal provider selections and MoA presets.

This intentionally does not change Telegram sticky-session migration or MoA fallback behavior; it closes the desktop-to-global bleed entry point described in the issue.

## Related Issue

Fixes #59480

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-model-controls.ts`
  - Append `--session` when the desktop picker applies a model switch to an active session.
- `apps/desktop/src/app/session/hooks/use-model-controls.test.tsx`
  - Assert active-session provider switches include `--session`.
  - Add a MoA preset regression test proving `BeastMode --provider moa --session` is sent.
- `apps/desktop/src/app/shell/model-menu-panel.tsx`
  - Update the MoA preset comment to reflect the live-session scoped path.
- `apps/desktop/src/app/shell/model-menu-panel.test.tsx`
  - Clarify the existing MoA picker routing assertion.

## How to Test

1. `cd apps/desktop && npm run test:ui -- src/app/session/hooks/use-model-controls.test.tsx src/app/shell/model-menu-panel.test.tsx`
2. `cd apps/desktop && npm run typecheck`
3. `git diff --check`

Additional source-level probe used during development:

```text
BeastMode --provider moa
  parsed= BeastMode moa global= False session= False
  persist_global= True
BeastMode --provider moa --session
  parsed= BeastMode moa global= False session= True
  persist_global= False
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS Darwin 24.6.0 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
