### PR TITLE
fix(proxy): honor CIDR notation in no_proxy for custom providers

### DIFF
--- a/agent/process_bootstrap.py
+++ b/agent/process_bootstrap.py
@@ -139,6 +139,22 @@ def _get_proxy_for_base_url(base_url: Optional[str]) -> Optional[str]:
     except Exception:
         pass
 
+    # CIDR-aware bypass: stdlib proxy_bypass_environment() does not honor
+    # CIDR notation in no_proxy (e.g. 10.10.10.0/24).  Parse those entries
+    # manually so private-subnet exclusions actually work.  See #59465.
+    try:
+        import ipaddress
+        no_proxy_raw = os.environ.get("no_proxy", os.environ.get("NO_PROXY", ""))
+        if no_proxy_raw and "/" in no_proxy_raw:
+            addr = ipaddress.ip_address(host)
+            for entry in no_proxy_raw.split(","):
+                entry = entry.strip()
+                if "/" in entry:
+                    if addr in ipaddress.ip_network(entry, strict=False):
+                        return None
+    except (ValueError, TypeError):
+        pass
+
     return proxy
 
 

--- a/agent/process_bootstrap.py
+++ b/agent/process_bootstrap.py
@@ -142,18 +142,21 @@ def _get_proxy_for_base_url(base_url: Optional[str]) -> Optional[str]:
     # CIDR-aware bypass: stdlib proxy_bypass_environment() does not honor
     # CIDR notation in no_proxy (e.g. 10.10.10.0/24).  Parse those entries
     # manually so private-subnet exclusions actually work.  See #59465.
-    try:
-        import ipaddress
-        no_proxy_raw = os.environ.get("no_proxy", os.environ.get("NO_PROXY", ""))
-        if no_proxy_raw and "/" in no_proxy_raw:
+    import ipaddress
+    no_proxy_raw = os.environ.get("no_proxy", os.environ.get("NO_PROXY", ""))
+    if no_proxy_raw and "/" in no_proxy_raw:
+        try:
             addr = ipaddress.ip_address(host)
-            for entry in no_proxy_raw.split(","):
-                entry = entry.strip()
-                if "/" in entry:
+        except ValueError:
+            return proxy
+        for entry in no_proxy_raw.split(","):
+            entry = entry.strip()
+            if "/" in entry:
+                try:
                     if addr in ipaddress.ip_network(entry, strict=False):
                         return None
-    except (ValueError, TypeError):
-        pass
+                except (ValueError, TypeError):
+                    continue  # malformed CIDR: skip this entry, try next
 
     return proxy
 

--- a/tests/agent/test_auxiliary_client_proxy_env.py
+++ b/tests/agent/test_auxiliary_client_proxy_env.py
@@ -90,6 +90,23 @@ def test_get_proxy_for_base_url_respects_no_proxy(monkeypatch):
     assert _get_proxy_for_base_url("https://api.openai.com/v1") == "http://127.0.0.1:7897"
 
 
+def test_get_proxy_for_base_url_cidr_skips_malformed_entry(monkeypatch):
+    """#59505: malformed CIDR before a valid one must not abort the scan.
+    The stdlib bypass in gateway.platforms.base handles this per-entry; we mirror it.
+    """
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy", "NO_PROXY", "no_proxy"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7897")
+    # malformed CIDR (missing prefixlen) followed by valid 10.0.0.0/8
+    monkeypatch.setenv("NO_PROXY", "10.0.0.0/,10.0.0.0/8")
+
+    # valid CIDR should still bypass the proxy for 10.0.5.12
+    assert _get_proxy_for_base_url("https://10.0.5.12/v1") is None
+    # non-matching host still goes through proxy
+    assert _get_proxy_for_base_url("https://api.openai.com/v1") == "http://127.0.0.1:7897"
+
+
 def test_openai_http_client_kwargs_async_mode():
     kwargs = _openai_http_client_kwargs(
         "https://litellm.internal.example.com/v1",


### PR DESCRIPTION
## What

Custom providers on private subnets are no longer routed through an unrelated proxy when `no_proxy` uses CIDR notation (e.g. `10.10.10.0/24`). Previously, `urllib.request.proxy_bypass_environment()` silently ignored CIDR ranges, causing 503 errors that looked like provider outages.

## Why

Python's stdlib `proxy_bypass_environment()` only matches exact hostnames/domain suffixes — it does not parse CIDR notation. An operator's `no_proxy=localhost,127.0.0.1,10.10.10.0/24` works everywhere else (curl, browsers) but silently breaks Hermes' HTTP clients.

## Fix

After the stdlib bypass check, parse `no_proxy` entries for CIDR ranges using `ipaddress.ip_network()`. If the target host falls within any listed subnet, bypass the proxy. Non-CIDR entries still use stdlib matching. 1 file, 16 insertions.

## Runtime Proof

Before: `no_proxy=10.10.10.0/24` + provider at `10.10.10.101` → routed through proxy → 503
After: same config → proxy bypassed → direct connection succeeds

## Duplicate Scan

No existing PRs for #59465.

Closes #59465