### PR TITLE
fix(gateway): notify user when stale-routing self-heal can't recover the old session

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1911,6 +1911,7 @@ from gateway.config import (
 )
 from gateway.session import (
     AsyncSessionStore,
+    SessionEntry,
     SessionStore,
     SessionSource,
     SessionContext,
@@ -12098,68 +12099,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # so the agent knows this is a fresh conversation (not an intentional /reset).
         if _was_auto_reset:
             reset_reason = getattr(session_entry, 'auto_reset_reason', None) or 'idle'
-            if reset_reason == "suspended":
-                context_note = "[System note: The user's previous session was stopped and suspended. This is a fresh conversation with no prior context.]"
-            elif reset_reason == "daily":
-                context_note = "[System note: The user's session was automatically reset by the daily schedule. This is a fresh conversation with no prior context.]"
-            elif reset_reason == "resume_pending_expired":
-                context_note = "[System note: The previous gateway session could not be recovered after a restart (API recovery timed out). This is a fresh conversation — use /resume to restore history if needed.]"
-            else:
-                context_note = "[System note: The user's previous session expired due to inactivity. This is a fresh conversation with no prior context.]"
-            turn_sidecar_notes.append(context_note)
-
-            # Send a user-facing notification explaining the reset, unless:
-            # - notifications are disabled in config
-            # - the platform is excluded (e.g. api_server, webhook)
-            # - the expired session had no activity (nothing was cleared)
+            turn_sidecar_notes.append(self._auto_reset_context_note(reset_reason))
             try:
-                policy = self.session_store.config.get_reset_policy(
-                    platform=source.platform,
-                    session_type=getattr(source, 'chat_type', 'dm'),
+                await self._maybe_send_auto_reset_notice(
+                    source, session_entry, reset_reason,
                 )
-                platform_name = source.platform.value if source.platform else ""
-                had_activity = getattr(session_entry, 'reset_had_activity', False)
-                # Suspended and restart-recovery-expired sessions always notify
-                # regardless of policy.notify — the user had an active session
-                # that was silently replaced, so they need to know they can
-                # /resume it.  Idle/daily resets respect the policy flag.
-                should_notify = reset_reason in {"suspended", "resume_pending_expired"} or (
-                    policy.notify
-                    and had_activity
-                    and platform_name not in policy.notify_exclude_platforms
-                )
-                if should_notify:
-                    adapter = self._adapter_for_source(source)
-                    if adapter:
-                        if reset_reason == "suspended":
-                            reason_text = "previous session was stopped or interrupted"
-                        elif reset_reason == "resume_pending_expired":
-                            reason_text = "gateway restart recovery timed out"
-                        elif reset_reason == "daily":
-                            reason_text = f"daily schedule at {policy.at_hour}:00"
-                        else:
-                            hours = policy.idle_minutes // 60
-                            mins = policy.idle_minutes % 60
-                            duration = f"{hours}h" if not mins else f"{hours}h {mins}m" if hours else f"{mins}m"
-                            reason_text = f"inactive for {duration}"
-                        notice = (
-                            f"◐ Session automatically reset ({reason_text}). "
-                            f"Conversation history cleared.\n"
-                            f"Use /resume to browse and restore a previous session.\n"
-                            f"Adjust reset timing in config.yaml under session_reset."
-                        )
-                        try:
-                            session_info = await asyncio.to_thread(
-                                self._reset_notice_session_info, source
-                            )
-                            if session_info:
-                                notice = f"{notice}\n\n{session_info}"
-                        except Exception:
-                            pass
-                        await adapter.send(
-                            source.chat_id, notice,
-                            metadata=self._thread_metadata_for_source(source),
-                        )
             except Exception as e:
                 logger.debug("Auto-reset notification failed (non-fatal): %s", e)
 
@@ -13568,6 +13512,110 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         finally:
             # Restore session context variables to their pre-handler state
             self._clear_session_env(_session_env_tokens)
+
+    @staticmethod
+    def _auto_reset_context_note(reset_reason: str) -> str:
+        """Agent-facing system note for an auto-reset turn."""
+        if reset_reason == "suspended":
+            return (
+                "[System note: The user's previous session was stopped and "
+                "suspended. This is a fresh conversation with no prior context.]"
+            )
+        if reset_reason == "daily":
+            return (
+                "[System note: The user's session was automatically reset by "
+                "the daily schedule. This is a fresh conversation with no prior context.]"
+            )
+        if reset_reason == "resume_pending_expired":
+            return (
+                "[System note: The previous gateway session could not be "
+                "recovered after a restart (API recovery timed out). This is a "
+                "fresh conversation — use /resume to restore history if needed.]"
+            )
+        if reset_reason == "stale_routing_recovered":
+            return (
+                "[System note: The previous session ended in a way that could "
+                "not be automatically resumed (e.g. the client disconnected). "
+                "This is a fresh conversation — use /resume to restore history "
+                "if needed.]"
+            )
+        return (
+            "[System note: The user's previous session expired due to "
+            "inactivity. This is a fresh conversation with no prior context.]"
+        )
+
+    async def _maybe_send_auto_reset_notice(
+        self,
+        source: SessionSource,
+        session_entry: SessionEntry,
+        reset_reason: str,
+    ) -> None:
+        """Send a user-facing auto-reset notice via the platform adapter.
+
+        Suspended, restart-recovery-expired, and stale-routing-reset sessions
+        always notify regardless of ``policy.notify`` — the user had an active
+        session that was silently replaced, so they need to know they can
+        ``/resume`` it. Idle/daily resets respect the policy flag.
+        """
+        policy = self.session_store.config.get_reset_policy(
+            platform=source.platform,
+            session_type=getattr(source, "chat_type", "dm"),
+        )
+        platform_name = source.platform.value if source.platform else ""
+        had_activity = getattr(session_entry, "reset_had_activity", False)
+        should_notify = reset_reason in {
+            "suspended",
+            "resume_pending_expired",
+            "stale_routing_recovered",
+        } or (
+            policy.notify
+            and had_activity
+            and platform_name not in policy.notify_exclude_platforms
+        )
+        if not should_notify:
+            return
+
+        adapter = self._adapter_for_source(source)
+        if not adapter:
+            return
+
+        if reset_reason == "suspended":
+            reason_text = "previous session was stopped or interrupted"
+        elif reset_reason == "resume_pending_expired":
+            reason_text = "gateway restart recovery timed out"
+        elif reset_reason == "stale_routing_recovered":
+            reason_text = "previous session ended and could not be auto-resumed"
+        elif reset_reason == "daily":
+            reason_text = f"daily schedule at {policy.at_hour}:00"
+        else:
+            hours = policy.idle_minutes // 60
+            mins = policy.idle_minutes % 60
+            duration = (
+                f"{hours}h" if not mins
+                else f"{hours}h {mins}m" if hours
+                else f"{mins}m"
+            )
+            reason_text = f"inactive for {duration}"
+
+        notice = (
+            f"◐ Session automatically reset ({reason_text}). "
+            f"Conversation history cleared.\n"
+            f"Use /resume to browse and restore a previous session.\n"
+            f"Adjust reset timing in config.yaml under session_reset."
+        )
+        try:
+            session_info = await asyncio.to_thread(
+                self._reset_notice_session_info, source
+            )
+            if session_info:
+                notice = f"{notice}\n\n{session_info}"
+        except Exception:
+            pass
+        await adapter.send(
+            source.chat_id,
+            notice,
+            metadata=self._thread_metadata_for_source(source),
+        )
 
     def _reset_notice_session_info(self, source: SessionSource) -> str:
         """Session-info block for the auto-reset notice, profile-scoped.

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1976,6 +1976,15 @@ class SessionStore:
         was_auto_reset = False
         auto_reset_reason = None
         reset_had_activity = False
+        # Set when the #54878 self-heal drops a routing entry whose session
+        # was already ended in state.db under a reason the recovery finder
+        # doesn't consider resumable (e.g. "tui_shutdown" — anything other
+        # than "agent_close" / still-open). Used after the recovery attempt
+        # to decide whether the user needs to be told their old thread is
+        # gone, since that path otherwise falls through to "Create new
+        # session" in total silence (#59580).
+        stale_routing_dropped_session_id = None
+        stale_routing_had_activity = False
 
         with self._lock:
             self._ensure_loaded_locked()
@@ -2001,6 +2010,11 @@ class SessionStore:
                         "(#54878)",
                         session_key, entry.session_id,
                     )
+                    # Snapshot before pop — recovery may still reopen the row
+                    # (agent_close); if it can't, these drive the user-facing
+                    # stale_routing_recovered notice (#59580).
+                    _dropped_session_id = entry.session_id
+                    _dropped_had_activity = entry.last_prompt_tokens > 0
                     self._entries.pop(session_key, None)
                     # If an expiry watcher (daily/idle reset) already finalized
                     # this session, honour the reset decision instead of silently
@@ -2008,8 +2022,11 @@ class SessionStore:
                     if _reset_reason:
                         was_auto_reset = True
                         auto_reset_reason = _reset_reason
-                        reset_had_activity = entry.last_prompt_tokens > 0
-                        db_end_session_id = entry.session_id
+                        reset_had_activity = _dropped_had_activity
+                        db_end_session_id = _dropped_session_id
+                    else:
+                        stale_routing_dropped_session_id = _dropped_session_id
+                        stale_routing_had_activity = _dropped_had_activity
                     entry = None
                     _needs_recover = True
                 elif entry.session_id != _stale_session_id:
@@ -2049,6 +2066,21 @@ class SessionStore:
                 _needs_save = True
 
         if entry is None:
+            # If the #54878 self-heal dropped a stale routing entry above and
+            # recovery just failed to reopen it (end_reason was outside the
+            # ended_at IS NULL / 'agent_close' whitelist — e.g. 'tui_shutdown'),
+            # the user is about to receive a brand-new, empty session in place
+            # of a thread they may believe is still live. That's the same
+            # "your previous session was silently replaced" situation as any
+            # other auto-reset, so surface it the same way instead of staying
+            # silent. NOTE: db_end_session_id is intentionally left unset here
+            # — the old session was already ended (with its real reason) by
+            # whatever finalized it, and we must not overwrite that reason.
+            if stale_routing_dropped_session_id is not None and not was_auto_reset:
+                was_auto_reset = True
+                auto_reset_reason = "stale_routing_recovered"
+                reset_had_activity = stale_routing_had_activity
+
             # Create a candidate outside the lock, then publish only if another
             # worker has not already populated this routing key.
             session_id = f"{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"

--- a/tests/gateway/test_session_reset_notify.py
+++ b/tests/gateway/test_session_reset_notify.py
@@ -6,10 +6,13 @@ Verifies that:
 - SessionResetPolicy.notify controls whether notifications are sent
 - notify_exclude_platforms skips notifications for excluded platforms
 - resume_pending_expired auto-reset sets the correct reason and DB end_reason
+- stale_routing_recovered notifies when #54878 self-heal can't reopen the old session
 """
 
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from gateway.config import (
     GatewayConfig,
@@ -480,3 +483,202 @@ class TestResumePendingExpiredAutoReset:
         assert refreshed.session_id == old.session_id
         db.end_session.assert_not_called()
         db.promote_to_session_reset.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# stale_routing_recovered: notify when #54878 self-heal can't reopen (#59580)
+# ---------------------------------------------------------------------------
+
+class TestStaleRoutingSelfHealNotify:
+    """When sessions.json points at a session state.db already ended under a
+    non-recoverable reason, get_or_create_session drops the stale entry and
+    tries recovery. If that also declines to reopen it, a brand-new session
+    is created — this must set was_auto_reset=True with reason
+    'stale_routing_recovered' so the user is told, instead of silently
+    switching them to an empty thread (#59580)."""
+
+    def test_unrecoverable_end_reason_notifies_and_creates_new_session(
+        self, tmp_path
+    ):
+        """end_reason='tui_shutdown' can't be auto-recovered -> new session
+        with auto_reset_reason='stale_routing_recovered'."""
+        db = _make_db_mock()
+        store = _make_store_with_db(tmp_path, db)
+        source = _make_source()
+
+        old = store.get_or_create_session(source)
+
+        # Simulate: a TUI client attached to this session_id closed and ended
+        # it in state.db, but sessions.json (in-memory _entries) still routes
+        # here — and automatic recovery has nothing recoverable to offer.
+        db.get_session.return_value = {
+            "id": old.session_id,
+            "end_reason": "tui_shutdown",
+        }
+        db.find_latest_gateway_session_for_peer.return_value = None
+
+        new = store.get_or_create_session(source)
+
+        assert new.session_id != old.session_id, "should have created a new session"
+        assert new.was_auto_reset is True
+        assert new.auto_reset_reason == "stale_routing_recovered"
+
+    def test_unrecoverable_end_reason_does_not_overwrite_db_end_reason(
+        self, tmp_path
+    ):
+        """The old session's real end_reason ('tui_shutdown') must be left
+        alone in state.db — it was already finalized elsewhere, so
+        get_or_create_session must not call end_session()/promote on it again."""
+        db = _make_db_mock()
+        store = _make_store_with_db(tmp_path, db)
+        source = _make_source()
+
+        old = store.get_or_create_session(source)
+        db.get_session.return_value = {
+            "id": old.session_id,
+            "end_reason": "tui_shutdown",
+        }
+        db.find_latest_gateway_session_for_peer.return_value = None
+
+        store.get_or_create_session(source)
+
+        db.end_session.assert_not_called()
+        db.promote_to_session_reset.assert_not_called()
+
+    def test_had_activity_reflects_dropped_session(self, tmp_path):
+        """reset_had_activity on the fresh session reflects whether the
+        dropped/stale session had real conversation activity."""
+        db = _make_db_mock()
+        store = _make_store_with_db(tmp_path, db)
+        source = _make_source()
+
+        old = store.get_or_create_session(source)
+        with store._lock:
+            old.last_prompt_tokens = 12_000
+            store._save()
+
+        db.get_session.return_value = {
+            "id": old.session_id,
+            "end_reason": "tui_shutdown",
+        }
+        db.find_latest_gateway_session_for_peer.return_value = None
+
+        new = store.get_or_create_session(source)
+        assert new.reset_had_activity is True
+
+    def test_recoverable_end_reason_reopens_without_notifying(self, tmp_path):
+        """Non-regression: end_reason='agent_close' IS recoverable — the
+        finder returns a row and the SAME session_id is reopened silently
+        (transcript preserved), so no auto-reset notification should fire."""
+        db = _make_db_mock()
+        store = _make_store_with_db(tmp_path, db)
+        source = _make_source()
+
+        old = store.get_or_create_session(source)
+        db.get_session.return_value = {
+            "id": old.session_id,
+            "end_reason": "agent_close",
+        }
+        db.find_latest_gateway_session_for_peer.return_value = {
+            "id": old.session_id,
+            "started_at": None,
+        }
+
+        recovered = store.get_or_create_session(source)
+
+        assert recovered.session_id == old.session_id, "should reopen the SAME session"
+        assert recovered.was_auto_reset is False
+        db.reopen_session.assert_called_once_with(old.session_id)
+
+    def test_brand_new_peer_does_not_trigger_stale_routing_reason(self, tmp_path):
+        """A peer with no prior routing entry at all must not be treated as a
+        stale-routing self-heal — that's just a normal first-ever session."""
+        db = _make_db_mock()
+        store = _make_store_with_db(tmp_path, db)
+        source = _make_source()
+
+        entry = store.get_or_create_session(source)
+
+        assert entry.was_auto_reset is False
+        assert entry.auto_reset_reason is None
+
+
+# ---------------------------------------------------------------------------
+# GatewayRunner adapter delivery for stale_routing_recovered (#59580)
+# ---------------------------------------------------------------------------
+
+class TestStaleRoutingAdapterDelivery:
+    """Sweeper-requested regression: the user-facing notice must actually
+    reach the platform adapter when reason is stale_routing_recovered,
+    even when policy.notify is False."""
+
+    def _make_runner(self, *, notify: bool = False):
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner.session_store = MagicMock()
+        runner.session_store.config.get_reset_policy.return_value = SessionResetPolicy(
+            mode="none",
+            notify=notify,
+            notify_exclude_platforms=["api_server", "webhook"],
+        )
+        runner._reset_notice_session_info = MagicMock(return_value="")
+        runner._thread_metadata_for_source = MagicMock(return_value={})
+        return runner
+
+    @pytest.mark.asyncio
+    async def test_stale_routing_always_notifies_even_when_policy_notify_false(self):
+        runner = self._make_runner(notify=False)
+        adapter = MagicMock()
+        adapter.send = AsyncMock()
+        runner._adapter_for_source = MagicMock(return_value=adapter)
+
+        source = _make_source()
+        entry = SessionEntry(
+            session_key="telegram:dm:123",
+            session_id="new_sess",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            was_auto_reset=True,
+            auto_reset_reason="stale_routing_recovered",
+            reset_had_activity=True,
+        )
+
+        await runner._maybe_send_auto_reset_notice(
+            source, entry, "stale_routing_recovered",
+        )
+
+        adapter.send.assert_awaited_once()
+        chat_id, notice = adapter.send.await_args.args[:2]
+        assert chat_id == source.chat_id
+        assert "could not be auto-resumed" in notice
+        assert "Session automatically reset" in notice
+
+    def test_stale_routing_context_note_mentions_resume(self):
+        from gateway.run import GatewayRunner
+
+        note = GatewayRunner._auto_reset_context_note("stale_routing_recovered")
+        assert "could not be automatically resumed" in note
+        assert "/resume" in note
+
+    @pytest.mark.asyncio
+    async def test_idle_respects_notify_false(self):
+        """Idle resets must still honour policy.notify=False (non-regression)."""
+        runner = self._make_runner(notify=False)
+        adapter = MagicMock()
+        adapter.send = AsyncMock()
+        runner._adapter_for_source = MagicMock(return_value=adapter)
+
+        source = _make_source()
+        entry = SessionEntry(
+            session_key="telegram:dm:123",
+            session_id="new_sess",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            was_auto_reset=True,
+            auto_reset_reason="idle",
+            reset_had_activity=True,
+        )
+
+        await runner._maybe_send_auto_reset_notice(source, entry, "idle")
+        adapter.send.assert_not_awaited()


### PR DESCRIPTION
## What does this PR do?

The #54878/#55485 stale-routing self-heal in `get_or_create_session` correctly detects when a `sessions.json` routing entry points at a session that state.db already marked ended (e.g. a TUI attached to the same `session_key` closed and wrote `end_reason="tui_shutdown"`, while the Gateway routing entry was left untouched). It drops the stale entry and falls through to `_recover_session_from_db`.

But when that recovery attempt *also* fails — because `hermes_state.py::find_latest_gateway_session_for_peer` only treats `ended_at IS NULL` or `end_reason='agent_close'` as recoverable, and `tui_shutdown` isn't in that set — a brand-new, empty session is created in **total silence**. The self-heal branch hardcodes `was_auto_reset = False`, so not even the generic idle/daily fallback notice (which `idle`/`daily`/`suspended`/`resume_pending_expired` resets already get) fires. The user has no way to learn their routing silently moved until they notice the missing context.

This PR implements the "safe" half of the two-part fix proposed in #59580 — the notification gap, which is a pure additive fix with no behavior-changing side effects. The second half (whether `tui_shutdown` should join `agent_close` in the recoverable `end_reason` set, i.e. whether the session itself should be reopened instead of replaced) is a design question that needs maintainer input and is intentionally left untouched here.

## Related Issue

Addresses #59580 (notification gap only — see the issue for the open design question on recoverability)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- **`gateway/session.py`** (`get_or_create_session`):
  - Track the session_id (and whether it had activity) dropped by the #54878 self-heal branch in new locals `stale_routing_dropped_session_id` / `stale_routing_had_activity`.
  - After `_recover_session_from_db` fails to reopen it, set `was_auto_reset=True` with a new `auto_reset_reason="stale_routing_recovered"` so the existing #58935 notification plumbing fires for this path too.
  - `db_end_session_id` is deliberately left unset for this path — the old session was already finalized elsewhere (with its real end_reason, e.g. `tui_shutdown`) and must not be overwritten.
  - A brand-new peer with no prior routing entry at all is unaffected (the local stays `None`), so this only fires for the actual self-heal case.

- **`gateway/run.py`** (`_handle_message_with_agent`, `_was_auto_reset` block):
  - Added `elif reset_reason == "stale_routing_recovered":` for the agent context note.
  - Added `"stale_routing_recovered"` to the `should_notify` always-on set (alongside `"suspended"`, `"resume_pending_expired"`).
  - Added `elif reset_reason == "stale_routing_recovered":` for the user-facing notice `reason_text`.

- **`tests/gateway/test_session_reset_notify.py`**:
  - Added `TestStaleRoutingSelfHealNotify` with 5 new tests:
    - `test_unrecoverable_end_reason_notifies_and_creates_new_session` — `end_reason='tui_shutdown'` → new session with `auto_reset_reason == "stale_routing_recovered"`
    - `test_unrecoverable_end_reason_does_not_overwrite_db_end_reason` — `db.end_session` is never called for the old session (its real reason is preserved)
    - `test_had_activity_reflects_dropped_session` — `reset_had_activity` reflects the dropped session's token usage
    - `test_recoverable_end_reason_reopens_without_notifying` — non-regression: `end_reason='agent_close'` IS recoverable, silently reopens the SAME `session_id`, no notification
    - `test_brand_new_peer_does_not_trigger_stale_routing_reason` — a peer with no prior routing entry is just a normal first session, not a self-heal

## How to Test

1. Route a session to `session_id = A` via any Gateway platform.
2. End `A` in state.db with `end_reason='tui_shutdown'` (e.g. attach and cleanly close a TUI against the same `session_key`) while `sessions.json` still points at `A`.
3. Send a new inbound message on the same routing key.
4. **Before this fix:** `gateway.session: routing key ... is ended in state.db ... (#54878)` is logged, a new empty session is created, and the user receives no notice at all.
5. **After this fix:** the user receives `◐ Session automatically reset (previous session ended and could not be auto-resumed). ...`, and `A`'s `end_reason` in state.db is untouched.

Or run the new unit tests:
```bash
pytest tests/gateway/test_session_reset_notify.py -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_session_reset_notify.py -v` and all 26 tests pass
- [x] I've added tests for my changes (5 new tests in `TestStaleRoutingSelfHealNotify`)
- [x] I've tested on my platform: Ubuntu 22.04 (Linux 6.8.0-134-generic), reproduced from the production incident described in #59580

### Documentation & Housekeeping

- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new config keys)
- [x] I've considered cross-platform impact — N/A (pure Python logic, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Field incident from #59580 (profile `dingding`, 2026-07-05 → 2026-07-06):

```
23:30:09  User /resume's back into session 57182b via WeChat — history=2146.
00:01:19  Session 57182b ends in state.db: end_reason="tui_shutdown"
          (a TUI attached to the same profile/session_key closed).
          sessions.json is NOT updated — still routes WeChat -> 57182b.
00:02:43  WeChat inbound message.
  WARNING gateway.session: routing key ... -> 57182b is ended in state.db
    but still live in sessions.json; dropping stale entry and
    recovering/recreating the session (#54878)
  -> NO user-facing notice sent.
00:04:11  New session 2717754c created, sessions.json now routes here.
09:21:22  User sends a message, unaware the routing switched 9 hours
          earlier — lands in the new session, not the thread they expected.
```

After this fix, the user would have received:
```
◐ Session automatically reset (previous session ended and could not be auto-resumed).
Conversation history cleared.
Use /resume to browse and restore a previous session.
Adjust reset timing in config.yaml under session_reset.
```

Made with [Cursor](https://cursor.com)