### PR TITLE
fix(tools): unescape \\n in replacement when escape_normalized strategy matched (#59188)

### DIFF
--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -133,6 +133,7 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
             # sequences in source code constants far more often than help.
             effective_new = _maybe_unescape_new_string(
                 new_string, content, matches,
+                unescape_newlines=(strategy_name == "escape_normalized"),
             )
             # Unicode-preservation guard: when strategy 7 (unicode_normalized)
             # matched, the file has Unicode characters (em-dashes, smart quotes,
@@ -282,8 +283,9 @@ def _reindent_replacement(file_region: str, old_string: str, new_string: str) ->
 
 def _maybe_unescape_new_string(new_string: str,
                                content: str,
-                               matches: List[Tuple[int, int]]) -> str:
-    """Conditionally unescape ``\\t``/``\\r`` in new_string.
+                               matches: List[Tuple[int, int]],
+                               unescape_newlines: bool = False) -> str:
+    """Conditionally unescape ``\\t``/``\\r`` (and optionally ``\\n``) in new_string.
 
     LLMs frequently send the two-character sequences ``\\t`` (backslash + t)
     and ``\\r`` (backslash + r) inside JSON tool-call arguments where they
@@ -298,13 +300,19 @@ def _maybe_unescape_new_string(new_string: str,
     ``sep = "\\t"``) get a backslash+t in the matched region instead of a
     tab, so we leave new_string alone.
 
-    ``\\n`` is intentionally excluded: newlines serialize correctly through
-    JSON and rewriting backslash-n would corrupt escape sequences in
-    string literals far more often than it would help.
+    When *unescape_newlines* is True (used by the ``escape_normalized``
+    strategy), ``\\n`` is also unescaped to actual newlines if the matched
+    region contains real newlines.  ``\\n`` is excluded by default because
+    newlines serialize correctly through JSON and rewriting backslash-n
+    would corrupt escape sequences in string literals far more often than
+    it would help — but when the *pattern* was matched with ``\\n`` → newline
+    normalization, the replacement must match or the file gets literal
+    ``\\n`` text instead of line breaks (#59188).
     """
     # Cheap pre-check — bail out unless new_string actually contains one of
     # the suspect sequences. Keeps the common case free.
-    if "\\t" not in new_string and "\\r" not in new_string:
+    if ("\\t" not in new_string and "\\r" not in new_string
+            and not (unescape_newlines and "\\n" in new_string)):
         return new_string
 
     matched_regions = "".join(content[start:end] for start, end in matches)
@@ -313,6 +321,8 @@ def _maybe_unescape_new_string(new_string: str,
         out = out.replace("\\t", "\t")
     if "\\r" in out and "\r" in matched_regions:
         out = out.replace("\\r", "\r")
+    if unescape_newlines and "\\n" in out and "\n" in matched_regions:
+        out = out.replace("\\n", "\n")
     return out
 
 


### PR DESCRIPTION
## Summary

The `escape_normalized` fuzzy-match strategy converts `\n` (literal backslash-n in the old_string pattern) to actual newlines for matching. But when writing the replacement, `\n` is **intentionally excluded** from the unescape path in `_maybe_unescape_new_string()` — newlines serialize correctly through JSON, so unconditionally rewriting backslash-n would mangle escape sequences in source code constants.

However, when the *pattern* itself was matched with `\n` → newline normalization (i.e. strategy `escape_normalized`), the replacement must also be unescaped or the file ends up with literal `\n` text instead of line breaks. Hermes reports a successful patch/edit while corrupting the file with backslash-n sequences.

## Fix

Add an `unescape_newlines` parameter (default `False`) to `_maybe_unescape_new_string()`. In `fuzzy_find_and_replace()`, pass `unescape_newlines=True` when the matched strategy is `escape_normalized`.

The `\n` unescape is still guarded by the same region-based heuristic as `\t`/`\r`: it only fires when the matched region of the file **actually contains** real newlines. Files that legitimately contain the literal two-character string `"\n"` (e.g. Python source defining `sep = r"\n"`) have backslash+n in the matched region instead of a real newline, so they are left untouched.

## Changes

| File | Δ |
|------|---|
| `tools/fuzzy_match.py` | +18 lines (parameter + guard in `_maybe_unescape_new_string`, flag in call site) |

## Tests

- `tests/tools/test_fuzzy_match.py`: **56/56 passed** ✅

Closes #59188