### PR TITLE
docs: add notion patrol skill

### DIFF
--- a/skills/productivity/notion-patrol/SKILL.md
+++ b/skills/productivity/notion-patrol/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: notion-patrol
+description: Use when running or maintaining the read-only Notion Patrol workflow that recursively scans Notion pages/databases for external URLs, checks link health, writes CSV results, and reports weekly Slack summaries.
+version: 1.1.0
+author: Legal AI / Hermes Agent
+license: MIT
+platforms: [linux]
+language: javascript
+runtime: node18+
+dependencies: none
+metadata:
+  hermes:
+    tags: [notion, link-checker, url-patrol, read-only, slack, cron]
+    related_skills: [notion, slack-mention-replies]
+---
+
+# Notionパトロール君
+
+## Overview
+
+Notionの指定ルート（ページまたはデータベース）配下を再帰的に読み取り、外部URLだけを抽出してHTTPステータスを確認するスキルです。Notion APIには **読み取りリクエストのみ** を行い、Notionへの作成・更新・削除・コメント投稿は行いません。
+
+主な用途:
+
+- 法務内マニュアルや法務関連DBに含まれる外部リンクの定期点検
+- リンク切れ・疎通エラーのCSV化
+- 週次CronによるSlack通知
+
+## When to Use
+
+- NotionページまたはNotionデータベース配下の外部リンクを網羅的に洗い出すとき
+- Notionリンクチェック結果をCSVで残したいとき
+- 法務Notionのリンクチェックを週次Cronで運用・保守するとき
+- Slack通知文面、CSV出力、対象Notionルートを変更・検証するとき
+
+Do **not** use this skill for:
+
+- Notionページ・DBの作成、更新、削除、コメント投稿
+- Notion内部リンクの疎通確認
+- 機密トークンやAPIキーの収集・表示
+
+## 既定の対象ルート
+
+| 種別 | 名称 | Notion ID |
+|---|---|---|
+| Page | 法務内マニュアル | `106173b008788028ac4efd380a88308c` |
+| Database | 法務関連DB | `8db170cdc5ba4c488ef9302e4e58cede` |
+
+`--root` を指定しない場合は、上記2ルートを対象にします。`--root` は複数回指定できます。Notion ID、UUID形式、Notion URLのいずれも受け付けます。
+
+## 実行方法
+
+```bash
+cd /home/kawazoe_taishi/.hermes/skills/productivity/notion-patrol
+node scripts/patrol.js --output-dir /home/kawazoe_taishi
+```
+
+主なオプション:
+
+```bash
+node scripts/patrol.js \
+  --root <NotionページIDまたはURL> \
+  --root <追加IDまたはURL> \
+  --output-dir <CSV出力先> \
+  --concurrency 10 \
+  --timeout-ms 10000 \
+  --notion-version 2022-06-28
+```
+
+| オプション | 内容 |
+|---|---|
+| `--root <id-or-url>` | 巡回対象ルート。複数指定可。未指定時は既定2ルート。 |
+| `--output-dir <dir>` | CSV出力先。 |
+| `--concurrency <n>` | 外部URLチェックの並列数。既定 `10`。 |
+| `--timeout-ms <ms>` | URLごとのタイムアウト。既定 `10000`。 |
+| `--notion-version <version>` | Notion APIバージョン。既定 `2022-06-28`。 |
+| `--no-check` | URL抽出のみ行い、外部URLへのHEAD/GET確認をスキップ。 |
+| `--help` | ヘルプ表示。 |
+
+## 環境変数
+
+以下のいずれかにNotion integration tokenを設定してください。スクリプトはトークンを表示しません。
+
+- `NOTION_API_KEY`
+- `NOTION_TOKEN`
+- `NOTION_API_TOKEN`
+
+`.env` は次の順に読み込み対象です。
+
+1. カレントディレクトリの `.env`
+2. Hermes標準の `~/.hermes/.env`
+3. このスキルディレクトリの `.env`
+
+Secrets handling:
+
+- トークン値は `SKILL.md`、Notion仕様ページ、GitHub、Slack本文、ログに記録しない。
+- トークンを標準出力・標準エラーに出さない。
+
+## URL抽出・判定仕様
+
+抽出対象:
+
+- Rich text の `href`
+- Rich text本文中の raw URL
+- `bookmark` / `embed` / `link_preview`
+- `image` / `video` / `file` / `pdf` 等の外部ファイルURL
+
+除外対象:
+
+- `notion.so`
+- `app.notion.com`
+- `http` / `https` 以外のURL
+
+判定:
+
+- `HEAD` で確認する。
+- `HEAD` が `405` の場合のみ `GET` にフォールバックする。
+- `2xx` / `3xx` は `OK`。
+- その他のHTTPステータス、ネットワークエラー、タイムアウトは `NG`。
+- `--no-check` 時はステータス `SKIPPED`、判定 `OK` とする。
+
+## 出力
+
+コンソール:
+
+- 件数サマリー
+- NGリンク一覧
+- CSVパス
+
+CSV:
+
+- ファイル名: `link_check_test_YYYYMMDD.csv`
+- 形式: BOM付きUTF-8
+- ヘッダー:
+  1. `ページ名`
+  2. `URL`
+  3. `ステータスコード`
+  4. `判定`
+  5. `Context（文脈）`
+
+CSVはExcelで開きやすいようにBOM付きUTF-8で出力し、カンマ・引用符をCSV escapingします。
+
+## Cron / Slack通知での運用
+
+定期実行にする場合も、Notionパトロール本体は読み取り専用のまま維持します。Cron用ラッパーは `~/.hermes/scripts/notion_patrol_weekly.py` に置き、巡回・集計・Slack通知整形だけを行います。
+
+現行の週次運用設定:
+
+| 項目 | 値 |
+|---|---|
+| ジョブ名 | `Notionパトロール君 週次リンクチェック` |
+| 実行頻度 | 毎週月曜 11:00 JST |
+| Cron式（UTC運用時） | `0 2 * * 1` |
+| Slack通知先 | `G01ACN6N2HW` |
+| 通知メンション | `<!subteam^S02FLCBKU0P>` |
+| 実行モード | `--no-agent` |
+| プロファイル | `default` |
+| 出力先 | `~/.hermes/cron/output/notion-patrol` |
+
+登録例:
+
+```bash
+hermes cron create '0 2 * * 1' \
+  --name 'Notionパトロール君 週次リンクチェック' \
+  --deliver 'slack:G01ACN6N2HW' \
+  --script notion_patrol_weekly.py \
+  --no-agent \
+  --profile default
+```
+
+JSTとしてCron時刻が解決される環境では、月曜11:00は `0 11 * * 1` です。`HERMES_TIMEZONE` 未設定かつホストUTC運用の場合は、月曜11:00 JST相当として `0 2 * * 1` を使います。
+
+通知本文には次を含めます。
+
+- `<!subteam^S02FLCBKU0P>`
+- 実行日時
+- 対象Notionルート
+- チェック件数
+- OK件数
+- NG件数
+- CSVパス
+- `MEDIA:<csv_path>` によるCSV添付指定
+- NGリンク最大20件
+
+Slack上での視認性確認として、Block Kit形式のテスト通知は成功確認済みです。定期実行の基本系は `--no-agent` でスクリプト出力を配送する構成です。Block Kitを本番経路に組み込む場合は、Slack API送信とHermes Cron配送の二重投稿を避けるため、送信成功時は `[SILENT]` または `{"wakeAgent": false}` 相当でCron配送を抑止してください。
+
+## テスト
+
+```bash
+node --test /home/kawazoe_taishi/.hermes/skills/productivity/notion-patrol/scripts/patrol.test.js
+node --check /home/kawazoe_taishi/.hermes/skills/productivity/notion-patrol/scripts/patrol.js
+node /home/kawazoe_taishi/.hermes/skills/productivity/notion-patrol/scripts/patrol.js --help
+python -m py_compile /home/kawazoe_taishi/.hermes/scripts/notion_patrol_weekly.py
+python /home/kawazoe_taishi/.hermes/scripts/notion_patrol_weekly.py --test-notification
+hermes cron list --all
+```
+
+## 実装メモ
+
+- Node.js 18+ 標準 `fetch` のみ使用（npm依存なし）。
+- 外部リンクチェックは `HEAD`、405時のみ `GET` にフォールバックします。
+- 既定タイムアウトは10秒、既定並列数は10です。
+- `notion.so` / `app.notion.com` のNotion内部リンクは対象外です。
+- ページ、ブロック子要素、データベースクエリを防御的に扱います。
+- 保守・拡張時の注意点は `references/implementation-notes.md` を参照してください。
+- 仕様書は `references/specification.md` を参照してください。
+- 週次Cron実行・Slack通知に配線する場合は、`references/cron-weekly-slack-notification.md` の運用メモを参照してください。
+
+## Common Pitfalls
+
+1. **Notion書き込みを混ぜること。** 本スキルは読み取り専用です。仕様変更がない限り、ページ作成・更新・削除・コメント投稿はしないでください。
+2. **トークンをログや仕様書へ出すこと。** 環境変数名だけを記載し、値は記録しないでください。
+3. **JST指定をUTCのまま登録すること。** 環境がUTCなら月曜11:00 JSTは `0 2 * * 1` です。
+4. **Block Kit送信とCron配送を二重化すること。** Slack APIで直接投稿する場合はCron側の通常配送を抑止してください。
+5. **Notion内部リンクを外部リンクとして扱うこと。** `notion.so` / `app.notion.com` は除外対象です。
+6. **現在セッションのスキル一覧キャッシュに依存すること。** 新規・更新スキルは新しいセッションまたはリロード後に見える場合があります。
+
+## Verification Checklist
+
+- [ ] `node --test .../patrol.test.js` が成功する。
+- [ ] `node --check .../patrol.js` が成功する。
+- [ ] `node .../patrol.js --help` が成功する。
+- [ ] `python -m py_compile ~/.hermes/scripts/notion_patrol_weekly.py` が成功する。
+- [ ] `python ~/.hermes/scripts/notion_patrol_weekly.py --test-notification` がメンション付き文面を出す。
+- [ ] `hermes cron list --all` で `Next run` と `Deliver` が意図どおりである。
+- [ ] 仕様書・GitHub・NotionDBに秘密値が含まれていない。

--- a/skills/productivity/notion-patrol/references/cron-weekly-slack-notification.md
+++ b/skills/productivity/notion-patrol/references/cron-weekly-slack-notification.md
@@ -1,0 +1,136 @@
+# Cron週次実行 + Slack通知の運用メモ
+
+Notionパトロール君を定期実行に配線する場合の再利用パターン。
+
+## 目的
+
+- Notionパトロール本体は読み取り専用のまま維持する。
+- Cron側では薄いラッパースクリプトを使い、標準出力にSlack通知本文を出す。
+- `hermes cron create ... --no-agent --deliver slack:<channel_id>` で、スクリプト出力をそのままSlackへ配送する。
+- Slack上での視認性確認にはBlock Kit形式のテスト通知を使える。ただし本番CronでSlack API直接投稿を使う場合は、Hermes Cron配送との二重投稿を抑止する。
+
+## 現行運用値
+
+| 項目 | 値 |
+|---|---|
+| ジョブ名 | `Notionパトロール君 週次リンクチェック` |
+| 通知先 | `slack:G01ACN6N2HW` |
+| メンション | `<!subteam^S02FLCBKU0P>` |
+| 実行時刻 | 毎週月曜 11:00 JST |
+| Cron式（UTC運用時） | `0 2 * * 1` |
+| 実行モード | `--no-agent` |
+| プロファイル | `default` |
+| ラッパー | `~/.hermes/scripts/notion_patrol_weekly.py` |
+| 出力先 | `~/.hermes/cron/output/notion-patrol` |
+
+## 推奨手順
+
+1. パトロール本体の健全性を確認する。
+
+```bash
+node --test /home/kawazoe_taishi/.hermes/skills/productivity/notion-patrol/scripts/patrol.test.js
+node --check /home/kawazoe_taishi/.hermes/skills/productivity/notion-patrol/scripts/patrol.js
+node /home/kawazoe_taishi/.hermes/skills/productivity/notion-patrol/scripts/patrol.js --help
+```
+
+2. Cron用ラッパーは `~/.hermes/scripts/` に置く。
+
+- Notionトークンは環境変数または `~/.hermes/.env` から読む。
+- トークン値はログ・Slack本文・スキルファイルに出さない。
+- 通知本文には、メンション、対象、チェック件数、OK/NG件数、CSVパス、NGリンクの抜粋を含める。
+- CSV添付は `MEDIA:<csv_path>` で指定する。
+
+3. 先にテスト通知を出力して、Slack上の見た目を確認する。
+
+```bash
+python ~/.hermes/scripts/notion_patrol_weekly.py --test-notification
+python -m py_compile ~/.hermes/scripts/notion_patrol_weekly.py
+```
+
+4. Cron登録する。
+
+```bash
+hermes cron create '0 2 * * 1'   --name 'Notionパトロール君 週次リンクチェック'   --deliver 'slack:G01ACN6N2HW'   --script notion_patrol_weekly.py   --no-agent   --profile default
+```
+
+5. 登録後に必ず確認する。
+
+```bash
+hermes cron list --all
+```
+
+確認する項目:
+
+- `Next run`
+- `Deliver`
+- `Script`
+- `Profile`
+- `Status`
+
+## タイムゾーン注意
+
+Hermes Cronの時刻解決は、実行環境の設定に依存する。少なくとも以下を確認する。
+
+```bash
+python - <<'PY'
+import os
+print(os.environ.get('HERMES_TIMEZONE') or 'missing')
+PY
+```
+
+`HERMES_TIMEZONE` や `config.yaml` の `timezone:` が未設定で、ホスト時刻がUTCとして運用されている場合、JST月曜11:00はUTC月曜02:00なので、Cron式は次のようにする。
+
+```text
+0 2 * * 1
+```
+
+JSTとして解決される環境では次の式になる。
+
+```text
+0 11 * * 1
+```
+
+`hermes cron list --all` の `Next run` を見て、意図した時刻になっているか確認する。
+
+## Slack通知形式の例
+
+```text
+<!subteam^S02FLCBKU0P>
+
+【Notionパトロール君】週次リンクチェック結果
+
+実行日時: YYYY-MM-DD HH:MM:SS UTC
+
+対象:
+- 法務内マニュアル（106173b008788028ac4efd380a88308c）
+- 法務関連DB（8db170cdc5ba4c488ef9302e4e58cede）
+
+チェック件数: <n>
+OK: <n>
+NG: <n>
+
+CSV: `<path>`
+MEDIA:<path>
+
+NGリンク（最大20件）:
+- [<status>] <url> / <page> / <context>
+```
+
+## Block Kit通知を使う場合
+
+Block Kit形式のテスト通知はSlack API応答 `ok: true` で成功確認済み。実装する場合は次を守る。
+
+- fallback `text` にも必ず `<!subteam^S02FLCBKU0P>` を含める。
+- blocksの先頭セクションにもメンションを含める。
+- header、divider、summary fields、NGリンク一覧、context noteの構成にする。
+- Slack APIで直接投稿に成功した場合、Hermes Cronの通常配送を `[SILENT]` または `{"wakeAgent": false}` で抑止する。
+- 直接投稿が失敗した場合は、標準出力に通常テキスト通知を出してHermes Cron配送にフォールバックする。
+- Slack token値は出力・保存しない。
+
+## Pitfalls
+
+- Notion書き込みはしない。Cronラッパーも巡回・集計・通知に限定する。
+- `.env` や環境変数の秘密値をスキル、ログ、Slack本文に保存しない。
+- `--no-agent` を使う場合、Slackに届く本文はスクリプトの標準出力そのものになる。文面確認用の `--test-notification` を先に用意する。
+- JST指定の依頼でも、Cron実行環境がUTCなら `0 11 * * 1` ではなく `0 2 * * 1` が必要になる。
+- Slack APIでBlock Kitを直接投稿する場合、Hermes Cron配送と二重投稿しない。

--- a/skills/productivity/notion-patrol/references/implementation-notes.md
+++ b/skills/productivity/notion-patrol/references/implementation-notes.md
@@ -1,0 +1,24 @@
+# Notion Patrol implementation notes
+
+Use these notes when maintaining or extending the Notion Patrol skill.
+
+## Durable workflow lessons
+
+- Treat the patrol as **read-only by design**: use Notion API reads for pages, block children, database queries, and metadata only. Do not add Notion create/update/delete/comment behavior unless the user explicitly changes the requirement.
+- Do not hardcode Notion integration tokens in `patrol.js` or examples. Read `NOTION_API_KEY`, `NOTION_TOKEN`, or `NOTION_API_TOKEN`; support `.env` loading from the current directory, `~/.hermes/.env`, and the skill directory.
+- Verify target IDs before or during implementation using read-only Notion calls. A 32-character ID may be a page or a database; handle both paths defensively.
+- Keep the implementation dependency-free for the original requirement: Node.js 18+ standard `fetch`, `node:test`, and built-in modules only.
+- Make the script importable and testable: export pure helpers, guard CLI execution with `if (require.main === module)`, and run `main()` only for direct invocation.
+- Preserve Excel-friendly CSV output: UTF-8 BOM, Japanese headers, and proper CSV escaping.
+- For link checks, prefer `HEAD`; fall back to `GET` only on `405`; classify `2xx/3xx` as `OK`, other HTTP statuses and network failures as `NG`.
+- Ignore Notion-internal URLs such as `notion.so` and `app.notion.com` unless the user explicitly asks to check internal Notion links.
+
+## Verification commands
+
+```bash
+node --test ~/.hermes/skills/productivity/notion-patrol/scripts/patrol.test.js
+node --check ~/.hermes/skills/productivity/notion-patrol/scripts/patrol.js
+node ~/.hermes/skills/productivity/notion-patrol/scripts/patrol.js --help
+```
+
+For live runs, ensure credentials are configured and keep output sanitized; never print tokens.

--- a/skills/productivity/notion-patrol/references/specification.md
+++ b/skills/productivity/notion-patrol/references/specification.md
@@ -1,0 +1,243 @@
+# Notionパトロール君 仕様書
+
+## 1. 目的
+
+Notionパトロール君は、Notionの指定ルート（ページまたはデータベース）配下を再帰的に読み取り、外部URLを抽出してリンク疎通を確認するローカルHermesスキルです。
+
+Notion APIに対して行う操作は読み取りのみです。Notionページ・データベースの作成、更新、削除、コメント投稿は行いません。
+
+## 2. スコープ
+
+### 対象
+
+- Notionページ配下のブロック
+- Notionデータベース配下のページ
+- ブロック内の外部URL
+- 添付・埋め込み系ブロックに含まれる外部URL
+- 抽出URLのHTTPステータス確認
+- CSV出力
+- 週次CronによるSlack通知
+
+### 対象外
+
+- Notion内部リンク（`notion.so` / `app.notion.com`）の疎通確認
+- Notionの作成・更新・削除・コメント投稿
+- APIトークン値の表示・保存
+- 外部リンク先コンテンツの本文解析
+
+## 3. 既定の巡回対象
+
+| 種別 | 名称 | Notion ID |
+|---|---|---|
+| Page | 法務内マニュアル | `106173b008788028ac4efd380a88308c` |
+| Database | 法務関連DB | `8db170cdc5ba4c488ef9302e4e58cede` |
+
+`--root` を指定しない場合、上記2ルートを使用します。
+
+## 4. 実行環境
+
+| 項目 | 内容 |
+|---|---|
+| 実装言語 | JavaScript |
+| 実行環境 | Node.js 18+ |
+| 依存 | npm依存なし |
+| HTTP実装 | Node.js標準 `fetch` |
+| テスト | `node:test` |
+| Cron wrapper | Python 3 |
+
+## 5. CLI仕様
+
+基本実行:
+
+```bash
+cd /home/kawazoe_taishi/.hermes/skills/productivity/notion-patrol
+node scripts/patrol.js --output-dir /home/kawazoe_taishi
+```
+
+オプション:
+
+| オプション | 内容 | 既定値 |
+|---|---|---|
+| `--root <id-or-url>` | 巡回対象ルート。複数指定可。 | 既定2ルート |
+| `--output-dir <dir>` | CSV出力先。 | カレントディレクトリ |
+| `--concurrency <n>` | 外部URLチェック並列数。 | `10` |
+| `--timeout-ms <ms>` | URLごとのタイムアウト。 | `10000` |
+| `--notion-version <version>` | Notion APIバージョン。 | `2022-06-28` |
+| `--no-check` | URL抽出のみ。疎通確認をスキップ。 | false |
+| `--help` | ヘルプ表示。 | - |
+
+## 6. 認証・秘密情報
+
+Notion tokenは以下のいずれかから読み込みます。
+
+- `NOTION_API_KEY`
+- `NOTION_TOKEN`
+- `NOTION_API_TOKEN`
+
+`.env` 読み込み対象:
+
+1. カレントディレクトリの `.env`
+2. `~/.hermes/.env`
+3. スキルディレクトリの `.env`
+
+秘密情報の運用:
+
+- トークン値はコード、仕様書、NotionDB、GitHub、Slack本文、ログに記録しません。
+- 記録するのは環境変数名のみです。
+
+## 7. Notion読み取り仕様
+
+読み取り対象:
+
+- Page metadata
+- Block children
+- Database query
+- Database metadata
+
+読み取り専用を維持するため、以下は行いません。
+
+- Page create/update/delete
+- Database create/update/delete
+- Block append/update/delete
+- Comment create
+
+## 8. URL抽出仕様
+
+抽出するURL:
+
+- Rich textの `href`
+- Rich text本文中の raw URL
+- `bookmark` の `url`
+- `embed` の `url`
+- `link_preview` の `url`
+- `image` / `video` / `file` / `pdf` 等の外部URL
+
+除外するURL:
+
+- `notion.so`
+- `app.notion.com`
+- `http` / `https` 以外
+
+## 9. リンクチェック判定
+
+1. `HEAD` で確認します。
+2. `HEAD` が `405` の場合のみ `GET` にフォールバックします。
+3. `2xx` / `3xx` は `OK` とします。
+4. その他のHTTPステータス、ネットワークエラー、タイムアウトは `NG` とします。
+5. `--no-check` 時はステータス `SKIPPED`、判定 `OK` とします。
+
+## 10. CSV出力仕様
+
+ファイル名:
+
+```text
+link_check_test_YYYYMMDD.csv
+```
+
+文字コード:
+
+```text
+BOM付きUTF-8
+```
+
+列:
+
+| 列 | ヘッダー |
+|---|---|
+| 1 | `ページ名` |
+| 2 | `URL` |
+| 3 | `ステータスコード` |
+| 4 | `判定` |
+| 5 | `Context（文脈）` |
+
+CSV escapingを行い、Excelで開きやすい形式にします。
+
+## 11. Cron / Slack運用仕様
+
+Cron wrapper:
+
+```text
+/home/kawazoe_taishi/.hermes/scripts/notion_patrol_weekly.py
+```
+
+Cron出力先:
+
+```text
+/home/kawazoe_taishi/.hermes/cron/output/notion-patrol
+```
+
+現行登録:
+
+| 項目 | 値 |
+|---|---|
+| ジョブ名 | `Notionパトロール君 週次リンクチェック` |
+| 実行頻度 | 毎週月曜 11:00 JST |
+| Cron式 | `0 2 * * 1` |
+| Cron式の前提 | `HERMES_TIMEZONE` 未設定・UTC運用 |
+| Slack通知先 | `G01ACN6N2HW` |
+| メンション | `<!subteam^S02FLCBKU0P>` |
+| 実行モード | `--no-agent` |
+| プロファイル | `default` |
+
+登録例:
+
+```bash
+hermes cron create '0 2 * * 1' \
+  --name 'Notionパトロール君 週次リンクチェック' \
+  --deliver 'slack:G01ACN6N2HW' \
+  --script notion_patrol_weekly.py \
+  --no-agent \
+  --profile default
+```
+
+## 12. Slack通知仕様
+
+通知本文に含める内容:
+
+- `<!subteam^S02FLCBKU0P>`
+- 実行日時
+- 対象Notionルート
+- チェック件数
+- OK件数
+- NG件数
+- CSVパス
+- `MEDIA:<csv_path>` によるCSV添付指定
+- NGリンク最大20件
+
+失敗時は、以下を区別して通知します。
+
+- `patrol.js` 不在
+- タイムアウト
+- 非ゼロ終了
+- CSV未検出
+
+Block Kit形式のテスト通知は成功確認済みです。Block Kitを本番経路に入れる場合は、Slack APIでの直接投稿とHermes Cron配送が二重投稿にならないよう、送信成功時にCron通常配送を抑止します。
+
+## 13. テスト・検証
+
+```bash
+node --test /home/kawazoe_taishi/.hermes/skills/productivity/notion-patrol/scripts/patrol.test.js
+node --check /home/kawazoe_taishi/.hermes/skills/productivity/notion-patrol/scripts/patrol.js
+node /home/kawazoe_taishi/.hermes/skills/productivity/notion-patrol/scripts/patrol.js --help
+python -m py_compile /home/kawazoe_taishi/.hermes/scripts/notion_patrol_weekly.py
+python /home/kawazoe_taishi/.hermes/scripts/notion_patrol_weekly.py --test-notification
+hermes cron list --all
+```
+
+確認観点:
+
+- Nodeテストが成功すること
+- `patrol.js` の構文チェックが成功すること
+- `--help` が表示されること
+- Cron wrapperのPython構文チェックが成功すること
+- テスト通知にメンション、対象、件数、注記が含まれること
+- Cronの `Next run` と `Deliver` が意図どおりであること
+- 秘密情報が出力・保存されていないこと
+
+## 14. 運用上の注意
+
+- 本スキルは読み取り専用です。Notion書き込み処理を追加しないでください。
+- APIトークン等の秘密値を記録しないでください。
+- JST指定のCronは、実行環境のタイムゾーンを確認してから登録してください。
+- Slack APIでBlock Kit投稿を行う場合、Cron配送との二重投稿を防止してください。
+- 現在セッションのスキル一覧はキャッシュされる場合があります。更新確認は新規セッションまたはファイル実体で行ってください。

--- a/skills/productivity/notion-patrol/scripts/notion_patrol_weekly.py
+++ b/skills/productivity/notion-patrol/scripts/notion_patrol_weekly.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Weekly Notion Patrol cron wrapper.
+
+Read-only: invokes the local notion-patrol Node script, summarizes the CSV,
+and prints a Slack-ready notification. No Notion writes are performed here.
+"""
+from __future__ import annotations
+
+import csv
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+MENTION = "<!subteam^S02FLCBKU0P>"
+ROOT_IDS = [
+    "106173b008788028ac4efd380a88308c",
+    "8db170cdc5ba4c488ef9302e4e58cede",
+]
+ROOT_LABELS = [
+    "法務内マニュアル（106173b008788028ac4efd380a88308c）",
+    "法務関連DB（8db170cdc5ba4c488ef9302e4e58cede）",
+]
+
+HOME = Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes").expanduser()
+SKILL_DIR = HOME / "skills" / "productivity" / "notion-patrol"
+PATROL_JS = SKILL_DIR / "scripts" / "patrol.js"
+OUTPUT_DIR = HOME / "cron" / "output" / "notion-patrol"
+
+
+def now_text() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+def clip(text: str, limit: int = 1200) -> str:
+    text = (text or "").strip()
+    if len(text) <= limit:
+        return text
+    return text[:limit] + "\n...（以下省略）"
+
+
+def latest_csv_path(stdout: str) -> Path | None:
+    for line in reversed((stdout or "").splitlines()):
+        if line.startswith("CSV:"):
+            return Path(line.split(":", 1)[1].strip())
+    files = sorted(OUTPUT_DIR.glob("link_check_test_*.csv"), key=lambda p: p.stat().st_mtime, reverse=True)
+    return files[0] if files else None
+
+
+def read_rows(csv_path: Path) -> list[dict[str, str]]:
+    with csv_path.open("r", encoding="utf-8-sig", newline="") as f:
+        return list(csv.DictReader(f))
+
+
+def summarize(csv_path: Path) -> str:
+    rows = read_rows(csv_path)
+    total = len(rows)
+    ok = sum(1 for r in rows if r.get("判定") == "OK")
+    ng_rows = [r for r in rows if r.get("判定") == "NG"]
+    lines = [
+        MENTION,
+        "【Notionパトロール君】週次リンクチェック結果",
+        f"実行日時: {now_text()}",
+        "対象:",
+        *[f"- {label}" for label in ROOT_LABELS],
+        f"チェック件数: {total}",
+        f"OK: {ok}",
+        f"NG: {len(ng_rows)}",
+        f"CSV: {csv_path}",
+        f"MEDIA:{csv_path}",
+    ]
+    if ng_rows:
+        lines.append("")
+        lines.append("NGリンク（最大20件）:")
+        for r in ng_rows[:20]:
+            lines.append(
+                f"- [{r.get('ステータスコード','')}] {r.get('URL','')} / "
+                f"{r.get('ページ名','')} / {clip(r.get('Context（文脈）',''), 160)}"
+            )
+        if len(ng_rows) > 20:
+            lines.append(f"...ほか {len(ng_rows) - 20} 件（CSV参照）")
+    else:
+        lines.append("NGリンクは検出されませんでした。")
+    return "\n".join(lines)
+
+
+def test_notification() -> str:
+    return "\n".join([
+        MENTION,
+        "【Notionパトロール君】週次リンクチェック結果（テスト通知）",
+        f"実行日時: {now_text()}",
+        "対象:",
+        *[f"- {label}" for label in ROOT_LABELS],
+        "チェック件数: 12",
+        "OK: 11",
+        "NG: 1",
+        "CSV: /home/kawazoe_taishi/.hermes/cron/output/notion-patrol/link_check_test_YYYYMMDD.csv",
+        "",
+        "NGリンク（最大20件）:",
+        "- [404] https://example.invalid/dead-link / サンプルページ / サンプル文脈",
+        "※これは通知形式確認用のテスト通知です。実際のNotion巡回は実行していません。",
+    ])
+
+
+def run_patrol() -> str:
+    if not PATROL_JS.exists():
+        return "\n".join([
+            MENTION,
+            "【Notionパトロール君】週次リンクチェック失敗",
+            f"実行日時: {now_text()}",
+            f"理由: patrol.js が見つかりません: {PATROL_JS}",
+        ])
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    cmd = ["node", str(PATROL_JS), "--output-dir", str(OUTPUT_DIR)]
+    for root in ROOT_IDS:
+        cmd.extend(["--root", root])
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=str(SKILL_DIR),
+            capture_output=True,
+            text=True,
+            timeout=int(os.environ.get("NOTION_PATROL_TIMEOUT_SECONDS", "110")),
+            env=os.environ.copy(),
+        )
+    except subprocess.TimeoutExpired:
+        return "\n".join([
+            MENTION,
+            "【Notionパトロール君】週次リンクチェック失敗",
+            f"実行日時: {now_text()}",
+            "理由: タイムアウトしました。",
+        ])
+
+    if proc.returncode != 0:
+        return "\n".join([
+            MENTION,
+            "【Notionパトロール君】週次リンクチェック失敗",
+            f"実行日時: {now_text()}",
+            f"終了コード: {proc.returncode}",
+            "stderr:",
+            clip(proc.stderr, 1800),
+            "stdout:",
+            clip(proc.stdout, 1800),
+        ])
+
+    csv_path = latest_csv_path(proc.stdout)
+    if not csv_path or not csv_path.exists():
+        return "\n".join([
+            MENTION,
+            "【Notionパトロール君】週次リンクチェック失敗",
+            f"実行日時: {now_text()}",
+            "理由: CSV出力を確認できませんでした。",
+            "stdout:",
+            clip(proc.stdout, 1800),
+        ])
+
+    return summarize(csv_path)
+
+
+def main(argv: list[str]) -> int:
+    if "--test-notification" in argv:
+        print(test_notification())
+        return 0
+    print(run_patrol())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))
+

--- a/skills/productivity/notion-patrol/scripts/patrol.js
+++ b/skills/productivity/notion-patrol/scripts/patrol.js
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DEFAULT_ROOTS = [
+  '106173b008788028ac4efd380a88308c',
+  '8db170cdc5ba4c488ef9302e4e58cede',
+];
+const DEFAULT_NOTION_VERSION = '2022-06-28';
+const NOTION_BASE = 'https://api.notion.com/v1';
+
+function normalizeNotionId(input) {
+  const s = String(input || '').trim();
+  const noQuery = s.split(/[?#]/)[0];
+  const match = noQuery.match(/([0-9a-fA-F]{32}|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})(?:\b|$)/);
+  if (!match) return s.replace(/-/g, '');
+  return match[1].replace(/-/g, '').toLowerCase();
+}
+
+function parseArgs(argv) {
+  const opts = { roots: [], outputDir: process.cwd(), concurrency: 10, timeoutMs: 10000, notionVersion: DEFAULT_NOTION_VERSION, noCheck: false, help: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--help' || a === '-h') opts.help = true;
+    else if (a === '--root') opts.roots.push(normalizeNotionId(argv[++i]));
+    else if (a === '--output-dir') opts.outputDir = argv[++i];
+    else if (a === '--concurrency') opts.concurrency = Number(argv[++i]);
+    else if (a === '--timeout-ms') opts.timeoutMs = Number(argv[++i]);
+    else if (a === '--notion-version') opts.notionVersion = argv[++i];
+    else if (a === '--no-check') opts.noCheck = true;
+    else throw new Error(`Unknown argument: ${a}`);
+  }
+  if (opts.roots.length === 0) opts.roots = [...DEFAULT_ROOTS];
+  if (!Number.isInteger(opts.concurrency) || opts.concurrency < 1) throw new Error('--concurrency must be a positive integer');
+  if (!Number.isInteger(opts.timeoutMs) || opts.timeoutMs < 1) throw new Error('--timeout-ms must be a positive integer');
+  return opts;
+}
+
+function loadEnvFile(file) {
+  if (!fs.existsSync(file)) return;
+  for (const line of fs.readFileSync(file, 'utf8').split(/\r?\n/)) {
+    const m = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\s*$/);
+    if (!m || process.env[m[1]]) continue;
+    process.env[m[1]] = m[2].replace(/^['"]|['"]$/g, '');
+  }
+}
+
+function getToken() {
+  loadEnvFile(path.join(process.cwd(), '.env'));
+  const hermesHome = process.env.HERMES_HOME || (process.env.HOME ? path.join(process.env.HOME, '.hermes') : '');
+  if (hermesHome) loadEnvFile(path.join(hermesHome, '.env'));
+  loadEnvFile(path.join(__dirname, '..', '.env'));
+  return process.env.NOTION_API_KEY || process.env.NOTION_TOKEN || process.env.NOTION_API_TOKEN || '';
+}
+
+function isExternalUrl(u) {
+  try {
+    const url = new URL(u);
+    return /^https?:$/.test(url.protocol) && !/(^|\.)notion\.so$/.test(url.hostname) && url.hostname !== 'app.notion.com';
+  } catch { return false; }
+}
+
+function cleanRawUrl(u) { return String(u).replace(/[\s\])}>,。、「」]+$/u, ''); }
+function richTextPlain(arr = []) { return arr.map(t => t.plain_text || '').join(''); }
+function addUrl(rows, url, pageTitle, context) { const cleaned = cleanRawUrl(url); if (isExternalUrl(cleaned)) rows.push({ pageTitle, url: cleaned, context: context || cleaned }); }
+
+function extractUrlsFromBlock(block, pageTitle = '') {
+  const rows = [];
+  const type = block.type;
+  const value = block[type] || {};
+  const texts = value.rich_text || value.caption || [];
+  const context = richTextPlain(texts) || value.url || '';
+  for (const t of texts) {
+    if (t.href) addUrl(rows, t.href, pageTitle, context);
+    const raw = t.plain_text || '';
+    for (const m of raw.matchAll(/https?:\/\/[^\s<>()"'「」]+/g)) addUrl(rows, m[0], pageTitle, context);
+  }
+  for (const key of ['bookmark', 'embed', 'link_preview']) if (type === key && value.url) addUrl(rows, value.url, pageTitle, value.url);
+  if (['image', 'video', 'file', 'pdf'].includes(type)) {
+    const u = value.type === 'external' && value.external ? value.external.url : value.url;
+    if (u) addUrl(rows, u, pageTitle, u);
+  }
+  return rows;
+}
+
+async function checkUrl(url, { fetchImpl = fetch, timeoutMs = 10000 } = {}) {
+  async function request(method) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try { return await fetchImpl(url, { method, redirect: 'follow', signal: controller.signal }); }
+    finally { clearTimeout(timer); }
+  }
+  try {
+    let res = await request('HEAD');
+    if (res.status === 405) res = await request('GET');
+    return { statusCode: res.status, judgement: res.status >= 200 && res.status < 400 ? 'OK' : 'NG' };
+  } catch (e) {
+    return { statusCode: e && e.name === 'AbortError' ? 'TIMEOUT' : 'ERROR', judgement: 'NG' };
+  }
+}
+
+async function mapLimit(items, limit, fn) {
+  const out = new Array(items.length); let next = 0;
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (next < items.length) { const i = next++; out[i] = await fn(items[i], i); }
+  }));
+  return out;
+}
+
+function csvEscape(v) { const s = String(v ?? ''); return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s; }
+function ymd(d = new Date()) { return `${d.getFullYear()}${String(d.getMonth()+1).padStart(2,'0')}${String(d.getDate()).padStart(2,'0')}`; }
+function writeCsv(rows, outputDir, date = new Date()) {
+  fs.mkdirSync(outputDir, { recursive: true });
+  const file = path.join(outputDir, `link_check_test_${ymd(date)}.csv`);
+  const header = ['ページ名','URL','ステータスコード','判定','Context（文脈）'];
+  const lines = [header, ...rows.map(r => [r.pageTitle, r.url, r.statusCode, r.judgement, r.context])].map(r => r.map(csvEscape).join(','));
+  fs.writeFileSync(file, '\ufeff' + lines.join('\n'), 'utf8');
+  return file;
+}
+
+class NotionClient {
+  constructor({ token, notionVersion = DEFAULT_NOTION_VERSION, fetchImpl = fetch }) { this.token = token; this.notionVersion = notionVersion; this.fetchImpl = fetchImpl; }
+  async request(method, endpoint, body) {
+    const res = await this.fetchImpl(`${NOTION_BASE}${endpoint}`, { method, headers: { Authorization: `Bearer ${this.token}`, 'Notion-Version': this.notionVersion, 'Content-Type': 'application/json' }, body: body ? JSON.stringify(body) : undefined });
+    if (!res.ok) throw new Error(`Notion API ${res.status} ${endpoint}`);
+    return res.json();
+  }
+  async listChildren(id) { let results = [], cursor; do { const q = cursor ? `?start_cursor=${encodeURIComponent(cursor)}` : ''; const j = await this.request('GET', `/blocks/${id}/children${q}`); results = results.concat(j.results || []); cursor = j.has_more ? j.next_cursor : null; } while (cursor); return results; }
+  async queryDatabase(id) { let results = [], cursor; do { const j = await this.request('POST', `/databases/${id}/query`, cursor ? { start_cursor: cursor } : {}); results = results.concat(j.results || []); cursor = j.has_more ? j.next_cursor : null; } while (cursor); return results; }
+  async getPage(id) { return this.request('GET', `/pages/${id}`); }
+  async getDatabase(id) { return this.request('GET', `/databases/${id}`); }
+}
+
+function titleFromObject(obj, fallback) {
+  const props = obj.properties || {}; for (const p of Object.values(props)) if (p.type === 'title') return richTextPlain(p.title) || fallback;
+  if (obj.title) return richTextPlain(obj.title) || fallback;
+  return fallback;
+}
+
+async function traverseNotion(rootIds, client) {
+  const visited = new Set(); const rows = [];
+  async function visit(id, titleHint) {
+    id = normalizeNotionId(id); if (visited.has(id)) return; visited.add(id);
+    let title = titleHint || id, blocks = [];
+    try { title = titleFromObject(await client.getPage(id), title); } catch {}
+    try { blocks = await client.listChildren(id); } catch (e) {
+      try { title = titleFromObject(await client.getDatabase(id), title); const pages = await client.queryDatabase(id); for (const p of pages) await visit(p.id, titleFromObject(p, p.id)); } catch { throw e; }
+      return;
+    }
+    for (const b of blocks) {
+      rows.push(...extractUrlsFromBlock(b, title));
+      if (b.type === 'child_page') await visit(b.id, b.child_page && b.child_page.title);
+      else if (b.type === 'child_database') { try { for (const p of await client.queryDatabase(b.id)) await visit(p.id, titleFromObject(p, p.id)); } catch {} }
+      else if (b.has_children) await visit(b.id, title);
+    }
+  }
+  for (const id of rootIds) await visit(id);
+  return rows;
+}
+
+function help() { return `Usage: node scripts/patrol.js [--root <page-id-or-url>]... [--output-dir <dir>] [--concurrency <n>] [--timeout-ms <ms>] [--notion-version <version>] [--no-check]\nEnv: NOTION_API_KEY or NOTION_TOKEN or NOTION_API_TOKEN (also .env). Read-only: no Notion writes are performed.`; }
+
+async function main(argv = process.argv.slice(2)) {
+  const opts = parseArgs(argv); if (opts.help) { console.log(help()); return 0; }
+  const token = getToken(); if (!token) throw new Error('Notion token not found. Set NOTION_API_KEY / NOTION_TOKEN / NOTION_API_TOKEN.');
+  const client = new NotionClient({ token, notionVersion: opts.notionVersion });
+  const extracted = await traverseNotion(opts.roots, client);
+  const checked = opts.noCheck ? extracted.map(r => ({ ...r, statusCode: 'SKIPPED', judgement: 'OK' })) : await mapLimit(extracted, opts.concurrency, async r => ({ ...r, ...(await checkUrl(r.url, { timeoutMs: opts.timeoutMs })) }));
+  const file = writeCsv(checked, opts.outputDir);
+  const ng = checked.filter(r => r.judgement === 'NG');
+  console.log(`Notion Patrol: ${checked.length} URLs checked/extracted, OK=${checked.length - ng.length}, NG=${ng.length}`);
+  for (const r of ng) console.log(`NG ${r.statusCode} ${r.url} (${r.pageTitle}) ${r.context}`);
+  console.log(`CSV: ${file}`);
+  return 0;
+}
+
+module.exports = { DEFAULT_ROOTS, normalizeNotionId, parseArgs, isExternalUrl, extractUrlsFromBlock, checkUrl, writeCsv, mapLimit, NotionClient, traverseNotion, main, help };
+if (require.main === module) main().catch(e => { console.error(e.message); process.exit(1); });

--- a/skills/productivity/notion-patrol/scripts/patrol.test.js
+++ b/skills/productivity/notion-patrol/scripts/patrol.test.js
@@ -1,0 +1,67 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const patrol = require('./patrol.js');
+
+test('parseArgs defaults and repeatable roots', () => {
+  assert.deepEqual(patrol.parseArgs([]).roots, patrol.DEFAULT_ROOTS);
+  const opts = patrol.parseArgs(['--root', 'https://www.notion.so/Foo-106173b008788028ac4efd380a88308c?v=abc', '--root', '8db170cd-c5ba-4c48-8ef9-302e4e58cede', '--output-dir', '/tmp/out', '--concurrency', '3', '--timeout-ms', '1234', '--no-check']);
+  assert.deepEqual(opts.roots, ['106173b008788028ac4efd380a88308c', '8db170cdc5ba4c488ef9302e4e58cede']);
+  assert.equal(opts.outputDir, '/tmp/out');
+  assert.equal(opts.concurrency, 3);
+  assert.equal(opts.timeoutMs, 1234);
+  assert.equal(opts.noCheck, true);
+});
+
+test('extractUrlsFromBlock extracts external URLs with context and ignores Notion internal URLs', () => {
+  const block = {
+    id: 'b1',
+    type: 'paragraph',
+    paragraph: { rich_text: [
+      { plain_text: 'See ', href: null },
+      { plain_text: 'example', href: 'https://example.com/a?x=1' },
+      { plain_text: ' and https://www.notion.so/internal-abc123', href: null },
+      { plain_text: ' plus raw https://docs.example.org/path).', href: null },
+    ] },
+  };
+  const rows = patrol.extractUrlsFromBlock(block, 'Page A');
+  assert.deepEqual(rows.map(r => r.url).sort(), ['https://docs.example.org/path', 'https://example.com/a?x=1']);
+  assert.equal(rows[0].pageTitle, 'Page A');
+  assert.match(rows[0].context, /example|docs/);
+});
+
+test('extractUrlsFromBlock supports bookmark/embed/file URLs', () => {
+  const blocks = [
+    { type: 'bookmark', bookmark: { url: 'https://bookmark.example/' } },
+    { type: 'embed', embed: { url: 'https://embed.example/' } },
+    { type: 'image', image: { type: 'external', external: { url: 'https://image.example/a.png' } } },
+  ];
+  const urls = blocks.flatMap(b => patrol.extractUrlsFromBlock(b, 'Assets').map(r => r.url));
+  assert.deepEqual(urls, ['https://bookmark.example/', 'https://embed.example/', 'https://image.example/a.png']);
+});
+
+test('checkUrl uses HEAD then GET on 405 and classifies 2xx/3xx as OK', async () => {
+  const calls = [];
+  const fakeFetch = async (url, options) => {
+    calls.push(options.method);
+    if (options.method === 'HEAD') return { status: 405 };
+    return { status: 301 };
+  };
+  const result = await patrol.checkUrl('https://example.com', { fetchImpl: fakeFetch, timeoutMs: 1000 });
+  assert.deepEqual(calls, ['HEAD', 'GET']);
+  assert.equal(result.statusCode, 301);
+  assert.equal(result.judgement, 'OK');
+});
+
+test('writeCsv writes BOM UTF-8 and Japanese headers', () => {
+  const dir = fs.mkdtempSync(path.join(require('node:os').tmpdir(), 'patrol-'));
+  const file = patrol.writeCsv([{ pageTitle: 'ページ', url: 'https://e.example', statusCode: 404, judgement: 'NG', context: 'ctx, quote " ok' }], dir, new Date('2026-07-06T00:00:00Z'));
+  const buf = fs.readFileSync(file);
+  assert.equal(buf.subarray(0, 3).toString('hex'), 'efbbbf');
+  const text = buf.toString('utf8');
+  assert.match(text, /^﻿ページ名,URL,ステータスコード,判定,Context（文脈）/);
+  assert.match(file, /link_check_test_20260706\.csv$/);
+  assert.match(text, /"ctx, quote "" ok"/);
+});


### PR DESCRIPTION
## Summary
- Add the `notion-patrol` Hermes skill under `skills/productivity/`
- Include the read-only Notion patrol implementation, tests, weekly Slack/Cron wrapper template, and Markdown specification
- Document current weekly operation: Monday 11:00 JST (`0 2 * * 1` UTC), Slack target `G01ACN6N2HW`, and usergroup mention `<!subteam^S02FLCBKU0P>`

## Test Plan
- `node --test skills/productivity/notion-patrol/scripts/patrol.test.js`
- `node --check skills/productivity/notion-patrol/scripts/patrol.js`
- `node skills/productivity/notion-patrol/scripts/patrol.js --help`
- `python -m py_compile skills/productivity/notion-patrol/scripts/notion_patrol_weekly.py`
- local SKILL.md frontmatter validation

## Notes
- The skill and spec are read-only for Notion patrol operations.
- No token or secret values are included.
