### PR TITLE
feat(mcp): add deapi catalog entry + wire Authorization header for http api_key MCPs

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -472,6 +472,18 @@ def _build_server_config(
         cfg["url"] = t.url
         if entry.auth.type == "oauth":
             cfg["auth"] = "oauth"
+        elif entry.auth.type == "api_key":
+            # Mirror the manual ``hermes mcp add`` path (mcp_config.py): the
+            # api_key is prompted for and saved to .env, but an http server only
+            # authenticates if that key is interpolated into an Authorization
+            # header. Prefer an explicit auth.env_var; else fall back to the
+            # first declared env name. Guarded so an api_key entry with no
+            # declared env var writes no unresolvable ``Bearer ${}`` placeholder.
+            env_name = entry.auth.env_var or (
+                entry.auth.env[0].name if entry.auth.env else None
+            )
+            if env_name:
+                cfg["headers"] = {"Authorization": f"Bearer ${{{env_name}}}"}
     return cfg
 
 

--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -77,6 +77,13 @@ class TransportSpec:
     args: List[str] = field(default_factory=list)
     url: Optional[str] = None
     version: Optional[str] = None  # informational, pinned
+    # http only. Extra request headers written verbatim into the
+    # mcp_servers.<name> block; ${VAR} placeholders are resolved by the MCP
+    # client's existing env interpolation at connect time, never at install
+    # time. Overrides the automatic Authorization header derived from
+    # auth.type: api_key - use for X-API-Key style schemes, non-Bearer
+    # prefixes, or multiple headers.
+    headers: Dict[str, str] = field(default_factory=dict)
 
 
 @dataclass
@@ -184,15 +191,25 @@ def _parse_manifest(path: Path) -> CatalogEntry:
     args = transport_raw.get("args") or []
     if not isinstance(args, list):
         raise CatalogError(f"{path}: transport.args must be a list")
+    headers_raw = transport_raw.get("headers") or {}
+    if not isinstance(headers_raw, dict) or not all(
+        isinstance(k, str) and isinstance(v, str) for k, v in headers_raw.items()
+    ):
+        raise CatalogError(
+            f"{path}: transport.headers must be a mapping of string to string"
+        )
     transport = TransportSpec(
         type=t_type,
         command=transport_raw.get("command"),
         args=[str(a) for a in args],
         url=transport_raw.get("url"),
         version=transport_raw.get("version"),
+        headers=dict(headers_raw),
     )
     if t_type == "stdio" and not transport.command:
         raise CatalogError(f"{path}: stdio transport requires 'command'")
+    if t_type == "stdio" and transport.headers:
+        raise CatalogError(f"{path}: transport.headers is only valid for http transport")
     if t_type == "http" and not transport.url:
         raise CatalogError(f"{path}: http transport requires 'url'")
 
@@ -470,9 +487,13 @@ def _build_server_config(
             cfg["args"] = [_expand_install_dir(a, install_dir) for a in t.args]
     elif t.type == "http":
         cfg["url"] = t.url
+        if t.headers:
+            # Explicit manifest headers win. Written verbatim - ${VAR}
+            # placeholders are resolved by the MCP client at connect time.
+            cfg["headers"] = dict(t.headers)
         if entry.auth.type == "oauth":
             cfg["auth"] = "oauth"
-        elif entry.auth.type == "api_key":
+        elif entry.auth.type == "api_key" and not t.headers:
             # Mirror the manual ``hermes mcp add`` path (mcp_config.py): the
             # api_key is prompted for and saved to .env, but an http server only
             # authenticates if that key is interpolated into an Authorization

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -420,11 +420,23 @@ def cmd_mcp_add(args):
 
     # Validate transport
     if not url and not command:
+        # Bare `hermes mcp add <name>`: if <name> is a catalog entry, route to
+        # the catalog installer so `mcp add deapi` and `mcp install deapi` are
+        # equivalent for shipped MCPs. Explicit --url/--command/--preset always
+        # means a custom server and never consults the catalog.
+        from hermes_cli.mcp_catalog import get_entry, install_entry
+
+        entry = get_entry(name)
+        if entry is not None:
+            _info(f"'{name}' is a catalog MCP - installing from the catalog.")
+            install_entry(entry, enable=True)
+            return
         _error("Must specify --url <endpoint>, --command <cmd>, or --preset <name>")
         _info("Examples:")
         _info('  hermes mcp add ink --url "https://mcp.ml.ink/mcp"')
         _info('  hermes mcp add github --command npx --args @modelcontextprotocol/server-github')
         _info('  hermes mcp add myserver --preset mypreset')
+        _info("Shipped catalog MCPs install by name: hermes mcp install <name>")
         return
 
     # Check if server already exists

--- a/optional-mcps/deapi/manifest.yaml
+++ b/optional-mcps/deapi/manifest.yaml
@@ -1,0 +1,65 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: deapi
+description: AI media generation via deAPI - images (FLUX.2 Klein), TTS, transcription (YouTube/X/Twitch), OCR, video, music, embeddings. Pay-per-use, ~20x cheaper than major providers.
+source: https://github.com/deapi-ai/mcp-server-deapi
+
+# deAPI ships a hosted remote MCP server (Streamable HTTP) at mcp.deapi.ai.
+# It authenticates with a static API key sent as a Bearer token. The server
+# also advertises OAuth, but its authorization server does not support
+# Dynamic Client Registration yet, so api_key is the reliable path for
+# Hermes today.
+transport:
+  type: http
+  url: https://mcp.deapi.ai/mcp
+
+auth:
+  type: api_key
+  env:
+    - name: DEAPI_API_KEY
+      prompt: "deAPI API key (dpn-sk-..., free $5 credit at https://app.deapi.ai)"
+      required: true
+      secret: true
+
+# Tool selection at install time:
+# The server exposes 39 tools; roughly half are *_price cost estimators.
+# Default to the actual capabilities + account utilities so a casual install
+# gets a clean surface - users can opt into the price calculators (and
+# anything else) in the install-time checklist.
+tools:
+  default_enabled:
+    - text_to_image
+    - image_to_image
+    - image_to_text
+    - image_remove_background
+    - image_upscale
+    - text_to_audio
+    - text_to_music
+    - audio_transcription
+    - audio_url_transcription
+    - video_file_transcription
+    - video_url_transcription
+    - text_to_video
+    - image_to_video
+    - audio_to_video
+    - video_replace
+    - video_remove_background
+    - video_upscale
+    - text_to_embedding
+    - prompt_booster
+    - get_balance
+    - get_available_models
+    - check_job_status
+
+post_install: |
+  deAPI is pay-per-use: every generation costs credits from your account
+  (images from ~$0.002, transcription ~$0.021/h). New accounts get $5 free
+  credit at https://app.deapi.ai - no card required. Check your balance any
+  time with the get_balance tool.
+
+  Generation jobs are asynchronous; tools poll automatically and may take
+  from seconds (images) to minutes (video/music).
+
+  Start a new Hermes session to load the deapi tools.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -332,6 +332,7 @@ locales = ["locales/*.yaml"]
 # catalog iterates over (a shared `optional-mcps/*/*` glob would collapse all
 # manifests into one colliding optional-mcps/manifest.yaml). One target per
 # entry; tests/test_packaging_metadata.py enforces an entry per optional-mcps/<name>.
+"optional-mcps/deapi" = ["optional-mcps/deapi/manifest.yaml"]
 "optional-mcps/linear" = ["optional-mcps/linear/manifest.yaml"]
 "optional-mcps/n8n" = ["optional-mcps/n8n/manifest.yaml"]
 

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -307,6 +307,36 @@ class TestInstall:
         assert server["url"] == "https://mcp.example.com/sse"
         assert server["auth"] == "oauth"
 
+    def test_install_http_api_key_writes_authorization_header(
+        self, catalog_dir, monkeypatch
+    ):
+        body = _basic_manifest(
+            transport={"type": "http", "url": "https://mcp.example.com/mcp"},
+            auth={
+                "type": "api_key",
+                "env": [{"name": "DEMO_API_KEY", "prompt": "key", "secret": True}],
+            },
+        )
+        _write_manifest(catalog_dir, "demo", body)
+
+        from hermes_cli import mcp_catalog
+
+        monkeypatch.setattr(mcp_catalog, "_prompt_input", lambda *a, **kw: "secret-val")
+
+        from hermes_cli.mcp_catalog import install_entry
+        from hermes_cli.config import get_config_path, get_env_value
+
+        install_entry(_entry("demo"), enable=True)
+
+        # Read the raw config file so we assert the persisted placeholder
+        # rather than load_config()'s ${VAR}-expanded value.
+        with open(get_config_path()) as f:
+            raw = yaml.safe_load(f)
+        server = raw["mcp_servers"]["demo"]
+        assert get_env_value("DEMO_API_KEY") == "secret-val"
+        assert server["url"] == "https://mcp.example.com/mcp"
+        assert server["headers"]["Authorization"] == "Bearer ${DEMO_API_KEY}"
+
     def test_install_required_env_missing_raises(self, catalog_dir, monkeypatch):
         body = _basic_manifest(
             auth={

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -143,6 +143,46 @@ class TestManifestParsing:
         assert e.auth.env[1].required is False
         assert e.auth.env[1].secret is False
 
+    def test_http_transport_headers_parsed(self, catalog_dir):
+        body = _basic_manifest(
+            transport={
+                "type": "http",
+                "url": "https://mcp.example.com/mcp",
+                "headers": {"X-API-Key": "${DEMO_KEY}", "X-Tenant": "acme"},
+            },
+        )
+        _write_manifest(catalog_dir, "demo", body)
+        from hermes_cli.mcp_catalog import list_catalog
+
+        e = list_catalog()[0]
+        assert e.transport.headers == {
+            "X-API-Key": "${DEMO_KEY}",
+            "X-Tenant": "acme",
+        }
+
+    def test_headers_rejected_for_stdio_transport(self, catalog_dir):
+        body = _basic_manifest()
+        body["transport"]["headers"] = {"Authorization": "Bearer ${DEMO_KEY}"}
+        path = _write_manifest(catalog_dir, "demo", body)
+        from hermes_cli.mcp_catalog import CatalogError, _parse_manifest
+
+        with pytest.raises(CatalogError, match="only valid for http"):
+            _parse_manifest(path)
+
+    def test_headers_must_be_string_mapping(self, catalog_dir):
+        body = _basic_manifest(
+            transport={
+                "type": "http",
+                "url": "https://mcp.example.com/mcp",
+                "headers": {"X-Retries": 3},
+            },
+        )
+        path = _write_manifest(catalog_dir, "demo", body)
+        from hermes_cli.mcp_catalog import CatalogError, _parse_manifest
+
+        with pytest.raises(CatalogError, match="string to string"):
+            _parse_manifest(path)
+
     def test_install_block(self, catalog_dir):
         body = _basic_manifest(
             install={
@@ -336,6 +376,38 @@ class TestInstall:
         assert get_env_value("DEMO_API_KEY") == "secret-val"
         assert server["url"] == "https://mcp.example.com/mcp"
         assert server["headers"]["Authorization"] == "Bearer ${DEMO_API_KEY}"
+
+    def test_install_explicit_headers_override_auto_bearer(
+        self, catalog_dir, monkeypatch
+    ):
+        """Manifest transport.headers win over the api_key auto-Bearer header."""
+        body = _basic_manifest(
+            transport={
+                "type": "http",
+                "url": "https://mcp.example.com/mcp",
+                "headers": {"X-API-Key": "${DEMO_API_KEY}"},
+            },
+            auth={
+                "type": "api_key",
+                "env": [{"name": "DEMO_API_KEY", "prompt": "key", "secret": True}],
+            },
+        )
+        _write_manifest(catalog_dir, "demo", body)
+
+        from hermes_cli import mcp_catalog
+
+        monkeypatch.setattr(mcp_catalog, "_prompt_input", lambda *a, **kw: "secret-val")
+
+        from hermes_cli.mcp_catalog import install_entry
+        from hermes_cli.config import get_config_path
+
+        install_entry(_entry("demo"), enable=True)
+
+        with open(get_config_path()) as f:
+            raw = yaml.safe_load(f)
+        server = raw["mcp_servers"]["demo"]
+        assert server["headers"] == {"X-API-Key": "${DEMO_API_KEY}"}
+        assert "Authorization" not in server["headers"]
 
     def test_install_required_env_missing_raises(self, catalog_dir, monkeypatch):
         body = _basic_manifest(

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -188,6 +188,31 @@ class TestMcpAdd:
         out = capsys.readouterr().out
         assert "Must specify" in out
 
+    def test_add_bare_catalog_name_routes_to_installer(self, capsys, monkeypatch):
+        """``hermes mcp add <name>`` with no transport falls back to the
+        catalog installer when <name> is a shipped catalog entry, making
+        ``mcp add deapi`` and ``mcp install deapi`` equivalent."""
+        installed = {}
+
+        class _FakeEntry:
+            name = "deapi"
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_catalog.get_entry",
+            lambda n: _FakeEntry if n == "deapi" else None,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.mcp_catalog.install_entry",
+            lambda entry, enable=True: installed.setdefault("entry", entry),
+        )
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+
+        cmd_mcp_add(_make_args(name="deapi"))
+        out = capsys.readouterr().out
+        assert "catalog" in out.lower()
+        assert installed["entry"] is _FakeEntry
+
     def test_add_http_server_all_tools(self, tmp_path, capsys, monkeypatch):
         """Add an HTTP server, accept all tools."""
         fake_tools = [


### PR DESCRIPTION
## What does this PR do?

Two tightly-coupled commits:

**1. `fix(mcp)`: wire the Authorization header for http-transport catalog MCPs using `auth.type: api_key`.** Installing such an MCP (`hermes mcp install <name>`) prompts for the key and saves it to `~/.hermes/.env`, but `_build_server_config()` emitted only `url` — no `Authorization` header — so the saved key was never sent and every tool call failed 401 with no obvious cause. The manual path (`hermes mcp add`, `hermes_cli/mcp_config.py`) already writes `headers: {Authorization: "Bearer ${VAR}"}` resolved by the client's existing env interpolation; this mirrors it in the catalog installer (prefer `auth.env_var`, else first declared env name, guarded against empty).

This **revives #51100** — same diagnosis and fix by @briandevans (credited via Co-authored-by), which was triaged `type/bug P2` but closed by its author after ~13 days without review. The difference here: this PR ships the first catalog entry that actually exercises the code path.

**2. `feat(mcp)`: add the `deapi` catalog entry** — [deAPI](https://deapi.ai)'s hosted remote MCP (Streamable HTTP, `mcp.deapi.ai`): image generation (FLUX.2 Klein etc.), TTS, transcription (incl. YouTube/X/Twitch URLs), OCR, video, music, embeddings. 39 tools total; `tools.default_enabled` curates the 22 real capabilities + account utilities, leaving the 17 `*_price` estimators opt-in via the install-time checklist. `auth: api_key` (free $5 signup credit, no card) — the server also advertises OAuth but its AS lacks Dynamic Client Registration today, so api_key is the reliable path (noted in a manifest comment; easy one-commit switch to `auth: oauth` once DCR lands).

## Related Issue

Revives #51100. No existing issue for the deapi entry (searched open/closed issues + PRs for "deapi").

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🎯 New skill (bundled or hub) — catalog MCP entry

## Changes Made

- `hermes_cli/mcp_catalog.py` — `_build_server_config()`: emit `headers: {Authorization: "Bearer ${ENV}"}` for http + api_key entries
- `tests/hermes_cli/test_mcp_catalog.py` — `test_install_http_api_key_writes_authorization_header` (asserts the persisted placeholder is unexpanded in config.yaml and the key landed in .env)
- `optional-mcps/deapi/manifest.yaml` — new catalog entry

## How to Test

1. `python -m pytest tests/hermes_cli/test_mcp_catalog.py -q` → 36 passed
2. `hermes mcp install deapi` (get a free key at https://app.deapi.ai) → inspect `~/.hermes/config.yaml`:
   `mcp_servers.deapi` = `url` + `headers.Authorization: Bearer ${DEAPI_API_KEY}` + curated `tools.include`
3. New session: `hermes chat -q "Call the deapi get_balance tool"` → returns the account balance

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits (`fix(mcp):`, `feat(mcp):`)
- [x] Searched existing PRs — #51100 is the prior art, closed unreviewed; credited via Co-authored-by
- [x] Only changes related to this fix/feature
- [x] `pytest tests/hermes_cli/test_mcp_catalog.py -q` — 36 passed
- [x] Test added for the fix
- [x] Tested on my platform: macOS 15 (Darwin 25.5), Hermes v0.18.0

### Documentation & Housekeeping

- [x] Docs — manifest comments cover the auth rationale; no repo docs affected — otherwise N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform — pure Python dict-building, no platform-specific code
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

Verified end-to-end in a live session (catalog install → new session → MCP tool call):

```
┊ ⚡ mcp_deapi   0.4s
Your exact balance is 4.967697 USD.
get_available_models returned 25 models.
```

_Disclosure: prepared with AI assistance (Claude Code); diagnosed, reviewed and live-tested by a human._

🤖 Generated with [Claude Code](https://claude.com/claude-code)