### PR TITLE
fix: preserve MEDIA: tags inside backtick-wrapped inline code

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3520,9 +3520,15 @@ class BasePlatformAdapter(ABC):
         for m in re.finditer(r'`[^`\n]+`', content):
             start = m.start()
             # Check if this is a backtick-quoted path after MEDIA:
+            #   MEDIA:`/path/file.png` ← backtick after MEDIA:
             prefix = content[max(0, start - 20):start]
             if re.search(r'MEDIA:\s*$', prefix):
                 continue  # This is a MEDIA path quote, not inline code
+            # Also skip if the backtick span itself contains a MEDIA: tag:
+            #   `MEDIA:/path/file.png` ← backtick wraps the whole MEDIA tag
+            body = content[start + 1 : m.end() - 1]
+            if re.match(r'MEDIA:\s*(?:`[^`\n]+`|"[^"\n]+"|\'[^\'\n]+\'|(?:~/|/|[A-Za-z]:[/\\])\S+\.\w+)', body, re.IGNORECASE):
+                continue
             spans.append((start, m.end()))
 
         # Blockquote lines: > at line start


### PR DESCRIPTION
## Problem

`_mask_protected_spans` masks inline code spans to prevent MEDIA: false positives, but only skipped masking when `MEDIA:` appeared *before* the opening backtick (`MEDIA:`/path``). Backtick-wrapped MEDIA tags (``MEDIA:/path``) were still masked.

## Fix

Add a body check: extract content between backticks and test whether it starts with a MEDIA: tag pattern. If so, skip masking so downstream `extract_media()` can pick it up.

## Testing

Verified with QQ Bot C2C chat — both bare and backtick-wrapped MEDIA tags now deliver files.