### PR TITLE
feat(cli): add --compact flag to 'hermes cron list'

### DIFF
--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -1771,10 +1771,11 @@ def _profile_status(_engine: HermesConsoleEngine, args: list[str]) -> str:
 def _cron_list(_engine: HermesConsoleEngine, args: list[str]) -> str:
     parser = _ArgumentParser(prog="cron list", add_help=False)
     parser.add_argument("--all", action="store_true")
+    parser.add_argument("--compact", action="store_true")
     ns = parser.parse_args(args)
     from hermes_cli.cron import cron_list
 
-    return _capture_output(lambda: cron_list(show_all=ns.all))
+    return _capture_output(lambda: cron_list(show_all=ns.all, compact=ns.compact))
 
 
 def _cron_status(_engine: HermesConsoleEngine, args: list[str]) -> str:

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -96,7 +96,7 @@ def _warn_if_gateway_not_running() -> None:
     print(color("     Check status:  hermes cron status", Colors.DIM))
 
 
-def cron_list(show_all: bool = False):
+def cron_list(show_all: bool = False, compact: bool = False):
     """List all scheduled jobs."""
     from cron.jobs import list_jobs
 
@@ -105,6 +105,27 @@ def cron_list(show_all: bool = False):
     if not jobs:
         print(color("No scheduled jobs.", Colors.DIM))
         print(color("Create one with 'hermes cron create ...' or the /cron command in chat.", Colors.DIM))
+        return
+
+    if compact:
+        # Compact one-line-per-job format
+        for job in jobs:
+            job_id = job.get("id", "?")[:8]
+            name = job.get("name", "") or ""
+            schedule = job.get("schedule_display", job.get("schedule", {}).get("value", "?"))
+            state = job.get("state", "scheduled" if job.get("enabled", True) else "paused")
+            next_run = job.get("next_run_at", "?")[:16] if job.get("next_run_at") else "?"
+            if state == "paused":
+                status = color("⏸", Colors.YELLOW)
+            elif state == "completed":
+                status = color("✓", Colors.BLUE)
+            elif job.get("enabled", True):
+                status = color("▶", Colors.GREEN)
+            else:
+                status = color("⛔", Colors.RED)
+            print(f"  {status} {color(job_id, Colors.YELLOW)} {name[:30]:30s} {schedule:15s} next:{next_run}")
+        print()
+        _warn_if_gateway_not_running()
         return
 
     print()


### PR DESCRIPTION
## Summary

Add `--compact` flag to `hermes cron list` for a concise one-job-per-line view.

## Changes

| File | Δ |
|------|---|
| `hermes_cli/cron.py` | +19 lines (compact rendering path) |
| `hermes_cli/console_engine.py` | +2 lines (--compact arg parsing) |

**Usage:**
```bash
hermes cron list --compact
▶ abc12345  Monitor merge dos PRs     every 30m      next:2026-07-06T11:22
▶ def67890  Daily briefing             0 9 * * *     next:2026-07-07T09:00
```

Compared to the full table format, compact is better for scanning many jobs quickly.