### PR TITLE
fix(dashboard): show full session history safely

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -8102,14 +8102,23 @@ async def get_session_latest_descendant(session_id: str):
     }
 
 @app.get("/api/sessions/{session_id}/messages")
-async def get_session_messages(session_id: str, profile: Optional[str] = None):
+async def get_session_messages(
+    session_id: str,
+    profile: Optional[str] = None,
+    include_compacted: bool = False,
+    include_inactive: bool = False,
+):
     db = _open_session_db_for_profile(profile)
     try:
         sid = db.resolve_session_id(session_id)
         if not sid:
             raise HTTPException(status_code=404, detail="Session not found")
         sid = db.resolve_resume_session_id(sid)
-        messages = db.get_messages(sid)
+        messages = db.get_messages(
+            sid,
+            include_inactive=include_inactive,
+            include_compacted=include_compacted,
+        )
         return {"session_id": sid, "messages": messages}
     finally:
         db.close()

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3701,19 +3701,29 @@ class SessionDB:
 
 
     def get_messages(
-        self, session_id: str, include_inactive: bool = False
+        self,
+        session_id: str,
+        include_inactive: bool = False,
+        include_compacted: bool = False,
     ) -> List[Dict[str, Any]]:
         """Load messages for a session in insertion order.
 
         By default only active messages are returned. Pass
-        ``include_inactive=True`` to load soft-deleted rows (e.g. for
-        audit / debug views of rewound history). See
+        ``include_compacted=True`` to include durable compaction-archived rows
+        (``active=0, compacted=1``) while still excluding user-rewound/undone
+        rows (``active=0, compacted=0``). Pass ``include_inactive=True`` to load
+        every soft-deleted row (e.g. for low-level audit / debug views). See
         :meth:`rewind_to_message` for the soft-delete mechanic.
 
         Ordered by AUTOINCREMENT id (true insertion order) rather than
         timestamp — see c03acca50 for the WSL2 clock-regression rationale.
         """
-        active_clause = "" if include_inactive else " AND active = 1"
+        if include_inactive:
+            active_clause = ""
+        elif include_compacted:
+            active_clause = " AND (active = 1 OR compacted = 1)"
+        else:
+            active_clause = " AND active = 1"
         with self._lock:
             cursor = self._conn.execute(
                 "SELECT * FROM messages WHERE session_id = ?"

--- a/tests/hermes_cli/test_session_messages_history.py
+++ b/tests/hermes_cli/test_session_messages_history.py
@@ -1,0 +1,86 @@
+import asyncio
+
+from hermes_cli import web_server
+from hermes_state import SessionDB
+
+
+def test_get_messages_include_compacted_keeps_compression_history_but_not_rewound(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("telegram_session", source="telegram")
+    db.append_message("telegram_session", role="user", content="original prompt")
+    db.append_message("telegram_session", role="assistant", content="original answer")
+
+    db.archive_and_compact(
+        "telegram_session",
+        [
+            {"role": "user", "content": "current prompt"},
+            {"role": "assistant", "content": "current answer"},
+        ],
+    )
+    rewound_id = db.append_message("telegram_session", role="user", content="undone prompt")
+    db._execute_write(
+        lambda conn: conn.execute(
+            "UPDATE messages SET active = 0, compacted = 0 WHERE id = ?",
+            (rewound_id,),
+        )
+    )
+
+    live = [m["content"] for m in db.get_messages("telegram_session")]
+    history = [
+        m["content"]
+        for m in db.get_messages("telegram_session", include_compacted=True)
+        if m["role"] in {"user", "assistant"}
+    ]
+    audit = [m["content"] for m in db.get_messages("telegram_session", include_inactive=True)]
+
+    assert live == ["current prompt", "current answer"]
+    assert history == [
+        "original prompt",
+        "original answer",
+        "current prompt",
+        "current answer",
+    ]
+    assert "undone prompt" in audit
+    assert "undone prompt" not in history
+
+    db.close()
+
+
+class _FakeDB:
+    def __init__(self):
+        self.calls = []
+        self.closed = False
+
+    def resolve_session_id(self, session_id):
+        return f"resolved-{session_id}"
+
+    def resolve_resume_session_id(self, session_id):
+        return f"tip-{session_id}"
+
+    def get_messages(self, session_id, **kwargs):
+        self.calls.append((session_id, kwargs))
+        return [{"role": "user", "content": "hello"}]
+
+    def close(self):
+        self.closed = True
+
+
+def test_web_session_messages_endpoint_accepts_compacted_history_flag(monkeypatch):
+    fake = _FakeDB()
+    monkeypatch.setattr(web_server, "_open_session_db_for_profile", lambda profile=None: fake)
+
+    response = asyncio.run(
+        web_server.get_session_messages("abc", include_compacted=True)
+    )
+
+    assert response == {
+        "session_id": "tip-resolved-abc",
+        "messages": [{"role": "user", "content": "hello"}],
+    }
+    assert fake.calls == [
+        (
+            "tip-resolved-abc",
+            {"include_inactive": False, "include_compacted": True},
+        )
+    ]
+    assert fake.closed is True

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -76,7 +76,7 @@ import ConfigPage from "@/pages/ConfigPage";
 import DocsPage from "@/pages/DocsPage";
 import EnvPage from "@/pages/EnvPage";
 import FilesPage from "@/pages/FilesPage";
-import SessionsPage from "@/pages/SessionsPage";
+import SessionsPage, { SessionDetailPage } from "@/pages/SessionsPage";
 import LogsPage from "@/pages/LogsPage";
 import AnalyticsPage from "@/pages/AnalyticsPage";
 import ModelsPage from "@/pages/ModelsPage";
@@ -133,6 +133,7 @@ const CHAT_NAV_ITEM: NavItem = {
 const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/": RootRedirect,
   "/sessions": SessionsPage,
+  "/sessions/:sessionId": SessionDetailPage,
   "/files": FilesPage,
   "/analytics": AnalyticsPage,
   "/models": ModelsPage,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -361,10 +361,22 @@ export const api = {
         profile,
       ),
     ),
-  getSessionMessages: (id: string, profile = getManagementProfile()) =>
-    fetchJSON<SessionMessagesResponse>(
-      appendProfileParam(`/api/sessions/${encodeURIComponent(id)}/messages`, profile),
-    ),
+  getSessionMessages: (
+    id: string,
+    profile = getManagementProfile(),
+    options?: { includeCompacted?: boolean; includeInactive?: boolean },
+  ) => {
+    const params = new URLSearchParams();
+    if (options?.includeCompacted) params.set("include_compacted", "true");
+    if (options?.includeInactive) params.set("include_inactive", "true");
+    const query = params.toString();
+    return fetchJSON<SessionMessagesResponse>(
+      appendProfileParam(
+        `/api/sessions/${encodeURIComponent(id)}/messages${query ? `?${query}` : ""}`,
+        profile,
+      ),
+    );
+  },
   getSessionDetail: (id: string, profile = getManagementProfile()) =>
     fetchJSON<SessionInfo>(
       appendProfileParam(`/api/sessions/${encodeURIComponent(id)}`, profile),
@@ -1734,7 +1746,10 @@ export interface TelegramOnboardingApplyResponse {
 
 export interface SessionMessage {
   role: "user" | "assistant" | "system" | "tool";
-  content: string | null;
+  content: string | null | Array<
+    | string
+    | { type?: string; text?: string; image_url?: { url?: string } | string; [key: string]: unknown }
+  >;
   tool_calls?: Array<{
     id: string;
     function: { name: string; arguments: string };

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -5,7 +5,7 @@ import {
   useCallback,
   useRef,
 } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import {
   AlertTriangle,
   CheckCircle2,
@@ -186,6 +186,24 @@ interface CompactionSplit {
   remainder: string;
 }
 
+function messageContentText(content: SessionMessage["content"]): string {
+  if (typeof content === "string") return content;
+  if (content == null) return "";
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => {
+        if (typeof part === "string") return part;
+        if (!part || typeof part !== "object") return "";
+        if (part.type === "text" && typeof part.text === "string") return part.text;
+        if (part.type === "image_url") return "[image]";
+        return `[${String(part.type ?? "attachment")}]`;
+      })
+      .filter(Boolean)
+      .join("\n\n");
+  }
+  return String(content);
+}
+
 function splitCompactionContent(content: string): CompactionSplit | null {
   const head = content.trimStart();
   if (!COMPACTION_PREFIXES.some((p) => head.startsWith(p))) return null;
@@ -252,10 +270,8 @@ function MessageBubble({
   // + <original assistant reply>``. We split it back into two visual
   // rows here so the operator's actual answer survives as a readable
   // bubble next to the (clearly-labelled) handoff metadata (#29824).
-  const compactionSplit =
-    typeof msg.content === "string"
-      ? splitCompactionContent(msg.content)
-      : null;
+  const contentText = messageContentText(msg.content);
+  const compactionSplit = contentText ? splitCompactionContent(contentText) : null;
 
   if (compactionSplit && compactionSplit.remainder) {
     return (
@@ -292,8 +308,8 @@ function MessageBubble({
 
   // Check if any search term appears as a prefix of any word in content
   const isHit = (() => {
-    if (!highlight || !msg.content) return false;
-    const content = msg.content.toLowerCase();
+    if (!highlight || !contentText) return false;
+    const content = contentText.toLowerCase();
     const terms = highlight.toLowerCase().split(/\s+/).filter(Boolean);
     return terms.some((term) => content.includes(term));
   })();
@@ -320,13 +336,13 @@ function MessageBubble({
           </span>
         )}
       </div>
-      {msg.content &&
+      {contentText &&
         (msg.role === "system" ? (
           <div className="text-sm text-foreground whitespace-pre-wrap leading-relaxed">
-            {msg.content}
+            {contentText}
           </div>
         ) : (
-          <Markdown content={msg.content} highlightTerms={highlightTerms} />
+          <Markdown content={contentText} highlightTerms={highlightTerms} />
         ))}
       {msg.tool_calls && msg.tool_calls.length > 0 && (
         <div className="mt-1">
@@ -343,9 +359,11 @@ function MessageBubble({
 function MessageList({
   messages,
   highlight,
+  fullHeight = false,
 }: {
   messages: SessionMessage[];
   highlight?: string;
+  fullHeight?: boolean;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -364,11 +382,97 @@ function MessageList({
   return (
     <div
       ref={containerRef}
-      className="flex flex-col gap-3 max-h-[600px] overflow-y-auto pr-2"
+      className={`flex flex-col gap-3 pr-2 ${fullHeight ? "overflow-visible" : "max-h-[600px] overflow-y-auto"}`}
     >
       {messages.map((msg, i) => (
         <MessageBubble key={i} msg={msg} highlight={highlight} />
       ))}
+    </div>
+  );
+}
+
+function FullSessionHistory({ sessionId }: { sessionId: string }) {
+  const [session, setSession] = useState<SessionInfo | null>(null);
+  const [messages, setMessages] = useState<SessionMessage[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+  const { t } = useI18n();
+
+  useEffect(() => {
+    let cancelled = false;
+
+    Promise.all([
+      api.getSessionDetail(sessionId),
+      api.getSessionMessages(sessionId, undefined, { includeCompacted: true }),
+    ])
+      .then(([detail, messageResp]) => {
+        if (cancelled) return;
+        setSession(detail);
+        setMessages(messageResp.messages);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(String(err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
+
+  const userPromptCount = messages?.filter((m) => m.role === "user").length ?? 0;
+  const title =
+    session?.title && session.title !== "Untitled"
+      ? session.title
+      : session?.preview
+        ? session.preview.slice(0, 80)
+        : sessionId;
+
+  return (
+    <div className="flex min-w-0 w-full max-w-full flex-col gap-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <Button outlined size="sm" onClick={() => navigate("/sessions")} prefix={<ChevronLeft />}>
+          Back
+        </Button>
+        <div className="min-w-0 flex-1">
+          <h2 className="truncate text-lg font-semibold">{title}</h2>
+          <div className="mt-1 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+            <Badge tone="outline" className="text-xs">
+              {session?.source ?? "session"}
+            </Badge>
+            <span>{sessionId}</span>
+            {messages && (
+              <>
+                <span className="text-border">&#183;</span>
+                <span>{messages.length} {t.common.msgs}</span>
+                <span className="text-border">&#183;</span>
+                <span>{userPromptCount} user prompts</span>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Full session history</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {loading && (
+            <div className="flex items-center justify-center py-12">
+              <Spinner className="text-xl text-primary" />
+            </div>
+          )}
+          {error && <p className="text-sm text-destructive py-4">{error}</p>}
+          {messages && messages.length === 0 && (
+            <p className="text-sm text-muted-foreground py-4">{t.sessions.noMessages}</p>
+          )}
+          {messages && messages.length > 0 && <MessageList messages={messages} fullHeight />}
+        </CardContent>
+      </Card>
     </div>
   );
 }
@@ -399,7 +503,7 @@ function SessionRow({
     if (isExpanded && messages === null && !loading) {
       setLoading(true);
       api
-        .getSessionMessages(session.id)
+        .getSessionMessages(session.id, undefined, { includeCompacted: true })
         .then((resp) => setMessages(resp.messages))
         .catch((err) => setError(String(err)))
         .finally(() => setLoading(false));
@@ -432,6 +536,20 @@ function SessionRow({
       <Badge tone="outline" className="text-xs">
         {session.source ?? "local"}
       </Badge>
+
+      <Button
+        ghost
+        size="icon"
+        className="text-muted-foreground hover:text-primary"
+        aria-label="Open full session history"
+        title="Open full session history"
+        onClick={(e) => {
+          e.stopPropagation();
+          navigate(`/sessions/${encodeURIComponent(session.id)}`);
+        }}
+      >
+        <Database />
+      </Button>
 
       {resumeInChatEnabled && (
         <Button
@@ -587,15 +705,20 @@ function SessionRow({
                     </Button>
                   </div>
                 ) : (
-                  <span
-                    className={`font-mondwest normal-case min-w-0 flex-1 truncate text-sm ${hasTitle ? "font-medium" : "text-muted-foreground italic"}`}
+                  <button
+                    type="button"
+                    className={`font-mondwest normal-case min-w-0 flex-1 truncate text-left text-sm hover:text-primary ${hasTitle ? "font-medium" : "text-muted-foreground italic"}`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      navigate(`/sessions/${encodeURIComponent(session.id)}`);
+                    }}
                   >
                     {hasTitle
                       ? session.title
                       : session.preview
                         ? session.preview.slice(0, 60)
                         : t.sessions.untitledSession}
-                  </span>
+                  </button>
                 )}
                 {session.is_active && (
                   <Badge tone="success" className="shrink-0 text-xs">
@@ -713,6 +836,11 @@ function SessionsPagination({
   );
 }
 
+export function SessionDetailPage() {
+  const { sessionId = "" } = useParams();
+  return <FullSessionHistory key={sessionId} sessionId={sessionId} />;
+}
+
 export default function SessionsPage() {
   const [sessions, setSessions] = useState<SessionInfo[]>([]);
   const [total, setTotal] = useState(0);
@@ -759,6 +887,7 @@ export default function SessionsPage() {
   const [pruning, setPruning] = useState(false);
   const { toast, showToast } = useToast();
   const { t } = useI18n();
+  const navigate = useNavigate();
   const { setAfterTitle, setEnd } = usePageHeader();
   const { activeAction, actionStatus, dismissLog } = useSystemActions();
   const resumeInChatEnabled = isDashboardEmbeddedChatEnabled();
@@ -1677,9 +1806,13 @@ export default function SessionsPage() {
                     className="flex min-w-0 max-w-full flex-col gap-2 border border-border p-3 sm:flex-row sm:items-center sm:justify-between"
                   >
                     <div className="flex min-w-0 flex-1 flex-col gap-1">
-                      <span className="font-mondwest normal-case min-w-0 truncate text-sm font-medium">
+                      <button
+                        type="button"
+                        className="font-mondwest normal-case min-w-0 truncate text-left text-sm font-medium hover:text-primary"
+                        onClick={() => navigate(`/sessions/${encodeURIComponent(s.id)}`)}
+                      >
                         {s.title ?? t.common.untitled}
-                      </span>
+                      </button>
 
                       <span className="min-w-0 break-words text-xs text-muted-foreground">
                         <span className="font-mono-ui">
@@ -1696,13 +1829,21 @@ export default function SessionsPage() {
                       )}
                     </div>
 
-                    <Badge
-                      tone="outline"
-                      className="shrink-0 self-start text-xs sm:self-center"
-                    >
-                      <Database className="mr-1 h-3 w-3" />
-                      {s.source ?? "local"}
-                    </Badge>
+                    <div className="flex shrink-0 items-center gap-2 self-start sm:self-center">
+                      <Button
+                        ghost
+                        size="icon"
+                        aria-label="Open full session history"
+                        title="Open full session history"
+                        className="text-muted-foreground hover:text-primary"
+                        onClick={() => navigate(`/sessions/${encodeURIComponent(s.id)}`)}
+                      >
+                        <Database />
+                      </Button>
+                      <Badge tone="outline" className="text-xs">
+                        {s.source ?? "local"}
+                      </Badge>
+                    </div>
                   </div>
                 ))}
               </CardContent>


### PR DESCRIPTION
## Summary
- add an `include_compacted` option for session message retrieval so dashboard history can show durable compaction-archived rows without including rewound/undone rows
- add a dedicated `/sessions/:sessionId` full-history route and wire session titles/history buttons to it, keeping the play button focused on resume-in-chat
- normalize non-string multimodal message content before rendering so session history does not crash on stored image/tool content arrays

## Related issues
- Refs #32561 — provides a dedicated full-history view so the dashboard can access the whole stored session without relying on resume-chat scrollback behavior
- Related to #51307 — avoids the inline fixed-height/scrolling history path for full-session review, but does not claim to fix the separate virtual-scrolling bug described there

## Why
The dashboard history view previously loaded only active messages. Older prompts preserved by context compaction are stored as `active=0, compacted=1`, so they were missing from history even though they are durable transcript history.

Some stored sessions also contain multimodal content arrays. Passing those directly into the Markdown renderer can crash the SPA with `TypeError: ...split is not a function`, leaving the session page blank.

## Tests
- `python3 -m pytest tests/hermes_cli/test_session_messages_history.py tests/hermes_cli/test_web_server_session_search.py tests/hermes_cli/test_sessions_delete.py -q`
- `npm --prefix web run build`
- `git diff --check`

Note: `npm --prefix web run lint` currently reports pre-existing repository lint errors outside this change; the build/typecheck path passes.
