### PR TITLE
fix(agent): strip hallucinated tool-call JSON from assistant content before delivery (#59291)

### DIFF
--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-from typing import Any
+from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -461,6 +461,45 @@ def _sanitize_structure_non_ascii(payload: Any) -> bool:
     return found
 
 
+# Known keys that indicate a JSON blob is a hallucinated tool-call envelope
+# rather than legitimate assistant content. No registered tool schema defines
+# these as top-level fields in assistant messages (#59291).
+_TOOLCALL_SHAPED_KEYS = frozenset({
+    "action",       # e.g. {"action":"clarify","question":...,"choices":...}
+})
+
+
+def _detect_toolcall_shaped_content(content: str) -> Optional[str]:
+    """Detect and strip tool-call-shaped JSON from assistant content.
+
+    Some local models (particularly Ollama) occasionally emit a JSON object
+    as plain assistant text that mimics a tool-call envelope (e.g.
+    ``{"action": "clarify", "question": ..., "choices": ...}``) instead of
+    issuing a native OpenAI-style ``tool_calls`` array.  This JSON then
+    leaks verbatim to end users (Telegram, WhatsApp, etc.) because the
+    message sanitizer only repairs malformed arguments *inside* an already-
+    recognised ``tool_calls`` block.
+
+    Returns an empty string if the content is entirely a tool-call-shaped
+    JSON blob, or ``None`` if no match.
+    """
+    if not content or not isinstance(content, str):
+        return None
+    stripped = content.strip()
+    if not stripped.startswith("{") or not stripped.endswith("}"):
+        return None
+    try:
+        obj = json.loads(stripped)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(obj, dict):
+        return None
+    # Check for tell-tale hallucinated tool-call keys at the top level
+    if any(k in obj for k in _TOOLCALL_SHAPED_KEYS):
+        return ""
+    return None
+
+
 __all__ = [
     "_SURROGATE_RE",
     "close_interrupted_tool_sequence",
@@ -474,4 +513,5 @@ __all__ = [
     "_sanitize_tools_non_ascii",
     "_strip_images_from_messages",
     "_sanitize_structure_non_ascii",
+    "_detect_toolcall_shaped_content",
 ]

--- a/run_agent.py
+++ b/run_agent.py
@@ -177,6 +177,7 @@ from agent.message_sanitization import (  # noqa: F401
     _sanitize_tools_non_ascii,
     _strip_images_from_messages,
     _sanitize_structure_non_ascii,
+    _detect_toolcall_shaped_content,
 )
 from agent.codex_responses_adapter import (
     _derive_responses_function_call_id as _codex_derive_responses_function_call_id,
@@ -5779,6 +5780,13 @@ class AIAgent:
             str: Final assistant response
         """
         result = self.run_conversation(message, stream_callback=stream_callback)
+        # Strip hallucinated tool-call JSON from assistant output before it
+        # reaches gateway delivery channels (Telegram, WhatsApp, etc.) (#59291)
+        resp = result.get("final_response")
+        if isinstance(resp, str):
+            sanitized = _detect_toolcall_shaped_content(resp)
+            if sanitized is not None:
+                result["final_response"] = sanitized
         return result["final_response"]
 
     def _run_codex_app_server_turn(


### PR DESCRIPTION
## Summary

Some local models (particularly Ollama) occasionally emit a JSON object as plain assistant `content` that mimics a tool-call envelope (e.g. `{"action": "clarify", "question": ..., "choices": ...}`) instead of issuing a native OpenAI-style `tool_calls` array. The existing message sanitizer only repairs malformed arguments *inside* an already-recognised `tool_calls` block, so this shape-alike JSON blob passes through untouched and reaches the end user verbatim over Telegram, WhatsApp, etc.

## Fix

1. **`_detect_toolcall_shaped_content()`** in `message_sanitization.py` — detects JSON objects with tell-tale hallucinated keys (`action`) at the top level and strips them
2. **Integration in `run_agent.py`** — the `final_response` is sanitized through this function before being returned from `run_conversation`

`action` is the key identified by the reporter; it is NOT a field any registered tool schema or legitimate assistant message produces at the top level. Future hallucination patterns can be added to the `_TOOLCALL_SHAPED_KEYS` frozenset.

## Changes

| File | Δ |
|------|---|
| `agent/message_sanitization.py` | +41 lines (detection function + export) |
| `run_agent.py` | +7 lines (import + call site) |

## Tests

```python
# Unit test
_detect_toolcall_shaped_content('{"action":"clarify"}') → ""       # detected
_detect_toolcall_shaped_content('Hello, world!') → None             # normal text
_detect_toolcall_shaped_content('{"name":"test"}') → None           # JSON without action
```

Closes #59291