### PR TITLE
fix(auxiliary): don't skip sibling models when a configured fallback_chain reuses the same provider

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3598,18 +3598,23 @@ def _try_configured_fallback_chain(
     ``base_url``, and ``api_key`` are optional.
 
     ``failed_model`` narrows the skip check to the exact (provider, model)
-    pair that just failed, rather than the whole provider. Without it (the
-    "no client could be built" callers, where credentials/auth are broken
-    for the whole provider regardless of model) every entry sharing that
-    provider is skipped, same as before. With it (the runtime request-error
-    callers), a chain that intentionally lists several models under the
-    same provider — e.g. two more NVIDIA NIM models after the primary NIM
-    model times out — is no longer skipped wholesale; only the entry that
-    is an exact match for what just failed is skipped, so the chain can
-    still serve the request from the same provider instead of jumping
-    straight to the main-agent-model safety net. See issue where an NVIDIA
-    NIM timeout on the primary compression model fell through to the main
-    Codex model instead of trying the two other configured NIM fallbacks.
+    pair that just failed, rather than the whole provider. Without it every
+    entry sharing the failed provider is skipped (the original behaviour).
+    Callers pass it only when a sibling model on the same provider could
+    plausibly recover:
+
+    - Model-specific runtime failures (timeout, connection, rate limit,
+      model-incompatible, invalid response) pass ``failed_model`` so a
+      chain that intentionally lists several models under the same provider
+      — e.g. two more NVIDIA NIM models after the primary NIM model times
+      out — is not skipped wholesale. Only the exact model that failed is
+      skipped; the siblings still run instead of jumping straight to the
+      main-agent-model safety net.
+    - Provider-wide failures (auth 401, payment 402) and "no client could
+      be built" callers leave ``failed_model`` as None, keeping the whole
+      provider skipped — the shared credentials/account behind every model
+      on that provider are broken, so a sibling can't help and the
+      main-agent-model safety net should be reached instead.
 
     Returns:
         (client, model, provider_label) or (None, None, "") if no fallback.
@@ -6568,6 +6573,15 @@ def call_llm(
             logger.info("Auxiliary %s: %s on %s (%s), trying fallback",
                         task or "call", reason, resolved_provider, first_err)
 
+            # Narrow the configured-chain skip to the exact model that
+            # failed ONLY for model-specific failures. Auth (401) and
+            # payment (402) errors are provider-wide — the credentials or
+            # account behind every model on that provider are the same — so
+            # a sibling model can't recover; keep skipping the whole
+            # provider so the main-agent-model safety net is still reached.
+            _chain_failed_model = (
+                None if reason in ("auth error", "payment error") else final_model
+            )
             # Fallback order (#26882, #26803):
             #   1. User-configured fallback_chain (per-task) if set
             #   2. For auto: top-level main fallback_providers/fallback_model
@@ -6577,7 +6591,7 @@ def call_llm(
             if is_auto:
                 fb_client, fb_model, fb_label = _try_configured_fallback_chain(
                     task, resolved_provider or "auto", reason=reason,
-                    failed_model=final_model)
+                    failed_model=_chain_failed_model)
                 if fb_client is None:
                     fb_client, fb_model, fb_label = _try_main_fallback_chain(
                         task, resolved_provider or "auto", reason=reason)
@@ -6587,7 +6601,7 @@ def call_llm(
             else:
                 fb_client, fb_model, fb_label = _try_configured_fallback_chain(
                     task, resolved_provider or "auto", reason=reason,
-                    failed_model=final_model)
+                    failed_model=_chain_failed_model)
                 if fb_client is None:
                     fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
                         resolved_provider, task, reason=reason)
@@ -7055,6 +7069,15 @@ async def async_call_llm(
             logger.info("Auxiliary %s (async): %s on %s (%s), trying fallback",
                         task or "call", reason, resolved_provider, first_err)
 
+            # Narrow the configured-chain skip to the exact model that
+            # failed ONLY for model-specific failures. Auth (401) and
+            # payment (402) errors are provider-wide — the credentials or
+            # account behind every model on that provider are the same — so
+            # a sibling model can't recover; keep skipping the whole
+            # provider so the main-agent-model safety net is still reached.
+            _chain_failed_model = (
+                None if reason in ("auth error", "payment error") else final_model
+            )
             # Fallback order (#26882, #26803):
             #   1. User-configured fallback_chain (per-task) if set
             #   2. For auto: top-level main fallback_providers/fallback_model
@@ -7064,7 +7087,7 @@ async def async_call_llm(
             if is_auto:
                 fb_client, fb_model, fb_label = _try_configured_fallback_chain(
                     task, resolved_provider or "auto", reason=reason,
-                    failed_model=final_model)
+                    failed_model=_chain_failed_model)
                 if fb_client is None:
                     fb_client, fb_model, fb_label = _try_main_fallback_chain(
                         task, resolved_provider or "auto", reason=reason)
@@ -7074,7 +7097,7 @@ async def async_call_llm(
             else:
                 fb_client, fb_model, fb_label = _try_configured_fallback_chain(
                     task, resolved_provider or "auto", reason=reason,
-                    failed_model=final_model)
+                    failed_model=_chain_failed_model)
                 if fb_client is None:
                     fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
                         resolved_provider, task, reason=reason)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3589,12 +3589,27 @@ def _try_configured_fallback_chain(
     task: str,
     failed_provider: str,
     reason: str = "error",
+    failed_model: Optional[str] = None,
 ) -> Tuple[Optional[Any], Optional[str], str]:
     """Try user-configured fallback_chain for a specific auxiliary task.
 
     Reads auxiliary.<task>.fallback_chain from config.yaml and tries each
     entry in order.  Each entry must have at least ``provider``; ``model``,
     ``base_url``, and ``api_key`` are optional.
+
+    ``failed_model`` narrows the skip check to the exact (provider, model)
+    pair that just failed, rather than the whole provider. Without it (the
+    "no client could be built" callers, where credentials/auth are broken
+    for the whole provider regardless of model) every entry sharing that
+    provider is skipped, same as before. With it (the runtime request-error
+    callers), a chain that intentionally lists several models under the
+    same provider — e.g. two more NVIDIA NIM models after the primary NIM
+    model times out — is no longer skipped wholesale; only the entry that
+    is an exact match for what just failed is skipped, so the chain can
+    still serve the request from the same provider instead of jumping
+    straight to the main-agent-model safety net. See issue where an NVIDIA
+    NIM timeout on the primary compression model fell through to the main
+    Codex model instead of trying the two other configured NIM fallbacks.
 
     Returns:
         (client, model, provider_label) or (None, None, "") if no fallback.
@@ -3608,6 +3623,7 @@ def _try_configured_fallback_chain(
         return None, None, ""
 
     skip = failed_provider.lower().strip()
+    skip_model = (failed_model or "").strip().lower() or None
     tried = []
     min_ctx = _task_minimum_context_length(task)
 
@@ -3615,9 +3631,14 @@ def _try_configured_fallback_chain(
         if not isinstance(entry, dict):
             continue
         fb_provider = str(entry.get("provider", "")).strip()
-        if not fb_provider or fb_provider.lower() == skip:
+        if not fb_provider:
             continue
-        fb_model = str(entry.get("model", "")).strip() or None
+        fb_model_raw = str(entry.get("model", "")).strip()
+        if fb_provider.lower() == skip and (
+            skip_model is None or fb_model_raw.lower() == skip_model
+        ):
+            continue
+        fb_model = fb_model_raw or None
 
         label = f"fallback_chain[{i}]({fb_provider})"
 
@@ -6555,7 +6576,8 @@ def call_llm(
             fb_client, fb_model, fb_label = (None, None, "")
             if is_auto:
                 fb_client, fb_model, fb_label = _try_configured_fallback_chain(
-                    task, resolved_provider or "auto", reason=reason)
+                    task, resolved_provider or "auto", reason=reason,
+                    failed_model=final_model)
                 if fb_client is None:
                     fb_client, fb_model, fb_label = _try_main_fallback_chain(
                         task, resolved_provider or "auto", reason=reason)
@@ -6564,7 +6586,8 @@ def call_llm(
                         resolved_provider, task, reason=reason)
             else:
                 fb_client, fb_model, fb_label = _try_configured_fallback_chain(
-                    task, resolved_provider or "auto", reason=reason)
+                    task, resolved_provider or "auto", reason=reason,
+                    failed_model=final_model)
                 if fb_client is None:
                     fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
                         resolved_provider, task, reason=reason)
@@ -7040,7 +7063,8 @@ async def async_call_llm(
             fb_client, fb_model, fb_label = (None, None, "")
             if is_auto:
                 fb_client, fb_model, fb_label = _try_configured_fallback_chain(
-                    task, resolved_provider or "auto", reason=reason)
+                    task, resolved_provider or "auto", reason=reason,
+                    failed_model=final_model)
                 if fb_client is None:
                     fb_client, fb_model, fb_label = _try_main_fallback_chain(
                         task, resolved_provider or "auto", reason=reason)
@@ -7049,7 +7073,8 @@ async def async_call_llm(
                         resolved_provider, task, reason=reason)
             else:
                 fb_client, fb_model, fb_label = _try_configured_fallback_chain(
-                    task, resolved_provider or "auto", reason=reason)
+                    task, resolved_provider or "auto", reason=reason,
+                    failed_model=final_model)
                 if fb_client is None:
                     fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
                         resolved_provider, task, reason=reason)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2308,9 +2308,12 @@ class TestAuxiliaryFallbackLayering:
             )
 
         assert main_chain_client.chat.completions.create.called
+        # Payment errors are provider-wide, so the configured chain is
+        # asked to skip the whole provider (failed_model=None), not just
+        # the failed model — a sibling model can't recover from a 402.
         mock_task_chain.assert_called_once_with(
             "title_generation", "auto", reason="payment error",
-            failed_model="qwen/qwen3.5-122b-a10b")
+            failed_model=None)
         mock_main_chain.assert_called_once_with(
             "title_generation", "auto", reason="payment error")
         mock_builtin_chain.assert_not_called()
@@ -2747,6 +2750,44 @@ class TestTransientTransportRetry:
         # Primary tried ONCE only — no same-provider timeout retry — then fallback.
         assert primary.chat.completions.create.call_count == 1
         assert fb_client.chat.completions.create.call_count == 1
+
+    def test_timeout_forwards_failed_model_to_configured_chain(self):
+        """A timeout is model-specific, so call_llm must forward the failed
+        model to the configured chain (failed_model=<model>, not None). This
+        lets a same-provider sibling in the chain be tried instead of the
+        whole provider being skipped — the exact NVIDIA NIM bug's trigger.
+        """
+        class _Timeout(Exception):
+            pass
+        _Timeout.__name__ = "APITimeoutError"
+
+        primary = MagicMock()
+        primary.base_url = "https://integrate.api.nvidia.com/v1"
+        primary.chat.completions.create.side_effect = _Timeout("Request timed out.")
+
+        fb_client = MagicMock()
+        fb_client.base_url = "https://integrate.api.nvidia.com/v1"
+        fb_client.chat.completions.create.return_value = {"fallback": True}
+
+        p1, p2, p3 = self._patches(primary)
+        with (
+            p1, p2, p3,
+            patch(
+                "agent.auxiliary_client._try_configured_fallback_chain",
+                return_value=(fb_client, "sibling-model", "fallback_chain[0](openrouter)"),
+            ) as mock_chain,
+            patch(
+                "agent.auxiliary_client._try_main_agent_model_fallback",
+                return_value=(None, None, ""),
+            ),
+        ):
+            result = call_llm(task="compression", messages=[{"role": "user", "content": "hi"}])
+        assert result == {"fallback": True}
+        _, kwargs = mock_chain.call_args
+        assert kwargs.get("failed_model") == "some-model", (
+            "A timeout is model-specific — the failed model must be forwarded "
+            "so a same-provider sibling can be tried, not skipped wholesale."
+        )
 
     def test_non_compression_still_retries_same_provider_on_timeout(self):
         """The timeout skip is scoped to compression only; other auxiliary

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2246,6 +2246,7 @@ class TestAuxiliaryFallbackLayering:
             "title_generation",
             "nvidia",
             reason="invalid provider response",
+            failed_model="minimaxai/minimax-m3",
         )
         mock_main.assert_not_called()
 
@@ -2279,6 +2280,7 @@ class TestAuxiliaryFallbackLayering:
             "compression",
             "nvidia",
             reason="invalid provider response",
+            failed_model="minimaxai/minimax-m3",
         )
 
     def test_auto_provider_uses_task_then_main_chain_before_builtin_chain(self, monkeypatch):
@@ -2307,7 +2309,8 @@ class TestAuxiliaryFallbackLayering:
 
         assert main_chain_client.chat.completions.create.called
         mock_task_chain.assert_called_once_with(
-            "title_generation", "auto", reason="payment error")
+            "title_generation", "auto", reason="payment error",
+            failed_model="qwen/qwen3.5-122b-a10b")
         mock_main_chain.assert_called_once_with(
             "title_generation", "auto", reason="payment error")
         mock_builtin_chain.assert_not_called()
@@ -5050,6 +5053,106 @@ class TestCompressionFallbackContextFilter:
 
         assert client is large_client
         assert model == "large-512k"
+
+    # ── same-provider, different-model chain entries ────────────────────
+    # A configured fallback_chain may legitimately list several models
+    # under the *same* provider (e.g. two more NVIDIA NIM models after the
+    # primary NIM model). failed_provider alone must not skip those
+    # sibling entries — only failed_model narrows the skip to the exact
+    # (provider, model) pair that just failed.
+
+    def test_same_provider_sibling_model_not_skipped_when_failed_model_given(
+        self, monkeypatch
+    ):
+        from agent.auxiliary_client import _try_configured_fallback_chain
+
+        sibling_client = MagicMock(name="sibling_nim_client")
+        entries = [
+            self._make_chain_entry("nvidia", "minimaxai/minimax-m3"),
+            self._make_chain_entry("nvidia", "deepseek-ai/deepseek-v4-flash"),
+        ]
+
+        def fake_resolve(entry):
+            if entry is entries[0]:
+                return sibling_client, "minimaxai/minimax-m3"
+            raise AssertionError("second entry should not be reached")
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {"fallback_chain": entries} if task == "compression" else {},
+        )
+
+        with patch("agent.auxiliary_client._resolve_fallback_entry",
+                   side_effect=fake_resolve), \
+             patch("agent.auxiliary_client.get_model_context_length",
+                   return_value=1_048_576):
+            client, model, label = _try_configured_fallback_chain(
+                task="compression",
+                failed_provider="nvidia",
+                failed_model="deepseek-ai/deepseek-v4-pro",
+            )
+
+        assert client is sibling_client, (
+            "A same-provider entry with a DIFFERENT model must still be "
+            "tried when failed_model narrows the skip — regression for the "
+            "bug where an NVIDIA NIM timeout fell straight through to the "
+            "main Codex model instead of trying the other two configured "
+            "NIM models."
+        )
+        assert model == "minimaxai/minimax-m3"
+        assert "nvidia" in label
+
+    def test_same_provider_same_model_still_skipped(self, monkeypatch):
+        """The exact (provider, model) pair that just failed is still
+        skipped — failed_model narrows the skip, it doesn't disable it."""
+        from agent.auxiliary_client import _try_configured_fallback_chain
+
+        entries = [
+            self._make_chain_entry("nvidia", "deepseek-ai/deepseek-v4-pro"),
+        ]
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {"fallback_chain": entries} if task == "compression" else {},
+        )
+
+        with patch("agent.auxiliary_client._resolve_fallback_entry",
+                   side_effect=AssertionError("must not be resolved")):
+            client, model, label = _try_configured_fallback_chain(
+                task="compression",
+                failed_provider="nvidia",
+                failed_model="deepseek-ai/deepseek-v4-pro",
+            )
+
+        assert client is None
+        assert model is None
+        assert label == ""
+
+    def test_same_provider_skipped_wholesale_without_failed_model(self, monkeypatch):
+        """Backward compat: callers that don't know the failed model (e.g.
+        client-build failures where the whole provider is unreachable)
+        still skip every entry sharing that provider, as before."""
+        from agent.auxiliary_client import _try_configured_fallback_chain
+
+        entries = [
+            self._make_chain_entry("nvidia", "minimaxai/minimax-m3"),
+            self._make_chain_entry("nvidia", "deepseek-ai/deepseek-v4-flash"),
+        ]
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {"fallback_chain": entries} if task == "compression" else {},
+        )
+
+        with patch("agent.auxiliary_client._resolve_fallback_entry",
+                   side_effect=AssertionError("must not be resolved")):
+            client, model, label = _try_configured_fallback_chain(
+                task="compression", failed_provider="nvidia",
+            )
+
+        assert client is None
+        assert model is None
+        assert label == ""
 
     # ── L3: main fallback chain ────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

`_try_configured_fallback_chain` skips every `auxiliary.<task>.fallback_chain`
entry whose `provider` matches the provider that just failed. That's correct
when the *provider itself* is unreachable (e.g. missing credentials), but it
also fires for a chain that intentionally lists several different **models**
under the *same* provider — e.g.

```yaml
auxiliary:
  compression:
    provider: nvidia
    model: deepseek-ai/deepseek-v4-pro
    fallback_chain:
      - provider: nvidia
        model: minimaxai/minimax-m3
      - provider: nvidia
        model: deepseek-ai/deepseek-v4-flash
```

When the primary NVIDIA NIM model times out, the provider-only skip check
(`fb_provider.lower() == skip`) discards *both* fallback entries — they all
say `provider: nvidia` — so the configured NIM fallback chain is silently a
no-op. The call falls straight through to the main-agent-model safety net
instead, which in our case was also degraded at the time, producing a
confusing final error that named the main model instead of NIM.

### Real trace that surfaced this (from `agent.log`)

```
Auxiliary compression: using nvidia (deepseek-ai/deepseek-v4-pro) at https://integrate.api.nvidia.com/v1/
Auxiliary compression: timeout on the critical path; skipping same-provider retry and falling back: Request timed out.
Auxiliary compression: connection error on nvidia (Request timed out.), trying fallback
Auxiliary compression: connection error on nvidia — falling back to main agent model main-agent(openai-codex) (gpt-5.5)
Failed to generate context summary: Codex auxiliary Responses stream exceeded 120.0s total timeout.
```

The two configured NIM fallback models were never attempted.

## Fix

Add an optional `failed_model` parameter to `_try_configured_fallback_chain`.
When provided, the skip narrows to the exact `(provider, model)` pair that
just failed, instead of the whole provider:

```python
if fb_provider.lower() == skip and (
    skip_model is None or fb_model_raw.lower() == skip_model
):
    continue
```

- `_try_configured_fallback_for_unavailable_client` (client-build failures,
  where the whole provider is unreachable regardless of model — e.g. missing
  API key) does **not** pass `failed_model`, so it keeps the old provider-wide
  skip. That's still correct there.
- The two runtime request-error call sites, `call_llm` and `async_call_llm`,
  now pass `failed_model=final_model` — the model that actually failed — so
  sibling models under the same provider get a chance.

## Tests

Added to `tests/agent/test_auxiliary_client.py`:
- `test_same_provider_sibling_model_not_skipped_when_failed_model_given` —
  regression test for this exact bug (NVIDIA NIM sibling model chain).
- `test_same_provider_same_model_still_skipped` — the exact failed
  `(provider, model)` pair is still excluded.
- `test_same_provider_skipped_wholesale_without_failed_model` — back-compat:
  callers that don't pass `failed_model` keep skipping the whole provider.

Also updated 3 pre-existing tests whose `assert_called_with(...)` checks
needed the new `failed_model` kwarg added to their expected call signature.

Full relevant suites pass locally: 302 in
`test_auxiliary_client.py`/`test_auxiliary_main_first.py`, and 495 across
compression + auxiliary related test files.

## Out of scope

Whether the main-agent-model safety net should itself retry/back off
differently when it also times out — that's a separate concern from making
the configured fallback_chain actually usable.

🤖 Patch authored with assistance from Claude Code