### PR TITLE
docs: correct Python support to 3.11-3.13

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ A well-built third-party-product plugin can clear automated review and still be 
 | Requirement | Notes |
 |-------------|-------|
 | **Git** | With the `git-lfs` extension installed |
-| **Python 3.11+** | uv will install it if missing |
+| **Python 3.11–3.13** | uv will install it if missing |
 | **uv** | Fast Python package manager ([install](https://docs.astral.sh/uv/)) |
 | **Node.js 20+** | Optional — needed for browser tools and WhatsApp bridge (matches root `package.json` engines) |
 

--- a/website/docs/developer-guide/contributing.md
+++ b/website/docs/developer-guide/contributing.md
@@ -34,7 +34,7 @@ We value contributions in this order:
 | Requirement | Notes |
 |-------------|-------|
 | **Git** | With the `git-lfs` extension installed |
-| **Python 3.11+** | uv will install it if missing |
+| **Python 3.11–3.13** | uv will install it if missing |
 | **uv** | Fast Python package manager ([install](https://docs.astral.sh/uv/)) |
 | **Node.js 20+** | Optional — needed for browser tools and WhatsApp bridge (matches root `package.json` engines) |
 


### PR DESCRIPTION
## Summary
Docs now state the real Python support range. `requires-python` is `>=3.11,<3.14`, so the `3.11+` phrasing was misleading — it implied 3.14+ works when the ceiling forbids it.

## Changes
- `CONTRIBUTING.md`: `Python 3.11+` → `Python 3.11–3.13`
- `website/docs/developer-guide/contributing.md`: same fix (docs-site mirror)

## Note
Scope is intentionally just the version-range wording. CI still tests only on 3.11 — expanding the test matrix to 3.12/3.13 is a separate decision, not bundled here.

## Infographic

![python-support-3-11-3-13](https://v3b.fal.media/files/b/0aa1271d/8F-bW8BMMJ1pYdCXTWhGl_Oa7mQS7m.png)
