### PR TITLE
feat(kanban): make block recurrence limit configurable

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2626,6 +2626,10 @@ DEFAULT_CONFIG = {
         # same task/profile (spawn_failed, timed_out, or crashed). Reassignment
         # resets the streak for the new profile.
         "failure_limit": 2,
+        # Route a human-blocked task to triage after this many same-cause
+        # block -> unblock -> re-block recurrences. Raises the tolerance for
+        # workflows that intentionally cycle through more than two review blocks.
+        "block_recurrence_limit": 2,
         # Worker stdout/stderr logs rotate at spawn time. Defaults preserve
         # the historical 2 MiB + one-backup behavior; long-running workers can
         # raise these to keep more early failure evidence.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -130,11 +130,42 @@ VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 # to ``blocked`` — breaking the infinite unblock↔re-block loop and forcing a
 # human-in-the-loop decision. Mirrors the dispatcher's ``DEFAULT_FAILURE_LIMIT``
 # spirit (default 2) but counts a different signal: manual unblock recurrences,
-# not dispatcher spawn/crash/timeout failures.
+# not dispatcher spawn/crash/timeout failures. Runtime config can override this
+# default via ``kanban.block_recurrence_limit``.
 BLOCK_RECURRENCE_LIMIT = 2
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 _IS_WINDOWS = sys.platform == "win32"
+
+
+def _coerce_block_recurrence_limit(value: Any, default: int = BLOCK_RECURRENCE_LIMIT) -> int:
+    """Return a positive block-loop threshold, falling back on bad config."""
+    try:
+        limit = int(value)
+    except (TypeError, ValueError):
+        return default
+    return limit if limit >= 1 else default
+
+
+def _configured_block_recurrence_limit() -> int:
+    """Read ``kanban.block_recurrence_limit`` from config.yaml when present."""
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
+        return _coerce_block_recurrence_limit(
+            kanban_cfg.get("block_recurrence_limit"),
+            BLOCK_RECURRENCE_LIMIT,
+        )
+    except Exception:
+        return BLOCK_RECURRENCE_LIMIT
+
+
+def _resolve_block_recurrence_limit(value: Optional[int]) -> int:
+    if value is not None:
+        return _coerce_block_recurrence_limit(value, BLOCK_RECURRENCE_LIMIT)
+    return _configured_block_recurrence_limit()
 
 
 def _fire_kanban_lifecycle_hook(event: str, task_id: str, **fields: Any) -> None:
@@ -4545,6 +4576,7 @@ def block_task(
     reason: Optional[str] = None,
     kind: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    block_recurrence_limit: Optional[int] = None,
 ) -> bool:
     """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
 
@@ -4562,9 +4594,10 @@ def block_task(
       "Type 1"). Lands in ``blocked`` for a human. BUT: each time such a task
       is re-blocked for the SAME kind after having been unblocked, the
       unblock-loop counter (``block_recurrences``) increments. When it reaches
-      :data:`BLOCK_RECURRENCE_LIMIT`, the task is routed to ``triage`` instead
-      of ``blocked`` — breaking the cron-unblock ↔ worker-re-block loop and
-      forcing a human-in-the-loop triage decision.
+      the configured block-recurrence limit (``kanban.block_recurrence_limit``,
+      defaulting to :data:`BLOCK_RECURRENCE_LIMIT`), the task is routed to
+      ``triage`` instead of ``blocked`` — breaking the cron-unblock ↔
+      worker-re-block loop and forcing a human-in-the-loop triage decision.
 
     * ``transient`` — treated like a generic block for routing, but a worker
       can use it to signal "this might clear on its own"; it still participates
@@ -4579,6 +4612,7 @@ def block_task(
         )
     routed_to = "blocked"
     recurrences = 0
+    recurrence_limit = _resolve_block_recurrence_limit(block_recurrence_limit)
     with write_txn(conn):
         cur_row = conn.execute(
             "SELECT status, block_kind, block_recurrences FROM tasks WHERE id = ?",
@@ -4649,7 +4683,7 @@ def block_task(
         same_cause = prev_kind == kind
         recurrences = prev_recurrences + 1 if same_cause else 1
 
-        if recurrences >= BLOCK_RECURRENCE_LIMIT:
+        if recurrences >= recurrence_limit:
             # Loop detected — stop letting the unblocker spin this task. Route
             # to triage for a human-in-the-loop decision instead of blocked.
             cur = conn.execute(
@@ -4684,7 +4718,7 @@ def block_task(
                     "reason": reason,
                     "kind": kind,
                     "recurrences": recurrences,
-                    "limit": BLOCK_RECURRENCE_LIMIT,
+                    "limit": recurrence_limit,
                 },
                 run_id=run_id,
             )

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -130,6 +130,36 @@ def test_block_loop_detected_event_emitted(kanban_home: Path) -> None:
         assert payload.get("kind") == "capability"
 
 
+def test_configured_block_recurrence_limit_defers_triage(kanban_home: Path) -> None:
+    """kanban.block_recurrence_limit lets longer human-review loops opt in."""
+    (kanban_home / "config.yaml").write_text(
+        "kanban:\n  block_recurrence_limit: 3\n",
+        encoding="utf-8",
+    )
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        kb.block_task(conn, tid, reason="first", kind="needs_input")
+        kb.unblock_task(conn, tid)
+        _make_running_again(conn, tid)
+
+        kb.block_task(conn, tid, reason="second", kind="needs_input")
+        t = kb.get_task(conn, tid)
+        assert t is not None
+        assert t.status == "blocked"
+        assert t.block_recurrences == 2
+
+        kb.unblock_task(conn, tid)
+        _make_running_again(conn, tid)
+        kb.block_task(conn, tid, reason="third", kind="needs_input")
+        t = kb.get_task(conn, tid)
+        assert t is not None
+        assert t.status == "triage"
+        assert t.block_recurrences == 3
+        events = [e for e in kb.list_events(conn, tid)
+                  if e.kind == "block_loop_detected"]
+        assert (events[-1].payload or {}).get("limit") == 3
+
+
 # ---------------------------------------------------------------------------
 # Dependency routing
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -506,6 +506,7 @@ Config knobs (all under `kanban:` in `~/.hermes/config.yaml`):
 |---|---|---|
 | `auto_decompose` | `true` | Dispatcher auto-runs the decomposer every tick. |
 | `auto_decompose_per_tick` | `3` | Cap on decompositions per dispatcher tick. Excess defers to the next tick. |
+| `block_recurrence_limit` | `2` | Same-cause block -> unblock -> re-block recurrences before the unblock-loop breaker routes the task to `triage` instead of `blocked`. Raise this for workflows that intentionally require more than two human-review blocks. |
 | `orchestrator_profile` | `""` | Profile assigned to the root/orchestration task after decomposition. Empty = fall back to active default profile. |
 | `default_assignee` | `""` | Where a child task lands when the LLM picks an unknown profile. Empty = fall back to active default. |
 | `auto_subscribe_on_create` | `true` | When a worker calls `kanban_create` from inside a session with a persistent delivery channel (messaging gateway or TUI), the originating session is auto-subscribed to the new task's completion/block events. The dispatcher still drives the delivery — this only changes whether the caller's chat/key shows up in the notify-sub table. Set to `false` to require explicit `kanban_notify-subscribe` calls per task. |
@@ -901,7 +902,7 @@ Every transition appends a row to `task_events`. Each row carries an optional `r
 | `completed` | `{result_len, summary?}` | Worker wrote `--result` / `--summary` and task hit `done`. `summary` is the first-line handoff (400-char cap); full version lives on the run row. If `complete_task` is called on a never-claimed task with handoff fields, a zero-duration run is synthesized so `run_id` still points at something. |
 | `blocked` | `{reason, kind, recurrences}` | Worker or human flipped the task to `blocked`. `kind` is the typed block reason (`needs_input`, `capability`, `transient`, or `null` for a generic block); `recurrences` is the unblock-loop counter. Synthesizes a zero-duration run when called on a never-claimed task with `--reason`. |
 | `dependency_wait` | `{reason, kind}` | Worker blocked with `kind=dependency` — the task is only waiting on another task, so it routes to `todo` (parent-gated, auto-promoted) instead of `blocked`. No human needed. |
-| `block_loop_detected` | `{reason, kind, recurrences, limit}` | A task was unblocked and re-blocked for the same reason `BLOCK_RECURRENCE_LIMIT` times (default 2). Instead of landing in `blocked` again — where a cron would keep unblocking it — it routes to `triage` for a human decision, breaking the unblock↔re-block loop. |
+| `block_loop_detected` | `{reason, kind, recurrences, limit}` | A task was unblocked and re-blocked for the same reason until it hit `kanban.block_recurrence_limit` (default 2). Instead of landing in `blocked` again — where a cron would keep unblocking it — it routes to `triage` for a human decision, breaking the unblock↔re-block loop. |
 | `unblocked` | — | `blocked → ready` (or `todo` if parents are still open), either manually or via `/unblock`. Resets the dispatcher's `consecutive_failures` but deliberately preserves `block_recurrences` so the loop breaker keeps its memory. `run_id` is `NULL`. |
 | `archived` | — | Hidden from the default board. If the task was still running, carries the `run_id` of the run that was reclaimed as a side effect. |
 


### PR DESCRIPTION
## What changed

Adds `kanban.block_recurrence_limit` so operators can choose how many same-cause block, unblock, re-block cycles are tolerated before the kanban unblock-loop breaker routes a task to `triage`.

The default stays `2`, preserving current behavior. Invalid values fall back to the default. The `block_loop_detected` event now reports the effective configured limit.

Closes #59333.

## Why

Some kanban pipelines intentionally need more than two human-review blocks before a task should be escalated to triage. Hardcoding the threshold made those workflows fragile across updates.

## Duplicate check

Checked open and closed issues and PRs for `BLOCK_RECURRENCE_LIMIT`, `BLOCK_RECURANCE_LIMIT`, `block recurrence`, and `unblock-loop`; only the feature request issue was relevant.

## Tests

- `scripts/run_tests.sh tests/hermes_cli/test_kanban_block_kinds.py -q` passed, 12 tests
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_block_kinds.py -q` passed, 235 tests
- `scripts/run_tests.sh tests/tools/test_kanban_tools.py tests/plugins/test_kanban_dashboard_plugin.py -q` passed, 193 tests
- `scripts/run_tests.sh tests/hermes_cli/test_kanban*.py -q` passed, 716 tests
- `uv run ruff check hermes_cli/kanban_db.py hermes_cli/config.py tests/hermes_cli/test_kanban_block_kinds.py` passed
- `python scripts/check-windows-footguns.py --diff upstream/main` passed
- `git diff --check` passed
- `python -m compileall -q hermes_cli/kanban_db.py hermes_cli/config.py` passed

Note: `python -m ruff check ...` failed in the ambient Python because `ruff` was not installed there, so I reran lint with `uv run ruff check ...`, which passed.
