### PR TITLE
fix(agent): support CIDR notation in NO_PROXY for custom provider proxy bypass (#59465)

### DIFF
--- a/agent/process_bootstrap.py
+++ b/agent/process_bootstrap.py
@@ -133,6 +133,32 @@ def _get_proxy_for_base_url(base_url: Optional[str]) -> Optional[str]:
     if not host:
         return proxy
 
+    # Python's urllib.request.proxy_bypass_environment does NOT support CIDR
+    # notation in NO_PROXY (e.g. "10.0.0.0/24" is never matched). Many other
+    # tools (curl, browsers) do support CIDR ranges, so a user's no_proxy that
+    # works everywhere else silently breaks Hermes' custom provider HTTP clients.
+    # Check for CIDR entries before falling through to the stdlib function.
+    # See https://github.com/NousResearch/hermes-agent/issues/59465
+    try:
+        no_proxy = os.environ.get("no_proxy", "") or os.environ.get("NO_PROXY", "")
+        if no_proxy:
+            for entry in no_proxy.split(","):
+                entry = entry.strip()
+                if "/" in entry:
+                    import ipaddress
+                    import socket
+                    try:
+                        network = ipaddress.ip_network(entry, strict=False)
+                        host_ip = socket.getaddrinfo(
+                            host, 0, socket.AF_INET, socket.SOCK_STREAM
+                        )
+                        if host_ip and ipaddress.ip_address(host_ip[0][4][0]) in network:
+                            return None
+                    except (ValueError, OSError, socket.gaierror):
+                        continue
+    except Exception:
+        pass
+
     try:
         if urllib.request.proxy_bypass_environment(host):
             return None


### PR DESCRIPTION
## Summary

When `NO_PROXY` uses CIDR notation (e.g. `no_proxy=localhost,127.0.0.1,10.10.10.0/24`), Python's `urllib.request.proxy_bypass_environment()` silently ignores it — CIDR is not a supported format. Custom/internal providers on private networks get routed through the proxy and fail with `Error code: 503` (empty body, proxy response).

## Root cause

`_get_proxy_for_base_url()` delegates to `urllib.request.proxy_bypass_environment(host)`, which only matches exact hostnames, domain suffixes, and exact IPs — not CIDR ranges.

Many tools (curl, browsers, wget) *do* support CIDR in `NO_PROXY`, so an operator's `no_proxy` that works everywhere else silently breaks specifically for Hermes.

## Fix

Add a CIDR-aware pre-check in `_get_proxy_for_base_url()` that:
1. Parses `NO_PROXY` for entries containing `/`
2. Resolves the target hostname to an IP via `socket.getaddrinfo()`
3. Checks if the IP falls within the CIDR range via `ipaddress`
4. Returns `None` (no proxy) on match, before falling through to the stdlib function

Only entries with `/` trigger the check — other entries pass through to the existing `proxy_bypass_environment()` unchanged.

## Changes

| File | Δ |
|------|---|
| `agent/process_bootstrap.py` | +26 lines (CIDR check block in `_get_proxy_for_base_url`) |

Closes #59465