### PR TITLE
fix(agent): merge extra_body into request debug dumps so they match t…

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1385,12 +1385,17 @@ def dump_api_request_debug(
     Dump a debug-friendly HTTP request record for the active inference API.
 
     Captures the request body from api_kwargs (excluding transport-only keys
-    like timeout). Intended for debugging provider-side 4xx failures where
-    retries are not useful.
+    like timeout). ``extra_body`` is shallow-merged into the body exactly as
+    the OpenAI SDK does at send time, so the dump matches the wire request
+    and stays replayable. Intended for debugging provider-side 4xx failures
+    where retries are not useful.
     """
     try:
         body = copy.deepcopy(api_kwargs)
         body.pop("timeout", None)
+        extra_body = body.pop("extra_body", None)
+        if isinstance(extra_body, dict):
+            body.update(extra_body)
         body = {k: v for k, v in body.items() if v is not None}
 
         api_key = None

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -2210,6 +2210,35 @@ def test_dump_api_request_debug_uses_chat_completions_url(monkeypatch, tmp_path)
     assert payload["request"]["url"] == "http://127.0.0.1:9208/v1/chat/completions"
 
 
+def test_dump_api_request_debug_merges_extra_body_like_sdk(monkeypatch, tmp_path):
+    """Dumps merge the ``extra_body`` kwarg into the body like the SDK does (#59283)."""
+    import json
+    _patch_agent_bootstrap(monkeypatch)
+    agent = run_agent.AIAgent(
+        model="gemini-2.5-pro",
+        base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+        api_key="test-key",
+        quiet_mode=True,
+        max_iterations=1,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.logs_dir = tmp_path
+
+    thinking = {"google": {"thinking_config": {"include_thoughts": True}}}
+    dump_file = agent._dump_api_request_debug(
+        {
+            "model": "gemini-2.5-pro",
+            "messages": [{"role": "user", "content": "hi"}],
+            "extra_body": {"extra_body": thinking},
+        },
+        reason="preflight",
+    )
+
+    body = json.loads(dump_file.read_text())["request"]["body"]
+    assert body["extra_body"] == thinking
+
+
 def test_dump_api_request_debug_redacts_request_and_error_secrets(monkeypatch, tmp_path, capsys):
     """Request debug dumps should redact secrets before disk/stdout output."""
     import json


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
Makes `HERMES_DUMP_REQUESTS` debug dumps match the actual wire request by merging the
`extra_body` SDK kwarg into the dumped body, the same way the OpenAI SDK does at send time.

`dump_api_request_debug()` writes `api_kwargs` verbatim as the `request.body` of a replayable
HTTP request record. But `extra_body` is an OpenAI-SDK kwarg, not a body field — the SDK
shallow-merges it into the JSON body before sending. So for any provider that uses `extra_body`
(Gemini OpenAI-compat `thinking_config`, Kimi/zai `thinking`, OpenRouter provider prefs), the
dump records a body that never existed on the wire.

This is what produced the misleading evidence in #59283: the dump shows
`{"extra_body": {"extra_body": {"google": ...}}}`, and replaying it via curl returns Google's
`400 Unknown name "extra_body" at 'extra_body'`. I verified with a mock HTTP transport against
`openai==2.24.0` that the **actual** wire body is single-nested —
`{"extra_body": {"google": {"thinking_config": ...}}}` — which is exactly Google's documented
OpenAI-compat shape, on both the gemini provider-profile path and the legacy fallback path.
The request builder is correct; the dump is what's wrong. Fixing the dump makes it
byte-for-byte replayable, which is its stated purpose (debugging provider-side 4xx failures).


## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #59283

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `agent/agent_runtime_helpers.py` — `dump_api_request_debug()`: pop `extra_body` from the
  dumped kwargs and shallow-merge it into the body, mirroring the SDK's request assembly;
  documented the merge in the docstring
- `tests/run_agent/test_run_agent_codex_responses.py` — new regression test
  `test_dump_api_request_debug_merges_extra_body_like_sdk` (fails without the fix)

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Run `scripts/run_tests.sh tests/run_agent/test_run_agent_codex_responses.py -k dump_api_request_debug`
   - 4 tests pass; the new one fails if the fix is reverted
2. Reproduce the original report: configure `provider: gemini` with base_url
   `https://generativelanguage.googleapis.com/v1beta/openai`, run
   `HERMES_DUMP_REQUESTS=1 hermes chat` with reasoning enabled, and inspect the newest
   `request_dump_*.json`
3. Before this fix the dump body contains a nested `extra_body.extra_body` wrapper and
   replaying it via curl returns `400 Unknown name "extra_body"`; after it, the body carries
   the single-nested shape the provider actually received and replays cleanly

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

```json
// before — this never went over the wire, replaying it 400s
{"model": "gemini-2.5-pro", "extra_body": {"extra_body": {"google": {"thinking_config": {"include_thoughts": true}}}}}

// after — matches the captured wire body
{"model": "gemini-2.5-pro", "extra_body": {"google": {"thinking_config": {"include_thoughts": true}}}}
```