### PR TITLE
fix(compression): skip empty post-handoff summary windows

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2777,6 +2777,19 @@ This compaction should PRIORITISE preserving all information related to the focu
             if summary_body and not self._previous_summary:
                 self._previous_summary = summary_body
             turns_to_summarize = messages[max(compress_start, summary_idx + 1):compress_end]
+            if not turns_to_summarize:
+                self._ineffective_compression_count += 1
+                self._last_compression_savings_pct = 0.0
+                if not self.quiet_mode:
+                    logger.warning(
+                        "Compression skipped: latest context summary leaves no "
+                        "new turns to summarize in window %d-%d. "
+                        "ineffective_compression_count=%d",
+                        compress_start,
+                        compress_end,
+                        self._ineffective_compression_count,
+                    )
+                return messages
         elif self._previous_summary:
             # No handoff summary found in the current messages, but
             # _previous_summary is non-empty — it was set by a different

--- a/tests/agent/test_context_compressor_summary_continuity.py
+++ b/tests/agent/test_context_compressor_summary_continuity.py
@@ -85,3 +85,34 @@ def test_handoff_in_protected_head_populates_previous_summary_before_update():
     assert compressor._previous_summary == old_summary
     assert seen_turns
     assert all(old_summary not in str(msg.get("content", "")) for msg in seen_turns)
+
+
+def test_empty_post_handoff_window_noops_without_summary_call():
+    """A latest handoff that consumes the window must not trigger an empty summary."""
+    compressor = _compressor()
+    old_summary = "WINDOW-END-SUMMARY durable facts already captured"
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": "protected first user turn"},
+        {"role": "assistant", "content": "old assistant turn already captured"},
+        {"role": "user", "content": f"{SUMMARY_PREFIX}\n{old_summary}"},
+        {"role": "assistant", "content": "recent tail response"},
+        {"role": "user", "content": "latest tail request"},
+        {"role": "assistant", "content": "latest tail answer"},
+    ]
+
+    with (
+        patch.object(compressor, "_find_tail_cut_by_tokens", return_value=4),
+        patch.object(compressor, "_generate_summary") as mock_generate_summary,
+    ):
+        result = compressor.compress(messages, current_tokens=90_000)
+
+    mock_generate_summary.assert_not_called()
+    assert result == messages
+    assert compressor._previous_summary == old_summary
+    assert compressor.compression_count == 0
+    assert compressor._ineffective_compression_count == 1
+    assert compressor._last_compression_savings_pct == 0.0
+    assert compressor._last_summary_dropped_count == 0
+    assert compressor._last_summary_fallback_used is False
+    assert compressor._last_compress_aborted is False


### PR DESCRIPTION
## What does this PR do?

Skips context summary generation when the latest handoff summary leaves no new turns after compression boundary adjustment.

This avoids calling `_generate_summary([])` / the configured context engine with an empty input window, which currently produces a noisy compression-aborted warning while preserving the transcript unchanged.

## Related Issue

Fixes #59496

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/context_compressor.py`: add a post-handoff empty-window guard that records ineffective compression and returns without calling `_generate_summary`.
- `tests/agent/test_context_compressor_summary_continuity.py`: add a regression test proving `_generate_summary` is not called when the latest handoff consumes the compression window.

## How to Test

1. `python -m pytest tests/agent/test_context_compressor_summary_continuity.py -q`
2. `python -m pytest tests/agent/test_context_compressor_cross_session_guard.py -q`
3. `python -m pytest tests/agent/test_context_compressor.py tests/run_agent/test_infinite_compaction_loop.py -q`
4. `python -m py_compile agent/context_compressor.py tests/agent/test_context_compressor_summary_continuity.py`
5. `git diff --check -- agent/context_compressor.py tests/agent/test_context_compressor_summary_continuity.py`

Notes:
- `scripts/run_tests.sh --files ...` could not run locally because this checkout has no `.venv` or `venv`.
- `ruff` was not available locally.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux, Python 3.10.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — pure Python logic/test change
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A — covered by regression tests.
