### PR TITLE
fix(agent): run Z.AI Coding overload adaptive backoff on the overloaded path

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -58,7 +58,12 @@ from agent.model_metadata import (
 )
 from agent.process_bootstrap import _install_safe_stdio
 from agent.prompt_caching import apply_anthropic_cache_control
-from agent.retry_utils import adaptive_rate_limit_backoff, jittered_backoff
+from agent.retry_utils import (
+    adaptive_rate_limit_backoff,
+    is_zai_coding_overload_error,
+    jittered_backoff,
+    zai_coding_overload_retry_ceiling,
+)
 from agent.trajectory import has_incomplete_scratchpad
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from hermes_constants import PARTIAL_STREAM_STUB_ID
@@ -3142,6 +3147,21 @@ def run_conversation(
                     FailoverReason.timeout,
                     FailoverReason.overloaded,
                 }
+                # Z.AI Coding Plan GLM-5.2 signals server overload as HTTP 429
+                # code 1305 ("temporarily overloaded"). classify_api_error routes
+                # that to `overloaded` (not `rate_limit`) so the credential pool
+                # isn't burned on a valid key — but `overloaded` is excluded from
+                # `is_rate_limited`, which is exactly what gates the adaptive Z.AI
+                # backoff below. Detect the overload 429 directly so its adaptive
+                # long-backoff schedule still runs, and raise the retry ceiling so
+                # the long tier (30/60/90/120s) is actually reachable: the default
+                # ceiling equals the short-retry threshold, so the loop otherwise
+                # gives up after a few quick retries and the long tier is dead code.
+                _is_zai_coding_overload = is_zai_coding_overload_error(
+                    base_url=str(_base), model=_model, error=api_error
+                )
+                if _is_zai_coding_overload:
+                    max_retries = max(max_retries, zai_coding_overload_retry_ceiling())
                 _should_fallback = (
                     is_rate_limited
                     or (_is_transport_failure and retry_count >= 2)
@@ -4092,7 +4112,7 @@ def run_conversation(
                                 pass
                 wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
                 _backoff_policy = None
-                if is_rate_limited and not _retry_after:
+                if (is_rate_limited or _is_zai_coding_overload) and not _retry_after:
                     wait_time, _backoff_policy = adaptive_rate_limit_backoff(
                         retry_count,
                         base_url=str(_base),
@@ -4100,13 +4120,14 @@ def run_conversation(
                         error=api_error,
                         default_wait=wait_time,
                     )
-                if is_rate_limited:
+                if is_rate_limited or _is_zai_coding_overload:
                     _policy_note = ""
                     if _backoff_policy == "zai_coding_overload_long":
                         _policy_note = " (Z.AI Coding overload adaptive long backoff)"
                     elif _backoff_policy == "zai_coding_overload_short":
                         _policy_note = " (Z.AI Coding overload short retry)"
-                    _rate_limit_status = f"⏱️ Rate limited. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries}){_policy_note}..."
+                    _wait_reason = "Provider overloaded" if _is_zai_coding_overload and not is_rate_limited else "Rate limited"
+                    _rate_limit_status = f"⏱️ {_wait_reason}. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries}){_policy_note}..."
                     # Normal retries are buffered to avoid noisy transient chatter. Long
                     # Z.AI Coding waits are different: they can last minutes, so surface
                     # progress immediately instead of making the TUI look frozen.

--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -127,3 +127,20 @@ def adaptive_rate_limit_backoff(
     # A smaller jitter ratio keeps long waits readable while still avoiding
     # synchronized retry storms across concurrent Hermes sessions.
     return jittered_backoff(1, base_delay=base_delay, max_delay=base_delay, jitter_ratio=0.2), "zai_coding_overload_long"
+
+
+def zai_coding_overload_retry_ceiling(short_attempts: int = 3) -> int:
+    """Retry-loop ceiling needed for the full Z.AI overload backoff schedule.
+
+    The adaptive policy runs ``short_attempts`` short retries, then walks the
+    long-backoff table one entry per subsequent attempt. The retry loop gives
+    up as soon as ``retry_count >= ceiling`` — and that check runs *before* the
+    attempt's backoff is computed — so the ceiling must sit one past the final
+    long-backoff entry for every long tier to actually execute.
+
+    With the default ``api_max_retries`` (3) equal to ``short_attempts`` (3),
+    the loop always gave up before reaching the long tier, leaving the whole
+    long-backoff schedule as dead code. Callers extend the ceiling to this
+    value for Z.AI Coding overload 429s so the 30/60/90/120s waits run.
+    """
+    return short_attempts + len(_ZAI_CODING_OVERLOAD_LONG_BACKOFF) + 1

--- a/tests/test_retry_utils.py
+++ b/tests/test_retry_utils.py
@@ -210,3 +210,48 @@ def test_non_zai_backoff_returns_default_wait():
     )
     assert wait == 12.0
     assert policy is None
+
+
+def test_zai_overload_retry_ceiling_exceeds_short_attempts():
+    """Invariant: the ceiling must sit above the short-retry threshold, or the
+    long-backoff tier is unreachable and the whole schedule is dead code
+    (the original bug: default api_max_retries == short_attempts == 3)."""
+    from agent.retry_utils import (
+        zai_coding_overload_retry_ceiling,
+        _ZAI_CODING_OVERLOAD_LONG_BACKOFF,
+    )
+
+    short_attempts = 3
+    ceiling = zai_coding_overload_retry_ceiling(short_attempts)
+    assert ceiling > short_attempts
+    # Room for every long-backoff entry to run before giving up: the loop's
+    # give-up check (retry_count >= ceiling) runs before the attempt's backoff,
+    # so the ceiling sits one past the final long entry.
+    assert ceiling == short_attempts + len(_ZAI_CODING_OVERLOAD_LONG_BACKOFF) + 1
+
+
+def test_zai_overload_ceiling_makes_long_tier_reachable(monkeypatch):
+    """End-to-end over the attempt range the retry loop actually walks: with the
+    extended ceiling, at least one attempt reaches the long-backoff tier and the
+    full 30/60/90/120s schedule is exercised."""
+    monkeypatch.setattr(retry_utils, "jittered_backoff", lambda *a, **kw: kw["base_delay"])
+    from agent.retry_utils import zai_coding_overload_retry_ceiling
+
+    err = _zai_overload_error()
+    ceiling = zai_coding_overload_retry_ceiling()
+
+    long_waits = []
+    # The loop computes backoff for attempts 1..ceiling-1 (it gives up at ceiling).
+    for attempt in range(1, ceiling):
+        _wait, policy = adaptive_rate_limit_backoff(
+            attempt,
+            base_url="https://api.z.ai/api/coding/paas/v4",
+            model="glm-5.2",
+            error=err,
+            default_wait=1.0,
+        )
+        if policy == "zai_coding_overload_long":
+            long_waits.append(_wait)
+
+    assert long_waits, "long-backoff tier never reached within the retry ceiling"
+    assert long_waits == [30.0, 60.0, 90.0, 120.0]


### PR DESCRIPTION
## Summary

Z.AI Coding Plan GLM-5.2 signals server overload as **HTTP 429 code 1305** ("The service may be temporarily overloaded, please try again later"). Hermes gives up after ~3 quick retries (~12s) instead of applying the adaptive long-backoff it already ships for exactly this case, so an overload that other clients recover from after 1–2 tries fails the whole turn. Reported on the forum by a Z.AI Coding Plan (Max) user on Raspberry Pi.

Two compounding causes, both on current `main`:

1. **The adaptive backoff never ran.** `classify_api_error` routes the overload 429 to `FailoverReason.overloaded` (commit `38e7bd8a0`, so a valid credential pool isn't burned). But the Z.AI adaptive backoff added in #52333 is gated on `is_rate_limited`, which **excludes** `overloaded`. Net effect: the overload 429 falls through to the generic short backoff (`policy=default`, ~2s/4s) — the adaptive path is dead on this error.
2. **Even if reached, the long tier was unreachable.** `adaptive_rate_limit_backoff` keeps the first `short_attempts` (3) retries short, then switches to the 30/60/90/120s long tier. But the default `api_max_retries` is also **3**, so `retry_count >= max_retries` fires *before* any long-tier attempt — the entire long-backoff schedule was dead code under the shipped config.

### Fix

- Detect the Z.AI overload 429 directly (`is_zai_coding_overload_error`) and let its adaptive backoff run on the `overloaded` path, not only the `rate_limit` path.
- Raise the retry ceiling for this narrow case via a new `zai_coding_overload_retry_ceiling()` so the long tier (30/60/90/120s) is actually reachable.

Scope is limited to the existing narrow `is_zai_coding_overload_error` match (base URL `api.z.ai/api/coding/paas/v4` + `glm-5.2` + code 1305 / "temporarily overloaded"), so other providers' 429/503/529 handling is unchanged. The credential-pool-preserving classification from `38e7bd8a0` is kept intact.

### Repro (before)

```
agent.conversation_loop: API call failed (attempt 3/3) error_type=RateLimitError ... provider=zai ... summary=HTTP 429: The service may be temporarily overloaded
agent.conversation_loop: Retrying API call in 2.7s (attempt 1/3) ... policy=default ...
agent.conversation_loop: API call failed after 3 retries. HTTP 429 ...
```

`policy=default` (adaptive path skipped) + give-up at 3 = ~12s total.

## Test plan

- [x] `scripts/run_tests.sh tests/test_retry_utils.py -q` (15 passed) — adds a ceiling-vs-short-attempts invariant and a reachability test walking the loop's actual attempt range, asserting the full 30/60/90/120s schedule runs.
- [x] `scripts/run_tests.sh tests/run_agent/test_api_max_retries_config.py tests/run_agent/test_32646_fallback_429_after_timeout.py tests/run_agent/test_31273_402_not_retried.py -q` (all passed) — retry-ceiling / fallback / non-retry paths unchanged.