### PR TITLE
fix(gateway): drop interrupt sentinel before chat delivery (salvage of #56841 by @waseemshahwan)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -54,6 +54,7 @@ from typing import Callable, Dict, Optional, Any, List, Union
 # preserving the established test-patch surface.
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.async_utils import safe_schedule_threadsafe
+from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from agent.i18n import t
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
@@ -424,6 +425,11 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
         return text
     if _gateway_surface_passes_raw_text(platform):
         return text
+
+    # Cancellation metadata, not assistant prose. ACP/TUI already suppress
+    # this sentinel; chat surfaces should too (#7921).
+    if str(text).strip().startswith(INTERRUPT_WAITING_FOR_MODEL_PREFIX):
+        return ""
 
     redacted = _redact_gateway_user_facing_secrets(str(text))
     if _looks_like_gateway_provider_error(redacted):

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -284,6 +284,7 @@ AUTHOR_MAP = {
     "157689911+itsflownium@users.noreply.github.com": "itsflownium",
     "dirtyren@users.noreply.github.com": "dirtyren",
     "285906080+AIalliAI@users.noreply.github.com": "AIalliAI",
+    "waseemshahwan@users.noreply.github.com": "waseemshahwan",
     "perkintahmaz50@gmail.com": "devatnull",
     "marxb@protonmail.com": "Marxb85",
     "153708448+hunjaiboy@users.noreply.github.com": "yyzquwu",  # PR #47567 salvage (Matrix: register inbound handlers with wait_sync=True so _dispatch_sync's gather awaits them; without it mautrix fire-and-forgets and inbound intake has no completion point)

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -144,6 +144,15 @@ def test_chat_gateways_keep_normal_answers(platform):
     assert _sanitize_gateway_final_response(platform, answer) == answer
 
 
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+def test_chat_gateways_drop_interrupt_sentinel(platform):
+    """The interrupt-while-waiting sentinel is metadata, not a reply (#7921)."""
+    sentinel = "Operation interrupted: waiting for model response (1.7s elapsed)."
+
+    assert _sanitize_gateway_final_response(platform, sentinel) == ""
+    assert _sanitize_gateway_final_response("local", sentinel) == sentinel
+
+
 def test_telegram_status_sanitizes_raw_provider_security_errors():
     """Provider policy/security bodies should be replaced before chat delivery."""
     raw = (


### PR DESCRIPTION
## Summary
Chat platforms no longer receive the "Operation interrupted: waiting for model response (N.Ns elapsed)." cancellation sentinel as a normal assistant message. ACP/TUI already suppressed it via `INTERRUPT_WAITING_FOR_MODEL_PREFIX` (#41720); the gateway's `_sanitize_gateway_final_response` never got the same guard.

Salvages #56841 by @waseemshahwan (cherry-picked, authorship preserved).

## Changes
- `gateway/run.py`: `_sanitize_gateway_final_response` drops text starting with the shared `INTERRUPT_WAITING_FOR_MODEL_PREFIX` constant for chat surfaces; raw surfaces (local/api/webhook) keep it — reuses the existing raw-surface gate, no new string literals.
- `tests/gateway/test_telegram_noise_filter.py`: regression test.

## Validation
| | Before | After |
|---|---|---|
| telegram/slack delivery of sentinel | delivered as assistant message | dropped ("") |
| local/api raw surfaces | raw text | raw text (unchanged, E2E verified) |
| tests/gateway/test_telegram_noise_filter.py | — | 210/210 pass |

Fixes #7921.

## Infographic

![interrupt-sentinel-suppression](https://v3b.fal.media/files/b/0aa126ad/bCDdd6eEwa7S4sLK26JI6_XVP8gDI5.png)
