### PR TITLE
Fix Codex app-server Kanban timeout finalization

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -228,6 +228,96 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
     }
 
 
+def _record_codex_app_server_kanban_failure(agent, turn) -> bool:
+    """Close a Kanban run when Codex app-server exits a turn unsuccessfully.
+
+    ``codex_app_server`` is an early-return runtime path. If its inner
+    ``run_turn`` hits the app-server deadline, Hermes receives a partial turn
+    result instead of flowing through ``turn_finalizer.py``. A Kanban worker
+    would then exit with the task still ``running`` and the dispatcher would
+    report a generic protocol violation. Record the concrete runtime failure
+    here so the claim/run are closed before process exit.
+    """
+    task_id = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+    if not task_id:
+        return False
+    if os.environ.get("HERMES_KANBAN_GOAL_MODE"):
+        return False
+
+    raw_run_id = (os.environ.get("HERMES_KANBAN_RUN_ID") or "").strip()
+    expected_run_id = None
+    if raw_run_id:
+        try:
+            expected_run_id = int(raw_run_id)
+        except (TypeError, ValueError):
+            logger.warning(
+                "codex app-server Kanban failure finalizer skipped task %s: "
+                "invalid HERMES_KANBAN_RUN_ID=%r",
+                task_id, raw_run_id,
+            )
+            return False
+
+    error_text = str(
+        getattr(turn, "error", None)
+        or "codex app-server turn interrupted before terminal Kanban acknowledgement"
+    )
+    lowered = error_text.lower()
+    interrupted = bool(getattr(turn, "interrupted", False))
+    outcome = (
+        "timed_out"
+        if interrupted or "timed out" in lowered or "timeout" in lowered
+        else "crashed"
+    )
+
+    payload = {
+        "runtime": "codex_app_server",
+    }
+    for key, value in (
+        ("turn_id", getattr(turn, "turn_id", None)),
+        ("thread_id", getattr(turn, "thread_id", None)),
+        ("session_id", getattr(agent, "session_id", None)),
+        ("tool_iterations", getattr(turn, "tool_iterations", None)),
+    ):
+        if value is not None:
+            payload[key] = value
+
+    try:
+        from hermes_cli import kanban_db as kb
+
+        with kb.connect_closing() as conn:
+            task = kb.get_task(conn, task_id)
+            if task is None or task.status != "running":
+                return False
+            if getattr(task, "goal_mode", False):
+                return False
+            if (
+                expected_run_id is not None
+                and task.current_run_id != expected_run_id
+            ):
+                return False
+            kb._record_task_failure(
+                conn,
+                task_id,
+                error=error_text,
+                outcome=outcome,
+                release_claim=True,
+                end_run=True,
+                event_payload_extra=payload,
+            )
+            logger.info(
+                "recorded codex app-server %s failure for Kanban task %s",
+                outcome, task_id,
+            )
+            return True
+    except Exception:
+        logger.warning(
+            "failed to record codex app-server Kanban failure for task %s",
+            task_id,
+            exc_info=True,
+        )
+        return False
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -354,6 +444,9 @@ def run_codex_app_server_turn(
         except Exception:
             pass
         agent._codex_session = None
+
+    if turn.interrupted or turn.error is not None:
+        _record_codex_app_server_kanban_failure(agent, turn)
 
     # Splice projected messages into the conversation. The projector emits
     # standard {role, content, tool_calls, tool_call_id} entries, which

--- a/tests/agent/test_codex_app_server_kanban_failure.py
+++ b/tests/agent/test_codex_app_server_kanban_failure.py
@@ -1,0 +1,134 @@
+"""Regression tests for Kanban finalization on Codex app-server failures."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent.codex_runtime import run_codex_app_server_turn
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _timeout_turn():
+    return SimpleNamespace(
+        interrupted=True,
+        error="turn timed out after 600.0s",
+        thread_id="thread-timeout",
+        turn_id="turn-timeout",
+        projected_messages=[],
+        tool_iterations=7,
+        final_text="",
+        should_retire=True,
+        token_usage_last=None,
+    )
+
+
+def _agent_for_turn(turn):
+    agent = MagicMock()
+    agent._codex_session = MagicMock()
+    agent._codex_session.run_turn.return_value = turn
+    agent._codex_session.close = MagicMock()
+    agent.tool_progress_callback = None
+    agent._iters_since_skill = 0
+    agent._skill_nudge_interval = 0
+    agent.valid_tool_names = set()
+    agent._session_db = None
+    agent._session_db_created = True
+    agent.session_id = "sess-kanban-timeout"
+    agent.session_api_calls = 0
+    agent.session_prompt_tokens = 0
+    agent.session_completion_tokens = 0
+    agent.session_total_tokens = 0
+    agent.session_input_tokens = 0
+    agent.session_output_tokens = 0
+    agent.session_cache_read_tokens = 0
+    agent.session_cache_write_tokens = 0
+    agent.session_reasoning_tokens = 0
+    agent.session_estimated_cost_usd = 0.0
+    agent.model = "codex"
+    agent.provider = "openai"
+    agent.base_url = ""
+    return agent
+
+
+def test_codex_app_server_timeout_records_kanban_failure(
+    kanban_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="long codex task", assignee="coder")
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None
+        run_id = claimed.current_run_id
+        assert run_id is not None
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+
+    result = run_codex_app_server_turn(
+        _agent_for_turn(_timeout_turn()),
+        user_message="run a long task",
+        original_user_message="run a long task",
+        messages=[{"role": "user", "content": "run a long task"}],
+        effective_task_id=task_id,
+    )
+
+    assert result["completed"] is False
+    assert result["partial"] is True
+    assert result["error"] == "turn timed out after 600.0s"
+
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, task_id)
+        run = kb.latest_run(conn, task_id)
+        events = kb.list_events(conn, task_id)
+
+    assert task.status == "ready"
+    assert task.current_run_id is None
+    assert task.consecutive_failures == 1
+    assert run.status == "timed_out"
+    assert run.outcome == "timed_out"
+    assert run.error == "turn timed out after 600.0s"
+    assert events[-1].kind == "timed_out"
+    assert events[-1].payload["error"] == "turn timed out after 600.0s"
+
+
+def test_codex_app_server_timeout_finalizer_noops_after_completion(
+    kanban_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="already done", assignee="coder")
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None
+        run_id = claimed.current_run_id
+        assert run_id is not None
+        assert kb.complete_task(conn, task_id, summary="done", expected_run_id=run_id)
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+
+    result = run_codex_app_server_turn(
+        _agent_for_turn(_timeout_turn()),
+        user_message="finish",
+        original_user_message="finish",
+        messages=[{"role": "user", "content": "finish"}],
+        effective_task_id=task_id,
+    )
+    assert result["partial"] is True
+
+    with kb.connect_closing() as conn:
+        assert kb.get_task(conn, task_id).status == "done"
+        assert kb.latest_run(conn, task_id).outcome == "completed"


### PR DESCRIPTION
## Summary

This fixes a Kanban lifecycle gap in the `codex_app_server` runtime. That runtime returns early from the standard conversation loop, so interrupted/error turns could bypass the normal turn finalizer and leave a Kanban worker task stuck in `running` until the dispatcher reported a generic `protocol_violation`.

The patch records a concrete Kanban failure from the Codex app-server adapter when a turn returns `interrupted` or `error` while the current task/run is still active. It uses the existing `_record_task_failure(...)` path, releasing the claim and closing the run as `timed_out` or `crashed` instead of leaving the task orphaned.

## Validation

- `python3 -m py_compile agent/codex_runtime.py tests/agent/test_codex_app_server_kanban_failure.py`
- One-off regression script using a temporary Kanban DB to simulate `turn timed out after 600.0s`; verified the task moved from `running` to `ready`, current run cleared, and run outcome/status recorded as `timed_out`.

`pytest` was not available in the live hei virtualenv, so the new test file was not run through pytest there.