### PR TITLE
fix(gemini): remove double-nested extra_body in thinking_config builder

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -433,11 +433,9 @@ class ChatCompletionsTransport(ProviderTransport):
             if _is_gemini_openai_compat_base_url(base_url):
                 thinking_config = _snake_case_gemini_thinking_config(raw_thinking_config)
                 if thinking_config:
-                    openai_compat_extra = extra_body.get("extra_body", {})
-                    google_extra = openai_compat_extra.get("google", {})
+                    google_extra = extra_body.get("google", {})
                     google_extra["thinking_config"] = thinking_config
-                    openai_compat_extra["google"] = google_extra
-                    extra_body["extra_body"] = openai_compat_extra
+                    extra_body["google"] = google_extra
             elif raw_thinking_config:
                 extra_body["thinking_config"] = raw_thinking_config
 


### PR DESCRIPTION
## What

Removed the redundant `extra_body` wrapper layer in the Gemini OpenAI-compat `thinking_config` builder. Previously nested the payload as `{"extra_body": {"extra_body": {"google": ...}}}` instead of `{"extra_body": {"google": ...}}`.

## Why

Google API rejects the double-nested payload with `400 Invalid JSON payload... Unknown name "extra_body" at 'extra_body': Cannot find field.` Hermes retries 3x and reports a generic empty-response error, making a one-line reproducible bug look like a flaky model issue.

## Fix

Removed the redundant wrapper. Now writes directly to `extra_body["google"]` which gets placed into `api_kwargs["extra_body"]`. 1 file changed, 2 insertions, 4 deletions.

## Runtime Proof

Before: request body contained `{"extra_body": {"extra_body": {"google": {"thinking_config": ...}}}}` → 400 error
After: request body contains `{"extra_body": {"google": {"thinking_config": ...}}}` → successful completion

## Duplicate Scan

No existing PRs for #59283.

Closes #59283