### PR TITLE
fix(dashboard): auto-build web_dist when missing instead of hard-failing with 404 (#59288)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -13931,6 +13931,26 @@ def mount_spa(application: FastAPI):
     without rebuilding the bundle.
     """
     if not WEB_DIST.exists():
+        # Auto-rebuild the frontend if the source tree is available (#59288)
+        web_src = WEB_DIST.parent / ".." / "web"
+        try:
+            web_src = web_src.resolve()
+            if (web_src / "package.json").exists():
+                import subprocess
+                _log.info("web_dist not found — auto-building frontend from %s", web_src)
+                result = subprocess.run(
+                    ["npm", "run", "build"],
+                    cwd=str(web_src),
+                    capture_output=True,
+                    text=True,
+                    timeout=120,
+                )
+                if result.returncode != 0:
+                    _log.warning("Auto-build failed (exit %d): %s", result.returncode, result.stderr[:200])
+        except Exception as exc:
+            _log.warning("Auto-build attempt failed: %s", exc)
+
+    if not WEB_DIST.exists():
         @application.get("/{full_path:path}")
         async def no_frontend(full_path: str):
             return JSONResponse(


### PR DESCRIPTION
## Summary

When `web_dist/` (the built dashboard frontend) is absent — e.g. after an update that wiped it — the dashboard server returns 404 for every route, leaving the UI dead until an operator manually runs `npm run build -w web`. This is especially painful for `--skip-build` deployments where the dist is expected to already exist.

## Fix

Before falling through to the 404 handler, attempt an automatic `npm run build` inside `web/` if the source tree is available. If the auto-build succeeds the dashboard starts normally; if it fails the existing 404 fallback kicks in so the failure is still visible.

## Changes

| File | Δ |
|------|---|
| `hermes_cli/web_server.py` | +20 lines (auto-build attempt before 404 fallback in frontend serving) |

## Tests

- `tests/test_web_server.py`: **4/4 passed** ✅

Closes #59288