### PR TITLE
fix(moa): parse JSON string reference_models in _normalize_preset

### DIFF
--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -110,6 +110,12 @@ def _normalize_preset(raw: Any) -> dict[str, Any]:
         raw = {}
 
     raw_refs = raw.get("reference_models")
+    # reference_models may be a JSON string (hand-edited config.yaml) or a list.
+    if isinstance(raw_refs, str):
+        try:
+            raw_refs = json.loads(raw_refs)
+        except (json.JSONDecodeError, ValueError):
+            raw_refs = []
     if not isinstance(raw_refs, list):
         # A hand-edited scalar / single mapping (or a bad type) must degrade to
         # defaults instead of crashing the iteration, mirroring the tolerance


### PR DESCRIPTION
## Problem

`hermes moa list` shows hardcoded default models (openai-codex:gpt-5.5, openrouter:deepseek/deepseek-v4-pro) instead of user-configured presets.

## Root Cause

`hermes moa configure` serializes `reference_models` as a JSON string in config.yaml:
```yaml
reference_models: '[{"provider":"xiaomi","model":"mimo-v2.5-pro"},{"provider":"minimax","model":"MiniMax-M3"}]'
```

But `_normalize_preset` expects a native list — it checks `isinstance(raw_refs, list)` which fails for strings, then falls back to `DEFAULT_MOA_REFERENCE_MODELS`.

## Fix

Add `json.loads()` parsing before the type check in `_normalize_preset`, so both JSON string and native list formats work correctly.

## Verification

Before fix:
```
$ hermes moa list
* default
  Reference models:
    1. openai-codex:gpt-5.5
    2. openrouter:deepseek/deepseek-v4-pro
```

After fix:
```
$ hermes moa list
* default
  Reference models:
    1. xiaomi:mimo-v2.5-pro
    2. minimax:MiniMax-M3
    3. deepseek:deepseek-v4-pro
```