### PR TITLE
fix(windows): write restart-pending marker before gateway relaunch

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -1673,6 +1673,15 @@ def restart() -> None:
 
     # Give Windows a moment to release the listening port.
     time.sleep(1.0)
+
+    # Write the restart-pending marker so the new gateway sends the
+    # home-channel back-online notification (♻️ Gateway online…).
+    try:
+        from hermes_cli.config import get_hermes_home
+        (Path(get_hermes_home()) / ".restart_pending.json").write_text("{}", encoding="utf-8")
+    except Exception:
+        pass
+
     start()
 
     if not _wait_for_gateway_ready(timeout_s=15.0):


### PR DESCRIPTION
## Problem

On Windows, `hermes gateway restart` stops the old process from the CLI and starts a new one. The gateway process never sets `_restart_requested=True`, so it cannot write `.restart_pending.json` on exit — the new process doesn't detect the restart and never sends the home-channel back-online notification.

This is the Windows-only gap left by b14e15c, which fixed the same issue for Linux/macOS (systemd/launchd paths) where the gateway exits under its own control.

Closes #33778

## Fix

Write `.restart_pending.json` from the CLI (`gateway_windows.restart()`) immediately before calling `start()`. One file, 9 lines. The gateway only checks `.exists()` on this marker — content is irrelevant — so a plain `write_text` suffices.

## Testing

Manually verified on Windows: `hermes gateway restart` triggers `♻️ Gateway online…` notification in Telegram after relaunch.