### PR TITLE
fix(tui): count full-width (CJK) chars as 2 columns in wrap estimator

### DIFF
--- a/ui-tui/src/__tests__/virtualHeights.test.ts
+++ b/ui-tui/src/__tests__/virtualHeights.test.ts
@@ -98,6 +98,25 @@ describe('virtual height estimates', () => {
     expect(withSep).toBe(base + 2)
   })
 
+  it('counts U+FE10 (Vertical Forms) as 2-column wide, matching Ink isEastAsianWide', () => {
+    // U+FE10 is in the Vertical Forms block (U+FE10–U+FE1F). Ink's
+    // isEastAsianWide classifies it as wide (2 columns). The prior
+    // isWideCodePoint predicate was missing this range, so 40 chars at width 20
+    // would be counted as 40 cells → 2 rows instead of 4.
+    const text = '\uFE10'.repeat(40)
+
+    expect(wrappedLines(text, 20)).toBe(4)
+  })
+
+  it('still finalizes rows when the bounded walk stops inside a surrogate pair', () => {
+    // maxLines=2 and width=2 set a six-code-unit walk budget. The high
+    // surrogate of U+20000 lands at the last visited code unit, so the
+    // estimator must not skip the i===budget row-finalization step.
+    const text = `${'x'.repeat(5)}\u{20000}suffix`
+
+    expect(wrappedLines(text, 2, 2)).toBe(2)
+  })
+
   it('caps wrapped-line counting so giant assistant turns do not block offset rebuilds', () => {
     // wrappedLines is invoked once per uncached message during
     // useVirtualHistory's offset rebuild. Unbounded counting on a long

--- a/ui-tui/src/__tests__/virtualHeights.test.ts
+++ b/ui-tui/src/__tests__/virtualHeights.test.ts
@@ -17,6 +17,17 @@ describe('virtual height estimates', () => {
     expect(estimatedMsgHeight(msg, 35, { compact: false, details: false })).toBeGreaterThan(5)
   })
 
+  it('counts full-width (CJK) characters as 2 columns when estimating wrap rows', () => {
+    // 40 zenkaku (full-width) characters at 2 cols each = 80 columns, which
+    // needs 4 rows at width 20 — a code-unit count would (wrongly) treat
+    // this as 40 "cells" needing only 2 rows, undercounting by ~2x and
+    // under-reserving space in the virtualized transcript (clipped text /
+    // a scrollHeight short of the real rendered bottom).
+    const text = 'あ'.repeat(40)
+
+    expect(wrappedLines(text, 20)).toBe(4)
+  })
+
   it('uses compound user prompt width when estimating user message wrapping', () => {
     const msg: Msg = { role: 'user', text: 'x'.repeat(21) }
 

--- a/ui-tui/src/lib/virtualHeights.ts
+++ b/ui-tui/src/lib/virtualHeights.ts
@@ -41,26 +41,51 @@ export const messageHeightKey = (msg: Msg) => {
 // ceiling was 16 lines, then full text — this is the sane middle).
 const MAX_ESTIMATE_LINES = 800
 
+// East-Asian "wide" code points (CJK ideographs, hiragana/katakana, hangul,
+// fullwidth forms, ...) render at 2 terminal columns instead of 1. Counting
+// them as width 1 (plain code-unit count) undercounts wrapped rows by ~2x
+// for CJK-heavy text, which under-reserves virtualized transcript space —
+// visible as clipped trailing lines and a scrollHeight that falls short of
+// the real rendered bottom. This is a cheap charCode-range check (not full
+// grapheme/emoji-width handling — that's `stringWidth` in inputMetrics.ts,
+// too costly to call per char across a multi-thousand-char wrap walk) so it
+// keeps the single-pass O(text) budget this estimator relies on.
+const isWideCodePoint = (code: number) =>
+  (code >= 0x1100 && code <= 0x115f) || // Hangul Jamo
+  (code >= 0x2e80 && code <= 0xa4cf && code !== 0x303f) || // CJK Radicals .. Yi Radicals
+  (code >= 0xac00 && code <= 0xd7a3) || // Hangul Syllables
+  (code >= 0xf900 && code <= 0xfaff) || // CJK Compatibility Ideographs
+  (code >= 0xff00 && code <= 0xff60) || // Fullwidth Forms
+  (code >= 0xffe0 && code <= 0xffe6)
+
+const charWidth = (code: number) => (isWideCodePoint(code) ? 2 : 1)
+
 export const wrappedLines = (text: string, width: number, maxLines: number = MAX_ESTIMATE_LINES) => {
   const w = Math.max(1, width)
   // Worst case: every cell is its own row at width=1, plus a small
   // slack for the trailing partial line. Walking past this byte budget
   // cannot increase n any further once n is already past maxLines, so
   // bail. Saves O(text) walks on multi-megabyte single-line messages.
+  // (Wide chars only make rows fill faster, so this char-count budget
+  // stays a safe, if generous, upper bound once widths are counted.)
   const budget = Math.min(text.length, maxLines * w + maxLines)
   let n = 0
-  let start = 0
+  let lineWidth = 0
 
   for (let i = 0; i <= budget; i++) {
     if (i === text.length || i === budget || text.charCodeAt(i) === 10) {
-      const rows = Math.max(1, Math.ceil((i - start) / w))
+      const rows = Math.max(1, Math.ceil(lineWidth / w))
       n += rows >= maxLines - n ? maxLines - n : rows
-      start = i + 1
+      lineWidth = 0
 
       if (n >= maxLines) {
         return maxLines
       }
+
+      continue
     }
+
+    lineWidth += charWidth(text.charCodeAt(i))
   }
 
   return n

--- a/ui-tui/src/lib/virtualHeights.ts
+++ b/ui-tui/src/lib/virtualHeights.ts
@@ -42,21 +42,30 @@ export const messageHeightKey = (msg: Msg) => {
 const MAX_ESTIMATE_LINES = 800
 
 // East-Asian "wide" code points (CJK ideographs, hiragana/katakana, hangul,
-// fullwidth forms, ...) render at 2 terminal columns instead of 1. Counting
-// them as width 1 (plain code-unit count) undercounts wrapped rows by ~2x
-// for CJK-heavy text, which under-reserves virtualized transcript space —
+// fullwidth forms, vertical forms, CJK compatibility forms, CJK extension
+// planes, ...) render at 2 terminal columns instead of 1. Counting them as
+// width 1 (plain code-unit count) undercounts wrapped rows by ~2x for
+// CJK-heavy text, which under-reserves virtualized transcript space —
 // visible as clipped trailing lines and a scrollHeight that falls short of
-// the real rendered bottom. This is a cheap charCode-range check (not full
-// grapheme/emoji-width handling — that's `stringWidth` in inputMetrics.ts,
-// too costly to call per char across a multi-thousand-char wrap walk) so it
-// keeps the single-pass O(text) budget this estimator relies on.
+// the real rendered bottom.
+//
+// This is a cheap code-point-range check aligned with Ink's bundled
+// isEastAsianWide (packages/hermes-ink/src/ink/termio/parser.ts). It is
+// NOT full grapheme/emoji-width handling (that's `stringWidth` in
+// inputMetrics.ts, too costly to call per char across a multi-thousand-char
+// wrap walk) so it keeps the single-pass O(text) budget this estimator
+// relies on.
 const isWideCodePoint = (code: number) =>
   (code >= 0x1100 && code <= 0x115f) || // Hangul Jamo
-  (code >= 0x2e80 && code <= 0xa4cf && code !== 0x303f) || // CJK Radicals .. Yi Radicals
+  (code >= 0x2e80 && code <= 0x9fff) || // CJK Radicals .. CJK Unified Ideographs
   (code >= 0xac00 && code <= 0xd7a3) || // Hangul Syllables
   (code >= 0xf900 && code <= 0xfaff) || // CJK Compatibility Ideographs
+  (code >= 0xfe10 && code <= 0xfe1f) || // Vertical Forms
+  (code >= 0xfe30 && code <= 0xfe6f) || // CJK Compatibility Forms
   (code >= 0xff00 && code <= 0xff60) || // Fullwidth Forms
-  (code >= 0xffe0 && code <= 0xffe6)
+  (code >= 0xffe0 && code <= 0xffe6) || // Fullwidth Signs
+  (code >= 0x20000 && code <= 0x2fffd) || // CJK Extension B..F
+  (code >= 0x30000 && code <= 0x3fffd) // CJK Extension G..H
 
 const charWidth = (code: number) => (isWideCodePoint(code) ? 2 : 1)
 
@@ -85,7 +94,28 @@ export const wrappedLines = (text: string, width: number, maxLines: number = MAX
       continue
     }
 
-    lineWidth += charWidth(text.charCodeAt(i))
+    const cc = text.charCodeAt(i)
+    let code: number
+
+    if (cc >= 0xd800 && cc <= 0xdbff) {
+      // Supplementary plane character (surrogate pair). Decode the full
+      // code point so isWideCodePoint can match Ink's supplementary-plane
+      // ranges (U+20000–U+2FFFD, U+30000–U+3FFFD). Only consume the low
+      // surrogate when it is inside this bounded walk; otherwise the next
+      // iteration must still finalize the accumulated row at i===budget.
+      const low = text.charCodeAt(i + 1)
+
+      if (i + 1 < budget && low >= 0xdc00 && low <= 0xdfff) {
+        code = (cc - 0xd800) * 0x400 + (low - 0xdc00) + 0x10000
+        i++ // skip the low surrogate
+      } else {
+        code = cc // unpaired or budget-split surrogate; count this code unit once
+      }
+    } else {
+      code = cc
+    }
+
+    lineWidth += charWidth(code)
   }
 
   return n


### PR DESCRIPTION
## Summary

`wrappedLines()` / `estimatedMsgHeight()` in `ui-tui/src/lib/virtualHeights.ts` estimated wrapping from UTF-16 code-unit count, so East Asian wide characters were treated as one terminal column even though the bundled Ink renderer allocates two cells. CJK-heavy messages could therefore under-reserve virtualized transcript height, clipping trailing lines and producing a `scrollHeight` shorter than the rendered content.

## Fix

- Count East Asian wide code points as two terminal columns while keeping the estimator bounded and single-pass.
- Align the estimator's range table with `ui-tui/packages/hermes-ink/src/ink/termio/parser.ts::isEastAsianWide`, including:
  - U+FE10–U+FE1F (Vertical Forms)
  - U+FE30–U+FE6F (CJK Compatibility Forms)
  - U+20000–U+2FFFD and U+30000–U+3FFFD (supplementary CJK planes)
- Decode valid surrogate pairs for supplementary-plane classification without consuming a low surrogate past the estimator's walk budget.

This remains a cheap range-based estimator rather than full grapheme/emoji width handling; the existing `MAX_ESTIMATE_LINES` cap and O(text) bounded walk are preserved.

## Regression coverage

- Existing `あ` case: 40 wide characters at width 20 estimate four rows.
- Added U+FE10 case from the range identified in review.
- Added a budget-boundary case where a supplementary-plane surrogate pair straddles the bounded walk limit, ensuring row finalization is not skipped.

## Validation

- Targeted U+FE10 and surrogate-boundary tests: **2 passed**.
- `virtualHeights.test.ts` in a current-`main` integration state: **13 passed**.
- Prettier check: **passed**.
- ESLint on changed files: **passed**.
- `tsc --noEmit -p tsconfig.json`: **passed**.
