### PR TITLE
fix(dashboard): only open the chat PTY once the chat tab is active

### DIFF
--- a/web/src/lib/chat-activation.test.ts
+++ b/web/src/lib/chat-activation.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { latchChatActivation } from "./chat-activation";
+
+describe("latchChatActivation", () => {
+  it("stays inactive while the chat tab has never been active", () => {
+    // A dashboard sitting on /sessions, /system, … must not flip the latch,
+    // so the persistently-mounted ChatPage never opens /api/pty (which would
+    // trigger the TUI/agent bootstrap on every page).
+    expect(latchChatActivation(false, false)).toBe(false);
+  });
+
+  it("activates when the chat tab becomes active", () => {
+    expect(latchChatActivation(false, true)).toBe(true);
+  });
+
+  it("stays activated after the chat tab is left (sticky / persistence)", () => {
+    // Once the user has opened /chat, the PTY must survive navigating away so
+    // a running agent turn is not torn down on every tab switch.
+    expect(latchChatActivation(true, false)).toBe(true);
+  });
+
+  it("stays activated while the chat tab remains active", () => {
+    expect(latchChatActivation(true, true)).toBe(true);
+  });
+});

--- a/web/src/lib/chat-activation.ts
+++ b/web/src/lib/chat-activation.ts
@@ -1,0 +1,17 @@
+/**
+ * Chat PTY activation latch.
+ *
+ * The dashboard keeps `ChatPage` mounted persistently (just hidden with CSS)
+ * on every route so the embedded chat PTY survives tab switches. The downside
+ * is that the PTY-connect effect would otherwise open `/api/pty` — which spawns
+ * the whole TUI + agent bootstrap (on a fresh checkout this prints
+ * `Installing TUI dependencies…` and runs `npm install`) — the moment the
+ * dashboard loads *any* page, even one the user never navigates the chat into.
+ *
+ * The fix is to only open the PTY once the chat tab has actually been active,
+ * while keeping activation **sticky** so the PTY still persists across later
+ * tab switches. This helper computes that latch: once `true`, it stays `true`.
+ */
+export function latchChatActivation(previous: boolean, isActive: boolean): boolean {
+  return previous || isActive;
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -35,6 +35,7 @@ import { ChatSessionList } from "@/components/ChatSessionList";
 import { usePageHeader } from "@/contexts/usePageHeader";
 import { useI18n } from "@/i18n";
 import { api } from "@/lib/api";
+import { latchChatActivation } from "@/lib/chat-activation";
 import { normalizeSessionTitle } from "@/lib/chat-title";
 import { PluginSlot } from "@/plugins";
 import { useTheme } from "@/themes";
@@ -114,6 +115,17 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   // the moment `isActive` flips back to true (display:none → display:flex
   // collapses the host's box, so ResizeObserver never fires on return).
   const syncMetricsRef = useRef<(() => void) | null>(null);
+  // Sticky activation latch: the PTY-connect effect below must not open
+  // `/api/pty` until the chat tab has actually been active at least once.
+  // The dashboard mounts ChatPage persistently (hidden) on every route, so
+  // without this gate merely loading /sessions, /system, etc. would spawn the
+  // TUI/agent bootstrap (`Installing TUI dependencies…`). Latching keeps the
+  // PTY alive across later tab switches (the persistence UX) — once true it
+  // stays true.
+  const [hasActivated, setHasActivated] = useState(isActive);
+  useEffect(() => {
+    setHasActivated((prev) => latchChatActivation(prev, isActive));
+  }, [isActive]);
   const [searchParams, setSearchParams] = useSearchParams();
   // Lazy-init: the missing-token check happens at construction so the effect
   // body doesn't have to setState (React 19's set-state-in-effect rule).
@@ -366,6 +378,12 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   };
 
   useEffect(() => {
+    // Don't spawn the chat PTY (and the TUI/agent bootstrap it triggers)
+    // until the chat tab has been activated. Prevents the persistently
+    // mounted, hidden ChatPage from opening `/api/pty` on every dashboard
+    // page. Sticky, so switching away from /chat keeps the PTY alive.
+    if (!hasActivated) return;
+
     const host = hostRef.current;
     if (!host) return;
 
@@ -855,7 +873,14 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         copyResetRef.current = null;
       }
     };
-  }, [channel, clearReconnectTimer, resumeParam, scopedProfile, reconnectNonce]);
+  }, [
+    hasActivated,
+    channel,
+    clearReconnectTimer,
+    resumeParam,
+    scopedProfile,
+    reconnectNonce,
+  ]);
 
   // When the user returns to the chat tab (isActive: false → true), the
   // terminal host just transitioned from display:none to display:flex.


### PR DESCRIPTION
## Summary

- The dashboard mounts `ChatPage` persistently (hidden via CSS) on **every** route so the embedded chat PTY survives tab switches (`web/src/App.tsx` → `<ChatPage isActive={isChatRoute} />`).
- But the PTY-connect effect in `web/src/pages/ChatPage.tsx` never checked `isActive`, so it opened `/api/pty` on mount for **any** dashboard page.
- On a source / Raspberry Pi install, opening `/api/pty` spawns the whole TUI + agent bootstrap — `_resolve_chat_argv` → `_make_tui_argv` prints `Installing TUI dependencies…` and runs `npm install`. This happens merely by loading `/sessions`, `/system`, etc., and is the trigger behind reports of the dashboard losing custom themes right when `Installing TUI dependencies…` is logged.

## Root cause

**Symptom** — loading any dashboard page kicks off the embedded chat/TUI bootstrap the user never asked for; on slow/RPi installs this coincides with `/api/dashboard/themes` dropping user themes.

**Root cause** — the connect effect (`ChatPage.tsx`) had deps `[channel, clearReconnectTimer, resumeParam, scopedProfile, reconnectNonce]` and opened the `/api/pty` WebSocket unconditionally. Because App.tsx keeps `ChatPage` mounted on every route (just `display:none` when off `/chat`), the effect ran — and dialed the PTY — regardless of whether the user was on the chat tab.

**Fix + why this level** — gate the connect effect on a **sticky activation latch** (`latchChatActivation`): the PTY is not opened until the chat tab has been active at least once, then stays connected across later tab switches so the intended persistence UX (a running agent turn survives navigating away) is preserved. Fixing it at the connect gate (rather than unmounting ChatPage off `/chat`) keeps persistence intact.

**Scope / risk** — one guard + one dep in the connect effect, plus a tiny pure helper. Direct `/chat` loads still connect immediately (`useState(isActive)` seeds the latch). No backend change.

## Verification

- `cd web && npx vitest run src/lib/chat-activation.test.ts` — 4 passed
- `cd web && npx tsc --noEmit` — clean

## Tests

- `web/src/lib/chat-activation.test.ts` — asserts the latch invariant: stays false until the tab is active (so the hidden ChatPage never dials `/api/pty`), flips true on activation, and stays true afterward (persistence).