### PR TITLE
fix(memory): substring replace preserves surrounding entry content

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -321,10 +321,29 @@ class TestMemoryStoreAdd:
 class TestMemoryStoreReplace:
     def test_replace_entry(self, store):
         store.add("memory", "Python 3.11 project")
-        result = store.replace("memory", "3.11", "Python 3.12 project")
+        result = store.replace("memory", "3.11", "3.12")
         assert result["success"] is True
         assert "Python 3.12 project" in store.memory_entries
         assert "Python 3.11 project" not in store.memory_entries
+
+    def test_replace_whole_entry_with_full_old_text(self, store):
+        """Backward compat: when old_text IS the full entry, whole entry is replaced."""
+        store.add("memory", "Python 3.11 project")
+        result = store.replace("memory", "Python 3.11 project", "Rust 1.75 project")
+        assert result["success"] is True
+        assert "Rust 1.75 project" in store.memory_entries
+        assert "Python 3.11 project" not in store.memory_entries
+
+    def test_replace_substring_preserves_surrounding(self, store):
+        """Fix for #59184: partial old_text replaces only the match, not the whole entry."""
+        store.add("memory", "Section A\ncontent A\nSection B\ncontent B\nSection C")
+        result = store.replace("memory", "Section B\ncontent B", "Section B\nnew content")
+        assert result["success"] is True
+        entry = store.memory_entries[0]
+        assert "Section A" in entry
+        assert "Section C" in entry
+        assert "new content" in entry
+        assert "content B\nSection C" not in entry  # old substring gone
 
     def test_replace_no_match(self, store):
         store.add("memory", "fact A")
@@ -652,6 +671,22 @@ class TestMemoryBatch:
         assert result["success"] is True
         assert store.memory_entries.count("already here") == 1
         assert "brand new" in store.memory_entries
+
+    def test_batch_replace_preserves_surrounding(self, store):
+        """Fix for #59184 in batch: substring replace preserves surrounding content."""
+        store.add("memory", "Section A\ncontent A\nSection B\ncontent B\nSection C")
+        result = json.loads(memory_tool(
+            target="memory",
+            operations=[
+                {"action": "replace", "old_text": "Section B\ncontent B", "content": "Section B\nnew content"},
+            ],
+            store=store,
+        ))
+        assert result["success"] is True
+        entry = store.memory_entries[0]
+        assert "Section A" in entry
+        assert "Section C" in entry
+        assert "new content" in entry
 
     def test_batch_injection_blocked_rejects_whole_batch(self, store):
         result = json.loads(memory_tool(

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -386,7 +386,15 @@ class MemoryStore:
         return self._success_response(target, "Entry added.")
 
     def replace(self, target: str, old_text: str, new_content: str) -> Dict[str, Any]:
-        """Find entry containing old_text substring, replace it with new_content."""
+        """Find entry containing old_text substring, replace the matched portion with new_content.
+
+        If old_text matches only part of an entry, only the matched substring is
+        replaced -- surrounding content is preserved (fix for issue #59184 where
+        whole-entry replacement silently destroyed composite entries).
+
+        If old_text matches the entire entry, behaviour is unchanged (the whole
+        entry is replaced with new_content).
+        """
         old_text = old_text.strip()
         new_content = new_content.strip()
         if not old_text:
@@ -429,9 +437,24 @@ class MemoryStore:
             idx = matches[0][0]
             limit = self._char_limit(target)
 
+            # Substring replacement: replace only the matched portion within
+            # the entry, preserving surrounding content (fix for #59184).
+            # If old_text matches the entire entry, this is equivalent to
+            # whole-entry replacement (backward compatible).
+            entry = entries[idx]
+            pos = entry.find(old_text)
+            if pos == -1:
+                # Should not happen (we matched above), but guard defensively
+                return self._consolidation_failure({
+                    "success": False,
+                    "error": f"Match found but position lost. This is a bug -- please report.",
+                    "current_entries": entries,
+                })
+            new_entry = entry[:pos] + new_content + entry[pos + len(old_text):]
+
             # Check that replacement doesn't blow the budget
             test_entries = entries.copy()
-            test_entries[idx] = new_content
+            test_entries[idx] = new_entry
             new_total = len(ENTRY_DELIMITER.join(test_entries))
 
             if new_total > limit:
@@ -448,7 +471,7 @@ class MemoryStore:
                     "usage": f"{current:,}/{limit:,}",
                 })
 
-            entries[idx] = new_content
+            entries[idx] = new_entry
             self._set_entries(target, entries)
             self.save_to_disk(target)
 
@@ -559,7 +582,13 @@ class MemoryStore:
                             target,
                             f"{pos}: '{old_text}' matched multiple distinct entries -- be more specific.",
                         )
-                    working[matches[0]] = content
+                    # Substring replacement: preserve surrounding content (fix for #59184)
+                    idx = matches[0]
+                    entry = working[idx]
+                    sub_pos = entry.find(old_text)
+                    if sub_pos == -1:
+                        return self._batch_error(target, f"{pos}: match position lost (bug).")
+                    working[idx] = entry[:sub_pos] + content + entry[sub_pos + len(old_text):]
 
                 elif act == "remove":
                     if not old_text:


### PR DESCRIPTION
Closes #59184. The memory tool replace action replaces the entire entry instead of only the matched substring, causing silent data loss on composite entries. Fix: replace only the matched portion, preserve surrounding content. Backward compatible (full-entry old_text still replaces whole entry). Same fix applied to apply_batch. 86 tests passed (3 new).