### PR TITLE
feat(tools): add delegate_completion one-shot completion tool (correct response extraction)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -503,6 +503,15 @@ prompt_caching:
 #     model: ""
 #     timeout: 30
 #
+#   # delegate_completion tool: one-shot text-transform offload (summarize /
+#   # classify / reformat) on a cheap or local model instead of the main one.
+#   # provider "main" routes to your OPENAI_BASE_URL endpoint (local Ollama
+#   # etc.); any OpenAI-compatible endpoint works.
+#   delegate_completion:
+#     provider: "auto"
+#     model: ""
+#     timeout: 60
+#
 #   # Session search — summarizes matching past sessions
 #   session_search:
 #     provider: "auto"

--- a/tests/tools/test_delegate_completion_tool.py
+++ b/tests/tools/test_delegate_completion_tool.py
@@ -1,0 +1,176 @@
+"""Tests for the delegate_completion one-shot completion tool.
+
+call_llm is mocked with the response shape it actually returns: a validated
+chat-completions object with .choices[0].message (see
+agent/auxiliary_client.py::_validate_llm_response, which coerces every
+provider response into that shape before call_llm returns it). Text
+extraction therefore goes through extract_content_or_reasoning, which also
+covers reasoning models that put output in message.reasoning with
+content=None.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import tools.delegate_completion_tool as dct
+from tools.delegate_completion_tool import delegate_completion
+
+
+def _chat_response(content, model="test-model", **message_fields):
+    """Build the chat-completions shape call_llm returns for every provider."""
+    message = SimpleNamespace(content=content, **message_fields)
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason="stop")],
+        model=model,
+    )
+
+
+class TestDispatch:
+    def test_single_prompt(self, monkeypatch):
+        calls = []
+
+        def fake_call_llm(*args, **kwargs):
+            calls.append((args, kwargs))
+            return _chat_response("hello world")
+
+        monkeypatch.setattr(dct, "call_llm", fake_call_llm)
+        result = json.loads(delegate_completion(prompt="hello"))
+
+        assert result["success"] is True
+        assert result["count"] == 1
+        assert result["failed"] == 0
+        assert result["results"][0]["text"] == "hello world"
+        assert result["results"][0]["model"] == "test-model"
+        # The auxiliary task name routes config resolution to
+        # auxiliary.delegate_completion.
+        args, kwargs = calls[0]
+        assert args[0] == "delegate_completion"
+        assert kwargs["messages"] == [{"role": "user", "content": "hello"}]
+
+    def test_reasoning_model_content_none(self, monkeypatch):
+        # DeepSeek-R1-style backends return content=None with the output in
+        # message.reasoning. These are exactly the cheap/local models this
+        # tool targets, so extraction must not come back empty.
+        monkeypatch.setattr(
+            dct, "call_llm",
+            lambda *a, **kw: _chat_response(None, reasoning="the answer"),
+        )
+        result = json.loads(delegate_completion(prompt="x"))
+        assert result["success"] is True
+        assert result["results"][0]["text"] == "the answer"
+
+    def test_batch_preserves_order(self, monkeypatch):
+        def fake_call_llm(task, *, messages, **kwargs):
+            return _chat_response(messages[-1]["content"].upper())
+
+        monkeypatch.setattr(dct, "call_llm", fake_call_llm)
+        result = json.loads(delegate_completion(batch=["alpha", "beta", "gamma"]))
+        assert result["success"] is True
+        assert result["count"] == 3
+        assert [r["text"] for r in result["results"]] == ["ALPHA", "BETA", "GAMMA"]
+
+    def test_both_prompt_and_batch_rejected(self):
+        result = json.loads(delegate_completion(prompt="a", batch=["b"]))
+        assert result["success"] is False
+        assert "not both" in result["error"]
+
+    def test_neither_prompt_nor_batch_rejected(self):
+        result = json.loads(delegate_completion())
+        assert result["success"] is False
+        assert "required" in result["error"]
+
+    def test_empty_batch_rejected(self):
+        result = json.loads(delegate_completion(batch=[]))
+        assert result["success"] is False
+        assert "non-empty" in result["error"]
+
+    def test_bare_string_batch_treated_as_singleton(self, monkeypatch):
+        monkeypatch.setattr(
+            dct, "call_llm", lambda *a, **kw: _chat_response("ok"),
+        )
+        result = json.loads(delegate_completion(batch="just one"))
+        assert result["success"] is True
+        assert result["count"] == 1
+
+    def test_overrides_forwarded(self, monkeypatch):
+        seen = {}
+
+        def fake_call_llm(*args, **kwargs):
+            seen.update(kwargs)
+            return _chat_response("ok")
+
+        monkeypatch.setattr(dct, "call_llm", fake_call_llm)
+        delegate_completion(
+            prompt="x",
+            provider="openrouter",
+            model="some/model",
+            timeout=12.5,
+            system="be terse",
+            temperature=0.2,
+            max_tokens=64,
+        )
+        assert seen["provider"] == "openrouter"
+        assert seen["model"] == "some/model"
+        assert seen["timeout"] == 12.5
+        assert seen["temperature"] == 0.2
+        assert seen["max_tokens"] == 64
+        assert seen["messages"][0] == {"role": "system", "content": "be terse"}
+        assert seen["messages"][1] == {"role": "user", "content": "x"}
+
+    def test_single_prompt_failure(self, monkeypatch):
+        def fake_call_llm(*args, **kwargs):
+            raise RuntimeError("no provider reachable")
+
+        monkeypatch.setattr(dct, "call_llm", fake_call_llm)
+        result = json.loads(delegate_completion(prompt="x"))
+        assert result["success"] is False
+        assert result["failed"] == 1
+        assert "RuntimeError" in result["results"][0]["error"]
+        assert "no provider reachable" in result["results"][0]["error"]
+
+    def test_batch_partial_failure_keeps_order(self, monkeypatch):
+        def fake_call_llm(task, *, messages, **kwargs):
+            text = messages[-1]["content"]
+            if text == "boom":
+                raise TimeoutError("backend timed out")
+            return _chat_response(text)
+
+        monkeypatch.setattr(dct, "call_llm", fake_call_llm)
+        result = json.loads(delegate_completion(batch=["a", "boom", "c"]))
+        assert result["success"] is False
+        assert result["count"] == 3
+        assert result["failed"] == 1
+        assert result["results"][0]["text"] == "a"
+        assert "TimeoutError" in result["results"][1]["error"]
+        assert result["results"][2]["text"] == "c"
+
+    def test_explicit_model_reported_when_response_lacks_model(self, monkeypatch):
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))],
+            model=None,
+        )
+        monkeypatch.setattr(dct, "call_llm", lambda *a, **kw: response)
+        result = json.loads(delegate_completion(prompt="x", model="my/override"))
+        assert result["results"][0]["model"] == "my/override"
+
+
+class TestRegistration:
+    def test_registered_in_delegation_toolset(self):
+        from tools.registry import registry
+
+        assert registry.get_toolset_for_tool("delegate_completion") == "delegation"
+
+    def test_schema_declares_documented_arguments(self):
+        props = dct.DELEGATE_COMPLETION_SCHEMA["parameters"]["properties"]
+        assert props["prompt"]["type"] == "string"
+        assert props["batch"]["type"] == "array"
+        for name in ("system", "provider", "model", "timeout", "temperature", "max_tokens"):
+            assert name in props
+        assert dct.DELEGATE_COMPLETION_SCHEMA["parameters"]["required"] == []
+
+    def test_advertised_in_core_toolset(self):
+        import toolsets
+
+        assert "delegate_completion" in toolsets._HERMES_CORE_TOOLS

--- a/tools/delegate_completion_tool.py
+++ b/tools/delegate_completion_tool.py
@@ -1,0 +1,203 @@
+"""delegate_completion tool: one-shot text completion via the auxiliary provider chain.
+
+Companion to ``delegate_task`` for work that needs no tools, no agent loop,
+and no subagent context: summarization, classification, reformatting,
+extraction. Each prompt becomes a single ``call_llm()`` request routed by the
+existing auxiliary resolution chain, so every provider that chain resolves
+(OpenRouter, Nous Portal, native Anthropic, direct API-key providers,
+``provider: "main"`` for local/OpenAI-compatible endpoints) works here with
+no new integration code.
+
+Config lives at ``auxiliary.delegate_completion`` (``provider`` / ``model`` /
+``timeout``), the same per-task shape as ``auxiliary.vision`` and
+``auxiliary.web_extract``. See #59070.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+from agent.auxiliary_client import call_llm, extract_content_or_reasoning
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+_TASK = "delegate_completion"
+
+
+DELEGATE_COMPLETION_SCHEMA = {
+    "name": "delegate_completion",
+    "description": (
+        "Run one-shot text completions on the configured auxiliary backend "
+        "without spawning a subagent. Use for self-contained text transforms "
+        "-- summarize, classify, reformat, extract, draft -- that need no "
+        "tools, files, web access, or follow-up turns; for those, use "
+        "delegate_task instead. Prompts must be fully self-contained: the "
+        "backend model sees nothing from this conversation. Backend is "
+        "resolved from auxiliary.delegate_completion config (provider/model/"
+        "timeout), falling back to the auto-detected auxiliary provider."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": (
+                    "A single self-contained prompt. Mutually exclusive "
+                    "with `batch`."
+                ),
+            },
+            "batch": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "List of self-contained prompts, each run as its own "
+                    "completion on the same backend. Results come back in "
+                    "input order. Mutually exclusive with `prompt`."
+                ),
+            },
+            "system": {
+                "type": "string",
+                "description": (
+                    "Optional system message applied to every prompt in "
+                    "the call."
+                ),
+            },
+            "provider": {
+                "type": "string",
+                "description": (
+                    "Override the configured provider for this call "
+                    "(e.g. 'openrouter', 'nous', 'main', 'anthropic')."
+                ),
+            },
+            "model": {
+                "type": "string",
+                "description": "Override the configured model for this call.",
+            },
+            "timeout": {
+                "type": "number",
+                "description": (
+                    "Request timeout in seconds. Defaults to "
+                    "auxiliary.delegate_completion.timeout."
+                ),
+            },
+            "temperature": {
+                "type": "number",
+                "description": "Sampling temperature (provider default when omitted).",
+            },
+            "max_tokens": {
+                "type": "integer",
+                "description": "Max output tokens (provider default when omitted).",
+            },
+        },
+        "required": [],
+    },
+}
+
+
+def _usage_error(message: str) -> str:
+    return json.dumps({"success": False, "error": message})
+
+
+def delegate_completion(
+    prompt: Optional[str] = None,
+    batch: Optional[List[str]] = None,
+    *,
+    provider: Optional[str] = None,
+    model: Optional[str] = None,
+    timeout: Optional[float] = None,
+    system: Optional[str] = None,
+    temperature: Optional[float] = None,
+    max_tokens: Optional[int] = None,
+) -> str:
+    """Run one or more prompts as plain completions through the auxiliary router.
+
+    Returns a JSON string. Results are in input order; each entry carries
+    either ``text`` (the completion) or ``error`` (that prompt failed)::
+
+        {"success": true, "count": 2, "failed": 0,
+         "results": [{"text": "...", "model": "..."}, ...]}
+
+    ``success`` is true only when every prompt succeeded. Argument-shape
+    errors return ``{"success": false, "error": "..."}`` with no results.
+    """
+    if prompt is not None and batch is not None:
+        return _usage_error("Pass either `prompt` or `batch`, not both.")
+    if prompt is None and batch is None:
+        return _usage_error("One of `prompt` or `batch` is required.")
+
+    if batch is not None:
+        if isinstance(batch, str):
+            # Tolerate a bare string in the batch slot.
+            prompts = [batch]
+        elif isinstance(batch, list) and batch:
+            prompts = [str(p) for p in batch]
+        else:
+            return _usage_error("`batch` must be a non-empty list of strings.")
+    else:
+        prompts = [str(prompt)]
+
+    base_messages: List[Dict[str, Any]] = (
+        [{"role": "system", "content": system}] if system else []
+    )
+
+    results: List[Dict[str, Any]] = []
+    failed = 0
+    for i, text in enumerate(prompts):
+        try:
+            response = call_llm(
+                _TASK,
+                messages=base_messages + [{"role": "user", "content": text}],
+                provider=provider,
+                model=model,
+                timeout=timeout,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+            results.append(
+                {
+                    "text": extract_content_or_reasoning(response),
+                    "model": getattr(response, "model", None) or model,
+                }
+            )
+        except Exception as e:
+            failed += 1
+            logger.warning(
+                "delegate_completion: prompt %d/%d failed: %s",
+                i + 1, len(prompts), e,
+            )
+            results.append({"error": f"{type(e).__name__}: {e}"})
+
+    return json.dumps(
+        {
+            "success": failed == 0,
+            "count": len(results),
+            "failed": failed,
+            "results": results,
+        },
+        ensure_ascii=False,
+    )
+
+
+# No check_fn: the auxiliary router auto-resolves a backend at call time and
+# raises an informative error when none is reachable, which surfaces as a
+# tool error. Gating on provider detection at schema-build time would make
+# the tool silently vanish instead.
+registry.register(
+    name="delegate_completion",
+    toolset="delegation",
+    schema=DELEGATE_COMPLETION_SCHEMA,
+    handler=lambda args, **kw: delegate_completion(
+        prompt=args.get("prompt"),
+        batch=args.get("batch"),
+        provider=args.get("provider"),
+        model=args.get("model"),
+        timeout=args.get("timeout"),
+        system=args.get("system"),
+        temperature=args.get("temperature"),
+        max_tokens=args.get("max_tokens"),
+    ),
+    emoji="⚡",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -63,6 +63,9 @@ _HERMES_CORE_TOOLS = [
     "clarify",
     # Code execution + delegation
     "execute_code", "delegate_task",
+    # One-shot text completion on the auxiliary provider chain — no
+    # subagent, no tools (#59070)
+    "delegate_completion",
     # Cronjob management
     "cronjob",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)


### PR DESCRIPTION
## What does this PR do?

Implements #59070 (which I filed, intending to implement): exposes the `agent/auxiliary_client.py` provider chain as a `delegate_completion` tool for one-shot text-transform work — summarize / classify / reformat / extract — that needs no tools, files, or agent loop. Routing config lives at `auxiliary.delegate_completion` (`provider` / `model` / `timeout`), the same per-task shape as `auxiliary.vision` / `auxiliary.web_extract` / `auxiliary.session_search`. `provider: "main"` covers local Ollama / any OpenAI-compatible endpoint; OpenRouter, Nous Portal, Anthropic, and direct API-key providers all resolve through the existing chain with no new integration code.

## Relationship to #59214

#59214 is an earlier PR for the same issue. I reviewed it before writing this and found its text extraction is broken for every standard provider: it extracts with `_extract_aux_response_text`, which only reads the Responses-API shape (`output_text` / `output`), while `call_llm` guarantees a validated chat-completions shape (`.choices[0].message`) via `_validate_llm_response`. Reproducible result: `{"success": true, "results": [{"text": ""}]}` on every real call — silent empty output. Its tests pass because the mocks fake `output_text` objects that `call_llm` never returns. Repro posted on that PR.

This implementation extracts with the public `extract_content_or_reasoning` helper instead, which reads the shape `call_llm` actually returns and also handles reasoning models (DeepSeek-R1-style `content=None` + `message.reasoning`) — exactly the cheap/local backends this tool targets. A regression test locks in both shapes.

## Changes Made

- `tools/delegate_completion_tool.py` (new): `delegate_completion(prompt | batch, system, provider, model, timeout, temperature, max_tokens)`. Single prompt or batch (results in input order, per-item error capture so one failed prompt doesn't discard the rest of a batch). Registers via `registry.register(...)` at module bottom, mirroring `tools/delegate_tool.py`. No `check_fn`: `call_llm` auto-resolves a backend at call time and raises informatively when none is reachable, which surfaces as a tool error rather than a silently missing tool.
- `toolsets.py`: advertise `delegate_completion` alongside `delegate_task`.
- `cli-config.yaml.example`: documented `auxiliary.delegate_completion` block next to the other auxiliary task blocks.
- `tests/tools/test_delegate_completion_tool.py` (new, 14 tests): dispatch (single, batch order, both/neither/empty-batch usage errors, override forwarding incl. system-message prepend, single failure, batch partial failure, model reporting), the chat-completions and reasoning-model extraction shapes, and registration via the public `registry.get_toolset_for_tool` API.

## Related Issue

Closes #59070

## Type of Change

- [x] ✨ New feature

## How to Test

```
pytest tests/tools/test_delegate_completion_tool.py -q     # 14 passed
pytest tests/test_toolsets.py tests/tools/test_registry.py -q   # 73 passed
pytest tests/tools/test_delegate.py tests/tools/test_delegate_toolset_scope.py \
       tests/hermes_cli/test_tools_config.py tests/cron/test_scheduler.py -q   # 480 passed
```

Shape-level end-to-end check (the exact scenario that breaks #59214):

```python
from types import SimpleNamespace
import tools.delegate_completion_tool as dct
resp = SimpleNamespace(
    choices=[SimpleNamespace(message=SimpleNamespace(content="THE ACTUAL ANSWER"), finish_reason="stop")],
    model="deepseek-chat",
)
dct.call_llm = lambda *a, **kw: resp
print(dct.delegate_completion(prompt="hello"))
# {"success": true, "count": 1, "failed": 0, "results": [{"text": "THE ACTUAL ANSWER", "model": "deepseek-chat"}]}
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits (`feat(tools): ...`)
- [x] I searched for existing PRs — #59214 addresses the same issue; differences and the extraction bug are documented above
- [x] My PR contains only changes related to this feature
- [x] I've run the test suite and all relevant tests pass (14 new + 553 adjacent)
- [x] I've added tests for my changes
- [x] Tested on: WSL2 (Ubuntu on Windows)

### Documentation & Housekeeping

- [x] Config documented in `cli-config.yaml.example` (`auxiliary.delegate_completion`)
- [x] Cross-platform: pure Python, no OS-specific calls; `scripts/check-windows-footguns.py` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
