### PR TITLE
fix(sessions): harden workspace resume guards

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -432,6 +432,46 @@ def _ensure_compressed_has_user_turn(original_messages: list, compressed: list) 
     })
 
 
+def _stamp_workspace_metadata_on_compressed_messages(agent: Any, compressed: list) -> None:
+    """Append workspace metadata to compressed summary messages in-place.
+
+    This is a secondary restore-boundary signal. The primary guard uses
+    sessions.git_repo_root/cwd, but legacy or rotated rows can lack those
+    fields. Appending to an existing compressed-summary message avoids adding
+    a new role and preserves strict alternation.
+    """
+    try:
+        from agent.context_compressor import (
+            COMPRESSED_SUMMARY_METADATA_KEY,
+            _append_text_to_content,
+        )
+        from hermes_cli.workspace_guard import stamp_compaction_metadata
+
+        db = getattr(agent, "_session_db", None)
+        session_id = getattr(agent, "session_id", "") or ""
+        if not db or not session_id:
+            return
+        try:
+            session_row = db.get_session(session_id) or {}
+        except Exception:
+            session_row = {}
+        marker = stamp_compaction_metadata("", session_row)
+        if not marker:
+            return
+
+        for msg in compressed:
+            if not isinstance(msg, dict):
+                continue
+            if not msg.get(COMPRESSED_SUMMARY_METADATA_KEY):
+                continue
+            content = msg.get("content", "")
+            if "HERMES_WORKSPACE:" in str(content):
+                continue
+            msg["content"] = _append_text_to_content(content, marker, prepend=False)
+    except Exception as exc:
+        logger.debug("Failed to stamp workspace metadata on compressed messages: %s", exc)
+
+
 def compress_context(
     agent: Any,
     messages: list,
@@ -689,6 +729,7 @@ def compress_context(
         if todo_snapshot:
             compressed.append({"role": "user", "content": todo_snapshot})
         _ensure_compressed_has_user_turn(messages, compressed)
+        _stamp_workspace_metadata_on_compressed_messages(agent, compressed)
 
         agent._invalidate_system_prompt()
         new_system_prompt = agent._build_system_prompt(system_message)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1303,9 +1303,23 @@ class SessionStore:
         source: Optional[SessionSource],
         display_name: Optional[str] = None,
     ) -> None:
-        """Persist the routing peer for an existing gateway session row."""
+        """Persist the routing peer for an existing gateway session row.
+
+        Also captures workspace identity (git_repo_root) at creation time so
+        that future resume restores can validate cross-workspace safety.
+        """
         if not self._db or not source:
             return
+        
+        # Resolve current working directory's git repo root for workspace capture
+        git_repo_root = ""
+        try:
+            from tui_gateway.git_probe import repo_root as _git_repo_root
+            cwd = os.getcwd()
+            git_repo_root = _git_repo_root(cwd) or ""
+        except Exception:
+            pass  # Non-critical; legacy sessions will have null
+        
         recorder = getattr(self._db, "record_gateway_session_peer", None)
         if not callable(recorder):
             return
@@ -1325,6 +1339,7 @@ class SessionStore:
                 thread_id=source.thread_id,
                 display_name=display_name or source.chat_name,
                 origin_json=origin_json,
+                git_repo_root=git_repo_root,  # NEW: workspace identity capture
             )
         except TypeError:
             # Older SessionDB without display_name/origin_json kwargs.

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -39,6 +39,7 @@ from gateway.session import (
     is_shared_multi_user_session,
 )
 from hermes_cli.config import atomic_config_write, cfg_get, clear_model_endpoint_credentials
+from hermes_cli.workspace_guard import validate_session_workspace
 from utils import (
     atomic_json_write,
     base_url_host_matches,
@@ -3604,6 +3605,31 @@ class GatewaySlashCommandsMixin:
             # non-Matrix adapter so one user can't attach to another's
             # persisted transcript.
             return t("gateway.resume.blocked_not_owner", name=name)
+
+        # Workspace guard: prevent cross-workspace context leakage on resume.
+        # Blocks restore if stored session's git_repo_root differs from current cwd's repo root.
+        # Legacy sessions with null git_repo_root get a warning but are allowed through.
+        try:
+            target_session = await self._session_db.get_session(target_id)
+            if target_session and target_session.get("git_repo_root"):
+                result = validate_session_workspace(
+                    session_row=target_session,
+                    current_cwd=os.getcwd(),
+                )
+                if not result.ok:
+                    return t(
+                        "gateway.resume.workspace_blocked",
+                        reason=result.reason,
+                        stored_workspace=result.stored_workspace,
+                        current_workspace=result.current_workspace,
+                    )
+                elif result.warning:
+                    logger.debug(
+                        "Workspace guard warning on resume %s: %s", target_id, result.reason
+                    )
+        except Exception as exc:
+            logger.debug("Workspace guard check failed for resume %s: %s", target_id, exc)
+        # Non-fatal: if guard module fails or DB lookup fails, allow resume to proceed.
 
         # Check if already on that session
         current_entry = self.session_store.get_or_create_session(source)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -39,7 +39,10 @@ from gateway.session import (
     is_shared_multi_user_session,
 )
 from hermes_cli.config import atomic_config_write, cfg_get, clear_model_endpoint_credentials
-from hermes_cli.workspace_guard import validate_session_workspace
+from hermes_cli.workspace_guard import (
+    augment_session_row_from_compaction,
+    validate_session_workspace,
+)
 from utils import (
     atomic_json_write,
     base_url_host_matches,
@@ -3608,10 +3611,19 @@ class GatewaySlashCommandsMixin:
 
         # Workspace guard: prevent cross-workspace context leakage on resume.
         # Blocks restore if stored session's git_repo_root differs from current cwd's repo root.
-        # Legacy sessions with null git_repo_root get a warning but are allowed through.
+        # Legacy sessions with null/empty git_repo_root get a warning but are allowed through.
+        resume_history = None
         try:
             target_session = await self._session_db.get_session(target_id)
-            if target_session and target_session.get("git_repo_root"):
+            if target_session:
+                try:
+                    resume_history = self.session_store.load_transcript(target_id)
+                except Exception:
+                    resume_history = None
+                target_session = augment_session_row_from_compaction(
+                    target_session,
+                    resume_history if resume_history is not None else [],
+                )
                 result = validate_session_workspace(
                     session_row=target_session,
                     current_cwd=os.getcwd(),
@@ -3625,7 +3637,7 @@ class GatewaySlashCommandsMixin:
                     )
                 elif result.warning:
                     logger.debug(
-                        "Workspace guard warning on resume %s: %s", target_id, result.reason
+                        "Workspace guard warning on resume %s: %s", target_id, result.warning
                     )
         except Exception as exc:
             logger.debug("Workspace guard check failed for resume %s: %s", target_id, exc)
@@ -3677,7 +3689,7 @@ class GatewaySlashCommandsMixin:
         title = await self._session_db.get_session_title(target_id) or name
 
         # Count messages for context
-        history = self.session_store.load_transcript(target_id)
+        history = resume_history if resume_history is not None else self.session_store.load_transcript(target_id)
         msg_count = len([m for m in history if m.get("role") == "user"]) if history else 0
         msg_part = f" ({msg_count} message{'s' if msg_count != 1 else ''})" if msg_count else ""
 

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -286,6 +286,29 @@ class CLIAgentSetupMixin:
                 resolved_meta = self._session_db.get_session(self.session_id)
                 if resolved_meta:
                     session_meta = resolved_meta
+            # Workspace guard: validate session identity before injecting history.
+            # Prevents cross-workspace context leakage (e.g. scout vs hermes-agent).
+            try:
+                from hermes_cli.workspace_guard import (
+                    format_workspace_mismatch_error,
+                    format_legacy_warning,
+                    validate_session_workspace,
+                )
+
+                session_meta = self._session_db.get_session(self.session_id) or {}
+                guard_result = validate_session_workspace(
+                    session_meta, current_cwd=self.cwd if hasattr(self, "cwd") else None
+                )
+                if guard_result.blocked:
+                    error_msg = format_workspace_mismatch_error(guard_result)
+                    ChatConsole().print(f"[bold red]{error_msg}[/]")
+                    print(error_msg, file=sys.stderr)
+                    return False
+                elif guard_result.warning:
+                    _cprint(format_legacy_warning(guard_result.warning))
+            except Exception as exc:
+                logger.debug("Workspace guard check failed for session %s: %s", self.session_id, exc)
+
             restored = self._session_db.get_messages_as_conversation(self.session_id)
             if restored:
                 restored = [m for m in restored if m.get("role") != "session_meta"]

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -286,16 +286,20 @@ class CLIAgentSetupMixin:
                 resolved_meta = self._session_db.get_session(self.session_id)
                 if resolved_meta:
                     session_meta = resolved_meta
+            restored = []
             # Workspace guard: validate session identity before injecting history.
             # Prevents cross-workspace context leakage (e.g. scout vs hermes-agent).
             try:
                 from hermes_cli.workspace_guard import (
+                    augment_session_row_from_compaction,
                     format_workspace_mismatch_error,
                     format_legacy_warning,
                     validate_session_workspace,
                 )
 
                 session_meta = self._session_db.get_session(self.session_id) or {}
+                restored = self._session_db.get_messages_as_conversation(self.session_id)
+                session_meta = augment_session_row_from_compaction(session_meta, restored)
                 guard_result = validate_session_workspace(
                     session_meta, current_cwd=self.cwd if hasattr(self, "cwd") else None
                 )
@@ -309,7 +313,8 @@ class CLIAgentSetupMixin:
             except Exception as exc:
                 logger.debug("Workspace guard check failed for session %s: %s", self.session_id, exc)
 
-            restored = self._session_db.get_messages_as_conversation(self.session_id)
+            if not restored:
+                restored = self._session_db.get_messages_as_conversation(self.session_id)
             if restored:
                 restored = [m for m in restored if m.get("role") != "session_meta"]
                 self.conversation_history = restored

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1139,14 +1139,37 @@ def _session_browse_picker(sessions: list) -> Optional[str]:
 
 
 def _resolve_last_session(source: str = "cli") -> Optional[str]:
-    """Look up the most recently-used session ID for a source."""
+    """Look up the most recently-used session ID for a source.
+
+    Workspace-aware: filters candidates by current workspace identity so that
+    auto-continue (hermes -c) picks sessions from the same project, not just
+    the chronologically last one across unrelated workspaces.
+    """
     db = None
     try:
         from hermes_state import SessionDB
 
         db = SessionDB()
-        sessions = db.search_sessions(source=source, limit=1)
-        return sessions[0]["id"] if sessions else None
+        # Fetch more candidates to allow workspace filtering (default limit=1 is too narrow)
+        sessions = db.search_sessions(source=source, limit=20)
+        if not sessions:
+            return None
+
+        # Workspace-aware filtering for auto-continue
+        try:
+            from hermes_cli.workspace_guard import filter_sessions_by_workspace
+            compatible, incompatible = filter_sessions_by_workspace(
+                sessions, current_cwd=None  # cwd resolved at resume boundary
+            )
+            if compatible:
+                return compatible[0]["id"]
+            elif incompatible:
+                # Legacy fallback: allow last resort with warning (handled at resume)
+                return incompatible[-1]["id"]
+        except Exception:
+            pass
+
+        return sessions[0]["id"]
     except Exception:
         pass
     finally:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1159,13 +1159,17 @@ def _resolve_last_session(source: str = "cli") -> Optional[str]:
         try:
             from hermes_cli.workspace_guard import filter_sessions_by_workspace
             compatible, incompatible = filter_sessions_by_workspace(
-                sessions, current_cwd=None  # cwd resolved at resume boundary
+                sessions, current_cwd=os.getcwd()  # resolve cwd at query time
             )
             if compatible:
                 return compatible[0]["id"]
             elif incompatible:
-                # Legacy fallback: allow last resort with warning (handled at resume)
-                return incompatible[-1]["id"]
+                logger.debug(
+                    "No workspace-compatible session found for auto-continue; "
+                    "skipped %d mismatched candidate(s)",
+                    len(incompatible),
+                )
+                return None
         except Exception:
             pass
 

--- a/hermes_cli/workspace_guard.py
+++ b/hermes_cli/workspace_guard.py
@@ -1,0 +1,244 @@
+"""Workspace identity guard for session resume / restore boundaries.
+
+Prevents cross-workspace context leakage when resuming sessions: if a stored
+session carries a reliable workspace identity (``git_repo_root`` or ``cwd``)
+that differs from the current working directory, block or warn at the restore
+boundary instead of silently injecting foreign history into the agent's prompt.
+
+Design decisions:
+- Workspace identity matching order: ``git_repo_root`` > ``cwd`` (never
+  ``git_branch`` — branch changes are normal and should not prevent resume).
+- If stored session has a reliable workspace identity and current workspace
+  differs → **block restore** with a clear error.
+- If stored session has no workspace identity because legacy/null fields →
+  **allow but warn**.
+- Auto-continue (``hermes -c`` with no explicit ID): filter candidates by
+  workspace when possible; skip mismatches; allow legacy as last resort with
+  warning.
+- Explicit ``--resume SESSION_ID``: strict validation and fail on known mismatch.
+
+This is the primary fix for context-compaction/session-state leakage across
+independent agent sessions (e.g. scout vs hermes-agent workspaces).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class WorkspaceGuardResult:
+    """Structured result from workspace identity validation."""
+
+    ok: bool  # True if restore is safe (no mismatch or legacy session)
+    warning: str | None = None  # Non-empty string for legacy/warning cases
+    reason: str | None = None  # Human-readable explanation
+    stored_workspace: str = ""  # Resolved workspace identity from DB row
+    current_workspace: str = ""  # Resolved workspace identity of current cwd
+
+    @property
+    def blocked(self) -> bool:
+        return not self.ok
+
+
+def _resolve_git_repo_root(cwd: str | None) -> str:
+    """Resolve the git repo root for a given working directory.
+
+    Returns empty string if cwd is missing, not a git repo, or probe fails.
+    Uses Path.resolve() to normalise paths before probing.
+    """
+    if not cwd:
+        return ""
+    try:
+        resolved = str(Path(cwd).resolve())
+    except (OSError, ValueError):
+        return ""
+
+    # Walk up from resolved cwd looking for .git directory or file
+    current = Path(resolved)
+    while True:
+        git_path = current / ".git"
+        if git_path.exists():
+            # Return the parent of .git (the repo root), not .git itself
+            return str(current.parent.resolve()) if current.name == ".git" else str(current.resolve())
+        parent = current.parent
+        if parent == current:
+            break  # reached filesystem root
+        current = parent
+
+    return ""
+
+
+def _resolve_workspace_identity(session_row: Dict[str, Any]) -> str:
+    """Extract workspace identity from a session DB row.
+
+    Returns the most reliable available signal: git_repo_root > cwd.
+    Empty string means no reliable identity (legacy/null fields).
+    """
+    repo_root = (session_row.get("git_repo_root") or "").strip()
+    if repo_root:
+        return repo_root
+
+    cwd = (session_row.get("cwd") or "").strip()
+    if cwd:
+        # Try to resolve cwd as a workspace identity too, but git_repo_root
+        # is preferred when both are available.
+        resolved = _resolve_git_repo_root(cwd)
+        return resolved if resolved else cwd
+
+    return ""
+
+
+def _current_workspace_identity(current_cwd: str | None) -> str:
+    """Resolve the current working directory's workspace identity."""
+    if not current_cwd:
+        return ""
+    # Try git_repo_root first (most reliable cross-workspace signal)
+    resolved = _resolve_git_repo_root(current_cwd)
+    if resolved:
+        return resolved
+    # Fall back to resolved cwd for non-git directories
+    try:
+        return str(Path(current_cwd).resolve())
+    except (OSError, ValueError):
+        return ""
+
+
+def validate_session_workspace(
+    session_row: Dict[str, Any],
+    current_cwd: str | None = None,
+) -> WorkspaceGuardResult:
+    """Validate whether resuming a session is safe given the current workspace.
+
+    Args:
+        session_row: Session metadata dict from DB (must have cwd/git_repo_root).
+        current_cwd: Current working directory of the caller process.
+
+    Returns:
+        WorkspaceGuardResult with ok/warning/blocked status.
+    """
+    stored = _resolve_workspace_identity(session_row)
+    current = _current_workspace_identity(current_cwd) if current_cwd else ""
+
+    # No stored identity → legacy session, allow but warn
+    if not stored:
+        return WorkspaceGuardResult(
+            ok=True,
+            warning="Session has no workspace identity recorded; resuming without cross-workspace check.",
+            reason="legacy_session",
+            stored_workspace="",
+            current_workspace=current,
+        )
+
+    # No current identity → can't validate, allow but warn
+    if not current:
+        return WorkspaceGuardResult(
+            ok=True,
+            warning="Current working directory has no workspace identity; resuming without cross-workspace check.",
+            reason="no_current_identity",
+            stored_workspace=stored,
+            current_workspace="",
+        )
+
+    # Both present — compare
+    if stored == current:
+        return WorkspaceGuardResult(
+            ok=True,
+            stored_workspace=stored,
+            current_workspace=current,
+        )
+
+    # Mismatch → block restore
+    return WorkspaceGuardResult(
+        ok=False,
+        reason="workspace_mismatch",
+        stored_workspace=stored,
+        current_workspace=current,
+    )
+
+
+def format_workspace_mismatch_error(result: WorkspaceGuardResult) -> str:
+    """Format a user-facing error message for workspace mismatch."""
+    return (
+        f"⚠️  Cross-workspace resume blocked.\n\n"
+        f"This session was created in: {result.stored_workspace}\n"
+        f"You are currently in:         {result.current_workspace}\n\n"
+        f"Hermes prevents resuming sessions from a different workspace to avoid "
+        f"context leakage. Start a new session or resume from the original workspace."
+    )
+
+
+def format_legacy_warning(message: str) -> str:
+    """Format a user-facing warning for legacy/null-session cases."""
+    return f"[dim]⚠ {message}[/dim]"
+
+
+def filter_sessions_by_workspace(
+    sessions: List[Dict[str, Any]],
+    current_cwd: str | None = None,
+) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Filter session list by workspace compatibility.
+
+    Returns (compatible, incompatible) — both lists contain the original dicts.
+    Compatible sessions are those that match the current workspace or have no
+    stored identity (legacy). Incompatible ones have a mismatched git_repo_root.
+
+    This is used for auto-continue (--resume with no explicit ID): prefer
+    compatible sessions over legacy ones, and skip incompatible ones entirely.
+    """
+    current = _current_workspace_identity(current_cwd) if current_cwd else ""
+    compatible: List[Dict[str, Any]] = []
+    incompatible: List[Dict[str, Any]] = []
+
+    for session in sessions:
+        stored = _resolve_workspace_identity(session)
+        if not stored:
+            # Legacy — compatible but lower priority (will be last resort)
+            compatible.append(session)
+        elif current and stored == current:
+            compatible.append(session)
+        else:
+            incompatible.append(session)
+
+    return compatible, incompatible
+
+
+def stamp_compaction_metadata(
+    summary_text: str,
+    session_row: Dict[str, Any],
+) -> str:
+    """Stamp a compaction summary with workspace metadata.
+
+    Adds a hidden header block to the compacted summary so future restores
+    can validate workspace identity even after raw message history is gone.
+    This is secondary defense — primary guard uses DB/session metadata.
+
+    The marker format is designed to be parseable by restore code but invisible
+    to models (prefixed with a comment-like token that models treat as neutral).
+    """
+    repo_root = _resolve_workspace_identity(session_row)
+    if not repo_root:
+        return summary_text
+
+    # Use a structured metadata block that models won't act on but restore
+    # code can parse. Format: <!-- HERMES_WORKSPACE:<value> -->
+    marker = f"\n<!-- HERMES_WORKSPACE:{repo_root} -->"
+    return summary_text + marker
+
+
+def extract_workspace_from_compaction(summary_text: str) -> str:
+    """Extract workspace identity from a stamped compaction summary."""
+    try:
+        import re
+        match = re.search(r"<!--\s*HERMES_WORKSPACE:(.+?)\s*-->", summary_text)
+        if match:
+            return match.group(1).strip()
+    except Exception:
+        pass
+    return ""

--- a/hermes_cli/workspace_guard.py
+++ b/hermes_cli/workspace_guard.py
@@ -242,3 +242,43 @@ def extract_workspace_from_compaction(summary_text: str) -> str:
     except Exception:
         pass
     return ""
+
+
+def _message_content_text(content: Any) -> str:
+    """Best-effort text extraction from string or multimodal message content."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text") or item.get("content")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n".join(parts)
+    return ""
+
+
+def augment_session_row_from_compaction(
+    session_row: Dict[str, Any],
+    messages: list[Dict[str, Any]] | None,
+) -> Dict[str, Any]:
+    """Fill missing workspace identity from stamped compaction summaries.
+
+    Does not mutate the input row. Existing git_repo_root/cwd wins.
+    """
+    if _resolve_workspace_identity(session_row):
+        return session_row
+    for msg in messages or []:
+        if not isinstance(msg, dict):
+            continue
+        workspace = extract_workspace_from_compaction(
+            _message_content_text(msg.get("content", ""))
+        )
+        if workspace:
+            updated = dict(session_row)
+            updated["git_repo_root"] = workspace
+            return updated
+    return session_row

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1673,6 +1673,7 @@ class SessionDB:
         thread_id: str = None,
         display_name: str = None,
         origin_json: str = None,
+        git_repo_root: str = None,  # NEW: workspace identity for resume validation
     ) -> None:
         """Persist the gateway routing peer for an existing session row.
 
@@ -1681,6 +1682,9 @@ class SessionDB:
         channel directory) can read routing data from state.db instead of
         sessions.json.  They are COALESCE'd only in the sense that ``None``
         leaves the existing value untouched.
+
+        ``git_repo_root`` captures the workspace identity at session creation
+        so that future resume restores can validate cross-workspace safety.
         """
         if not session_id or not session_key:
             return
@@ -1691,7 +1695,8 @@ class SessionDB:
                    SET session_key = ?, source = ?, user_id = ?, chat_id = ?,
                        chat_type = ?, thread_id = ?,
                        display_name = COALESCE(?, display_name),
-                       origin_json = COALESCE(?, origin_json)
+                       origin_json = COALESCE(?, origin_json),
+                       git_repo_root = COALESCE(?, git_repo_root)
                    WHERE id = ?""",
                 (
                     session_key,
@@ -1702,6 +1707,7 @@ class SessionDB:
                     thread_id,
                     display_name,
                     origin_json,
+                    git_repo_root,  # NEW: workspace identity capture
                     session_id,
                 ),
             )

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -240,6 +240,7 @@ Use `/title My Session` to name the current room session, `/resume --all` to lis
     matrix_cross_room_success: "⚠️ Cross-room resume: resumed **{title}** inside Matrix room **{room}**.
 Future messages in this room will use that transcript until `/reset` or another `/resume`.{msg_part}"
     blocked_not_owner:     "⚠️ /resume blocked: '**{name}**' belongs to a different user or chat. You can only resume sessions from this chat."
+    workspace_blocked:     "⚠️ Cross-workspace resume blocked. This session was created in a different project/workspace ({stored_workspace}). Resuming would inject foreign context into your current conversation. Start a new session or resume from the original workspace."
     no_named_sessions:     "Geen benoemde sessies gevind nie.\nGebruik `/title My Sessie` om jou huidige sessie 'n naam te gee, en dan `/resume My Sessie` om later daarheen terug te keer."
     list_header:           "📋 **Benoemde Sessies**\n"
     list_item:             "• **{title}**{preview_part}"

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -240,6 +240,7 @@ Use `/title My Session` to name the current room session, `/resume --all` to lis
     matrix_cross_room_success: "⚠️ Cross-room resume: resumed **{title}** inside Matrix room **{room}**.
 Future messages in this room will use that transcript until `/reset` or another `/resume`.{msg_part}"
     blocked_not_owner:     "⚠️ /resume blocked: '**{name}**' belongs to a different user or chat. You can only resume sessions from this chat."
+    workspace_blocked:     "⚠️ Cross-workspace resume blocked. This session was created in a different project/workspace ({stored_workspace}). Resuming would inject foreign context into your current conversation. Start a new session or resume from the original workspace."
     no_named_sessions:     "Keine benannten Sitzungen gefunden.\nVerwenden Sie `/title Meine Sitzung`, um die aktuelle Sitzung zu benennen, dann `/resume Meine Sitzung`, um später dorthin zurückzukehren."
     list_header:           "📋 **Benannte Sitzungen**\n"
     list_item:             "• **{title}**{preview_part}"

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -252,6 +252,7 @@ gateway:
     matrix_blocked_other_room: "⚠️ Matrix /resume blocked: that session belongs to a different Matrix room ({room}). Use `/resume --cross-room {name}` if you intentionally want to resume it here."
     matrix_cross_room_success: "⚠️ Cross-room resume: resumed **{title}** inside Matrix room **{room}**.\nFuture messages in this room will use that transcript until `/reset` or another `/resume`.{msg_part}"
     blocked_not_owner:     "⚠️ /resume blocked: '**{name}**' belongs to a different user or chat. You can only resume sessions from this chat."
+    workspace_blocked:     "⚠️ Cross-workspace resume blocked. This session was created in a different project/workspace ({stored_workspace}). Resuming would inject foreign context into your current conversation. Start a new session or resume from the original workspace."
     no_named_sessions:     "No named sessions found.\nUse `/title My Session` to name your current session, then `/resume My Session` to return to it later."
     list_header:           "📋 **Named Sessions**\n"
     list_item:             "• **{title}**{preview_part}"

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -237,6 +237,7 @@ gateway:
     matrix_blocked_other_room: "⚠️ Matrix /resume bloqueado: esa sesión pertenece a una sala de Matrix diferente ({room}). Usa `/resume --cross-room {name}` si quieres reanudarla aquí intencionadamente."
     matrix_cross_room_success: "⚠️ Reanudación entre salas: **{title}** reanudada dentro de la sala de Matrix **{room}**.\nLos próximos mensajes en esta sala usarán esa transcripción hasta `/reset` u otro `/resume`.{msg_part}"
     blocked_not_owner:     "⚠️ /resume blocked: '**{name}**' belongs to a different user or chat. You can only resume sessions from this chat."
+    workspace_blocked:     "⚠️ Cross-workspace resume blocked. This session was created in a different project/workspace ({stored_workspace}). Resuming would inject foreign context into your current conversation. Start a new session or resume from the original workspace."
     no_named_sessions:     "No se encontraron sesiones con nombre.\nUsa `/title Mi sesión` para nombrar la sesión actual y luego `/resume Mi sesión` para volver a ella."
     list_header:           "📋 **Sesiones con nombre**\n"
     list_item:             "• **{title}**{preview_part}"

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -240,6 +240,7 @@ Use `/title My Session` to name the current room session, `/resume --all` to lis
     matrix_cross_room_success: "⚠️ Cross-room resume: resumed **{title}** inside Matrix room **{room}**.
 Future messages in this room will use that transcript until `/reset` or another `/resume`.{msg_part}"
     blocked_not_owner:     "⚠️ /resume blocked: '**{name}**' belongs to a different user or chat. You can only resume sessions from this chat."
+    workspace_blocked:     "⚠️ Cross-workspace resume blocked. This session was created in a different project/workspace ({stored_workspace}). Resuming would inject foreign context into your current conversation. Start a new session or resume from the original workspace."
     no_named_sessions:     "Aucune session nommée trouvée.\nUtilisez `/title Ma session` pour nommer la session actuelle, puis `/resume Ma session` pour y revenir plus tard."
     list_header:           "📋 **Sessions nommées**\n"
     list_item:             "• **{title}**{preview_part}"

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -244,6 +244,7 @@ Use `/title My Session` to name the current room session, `/resume --all` to lis
     matrix_cross_room_success: "⚠️ Cross-room resume: resumed **{title}** inside Matrix room **{room}**.
 Future messages in this room will use that transcript until `/reset` or another `/resume`.{msg_part}"
     blocked_not_owner:     "⚠️ /resume blocked: '**{name}**' belongs to a different user or chat. You can only resume sessions from this chat."
+    workspace_blocked:     "⚠️ Cross-workspace resume blocked. This session was created in a different project/workspace ({stored_workspace}). Resuming would inject foreign context into your current conversation. Start a new session or resume from the original workspace."
     no_named_sessions:     "Níor aimsíodh aon seisiún ainmnithe.\nÚsáid `/title M'Ainm Seisiúin` chun do sheisiún reatha a ainmniú, ansin `/resume M'Ainm Seisiúin` chun filleadh air níos déanaí."
     list_header:           "📋 **Seisiúin Ainmnithe**\n"
     list_item:             "• **{title}**{preview_part}"

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -240,6 +240,7 @@ Use `/title My Session` to name the current room session, `/resume --all` to lis
     matrix_cross_room_success: "⚠️ Cross-room resume: resumed **{title}** inside Matrix room **{room}**.
 Future messages in this room will use that transcript until `/reset` or another `/resume`.{msg_part}"
     blocked_not_owner:     "⚠️ /resume blocked: '**{name}**' belongs to a different user or chat. You can only resume sessions from this chat."
+    workspace_blocked:     "⚠️ Cross-workspace resume blocked. This session was created in a different project/workspace ({stored_workspace}). Resuming would inject foreign context into your current conversation. Start a new session or resume from the original workspace."
     no_named_sessions:     "Nem található elnevezett munkamenet.\nHasználd a `/title Saját munkamenet` parancsot a jelenlegi munkamenet elnevezéséhez, majd a `/resume Saját munkamenet` paranccsal térhetsz vissza hozzá."
     list_header:           "📋 **Elnevezett munkamenetek**\n"
     list_item:             "• **{title}**{preview_part}"

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -240,6 +240,7 @@ Use `/title My Session` to name the current room session, `/resume --all` to lis
     matrix_cross_room_success: "⚠️ Cross-room resume: resumed **{title}** inside Matrix room **{room}**.
 Future messages in this room will use that transcript until `/reset` or another `/resume`.{msg_part}"
     blocked_not_owner:     "⚠️ /resume blocked: '**{name}**' belongs to a different user or chat. You can only resume sessions from this chat."
+    workspace_blocked:     "⚠️ Cross-workspace resume blocked. This session was created in a different project/workspace ({stored_workspace}). Resuming would inject foreign context into your current conversation. Start a new session or resume from the original workspace."
     no_named_sessions:     "Nessuna sessione con nome trovata.\nUsa `/title My Session` per dare un nome alla sessione attuale, poi `/resume My Session` per tornare a essa in seguito."
     list_header:           "📋 **Sessioni con nome**\n"
     list_item:             "• **{title}**{preview_part}"

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -240,6 +240,7 @@ Use `/title My Session` to name the current room session, `/resume --all` to lis
     matrix_cross_room_success: "⚠️ Cross-room resume: resumed **{title}** inside Matrix room **{room}**.
 Future messages in this room will use that transcript until `/reset` or another `/resume`.{msg_part}"
     blocked_not_owner:     "⚠️ /resume blocked: '**{name}**' belongs to a different user or chat. You can only resume sessions from this chat."
+    workspace_blocked:     "⚠️ Cross-workspace resume blocked. This session was created in a different project/workspace ({stored_workspace}). Resuming would inject foreign context into your current conversation. Start a new session or resume from the original workspace."
     no_named_sessions:     "名前付きセッションが見つかりません。\n`/title セッション名` で現在のセッションに名前を付けると、後で `/resume セッション名` で戻れます。"
     list_header:           "📋 **名前付きセッション**\n"
     list_item:             "• **{title}**{preview_part}"

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -240,6 +240,7 @@ Use `/title My Session` to name the current room session, `/resume --all` to lis
     matrix_cross_room_success: "⚠️ Cross-room resume: resumed **{title}** inside Matrix room **{room}**.
 Future messages in this room will use that transcript until `/reset` or another `/resume`.{msg_part}"
     blocked_not_owner:     "⚠️ /resume blocked: '**{name}**' belongs to a different user or chat. You can only resume sessions from this chat."
+    workspace_blocked:     "⚠️ Cross-workspace resume blocked. This session was created in a different project/workspace ({stored_workspace}). Resuming would inject foreign context into your current conversation. Start a new session or resume from the original workspace."
     no_named_sessions:     "이름이 지정된 세션이 없습니다.\n현재 세션에 이름을 지정하려면 `/title 내 세션`을 사용하고, 나중에 `/resume 내 세션`으로 돌아오세요."
     list_header:           "📋 **이름이 지정된 세션**\n"
     list_item:             "• **{title}**{preview_part}"

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -240,6 +240,7 @@ Use `/title My Session` to name the current room session, `/resume --all` to lis
     matrix_cross_room_success: "⚠️ Cross-room resume: resumed **{title}** inside Matrix room **{room}**.
 Future messages in this room will use that transcript until `/reset` or another `/resume`.{msg_part}"
     blocked_not_owner:     "⚠️ /resume blocked: '**{name}**' belongs to a different user or chat. You can only resume sessions from this chat."
+    workspace_blocked:     "⚠️ Cross-workspace resume blocked. This session was created in a different project/workspace ({stored_workspace}). Resuming would inject foreign context into your current conversation. Start a new session or resume from the original workspace."
     no_named_sessions:     "Não foram encontradas sessões com nome.\nUsa `/title A minha sessão` para nomear a sessão atual e depois `/resume A minha sessão` para voltar a ela."
     list_header:           "📋 **Sessões com nome**\n"
     list_item:             "• **{title}**{preview_part}"

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -240,6 +240,7 @@ Use `/title My Session` to name the current room session, `/resume --all` to lis
     matrix_cross_room_success: "⚠️ Cross-room resume: resumed **{title}** inside Matrix room **{room}**.
 Future messages in this room will use that transcript until `/reset` or another `/resume`.{msg_part}"
     blocked_not_owner:     "⚠️ /resume blocked: '**{name}**' belongs to a different user or chat. You can only resume sessions from this chat."
+    workspace_blocked:     "⚠️ Cross-workspace resume blocked. This session was created in a different project/workspace ({stored_workspace}). Resuming would inject foreign context into your current conversation. Start a new session or resume from the original workspace."
     no_named_sessions:     "Именованных сеансов не найдено.\nИспользуйте `/title Мой сеанс`, чтобы назвать текущий сеанс, затем `/resume Мой сеанс`, чтобы вернуться к нему позже."
     list_header:           "📋 **Именованные сеансы**\n"
     list_item:             "• **{title}**{preview_part}"

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -240,6 +240,7 @@ Use `/title My Session` to name the current room session, `/resume --all` to lis
     matrix_cross_room_success: "⚠️ Cross-room resume: resumed **{title}** inside Matrix room **{room}**.
 Future messages in this room will use that transcript until `/reset` or another `/resume`.{msg_part}"
     blocked_not_owner:     "⚠️ /resume blocked: '**{name}**' belongs to a different user or chat. You can only resume sessions from this chat."
+    workspace_blocked:     "⚠️ Cross-workspace resume blocked. This session was created in a different project/workspace ({stored_workspace}). Resuming would inject foreign context into your current conversation. Start a new session or resume from the original workspace."
     no_named_sessions:     "Adlandırılmış oturum bulunamadı.\nMevcut oturumu adlandırmak için `/title Oturumum`, daha sonra geri dönmek için `/resume Oturumum` kullanın."
     list_header:           "📋 **Adlandırılmış Oturumlar**\n"
     list_item:             "• **{title}**{preview_part}"

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -240,6 +240,7 @@ Use `/title My Session` to name the current room session, `/resume --all` to lis
     matrix_cross_room_success: "⚠️ Cross-room resume: resumed **{title}** inside Matrix room **{room}**.
 Future messages in this room will use that transcript until `/reset` or another `/resume`.{msg_part}"
     blocked_not_owner:     "⚠️ /resume blocked: '**{name}**' belongs to a different user or chat. You can only resume sessions from this chat."
+    workspace_blocked:     "⚠️ Cross-workspace resume blocked. This session was created in a different project/workspace ({stored_workspace}). Resuming would inject foreign context into your current conversation. Start a new session or resume from the original workspace."
     no_named_sessions:     "Іменованих сеансів не знайдено.\nВикористайте `/title Мій сеанс`, щоб назвати поточний сеанс, потім `/resume Мій сеанс`, щоб повернутися до нього."
     list_header:           "📋 **Іменовані сеанси**\n"
     list_item:             "• **{title}**{preview_part}"

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -240,6 +240,7 @@ Use `/title My Session` to name the current room session, `/resume --all` to lis
     matrix_cross_room_success: "⚠️ Cross-room resume: resumed **{title}** inside Matrix room **{room}**.
 Future messages in this room will use that transcript until `/reset` or another `/resume`.{msg_part}"
     blocked_not_owner:     "⚠️ /resume blocked: '**{name}**' belongs to a different user or chat. You can only resume sessions from this chat."
+    workspace_blocked:     "⚠️ Cross-workspace resume blocked. This session was created in a different project/workspace ({stored_workspace}). Resuming would inject foreign context into your current conversation. Start a new session or resume from the original workspace."
     no_named_sessions:     "找不到已命名的工作階段。\n使用 `/title 我的工作階段` 為目前工作階段命名，然後使用 `/resume 我的工作階段` 返回。"
     list_header:           "📋 **已命名工作階段**\n"
     list_item:             "• **{title}**{preview_part}"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -240,6 +240,7 @@ Use `/title My Session` to name the current room session, `/resume --all` to lis
     matrix_cross_room_success: "⚠️ Cross-room resume: resumed **{title}** inside Matrix room **{room}**.
 Future messages in this room will use that transcript until `/reset` or another `/resume`.{msg_part}"
     blocked_not_owner:     "⚠️ /resume blocked: '**{name}**' belongs to a different user or chat. You can only resume sessions from this chat."
+    workspace_blocked:     "⚠️ Cross-workspace resume blocked. This session was created in a different project/workspace ({stored_workspace}). Resuming would inject foreign context into your current conversation. Start a new session or resume from the original workspace."
     no_named_sessions:     "未找到已命名的会话。\n使用 `/title 我的会话` 为当前会话命名，然后用 `/resume 我的会话` 返回。"
     list_header:           "📋 **已命名会话**\n"
     list_item:             "• **{title}**{preview_part}"

--- a/tests/agent/test_compression_workspace_metadata.py
+++ b/tests/agent/test_compression_workspace_metadata.py
@@ -1,0 +1,69 @@
+"""Workspace metadata stamping at the runtime compression boundary."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from hermes_state import SessionDB
+
+
+def test_compress_context_stamps_workspace_metadata_on_summary(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "PARENT_WORKSPACE_STAMP"
+    db.create_session(session_id, source="cli", cwd=str(repo))
+    with db._lock:
+        assert db._conn is not None
+        db._conn.execute(
+            "UPDATE sessions SET cwd=?, git_repo_root=? WHERE id=?",
+            (str(repo), str(repo), session_id),
+        )
+        db._conn.commit()
+
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+        from agent.context_compressor import COMPRESSED_SUMMARY_METADATA_KEY
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    compressor = MagicMock()
+    compressor.compress.return_value = [
+        {
+            "role": "user",
+            "content": "[CONTEXT COMPACTION] summary",
+            COMPRESSED_SUMMARY_METADATA_KEY: True,
+        },
+        {"role": "user", "content": "tail"},
+    ]
+    compressor.compression_count = 1
+    compressor.last_prompt_tokens = 0
+    compressor.last_completion_tokens = 0
+    compressor._last_summary_error = None
+    compressor._last_compress_aborted = False
+    compressor._last_aux_model_failure_model = None
+    compressor._last_aux_model_failure_error = None
+    setattr(agent, "context_compressor", compressor)
+    setattr(agent, "compression_in_place", True)
+
+    compressed, _ = agent._compress_context(
+        [{"role": "user", "content": f"m{i}"} for i in range(20)],
+        "sys",
+        approx_tokens=120_000,
+    )
+
+    summary = next(m for m in compressed if m.get(COMPRESSED_SUMMARY_METADATA_KEY))
+    assert f"HERMES_WORKSPACE:{repo}" in summary["content"]

--- a/tests/cli/test_workspace_guard.py
+++ b/tests/cli/test_workspace_guard.py
@@ -1,0 +1,247 @@
+"""Tests for hermes_cli.workspace_guard — workspace identity validation."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def git_repo(tmp_path: Path) -> Path:
+    """Create a minimal git repo at tmp_path and return its root."""
+    (tmp_path / "README.md").write_text("# test\n")
+    os.chdir(str(tmp_path))
+    # Use subprocess to init git without importing it at module level
+    import subprocess
+
+    subprocess.run(["git", "init"], cwd=str(tmp_path), check=True, capture_output=True)
+    return tmp_path
+
+
+class TestResolveGitRepoRoot:
+    """Test _resolve_git_repo_root helper."""
+
+    def test_returns_empty_for_none(self):
+        from hermes_cli.workspace_guard import _resolve_git_repo_root
+
+        assert _resolve_git_repo_root(None) == ""
+        assert _resolve_git_repo_root("") == ""
+
+    def test_returns_repo_root_for_git_dir(self, git_repo: Path):
+        from hermes_cli.workspace_guard import _resolve_git_repo_root
+
+        result = _resolve_git_repo_root(str(git_repo))
+        assert result == str(git_repo.resolve())
+
+    def test_returns_empty_for_non_git_dir(self, tmp_path: Path):
+        from hermes_cli.workspace_guard import _resolve_git_repo_root
+
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "file.txt").write_text("x")
+        result = _resolve_git_repo_root(str(sub))
+        assert result == ""
+
+
+class TestResolveWorkspaceIdentity:
+    """Test _resolve_workspace_identity helper."""
+
+    def test_prefers_git_repo_root_over_cwd(self):
+        from hermes_cli.workspace_guard import _resolve_workspace_identity
+
+        row = {
+            "git_repo_root": "/a/b/c",
+            "cwd": "/x/y/z",
+        }
+        assert _resolve_workspace_identity(row) == "/a/b/c"
+
+    def test_falls_back_to_cwd_when_no_git_repo_root(self):
+        from hermes_cli.workspace_guard import _resolve_workspace_identity
+
+        row = {
+            "git_repo_root": "",
+            "cwd": "/some/path",
+        }
+        # Should resolve cwd to git root if possible, else return cwd
+        result = _resolve_workspace_identity(row)
+        assert result == "/some/path"  # not a git repo
+
+    def test_returns_empty_for_missing_fields(self):
+        from hermes_cli.workspace_guard import _resolve_workspace_identity
+
+        row: dict[str, str] = {}
+        assert _resolve_workspace_identity(row) == ""
+
+
+class TestCurrentWorkspaceIdentity:
+    """Test _current_workspace_identity helper."""
+
+    def test_returns_empty_for_none(self):
+        from hermes_cli.workspace_guard import _current_workspace_identity
+
+        assert _current_workspace_identity(None) == ""
+        assert _current_workspace_identity("") == ""
+
+    def test_resolves_git_repo_root(self, git_repo: Path):
+        from hermes_cli.workspace_guard import _current_workspace_identity
+
+        result = _current_workspace_identity(str(git_repo))
+        assert result == str(git_repo.resolve())
+
+
+class TestValidateSessionWorkspace:
+    """Test validate_session_workspace main validation function."""
+
+    def test_ok_when_both_match(self):
+        from hermes_cli.workspace_guard import (
+            WorkspaceGuardResult,
+            _resolve_git_repo_root,
+            validate_session_workspace,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            # Create a git repo
+            import subprocess
+
+            (Path(tmp) / "README.md").write_text("# test\n")
+            subprocess.run(["git", "init"], cwd=tmp, check=True, capture_output=True)
+            root = str(Path(tmp).resolve())
+
+            row = {"git_repo_root": root}
+            result = validate_session_workspace(row, current_cwd=root)
+
+            assert result.ok is True
+            assert result.blocked is False
+            assert result.reason is None
+            assert result.stored_workspace == root
+            assert result.current_workspace == root
+
+    def test_blocked_on_mismatch(self):
+        from hermes_cli.workspace_guard import validate_session_workspace
+
+        row = {"git_repo_root": "/repo/scout"}
+        result = validate_session_workspace(row, current_cwd="/repo/hermes-agent")
+
+        assert result.ok is False
+        assert result.blocked is True
+        assert result.reason == "workspace_mismatch"
+        assert result.stored_workspace == "/repo/scout"
+        assert result.current_workspace == "/repo/hermes-agent"
+
+    def test_warns_on_legacy_session(self):
+        from hermes_cli.workspace_guard import validate_session_workspace
+
+        row: dict[str, str] = {}  # no git_repo_root or cwd
+        result = validate_session_workspace(row, current_cwd="/some/path")
+
+        assert result.ok is True
+        assert result.blocked is False
+        assert result.reason == "legacy_session"
+        assert result.warning is not None
+
+    def test_warns_on_no_current_identity(self):
+        from hermes_cli.workspace_guard import validate_session_workspace
+
+        row = {"git_repo_root": "/repo/scout"}
+        result = validate_session_workspace(row, current_cwd=None)
+
+        assert result.ok is True
+        assert result.blocked is False
+        assert result.reason == "no_current_identity"
+
+
+class TestFilterSessionsByWorkspace:
+    """Test filter_sessions_by_workspace helper."""
+
+    def test_separates_compatible_from_incompatible(self):
+        from hermes_cli.workspace_guard import filter_sessions_by_workspace
+
+        sessions = [
+            {"git_repo_root": "/repo/scout"},  # matches current
+            {"git_repo_root": "/repo/hermes-agent"},  # doesn't match
+            {},  # legacy — compatible but lower priority
+        ]
+        compatible, incompatible = filter_sessions_by_workspace(
+            sessions, current_cwd="/repo/scout"
+        )
+
+        assert len(compatible) == 2
+        assert len(incompatible) == 1
+        assert incompatible[0]["git_repo_root"] == "/repo/hermes-agent"
+
+
+class TestStampCompactionMetadata:
+    """Test stamp_compaction_metadata helper."""
+
+    def test_stamps_when_git_repo_root_present(self):
+        from hermes_cli.workspace_guard import stamp_compaction_metadata
+
+        row = {"git_repo_root": "/repo/scout"}
+        summary = "some compaction text"
+        result = stamp_compaction_metadata(summary, row)
+
+        assert "<!-- HERMES_WORKSPACE:/repo/scout -->" in result
+        assert result.startswith("some compaction text")
+
+    def test_returns_unchanged_when_no_git_repo_root(self):
+        from hermes_cli.workspace_guard import stamp_compaction_metadata
+
+        row: dict[str, str] = {}
+        summary = "some compaction text"
+        result = stamp_compaction_metadata(summary, row)
+
+        assert result == summary
+
+
+class TestExtractWorkspaceFromCompaction:
+    """Test extract_workspace_from_compaction helper."""
+
+    def test_parses_stamped_marker(self):
+        from hermes_cli.workspace_guard import extract_workspace_from_compaction
+
+        text = "some text\n<!-- HERMES_WORKSPACE:/repo/scout -->\nmore text"
+        result = extract_workspace_from_compaction(text)
+        assert result == "/repo/scout"
+
+    def test_returns_empty_when_no_marker(self):
+        from hermes_cli.workspace_guard import extract_workspace_from_compaction
+
+        result = extract_workspace_from_compaction("no marker here")
+        assert result == ""
+
+
+class TestFormatWorkspaceMismatchError:
+    """Test format_workspace_mismatch_error helper."""
+
+    def test_formats_user_message(self):
+        from hermes_cli.workspace_guard import (
+            WorkspaceGuardResult,
+            format_workspace_mismatch_error,
+        )
+
+        result = WorkspaceGuardResult(
+            ok=False,
+            reason="workspace_mismatch",
+            stored_workspace="/repo/scout",
+            current_workspace="/repo/hermes-agent",
+        )
+        msg = format_workspace_mismatch_error(result)
+
+        assert "Cross-workspace resume blocked" in msg
+        assert "/repo/scout" in msg
+        assert "/repo/hermes-agent" in msg
+
+
+class TestFormatLegacyWarning:
+    """Test format_legacy_warning helper."""
+
+    def test_wraps_in_dim_markup(self):
+        from hermes_cli.workspace_guard import format_legacy_warning
+
+        result = format_legacy_warning("test message")
+        assert "[dim]" in result
+        assert "test message" in result
+        assert "[/dim]" in result

--- a/tests/cli/test_workspace_guard.py
+++ b/tests/cli/test_workspace_guard.py
@@ -213,6 +213,57 @@ class TestExtractWorkspaceFromCompaction:
         assert result == ""
 
 
+class TestAugmentSessionRowFromCompaction:
+    """Test stamped compaction metadata fallback for legacy session rows."""
+
+    def test_fills_missing_workspace_from_stamped_summary(self):
+        from hermes_cli.workspace_guard import augment_session_row_from_compaction
+
+        row: dict[str, str] = {"id": "session-1", "git_repo_root": "", "cwd": ""}
+        messages = [
+            {
+                "role": "user",
+                "content": "summary\n<!-- HERMES_WORKSPACE:/repo/from-summary -->",
+            }
+        ]
+
+        augmented = augment_session_row_from_compaction(row, messages)
+
+        assert augmented["git_repo_root"] == "/repo/from-summary"
+        assert row["git_repo_root"] == ""
+
+    def test_existing_workspace_identity_wins_over_summary_marker(self):
+        from hermes_cli.workspace_guard import augment_session_row_from_compaction
+
+        row = {"id": "session-1", "git_repo_root": "/repo/db"}
+        messages = [
+            {
+                "role": "user",
+                "content": "summary\n<!-- HERMES_WORKSPACE:/repo/from-summary -->",
+            }
+        ]
+
+        assert augment_session_row_from_compaction(row, messages) is row
+
+    def test_extracts_marker_from_multimodal_content(self):
+        from hermes_cli.workspace_guard import augment_session_row_from_compaction
+
+        row: dict[str, str] = {}
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "summary"},
+                    {"type": "text", "text": "<!-- HERMES_WORKSPACE:/repo/mm -->"},
+                ],
+            }
+        ]
+
+        augmented = augment_session_row_from_compaction(row, messages)
+
+        assert augmented["git_repo_root"] == "/repo/mm"
+
+
 class TestFormatWorkspaceMismatchError:
     """Test format_workspace_mismatch_error helper."""
 

--- a/tests/gateway/test_resume_workspace_guard.py
+++ b/tests/gateway/test_resume_workspace_guard.py
@@ -1,73 +1,161 @@
-"""Integration test: gateway /resume workspace guard blocks cross-workspace restores."""
+"""Gateway /resume workspace guard integration tests."""
 
-import os
+from __future__ import annotations
+
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from gateway.config import Platform
+from gateway.session import SessionSource
+from gateway.slash_commands import GatewaySlashCommandsMixin
+
+
+class _ResumeHarness(GatewaySlashCommandsMixin):
+    def __init__(self):
+        self._session_db = AsyncMock()
+        self.session_store = MagicMock()
+        self.session_store.get_or_create_session.return_value = SimpleNamespace(session_id="current-session")
+        self.session_store.switch_session.return_value = SimpleNamespace(session_id="target-session")
+        self.session_store.load_transcript.return_value = [{"role": "user", "content": "hello"}]
+
+        self._resume_target_allowed = AsyncMock(return_value=True)
+        self._session_key_for_source = MagicMock(return_value="telegram:user:chat")
+        self._gateway_session_origin_for_id = MagicMock(return_value=None)
+        self._same_matrix_room = MagicMock(return_value=False)
+        self._release_running_agent_state = MagicMock()
+        self._clear_session_boundary_security_state = MagicMock()
+        self._set_session_reasoning_override = MagicMock()
+        self._evict_cached_agent = MagicMock()
+        self._session_model_overrides = {}
+        self._pending_model_notes = {}
+        self._last_resolved_model = {}
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="chat-1",
+        chat_type="dm",
+        user_id="user-1",
+    )
+
+
+def _event(args: str):
+    event = MagicMock()
+    event.source = _source()
+    event.get_command_args.return_value = args
+    return event
+
+
+def _db_for_target(row: dict):
+    db = AsyncMock()
+    # First get_session(name) resolves the direct session id. Second
+    # get_session(target_id) is the workspace-guard lookup after
+    # resolve_resume_session_id().
+    db.get_session = AsyncMock(side_effect=[{"id": "target-session"}, row])
+    db.resolve_resume_session_id = AsyncMock(return_value="target-session")
+    db.resolve_session_by_title = AsyncMock(return_value=None)
+    db.get_session_title = AsyncMock(return_value="Target Session")
+    return db
+
 
 @pytest.mark.asyncio
-async def test_gateway_resume_blocks_cross_workspace():
-    """When resuming a session from a different workspace, the guard should block it."""
-    # This tests the validate_session_workspace logic used in slash_commands.py resume handler
-    
-    from hermes_cli.workspace_guard import validate_session_workspace
-    
-    # Create two fake sessions with different git_repo_root values
-    stored_session = {
-        "id": "session-1",
-        "git_repo_root": "/path/to/other-repo",
-    }
-    
-    current_cwd = "/path/to/current-repo"
-    
-    result = validate_session_workspace(
-        session_row=stored_session,
-        current_cwd=current_cwd,
-    )
-    
-    assert not result.ok, "Cross-workspace resume should be blocked"
-    assert result.reason == "workspace_mismatch", \
-        f"Expected workspace_mismatch, got {result.reason}"
+async def test_gateway_resume_handler_blocks_cross_workspace_before_switch():
+    harness = _ResumeHarness()
+    harness._session_db = _db_for_target({
+        "id": "target-session",
+        "git_repo_root": "/workspace/other",
+    })
+
+    with patch("os.getcwd", return_value="/workspace/current"):
+        response = await GatewaySlashCommandsMixin._handle_resume_command(
+            harness, _event("target-session")
+        )
+
+    assert "Cross-workspace resume blocked" in response
+    harness.session_store.switch_session.assert_not_called()
+    harness._release_running_agent_state.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_gateway_resume_allows_same_workspace():
-    """When resuming a session from the same workspace, it should be allowed."""
-    from hermes_cli.workspace_guard import validate_session_workspace
-    
-    stored_session = {
-        "id": "session-1",
-        "git_repo_root": "/path/to/current-repo",
-    }
-    
-    current_cwd = "/path/to/current-repo"
-    
-    result = validate_session_workspace(
-        session_row=stored_session,
-        current_cwd=current_cwd,
+async def test_gateway_resume_handler_allows_same_workspace_and_switches():
+    harness = _ResumeHarness()
+    harness._session_db = _db_for_target({
+        "id": "target-session",
+        "git_repo_root": "/workspace/current",
+    })
+
+    with patch("os.getcwd", return_value="/workspace/current"):
+        response = await GatewaySlashCommandsMixin._handle_resume_command(
+            harness, _event("target-session")
+        )
+
+    assert "Target Session" in response
+    harness.session_store.switch_session.assert_called_once_with(
+        "telegram:user:chat", "target-session"
     )
-    
-    assert result.ok, "Same-workspace resume should be allowed"
 
 
 @pytest.mark.asyncio
-async def test_gateway_resume_warns_on_legacy_session():
-    """When resuming a legacy session (null git_repo_root), it should warn but allow."""
-    from hermes_cli.workspace_guard import validate_session_workspace
-    
-    stored_session = {
-        "id": "session-1",
-        "git_repo_root": None,  # Legacy session with no workspace identity
-    }
-    
-    current_cwd = "/path/to/current-repo"
-    
-    result = validate_session_workspace(
-        session_row=stored_session,
-        current_cwd=current_cwd,
-    )
-    
-    assert result.ok, "Legacy sessions should be allowed through"
-    assert result.warning is not None, \
-        "Legacy sessions should produce a warning"
+async def test_gateway_resume_handler_allows_true_legacy_session_with_warning(caplog):
+    harness = _ResumeHarness()
+    harness._session_db = _db_for_target({
+        "id": "target-session",
+        "git_repo_root": None,
+        "cwd": None,
+    })
+
+    with patch("os.getcwd", return_value="/workspace/current"), caplog.at_level("DEBUG"):
+        response = await GatewaySlashCommandsMixin._handle_resume_command(
+            harness, _event("target-session")
+        )
+
+    assert "Target Session" in response
+    harness.session_store.switch_session.assert_called_once()
+    assert "Workspace guard warning" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_gateway_resume_handler_blocks_legacy_cwd_mismatch_before_switch():
+    harness = _ResumeHarness()
+    harness._session_db = _db_for_target({
+        "id": "target-session",
+        "git_repo_root": None,
+        "cwd": "/workspace/other",
+    })
+
+    with patch("os.getcwd", return_value="/workspace/current"):
+        response = await GatewaySlashCommandsMixin._handle_resume_command(
+            harness, _event("target-session")
+        )
+
+    assert "Cross-workspace resume blocked" in response
+    harness.session_store.switch_session.assert_not_called()
+    harness._release_running_agent_state.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_gateway_resume_handler_blocks_compaction_stamped_mismatch_before_switch():
+    harness = _ResumeHarness()
+    harness._session_db = _db_for_target({
+        "id": "target-session",
+        "git_repo_root": None,
+        "cwd": None,
+    })
+    harness.session_store.load_transcript.return_value = [
+        {
+            "role": "user",
+            "content": "[CONTEXT COMPACTION] summary\n<!-- HERMES_WORKSPACE:/workspace/other -->",
+        }
+    ]
+
+    with patch("os.getcwd", return_value="/workspace/current"):
+        response = await GatewaySlashCommandsMixin._handle_resume_command(
+            harness, _event("target-session")
+        )
+
+    assert "Cross-workspace resume blocked" in response
+    harness.session_store.switch_session.assert_not_called()
+    harness._release_running_agent_state.assert_not_called()

--- a/tests/gateway/test_resume_workspace_guard.py
+++ b/tests/gateway/test_resume_workspace_guard.py
@@ -1,0 +1,73 @@
+"""Integration test: gateway /resume workspace guard blocks cross-workspace restores."""
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_gateway_resume_blocks_cross_workspace():
+    """When resuming a session from a different workspace, the guard should block it."""
+    # This tests the validate_session_workspace logic used in slash_commands.py resume handler
+    
+    from hermes_cli.workspace_guard import validate_session_workspace
+    
+    # Create two fake sessions with different git_repo_root values
+    stored_session = {
+        "id": "session-1",
+        "git_repo_root": "/path/to/other-repo",
+    }
+    
+    current_cwd = "/path/to/current-repo"
+    
+    result = validate_session_workspace(
+        session_row=stored_session,
+        current_cwd=current_cwd,
+    )
+    
+    assert not result.ok, "Cross-workspace resume should be blocked"
+    assert result.reason == "workspace_mismatch", \
+        f"Expected workspace_mismatch, got {result.reason}"
+
+
+@pytest.mark.asyncio
+async def test_gateway_resume_allows_same_workspace():
+    """When resuming a session from the same workspace, it should be allowed."""
+    from hermes_cli.workspace_guard import validate_session_workspace
+    
+    stored_session = {
+        "id": "session-1",
+        "git_repo_root": "/path/to/current-repo",
+    }
+    
+    current_cwd = "/path/to/current-repo"
+    
+    result = validate_session_workspace(
+        session_row=stored_session,
+        current_cwd=current_cwd,
+    )
+    
+    assert result.ok, "Same-workspace resume should be allowed"
+
+
+@pytest.mark.asyncio
+async def test_gateway_resume_warns_on_legacy_session():
+    """When resuming a legacy session (null git_repo_root), it should warn but allow."""
+    from hermes_cli.workspace_guard import validate_session_workspace
+    
+    stored_session = {
+        "id": "session-1",
+        "git_repo_root": None,  # Legacy session with no workspace identity
+    }
+    
+    current_cwd = "/path/to/current-repo"
+    
+    result = validate_session_workspace(
+        session_row=stored_session,
+        current_cwd=current_cwd,
+    )
+    
+    assert result.ok, "Legacy sessions should be allowed through"
+    assert result.warning is not None, \
+        "Legacy sessions should produce a warning"

--- a/tests/gateway/test_workspace_capture.py
+++ b/tests/gateway/test_workspace_capture.py
@@ -1,0 +1,96 @@
+"""Integration test: gateway captures git_repo_root at session creation."""
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_record_gateway_session_peer_captures_git_repo_root(tmp_path):
+    """When _record_gateway_session_peer is called, it should resolve and persist git_repo_root."""
+    from gateway.session import SessionStore
+    
+    # Create a mock DB that tracks calls to record_gateway_session_peer
+    mock_db = MagicMock()
+    mock_db.record_gateway_session_peer = MagicMock()
+    
+    # Create session store with mocked DB (pass sessions_dir + config)
+    from gateway.config import GatewayConfig
+    config = GatewayConfig()
+    store = SessionStore(tmp_path, config)
+    store._db = mock_db
+    
+    # Mock the source
+    from gateway.config import Platform
+    source = MagicMock()
+    source.platform = Platform.TELEGRAM
+    source.user_id = "user123"
+    source.chat_id = "chat456"
+    source.chat_name = "test-chat"
+    source.to_dict.return_value = {"platform": "telegram"}
+    
+    # Create a temp dir with .git marker for git_probe to resolve
+    repo_dir = tmp_path / "test-repo"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()  # Simple .git dir marker
+    
+    original_cwd = os.getcwd()
+    try:
+        os.chdir(repo_dir)
+        
+        # Mock git_probe to return our temp dir as the repo root
+        with patch("tui_gateway.git_probe.repo_root", return_value=str(repo_dir)):
+            store._record_gateway_session_peer(
+                session_id="test-session-id",
+                session_key="agent:test-key",
+                source=source,
+            )
+        
+        # Verify DB was called with git_repo_root parameter
+        mock_db.record_gateway_session_peer.assert_called_once()
+        call_kwargs = mock_db.record_gateway_session_peer.call_args[1]
+        
+        assert "git_repo_root" in call_kwargs, \
+            "git_repo_root should be passed to DB recorder"
+        assert call_kwargs["git_repo_root"] == str(repo_dir), \
+            f"Expected {repo_dir}, got {call_kwargs['git_repo_root']}"
+    finally:
+        os.chdir(original_cwd)
+
+
+def test_record_gateway_session_peer_handles_git_probe_failure(tmp_path):
+    """When git_probe fails, _record_gateway_session_peer should still work (non-critical)."""
+    from gateway.session import SessionStore
+    
+    mock_db = MagicMock()
+    mock_db.record_gateway_session_peer = MagicMock()
+    
+    from gateway.config import GatewayConfig
+    config = GatewayConfig()
+    store = SessionStore(tmp_path, config)
+    store._db = mock_db
+    
+    from gateway.config import Platform
+    source = MagicMock()
+    source.platform = Platform.TELEGRAM
+    source.user_id = "user123"
+    source.chat_id = "chat456"
+    source.chat_name = "test-chat"
+    source.to_dict.return_value = {"platform": "telegram"}
+    
+    # Patch git_probe to raise an exception
+    with patch("tui_gateway.git_probe.repo_root", side_effect=OSError("probe failed")):
+        store._record_gateway_session_peer(
+            session_id="test-session-id",
+            session_key="agent:test-key",
+            source=source,
+        )
+        
+        # Should still call DB recorder (with empty git_repo_root)
+        mock_db.record_gateway_session_peer.assert_called_once()
+        call_kwargs = mock_db.record_gateway_session_peer.call_args[1]
+        
+        assert "git_repo_root" in call_kwargs
+        assert call_kwargs["git_repo_root"] == "", \
+            "git_probe failure should result in empty git_repo_root, not crash"

--- a/tests/hermes_cli/test_cli_resume_workspace_guard.py
+++ b/tests/hermes_cli/test_cli_resume_workspace_guard.py
@@ -1,0 +1,65 @@
+"""CLI resume workspace guard entrypoint tests."""
+
+from __future__ import annotations
+
+from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
+
+
+class _FakeDB:
+    def get_session(self, session_id: str):
+        assert session_id == "target-session"
+        return {"id": session_id, "git_repo_root": None, "cwd": None}
+
+    def resolve_resume_session_id(self, session_id: str) -> str:
+        return session_id
+
+    def get_messages_as_conversation(self, session_id: str):
+        assert session_id == "target-session"
+        return [
+            {
+                "role": "user",
+                "content": "[CONTEXT COMPACTION] summary\n<!-- HERMES_WORKSPACE:/workspace/other -->",
+            }
+        ]
+
+
+class _Harness(CLIAgentSetupMixin):
+    def __init__(self):
+        self.agent = None
+        self._resumed = True
+        self._session_db = _FakeDB()
+        self.session_id = "target-session"
+        self.conversation_history = []
+        self.cwd = "/workspace/current"
+        self.tool_progress_mode = "off"
+        self.restore_cwd_called = False
+
+    def _prepare_runtime(self):  # unused; protects against accidental calls
+        raise AssertionError("unexpected runtime preparation")
+
+    def _install_tool_callbacks(self):
+        pass
+
+    def _ensure_tirith_security(self):
+        pass
+
+    def _ensure_runtime_credentials(self) -> bool:
+        return True
+
+    def _restore_session_cwd(self, *_args, **_kwargs):
+        self.restore_cwd_called = True
+
+
+def test_cli_resume_blocks_compaction_stamped_workspace_mismatch(monkeypatch):
+    import cli
+    import hermes_cli.mcp_startup
+
+    monkeypatch.setattr(cli, "_prepare_deferred_agent_startup", lambda: None)
+    monkeypatch.setattr(hermes_cli.mcp_startup, "wait_for_mcp_discovery", lambda: None)
+
+    harness = _Harness()
+
+    assert harness._init_agent() is False
+    assert harness.agent is None
+    assert harness.conversation_history == []
+    assert harness.restore_cwd_called is False

--- a/tests/hermes_cli/test_resolve_last_session.py
+++ b/tests/hermes_cli/test_resolve_last_session.py
@@ -155,3 +155,53 @@ def test_resolve_last_session_not_limited_to_newest_started_20(tmp_path, monkeyp
 
     monkeypatch.setattr("hermes_state.SessionDB", lambda: real_session_db(db_path=state_db))
     assert _resolve_last_session("cli") == target
+
+
+def test_resolve_last_session_prefers_same_workspace_over_newer_mismatch(tmp_path, monkeypatch):
+    current_repo = tmp_path / "current"
+    other_repo = tmp_path / "other"
+    current_repo.mkdir()
+    other_repo.mkdir()
+    (current_repo / ".git").mkdir()
+    (other_repo / ".git").mkdir()
+    monkeypatch.chdir(current_repo)
+
+    rows = [
+        {
+            "id": "newer_other_workspace",
+            "source": "cli",
+            "last_active": 200.0,
+            "git_repo_root": str(other_repo),
+        },
+        {
+            "id": "older_current_workspace",
+            "source": "cli",
+            "last_active": 100.0,
+            "git_repo_root": str(current_repo),
+        },
+    ]
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: _FakeDB(rows))
+
+    assert _resolve_last_session("cli") == "older_current_workspace"
+
+
+def test_resolve_last_session_does_not_auto_resume_known_mismatch(tmp_path, monkeypatch):
+    current_repo = tmp_path / "current"
+    other_repo = tmp_path / "other"
+    current_repo.mkdir()
+    other_repo.mkdir()
+    (current_repo / ".git").mkdir()
+    (other_repo / ".git").mkdir()
+    monkeypatch.chdir(current_repo)
+
+    rows = [
+        {
+            "id": "other_workspace",
+            "source": "cli",
+            "last_active": 200.0,
+            "git_repo_root": str(other_repo),
+        },
+    ]
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: _FakeDB(rows))
+
+    assert _resolve_last_session("cli") is None


### PR DESCRIPTION
## Summary
- Adds workspace identity stamping to runtime context compression summaries.
- Uses stamped compaction metadata as a fallback for CLI and gateway resume guards when DB workspace columns are missing.
- Makes CLI auto-continue skip known cross-workspace mismatches instead of silently resuming them.
- Replaces copied-fragment gateway /resume tests with real handler-entrypoint coverage and restores i18n catalog parity.

## Test plan
- `scripts/run_tests.sh tests/agent/test_i18n.py tests/gateway/test_resume_workspace_guard.py tests/hermes_cli/test_resolve_last_session.py tests/hermes_cli/test_cli_resume_workspace_guard.py tests/cli/test_workspace_guard.py tests/agent/test_compression_workspace_metadata.py`
- `python3 -m py_compile agent/conversation_compression.py gateway/slash_commands.py hermes_cli/cli_agent_setup_mixin.py hermes_cli/main.py hermes_cli/workspace_guard.py tests/agent/test_compression_workspace_metadata.py tests/gateway/test_resume_workspace_guard.py tests/hermes_cli/test_resolve_last_session.py tests/hermes_cli/test_cli_resume_workspace_guard.py tests/cli/test_workspace_guard.py`
- `git diff --check HEAD`

## Notes
- Leaves the separate gateway `os.getcwd()` versus configured `terminal.cwd` capture concern for a follow-up design pass.