### PR TITLE
fix(dashboard): accept HA ingress prefix paths (salvage #59479)

### DIFF
--- a/hermes_cli/dashboard_auth/prefix.py
+++ b/hermes_cli/dashboard_auth/prefix.py
@@ -26,6 +26,11 @@ from typing import Optional
 
 _log = logging.getLogger(__name__)
 
+# Home Assistant Supervisor ingress prefixes are already 63 chars before
+# deployments add their own sub-path. Keep a bounded header budget, but leave
+# room for mainstream reverse-proxy path mounts.
+_MAX_PREFIX_LENGTH = 256
+
 # Characters that, if present in a public_url or prefix value, indicate
 # either a typo or a header-injection attempt. Reject the whole value
 # rather than try to sanitise — the operator can fix their config.
@@ -37,6 +42,7 @@ _REJECT_CHARS = frozenset(('"', "'", "<", ">", " ", "\n", "\r", "\t"))
 # misconfigured deploy. Keyed on the raw value too, so changing the
 # config and reloading surfaces a fresh warning.
 _warned_malformed_public_urls: set = set()
+_warned_malformed_prefixes: set = set()
 
 
 def _warn_if_malformed(source: str, raw: str) -> None:
@@ -72,6 +78,23 @@ def _warn_if_malformed(source: str, raw: str) -> None:
     )
 
 
+def _warn_if_malformed_prefix(raw: Optional[str], reason: str) -> None:
+    """Warn once when a non-empty X-Forwarded-Prefix value is rejected."""
+    cleaned = raw.strip() if raw else ""
+    if not cleaned:
+        return
+    key = (cleaned, reason)
+    if key in _warned_malformed_prefixes:
+        return
+    _warned_malformed_prefixes.add(key)
+    _log.warning(
+        "X-Forwarded-Prefix header %r was ignored because %s. "
+        "Dashboard URLs will be generated without a reverse-proxy path prefix.",
+        cleaned,
+        reason,
+    )
+
+
 def normalise_prefix(raw: Optional[str]) -> str:
     """Normalise an X-Forwarded-Prefix header value.
 
@@ -94,8 +117,16 @@ def normalise_prefix(raw: Optional[str]) -> str:
         or ".." in p
         or any(c in p for c in _REJECT_CHARS)
     ):
+        _warn_if_malformed_prefix(
+            raw,
+            "it contains a disallowed character or path sequence",
+        )
         return ""
-    if len(p) > 64:
+    if len(p) > _MAX_PREFIX_LENGTH:
+        _warn_if_malformed_prefix(
+            raw,
+            f"it is longer than {_MAX_PREFIX_LENGTH} characters",
+        )
         return ""
     return p
 

--- a/tests/hermes_cli/test_dashboard_auth_prefix.py
+++ b/tests/hermes_cli/test_dashboard_auth_prefix.py
@@ -30,13 +30,22 @@ those rules surfaces before a Mission Control deploy.
 """
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 from fastapi.testclient import TestClient
 
 from hermes_cli import web_server
 from hermes_cli.dashboard_auth import clear_providers, register_provider
+from hermes_cli.dashboard_auth import prefix as prefix_mod
 from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+
+
+HA_INGRESS_DASHBOARD_PREFIX = (
+    "/api/hassio_ingress/8AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCdEf"
+    "/dashboard"
+)
 
 
 @pytest.fixture
@@ -90,6 +99,53 @@ def gated_app_direct():
     web_server.app.state.bound_host = prev_host
     web_server.app.state.bound_port = prev_port
     web_server.app.state.auth_required = prev_required
+
+
+# ---------------------------------------------------------------------------
+# X-Forwarded-Prefix normalisation
+# ---------------------------------------------------------------------------
+
+
+class TestForwardedPrefixNormalisation:
+    def test_home_assistant_ingress_prefix_with_subpath_is_accepted(
+        self, caplog
+    ):
+        """Home Assistant Supervisor ingress prefixes are 63 chars before
+        add-ons append their own mount path. They must survive validation so
+        the SPA receives the correct __HERMES_BASE_PATH__ and asset prefix."""
+        prefix_mod._warned_malformed_prefixes.clear()
+        assert len(HA_INGRESS_DASHBOARD_PREFIX) > 64
+
+        with caplog.at_level(logging.WARNING, logger=prefix_mod.__name__):
+            result = prefix_mod.normalise_prefix(HA_INGRESS_DASHBOARD_PREFIX)
+
+        assert result == HA_INGRESS_DASHBOARD_PREFIX
+        assert not [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "X-Forwarded-Prefix" in r.getMessage()
+        ]
+
+    def test_overlong_prefix_is_rejected_with_deduplicated_warning(
+        self, caplog
+    ):
+        """Keep a bounded header budget, but make rejected non-empty
+        prefixes diagnosable instead of silently producing root-relative
+        dashboard URLs."""
+        prefix_mod._warned_malformed_prefixes.clear()
+        too_long = "/" + ("a" * 257)
+
+        with caplog.at_level(logging.WARNING, logger=prefix_mod.__name__):
+            for _ in range(3):
+                assert prefix_mod.normalise_prefix(too_long) == ""
+
+        warnings = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "X-Forwarded-Prefix" in r.getMessage()
+        ]
+        assert len(warnings) == 1
+        assert "longer than 256 characters" in warnings[0].getMessage()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The dashboard now boots behind Home Assistant Supervisor ingress instead of rendering a blank white page.

Root cause: `normalise_prefix()` in `hermes_cli/dashboard_auth/prefix.py` rejected any `X-Forwarded-Prefix` longer than 64 chars by returning `""`. HA ingress prefixes are `/api/hassio_ingress/<43-char-token>` = 63 chars before any sub-path, so `/api/hassio_ingress/<token>/dashboard` (73) was silently dropped. The dashboard then injected an empty `window.__HERMES_BASE_PATH__`, left SPA asset URLs root-relative, and the browser fetched them against the HA origin — blank page, nothing in any log.

Salvages #59479 by @izumi0uu (cherry-picked, authorship preserved). Fixes #59476.

## Changes
- `hermes_cli/dashboard_auth/prefix.py`: raise the `X-Forwarded-Prefix` cap from 64 to 256 (`_MAX_PREFIX_LENGTH`); warn once (deduped, reason-keyed) when a non-empty prefix is rejected. All existing traversal/injection/char rejections unchanged.
- `tests/hermes_cli/test_dashboard_auth_prefix.py`: HA-ingress-accepted regression case + overlong-prefix dedup-warning lock.

## Validation
| Check | Before | After |
|---|---|---|
| HA 73-char ingress prefix | `""` (dropped) | round-trips |
| Short `/hermes` | `/hermes` | `/hermes` |
| Traversal / `//` / injection / whitespace | rejected | rejected |
| 256 cap (257 vs 256 chars) | n/a | 257 rejected, 256 accepted |
| Targeted tests | — | 24/24 pass |

The 64-char cap was never a security control — the character/path-sequence rejections above it block injection and traversal. 256 restores headroom for HA and k8s ingress while staying bounded.

## Infographic

![dashboard-prefix-fix](https://v3b.fal.media/files/b/0aa1268f/qI4Kng-MIn4E8ICMWmop9_dAmrIRe5.png)
