### PR TITLE
docs(slack): add caution about manifest timing before install

### DIFF
--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -34,6 +34,10 @@ declares every built-in slash command (`/btw`, `/stop`, `/model`, …),
 every required OAuth scope, every event subscription, and enables Socket
 Mode — all at once.
 
+:::caution Manifest timing is critical
+Slack only grants the manifest's OAuth scopes **at install time**. If you apply (or edit) the manifest **after** installing the app, the bot token keeps the old scopes and will silently miss required permissions (e.g., bot ignores @mentions or DMs). **Always apply the manifest before Install App**, and after any manifest change, click **Reinstall to Workspace** at api.slack.com/apps → Install App.
+:::
+
 ### Option A: From a Hermes-generated manifest (recommended)
 
 1. Generate the manifest:


### PR DESCRIPTION
## What does this PR do?

Adds a critical caution block to the Slack setup documentation explaining that Slack OAuth scopes are granted **only at install time**. If users apply the manifest after installing (or edit the manifest after initial install), the bot token keeps the old scopes and silently fails to acquire required permissions (e.g., bot ignores @mentions or DMs despite `✓ slack connected` in logs).

The guidance: **always apply the manifest before Install App**, and after any manifest change, click **Reinstall to Workspace** at api.slack.com/apps → Install App. This prevents the silent failure mode the reporter encountered (gateway reports healthy but bot never receives messages).

## Related Issue

Fixes #59539

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `website/docs/user-guide/messaging/slack.md`: Added a `:::caution Manifest timing is critical` block after the "manifest is the fastest path" paragraph but before "Option A", emphasizing the install-time scope grant behavior and the need to reinstall after manifest changes.

## How to Test

1. View the updated Slack setup guide at Step 1 → "From a Hermes-generated manifest (recommended)"
2. Verify the caution block appears with bolded key phrases (**at install time**, **Always apply the manifest before Install App**, **Reinstall to Workspace**)
3. Confirm the warning explains the silent failure mode (bot ignores @mentions/DMs despite healthy connection)
4. Observed result: The caution block renders correctly in Docusaurus `:::caution` syntax and provides actionable remediation steps

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`docs(slack):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (docs-only change, no code behavior change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — N/A (docs-only change, no testable code)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
