### PR TITLE
fix(mcp): sanitize server names for auth env keys

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -152,7 +152,8 @@ def _replace_mcp_servers(servers: Dict[str, dict]) -> Tuple[bool, List[str]]:
 
 def _env_key_for_server(name: str) -> str:
     """Convert server name to an env-var key like ``MCP_MYSERVER_API_KEY``."""
-    return f"MCP_{name.upper().replace('-', '_')}_API_KEY"
+    suffix = re.sub(r"[^A-Za-z0-9_]", "_", name.upper()).strip("_")
+    return f"MCP_{suffix}_API_KEY"
 
 
 def _strip_bearer_prefix(token: str) -> str:

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -776,6 +776,8 @@ class TestConfigHelpers:
 
         assert _env_key_for_server("ink") == "MCP_INK_API_KEY"
         assert _env_key_for_server("my-server") == "MCP_MY_SERVER_API_KEY"
+        assert _env_key_for_server("my.server") == "MCP_MY_SERVER_API_KEY"
+        assert _env_key_for_server("github/mcp") == "MCP_GITHUB_MCP_API_KEY"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
MCP server names with non-env-safe characters now derive valid auth env-var keys instead of broken ones.

Root cause: `_env_key_for_server` only replaced `-`, so a server named `my.server` or `github/mcp` produced `MCP_MY.SERVER_API_KEY` / `MCP_GITHUB/MCP_API_KEY` — invalid env-var names that break both the `.env` write and the `${MCP_..._API_KEY}` header substitution.

## Changes
- `hermes_cli/mcp_config.py`: `_env_key_for_server` replaces any char outside `[A-Za-z0-9_]` with `_` and strips edge underscores.
- `tests/hermes_cli/test_mcp_config.py`: added dotted + slash-containing server name cases.

## Validation
| server name | Before | After |
|---|---|---|
| `my.server` | `MCP_MY.SERVER_API_KEY` (invalid) | `MCP_MY_SERVER_API_KEY` |
| `github/mcp` | `MCP_GITHUB/MCP_API_KEY` (invalid) | `MCP_GITHUB_MCP_API_KEY` |
| `context 7` | `MCP_CONTEXT 7_API_KEY` (invalid) | `MCP_CONTEXT_7_API_KEY` |

Targeted tests: `tests/hermes_cli/test_mcp_config.py` → 56/56 pass. E2E confirmed every derived key is a valid POSIX env-var name.

Salvaged from #59481 by @giggling-ginger (unrelated CONTRIBUTING.md doc edits dropped; core fix + tests preserved with authorship).

## Infographic

![mcp-auth-env-key-sanitizer](https://v3b.fal.media/files/b/0aa12531/XZrzZRfMEsbTrgsec4E07_xP2nMIEq.png)
