### PR TITLE
feat(cli): add sessions transcript search

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13392,7 +13392,7 @@ def main():
     # =========================================================================
     sessions_parser = subparsers.add_parser(
         "sessions",
-        help="Manage session history (list, rename, export, prune, delete)",
+        help="Manage session history (list, search, rename, export, prune, delete)",
         description="View and manage the SQLite session store",
     )
     sessions_subparsers = sessions_parser.add_subparsers(dest="sessions_action")
@@ -13403,6 +13403,44 @@ def main():
     )
     sessions_list.add_argument(
         "--limit", type=int, default=20, help="Max sessions to show"
+    )
+
+    sessions_search = sessions_subparsers.add_parser(
+        "search",
+        help="Full-text search session transcripts",
+        description=(
+            "Search saved session messages using the same FTS5-backed recall "
+            "engine as the session_search tool."
+        ),
+    )
+    sessions_search.add_argument(
+        "query",
+        nargs="+",
+        help=(
+            "Search query. Supports FTS5 syntax such as exact phrases, OR, "
+            "NOT, and prefix terms like deploy*."
+        ),
+    )
+    sessions_search.add_argument(
+        "--limit",
+        type=int,
+        default=5,
+        help="Max matching sessions to show (default: 5, max: 10)",
+    )
+    sessions_search.add_argument(
+        "--sort",
+        choices=["newest", "oldest"],
+        help="Order matches by message recency instead of FTS rank",
+    )
+    sessions_search.add_argument(
+        "--role",
+        dest="role_filter",
+        help="Comma-separated roles to search (default: user,assistant; e.g. tool)",
+    )
+    sessions_search.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the raw structured search payload as JSON",
     )
 
     sessions_export = sessions_subparsers.add_parser(
@@ -13687,6 +13725,28 @@ def main():
                 else:
                     sid = s["id"]
                     print(f"{preview:<50} {last_active:<13} {s['source']:<6} {sid}")
+
+        elif action == "search":
+            from hermes_cli.session_search_cli import format_session_search_results
+            from tools.session_search_tool import session_search as _session_search
+
+            search_query = " ".join(getattr(args, "query", []) or []).strip()
+            result_text = _session_search(
+                query=search_query,
+                role_filter=getattr(args, "role_filter", None),
+                limit=getattr(args, "limit", 5),
+                sort=getattr(args, "sort", None),
+                db=db,
+            )
+            if getattr(args, "json", False):
+                sys.stdout.write(result_text.rstrip() + "\n")
+            else:
+                try:
+                    payload = _json.loads(result_text)
+                except Exception as e:
+                    print(f"Error: Could not decode search results: {e}")
+                else:
+                    print(format_session_search_results(payload, query=search_query))
 
         elif action == "export":
             if args.session_id:

--- a/hermes_cli/session_search_cli.py
+++ b/hermes_cli/session_search_cli.py
@@ -1,0 +1,61 @@
+"""Formatting helpers for `hermes sessions search`."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+_HIGHLIGHT_START = ">>>"
+_HIGHLIGHT_END = "<<<"
+
+
+def _single_line(value: Any, limit: int = 220) -> str:
+    text = " ".join(str(value or "").split())
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)].rstrip() + "…"
+
+
+def _clean_snippet(snippet: Any) -> str:
+    text = str(snippet or "")
+    text = text.replace(_HIGHLIGHT_START, "").replace(_HIGHLIGHT_END, "")
+    return _single_line(text)
+
+
+def format_session_search_results(payload: dict[str, Any], *, query: str) -> str:
+    """Render the session_search discovery payload for terminal users."""
+    if not payload.get("success"):
+        error = payload.get("error") or payload.get("message") or "session search failed"
+        return f"Error: {error}"
+
+    results = payload.get("results") or []
+    if not results:
+        return (
+            f'No sessions matched "{query}".\n'
+            "Tip: session search uses FTS5 syntax, so try fewer terms, an exact "
+            'phrase like "auth refactor", OR, NOT, or a prefix such as deploy*. '
+            "Use `hermes sessions list` to browse recent sessions."
+        )
+
+    count = int(payload.get("count") or len(results))
+    lines = [f'Found {count} matching session(s) for "{query}":']
+    for index, hit in enumerate(results, start=1):
+        session_id = str(hit.get("session_id") or "").strip()
+        title = _single_line(hit.get("title") or "(untitled)", limit=80)
+        source = str(hit.get("source") or "unknown")
+        when = str(hit.get("when") or "unknown")
+        role = str(hit.get("matched_role") or "message")
+        message_id = hit.get("match_message_id")
+        snippet = _clean_snippet(hit.get("snippet"))
+
+        lines.append(f"{index}. {title}")
+        lines.append(f"   id: {session_id}  source: {source}  when: {when}")
+        if message_id is not None:
+            lines.append(f"   match: {role} message {message_id}")
+        else:
+            lines.append(f"   match: {role}")
+        if snippet:
+            lines.append(f"   snippet: {snippet}")
+        if session_id:
+            lines.append(f"   resume: hermes --resume {session_id}")
+    return "\n".join(lines)

--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -176,6 +176,7 @@ Platform docs: https://hermes-agent.nousresearch.com/docs/user-guide/messaging/
 
 ```
 hermes sessions list        List recent sessions
+hermes sessions search Q    Full-text search saved session transcripts
 hermes sessions browse      Interactive picker
 hermes sessions export OUT  Export to JSONL
 hermes sessions rename ID T Rename a session

--- a/tests/hermes_cli/test_sessions_search.py
+++ b/tests/hermes_cli/test_sessions_search.py
@@ -1,0 +1,87 @@
+import json
+import sys
+
+
+class _DBFactory:
+    def __init__(self, db):
+        self.db = db
+
+    def __call__(self):
+        return self.db
+
+
+def _seed_search_db(tmp_path):
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("s_alpha", source="cli")
+    db.set_session_title("s_alpha", "Alpha Rollout")
+    db.append_message("s_alpha", role="user", content="Plan the nebula rollout checklist")
+    db.append_message("s_alpha", role="assistant", content="Nebula rollout has three gates.")
+
+    db.create_session("s_beta", source="telegram")
+    db.set_session_title("s_beta", "Beta Notes")
+    db.append_message("s_beta", role="user", content="Discuss unrelated billing notes")
+    return db
+
+
+def test_sessions_search_prints_transcript_matches(monkeypatch, capsys, tmp_path):
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    db = _seed_search_db(tmp_path)
+    monkeypatch.setattr(hermes_state, "SessionDB", _DBFactory(db))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "sessions", "search", "nebula", "--limit", "3"],
+    )
+
+    main_mod.main()
+
+    out = capsys.readouterr().out
+    assert 'Found 1 matching session(s) for "nebula"' in out
+    assert "Alpha Rollout" in out
+    assert "s_alpha" in out
+    assert "snippet:" in out
+    assert "hermes --resume s_alpha" in out
+
+
+def test_sessions_search_json_outputs_tool_payload(monkeypatch, capsys, tmp_path):
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    db = _seed_search_db(tmp_path)
+    monkeypatch.setattr(hermes_state, "SessionDB", _DBFactory(db))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "sessions", "search", "nebula", "--json"],
+    )
+
+    main_mod.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["success"] is True
+    assert payload["mode"] == "discover"
+    assert payload["query"] == "nebula"
+    assert payload["results"][0]["session_id"] == "s_alpha"
+
+
+def test_sessions_search_empty_result_has_human_message(monkeypatch, capsys, tmp_path):
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    db = _seed_search_db(tmp_path)
+    monkeypatch.setattr(hermes_state, "SessionDB", _DBFactory(db))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "sessions", "search", "missingterm"],
+    )
+
+    main_mod.main()
+
+    out = capsys.readouterr().out
+    assert 'No sessions matched "missingterm"' in out
+    assert "FTS5 syntax" in out

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1361,6 +1361,7 @@ Subcommands:
 | Subcommand | Description |
 |------------|-------------|
 | `list` | List recent sessions. |
+| `search <query>` | Full-text search saved session transcripts. Supports `--limit`, `--sort newest|oldest`, `--role`, and `--json`. |
 | `browse` | Interactive session picker with search and resume. |
 | `export <output> [--session-id ID]` | Export sessions to JSONL. |
 | `delete <session-id>` | Delete one session. |

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -351,7 +351,7 @@ hermes -r 20260225_143052_a1b2c3           # Short form
 
 Resuming restores the full conversation history from SQLite. The agent sees all previous messages, tool calls, and responses — just as if you never left.
 
-Use `/title My Session Name` inside a chat to name the current session, or `hermes sessions rename <id> <title>` from the command line. Use `hermes sessions list` to browse past sessions.
+Use `/title My Session Name` inside a chat to name the current session, or `hermes sessions rename <id> <title>` from the command line. Use `hermes sessions list` to browse past sessions and `hermes sessions search <query>` to search their transcript text.
 
 ### Session Storage
 

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -292,6 +292,23 @@ Help me refactor the auth module please             2h ago        cli    2025030
 What's the weather in Las Vegas?                    3d ago        tele   20250303_101500_f
 ```
 
+### Search Session Text
+
+Use `hermes sessions search` when you remember words from the conversation but not the title or ID. It searches saved user and assistant messages with the same FTS5-backed recall index used by the `session_search` tool.
+
+```bash
+# Search transcript text and print matching session IDs plus snippets
+hermes sessions search "auth refactor"
+
+# Show more matches or bias toward recent messages
+hermes sessions search deploy --limit 10 --sort newest
+
+# Script against the structured payload
+hermes sessions search "rate limit" --json
+```
+
+The query supports FTS5 syntax, including quoted phrases, `OR`, `NOT`, and prefix terms like `deploy*`. Search results include a ready-to-run `hermes --resume <session-id>` command.
+
 ### Export Sessions
 
 ```bash

--- a/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
+++ b/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
@@ -180,6 +180,7 @@ Platform docs: https://hermes-agent.nousresearch.com/docs/user-guide/messaging/
 
 ```
 hermes sessions list        List recent sessions
+hermes sessions search Q    Full-text search saved session transcripts
 hermes sessions browse      Interactive picker
 hermes sessions export OUT  Export to JSONL
 hermes sessions rename ID T Rename a session


### PR DESCRIPTION
## Summary

Add a `hermes sessions search <query>` command for terminal users who remember words from a past conversation but not the session title or ID.

This PR:
- wires a new `sessions search` subcommand into the CLI
- reuses the existing `session_search` FTS5 recall engine so CLI search and agent recall stay consistent
- formats matches with title, source, timestamp, snippet, and a ready-to-run `hermes --resume <session-id>` command
- adds `--limit`, `--sort newest|oldest`, `--role`, and `--json` for scripting
- documents the command in the sessions guide, CLI reference, and bundled Hermes skill docs

## Why

`hermes sessions list` is useful when you know roughly when a session happened or gave it a good title. It is much harder to recover a session when all you remember is transcript text like "auth refactor" or "rate limit". The agent already has a strong SQLite FTS path through `session_search`; this exposes that same capability directly to users in the terminal.

## Overlap check

I searched open and closed issues and PRs for `sessions search`, `session search`, and `hermes sessions search`. Existing open work I found covers gateway `/sessions search` punctuation normalization or `session_search` tool scoping, not a CLI transcript search subcommand.

## Tests

- `scripts/run_tests.sh tests/hermes_cli/test_sessions_search.py -q`
  - Result: 3 passed
- `scripts/run_tests.sh tests/hermes_cli/test_sessions_search.py tests/tools/test_session_search.py tests/hermes_cli/test_session_listing.py -q`
  - Result: 72 passed
- `scripts/run_tests.sh tests/hermes_cli/test_sessions_search.py tests/hermes_cli/test_session_listing.py tests/hermes_cli/test_session_browse.py tests/hermes_cli/test_sessions_delete.py tests/tools/test_session_search.py -q`
  - Result: 113 passed
- `python3 -m py_compile hermes_cli/session_search_cli.py hermes_cli/main.py tests/hermes_cli/test_sessions_search.py`
  - Result: passed
- `uv run ruff check hermes_cli/session_search_cli.py tests/hermes_cli/test_sessions_search.py hermes_cli/main.py`
  - Result: passed
- `python3 scripts/check-windows-footguns.py`
  - Result: passed
- `git diff --cached --check`
  - Result: passed

Full suite not run because this is a focused CLI/session command change and the targeted session search, listing, browse, and delete tests passed locally.
