### PR TITLE
fix(cli): ignore stale missing profile homes at startup

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -341,6 +341,7 @@ def _apply_profile_override() -> None:
     """Pre-parse --profile/-p and set HERMES_HOME before imports."""
     argv = sys.argv[1:]
     profile_name = None
+    profile_source = None
     consume = 0
     profile_index = None
 
@@ -410,11 +411,13 @@ def _apply_profile_override() -> None:
             break
         if arg in {"--profile", "-p"} and i + 1 < len(argv):
             profile_name = argv[i + 1]
+            profile_source = "flag"
             consume = 2
             profile_index = i
             break
         if arg.startswith("--profile="):
             profile_name = arg.split("=", 1)[1]
+            profile_source = "flag"
             consume = 1
             profile_index = i
             break
@@ -453,8 +456,21 @@ def _apply_profile_override() -> None:
     # See issue #22502.
     hermes_home_env = os.environ.get("HERMES_HOME", "")
     if profile_name is None and hermes_home_env:
-        if Path(hermes_home_env).parent.name == "profiles":
-            return
+        env_path = Path(hermes_home_env)
+        if env_path.parent.name == "profiles":
+            try:
+                if env_path.is_dir():
+                    return
+            except OSError:
+                return
+            try:
+                sys.stderr.write(
+                    f"Warning: ignoring stale HERMES_HOME for missing profile: {env_path}\n"
+                )
+                sys.stderr.flush()
+            except Exception:
+                pass
+            os.environ.pop("HERMES_HOME", None)
 
     # 2. If no flag, check active_profile in the hermes root.
     #
@@ -477,6 +493,7 @@ def _apply_profile_override() -> None:
                 name = active_path.read_text().strip()
                 if name and name != "default":
                     profile_name = name
+                    profile_source = "active_profile"
                     consume = 0  # don't strip anything from argv
         except (UnicodeDecodeError, OSError):
             pass  # corrupted file, skip
@@ -488,6 +505,15 @@ def _apply_profile_override() -> None:
 
             hermes_home = resolve_profile_env(profile_name)
         except FileNotFoundError as exc:
+            if profile_source == "active_profile":
+                try:
+                    sys.stderr.write(
+                        f"Warning: ignoring stale active_profile for missing profile: {profile_name}\n"
+                    )
+                    sys.stderr.flush()
+                except Exception:
+                    pass
+                return
             hermes_home = _resolve_sudo_user_profile_env(profile_name)
             if not hermes_home:
                 print(f"Error: {exc}", file=sys.stderr)

--- a/tests/hermes_cli/test_apply_profile_override_missing_profile.py
+++ b/tests/hermes_cli/test_apply_profile_override_missing_profile.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def test_stale_profile_env_is_ignored_instead_of_recreating_profile(
+    tmp_path, monkeypatch, capsys
+):
+    hermes_root = tmp_path / ".hermes"
+    hermes_root.mkdir(parents=True, exist_ok=True)
+    missing_profile = hermes_root / "profiles" / "ghost"
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(missing_profile))
+    monkeypatch.setattr(sys, "argv", ["hermes", "profile", "list"])
+
+    from hermes_cli.main import _apply_profile_override
+
+    _apply_profile_override()
+
+    assert os.environ.get("HERMES_HOME") is None
+    assert not missing_profile.exists()
+    assert "ignoring stale HERMES_HOME" in capsys.readouterr().err
+
+
+def test_stale_active_profile_is_ignored_instead_of_exiting(
+    tmp_path, monkeypatch, capsys
+):
+    hermes_root = tmp_path / ".hermes"
+    hermes_root.mkdir(parents=True, exist_ok=True)
+    (hermes_root / "active_profile").write_text("ghost\n", encoding="utf-8")
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setattr(sys, "argv", ["hermes", "profile", "list"])
+
+    from hermes_cli.main import _apply_profile_override
+
+    _apply_profile_override()
+
+    assert os.environ.get("HERMES_HOME") is None
+    assert not (hermes_root / "profiles" / "ghost").exists()
+    assert "ignoring stale active_profile" in capsys.readouterr().err


### PR DESCRIPTION
What changed and why

Per the reporter's clarification on July 6, 2026, the ghost-profile symptom was still reproducible on v0.18.0 and also showed up after rename. The concrete startup bug here was that Hermes trusted a stale `HERMES_HOME` pointing at `.../profiles/<name>` even after that profile directory had been deleted, so early startup work could recreate the missing profile before `profile list` or the dashboard finished booting.

This change updates `_apply_profile_override()` to:
- keep trusting `HERMES_HOME` when it already points at a real profile directory
- ignore a stale `HERMES_HOME` when it points at a missing named-profile path, falling back to normal root/default resolution instead of reviving the profile
- ignore a stale `active_profile` entry when that named profile no longer exists, instead of aborting or recreating it

I also added regression coverage for both stale-startup cases so deleted/renamed profile paths do not come back just because Hermes starts.

How to test

1. Run `pytest -q tests/hermes_cli/test_apply_profile_override.py tests/hermes_cli/test_apply_profile_override_missing_profile.py`.
2. Reproduce the stale-env case manually: set `HERMES_HOME` to a deleted `~/.hermes/profiles/<name>` path, run `python -m hermes_cli.main profile list`, and confirm Hermes stays on the default profile and does not recreate the missing directory.
3. Reproduce the stale-active case manually: write a missing profile name into `~/.hermes/active_profile`, run `python -m hermes_cli.main profile list`, and confirm Hermes warns and does not recreate `profiles/<name>`.

What platforms tested on

- macOS (local worktree)
- Python test run via pytest

Fixes #47368

Related: #45474

<!-- autocontrib:worker-id=issue-followup-16676f92 kind=pr-open -->