### PR TITLE
fix(cli): pass custom_providers to resolve_display_context_length (#59314)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7844,6 +7844,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 api_key=result.api_key or self.api_key or "",
                 model_info=mi,
                 config_context_length=getattr(self.agent, "_config_context_length", None) if self.agent else None,
+                custom_providers=getattr(self.agent, "_custom_providers", None) if self.agent else None,
             )
             if ctx:
                 _cprint(f"    Context: {ctx:,} tokens")
@@ -8152,6 +8153,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             api_key=result.api_key or self.api_key or "",
             model_info=mi,
             config_context_length=getattr(self.agent, "_config_context_length", None) if self.agent else None,
+            custom_providers=getattr(self.agent, "_custom_providers", None) if self.agent else None,
         )
         if ctx:
             _cprint(f"    Context: {ctx:,} tokens")

--- a/tests/hermes_cli/test_model_switch_context_display.py
+++ b/tests/hermes_cli/test_model_switch_context_display.py
@@ -146,3 +146,30 @@ class TestResolveDisplayContextLength:
                 custom_providers=custom_provs,
             )
         assert ctx == 400_000
+
+    def test_without_custom_providers_returns_default_fallback(self):
+        """Regression for #59314: When custom_providers is NOT passed
+        (the bug pre-fix), a custom provider model falls through to
+        probe-down default (256K) instead of the configured per-model
+        context_length."""
+        from unittest.mock import patch as _p
+        from agent import model_metadata as _mm
+        with _p.object(_mm, "get_cached_context_length", return_value=None), \
+             _p.object(_mm, "fetch_endpoint_model_metadata", return_value={}), \
+             _p.object(_mm, "fetch_model_metadata", return_value={}), \
+             _p.object(_mm, "is_local_endpoint", return_value=False), \
+             _p.object(_mm, "_is_known_provider_base_url", return_value=False):
+            # Without custom_providers, the function probes and gets default
+            ctx = resolve_display_context_length(
+                "test-model-unconfigured",
+                "custom",
+                base_url="https://example.invalid/v1",
+                api_key="k",
+                model_info=None,
+            )
+        # Without custom_providers, the function falls to probe-down default
+        assert ctx == 256_000, (
+            "Without custom_providers, an un-cached model gets 256K default. "
+            "The fix ensures custom_providers is passed so per-model overrides "
+            "are honored."
+        )


### PR DESCRIPTION
## Summary
`/model` switch now shows the correct context length for models defined only in `custom_providers` — previously it always displayed 256K even when the per-model `context_length` override was 1M.

Root cause: the two CLI model-switch display paths called `resolve_display_context_length()` without `custom_providers=`, so resolution fell through to the probe-down default. The gateway paths already passed it.

Salvage of #59484 by @Tranquil-Flow, closes #59314.

## Changes
- `cli.py` (`_apply_model_switch_result`, `_handle_model_switch`): pass `custom_providers=getattr(self.agent, "_custom_providers", None)` at both `resolve_display_context_length()` call sites, matching the adjacent `config_context_length` pattern.
- Regression test in `tests/hermes_cli/test_model_switch_context_display.py`.

## Validation
| | Before | After |
|---|---|---|
| custom_providers model `/model` display | 256,000 | 1,000,000 |
| targeted tests | — | 8/8 pass |

E2E via real `resolve_display_context_length` (network/cache probes blocked): without `custom_providers` → 256,000; with it → 1,000,000 — the exact symptom in #59314. All 4 call sites (2 CLI + 2 gateway) now pass the param; no orphan sites.

## Infographic

![custom-provider-context-fixed](https://v3b.fal.media/files/b/0aa12541/ngiU8QHbLbmv3VZ9te9lc_Pl0KzWmF.png)
