### PR TITLE
fix(agent): preserve gateway metadata across compression rotation

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -741,6 +741,11 @@ def compress_context(
                         agent._flush_messages_to_session_db(messages)
                     except Exception:
                         pass  # best-effort — don't block compression on a flush error
+                    parent_session_row = {}
+                    try:
+                        parent_session_row = agent._session_db.get_session(agent.session_id) or {}
+                    except Exception:
+                        parent_session_row = {}
                     # Propagate title to the new session with auto-numbering
                     old_title = agent._session_db.get_session_title(agent.session_id)
                     agent._session_db.end_session(agent.session_id, "compression")
@@ -771,12 +776,28 @@ def compress_context(
                         pass
                     agent._session_db_created = False
                     try:
+                        child_session_kwargs = {
+                            key: parent_session_row.get(key)
+                            for key in (
+                                "user_id",
+                                "session_key",
+                                "chat_id",
+                                "chat_type",
+                                "thread_id",
+                            )
+                            if parent_session_row.get(key) is not None
+                        }
                         agent._session_db.create_session(
                             session_id=agent.session_id,
-                            source=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                            source=(
+                                agent.platform
+                                or parent_session_row.get("source")
+                                or os.environ.get("HERMES_SESSION_SOURCE", "cli")
+                            ),
                             model=agent.model,
                             model_config=agent._session_init_model_config,
                             parent_session_id=old_session_id,
+                            **child_session_kwargs,
                         )
                     except Exception as _cs_err:
                         # The child row could not be created (e.g. FK constraint,

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -130,3 +130,29 @@ class TestPlatformForwardedAtBoundary:
         kwargs = calls[-1].kwargs
         assert kwargs.get("platform") == "telegram"
         assert kwargs.get("boundary_reason") == "compression"
+
+
+class TestGatewayMetadataFollowsRotation:
+    def test_gateway_origin_metadata_is_copied_to_compression_child(self, tmp_path: Path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        parent = "PARENT_GATEWAY_META_ROT"
+        origin = {
+            "source": "telegram",
+            "user_id": "user-123",
+            "session_key": "agent:main:telegram:dm:chat-456",
+            "chat_id": "chat-456",
+            "chat_type": "dm",
+            "thread_id": "topic-789",
+        }
+        db.create_session(parent, **origin)
+        agent = _build_agent_with_db(db, parent, platform="telegram")
+
+        agent._compress_context(_msgs(), "sys", approx_tokens=120_000)
+
+        child = agent.session_id
+        assert child != parent
+        child_row = db.get_session(child)
+        assert child_row is not None
+        assert child_row["parent_session_id"] == parent
+        for key, value in origin.items():
+            assert child_row[key] == value


### PR DESCRIPTION
## What does this PR do?

Preserves gateway origin metadata when legacy/fallback context compression rotates a session into a continuation child.

Normal gateway session creation records `user_id`, `session_key`, `chat_id`, `chat_type`, and `thread_id` so persisted `/sessions` and `/resume` checks can prove the same caller/chat after a session is inactive. The compression rotation path created the child row with only `source`, `model`, and `parent_session_id`, so the stricter resume scoping correctly failed closed for compressed continuations.

This keeps in-place compaction unchanged and only copies existing parent-row gateway provenance into the rotation child.

## Related Issue

Fixes #59527

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/conversation_compression.py`
  - Reads the parent session row before rotation ends the parent.
  - Copies `user_id`, `session_key`, `chat_id`, `chat_type`, and `thread_id` to the continuation child row when present.
  - Falls back to the parent row `source` when `agent.platform` is absent.
- `tests/agent/test_compression_rotation_state.py`
  - Adds a regression test proving a Telegram-origin parent session keeps all gateway metadata on the compression child.

## How to Test

1. Reproduce the old behavior by forcing compression rotation from a Telegram-origin parent session: the child row had `user_id/session_key/chat_id/chat_type/thread_id = NULL`.
2. Apply this patch and run the regression test.
3. Confirm existing gateway resume scoping still passes.

Validation run locally on macOS/Darwin arm64 with the lane `.venv` Python 3.11.15:

```bash
.hermes/with-env.sh pytest tests/agent/test_compression_rotation_state.py -q
.hermes/with-env.sh pytest tests/gateway/test_resume_command.py -q
python -m py_compile agent/conversation_compression.py tests/agent/test_compression_rotation_state.py
git diff --check
```

Results:

```text
4 passed
52 passed
py_compile passed
git diff --check clean
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS/Darwin arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — no platform-specific APIs added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before fix, the targeted regression failed with the child row missing ownership metadata:

```text
AssertionError: assert None == 'user-123'
```

After fix, a direct state.db probe showed the compression child row contains:

```text
{'source': 'telegram', 'user_id': 'user-123', 'session_key': 'agent:main:telegram:dm:chat-456', 'chat_id': 'chat-456', 'chat_type': 'dm', 'thread_id': 'thread-789', 'parent_session_id': 'parent_gateway_meta'}
```
