### PR TITLE
fix: scrub MiniMax reasoning markers

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -611,7 +611,8 @@ def strip_think_blocks(agent, content: str) -> str:
          ``<think>`` in prose aren't over-stripped.
       3. Stray orphan open/close tags that slip through.
       4. Tag variants: ``<think>``, ``<thinking>``, ``<reasoning>``,
-         ``<REASONING_SCRATCHPAD>``, ``<thought>`` (Gemma 4), all
+         ``<REASONING_SCRATCHPAD>``, ``<thought>`` (Gemma 4),
+         ``<mm:think>`` (MiniMax M3), all
          case-insensitive.
 
     Additionally strips standalone tool-call XML blocks that some open
@@ -638,6 +639,7 @@ def strip_think_blocks(agent, content: str) -> str:
     content = re.sub(r'<reasoning>.*?</reasoning>', '', content, flags=re.DOTALL | re.IGNORECASE)
     content = re.sub(r'<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>', '', content, flags=re.DOTALL | re.IGNORECASE)
     content = re.sub(r'<thought>.*?</thought>', '', content, flags=re.DOTALL | re.IGNORECASE)
+    content = re.sub(r'<mm:think>.*?</mm:think>', '', content, flags=re.DOTALL | re.IGNORECASE)
     # 1b. Tool-call XML blocks (openclaw/openclaw#67318). Handle the
     #     generic tag names first — they have no attribute gating since
     #     a literal <tool_call> in prose is already vanishingly rare.
@@ -667,14 +669,14 @@ def strip_think_blocks(agent, content: str) -> str:
     #    Strip from the tag to end of string.  Fixes #8878 / #9568
     #    (MiniMax M2.7 leaking raw reasoning into assistant content).
     content = re.sub(
-        r'(?:^|\n)[ \t]*<(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)\b[^>]*>.*$',
+        r'(?:^|\n)[ \t]*<(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD|mm:think)\b[^>]*>.*$',
         '',
         content,
         flags=re.DOTALL | re.IGNORECASE,
     )
     # 3. Stray orphan open/close tags that slipped through.
     content = re.sub(
-        r'</?(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)>\s*',
+        r'</?(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD|mm:think)>\s*',
         '',
         content,
         flags=re.IGNORECASE,

--- a/cli.py
+++ b/cli.py
@@ -188,6 +188,7 @@ _REASONING_TAGS = (
     "thinking",
     "reasoning",
     "thought",
+    "mm:think",
 )
 
 
@@ -202,8 +203,8 @@ def _strip_reasoning_tags(text: str) -> str:
         partial-content dumps.
 
     Covers the variants emitted by reasoning models today: ``<think>``,
-    ``<thinking>``, ``<reasoning>``, ``<REASONING_SCRATCHPAD>``, and
-    ``<thought>`` (Gemma 4).  Must stay in sync with
+    ``<thinking>``, ``<reasoning>``, ``<REASONING_SCRATCHPAD>``,
+    ``<thought>`` (Gemma 4), and ``<mm:think>`` (MiniMax M3). Must stay in sync with
     ``run_agent.py::_strip_think_blocks`` and the stream consumer's
     ``_OPEN_THINK_TAGS`` / ``_CLOSE_THINK_TAGS`` tuples.
 
@@ -5628,8 +5629,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # suppress them during streaming too — unless show_reasoning is
         # enabled, in which case we route the inner content to the
         # reasoning display box instead of discarding it.
-        _OPEN_TAGS = ("<REASONING_SCRATCHPAD>", "<think>", "<reasoning>", "<THINKING>", "<thinking>", "<thought>")
-        _CLOSE_TAGS = ("</REASONING_SCRATCHPAD>", "</think>", "</reasoning>", "</THINKING>", "</thinking>", "</thought>")
+        _OPEN_TAGS = ("<REASONING_SCRATCHPAD>", "<think>", "<reasoning>", "<THINKING>", "<thinking>", "<thought>", "<mm:think>")
+        _CLOSE_TAGS = ("</REASONING_SCRATCHPAD>", "</think>", "</reasoning>", "</THINKING>", "</thinking>", "</thought>", "</mm:think>")
 
         # Append to a pre-filter buffer first
         self._stream_prefilt = getattr(self, "_stream_prefilt", "") + text

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -104,11 +104,11 @@ class GatewayStreamConsumer:
     # run_agent.py _strip_think_blocks() tag variants.
     _OPEN_THINK_TAGS = (
         "<REASONING_SCRATCHPAD>", "<think>", "<reasoning>",
-        "<THINKING>", "<thinking>", "<thought>",
+        "<THINKING>", "<thinking>", "<thought>", "<mm:think>",
     )
     _CLOSE_THINK_TAGS = (
         "</REASONING_SCRATCHPAD>", "</think>", "</reasoning>",
-        "</THINKING>", "</thinking>", "</thought>",
+        "</THINKING>", "</thinking>", "</thought>", "</mm:think>",
     )
 
     # Class-wide monotonic counter for native-streaming draft ids.  Telegram

--- a/tests/cli/test_stream_delta_think_tag.py
+++ b/tests/cli/test_stream_delta_think_tag.py
@@ -125,6 +125,15 @@ class TestRealReasoningBlock:
         assert full == "Visible answer"
         assert "hidden reasoning" not in full
 
+    def test_minimax_mm_think_tag_suppressed(self):
+        """MiniMax M3's <mm:think> channel marker should not reach the TUI."""
+        cli = _make_cli_stub()
+        cli._stream_delta("<mm:think>provider reasoning</mm:think>Visible answer")
+        assert not cli._in_reasoning_block
+        full = "".join(cli._emitted)
+        assert full == "Visible answer"
+        assert "provider reasoning" not in full
+
 
 class TestFlushRecovery:
     """_flush_stream should recover content from false-positive reasoning blocks."""

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -1452,6 +1452,13 @@ class TestFilterAndAccumulate:
         c._filter_and_accumulate("<thought>Gemma style</thought>Output")
         assert c._accumulated == "Output"
 
+    def test_minimax_mm_think_tag_variant(self):
+        """MiniMax M3 emits <mm:think> blocks that must stay hidden."""
+        c = _make_consumer()
+        c._filter_and_accumulate("<mm:think>provider reasoning</mm:think>Answer")
+        assert c._accumulated == "Answer"
+        assert "provider reasoning" not in c._accumulated
+
     def test_reasoning_scratchpad_variant(self):
         c = _make_consumer()
         c._filter_and_accumulate(

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -392,6 +392,15 @@ class TestStripThinkBlocks:
         assert "<thought>" not in result
         assert "answer" in result
 
+    def test_minimax_mm_think_block_removed(self, agent):
+        """MiniMax M3 uses <mm:think> tags for provider-side reasoning."""
+        result = agent._strip_think_blocks(
+            "<mm:think>internal reasoning</mm:think> answer"
+        )
+        assert "internal reasoning" not in result
+        assert "<mm:think>" not in result
+        assert "answer" in result
+
     def test_orphaned_thought_tag(self, agent):
         result = agent._strip_think_blocks("<thought>orphaned reasoning without close")
         assert "<thought>" not in result


### PR DESCRIPTION
## Summary

Fixes #59461.

MiniMax M3 can emit provider reasoning in `<mm:think>...</mm:think>` blocks. The existing scrubbers already handled tags like `<think>`, `<thinking>`, `<reasoning>`, and `<thought>`, but not the MiniMax namespaced form, so those markers could leak into streamed gateway output, the CLI stream, and stored final assistant text.

This adds `<mm:think>` to the same scrub paths and covers all three surfaces with regression tests.

## Tests

- `PYTHONPATH=. $HOME/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_stream_consumer.py::TestFilterAndAccumulate::test_minimax_mm_think_tag_variant tests/cli/test_stream_delta_think_tag.py::TestRealReasoningBlock::test_minimax_mm_think_tag_suppressed tests/run_agent/test_run_agent.py::TestStripThinkBlocks::test_minimax_mm_think_block_removed -q` before the fix, expected failure: 3 failed
- `PYTHONPATH=. $HOME/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_stream_consumer.py::TestFilterAndAccumulate::test_minimax_mm_think_tag_variant tests/cli/test_stream_delta_think_tag.py::TestRealReasoningBlock::test_minimax_mm_think_tag_suppressed tests/run_agent/test_run_agent.py::TestStripThinkBlocks::test_minimax_mm_think_block_removed -q` after the fix: 3 passed
- `PYTHONPATH=. $HOME/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_stream_consumer.py::TestFilterAndAccumulate tests/gateway/test_stream_consumer.py::TestFilterAndAccumulateIntegration tests/cli/test_stream_delta_think_tag.py tests/run_agent/test_run_agent.py::TestStripThinkBlocks -q`: 70 passed
- `PYTHONPATH=. $HOME/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_stream_consumer.py tests/cli/test_stream_delta_think_tag.py -q`: 138 passed
- `PYTHONPATH=. $HOME/.hermes/hermes-agent/venv/bin/python -m ruff check gateway/stream_consumer.py cli.py agent/agent_runtime_helpers.py tests/gateway/test_stream_consumer.py tests/cli/test_stream_delta_think_tag.py tests/run_agent/test_run_agent.py`: All checks passed
