### PR TITLE
test(tui_gateway): isolate verification.status not_applicable test from stray tmp markers

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6476,7 +6476,17 @@ def test_verification_status_returns_recorded_evidence(tmp_path):
     assert verification["evidence"]["scope"] == "full"
 
 
-def test_verification_status_outside_workspace_is_not_applicable(tmp_path):
+def test_verification_status_outside_workspace_is_not_applicable(monkeypatch, tmp_path):
+    # A cwd with no project facts (outside any code workspace) must report
+    # not_applicable. Force the "no facts" precondition rather than relying on
+    # tmp_path's ancestors being pristine — a stray marker file in a shared
+    # tmp-root ancestor (e.g. /tmp/package.json left by another tool) would
+    # otherwise make _marker_root() resolve tmp_path as a workspace and flip
+    # the status to "unverified".
+    import agent.coding_context as coding_context
+
+    monkeypatch.setattr(coding_context, "project_facts_for", lambda _cwd=None: None)
+
     home = tmp_path / ".hermes"
     home.mkdir()
     token = set_hermes_home_override(home)


### PR DESCRIPTION
## Summary
`test_verification_status_outside_workspace_is_not_applicable` now passes deterministically regardless of ambient `/tmp` state. It was green in clean CI but red on any dev box with a stray project-marker file in a shared tmp-root ancestor.

Root cause: the test passed `tmp_path` as the cwd and asserted `status == not_applicable`, relying on `tmp_path` having no project-marker ancestor. `_marker_root()` in `agent/coding_context.py` walks up ~6 levels, so a stray `/tmp/package.json` (left by another tool) made `project_facts_for()` resolve the temp dir as a workspace → status flipped to `unverified`.

## Changes
- `tests/test_tui_gateway_server.py`: monkeypatch `agent.coding_context.project_facts_for -> None` to force the no-facts precondition, so the `not_applicable` branch is exercised independent of filesystem state. Test-only; no production change.

## Validation
| | Result |
|---|---|
| Before (with a stray `/tmp/package.json`) | `unverified` — 1 failed |
| After | `not_applicable` — full file 306/306 passing |

Reproduced the failing condition (`/tmp/package.json` present) and confirmed the test passes after the fix. Full `tests/test_tui_gateway_server.py` green.

## Infographic
![verification-status-test-isolation](https://v3b.fal.media/files/b/0aa12697/K6dr6wza-EIxTKMrmiwck_ndxZIdXh.png)
