### PR TITLE
feat(skills): add hermes-backup skill — self-restoring disaster recovery for Hermes

### DIFF
--- a/skills/devops/hermes-backup/SKILL.md
+++ b/skills/devops/hermes-backup/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: hermes-backup
+description: Use when setting up backup/disaster recovery for Hermes, or when recovering from a crash. Supports pCloud, Google Drive, Dropbox, S3-compatible, local, and any rclone-compatible storage.
+version: 1.1.0
+author: AndyN (@andynguyendk)
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [backup, disaster-recovery, restore, rclone, pcloud]
+    related_skills: [hermes-agent]
+---
+
+# Hermes Backup
+
+Disaster recovery system for Hermes AI agents. Backs up config, skills, memories, sessions, and scripts to any rclone-compatible storage — then lets a fresh agent self-restore by reading `RESTORE.md` from the backup itself.
+
+## Problem
+
+Hermes stores valuable agent state in `~/.hermes/` — skills learned over months, persistent memory, conversation history. There's no built-in backup. If the machine dies or the install corrupts, everything is lost.
+
+This skill solves that with a backup that **is its own restore manual**.
+
+## How It Works
+
+1. **Backup script** packages Hermes state + restore assets into a staging folder
+2. **rclone** syncs to your storage (pCloud, Google Drive, Dropbox, S3, local, 40+ backends)
+3. **`RESTORE.md` and `restore.sh`** are stored INSIDE the backup on cloud — a fresh agent can download the backup and read one file to know what to do
+4. **Manifest** with SHA256 checksums verifies integrity
+
+## Supported Storage Backends
+
+Any [rclone-compatible storage](https://rclone.org/overview/). The backup script only needs the `REMOTE` variable:
+
+| Storage | `REMOTE` value |
+|---|---|
+| pCloud | `pcloud:hermes-backup` |
+| Google Drive | `gdrive:hermes-backup` |
+| Dropbox | `dropbox:hermes-backup` |
+| S3-compatible | `s3:my-bucket/hermes-backup` |
+| Local USB/dir | `/mnt/usb/hermes-backup` |
+
+Setup rclone first (one-time):
+
+```bash
+# Install
+curl https://rclone.org/install.sh | sudo bash
+
+# Google Drive
+rclone config create gdrive drive scope drive.file
+
+# pCloud
+rclone authorize "pcloud"
+
+# Dropbox
+rclone authorize "dropbox"
+
+# S3-compatible
+rclone config create s3 aws access_key_id XXX secret_access_key YYY
+```
+
+## Setup
+
+### 1. Deploy backup assets
+
+```bash
+mkdir -p ~/.hermes/backup-assets
+
+# Copy restore files from skill
+cp -r $(hermes skills inspect hermes-backup 2>/dev/null || echo "$HOME/.hermes/skills/devops/hermes-backup")/* ~/.hermes/backup-assets/
+# OR find the skill manually:
+find ~/.hermes -path "*/hermes-backup/scripts" -type d 2>/dev/null | head -1
+```
+
+### 2. Create backup script from template
+
+```bash
+cp ~/.hermes/backup-assets/templates/pcloud-backup.sh.template ~/scripts/pcloud-backup.sh
+# Edit REMOTE to point to your storage
+```
+
+### 3. Add cron (daily 3AM)
+
+```bash
+(crontab -l 2>/dev/null | grep -v pcloud-backup; \
+ echo "0 3 * * * /home/nd/scripts/pcloud-backup.sh") | crontab -
+```
+
+### 4. Run once to verify
+
+```bash
+~/scripts/pcloud-backup.sh
+tail -5 ~/.hermes/logs/pcloud-backup.log
+```
+
+## Disaster Recovery
+
+If Hermes is destroyed, a new agent can self-restore:
+
+```bash
+# 1. Install rclone + auth your storage
+curl https://rclone.org/install.sh | sudo bash
+rclone authorize "pcloud"  # or gdrive, dropbox, etc.
+
+# 2. Pull the backup
+mkdir -p /tmp/restore
+rclone copy pcloud:hermes-backup/ /tmp/restore/
+
+# 3. Read the restore guide
+cat /tmp/restore/RESTORE.md
+
+# 4. Run automated restore
+bash /tmp/restore/restore.sh
+```
+
+No prior knowledge needed — the backup contains everything.
+
+## Backup Contents
+
+| Item | Why it matters | Size (typical) |
+|---|---|---|
+| `config.yaml` | Provider config, MCP servers, settings | ~17 KB |
+| `hermes-env` | API keys (.env, renamed for safety) | ~2 KB |
+| `skills/` | Cumulated knowledge — most valuable asset | ~35 MB |
+| `memories/` | MEMORY.md + USER.md — persistent memory | ~12 KB |
+| `sessions.tar.gz` | Full conversation history | ~40 MB |
+| `engram/` | FSRS learning engine state | ~52 KB |
+| `restore.sh` | Automated restore script | ~5 KB |
+| `MANIFEST.txt` | SHA256 checksums for all files | ~200 KB |
+
+## Common Pitfalls
+
+- **pCloud DNS failures**: `dial tcp: lookup api.pcloud.com:53: server misbehaving`. Transient — retry with `--retries 5`.
+- **OAuth expired**: Re-run `rclone authorize "pcloud"` — tokens don't survive crashes.
+- **Local storage**: If using a local path, skip rclone — just use `rsync` or `cp -r`.
+- **Sessions backup timeout**: For large history, rclone may time out during hash comparison. The script retries up to 3 times.
+
+## Template Configuration
+
+The backup script template (`templates/pcloud-backup.sh.template`) is fully configurable:
+
+```bash
+# === CONFIGURATION — customize these ===
+REMOTE="pcloud:hermes-backup"           # rclone remote:path
+BACKUP_DIRS=(skills scripts cron state career memories engram)  # dirs to back up
+CONFIG_FILES=("$HOME/.hermes/config.yaml")
+ENV_FILE="$HOME/.hermes/.env"
+```
+
+## Verification
+
+```bash
+# Check backup integrity
+rclone check pcloud:hermes-backup/ /tmp/verify/ --size-only
+
+# Show size and file count
+rclone size pcloud:hermes-backup/
+rclone lsf pcloud:hermes-backup/ -R --files-only | wc -l
+```
+
+## Files
+
+- `references/restore-guide.md` — Full disaster recovery guide (also stored inside backup)
+- `scripts/restore.sh` — Automated restore script (also stored in backup)
+- `scripts/generate-manifest.sh` — SHA256 manifest generator
+- `templates/pcloud-backup.sh.template` — Configurable backup script template

--- a/skills/devops/hermes-backup/references/restore-guide.md
+++ b/skills/devops/hermes-backup/references/restore-guide.md
@@ -1,0 +1,106 @@
+# Hermes Backup — Disaster Recovery Guide
+
+> **If you are a fresh AI agent reading this**: your predecessor backed up this
+> Hermes instance to cloud storage using the `hermes-backup` skill.
+> Follow the steps below to restore everything.
+> Read this file FIRST before doing anything else.
+
+## What's in this backup
+
+| Path in backup | Restores to | Notes |
+|---|---|---|
+| `config.yaml` | `~/.hermes/config.yaml` | Main Hermes config (providers, models, MCP servers) |
+| `hermes-env` | `~/.hermes/.env` | API keys — rename required |
+| `skills/` | `~/.hermes/skills/` | All custom skills |
+| `scripts/` | `~/.hermes/scripts/` | Custom scripts |
+| `cron/` | `~/.hermes/cron/` | Cron job definitions |
+| `state/` | `~/.hermes/state/` | Hermes internal state |
+| `memories/` | `~/.hermes/memories/` | MEMORY.md + USER.md (persistent memory) |
+| `engram/` | `~/.hermes/engram/` | Engram FSRS learning engine (if used) |
+| `sessions.tar.gz` | `~/.hermes/sessions/` | Conversation history (compressed) |
+| `RESTORE.md` | (read this file) | Disaster recovery guide |
+| `restore.sh` | (run this) | Automated restore script |
+| `MANIFEST.txt` | (verify this) | SHA256 checksums |
+
+## Restore procedure
+
+### Step 1: Install rclone
+
+```bash
+sudo -v ; curl https://rclone.org/install.sh | sudo bash
+```
+
+### Step 2: Authenticate storage
+
+OAuth tokens don't transfer. You must re-auth:
+
+```bash
+# pCloud
+rclone authorize "pcloud"
+
+# Google Drive
+rclone config create gdrive drive scope drive.file
+
+# Dropbox
+rclone authorize "dropbox"
+```
+
+Name your remote whatever the backup script expects. Check `RESTORE.md`
+or look at the pcloud-backup.sh file in this directory for the remote name.
+
+### Step 3: Pull the backup
+
+```bash
+mkdir -p /tmp/restore
+rclone copy <REMOTE>:/tmp/restore/ --progress
+```
+
+### Step 4: Run restore script
+
+```bash
+bash /tmp/restore/restore.sh
+```
+
+This will:
+- Copy `config.yaml` → `~/.hermes/config.yaml`
+- Copy `hermes-env` → `~/.hermes/.env` (chmod 600)
+- Restore all directories (skills, memories, engram, etc.)
+- Extract `sessions.tar.gz` → `~/.hermes/sessions/`
+- Run verification checks
+
+### Step 5: Verify
+
+```bash
+hermes config show          # config loaded OK
+hermes secrets audit        # no plaintext keys leaked
+ls ~/.hermes/sessions/      # history restored
+cat ~/.hermes/memories/*.md # memory intact
+```
+
+### Step 6: Re-setup backup cron
+
+```bash
+cp /tmp/restore/pcloud-backup.sh ~/scripts/
+chmod +x ~/scripts/pcloud-backup.sh
+(crontab -l 2>/dev/null | grep -v pcloud-backup; \
+ echo "0 3 * * * /home/nd/scripts/pcloud-backup.sh") | crontab -
+```
+
+## What's NOT backed up (and why)
+
+| Item | Reason |
+|---|---|
+| `hermes-agent/` (2.8GB) | Source code — in git fork or reinstallable |
+| `node/`, `bin/`, `lsp/` | Runtime binaries — reinstalled by Hermes |
+| `logs/`, `cache/` | Transient, rebuilt automatically |
+| Docker volumes | Need separate machine-level backup |
+
+## API Keys (in `.env`)
+
+The `.env` file contains live API keys. After restore:
+- Verify keys still work: `source ~/.hermes/.env`
+- If keys rotated: update `.env`, then run `hermes secrets audit --fix`
+
+## Backup manifest
+
+See `MANIFEST.txt` in the backup root for exact file list + SHA256 checksums.

--- a/skills/devops/hermes-backup/scripts/generate-manifest.sh
+++ b/skills/devops/hermes-backup/scripts/generate-manifest.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Generates a manifest with SHA256 checksums for the backup
+# Included in every backup so restore can verify integrity
+# Usage: bash generate-manifest.sh /path/to/backup/dir
+set -euo pipefail
+
+BACKUP_DIR="${1:-.}"
+OUTPUT="$BACKUP_DIR/MANIFEST.txt"
+
+echo "# Hermes Backup Manifest" > "$OUTPUT"
+echo "# Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$OUTPUT"
+echo "# Format: SHA256  SIZE  PATH" >> "$OUTPUT"
+echo "" >> "$OUTPUT"
+
+cd "$BACKUP_DIR"
+find . -type f ! -name "MANIFEST.txt" -print0 | while IFS= read -r -d '' f; do
+  HASH=$(sha256sum "$f" | awk '{print $1}')
+  SIZE=$(stat --format='%s' "$f")
+  CLEAN="${f#./}"
+  echo "$HASH  $SIZE  $CLEAN" >> "$OUTPUT"
+done
+
+TOTAL_FILES=$(grep -cE '^[a-f0-9]' "$OUTPUT" || true)
+TOTAL_SIZE=$(du -sh "$BACKUP_DIR" | awk '{print $1}')
+echo "" >> "$OUTPUT"
+echo "# Total files: $TOTAL_FILES" >> "$OUTPUT"
+echo "# Total size: $TOTAL_SIZE" >> "$OUTPUT"
+
+echo "Manifest written: $OUTPUT ($TOTAL_FILES files, $TOTAL_SIZE)"

--- a/skills/devops/hermes-backup/scripts/restore.sh
+++ b/skills/devops/hermes-backup/scripts/restore.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Hermes Restore Script
+# Usage: bash restore.sh
+#
+# Restores Hermes config, skills, sessions, memories from backup.
+# Run this AFTER downloading the backup folder from cloud storage.
+set -euo pipefail
+
+PBACKUP_DIR="$(cd "$(dirname "$0")" && pwd)"
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+
+echo "============================================"
+echo "  Hermes Restore from Backup"
+echo "============================================"
+echo "Backup dir:   $PBACKUP_DIR"
+echo "Hermes home:  $HERMES_HOME"
+echo ""
+
+# Safety check
+if [ ! -f "$PBACKUP_DIR/config.yaml" ]; then
+  echo "❌ ERROR: config.yaml not found in $PBACKUP_DIR"
+  echo "   Make sure you're running this from inside the backup folder."
+  exit 1
+fi
+
+echo "The following will be restored:"
+echo "  • config.yaml        → $HERMES_HOME/config.yaml"
+echo "  • .env (API keys)    → $HERMES_HOME/.env"
+echo "  • skills/            → $HERMES_HOME/skills/"
+echo "  • memories/          → $HERMES_HOME/memories/"
+echo "  • sessions/ (tar.gz) → $HERMES_HOME/sessions/"
+echo "  • engram/            → $HERMES_HOME/engram/"
+echo "  • scripts/           → $HERMES_HOME/scripts/"
+echo "  • cron/              → $HERMES_HOME/cron/"
+echo "  • state/             → $HERMES_HOME/state/"
+echo ""
+echo "Existing files will be backed up to .bak"
+echo ""
+read -p "Proceed? (yes/no): " confirm
+if [ "$confirm" != "yes" ]; then
+  echo "Aborted."
+  exit 0
+fi
+
+mkdir -p "$HERMES_HOME"
+
+restore_file() {
+  local src="$1"
+  local dst="$2"
+  if [ -f "$dst" ]; then
+    cp "$dst" "${dst}.bak.$(date +%s)"
+    echo "  ⚠️  Existing file backed up: ${dst}.bak"
+  fi
+  cp "$src" "$dst"
+  echo "  ✅ $dst"
+}
+
+restore_dir() {
+  local src="$1"
+  local dst="$2"
+  if [ -d "$dst" ]; then
+    mv "$dst" "${dst}.bak.$(date +%s)"
+    echo "  ⚠️  Existing dir backed up: ${dst}.bak"
+  fi
+  cp -r "$src" "$dst"
+  echo "  ✅ $dst"
+}
+
+echo ""
+echo "--- Restoring files ---"
+
+# 1. Config
+[ -f "$PBACKUP_DIR/config.yaml" ] && restore_file "$PBACKUP_DIR/config.yaml" "$HERMES_HOME/config.yaml"
+
+# 2. .env
+if [ -f "$PBACKUP_DIR/hermes-env" ]; then
+  restore_file "$PBACKUP_DIR/hermes-env" "$HERMES_HOME/.env"
+  chmod 600 "$HERMES_HOME/.env"
+  echo "  🔒 chmod 600 $HERMES_HOME/.env"
+fi
+
+# 3. Directories
+for d in skills scripts cron state career memories engram; do
+  [ -d "$PBACKUP_DIR/$d" ] && restore_dir "$PBACKUP_DIR/$d" "$HERMES_HOME/$d"
+done
+
+# 4. Sessions
+if [ -f "$PBACKUP_DIR/sessions.tar.gz" ]; then
+  if [ -d "$HERMES_HOME/sessions" ]; then
+    mv "$HERMES_HOME/sessions" "$HERMES_HOME/sessions.bak.$(date +%s)"
+    echo "  ⚠️  Existing sessions backed up"
+  fi
+  mkdir -p "$HERMES_HOME"
+  tar xzf "$PBACKUP_DIR/sessions.tar.gz" -C "$HERMES_HOME"
+  echo "  ✅ $HERMES_HOME/sessions/ (extracted)"
+elif [ -d "$PBACKUP_DIR/sessions" ]; then
+  restore_dir "$PBACKUP_DIR/sessions" "$HERMES_HOME/sessions"
+fi
+
+# --- Verification ---
+echo ""
+echo "============================================"
+echo "  Verification"
+echo "============================================"
+
+PASS=0; FAIL=0
+check() {
+  if eval "$2" 2>/dev/null; then
+    echo "  ✅ $1"; PASS=$((PASS + 1))
+  else
+    echo "  ❌ $1"; FAIL=$((FAIL + 1))
+  fi
+}
+
+check "Config exists"   "[ -f $HERMES_HOME/config.yaml ]"
+check "Env file exists" "[ -f $HERMES_HOME/.env ]"
+check "Skills restored" "[ -d $HERMES_HOME/skills ]"
+check "Memories restored" "[ -d $HERMES_HOME/memories ]"
+check "Sessions restored" "[ -d $HERMES_HOME/sessions ]"
+
+echo ""
+echo "Passed: $PASS  Failed: $FAIL"
+
+echo ""
+echo "Next steps:"
+echo "  1. source ~/.hermes/.env"
+echo "  2. hermes config show"
+echo "  3. hermes secrets audit"
+echo "  4. Re-setup backup cron (if desired)"
+echo ""
+echo "Welcome back. 🔄"

--- a/skills/devops/hermes-backup/templates/pcloud-backup.sh.template
+++ b/skills/devops/hermes-backup/templates/pcloud-backup.sh.template
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Backup Script Template — Customize REMOTE and PATHS before deploying
+# Copy this to ~/scripts/pcloud-backup.sh and edit the CONFIGURATION section
+set -euo pipefail
+
+# === CONFIGURATION — customize these ===
+REMOTE="pcloud:hermes-backup"           # rclone remote:path (change to your storage)
+STAGING="/tmp/pcloud-backup-staging"
+LOG="$HOME/.hermes/logs/pcloud-backup.log"
+BACKUP_ASSETS="$HOME/.hermes/backup-assets"
+# ======================================
+
+# Directories to back up (relative to $HOME/.hermes/)
+HERMES_DIRS=(skills scripts cron state career memories engram)
+
+# Config files to back up
+CONFIG_FILES=("$HOME/.hermes/config.yaml")
+ENV_FILE="$HOME/.hermes/.env"
+BACKUP_SCRIPT_SELF="$HOME/scripts/pcloud-backup.sh"
+
+mkdir -p "$STAGING"
+mkdir -p "$(dirname "$LOG")"
+mkdir -p "$BACKUP_ASSETS"
+
+echo "[$(date)] Starting backup to $REMOTE..." >> "$LOG"
+
+# Clean staging
+rm -rf "${STAGING:?}"/*
+
+# 1. Hermes core config files
+for f in "${CONFIG_FILES[@]}"; do
+  [ -f "$f" ] && cp "$f" "$STAGING/" 2>> "$LOG" || true
+done
+
+# 2. .env renamed for safety
+[ -f "$ENV_FILE" ] && cp "$ENV_FILE" "$STAGING/hermes-env" 2>> "$LOG" || true
+
+# 3. Hermes directories
+for d in "${HERMES_DIRS[@]}"; do
+  [ -d "$HOME/.hermes/$d" ] && cp -r "$HOME/.hermes/$d" "$STAGING/$d" 2>> "$LOG" || true
+done
+
+# 4. Sessions — compress before upload
+if [ -d "$HOME/.hermes/sessions" ] && [ -n "$(ls -A "$HOME/.hermes/sessions/" 2>/dev/null)" ]; then
+  tar czf "$STAGING/sessions.tar.gz" -C "$HOME/.hermes" sessions/ 2>> "$LOG" || true
+fi
+
+# 5. Restore assets — so a fresh install can self-heal
+cp "$BACKUP_ASSETS/RESTORE.md" "$STAGING/RESTORE.md" 2>> "$LOG" || true
+cp "$BACKUP_ASSETS/restore.sh" "$STAGING/restore.sh" 2>> "$LOG" || true
+cp "$BACKUP_ASSETS/generate-manifest.sh" "$STAGING/generate-manifest.sh" 2>> "$LOG" || true
+[ -f "$BACKUP_SCRIPT_SELF" ] && cp "$BACKUP_SCRIPT_SELF" "$STAGING/pcloud-backup.sh" 2>> "$LOG" || true
+
+# 6. Generate manifest with checksums
+bash "$BACKUP_ASSETS/generate-manifest.sh" "$STAGING" 2>> "$LOG" || true
+
+# Sync to storage
+rclone sync "$STAGING/" "$REMOTE/" \
+  --transfers 4 \
+  --checkers 8 \
+  --timeout 120s \
+  --retries 3 \
+  --low-level-retries 5 \
+  --stats 0 2>> "$LOG"
+
+RESULT=$?
+if [ $RESULT -eq 0 ]; then
+  SIZE=$(rclone size "$REMOTE/" 2>/dev/null | grep "Total size" || echo "unknown")
+  echo "[$(date)] ✅ Backup OK — $SIZE" >> "$LOG"
+else
+  echo "[$(date)] ❌ Backup FAILED (exit $RESULT)" >> "$LOG"
+fi
+
+# Clean staging
+rm -rf "${STAGING:?}"/*
+echo "[$(date)] Done." >> "$LOG"


### PR DESCRIPTION
## Summary

Adds the `hermes-backup` skill — a complete disaster recovery system for Hermes agents. Backs up config, skills, memories, sessions, and scripts to any rclone-compatible storage (pCloud, Google Drive, Dropbox, S3, local, 40+ backends), with a self-restoring design: the backup IS its own restore manual.

## Motivation

Issue #12238 — "Built-in Automatic Backup & Version Control for Agent Data (~/.hermes/)" — has been open for over a year with no implementation. Hermes has no built-in backup. If a user's machine dies or install corrupts, months of agent learning (skills, memory, conversation history) are lost with no recovery path.

This skill is a lightweight, dependency-minimal solution that uses **rclone** as the abstraction layer — no new core tooling, no database changes, just a skill that any Hermes user can install and configure.

## Key Design

1. **Self-restoring**: `RESTORE.md` and `restore.sh` are stored INSIDE the backup on cloud storage. A fresh agent pulls the backup and reads `RESTORE.md` to know what to do — no external docs needed.
2. **Storage-agnostic**: Uses rclone as abstraction layer. Works with pCloud, Google Drive, Dropbox, S3, local USB, or any of 40+ backends.
3. **Verifiable**: Every backup contains a SHA256 manifest (`MANIFEST.txt`) for integrity checks.
4. **Delta sync**: rclone sync only transfers changed files on subsequent runs.
5. **Cron-ready**: Configurable daily schedule (default 3AM).

## Backup Contents

| Item | Size (typical) |
|---|---|
| `config.yaml` | ~17 KB |
| `hermes-env` (API keys) | ~2 KB |
| `skills/` | ~35 MB |
| `memories/` | ~12 KB |
| `sessions.tar.gz` | ~40 MB |
| `restore.sh` + `RESTORE.md` | ~8 KB |
| `MANIFEST.txt` (SHA256) | ~200 KB |

## Files

```
skills/devops/hermes-backup/
├── SKILL.md                          # Skill definition + usage
├── references/restore-guide.md       # Disaster recovery guide
├── scripts/restore.sh                # Automated restore script
├── scripts/generate-manifest.sh      # SHA256 manifest generator
└── templates/pcloud-backup.sh.template  # Configurable backup script
```

## Usage

```bash
# 1. Install rclone + auth
curl https://rclone.org/install.sh | sudo bash
rclone authorize "pcloud"

# 2. Deploy
mkdir -p ~/.hermes/backup-assets
cp -r skills/devops/hermes-backup/* ~/.hermes/backup-assets/
# Customize REMOTE in the template, save as ~/scripts/pcloud-backup.sh

# 3. Add cron
(crontab -l | grep -v pcloud-backup; echo '0 3 * * * ~/scripts/pcloud-backup.sh') | crontab -

# 4. Manual run
~/scripts/pcloud-backup.sh
```

## Related

- Closes #12238 (implements the backup/restore CLI replacement using a skill)