### PR TITLE
fix(honcho): warn about minimal reasoning_level's 250-token output cap

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -94,8 +94,8 @@ REASONING_SCHEMA = {
         "Ask Honcho a natural language question and get a synthesized answer. "
         "Uses Honcho's LLM (dialectic reasoning) — higher cost than honcho_profile or honcho_search. "
         "Can query about any peer via alias or explicit peer ID. "
-        "Pass reasoning_level to control depth: minimal (fast/cheap), low (default), "
-        "medium, high, max (deep/expensive). Omit for configured default."
+        "Pass reasoning_level to control depth: minimal (fast/cheap, 250-token cap — single facts only), "
+        "low (default), medium, high, max (deep/expensive). Omit for configured default."
     ),
     "parameters": {
         "type": "object",
@@ -110,7 +110,8 @@ REASONING_SCHEMA = {
                     "Override the default reasoning depth. "
                     "Omit to use the configured default (typically low). "
                     "Guide:\n"
-                    "- minimal: quick factual lookups (name, role, simple preference)\n"
+                    "- minimal: quick factual lookups ONLY (name, role, single preference). "
+                    "Hard 250-token output cap — will truncate multi-fact or synthesis queries.\n"
                     "- low: straightforward questions with clear answers\n"
                     "- medium: multi-aspect questions requiring synthesis across observations\n"
                     "- high: complex behavioral patterns, contradictions, deep analysis\n"


### PR DESCRIPTION
## What

Expanded the `reasoning_level` parameter description in `REASONING_SCHEMA` to document `minimal`'s hard 250-token output cap and steer models to `low`+ for anything beyond single-fact lookups.

## Why

Honcho's `minimal` dialectic tier hard-caps output at 250 tokens — intended for single fast factual lookups. On reasoning-capable models, hidden reasoning tokens share that budget, so synthesis queries truncate before producing a final answer. The schema gave no signal this would happen.

## Fix

Schema-string-only change in `plugins/memory/honcho/__init__.py`:
- Tool description: added '250-token cap — single facts only' to minimal
- Parameter description: added warning about truncation behavior

No behavioral code modified.

## Runtime Proof

Before: model chose `minimal` for multi-fact query → truncated output
After: same query with updated schema → model chose `low` unprompted → complete answer

## Duplicate Scan

No existing PRs for #59470.

Closes #59470