### PR TITLE
docs: document config.yaml security gate in hermes-agent skill

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -119,6 +119,8 @@ hermes doctor [--fix]       Check dependencies and config
 hermes status [--all]       Show component status
 ```
 
+> **Agents: do NOT use `patch` or `write_file` to edit `config.yaml` or `.env`.** These paths are security-gated — the tools will refuse with an error. Always use `hermes config set` or `hermes config edit` instead. This prevents a prompt-injected agent from silently disabling security settings.
+
 Credentials (OAuth + API keys, with pooling) are managed under `hermes auth` — see the Credentials & Pools section below.
 
 ### Tools & Skills
@@ -572,6 +574,10 @@ Note: YOLO / `approvals.mode: off` does NOT turn off secret redaction. They are 
 ### Shell hooks allowlist
 
 Some shell-hook integrations require explicit allowlisting before they fire. Managed via `~/.hermes/shell-hooks-allowlist.json` — prompted interactively the first time a hook wants to run.
+
+### Config file protection
+
+The `patch` and `write_file` tools refuse to write to the Hermes `config.yaml`. This is deliberate — security settings like `approvals.mode` and `security.redact_secrets` live here, and a prompt-injected agent could disable them by editing this file. The guard resolves symlinks, so writing through a symlinked target also triggers the block. Always use `hermes config set` or `hermes config edit` to change config values.
 
 ### Disabling the web/browser/image-gen tools
 


### PR DESCRIPTION
## Problem

The `patch` and `write_file` tools refuse to write to `config.yaml`, `.env`, and `auth.json` with an error message telling the agent to use `hermes config` instead. But the `hermes-agent` skill never explained **why** this guard exists or that agents should prefer the CLI over direct file writes. This caused agents to repeatedly attempt direct edits, get blocked, and waste turns.

## Changes

Two additions to `skills/autonomous-ai-agents/hermes-agent/SKILL.md`:

1. **Configuration CLI section** — a blockquote callout after the `hermes config` command list telling agents to use the CLI instead of `patch`/`write_file`, with the security rationale.

2. **Security & Privacy Toggles** — a new `Config file protection` section explaining the guard exists to prevent prompt-injected agents from silently disabling security settings, and that it resolves symlinks.

## Testing

The guard itself is already tested upstream in `tests/tools/test_file_tools.py::TestSensitivePathCheck` (write_file and patch variants). This is documentation-only.

## Related

Addresses the common issue pattern of agents getting stuck on `"Refusing to write to Hermes config file"` errors.