### PR TITLE
fix(gateway): FIFO-queue mid-run photo follow-ups in queue mode

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11679,10 +11679,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
 
             if event.message_type == MessageType.PHOTO:
-                logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key)
+                # A photo follow-up arriving mid-run is a complete user turn:
+                # album/burst grouping already collapsed multi-photo messages
+                # into ONE event upstream (adapter._media_group_events /
+                # _pending_photo_batches), so each event here is a distinct
+                # user intent. In queue mode, enqueue it as its own FIFO turn
+                # so several photos sent one after another each get their own
+                # turn instead of collapsing into a single pending slot (the
+                # slot is a single "next-up" cell — a second photo would merge
+                # into / overwrite the first, silently losing it). In non-queue
+                # (interrupt/steer) mode, keep the legacy single-slot merge so
+                # rapid photo bursts still coalesce as before.
                 adapter = self._adapter_for_source(source)
                 if adapter:
-                    merge_pending_message_event(adapter._pending_messages, _quick_key, event)
+                    if self._busy_input_mode == "queue":
+                        logger.debug(
+                            "PHOTO follow-up for session %s — FIFO-queued (queue mode)",
+                            _quick_key,
+                        )
+                        self._enqueue_fifo(_quick_key, event, adapter)
+                    else:
+                        logger.debug(
+                            "PRIORITY photo follow-up for session %s — queueing without interrupt",
+                            _quick_key,
+                        )
+                        merge_pending_message_event(adapter._pending_messages, _quick_key, event)
                 return None
 
             _telegram_followup_grace = float(

--- a/tests/gateway/test_telegram_photo_interrupts.py
+++ b/tests/gateway/test_telegram_photo_interrupts.py
@@ -46,3 +46,77 @@ async def test_handle_message_does_not_priority_interrupt_photo_followup():
     assert result is None
     running_agent.interrupt.assert_not_called()
     assert runner.adapters[Platform.TELEGRAM]._pending_messages[session_key] is event
+
+
+@pytest.mark.asyncio
+async def test_queue_mode_photo_followups_do_not_collapse():
+    """In queue mode, two photos sent one-after-another mid-run must each
+    become their OWN FIFO turn — not merge into a single pending slot.
+
+    Regression for the single-slot collapse: previously every mid-run photo
+    went through merge_pending_message_event into adapter._pending_messages,
+    so a second (distinct, non-album) photo merged into / overwrote the first
+    and was silently lost. In queue mode each photo is a complete user turn
+    and must be enqueued via the FIFO chain (slot + overflow).
+    """
+    runner = _make_runner()
+    runner._busy_input_mode = "queue"
+    runner._queued_events = {}
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm", user_id="u1")
+    session_key = build_session_key(source)
+    running_agent = MagicMock()
+    runner._running_agents[session_key] = running_agent
+
+    photo_a = MessageEvent(
+        text="first", message_type=MessageType.PHOTO, source=source,
+        media_urls=["/tmp/photo-a.jpg"], media_types=["image/jpeg"],
+    )
+    photo_b = MessageEvent(
+        text="second", message_type=MessageType.PHOTO, source=source,
+        media_urls=["/tmp/photo-b.jpg"], media_types=["image/jpeg"],
+    )
+
+    assert await runner._handle_message(photo_a) is None
+    assert await runner._handle_message(photo_b) is None
+    running_agent.interrupt.assert_not_called()
+
+    adapter = runner.adapters[Platform.TELEGRAM]
+    # First photo occupies the "next-up" slot, second lands in the overflow —
+    # total FIFO depth is 2, and both distinct events survive independently.
+    assert runner._queue_depth(session_key, adapter=adapter) == 2
+    assert adapter._pending_messages[session_key] is photo_a
+    assert runner._queued_events[session_key] == [photo_b]
+    # The two events did NOT get merged: photo_a still carries only its own media.
+    assert photo_a.media_urls == ["/tmp/photo-a.jpg"]
+    assert photo_b.media_urls == ["/tmp/photo-b.jpg"]
+
+
+@pytest.mark.asyncio
+async def test_interrupt_mode_photo_burst_still_merges():
+    """In non-queue (interrupt) mode, the legacy single-slot merge is kept so
+    rapid photo bursts still coalesce into one pending event (album behavior).
+    """
+    runner = _make_runner()
+    runner._busy_input_mode = "interrupt"
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm", user_id="u1")
+    session_key = build_session_key(source)
+    running_agent = MagicMock()
+    runner._running_agents[session_key] = running_agent
+
+    photo_a = MessageEvent(
+        text="a", message_type=MessageType.PHOTO, source=source,
+        media_urls=["/tmp/photo-a.jpg"], media_types=["image/jpeg"],
+    )
+    photo_b = MessageEvent(
+        text="b", message_type=MessageType.PHOTO, source=source,
+        media_urls=["/tmp/photo-b.jpg"], media_types=["image/jpeg"],
+    )
+
+    assert await runner._handle_message(photo_a) is None
+    assert await runner._handle_message(photo_b) is None
+    running_agent.interrupt.assert_not_called()
+
+    adapter = runner.adapters[Platform.TELEGRAM]
+    merged = adapter._pending_messages[session_key]
+    # Both photos merged into the single slot event (legacy album coalescing).
+    assert merged.media_urls == ["/tmp/photo-a.jpg", "/tmp/photo-b.jpg"]


### PR DESCRIPTION
## Problem

When an agent turn is running and the user sends **several photos one after another** (each a distinct, non-album message), only one of them survives to the next turn — the others are silently lost.

Root cause is an inconsistency between two adjacent branches in the running-agent guard of `GatewayRunner._handle_message`:

- The **text follow-up** path already honors `busy_input_mode`: in `queue` mode it calls `_enqueue_fifo` (one full turn per message), otherwise it merges into the single `_pending_messages` slot.
- The **photo follow-up** path did **not** — it always called `merge_pending_message_event` into the single-slot dict, regardless of mode.

`_pending_messages` is a single "next-up" cell per session. Two distinct photos arriving mid-run therefore merge into / overwrite each other, so only the last one reaches the next turn. Album/burst grouping already collapses genuine multi-photo *messages* into one event upstream, so each event reaching this path is a separate user turn and should be treated as such under `queue` mode.

## Fix

Make the photo path mode-aware, mirroring the text-grace path directly below it:

- `busy_input_mode == "queue"` → `_enqueue_fifo(...)` so each photo becomes its own FIFO turn.
- `interrupt` / `steer` → keep the legacy single-slot `merge_pending_message_event(...)` so rapid album bursts still coalesce as before.

No interface changes, no new config keys, no new env vars — reuses the existing `_enqueue_fifo` infrastructure.

## Tests

Adds two regression tests to `tests/gateway/test_telegram_photo_interrupts.py`:

- `test_queue_mode_photo_followups_do_not_collapse` — two sequential photos in queue mode produce FIFO depth 2 (slot + overflow), both events survive independently. **RED without the fix** (depth collapses 2→1), green with it.
- `test_interrupt_mode_photo_burst_still_merges` — interrupt mode still merges the burst into one pending event (legacy album behavior preserved).

Verified against current `main`; the full `tests/gateway/test_telegram_photo_interrupts.py` suite passes.
