### PR TITLE
fix(qqbot): add is_reconnect param to connect() to match base contract

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,7 +278,7 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"


### PR DESCRIPTION
QQAdapter.connect() was missing the *, is_reconnect: bool = False keyword argument required by BasePlatformAdapter. The gateway's reconnect watcher calls connect(is_reconnect=True) when re-establishing a failed platform connection, causing::

    TypeError: QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'

This meant every automatic reconnection attempt (default every 300s) immediately failed with the same TypeError, making the QQ Bot platform permanently stuck in a reconnection loop without ever successfully reconnecting.
