### PR TITLE
feat(tui): consistent interactive menus and pager display for slash commands

### DIFF
--- a/ui-tui/src/app/createSlashHandler.ts
+++ b/ui-tui/src/app/createSlashHandler.ts
@@ -82,7 +82,10 @@ export function createSlashHandler(ctx: SlashHandlerContext): (cmd: string) => b
       }
 
       if (d.type === 'exec' || d.type === 'plugin') {
-        return sys(d.output || '(no output)')
+        const output = d.output || '(no output)'
+        const long = output.length > 180 || output.split('\n').filter(Boolean).length > 2
+
+        return long ? page(output, parsed.name[0]!.toUpperCase() + parsed.name.slice(1)) : sys(output)
       }
 
       if (d.type === 'alias') {

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -127,6 +127,40 @@ export interface BillingOverlayState {
   state: BillingStateResponse
 }
 
+export interface ListPickerItem {
+  id: string
+  label: string
+  description?: string
+  meta?: string
+}
+
+/**
+ * Configuration for the generic ListPicker overlay.  Stored in
+ * ``OverlayState.listPicker`` when active; the ListPicker component reads
+ * this config and manages its own internal runtime state (items, loading,
+ * selection, etc.) — same pattern as ActiveSessionSwitcher / ModelPicker.
+ */
+export interface ListPickerConfig {
+  /** RPC method to fetch items, e.g. 'cron.manage'. */
+  fetchMethod: string
+  /** Params sent with the fetch RPC call. */
+  fetchParams?: Record<string, unknown>
+  /** Extract the list of items from the RPC response. */
+  mapResponse: (r: Record<string, unknown>) => ListPickerItem[]
+  /** Overlay title shown at the top. */
+  title: string
+  /** Optional RPC method invoked when the user presses Enter on an item. */
+  actionMethod?: string
+  /** Params builder for the action RPC — { id: item.id } is merged in. */
+  actionParams?: (item: ListPickerItem) => Record<string, unknown>
+  /** Message shown after a successful action. */
+  actionLabel?: (item: ListPickerItem) => string
+  /** Hint text shown at the bottom. */
+  hint?: string
+  /** If true, Enter does nothing — picker is view-only. */
+  viewOnly?: boolean
+}
+
 export interface OverlayState {
   agents: boolean
   agentsInitialHistoryIndex: number
@@ -135,6 +169,7 @@ export interface OverlayState {
   clarify: ClarifyReq | null
   confirm: ConfirmReq | null
   journey: boolean
+  listPicker: null | ListPickerConfig
   modelPicker: boolean
   pager: null | PagerState
   petPicker: boolean

--- a/ui-tui/src/app/overlayStore.ts
+++ b/ui-tui/src/app/overlayStore.ts
@@ -10,6 +10,7 @@ const buildOverlayState = (): OverlayState => ({
   clarify: null,
   confirm: null,
   journey: false,
+  listPicker: null,
   modelPicker: false,
   pager: null,
   petPicker: false,
@@ -31,6 +32,7 @@ export const $isBlocked = computed(
     clarify,
     confirm,
     journey,
+    listPicker,
     modelPicker,
     pager,
     petPicker,
@@ -42,19 +44,20 @@ export const $isBlocked = computed(
   }) =>
     Boolean(
       agents ||
-      approval ||
-      billing ||
-      clarify ||
-      confirm ||
-      journey ||
-      modelPicker ||
-      pager ||
-      petPicker ||
-      pluginsHub ||
-      secret ||
-      sessions ||
-      skillsHub ||
-      sudo
+        approval ||
+        billing ||
+        clarify ||
+        confirm ||
+        journey ||
+        listPicker ||
+        modelPicker ||
+        pager ||
+        petPicker ||
+        pluginsHub ||
+        secret ||
+        sessions ||
+        skillsHub ||
+        sudo
     )
 )
 
@@ -68,11 +71,12 @@ export const resetOverlayState = () => $overlayState.set(buildOverlayState())
 
 /**
  * Soft reset: drop FLOW-scoped overlays (approval / clarify / confirm / sudo
- * / secret / pager) but PRESERVE user-toggled ones — agents dashboard, model
- * picker, skills hub, sessions overlay.  Those are opened deliberately and
- * shouldn't vanish when a turn ends.  Called from turnController.idle() on
- * every turn completion / interrupt; the old "reset everything" behaviour
- * silently closed /agents the moment delegation finished.
+ * / secret / pager / listPicker) but PRESERVE user-toggled ones — agents
+ * dashboard, model picker, skills hub, sessions overlay.  Those are opened
+ * deliberately and shouldn't vanish when a turn ends.  Called from
+ * turnController.idle() on every turn completion / interrupt; the old "reset
+ * everything" behaviour silently closed /agents the moment delegation
+ * finished.
  */
 export const resetFlowOverlays = () =>
   $overlayState.set({

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -11,7 +11,8 @@ import type {
   SessionStatusResponse,
   SessionSteerResponse,
   SessionTitleResponse,
-  SessionUndoResponse
+  SessionUndoResponse,
+  SlashExecResponse
 } from '../../../gatewayTypes.js'
 import { writeClipboardText } from '../../../lib/clipboard.js'
 import { writeOsc52Clipboard } from '../../../lib/osc52.js'
@@ -676,6 +677,33 @@ export const coreCommands: SlashCommand[] = [
           ctx.transcript.send(last)
         })
       )
+    }
+  },
+
+  // ── Pager-display config commands ────────────────────────────────
+  // These commands show formatted output in the pager overlay when called
+  // bare, with a proper title. With arguments they fall through to slash.exec.
+
+  {
+    help: 'toggle gateway runtime-metadata footer on final replies',
+    name: 'footer',
+    run: (arg, ctx) => {
+      const trimmed = arg.trim().toLowerCase()
+
+      // Bare or "status" → show footer status in pager
+      if (!arg.trim() || trimmed === 'status') {
+        return ctx.gateway
+          .rpc<SlashExecResponse>('slash.exec', { command: `footer ${trimmed || 'status'}`, session_id: ctx.sid })
+          .then(
+            ctx.guarded<SlashExecResponse>(r => {
+              const output = r?.output || 'footer: off'
+              ctx.transcript.sys(output)
+            })
+          )
+          .catch(ctx.guardedErr)
+      }
+
+      // With args (on/off) → fall through to slash.exec
     }
   }
 ]

--- a/ui-tui/src/app/slash/commands/ops.ts
+++ b/ui-tui/src/app/slash/commands/ops.ts
@@ -1,7 +1,10 @@
 import type {
   BrowserManageResponse,
   CommandsCatalogResponse,
+  CronJobItem,
+  CronManageResponse,
   DelegationPauseResponse,
+  InsightsGetResponse,
   ProcessStopResponse,
   ReloadEnvResponse,
   ReloadMcpResponse,
@@ -11,8 +14,11 @@ import type {
   SlashExecResponse,
   SpawnTreeListResponse,
   SpawnTreeLoadResponse,
+  ToolsetItem,
+  ToolsetsListResponse,
   ToolsConfigureResponse
 } from '../../../gatewayTypes.js'
+import type { ListPickerConfig, ListPickerItem } from '../../interfaces.js'
 import type { PanelSection } from '../../../types.js'
 import { applyDelegationStatus, getDelegationState } from '../../delegationStore.js'
 import { patchOverlayState } from '../../overlayStore.js'
@@ -754,6 +760,181 @@ export const opsCommands: SlashCommand[] = [
             if (r.reset) {
               ctx.transcript.sys('session reset. new tool configuration is active.')
             }
+          })
+        )
+        .catch(ctx.guardedErr)
+    }
+  },
+
+  // ── Interactive-picker commands ──────────────────────────────────
+  // When called bare (no args), these commands open a ListPicker overlay so
+  // the user can navigate and act on items with the keyboard — the same UX
+  // pattern as /resume (ActiveSessionSwitcher) and /model (ModelPicker).
+  // With arguments they fall through to slash.exec as before.
+
+  {
+    help: 'list or toggle toolsets',
+    name: 'toolsets',
+    run: (arg, ctx) => {
+      if (arg.trim()) {
+        // Delegated to slash.exec for non-bare usage (list/disable/enable)
+        return
+      }
+
+      const config: ListPickerConfig = {
+        fetchMethod: 'toolsets.list',
+        fetchParams: ctx.sid ? { session_id: ctx.sid } : {},
+        mapResponse: (r): ListPickerItem[] => {
+          const toolsets = (r.toolsets ?? []) as ToolsetItem[]
+
+          return toolsets.map(ts => ({
+            description: ts.description,
+            id: ts.name,
+            label: ts.name,
+            meta: ts.enabled ? 'enabled' : 'disabled'
+          }))
+        },
+        title: 'Toolsets',
+        hint: '↑/↓ select · Esc/q close'
+      }
+
+      patchOverlayState({ listPicker: config })
+    }
+  },
+
+  {
+    help: 'list or manage scheduled tasks',
+    name: 'cron',
+    run: (arg, ctx) => {
+      if (arg.trim()) {
+        return
+      }
+
+      const config: ListPickerConfig = {
+        fetchMethod: 'cron.manage',
+        fetchParams: { action: 'list' },
+        mapResponse: (r): ListPickerItem[] => {
+          const jobs = (r.jobs ?? []) as CronJobItem[]
+
+          return jobs.map(job => ({
+            description: job.prompt || '',
+            id: job.job_id || job.id || '',
+            label: job.name || job.job_id || job.id || '(unnamed)',
+            meta: job.status || ''
+          }))
+        },
+        title: 'Cron Jobs',
+        hint: '↑/↓ select · Esc/q close'
+      }
+
+      patchOverlayState({ listPicker: config })
+    }
+  },
+
+  // ── Pager-display commands ────────────────────────────────────────
+  // These commands show formatted output in the pager overlay when called
+  // bare, with a proper title. With arguments they fall through to slash.exec.
+
+  {
+    help: 'show usage insights and analytics',
+    name: 'insights',
+    run: (arg, ctx) => {
+      const days = parseInt(arg.trim(), 10) || 30
+
+      ctx.gateway
+        .rpc<InsightsGetResponse>('insights.get', { days })
+        .then(
+          ctx.guarded<InsightsGetResponse>(r => {
+            if (!r) return
+
+            const lines = [
+              `Period: last ${r.days ?? days} days`,
+              `Sessions: ${r.sessions ?? 0}`,
+              `Messages: ${r.messages ?? 0}`
+            ]
+
+            ctx.transcript.page(lines.join('\n'), 'Insights')
+          })
+        )
+        .catch(ctx.guardedErr)
+    }
+  },
+
+  {
+    help: 'review suggested automations (accept/dismiss)',
+    name: 'suggestions',
+    run: (arg, ctx) => {
+      if (arg.trim()) return
+
+      // Fetch via slash.exec so we get the same formatted output the CLI produces
+      ctx.gateway
+        .rpc<SlashExecResponse>('slash.exec', { command: 'suggestions', session_id: ctx.sid })
+        .then(
+          ctx.guarded<SlashExecResponse>(r => {
+            const output = r?.output || 'no suggestions'
+            const long = output.length > 180 || output.split('\n').filter(Boolean).length > 2
+
+            long ? ctx.transcript.page(output, 'Suggestions') : ctx.transcript.sys(output)
+          })
+        )
+        .catch(ctx.guardedErr)
+    }
+  },
+
+  {
+    help: 'review pending memory writes / toggle approval gate',
+    name: 'memory',
+    run: (arg, ctx) => {
+      if (arg.trim()) return
+
+      ctx.gateway
+        .rpc<SlashExecResponse>('slash.exec', { command: 'memory pending', session_id: ctx.sid })
+        .then(
+          ctx.guarded<SlashExecResponse>(r => {
+            const output = r?.output || 'no pending memory writes'
+            const long = output.length > 180 || output.split('\n').filter(Boolean).length > 2
+
+            long ? ctx.transcript.page(output, 'Memory') : ctx.transcript.sys(output)
+          })
+        )
+        .catch(ctx.guardedErr)
+    }
+  },
+
+  {
+    help: 'list skill bundles',
+    name: 'bundles',
+    run: (arg, ctx) => {
+      if (arg.trim()) return
+
+      ctx.gateway
+        .rpc<SlashExecResponse>('slash.exec', { command: 'bundles', session_id: ctx.sid })
+        .then(
+          ctx.guarded<SlashExecResponse>(r => {
+            const output = r?.output || 'no bundles'
+            const long = output.length > 180 || output.split('\n').filter(Boolean).length > 2
+
+            long ? ctx.transcript.page(output, 'Bundles') : ctx.transcript.sys(output)
+          })
+        )
+        .catch(ctx.guardedErr)
+    }
+  },
+
+  {
+    help: 'background skill maintenance (status, run, pin, archive)',
+    name: 'curator',
+    run: (arg, ctx) => {
+      if (arg.trim()) return
+
+      ctx.gateway
+        .rpc<SlashExecResponse>('slash.exec', { command: 'curator status', session_id: ctx.sid })
+        .then(
+          ctx.guarded<SlashExecResponse>(r => {
+            const output = r?.output || 'curator idle'
+            const long = output.length > 180 || output.split('\n').filter(Boolean).length > 2
+
+            long ? ctx.transcript.page(output, 'Curator') : ctx.transcript.sys(output)
           })
         )
         .catch(ctx.guardedErr)

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -619,5 +619,54 @@ export const sessionCommands: SlashCommand[] = [
         ctx.transcript.panel('Usage', sections)
       })
     }
+  },
+
+  // ── Pager-display session commands ───────────────────────────────
+  // These commands show formatted output in the pager overlay when called
+  // bare, with a proper title. With arguments they fall through to slash.exec.
+
+  {
+    help: 'set or inspect a standing goal',
+    name: 'goal',
+    run: (arg, ctx) => {
+      const trimmed = arg.trim().toLowerCase()
+
+      // Bare or "status" → show goal status in pager
+      if (!arg.trim() || trimmed === 'status') {
+        return ctx.gateway
+          .rpc<SlashExecResponse>('slash.exec', { command: `goal ${trimmed || 'status'}`, session_id: ctx.sid })
+          .then(
+            ctx.guarded<SlashExecResponse>(r => {
+              const output = r?.output || 'no goal set'
+              const long = output.length > 180 || output.split('\n').filter(Boolean).length > 2
+
+              long ? ctx.transcript.page(output, 'Goal') : ctx.transcript.sys(output)
+            })
+          )
+          .catch(ctx.guardedErr)
+      }
+
+      // With args (pause/resume/clear/text) → fall through to slash.exec
+    }
+  },
+
+  {
+    help: 'add or manage extra criteria on the active goal',
+    name: 'subgoal',
+    run: (arg, ctx) => {
+      if (arg.trim()) return
+
+      ctx.gateway
+        .rpc<SlashExecResponse>('slash.exec', { command: 'subgoal', session_id: ctx.sid })
+        .then(
+          ctx.guarded<SlashExecResponse>(r => {
+            const output = r?.output || 'no subgoals'
+            const long = output.length > 180 || output.split('\n').filter(Boolean).length > 2
+
+            long ? ctx.transcript.page(output, 'Subgoals') : ctx.transcript.sys(output)
+          })
+        )
+        .catch(ctx.guardedErr)
+    }
   }
 ]

--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -12,6 +12,7 @@ import { BillingOverlay } from './billingOverlay.js'
 import { MaskedPrompt } from './maskedPrompt.js'
 import { ModelPicker } from './modelPicker.js'
 import { OverlayHint } from './overlayControls.js'
+import { ListPicker } from './listPicker.js'
 import { PetPicker } from './petPicker.js'
 import { PluginsHub } from './pluginsHub.js'
 import { ApprovalPrompt, ClarifyPrompt, ConfirmPrompt } from './prompts.js'
@@ -140,6 +141,7 @@ export function FloatingOverlays({
 
   const hasAny =
     overlay.modelPicker ||
+    overlay.listPicker ||
     overlay.pager ||
     overlay.petPicker ||
     overlay.sessions ||
@@ -203,6 +205,17 @@ export function FloatingOverlays({
       {overlay.pluginsHub && (
         <FloatBox color={theme.color.border}>
           <PluginsHub gw={gw} onClose={() => patchOverlayState({ pluginsHub: false })} t={theme} />
+        </FloatBox>
+      )}
+
+      {overlay.listPicker && (
+        <FloatBox color={theme.color.border}>
+          <ListPicker
+            config={overlay.listPicker}
+            gw={gw}
+            onCancel={() => patchOverlayState({ listPicker: null })}
+            t={theme}
+          />
         </FloatBox>
       )}
 

--- a/ui-tui/src/components/listPicker.tsx
+++ b/ui-tui/src/components/listPicker.tsx
@@ -1,0 +1,249 @@
+import { Box, Text, useInput, useStdout } from '@hermes/ink'
+import { useEffect, useState } from 'react'
+
+import type { GatewayClient } from '../gatewayClient.js'
+import type { ListPickerConfig, ListPickerItem } from '../app/interfaces.js'
+import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
+import type { Theme } from '../theme.js'
+
+import { OverlayHint, windowItems } from './overlayControls.js'
+
+const VISIBLE = 12
+const MIN_WIDTH = 44
+const MAX_WIDTH = 96
+
+export interface ListPickerProps {
+  config: ListPickerConfig
+  gw: GatewayClient
+  onCancel: () => void
+  onSelect?: (item: ListPickerItem) => void
+  t: Theme
+}
+
+export function ListPicker({ config, gw, onCancel, onSelect, t }: ListPickerProps) {
+  const [items, setItems] = useState<ListPickerItem[]>([])
+  const [err, setErr] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [sel, setSel] = useState(0)
+  const [actionMsg, setActionMsg] = useState('')
+  const [acting, setActing] = useState(false)
+
+  const { stdout } = useStdout()
+  const width = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, (stdout?.columns ?? 80) - 6))
+
+  useEffect(() => {
+    let cancelled = false
+
+    setLoading(true)
+    gw
+      .request<Record<string, unknown>>(config.fetchMethod, config.fetchParams ?? {})
+      .then(raw => {
+        if (cancelled) return
+        const r = asRpcResult<Record<string, unknown>>(raw)
+
+        if (!r) {
+          setErr('invalid response')
+          setLoading(false)
+          return
+        }
+
+        const mapped = config.mapResponse(r)
+
+        setItems(mapped)
+        setErr('')
+        setLoading(false)
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return
+        setErr(rpcErrorMessage(e))
+        setLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [config.fetchMethod, config.fetchParams, config.mapResponse, gw])
+
+  useInput((ch, key) => {
+    if (acting) return
+
+    if (key.escape || ch === 'q') {
+      return onCancel()
+    }
+
+    if (key.upArrow && sel > 0) {
+      setSel(s => Math.max(0, s - 1))
+      return
+    }
+
+    if (key.downArrow && sel < items.length - 1) {
+      setSel(s => Math.min(items.length - 1, s + 1))
+      return
+    }
+
+    if (key.return && items[sel]) {
+      const item = items[sel]!
+
+      if (config.viewOnly) {
+        return onSelect?.(item)
+      }
+
+      if (!config.actionMethod) {
+        return onSelect?.(item)
+      }
+
+      setActing(true)
+      setActionMsg('')
+      const params = { ...(config.actionParams?.(item) ?? {}), ...{ name: item.id, job_id: item.id } }
+
+      gw
+        .request<Record<string, unknown>>(config.actionMethod, params)
+        .then(raw => {
+          const r = asRpcResult<Record<string, unknown>>(raw)
+
+          setActing(false)
+
+          if (!r) {
+            setActionMsg('error: invalid response')
+            return
+          }
+
+          setActionMsg(config.actionLabel?.(item) ?? `✓ ${item.id}`)
+          // Refresh the list after action
+          setLoading(true)
+          gw
+            .request<Record<string, unknown>>(config.fetchMethod, config.fetchParams ?? {})
+            .then(refreshRaw => {
+              const rr = asRpcResult<Record<string, unknown>>(refreshRaw)
+              if (rr) {
+                setItems(config.mapResponse(rr))
+              }
+              setSel(s => Math.min(s, items.length - 1))
+              setLoading(false)
+            })
+            .catch(() => setLoading(false))
+        })
+        .catch((e: unknown) => {
+          setActing(false)
+          setActionMsg(`error: ${rpcErrorMessage(e)}`)
+        })
+    }
+  })
+
+  if (loading) {
+    return (
+      <Box flexDirection="column" width={width}>
+        <Text bold color={t.color.accent}>
+          {config.title}
+        </Text>
+        <Text color={t.color.muted}>loading…</Text>
+        <OverlayHint t={t}>Esc/q close</OverlayHint>
+      </Box>
+    )
+  }
+
+  if (err) {
+    return (
+      <Box flexDirection="column" width={width}>
+        <Text bold color={t.color.accent}>
+          {config.title}
+        </Text>
+        <Text color={t.color.label}>error: {err}</Text>
+        <OverlayHint t={t}>Esc/q close</OverlayHint>
+      </Box>
+    )
+  }
+
+  if (!items.length) {
+    return (
+      <Box flexDirection="column" width={width}>
+        <Text bold color={t.color.accent}>
+          {config.title}
+        </Text>
+        <Text color={t.color.muted}>no items</Text>
+        <OverlayHint t={t}>Esc/q close</OverlayHint>
+      </Box>
+    )
+  }
+
+  const { items: visible, offset } = windowItems(items, sel, VISIBLE)
+
+  return (
+    <Box flexDirection="column" width={width}>
+      <Text bold color={t.color.accent} wrap="truncate-end">
+        {config.title}
+      </Text>
+      <Text color={t.color.muted} wrap="truncate-end">
+        {items.length} {items.length === 1 ? 'item' : 'items'}
+      </Text>
+
+      {offset > 0 && (
+        <Text color={t.color.muted} wrap="truncate-end">
+          {' '}
+          ↑ {offset} more
+        </Text>
+      )}
+
+      {visible.map((item, i) => {
+        const idx = offset + i
+        const selected = sel === idx
+
+        return (
+          <Box
+            backgroundColor={selected ? t.color.selectionBg : undefined}
+            flexDirection="row"
+            key={item.id ?? `row-${idx}`}
+            width="100%"
+          >
+            <Text bold={selected} color={selected ? t.color.accent : t.color.muted}>
+              {selected ? '▸ ' : '  '}
+            </Text>
+            <Box flexShrink={0} width={4}>
+              <Text bold={selected} color={selected ? t.color.accent : t.color.muted}>
+                {String(idx + 1).padStart(2)}
+              </Text>
+            </Box>
+            <Box flexShrink={0} width={20}>
+              <Text bold={selected} color={selected ? t.color.accent : t.color.text} wrap="truncate-end">
+                {item.label}
+              </Text>
+            </Box>
+            {item.meta ? (
+              <Box flexShrink={0} width={14}>
+                <Text color={selected ? t.color.accent : t.color.muted} wrap="truncate-end">
+                  {item.meta}
+                </Text>
+              </Box>
+            ) : null}
+            <Box flexGrow={1} flexShrink={1} minWidth={0}>
+              <Text color={selected ? t.color.accent : t.color.muted} wrap="truncate-end">
+                {item.description ?? ''}
+              </Text>
+            </Box>
+          </Box>
+        )
+      })}
+
+      {offset + VISIBLE < items.length && (
+        <Text color={t.color.muted} wrap="truncate-end">
+          {' '}
+          ↓ {items.length - offset - VISIBLE} more
+        </Text>
+      )}
+
+      {actionMsg && (
+        <Text color={actionMsg.startsWith('error') ? t.color.label : t.color.ok} wrap="truncate-end">
+          {actionMsg}
+        </Text>
+      )}
+
+      {acting && (
+        <Text color={t.color.muted} wrap="truncate-end">
+          acting…
+        </Text>
+      )}
+
+      <OverlayHint t={t}>{config.hint ?? '↑/↓ select · Esc/q close'}</OverlayHint>
+    </Box>
+  )
+}

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -467,6 +467,38 @@ export interface ToolsConfigureResponse {
   unknown?: string[]
 }
 
+export interface ToolsetItem {
+  description?: string
+  enabled: boolean
+  name: string
+  tool_count?: number
+}
+
+export interface ToolsetsListResponse {
+  toolsets?: ToolsetItem[]
+}
+
+export interface CronJobItem {
+  id?: string
+  job_id?: string
+  name?: string
+  prompt?: string
+  schedule?: string
+  skill?: string
+  status?: string
+}
+
+export interface CronManageResponse {
+  jobs?: CronJobItem[]
+  ok?: boolean
+}
+
+export interface InsightsGetResponse {
+  days?: number
+  messages?: number
+  sessions?: number
+}
+
 // ── Model picker ─────────────────────────────────────────────────────
 
 export interface ModelOptionProvider {


### PR DESCRIPTION
## Summary

Some slash commands, when run bare (no arguments) in the TUI, show an interactive menu/picker overlay — e.g. `/resume` opens the `ActiveSessionSwitcher`, `/model` opens the `ModelPicker`, `/skills` opens the `SkillsHub`. Other commands that would benefit from the same treatment fell through to the Python backend (`slash.exec` / `command.dispatch`) and could only produce text output, not interactive menus or formatted pagers.

This PR ensures those commands display consistently by:
1. Fixing the `command.dispatch` output path to use the pager for long text
2. Adding a reusable `ListPicker` overlay component for interactive selection
3. Adding local TUI handlers for 10 commands that should show formatted/interactive output when called bare

Closes #59513

---

## Changes

### 1. Fix `command.dispatch` output path (`createSlashHandler.ts`)

The `slash.exec` path already had logic to use `page(text, title)` (pager overlay) for long output and `sys(text)` for short output. But the `command.dispatch` fallback path used `sys(d.output)` for ALL `exec`/`plugin` responses, regardless of length. This meant long output from `command.dispatch` was shown as a flat system message instead of a scrollable pager.

**Fix:** Apply the same long-output detection (`> 180` chars or `> 2` non-empty lines) and use `page()` for long text, matching `slash.exec` behavior.

### 2. Generic `ListPicker` overlay component (`listPicker.tsx`)

A reusable Ink overlay that:
- Fetches items via a configured RPC method (`fetchMethod` + `fetchParams`)
- Maps the RPC response to `ListPickerItem[]` via a `mapResponse` callback
- Renders a scrollable, navigable list with ↑/↓ keys
- Optionally performs an action on the selected item via `actionMethod` + `actionParams`
- Shows loading/error/empty states
- Follows the same pattern as `ActiveSessionSwitcher` and `ModelPicker`

The picker is configured via `ListPickerConfig` (stored in `OverlayState.listPicker`), which includes the RPC method, response mapper, title, optional action RPC, and hint text.

### 3. New `listPicker` overlay state

- **`interfaces.ts`** — Added `ListPickerItem`, `ListPickerConfig`, and `listPicker: null | ListPickerConfig` to `OverlayState`
- **`overlayStore.ts`** — Added `listPicker` to `buildOverlayState()`, `$isBlocked` computed, and `resetFlowOverlays()` (listPicker is flow-scoped — it closes when a turn ends)
- **`appOverlays.tsx`** — Renders `ListPicker` inside a `FloatBox` when `overlay.listPicker` is set

### 4. Local TUI slash command handlers

All handlers intercept the **bare** (no-arg) case. With arguments, they fall through to `slash.exec` as before.

#### Interactive ListPicker overlays (via gateway RPC)

| Command | RPC method | Title | Description |
|---|---|---|---|
| `/toolsets` (bare) | `toolsets.list` | Toolsets | Shows all toolsets with enabled/disabled status |
| `/cron` (bare) | `cron.manage` (action=list) | Cron Jobs | Shows all scheduled jobs with status |

#### Pager-display commands (formatted output with proper title)

| Command | Source | Title | Description |
|---|---|---|---|
| `/insights` (bare) | `insights.get` RPC | Insights | Shows session/message analytics |
| `/suggestions` (bare) | `slash.exec` | Suggestions | Shows suggested automations |
| `/memory` (bare) | `slash.exec` (memory pending) | Memory | Shows pending memory writes |
| `/bundles` (bare) | `slash.exec` | Bundles | Shows skill bundles |
| `/curator` (bare) | `slash.exec` (curator status) | Curator | Shows curator status |
| `/goal` (bare or status) | `slash.exec` (goal status) | Goal | Shows standing goal status |
| `/subgoal` (bare) | `slash.exec` | Subgoals | Shows active subgoals |
| `/footer` (bare or status) | `slash.exec` | — | Shows footer toggle status |

### 5. Gateway response types (`gatewayTypes.ts`)

Added: `ToolsetItem`, `ToolsetsListResponse`, `CronJobItem`, `CronManageResponse`, `InsightsGetResponse`

---

## Architecture

### ListPicker flow

```
User types /toolsets (bare, no arg)
  → createSlashHandler.ts finds "toolsets" in SLASH_COMMANDS (registry.ts)
  → calls found.run("", runCtx)
  → ops.ts: patchOverlayState({ listPicker: config })
  → overlayStore: $overlayState.set({ ...state, listPicker: config })
  → appOverlays.tsx: <ListPicker config={...} /> renders as floating overlay
  → ListPicker fetches items via toolsets.list RPC
  → User navigates with ↑/↓, Esc/q closes
  → patchOverlayState({ listPicker: null }) closes the overlay
```

### Pager flow

```
User types /goal (bare)
  → session.ts: ctx.gateway.rpc('slash.exec', { command: 'goal status' })
  → output is long? → ctx.transcript.page(output, 'Goal') (pager overlay)
  → output is short? → ctx.transcript.sys(output) (system line)
```

---

## Key principle

**Any command that needs an interactive menu or formatted pager display must be a TUI-local command** (in `ui-tui/src/app/slash/commands/`). Commands that fall through to the Python backend can only produce text. This PR adds local handlers for 10 commands that previously fell through, ensuring they all display consistently — either via the `ListPicker` overlay (interactive selection) or the pager overlay (formatted text with title).

---

## Testing

```bash
npm --prefix ui-tui run build
hermes --tui
```

Test each command bare (no args) to verify the overlay/pager opens:
- `/toolsets` → ListPicker overlay
- `/cron` → ListPicker overlay
- `/insights` → pager with analytics
- `/suggestions` → pager with suggestions
- `/memory` → pager with pending writes
- `/bundles` → pager with bundles
- `/curator` → pager with curator status
- `/goal` → pager with goal status
- `/subgoal` → pager with subgoals
- `/footer` → system message with status

Also test that commands with arguments still work (fall through to `slash.exec`):
- `/toolsets disable browser` → slash.exec as before
- `/cron list` → slash.exec as before
- `/goal pause` → slash.exec as before