### PR TITLE
fix(skills): apply disabled-skill gate to CLI/TUI preloaded skills

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -696,13 +696,26 @@ def build_preloaded_skills_prompt(
     skill_identifiers: list[str],
     task_id: str | None = None,
 ) -> tuple[str, list[str], list[str]]:
-    """Load one or more skills for session-wide CLI preloading.
+    """Load one or more skills for session-wide CLI/TUI preloading.
 
     Returns (prompt_text, loaded_skill_names, missing_identifiers).
+
+    Disabled skills are treated the same as missing ones: this loads via a
+    raw identifier straight into ``_load_skill_payload``, bypassing
+    ``get_skill_commands()``'s scan-time disabled filter — mirrors the
+    bundle-invocation gate (#59156). Without this, ``hermes -s <skill>`` or
+    a deployment's ``HERMES_TUI_SKILLS`` env var could force-load a skill an
+    operator disabled via ``skills.disabled``/``skills.platform_disabled``.
     """
     prompt_parts: list[str] = []
     loaded_names: list[str] = []
     missing: list[str] = []
+
+    try:
+        from agent.skill_utils import get_disabled_skill_names
+        disabled_names = get_disabled_skill_names()
+    except Exception:
+        disabled_names = set()
 
     seen: set[str] = set()
     for raw_identifier in skill_identifiers:
@@ -717,6 +730,10 @@ def build_preloaded_skills_prompt(
             continue
 
         loaded_skill, skill_dir, skill_name = loaded
+
+        if skill_name in disabled_names or identifier in disabled_names:
+            missing.append(identifier)
+            continue
 
         # Track active usage for Curator lifecycle management (#17782)
         try:

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -451,6 +451,43 @@ class TestBuildPreloadedSkillsPrompt:
         assert loaded == ["present-skill"]
         assert missing == ["missing-skill"]
 
+    def test_skips_disabled_skill(self, tmp_path, monkeypatch):
+        """A globally-disabled skill must not be force-loaded via -s /
+        HERMES_TUI_SKILLS preloading (mirrors the bundle gate, #59156)."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "enabled-skill", body="Enabled content.")
+            _make_skill(tmp_path, "disabled-skill", body="SECRET DISABLED CONTENT.")
+
+            import agent.skill_utils as su_module
+            monkeypatch.setattr(
+                su_module, "get_disabled_skill_names", lambda platform=None: {"disabled-skill"}
+            )
+
+            prompt, loaded, missing = build_preloaded_skills_prompt(
+                ["enabled-skill", "disabled-skill"]
+            )
+
+        assert loaded == ["enabled-skill"]
+        assert missing == ["disabled-skill"]
+        assert "SECRET DISABLED CONTENT." not in prompt
+        assert "enabled-skill" in prompt
+
+    def test_loads_normally_when_nothing_disabled(self, tmp_path, monkeypatch):
+        """Positive control: without a disabled-skills config, both load."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "first-skill")
+            _make_skill(tmp_path, "second-skill")
+
+            import agent.skill_utils as su_module
+            monkeypatch.setattr(su_module, "get_disabled_skill_names", lambda platform=None: set())
+
+            prompt, loaded, missing = build_preloaded_skills_prompt(
+                ["first-skill", "second-skill"]
+            )
+
+        assert missing == []
+        assert loaded == ["first-skill", "second-skill"]
+
 
 class TestBuildSkillInvocationMessage:
     def test_loads_skill_by_stored_path_when_frontmatter_name_differs(self, tmp_path):


### PR DESCRIPTION
## Summary
A skill an operator disabled via `skills.disabled` no longer gets force-loaded through the CLI/TUI preload path.

`build_preloaded_skills_prompt()` (`hermes -s <skill>` and `tui_gateway`'s `HERMES_TUI_SKILLS`) loads via a raw identifier straight into `_load_skill_payload`, bypassing `get_skill_commands()`'s scan-time disabled filter. This was the parallel `_load_skill_payload` call site still missing the disabled-skill gate the bundle path already got in #59156 (same class as #59478).

## Changes
- `agent/skill_commands.py`: re-check `get_disabled_skill_names()` in `build_preloaded_skills_prompt()`; disabled skills route into the existing `missing` list — no return-shape or caller changes.
- `tests/agent/test_skill_commands.py`: regression test (`test_skips_disabled_skill`) + positive control (`test_loads_normally_when_nothing_disabled`).

## Validation
| | Before | After |
|---|---|---|
| disabled skill via `-s` / `HERMES_TUI_SKILLS` | force-loaded into every session | skipped, reported in `missing` |
| no disabled skills configured | loads normally | loads normally (no change) |

Falsification confirmed: `test_skips_disabled_skill` fails on `origin/main` without the fix, passes with it. 89/89 in `test_skill_commands` + `test_skill_bundles`.

Salvaged from #59485 by @pierrenode (authorship preserved via cherry-pick). Closes #59485.

## Infographic

![disabled-skill-gate-preload-path](https://v3b.fal.media/files/b/0aa12555/IVdM9llcWXD7Dsp3sC3tX_vjObCgmO.png)
