### PR TITLE
fix(tui): keep default sessions on launch state db

### DIFF
--- a/tests/test_lazy_session_regressions.py
+++ b/tests/test_lazy_session_regressions.py
@@ -88,8 +88,9 @@ class TestFinalizeSessionUsesAgentSessionId:
             history=[{"role": "user", "content": "hello"}],
         )
 
-        # Monkeypatch _get_db to return our test DB
-        with patch.object(server, "_get_db", return_value=db):
+        # Finalization must use the DB selected from the live session.
+        with patch.object(server, "_session_db") as mock_session_db:
+            mock_session_db.return_value.__enter__.return_value = db
             with patch.object(server, "_notify_session_boundary", lambda *a: None):
                 server._finalize_session(session, end_reason="tui_close")
 
@@ -111,7 +112,8 @@ class TestFinalizeSessionUsesAgentSessionId:
 
         session = _tui_session(agent=None, session_key="orphan-key")
 
-        with patch.object(server, "_get_db", return_value=db):
+        with patch.object(server, "_session_db") as mock_session_db:
+            mock_session_db.return_value.__enter__.return_value = db
             with patch.object(server, "_notify_session_boundary", lambda *a: None):
                 server._finalize_session(session, end_reason="tui_close")
 

--- a/tests/test_lazy_session_regressions.py
+++ b/tests/test_lazy_session_regressions.py
@@ -88,8 +88,9 @@ class TestFinalizeSessionUsesAgentSessionId:
             history=[{"role": "user", "content": "hello"}],
         )
 
-        # Monkeypatch _get_db to return our test DB
-        with patch.object(server, "_get_db", return_value=db):
+        # Finalization must use the DB selected from the live session.
+        with patch.object(server, "_session_db") as mock_session_db:
+            mock_session_db.return_value.__enter__.return_value = db
             with patch.object(server, "_notify_session_boundary", lambda *a: None):
                 server._finalize_session(session, end_reason="tui_close")
 
@@ -100,8 +101,6 @@ class TestFinalizeSessionUsesAgentSessionId:
             "not the already-ended parent"
         )
         assert continuation["end_reason"] == "tui_close"
-
-
 
 # ===========================================================================
 # Bug #20001: _sync_session_key_after_compress post-run_conversation
@@ -215,6 +214,7 @@ class TestPendingTitleValueError:
         )
 
         monkeypatch.setattr(server, "_get_db", lambda: mock_db)
+        monkeypatch.setattr(server, "_new_session_db", lambda *_a, **_k: mock_db)
         monkeypatch.setattr(server, "_emit", lambda *a, **kw: None)
         monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
         monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
@@ -364,8 +364,6 @@ class TestFinalizeOrphanedCompressionSessions:
         session = db.get_session("ghost-cont")
         assert session["ended_at"] is not None
         assert session["end_reason"] == "orphaned_compression"
-
-
 
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2431,7 +2431,7 @@ def test_finalize_session_closes_slash_worker(monkeypatch):
             closed["count"] += 1
 
     monkeypatch.setattr(server, "_notify_session_boundary", lambda *a, **k: None)
-    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_new_session_db", lambda *_a, **_k: None)
 
     session = _session(slash_worker=_FakeWorker())
 
@@ -3449,7 +3449,7 @@ def test_ensure_session_db_row_persists_explicit_cwd(monkeypatch, tmp_path):
                 {"key": key, "source": source, "model": model, "model_config": model_config, "cwd": cwd}
             )
 
-    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(server, "_new_session_db", lambda _session, _label: _FakeDB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
 
     server._ensure_session_db_row({"session_key": "k1", "cwd": str(tmp_path), "explicit_cwd": True})
@@ -3468,7 +3468,7 @@ def test_ensure_session_db_row_persists_session_source(monkeypatch):
                 {"key": key, "source": source, "model": model, "model_config": model_config, "cwd": cwd}
             )
 
-    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(server, "_new_session_db", lambda _session, _label: _FakeDB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
 
     server._ensure_session_db_row({"session_key": "k1", "source": "tool"})
@@ -3489,7 +3489,7 @@ def test_ensure_session_db_row_defaults_to_no_workspace(monkeypatch, tmp_path):
                 {"key": key, "source": source, "model": model, "model_config": model_config, "cwd": cwd}
             )
 
-    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(server, "_new_session_db", lambda _session, _label: _FakeDB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
 
     server._ensure_session_db_row({"session_key": "k1", "cwd": str(tmp_path)})
@@ -3516,7 +3516,7 @@ def test_ensure_session_db_row_persists_session_model_override(monkeypatch):
                 {"key": key, "model": model, "model_config": model_config, "cwd": cwd}
             )
 
-    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(server, "_new_session_db", lambda _session, _label: _FakeDB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "global/default")
 
     server._ensure_session_db_row(
@@ -3546,12 +3546,44 @@ def test_ensure_session_db_row_no_override_uses_global(monkeypatch):
         def create_session(self, key, source=None, model=None, model_config=None, parent_session_id=None, cwd=None):
             created.append({"model": model, "model_config": model_config})
 
-    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(server, "_new_session_db", lambda _session, _label: _FakeDB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "global/default")
 
     server._ensure_session_db_row({"session_key": "k1", "model_override": None})
 
     assert created == [{"model": "global/default", "model_config": None}]
+
+
+def test_default_session_db_row_uses_launch_home_not_cached_global(monkeypatch, tmp_path):
+    """A default-profile session row must not reuse a stale global DB handle."""
+    from hermes_state import SessionDB
+
+    launch_home = tmp_path / "launch"
+    other_home = tmp_path / "profiles" / "other"
+    launch_home.mkdir()
+    other_home.mkdir(parents=True)
+
+    stale_db = SessionDB(db_path=other_home / "state.db")
+    monkeypatch.setattr(server, "_db", stale_db)
+    monkeypatch.setattr(server, "_db_error", None)
+    monkeypatch.setattr(server, "_hermes_home", launch_home)
+
+    server._ensure_session_db_row(
+        {
+            "session_key": "default-session",
+            "profile_home": None,
+            "model_override": {"model": "test-model"},
+            "source": "desktop",
+        }
+    )
+
+    launch_db = SessionDB(db_path=launch_home / "state.db")
+    try:
+        assert launch_db.get_session("default-session") is not None
+        assert stale_db.get_session("default-session") is None
+    finally:
+        launch_db.close()
+        stale_db.close()
 
 
 def test_session_title_clears_pending_after_persist(monkeypatch):
@@ -10277,7 +10309,7 @@ def test_session_create_records_ui_model_as_session_override(monkeypatch):
         server._sessions.clear()
 
 
-def test_start_agent_build_passes_session_model_override(monkeypatch):
+def test_start_agent_build_passes_session_model_override(monkeypatch, tmp_path):
     """A model staged on the session (e.g. by session.create from the desktop
     composer) must reach _make_agent so the first build runs on it directly —
     no global config, no build-then-switch.
@@ -10293,6 +10325,7 @@ def test_start_agent_build_passes_session_model_override(monkeypatch):
 
     def fake_make_agent(sid, key, session_id=None, session_db=None, **kwargs):
         captured.update(kwargs)
+        captured["session_db"] = session_db
         return types.SimpleNamespace(model="claude-sonnet-4.6")
 
     monkeypatch.setattr(server, "_set_session_context", lambda target: [])
@@ -10306,6 +10339,9 @@ def test_start_agent_build_passes_session_model_override(monkeypatch):
     monkeypatch.setattr(server, "_start_notification_poller", lambda *a, **k: None)
     monkeypatch.setattr(server, "_notify_session_boundary", lambda *a, **k: None)
     monkeypatch.setattr(server, "_probe_config_health", lambda *_a: None)
+    launch_home = tmp_path / "launch"
+    launch_home.mkdir()
+    monkeypatch.setattr(server, "_hermes_home", launch_home)
 
     sid = "build-sid"
     override = {"model": "claude-sonnet-4.6", "provider": "anthropic"}
@@ -10326,8 +10362,11 @@ def test_start_agent_build_passes_session_model_override(monkeypatch):
         assert captured.get("model_override") == override
         assert captured.get("reasoning_config_override") == reasoning
         assert captured.get("service_tier_override") == "priority"
+        assert captured["session_db"].db_path == launch_home / "state.db"
         assert session["agent"].model == "claude-sonnet-4.6"
     finally:
+        if captured.get("session_db") is not None:
+            captured["session_db"].close()
         server._sessions.clear()
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -36,6 +36,27 @@ def _dispatch_sync(req: dict, transport=None) -> dict | None:
         reset_transport(token)
 
 
+class _BorrowedSessionDB:
+    """Delegate to a test DB while keeping production close calls harmless."""
+
+    def __init__(self, db):
+        self._db = db
+
+    def __getattr__(self, name):
+        return getattr(self._db, name)
+
+    def close(self):
+        pass
+
+
+def _patch_session_db(monkeypatch, db) -> None:
+    monkeypatch.setattr(
+        server,
+        "_new_session_db",
+        lambda *_args, **_kwargs: _BorrowedSessionDB(db),
+    )
+
+
 @pytest.fixture(autouse=True)
 def _neuter_agent_prewarm_timer(request, monkeypatch):
     """Stub the deferred agent pre-warm timer for every test in this module.
@@ -4699,7 +4720,7 @@ def test_finalize_session_closes_slash_worker(monkeypatch):
             closed["count"] += 1
 
     monkeypatch.setattr(server, "_notify_session_boundary", lambda *a, **k: None)
-    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_new_session_db", lambda *_a, **_k: None)
 
     session = _session(slash_worker=_FakeWorker())
 
@@ -5483,8 +5504,10 @@ def test_prompt_submit_refuses_ordinal_only_when_durable_history_is_unstamped(mo
         def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
             replaced.append((key, list(messages)))
 
+    db = _FakeDB()
     server._sessions["unstamped-durable-sid"] = _session(history=list(history))
-    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    _patch_session_db(monkeypatch, db)
     monkeypatch.setattr(
         server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
     )
@@ -6610,7 +6633,7 @@ def test_ensure_session_db_row_persists_explicit_cwd(monkeypatch, tmp_path):
                 {"key": key, "source": source, "model": model, "model_config": model_config, "cwd": cwd}
             )
 
-    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(server, "_new_session_db", lambda _session, _label: _FakeDB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
     monkeypatch.delenv("HERMES_DESKTOP", raising=False)
     monkeypatch.delenv("HERMES_DESKTOP_TERMINAL", raising=False)
@@ -6631,7 +6654,7 @@ def test_ensure_session_db_row_persists_session_source(monkeypatch):
                 {"key": key, "source": source, "model": model, "model_config": model_config, "cwd": cwd}
             )
 
-    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(server, "_new_session_db", lambda _session, _label: _FakeDB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
 
     server._ensure_session_db_row({"session_key": "k1", "source": "tool"})
@@ -6656,7 +6679,7 @@ def test_ensure_session_db_row_records_a_terminal_workspace(monkeypatch, tmp_pat
                 {"key": key, "source": source, "model": model, "model_config": model_config, "cwd": cwd}
             )
 
-    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    _patch_session_db(monkeypatch, _FakeDB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
     monkeypatch.delenv("HERMES_DESKTOP", raising=False)
     monkeypatch.delenv("HERMES_DESKTOP_TERMINAL", raising=False)
@@ -6679,7 +6702,7 @@ def test_ensure_session_db_row_defaults_desktop_to_no_workspace(monkeypatch, tmp
                 {"key": key, "source": source, "model": model, "model_config": model_config, "cwd": cwd}
             )
 
-    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(server, "_new_session_db", lambda _session, _label: _FakeDB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
 
     server._ensure_session_db_row({"session_key": "k1", "source": "desktop", "cwd": str(tmp_path)})
@@ -6706,7 +6729,7 @@ def test_ensure_session_db_row_persists_session_model_override(monkeypatch):
                 {"key": key, "model": model, "model_config": model_config, "cwd": cwd}
             )
 
-    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(server, "_new_session_db", lambda _session, _label: _FakeDB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "global/default")
 
     server._ensure_session_db_row(
@@ -6736,7 +6759,7 @@ def test_ensure_session_db_row_no_override_uses_global(monkeypatch):
         def create_session(self, key, source=None, model=None, model_config=None, parent_session_id=None, cwd=None, profile_name=None):
             created.append({"model": model, "model_config": model_config})
 
-    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(server, "_new_session_db", lambda _session, _label: _FakeDB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "global/default")
 
     server._ensure_session_db_row({"session_key": "k1", "model_override": None})
@@ -6774,6 +6797,38 @@ def test_ensure_session_db_row_stamps_profile_name(monkeypatch, tmp_path):
     assert created[0]["db_path"] == profile_home / "state.db"
 
 
+def test_default_session_db_row_uses_launch_home_not_cached_global(monkeypatch, tmp_path):
+    """A default-profile session row must not reuse a stale global DB handle."""
+    from hermes_state import SessionDB
+
+    launch_home = tmp_path / "launch"
+    other_home = tmp_path / "profiles" / "other"
+    launch_home.mkdir()
+    other_home.mkdir(parents=True)
+
+    stale_db = SessionDB(db_path=other_home / "state.db")
+    monkeypatch.setattr(server, "_db", stale_db)
+    monkeypatch.setattr(server, "_db_error", None)
+    monkeypatch.setattr(server, "_hermes_home", launch_home)
+
+    server._ensure_session_db_row(
+        {
+            "session_key": "default-session",
+            "profile_home": None,
+            "model_override": {"model": "test-model"},
+            "source": "desktop",
+        }
+    )
+
+    launch_db = SessionDB(db_path=launch_home / "state.db")
+    try:
+        assert launch_db.get_session("default-session") is not None
+        assert stale_db.get_session("default-session") is None
+    finally:
+        launch_db.close()
+        stale_db.close()
+
+
 def test_session_title_clears_pending_after_persist(monkeypatch):
     class _FakeDB:
         def __init__(self):
@@ -6793,6 +6848,7 @@ def test_session_title_clears_pending_after_persist(monkeypatch):
     emitted = []
     server._sessions["sid"] = _session(pending_title="stale")
     monkeypatch.setattr(server, "_get_db", lambda: db)
+    _patch_session_db(monkeypatch, db)
     monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
     try:
         resp = server.handle_request(
@@ -6829,6 +6885,7 @@ def test_session_title_does_not_queue_noop_when_row_exists(monkeypatch):
 
     server._sessions["sid"] = _session(pending_title="stale")
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    _patch_session_db(monkeypatch, _FakeDB())
     try:
         resp = server.handle_request(
             {
@@ -6852,6 +6909,7 @@ def test_session_title_get_falls_back_to_pending_when_db_read_throws(monkeypatch
 
     server._sessions["sid"] = _session(pending_title="queued title")
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    _patch_session_db(monkeypatch, _FakeDB())
     try:
         resp = server.handle_request(
             {"id": "1", "method": "session.title", "params": {"session_id": "sid"}}
@@ -6879,6 +6937,7 @@ def test_session_title_get_retries_persist_for_pending_title(monkeypatch):
     db = _FakeDB()
     server._sessions["sid"] = _session(pending_title="queued title")
     monkeypatch.setattr(server, "_get_db", lambda: db)
+    _patch_session_db(monkeypatch, db)
     try:
         resp = server.handle_request(
             {"id": "1", "method": "session.title", "params": {"session_id": "sid"}}
@@ -6907,6 +6966,7 @@ def test_session_title_get_retries_pending_even_when_db_has_title(monkeypatch):
     db = _FakeDB()
     server._sessions["sid"] = _session(pending_title="queued title")
     monkeypatch.setattr(server, "_get_db", lambda: db)
+    _patch_session_db(monkeypatch, db)
     try:
         resp = server.handle_request(
             {"id": "1", "method": "session.title", "params": {"session_id": "sid"}}
@@ -6924,6 +6984,7 @@ def test_session_title_rejects_empty_title_with_specific_error_code(monkeypatch)
 
     server._sessions["sid"] = _session()
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    _patch_session_db(monkeypatch, _FakeDB())
     try:
         resp = server.handle_request(
             {
@@ -6951,6 +7012,7 @@ def test_session_title_set_maps_valueerror_to_user_error(monkeypatch):
 
     server._sessions["sid"] = _session()
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    _patch_session_db(monkeypatch, _FakeDB())
     try:
         resp = server.handle_request(
             {
@@ -6979,6 +7041,7 @@ def test_session_title_set_errors_when_row_lookup_fails_after_noop(monkeypatch):
 
     server._sessions["sid"] = _session()
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    _patch_session_db(monkeypatch, _FakeDB())
     try:
         resp = server.handle_request(
             {
@@ -7044,6 +7107,7 @@ def test_session_create_drops_pending_title_on_valueerror(monkeypatch):
 
     server._sessions["sid"] = session
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    _patch_session_db(monkeypatch, _FakeDB())
     monkeypatch.setattr(server, "_emit", lambda *a, **kw: None)
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
@@ -9886,7 +9950,9 @@ def test_session_status_reads_live_gateway_agent(monkeypatch):
                 "updated_at": 1_700_000_060,
             }
 
-    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    db = _DB()
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    _patch_session_db(monkeypatch, db)
     try:
         resp = server.handle_request(
             {"id": "1", "method": "session.status", "params": {"session_id": "sid"}}
@@ -10554,6 +10620,7 @@ def test_session_info_includes_session_title(monkeypatch):
             return "Dashboard title"
 
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    _patch_session_db(monkeypatch, _FakeDB())
 
     info = server._session_info(
         types.SimpleNamespace(tools=[], model="test/model", provider="openai-codex"),
@@ -11149,6 +11216,7 @@ def test_prompt_submit_can_truncate_before_user_ordinal(monkeypatch):
         monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
         monkeypatch.setattr(server, "_emit", lambda *a: None)
         monkeypatch.setattr(server, "_get_db", lambda: stub_db)
+        _patch_session_db(monkeypatch, stub_db)
 
         resp = server.handle_request(
             {
@@ -11201,7 +11269,9 @@ def test_prompt_submit_refuses_turn_when_truncate_persist_fails(monkeypatch):
         def replace_messages(self, session_id, messages, active_only=False, archive_dropped=False):
             raise OSError("disk full")
 
-    monkeypatch.setattr(server, "_get_db", lambda: _FailDb())
+    db = _FailDb()
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    _patch_session_db(monkeypatch, db)
     monkeypatch.setattr(
         server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
     )
@@ -11304,6 +11374,7 @@ def test_prompt_submit_truncate_ordinal_skips_display_kind_rows(monkeypatch):
         monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
         monkeypatch.setattr(server, "_emit", lambda *a: None)
         monkeypatch.setattr(server, "_get_db", lambda: stub_db)
+        _patch_session_db(monkeypatch, stub_db)
 
         # ordinal=1 means "truncate before the 2nd-from-last real user turn"
         # which is "first". The display_kind marker must NOT shift the ordinal.
@@ -11407,6 +11478,7 @@ def test_prompt_submit_truncate_translates_display_prefix_ordinal(monkeypatch):
         monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
         monkeypatch.setattr(server, "_emit", lambda *a: None)
         monkeypatch.setattr(server, "_get_db", lambda: stub_db)
+        _patch_session_db(monkeypatch, stub_db)
 
         resp = server.handle_request(
             {
@@ -12929,7 +13001,7 @@ def test_get_db_degrades_cleanly_when_sessiondb_init_fails(monkeypatch):
     fake_mod = types.ModuleType("hermes_state")
 
     class _BrokenSessionDB:
-        def __init__(self):
+        def __init__(self, **_kwargs):
             raise RuntimeError("locking protocol")
 
     fake_mod.SessionDB = _BrokenSessionDB
@@ -12939,6 +13011,31 @@ def test_get_db_degrades_cleanly_when_sessiondb_init_fails(monkeypatch):
 
     assert server._get_db() is None
     assert server._db_error == "locking protocol"
+
+
+def test_get_db_uses_launch_home_under_session_override(monkeypatch, tmp_path):
+    """The process-global handle must not bind to an ambient profile override."""
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    launch_home = tmp_path / "launch"
+    profile_home = tmp_path / "profiles" / "researcher"
+    launch_home.mkdir()
+    profile_home.mkdir(parents=True)
+    monkeypatch.setattr(server, "_hermes_home", launch_home)
+    monkeypatch.setattr(server, "_db", None)
+    monkeypatch.setattr(server, "_db_error", None)
+
+    token = set_hermes_home_override(profile_home)
+    db = None
+    try:
+        db = server._get_db()
+        assert db is not None
+        assert db.db_path == launch_home / "state.db"
+    finally:
+        reset_hermes_home_override(token)
+        if db is not None:
+            db.close()
+        server._db = None
 
 
 @pytest.mark.real_agent_prewarm
@@ -13514,7 +13611,9 @@ def test_session_history_ships_durable_row_ids(monkeypatch):
         "created_at": 1.0,
         "last_active": 1.0,
     }
-    monkeypatch.setattr(server, "_get_db", lambda: _Db())
+    db = _Db()
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    _patch_session_db(monkeypatch, db)
     try:
         resp = server.handle_request(
             {"id": "1", "method": "session.history", "params": {"session_id": "rowid-hist-sid"}}
@@ -14448,7 +14547,9 @@ def test_session_active_list_reports_live_sessions(monkeypatch):
 
     previous_sessions = dict(server._sessions)
     server._sessions.clear()
-    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    db = _DB()
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    _patch_session_db(monkeypatch, db)
     server._sessions["sid-a"] = _session(
         agent=types.SimpleNamespace(model="model-a"),
         history=[{"role": "user", "content": "find docs"}],
@@ -14581,6 +14682,7 @@ def test_session_activate_returns_inflight_stream_before_completion(monkeypatch)
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
     monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_new_session_db", lambda *_a, **_k: None)
     monkeypatch.setattr(server, "_session_info", lambda agent: {"model": agent.model})
 
     def _emit(event, sid, payload=None):
@@ -17077,7 +17179,7 @@ def test_session_create_records_ui_model_as_session_override(monkeypatch):
 
 @pytest.mark.parametrize("service_tier_override", ["priority", ""])
 def test_start_agent_build_passes_session_model_override(
-    monkeypatch, service_tier_override
+    monkeypatch, tmp_path, service_tier_override
 ):
     """A model staged on the session (e.g. by session.create from the desktop
     composer) must reach _make_agent so the first build runs on it directly —
@@ -17094,6 +17196,7 @@ def test_start_agent_build_passes_session_model_override(
 
     def fake_make_agent(sid, key, session_id=None, session_db=None, **kwargs):
         captured.update(kwargs)
+        captured["session_db"] = session_db
         return types.SimpleNamespace(model="claude-sonnet-4.6")
 
     monkeypatch.setattr(server, "_set_session_context", lambda target: [])
@@ -17107,6 +17210,9 @@ def test_start_agent_build_passes_session_model_override(
     monkeypatch.setattr(server, "_start_notification_poller", lambda *a, **k: None)
     monkeypatch.setattr(server, "_notify_session_boundary", lambda *a, **k: None)
     monkeypatch.setattr(server, "_probe_config_health", lambda *_a: None)
+    launch_home = tmp_path / "launch"
+    launch_home.mkdir()
+    monkeypatch.setattr(server, "_hermes_home", launch_home)
 
     sid = "build-sid"
     override = {"model": "claude-sonnet-4.6", "provider": "anthropic"}
@@ -17127,8 +17233,11 @@ def test_start_agent_build_passes_session_model_override(
         assert captured.get("model_override") == override
         assert captured.get("reasoning_config_override") == reasoning
         assert captured.get("service_tier_override") == service_tier_override
+        assert captured["session_db"].db_path == launch_home / "state.db"
         assert session["agent"].model == "claude-sonnet-4.6"
     finally:
+        if captured.get("session_db") is not None:
+            captured["session_db"].close()
         server._sessions.clear()
 
 
@@ -17158,6 +17267,7 @@ def test_reset_session_agent_clears_session_overrides(monkeypatch):
 
     monkeypatch.setattr(server, "_set_session_context", lambda _key: [])
     monkeypatch.setattr(server, "_clear_session_context", lambda _tokens: None)
+    monkeypatch.setattr(server, "_new_session_db", lambda *_args: None)
     monkeypatch.setattr(server, "_make_agent", make_agent)
     monkeypatch.setattr(server, "_config_model_target", lambda: ("", ""))
     monkeypatch.setattr(server, "_load_show_reasoning", lambda: True)
@@ -18602,6 +18712,7 @@ def test_persist_branch_seed_keeps_reasoning_fields(monkeypatch, tmp_path):
     try:
         db.create_session("branch-key", source="tui")
         monkeypatch.setattr(server, "_get_db", lambda: db)
+        _patch_session_db(monkeypatch, db)
 
         server._persist_branch_seed(session)
 
@@ -18634,6 +18745,7 @@ def test_session_branch_keeps_reasoning_fields(monkeypatch, tmp_path):
     try:
         db.create_session("session-key", source="tui")
         monkeypatch.setattr(server, "_get_db", lambda: db)
+        _patch_session_db(monkeypatch, db)
         monkeypatch.setattr(server, "_new_session_key", lambda: "branch-key")
         monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
         monkeypatch.setattr(server, "_wait_agent", lambda session, rid: None)
@@ -18860,6 +18972,7 @@ def test_personality_marker_does_not_shift_truncate_ordinal(monkeypatch):
         monkeypatch.setattr(server, "_get_usage", lambda _a: {})
         monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
         monkeypatch.setattr(server, "_get_db", lambda: stub_db)
+        _patch_session_db(monkeypatch, stub_db)
 
         # The client counts three user bubbles (first=0, second=1, third=2) —
         # it never sees the pivot. Rewinding to "third" must cut exactly there.
@@ -18951,7 +19064,9 @@ def test_prompt_submit_truncation_archives_instead_of_deleting(monkeypatch):
         monkeypatch.setattr(server, "_emit", lambda *a: None)
         monkeypatch.setattr(server, "_get_usage", lambda _a: {})
         monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
-        monkeypatch.setattr(server, "_get_db", lambda: _StubDb())
+        db = _StubDb()
+        monkeypatch.setattr(server, "_get_db", lambda: db)
+        _patch_session_db(monkeypatch, db)
 
         resp = server.handle_request(
             {
@@ -19104,7 +19219,9 @@ def test_prompt_submit_row_id_resolves_via_db_when_memory_lacks_stamps(monkeypat
 
     sess = _session(history=list(live_history), session_key="db-row-key")
     server._sessions["db-row-resolve-sid"] = sess
-    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    db = _FakeDB()
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    _patch_session_db(monkeypatch, db)
     monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
 
     try:
@@ -19167,6 +19284,7 @@ def test_prompt_submit_row_id_real_sessiondb_resolve_without_memory_stamps(
     sid = "real-db-row-trunc-sid"
     server._sessions[sid] = sess
     monkeypatch.setattr(server, "_get_db", lambda: db)
+    _patch_session_db(monkeypatch, db)
     monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
     monkeypatch.setattr(server, "_start_inflight_turn", lambda *a, **k: None)
 
@@ -19360,6 +19478,7 @@ def test_prompt_submit_row_id_misaligned_memory_role_shift_targets_real_turn(
     sid = "misalign-role-sid"
     server._sessions[sid] = sess
     monkeypatch.setattr(server, "_get_db", lambda: db)
+    _patch_session_db(monkeypatch, db)
     monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
     monkeypatch.setattr(server, "_start_inflight_turn", lambda *a, **k: None)
 

--- a/tests/tui_gateway/test_custom_provider_session_persistence.py
+++ b/tests/tui_gateway/test_custom_provider_session_persistence.py
@@ -338,7 +338,7 @@ class TestBareCustomNoBaseUrlHealsFromConfig:
 
         from tui_gateway import server as srv
 
-        monkeypatch.setattr(srv, "_get_db", lambda: _DB())
+        monkeypatch.setattr(srv, "_new_session_db", lambda _session, _label: _DB())
         monkeypatch.setattr(srv, "_resolve_model", lambda: "mimo-v2.5-pro")
 
         session = {
@@ -350,5 +350,4 @@ class TestBareCustomNoBaseUrlHealsFromConfig:
 
         persisted = captured.get("model_config") or {}
         assert persisted.get("provider") == "custom:mimo-v2.5-pro"
-
 

--- a/tests/tui_gateway/test_custom_provider_session_persistence.py
+++ b/tests/tui_gateway/test_custom_provider_session_persistence.py
@@ -280,7 +280,7 @@ class TestBareCustomNoBaseUrlHealsFromConfig:
 
         from tui_gateway import server as srv
 
-        monkeypatch.setattr(srv, "_get_db", lambda: _DB())
+        monkeypatch.setattr(srv, "_new_session_db", lambda _session, _label: _DB())
         monkeypatch.setattr(srv, "_resolve_model", lambda: "mimo-v2.5-pro")
 
         session = {
@@ -292,7 +292,6 @@ class TestBareCustomNoBaseUrlHealsFromConfig:
 
         persisted = captured.get("model_config") or {}
         assert persisted.get("provider") == "custom:mimo-v2.5-pro"
-
 
 # --- Regression: bare "custom" + no base_url + DIFFERENT default provider ----
 #
@@ -341,5 +340,3 @@ class TestModelNameRecoversEntryIdentity:
             rp.find_custom_provider_identity_by_model("hermes-ultra-sft")
             == "custom:hermes-ultra"
         )
-
-

--- a/tests/tui_gateway/test_delegation_session_lifecycle.py
+++ b/tests/tui_gateway/test_delegation_session_lifecycle.py
@@ -124,11 +124,11 @@ class TestFinalizeInterruptsOwnDelegations:
             "_sid": sid,
         }
 
-    @patch("tui_gateway.server._get_db")
-    def test_finalize_interrupts_sessions_delegations(self, mock_get_db):
+    @patch("tui_gateway.server._session_db")
+    def test_finalize_interrupts_sessions_delegations(self, mock_session_db):
         mock_db = MagicMock()
         mock_db.get_session.return_value = {"source": "tui"}
-        mock_get_db.return_value = mock_db
+        mock_session_db.return_value.__enter__.return_value = mock_db
 
         with patch("tools.async_delegation.interrupt_for_session") as mock_int:
             _finalize_session(self._make_session(), end_reason="tui_close")
@@ -138,14 +138,14 @@ class TestFinalizeInterruptsOwnDelegations:
         assert kwargs["session_key"] == "sess_A"
         assert kwargs["origin_ui_session_id"] == "tab1"
 
-    @patch("tui_gateway.server._get_db")
-    def test_viewer_of_gateway_session_only_interrupts_by_origin(self, mock_get_db):
+    @patch("tui_gateway.server._session_db")
+    def test_viewer_of_gateway_session_only_interrupts_by_origin(self, mock_session_db):
         """Closing a TUI viewer tab on a live gateway session must not kill
         the gateway's own background work — key-based interrupt is skipped,
         origin-id interrupt (this tab's own dispatches) still applies."""
         mock_db = MagicMock()
         mock_db.get_session.return_value = {"source": "telegram"}
-        mock_get_db.return_value = mock_db
+        mock_session_db.return_value.__enter__.return_value = mock_db
 
         with patch("tools.async_delegation.interrupt_for_session") as mock_int:
             _finalize_session(

--- a/tests/tui_gateway/test_finalize_session_persist.py
+++ b/tests/tui_gateway/test_finalize_session_persist.py
@@ -166,19 +166,20 @@ class TestFinalizeSessionPersist:
         # commit_memory_session should still be called
         agent.commit_memory_session.assert_called_once()
 
-    @patch("tui_gateway.server._get_db")
-    def test_db_end_session_still_called(self, mock_get_db):
+    @patch("tui_gateway.server._session_db")
+    def test_db_end_session_still_called(self, mock_session_db):
         """Existing db.end_session() path is preserved after the new code."""
         from tui_gateway.server import _finalize_session
 
         mock_db = MagicMock()
-        mock_get_db.return_value = mock_db
+        mock_session_db.return_value.__enter__.return_value = mock_db
 
         agent = _make_agent(session_id="sess_123")
         session = _make_session(agent=agent, history=[{"role": "user", "content": "x"}])
 
         _finalize_session(session, end_reason="test")
 
+        mock_session_db.assert_called_once_with(session)
         mock_db.end_session.assert_called_once_with("sess_123", "test")
 
 
@@ -216,6 +217,44 @@ class TestFinalizeSessionPersistE2E:
         # commit_memory_session runs heavy machinery we don't exercise here.
         agent.commit_memory_session = lambda *a, **k: None
         return agent
+
+    def test_default_session_finalize_uses_launch_home_not_cached_global(
+        self, tmp_path, monkeypatch
+    ):
+        """Finalization must end the row owned by the live default session."""
+        from hermes_state import SessionDB
+        import tui_gateway.server as srv
+
+        launch_home = tmp_path / "launch"
+        other_home = tmp_path / "profiles" / "other"
+        launch_home.mkdir()
+        other_home.mkdir(parents=True)
+
+        session_id = "default-finalize"
+        launch_db = SessionDB(db_path=launch_home / "state.db")
+        stale_db = SessionDB(db_path=other_home / "state.db")
+        launch_db.create_session(session_id=session_id, source="desktop")
+        stale_db.create_session(session_id=session_id, source="desktop")
+
+        monkeypatch.setattr(srv, "_hermes_home", launch_home)
+        monkeypatch.setattr(srv, "_db", stale_db)
+        monkeypatch.setattr(srv, "_db_error", None)
+
+        agent = _make_agent(session_id=session_id)
+        session = _make_session(agent=agent, session_key=session_id)
+        session["profile_home"] = None
+
+        try:
+            srv._finalize_session(session, end_reason="ws_disconnect")
+
+            launch_row = launch_db.get_session(session_id)
+            stale_row = stale_db.get_session(session_id)
+            assert launch_row["ended_at"] is not None
+            assert launch_row["end_reason"] == "ws_disconnect"
+            assert stale_row["ended_at"] is None
+        finally:
+            launch_db.close()
+            stale_db.close()
 
     def test_unflushed_turn_survives_disconnect(self, tmp_path, monkeypatch):
         """A completed turn whose transcript flush did NOT durably persist

--- a/tests/tui_gateway/test_finalize_session_persist.py
+++ b/tests/tui_gateway/test_finalize_session_persist.py
@@ -132,19 +132,20 @@ class TestFinalizeSessionPersist:
         agent._persist_session.assert_not_called()
 
 
-    @patch("tui_gateway.server._get_db")
-    def test_db_end_session_still_called(self, mock_get_db):
+    @patch("tui_gateway.server._session_db")
+    def test_db_end_session_still_called(self, mock_session_db):
         """Existing db.end_session() path is preserved after the new code."""
         from tui_gateway.server import _finalize_session
 
         mock_db = MagicMock()
-        mock_get_db.return_value = mock_db
+        mock_session_db.return_value.__enter__.return_value = mock_db
 
         agent = _make_agent(session_id="sess_123")
         session = _make_session(agent=agent, history=[{"role": "user", "content": "x"}])
 
         _finalize_session(session, end_reason="test")
 
+        mock_session_db.assert_called_once_with(session)
         mock_db.end_session.assert_called_once_with("sess_123", "test")
 
 
@@ -182,6 +183,44 @@ class TestFinalizeSessionPersistE2E:
         # commit_memory_session runs heavy machinery we don't exercise here.
         agent.commit_memory_session = lambda *a, **k: None
         return agent
+
+    def test_default_session_finalize_uses_launch_home_not_cached_global(
+        self, tmp_path, monkeypatch
+    ):
+        """Finalization must end the row owned by the live default session."""
+        from hermes_state import SessionDB
+        import tui_gateway.server as srv
+
+        launch_home = tmp_path / "launch"
+        other_home = tmp_path / "profiles" / "other"
+        launch_home.mkdir()
+        other_home.mkdir(parents=True)
+
+        session_id = "default-finalize"
+        launch_db = SessionDB(db_path=launch_home / "state.db")
+        stale_db = SessionDB(db_path=other_home / "state.db")
+        launch_db.create_session(session_id=session_id, source="desktop")
+        stale_db.create_session(session_id=session_id, source="desktop")
+
+        monkeypatch.setattr(srv, "_hermes_home", launch_home)
+        monkeypatch.setattr(srv, "_db", stale_db)
+        monkeypatch.setattr(srv, "_db_error", None)
+
+        agent = _make_agent(session_id=session_id)
+        session = _make_session(agent=agent, session_key=session_id)
+        session["profile_home"] = None
+
+        try:
+            srv._finalize_session(session, end_reason="ws_disconnect")
+
+            launch_row = launch_db.get_session(session_id)
+            stale_row = stale_db.get_session(session_id)
+            assert launch_row["ended_at"] is not None
+            assert launch_row["end_reason"] == "ws_disconnect"
+            assert stale_row["ended_at"] is None
+        finally:
+            launch_db.close()
+            stale_db.close()
 
     def test_unflushed_turn_survives_disconnect(self, tmp_path, monkeypatch):
         """A completed turn whose transcript flush did NOT durably persist

--- a/tests/tui_gateway/test_gateway_owned_session_reap.py
+++ b/tests/tui_gateway/test_gateway_owned_session_reap.py
@@ -50,33 +50,33 @@ def _make_session(session_id="sess_1"):
 
 
 class TestFinalizeSkipsGatewaySessions:
-    @patch("tui_gateway.server._get_db")
-    def test_gateway_session_not_ended(self, mock_get_db):
+    @patch("tui_gateway.server._session_db")
+    def test_gateway_session_not_ended(self, mock_session_db):
         db = MagicMock()
         db.get_session.return_value = {"id": "sess_1", "source": "telegram"}
-        mock_get_db.return_value = db
+        mock_session_db.return_value.__enter__.return_value = db
 
         _finalize_session(_make_session(), end_reason="ws_orphan_reap")
 
         db.end_session.assert_not_called()
 
-    @patch("tui_gateway.server._get_db")
-    def test_tui_session_still_ended(self, mock_get_db):
+    @patch("tui_gateway.server._session_db")
+    def test_tui_session_still_ended(self, mock_session_db):
         db = MagicMock()
         db.get_session.return_value = {"id": "sess_1", "source": "tui"}
-        mock_get_db.return_value = db
+        mock_session_db.return_value.__enter__.return_value = db
 
         _finalize_session(_make_session(), end_reason="ws_orphan_reap")
 
         db.end_session.assert_called_once_with("sess_1", "ws_orphan_reap")
 
-    @patch("tui_gateway.server._get_db")
-    def test_missing_row_still_ended(self, mock_get_db):
+    @patch("tui_gateway.server._session_db")
+    def test_missing_row_still_ended(self, mock_session_db):
         """A session with no state.db row can't be gateway-owned — keep the
         pre-existing reap behavior."""
         db = MagicMock()
         db.get_session.return_value = None
-        mock_get_db.return_value = db
+        mock_session_db.return_value.__enter__.return_value = db
 
         _finalize_session(_make_session(), end_reason="tui_close")
 

--- a/tests/tui_gateway/test_gateway_owned_session_reap.py
+++ b/tests/tui_gateway/test_gateway_owned_session_reap.py
@@ -50,24 +50,23 @@ def _make_session(session_id="sess_1"):
 
 
 class TestFinalizeSkipsGatewaySessions:
-    @patch("tui_gateway.server._get_db")
-    def test_gateway_session_not_ended(self, mock_get_db):
+    @patch("tui_gateway.server._session_db")
+    def test_gateway_session_not_ended(self, mock_session_db):
         db = MagicMock()
         db.get_session.return_value = {"id": "sess_1", "source": "telegram"}
-        mock_get_db.return_value = db
+        mock_session_db.return_value.__enter__.return_value = db
 
         _finalize_session(_make_session(), end_reason="ws_orphan_reap")
 
         db.end_session.assert_not_called()
 
-
-    @patch("tui_gateway.server._get_db")
-    def test_missing_row_still_ended(self, mock_get_db):
+    @patch("tui_gateway.server._session_db")
+    def test_missing_row_still_ended(self, mock_session_db):
         """A session with no state.db row can't be gateway-owned — keep the
         pre-existing reap behavior."""
         db = MagicMock()
         db.get_session.return_value = None
-        mock_get_db.return_value = db
+        mock_session_db.return_value.__enter__.return_value = db
 
         _finalize_session(_make_session(), end_reason="tui_close")
 

--- a/tests/tui_gateway/test_session_db_ownership_teardown.py
+++ b/tests/tui_gateway/test_session_db_ownership_teardown.py
@@ -1,4 +1,4 @@
-"""Dedicated profile ``SessionDB`` handles must be closed by whoever ends up owning them.
+"""Dedicated session ``SessionDB`` handles must be closed by their final owner.
 
 Companion to ``test_session_resume_db_ownership.py``, which pins the paths that
 return BEFORE a handle reaches an agent. This file pins the other half — the two
@@ -19,8 +19,9 @@ gaps that survived that change:
     branch handler and the compute host all open a dedicated handle, pass it to
     ``_make_agent``, and had no close on their failure paths.
 
-The direction that must NOT regress is asserted everywhere: the shared launch
-handle is never closed, and a handle that WAS transferred is not closed twice.
+The direction that must NOT regress is asserted everywhere: the process-global
+launch handle is never closed, and a handle that WAS transferred is not closed
+twice.
 """
 
 from __future__ import annotations
@@ -82,10 +83,9 @@ def test_close_closes_a_dedicated_handle_it_owns():
 def test_close_never_closes_a_shared_handle():
     """The direction that must not regress.
 
-    Almost every agent is handed the SHARED launch handle, which outlives it and
-    is used by every other live session. Closing that on teardown would break
-    every other chat in the gateway, so ownership defaults to False and only the
-    dedicated-open sites set it.
+    Process-global queries still use a SHARED launch handle that outlives every
+    agent. Closing it from any teardown would break later gateway operations,
+    so ownership defaults to False and only dedicated-open sites set it.
     """
     db = _RecordingDB()
     agent = _bare_agent(_session_db=db, _owns_session_db=False)
@@ -369,18 +369,24 @@ def test_deferred_build_closes_the_handle_when_the_session_is_reaped_midbuild(
     assert session["agent"]._owns_session_db is False
 
 
-def test_deferred_build_never_opens_or_closes_for_the_launch_profile(
+def test_deferred_build_transfers_launch_profile_handle(
     build_env, registered, monkeypatch
 ):
-    """No profile scope -> no dedicated handle; the shared one is untouched."""
-    monkeypatch.setattr(
-        server,
-        "_make_agent",
-        lambda *a, **k: types.SimpleNamespace(_session_db=None, _owns_session_db=False),
-    )
+    """Launch sessions also use a dedicated, explicitly rooted handle."""
+
+    def _fake_make_agent(*_args, session_db=None, **_kwargs):
+        return types.SimpleNamespace(
+            _session_db=session_db,
+            _owns_session_db=False,
+        )
+
+    monkeypatch.setattr(server, "_make_agent", _fake_make_agent)
     sid, session = "sid-launch", _session(None)
     registered(sid, session)
 
     _run_build(sid, session)
 
-    assert build_env.opened == []
+    assert len(build_env.opened) == 1
+    assert build_env.opened[0].db_path == server._session_db_path(session)
+    assert build_env.opened[0].closed == 0
+    assert session["agent"]._owns_session_db is True

--- a/tests/tui_gateway/test_session_git_metadata_generation.py
+++ b/tests/tui_gateway/test_session_git_metadata_generation.py
@@ -29,7 +29,7 @@ def test_cwd_claim_precedes_probe_and_generation_reaches_publish(monkeypatch):
             )
             return True
 
-    monkeypatch.setattr(server, "_get_db", lambda: DB())
+    monkeypatch.setattr(server, "_new_session_db", lambda *_a, **_k: DB())
     monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
     monkeypatch.setattr(
         server,
@@ -59,7 +59,7 @@ def test_cwd_claim_precedes_probe_and_generation_reaches_publish(monkeypatch):
 
 def test_missing_db_claim_never_starts_git_probe(monkeypatch):
     probed = []
-    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_new_session_db", lambda *_a, **_k: None)
     monkeypatch.setattr(
         server, "_git_branch_for_cwd", lambda cwd: probed.append(cwd)
     )

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -645,20 +645,20 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
     _tui_owns_lifecycle = True
     if session_id:
         try:
-            db = _get_db()
-            if db is not None:
-                # Don't end gateway-originated sessions — the gateway owns
-                # their lifecycle.  The TUI is a viewer, not the owner.
-                # Ending a gateway session in state.db triggers a Groundhog
-                # Day routing loop: the gateway's #54878 self-heal detects
-                # the stale entry, recovers to the parent session, context
-                # compression splits back to the reaped child, and the cycle
-                # repeats on every inbound message.  (#60609)
-                row = db.get_session(session_id)
-                source = (row or {}).get("source", "")
-                _tui_owns_lifecycle = not _is_gateway_owned_source(source)
-                if _tui_owns_lifecycle:
-                    db.end_session(session_id, end_reason)
+            with _session_db(session) as db:
+                if db is not None:
+                    # Don't end gateway-originated sessions — the gateway owns
+                    # their lifecycle.  The TUI is a viewer, not the owner.
+                    # Ending a gateway session in state.db triggers a Groundhog
+                    # Day routing loop: the gateway's #54878 self-heal detects
+                    # the stale entry, recovers to the parent session, context
+                    # compression splits back to the reaped child, and the cycle
+                    # repeats on every inbound message.  (#60609)
+                    row = db.get_session(session_id)
+                    source = (row or {}).get("source", "")
+                    _tui_owns_lifecycle = not _is_gateway_owned_source(source)
+                    if _tui_owns_lifecycle:
+                        db.end_session(session_id, end_reason)
         except Exception:
             pass
 
@@ -1572,15 +1572,9 @@ def _start_agent_build(sid: str, session: dict) -> None:
             # Build against the session's profile (global-remote): bind its
             # HERMES_HOME so config/skills/model resolve to it, and hand the
             # agent that profile's db so turns persist to the right state.db.
-            session_db = None
             if profile_home:
                 home_token = set_hermes_home_override(profile_home)
-                try:
-                    from hermes_state import SessionDB
-
-                    session_db = SessionDB(db_path=Path(profile_home) / "state.db")
-                except Exception:
-                    session_db = None
+            session_db = _new_session_db(current, "agent build")
             try:
                 # Lazy-resumed (watch) sessions carry the stored conversation
                 # id — pass it through so the upgrade continues that session
@@ -1890,6 +1884,24 @@ def _session_source(session: dict | None) -> str:
     return _resolve_session_platform()
 
 
+def _session_db_path(session: dict) -> Path:
+    """Return the state.db path that owns this live session."""
+    profile_home = session.get("profile_home")
+    if profile_home:
+        return Path(profile_home) / "state.db"
+    return Path(_hermes_home) / "state.db"
+
+
+def _new_session_db(session: dict, label: str):
+    from hermes_state import SessionDB
+
+    try:
+        return SessionDB(db_path=_session_db_path(session))
+    except Exception:
+        logger.debug("failed to open %s db for session", label, exc_info=True)
+        return None
+
+
 def _register_session_cwd(session: dict | None) -> None:
     if not session:
         return
@@ -1921,22 +1933,10 @@ def _ensure_session_db_row(session: dict) -> None:
     key = session.get("session_key")
     if not key:
         return
-    # Persist into the session's own profile db (global remote mode), not the
-    # launch profile's — otherwise the row lands in the wrong state.db, the
-    # unified list mis-tags it, and resume 404s ("session not found").
-    profile_home = session.get("profile_home")
-    if profile_home:
-        from hermes_state import SessionDB
-
-        try:
-            db = SessionDB(db_path=Path(profile_home) / "state.db")
-        except Exception:
-            logger.debug("failed to open profile db for session row", exc_info=True)
-            return
-        close_db = True
-    else:
-        db = _get_db()
-        close_db = False
+    # Persist into the session's own DB. Even the launch/default profile uses
+    # an explicit path here so a stale process-global _get_db() handle cannot
+    # write this session into another profile's state.db.
+    db = _new_session_db(session, "row")
     if db is None:
         return
     # The session's own model/effort/fast pick — the composer override shipped on
@@ -2004,11 +2004,10 @@ def _ensure_session_db_row(session: dict) -> None:
     except Exception:
         logger.debug("failed to persist desktop session row", exc_info=True)
     finally:
-        if close_db:
-            try:
-                db.close()
-            except Exception:
-                pass
+        try:
+            db.close()
+        except Exception:
+            pass
 
 
 def _persist_branch_seed(session: dict) -> None:
@@ -2044,26 +2043,15 @@ def _persist_branch_seed(session: dict) -> None:
 def _session_db(session: dict):
     """Yield the SessionDB that owns this session's row (profile-aware).
 
-    Mirrors :func:`_ensure_session_db_row`: a remote/profile session persists
-    into its own profile's ``state.db`` (a fresh handle we close on exit);
-    everything else borrows the shared ``_get_db()`` handle (left open). Yields
-    None when the db is unavailable.
+    Mirrors :func:`_ensure_session_db_row`: session-owned writes always use an
+    explicit ``state.db`` path derived from the live session/profile, including
+    launch-profile sessions. Yields None when the db is unavailable.
     """
-    db, close_db = None, False
-    profile_home = session.get("profile_home")
-    if profile_home:
-        from hermes_state import SessionDB
-
-        try:
-            db, close_db = SessionDB(db_path=Path(profile_home) / "state.db"), True
-        except Exception:
-            logger.debug("failed to open profile db for session", exc_info=True)
-    else:
-        db = _get_db()
+    db = _new_session_db(session, "profile")
     try:
         yield db
     finally:
-        if close_db and db is not None:
+        if db is not None:
             with contextlib.suppress(Exception):
                 db.close()
 
@@ -4752,7 +4740,10 @@ def _reset_session_agent(sid: str, session: dict) -> dict:
         # reset doesn't silently revert to global config (or to a model
         # another session set). See the cross-session-contamination note in
         # _apply_model_switch.
-        reset_kw = {"model_override": session.get("model_override")}
+        reset_kw = {
+            "model_override": session.get("model_override"),
+            "session_db": _new_session_db(session, "agent reset"),
+        }
         old_reasoning = getattr(session.get("agent"), "reasoning_config", None)
         if old_reasoning is None:
             old_reasoning = session.get("create_reasoning_override")
@@ -4921,11 +4912,14 @@ def _resolve_runtime_with_fallback(
         raise
 
 
+_SESSION_DB_UNSET = object()
+
+
 def _make_agent(
     sid: str,
     key: str,
     session_id: str | None = None,
-    session_db=None,
+    session_db=_SESSION_DB_UNSET,
     model_override: dict | str | None = None,
     provider_override: str | None = None,
     reasoning_config_override: dict | None = None,
@@ -5095,7 +5089,7 @@ def _make_agent(
         provider_data_collection=_pr.get("data_collection"),
         platform=_resolve_agent_platform(platform_override),
         session_id=session_id or key,
-        session_db=session_db if session_db is not None else _get_db(),
+        session_db=_get_db() if session_db is _SESSION_DB_UNSET else session_db,
         ephemeral_system_prompt=system_prompt or None,
         checkpoints_enabled=is_truthy_value(os.environ.get("HERMES_TUI_CHECKPOINTS")),
         pass_session_id=is_truthy_value(os.environ.get("HERMES_TUI_PASS_SESSION_ID")),

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -818,8 +818,8 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
     _tui_owns_lifecycle = True
     if session_id:
         try:
-            # End the row in the *session's* profile state.db (app-global
-            # remote mode), not the launch profile's shared handle.
+            # End the row in the state.db owned by this live session, not a
+            # possibly stale process-global launch-profile handle.
             with _session_db(session) as db:
                 if db is not None:
                     # Don't end gateway-originated sessions — the gateway owns
@@ -1406,7 +1406,9 @@ def _get_db():
         from hermes_state import SessionDB
 
         try:
-            _db = SessionDB()
+            # This is the process-global launch-profile handle. An ambient
+            # per-session HERMES_HOME override must never redirect it.
+            _db = SessionDB(db_path=Path(_hermes_home) / "state.db")
             _db_error = None
         except Exception as exc:
             _db_error = str(exc)
@@ -2331,7 +2333,6 @@ def _start_agent_build(sid: str, session: dict) -> None:
             # Build against the session's profile (global-remote): bind its
             # HERMES_HOME so config/skills/model resolve to it, and hand the
             # agent that profile's db so turns persist to the right state.db.
-            session_db = None
             if profile_home:
                 home_token = set_hermes_home_override(profile_home)
                 try:
@@ -2340,17 +2341,6 @@ def _start_agent_build(sid: str, session: dict) -> None:
                     secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
                 except Exception:
                     pass
-                try:
-                    from hermes_state import SessionDB
-
-                    # DEDICATED handle — ours until _transfer_db_to_agent hands
-                    # it to the built agent in the finally below. Every path
-                    # that leaves this build without that transfer (the except
-                    # below, and a session reaped mid-build) must close it.
-                    session_db = SessionDB(db_path=Path(profile_home) / "state.db")
-                    owns_db = True
-                except Exception:
-                    session_db = None
 
             try:
                 from tui_gateway.entry import ensure_mcp_discovery_started
@@ -2359,6 +2349,8 @@ def _start_agent_build(sid: str, session: dict) -> None:
             except Exception:
                 logger.warning("MCP discovery startup failed", exc_info=True)
 
+            session_db = _new_session_db(current, "agent build")
+            owns_db = session_db is not None
             try:
                 # Lazy-resumed (watch) sessions carry the stored conversation
                 # id — pass it through so the upgrade continues that session
@@ -2492,7 +2484,7 @@ def _start_agent_build(sid: str, session: dict) -> None:
                     unregister_gateway_notify(key)
                 except Exception:
                     pass
-            # Dedicated profile handle: hand it to the agent that will actually
+            # Dedicated session handle: hand it to the agent that will actually
             # be torn down, or close it here when no such agent exists. Both
             # non-transfer cases are real: the except above (build raised, so
             # nothing holds the handle) and `replaced` (the session was reaped
@@ -2892,6 +2884,24 @@ def _session_source(session: dict | None) -> str:
     return _resolve_session_platform()
 
 
+def _session_db_path(session: dict) -> Path:
+    """Return the state.db path that owns this live session."""
+    profile_home = session.get("profile_home")
+    if profile_home:
+        return Path(profile_home) / "state.db"
+    return Path(_hermes_home) / "state.db"
+
+
+def _new_session_db(session: dict, label: str):
+    from hermes_state import SessionDB
+
+    try:
+        return SessionDB(db_path=_session_db_path(session))
+    except Exception:
+        logger.debug("failed to open %s db for session", label, exc_info=True)
+        return None
+
+
 def _register_session_cwd(session: dict | None) -> None:
     if not session:
         return
@@ -2931,22 +2941,11 @@ def _ensure_session_db_row(session: dict) -> None:
     key = session.get("session_key")
     if not key:
         return
-    # Persist into the session's own profile db (global remote mode), not the
-    # launch profile's — otherwise the row lands in the wrong state.db, the
-    # unified list mis-tags it, and resume 404s ("session not found").
     profile_home = session.get("profile_home")
-    if profile_home:
-        from hermes_state import SessionDB
-
-        try:
-            db = SessionDB(db_path=Path(profile_home) / "state.db")
-        except Exception:
-            logger.debug("failed to open profile db for session row", exc_info=True)
-            return
-        close_db = True
-    else:
-        db = _get_db()
-        close_db = False
+    # Persist into the session's own DB. Even the launch/default profile uses
+    # an explicit path here so a stale process-global _get_db() handle cannot
+    # write this session into another profile's state.db.
+    db = _new_session_db(session, "row")
     if db is None:
         return
     # The session's own model/effort/fast pick — the composer override shipped on
@@ -3039,11 +3038,10 @@ def _ensure_session_db_row(session: dict) -> None:
             raise
         logger.debug("failed to persist desktop session row", exc_info=True)
     finally:
-        if close_db:
-            try:
-                db.close()
-            except Exception:
-                pass
+        try:
+            db.close()
+        except Exception:
+            pass
 
 
 def _persist_branch_seed(session: dict) -> None:
@@ -3113,26 +3111,15 @@ def _persist_branch_seed(session: dict) -> None:
 def _session_db(session: dict):
     """Yield the SessionDB that owns this session's row (profile-aware).
 
-    Mirrors :func:`_ensure_session_db_row`: a remote/profile session persists
-    into its own profile's ``state.db`` (a fresh handle we close on exit);
-    everything else borrows the shared ``_get_db()`` handle (left open). Yields
-    None when the db is unavailable.
+    Mirrors :func:`_ensure_session_db_row`: session-owned writes always use an
+    explicit ``state.db`` path derived from the live session/profile, including
+    launch-profile sessions. Yields None when the db is unavailable.
     """
-    db, close_db = None, False
-    profile_home = session.get("profile_home")
-    if profile_home:
-        from hermes_state import SessionDB
-
-        try:
-            db, close_db = SessionDB(db_path=Path(profile_home) / "state.db"), True
-        except Exception:
-            logger.debug("failed to open profile db for session", exc_info=True)
-    else:
-        db = _get_db()
+    db = _new_session_db(session, "profile")
     try:
         yield db
     finally:
-        if close_db and db is not None:
+        if db is not None:
             with contextlib.suppress(Exception):
                 db.close()
 
@@ -6840,6 +6827,7 @@ def _preview_restart_callbacks(parent: str, task_id: str) -> dict:
 
 def _reset_session_agent(sid: str, session: dict) -> dict:
     tokens = _set_session_context(session["session_key"])
+    session_db = None
     try:
         # /new is a full conversation boundary: session-scoped runtime
         # overrides (/model, /reasoning, /fast) do NOT carry forward — the
@@ -6852,12 +6840,23 @@ def _reset_session_agent(sid: str, session: dict) -> dict:
         session.pop("create_reasoning_override", None)
         session.pop("create_service_tier_override", None)
         session.pop("one_turn_model_restore", None)
+        session_db = _new_session_db(session, "agent reset")
         new_agent = _make_agent(
             sid,
             session["session_key"],
             session_id=session["session_key"],
+            session_db=session_db,
             platform_override=_session_source(session),
         )
+        if session_db is not None and not _transfer_db_to_agent(new_agent, session_db):
+            with contextlib.suppress(Exception):
+                session_db.close()
+            session_db = None
+    except Exception:
+        if session_db is not None:
+            with contextlib.suppress(Exception):
+                session_db.close()
+        raise
     finally:
         _clear_session_context(tokens)
     session["agent"] = new_agent
@@ -7017,11 +7016,14 @@ def _resolve_runtime_with_fallback(
         raise
 
 
+_SESSION_DB_UNSET = object()
+
+
 def _make_agent(
     sid: str,
     key: str,
     session_id: str | None = None,
-    session_db=None,
+    session_db=_SESSION_DB_UNSET,
     model_override: dict | str | None = None,
     provider_override: str | None = None,
     reasoning_config_override: dict | None = None,
@@ -7194,7 +7196,7 @@ def _make_agent(
         provider_data_collection=_pr.get("data_collection"),
         platform=_resolve_agent_platform(platform_override),
         session_id=session_id or key,
-        session_db=session_db if session_db is not None else _get_db(),
+        session_db=_get_db() if session_db is _SESSION_DB_UNSET else session_db,
         ephemeral_system_prompt=system_prompt or None,
         checkpoints_enabled=is_truthy_value(os.environ.get("HERMES_TUI_CHECKPOINTS")),
         pass_session_id=is_truthy_value(os.environ.get("HERMES_TUI_PASS_SESSION_ID")),


### PR DESCRIPTION
## What does this PR do?

Fixes Desktop/Dashboard default-profile session persistence so session-owned writes do not reuse a stale process-global `SessionDB` handle. In app-global remote mode one backend can serve multiple profiles; if `_get_db()` had already cached another profile's `state.db`, default/launch-profile sessions could run under the correct profile while their session row/messages landed in the other profile DB.

This PR derives the owning DB path from the live session every time session-owned persistence is needed:

- default/launch profile -> launch `_hermes_home/state.db`
- non-default profile -> `profile_home/state.db`

`_get_db()` remains available for process-global launch-profile/listing operations, but first-row creation, profile-aware `_session_db()`, deferred agent build, and `/new` reset rebuilds now use explicit session DB handles.

## Related Issue

Fixes #59566

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tui_gateway/server.py`
  - Added `_session_db_path()` and `_new_session_db()` for session-derived `state.db` ownership.
  - Updated `_ensure_session_db_row()` and `_session_db()` to use explicit session DB handles for both default and non-default profiles.
  - Updated deferred agent build and reset rebuild paths to pass the same session-derived DB into `AIAgent`.
  - Added a sentinel for `_make_agent(session_db=...)` so an explicitly passed `None` cannot silently fall back to `_get_db()`.
- `tests/test_tui_gateway_server.py`
  - Added a stale global `_db` regression test proving a default session writes to launch home, not the cached other-profile DB.
  - Extended the deferred agent build test to assert default sessions receive a launch-home `SessionDB`.

## How to Test

1. Reproduce the old failure shape by preloading `tui_gateway.server._db` with another profile's `SessionDB`, then persisting a default-profile session row.
2. Verify the row lands in launch/default `state.db` and not the stale cached profile DB.
3. Run the targeted test slice:

```bash
./scripts/run_tests.sh tests/test_tui_gateway_server.py -q -k 'ensure_session_db_row or default_session_db_row or start_agent_build_passes_session_model_override or session_cwd_set_profile_session_updates_profile_db or session_resume_profile_uses_profile_db_cwd'
python3 -m py_compile tui_gateway/server.py hermes_state.py
```

Manual before/after probe after the fix:

```text
row_in_stale_other_db=False
row_in_default_db=True
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS / local Hermes worktree

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — path handling uses `Path` consistently with existing code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Targeted validation:

```text
9 passed, 0 failed
```

Syntax validation:

```text
python3 -m py_compile tui_gateway/server.py hermes_state.py
```

One broader check was also run:

```text
./scripts/run_tests.sh tests/test_tui_gateway_server.py -q
306 passed, 1 failed
```

The single failure is an unrelated `browser.manage` Chromium launch-hint assertion on this host; the failing assertion is not in the session/profile DB path touched by this PR.
