### PR TITLE
feat(gateway): guard agent email loops with AI judge and deterministic safeguards

### DIFF
--- a/docs/observability/gateway-loop-guard.md
+++ b/docs/observability/gateway-loop-guard.md
@@ -1,0 +1,81 @@
+# Gateway agent-loop guard
+
+Hermes gateways can receive messages from other Hermes agents over transports
+such as email.  Without a substrate-level guard, runtime notices like progress,
+shutdown, restart, or "received" acknowledgements can be mistaken for fresh
+human instructions and bounce between agents.
+
+The gateway loop guard runs outside the agent conversation, before dispatching
+an inbound message to the agent and before sending an outbound email reply.
+It has three layers:
+
+1. Runtime quarantine state in `gateway-loop-guard-state.json` under the active
+   `HERMES_HOME`.
+2. Deterministic safety signals for obvious loops: agent-to-agent restart
+   requests, Hermes runtime/status notices, duplicate low-novelty replies, hop
+   count overflow, and too many recent pair events.
+3. Optional auxiliary LLM judge (`loop_guard`) for semantic agent-agent loops
+   that do not match fixed patterns.
+
+## Email configuration
+
+Enable per email platform profile in `config.yaml`:
+
+```yaml
+platforms:
+  email:
+    extra:
+      loop_guard:
+        enabled: true
+        mode: protect        # observe | protect | strict | off
+        ai_enabled: true     # optional; uses auxiliary task=loop_guard
+        agent_id: alfred
+        agent_identities:
+          - alfred@sqmnet.es
+          - selina@sqmnet.es
+          - bishop@sqmnet.es
+        quarantine_ttl_seconds: 7200
+```
+
+`observe` records decisions but allows traffic.  Use it during rollout.
+`protect` suppresses high/critical loop decisions and can quarantine an agent
+pair temporarily.  `strict` also suppresses medium-risk agent acknowledgements.
+
+The email adapter adds these headers to outbound Hermes email:
+
+- `X-Hermes-Origin-Agent`
+- `X-Hermes-Origin-Address`
+- `X-Hermes-Intent`
+- `X-Hermes-Hop-Count`
+- `X-Hermes-Reply-Policy`
+
+Inbound emails with these headers are treated as agent-originated even when the
+sender address is not listed explicitly in `agent_identities`.
+
+## Self-restart guard
+
+Terminal approval now hard-blocks gateway self-targeting commands when the
+process is running inside a gateway (`_HERMES_GATEWAY=1`), even if yolo or
+`approvals.mode: off` is active.  Blocked examples:
+
+```bash
+hermes gateway restart
+hermes update
+systemctl --user restart hermes-gateway
+systemctl --user restart hermes-gateway-selina-email.service
+```
+
+Use the gateway `/restart` command or restart externally from SSH/systemd
+instead.  The internal `/restart` path remains available because it does not run
+through the terminal tool and its detached watcher clears `_HERMES_GATEWAY`.
+
+## Testing
+
+Minimal focused regression suite:
+
+```bash
+python -m unittest \
+  tests.gateway.test_loop_guard \
+  tests.gateway.test_email_loop_guard \
+  tests.tools.test_gateway_self_restart_guard
+```

--- a/gateway/loop_guard.py
+++ b/gateway/loop_guard.py
@@ -1,0 +1,564 @@
+"""AI-assisted loop guard for gateway message dispatch and delivery.
+
+The guard is deliberately outside the agent conversation.  It decides whether a
+message should enter the agent loop or leave the gateway at all, using a small
+set of deterministic safety signals plus an optional auxiliary LLM judge for
+semantic agent-agent recursion.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass, field, replace
+from typing import Any, Dict, Iterable, Optional
+
+from gateway.loop_state import LoopStateStore, default_loop_state_path
+
+logger = logging.getLogger(__name__)
+
+_RISK_ORDER = {"low": 0, "medium": 1, "high": 2, "critical": 3}
+_BLOCKING_ACTIONS = {"suppress", "quarantine_pair", "ask_human"}
+_RUNTIME_INTENTS = {"status", "progress", "shutdown", "restart", "error", "notice"}
+
+_META_STATUS_RE = re.compile(
+    r"("
+    r"gateway\s+(?:restarted|restart(?:ing)?|online|shutdown|stopp(?:ed|ing))"
+    r"|hermes\s+(?:gateway|update)"
+    r"|previous\s+(?:agent\s+)?run\s+was\s+interrupted"
+    r"|auto-?resume"
+    r"|processing\s+(?:started|complete|cancelled|failed)"
+    r"|handler\s+returned\s+empty"
+    r"|auxiliary\s+.+\s+failed"
+    r"|runtime\s+notice"
+    r")",
+    re.IGNORECASE | re.DOTALL,
+)
+
+_RESTART_REQUEST_RE = re.compile(
+    r"("
+    r"(?:^|\b)/(?:restart|update)\b"
+    r"|(?:reinicia|reiniciar|rearranca|restart)\s+(?:tu\s+|el\s+|the\s+)?(?:gateway|hermes)"
+    r"|systemctl\s+(?:--user\s+)?restart\s+.+hermes"
+    r"|hermes\s+gateway\s+restart"
+    r")",
+    re.IGNORECASE,
+)
+
+_ACK_ONLY_RE = re.compile(
+    r"^(?:[\s\W]*(?:ok|vale|recibido|entendido|done|ack|acknowledged|noted|sin accion|no action|no actuo|hilo cerrado|closed)[\s\W]*){1,8}$",
+    re.IGNORECASE,
+)
+
+
+def _bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+        return default
+    return bool(value)
+
+
+def _int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _float(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _split_identities(raw: Any) -> set[str]:
+    if raw is None:
+        return set()
+    if isinstance(raw, str):
+        items = raw.split(",")
+    elif isinstance(raw, Iterable):
+        items = list(raw)
+    else:
+        return set()
+    return {str(item).strip().lower() for item in items if str(item).strip()}
+
+
+def _risk_at_least(risk: str, threshold: str) -> bool:
+    return _RISK_ORDER.get(risk, 0) >= _RISK_ORDER.get(threshold, 0)
+
+
+def _agent_slug(identity: str) -> str:
+    local = (identity or "hermes").split("@", 1)[0].strip().lower()
+    return re.sub(r"[^a-z0-9_.-]+", "-", local) or "hermes"
+
+
+@dataclass
+class LoopGuardConfig:
+    enabled: bool = True
+    mode: str = "protect"  # observe|protect|strict
+    ai_enabled: bool = False
+    ai_timeout_seconds: float = 12.0
+    quarantine_ttl_seconds: int = 7200
+    agent_identities: set[str] = field(default_factory=set)
+    local_identity: str = ""
+    agent_id: str = ""
+    state_path: str = ""
+    window_seconds: int = 1800
+    max_agent_pair_events: int = 6
+    max_hop_count: int = 4
+    duplicate_window_seconds: int = 1800
+
+    @classmethod
+    def from_mapping(
+        cls,
+        mapping: Dict[str, Any] | None,
+        *,
+        local_identity: str = "",
+    ) -> "LoopGuardConfig":
+        mapping = mapping or {}
+        env_identities = _split_identities(os.getenv("HERMES_LOOP_GUARD_AGENT_IDENTITIES"))
+        cfg_identities = _split_identities(
+            mapping.get("agent_identities")
+            or mapping.get("agent_email_addresses")
+            or mapping.get("agent_addresses")
+        )
+        identities = env_identities | cfg_identities
+        if local_identity:
+            identities.add(local_identity.strip().lower())
+
+        state_path = (
+            os.getenv("HERMES_LOOP_GUARD_STATE_PATH")
+            or str(mapping.get("state_path") or "")
+            or str(default_loop_state_path())
+        )
+        mode = (os.getenv("HERMES_LOOP_GUARD_MODE") or str(mapping.get("mode") or "protect")).strip().lower()
+        if mode not in {"observe", "protect", "strict", "off"}:
+            mode = "protect"
+
+        return cls(
+            enabled=_bool(os.getenv("HERMES_LOOP_GUARD_ENABLED"), _bool(mapping.get("enabled"), True)) and mode != "off",
+            mode=mode,
+            ai_enabled=_bool(os.getenv("HERMES_LOOP_GUARD_AI_ENABLED"), _bool(mapping.get("ai_enabled"), False)),
+            ai_timeout_seconds=_float(mapping.get("ai_timeout_seconds"), 12.0),
+            quarantine_ttl_seconds=_int(mapping.get("quarantine_ttl_seconds"), 7200),
+            agent_identities=identities,
+            local_identity=(local_identity or str(mapping.get("local_identity") or "")).strip().lower(),
+            agent_id=str(mapping.get("agent_id") or "").strip() or _agent_slug(local_identity),
+            state_path=state_path,
+            window_seconds=_int(mapping.get("window_seconds"), 1800),
+            max_agent_pair_events=_int(mapping.get("max_agent_pair_events"), 6),
+            max_hop_count=_int(mapping.get("max_hop_count"), 4),
+            duplicate_window_seconds=_int(mapping.get("duplicate_window_seconds"), 1800),
+        )
+
+
+@dataclass
+class LoopContext:
+    platform: str
+    direction: str  # inbound|outbound
+    local_identity: str
+    remote_identity: str
+    text: str
+    subject: str = ""
+    message_id: str = ""
+    in_reply_to: str = ""
+    headers: Dict[str, Any] = field(default_factory=dict)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def pair_key(self) -> str:
+        return LoopStateStore.pair_key(self.platform, self.local_identity, self.remote_identity)
+
+
+@dataclass
+class LoopDecision:
+    risk: str = "low"
+    category: str = "normal"
+    should_dispatch_to_agent: bool = True
+    should_send_reply: bool = True
+    recommended_action: str = "allow"
+    confidence: float = 1.0
+    reason: str = ""
+    owner_summary: str = ""
+    source: str = "deterministic"
+
+    @classmethod
+    def allow(cls, *, reason: str = "allowed", source: str = "deterministic") -> "LoopDecision":
+        return cls(risk="low", category="normal", reason=reason, source=source)
+
+    @classmethod
+    def from_mapping(cls, data: Dict[str, Any], *, source: str) -> "LoopDecision":
+        risk = str(data.get("risk") or "low").lower()
+        if risk not in _RISK_ORDER:
+            risk = "low"
+        action = str(data.get("recommended_action") or "allow").lower()
+        category = str(data.get("category") or "unclear").lower()
+        should_dispatch = data.get("should_dispatch_to_agent")
+        should_send = data.get("should_send_reply")
+        if should_dispatch is None:
+            should_dispatch = action not in _BLOCKING_ACTIONS
+        if should_send is None:
+            should_send = action not in _BLOCKING_ACTIONS
+        try:
+            confidence = float(data.get("confidence", 0.0))
+        except (TypeError, ValueError):
+            confidence = 0.0
+        return cls(
+            risk=risk,
+            category=category,
+            should_dispatch_to_agent=bool(should_dispatch),
+            should_send_reply=bool(should_send),
+            recommended_action=action,
+            confidence=max(0.0, min(1.0, confidence)),
+            reason=str(data.get("reason") or ""),
+            owner_summary=str(data.get("owner_summary") or ""),
+            source=source,
+        )
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "risk": self.risk,
+            "category": self.category,
+            "should_dispatch_to_agent": self.should_dispatch_to_agent,
+            "should_send_reply": self.should_send_reply,
+            "recommended_action": self.recommended_action,
+            "confidence": self.confidence,
+            "reason": self.reason,
+            "owner_summary": self.owner_summary,
+            "source": self.source,
+        }
+
+
+class AgentLoopGuard:
+    """Gateway-level loop guard with optional AI semantic judge."""
+
+    def __init__(self, config: LoopGuardConfig, *, state: LoopStateStore | None = None):
+        self.config = config
+        self.state = state or LoopStateStore(config.state_path)
+
+    @classmethod
+    def from_platform_config(cls, platform_config: Any, *, local_identity: str = "") -> "AgentLoopGuard":
+        extra = getattr(platform_config, "extra", {}) or {}
+        mapping = extra.get("loop_guard", extra.get("agent_loop_guard", {}))
+        cfg = LoopGuardConfig.from_mapping(mapping, local_identity=local_identity)
+        return cls(cfg)
+
+    def is_agent_identity(self, value: str) -> bool:
+        ident = (value or "").strip().lower()
+        return bool(ident and ident in self.config.agent_identities)
+
+    def context_is_agent_to_agent(self, ctx: LoopContext) -> bool:
+        headers = {str(k).lower(): str(v) for k, v in (ctx.headers or {}).items()}
+        remote_has_hermes_header = bool(headers.get("x-hermes-origin-agent"))
+        local_is_agent = self.is_agent_identity(ctx.local_identity) or bool(self.config.local_identity)
+        remote_is_agent = self.is_agent_identity(ctx.remote_identity) or remote_has_hermes_header
+        return local_is_agent and remote_is_agent
+
+    async def evaluate(self, ctx: LoopContext, *, stage: str) -> LoopDecision:
+        """Evaluate a message at ``pre_dispatch`` or ``pre_send`` stage."""
+
+        if not self.config.enabled:
+            return LoopDecision.allow(reason="loop guard disabled")
+
+        deterministic = self._deterministic_decision(ctx)
+        decision = deterministic
+        if self.config.ai_enabled and self._should_call_ai(ctx, deterministic):
+            ai_decision = await self._call_ai_judge(ctx, deterministic)
+            if ai_decision is not None:
+                decision = self._combine_decisions(deterministic, ai_decision)
+
+        decision = self._apply_mode(decision)
+        self._record(ctx, decision, stage=stage)
+        return decision
+
+    def _deterministic_decision(self, ctx: LoopContext) -> LoopDecision:
+        pair_key = ctx.pair_key
+        quarantine = self.state.get_quarantine(pair_key)
+        if quarantine is not None:
+            return LoopDecision(
+                risk="critical",
+                category=str(quarantine.get("category") or "agent_agent_loop"),
+                should_dispatch_to_agent=False,
+                should_send_reply=False,
+                recommended_action="suppress",
+                confidence=1.0,
+                reason=f"pair is quarantined until {quarantine.get('expires_at')}",
+            )
+
+        is_agent_pair = self.context_is_agent_to_agent(ctx)
+        headers = {str(k).lower(): str(v) for k, v in (ctx.headers or {}).items()}
+        intent = (headers.get("x-hermes-intent") or str(ctx.metadata.get("hermes_intent") or "")).strip().lower()
+        hop_count = self._hop_count(ctx, headers)
+        text = ctx.text or ""
+        subject = ctx.subject or ""
+        recent = self.state.recent_events(pair_key, window_seconds=self.config.window_seconds)
+        duplicate_count = self.state.duplicate_count(
+            pair_key,
+            text,
+            window_seconds=self.config.duplicate_window_seconds,
+        )
+
+        if is_agent_pair and self._is_restart_loop(text, intent):
+            return LoopDecision(
+                risk="critical",
+                category="restart_loop",
+                should_dispatch_to_agent=False,
+                should_send_reply=False,
+                recommended_action="quarantine_pair",
+                confidence=1.0,
+                reason="agent-to-agent message attempts to restart/update the gateway or reports restart recursion",
+                owner_summary="Suppressed an agent-to-agent gateway restart loop.",
+            )
+
+        if is_agent_pair and hop_count >= self.config.max_hop_count:
+            return LoopDecision(
+                risk="high",
+                category="agent_agent_loop",
+                should_dispatch_to_agent=False,
+                should_send_reply=False,
+                recommended_action="quarantine_pair",
+                confidence=0.95,
+                reason=f"Hermes hop count {hop_count} exceeded limit {self.config.max_hop_count}",
+            )
+
+        if is_agent_pair and self._is_meta_status(text, subject, intent):
+            return LoopDecision(
+                risk="high",
+                category="meta_status_loop",
+                should_dispatch_to_agent=False,
+                should_send_reply=False,
+                recommended_action="suppress",
+                confidence=0.9,
+                reason="agent-to-agent runtime/status notice should not enter or leave the agent conversation",
+            )
+
+        if is_agent_pair and len(recent) >= self.config.max_agent_pair_events:
+            return LoopDecision(
+                risk="high",
+                category="agent_agent_loop",
+                should_dispatch_to_agent=False,
+                should_send_reply=False,
+                recommended_action="quarantine_pair",
+                confidence=0.9,
+                reason=f"{len(recent)} recent agent-agent events in the loop window",
+            )
+
+        if is_agent_pair and duplicate_count >= 1:
+            return LoopDecision(
+                risk="high",
+                category="duplicate_ack_loop" if self._is_low_information_ack(text) else "agent_agent_loop",
+                should_dispatch_to_agent=False,
+                should_send_reply=False,
+                recommended_action="suppress",
+                confidence=0.85,
+                reason="duplicate low-novelty agent-agent message in recent window",
+            )
+
+        if is_agent_pair and self._is_low_information_ack(text):
+            return LoopDecision(
+                risk="medium",
+                category="duplicate_ack_loop",
+                should_dispatch_to_agent=True,
+                should_send_reply=True,
+                recommended_action="allow_once",
+                confidence=0.75,
+                reason="first low-information agent acknowledgement; allow once and watch for repetition",
+            )
+
+        return LoopDecision.allow(reason="no loop signal")
+
+    def _hop_count(self, ctx: LoopContext, headers: Dict[str, str]) -> int:
+        raw = ctx.metadata.get("hermes_hop_count") or headers.get("x-hermes-hop-count") or 0
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            return 0
+
+    def _is_restart_loop(self, text: str, intent: str) -> bool:
+        return intent == "restart" or bool(_RESTART_REQUEST_RE.search(text or ""))
+
+    def _is_meta_status(self, text: str, subject: str, intent: str) -> bool:
+        if intent in _RUNTIME_INTENTS:
+            return True
+        combined = f"{subject}\n{text}"
+        return bool(_META_STATUS_RE.search(combined))
+
+    def _is_low_information_ack(self, text: str) -> bool:
+        normalized = " ".join((text or "").strip().lower().split())
+        if not normalized:
+            return True
+        if len(normalized) <= 120 and _ACK_ONLY_RE.match(normalized):
+            return True
+        if len(normalized) <= 220 and any(
+            phrase in normalized
+            for phrase in (
+                "no realizo ninguna accion",
+                "no realizo ninguna acción",
+                "no additional action",
+                "nothing else to do",
+                "hilo cerrado",
+                "thread closed",
+            )
+        ):
+            return True
+        return False
+
+    def _should_call_ai(self, ctx: LoopContext, deterministic: LoopDecision) -> bool:
+        if not self.context_is_agent_to_agent(ctx):
+            return False
+        if deterministic.risk in {"high", "critical"}:
+            return False  # deterministic guard already has enough confidence
+        return True
+
+    async def _call_ai_judge(self, ctx: LoopContext, deterministic: LoopDecision) -> Optional[LoopDecision]:
+        payload = {
+            "stage_context": {
+                "platform": ctx.platform,
+                "direction": ctx.direction,
+                "local_identity": ctx.local_identity,
+                "remote_identity": ctx.remote_identity,
+                "subject": ctx.subject[:240],
+                "text_excerpt": (ctx.text or "")[:1800],
+                "headers": {
+                    key: value
+                    for key, value in (ctx.headers or {}).items()
+                    if str(key).lower().startswith("x-hermes-")
+                },
+            },
+            "deterministic_decision": deterministic.as_dict(),
+            "allowed_actions": ["allow", "allow_once", "suppress", "quarantine_pair", "notify_owner", "ask_human"],
+        }
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "You are Hermes gateway's internal loop-safety judge. "
+                    "Classify whether an agent-to-agent message advances a human goal or is recursively "
+                    "processing runtime/progress/restart/status/meta chatter. Return STRICT JSON only with: "
+                    "risk low|medium|high|critical, category normal|agent_agent_loop|meta_status_loop|"
+                    "restart_loop|duplicate_ack_loop|tool_failure_loop|unclear, should_dispatch_to_agent, "
+                    "should_send_reply, recommended_action, confidence, reason, owner_summary. "
+                    "Do not address the remote agent; this decision is internal."
+                ),
+            },
+            {"role": "user", "content": json.dumps(payload, ensure_ascii=False)},
+        ]
+
+        def _call() -> Any:
+            from agent.auxiliary_client import call_llm
+
+            return call_llm(
+                task="loop_guard",
+                messages=messages,
+                temperature=0,
+                max_tokens=500,
+                timeout=self.config.ai_timeout_seconds,
+            )
+
+        try:
+            response = await asyncio.to_thread(_call)
+            content = response.choices[0].message.content
+            data = self._parse_json_object(str(content or ""))
+            if not isinstance(data, dict):
+                return None
+            return LoopDecision.from_mapping(data, source="ai")
+        except Exception as exc:
+            logger.warning("Loop guard AI judge failed; using deterministic decision: %s", exc)
+            return None
+
+    def _parse_json_object(self, text: str) -> Optional[Dict[str, Any]]:
+        text = (text or "").strip()
+        if not text:
+            return None
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            pass
+        start = text.find("{")
+        end = text.rfind("}")
+        if start >= 0 and end > start:
+            try:
+                return json.loads(text[start : end + 1])
+            except json.JSONDecodeError:
+                return None
+        return None
+
+    def _combine_decisions(self, deterministic: LoopDecision, ai_decision: LoopDecision) -> LoopDecision:
+        if _RISK_ORDER.get(ai_decision.risk, 0) > _RISK_ORDER.get(deterministic.risk, 0):
+            return ai_decision
+        if _RISK_ORDER.get(ai_decision.risk, 0) == _RISK_ORDER.get(deterministic.risk, 0) and ai_decision.confidence >= deterministic.confidence:
+            return ai_decision
+        return deterministic
+
+    def _apply_mode(self, decision: LoopDecision) -> LoopDecision:
+        mode = self.config.mode
+        if mode == "observe":
+            return replace(
+                decision,
+                should_dispatch_to_agent=True,
+                should_send_reply=True,
+                recommended_action="allow",
+                reason=f"observe mode: would have {decision.recommended_action} ({decision.reason})",
+            )
+
+        threshold = "medium" if mode == "strict" else "high"
+        should_block = _risk_at_least(decision.risk, threshold) or decision.recommended_action in {"quarantine_pair", "ask_human"}
+        if should_block:
+            return replace(
+                decision,
+                should_dispatch_to_agent=False,
+                should_send_reply=False,
+                recommended_action="quarantine_pair" if decision.recommended_action == "quarantine_pair" else "suppress",
+            )
+        return decision
+
+    def _record(self, ctx: LoopContext, decision: LoopDecision, *, stage: str) -> None:
+        try:
+            self.state.add_event(
+                ctx.pair_key,
+                direction=ctx.direction,
+                text=ctx.text,
+                subject=ctx.subject,
+                risk=decision.risk,
+                category=decision.category,
+                action=decision.recommended_action,
+                stage=stage,
+            )
+            if decision.recommended_action == "quarantine_pair" and self.config.mode != "observe":
+                self.state.set_quarantine(
+                    ctx.pair_key,
+                    ttl_seconds=self.config.quarantine_ttl_seconds,
+                    reason=decision.reason,
+                    category=decision.category,
+                )
+        except Exception:
+            logger.debug("Loop guard state update failed", exc_info=True)
+
+    def outbound_headers(self, *, to_addr: str, metadata: Dict[str, Any] | None = None, inbound_hop_count: int = 0) -> Dict[str, str]:
+        metadata = metadata or {}
+        intent = str(metadata.get("hermes_intent") or "assistant_reply")
+        reply_policy = str(metadata.get("hermes_reply_policy") or "human-or-allow-once")
+        try:
+            if "hermes_hop_count" in metadata:
+                hop_count = int(metadata.get("hermes_hop_count") or 0)
+            else:
+                hop_count = int(inbound_hop_count or 0) + 1
+        except (TypeError, ValueError):
+            hop_count = 1
+        return {
+            "X-Hermes-Origin-Agent": str(metadata.get("hermes_origin_agent") or self.config.agent_id or _agent_slug(self.config.local_identity)),
+            "X-Hermes-Origin-Address": self.config.local_identity,
+            "X-Hermes-Intent": intent,
+            "X-Hermes-Hop-Count": str(max(1, hop_count)),
+            "X-Hermes-Reply-Policy": reply_policy,
+        }

--- a/gateway/loop_state.py
+++ b/gateway/loop_state.py
@@ -1,0 +1,208 @@
+"""Persistent runtime state for gateway loop protection.
+
+The store is intentionally small and JSON-backed: gateways need a durable,
+crash-safe way to remember recent agent-agent exchanges and temporary
+quarantines, but this path must not introduce a database dependency or block
+startup if the file is malformed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from hermes_cli.config import get_hermes_home
+
+
+_DEFAULT_STATE_FILE = "gateway-loop-guard-state.json"
+
+
+def default_loop_state_path() -> Path:
+    """Return the default loop guard state path for the active profile."""
+
+    return get_hermes_home() / _DEFAULT_STATE_FILE
+
+
+def text_fingerprint(text: str) -> str:
+    """Stable hash for loop-novelty comparisons."""
+
+    normalized = " ".join((text or "").lower().split())
+    return hashlib.sha256(normalized.encode("utf-8", errors="ignore")).hexdigest()
+
+
+class LoopStateStore:
+    """JSON-backed rolling event/quarantine store.
+
+    Shape on disk::
+
+        {
+          "version": 1,
+          "events": {"email:a<->b": [{...}, ...]},
+          "quarantines": {"email:a<->b": {"expires_at": 123, ...}}
+        }
+    """
+
+    def __init__(self, path: str | os.PathLike[str] | None = None, *, max_events_per_pair: int = 80):
+        self.path = Path(path) if path else default_loop_state_path()
+        self.max_events_per_pair = max(10, int(max_events_per_pair or 80))
+
+    @staticmethod
+    def pair_key(platform: str, left: str, right: str) -> str:
+        """Return a stable key for an unordered communication pair."""
+
+        a = (left or "").strip().lower()
+        b = (right or "").strip().lower()
+        ordered = sorted([a, b])
+        return f"{(platform or '').strip().lower()}:{ordered[0]}<->{ordered[1]}"
+
+    def _empty(self) -> Dict[str, Any]:
+        return {"version": 1, "events": {}, "quarantines": {}}
+
+    def _load(self) -> Dict[str, Any]:
+        try:
+            if not self.path.exists():
+                return self._empty()
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                return self._empty()
+            data.setdefault("version", 1)
+            if not isinstance(data.get("events"), dict):
+                data["events"] = {}
+            if not isinstance(data.get("quarantines"), dict):
+                data["quarantines"] = {}
+            return data
+        except Exception:
+            # Corrupt state must never prevent the gateway from starting.
+            return self._empty()
+
+    def _save(self, data: Dict[str, Any]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{self.path.name}.",
+            suffix=".tmp",
+            dir=str(self.path.parent),
+            text=True,
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(data, fh, ensure_ascii=False, separators=(",", ":"))
+            os.replace(tmp_name, self.path)
+        finally:
+            try:
+                os.unlink(tmp_name)
+            except FileNotFoundError:
+                pass
+
+    def _prune_expired_quarantines(self, data: Dict[str, Any], *, now: float | None = None) -> bool:
+        now = time.time() if now is None else now
+        quarantines = data.setdefault("quarantines", {})
+        expired = [key for key, item in quarantines.items() if float(item.get("expires_at", 0) or 0) <= now]
+        for key in expired:
+            quarantines.pop(key, None)
+        return bool(expired)
+
+    def get_quarantine(self, pair_key: str) -> Optional[Dict[str, Any]]:
+        data = self._load()
+        changed = self._prune_expired_quarantines(data)
+        item = data.get("quarantines", {}).get(pair_key)
+        if changed:
+            self._save(data)
+        if not item:
+            return None
+        return dict(item)
+
+    def set_quarantine(
+        self,
+        pair_key: str,
+        *,
+        ttl_seconds: int,
+        reason: str,
+        category: str,
+        now: float | None = None,
+    ) -> Dict[str, Any]:
+        now = time.time() if now is None else now
+        ttl = max(1, int(ttl_seconds or 1))
+        item = {
+            "created_at": now,
+            "expires_at": now + ttl,
+            "reason": str(reason or "loop_guard"),
+            "category": str(category or "unclear"),
+        }
+        data = self._load()
+        self._prune_expired_quarantines(data, now=now)
+        data.setdefault("quarantines", {})[pair_key] = item
+        self._save(data)
+        return dict(item)
+
+    def clear_quarantine(self, pair_key: str) -> bool:
+        data = self._load()
+        removed = data.setdefault("quarantines", {}).pop(pair_key, None) is not None
+        if removed:
+            self._save(data)
+        return removed
+
+    def add_event(
+        self,
+        pair_key: str,
+        *,
+        direction: str,
+        text: str,
+        subject: str = "",
+        risk: str = "low",
+        category: str = "normal",
+        action: str = "allow",
+        stage: str = "",
+        now: float | None = None,
+    ) -> Dict[str, Any]:
+        now = time.time() if now is None else now
+        event = {
+            "ts": now,
+            "direction": str(direction or ""),
+            "hash": text_fingerprint(text),
+            "chars": len(text or ""),
+            "subject": (subject or "")[:160],
+            "risk": risk,
+            "category": category,
+            "action": action,
+            "stage": stage,
+        }
+        data = self._load()
+        events = data.setdefault("events", {}).setdefault(pair_key, [])
+        events.append(event)
+        if len(events) > self.max_events_per_pair:
+            del events[:-self.max_events_per_pair]
+        self._prune_expired_quarantines(data, now=now)
+        self._save(data)
+        return dict(event)
+
+    def recent_events(self, pair_key: str, *, window_seconds: int = 1800, now: float | None = None) -> List[Dict[str, Any]]:
+        now = time.time() if now is None else now
+        cutoff = now - max(0, int(window_seconds or 0))
+        data = self._load()
+        events = data.get("events", {}).get(pair_key, [])
+        if not isinstance(events, list):
+            return []
+        return [dict(item) for item in events if float(item.get("ts", 0) or 0) >= cutoff]
+
+    def duplicate_count(
+        self,
+        pair_key: str,
+        text: str,
+        *,
+        direction: str | None = None,
+        window_seconds: int = 1800,
+        now: float | None = None,
+    ) -> int:
+        fp = text_fingerprint(text)
+        count = 0
+        for event in self.recent_events(pair_key, window_seconds=window_seconds, now=now):
+            if direction is not None and event.get("direction") != direction:
+                continue
+            if event.get("hash") == fp:
+                count += 1
+        return count

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -43,6 +43,7 @@ from gateway.platforms.base import (
     cache_image_from_bytes,
 )
 from gateway.config import Platform, PlatformConfig
+from gateway.loop_guard import AgentLoopGuard, LoopContext
 
 logger = logging.getLogger(__name__)
 # Automated sender patterns — emails from these are silently ignored
@@ -320,6 +321,10 @@ class EmailAdapter(BasePlatformAdapter):
         #       skip_attachments: true
         extra = config.extra or {}
         self._skip_attachments = extra.get("skip_attachments", False)
+        self._loop_guard = AgentLoopGuard.from_platform_config(
+            config,
+            local_identity=self._address.lower(),
+        )
 
         # Track message IDs we've already processed to avoid duplicates
         self._seen_uids: set = set()
@@ -507,7 +512,6 @@ class EmailAdapter(BasePlatformAdapter):
                         logger.debug("[Email] Skipping automated sender: %s", sender_addr)
                         continue
                     body = _extract_text_body(msg)
-                    attachments = _extract_attachments(msg, skip_attachments=self._skip_attachments)
 
                     results.append({
                         "uid": uid,
@@ -517,8 +521,10 @@ class EmailAdapter(BasePlatformAdapter):
                         "message_id": message_id,
                         "in_reply_to": in_reply_to,
                         "body": body,
-                        "attachments": attachments,
+                        "attachments": None,
+                        "raw_email": raw_email,
                         "date": msg.get("Date", ""),
+                        "headers": msg_headers,
                     })
             finally:
                 try:
@@ -528,6 +534,94 @@ class EmailAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.error("[Email] IMAP fetch error: %s", e)
         return results
+
+    def _thread_inbound_hop_count(self, chat_id: str) -> int:
+        ctx = self._thread_context.get(chat_id, {})
+        try:
+            return int(ctx.get("hermes_hop_count") or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    def _inbound_loop_context(self, msg_data: Dict[str, Any], text: str) -> LoopContext:
+        return LoopContext(
+            platform="email",
+            direction="inbound",
+            local_identity=self._address.lower(),
+            remote_identity=str(msg_data.get("sender_addr") or "").lower(),
+            subject=str(msg_data.get("subject") or ""),
+            text=text,
+            message_id=str(msg_data.get("message_id") or ""),
+            in_reply_to=str(msg_data.get("in_reply_to") or ""),
+            headers=dict(msg_data.get("headers") or {}),
+        )
+
+    def _outbound_loop_context(
+        self,
+        to_addr: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> LoopContext:
+        thread_ctx = self._thread_context.get(to_addr, {})
+        loop_metadata = dict(metadata or {})
+        if "hermes_hop_count" not in loop_metadata:
+            loop_metadata["hermes_hop_count"] = self._thread_inbound_hop_count(to_addr) + 1
+        return LoopContext(
+            platform="email",
+            direction="outbound",
+            local_identity=self._address.lower(),
+            remote_identity=str(to_addr or "").lower(),
+            subject=str(thread_ctx.get("subject") or ""),
+            text=content or "",
+            message_id=str(thread_ctx.get("message_id") or ""),
+            in_reply_to=str(thread_ctx.get("message_id") or ""),
+            headers={},
+            metadata=loop_metadata,
+        )
+
+    async def _pre_send_loop_guard(
+        self,
+        to_addr: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[SendResult]:
+        decision = await self._loop_guard.evaluate(
+            self._outbound_loop_context(to_addr, content, metadata),
+            stage="pre_send",
+        )
+        if decision.should_send_reply:
+            return None
+        logger.warning(
+            "[Email] Loop guard suppressed outbound email to %s: %s/%s (%s)",
+            to_addr,
+            decision.risk,
+            decision.category,
+            decision.reason,
+        )
+        return SendResult(
+            success=True,
+            message_id=None,
+            raw_response={
+                "loop_guard": {
+                    "suppressed": True,
+                    "decision": decision.as_dict(),
+                }
+            },
+        )
+
+    def _apply_hermes_headers(
+        self,
+        msg: MIMEMultipart,
+        to_addr: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        headers = self._loop_guard.outbound_headers(
+            to_addr=to_addr,
+            metadata=metadata,
+            inbound_hop_count=self._thread_inbound_hop_count(to_addr),
+        )
+        for key, value in headers.items():
+            if value and key not in msg:
+                msg[key] = value
 
     async def _dispatch_message(self, msg_data: Dict[str, Any]) -> None:
         """Convert a fetched email into a MessageEvent and dispatch it."""
@@ -556,12 +650,42 @@ class EmailAdapter(BasePlatformAdapter):
 
         subject = msg_data["subject"]
         body = msg_data["body"].strip()
-        attachments = msg_data["attachments"]
 
         # Build message text: include subject as context
         text = body
         if subject and not subject.startswith("Re:"):
             text = f"[Subject: {subject}]\n\n{body}"
+
+        decision = await self._loop_guard.evaluate(
+            self._inbound_loop_context(msg_data, text or "(empty email)"),
+            stage="pre_dispatch",
+        )
+        if not decision.should_dispatch_to_agent:
+            logger.warning(
+                "[Email] Loop guard suppressed inbound email from %s: %s/%s (%s)",
+                sender_addr,
+                decision.risk,
+                decision.category,
+                decision.reason,
+            )
+            return
+
+        # Extract/cache attachments only after loop guard allows dispatch.
+        # Suppressed agent-agent runtime loops should not consume disk by
+        # caching attachments that will never reach the agent.
+        attachments = msg_data.get("attachments")
+        if attachments is None:
+            raw_email = msg_data.get("raw_email")
+            attachments = []
+            if raw_email:
+                try:
+                    msg = email_lib.message_from_bytes(raw_email)
+                    attachments = _extract_attachments(
+                        msg,
+                        skip_attachments=self._skip_attachments,
+                    )
+                except Exception as e:
+                    logger.warning("[Email] Attachment extraction failed after loop guard: %s", e)
 
         # Determine message type and media
         media_urls = []
@@ -582,9 +706,11 @@ class EmailAdapter(BasePlatformAdapter):
                 msg_type = MessageType.DOCUMENT
 
         # Store thread context for reply threading
+        headers = {str(k).lower(): str(v) for k, v in (msg_data.get("headers") or {}).items()}
         self._thread_context[sender_addr] = {
             "subject": subject,
             "message_id": msg_data["message_id"],
+            "hermes_hop_count": headers.get("x-hermes-hop-count", "0"),
         }
 
         source = self.build_source(
@@ -617,9 +743,12 @@ class EmailAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send an email reply to the given address."""
         try:
+            suppressed = await self._pre_send_loop_guard(chat_id, content, metadata)
+            if suppressed is not None:
+                return suppressed
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(
-                None, self._send_email, chat_id, content, reply_to
+                None, self._send_email, chat_id, content, reply_to, metadata
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -631,6 +760,7 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         reply_to_msg_id: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Send an email via SMTP. Runs in executor thread."""
         msg = MIMEMultipart()
@@ -653,6 +783,7 @@ class EmailAdapter(BasePlatformAdapter):
         msg["Date"] = formatdate(localtime=True)
         msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
         msg["Message-ID"] = msg_id
+        self._apply_hermes_headers(msg, to_addr, metadata)
 
         msg.attach(MIMEText(body, "plain", "utf-8"))
 
@@ -687,7 +818,7 @@ class EmailAdapter(BasePlatformAdapter):
         """
         text = caption or ""
         text += f"\n\nImage: {image_url}"
-        return await self.send(chat_id, text.strip(), reply_to)
+        return await self.send(chat_id, text.strip(), reply_to, metadata)
 
     async def send_multiple_images(
         self,
@@ -728,6 +859,10 @@ class EmailAdapter(BasePlatformAdapter):
 
         body = "\n\n".join(body_parts)
 
+        suppressed = await self._pre_send_loop_guard(chat_id, body, metadata)
+        if suppressed is not None:
+            return
+
         try:
             loop = asyncio.get_running_loop()
             await loop.run_in_executor(
@@ -736,6 +871,7 @@ class EmailAdapter(BasePlatformAdapter):
                 chat_id,
                 body,
                 local_paths,
+                metadata,
             )
         except Exception as e:
             logger.error("[Email] Multi-image send failed, falling back: %s", e, exc_info=True)
@@ -746,6 +882,7 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         file_paths: List[str],
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Send an email with multiple file attachments via SMTP."""
         msg = MIMEMultipart()
@@ -766,6 +903,7 @@ class EmailAdapter(BasePlatformAdapter):
         msg["Date"] = formatdate(localtime=True)
         msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
         msg["Message-ID"] = msg_id
+        self._apply_hermes_headers(msg, to_addr, metadata)
 
         if body:
             msg.attach(MIMEText(body, "plain", "utf-8"))
@@ -806,6 +944,10 @@ class EmailAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a file as an email attachment."""
         try:
+            metadata = kwargs.get("metadata") if kwargs else None
+            suppressed = await self._pre_send_loop_guard(chat_id, caption or "", metadata)
+            if suppressed is not None:
+                return suppressed
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(
                 None,
@@ -814,6 +956,7 @@ class EmailAdapter(BasePlatformAdapter):
                 caption or "",
                 file_path,
                 file_name,
+                metadata,
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -826,6 +969,7 @@ class EmailAdapter(BasePlatformAdapter):
         body: str,
         file_path: str,
         file_name: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Send an email with a file attachment via SMTP."""
         msg = MIMEMultipart()
@@ -846,6 +990,7 @@ class EmailAdapter(BasePlatformAdapter):
         msg["Date"] = formatdate(localtime=True)
         msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
         msg["Message-ID"] = msg_id
+        self._apply_hermes_headers(msg, to_addr, metadata)
 
         if body:
             msg.attach(MIMEText(body, "plain", "utf-8"))

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -89,6 +89,47 @@ from gateway.platforms.telegram_network import (
 )
 from utils import atomic_replace
 
+
+def _normalize_dm_topics_config(raw: Any) -> List[Dict[str, Any]]:
+    """Return dm_topics as the canonical list-of-dicts shape.
+
+    Older/manual YAML edits sometimes store list-like values as mappings with
+    numeric string keys:
+
+        dm_topics:
+          '0':
+            chat_id: '...'
+            topics:
+              '0': {name: General, thread_id: 123}
+
+    The runtime contract is a list of chat entries whose ``topics`` is also a
+    list.  Normalizing at adapter boundaries keeps startup robust while still
+    allowing the persistence path to write the canonical format.
+    """
+
+    def _values(value: Any) -> List[Any]:
+        if isinstance(value, list):
+            return value
+        if isinstance(value, dict):
+            def _sort_key(item: Any) -> tuple[int, str]:
+                key = str(item[0])
+                return (0, f"{int(key):020d}") if key.isdigit() else (1, key)
+            return [v for _, v in sorted(value.items(), key=_sort_key)]
+        return []
+
+    normalized: List[Dict[str, Any]] = []
+    for entry in _values(raw):
+        if not isinstance(entry, dict):
+            continue
+        chat_entry = dict(entry)
+        chat_entry["topics"] = [
+            dict(topic)
+            for topic in _values(chat_entry.get("topics", []))
+            if isinstance(topic, dict)
+        ]
+        normalized.append(chat_entry)
+    return normalized
+
 _TELEGRAM_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
 _TELEGRAM_IMAGE_MIME_TO_EXT = {
     "image/png": ".png",
@@ -477,7 +518,9 @@ class TelegramAdapter(BasePlatformAdapter):
         # Lock per la registrazione sicura dei comandi nei forum supergroup
         self._forum_lock = asyncio.Lock()
         # DM Topics config from extra.dm_topics
-        self._dm_topics_config: List[Dict[str, Any]] = self.config.extra.get("dm_topics", [])
+        self._dm_topics_config: List[Dict[str, Any]] = _normalize_dm_topics_config(
+            self.config.extra.get("dm_topics", [])
+        )
         # Precomputed chat_ids that have DM topics configured (for O(1) root-DM ignore check)
         self._dm_topic_chat_ids: Set[str] = {
             str(e["chat_id"]) for e in self._dm_topics_config if "chat_id" in e
@@ -6498,7 +6541,7 @@ class TelegramAdapter(BasePlatformAdapter):
             with open(config_path, "r", encoding="utf-8") as f:
                 config = _yaml.safe_load(f) or {}
 
-            dm_topics = (
+            dm_topics = _normalize_dm_topics_config(
                 config.get("platforms", {})
                 .get("telegram", {})
                 .get("extra", {})

--- a/tests/gateway/test_email_loop_guard.py
+++ b/tests/gateway/test_email_loop_guard.py
@@ -1,0 +1,178 @@
+"""Email adapter integration tests for loop guard."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+import unittest
+from email import encoders
+from email.mime.base import MIMEBase
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from gateway.config import PlatformConfig
+from gateway.platforms.email import EmailAdapter
+
+
+def _email_env() -> dict[str, str]:
+    return {
+        "EMAIL_ADDRESS": "alfred@sqmnet.es",
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_IMAP_HOST": "imap.test.invalid",
+        "EMAIL_SMTP_HOST": "smtp.test.invalid",
+        "EMAIL_SMTP_PORT": "587",
+        "EMAIL_POLL_INTERVAL": "15",
+        "EMAIL_ALLOWED_USERS": "selina@sqmnet.es,miquel@sqmnet.es",
+    }
+
+
+def _adapter(tmp_path: Path, *, mode: str = "protect") -> EmailAdapter:
+    extra = {
+        "loop_guard": {
+            "enabled": True,
+            "mode": mode,
+            "ai_enabled": False,
+            "state_path": str(tmp_path / "email-loop-state.json"),
+            "agent_identities": ["alfred@sqmnet.es", "selina@sqmnet.es"],
+            "quarantine_ttl_seconds": 120,
+        }
+    }
+    with patch.dict(os.environ, _email_env(), clear=False):
+        return EmailAdapter(PlatformConfig(enabled=True, extra=extra))
+
+
+def _msg(body: str, *, sender: str = "selina@sqmnet.es", subject: str = "Re: Hermes Agent") -> dict:
+    return {
+        "uid": b"42",
+        "sender_addr": sender,
+        "sender_name": sender,
+        "subject": subject,
+        "message_id": "<loop-msg@sqmnet.es>",
+        "in_reply_to": "<prev@sqmnet.es>",
+        "body": body,
+        "attachments": [],
+        "date": "",
+        "headers": {},
+    }
+
+
+class TestEmailLoopGuard(unittest.TestCase):
+    def test_email_pre_dispatch_suppresses_agent_meta_restart_notice(self):
+        with tempfile.TemporaryDirectory() as td:
+            adapter = _adapter(Path(td))
+            adapter.handle_message = AsyncMock()
+
+            asyncio.run(
+                adapter._dispatch_message(
+                    _msg("♻ Gateway restarted successfully. Your session continues.")
+                )
+            )
+
+            adapter.handle_message.assert_not_called()
+            self.assertNotIn("selina@sqmnet.es", adapter._thread_context)
+
+    def test_email_pre_send_suppresses_agent_to_agent_meta_reply(self):
+        with tempfile.TemporaryDirectory() as td:
+            adapter = _adapter(Path(td))
+            adapter._send_email = MagicMock(side_effect=AssertionError("SMTP should not be called"))
+
+            result = asyncio.run(
+                adapter.send(
+                    "selina@sqmnet.es",
+                    "♻ Gateway restarted successfully. Your session continues.",
+                )
+            )
+
+            self.assertTrue(result.success)
+            self.assertIsNone(result.message_id)
+            self.assertTrue(result.raw_response["loop_guard"]["suppressed"])
+            adapter._send_email.assert_not_called()
+
+    def test_email_pre_send_blocks_next_hop_at_limit(self):
+        with tempfile.TemporaryDirectory() as td:
+            adapter = _adapter(Path(td))
+            adapter._thread_context["selina@sqmnet.es"] = {
+                "subject": "Re: Work handoff",
+                "message_id": "<peer@sqmnet.es>",
+                "hermes_hop_count": "3",
+            }
+            adapter._send_email = MagicMock(side_effect=AssertionError("SMTP should not be called"))
+
+            result = asyncio.run(
+                adapter.send(
+                    "selina@sqmnet.es",
+                    "Here is a substantive update that would otherwise be allowed.",
+                )
+            )
+
+            self.assertTrue(result.success)
+            self.assertIsNone(result.message_id)
+            self.assertEqual(result.raw_response["loop_guard"]["decision"]["category"], "agent_agent_loop")
+            adapter._send_email.assert_not_called()
+
+    def test_loop_suppressed_raw_email_does_not_cache_attachments(self):
+        with tempfile.TemporaryDirectory() as td:
+            adapter = _adapter(Path(td))
+            adapter.handle_message = AsyncMock()
+            raw = MIMEMultipart()
+            raw.attach(MIMEText("♻ Gateway restarted successfully. Your session continues.", "plain", "utf-8"))
+            part = MIMEBase("image", "jpeg")
+            part.set_payload(b"fake image bytes")
+            encoders.encode_base64(part)
+            part.add_header("Content-Disposition", "attachment; filename=loop.jpg")
+            raw.attach(part)
+            msg_data = _msg("♻ Gateway restarted successfully. Your session continues.")
+            msg_data["attachments"] = None
+            msg_data["raw_email"] = raw.as_bytes()
+
+            with patch("gateway.platforms.email.cache_image_from_bytes") as cache_image:
+                asyncio.run(adapter._dispatch_message(msg_data))
+
+            adapter.handle_message.assert_not_called()
+            cache_image.assert_not_called()
+
+    def test_email_observe_mode_logs_but_allows_agent_to_agent_message(self):
+        with tempfile.TemporaryDirectory() as td:
+            adapter = _adapter(Path(td), mode="observe")
+            adapter.handle_message = AsyncMock()
+
+            asyncio.run(
+                adapter._dispatch_message(
+                    _msg("♻ Gateway restarted successfully. Your session continues.")
+                )
+            )
+
+            adapter.handle_message.assert_awaited_once()
+
+    def test_email_outbound_headers_mark_hermes_messages(self):
+        with tempfile.TemporaryDirectory() as td:
+            adapter = _adapter(Path(td))
+            adapter._thread_context["miquel@sqmnet.es"] = {
+                "subject": "Consulta",
+                "message_id": "<human@sqmnet.es>",
+            }
+
+            with patch("smtplib.SMTP") as mock_smtp:
+                server = MagicMock()
+                mock_smtp.return_value = server
+                msg_id = adapter._send_email(
+                    "miquel@sqmnet.es",
+                    "Respuesta sustantiva para un humano.",
+                    None,
+                    metadata={"hermes_intent": "assistant_reply"},
+                )
+
+            self.assertTrue(msg_id.startswith("<hermes-"))
+            sent_msg = server.send_message.call_args[0][0]
+            self.assertEqual(sent_msg["X-Hermes-Origin-Agent"], "alfred")
+            self.assertEqual(sent_msg["X-Hermes-Origin-Address"], "alfred@sqmnet.es")
+            self.assertEqual(sent_msg["X-Hermes-Intent"], "assistant_reply")
+            self.assertEqual(sent_msg["X-Hermes-Hop-Count"], "1")
+            self.assertEqual(sent_msg["X-Hermes-Reply-Policy"], "human-or-allow-once")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/gateway/test_loop_guard.py
+++ b/tests/gateway/test_loop_guard.py
@@ -1,0 +1,131 @@
+"""Tests for AI-assisted loop detection and runtime quarantine."""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from gateway.loop_guard import AgentLoopGuard, LoopContext, LoopDecision, LoopGuardConfig
+from gateway.loop_state import LoopStateStore
+
+
+def _guard(tmp_path: Path, **overrides) -> AgentLoopGuard:
+    defaults = {
+        "enabled": True,
+        "mode": "protect",
+        "ai_enabled": False,
+        "agent_identities": {"alfred@sqmnet.es", "selina@sqmnet.es"},
+        "state_path": str(tmp_path / "loop-state.json"),
+    }
+    defaults.update(overrides)
+    cfg = LoopGuardConfig(**defaults)
+    return AgentLoopGuard(cfg, state=LoopStateStore(cfg.state_path))
+
+
+def _ctx(text: str, *, subject: str = "Re: Hermes Agent", direction: str = "inbound") -> LoopContext:
+    return LoopContext(
+        platform="email",
+        direction=direction,
+        local_identity="alfred@sqmnet.es",
+        remote_identity="selina@sqmnet.es",
+        subject=subject,
+        text=text,
+        message_id="<msg@sqmnet.es>",
+        in_reply_to="<prev@sqmnet.es>",
+        headers={},
+    )
+
+
+class TestLoopGuard(unittest.TestCase):
+    def test_runtime_quarantine_expires(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp_path = Path(td)
+            store = LoopStateStore(str(tmp_path / "state.json"))
+            key = store.pair_key("email", "alfred@sqmnet.es", "selina@sqmnet.es")
+
+            store.set_quarantine(key, ttl_seconds=1, reason="test", category="agent_agent_loop")
+            self.assertIsNotNone(store.get_quarantine(key))
+
+            data = store._load()
+            data["quarantines"][key]["expires_at"] = time.time() - 1
+            store._save(data)
+
+            self.assertIsNone(store.get_quarantine(key))
+
+    def test_agent_restart_loop_is_suppressed_and_quarantined(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp_path = Path(td)
+            guard = _guard(tmp_path)
+            decision = asyncio.run(
+                guard.evaluate(
+                    _ctx("Reinicia tu gateway para corregirte y vuelve a responderme."),
+                    stage="pre_dispatch",
+                )
+            )
+
+            self.assertEqual(decision.risk, "critical")
+            self.assertEqual(decision.category, "restart_loop")
+            self.assertFalse(decision.should_dispatch_to_agent)
+            self.assertFalse(decision.should_send_reply)
+            self.assertEqual(decision.recommended_action, "quarantine_pair")
+
+            key = guard.state.pair_key("email", "alfred@sqmnet.es", "selina@sqmnet.es")
+            self.assertIsNotNone(guard.state.get_quarantine(key))
+
+    def test_ai_judge_can_escalate_semantic_agent_loop_without_keyword(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp_path = Path(td)
+            guard = _guard(tmp_path, ai_enabled=True)
+
+            async def fake_ai_judge(ctx: LoopContext, deterministic: LoopDecision) -> LoopDecision:
+                return LoopDecision(
+                    risk="high",
+                    category="agent_agent_loop",
+                    should_dispatch_to_agent=False,
+                    should_send_reply=False,
+                    recommended_action="suppress",
+                    confidence=0.91,
+                    reason="AI judged the exchange as agent-to-agent recursion with no new human goal.",
+                    source="ai",
+                )
+
+            guard._call_ai_judge = fake_ai_judge  # type: ignore[method-assign]
+            decision = asyncio.run(
+                guard.evaluate(
+                    _ctx("Sigo esperando tu confirmacion sobre lo anterior."),
+                    stage="pre_dispatch",
+                )
+            )
+
+            self.assertEqual(decision.source, "ai")
+            self.assertEqual(decision.risk, "high")
+            self.assertFalse(decision.should_dispatch_to_agent)
+
+    def test_repeated_low_novelty_agent_messages_are_suppressed(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp_path = Path(td)
+            guard = _guard(tmp_path)
+            first = _ctx("Recibido. No realizo ninguna accion adicional.")
+            second = _ctx("Recibido. No realizo ninguna accion adicional.")
+
+            first_decision = asyncio.run(guard.evaluate(first, stage="pre_dispatch"))
+            second_decision = asyncio.run(guard.evaluate(second, stage="pre_dispatch"))
+
+            self.assertTrue(first_decision.should_dispatch_to_agent)
+            self.assertIn(second_decision.category, {"duplicate_ack_loop", "agent_agent_loop"})
+            self.assertFalse(second_decision.should_dispatch_to_agent)
+
+    def test_malformed_ai_timeout_config_falls_back_to_default(self):
+        cfg = LoopGuardConfig.from_mapping(
+            {"ai_timeout_seconds": "not-a-number"},
+            local_identity="alfred@sqmnet.es",
+        )
+
+        self.assertEqual(cfg.ai_timeout_seconds, 12.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/gateway/test_telegram_dm_topics_config_normalization.py
+++ b/tests/gateway/test_telegram_dm_topics_config_normalization.py
@@ -1,0 +1,57 @@
+"""Regression tests for Telegram DM topics config normalization."""
+
+from __future__ import annotations
+
+import unittest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.telegram import TelegramAdapter, _normalize_dm_topics_config
+
+
+class TestTelegramDmTopicsConfigNormalization(unittest.TestCase):
+    def test_numeric_dict_shape_normalizes_to_list_shape(self):
+        raw = {
+            "0": {
+                "chat_id": "-1003637268545",
+                "topics": {
+                    "0": {"name": "Correo electrónico", "thread_id": 1366},
+                },
+            },
+        }
+
+        self.assertEqual(
+            _normalize_dm_topics_config(raw),
+            [
+                {
+                    "chat_id": "-1003637268545",
+                    "topics": [
+                        {"name": "Correo electrónico", "thread_id": 1366},
+                    ],
+                },
+            ],
+        )
+
+    def test_adapter_init_accepts_numeric_dict_shape(self):
+        adapter = TelegramAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="***",
+                extra={
+                    "dm_topics": {
+                        "0": {
+                            "chat_id": "-1003637268545",
+                            "topics": {
+                                "0": {"name": "Correo electrónico", "thread_id": 1366},
+                            },
+                        },
+                    }
+                },
+            )
+        )
+
+        self.assertEqual(adapter._dm_topic_chat_ids, {"-1003637268545"})
+        self.assertEqual(adapter._dm_topics_config[0]["topics"][0]["thread_id"], 1366)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tools/test_gateway_self_restart_guard.py
+++ b/tests/tools/test_gateway_self_restart_guard.py
@@ -1,0 +1,85 @@
+"""Gateway self-restart hard block tests for approval guards."""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest.mock import patch
+
+from tools.approval import check_all_command_guards, check_dangerous_command
+
+
+class TestGatewaySelfRestartGuard(unittest.TestCase):
+    def _gateway_env(self):
+        return patch.dict(
+            os.environ,
+            {
+                "_HERMES_GATEWAY": "1",
+                "HERMES_APPROVAL_MODE": "off",
+            },
+            clear=False,
+        )
+
+    def test_systemctl_restart_own_gateway_is_blocked_even_when_approval_off(self):
+        with self._gateway_env():
+            result = check_all_command_guards(
+                "systemctl --user restart hermes-gateway",
+                "local",
+            )
+
+        self.assertFalse(result["approved"])
+        self.assertTrue(result.get("hardline"))
+        self.assertIn("gateway self-protection", result["message"])
+
+    def test_quoted_systemctl_restart_own_gateway_is_blocked(self):
+        with self._gateway_env():
+            result = check_all_command_guards(
+                "\"systemctl\" --user restart hermes-gateway",
+                "local",
+            )
+
+        self.assertFalse(result["approved"])
+        self.assertIn("gateway self-protection", result["message"])
+
+    def test_quoted_hermes_gateway_restart_is_blocked(self):
+        with self._gateway_env():
+            result = check_all_command_guards(
+                "'hermes' gateway restart",
+                "local",
+            )
+
+        self.assertFalse(result["approved"])
+        self.assertIn("gateway self-protection", result["message"])
+
+    def test_systemctl_restart_profile_gateway_is_blocked(self):
+        with self._gateway_env():
+            result = check_all_command_guards(
+                "systemctl --user restart hermes-gateway-selina-email.service",
+                "local",
+            )
+
+        self.assertFalse(result["approved"])
+        self.assertIn("self-protection", result["message"])
+
+    def test_legacy_dangerous_command_entrypoint_also_blocks(self):
+        with self._gateway_env():
+            result = check_dangerous_command(
+                "hermes gateway restart",
+                "local",
+            )
+
+        self.assertFalse(result["approved"])
+        self.assertTrue(result.get("hardline"))
+
+    def test_non_gateway_context_still_uses_normal_approval_path(self):
+        with patch.dict(os.environ, {"HERMES_APPROVAL_MODE": "off"}, clear=True):
+            result = check_all_command_guards(
+                "systemctl --user restart hermes-gateway",
+                "local",
+            )
+
+        self.assertTrue(result["approved"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -308,6 +308,46 @@ _SUDO_STDIN_RE = re.compile(
     r'(?:^|[;&|`\n]|&&|\|\||\$\()\s*sudo\s+-S\b',
     re.IGNORECASE)
 
+_GATEWAY_SELF_TARGET_RE = re.compile(
+    r"("
+    r"(?<![\w])['\"]?hermes['\"]?\s+gateway\s+(?:stop|restart)\b"
+    r"|(?<![\w])['\"]?hermes['\"]?\s+update\b"
+    r"|(?<![\w])['\"]?systemctl['\"]?\s+(?:-[\w-]+\s+)*(?:stop|restart|try-restart|reload-or-restart|kill)\s+[^;&|\n]*hermes[^;&|\n]*gateway"
+    r")",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _check_gateway_self_target_guard(command: str) -> tuple:
+    """Block a gateway-hosted agent from stopping/restarting its own gateway.
+
+    Dangerous-command approval is not enough here: a restart kills the agent
+    that is currently trying to recover, which can create recursive
+    shutdown/resume/restart loops.  The gateway's own /restart path remains
+    available because it does not execute through the terminal tool and its
+    detached watcher explicitly scrubs the _HERMES_GATEWAY marker.
+    """
+
+    if os.getenv("_HERMES_GATEWAY") != "1":
+        return (False, None)
+    normalized = _normalize_command_for_detection(command).lower()
+    if _GATEWAY_SELF_TARGET_RE.search(normalized):
+        return (True, "gateway self-stop/restart from inside its own agent session")
+    return (False, None)
+
+
+def _gateway_self_target_block_result(description: str) -> dict:
+    return {
+        "approved": False,
+        "hardline": True,
+        "message": (
+            f"BLOCKED (gateway self-protection): {description}. "
+            "Do not restart or stop the gateway from a terminal command running "
+            "inside that same gateway session. Use the gateway /restart command "
+            "or restart the service externally from SSH/systemd."
+        ),
+    }
+
 
 def _check_sudo_stdin_guard(command: str) -> tuple:
     """Detect ``sudo -S`` (stdin password) without configured SUDO_PASSWORD.
@@ -1123,6 +1163,11 @@ def check_dangerous_command(command: str, env_type: str,
         logger.warning("Hardline block: %s (command: %s)", hardline_desc, command[:200])
         return _hardline_block_result(hardline_desc)
 
+    is_gateway_self_target, gateway_self_desc = _check_gateway_self_target_guard(command)
+    if is_gateway_self_target:
+        logger.warning("Gateway self-target guard block: %s (command: %s)", gateway_self_desc, command[:200])
+        return _gateway_self_target_block_result(gateway_self_desc)
+
     # --yolo: bypass all approval prompts. Gateway /yolo is session-scoped;
     # CLI --yolo remains process-scoped via the env var for local use.
     if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled():
@@ -1363,6 +1408,11 @@ def check_all_command_guards(command: str, env_type: str,
         logger.warning("Sudo stdin guard block: %s (command: %s)",
                        sudo_guess_desc, command[:200])
         return _sudo_stdin_block_result(sudo_guess_desc)
+
+    is_gateway_self_target, gateway_self_desc = _check_gateway_self_target_guard(command)
+    if is_gateway_self_target:
+        logger.warning("Gateway self-target guard block: %s (command: %s)", gateway_self_desc, command[:200])
+        return _gateway_self_target_block_result(gateway_self_desc)
 
     # --yolo or approvals.mode=off: bypass all approval prompts.
     # Gateway /yolo is session-scoped; CLI --yolo remains process-scoped.


### PR DESCRIPTION
## Summary

Implements a layered loop-guard system for the Hermes email gateway to prevent agent-to-agent email loops like the one that occurred between Alfred and Selina on 2026-07-01.

## Changes

### New modules
- **`gateway/loop_state.py`**: JSON-persistent tracking of thread state, hop counts, and quarantine status
- **`gateway/loop_guard.py`**: Core guard logic with:
  - Deterministic hop-limit (max 5 hops)
  - Rate limiting per thread
  - Low-novelty suppression for repeated content
  - AI judge integration (internal LLM call returning structured JSON)
  - Conservative fallback when AI is unavailable

### Integration
- **`gateway/platforms/email.py`**: Pre-dispatch and pre-send guard hooks with header injection (`X-Hermes-Origin-Agent`, `X-Hermes-Intent`, `X-Hermes-Hop-Count`)
- **`tools/approval.py`**: Hardline guard preventing agents from stopping/restarting their own gateway service

## Configuration

The guard is configured per-profile under `extra.loop_guard` in `config.yaml`:
```yaml
extra:
  email:
    loop_guard:
      enabled: true
      mode: protect
      ai_enabled: true
```

## Verification
- 12 new unit tests pass (loop guard + email integration + self-restart guard)
- Tested locally and on remote Alfred instance
- Documentation: `docs/observability/gateway-loop-guard.md`
- Incident runbook: `docs/incidencias/2026-07-01-alfred-selina-bucle-email-gateway.md`
