### PR TITLE
fix(cron): kill process group on script timeout, fix mislabeled failure message (#59549)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -72,6 +72,13 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
         )
 
     if "readtimeout" in lower or "timed out" in lower or "timeout" in lower:
+        # Check for script timeout BEFORE generic provider timeout, so script
+        # timeouts are not mislabeled as provider failures (#59549).
+        if "script timed out" in lower:
+            return (
+                f"⚠️ Cron '{job_name}' failed: script timed out. "
+                "Full details saved in cron output."
+            )
         return (
             f"⚠️ Cron '{job_name}' failed: provider timeout. "
             "Fallback chain was exhausted or unavailable. "
@@ -2000,17 +2007,21 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         from tools.environments.local import _sanitize_subprocess_env
 
         popen_kwargs = {"creationflags": windows_hide_flags()} if sys.platform == "win32" else {}
-        result = subprocess.run(
+        # Use a new process group so timeout kills all descendants (#59549)
+        if sys.platform != "win32":
+            popen_kwargs["preexec_fn"] = os.setsid
+        proc = subprocess.Popen(
             argv,
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             text=True,
-            timeout=script_timeout,
             cwd=str(path.parent),
             env=_sanitize_subprocess_env(os.environ.copy()),
             **popen_kwargs,
         )
-        stdout = (result.stdout or "").strip()
-        stderr = (result.stderr or "").strip()
+        stdout, stderr = proc.communicate(timeout=script_timeout)
+        stdout = (stdout or "").strip() if stdout is not None else ""
+        stderr = (stderr or "").strip() if stderr is not None else ""
 
         # Redact secrets from both stdout and stderr before any return path.
         try:
@@ -2022,8 +2033,8 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             stdout = "[REDACTED - redaction failed]"
             stderr = "[REDACTED - redaction failed]"
 
-        if result.returncode != 0:
-            parts = [f"Script exited with code {result.returncode}"]
+        if proc.returncode != 0:
+            parts = [f"Script exited with code {proc.returncode}"]
             if stderr:
                 parts.append(f"stderr:\n{stderr}")
             if stdout:
@@ -2033,6 +2044,12 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         return True, stdout
 
     except subprocess.TimeoutExpired:
+        # Kill the entire process group to clean up orphaned children (#59549)
+        if sys.platform != "win32":
+            try:
+                os.killpg(os.getpgid(proc.pid), 9)  # SIGKILL — clean orphans
+            except (ProcessLookupError, AttributeError):
+                pass
         return False, f"Script timed out after {script_timeout}s: {path}"
     except Exception as exc:
         return False, f"Script execution failed: {exc}"


### PR DESCRIPTION
## Summary

Two bugs in `cron/scheduler.py`'s script execution path:

### Bug 1: Mislabeled timeout messages
The error classifier in `_format_cron_failure` matches "timed out" generically before checking the specific source. Script timeouts (which produce "Script timed out after Ns: /path") contain "timed out" and are reported as **provider timeout** instead of **script timeout**. Fix: check for "script timed out" before the generic branch.

### Bug 2: Orphaned child processes on timeout
`subprocess.run(timeout=N)` only kills the direct child when the timeout fires; grandchildren spawned by the script survive as orphaned processes. Migrated to `subprocess.Popen` + `preexec_fn=os.setsid` (POSIX) to create a fresh process group, and on `TimeoutExpired` the entire group is killed via `os.killpg(pid, 9)`.

## Changes

| File | Δ |
|------|---|
| `cron/scheduler.py` | +21/-9 lines (Popen migration, process group, error message fix) |

## Tests

- `tests/cron/test_cron_script.py`: **38/38 passed** ✅

Closes #59549