### PR TITLE
fix(honcho): skip dialectic char cap for explicit honcho_reasoning tool calls

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1359,6 +1359,7 @@ class HonchoMemoryProvider(MemoryProvider):
                     self._session_key, query,
                     reasoning_level=reasoning_level,
                     peer=peer,
+                    apply_injection_cap=False,
                 )
                 # Update cadence tracker so auto-injection respects the gap after an explicit call
                 self._last_dialectic_turn = self._turn_count

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -602,6 +602,7 @@ class HonchoSessionManager:
         self, session_key: str, query: str,
         reasoning_level: str | None = None,
         peer: str = "user",
+        apply_injection_cap: bool = True,
     ) -> str:
         """
         Query Honcho's dialectic endpoint about a peer.
@@ -655,8 +656,10 @@ class HonchoSessionManager:
                 target_peer = self._get_or_create_peer(target_peer_id)
                 result = target_peer.chat(query, reasoning_level=level) or ""
 
-            # Apply Hermes-side char cap before caching
-            if result and self._dialectic_max_chars and len(result) > self._dialectic_max_chars:
+            # Apply Hermes-side char cap before caching (auto-injection only;
+            # the honcho_reasoning tool passes apply_injection_cap=False so
+            # explicit user queries get the full server response — #59469).
+            if apply_injection_cap and result and self._dialectic_max_chars and len(result) > self._dialectic_max_chars:
                 result = result[:self._dialectic_max_chars].rsplit(" ", 1)[0] + " …"
             return result
         except Exception as e:


### PR DESCRIPTION
## What

Skip the `dialecticMaxChars` truncation cap when `honcho_reasoning` is called explicitly by the model. Previously, tool results were silently clipped to 600 chars mid-word even when the model spent a turn requesting a full synthesized answer.

## Why

`dialectic_query()` shared one truncation path for two call sites:
1. Auto-injection (system prompt supplement) — tight cap correct
2. `honcho_reasoning` tool — model explicitly requested a full answer, no reason to clip

The server returns untruncated results; the clip is purely client-side.

## Fix

Add `apply_injection_cap: bool = True` parameter to `dialectic_query()`. The `honcho_reasoning` tool handler passes `False`. Auto-injection path unchanged (default `True`).

Files changed:
- `plugins/memory/honcho/session.py`: new parameter + guard on truncation
- `plugins/memory/honcho/__init__.py`: tool handler passes `apply_injection_cap=False`

## Runtime Proof

Before: `honcho_reasoning` result truncated at 600 chars with trailing `…`
After: full server response returned, no truncation

## Duplicate Scan

No existing PRs for #59469.

Closes #59469