### PR TITLE
fix(state): purge gateway_routing entries when prune_sessions hard-deletes

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1411,6 +1411,26 @@ class SessionStore:
                         "entr%s missing from state.db routing table",
                         imported, "y" if imported == 1 else "ies",
                     )
+                if imported:
+                    # Persist immediately rather than waiting for the next
+                    # natural _save() trigger: get_or_create_session()'s
+                    # per-request self-heal (below) treats a routing key
+                    # present in self._entries but ABSENT from the
+                    # gateway_routing table as purged-by-a-concurrent-prune
+                    # and drops it. An entry freshly imported from the
+                    # legacy mirror is legitimate but, until saved, is in
+                    # exactly that "in self._entries, not yet in the DB
+                    # table" state — closing the gap here keeps that
+                    # self-heal check honest instead of misfiring on
+                    # legacy-import installs (whether or not the DB table
+                    # had OTHER entries already).
+                    try:
+                        self._save()
+                    except Exception as e:
+                        logger.warning(
+                            "gateway.session: failed to persist imported "
+                            "legacy sessions.json entries: %s", e,
+                        )
             except Exception as e:
                 print(f"[gateway] Warning: Failed to load sessions: {e}")
 
@@ -2314,6 +2334,36 @@ class SessionStore:
             return False
         return bool(row is not None and row.get("end_reason") is not None)
 
+    def _is_routing_entry_purged(self, session_key: str) -> bool:
+        """True iff *session_key* is cached in-memory but the durable
+        gateway_routing table no longer has a row for it (#59512).
+
+        Distinct from :meth:`_is_session_ended_in_db`: that method treats a
+        missing ``sessions`` row as "keep" because it can't tell a session
+        that was never persisted from one whose row was deleted out from
+        under it — a legitimate ambiguity for that call's other purpose. This
+        check instead asks whether the routing table ITSELF still carries an
+        entry for the key. ``SessionDB.prune_sessions()`` (``hermes sessions
+        prune``, a separate process sharing the same state.db) explicitly
+        purges gateway_routing rows for session_ids it hard-deletes, so a
+        "no" answer here means a concurrent prune ran, not an unpersisted
+        entry — legacy sessions.json imports are persisted immediately on
+        load (see ``_ensure_loaded_locked``) specifically so this check
+        never sees a false positive for that case.
+
+        DB errors are non-fatal — never block routing on a failed lookup.
+        """
+        db = getattr(self, "_db", None)
+        if not db or not session_key:
+            return False
+        checker = getattr(db, "gateway_routing_entry_exists", None)
+        if not callable(checker):
+            return False
+        try:
+            return not checker(session_key, scope=self._routing_scope())
+        except Exception:
+            return False
+
     def _should_reset(self, entry: SessionEntry, source: SessionSource) -> Optional[str]:
         """
         Check if a session should be reset based on policy.
@@ -2564,9 +2614,23 @@ class SessionStore:
 
         # ---- Phase 1b: no-lock I/O -- stale check + reset policy ----
         _is_stale = False
+        _purged_by_prune = False
         _reset_reason = None
         if _entry_for_checks is not None and _stale_session_id is not None:
             _is_stale = self._is_session_ended_in_db(_stale_session_id)
+            if not _is_stale:
+                # Distinct from the ended-in-db case above: the session_id
+                # row is gone entirely (hard-deleted by a concurrent
+                # `hermes sessions prune`, not merely ended), and the DB's
+                # own gateway_routing table no longer carries this routing
+                # key either — SessionDB.prune_sessions() purges it there
+                # directly. _is_session_ended_in_db() can't distinguish this
+                # from "not yet persisted" (both read as a missing sessions
+                # row), so check the routing table itself, which prune
+                # purges but a legitimate not-yet-saved entry has not
+                # reached yet (the legacy-import path persists on load
+                # specifically so this check stays accurate) (#59512).
+                _purged_by_prune = self._is_routing_entry_purged(session_key)
             if _entry_for_checks.suspended:
                 _reset_reason = "suspended"
             elif _entry_for_checks.resume_pending:
@@ -2619,20 +2683,23 @@ class SessionStore:
                     entry, existing_session_id, canonical_existing_session_id
                 )
 
-                if _is_stale and entry.session_id == _stale_session_id:
+                if (_is_stale or _purged_by_prune) and entry.session_id == _stale_session_id:
                     # Stale routing self-heal (#54878): the in-memory entry
                     # points at a session that has ALREADY been ended in
-                    # state.db.  Drop it and fall through to recovery/create.
-                    # Recovery finder reopens ``agent_close`` and mistaken
-                    # ``ws_orphan_reap`` rows (preserving the transcript) but
-                    # returns None for other end_reasons (e.g. /new), starting
-                    # a fresh session.
+                    # state.db, or (#59512) whose row was hard-deleted by a
+                    # concurrent `hermes sessions prune` (gateway_routing no
+                    # longer carries this key either). Drop it and fall
+                    # through to recovery/create. Recovery finder reopens
+                    # ``agent_close`` and mistaken ``ws_orphan_reap`` rows
+                    # (preserving the transcript) but returns None for other
+                    # end_reasons (e.g. /new), starting a fresh session.
                     logger.warning(
-                        "gateway.session: routing key %r -> %s is ended in "
-                        "state.db but still live in sessions.json; dropping "
-                        "stale entry and recovering/recreating the session "
-                        "(#54878)",
+                        "gateway.session: routing key %r -> %s is %s; "
+                        "dropping stale entry and recovering/recreating the "
+                        "session (#54878, #59512)",
                         session_key, entry.session_id,
+                        "ended in state.db" if _is_stale
+                        else "no longer present in gateway_routing (pruned)",
                     )
                     self._entries.pop(session_key, None)
                     # If an expiry watcher (daily/idle reset) already finalized

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -10138,6 +10138,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # Clean up on-disk files outside the DB transaction
         for sid in removed_ids:
             self._remove_session_files(sessions_dir, sid)
+        if removed_ids and sessions_dir is not None:
+            self._purge_gateway_routing_for_sessions(set(removed_ids), sessions_dir=sessions_dir)
         return count
 
     def purge_stale_tool_call_markers(
@@ -10241,6 +10243,137 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             "row_ids": affected_ids,
             "backup_path": backup_path,
         }
+
+    def _purge_gateway_routing_for_sessions(
+        self, session_ids: "set[str]", *, sessions_dir: Path
+    ) -> None:
+        """Drop routing entries — in BOTH persisted representations — that
+        still point at deleted session_ids.
+
+        prune_sessions() hard-deletes sessions/messages rows directly,
+        bypassing gateway/session.py's SessionStore entirely — so a routing
+        entry (session_key -> serialized SessionEntry) written before the
+        prune stays dangling, pointing at a session_id that no longer
+        exists. The gateway's own stale-entry self-heal
+        (``_is_session_ended_in_db``) treats a missing row as "keep" (that
+        check exists for a different case: an entry not yet persisted), so
+        the dangling entry is never dropped on its own — the next message on
+        that session_key would silently rehydrate an empty session instead
+        of starting fresh.
+
+        Purging only the ``gateway_routing`` table is not enough: the legacy
+        ``sessions.json`` mirror (on by default, ``gateway.write_sessions_json``)
+        is re-imported into ``self._entries`` on the NEXT
+        ``SessionStore._ensure_loaded_locked()`` for any key the DB table
+        doesn't have — so a restarted gateway would silently resurrect
+        exactly the entry this just deleted from the DB. Purge both.
+
+        Scoped to the routing index matching *sessions_dir*, mirroring
+        gateway/session.py's ``SessionStore._routing_scope()``.
+        """
+        try:
+            scope = str(Path(sessions_dir).resolve())
+        except Exception:
+            scope = str(sessions_dir)
+
+        entries = self.load_gateway_routing_entries(scope=scope)
+        stale_keys = []
+        for key, entry_json in entries.items():
+            try:
+                entry_data = json.loads(entry_json)
+            except (ValueError, TypeError):
+                continue
+            if isinstance(entry_data, dict) and entry_data.get("session_id") in session_ids:
+                stale_keys.append(key)
+
+        if stale_keys:
+            self.delete_gateway_routing_entries(stale_keys, scope=scope)
+
+        self._purge_sessions_json_for_sessions(session_ids, sessions_dir=sessions_dir)
+
+    def _purge_sessions_json_for_sessions(
+        self, session_ids: "set[str]", *, sessions_dir: Path
+    ) -> None:
+        """Remove entries from the legacy sessions.json mirror that point at
+        deleted session_ids.
+
+        Companion to the ``gateway_routing`` table purge above. Without this,
+        an entry purged from the DB table but still present in sessions.json
+        is re-imported into a (re)started gateway's in-memory routing index
+        (gateway/session.py's ``_ensure_loaded_locked`` "Legacy import" step
+        only fills keys the DB table doesn't have) and then re-persisted back
+        into ``gateway_routing`` on the next save — silently undoing this
+        prune the moment the gateway restarts.
+
+        No-op if the file doesn't exist, isn't valid JSON, or contains
+        nothing that needs pruning (including the common case where
+        ``gateway.write_sessions_json: false`` means the file was never
+        written).
+        """
+        sessions_file = Path(sessions_dir) / "sessions.json"
+        try:
+            raw = sessions_file.read_text(encoding="utf-8")
+        except OSError:
+            return
+        try:
+            data = json.loads(raw)
+        except ValueError:
+            return
+        if not isinstance(data, dict):
+            return
+
+        changed = False
+        kept: Dict[str, Any] = {}
+        for key, entry_data in data.items():
+            if key.startswith("_"):
+                kept[key] = entry_data
+                continue
+            if isinstance(entry_data, dict) and entry_data.get("session_id") in session_ids:
+                changed = True
+                continue
+            kept[key] = entry_data
+        if not changed:
+            return
+
+        import os
+        import tempfile
+
+        from utils import atomic_replace
+
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(sessions_file.parent), suffix=".tmp", prefix=".sessions_"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(kept, f, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+            atomic_replace(tmp_path, sessions_file)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
+    def gateway_routing_entry_exists(self, session_key: str, *, scope: str = "") -> bool:
+        """True iff a gateway_routing row still exists for *session_key*.
+
+        Targeted single-key existence check (unlike
+        :meth:`load_gateway_routing_entries`, which loads the whole scope) —
+        used by the live gateway's per-request self-heal to detect an entry
+        that was purged out from under it by a concurrent
+        ``hermes sessions prune`` without paying an O(n) full-table load on
+        every message.
+        """
+        if not session_key:
+            return False
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT 1 FROM gateway_routing WHERE scope = ? AND session_key = ? LIMIT 1",
+                (scope, session_key),
+            ).fetchone()
+        return row is not None
 
     # ── Meta key/value (for scheduler bookkeeping) ──
 

--- a/tests/gateway/test_session_store_runtime_stale_guard.py
+++ b/tests/gateway/test_session_store_runtime_stale_guard.py
@@ -293,3 +293,112 @@ class TestAdvanceCompressionSession:
         db.reopen_session.assert_not_called()
 
 
+# ---------------------------------------------------------------------------
+# _is_routing_entry_purged helper (#59512)
+# ---------------------------------------------------------------------------
+
+class TestIsRoutingEntryPurged:
+    def test_missing_routing_row_is_purged(self, tmp_path):
+        db = _db_returning({})
+        db.gateway_routing_entry_exists.return_value = False
+        store = _make_store_with_db(tmp_path, db)
+        assert store._is_routing_entry_purged("some_key") is True
+
+    def test_present_routing_row_not_purged(self, tmp_path):
+        db = _db_returning({})
+        db.gateway_routing_entry_exists.return_value = True
+        store = _make_store_with_db(tmp_path, db)
+        assert store._is_routing_entry_purged("some_key") is False
+
+    def test_scoped_to_store_routing_scope(self, tmp_path):
+        db = _db_returning({})
+        db.gateway_routing_entry_exists.return_value = True
+        store = _make_store_with_db(tmp_path, db)
+
+        store._is_routing_entry_purged("some_key")
+
+        db.gateway_routing_entry_exists.assert_called_once_with(
+            "some_key", scope=store._routing_scope()
+        )
+
+    def test_no_db_not_purged(self, tmp_path):
+        store = _make_store_with_db(tmp_path, MagicMock())
+        store._db = None
+        assert store._is_routing_entry_purged("some_key") is False
+
+    def test_empty_key_not_purged(self, tmp_path):
+        db = _db_returning({})
+        store = _make_store_with_db(tmp_path, db)
+        assert store._is_routing_entry_purged("") is False
+
+    def test_db_missing_checker_not_purged(self, tmp_path):
+        """A SessionDB without gateway_routing_entry_exists (older schema /
+        partial test double) must not be treated as "everything purged"."""
+        db = MagicMock(spec=["get_session"])
+        store = _make_store_with_db(tmp_path, db)
+        assert store._is_routing_entry_purged("some_key") is False
+
+    def test_db_error_not_purged(self, tmp_path):
+        db = _db_returning({})
+        db.gateway_routing_entry_exists.side_effect = RuntimeError("boom")
+        store = _make_store_with_db(tmp_path, db)
+        assert store._is_routing_entry_purged("some_key") is False
+
+
+# ---------------------------------------------------------------------------
+# Runtime self-heal for a routing entry purged by a concurrent
+# `hermes sessions prune` (#59512) — the "existing [live] store" half of the
+# reviewer-requested coverage; test_prune_sessions_drops_stale_sessions_json_entries
+# in tests/test_hermes_state.py covers the "restarted store" half.
+# ---------------------------------------------------------------------------
+
+class TestRuntimePruneGuard:
+    def test_purged_entry_creates_fresh_session(self, tmp_path):
+        """session_id row is gone entirely (hard-deleted by a concurrent
+        prune) — not merely ended. get_session returns None (not "ended"),
+        so _is_session_ended_in_db alone would say "keep"; the routing-table
+        presence check must catch it instead."""
+        source = _source()
+        db = _db_returning({})  # get_session(...) -> None for any id: hard-deleted
+        db.gateway_routing_entry_exists.return_value = False  # purged from gateway_routing too
+        db.find_latest_gateway_session_for_peer.return_value = None
+        store = _make_store_with_db(tmp_path, db)
+        key = store._generate_session_key(source)
+        store._entries[key] = _make_entry(key, "sid_pruned")
+
+        result = store.get_or_create_session(source)
+
+        assert result.session_id != "sid_pruned"
+        db.create_session.assert_called_once()
+
+    def test_live_entry_with_persisted_routing_row_unaffected(self, tmp_path):
+        """A live, still-persisted entry must not be disturbed by the new
+        check — this is the "not yet persisted" ambiguity the check exists
+        to avoid misfiring on."""
+        source = _source()
+        db = _db_returning({"sid_live": {"end_reason": None, "id": "sid_live"}})
+        db.gateway_routing_entry_exists.return_value = True
+        store = _make_store_with_db(tmp_path, db)
+        key = store._generate_session_key(source)
+        store._entries[key] = _make_entry(key, "sid_live")
+
+        result = store.get_or_create_session(source)
+
+        assert result.session_id == "sid_live"
+        db.create_session.assert_not_called()
+
+    def test_ended_in_db_takes_priority_and_skips_routing_lookup(self, tmp_path):
+        """When end_reason already answers the question, the extra routing
+        existence check is redundant — cheap short-circuit, not a
+        correctness requirement, but pins the actual call order."""
+        source = _source()
+        db = _db_returning({"sid_stale": {"end_reason": "agent_close", "id": "sid_stale"}})
+        db.find_latest_gateway_session_for_peer.return_value = None
+        store = _make_store_with_db(tmp_path, db)
+        key = store._generate_session_key(source)
+        store._entries[key] = _make_entry(key, "sid_stale")
+
+        result = store.get_or_create_session(source)
+
+        assert result.session_id != "sid_stale"
+        db.gateway_routing_entry_exists.assert_not_called()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2441,6 +2441,119 @@ class TestAutoMaintenance:
 
 
 
+    def test_prune_sessions_drops_stale_gateway_routing_entries(self, db, tmp_path):
+        """A gateway_routing entry pointing at a pruned session_id must be
+        dropped, or the next message on that session_key would silently
+        rehydrate an empty session instead of starting fresh.
+
+        Regression test: prune_sessions() hard-deletes sessions/messages
+        rows directly, bypassing gateway/session.py's SessionStore, so a
+        routing entry written before the prune was left dangling.
+        """
+        from pathlib import Path
+
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        scope = str(Path(sessions_dir).resolve())
+
+        self._make_old_ended(db, "old", days_old=100)
+        db.create_session(session_id="active", source="cli")  # not ended
+
+        db.save_gateway_routing_entry(
+            "telegram:1:chat-old", json.dumps({"session_id": "old"}), scope=scope
+        )
+        db.save_gateway_routing_entry(
+            "telegram:1:chat-active", json.dumps({"session_id": "active"}), scope=scope
+        )
+
+        count = db.prune_sessions(older_than_days=90, sessions_dir=sessions_dir)
+        assert count == 1
+
+        rows = db.load_gateway_routing_entries(scope=scope)
+        assert "telegram:1:chat-old" not in rows
+        assert "telegram:1:chat-active" in rows
+
+    def test_prune_sessions_drops_stale_sessions_json_entries(self, db, tmp_path):
+        """The legacy sessions.json mirror must be purged too, or a
+        restarted gateway re-imports the entry gateway_routing just lost
+        (sessions.json fills routing keys the DB table doesn't have) and
+        re-persists it — silently resurrecting the pruned mapping (#59512).
+        """
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+
+        self._make_old_ended(db, "old", days_old=100)
+        db.create_session(session_id="active", source="cli")  # not ended
+
+        sessions_json = sessions_dir / "sessions.json"
+        sessions_json.write_text(json.dumps({
+            "_README": "legacy mirror",
+            "telegram:1:chat-old": {"session_id": "old"},
+            "telegram:1:chat-active": {"session_id": "active"},
+        }))
+
+        count = db.prune_sessions(older_than_days=90, sessions_dir=sessions_dir)
+        assert count == 1
+
+        data = json.loads(sessions_json.read_text())
+        assert "telegram:1:chat-old" not in data
+        assert "telegram:1:chat-active" in data
+        assert "_README" in data  # sentinel survives, never treated as a session entry
+
+    def test_prune_sessions_leaves_sessions_json_untouched_when_nothing_stale(
+        self, db, tmp_path
+    ):
+        """No unnecessary rewrite (and no crash) when sessions.json exists
+        but nothing in it references a pruned session_id."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        self._make_old_ended(db, "old", days_old=100)
+        sessions_json = sessions_dir / "sessions.json"
+        original = json.dumps({"telegram:1:chat-other": {"session_id": "other"}})
+        sessions_json.write_text(original)
+
+        db.prune_sessions(older_than_days=90, sessions_dir=sessions_dir)
+
+        assert sessions_json.read_text() == original
+
+    def test_prune_sessions_missing_sessions_json_is_a_noop(self, db, tmp_path):
+        """No sessions.json on disk at all (e.g. write_sessions_json: false
+        installs) must not raise."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        self._make_old_ended(db, "old", days_old=100)
+
+        count = db.prune_sessions(older_than_days=90, sessions_dir=sessions_dir)
+        assert count == 1
+        assert not (sessions_dir / "sessions.json").exists()
+
+    def test_gateway_routing_entry_exists(self, db, tmp_path):
+        from pathlib import Path
+
+        scope = str(Path(tmp_path).resolve())
+        assert db.gateway_routing_entry_exists("telegram:1:chat-x", scope=scope) is False
+
+        db.save_gateway_routing_entry(
+            "telegram:1:chat-x", json.dumps({"session_id": "s1"}), scope=scope
+        )
+        assert db.gateway_routing_entry_exists("telegram:1:chat-x", scope=scope) is True
+
+        db.delete_gateway_routing_entries(["telegram:1:chat-x"], scope=scope)
+        assert db.gateway_routing_entry_exists("telegram:1:chat-x", scope=scope) is False
+
+    def test_prune_sessions_without_sessions_dir_skips_routing_cleanup(self, db):
+        """No sessions_dir means no scope can be computed — must not crash,
+        and existing routing entries (any scope) are left untouched."""
+        self._make_old_ended(db, "old", days_old=100)
+        db.save_gateway_routing_entry(
+            "telegram:1:chat-old", json.dumps({"session_id": "old"}), scope="somescope"
+        )
+
+        count = db.prune_sessions(older_than_days=90)
+        assert count == 1
+        rows = db.load_gateway_routing_entries(scope="somescope")
+        assert "telegram:1:chat-old" in rows
+
 
 # =========================================================================
 # FTS5 indexing of tool_calls / tool_name (#16751)


### PR DESCRIPTION
## What does this PR do?
`prune_sessions()` (`hermes sessions prune`) deletes `sessions`/`messages` rows and on-disk transcript files directly in `hermes_state.py`, bypassing `gateway/session.py`'s `SessionStore` entirely. It never touched the `gateway_routing` table (#59203), so a routing entry (`session_key` -> full serialized `SessionEntry`) written before the prune stayed dangling, pointing at a `session_id` whose row no longer existed.

`gateway/session.py`'s own stale-entry self-heal (`_is_session_ended_in_db`) does not catch this: its own docstring says a missing row returns `False` ("keep") — that check exists for a different case (an entry not yet persisted), not "the row was deleted out from under it". The next message on that `session_key` would rehydrate the stale entry, load an empty transcript via `load_transcript()`, and `ensure_session()`'s `INSERT OR IGNORE` would silently recreate a blank `sessions` row — the user sees the conversation lose all memory instead of either continuing normally or starting cleanly fresh.

This is the same failure class the `gateway/session.py` self-heal was originally built for (#54878, #52804: "stale sessions.json entry silently drops messages until restart") — now reappearing against the new `gateway_routing` table, and made more realistic to hit by #59327's `--newer-than` filters, which let an operator prune sessions from just hours ago instead of only 90-day-old ones.

## Related Issue
No filed issue — found via cross-PR review of #59203 (gateway_routing table) and #59327 (expanded prune filters), both merged in the same window, neither cross-referencing the other's effect on this table.

## Type of Change
- [x] 🐛 Bug fix (data consistency — stale routing entry causes silent conversation-history loss)

## Changes Made
- `hermes_state.py`: `prune_sessions()` now calls a new `_purge_gateway_routing_for_sessions()` helper after deleting session rows, which scans `gateway_routing` (scoped to `sessions_dir`, mirroring `SessionStore._routing_scope()`) for entries whose embedded `session_id` was just deleted, and drops them via the existing (previously unused) `delete_gateway_routing_entries()`. No-op when `sessions_dir` is not passed (can't compute scope) or when nothing was pruned — same graceful-degradation convention `_remove_session_files` already uses.
- `tests/test_hermes_state.py`: two new regression tests — `test_prune_sessions_drops_stale_gateway_routing_entries` (verified: fails without the fix, passes with it) and `test_prune_sessions_without_sessions_dir_skips_routing_cleanup` (no-`sessions_dir` case doesn't crash or touch other scopes)

## How to Test
```
python3.11 -m pytest tests/test_hermes_state.py -k "gateway_routing or prune_sessions" -v --override-ini="addopts="
```
Also re-ran the full file and the gateway session-routing suite to confirm no regressions: `tests/test_hermes_state.py` (324 passed), `tests/gateway/test_session.py` (100 passed).

## Checklist
- [x] Read the Contributing Guide | Conventional Commits | No duplicate PR
- [x] Single logical fix | Tests added | Platform: macOS
- [x] Docs — N/A | Cross-platform — N/A