### PR TITLE
Hide injected cron scheduler hint from user message UI

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/timeline-data.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline-data.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from 'vitest'
 
-import { activeTimelineIndex, deriveTimelineEntries, timelinePreview } from './timeline-data'
+import { activeTimelineIndex, deriveTimelineEntries, stripCronPromptHint, timelinePreview } from './timeline-data'
+
+// Mirrors cron/scheduler.py cron_hint — a single bracketed paragraph with
+// interior [SILENT] mentions, followed by a blank line and the real prompt.
+const CRON_HINT =
+  '[IMPORTANT: You are running as a scheduled cron job. ' +
+  'DELIVERY: Your final response will be automatically delivered to the user — do NOT use send_message ' +
+  'or try to deliver the output yourself. Just produce your report/output as your final response and the ' +
+  'system handles the rest. SILENT: If there is genuinely nothing new to report, respond with exactly ' +
+  '"[SILENT]" (nothing else) to suppress delivery. Never combine [SILENT] with content — either report ' +
+  'your findings normally, or say [SILENT] and nothing more.]\n\n'
 
 describe('timelinePreview', () => {
   it('collapses whitespace to a single line', () => {
@@ -36,6 +46,32 @@ describe('deriveTimelineEntries', () => {
         { id: 'u3', role: 'user', text: 'real prompt' }
       ]).map(e => e.id)
     ).toEqual(['u3'])
+  })
+
+  it('previews the real prompt of a cron message, not the injected hint', () => {
+    expect(deriveTimelineEntries([{ id: 'u1', role: 'user', text: `${CRON_HINT}Morning briefing` }])).toEqual([
+      { id: 'u1', preview: 'Morning briefing' }
+    ])
+  })
+})
+
+describe('stripCronPromptHint', () => {
+  it('removes the scheduler hint and keeps the real prompt (#59537)', () => {
+    expect(stripCronPromptHint(`${CRON_HINT}Summarize today's news`)).toBe("Summarize today's news")
+  })
+
+  it('handles the interior [SILENT] brackets without truncating mid-hint', () => {
+    const stripped = stripCronPromptHint(`${CRON_HINT}real prompt`)
+    expect(stripped).not.toContain('[SILENT]')
+    expect(stripped).toBe('real prompt')
+  })
+
+  it('returns empty for a hint-only message', () => {
+    expect(stripCronPromptHint(CRON_HINT.trim())).toBe('')
+  })
+
+  it('leaves ordinary prompts untouched', () => {
+    expect(stripCronPromptHint('just a normal prompt')).toBe('just a normal prompt')
   })
 })
 

--- a/apps/desktop/src/components/assistant-ui/thread/timeline-data.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline-data.ts
@@ -14,6 +14,23 @@ export interface TimelineEntry {
 // Injected as user messages for alternation; not human prompts (thread.tsx).
 const PROCESS_NOTIFICATION_RE = /^\[IMPORTANT: Background process [\s\S]*\]$/
 
+// The cron scheduler prepends a delivery/[SILENT] guidance paragraph to every
+// job prompt (cron/scheduler.py cron_hint). It's agent plumbing, not something
+// the human wrote — strip it so the UI shows only the actual job prompt.
+const CRON_HINT_PREFIX = '[IMPORTANT: You are running as a scheduled cron job.'
+
+export function stripCronPromptHint(text: string): string {
+  if (!text.startsWith(CRON_HINT_PREFIX)) {
+    return text
+  }
+
+  // The hint is a single paragraph whose closing `]` sits at a line end
+  // (interior `[SILENT]` mentions are mid-sentence, never before a newline).
+  const end = text.indexOf(']\n')
+
+  return end === -1 ? '' : text.slice(end + 1).trimStart()
+}
+
 const PREVIEW_MAX = 120
 
 export function timelinePreview(text: string, max: number = PREVIEW_MAX): string {
@@ -34,7 +51,7 @@ export function deriveTimelineEntries(messages: readonly TimelineSourceMessage[]
       continue
     }
 
-    const text = message.text.trim()
+    const text = stripCronPromptHint(message.text.trim()).trim()
 
     if (!text || PROCESS_NOTIFICATION_RE.test(text)) {
       continue

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -3,6 +3,7 @@ import { type FC, type ReactNode, useCallback, useRef, useState } from 'react'
 
 import { DirectiveContent } from '@/components/assistant-ui/directive-text'
 import { messageAttachmentRefs, messageContentText } from '@/components/assistant-ui/thread/content'
+import { stripCronPromptHint } from '@/components/assistant-ui/thread/timeline-data'
 import { type RestoreMessageTarget } from '@/components/assistant-ui/thread/types'
 import { UserMessageText } from '@/components/assistant-ui/thread/user-message-text'
 import { Codicon } from '@/components/ui/codicon'
@@ -106,6 +107,9 @@ export const UserMessage: FC<{
   const messageId = useAuiState(s => s.message.id)
   const content = useAuiState(s => s.message.content)
   const messageText = messageContentText(content)
+  // Cron sessions store the scheduler's injected guidance as part of the user
+  // message — hide it in the bubble; edit/restore still use the full text.
+  const displayText = stripCronPromptHint(messageText)
   const threadRunning = useAuiState(s => s.thread.isRunning)
 
   const latestUserId = useAuiState(s => {
@@ -209,7 +213,7 @@ export const UserMessage: FC<{
     )
   }
 
-  const hasBody = messageText.trim().length > 0
+  const hasBody = displayText.trim().length > 0
   const isLatestUser = messageId === latestUserId
   const showStop = !readOnly && isLatestUser && threadRunning && Boolean(onCancel)
   // Restore (re-run this exact prompt) is available everywhere the Stop button
@@ -235,7 +239,7 @@ export const UserMessage: FC<{
           clicking to edit can't grow the bubble by a sub-pixel and reflow the
           turn 1px. */}
       <div className="min-h-[1.25rem]" ref={clampInnerRef}>
-        <UserMessageText className="wrap-anywhere" text={messageText} />
+        <UserMessageText className="wrap-anywhere" text={displayText} />
       </div>
     </div>
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1902,7 +1902,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1919,7 +1918,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1936,7 +1934,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1953,7 +1950,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1970,7 +1966,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1987,7 +1982,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2004,7 +1998,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2021,7 +2014,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2038,7 +2030,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2055,7 +2046,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2072,7 +2062,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2089,7 +2078,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2106,7 +2094,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2123,7 +2110,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2140,7 +2126,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2157,7 +2142,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2174,7 +2158,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2191,7 +2174,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2208,7 +2190,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2225,7 +2206,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2242,7 +2222,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2259,7 +2238,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2276,7 +2254,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2293,7 +2270,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2310,7 +2286,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2327,7 +2302,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }


### PR DESCRIPTION
This PR hides the scheduler's injected guidance prompt (the `[IMPORTANT: You are running as a scheduled cron job...]` paragraph) from the user message bubble and timeline preview.

Changes:
- Added `stripCronPromptHint` in `timeline-data.ts` to detect and remove the cron hint prefix.
- Applied the stripping function in `UserMessage` and `deriveTimelineEntries` to display only the actual job prompt.
- Added unit tests to verify the hint is stripped correctly while leaving ordinary prompts untouched.

Closes #59537