### PR TITLE
fix(agent): lower compression retry threshold from 5% to any positive reduction (#59587)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3366,7 +3366,7 @@ def run_conversation(
                     new_tokens = estimate_messages_tokens_rough(messages)
                     approx_tokens = new_tokens  # update for downstream logging
 
-                    if len(messages) < original_len or (new_tokens > 0 and new_tokens < original_tokens * 0.95):
+                    if len(messages) < original_len or (new_tokens > 0 and new_tokens < original_tokens):
                         if len(messages) < original_len:
                             agent._buffer_status(f"🗜️ Compressed {original_len} → {len(messages)} messages, retrying...")
                         else:
@@ -3589,10 +3589,10 @@ def run_conversation(
                     new_tokens = estimate_messages_tokens_rough(messages)
                     approx_tokens = new_tokens  # update for downstream logging
 
-                    if len(messages) < original_len or (new_tokens > 0 and new_tokens < original_tokens * 0.95) or (new_ctx and new_ctx < old_ctx):
+                    if len(messages) < original_len or (new_tokens > 0 and new_tokens < original_tokens) or (new_ctx and new_ctx < old_ctx):
                         if len(messages) < original_len:
                             agent._buffer_status(f"🗜️ Compressed {original_len} → {len(messages)} messages, retrying...")
-                        elif new_tokens > 0 and new_tokens < original_tokens * 0.95:
+                        elif new_tokens > 0 and new_tokens < original_tokens:
                             agent._buffer_status(f"🗜️ Compressed ~{original_tokens:,} → ~{new_tokens:,} tokens, retrying...")
                         time.sleep(2)  # Brief pause between compression retries
                         _retry.restart_with_compressed_messages = True


### PR DESCRIPTION
## Summary

The 413 payload-too-large and context-overflow handlers in `conversation_loop.py` both require **≥5% estimated token reduction** before retrying after compression. A genuine 3–4% reduction may be exactly what is needed to fit within the provider's limit, and the current gate causes a terminal failure unnecessarily.

## Root cause

The 5% threshold (`original_tokens * 0.95`) existed as a loop-progress guard, but `max_compression_attempts = 3` (line 1087) already provides an absolute upper bound, making the percentage gate redundant.

## Fix

Remove the `* 0.95` multiplier on all three sites (lines 3369, 3592, 3595), accepting **any** positive token reduction. The `new_tokens > 0 and new_tokens < original_tokens` check prevents zero-estimate or failed compressions from triggering a retry with a broken message list.

The `len(messages) < original_len` branch (message-count reduction) was already unconditional and is unchanged.

## Safety

- `max_compression_attempts = 3` bounds the retry loop absolutely
- A zero/negative estimate cannot trigger a retry (`new_tokens > 0` check)
- Compression is monotonically destructive — it never makes messages larger

## Changes

| File | Δ |
|------|---|
| `agent/conversation_loop.py` | 3 lines changed (remove `* 0.95` at lines 3369, 3592, 3595) |

## Tests

- `tests/run_agent/test_infinite_compaction_loop.py`: **14/14 passed** ✅

Closes #59587